### PR TITLE
feat: enhance pr-comment-responder with memory patterns and agent routing

### DIFF
--- a/claude/orchestrator.md
+++ b/claude/orchestrator.md
@@ -191,13 +191,26 @@ Assess complexity BEFORE selecting agents:
 |-----------|---------------|----------|
 | C# implementation | implementer | analyst |
 | Architecture review | architect | analyst |
-| Task decomposition | planner | roadmap |
-| Challenge assumptions | critic | analyst |
+| Epic → Milestones | planner | roadmap |
+| Milestones → Atomic tasks | task-generator | planner |
+| Challenge assumptions | independent-thinker | critic |
+| Plan validation | critic | analyst |
 | Test strategy | qa | implementer |
 | Research/investigation | analyst | - |
 | Strategic decisions | roadmap | architect |
 | Security assessment | security | analyst |
 | Infrastructure changes | devops | security |
+
+### Planner vs Task-Generator
+
+| Agent | Input | Output | When to Use |
+|-------|-------|--------|-------------|
+| **planner** | Epic/Feature | Milestones with deliverables | Breaking down large scope |
+| **task-generator** | PRD/Milestone | Atomic tasks with acceptance criteria | Before implementer/qa/devops work |
+
+**Workflow**: `roadmap → planner → task-generator → implementer/qa/devops`
+
+The task-generator produces work items sized for individual agents (implementer, qa, devops, architect).
 
 ## Handoff Protocol
 

--- a/copilot-cli/orchestrator.agent.md
+++ b/copilot-cli/orchestrator.agent.md
@@ -180,13 +180,26 @@ Assess complexity BEFORE selecting agents:
 |-----------|---------------|----------|
 | C# implementation | implementer | analyst |
 | Architecture review | architect | analyst |
-| Task decomposition | planner | roadmap |
-| Challenge assumptions | critic | analyst |
+| Epic → Milestones | planner | roadmap |
+| Milestones → Atomic tasks | task-generator | planner |
+| Challenge assumptions | independent-thinker | critic |
+| Plan validation | critic | analyst |
 | Test strategy | qa | implementer |
 | Research/investigation | analyst | - |
 | Strategic decisions | roadmap | architect |
 | Security assessment | security | analyst |
 | Infrastructure changes | devops | security |
+
+### Planner vs Task-Generator
+
+| Agent | Input | Output | When to Use |
+|-------|-------|--------|-------------|
+| **planner** | Epic/Feature | Milestones with deliverables | Breaking down large scope |
+| **task-generator** | PRD/Milestone | Atomic tasks with acceptance criteria | Before implementer/qa/devops work |
+
+**Workflow**: `roadmap → planner → task-generator → implementer/qa/devops`
+
+The task-generator produces work items sized for individual agents (implementer, qa, devops, architect).
 
 ## Handoff Protocol
 

--- a/copilot-cli/pr-comment-responder.agent.md
+++ b/copilot-cli/pr-comment-responder.agent.md
@@ -160,6 +160,8 @@ Copilot responds differently than humans:
 
 ## Routing Heuristics
 
+### By Comment Pattern
+
 | Comment Pattern | Path | Delegation |
 |-----------------|------|------------|
 | "Typo in..." | Quick Fix | implementer |
@@ -172,20 +174,95 @@ Copilot responds differently than humans:
 | "Why not do X instead?" | Strategic | orchestrator |
 | "This seems like scope creep" | Strategic | orchestrator |
 
+### By File Domain (Direct Agent Routing)
+
+Some comments warrant direct agent routing without full orchestration:
+
+| File Pattern | Comment Type | Direct To | Why |
+|--------------|--------------|-----------|-----|
+| `.github/workflows/*` | CI/CD issues | devops | Domain expertise |
+| `.githooks/*` | Hook problems | devops + security | Infrastructure + security |
+| `**/Auth/**`, `*.env*` | Security concerns | security | Critical path |
+| Any file | "WHETHER to do X" | independent-thinker | Challenge assumptions first |
+
+### Domain-Specific Delegation
+
+#### DevOps Comments (skip orchestrator)
+
+```bash
+# For CI/CD, pipeline, or infrastructure comments
+copilot --agent devops --prompt "PR review comment on infrastructure file:
+
+Comment: [comment text]
+File: [.github/workflows/build.yml]
+Line: [line number]
+Author: @[author]
+
+Assess the infrastructure concern and implement fix if valid.
+Coordinate with security agent if .githooks/* or secrets involved."
+```
+
+#### Strategic "WHETHER" Questions (independent-thinker first)
+
+```bash
+# When reviewer questions WHETHER to do something
+copilot --agent independent-thinker --prompt "Evaluate this PR review challenge:
+
+Comment: [Why not use X instead?]
+File: [file path]
+Context: [relevant code]
+
+Provide unfiltered analysis:
+1. Is the reviewer's concern valid?
+2. What are the actual tradeoffs?
+3. Should we change approach or defend current choice?
+
+Be intellectually honest - don't automatically agree with either side."
+```
+
 ## Memory Protocol (cloudmcp-manager)
 
-**Retrieve at start:**
+Memory is a critical strength for PR comment handling. Reviewers (especially bots) have predictable patterns that improve triage accuracy over time.
+
+### Retrieval (MANDATORY at start)
 
 ```text
+# General PR patterns
 cloudmcp-manager/memory-search_nodes with query="PR review patterns"
-cloudmcp-manager/memory-search_nodes with query="[bot name] false positives"
+
+# Bot-specific false positives (critical for efficiency)
+cloudmcp-manager/memory-search_nodes with query="CodeRabbit false positives"
+cloudmcp-manager/memory-search_nodes with query="Copilot suggestions patterns"
+
+# Reviewer preferences (human reviewers have patterns too)
+cloudmcp-manager/memory-search_nodes with query="reviewer [username] preferences"
+
+# Domain-specific patterns
+cloudmcp-manager/memory-search_nodes with query="[file type] review patterns"
 ```
 
-**Store after handling:**
+### Storage (After EVERY triage decision)
 
 ```text
-cloudmcp-manager/memory-add_observations for new patterns learned
+# Store bot false positive patterns
+cloudmcp-manager/memory-create_entities with entities for BotFalsePositive type
+
+# Store successful triage decisions
+cloudmcp-manager/memory-add_observations for pattern → path → outcome
+
+# Link reviewer to their patterns
+cloudmcp-manager/memory-create_relations linking reviewer to patterns
 ```
+
+### What to Remember
+
+| Category | Store | Why |
+|----------|-------|-----|
+| **Bot False Positives** | Pattern, trigger, resolution | Avoid re-investigating known issues |
+| **Reviewer Preferences** | Style preferences, common concerns | Anticipate feedback |
+| **Triage Decisions** | Comment → Path → Outcome | Improve classification accuracy |
+| **Domain Patterns** | File type + common issues | Route faster |
+| **Successful Rebuttals** | When "no action" was correct | Confidence in declining |
 
 ## Communication Guidelines
 
@@ -223,6 +300,10 @@ cloudmcp-manager/memory-add_observations for new patterns learned
 | Situation | Delegate To | Why |
 |-----------|-------------|-----|
 | Quick fix (one-sentence explanation) | implementer | Skip orchestrator overhead |
+| CI/CD, pipeline, workflow comments | devops | Domain expertise, skip orchestrator |
+| Security-sensitive files | security | Critical path, no delays |
+| "WHETHER to do X" questions | independent-thinker | Challenge assumptions before deciding |
 | Needs investigation | orchestrator (Standard path) | Full workflow needed |
 | Scope/priority question | orchestrator (Strategic path) | Strategic evaluation needed |
 | Bot follow-up handling | (self) | Specialized bot knowledge |
+| Known bot false positive (from memory) | (self) | Decline with stored rationale |

--- a/vs-code-agents/orchestrator.agent.md
+++ b/vs-code-agents/orchestrator.agent.md
@@ -178,15 +178,28 @@ Assess complexity BEFORE selecting agents:
 
 | Task Type | Primary Agent | Fallback |
 |-----------|---------------|----------|
-| C# implementation | implementer | - |
+| C# implementation | implementer | analyst |
 | Architecture review | architect | analyst |
-| Task decomposition | planner | roadmap |
-| Challenge assumptions | critic | analyst |
+| Epic → Milestones | planner | roadmap |
+| Milestones → Atomic tasks | task-generator | planner |
+| Challenge assumptions | independent-thinker | critic |
+| Plan validation | critic | analyst |
 | Test strategy | qa | implementer |
 | Research/investigation | analyst | - |
 | Strategic decisions | roadmap | architect |
 | Security assessment | security | analyst |
 | Infrastructure changes | devops | security |
+
+### Planner vs Task-Generator
+
+| Agent | Input | Output | When to Use |
+|-------|-------|--------|-------------|
+| **planner** | Epic/Feature | Milestones with deliverables | Breaking down large scope |
+| **task-generator** | PRD/Milestone | Atomic tasks with acceptance criteria | Before implementer/qa/devops work |
+
+**Workflow**: `roadmap → planner → task-generator → implementer/qa/devops`
+
+The task-generator produces work items sized for individual agents (implementer, qa, devops, architect).
 
 ## Handoff Protocol
 

--- a/vs-code-agents/pr-comment-responder.agent.md
+++ b/vs-code-agents/pr-comment-responder.agent.md
@@ -153,6 +153,8 @@ Copilot responds differently than humans:
 
 ## Routing Heuristics
 
+### By Comment Pattern
+
 | Comment Pattern | Path | Delegation |
 |-----------------|------|------------|
 | "Typo in..." | Quick Fix | @implementer |
@@ -165,20 +167,93 @@ Copilot responds differently than humans:
 | "Why not do X instead?" | Strategic | @orchestrator |
 | "This seems like scope creep" | Strategic | @orchestrator |
 
+### By File Domain (Direct Agent Routing)
+
+Some comments warrant direct agent routing without full orchestration:
+
+| File Pattern | Comment Type | Direct To | Why |
+|--------------|--------------|-----------|-----|
+| `.github/workflows/*` | CI/CD issues | @devops | Domain expertise |
+| `.githooks/*` | Hook problems | @devops + @security | Infrastructure + security |
+| `**/Auth/**`, `*.env*` | Security concerns | @security | Critical path |
+| Any file | "WHETHER to do X" | @independent-thinker | Challenge assumptions first |
+
+### Domain-Specific Delegation
+
+#### DevOps Comments (skip orchestrator)
+
+```text
+@devops PR review comment on infrastructure file:
+
+Comment: [comment text]
+File: [.github/workflows/build.yml]
+Line: [line number]
+Author: @[author]
+
+Assess the infrastructure concern and implement fix if valid.
+Coordinate with @security if .githooks/* or secrets involved.
+```
+
+#### Strategic "WHETHER" Questions (independent-thinker first)
+
+```text
+@independent-thinker Evaluate this PR review challenge:
+
+Comment: [Why not use X instead?]
+File: [file path]
+Context: [relevant code]
+
+Provide unfiltered analysis:
+1. Is the reviewer's concern valid?
+2. What are the actual tradeoffs?
+3. Should we change approach or defend current choice?
+
+Be intellectually honest - don't automatically agree with either side.
+```
+
 ## Memory Protocol (cloudmcp-manager)
 
-**Retrieve at start:**
+Memory is a critical strength for PR comment handling. Reviewers (especially bots) have predictable patterns that improve triage accuracy over time.
+
+### Retrieval (MANDATORY at start)
 
 ```text
+# General PR patterns
 cloudmcp-manager/memory-search_nodes with query="PR review patterns"
-cloudmcp-manager/memory-search_nodes with query="[bot name] false positives"
+
+# Bot-specific false positives (critical for efficiency)
+cloudmcp-manager/memory-search_nodes with query="CodeRabbit false positives"
+cloudmcp-manager/memory-search_nodes with query="Copilot suggestions patterns"
+
+# Reviewer preferences (human reviewers have patterns too)
+cloudmcp-manager/memory-search_nodes with query="reviewer [username] preferences"
+
+# Domain-specific patterns
+cloudmcp-manager/memory-search_nodes with query="[file type] review patterns"
 ```
 
-**Store after handling:**
+### Storage (After EVERY triage decision)
 
 ```text
-cloudmcp-manager/memory-add_observations for new patterns learned
+# Store bot false positive patterns
+cloudmcp-manager/memory-create_entities with entities for BotFalsePositive type
+
+# Store successful triage decisions
+cloudmcp-manager/memory-add_observations for pattern → path → outcome
+
+# Link reviewer to their patterns
+cloudmcp-manager/memory-create_relations linking reviewer to patterns
 ```
+
+### What to Remember
+
+| Category | Store | Why |
+|----------|-------|-----|
+| **Bot False Positives** | Pattern, trigger, resolution | Avoid re-investigating known issues |
+| **Reviewer Preferences** | Style preferences, common concerns | Anticipate feedback |
+| **Triage Decisions** | Comment → Path → Outcome | Improve classification accuracy |
+| **Domain Patterns** | File type + common issues | Route faster |
+| **Successful Rebuttals** | When "no action" was correct | Confidence in declining |
 
 ## Communication Guidelines
 
@@ -216,6 +291,10 @@ cloudmcp-manager/memory-add_observations for new patterns learned
 | Situation | Delegate To | Why |
 |-----------|-------------|-----|
 | Quick fix (one-sentence explanation) | @implementer | Skip orchestrator overhead |
+| CI/CD, pipeline, workflow comments | @devops | Domain expertise, skip orchestrator |
+| Security-sensitive files | @security | Critical path, no delays |
+| "WHETHER to do X" questions | @independent-thinker | Challenge assumptions before deciding |
 | Needs investigation | @orchestrator (Standard path) | Full workflow needed |
 | Scope/priority question | @orchestrator (Strategic path) | Strategic evaluation needed |
 | Bot follow-up handling | (self) | Specialized bot knowledge |
+| Known bot false positive (from memory) | (self) | Decline with stored rationale |


### PR DESCRIPTION
# Pull Request

## Summary

Enhance pr-comment-responder to leverage persistent memory for bot patterns, add domain-specific agent routing, and clarify planner vs task-generator roles across all three platforms.

## Changes

- Add comprehensive memory protocol for bot false positive patterns (CodeRabbit, Copilot)
- Store reviewer preferences and triage decisions for accuracy improvement
- Add domain-specific routing: devops for CI/CD, security for auth files, independent-thinker for "WHETHER" questions
- Clarify planner vs task-generator roles in orchestrator routing heuristics
- Add Phase 0 Triage with Weinberg/Schrag principles for token efficiency
- Sync all changes across claude, copilot-cli, and vs-code-agents platforms

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change
- [x] Refactoring (no functional changes)

## Testing

- [ ] Tests added/updated
- [ ] Manual testing completed
- [x] No testing required (documentation only)

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [x] No security-critical changes in this PR
- [ ] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [ ] Security patterns applied (see `.agents/security/`)

**Files requiring security review:**

None - agent documentation only.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Fixes #2

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)