### PR TITLE
Latta code generation c3f52168-5571-48e0-96a1-889f61f126fa

### DIFF
--- a/.github/agents/pr-comment-responder.agent.md
+++ b/.github/agents/pr-comment-responder.agent.md
@@ -574,6 +574,15 @@ if [ "$ADDRESSED" -lt "$TOTAL" ]; then
 fi
 ```
 
+### Phase 9: Cleanup
+
+```bash
+# Remove temporary files
+if [ -d ".agents/temp" ]; then
+  rm -rf .agents/temp/*
+fi
+```
+
 ## Bot-Specific Handling
 
 ### Copilot Behavior

--- a/.github/agents/pr-comment-responder.prompt.md
+++ b/.github/agents/pr-comment-responder.prompt.md
@@ -574,6 +574,15 @@ if [ "$ADDRESSED" -lt "$TOTAL" ]; then
 fi
 ```
 
+### Phase 9: Cleanup
+
+```bash
+# Remove temporary files
+if [ -d ".agents/temp" ]; then
+  rm -rf .agents/temp/*
+fi
+```
+
 ## Bot-Specific Handling
 
 ### Copilot Behavior

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,8 @@
 # Build artifacts
 artifacts/
 
-# Agent PR scratch files
+# Agent temporary files (cleaned after workflow completion)
+.agents/temp/
+
+# Agent PR scratch files (persistent during PR review)
 .agents/pr-comments/

--- a/src/claude/pr-comment-responder.md
+++ b/src/claude/pr-comment-responder.md
@@ -748,6 +748,15 @@ if [ "$ADDRESSED" -lt "$TOTAL" ]; then
 fi
 ```
 
+### Phase 9: Cleanup
+
+```bash
+# Remove temporary files
+if [ -d ".agents/temp" ]; then
+  rm -rf .agents/temp/*
+fi
+```
+
 ## Memory Protocol
 
 Use cloudmcp-manager memory tools directly for cross-session context. Memory is critical for PR comment handling - reviewers have predictable patterns.

--- a/src/copilot-cli/pr-comment-responder.agent.md
+++ b/src/copilot-cli/pr-comment-responder.agent.md
@@ -574,6 +574,15 @@ if [ "$ADDRESSED" -lt "$TOTAL" ]; then
 fi
 ```
 
+### Phase 9: Cleanup
+
+```bash
+# Remove temporary files
+if [ -d ".agents/temp" ]; then
+  rm -rf .agents/temp/*
+fi
+```
+
 ## Bot-Specific Handling
 
 ### Copilot Behavior

--- a/src/vs-code-agents/pr-comment-responder.agent.md
+++ b/src/vs-code-agents/pr-comment-responder.agent.md
@@ -574,6 +574,15 @@ if [ "$ADDRESSED" -lt "$TOTAL" ]; then
 fi
 ```
 
+### Phase 9: Cleanup
+
+```bash
+# Remove temporary files
+if [ -d ".agents/temp" ]; then
+  rm -rf .agents/temp/*
+fi
+```
+
 ## Bot-Specific Handling
 
 ### Copilot Behavior

--- a/templates/agents/pr-comment-responder.shared.md
+++ b/templates/agents/pr-comment-responder.shared.md
@@ -574,6 +574,15 @@ if [ "$ADDRESSED" -lt "$TOTAL" ]; then
 fi
 ```
 
+### Phase 9: Cleanup
+
+```bash
+# Remove temporary files
+if [ -d ".agents/temp" ]; then
+  rm -rf .agents/temp/*
+fi
+```
+
 ## Bot-Specific Handling
 
 ### Copilot Behavior


### PR DESCRIPTION
PR comment responder agent was updated to include Phase 9 cleanup steps across multiple variants and templates, with .gitignore modified to track temporary agent files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Phase 9 cleanup step across PR comment responder variants/templates and ignore `.agents/temp/` in git, while standardizing completion verification sections.
> 
> - **Agents/Templates**:
>   - Add `Phase 9: Cleanup` with script to remove `.agents/temp/*` in `src/claude/pr-comment-responder.md`, `.github/agents/pr-comment-responder.*.md`, `templates/agents/pr-comment-responder.shared.md`, and VS Code/Copilot variants.
>   - Standardize and (re)introduce `Phase 8: Completion Verification` blocks in VS Code and Copilot agent docs.
> - **Repo Config**:
>   - Update `.gitignore` to exclude `/.agents/temp/` and clarify persistent `.agents/pr-comments/` scratch files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62e0624b82b25aacc029dd3b34e349d26a1e4526. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->