### PR TITLE
Latta code generation 40913f28-49d6-4bae-94d2-d522d4580d14

### DIFF
--- a/.claude/skills/github/scripts/issue/Set-IssueLabels.ps1
+++ b/.claude/skills/github/scripts/issue/Set-IssueLabels.ps1
@@ -109,5 +109,5 @@ $output = [PSCustomObject]@{
 }
 
 Write-Output $output
-if ($applied.Count -gt 0) { Write-Host "Applied $($applied.Count) label(s) to issue #$Issue: $($applied -join ', ')" -ForegroundColor Green }
+if ($applied.Count -gt 0) { Write-Host "Applied $($applied.Count) label(s) to issue #${Issue}: $($applied -join ', ')" -ForegroundColor Green }
 if ($failed.Count -gt 0) { Write-Host "Failed: $($failed -join ', ')" -ForegroundColor Red; exit 3 }


### PR DESCRIPTION
PowerShell parsing error was fixed by correcting variable syntax in the issue labeling script.