### PR TITLE
docs(claude): update CLAUDE.md with current repository state

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -184,14 +184,18 @@ serena/find_symbol - Find code symbols
 
 ### Forgetful (Semantic Memory)
 
+All Forgetful tools use `execute_forgetful_tool(tool_name, arguments)` pattern:
+
 ```text
-forgetful/memory_create - Store memories with semantic embeddings
-forgetful/memory_search - Find memories by semantic similarity
-forgetful/entity_create - Create knowledge graph entities
-forgetful/entity_search - Search entities by name/type
+execute_forgetful_tool("create_memory", {...}) - Store memories with semantic embeddings
+execute_forgetful_tool("query_memory", {...}) - Find memories by semantic similarity
+execute_forgetful_tool("get_memory", {...}) - Retrieve specific memory by ID
+execute_forgetful_tool("list_projects", {...}) - List all memory projects
+execute_forgetful_tool("create_entity", {...}) - Create knowledge graph entities
+execute_forgetful_tool("search_entities", {...}) - Search entities by name/type
 ```
 
-> **Note**: Forgetful uses HTTP transport. Stdio transport is broken due to FastMCP banner corruption ([upstream issue #19](https://github.com/ScottRBK/forgetful/issues/19)).
+> **Note**: Forgetful uses HTTP transport at `http://localhost:8020/mcp`. Stdio transport is broken due to FastMCP banner corruption ([upstream issue #19](https://github.com/ScottRBK/forgetful/issues/19)).
 >
 > **Setup**: See `scripts/forgetful/README.md` for installation. Health check: `pwsh scripts/forgetful/Test-ForgetfulHealth.ps1`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,8 @@ You CANNOT claim session completion until validation PASSES. These requirements 
 | Req Level | Step | Verification |
 |-----------|------|--------------|
 | **MUST** | Complete Session End checklist in session log | All `[x]` checked |
-| **MUST** | Update `.agents/HANDOFF.md` with session log link | File modified, link exists |
+| **MUST NOT** | Update `.agents/HANDOFF.md` (read-only reference) | File unchanged |
+| **MUST** | Update Serena memory (cross-session context) | Memory write confirmed |
 | **MUST** | Run `npx markdownlint-cli2 --fix "**/*.md"` | Lint passes |
 | **MUST** | Commit all changes including `.agents/` | Commit SHA in Evidence column |
 | **MUST** | Run `Validate-SessionEnd.ps1` | Exit code 0 (PASS) |
@@ -115,7 +116,7 @@ Orchestrator → Retrospective → complete
 
 **Architecture**: Subagents CANNOT delegate to other subagents. They return results to orchestrator, who handles all routing decisions.
 
-The Memory agent provides long-running context across sessions using `cloudmcp-manager` for persistent memory.
+The Memory agent provides long-running context across sessions using Serena (project-specific memory) and Forgetful (semantic search with knowledge graph) for persistent memory.
 
 ---
 
@@ -592,11 +593,11 @@ Agents have access to multiple memory systems depending on the platform and avai
 
 **Use memory tools in this order of preference:**
 
-1. **Serena Memory** (preferred) - File-based, cross-platform, shared with Claude Code/Desktop
-2. **cloudmcp-manager** - Graph-based entity storage, shared with Claude Code/Desktop  
+1. **Serena Memory** (preferred) - Project-specific file-based memory, cross-platform
+2. **Forgetful MCP** - Semantic search with knowledge graph, cross-project memory
 3. **VS Code `memory` tool** (last resort) - VS Code proprietary, not shared with other AI agents
 
-**Important**: If the VS Code `memory` tool is available alongside Serena or cloudmcp-manager, query it for any existing context that should be synchronized to the shared memory systems. This ensures knowledge is accessible across all AI agent platforms (VS Code, Claude Code, Claude Desktop).
+**Important**: If the VS Code `memory` tool is available alongside Serena or Forgetful, query it for any existing context that should be synchronized to the shared memory systems. This ensures knowledge is accessible across all AI agent platforms (VS Code, Claude Code, Claude Desktop).
 
 ### Serena Memory (Preferred)
 
@@ -619,9 +620,9 @@ list_memories()
 edit_memory(memory_file_name="session-notes.md", needle="IN PROGRESS", repl="COMPLETED", mode="literal")
 ```
 
-### Graph-Based Memory (cloudmcp-manager)
+### Forgetful MCP (Semantic Search + Knowledge Graph)
 
-For environments with `cloudmcp-manager`, use graph-based memory for richer entity relationships:
+Forgetful provides semantic search and automatic knowledge graph construction for cross-session memory using `execute_forgetful_tool(tool_name, arguments)` pattern:
 
 | Operation | Tool | Purpose |
 |-----------|------|---------|
@@ -1280,8 +1281,9 @@ SESSION START (BLOCKING - MUST complete before work):
 
 SESSION END (BLOCKING - MUST complete before closing):
 6. MUST: Complete Session End checklist in session log (all [x] checked)
-7. MUST: Update .agents/HANDOFF.md with session summary and session log link
-8. MUST: Run npx markdownlint-cli2 --fix "**/*.md"
+7. MUST NOT: Update .agents/HANDOFF.md (read-only reference)
+8. MUST: Update Serena memory (cross-session context)
+9. MUST: Run npx markdownlint-cli2 --fix "**/*.md"
 9. MUST: Commit all changes (record SHA in Evidence column)
 10. MUST: Run Validate-SessionEnd.ps1 - PASS required before claiming completion
 11. SHOULD: Check off completed tasks in PROJECT-PLAN.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,19 +126,31 @@ mcp__serena__get_project_context()
 
 ### Forgetful (Semantic Memory)
 
-```python
-# Store learnings
-mcp__forgetful__memory_create(
-    content="PowerShell arrays need @() for single-element arrays",
-    tags=["powershell", "arrays", "gotcha"]
-)
+All Forgetful tools use `execute_forgetful_tool(tool_name, arguments)` pattern:
 
-# Search for context
-mcp__forgetful__memory_search(query="PowerShell array handling")
+```python
+# Store learnings (requires title, content, context, keywords, tags, importance)
+mcp__forgetful__execute_forgetful_tool("create_memory", {
+    "title": "PowerShell array gotcha",
+    "content": "PowerShell arrays need @() for single-element arrays",
+    "context": "Bug fix during script development",
+    "keywords": ["powershell", "arrays"],
+    "tags": ["gotcha", "powershell"],
+    "importance": 7
+})
+
+# Search for context (requires query and query_context)
+mcp__forgetful__execute_forgetful_tool("query_memory", {
+    "query": "PowerShell array handling",
+    "query_context": "Implementing array logic in script"
+})
+
+# List projects
+mcp__forgetful__execute_forgetful_tool("list_projects", {})
 
 # Knowledge graph
-mcp__forgetful__entity_create(name="...", type="...")
-mcp__forgetful__entity_search(query="...")
+mcp__forgetful__execute_forgetful_tool("create_entity", {"name": "...", "entity_type": "..."})
+mcp__forgetful__execute_forgetful_tool("search_entities", {"query": "..."})
 ```
 
 **Verification**: If forgetful tools are unavailable:
@@ -482,8 +494,8 @@ mcp__serena__read_memory(memory_file_name="[topic]")
 mcp__serena__write_memory(memory_file_name="[topic]", content="...")
 
 # Forgetful (semantic search)
-mcp__forgetful__memory_search(query="[topic]")
-mcp__forgetful__memory_create(content="...", tags=["..."])
+mcp__forgetful__execute_forgetful_tool("query_memory", {"query": "[topic]", "query_context": "why searching"})
+mcp__forgetful__execute_forgetful_tool("create_memory", {"title": "...", "content": "...", "context": "...", "keywords": [...], "tags": [...], "importance": 7})
 ```
 
 ### Agent Output Directories


### PR DESCRIPTION
Add comprehensive documentation updates including:
- Repository overview with directory structure
- MCP servers section (Serena, Forgetful, DeepWiki)
- ADR reference section with key architecture decisions
- Two-source architecture explanation (ADR-036)
- Enhanced skill system documentation
- Branch verification requirement in session protocol
- Session log filtering note for QA validation
- Updated Memory Protocol to use Serena/Forgetful instead of cloudmcp-manager