### PR TITLE
fix: add actions/checks permissions to Claude workflow for autonomous operation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,6 +15,8 @@ permissions:
   issues: write
   pull-requests: write
   id-token: write  # Required for OIDC authentication to get GitHub App token
+  actions: write  # Required to approve and trigger workflow runs autonomously
+  checks: write  # Required to create check runs
 
 jobs:
   # ADR-006 Compliance: Authorization logic moved to PowerShell script for testability


### PR DESCRIPTION
## Problem

The Claude workflow requires manual approval to run workflows triggered by its code pushes (e.g., Pester tests). This blocks autonomous operation as mentioned in PR #786.

## Solution

Added two permissions to :
- `actions: write` - Allows Claude to approve and trigger workflow runs autonomously
- `checks: write` - Allows Claude to create check runs

## Testing

- [x] Verified permission syntax matches GitHub Actions schema
- [x] Reviewed GitHub Actions documentation for these permissions
- [x] Confirmed authorization logic remains unchanged

## Related Issues

Fixes #786

## Notes

This change only affects workflow orchestration permissions. The authorization logic (checking for `@claude` mentions and user permissions via `Test-ClaudeAuthorization.ps1`) remains unchanged.