### PR TITLE
fix(ci): update metrics script path to new location

### DIFF
--- a/.github/workflows/agent-metrics.yml
+++ b/.github/workflows/agent-metrics.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Collect metrics
         id: metrics
         run: |
-          python .agents/utilities/metrics/collect_metrics.py \
+          python .claude/skills/metrics/collect_metrics.py \
             --since ${{ steps.period.outputs.days }} \
             --output ${{ steps.period.outputs.format }} \
             > metrics-report.txt
@@ -117,7 +117,7 @@ jobs:
         id: check
         run: |
           # Collect metrics as JSON for parsing
-          python .agents/utilities/metrics/collect_metrics.py \
+          python .claude/skills/metrics/collect_metrics.py \
             --since 7 \
             --output json > metrics.json
 


### PR DESCRIPTION
# Pull Request

## Summary

Fixes the Agent Metrics workflow which was failing due to an incorrect script path reference. The collect_metrics.py script was relocated from .agents/utilities/metrics/ to .claude/skills/metrics/ but the workflow was not updated.

**Root Cause**: Workflow run [20886792154](https://github.com/rjmurillo/ai-agents/actions/runs/20886792154/job/60011224658) failed with:
```
python: can't open file '.agents/utilities/metrics/collect_metrics.py': [Errno 2] No such file or directory
```

## Changes

- Update script path in collect-metrics job (line 70)
- Update script path in check-thresholds job (line 120)

Both references now point to .claude/skills/metrics/collect_metrics.py

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Testing

- [ ] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

**Verification**: Confirmed the script exists at the new path via GitHub code search.

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [x] No security-critical changes in this PR

This is a path correction only - no logic, permissions, or security-sensitive code was modified.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced