### PR TITLE
chore(skills): improve fix-markdown-fences skill via SkillForge

### DIFF
--- a/.claude/skills/fix-markdown-fences/SKILL.md
+++ b/.claude/skills/fix-markdown-fences/SKILL.md
@@ -136,7 +136,7 @@ def fix_markdown_files(directory: Path, pattern: str = "**/*.md") -> list[str]:
 
 ```bash
 # Find files with potential issues
-grep -rEn -- '```\w+' --include="*.md" . | grep -vE "^[^:]*:[0-9]*:[[:space:]]*```\w+[[:space:]]*$"
+grep -rEn --include="*.md" -- '```\w+' . | grep -vE "^[^:]*:[0-9]*:[[:space:]]*```\w+[[:space:]]*$"
 ```
 
 </details>


### PR DESCRIPTION
## Summary

Improves the fix-markdown-fences skill to comply with SkillForge conventions and CLAUDE.md standards.

## Changes

### Before
- version and model nested under metadata: (fails SkillForge validation)
- 4 trigger phrases (below recommended 3-5 range minimum)
- No Quick Reference table for fast symptom lookup
- Implementation code inline at top level (231 lines total)
- No progressive disclosure

### After
- version and model as top-level frontmatter keys (passes validation)
- 5 backtick-wrapped trigger phrases
- Quick Reference table mapping symptoms to causes and fixes
- Implementation code in details tags for progressive disclosure (163 lines total)
- Reduced line count by 29% (231 to 163 lines)

## Test plan

- [ ] Verify frontmatter parses correctly with version and model at top level
- [ ] Confirm 5 trigger phrases render in backtick format
- [ ] Check details sections expand correctly in GitHub markdown preview
- [ ] Validate skill stays under 500-line limit (163 lines)