### PR TITLE
fix(skills): remove trailing ellipsis from planner milestone heading

### DIFF
--- a/.claude/skills/planner/resources/plan-format.md
+++ b/.claude/skills/planner/resources/plan-format.md
@@ -156,7 +156,7 @@ See `resources/diff-format.md` for specification.
    more_existing_code()
 ````
 
-### Milestone N: ...
+### Milestone N
 
 ### Milestone [Last]: Documentation
 


### PR DESCRIPTION
## Summary
- Removes trailing `: ...` from `### Milestone N` heading in planner plan-format template

## Test plan
- [ ] Plan format template renders correctly

Generated with Claude Code