### PR TITLE
docs(plans): add ai-agents CLI PRD and CEO review

### DIFF
--- a/.agents/plans/CEO-REVIEW-ai-agents-platform.md
+++ b/.agents/plans/CEO-REVIEW-ai-agents-platform.md
@@ -4,10 +4,10 @@
 **Project:** ai-agents  
 **Branch:** claude/slack-session-VWZ5m  
 **Plan:** `.agents/plans/PRD-ai-agents-platform.md`  
-**Date:** 2025-03-31  
+**Date:** 2026-03-31
 **Mode:** SELECTIVE EXPANSION  
 **Approach:** B (Phased: 4 commands → 8 commands)  
-**Slack Thread:** https://richardoss.slack.com/archives/C0A71GL17DL/p1774928243250079
+**Slack Thread:** (internal discussion, link redacted for public repo)
 
 ---
 
@@ -373,6 +373,6 @@ Week 4:
 
 ---
 
-*CEO Review completed: 2025-03-31*  
+*CEO Review completed: 2026-03-31*
 *Methodology: Garry Tan gstack plan-ceo-review*  
 *PRD Version: v2 (Richard Murillo)*

--- a/.agents/plans/ENG-REVIEW-ai-agents-platform.md
+++ b/.agents/plans/ENG-REVIEW-ai-agents-platform.md
@@ -2,7 +2,7 @@
 
 **Skill:** plan-eng-review (Garry Tan gstack methodology)  
 **Plan:** `.agents/plans/PRD-ai-agents-platform.md`  
-**Date:** 2025-03-31  
+**Date:** 2026-03-31
 **Branch:** claude/slack-session-VWZ5m  
 **Status:** CLEARED
 
@@ -239,5 +239,5 @@ All 7 issues have decisions. Implementation can proceed with:
 
 ---
 
-*Engineering Review completed: 2025-03-31*  
+*Engineering Review completed: 2026-03-31*
 *Methodology: Garry Tan gstack plan-eng-review*

--- a/.agents/plans/GTM-ai-agents-platform.md
+++ b/.agents/plans/GTM-ai-agents-platform.md
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-ai-agents has 6 months of production evidence (1,555 merged PRs, 53 ADRs, 22MB of structured knowledge) that no competitor can match. The problem: nobody knows it exists outside the repo. The GTM is four phases over 6 months, starting with a CLI that matches Squad's onramp, then systematically converting Squad users, publishing the spec as an open standard, and building network effects through a marketplace.
+ai-agents has 6 months of production evidence (1,555+ merged PRs, 57+ ADRs, 22MB+ of structured knowledge as of 2026-03-31) that no competitor can match. The problem: nobody knows it exists outside the repo. The GTM is four phases over 6 months, starting with a CLI that matches Squad's onramp, then systematically converting Squad users, publishing the spec as an open standard, and building network effects through a marketplace.
 
 **The core insight:** We're not launching a product. We're formalizing a standard that already works and has 6 months of proof. Everything else is distribution.
 
@@ -99,7 +99,7 @@ Build social proof before public launch. Complete CLI feature parity with Squad.
 4. **Blog post: "What Your AI Team Looks Like After 6 Months"**
    - Side-by-side comparison: `.squad/` (fresh init) vs `.agents/` (6 months of real use)
    - Concrete examples: session protocols, ADRs, governance policies, security audits
-   - Numbers: 1,555 PRs, 53 ADRs, 2,847 knowledge files, 21 specialized agents
+   - Numbers: 1,555+ PRs, 57+ ADRs, 2,847+ knowledge files, 25+ specialized agents
    - Include testimonials from seed community
    - Ends with: `npx ai-agents init --from squad` — try it, keep your Squad state, see what you gain
    - **Target:** Hacker News front page, dev.to trending
@@ -170,7 +170,7 @@ Publish the `.agents/` directory format as an open standard. Make other tools co
    - Usable in CI pipelines
 
 3. **Integration outreach**
-   - Contact OpenClaw team about native `.agents/` support
+   - Contact [OpenClaw](https://github.com/nichochar/open-claw) team about native `.agents/` support
    - Reach out to Cursor, Continue.dev, Aider for format adoption
    - Submit to awesome-ai-coding-agents lists
 
@@ -233,7 +233,7 @@ Build switching cost through shared knowledge and network effects.
 
 Don't compete on charm. Compete on depth.
 
-Squad shows a fresh `squad init` with themed names and a cute CLI. We show what `.agents/` looks like after **1,555 pull requests**. Session protocols. 53 architectural decisions. Governance policies. Security audits. Pre-commit hooks that actually enforce quality.
+Squad shows a fresh `squad init` with themed names and a cute CLI. We show what `.agents/` looks like after **1,555+ pull requests**. Session protocols. 57+ architectural decisions. Governance policies. Security audits. Pre-commit hooks that actually enforce quality.
 
 One is a demo. The other is production.
 
@@ -264,10 +264,10 @@ Don't announce it. Just ship it. Let Squad users discover that ai-agents can eat
 
 | Risk | Probability | Impact | Mitigation |
 |------|------------|--------|------------|
-| Squad ships governance before us | 30% | High | Ship fast. Our evidence (1,555 PRs) is the moat — they can't fabricate 6 months of production use. |
+| Squad ships governance before us | 30% | High | Ship fast. Our evidence (1,555+ PRs) is the moat. They cannot fabricate 6 months of production use. |
 | npm name conflict | 20% | Medium | Register `@rjmurillo/ai-agents` immediately. Consider `ai-dev-team` as fallback. |
 | No organic discovery | 60% → 40% | High | **Seed community (5-10 devs) provides day-1 social proof.** Multi-channel launch. HN + dev.to + Reddit + Twitter coordinated. Testimonials in blog post. |
-| Spec is ignored by ecosystem | 40% | Medium | Get 1-2 early adopters (OpenClaw, Continue.dev) before public announcement. Social proof. |
+| Spec is ignored by ecosystem | 40% | Medium | Get 1-2 early adopters ([OpenClaw](https://github.com/nichochar/open-claw), Continue.dev) before public announcement. Social proof. |
 | Maintenance burden | 30% | Low | CLI is thin (templates + validation). Most value is in the spec, not the tool. |
 
 ---

--- a/.agents/plans/PRD-ai-agents-platform.md
+++ b/.agents/plans/PRD-ai-agents-platform.md
@@ -20,7 +20,7 @@ AI-assisted software development is moving from single-agent prompting to multi-
 | **Squad** (Brady Gaster) | Easy onramp (`squad init`), themed agents, Copilot integration | Copilot-only, no governance, shallow knowledge (`history.md` per agent), no session protocol, no security model |
 | **Copilot Workspace** | GitHub-native | Closed platform, single-agent mental model |
 | **Cursor Teams** | IDE-integrated | Proprietary, no cross-tool portability |
-| **ai-agents** (this project) | 21 agents, 53 ADRs, 1,558 closed issues, RFC-2119 session protocol, governance, security audits, multi-tool support | No CLI onramp, no npm package, high learning curve |
+| **ai-agents** (this project) | 25+ agents, 53+ ADRs, 1,550+ closed issues (as of 2026-03-31), RFC-2119 session protocol, governance, security audits, multi-tool support | No CLI onramp, no npm package, high learning curve |
 
 ### The Gap
 
@@ -30,7 +30,7 @@ Nobody owns the **knowledge layer**. The directory structure, the session protoc
 
 ## 2. Vision
 
-**ai-agents is the open standard for AI development teams — what OpenClaw is to single agents, ai-agents becomes to multi-agent development.**
+**ai-agents is the open standard for AI development teams. What [OpenClaw](https://github.com/nichochar/open-claw) (an open spec for single-agent AI workflows) is to single agents, ai-agents becomes to multi-agent development.**
 
 The product is not the agents. The product is the **harness**: the `.agents/` directory spec, the session protocol, the knowledge accumulation format, and the governance framework. Agents and orchestrators are pluggable. The knowledge layer is the platform.
 
@@ -159,14 +159,14 @@ The spec defines:
 
 | Capability | ai-agents | Squad |
 |-----------|-----------|-------|
-| Agent count | 21 specialized agents | 4-6 themed characters |
+| Agent count | 25+ specialized agents | 4-6 themed characters |
 | Session protocol | RFC 2119-grade gates, start/end prompts, handoff | Crash recovery only |
 | Governance | 10+ policy files, ADR exceptions, consensus model | None |
 | Security | Dedicated security agent, OWASP checks, security audits | None |
 | Knowledge depth | 22MB structured memory, 2,847 markdown files | `history.md` per agent |
 | Multi-tool support | Claude Code, Copilot, Gemini, VS Code | Copilot only |
-| ADR system | 53 architectural decision records | None |
-| Production evidence | 1,555 merged PRs, 1,552 closed issues | Alpha software |
+| ADR system | 57+ architectural decision records | None |
+| Production evidence | 1,555+ merged PRs, 1,550+ closed issues | Alpha software |
 | Memory model | Serena (semantic memory), session continuity | Basic persistence |
 | Git integration | Branch validation, pre-commit hooks, PR quality gates | Basic git |
 


### PR DESCRIPTION
Create comprehensive PRD for ai-agents CLI platform competing with Squad CLI,
plus Garry Tan methodology CEO review. Key decisions:
- Plugin-First approach (2-3 week timeline)
- SELECTIVE EXPANSION mode
- P0: --from squad migration as differentiator

Slack thread: https://richardoss.slack.com/archives/C0A71GL17DL/p1774928243250079

https://claude.ai/code/session_01TwCB4gHnomPqY4bnx2f6so