### PR TITLE
fix(memory): call reinforce_memories and apply_confidence_decay at session end

### DIFF
--- a/scripts/memory_enhancement/health.py
+++ b/scripts/memory_enhancement/health.py
@@ -18,7 +18,12 @@ from .serena_integration import load_memories
 from .verification import STALE_REASON_MARKERS, verify_all_citations
 
 
-def generate_health_report(memories_dir: Path, repo_root: Path) -> HealthReport:
+def generate_health_report(
+    memories_dir: Path,
+    repo_root: Path,
+    *,
+    preloaded_memories: list[MemoryWithCitations] | None = None,
+) -> HealthReport:
     """Generate a comprehensive health report for all memories.
 
     Loads memories once and verifies citations once, then passes results
@@ -27,11 +32,12 @@ def generate_health_report(memories_dir: Path, repo_root: Path) -> HealthReport:
     Args:
         memories_dir: Directory containing memory .md files.
         repo_root: Repository root for citation verification.
+        preloaded_memories: Optional pre-loaded memories to skip redundant I/O.
 
     Returns:
         HealthReport with aggregated statistics and recommendations.
     """
-    memories = load_memories(memories_dir)
+    memories = preloaded_memories if preloaded_memories is not None else load_memories(memories_dir)
     all_results = _verify_all_memories(memories, repo_root)
     counts = _count_citation_statuses_from_results(all_results)
     stale = _detect_stale_from_results(memories, all_results, max_age_days=30)

--- a/scripts/memory_enhancement/hooks/session_end_memory.py
+++ b/scripts/memory_enhancement/hooks/session_end_memory.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 
 from ..models import HealthReport
-from ..reflection import extract_session_facts
+from ..reflection import apply_confidence_decay, extract_session_facts, reinforce_memories
 
 
 def main() -> int:
@@ -51,6 +51,12 @@ def _generate_reflection(memories_dir: Path, repo_root: Path) -> str:
     """
     from ..health import generate_health_report
 
+    # Recalculate confidence scores
+    reinforce_memories(memories_dir, repo_root)
+
+    # Identify memories needing re-verification due to age
+    decayed = apply_confidence_decay(memories_dir, repo_root)
+
     # Track session activity
     session_facts = extract_session_facts(memories_dir)
 
@@ -58,15 +64,20 @@ def _generate_reflection(memories_dir: Path, repo_root: Path) -> str:
     if report.total_memories == 0:
         return ""
 
-    return _format_reflection(report, session_facts)
+    return _format_reflection(report, session_facts, decayed)
 
 
-def _format_reflection(report: HealthReport, session_facts: list[str] | None = None) -> str:
+def _format_reflection(
+    report: HealthReport,
+    session_facts: list[str] | None = None,
+    decayed: list[str] | None = None,
+) -> str:
     """Format the session reflection block for stderr.
 
     Args:
         report: HealthReport with health data and recommendations.
         session_facts: Memory IDs updated this session.
+        decayed: Memory IDs flagged for confidence decay.
 
     Returns:
         Formatted reflection string.
@@ -82,6 +93,9 @@ def _format_reflection(report: HealthReport, session_facts: list[str] | None = N
         f"- Total: {total} memories, {health_score:.0%} health",
         f"- Stale: {len(stale)} need verification",
     ]
+
+    if decayed:
+        lines.append(f"- Decayed: {len(decayed)} exceed age threshold")
 
     if session_facts:
         lines.append(f"- Updated this session: {len(session_facts)} memories")

--- a/scripts/memory_enhancement/hooks/session_end_memory.py
+++ b/scripts/memory_enhancement/hooks/session_end_memory.py
@@ -95,7 +95,9 @@ def _format_reflection(
     ]
 
     if decayed:
-        lines.append(f"- Decayed: {len(decayed)} exceed age threshold")
+        decayed_count = len(decayed)
+        verb = "exceeds" if decayed_count == 1 else "exceed"
+        lines.append(f"- Decayed: {decayed_count} {verb} the age threshold")
 
     if session_facts:
         lines.append(f"- Updated this session: {len(session_facts)} memories")

--- a/scripts/memory_enhancement/hooks/session_end_memory.py
+++ b/scripts/memory_enhancement/hooks/session_end_memory.py
@@ -51,14 +51,14 @@ def _generate_reflection(memories_dir: Path, repo_root: Path) -> str:
     """
     from ..health import generate_health_report
 
-    # Recalculate confidence scores
+    # Track session activity first (before any writes that update mtime)
+    session_facts = extract_session_facts(memories_dir)
+
+    # Recalculate confidence scores (may write to disk)
     reinforce_memories(memories_dir, repo_root)
 
     # Identify memories needing re-verification due to age
     decayed = apply_confidence_decay(memories_dir, repo_root)
-
-    # Track session activity
-    session_facts = extract_session_facts(memories_dir)
 
     report = generate_health_report(memories_dir, repo_root)
     if report.total_memories == 0:

--- a/scripts/memory_enhancement/hooks/session_end_memory.py
+++ b/scripts/memory_enhancement/hooks/session_end_memory.py
@@ -55,12 +55,15 @@ def _generate_reflection(memories_dir: Path, repo_root: Path) -> str:
     session_facts = extract_session_facts(memories_dir)
 
     # Recalculate confidence scores (may write to disk)
-    reinforce_memories(memories_dir, repo_root)
+    _scores, memories = reinforce_memories(memories_dir, repo_root)
 
     # Identify memories needing re-verification due to age
     decayed = apply_confidence_decay(memories_dir, repo_root)
 
-    report = generate_health_report(memories_dir, repo_root)
+    # Pass pre-loaded memories to avoid redundant load + citation verification.
+    report = generate_health_report(
+        memories_dir, repo_root, preloaded_memories=memories
+    )
     if report.total_memories == 0:
         return ""
 

--- a/scripts/memory_enhancement/reflection.py
+++ b/scripts/memory_enhancement/reflection.py
@@ -20,7 +20,7 @@ _CONFIDENCE_EPSILON = 0.01
 
 def reinforce_memories(
     memories_dir: Path, repo_root: Path
-) -> dict[str, float]:
+) -> tuple[dict[str, float], list]:
     """Recalculate and persist confidence scores for all memories.
 
     Loads all memories, computes updated confidence scores, and
@@ -32,7 +32,7 @@ def reinforce_memories(
         repo_root: Repository root for citation verification.
 
     Returns:
-        Dict mapping memory_id to updated confidence score.
+        Tuple of (scores dict mapping memory_id to confidence, loaded memories).
     """
     scores, memories = update_confidence_scores_with_memories(memories_dir, repo_root)
 
@@ -42,7 +42,7 @@ def reinforce_memories(
             memory.confidence = new_score
             save_memory(memory, memories_dir)
 
-    return scores
+    return scores, memories
 
 
 def generate_skill_candidates(

--- a/scripts/memory_enhancement/reflection.py
+++ b/scripts/memory_enhancement/reflection.py
@@ -15,6 +15,7 @@ from .serena_integration import load_memories, save_memory
 
 _SKILL_CONFIDENCE_THRESHOLD = 0.8
 _SKILL_MIN_LINKS = 2
+_CONFIDENCE_EPSILON = 0.01
 
 
 def reinforce_memories(
@@ -23,7 +24,8 @@ def reinforce_memories(
     """Recalculate and persist confidence scores for all memories.
 
     Loads all memories, computes updated confidence scores, and
-    persists the updated scores back to disk.
+    persists the updated scores back to disk. Uses epsilon comparison
+    to avoid unnecessary writes from time-dependent score drift.
 
     Args:
         memories_dir: Path to .serena/memories/.
@@ -36,7 +38,7 @@ def reinforce_memories(
 
     for memory in memories:
         new_score = scores.get(memory.memory_id)
-        if new_score is not None and new_score != memory.confidence:
+        if new_score is not None and abs(new_score - memory.confidence) > _CONFIDENCE_EPSILON:
             memory.confidence = new_score
             save_memory(memory, memories_dir)
 

--- a/scripts/memory_enhancement/reflection.py
+++ b/scripts/memory_enhancement/reflection.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 
-from .confidence import update_confidence_scores, update_confidence_scores_with_memories
-from .serena_integration import load_memories
+from .confidence import update_confidence_scores_with_memories
+from .serena_integration import load_memories, save_memory
 
 _SKILL_CONFIDENCE_THRESHOLD = 0.8
 _SKILL_MIN_LINKS = 2
@@ -20,10 +20,10 @@ _SKILL_MIN_LINKS = 2
 def reinforce_memories(
     memories_dir: Path, repo_root: Path
 ) -> dict[str, float]:
-    """Recalculate confidence scores for all memories.
+    """Recalculate and persist confidence scores for all memories.
 
-    Wraps update_confidence_scores to provide a stable interface
-    for the reflection pipeline.
+    Loads all memories, computes updated confidence scores, and
+    persists the updated scores back to disk.
 
     Args:
         memories_dir: Path to .serena/memories/.
@@ -32,7 +32,15 @@ def reinforce_memories(
     Returns:
         Dict mapping memory_id to updated confidence score.
     """
-    return update_confidence_scores(memories_dir, repo_root)
+    scores, memories = update_confidence_scores_with_memories(memories_dir, repo_root)
+
+    for memory in memories:
+        new_score = scores.get(memory.memory_id)
+        if new_score is not None and new_score != memory.confidence:
+            memory.confidence = new_score
+            save_memory(memory, memories_dir)
+
+    return scores
 
 
 def generate_skill_candidates(

--- a/scripts/memory_enhancement/serena_integration.py
+++ b/scripts/memory_enhancement/serena_integration.py
@@ -186,6 +186,10 @@ def load_memories(memories_dir: Path) -> list[MemoryWithCitations]:
             continue
         memory = load_memory(md_file)
         if memory is not None:
+            # Preserve subdirectory structure in memory_id so save_memory
+            # writes back to the correct location (not flattened to root).
+            relative = md_file.relative_to(memories_dir)
+            memory.memory_id = str(relative.with_suffix(""))
             memories.append(memory)
 
     if not memories:
@@ -220,6 +224,9 @@ def save_memory(memory: MemoryWithCitations, memories_dir: Path) -> Path:
     except ValueError:
         msg = f"Invalid memory_id: path traversal detected in '{memory.memory_id}'"
         raise ValueError(msg) from None
+
+    # Ensure subdirectory exists (memory_id may contain path separators).
+    file_path.parent.mkdir(parents=True, exist_ok=True)
 
     metadata = {
         "title": memory.title,

--- a/tests/test_memory_hook_reflection.py
+++ b/tests/test_memory_hook_reflection.py
@@ -95,16 +95,18 @@ class TestGenerateReflection:
 
     @pytest.mark.unit
     @patch("memory_enhancement.hooks.session_end_memory.extract_session_facts")
-    @patch("memory_enhancement.reflection.reinforce_memories")
+    @patch("memory_enhancement.hooks.session_end_memory.apply_confidence_decay")
+    @patch("memory_enhancement.hooks.session_end_memory.reinforce_memories")
     @patch("memory_enhancement.health.generate_health_report")
     def test_generates_reflection(
-        self, mock_report, mock_reinforce, mock_facts, tmp_path: Path
+        self, mock_report, mock_reinforce, mock_decay, mock_facts, tmp_path: Path
     ):
         memories_dir = tmp_path / "memories"
         memories_dir.mkdir()
         (memories_dir / "test.md").write_text("# Test (2026-01-01)\n\nContent\n")
 
-        mock_reinforce.return_value = None
+        mock_reinforce.return_value = {"test": 0.85}
+        mock_decay.return_value = []
         mock_facts.return_value = ["test"]
         mock_report.return_value = MagicMock(
             total_memories=1,
@@ -116,19 +118,47 @@ class TestGenerateReflection:
         result = _generate_reflection(memories_dir, tmp_path)
         assert "<session-reflection>" in result
         assert "1 memories" in result
+        mock_reinforce.assert_called_once_with(memories_dir, tmp_path)
+        mock_decay.assert_called_once_with(memories_dir, tmp_path)
 
     @pytest.mark.unit
     @patch("memory_enhancement.hooks.session_end_memory.extract_session_facts")
-    @patch("memory_enhancement.reflection.reinforce_memories")
+    @patch("memory_enhancement.hooks.session_end_memory.apply_confidence_decay")
+    @patch("memory_enhancement.hooks.session_end_memory.reinforce_memories")
     @patch("memory_enhancement.health.generate_health_report")
     def test_empty_memories_returns_empty(
-        self, mock_report, mock_reinforce, mock_facts, tmp_path: Path
+        self, mock_report, mock_reinforce, mock_decay, mock_facts, tmp_path: Path
     ):
         memories_dir = tmp_path / "memories"
         memories_dir.mkdir()
-        mock_reinforce.return_value = None
+        mock_reinforce.return_value = {}
+        mock_decay.return_value = []
         mock_facts.return_value = []
         mock_report.return_value = MagicMock(total_memories=0)
 
         result = _generate_reflection(memories_dir, tmp_path)
         assert result == ""
+
+    @pytest.mark.unit
+    @patch("memory_enhancement.hooks.session_end_memory.extract_session_facts")
+    @patch("memory_enhancement.hooks.session_end_memory.apply_confidence_decay")
+    @patch("memory_enhancement.hooks.session_end_memory.reinforce_memories")
+    @patch("memory_enhancement.health.generate_health_report")
+    def test_decayed_memories_shown_in_reflection(
+        self, mock_report, mock_reinforce, mock_decay, mock_facts, tmp_path: Path
+    ):
+        memories_dir = tmp_path / "memories"
+        memories_dir.mkdir()
+
+        mock_reinforce.return_value = {"old1": 0.3, "old2": 0.2}
+        mock_decay.return_value = ["old1", "old2"]
+        mock_facts.return_value = []
+        mock_report.return_value = MagicMock(
+            total_memories=2,
+            health_score=0.5,
+            stale_memories=[],
+            recommendations=[],
+        )
+
+        result = _generate_reflection(memories_dir, tmp_path)
+        assert "Decayed: 2 exceed age threshold" in result

--- a/tests/test_memory_hook_reflection.py
+++ b/tests/test_memory_hook_reflection.py
@@ -79,6 +79,28 @@ class TestFormatReflection:
         assert "r5" not in result
 
     @pytest.mark.unit
+    def test_format_singular_decay_verb(self):
+        report = MagicMock(
+            total_memories=1,
+            health_score=0.8,
+            stale_memories=[],
+            recommendations=[],
+        )
+        result = _format_reflection(report, session_facts=[], decayed=["mem-1"])
+        assert "1 exceeds the age threshold" in result
+
+    @pytest.mark.unit
+    def test_format_plural_decay_verb(self):
+        report = MagicMock(
+            total_memories=3,
+            health_score=0.6,
+            stale_memories=[],
+            recommendations=[],
+        )
+        result = _format_reflection(report, session_facts=[], decayed=["m1", "m2"])
+        assert "2 exceed the age threshold" in result
+
+    @pytest.mark.unit
     def test_format_empty_scores(self):
         report = MagicMock(
             total_memories=0,
@@ -88,6 +110,44 @@ class TestFormatReflection:
         )
         result = _format_reflection(report)
         assert "0 memories" in result
+
+
+class TestReinforceMemories:
+    """Tests for reinforce_memories persistence logic."""
+
+    @pytest.mark.unit
+    @patch("memory_enhancement.reflection.save_memory")
+    @patch("memory_enhancement.reflection.update_confidence_scores_with_memories")
+    def test_saves_when_score_exceeds_epsilon(self, mock_update, mock_save, tmp_path: Path):
+        memory = MagicMock()
+        memory.memory_id = "mem-1"
+        memory.confidence = 0.50
+
+        mock_update.return_value = ({"mem-1": 0.62}, [memory])
+
+        from memory_enhancement.reflection import reinforce_memories
+
+        result = reinforce_memories(tmp_path, tmp_path)
+
+        assert result == {"mem-1": 0.62}
+        mock_save.assert_called_once_with(memory, tmp_path)
+        assert memory.confidence == 0.62
+
+    @pytest.mark.unit
+    @patch("memory_enhancement.reflection.save_memory")
+    @patch("memory_enhancement.reflection.update_confidence_scores_with_memories")
+    def test_skips_save_when_within_epsilon(self, mock_update, mock_save, tmp_path: Path):
+        memory = MagicMock()
+        memory.memory_id = "mem-1"
+        memory.confidence = 0.50
+
+        mock_update.return_value = ({"mem-1": 0.505}, [memory])
+
+        from memory_enhancement.reflection import reinforce_memories
+
+        reinforce_memories(tmp_path, tmp_path)
+
+        mock_save.assert_not_called()
 
 
 class TestGenerateReflection:
@@ -161,4 +221,4 @@ class TestGenerateReflection:
         )
 
         result = _generate_reflection(memories_dir, tmp_path)
-        assert "Decayed: 2 exceed age threshold" in result
+        assert "Decayed: 2 exceed the age threshold" in result

--- a/tests/test_memory_hook_reflection.py
+++ b/tests/test_memory_hook_reflection.py
@@ -129,7 +129,7 @@ class TestReinforceMemories:
 
         result = reinforce_memories(tmp_path, tmp_path)
 
-        assert result == {"mem-1": 0.62}
+        assert result == ({"mem-1": 0.62}, [memory])
         mock_save.assert_called_once_with(memory, tmp_path)
         assert memory.confidence == 0.62
 
@@ -165,7 +165,7 @@ class TestGenerateReflection:
         memories_dir.mkdir()
         (memories_dir / "test.md").write_text("# Test (2026-01-01)\n\nContent\n")
 
-        mock_reinforce.return_value = {"test": 0.85}
+        mock_reinforce.return_value = ({"test": 0.85}, [])
         mock_decay.return_value = []
         mock_facts.return_value = ["test"]
         mock_report.return_value = MagicMock(
@@ -191,7 +191,7 @@ class TestGenerateReflection:
     ):
         memories_dir = tmp_path / "memories"
         memories_dir.mkdir()
-        mock_reinforce.return_value = {}
+        mock_reinforce.return_value = ({}, [])
         mock_decay.return_value = []
         mock_facts.return_value = []
         mock_report.return_value = MagicMock(total_memories=0)
@@ -210,7 +210,7 @@ class TestGenerateReflection:
         memories_dir = tmp_path / "memories"
         memories_dir.mkdir()
 
-        mock_reinforce.return_value = {"old1": 0.3, "old2": 0.2}
+        mock_reinforce.return_value = ({"old1": 0.3, "old2": 0.2}, [])
         mock_decay.return_value = ["old1", "old2"]
         mock_facts.return_value = []
         mock_report.return_value = MagicMock(

--- a/tests/test_memory_reflection.py
+++ b/tests/test_memory_reflection.py
@@ -36,17 +36,19 @@ class TestReinforceMemories:
     def test_empty_directory(self, tmp_path):
         mem_dir = tmp_path / "memories"
         mem_dir.mkdir()
-        scores = reinforce_memories(mem_dir, tmp_path)
+        scores, memories = reinforce_memories(mem_dir, tmp_path)
         assert scores == {}
+        assert memories == []
 
     @pytest.mark.unit
     def test_single_memory(self, tmp_path):
         mem_dir = tmp_path / "memories"
         mem_dir.mkdir()
         _write_memory(mem_dir, "m1", "# M1 (2026-01-01)\n\nContent\n")
-        scores = reinforce_memories(mem_dir, tmp_path)
+        scores, memories = reinforce_memories(mem_dir, tmp_path)
         assert "m1" in scores
         assert 0.0 <= scores["m1"] <= 1.0
+        assert len(memories) == 1
 
     @pytest.mark.unit
     def test_multiple_memories(self, tmp_path):
@@ -54,8 +56,9 @@ class TestReinforceMemories:
         mem_dir.mkdir()
         _write_memory(mem_dir, "m1", "# M1 (2026-01-01)\n\nContent\n")
         _write_memory(mem_dir, "m2", "# M2 (2026-01-01)\n\nOther content\n")
-        scores = reinforce_memories(mem_dir, tmp_path)
+        scores, memories = reinforce_memories(mem_dir, tmp_path)
         assert len(scores) == 2
+        assert len(memories) == 2
 
 
 class TestGenerateSkillCandidates:


### PR DESCRIPTION
The session_end hook documented confidence recalculation and decay but
never actually called reinforce_memories or apply_confidence_decay from
reflection.py. This wires up both calls in _generate_reflection and
surfaces decayed memory counts in the reflection output.

Fixes review comment on #1576.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_016XD7JEUNpJjgDHsw79xhKU