### PR TITLE
fix(ci): add renovate[bot] to PR validation skip list

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -59,7 +59,7 @@ jobs:
         shell: pwsh
         run: |
           $actor = "${{ github.actor }}"
-          $excludedBots = @('dependabot[bot]', 'github-actions[bot]')
+          $excludedBots = @('dependabot[bot]', 'github-actions[bot]', 'renovate[bot]')
           
           if ($actor -in $excludedBots) {
             Write-Host "Skipping validation for bot actor: $actor"

--- a/.github/workflows/semantic-pr-title-check.yml
+++ b/.github/workflows/semantic-pr-title-check.yml
@@ -22,13 +22,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Skip for bot actors
-        if: github.actor == 'dependabot[bot]' || github.actor == 'github-actions[bot]'
+        if: github.actor == 'dependabot[bot]' || github.actor == 'github-actions[bot]' || github.actor == 'renovate[bot]'
         env:
           GH_ACTOR: ${{ github.actor }}
         run: echo "Skipped - bot actor ($GH_ACTOR)"
 
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
-        if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
+        if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' && github.actor != 'renovate[bot]'
         with:
           types: |
             feat


### PR DESCRIPTION
## Summary

- Adds renovate[bot] to the actor skip list in pr-validation.yml and semantic-pr-title-check.yml
- Prevents concurrency race where cancel-in-progress creates CANCELLED check runs that block merge
- Root cause: Renovate fires opened+edited events in rapid succession, first run gets cancelled

Fixes the pattern affecting PRs #1587, #1585, #1561.

## Test plan

- [ ] Verify renovate[bot] PRs skip validation checks
- [ ] Verify human PRs still run validation checks
- [ ] Verify dependabot[bot] PRs continue to be skipped