### PR TITLE
chore(skills): update model versions from 4-5 to 4-6

### DIFF
--- a/.claude/skills/SkillForge/SKILL.md
+++ b/.claude/skills/SkillForge/SKILL.md
@@ -2,7 +2,7 @@
 name: skillforge
 description: "Intelligent skill router and creator. Analyzes ANY input to recommend existing skills, improve them, or create new ones. Uses deep iterative analysis with 11 thinking models, regression questioning, evolution lens, and multi-agent synthesis panel. Phase 0 triage ensures you never duplicate existing functionality."
 license: MIT
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 user-invocable: true
 allowed-tools:
   - Read
@@ -12,7 +12,7 @@ allowed-tools:
   - Edit
 metadata:
   version: 4.1.0
-  subagent_model: claude-opus-4-5-20251101
+  subagent_model: claude-opus-4-6
   domains: [meta-skill, automation, skill-creation, orchestration, agentic, routing]
   type: orchestrator
   inputs: [any-input, user-goal, domain-hints]
@@ -287,7 +287,7 @@ Skills must use only these allowed frontmatter properties:
 name: my-skill
 description: What this skill does and when to use it
 license: MIT
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 user-invocable: true
 metadata:
   version: 1.0.0
@@ -301,7 +301,7 @@ metadata:
 name: isolated-analyzer
 description: Runs analysis in isolated context with validation hooks
 license: MIT
-model: claude-opus-4-5-20251101
+model: claude-opus-4-6
 context: fork
 agent: Explore
 user-invocable: true
@@ -922,8 +922,8 @@ SKILLCREATOR_CONFIG:
     require_temporal_projection: true
 
   model:
-    primary: claude-opus-4-5-20251101
-    subagents: claude-opus-4-5-20251101
+    primary: claude-opus-4-6
+    subagents: claude-opus-4-6
 ```
 
 </details>

--- a/.claude/skills/adr-review/SKILL.md
+++ b/.claude/skills/adr-review/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: adr-review
 version: 1.0.0
-model: claude-opus-4-5
+model: claude-opus-4-6
 description: Multi-agent debate orchestration for Architecture Decision Records. Automatically triggers on ADR create/edit/delete. Coordinates architect, critic, independent-thinker, security, analyst, and high-level-advisor agents in structured debate rounds until consensus.
 license: MIT
 metadata:
-  subagent_model: claude-opus-4-5
+  subagent_model: claude-opus-4-6
   domains: [architecture, governance, multi-agent, consensus]
   type: orchestrator
   inputs: [adr-file-path, change-type]

--- a/.claude/skills/analysis-provenance/SKILL.md
+++ b/.claude/skills/analysis-provenance/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: analysis-provenance
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Identify code ownership before modifying validators or linters. Checks file headers for provenance indicators, reviews documentation, and determines provenance as UPSTREAM, LOCAL, VENDOR, or UNKNOWN. Prevents accidental modification of upstream tools.
 license: MIT
 user-invocable: true

--- a/.claude/skills/analyze/SKILL.md
+++ b/.claude/skills/analyze/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: analyze
 version: 1.1.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Systematic multi-step codebase analysis producing prioritized findings with file-line evidence. Covers architecture reviews, security assessments, and code quality evaluations through guided exploration, investigation planning, and synthesis.
 license: MIT
 user-invocable: true

--- a/.claude/skills/buy-vs-build-framework/SKILL.md
+++ b/.claude/skills/buy-vs-build-framework/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: buy-vs-build-framework
 version: 1.0.1
-model: claude-opus-4-5
+model: claude-opus-4-6
 description: Strategic framework for evaluating build, buy, partner, or defer decisions with four-phase process, tiered TCO analysis, and integration with decision quality tools
 license: MIT
 metadata:

--- a/.claude/skills/chaos-experiment/SKILL.md
+++ b/.claude/skills/chaos-experiment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: chaos-experiment
 version: 1.1.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Design and document chaos engineering experiments. Guide steady state baseline, hypothesis formation, failure injection plans, and results analysis. Use for resilience testing, game days, failure injection experiments, and building confidence in system stability.
 license: MIT
 user-invocable: true

--- a/.claude/skills/chestertons-fence/SKILL.md
+++ b/.claude/skills/chestertons-fence/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: chestertons-fence
 version: 1.1.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Investigate historical context of existing code, patterns, or constraints before proposing changes. Automates git archaeology, PR/ADR search, and dependency analysis to prevent removing structures without understanding their purpose.
 license: MIT
 user-invocable: true

--- a/.claude/skills/code-qualities-assessment/SKILL.md
+++ b/.claude/skills/code-qualities-assessment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-qualities-assessment
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Assess code maintainability through 5 foundational qualities (cohesion, coupling, encapsulation, testability, non-redundancy) with quantifiable scoring rubrics. Works at method/class/module levels across multiple languages. Produces markdown reports with remediation guidance.
 version: 1.1.0
 license: MIT

--- a/.claude/skills/codeql-scan/SKILL.md
+++ b/.claude/skills/codeql-scan/SKILL.md
@@ -3,7 +3,7 @@ name: codeql-scan
 version: 1.0.1
 description: Execute CodeQL security scans with language detection, database caching, and SARIF output. Use when performing static security analysis on Python or GitHub Actions code.
 license: MIT
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 ---
 
 # CodeQL Scan Skill

--- a/.claude/skills/context-optimizer/SKILL.md
+++ b/.claude/skills/context-optimizer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: context-optimizer
 version: 1.1.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Analyze skill content for optimal placement (Skill vs Passive Context vs Hybrid), compress markdown to pipe-delimited format (60-80% token reduction), and validate compliance against the decision framework. Based on Vercel research showing passive context achieves 100% pass rates vs 53-79% for skills.
 license: MIT
 user-invocable: true

--- a/.claude/skills/curating-memories/SKILL.md
+++ b/.claude/skills/curating-memories/SKILL.md
@@ -3,7 +3,7 @@ name: curating-memories
 description: Guidance for maintaining memory quality through curation. Covers updating outdated memories, marking obsolete content, and linking related knowledge. Use when memories need modification, when new information supersedes old, or when building knowledge graph connections.
 license: MIT
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 ---
 
 # Curating Memories

--- a/.claude/skills/cva-analysis/SKILL.md
+++ b/.claude/skills/cva-analysis/SKILL.md
@@ -409,7 +409,6 @@ See `references/matrix-building-examples.md` for complete .NET examples:
 - [Matrix Building Examples](references/matrix-building-examples.md) - .NET examples with complete CVA workflows
 - [Multidimensional CVA](references/multidimensional-cva.md) - Advanced: handling multiple axes of variability
 - [Coplien Multi-Paradigm Design](references/coplien-multi-paradigm-design.md) - Academic foundation and further reading
-- [GoF Pattern Selection](references/gof-pattern-selection.md) - Decision table for mapping CVA results to GoF patterns
 
 ## Scripts
 

--- a/.claude/skills/cva-analysis/SKILL.md
+++ b/.claude/skills/cva-analysis/SKILL.md
@@ -2,7 +2,7 @@
 name: cva-analysis
 version: 1.0.0
 description: Systematic abstraction discovery using Commonality Variability Analysis. Build matrix of what varies vs what's constant, then let patterns emerge. Prevents wrong abstractions by deferring pattern selection until requirements are analyzed. Use when facing multiple similar requirements and need to discover natural abstractions.
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 license: MIT
 metadata:
   tier: 3
@@ -409,6 +409,7 @@ See `references/matrix-building-examples.md` for complete .NET examples:
 - [Matrix Building Examples](references/matrix-building-examples.md) - .NET examples with complete CVA workflows
 - [Multidimensional CVA](references/multidimensional-cva.md) - Advanced: handling multiple axes of variability
 - [Coplien Multi-Paradigm Design](references/coplien-multi-paradigm-design.md) - Academic foundation and further reading
+- [GoF Pattern Selection](references/gof-pattern-selection.md) - Decision table for mapping CVA results to GoF patterns
 
 ## Scripts
 

--- a/.claude/skills/cynefin-classifier/SKILL.md
+++ b/.claude/skills/cynefin-classifier/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cynefin-classifier
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Classify problems into Cynefin Framework domains (Clear, Complicated, Complex, Chaotic, Confusion) and recommend appropriate response strategies. Use when unsure how to approach a problem, facing analysis paralysis, or needing to choose between expert analysis and experimentation.
 license: MIT
 metadata:

--- a/.claude/skills/decision-critic/SKILL.md
+++ b/.claude/skills/decision-critic/SKILL.md
@@ -7,7 +7,7 @@ triggers:
   - "poke holes in this decision"
   - "stress-test this"
   - "criticize this approach"
-model: claude-opus-4-5
+model: claude-opus-4-6
 license: MIT
 ---
 

--- a/.claude/skills/doc-accuracy/SKILL.md
+++ b/.claude/skills/doc-accuracy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: doc-accuracy
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: >-
   Multi-phase documentation verification treating code as source of truth.
   Consolidates incoherence, doc-coverage, doc-sync, and comment-analyzer into

--- a/.claude/skills/doc-coverage/SKILL.md
+++ b/.claude/skills/doc-coverage/SKILL.md
@@ -4,7 +4,7 @@ description: Detect missing documentation in code (XML docs, docstrings, JSDoc) 
 license: MIT
 metadata:
   version: 1.0.0
-  model: claude-sonnet-4-5
+  model: claude-sonnet-4-6
 ---
 
 # Documentation Coverage

--- a/.claude/skills/doc-sync/SKILL.md
+++ b/.claude/skills/doc-sync/SKILL.md
@@ -4,7 +4,7 @@ description: Synchronizes CLAUDE.md navigation indexes and README.md architectur
 license: MIT
 metadata:
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 ---
 
 # Doc Sync

--- a/.claude/skills/encode-repo-serena/SKILL.md
+++ b/.claude/skills/encode-repo-serena/SKILL.md
@@ -4,7 +4,7 @@ version: 1.1.0
 description: Systematically populate the Forgetful knowledge base using Serena's LSP-powered
   symbol analysis for accurate, comprehensive codebase understanding.
 license: MIT
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 metadata:
   argument-hint: 'Project path or name to encode (default: current directory)'
 ---

--- a/.claude/skills/execution-plans/SKILL.md
+++ b/.claude/skills/execution-plans/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: execution-plans
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Manage execution plans as versioned artifacts with progress tracking and decision logs. Use when creating, updating, or archiving plans for complex multi-step work.
 license: MIT
 ---

--- a/.claude/skills/exploring-knowledge-graph/SKILL.md
+++ b/.claude/skills/exploring-knowledge-graph/SKILL.md
@@ -4,7 +4,7 @@ description: Guidance for deep knowledge graph traversal across memories, entiti
 license: MIT
 metadata:
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 ---
 
 # Exploring the Knowledge Graph

--- a/.claude/skills/git-advanced-workflows/SKILL.md
+++ b/.claude/skills/git-advanced-workflows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git-advanced-workflows
 version: 1.1.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Advanced Git workflows including rebasing, cherry-picking, bisect, worktrees, and reflog. Use when managing complex Git histories, collaborating on feature branches, or recovering from repository issues.
 license: MIT
 ---

--- a/.claude/skills/github-url-intercept/SKILL.md
+++ b/.claude/skills/github-url-intercept/SKILL.md
@@ -3,7 +3,7 @@ name: github-url-intercept
 version: 2.1.0
 description: "BLOCKING INTERCEPT: When ANY github.com URL appears in user input, STOP and use this skill. Never fetch GitHub HTML pages directly - they are 5-10MB and will exhaust your context window. This skill routes URLs to efficient API calls (1-50KB). Triggers on: pull/, issues/, blob/, tree/, commit/, compare/, discussions/."
 license: MIT
-model: claude-opus-4-5
+model: claude-opus-4-6
 metadata:
   domains:
   - github

--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github
 version: 4.0.0
-model: claude-opus-4-5
+model: claude-opus-4-6
 description: Execute GitHub operations (PRs, issues, milestones, labels, comments, merges)
   using Python scripts with structured output and error handling. Use when working
   with pull requests, issues, review comments, CI checks, or milestones instead of raw gh.

--- a/.claude/skills/golden-principles/SKILL.md
+++ b/.claude/skills/golden-principles/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: golden-principles
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Scan repository for golden principle violations with agent-readable remediation. Enforces GP-001 through GP-008 from .agents/governance/golden-principles.md. Use when auditing compliance, preparing PRs, or running garbage collection scans.
 license: MIT
 ---

--- a/.claude/skills/incoherence/SKILL.md
+++ b/.claude/skills/incoherence/SKILL.md
@@ -4,7 +4,7 @@ description: Detect contradictions between documentation and code, ambiguous spe
   and policy violations across a codebase. Use when documentation seems stale,
   specs conflict with implementation, or a pre-release consistency audit is needed.
   Produces an actionable incoherence report with resolution workflow.
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 license: MIT
 metadata:
   version: 1.0.0

--- a/.claude/skills/memory-documentary/SKILL.md
+++ b/.claude/skills/memory-documentary/SKILL.md
@@ -6,7 +6,7 @@ description: Generate evidence-based documentary reports by searching across all
   GitHub issues. Produces investigative journalism-style analysis with full citation
   chains.
 license: MIT
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 metadata:
   timelessness: 8/10
   category: analysis

--- a/.claude/skills/memory-enhancement/SKILL.md
+++ b/.claude/skills/memory-enhancement/SKILL.md
@@ -4,7 +4,7 @@ version: 1.0.0
 description: >
   Manage memory citations, verify code references, and track confidence scores. Use when adding citations to memories, checking memory health, or verifying code references are still valid.
 license: MIT
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 metadata:
   domains: [memory, citations, verification]
   type: utility

--- a/.claude/skills/memory/SKILL.md
+++ b/.claude/skills/memory/SKILL.md
@@ -5,7 +5,7 @@ description: Unified four-tier memory system for AI agents. Tier 1 Semantic (Ser
   search), Tier 2 Episodic (session replay), Tier 3 Causal (decision patterns). Enables
   memory-first architecture per ADR-007.
 license: MIT
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 metadata:
   adr: ADR-037, ADR-038
   timelessness: 8/10

--- a/.claude/skills/merge-resolver/SKILL.md
+++ b/.claude/skills/merge-resolver/SKILL.md
@@ -3,7 +3,7 @@ name: merge-resolver
 version: 2.1.0
 description: Resolve merge conflicts by analyzing git history and commit intent. Handles PR conflicts, branch conflicts, and session file conflicts with automated resolution for known patterns.
 license: MIT
-model: claude-opus-4-5
+model: claude-opus-4-6
 metadata:
   domains:
   - git

--- a/.claude/skills/pipeline-validator/SKILL.md
+++ b/.claude/skills/pipeline-validator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pipeline-validator
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Discovers, triggers, and monitors Azure DevOps pipelines (PR, Buddy Build, Buddy Release) for the current repo and branch. Auto-diagnoses failures from build logs, applies fixes, commits, pushes, and re-triggers until all pipelines pass or max retries reached. Validates PR existence and description completeness. Designed to be invoked automatically after any change-making skill creates a PR.
 license: MIT
 ---

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -4,7 +4,7 @@ description: Interactive planning and execution for complex tasks. Use when brea
 license: MIT
 metadata:
 version: 1.0.0
-model: claude-opus-4-5
+model: claude-opus-4-6
 ---
 
 # Planner Skill

--- a/.claude/skills/pr-comment-responder/SKILL.md
+++ b/.claude/skills/pr-comment-responder/SKILL.md
@@ -6,7 +6,7 @@ description: PR review coordinator who gathers comment context, acknowledges eve
   Triages by actionability, tracks thread conversations, and maps each comment to
   resolution status. Use when handling PR feedback, review threads, or bot comments.
 license: MIT
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 metadata:
   argument-hint: Specify the PR number or review comments to address
 ---

--- a/.claude/skills/pre-mortem/SKILL.md
+++ b/.claude/skills/pre-mortem/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pre-mortem
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Guide prospective hindsight analysis to identify project risks before failure occurs. Teams imagine the project has failed spectacularly, then work backward to identify causes. Increases risk identification by 30% compared to traditional planning.
 license: MIT
 metadata:

--- a/.claude/skills/programming-advisor/SKILL.md
+++ b/.claude/skills/programming-advisor/SKILL.md
@@ -4,7 +4,7 @@ description: Evaluate existing solutions (libraries, SaaS, open source) before c
 license: MIT
 metadata:
   version: 1.0.0
-  model: claude-opus-4-5
+  model: claude-opus-4-6
 ---
 
 # Programming Advisor - "Reinventing the Wheel" Detector

--- a/.claude/skills/quality-grades/SKILL.md
+++ b/.claude/skills/quality-grades/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: quality-grades
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Grade quality per product domain and architectural layer with gap tracking. Produces markdown or JSON reports showing grades (A-F), file counts, gaps, and trends over time. Use when auditing repo quality, tracking improvement, or identifying domains that need attention.
 license: MIT
 ---

--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reflect
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: CRITICAL learning capture. Extracts HIGH/MED/LOW confidence patterns from conversations to prevent repeating mistakes and preserve what works. Use PROACTIVELY after user corrections ("no", "wrong"), after praise ("perfect", "exactly"), when discovering edge cases, or when skills are heavily used. Without reflection, valuable learnings are LOST forever. Acts as continuous improvement engine for all skills. Invoke EARLY and OFTEN - every correction is a learning opportunity.
 license: MIT
 metadata:

--- a/.claude/skills/research-and-incorporate/SKILL.md
+++ b/.claude/skills/research-and-incorporate/SKILL.md
@@ -5,7 +5,7 @@ description: Research external topics, create comprehensive analysis, determine 
   applicability, and incorporate learnings into Serena and Forgetful memory systems.
   Transforms knowledge into searchable, actionable project context.
 license: MIT
-model: claude-opus-4-5
+model: claude-opus-4-6
 metadata:
   timelessness: 8/10
   source: Chesterton's Fence research workflow (Session 203)

--- a/.claude/skills/security-scan/SKILL.md
+++ b/.claude/skills/security-scan/SKILL.md
@@ -4,7 +4,7 @@ description: Scan code content for CWE-22 (path traversal) and CWE-78 (command i
 license: MIT
 metadata:
   version: 1.0.0
-  model: claude-sonnet-4-5
+  model: claude-sonnet-4-6
 ---
 
 # Security Scan

--- a/.claude/skills/serena-code-architecture/SKILL.md
+++ b/.claude/skills/serena-code-architecture/SKILL.md
@@ -4,7 +4,7 @@ description: Architectural analysis workflow using Serena symbols and Forgetful 
 license: MIT
 metadata:
 version: 1.0.0
-model: claude-opus-4-5
+model: claude-opus-4-6
 ---
 
 # Architectural Analysis with Serena + Forgetful

--- a/.claude/skills/session-end/SKILL.md
+++ b/.claude/skills/session-end/SKILL.md
@@ -5,7 +5,7 @@ description: Validate and complete session logs before commit. Auto-populates se
   when finishing a session, before committing, or when session validation fails.
 version: 1.0.0
 license: MIT
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 metadata:
   domains:
     - session-protocol

--- a/.claude/skills/session-init/SKILL.md
+++ b/.claude/skills/session-init/SKILL.md
@@ -3,7 +3,7 @@ name: session-init
 description: Create protocol-compliant JSON session logs with verification-based enforcement. Autonomous operation with auto-incremented session numbers and objective derivation from git state. Use when starting any new session.
 version: 1.0.0
 license: MIT
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 metadata:
   domains:
     - session-protocol

--- a/.claude/skills/session-log-fixer/SKILL.md
+++ b/.claude/skills/session-log-fixer/SKILL.md
@@ -7,7 +7,7 @@ description: Fix session protocol validation failures in GitHub Actions. Use whe
   requirements directly in Job Summary - no artifact downloads needed.
 version: 3.0.0
 license: MIT
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 metadata:
   domains:
   - ci

--- a/.claude/skills/session-migration/SKILL.md
+++ b/.claude/skills/session-migration/SKILL.md
@@ -3,7 +3,7 @@ name: session-migration
 description: Migrate session logs from markdown to JSON format. Use when PRs contain markdown session logs that need conversion to the new JSON schema, or when batch-migrating historical sessions.
 license: MIT
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 metadata:
   domains:
     - session-protocol

--- a/.claude/skills/session-qa-eligibility/SKILL.md
+++ b/.claude/skills/session-qa-eligibility/SKILL.md
@@ -3,7 +3,7 @@ name: session-qa-eligibility
 description: Check investigation session QA skip eligibility per ADR-034. Validates if staged files qualify for investigation-only exemption by checking against allowed paths (.agents/sessions/, .agents/analysis/, .serena/memories/, etc).
 version: 1.0.0
 license: MIT
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 ---
 
 # Session QA Eligibility

--- a/.claude/skills/session/SKILL.md
+++ b/.claude/skills/session/SKILL.md
@@ -3,7 +3,7 @@ name: session
 version: 1.0.0
 description: Session management and protocol compliance skills. Use Test-InvestigationEligibility to check if staged files qualify for investigation-only QA skip per ADR-034 before committing with 'SKIPPED investigation-only' verdict.
 license: MIT
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 metadata:
   domains:
     - session-protocol

--- a/.claude/skills/slashcommandcreator/SKILL.md
+++ b/.claude/skills/slashcommandcreator/SKILL.md
@@ -3,7 +3,7 @@ name: slashcommandcreator
 description: Autonomous meta-skill for creating high-quality custom slash commands using 5-phase workflow with multi-agent validation and quality gates. Use when user requests new slash command, reusable prompt automation, or wants to convert repetitive workflows into documented commands.
 version: 1.0.0
 license: MIT
-model: claude-opus-4-5
+model: claude-opus-4-6
 trigger: SlashCommandCreator
 ---
 

--- a/.claude/skills/slo-designer/SKILL.md
+++ b/.claude/skills/slo-designer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: slo-designer
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Design Service Level Objectives (SLOs) with SLIs, targets, alerting thresholds, and error budget calculations following Google SRE best practices. Use when defining reliability targets, designing SLOs, calculating error budgets, or establishing service level indicators.
 license: MIT
 metadata:

--- a/.claude/skills/style-enforcement/SKILL.md
+++ b/.claude/skills/style-enforcement/SKILL.md
@@ -4,7 +4,7 @@ description: Validate code against style rules from .editorconfig, StyleCop.json
 license: MIT
 metadata:
   version: 1.0.0
-  model: claude-sonnet-4-5
+  model: claude-sonnet-4-6
 ---
 
 # Style Enforcement

--- a/.claude/skills/taste-lints/SKILL.md
+++ b/.claude/skills/taste-lints/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: taste-lints
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Custom lints with agent-readable remediation instructions. Enforces taste invariants (file size, naming conventions, structured logging, complexity) and surfaces errors that agents can act on directly. Use when writing or reviewing code to catch style violations early.
 license: MIT
 ---

--- a/.claude/skills/threat-modeling/SKILL.md
+++ b/.claude/skills/threat-modeling/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: threat-modeling
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 description: Structured security analysis using OWASP Four-Question Framework and STRIDE methodology. Generates threat matrices with risk ratings, mitigations, and prioritization. Use for attack surface analysis, security architecture review, or when asking what can go wrong.
 license: MIT
 ---

--- a/.claude/skills/using-forgetful-memory/SKILL.md
+++ b/.claude/skills/using-forgetful-memory/SKILL.md
@@ -4,7 +4,7 @@ description: Guidance for using Forgetful semantic memory effectively. Applies Z
 license: MIT
 metadata:
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 ---
 
 # Using Forgetful Memory

--- a/.claude/skills/using-serena-symbols/SKILL.md
+++ b/.claude/skills/using-serena-symbols/SKILL.md
@@ -4,7 +4,7 @@ description: Guidance for using Serena's LSP-powered symbol analysis. Use when e
 license: MIT
 metadata:
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 ---
 
 # Using Serena Symbol Analysis

--- a/.claude/skills/workflow/SKILL.md
+++ b/.claude/skills/workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow
 version: 1.0.0
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 license: MIT
 description: |
   DEPRECATED: Workflow commands replaced by lifecycle commands (/spec, /plan, /build, /test, /review, /ship).


### PR DESCRIPTION
## Summary
- Update 53 SKILL.md files from claude-sonnet-4-5/claude-opus-4-5 to claude-sonnet-4-6/claude-opus-4-6
- Includes SkillForge dated variant (claude-opus-4-5-20251101 to claude-opus-4-6)
- No logic changes, frontmatter model field only

## Test plan
- [ ] Verify no claude-sonnet-4-5 or claude-opus-4-5 references remain in .claude/skills/*/SKILL.md
- [ ] Spot-check 3 skills load correctly after merge