### PR TITLE
feat(init): scaffold starter agent definitions in .claude/agents/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "tiktoken>=0.5.0",
 ]
 
+[project.scripts]
+ai-agents = "scripts.init_project:main"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0.0",

--- a/scripts/init_project.py
+++ b/scripts/init_project.py
@@ -79,6 +79,57 @@ _GITIGNORE_ENTRIES: list[str] = [
     ".agents/sessions/*.json",
 ]
 
+_SERENA_PROJECT_TEMPLATE = """\
+# Serena project configuration for ai-agents
+# See https://github.com/rjmurillo/ai-agents for details.
+languages:
+- python
+- markdown
+
+encoding: "utf-8"
+ignore_all_files_in_gitignore: true
+ignored_paths: []
+read_only: false
+excluded_tools: []
+initial_prompt: ""
+project_name: "{project_name}"
+included_optional_tools: []
+base_modes:
+default_modes:
+fixed_tools: []
+symbol_info_budget:
+language_backend:
+line_ending:
+read_only_memory_patterns: []
+ignored_memory_patterns: []
+ls_specific_settings: {{}}
+"""
+
+_TEAM_YAML_TEMPLATE = """\
+# Default agent team configuration
+# Defines the starter set of agents available after `ai-agents init`.
+# Each agent maps to a shared template in templates/agents/.
+#
+# Customize roles, add new agents, or remove unused ones as your project grows.
+team:
+  - name: orchestrator
+    role: Task coordination and multi-step workflow management
+  - name: implementer
+    role: Code implementation with quality standards
+  - name: analyst
+    role: Research, investigation, and root cause analysis
+  - name: architect
+    role: System design, ADRs, and architectural governance
+  - name: qa
+    role: Testing, verification, and coverage validation
+  - name: security
+    role: Threat modeling, vulnerability scanning, OWASP compliance
+  - name: devops
+    role: CI/CD pipelines, build automation, deployment
+  - name: critic
+    role: Plan validation and gap analysis
+"""
+
 _COPILOT_INSTRUCTIONS_TEMPLATE = """\
 # GitHub Copilot Instructions
 
@@ -172,6 +223,28 @@ class ProjectInitializer:
             _CLAUDE_MD_TEMPLATE,
         )
 
+    def scaffold_serena(self) -> bool:
+        """Create .serena/ directory with project.yml and memories/."""
+        serena_root = self.target_dir / ".serena"
+        project_name = self.target_dir.name
+
+        if not self._make_dir(serena_root / "memories"):
+            return False
+
+        return self._write_file(
+            serena_root / "project.yml",
+            _SERENA_PROJECT_TEMPLATE.format(project_name=project_name),
+        )
+
+    def scaffold_team_manifest(self) -> bool:
+        """Create .agents/team.yaml with the default agent team."""
+        if self.minimal:
+            return True
+        return self._write_file(
+            self.target_dir / ".agents" / "team.yaml",
+            _TEAM_YAML_TEMPLATE,
+        )
+
     def scaffold_copilot_instructions(self) -> bool:
         """Create .github/copilot-instructions.md."""
         if self.minimal:
@@ -223,6 +296,8 @@ class ProjectInitializer:
             self.scaffold_agents_dirs,
             self.scaffold_agents_md,
             self.scaffold_claude_md,
+            self.scaffold_serena,
+            self.scaffold_team_manifest,
             self.scaffold_copilot_instructions,
             self.update_gitignore,
         ]
@@ -252,12 +327,8 @@ class ProjectInitializer:
             )
 
 
-def main() -> int:
-    """Entry point for project initialization."""
-    parser = argparse.ArgumentParser(
-        description="Initialize ai-agents project scaffolding",
-    )
-
+def _add_init_args(parser: argparse.ArgumentParser) -> None:
+    """Add shared init arguments to a parser."""
     parser.add_argument(
         "--target-dir",
         type=Path,
@@ -280,8 +351,9 @@ def main() -> int:
         help="Preview changes without writing files",
     )
 
-    args = parser.parse_args()
 
+def _run_init(args: argparse.Namespace) -> int:
+    """Run the init command from parsed args."""
     initializer = ProjectInitializer(
         target_dir=args.target_dir,
         minimal=args.minimal,
@@ -289,6 +361,39 @@ def main() -> int:
         dry_run=args.dry_run,
     )
     return initializer.run()
+
+
+def main() -> int:
+    """Entry point for the ai-agents CLI.
+
+    Supports subcommands:
+        ai-agents init [--target-dir DIR] [--minimal] [--force] [--dry-run]
+
+    When invoked without a subcommand (for backwards compatibility),
+    behaves as if 'init' was specified.
+    """
+    parser = argparse.ArgumentParser(
+        prog="ai-agents",
+        description="AI agent orchestration framework",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    init_parser = subparsers.add_parser(
+        "init",
+        help="Initialize ai-agents project scaffolding",
+    )
+    _add_init_args(init_parser)
+
+    # Backwards compatibility: support direct flags without 'init' subcommand
+    _add_init_args(parser)
+
+    args = parser.parse_args()
+
+    if args.command == "init" or args.command is None:
+        return _run_init(args)
+
+    parser.print_help()
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/init_project.py
+++ b/scripts/init_project.py
@@ -136,6 +136,178 @@ _COPILOT_INSTRUCTIONS_TEMPLATE = """\
 See AGENTS.md for cross-platform agent instructions.
 """
 
+_STARTER_AGENTS: dict[str, str] = {
+    "orchestrator": """\
+---
+name: orchestrator
+description: >-
+  Task coordinator that routes work to specialized agents,
+  manages handoffs, and synthesizes results.
+model: sonnet
+---
+# Orchestrator Agent
+
+Coordinate multi-step tasks by delegating to specialized agents.
+Classify complexity, sequence workflows, and synthesize results.
+
+## Workflow
+
+1. Analyze the request and identify required capabilities.
+2. Delegate to the appropriate specialist agent.
+3. Verify outputs meet acceptance criteria.
+4. Synthesize results into a coherent response.
+""",
+    "implementer": """\
+---
+name: implementer
+description: >-
+  Engineering expert that implements plans with production-quality code.
+  Enforces testability, encapsulation, and intentional coupling.
+model: sonnet
+---
+# Implementer Agent
+
+Implement approved plans with production-quality code.
+Write tests alongside code. Commit atomically with conventional messages.
+
+## Standards
+
+- Cyclomatic complexity <=10, methods <=60 lines
+- SOLID, DRY, YAGNI
+- Programming by intention: sergeant methods direct workflow
+""",
+    "analyst": """\
+---
+name: analyst
+description: >-
+  Research specialist that investigates root causes, surfaces unknowns,
+  and gathers evidence before implementation.
+model: sonnet
+---
+# Analyst Agent
+
+Investigate before implementing. Gather evidence, evaluate feasibility,
+identify dependencies and risks. Document findings with sources.
+
+## Process
+
+1. Define the question precisely.
+2. Search code, docs, and history for evidence.
+3. Evaluate feasibility and identify risks.
+4. Report findings with confidence levels.
+""",
+    "architect": """\
+---
+name: architect
+description: >-
+  System design authority that guards architectural coherence,
+  enforces patterns, and maintains boundaries.
+model: sonnet
+---
+# Architect Agent
+
+Guard architectural coherence. Create ADRs, conduct design reviews,
+ensure decisions align with separation, extensibility, and consistency.
+
+## Responsibilities
+
+- Review proposed changes for architectural impact.
+- Create Architecture Decision Records for significant decisions.
+- Enforce module boundaries and dependency direction.
+""",
+    "qa": """\
+---
+name: qa
+description: >-
+  Quality assurance specialist that verifies implementations work
+  correctly for real users, not just passing tests.
+model: sonnet
+---
+# QA Agent
+
+Verify implementations work for real users. Design test strategies,
+validate coverage against acceptance criteria, report results with evidence.
+
+## Approach
+
+1. Identify acceptance criteria and edge cases.
+2. Design test scenarios covering happy path and failure modes.
+3. Execute tests and document results.
+4. Report gaps between expected and actual behavior.
+""",
+    "security": """\
+---
+name: security
+description: >-
+  Security specialist fluent in threat modeling, vulnerability assessment,
+  and OWASP Top 10.
+model: sonnet
+---
+# Security Agent
+
+Defense-first security analysis. Scan for CWE patterns, detect secrets,
+audit dependencies, map attack surfaces.
+
+## Focus Areas
+
+- OWASP Top 10 vulnerability patterns
+- Secret and credential detection
+- Dependency supply chain risks
+- Input validation and output encoding
+""",
+    "devops": """\
+---
+name: devops
+description: >-
+  CI/CD specialist that designs pipelines, configures build systems,
+  and manages deployment workflows.
+model: sonnet
+---
+# DevOps Agent
+
+Design and maintain CI/CD pipelines. Configure build systems,
+manage secrets, optimize caching, ensure reliable deployments.
+
+## Capabilities
+
+- GitHub Actions workflow design
+- Build optimization and caching
+- Environment and secrets management
+- Deployment strategy and rollback planning
+""",
+    "critic": """\
+---
+name: critic
+description: >-
+  Constructive reviewer that stress-tests plans before implementation.
+  Validates completeness, identifies gaps, catches ambiguity.
+model: sonnet
+---
+# Critic Agent
+
+Stress-test plans before implementation. Challenge assumptions,
+check alignment, block approval when risks are not mitigated.
+
+## Review Checklist
+
+1. Are acceptance criteria complete and testable?
+2. Are edge cases and failure modes addressed?
+3. Are dependencies identified and risks mitigated?
+4. Is the scope appropriately bounded?
+""",
+}
+
+_NEXT_STEPS_MESSAGE = """\
+Next steps:
+
+  1. Review the generated files and customize for your project.
+  2. Edit AGENTS.md to add project-specific conventions.
+  3. Customize agent definitions in .claude/agents/ as needed.
+  4. Start working: agents are ready to use immediately.
+
+Documentation: https://github.com/rjmurillo/ai-agents
+"""
+
 
 class ProjectInitializer:
     """Scaffolds ai-agents directory structure for a project."""
@@ -146,11 +318,13 @@ class ProjectInitializer:
         minimal: bool = False,
         force: bool = False,
         dry_run: bool = False,
+        no_agents: bool = False,
     ) -> None:
         self.target_dir = target_dir.resolve()
         self.minimal = minimal
         self.force = force
         self.dry_run = dry_run
+        self.no_agents = no_agents
         self.created_dirs: list[Path] = []
         self.created_files: list[Path] = []
         self.skipped_files: list[Path] = []
@@ -245,6 +419,20 @@ class ProjectInitializer:
             _TEAM_YAML_TEMPLATE,
         )
 
+    def scaffold_starter_agents(self) -> bool:
+        """Create .claude/agents/ with starter agent definitions."""
+        if self.no_agents or self.minimal:
+            return True
+
+        agents_dir = self.target_dir / ".claude" / "agents"
+        if not self._make_dir(agents_dir):
+            return False
+
+        for name, content in _STARTER_AGENTS.items():
+            if not self._write_file(agents_dir / f"{name}.md", content):
+                return False
+        return True
+
     def scaffold_copilot_instructions(self) -> bool:
         """Create .github/copilot-instructions.md."""
         if self.minimal:
@@ -298,6 +486,7 @@ class ProjectInitializer:
             self.scaffold_claude_md,
             self.scaffold_serena,
             self.scaffold_team_manifest,
+            self.scaffold_starter_agents,
             self.scaffold_copilot_instructions,
             self.update_gitignore,
         ]
@@ -311,7 +500,7 @@ class ProjectInitializer:
         return 0
 
     def _print_summary(self) -> None:
-        """Print a summary of actions taken."""
+        """Print a summary of actions taken and next steps."""
         if self.dry_run:
             logger.info(
                 "Dry run complete. %d files and %d directories would be created.",
@@ -325,6 +514,8 @@ class ProjectInitializer:
                 len(self.created_dirs),
                 len(self.skipped_files),
             )
+            logger.info("")
+            logger.info(_NEXT_STEPS_MESSAGE)
 
 
 def _add_init_args(parser: argparse.ArgumentParser) -> None:
@@ -350,6 +541,11 @@ def _add_init_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Preview changes without writing files",
     )
+    parser.add_argument(
+        "--no-agents",
+        action="store_true",
+        help="Skip scaffolding starter agent definitions in .claude/agents/",
+    )
 
 
 def _run_init(args: argparse.Namespace) -> int:
@@ -359,6 +555,7 @@ def _run_init(args: argparse.Namespace) -> int:
         minimal=args.minimal,
         force=args.force,
         dry_run=args.dry_run,
+        no_agents=args.no_agents,
     )
     return initializer.run()
 

--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -121,6 +121,79 @@ class TestScaffoldFiles:
         assert content == _CLAUDE_MD_TEMPLATE
 
 
+class TestScaffoldSerena:
+    """Tests for .serena/ directory and project.yml creation."""
+
+    def test_creates_serena_memories_dir(self, tmp_path: Path) -> None:
+        init = ProjectInitializer(target_dir=tmp_path)
+        assert init.scaffold_serena() is True
+        assert (tmp_path / ".serena" / "memories").is_dir()
+
+    def test_creates_project_yml(self, tmp_path: Path) -> None:
+        init = ProjectInitializer(target_dir=tmp_path)
+        assert init.scaffold_serena() is True
+
+        path = tmp_path / ".serena" / "project.yml"
+        assert path.exists()
+        content = path.read_text(encoding="utf-8")
+        assert f'project_name: "{tmp_path.name}"' in content
+
+    def test_skips_existing_project_yml_without_force(self, tmp_path: Path) -> None:
+        serena_dir = tmp_path / ".serena"
+        serena_dir.mkdir()
+        existing = "# custom config"
+        (serena_dir / "project.yml").write_text(existing)
+
+        init = ProjectInitializer(target_dir=tmp_path)
+        init.scaffold_serena()
+
+        content = (serena_dir / "project.yml").read_text(encoding="utf-8")
+        assert content == existing
+
+    def test_overwrites_project_yml_with_force(self, tmp_path: Path) -> None:
+        serena_dir = tmp_path / ".serena"
+        serena_dir.mkdir()
+        (serena_dir / "project.yml").write_text("# old")
+
+        init = ProjectInitializer(target_dir=tmp_path, force=True)
+        init.scaffold_serena()
+
+        content = (serena_dir / "project.yml").read_text(encoding="utf-8")
+        assert "languages:" in content
+
+
+class TestScaffoldTeamManifest:
+    """Tests for .agents/team.yaml creation."""
+
+    def test_creates_team_yaml(self, tmp_path: Path) -> None:
+        init = ProjectInitializer(target_dir=tmp_path)
+        init.scaffold_agents_dirs()
+        assert init.scaffold_team_manifest() is True
+
+        path = tmp_path / ".agents" / "team.yaml"
+        assert path.exists()
+        content = path.read_text(encoding="utf-8")
+        assert "orchestrator" in content
+        assert "implementer" in content
+
+    def test_minimal_skips_team_yaml(self, tmp_path: Path) -> None:
+        init = ProjectInitializer(target_dir=tmp_path, minimal=True)
+        assert init.scaffold_team_manifest() is True
+        assert not (tmp_path / ".agents" / "team.yaml").exists()
+
+    def test_skips_existing_team_yaml_without_force(self, tmp_path: Path) -> None:
+        agents_dir = tmp_path / ".agents"
+        agents_dir.mkdir()
+        existing = "# my team"
+        (agents_dir / "team.yaml").write_text(existing)
+
+        init = ProjectInitializer(target_dir=tmp_path)
+        init.scaffold_team_manifest()
+
+        content = (agents_dir / "team.yaml").read_text(encoding="utf-8")
+        assert content == existing
+
+
 class TestDryRun:
     """Tests for --dry-run mode."""
 
@@ -186,6 +259,9 @@ class TestFullRun:
         assert (tmp_path / "AGENTS.md").exists()
         assert (tmp_path / ".agents" / "architecture").is_dir()
         assert (tmp_path / ".agents" / "sessions").is_dir()
+        assert (tmp_path / ".agents" / "team.yaml").exists()
+        assert (tmp_path / ".serena" / "project.yml").exists()
+        assert (tmp_path / ".serena" / "memories").is_dir()
         assert (tmp_path / ".github" / "copilot-instructions.md").exists()
 
     def test_minimal_run_succeeds(self, tmp_path: Path) -> None:
@@ -196,7 +272,9 @@ class TestFullRun:
         assert (tmp_path / "CLAUDE.md").exists()
         assert (tmp_path / "AGENTS.md").exists()
         assert (tmp_path / ".agents" / "architecture").is_dir()
+        assert (tmp_path / ".serena" / "project.yml").exists()
         assert not (tmp_path / ".agents" / "governance").exists()
+        assert not (tmp_path / ".agents" / "team.yaml").exists()
         assert not (tmp_path / ".github" / "copilot-instructions.md").exists()
 
     def test_invalid_target_returns_exit_code_2(self, tmp_path: Path) -> None:
@@ -208,10 +286,22 @@ class TestFullRun:
 class TestMainEntryPoint:
     """Tests for the main() CLI entry point."""
 
-    def test_main_with_target_dir(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    def test_main_with_init_subcommand(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         monkeypatch.setattr(
             "sys.argv",
-            ["init_project.py", "--target-dir", str(tmp_path)],
+            ["ai-agents", "init", "--target-dir", str(tmp_path)],
+        )
+        result = main()
+        assert result == 0
+        assert (tmp_path / "CLAUDE.md").exists()
+        assert (tmp_path / ".serena" / "project.yml").exists()
+
+    def test_main_backwards_compat_without_subcommand(
+        self, tmp_path: Path, monkeypatch: MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "sys.argv",
+            ["ai-agents", "--target-dir", str(tmp_path)],
         )
         result = main()
         assert result == 0
@@ -220,7 +310,7 @@ class TestMainEntryPoint:
     def test_main_dry_run(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         monkeypatch.setattr(
             "sys.argv",
-            ["init_project.py", "--target-dir", str(tmp_path), "--dry-run"],
+            ["ai-agents", "init", "--target-dir", str(tmp_path), "--dry-run"],
         )
         result = main()
         assert result == 0
@@ -229,8 +319,9 @@ class TestMainEntryPoint:
     def test_main_minimal(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
         monkeypatch.setattr(
             "sys.argv",
-            ["init_project.py", "--target-dir", str(tmp_path), "--minimal"],
+            ["ai-agents", "init", "--target-dir", str(tmp_path), "--minimal"],
         )
         result = main()
         assert result == 0
         assert not (tmp_path / ".agents" / "governance").exists()
+        assert (tmp_path / ".serena" / "project.yml").exists()

--- a/tests/test_init_project.py
+++ b/tests/test_init_project.py
@@ -16,6 +16,7 @@ from scripts.init_project import (
     _CLAUDE_MD_TEMPLATE,
     _COPILOT_INSTRUCTIONS_TEMPLATE,
     _GITIGNORE_ENTRIES,
+    _STARTER_AGENTS,
     ProjectInitializer,
     main,
 )
@@ -194,6 +195,58 @@ class TestScaffoldTeamManifest:
         assert content == existing
 
 
+class TestScaffoldStarterAgents:
+    """Tests for .claude/agents/ starter agent creation."""
+
+    def test_creates_all_starter_agents(self, tmp_path: Path) -> None:
+        init = ProjectInitializer(target_dir=tmp_path)
+        assert init.scaffold_starter_agents() is True
+
+        agents_dir = tmp_path / ".claude" / "agents"
+        assert agents_dir.is_dir()
+
+        for name in _STARTER_AGENTS:
+            agent_file = agents_dir / f"{name}.md"
+            assert agent_file.exists(), f"Missing agent: {name}"
+            content = agent_file.read_text(encoding="utf-8")
+            assert content.startswith("---")
+            assert f"name: {name}" in content
+
+    def test_minimal_skips_starter_agents(self, tmp_path: Path) -> None:
+        init = ProjectInitializer(target_dir=tmp_path, minimal=True)
+        assert init.scaffold_starter_agents() is True
+        assert not (tmp_path / ".claude" / "agents").exists()
+
+    def test_no_agents_flag_skips_starter_agents(self, tmp_path: Path) -> None:
+        init = ProjectInitializer(target_dir=tmp_path, no_agents=True)
+        assert init.scaffold_starter_agents() is True
+        assert not (tmp_path / ".claude" / "agents").exists()
+
+    def test_skips_existing_agents_without_force(self, tmp_path: Path) -> None:
+        agents_dir = tmp_path / ".claude" / "agents"
+        agents_dir.mkdir(parents=True)
+        existing = "# My custom orchestrator"
+        (agents_dir / "orchestrator.md").write_text(existing)
+
+        init = ProjectInitializer(target_dir=tmp_path)
+        init.scaffold_starter_agents()
+
+        content = (agents_dir / "orchestrator.md").read_text(encoding="utf-8")
+        assert content == existing
+        assert len(init.skipped_files) == 1
+
+    def test_overwrites_agents_with_force(self, tmp_path: Path) -> None:
+        agents_dir = tmp_path / ".claude" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "orchestrator.md").write_text("# old")
+
+        init = ProjectInitializer(target_dir=tmp_path, force=True)
+        init.scaffold_starter_agents()
+
+        content = (agents_dir / "orchestrator.md").read_text(encoding="utf-8")
+        assert "name: orchestrator" in content
+
+
 class TestDryRun:
     """Tests for --dry-run mode."""
 
@@ -263,6 +316,9 @@ class TestFullRun:
         assert (tmp_path / ".serena" / "project.yml").exists()
         assert (tmp_path / ".serena" / "memories").is_dir()
         assert (tmp_path / ".github" / "copilot-instructions.md").exists()
+        assert (tmp_path / ".claude" / "agents").is_dir()
+        for name in _STARTER_AGENTS:
+            assert (tmp_path / ".claude" / "agents" / f"{name}.md").exists()
 
     def test_minimal_run_succeeds(self, tmp_path: Path) -> None:
         init = ProjectInitializer(target_dir=tmp_path, minimal=True)
@@ -276,6 +332,7 @@ class TestFullRun:
         assert not (tmp_path / ".agents" / "governance").exists()
         assert not (tmp_path / ".agents" / "team.yaml").exists()
         assert not (tmp_path / ".github" / "copilot-instructions.md").exists()
+        assert not (tmp_path / ".claude" / "agents").exists()
 
     def test_invalid_target_returns_exit_code_2(self, tmp_path: Path) -> None:
         init = ProjectInitializer(target_dir=tmp_path / "nonexistent")
@@ -325,3 +382,13 @@ class TestMainEntryPoint:
         assert result == 0
         assert not (tmp_path / ".agents" / "governance").exists()
         assert (tmp_path / ".serena" / "project.yml").exists()
+
+    def test_main_no_agents(self, tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "sys.argv",
+            ["ai-agents", "init", "--target-dir", str(tmp_path), "--no-agents"],
+        )
+        result = main()
+        assert result == 0
+        assert (tmp_path / "CLAUDE.md").exists()
+        assert not (tmp_path / ".claude" / "agents").exists()


### PR DESCRIPTION
## Summary

- Enhances `ai-agents init` to scaffold 8 starter agent definitions (orchestrator, implementer, analyst, architect, qa, security, devops, critic) in `.claude/agents/`, giving new users a working agent team immediately.
- Adds post-init "next steps" guidance so users know what to do after running init.
- Adds `--no-agents` CLI flag to skip agent scaffolding when not wanted.

Fixes #1574

## Test plan

- [x] All 37 tests pass (5 new tests for starter agent scaffolding)
- [x] Ruff linter passes with no warnings
- [ ] Verify `ai-agents init` creates `.claude/agents/` with 8 agent files
- [ ] Verify `ai-agents init --minimal` skips agent scaffolding
- [ ] Verify `ai-agents init --no-agents` skips agent scaffolding
- [ ] Verify `ai-agents init --dry-run` previews agent files without creating them
- [ ] Verify existing agent files are preserved without `--force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)