### PR TITLE
feat: Add always-on security review scope to security.md

### DIFF
--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -55,6 +55,29 @@ You have direct access to:
 
 Identify security vulnerabilities, recommend mitigations, and ensure secure development practices across the codebase.
 
+## Security Review Scope
+
+**All PRs require security review.** Security scanning is not opt-in or label-triggered — it is a mandatory gate for any code change.
+
+### Workflow File Changes (Highest Risk)
+
+If the PR modifies `.github/workflows/`, `.gitlab-ci.yml`, or other CI/CD automation:
+
+1. **Check for hardened alternatives first**: Search the repo for existing utilities that handle the same operation securely (e.g., PowerShell cmdlets vs. bash scripts for file operations).
+2. **Prefer existing hardened tools**: If a secure implementation already exists, the PR should use it rather than introducing a new (potentially vulnerable) one.
+3. **Reject shell injection vectors**: Any use of `eval`, unquoted variables, or dynamic command construction in bash/shell scripts is a [FAIL] unless explicitly justified and mitigated.
+
+### Stop Criteria
+
+Do NOT approve a PR that:
+- Introduces shell command execution without input validation (CWE-78)
+- Bypasses existing hardened utilities without justification
+- Modifies workflow files without security review
+
+If you cannot verify whether a hardened alternative exists, call `work_finish(blocked, "Need codebase search for existing secure implementations")`.
+
+**Success definition**: You can state whether this PR uses existing hardened utilities or introduces new code, and if new code is justified.
+
 ## Key Responsibilities
 
 ### Capability 1: Static Analysis & Vulnerability Scanning

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -70,6 +70,7 @@ If the PR modifies `.github/workflows/`, `.gitlab-ci.yml`, or other CI/CD automa
 ### Stop Criteria
 
 Do NOT approve a PR that:
+
 - Introduces shell command execution without input validation (CWE-78)
 - Bypasses existing hardened utilities without justification
 - Modifies workflow files without security review

--- a/src/claude/security.md
+++ b/src/claude/security.md
@@ -54,6 +54,30 @@ You have direct access to:
 
 Identify security vulnerabilities, recommend mitigations, and ensure secure development practices across the codebase.
 
+## Security Review Scope
+
+**All PRs require security review.** Security scanning is not opt-in or label-triggered — it is a mandatory gate for any code change.
+
+### Workflow File Changes (Highest Risk)
+
+If the PR modifies `.github/workflows/`, `.gitlab-ci.yml`, or other CI/CD automation:
+
+1. **Check for hardened alternatives first**: Search the repo for existing utilities that handle the same operation securely (e.g., PowerShell cmdlets vs. bash scripts for file operations).
+2. **Prefer existing hardened tools**: If a secure implementation already exists, the PR should use it rather than introducing a new (potentially vulnerable) one.
+3. **Reject shell injection vectors**: Any use of `eval`, unquoted variables, or dynamic command construction in bash/shell scripts is a [FAIL] unless explicitly justified and mitigated.
+
+### Stop Criteria
+
+Do NOT approve a PR that:
+
+- Introduces shell command execution without input validation (CWE-78)
+- Bypasses existing hardened utilities without justification
+- Modifies workflow files without security review
+
+If you cannot verify whether a hardened alternative exists, call `work_finish(blocked, "Need codebase search for existing secure implementations")`.
+
+**Success definition**: You can state whether this PR uses existing hardened utilities or introduces new code, and if new code is justified.
+
 ## Key Responsibilities
 
 ### Capability 1: Static Analysis & Vulnerability Scanning

--- a/src/copilot-cli/security.agent.md
+++ b/src/copilot-cli/security.agent.md
@@ -61,6 +61,30 @@ You have direct access to:
 
 Identify security vulnerabilities, recommend mitigations, and ensure secure development practices across the codebase.
 
+## Security Review Scope
+
+**All PRs require security review.** Security scanning is not opt-in or label-triggered — it is a mandatory gate for any code change.
+
+### Workflow File Changes (Highest Risk)
+
+If the PR modifies `.github/workflows/`, `.gitlab-ci.yml`, or other CI/CD automation:
+
+1. **Check for hardened alternatives first**: Search the repo for existing utilities that handle the same operation securely (e.g., PowerShell cmdlets vs. bash scripts for file operations).
+2. **Prefer existing hardened tools**: If a secure implementation already exists, the PR should use it rather than introducing a new (potentially vulnerable) one.
+3. **Reject shell injection vectors**: Any use of `eval`, unquoted variables, or dynamic command construction in bash/shell scripts is a [FAIL] unless explicitly justified and mitigated.
+
+### Stop Criteria
+
+Do NOT approve a PR that:
+
+- Introduces shell command execution without input validation (CWE-78)
+- Bypasses existing hardened utilities without justification
+- Modifies workflow files without security review
+
+If you cannot verify whether a hardened alternative exists, call `work_finish(blocked, "Need codebase search for existing secure implementations")`.
+
+**Success definition**: You can state whether this PR uses existing hardened utilities or introduces new code, and if new code is justified.
+
 ## Key Responsibilities
 
 ### Capability 1: Static Analysis & Vulnerability Scanning

--- a/src/vs-code-agents/security.agent.md
+++ b/src/vs-code-agents/security.agent.md
@@ -62,6 +62,30 @@ You have direct access to:
 
 Identify security vulnerabilities, recommend mitigations, and ensure secure development practices across the codebase.
 
+## Security Review Scope
+
+**All PRs require security review.** Security scanning is not opt-in or label-triggered — it is a mandatory gate for any code change.
+
+### Workflow File Changes (Highest Risk)
+
+If the PR modifies `.github/workflows/`, `.gitlab-ci.yml`, or other CI/CD automation:
+
+1. **Check for hardened alternatives first**: Search the repo for existing utilities that handle the same operation securely (e.g., PowerShell cmdlets vs. bash scripts for file operations).
+2. **Prefer existing hardened tools**: If a secure implementation already exists, the PR should use it rather than introducing a new (potentially vulnerable) one.
+3. **Reject shell injection vectors**: Any use of `eval`, unquoted variables, or dynamic command construction in bash/shell scripts is a [FAIL] unless explicitly justified and mitigated.
+
+### Stop Criteria
+
+Do NOT approve a PR that:
+
+- Introduces shell command execution without input validation (CWE-78)
+- Bypasses existing hardened utilities without justification
+- Modifies workflow files without security review
+
+If you cannot verify whether a hardened alternative exists, call `work_finish(blocked, "Need codebase search for existing secure implementations")`.
+
+**Success definition**: You can state whether this PR uses existing hardened utilities or introduces new code, and if new code is justified.
+
 ## Key Responsibilities
 
 ### Capability 1: Static Analysis & Vulnerability Scanning

--- a/templates/agents/security.shared.md
+++ b/templates/agents/security.shared.md
@@ -60,6 +60,30 @@ You have direct access to:
 
 Identify security vulnerabilities, recommend mitigations, and ensure secure development practices across the codebase.
 
+## Security Review Scope
+
+**All PRs require security review.** Security scanning is not opt-in or label-triggered — it is a mandatory gate for any code change.
+
+### Workflow File Changes (Highest Risk)
+
+If the PR modifies `.github/workflows/`, `.gitlab-ci.yml`, or other CI/CD automation:
+
+1. **Check for hardened alternatives first**: Search the repo for existing utilities that handle the same operation securely (e.g., PowerShell cmdlets vs. bash scripts for file operations).
+2. **Prefer existing hardened tools**: If a secure implementation already exists, the PR should use it rather than introducing a new (potentially vulnerable) one.
+3. **Reject shell injection vectors**: Any use of `eval`, unquoted variables, or dynamic command construction in bash/shell scripts is a [FAIL] unless explicitly justified and mitigated.
+
+### Stop Criteria
+
+Do NOT approve a PR that:
+
+- Introduces shell command execution without input validation (CWE-78)
+- Bypasses existing hardened utilities without justification
+- Modifies workflow files without security review
+
+If you cannot verify whether a hardened alternative exists, call `work_finish(blocked, "Need codebase search for existing secure implementations")`.
+
+**Success definition**: You can state whether this PR uses existing hardened utilities or introduces new code, and if new code is justified.
+
 ## Key Responsibilities
 
 ### Capability 1: Static Analysis & Vulnerability Scanning


### PR DESCRIPTION
Closes #1677

## Problem
Security agent focused on identifying vulnerabilities but provided no guidance on preventing introduction during review. Security review was opt-in (label/gate-triggered), not always-on.

From retrospective (2025-12-20): Bash CWE-20/CWE-78 vulnerability introduced in PR #60, not caught until PR #211 triggered quality gate review. PowerShell hardened utilities existed but workflow bypassed them.

## Solution
Added a "Security Review Scope" section across every security agent surface that ships with this repo:

1. **All PRs get security review** (not opt-in)
2. Check for existing hardened utilities before approving new code
3. Explicit stop criteria for workflow file changes (shell injection, missing validation, bypassing existing tools)
4. Success definition for completion verification

## Changes
- `.claude/agents/security.md`: Added "Security Review Scope" section after "Core Mission"
- `src/claude/security.md`: Mirrored the new section for the source-of-truth Claude prompt
- `src/copilot-cli/security.agent.md`: Propagated scope rules to the Copilot CLI variant
- `src/vs-code-agents/security.agent.md`: Propagated scope rules to the VS Code agents variant
- `templates/agents/security.shared.md`: Updated shared template so downstream renders inherit the scope

## Evidence
- Retrospective (not in diff): .agents/retrospective/2025-12-20-pr-211-security-miss.md
- Related: Agent Failure Mode #8 (security drift through phase gaps)
- CWE-20 (Improper Input Validation), CWE-78 (OS Command Injection)

## Testing
- [x] `python3 scripts/validation/pr_description.py --pr-number 1681 --ci` passes locally
- [ ] Security agent reads new section on PR review
- [ ] Stop criteria enforced for workflow file changes
- [ ] Hardened utility check performed before approving new implementations
