### PR TITLE
ci(renovate): enable automerge with platform auto-merge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "automerge": true,
+  "platformAutomerge": true
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,11 @@
   "extends": [
     "config:recommended"
   ],
-  "automerge": true,
+  "minor": {
+    "automerge": true
+  },
+  "patch": {
+    "automerge": true
+  },
   "platformAutomerge": true
 }


### PR DESCRIPTION
## Summary

Resolves the "Automerge: Disabled by config" status on the Renovate dashboard. Sets `automerge: true` and `platformAutomerge: true` in the renovate config so GitHub's native auto-merge merges Renovate PRs once required checks pass.

## Specification References

No tracking issue. Infrastructure change only.

## Changes

- `renovate.json`: add automerge and platformAutomerge flags alongside the existing config:recommended extends.

## Type of Change

- [x] Infrastructure/CI change

## Why this is safe now

The previously documented PR-validation race condition (CANCELLED + SUCCESS check runs blocking merge) is mitigated: the renovate bot is in the bot skip list for both pr-validation and semantic-pr-title-check workflows, so Renovate PRs no longer hit the cancellation race that blocked auto-merge.

The platformAutomerge flag delegates the actual merge to GitHub's native auto-merge, which respects branch protection and required checks. Renovate just enables the flag rather than polling and merging itself.

## Testing

- [x] JSON syntax validated locally with python json.load
- [x] No code paths changed; effect is observable on the next Renovate run when the dashboard status flips and a passing PR auto-merges.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

Auto-merge respects existing branch protection rules and required status checks; this change only flips the Renovate-side flag and does not modify any check, permission, or secret.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation not required (renovate config is self-documenting via $schema)
- [x] No new warnings introduced
