### PR TITLE
fix(eval): align adr-generator S5 desc with CLARIFY verdict

### DIFF
--- a/tests/evals/adr-generator-scenarios.json
+++ b/tests/evals/adr-generator-scenarios.json
@@ -38,12 +38,12 @@
     },
     {
       "id": "S5",
-      "desc": "Does not generate ADR without sufficient decision context",
+      "desc": "Requests clarification when decision context is insufficient",
       "input": "We should probably use Kafka. Write an ADR.",
       "expected_verdict": "CLARIFY",
       "verdict_options": ["GENERATE", "CLARIFY", "REFUSE"],
       "expected_reason_contains": "clarify",
-      "rationale": "Vague inputs produce low-value ADRs. Generator should request clarification on what problem Kafka solves, what alternatives were considered."
+      "rationale": "Vague inputs produce low-value ADRs. Generator should request clarification on what problem Kafka solves, what alternatives were considered, rather than generating an incomplete ADR."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Aligns adr-generator scenario S5 description and rationale with the CLARIFY verdict
- Follow-up to PR #1735 where S5 verdict was changed but desc/rationale were not

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **PR** | Follow-up to #1735 | Address reviewer feedback that landed on wrong branch state |

## Changes

- tests/evals/adr-generator-scenarios.json: S5 desc changed from "Does not generate ADR without sufficient decision context" to "Requests clarification when decision context is insufficient". Rationale updated to mention generator should clarify "rather than generating an incomplete ADR".

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Testing

- [x] No testing required (test fixture only)

## Context

CodeRabbit and Gemini flagged S5 contradiction in PR #1735: verdict was GENERATE but desc said "does not generate". Verdict was changed to CLARIFY in commit fa971e2c but that commit went to a side branch (feat/eval-scenario-files) and squash-merge of #1735 only included the verdict change, not the desc/rationale updates. This PR completes the fix on main.
