### PR TITLE
fix(ci): ignore pip CVE-2026-3219 in pip-audit until pip 26.1 ships

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -139,7 +139,17 @@ jobs:
 
       - name: Run pip-audit
         run: |
-          pip-audit --ignore-vuln CVE-2026-4539  # pygments 2.19.2, no fix available
+          # Ignored CVEs (re-evaluate when upstream releases a fix):
+          #   CVE-2026-4539: pygments 2.19.2, no fix available.
+          #   CVE-2026-3219: pip 26.0/26.0.1 mishandles concatenated tar/ZIP
+          #     archives (CWE-434, CVSS 4.6, local + user interaction).
+          #     Fix is merged on pip main (PR pypa/pip#13870), pending pip 26.1
+          #     release. CI installs trusted deps from PyPI via uv lockfile, so
+          #     the local-only attack surface does not apply. Remove this ignore
+          #     once pip 26.1 ships.
+          pip-audit \
+            --ignore-vuln CVE-2026-4539 \
+            --ignore-vuln CVE-2026-3219
 
       - name: Run Bandit
         run: |


### PR DESCRIPTION
## Summary

- Extend pip-audit ignore list in \`.github/workflows/pytest.yml\` to cover CVE-2026-3219 (pip 26.0/26.0.1) alongside the existing CVE-2026-4539 (pygments) ignore.
- Document the rationale and removal trigger inline so future readers can drop the ignore once pip 26.1 ships.

## Why ignore instead of upgrade

CVE-2026-3219 is a real, published advisory (NVD, OSV/GHSA-58qw-9mgm-455v):
- **Severity**: CVSS 4.6 MEDIUM, CWE-434, AV:L (local + user interaction)
- **Description**: pip mishandles archives that are simultaneously valid tar AND ZIP, leading to confusing install behavior.
- **Affected**: pip 0 through 26.0.1 inclusive (OSV \`last_affected: 26.0.1\`).
- **Fix**: merged in pypa/pip#13870 on 2026-04-19, **targeting pip 26.1, not yet released**. Latest PyPI release is 26.0.1 (2026-02-05).

I attempted to upgrade pip via direct constraint in \`pyproject.toml\` (\`pip>=26.0.1\`) and \`uv lock --upgrade-package pip\`. Local pip-audit confirmed pip 26.0.1 is still flagged. No released version is patched.

## Risk in this CI

- The CVE requires local access plus user interaction on a specifically crafted archive.
- This workflow installs pinned dev deps from PyPI through uv with a checked-in lockfile.
- The local-only attack surface does not apply to CI execution.

## Removal Trigger

Tracked in #1778. When pip 26.1 ships:
1. Add \`pip>=26.1\` to \`pyproject.toml\` dev deps.
2. \`uv lock --upgrade-package pip\`.
3. Drop \`--ignore-vuln CVE-2026-3219\` from \`pytest.yml\`.
4. Verify pip-audit clean.

## Test plan

- [ ] CI \`Run Python Tests\` job passes the \`Run pip-audit\` step.
- [ ] No new vulnerabilities surface (only the two documented ignores).
- [ ] Comment block is preserved verbatim for future readers.

Closes #1778 will NOT be applied here; the issue stays open until pip 26.1 lands and the ignore is dropped.