### PR TITLE
fix(rules): correct script references in templates.md

### DIFF
--- a/.claude/rules/templates.md
+++ b/.claude/rules/templates.md
@@ -9,7 +9,7 @@ priority: high
 
 ## MUST
 
-1. **Regenerate after edits**. Changes MUST be followed by running `python3 build/generate_agents.py` (or the equivalent `Generate-Agents.ps1`) before commit. Uncommitted generator output is a protocol failure.
+1. **Regenerate after edits**. Changes MUST be followed by running `python3 build/generate_agents.py` before commit. Uncommitted generator output is a protocol failure.
 2. **Commit generated output**. Regenerated files under `src/claude/`, `.github/agents/`, and similar target directories MUST be committed in the same PR as the template change.
 3. **Toolset integrity**. Changes that add or remove tools MUST update `templates/toolsets.yaml` consistently.
 4. **Frontmatter fields**. Agent templates MUST keep required YAML frontmatter fields (`name`, `description`, `model`) present and valid per ADR-002.
@@ -19,7 +19,7 @@ priority: high
 
 1. **Minimal diff**. Template edits SHOULD make one logical change at a time; avoid bundling prompt rewrites with toolset changes.
 2. **Preview per platform**. SHOULD inspect the generated output for at least two platforms (e.g., `src/claude/<agent>.md` and `.github/agents/<agent>.md`) to confirm the change renders correctly.
-3. **Check drift detection**. SHOULD run the drift-detection script (`scripts/validation/agent_drift` if present) after generation.
+3. **Check drift detection**. SHOULD run `python3 build/scripts/detect_agent_drift.py` after generation to confirm the templates and generated files agree.
 
 ## MUST NOT
 


### PR DESCRIPTION
## Summary

Follow-up to #1788. Two script references in `.claude/rules/templates.md` are wrong:

1. `Generate-Agents.ps1` does not exist. Removed.
2. `scripts/validation/agent_drift` does not exist. Replaced with actual `python3 build/scripts/detect_agent_drift.py`.

## Why

PR #1788 review thread caught these. The fix commit landed on the branch after auto-merge fired, leaving the bad references in main.

## Changes

- `.claude/rules/templates.md`: corrected script references.

## Test plan

- [ ] grep verifies referenced scripts exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)