### PR TITLE
docs(rules): align DDIA frontmatter with Kleppmann's actual themes (#1765 follow-up)

### DIFF
--- a/.claude/rules/data-intensive-applications.md
+++ b/.claude/rules/data-intensive-applications.md
@@ -1,5 +1,5 @@
 ---
-description: Data ownership, consistency, schema evolution, and idempotency rules from Kleppmann's Designing Data-Intensive Applications. Apply when changing how state is stored, replicated, or exchanged between agents, sessions, memory, or workspaces.
+description: System-of-record ownership, consistency models per boundary, schema evolution (backward and forward compatibility), event ordering and delivery semantics (at-least-once with idempotent receivers, no exactly-once wishful thinking) from Kleppmann's _Designing Data-Intensive Applications_. Apply when changing how state is stored, replicated, derived, or exchanged between agents, sessions, memory, workspaces, or external services.
 alwaysApply: false
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1765 (data-intensive-applications rule). The frontmatter
description used loose project paraphrase ("data ownership") and missed core
themes the rule body actually covers. This PR corrects the description to
match Kleppmann's DDIA vocabulary and the rule sections.

## Verification

Cross-referenced DDIA TOC via O'Reilly catalog. Confirmed structure:

- Part I (Foundations): Reliability/Scalability/Maintainability, Data Models, Storage & Retrieval, Encoding & Evolution
- Part II (Distributed Data): Replication, Partitioning, Transactions, Trouble with Distributed Systems, Consistency & Consensus
- Part III (Derived Data): Batch Processing, Stream Processing, Future of Data Systems

## Issues with prior description

1. **"Data ownership"** is project paraphrase. DDIA's term is **system of record (SoR)** vs **derived data** (Ch 5, 11).
2. **"Idempotency"** is not a DDIA chapter title. It surfaces in Ch 11 as the mechanism for at-least-once + dedupe -> exactly-once. The proper framing is **delivery semantics**.
3. **Missing themes the rule body covers**: event ordering (Ch 9, 11), no-exactly-once-wishful-thinking (Ch 11 explicit), schema forward/backward compatibility (Ch 4 already implied, now explicit).
4. **Missing scope**: external services (rule body's idempotency section covers HTTP/queue calls).

## Files Changed

- `.claude/rules/data-intensive-applications.md` (frontmatter description only, single line)

## Test plan

- [x] Description references actual DDIA terminology (system of record, delivery semantics, etc.)
- [x] Description names rule sections (event ordering, no exactly-once, schema evolution)
- [x] Activation triggers expanded to cover external services

Refs #1751

🤖 Generated with [Claude Code](https://claude.com/claude-code)
