### PR TITLE
chore(serena): add typescript, json, toml to active language servers

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -32,6 +32,9 @@ languages:
 - python
 - markdown
 - powershell
+- typescript
+- json
+- toml
 
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings


### PR DESCRIPTION
## Summary

- The recent Serena schema refresh (#1824) expanded the upstream supported-language-server list.
- Three of the new entries cover languages this repo already writes and edits but was not activating Serena LSP support for.
- Add `typescript`, `json`, and `toml` to the active `languages:` list in this project's Serena config so Serena's symbol tools (find_symbol, get_symbols_overview, find_referencing_symbols, etc.) work on those files.

## Why these three

File counts in the repo today (excluding node_modules, .venv, .git):

| Language | Files | Surfaces |
|----------|-------|----------|
| TypeScript | 6 | the ai-agents-cli package source and tests, plus the agent registry schema in src |
| TOML | 4 | the project pyproject, the semantic-hooks package pyproject, the bun build config, and a worktree config |
| JSON | ~770 | plugin manifests, settings files, marketplace and plugin manifests, package and tsconfig files, agent baselines, memory exports, and MCP configs |

JSON is by far the largest by file count and is the most-edited config surface in the repo (every plugin and skill carries JSON manifests). TypeScript is small but is real source code with imports, types, and tests where LSP-driven navigation matters. TOML is small but is the canonical surface for Python and Bun build config.

## Languages NOT added and why

- python_jedi / python_ty: alternatives to the default python LSP. Default python is already configured and sufficient.
- typescript_vts: alternative TypeScript server (Volar-based). Default typescript covers the existing source files.
- ansible / vue / lean4 / matlab / etc.: not used in this repo.

## Test plan

- [x] Confirmed the typescript files exist via filesystem check.
- [x] Confirmed the toml files exist via filesystem check.
- [ ] Reviewer activates Serena on this branch and confirms find_symbol / get_symbols_overview work against the ai-agents-cli source and the project pyproject.

## References

The Serena schema refresh in #1824 introduced the new language values. The Serena upstream maintains the canonical Language enum that backs these entries; see https://github.com/oraios/serena.

Refs #1824

https://claude.ai/code/session_01PVTYLq4zido5pmHu7Q4P11