### PR TITLE
fix(tests): unblock Run Python Tests on REQ-003 branch (3 failures)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,12 +18,12 @@
     },
     {
       "name": "project-toolkit",
-      "description": "Complete project development toolkit: 23 agents, 23 slash commands, 29 lifecycle hooks, and 67 reusable skills for Claude Code workflows",
+      "description": "Complete project development toolkit: 23 agents, 23 slash commands, 29 lifecycle hooks, and 69 reusable skills for Claude Code workflows",
       "source": "./.claude"
     },
     {
       "name": "claude-toolkit",
-      "description": "23 agents, 67 reusable skills, 23 slash commands, 29 lifecycle hooks - canonical Claude Code authoring source",
+      "description": "23 agents, 69 reusable skills, 23 slash commands, 29 lifecycle hooks - canonical Claude Code authoring source",
       "source": "./.claude"
     },
     {


### PR DESCRIPTION
## Summary

Three CI failures on `feat/req-003-multi-tool-build` (Run Python Tests check) that did not repro on `main`. Root-caused and fixed:

| # | Test | Cause | Fix |
|---|---|---|---|
| 1 | `tests/hooks/test_skill_learning.py::TestSafeBaseDirM7T5::test_safe_base_dir_honors_claude_project_dir` | M7-T5 (`6f42c64`) added `_detect_safe_base_dir()`. Commit `be11bd5` added a CWE-22 containment guard requiring the hook script to live under the env-supplied root. Test predates the guard and just sets `env_dir=tmp_path`; guard refuses (script is at `/home/.../.claude/hooks/Stop/...`, not under `tmp_path`), function falls through to cwd walk-up, assertion fails. | Stage a fake `tmp_path/.claude/hooks/Stop/invoke_skill_learning.py` and `monkeypatch.setattr(invoke_skill_learning, "__file__", str(fake_script))` so the guard accepts the env value. |
| 2 | `tests/test_marketplace_two_plugin.py::TestCounterValidatorGreen::test_validate_marketplace_counts_exits_zero` | Real count drift: skills `panning-for-gold` and `work-operating-model` were added under `.claude/skills/` (count: 69) but `marketplace.json` still declared `"67 reusable skills"`. | Ran `python3 build/scripts/validate_marketplace_counts.py --fix`. |
| 3 | `tests/test_validate_marketplace_counts.py::TestValidateIntegration::test_current_counts_are_valid` | Same drift as #2. | Same fix. |

## Verification

- All 3 target tests pass.
- Full local pytest now matches the `main` baseline (16 fail + 7 errors, all pre-existing root/env-dependent tests unrelated to any commit).
- `build_all.py --check` reports no drift.

## PR target

This PR targets `feat/req-003-multi-tool-build` (PR #1819's branch), not `main`, because:
- The failing test `TestSafeBaseDirM7T5` exists only on the REQ-003 branch.
- The marketplace count drift is also branch-local (main's count of 67 is correct on main).

Refs #REQ-003

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFLQZG6UVu11QKBjsc5pDi)_