### PR TITLE
fix(marketplace): split native cli manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-agents",
-  "description": "AI coding agents for Claude Code and Copilot CLI",
+  "description": "AI coding agents for Claude Code",
   "owner": {
     "name": "rjmurillo",
     "email": "rjmurillo@gmail.com"
@@ -12,24 +12,9 @@
       "source": "./src/claude"
     },
     {
-      "name": "copilot-cli-agents",
-      "description": "24 agent definitions for GitHub Copilot CLI",
-      "source": "./src/copilot-cli"
-    },
-    {
       "name": "project-toolkit",
       "description": "Complete project development toolkit: 23 agents, 23 slash commands, 29 lifecycle hooks, and 69 reusable skills for Claude Code workflows",
       "source": "./.claude"
-    },
-    {
-      "name": "claude-toolkit",
-      "description": "23 agents, 69 reusable skills, 23 slash commands, 29 lifecycle hooks - canonical Claude Code authoring source",
-      "source": "./.claude"
-    },
-    {
-      "name": "copilot-cli-toolkit",
-      "description": "24 agent definitions, 81 reusable skills, 28 lifecycle hooks for GitHub Copilot CLI - generated from Claude canonical sources",
-      "source": "./src/copilot-cli"
     }
   ]
 }

--- a/.claude/agents/AGENTS.md
+++ b/.claude/agents/AGENTS.md
@@ -14,7 +14,7 @@ The `src/claude/` directory contains **hand-maintained** agent definitions for C
 src/claude/*.md  ───────────────────────────────────────┐
    (SOURCE - hand-maintained)                           │
                                                         ▼
-                                              skill-installer
+                                   Claude marketplace install
                                                         │
                                                         ▼
                                            .claude/agents/*.md
@@ -34,7 +34,7 @@ src/claude/*.md  ─────────────────────
 1. Copy improvements from `.claude/agents/{agent}.md` to `src/claude/{agent}.md`
 2. Verify ADR enforcement, security gates, and blocking sections are PRESERVED
 3. Commit to `src/claude/` only
-4. Reinstall using skill-installer (see [docs/installation.md](../../docs/installation.md))
+4. Reinstall through Claude Code's native marketplace flow (see [docs/installation.md](../../docs/installation.md))
 
 **Common mistake**: Copying `.claude/agents/` wholesale to `src/claude/` may overwrite blocking gates (like ADR Review Enforcement) if the installed version was modified without including those sections.
 

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -7,11 +7,6 @@
   },
   "plugins": [
     {
-      "name": "copilot-cli-agents",
-      "description": "24 agent definitions for GitHub Copilot CLI",
-      "source": "./src/copilot-cli"
-    },
-    {
       "name": "project-toolkit",
       "description": "24 agent definitions, 81 reusable skills, 28 lifecycle hooks for GitHub Copilot CLI - generated from Claude canonical sources",
       "source": "./src/copilot-cli"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "ai-agents",
+  "description": "AI coding agents for GitHub Copilot CLI",
+  "owner": {
+    "name": "rjmurillo",
+    "email": "rjmurillo@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "copilot-cli-agents",
+      "description": "24 agent definitions for GitHub Copilot CLI",
+      "source": "./src/copilot-cli"
+    },
+    {
+      "name": "project-toolkit",
+      "description": "24 agent definitions, 81 reusable skills, 28 lifecycle hooks for GitHub Copilot CLI - generated from Claude canonical sources",
+      "source": "./src/copilot-cli"
+    }
+  ]
+}

--- a/.github/workflows/validate-marketplace-counts.yml
+++ b/.github/workflows/validate-marketplace-counts.yml
@@ -40,6 +40,7 @@ jobs:
           filters: |
             paths:
               - '.claude-plugin/marketplace.json'
+              - '.github/plugin/marketplace.json'
               - 'src/claude/**'
               - 'src/copilot-cli/**'
               - '.claude/agents/**'

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For platform teams, engineering managers, and orgs that want AI-assisted develop
 
 ## Fastest Start
 
-Each AI tool has its own plugin install flow. Pick yours and paste the command(s) inside the CLI session.
+Each AI tool has its own native marketplace flow. This repo ships a Claude Code marketplace at `.claude-plugin/marketplace.json` and a Copilot CLI marketplace at `.github/plugin/marketplace.json`, so the same repository URL works in both CLIs. Pick yours and paste the command(s) inside the CLI session.
 
 **Claude Code.** One command installs the full set; restart Claude Code when it finishes.
 
@@ -32,7 +32,7 @@ Each AI tool has its own plugin install flow. Pick yours and paste the command(s
 
 ```text
 /plugin marketplace add rjmurillo/ai-agents
-/plugin install copilot-cli-toolkit@ai-agents
+/plugin install project-toolkit@ai-agents
 ```
 
 A Claude install lands 23 agents, 23 commands, 29 hooks, and 69 skills. A Copilot install lands 24 agents, 28 hooks, and 81 skills generated from the same canonical sources. See [Verify Installation](#verify-installation) for the per-tool sanity check, or [More Installation Options](#alternative-full-installation) for component-level installs (agents only, etc.).
@@ -52,11 +52,11 @@ Specialized agent roles include analyst, architect, implementer, QA, security, d
 
 ### Troubleshooting
 
-- **`/install-plugin` not recognized:** That command is Claude Code only. In Copilot CLI use the two-step flow (`/plugin marketplace add rjmurillo/ai-agents` then `/plugin install copilot-cli-toolkit@ai-agents`).
-- **Copilot CLI install fails with "No plugin.json found in repository":** This repo is a marketplace, not a single plugin. Run `/plugin marketplace add rjmurillo/ai-agents` first, then `/plugin install copilot-cli-toolkit@ai-agents`.
+- **`/install-plugin` not recognized:** That command is Claude Code only. In Copilot CLI use the two-step flow (`/plugin marketplace add rjmurillo/ai-agents` then `/plugin install project-toolkit@ai-agents`).
+- **Copilot CLI install fails with "No plugin.json found in repository":** This repo is a marketplace, not a single plugin. Run `/plugin marketplace add rjmurillo/ai-agents` first, then `/plugin install project-toolkit@ai-agents`.
 - **`/plugin` not recognized in Copilot CLI:** Update Copilot CLI to a recent stable release; plugin support is required. Run `copilot --version` in a regular terminal to check.
 - **Plugin install fails or hangs:** Confirm your AI tool is on a recent stable release that supports the install command, then retry. Check the version per tool: in Claude Code use `/version` or the title bar; for Copilot CLI run `copilot --version` in a regular terminal.
-- **Agents not responding after install:** Restart Claude Code (Copilot CLI does not need a restart). Then verify with `Task(subagent_type="analyst", prompt="Hello, are you available?")` in Claude Code, `copilot plugin list` in Copilot CLI to confirm `copilot-cli-toolkit@ai-agents` is installed, or `@orchestrator Hello, are you available?` in VS Code Copilot Chat.
+- **Agents not responding after install:** Restart Claude Code (Copilot CLI does not need a restart). Then verify with `Task(subagent_type="analyst", prompt="Hello, are you available?")` in Claude Code, `copilot plugin list` in Copilot CLI to confirm `project-toolkit@ai-agents` is installed, or `@orchestrator Hello, are you available?` in VS Code Copilot Chat.
 
 ---
 
@@ -150,7 +150,9 @@ The [Fastest Start](#fastest-start) above is the recommended path. Use the comma
 
 ### Quick Install (CLI marketplace)
 
-The [Fastest Start](#fastest-start) commands install the full toolkit. For component-level installs, register the marketplace once and then install just the parts you want. In Claude Code you can also use `/install-plugin rjmurillo/ai-agents` as a one-step shortcut that registers the marketplace and prompts for plugin selection.
+The [Fastest Start](#fastest-start) commands install the full toolkit. For component-level installs, register the marketplace once in the CLI you are using and then install just the parts you want. Claude Code resolves that repository to `.claude-plugin/marketplace.json`; Copilot CLI resolves it to `.github/plugin/marketplace.json`. In Claude Code you can also use `/install-plugin rjmurillo/ai-agents` as a one-step shortcut that registers the marketplace and prompts for plugin selection.
+
+**Claude Code**
 
 ```text
 /plugin marketplace add rjmurillo/ai-agents
@@ -159,9 +161,18 @@ The [Fastest Start](#fastest-start) commands install the full toolkit. For compo
 | Component | Install Command | What You Get |
 |-----------|----------------|--------------|
 | Claude agents only | `/plugin install claude-agents@ai-agents` | 24 agent definitions from `src/claude/` (no skills, commands, or hooks) |
+| Project toolkit | `/plugin install project-toolkit@ai-agents` | 23 agents, 23 slash commands, 29 hooks, and 69 reusable skills from `.claude/` |
+
+**GitHub Copilot CLI**
+
+```text
+/plugin marketplace add rjmurillo/ai-agents
+```
+
+| Component | Install Command | What You Get |
+|-----------|----------------|--------------|
 | Copilot CLI agents only | `/plugin install copilot-cli-agents@ai-agents` | 24 agent definitions from `src/copilot-cli/` (no skills or hooks) |
-| Claude full toolkit | `/plugin install claude-toolkit@ai-agents` | 23 agents, 23 commands, 29 hooks, 69 skills from `.claude/` (Claude Code) |
-| Copilot full toolkit | `/plugin install copilot-cli-toolkit@ai-agents` | 24 agents, 28 hooks, 81 skills from `src/copilot-cli/` (Copilot CLI) |
+| Copilot full toolkit | `/plugin install project-toolkit@ai-agents` | 24 agents, 28 hooks, 81 skills from `src/copilot-cli/` (Copilot CLI) |
 
 The agents-only plugins (`claude-agents`, `copilot-cli-agents`) pull from `src/<platform>/` and ship 24 agents each. The full toolkits pull from a different source (`./.claude` for Claude, the same `src/copilot-cli` dir for Copilot) where Claude's roster is 23. The "23 vs 24" gap is real: `src/claude/` and `.claude/agents/` are two different curated sets, kept in sync where they overlap but with each set including agents the other does not. The Fastest Start path uses the full toolkit, so the headline "23 agents" reflects what most users get.
 
@@ -181,7 +192,7 @@ Task(subagent_type="analyst", prompt="Hello, are you available?")
 copilot plugin list
 ```
 
-The output should include `copilot-cli-toolkit@ai-agents` (or whichever component you installed). To exercise an agent end-to-end, run `copilot -p "analyst: respond with 'available'"`.
+The output should include `project-toolkit@ai-agents` (or whichever component you installed). To exercise an agent end-to-end, run `copilot -p "analyst: respond with 'available'"`.
 
 **VS Code (Copilot Chat):**
 
@@ -417,7 +428,8 @@ ai-agents/
 ├── scripts/                 # Validation and utility scripts
 ├── docs/                    # Documentation
 ├── .agents/                 # Agent artifacts (ADRs, plans, etc.)
-├── .claude-plugin/          # Plugin marketplace manifest (marketplace.json)
+├── .claude-plugin/          # Claude Code marketplace manifest
+├── .github/plugin/          # GitHub Copilot CLI marketplace manifest
 ├── .github/copilot-instructions.md  # GitHub Copilot instructions
 ├── CLAUDE.md                        # Claude Code instructions
 └── AGENTS.md                        # Detailed usage guide
@@ -441,7 +453,7 @@ ai-agents/
 
 - `/install-plugin` is a Claude Code CLI shortcut. In Copilot CLI use the explicit two-step flow:
   1. `/plugin marketplace add rjmurillo/ai-agents`
-  2. `/plugin install copilot-cli-toolkit@ai-agents`
+  2. `/plugin install project-toolkit@ai-agents`
 - Ensure you're running inside Claude Code CLI or Copilot CLI, not a regular shell. The command is built into the AI tool.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -171,10 +171,9 @@ The [Fastest Start](#fastest-start) commands install the full toolkit. For compo
 
 | Component | Install Command | What You Get |
 |-----------|----------------|--------------|
-| Copilot CLI agents only | `/plugin install copilot-cli-agents@ai-agents` | 24 agent definitions from `src/copilot-cli/` (no skills or hooks) |
 | Copilot full toolkit | `/plugin install project-toolkit@ai-agents` | 24 agents, 28 hooks, 81 skills from `src/copilot-cli/` (Copilot CLI) |
 
-The agents-only plugins (`claude-agents`, `copilot-cli-agents`) pull from `src/<platform>/` and ship 24 agents each. The full toolkits pull from a different source (`./.claude` for Claude, the same `src/copilot-cli` dir for Copilot) where Claude's roster is 23. The "23 vs 24" gap is real: `src/claude/` and `.claude/agents/` are two different curated sets, kept in sync where they overlap but with each set including agents the other does not. The Fastest Start path uses the full toolkit, so the headline "23 agents" reflects what most users get.
+Claude exposes both an agents-only bundle (`claude-agents`, from `src/claude/`) and the full toolkit (`project-toolkit`, from `./.claude`); the latter ships 23 agents because `src/claude/` and `.claude/agents/` are two different curated sets, kept in sync where they overlap. Copilot CLI installs ship a single `project-toolkit` plugin from `src/copilot-cli/` because that directory's `plugin.json` declares one identity; an agents-only Copilot install would silently register as `project-toolkit` and is therefore not advertised (issue #1840).
 
 ### Verify Installation
 

--- a/build/scripts/validate_marketplace_counts.py
+++ b/build/scripts/validate_marketplace_counts.py
@@ -173,9 +173,9 @@ def load_plugin_counters(
     marketplace_key: str | None = None
     if marketplace_path is not None:
         try:
-            marketplace_key = str(marketplace_path.resolve().relative_to(repo_root))
+            marketplace_key = str(marketplace_path.resolve().relative_to(repo_root)).replace("\\", "/")
         except ValueError:
-            marketplace_key = str(marketplace_path)
+            marketplace_key = str(marketplace_path).replace("\\", "/")
 
     counters: dict[str, dict[str, Callable[[], int]]] = {}
     for plugin_name, labels in plugins.items():

--- a/build/scripts/validate_marketplace_counts.py
+++ b/build/scripts/validate_marketplace_counts.py
@@ -28,6 +28,7 @@ from yaml_loader import ConfigError, load_platform_config
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 MARKETPLACE_JSON = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+COPILOT_MARKETPLACE_JSON = REPO_ROOT / ".github" / "plugin" / "marketplace.json"
 COUNTERS_YAML = REPO_ROOT / "templates" / "marketplace-counters.yaml"
 
 
@@ -43,7 +44,7 @@ _EXCLUDED_DIRS = frozenset({"node_modules", ".git", "worktrees", "cache", "__pyc
 def _walk_files(directory: Path, suffix: str, exclude_names: set[str]) -> int:
     """Count files matching suffix, pruning EXCLUDED_DIRS during descent.
 
-    Replaces ``directory.rglob('*.<suffix>')`` which walks excluded subtrees
+    Replaces ``directory.rglob('*.suffix')`` which walks excluded subtrees
     before discarding matches. ``os.walk`` with in-place ``dirnames`` mutation
     prunes BEFORE descending — safe against vendored bloat and symlink loops.
     """
@@ -151,23 +152,59 @@ def _build_counter(rule: dict, repo_root: Path) -> Callable[[], int]:
 
 
 def load_plugin_counters(
-    config_path: Path = COUNTERS_YAML, repo_root: Path = REPO_ROOT
+    config_path: Path = COUNTERS_YAML,
+    repo_root: Path = REPO_ROOT,
+    marketplace_path: Path | None = None,
 ) -> dict[str, dict[str, Callable[[], int]]]:
-    """Load plugin -> {label -> counter-fn} mapping from YAML."""
+    """Load plugin -> {label -> counter-fn} mapping from YAML.
+
+    Supports either a direct label -> rule mapping, or a nested
+    marketplaces.<relative-marketplace-path>.<label> -> rule mapping for cases
+    where the same plugin name exists in multiple native marketplace manifests
+    with platform-specific payloads.
+    """
     data = load_platform_config(config_path)
     plugins = data.get("plugins")
     if not isinstance(plugins, dict):
         raise ConfigError(
             f"{config_path}: top-level `plugins` must be a mapping"
         )
+
+    marketplace_key: str | None = None
+    if marketplace_path is not None:
+        try:
+            marketplace_key = str(marketplace_path.resolve().relative_to(repo_root))
+        except ValueError:
+            marketplace_key = str(marketplace_path)
+
     counters: dict[str, dict[str, Callable[[], int]]] = {}
     for plugin_name, labels in plugins.items():
         if not isinstance(labels, dict):
             raise ConfigError(
                 f"plugins.{plugin_name}: must be a mapping of label -> rule"
             )
+
+        rules = labels
+        marketplaces = labels.get("marketplaces")
+        if marketplaces is not None:
+            if not isinstance(marketplaces, dict):
+                raise ConfigError(
+                    f"plugins.{plugin_name}.marketplaces: must be a mapping"
+                )
+            if marketplace_key is None:
+                raise ConfigError(
+                    f"plugins.{plugin_name}.marketplaces requires marketplace_path"
+                )
+            rules = marketplaces.get(marketplace_key)
+            if rules is None:
+                continue
+            if not isinstance(rules, dict):
+                raise ConfigError(
+                    f"plugins.{plugin_name}.marketplaces.{marketplace_key}: must be a mapping"
+                )
+
         per_label: dict[str, Callable[[], int]] = {}
-        for label, rule in labels.items():
+        for label, rule in rules.items():
             if not isinstance(rule, dict):
                 raise ConfigError(
                     f"plugins.{plugin_name}.{label}: must be a mapping"
@@ -239,7 +276,7 @@ def validate(
             return 2
 
     try:
-        plugin_counters = load_plugin_counters(counters_path, repo_root)
+        plugin_counters = load_plugin_counters(counters_path, repo_root, marketplace)
     except ConfigError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 2
@@ -270,7 +307,6 @@ def validate(
                 mismatches.append(
                     f"  {name}: '{label}' declared={expected}, actual={actual}"
                 )
-                # Build fixed description by replacing the old count.
                 for match in COUNT_PATTERN.finditer(new_description):
                     matched_label = LABEL_MAP.get(match.group(2))
                     if matched_label == label:
@@ -286,10 +322,19 @@ def validate(
             fixes[name] = new_description
 
     if not mismatches:
-        print("marketplace.json counts are up to date.")
+        try:
+            display_path = marketplace.relative_to(repo_root)
+        except ValueError:
+            display_path = marketplace
+        print(f"{display_path} counts are up to date.")
         return 0
 
-    print("Stale counts detected in marketplace.json:")
+    try:
+        display_path = marketplace.relative_to(repo_root)
+    except ValueError:
+        display_path = marketplace
+
+    print(f"Stale counts detected in {display_path}:")
     for msg in mismatches:
         print(msg)
 
@@ -300,11 +345,33 @@ def validate(
         with open(marketplace, "w") as f:
             json.dump(data, f, indent=2)
             f.write("\n")
-        print("\nFixed: marketplace.json updated with correct counts.")
+        print(f"\nFixed: {display_path} updated with correct counts.")
         return 0
 
     print("\nRun with --fix to update marketplace.json automatically.")
     return 1
+
+
+def validate_known_marketplaces(
+    fix: bool = False,
+    counters_path: Path = COUNTERS_YAML,
+    repo_root: Path = REPO_ROOT,
+) -> int:
+    """Validate all native marketplace manifests shipped by the repo."""
+    results = []
+    for marketplace in (MARKETPLACE_JSON, COPILOT_MARKETPLACE_JSON):
+        result = validate(
+            fix=fix,
+            counters_path=counters_path,
+            marketplace_path=marketplace,
+            repo_root=repo_root,
+        )
+        results.append(result)
+    if any(result == 2 for result in results):
+        return 2
+    if any(result == 1 for result in results):
+        return 1
+    return 0
 
 
 def main() -> None:
@@ -316,8 +383,17 @@ def main() -> None:
         action="store_true",
         help="Automatically fix stale counts in marketplace.json.",
     )
+    parser.add_argument(
+        "--marketplace",
+        type=Path,
+        help="Validate one specific marketplace.json instead of all native marketplaces.",
+    )
     args = parser.parse_args()
-    sys.exit(validate(fix=args.fix))
+
+    if args.marketplace is not None:
+        sys.exit(validate(fix=args.fix, marketplace_path=args.marketplace.resolve()))
+
+    sys.exit(validate_known_marketplaces(fix=args.fix))
 
 
 if __name__ == "__main__":

--- a/build/scripts/validate_marketplace_counts.py
+++ b/build/scripts/validate_marketplace_counts.py
@@ -44,7 +44,7 @@ _EXCLUDED_DIRS = frozenset({"node_modules", ".git", "worktrees", "cache", "__pyc
 def _walk_files(directory: Path, suffix: str, exclude_names: set[str]) -> int:
     """Count files matching suffix, pruning EXCLUDED_DIRS during descent.
 
-    Replaces ``directory.rglob('*.suffix')`` which walks excluded subtrees
+    Replaces ``directory.rglob(f'*{suffix}')`` which walks excluded subtrees
     before discarding matches. ``os.walk`` with in-place ``dirnames`` mutation
     prunes BEFORE descending — safe against vendored bloat and symlink loops.
     """
@@ -357,9 +357,19 @@ def validate_known_marketplaces(
     counters_path: Path = COUNTERS_YAML,
     repo_root: Path = REPO_ROOT,
 ) -> int:
-    """Validate all native marketplace manifests shipped by the repo."""
+    """Validate all native marketplace manifests shipped by the repo.
+
+    Marketplace paths are resolved relative to ``repo_root`` so test
+    callers that override the root validate the marketplaces that live
+    inside that root, not the ones derived from the module-level
+    ``REPO_ROOT``.
+    """
+    marketplaces = (
+        repo_root / ".claude-plugin" / "marketplace.json",
+        repo_root / ".github" / "plugin" / "marketplace.json",
+    )
     results = []
-    for marketplace in (MARKETPLACE_JSON, COPILOT_MARKETPLACE_JSON):
+    for marketplace in marketplaces:
         result = validate(
             fix=fix,
             counters_path=counters_path,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,7 +70,9 @@ Do not edit files in `src/vs-code-agents/` or `src/copilot-cli/` directly. They 
 
 ## Plugin Structure
 
-The project distributes agents through the Claude Code plugin marketplace using `.claude-plugin/marketplace.json`:
+The project distributes agents through two native marketplace manifests, one per CLI runtime. `.claude-plugin/marketplace.json` is read by Claude Code; `.github/plugin/marketplace.json` is read by GitHub Copilot CLI. Each manifest only advertises plugins that load cleanly on its own runtime (issue #1840).
+
+Claude Code marketplace (`.claude-plugin/marketplace.json`):
 
 ```json
 {
@@ -78,24 +80,34 @@ The project distributes agents through the Claude Code plugin marketplace using 
   "plugins": [
     {
       "name": "claude-agents",
-      "description": "26 specialized agent definitions...",
+      "description": "Specialized agent definitions for Claude Code",
       "source": "./src/claude"
     },
     {
-      "name": "copilot-cli-agents",
-      "description": "Agent definitions for GitHub Copilot CLI",
-      "source": "./src/copilot-cli"
-    },
-    {
       "name": "project-toolkit",
-      "description": "Complete project development toolkit...",
+      "description": "Complete project development toolkit for Claude Code",
       "source": "./.claude"
     }
   ]
 }
 ```
 
-Users install plugins with `/install-plugin rjmurillo/ai-agents` or selectively with `/plugin install <plugin-name>@ai-agents`.
+Copilot CLI marketplace (`.github/plugin/marketplace.json`):
+
+```json
+{
+  "name": "ai-agents",
+  "plugins": [
+    {
+      "name": "project-toolkit",
+      "description": "Agents, hooks, and skills for GitHub Copilot CLI",
+      "source": "./src/copilot-cli"
+    }
+  ]
+}
+```
+
+Users install plugins with `/plugin install <plugin-name>@ai-agents` after registering the marketplace with `/plugin marketplace add rjmurillo/ai-agents`.
 
 ## Platform Differences
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This guide walks you through installing and using the AI Agents system in your p
 
 ## Fastest Start
 
-Each AI tool has its own plugin install flow. Pick yours and paste the command(s) inside the CLI session.
+Each AI tool has its own native marketplace flow. This repo ships a Claude Code marketplace at `.claude-plugin/marketplace.json` and a Copilot CLI marketplace at `.github/plugin/marketplace.json`, so the same repository URL works in both CLIs. Pick yours and paste the command(s) inside the CLI session.
 
 **Claude Code.** Use the one-step shortcut to register the marketplace and install the full Claude toolkit; restart Claude Code when it finishes.
 
@@ -16,7 +16,7 @@ Each AI tool has its own plugin install flow. Pick yours and paste the command(s
 
 ```text
 /plugin marketplace add rjmurillo/ai-agents
-/plugin install copilot-cli-toolkit@ai-agents
+/plugin install project-toolkit@ai-agents
 ```
 
 After install, verify agents loaded:
@@ -43,7 +43,7 @@ End users do not need Python or any build tooling to install the plugins. Contri
 
 ## Step 1: Install
 
-The fastest method uses the built-in plugin marketplace. Run the commands below inside your AI coding tool (not a regular terminal).
+The fastest method uses the built-in plugin marketplace. Run the commands below inside your AI coding tool (not a regular terminal). Claude Code reads the Claude marketplace manifest from this repo; Copilot CLI reads the Copilot marketplace manifest.
 
 **Claude Code:**
 
@@ -55,10 +55,10 @@ The fastest method uses the built-in plugin marketplace. Run the commands below 
 
 ```text
 /plugin marketplace add rjmurillo/ai-agents
-/plugin install copilot-cli-toolkit@ai-agents
+/plugin install project-toolkit@ai-agents
 ```
 
-The Copilot CLI flow also works from a regular shell: `copilot plugin marketplace add rjmurillo/ai-agents` then `copilot plugin install copilot-cli-toolkit@ai-agents`.
+The Copilot CLI flow also works from a regular shell: `copilot plugin marketplace add rjmurillo/ai-agents` then `copilot plugin install project-toolkit@ai-agents`.
 
 This installs the full toolkit for your platform. The Claude bundle ships 23 agents, 23 commands, 29 hooks, and 69 skills. The Copilot bundle ships 24 agents, 28 hooks, and 81 skills. For selective installation (agents only, etc.), see [docs/installation.md](installation.md).
 
@@ -136,7 +136,7 @@ Task(subagent_type="analyst", prompt="Hello, are you available?")
 copilot plugin list
 ```
 
-The output should include `copilot-cli-toolkit@ai-agents` (or whichever component you installed). To exercise an agent end-to-end, run `copilot -p "analyst: respond with 'available'"`.
+The output should include `project-toolkit@ai-agents` (or whichever component you installed). To exercise an agent end-to-end, run `copilot -p "analyst: respond with 'available'"`.
 
 **VS Code (Copilot Chat):**
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,116 +1,92 @@
 # Installation Guide
 
-This guide covers installation of the AI Agents system using [skill-installer](https://github.com/rjmurillo/skill-installer), a Python-based TUI tool.
+This guide covers native marketplace installation for the AI Agents system.
 
 ## Prerequisites
 
-- Python 3.10+
-- [UV](https://docs.astral.sh/uv/) package manager
+You need one of these AI coding tools:
 
-### Installing UV
+- Claude Code CLI
+- GitHub Copilot CLI
+- VS Code with GitHub Copilot Chat
+- Visual Studio 2022/2026 with GitHub Copilot Chat
 
-**macOS/Linux:**
+For development work on this repository, see [CONTRIBUTING.md](../CONTRIBUTING.md#prerequisites) for Python, uv, and test setup.
+
+## Fastest Start
+
+Use the built-in marketplace support in the CLI you are actually running.
+
+### Claude Code
+
+Run this inside Claude Code:
+
+```text
+/install-plugin rjmurillo/ai-agents
+```
+
+That installs the full Claude toolkit from `.claude-plugin/marketplace.json`.
+
+### GitHub Copilot CLI
+
+Run this inside Copilot CLI:
+
+```text
+/plugin marketplace add rjmurillo/ai-agents
+/plugin install project-toolkit@ai-agents
+```
+
+The same flow also works from a regular shell with the `copilot` prefix:
 
 ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
+copilot plugin marketplace add rjmurillo/ai-agents
+copilot plugin install project-toolkit@ai-agents
 ```
 
-**Windows (PowerShell):**
+Copilot CLI resolves this repository through `.github/plugin/marketplace.json`.
 
-```powershell
-powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+### VS Code and Visual Studio
+
+Repository-level agents work automatically when the repository contains `.github/agents/` and `.github/copilot-instructions.md`.
+
+Usage examples in Copilot Chat:
+
+```text
+@orchestrator Help me implement a feature
+@analyst Review this code for issues
 ```
 
-## Quick Start (Try Without Installing)
+## Component-Level Installation
 
-Run skill-installer directly without installing it:
+If you want a partial install instead of the full toolkit, use the marketplace commands below.
 
-```bash
-# Latest version
-uvx --from git+https://github.com/rjmurillo/skill-installer skill-installer interactive
+### Claude Code
 
-# Specific version (e.g., v0.2.0)
-uvx --from git+https://github.com/rjmurillo/skill-installer@v0.2.0 skill-installer interactive
+Register the marketplace once if you want explicit component installs instead of `/install-plugin`:
 
-# Older version (e.g., v0.1.0)
-uvx --from git+https://github.com/rjmurillo/skill-installer@v0.1.0 skill-installer interactive
+```text
+/plugin marketplace add rjmurillo/ai-agents
 ```
 
-This launches the TUI where you can browse and install agents.
+| Component | Install Command | What You Get |
+|-----------|----------------|--------------|
+| Claude agents only | `/plugin install claude-agents@ai-agents` | 24 agent definitions from `src/claude/` |
+| Project toolkit | `/plugin install project-toolkit@ai-agents` | 23 agents, 23 slash commands, 29 hooks, and 69 reusable skills from `.claude/` |
 
-## Global Installation
+### GitHub Copilot CLI
 
-Install skill-installer as a tool for repeated use:
+Register the marketplace once:
 
-```bash
-# Latest version (main branch)
-uv tool install git+https://github.com/rjmurillo/skill-installer
-
-# Specific version (e.g., v0.2.0)
-uv tool install git+https://github.com/rjmurillo/skill-installer@v0.2.0
-
-# Older version (e.g., v0.1.0)
-uv tool install git+https://github.com/rjmurillo/skill-installer@v0.1.0
+```text
+/plugin marketplace add rjmurillo/ai-agents
 ```
 
-**Note:** Installing a specific version provides stability and reproducibility. Use latest for bleeding-edge features.
-
-## Adding This Repository as a Source
-
-Add ai-agents as a source for discovering agents:
-
-```bash
-skill-installer source add rjmurillo/ai-agents
-```
-
-## Using the TUI
-
-Launch the interactive interface:
-
-```bash
-skill-installer interactive
-```
-
-**Navigation:**
-
-1. Navigate to the **Discover** tab
-2. Browse available plugins (claude-agents, copilot-cli-agents, vscode-agents)
-3. Select platform(s) to install
-4. Press `i` to install
-
-## CLI Installation (Non-Interactive)
-
-Install specific items without the TUI:
-
-```bash
-# Install Claude agents
-skill-installer install claude-agents --platform claude
-
-# Install Copilot CLI agents
-skill-installer install copilot-cli-agents --platform copilot
-
-# Install VS Code agents
-skill-installer install vscode-agents --platform vscode
-
-# Install Visual Studio agents (repository-level)
-skill-installer install vscode-agents --platform visual-studio
-```
+| Component | Install Command | What You Get |
+|-----------|----------------|--------------|
+| Copilot CLI agents only | `/plugin install copilot-cli-agents@ai-agents` | 24 agent definitions from `src/copilot-cli/` |
+| Copilot full toolkit | `/plugin install project-toolkit@ai-agents` | 24 agents, 28 hooks, 81 skills from `src/copilot-cli/` |
 
 ## Installation Paths
-
-### Global Installation Paths
-
-| Platform | Agents | Skills |
-|----------|--------|--------|
-| Claude Code | `~/.claude/agents/` | `~/.claude/skills/` |
-| Copilot CLI | `~/.copilot/agents/` | N/A |
-| VS Code | `~/.copilot/agents/` | N/A |
-| Visual Studio 2022/2026 | TBD, see note below | N/A |
-
-> **Note (Visual Studio user-level path):** The user-level (global) agent storage path for
-> Visual Studio 2022/2026 is not yet documented by Microsoft. Repository-level installation
-> (`.github/agents/`) works today. User-level support will be added once the path is confirmed.
-> Track progress in [issue #51](https://github.com/rjmurillo/ai-agents/issues/51).
 
 ### Repository Installation Paths
 
@@ -123,45 +99,21 @@ skill-installer install vscode-agents --platform visual-studio
 
 ### Visual Studio 2022/2026 Notes
 
-Visual Studio 2022 (version 17.14+) and Visual Studio 2026 support GitHub Copilot agent mode
-using the same `.github/agents/*.agent.md` format as VS Code. Repository-level agents work
-automatically when you open a solution in a repository containing `.github/agents/`.
+Visual Studio 2022 (version 17.14+) and Visual Studio 2026 support GitHub Copilot agent mode using the same `.github/agents/*.agent.md` format as VS Code. Repository-level agents work automatically when you open a solution in a repository containing `.github/agents/`.
 
-**Requirements:**
+Requirements:
 
 - Visual Studio 2022 version 17.14 or later, or Visual Studio 2026
 - GitHub Copilot subscription
-- "Enable project specific .NET instructions" feature enabled (on by default in VS 2026)
+- "Enable project specific .NET instructions" feature enabled
 
-**Usage in Copilot Chat:**
+## Skills
 
-```text
-@orchestrator Help me implement a feature
-@analyst Review this code for issues
-```
+Claude skills ship as part of `project-toolkit`.
 
-## Skills Installation
+Skills live in `.claude/skills/` in the repository and install into Claude's runtime layout with the rest of the Claude toolkit. The `SKILL.md` file requires YAML frontmatter with `name` and `description` fields.
 
-Skills are reusable prompt modules that extend agent capabilities. They install as part of the `project-toolkit` plugin.
-
-### Installing Skills
-
-Skills are included in the `project-toolkit` plugin:
-
-```bash
-# Via CLI marketplace (recommended)
-skill-installer install project-toolkit --platform claude
-
-# Via TUI
-skill-installer interactive
-# Navigate to Discover > project-toolkit > Install
-```
-
-Skills install to `~/.claude/skills/` for global access, or remain in `.claude/skills/` for repository-scoped use.
-
-### Skill Structure
-
-Each skill follows a standard directory layout:
+Skill directory layout:
 
 ```text
 .claude/skills/{skill-name}/
@@ -171,71 +123,73 @@ Each skill follows a standard directory layout:
   modules/       # Optional: PowerShell modules
 ```
 
-The `SKILL.md` file requires YAML frontmatter with `name` and `description` fields.
-
-### Validating Skill Installation
-
-Run the validation script to confirm skills are structured correctly:
+To validate the repository copy of the skills structure:
 
 ```bash
-# Validate repository skills
 python3 scripts/validate_skill_installation.py
-
-# Validate with details per skill
 python3 scripts/validate_skill_installation.py --verbose
-
-# Also check global installation paths
-python3 scripts/validate_skill_installation.py --check-global
 ```
-
-Exit code 0 means all skills pass validation.
-
-### Skills Troubleshooting
-
-**Skills not discovered by Claude Code:**
-
-1. Confirm the skill directory contains a `SKILL.md` file
-2. Verify the frontmatter `name` matches the directory name
-3. Restart Claude Code after installation
-
-**Frontmatter validation errors:**
-
-Run `python3 scripts/validate_skill_installation.py --verbose` to identify which skills have issues.
 
 ## Uninstallation
 
-Remove installed items:
+Use your tool's native uninstall support.
 
-```bash
-skill-installer uninstall claude-agents
+### Claude Code
+
+```text
+/plugin uninstall claude-agents@ai-agents
+/plugin uninstall project-toolkit@ai-agents
+```
+
+### GitHub Copilot CLI
+
+```text
+/plugin uninstall copilot-cli-agents@ai-agents
+/plugin uninstall project-toolkit@ai-agents
 ```
 
 ## Troubleshooting
 
-### UV Not Found
+### Claude Code
 
-Ensure UV is installed and in your PATH:
+- Restart Claude Code after install so the new agents, hooks, commands, and skills load.
+- If `/install-plugin` is not recognized, update Claude Code to a build that supports plugin marketplaces.
 
-```bash
-which uv  # macOS/Linux
-where.exe uv  # Windows
+### GitHub Copilot CLI
+
+- If `/plugin` is not recognized, update Copilot CLI to a recent stable release.
+- If install fails with "No plugin.json found in repository", add the marketplace first with `/plugin marketplace add rjmurillo/ai-agents`.
+- No restart is needed after Copilot installation.
+
+### VS Code / Visual Studio
+
+- Restart the IDE or reload the window if newly added repository agents do not appear.
+- Repository-level agent loading is the supported path described in `.github/copilot-instructions.md`.
+
+### Verify Installation
+
+Claude Code:
+
+```text
+Task(subagent_type="analyst", prompt="Hello, are you available?")
 ```
 
-If not found, install UV using the commands in the Prerequisites section.
+VS Code / Visual Studio:
 
-### Python Version
-
-skill-installer requires Python 3.10+. Check your version:
-
-```bash
-python --version
+```text
+@orchestrator Hello, are you available?
 ```
 
-### Network Issues
+Copilot CLI:
 
-If downloads fail, check internet connectivity and try again. The tool downloads from GitHub.
+```bash
+copilot plugin list
+copilot --agent analyst --prompt "Hello, are you available?"
+```
 
-### Security Scanning (Recommended)
+The Copilot plugin list should include whichever package you installed, such as `project-toolkit@ai-agents`.
+
+### Security Scanning (Recommended for contributors)
 
 For local security scanning before push, install semgrep:
 
@@ -249,99 +203,29 @@ Or install manually:
 pip install semgrep
 ```
 
-Semgrep runs automatically in the pre-push hook and scans Python, PowerShell, JavaScript, and YAML files for security issues. Blocks push on HIGH/CRITICAL findings.
-
-**Benefits:**
-
-- Fast feedback (<1 minute vs 10-30 minutes for CI)
-- Catches OWASP Top 10 vulnerabilities locally
-- Reduces PR review cycles
+Semgrep runs automatically in the pre-push hook and scans Python, PowerShell, JavaScript, and YAML files for security issues. It blocks push on HIGH/CRITICAL findings.
 
 ### Worktrunk Setup (Optional)
 
 For parallel agent workflows using git worktrees, install Worktrunk:
 
-**Homebrew (macOS and Linux):**
+Homebrew:
 
 ```bash
 brew install max-sixty/worktrunk/wt && wt config shell install
 ```
 
-**Cargo:**
+Cargo:
 
 ```bash
 cargo install worktrunk && wt config shell install
 ```
 
-**Shell integration** is required for `wt switch` command.
-
-**Claude Code Plugin:**
+Claude Code plugin:
 
 ```bash
 claude plugin marketplace add max-sixty/worktrunk
 claude plugin install worktrunk@worktrunk
 ```
 
-The repository includes `.config/wt.toml` with lifecycle hooks that:
-
-- Configure git hooks automatically on worktree creation
-- Copy dependencies (node_modules, .cache) from main worktree
-- Run markdown linting before merge
-
-**See**: [Worktrunk Documentation](https://worktrunk.dev/) and `.config/wt.toml` for complete workflow configuration.
-
-## Post-Installation
-
-### Restart Your Editor
-
-After installation, restart your editor/CLI to load new agents:
-
-- **Claude Code**: Restart Claude Code
-- **VS Code**: Restart VS Code or reload window (`Ctrl+Shift+P` -> "Developer: Reload Window")
-- **Visual Studio**: Restart Visual Studio to load new agents
-- **Copilot CLI**: No restart needed
-
-### Verify Installation
-
-**Validate skills:**
-
-```bash
-python3 scripts/validate_skill_installation.py --check-global --verbose
-```
-
-**Claude Code:**
-
-```python
-# In Claude Code, verify agents are available
-Task(subagent_type="analyst", prompt="Hello, are you available?")
-```
-
-**VS Code:**
-
-```text
-# In VS Code chat
-@orchestrator Hello, are you available?
-```
-
-**Visual Studio:**
-
-```text
-# In Visual Studio Copilot Chat
-@orchestrator Hello, are you available?
-```
-
-**Copilot CLI:**
-
-```bash
-# List available agents
-copilot --list-agents
-
-# Test an agent
-copilot --agent analyst --prompt "Hello, are you available?"
-```
-
-## Related Documentation
-
-- [USING-AGENTS.md](../USING-AGENTS.md) - How to use the agent system
-- [CLAUDE.md](../CLAUDE.md) - Claude Code specific instructions
-- [copilot-instructions.md](../copilot-instructions.md) - GitHub Copilot instructions
+The repository includes `.config/wt.toml` with lifecycle hooks that configure git hooks automatically on worktree creation, copy dependencies from the main worktree, and run markdown linting before merge.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,7 +83,6 @@ Register the marketplace once:
 
 | Component | Install Command | What You Get |
 |-----------|----------------|--------------|
-| Copilot CLI agents only | `/plugin install copilot-cli-agents@ai-agents` | 24 agent definitions from `src/copilot-cli/` |
 | Copilot full toolkit | `/plugin install project-toolkit@ai-agents` | 24 agents, 28 hooks, 81 skills from `src/copilot-cli/` |
 
 ## Installation Paths
@@ -144,7 +143,6 @@ Use your tool's native uninstall support.
 ### GitHub Copilot CLI
 
 ```text
-/plugin uninstall copilot-cli-agents@ai-agents
 /plugin uninstall project-toolkit@ai-agents
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -110,7 +110,7 @@ Requirements:
 
 Claude skills ship as part of `project-toolkit`.
 
-Skills live in `.claude/skills/` in the repository and install into Claude's runtime layout with the rest of the Claude toolkit. The `SKILL.md` file requires YAML frontmatter with `name` and `description` fields.
+Skills live in `.claude/skills/` in the repository and install into Claude's runtime layout with the rest of the Claude toolkit. The `SKILL.md` file requires YAML frontmatter with `name`, `version`, and `description` fields, per `.agents/steering/claude-skills.md`.
 
 Skill directory layout:
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -39,6 +39,8 @@ ai-agents/
 │
 ├── .github/                  # GitHub automation + Copilot integration
 │   ├── agents/               # Copilot/VS Code agents used by GitHub tooling
+│   ├── plugin/               # Copilot CLI native marketplace manifest
+│   │   └── marketplace.json  # `/plugin marketplace add rjmurillo/ai-agents`
 │   ├── prompts/              # Prompts used by workflows (quality gates, triage)
 │   └── workflows/            # CI workflows (keep logic in scripts, not YAML)
 │

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -20,7 +20,7 @@ ai-agents/
 ├── LICENSE
 │
 ├── docs/                     # Human documentation (this folder)
-│   ├── installation.md       # How to install agents via skill-installer
+│   ├── installation.md       # Native marketplace and repository install paths
 │   ├── ideation-workflow.md  # "shower thought" → PRD/plan workflow
 │   ├── autonomous-*.md       # Autonomous workflows (PR monitor, issue dev)
 │   └── project-structure.md  # (this file)

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -162,7 +162,7 @@ flowchart TD
     style Scripts fill:#fff3e0
 ```
 
-> **Note**: Agent installation is handled by [skill-installer](https://github.com/rjmurillo/skill-installer).
+> **Note**: Agent installation is handled through each tool's native marketplace support.
 > See [docs/installation.md](../docs/installation.md) for installation instructions.
 
 ## Agent Catalog

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,11 +23,11 @@ See [ADR-019](../.agents/architecture/ADR-019-script-organization.md) for detail
 
 ## Installation
 
-For installing agents to Claude Code, VS Code, or Copilot CLI, use [skill-installer](https://github.com/rjmurillo/skill-installer):
+For installing agents to Claude Code, Copilot CLI, VS Code, or Visual Studio, use each tool's native marketplace or repository-level integration.
 
-```bash
-uvx --from git+https://github.com/rjmurillo/skill-installer skill-installer interactive
-```
+- Claude Code: `/install-plugin rjmurillo/ai-agents`
+- Copilot CLI: `/plugin marketplace add rjmurillo/ai-agents` then `/plugin install project-toolkit@ai-agents`
+- VS Code / Visual Studio: open the repository so `.github/agents/` and `.github/copilot-instructions.md` load automatically
 
 See [docs/installation.md](../docs/installation.md) for complete installation documentation.
 

--- a/scripts/validate_skill_installation.py
+++ b/scripts/validate_skill_installation.py
@@ -147,7 +147,11 @@ def check_global_installation(verbose: bool = False) -> int:
     if not found_any:
         logger.info("")
         logger.info("No global skill installations found.")
-        logger.info("Install with Claude Code's native marketplace flow from docs/installation.md")
+        logger.info(
+            "Install via Claude Code:  "
+            "/plugin marketplace add rjmurillo/ai-agents  "
+            "then  /plugin install project-toolkit@ai-agents"
+        )
         return 0
 
     if all_errors:

--- a/scripts/validate_skill_installation.py
+++ b/scripts/validate_skill_installation.py
@@ -147,7 +147,7 @@ def check_global_installation(verbose: bool = False) -> int:
     if not found_any:
         logger.info("")
         logger.info("No global skill installations found.")
-        logger.info("Install with: skill-installer install project-toolkit --platform claude")
+        logger.info("Install with Claude Code's native marketplace flow from docs/installation.md")
         return 0
 
     if all_errors:

--- a/src/claude/AGENTS.md
+++ b/src/claude/AGENTS.md
@@ -14,7 +14,7 @@ The `src/claude/` directory contains **hand-maintained** agent definitions for C
 src/claude/*.md  ───────────────────────────────────────┐
    (SOURCE - hand-maintained)                           │
                                                         ▼
-                                              skill-installer
+                                   Claude marketplace install
                                                         │
                                                         ▼
                                            .claude/agents/*.md
@@ -34,7 +34,7 @@ src/claude/*.md  ─────────────────────
 1. Copy improvements from `.claude/agents/{agent}.md` to `src/claude/{agent}.md`
 2. Verify ADR enforcement, security gates, and blocking sections are PRESERVED
 3. Commit to `src/claude/` only
-4. Reinstall using skill-installer (see [docs/installation.md](../../docs/installation.md))
+4. Reinstall through Claude Code's native marketplace flow (see [docs/installation.md](../../docs/installation.md))
 
 **Common mistake**: Copying `.claude/agents/` wholesale to `src/claude/` may overwrite blocking gates (like ADR Review Enforcement) if the installed version was modified without including those sections.
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "copilot-cli-toolkit",
+  "name": "project-toolkit",
   "description": "24 agent definitions, 81 reusable skills, 28 lifecycle hooks for GitHub Copilot CLI workflows",
   "version": "0.4.0",
   "author": { "name": "rjmurillo" },

--- a/src/copilot-cli/copilot-instructions.md
+++ b/src/copilot-cli/copilot-instructions.md
@@ -46,7 +46,7 @@ See `.github/agents/` for the full catalog. Each agent file contains its descrip
 
 ### Known Limitations
 
-User-level (global) agent loading has a known issue. Use repository-level installation through each tool's native support instead:
+User-level (global) agent loading has a known issue. Use the supported native install path for each tool instead:
 
-- Copilot CLI: add the marketplace with `/plugin marketplace add rjmurillo/ai-agents`, then install `project-toolkit@ai-agents`
-- VS Code / Visual Studio: open the repository so `.github/agents/` and `.github/copilot-instructions.md` load automatically
+- Copilot CLI: add the marketplace with `/plugin marketplace add rjmurillo/ai-agents`, then run `/plugin install project-toolkit@ai-agents` (a marketplace install, not a repository-level setup)
+- VS Code / Visual Studio: open the repository so `.github/agents/` and `.github/copilot-instructions.md` load automatically (true repository-level loading)

--- a/src/copilot-cli/copilot-instructions.md
+++ b/src/copilot-cli/copilot-instructions.md
@@ -29,16 +29,16 @@ Implement the login form per the plan in .agents/planning/
 
 When handing off between agents:
 
-1. **Announce**: "Completing [task]. Handing off to [agent] for [purpose]"
-2. **Save Artifacts**: Store outputs in appropriate `.agents/` directory
-3. **Route**: Use `/agent [agent_name]`
+1. Announce: "Completing [task]. Handing off to [agent] for [purpose]"
+2. Save artifacts: store outputs in the appropriate `.agents/` directory
+3. Route: use `/agent [agent_name]`
 
 ### Best Practices
 
-1. **Memory First**: Retrieve context before multi-step reasoning
-2. **Clear Handoffs**: Announce next agent and purpose
-3. **Follow Plans**: The plan document is authoritative
-4. **Commit Atomically**: Small, conventional commits
+1. Memory first: retrieve context before multi-step reasoning
+2. Clear handoffs: announce next agent and purpose
+3. Follow plans: the plan document is authoritative
+4. Commit atomically: small, conventional commits
 
 ### Available Agents
 
@@ -46,21 +46,7 @@ See `.github/agents/` for the full catalog. Each agent file contains its descrip
 
 ### Known Limitations
 
-**Note**: User-level (global) agent loading has a known issue. For best results, install agents at the repository level using skill-installer:
+User-level (global) agent loading has a known issue. Use repository-level installation through each tool's native support instead:
 
-```bash
-# One-liner (no install required) - latest version
-uvx --from git+https://github.com/rjmurillo/skill-installer skill-installer interactive
-
-# OR specific version for stability
-uvx --from git+https://github.com/rjmurillo/skill-installer@v0.2.0 skill-installer interactive
-
-# Install globally (latest)
-uv tool install git+https://github.com/rjmurillo/skill-installer
-
-# OR install globally (specific version)
-uv tool install git+https://github.com/rjmurillo/skill-installer@v0.2.0
-
-# Run interactive installer
-skill-installer interactive
-```
+- Copilot CLI: add the marketplace with `/plugin marketplace add rjmurillo/ai-agents`, then install `project-toolkit@ai-agents`
+- VS Code / Visual Studio: open the repository so `.github/agents/` and `.github/copilot-instructions.md` load automatically

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -27,8 +27,8 @@ templates/agents/*.shared.md ─────────┐
 src/claude/*.md ──────────────────────────────────────────────┘
    (HAND-MAINTAINED - separate flow)                          │
                                                               ▼
-                                                      skill-installer
-                                                   (Python TUI tool)
+                                           Claude marketplace install
+                                           (native Claude Code flow)
                                                               │
                                                               ▼
                                                    .claude/agents/*.md

--- a/templates/marketplace-counters.yaml
+++ b/templates/marketplace-counters.yaml
@@ -26,40 +26,28 @@ plugins:
       strategy: "agent_md"
       sourceDir: "src/copilot-cli"
   project-toolkit:
-    agent:
-      strategy: "md_agents"
-      sourceDir: ".claude/agents"
-      exclude: ["AGENTS.md", "CLAUDE.md"]
-    slash command:
-      strategy: "commands"
-      sourceDir: ".claude/commands"
-    lifecycle hook:
-      strategy: "hooks"
-      sourceDir: ".claude/hooks"
-    reusable skill:
-      strategy: "skill_dirs"
-      sourceDir: ".claude/skills"
-  claude-toolkit:
-    agent:
-      strategy: "md_agents"
-      sourceDir: ".claude/agents"
-      exclude: ["AGENTS.md", "CLAUDE.md"]
-    reusable skill:
-      strategy: "skill_dirs"
-      sourceDir: ".claude/skills"
-    slash command:
-      strategy: "commands"
-      sourceDir: ".claude/commands"
-    lifecycle hook:
-      strategy: "hooks"
-      sourceDir: ".claude/hooks"
-  copilot-cli-toolkit:
-    agent:
-      strategy: "agent_md"
-      sourceDir: "src/copilot-cli"
-    reusable skill:
-      strategy: "skill_dirs"
-      sourceDir: "src/copilot-cli/skills"
-    lifecycle hook:
-      strategy: "hooks"
-      sourceDir: "src/copilot-cli/hooks"
+    marketplaces:
+      .claude-plugin/marketplace.json:
+        agent:
+          strategy: "md_agents"
+          sourceDir: ".claude/agents"
+          exclude: ["AGENTS.md", "CLAUDE.md"]
+        slash command:
+          strategy: "commands"
+          sourceDir: ".claude/commands"
+        lifecycle hook:
+          strategy: "hooks"
+          sourceDir: ".claude/hooks"
+        reusable skill:
+          strategy: "skill_dirs"
+          sourceDir: ".claude/skills"
+      .github/plugin/marketplace.json:
+        agent:
+          strategy: "agent_md"
+          sourceDir: "src/copilot-cli"
+        reusable skill:
+          strategy: "skill_dirs"
+          sourceDir: "src/copilot-cli/skills"
+        lifecycle hook:
+          strategy: "hooks"
+          sourceDir: "src/copilot-cli/hooks"

--- a/templates/marketplace-counters.yaml
+++ b/templates/marketplace-counters.yaml
@@ -21,10 +21,6 @@ plugins:
       strategy: "md_agents"
       sourceDir: "src/claude"
       exclude: ["AGENTS.md"]
-  copilot-cli-agents:
-    agent:
-      strategy: "agent_md"
-      sourceDir: "src/copilot-cli"
   project-toolkit:
     marketplaces:
       .claude-plugin/marketplace.json:

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -1,4 +1,4 @@
-"""End-to-end install integration tests for copilot-cli-toolkit (REQ-003-007).
+"""End-to-end install integration tests for project-toolkit in Copilot CLI (REQ-003-007).
 
 Heavy integration tests that simulate installing src/copilot-cli/ as a
 Copilot CLI plugin into a temp directory and verify the resulting
@@ -14,7 +14,7 @@ Verification scope (per task M6-T5):
   3. sample agent file readable
   4. sample skill SKILL.md readable
   5. (conditional) copilot plugin install + copilot plugin list shows
-     copilot-cli-toolkit
+     project-toolkit
 """
 
 from __future__ import annotations
@@ -51,7 +51,7 @@ def installed_plugin(tmp_path: Path) -> Path:
 
     Returns the install root inside tmp_path.
     """
-    install_root = tmp_path / "copilot-cli-toolkit"
+    install_root = tmp_path / "project-toolkit"
     shutil.copytree(COPILOT_PLUGIN_SRC, install_root)
     return install_root
 
@@ -71,12 +71,12 @@ class TestInstalledManifest:
         data = json.loads(manifest.read_text(encoding="utf-8"))
         assert isinstance(data, dict)
 
-    def test_manifest_name_is_copilot_cli_toolkit(
+    def test_manifest_name_is_project_toolkit(
         self, installed_plugin: Path
     ) -> None:
         manifest = installed_plugin / ".claude-plugin" / "plugin.json"
         data = json.loads(manifest.read_text(encoding="utf-8"))
-        assert data.get("name") == "copilot-cli-toolkit"
+        assert data.get("name") == "project-toolkit"
 
     def test_manifest_declares_required_paths(self, installed_plugin: Path) -> None:
         """plugin.json must point at the agents and skills surface."""
@@ -197,7 +197,7 @@ class TestCopilotBinaryInstall:
             timeout=30,
         )
         assert list_result.returncode == 0
-        assert "copilot-cli-toolkit" in list_result.stdout, (
-            f"copilot-cli-toolkit not registered after install:\n"
+        assert "project-toolkit" in list_result.stdout, (
+            f"project-toolkit not registered after install:\n"
             f"{list_result.stdout}"
         )

--- a/tests/test_marketplace_two_plugin.py
+++ b/tests/test_marketplace_two_plugin.py
@@ -35,6 +35,22 @@ def _load_marketplace(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _is_valid_claude_marketplace_shape(plugins: list[dict]) -> bool:
+    """Return True iff `plugins` matches the rule the production manifest
+    must satisfy: the set of plugin names equals ``CLAUDE_PLUGIN_NAMES``
+    and contains no name in ``CLAUDE_REJECTED_PLUGIN_NAMES``.
+
+    Shared by the production-marketplace test and the synthetic-regression
+    test so both exercise the same decision: weakening this helper would
+    fail both tests at once.
+    """
+    names = {p["name"] for p in plugins}
+    return (
+        names == CLAUDE_PLUGIN_NAMES
+        and names.isdisjoint(CLAUDE_REJECTED_PLUGIN_NAMES)
+    )
+
+
 class TestMarketplaceShape:
     """Validate each CLI sees only its native marketplace entries."""
 
@@ -59,7 +75,10 @@ class TestMarketplaceShape:
 
     def test_claude_marketplace_contains_only_claude_plugins(self) -> None:
         data = _load_marketplace(CLAUDE_MARKETPLACE)
-        assert {p["name"] for p in data["plugins"]} == CLAUDE_PLUGIN_NAMES
+        assert _is_valid_claude_marketplace_shape(data["plugins"]), (
+            "Production Claude marketplace must satisfy the shape rule "
+            "shared with the synthetic-regression test"
+        )
 
     def test_copilot_marketplace_contains_only_copilot_plugins(self) -> None:
         data = _load_marketplace(COPILOT_MARKETPLACE)
@@ -68,7 +87,7 @@ class TestMarketplaceShape:
     def test_claude_marketplace_excludes_copilot_only_plugins(self) -> None:
         data = _load_marketplace(CLAUDE_MARKETPLACE)
         names = {p["name"] for p in data["plugins"]}
-        assert "copilot-cli-agents" not in names
+        assert names.isdisjoint(CLAUDE_REJECTED_PLUGIN_NAMES)
 
 
 class TestSourceDirsExist:
@@ -153,18 +172,15 @@ class TestClaudeMarketplaceRejectsCopilotAgentBundle:
     """Guard against reintroducing Copilot-only agent bundles into Claude's marketplace."""
 
     def test_synthetic_claude_marketplace_with_copilot_plugin_is_invalid_shape(self) -> None:
-        synthetic = {
-            "plugins": [
-                {"name": "project-toolkit", "source": "./.claude"},
-                {"name": "copilot-cli-agents", "source": "./src/copilot-cli"},
-            ],
-        }
-        names = {p["name"] for p in synthetic["plugins"]}
-        assert names != CLAUDE_PLUGIN_NAMES, (
-            "Fixture with a Copilot-only plugin must not match the allowed "
-            "Claude plugin set"
-        )
-        assert names & CLAUDE_REJECTED_PLUGIN_NAMES, (
-            "Fixture must overlap the Claude-rejected name set so the "
-            "marketplace honesty rule has something to catch"
+        synthetic_plugins = [
+            {"name": "project-toolkit", "source": "./.claude"},
+            {"name": "copilot-cli-agents", "source": "./src/copilot-cli"},
+        ]
+        # Drives the same helper as the production test: if anyone weakens
+        # _is_valid_claude_marketplace_shape so it accepts copilot-cli-agents,
+        # the production test starts failing AND this test stops failing,
+        # so the regression cannot land silently.
+        assert not _is_valid_claude_marketplace_shape(synthetic_plugins), (
+            "Claude marketplace must reject any shape that contains a "
+            "Copilot-only plugin name"
         )

--- a/tests/test_marketplace_two_plugin.py
+++ b/tests/test_marketplace_two_plugin.py
@@ -19,7 +19,15 @@ CLAUDE_MARKETPLACE = REPO_ROOT / ".claude-plugin" / "marketplace.json"
 COPILOT_MARKETPLACE = REPO_ROOT / ".github" / "plugin" / "marketplace.json"
 
 CLAUDE_PLUGIN_NAMES = {"claude-agents", "project-toolkit"}
-COPILOT_PLUGIN_NAMES = {"copilot-cli-agents", "project-toolkit"}
+COPILOT_PLUGIN_NAMES = {"project-toolkit"}
+
+# Names that previously appeared in Claude's marketplace but advertised
+# Copilot-only bundles. Kept as an explicit denylist so the marketplace-
+# honesty rule (issue #1840) has a named target the test can guard against
+# regression even after both names were dropped from every shipped manifest.
+CLAUDE_REJECTED_PLUGIN_NAMES = frozenset(
+    {"copilot-cli-agents", "copilot-cli-toolkit"}
+)
 
 
 def _load_marketplace(path: Path) -> dict:
@@ -152,4 +160,11 @@ class TestClaudeMarketplaceRejectsCopilotAgentBundle:
             ],
         }
         names = {p["name"] for p in synthetic["plugins"]}
-        assert "copilot-cli-agents" in names
+        assert names != CLAUDE_PLUGIN_NAMES, (
+            "Fixture with a Copilot-only plugin must not match the allowed "
+            "Claude plugin set"
+        )
+        assert names & CLAUDE_REJECTED_PLUGIN_NAMES, (
+            "Fixture must overlap the Claude-rejected name set so the "
+            "marketplace honesty rule has something to catch"
+        )

--- a/tests/test_marketplace_two_plugin.py
+++ b/tests/test_marketplace_two_plugin.py
@@ -1,15 +1,8 @@
-"""Integration tests for the two-plugin marketplace model (REQ-003-003, -012).
+"""Integration tests for the split native marketplace model.
 
-Verifies that the additive marketplace.json entries claude-toolkit and
-copilot-cli-toolkit coexist with the legacy claude-agents,
-copilot-cli-agents, and project-toolkit entries during the backward
-compatibility window (REQ-003-012).
-
-The legacy preservation rule is BLOCKING: removing any of the three
-legacy plugin entries in this PR would violate REQ-003-012 and is
-caught by these tests.
-
-Plugin name uniqueness is also BLOCKING (R10 in plan risk register).
+Claude Code and GitHub Copilot CLI now read separate marketplace manifests
+from the same repository. Both CLIs share `project-toolkit` as the full-install
+plugin name, while keeping platform-specific agent-only bundles.
 """
 
 from __future__ import annotations
@@ -22,72 +15,62 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-MARKETPLACE = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+CLAUDE_MARKETPLACE = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+COPILOT_MARKETPLACE = REPO_ROOT / ".github" / "plugin" / "marketplace.json"
 
-LEGACY_PLUGIN_NAMES = {"claude-agents", "copilot-cli-agents", "project-toolkit"}
-NEW_PLUGIN_NAMES = {"claude-toolkit", "copilot-cli-toolkit"}
-EXPECTED_MIN_PLUGINS = 5  # 3 legacy + 2 new
-
-
-def _load_marketplace() -> dict:
-    """Read and parse the marketplace.json file."""
-    return json.loads(MARKETPLACE.read_text(encoding="utf-8"))
+CLAUDE_PLUGIN_NAMES = {"claude-agents", "project-toolkit"}
+COPILOT_PLUGIN_NAMES = {"copilot-cli-agents", "project-toolkit"}
 
 
-# ---- Positive tests ------------------------------------------------------
+def _load_marketplace(path: Path) -> dict:
+    """Read and parse a marketplace.json file."""
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 class TestMarketplaceShape:
-    """Validate the additive two-plugin model is in place."""
+    """Validate each CLI sees only its native marketplace entries."""
 
-    def test_marketplace_file_exists(self) -> None:
-        assert MARKETPLACE.exists(), f"{MARKETPLACE} must exist"
+    @pytest.mark.parametrize("path", [CLAUDE_MARKETPLACE, COPILOT_MARKETPLACE])
+    def test_marketplace_file_exists(self, path: Path) -> None:
+        assert path.exists(), f"{path} must exist"
 
-    def test_marketplace_parses_as_json(self) -> None:
-        data = _load_marketplace()
+    @pytest.mark.parametrize("path", [CLAUDE_MARKETPLACE, COPILOT_MARKETPLACE])
+    def test_marketplace_parses_as_json(self, path: Path) -> None:
+        data = _load_marketplace(path)
         assert isinstance(data, dict)
         assert "plugins" in data
         assert isinstance(data["plugins"], list)
 
-    def test_minimum_plugin_count(self) -> None:
-        """REQ-003-012 + REQ-003-003: at least 5 plugins (3 legacy + 2 new)."""
-        data = _load_marketplace()
-        assert len(data["plugins"]) >= EXPECTED_MIN_PLUGINS, (
-            f"Expected at least {EXPECTED_MIN_PLUGINS} plugins, "
-            f"got {len(data['plugins'])}"
-        )
-
-    def test_all_plugin_names_unique(self) -> None:
-        """R10: name collision would break plugin discovery."""
-        data = _load_marketplace()
+    @pytest.mark.parametrize("path", [CLAUDE_MARKETPLACE, COPILOT_MARKETPLACE])
+    def test_all_plugin_names_unique(self, path: Path) -> None:
+        data = _load_marketplace(path)
         names = [p["name"] for p in data["plugins"]]
         assert len(names) == len(set(names)), (
-            f"Duplicate plugin names detected: {names}"
+            f"Duplicate plugin names detected in {path}: {names}"
         )
 
-    def test_claude_toolkit_present(self) -> None:
-        """REQ-003-003: claude-toolkit entry shall exist with source ./.claude."""
-        data = _load_marketplace()
-        match = [p for p in data["plugins"] if p["name"] == "claude-toolkit"]
-        assert len(match) == 1, "claude-toolkit must be declared exactly once"
-        assert match[0]["source"] == "./.claude"
+    def test_claude_marketplace_contains_only_claude_plugins(self) -> None:
+        data = _load_marketplace(CLAUDE_MARKETPLACE)
+        assert {p["name"] for p in data["plugins"]} == CLAUDE_PLUGIN_NAMES
 
-    def test_copilot_cli_toolkit_present(self) -> None:
-        """REQ-003-003: copilot-cli-toolkit shall exist with source ./src/copilot-cli."""
-        data = _load_marketplace()
-        match = [p for p in data["plugins"] if p["name"] == "copilot-cli-toolkit"]
-        assert len(match) == 1, "copilot-cli-toolkit must be declared exactly once"
-        assert match[0]["source"] == "./src/copilot-cli"
+    def test_copilot_marketplace_contains_only_copilot_plugins(self) -> None:
+        data = _load_marketplace(COPILOT_MARKETPLACE)
+        assert {p["name"] for p in data["plugins"]} == COPILOT_PLUGIN_NAMES
+
+    def test_claude_marketplace_excludes_copilot_only_plugins(self) -> None:
+        data = _load_marketplace(CLAUDE_MARKETPLACE)
+        names = {p["name"] for p in data["plugins"]}
+        assert "copilot-cli-agents" not in names
 
 
 class TestSourceDirsExist:
     """Each plugin's `source` path must resolve to an existing directory."""
 
-    def test_all_source_dirs_exist(self) -> None:
-        data = _load_marketplace()
+    @pytest.mark.parametrize("path", [CLAUDE_MARKETPLACE, COPILOT_MARKETPLACE])
+    def test_all_source_dirs_exist(self, path: Path) -> None:
+        data = _load_marketplace(path)
         for plugin in data["plugins"]:
             source = plugin["source"]
-            # `source` is "./<rel-path>" relative to repo root.
             assert source.startswith("./"), (
                 f"plugin {plugin['name']!r}: source must start with './' "
                 f"(got {source!r})"
@@ -103,13 +86,16 @@ class TestSourceDirsExist:
 
 
 class TestCounterValidatorGreen:
-    """REQ-003-003 verification: validator exits 0 on the current marketplace."""
+    """Count and manifest validators stay green for both native marketplaces."""
 
-    def test_validate_marketplace_counts_exits_zero(self) -> None:
+    @pytest.mark.parametrize("marketplace", [CLAUDE_MARKETPLACE, COPILOT_MARKETPLACE])
+    def test_validate_marketplace_counts_exits_zero(self, marketplace: Path) -> None:
         result = subprocess.run(
             [
                 sys.executable,
                 str(REPO_ROOT / "build" / "scripts" / "validate_marketplace_counts.py"),
+                "--marketplace",
+                str(marketplace),
             ],
             capture_output=True,
             text=True,
@@ -138,34 +124,15 @@ class TestCounterValidatorGreen:
         )
 
 
-# ---- Negative / preservation tests ---------------------------------------
-
-
-class TestLegacyPreservation:
-    """REQ-003-012: legacy entries must NOT be removed in the introducing PR."""
-
-    @pytest.mark.parametrize("legacy_name", sorted(LEGACY_PLUGIN_NAMES))
-    def test_legacy_plugin_present(self, legacy_name: str) -> None:
-        """Each legacy plugin shall remain in marketplace.json."""
-        data = _load_marketplace()
-        names = {p["name"] for p in data["plugins"]}
-        assert legacy_name in names, (
-            f"REQ-003-012 violation: legacy plugin {legacy_name!r} "
-            f"removed from marketplace.json. Legacy entries must persist "
-            f"for one release cycle."
-        )
-
-
 class TestUniquenessAssertionDetectsCollision:
     """Verify the uniqueness check actually catches duplicates (test the test)."""
 
     def test_duplicate_name_detected_in_synthetic_fixture(self) -> None:
-        """Synthetic fixture with duplicate plugin names fails the uniqueness check."""
         synthetic = {
             "name": "ai-agents",
             "plugins": [
-                {"name": "claude-toolkit", "source": "./.claude"},
-                {"name": "claude-toolkit", "source": "./other"},  # collision
+                {"name": "project-toolkit", "source": "./.claude"},
+                {"name": "project-toolkit", "source": "./other"},
             ],
         }
         names = [p["name"] for p in synthetic["plugins"]]
@@ -174,23 +141,15 @@ class TestUniquenessAssertionDetectsCollision:
         )
 
 
-class TestLegacyDeletionDetected:
-    """Verify the preservation tests catch deletion of a legacy entry."""
+class TestClaudeMarketplaceRejectsCopilotAgentBundle:
+    """Guard against reintroducing Copilot-only agent bundles into Claude's marketplace."""
 
-    def test_synthetic_marketplace_missing_legacy_fails(self) -> None:
-        """A marketplace without claude-agents fails the legacy preservation check."""
+    def test_synthetic_claude_marketplace_with_copilot_plugin_is_invalid_shape(self) -> None:
         synthetic = {
             "plugins": [
-                {"name": "claude-toolkit", "source": "./.claude"},
-                {"name": "copilot-cli-toolkit", "source": "./src/copilot-cli"},
-                # claude-agents intentionally removed
-                # copilot-cli-agents intentionally removed
-                # project-toolkit intentionally removed
+                {"name": "project-toolkit", "source": "./.claude"},
+                {"name": "copilot-cli-agents", "source": "./src/copilot-cli"},
             ],
         }
         names = {p["name"] for p in synthetic["plugins"]}
-        # Each legacy must be missing from this fixture.
-        for legacy in LEGACY_PLUGIN_NAMES:
-            assert legacy not in names, (
-                f"Test fixture must omit {legacy!r} to verify the assertion fires"
-            )
+        assert "copilot-cli-agents" in names

--- a/tests/test_validate_marketplace_counts.py
+++ b/tests/test_validate_marketplace_counts.py
@@ -76,6 +76,16 @@ class TestValidateIntegration:
         """Default CLI mode validates every shipped marketplace."""
         assert validate_known_marketplaces(fix=False) == 0
 
+    def test_known_marketplaces_resolve_paths_relative_to_repo_root(
+        self, tmp_path: Path
+    ) -> None:
+        """`repo_root` override must steer the resolver away from the
+        module-level marketplace constants. With an empty fake repo, the
+        function must report a config error (exit 2) instead of silently
+        validating the production manifests under the real REPO_ROOT.
+        """
+        assert validate_known_marketplaces(fix=False, repo_root=tmp_path) == 2
+
 
 class TestValidateWithFixtures:
     """Test validation logic with temporary marketplace.json files."""

--- a/tests/test_validate_marketplace_counts.py
+++ b/tests/test_validate_marketplace_counts.py
@@ -17,8 +17,10 @@ _BUILD_SCRIPTS = Path(__file__).resolve().parent.parent / "build" / "scripts"
 sys.path.insert(0, str(_BUILD_SCRIPTS))
 
 from validate_marketplace_counts import (  # noqa: E402
+    COPILOT_MARKETPLACE_JSON,
     parse_counts_from_description,
     validate,
+    validate_known_marketplaces,
 )
 
 
@@ -63,8 +65,16 @@ class TestValidateIntegration:
     """Integration test against the real repo structure."""
 
     def test_current_counts_are_valid(self) -> None:
-        """After --fix, the marketplace.json should pass validation."""
+        """Claude marketplace should pass validation."""
         assert validate(fix=False) == 0
+
+    def test_copilot_marketplace_counts_are_valid(self) -> None:
+        """Copilot marketplace should pass validation."""
+        assert validate(fix=False, marketplace_path=COPILOT_MARKETPLACE_JSON) == 0
+
+    def test_all_known_marketplaces_are_valid(self) -> None:
+        """Default CLI mode validates every shipped marketplace."""
+        assert validate_known_marketplaces(fix=False) == 0
 
 
 class TestValidateWithFixtures:
@@ -148,15 +158,12 @@ class TestZeroEditExtensibility:
     def test_new_plugin_validates_without_python_changes(
         self, tmp_path: Path
     ) -> None:
-        # Fake source tree: 4 .md agents under <repo>/fake-plugin-src.
         src = tmp_path / "fake-plugin-src"
         src.mkdir()
         for name in ["one.md", "two.md", "three.md", "four.md"]:
             (src / name).write_text("agent body\n")
-        # README.md should be excluded so we still count 4.
         (src / "README.md").write_text("docs\n")
 
-        # New plugin counter config (uses existing md_agents strategy).
         counters_yaml = tmp_path / "marketplace-counters.yaml"
         counters_yaml.write_text(
             'schemaVersion: "1.0"\n'
@@ -168,7 +175,6 @@ class TestZeroEditExtensibility:
             '      exclude: ["README.md"]\n'
         )
 
-        # Marketplace.json with description containing the count token.
         marketplace = tmp_path / "marketplace.json"
         marketplace.write_text(
             json.dumps(
@@ -184,7 +190,6 @@ class TestZeroEditExtensibility:
             )
         )
 
-        # Validate: returns 0 with no Python edits required.
         assert (
             validate(
                 fix=False,
@@ -263,8 +268,7 @@ class TestP1Fixes:
     def test_missing_source_dir_yields_config_error_not_traceback(
         self, tmp_path: Path
     ) -> None:
-        """Gate-1 F-001: misconfigured sourceDir → exit 2 (ConfigError),
-        NOT a Python traceback. Hardened in _build_counter."""
+        """Gate-1 F-001: misconfigured sourceDir → exit 2 (ConfigError)."""
         counters_yaml = tmp_path / "marketplace-counters.yaml"
         counters_yaml.write_text(
             'schemaVersion: "1.0"\n'
@@ -276,7 +280,6 @@ class TestP1Fixes:
         )
         marketplace = tmp_path / "marketplace.json"
         marketplace.write_text(json.dumps({"plugins": []}))
-        # Exit 2 is config error per ADR-035 contract.
         assert (
             validate(
                 fix=False,
@@ -288,23 +291,17 @@ class TestP1Fixes:
         )
 
     def test_walk_files_prunes_excluded_dirs(self, tmp_path: Path) -> None:
-        """Gate-2 finding: rglob without pruning walks node_modules etc.
-
-        Counter must skip excluded dirs to prevent CI hang on vendored bloat.
-        """
+        """Counters must skip excluded dirs to prevent CI hangs."""
         from validate_marketplace_counts import _walk_files
 
         src = tmp_path / "src"
         src.mkdir()
         (src / "real.py").write_text("# real\n")
-        # Vendored subtree that MUST be pruned
         node_modules = src / "node_modules" / "deep" / "more"
         node_modules.mkdir(parents=True)
         (node_modules / "vendored.py").write_text("# vendored\n")
-        # .git dir also pruned
         git_dir = src / ".git" / "objects"
         git_dir.mkdir(parents=True)
         (git_dir / "should-skip.py").write_text("# skip\n")
 
-        # Only real.py counted; node_modules + .git pruned during walk.
         assert _walk_files(src, ".py", set()) == 1


### PR DESCRIPTION
# Pull Request

## Summary

Fixes issue #1840 by splitting native marketplace installation paths by CLI. Claude Code now only advertises Claude-compatible plugins from `.claude-plugin/marketplace.json`, while GitHub Copilot CLI uses a dedicated `.github/plugin/marketplace.json` with a single `project-toolkit` plugin (the only identity declared in `src/copilot-cli/.claude-plugin/plugin.json`). The marketplace count validator, focused tests, and install docs were updated to reflect the split-manifest, project-toolkit-only Copilot model.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #1840 | Claude marketplace should not advertise Copilot-only plugins |

## Changes

- Removed `copilot-cli-agents` and `copilot-cli-toolkit` from Claude's marketplace manifest
- Added `.github/plugin/marketplace.json` for GitHub Copilot CLI native marketplace installs
- Dropped `copilot-cli-agents` from Copilot marketplace (same `plugin.json` identity conflict that #1840 fixed on the Claude side)
- Updated `build/scripts/validate_marketplace_counts.py`: fixed `validate_known_marketplaces` to resolve marketplace paths from the supplied `repo_root` instead of module-level constants; corrected `_walk_files` docstring
- Updated `templates/marketplace-counters.yaml` to remove the orphaned `copilot-cli-agents` counter stanza
- Updated focused tests: extracted `_is_valid_claude_marketplace_shape` shared helper for both production and synthetic-regression tests; added `CLAUDE_REJECTED_PLUGIN_NAMES` denylist; added `test_known_marketplaces_resolve_paths_relative_to_repo_root` regression test
- Updated `README.md`, `docs/installation.md`, `docs/architecture.md`, and `docs/project-structure.md` to describe native marketplace flows for Claude Code and Copilot CLI (single `project-toolkit` install for Copilot)
- Replaced remaining repo-facing `skill-installer` references in agent and script guidance with native marketplace wording
- Updated `src/copilot-cli/copilot-instructions.md` Known Limitations: corrected misleading "repository-level installation" lead-in
- Updated `docs/installation.md` to list `version` as a required SKILL.md frontmatter field, citing the canonical skill steering document
- Updated `scripts/validate_skill_installation.py` `--check-global` empty-state message to include the actual install command pair
- Updated workflow path filters so marketplace validation runs when the Copilot marketplace manifest changes

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [x] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Testing

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Commands run:

- `python3 -m pytest tests/test_marketplace_two_plugin.py tests/test_validate_marketplace_counts.py tests/test_validate_skill_installation.py -v --tb=short` (46 pass)
- `python3 build/scripts/validate_marketplace_counts.py` (both manifests pass)
- `python3 build/scripts/validate_plugin_manifests.py` (3 manifests valid)

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [ ] No security-critical changes in this PR
- [x] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [x] Security patterns applied (see security folder)

**Files requiring security review:**

- `.github/workflows/validate-marketplace-counts.yml`
- `.claude-plugin/marketplace.json`
- `.github/plugin/marketplace.json`

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [x] QA verified test coverage

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Fixes #1840