### PR TITLE
docs(github): align PR template with code review culture norms

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,29 @@
 # Pull Request
 
+<!--
+Code review norms for this repo: assume competence and goodwill on both sides.
+Authors: provide context, satisfy preconditions, state expectations.
+Reviewers: explain *why*, reply within ~1 business day, prefer "approve with
+suggestions" for minor issues. The "Notes for Reviewers" section near the
+bottom of this template renders the full norms; see also
+`.claude/rules/`.
+-->
+
 ## Summary
 
-<!-- Brief description of changes -->
+<!--
+What changed and *why*. The "why" is the part reviewers cannot get from the diff.
+Keep this section short. Prefer many small PRs over one large one; isolate
+rebases and pure refactors into their own commits or PRs.
+-->
+
+### What
+
+<!-- 1-3 sentences on the change itself -->
+
+### Why
+
+<!-- The motivation: bug, requirement, ADR, incident, or constraint that drove this -->
 
 ## Specification References
 
@@ -19,7 +40,7 @@
 
 | PR Type | Spec Required? | Guidance |
 |---------|----------------|----------|
-| **Feature** (`feat:`, `feat(scope):`) | ✅ Required | Link issue, REQ-*, or spec file in `.agents/planning/` |
+| **Feature** (`feat:`, `feat(scope):`) | Required | Link issue, REQ-*, or spec file in `.agents/planning/` |
 | **Bug fix** (`fix:`, `fix(scope):`) | Optional | Link issue if exists; explain root cause if complex |
 | **Refactor** (`refactor:`, `refactor(scope):`) | Optional | Explain rationale and scope in PR description |
 | **Documentation** (`docs:`) | Not required | N/A |
@@ -50,7 +71,24 @@ For other PRs: Add references when traceability adds value.
 - [ ] Infrastructure/CI change
 - [ ] Refactoring (no functional changes)
 
+## Reviewer Expectations
+
+**Review kind / scrutiny / urgency**: <!-- e.g., "design review, high scrutiny, blocks release" or "rubber stamp, low, no rush" -->
+
+**Focus areas**: <!-- Files, sections, or trade-offs you want reviewers to weigh in on -->
+
+<details>
+<summary>Detailed options (expand if useful)</summary>
+
+**Review kind**: full / design / targeted / rubber stamp
+**Scrutiny**: high (security, data integrity, public API, governance) · standard · low (typo, doc tweak, dep bump)
+**Urgency**: blocks release · soft target · no rush
+
+</details>
+
 ## Testing
+
+Deliverables in this PR:
 
 - [ ] Tests added/updated
 - [ ] Manual testing completed
@@ -83,13 +121,45 @@ For other PRs: Add references when traceability adds value.
 - [ ] Critic validated implementation plan
 - [ ] QA verified test coverage
 
-## Checklist
+## Author Pre-flight
 
-- [ ] Code follows project style guidelines
-- [ ] Self-review completed
-- [ ] Comments added for complex logic
+<!--
+Adapted from "Satisfy preconditions" in the team's code review norms.
+Run these locally before requesting review so reviewers spend their time on
+substance, not on catching what tooling already catches.
+-->
+
+- [ ] Builds locally (or N/A)
+- [ ] Pre-PR validation passed (`python3 scripts/validation/pre_pr.py` or scoped suite)
+- [ ] Lint and formatting clean (scoped to changed files)
+- [ ] Code follows project style guidelines (`.claude/rules/`)
+- [ ] Self-review completed (read the diff as if you did not write it)
+- [ ] Comments added only where the *why* is non-obvious
 - [ ] Documentation updated (if applicable)
 - [ ] No new warnings introduced
+
+## Notes for Reviewers
+
+<details>
+<summary>Review norms (expand)</summary>
+
+- **Assume competence and goodwill.** A "bad" PR usually means one party has information the other does not.
+- **Explain *why*, not just *what*.** "This is wrong because..." beats "this is wrong."
+- **Approve once the change improves overall code health.** Perfect is not the bar.
+- **Target reply within ~1 business day.** If you cannot, leave a comment saying when you can.
+- **Prefer "Approve with suggestions"** for minor issues, especially across timezones.
+- **Authors: address every comment** by adopting, deferring (with a tracking issue), or pushing back with reasoning. Silence is not resolution.
+
+**Comment severity prefixes** (so authors can triage):
+
+| Prefix | Meaning |
+|---|---|
+| `Nit:` | Minor / style; do not block on it |
+| `Optional:` | Worth considering; author may defer |
+| `FYI:` | Future thought; no action needed |
+| *(no prefix)* | Must address before merge |
+
+</details>
 
 ## Related Issues
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Authors: provide context, satisfy preconditions, state expectations.
 Reviewers: explain *why*, reply within ~1 business day, prefer "approve with
 suggestions" for minor issues. The "Notes for Reviewers" section near the
 bottom of this template renders the full norms; see also
-`.claude/rules/`.
+`.gemini/styleguide.md`.
 -->
 
 ## Summary
@@ -130,9 +130,9 @@ substance, not on catching what tooling already catches.
 -->
 
 - [ ] Builds locally (or N/A)
-- [ ] Pre-PR validation passed (`python3 scripts/validation/pre_pr.py` or scoped suite)
+- [ ] Pre-PR validation passed (`python3 scripts/validation/pre_pr.py`; pass `--quick` to skip slow validations or `--skip-tests` for very fast iterations)
 - [ ] Lint and formatting clean (scoped to changed files)
-- [ ] Code follows project style guidelines (`.claude/rules/`)
+- [ ] Code follows project style guidelines (`.gemini/styleguide.md`)
 - [ ] Self-review completed (read the diff as if you did not write it)
 - [ ] Comments added only where the *why* is non-obvious
 - [ ] Documentation updated (if applicable)


### PR DESCRIPTION
## Summary

### What

Restructures `.github/PULL_REQUEST_TEMPLATE.md` to surface the team's code review norms (assume competence and goodwill; explain *why*; ~1 business day reply target; approve-with-suggestions for minor issues) directly inside the template authors and reviewers fill out.

### Why

The prior template captured *what* changed and what type of change it was, but not the social norms that make review fast and respectful. Without those norms surfaced in the template, reviewers default to terse comments and authors default to terse summaries, which stretch reviews across timezones and produce review-thread churn. Putting the norms next to the inputs makes them load-bearing instead of aspirational.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Closes #1862 | docs(github): align PR template with code review culture norms |

## Changes

- Split Summary into `What` and `Why` subsections so motivation is requested alongside description.
- Add `Reviewer Expectations` section: a compact one-liner for review kind / scrutiny / urgency, plus `Focus areas`, with the verbose option menu in a collapsed `<details>` block.
- Add `Author Pre-flight` section (build, pre-PR validation, lint, styleguide, self-review, comments, docs, warnings) distinct from the existing `Testing` deliverables checklist.
- Add a rendered (non-comment) `Notes for Reviewers` `<details>` block with norms and the `Nit:`/`Optional:`/`FYI:` comment severity prefixes, so reviewers see guidance on the rendered PR — not only in the editor.
- Drop the green-check emoji from the Spec Requirement Guidelines table for consistency with sibling rows.
- Reference `.claude/rules/` (in-repo) as the source of code-quality norms; replaces a prior reference to an external wiki path that is not available in this repository.

## Type of Change

- [x] Documentation update

## Reviewer Expectations

**Review kind / scrutiny / urgency**: rubber stamp / low / no rush — pure docs change to a single template file.

**Focus areas**: whether the wording of the new `Reviewer Expectations` and `Notes for Reviewers` sections feels right for this team, and whether the collapsed `<details>` blocks render the way you want them to in PR descriptions.

## Testing

- [x] No testing required (documentation only)

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [x] Reviewed via `/review` (3 passes; all findings addressed before commit)

## Author Pre-flight

- [x] Builds locally (or N/A) — N/A, markdown only
- [x] Pre-PR validation passed — N/A for template-only docs change
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines (`.claude/rules/`)
- [x] Self-review completed
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (the template *is* the documentation)
- [x] No new warnings introduced

## Related Issues

Closes #1862.

Generated with [Claude Code](https://claude.com/claude-code)
