### PR TITLE
chore(repo): ignore PR-skip audit logs and scheduled-task lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ testResults.xml
 # Transient eval artifacts (ADR-057): re-runnable, not source of truth
 .agents/audit/eval-*/
 
+# Transient PR-creation validation-skip audit logs: one record per
+# `new_pr.py --skip-validation` invocation; reproducible from git
+# history + hook output, not source of truth.
+.agents/audit/pr-creation-skip-*.txt
+
 # Runtime caches
 .cache/
 
@@ -44,6 +49,9 @@ ENV/
 # Hook runtime logs and caches
 .claude/hooks/audit.log
 .claude/hooks/Stop/.skill_pattern_cache.json
+
+# Scheduled-task runtime lock (held while ScheduleWakeup-managed loops run)
+.claude/scheduled_tasks.lock
 
 # IDE settings
 .idea/


### PR DESCRIPTION
## Summary

Adds two `.gitignore` patterns for session-local artifacts that accumulate as untracked noise across Claude Code sessions:

```gitignore
# Transient PR-creation validation-skip audit logs: one record per
# `new_pr.py --skip-validation` invocation; reproducible from git
# history + hook output, not source of truth.
.agents/audit/pr-creation-skip-*.txt

# Scheduled-task runtime lock (held while ScheduleWakeup-managed loops run)
.claude/scheduled_tasks.lock
```

## Why

In a single recent session, `git status` showed 11 untracked files:

- 10× `.agents/audit/pr-creation-skip-YYYYMMDD-HHMMSS.txt` — one per `new_pr.py --skip-validation` invocation. These accumulate because the project's `detect_skill_violation.py` validator hangs at 30s on this repo, so almost every spec/doc-only PR creation requires the bypass with audit reason.
- 1× `.claude/scheduled_tasks.lock` — runtime lock for `ScheduleWakeup`-managed dynamic `/loop` tasks.

Both are transient artifacts; the audit reasons are also recorded inline in the resulting PRs so nothing is lost by ignoring the files.

The existing `.agents/audit/eval-*/` rule (line 12, "Transient eval artifacts") establishes precedent for this pattern: eval audits are ignored because they're re-runnable and not source-of-truth. The PR-skip audits are the same shape.

## Why not bundle with #1873

PR #1873 is the agent-eval-harness spike for issue #1854. That branch did not touch `.claude/skills/` or `.claude/commands/` source directories, so no `src/copilot-cli/skills/` regen was warranted in that scope. The 17 stale working-tree modifications in `src/copilot-cli/skills/` that have been showing across sessions came from `c00a32e5` (#1819's M4 build system, 2026-04-30) — drift that predates this work.

Verified during this PR's branch creation:

```
$ git checkout -- src/copilot-cli/skills/      # discard stale hand-edits
$ uv run python build/scripts/generate_skills.py
Skills processed: 69
Files written: 457
$ git diff --stat main                         # zero diff
```

So the source directories are in sync with the generated copies on main; no separate regen PR is needed. Only the `.gitignore` additions land here.

## Verification

```
$ git check-ignore -v .agents/audit/pr-creation-skip-20260430-092119.txt
.gitignore:17:.agents/audit/pr-creation-skip-*.txt	.agents/audit/pr-creation-skip-20260430-092119.txt

$ git check-ignore -v .claude/scheduled_tasks.lock
.gitignore:54:.claude/scheduled_tasks.lock	.claude/scheduled_tasks.lock
```

Both patterns match.

## Test plan

- [x] `git check-ignore -v` confirms patterns match the offending files
- [x] No source files affected (only `.gitignore` modified)
- [x] `git status` on a clean working tree should show no spurious untracked entries from these locations after the PR merges
- [x] Net diff: +8 lines in `.gitignore`, no other files

## Related

- Background context: PR #1873 documented `detect_skill_violation.py` hangs in audit-reason; that's why these audit files keep appearing.
- Sibling pattern: `.agents/audit/eval-*/` (line 12) — same pattern, different artifact class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
