### PR TITLE
feat(commands): wire skills as /build exit gates (Refs #1887 retro Layer 2)

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -49,7 +49,7 @@ The build is not complete until all three gates below return clean. These are **
 
 Run, in order:
 
-1. Skill(skill="code-qualities-assessment") with `--changed-only` against the changed files. Reject the build if any new or modified method scores below the configured thresholds in `.qualityrc.json`.
+1. Skill(skill="code-qualities-assessment") with `--diff-base main` against the changed files. Reject the build if any new or modified method scores below the configured thresholds in `.qualityrc.json`.
 2. Skill(skill="taste-lints") against the changed files (use `--git-staged` or pass paths explicitly). Reject the build on any error-level violation; address every warning surfaced on lines you touched.
 3. Skill(skill="doc-accuracy") with `--diff-base main` so it audits changed comments, docstrings, and prose. Reject the build on any critical or high finding in code or docs you authored.
 

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -17,6 +17,10 @@ Before implementation, Task(subagent_type="analyst"): Read `.claude/skills/analy
 - Tier 3: Validate approach before coding. Active mentorship pattern (check in at milestones).
 - Tier 4-5: Proof-of-concept first. Get design sign-off before full implementation.
 
+## Pre-Mortem (Risk Identification)
+
+Before any code changes, invoke Skill(skill="pre-mortem") on the task as briefed. Capture the top 2-3 critical risks and their mitigations into the session log. The retrospective on PR #1887 (`.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`) flagged that risks surfaced by reviewers late in the cycle were knowable up front. A 5-minute pre-mortem is cheaper than a 10-round bot review.
+
 ## Agent
 
 Task(subagent_type="implementer"): You are a senior engineer. Discover the project's tech stack, coding patterns, and test conventions by reading the codebase. Build in thin vertical slices. Test-first when the project has tests. Commit atomically.
@@ -32,14 +36,24 @@ For each slice:
 
 ## Quality Signals
 
-After implementation, invoke Skill(skill="code-qualities-assessment") to score the result.
-
 The agent should self-check:
 
 - Is this hard to test? That indicates a design problem, not a test problem.
 - Does every method read like a sentence? (Programming by Intention)
 - Is coupling intentional or accidental?
 - Would a stranger understand this code without asking questions?
+
+## Mandatory Exit Gates
+
+The build is not complete until all three gates below return clean. These are **hard preconditions for declaring done**, not advisory output. If any gate returns findings, the implementer must address them in the same `/build` cycle. Do not kick the can to PR review; that is exactly the iteration cost the retrospective on PR #1887 (`.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`) names as the failure mode this gate fixes.
+
+Run, in order:
+
+1. Skill(skill="code-qualities-assessment") with `--changed-only` against the changed files. Reject the build if any new or modified method scores below the configured thresholds in `.qualityrc.json`.
+2. Skill(skill="taste-lints") against the changed files (use `--git-staged` or pass paths explicitly). Reject the build on any error-level violation; address every warning surfaced on lines you touched.
+3. Skill(skill="doc-accuracy") with `--diff-base main` so it audits changed comments, docstrings, and prose. Reject the build on any critical or high finding in code or docs you authored.
+
+If a gate flags an item that is genuinely out of scope for this build, document the rationale in the session log and link to the follow-up issue. "I will fix it in review" is not an acceptable rationale.
 
 ## Guardrails
 

--- a/.claude/skills/code-qualities-assessment/SKILL.md
+++ b/.claude/skills/code-qualities-assessment/SKILL.md
@@ -109,7 +109,8 @@ python3 scripts/assess.py --target <path> [options]
 |-----------|----------|---------|-------------|
 | `--target` | Yes | - | File, directory, or glob pattern |
 | `--context` | No | production | production, test, or generated |
-| `--changed-only` | No | false | Only assess changed files (git diff) |
+| `--changed-only` | No | false | Only assess changed files (git diff HEAD) |
+| `--diff-base` | No | - | Assess files changed since specified base ref (e.g., 'main') |
 | `--format` | No | markdown | markdown, json, or html |
 | `--config` | No | .qualityrc.json | Path to config file |
 | `--output` | No | stdout | Output file path |

--- a/.claude/skills/code-qualities-assessment/SKILL.md
+++ b/.claude/skills/code-qualities-assessment/SKILL.md
@@ -135,7 +135,7 @@ Create `.qualityrc.json` to customize thresholds:
 {
   "thresholds": {
     "cohesion": { "min": 7, "warn": 5 },
-    "coupling": { "max": 3, "warn": 5 },
+    "coupling": { "min": 7, "warn": 5 },
     "encapsulation": { "min": 7, "warn": 5 },
     "testability": { "min": 6, "warn": 4 },
     "nonRedundancy": { "min": 8, "warn": 6 }

--- a/.claude/skills/code-qualities-assessment/scripts/assess.py
+++ b/.claude/skills/code-qualities-assessment/scripts/assess.py
@@ -72,7 +72,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--changed-only",
         action="store_true",
-        help="Only assess changed files (git diff)"
+        help="Only assess changed files (git diff HEAD)"
+    )
+    parser.add_argument(
+        "--diff-base",
+        help="Assess files changed since specified base ref (e.g., 'main')"
     )
     parser.add_argument(
         "--format",
@@ -121,13 +125,22 @@ def load_config(config_path: str) -> dict:
         }
 
 
-def get_files_to_assess(target: str, changed_only: bool) -> list[Path]:
+def get_files_to_assess(
+    target: str, changed_only: bool, diff_base: str | None
+) -> list[Path]:
     """Get list of files to assess"""
     import subprocess
     from glob import glob
 
-    if changed_only:
-        # Get changed files from git
+    if diff_base:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", diff_base],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        files = [Path(f) for f in result.stdout.strip().split('\n') if f]
+    elif changed_only:
         result = subprocess.run(
             ["git", "diff", "--name-only", "HEAD"],
             capture_output=True,
@@ -146,7 +159,6 @@ def get_files_to_assess(target: str, changed_only: bool) -> list[Path]:
                     list(target_path.rglob("*.cs")) + \
                     list(target_path.rglob("*.java"))
         else:
-            # Glob pattern
             files = [Path(f) for f in glob(target, recursive=True)]
 
     return [f for f in files if f.exists()]
@@ -421,7 +433,7 @@ def main() -> int:
 
     # Get files to assess
     try:
-        files = get_files_to_assess(target_path, args.changed_only)
+        files = get_files_to_assess(target_path, args.changed_only, args.diff_base)
     except Exception as e:
         print(f"Error getting files: {e}", file=sys.stderr)
         return 1

--- a/.claude/skills/code-qualities-assessment/scripts/assess.py
+++ b/.claude/skills/code-qualities-assessment/scripts/assess.py
@@ -352,6 +352,20 @@ def generate_json_report(assessments: list[FileAssessment]) -> str:
     }, indent=2)
 
 
+def _get_threshold(quality_thresholds: dict, key: str = "min") -> float:
+    """Get threshold value with backward compatibility for legacy 'max' key.
+
+    Legacy configs may use 'max' instead of 'min' for coupling thresholds.
+    This helper provides backward compatibility by falling back to 'max'
+    when 'min' is not present.
+    """
+    if key in quality_thresholds:
+        return quality_thresholds[key]
+    if "max" in quality_thresholds:
+        return quality_thresholds["max"]
+    raise KeyError(f"Neither '{key}' nor 'max' found in threshold config")
+
+
 def check_thresholds(assessments: list[FileAssessment], config: dict, context: str) -> int:
     """
     Check if quality scores meet configured thresholds.
@@ -368,42 +382,47 @@ def check_thresholds(assessments: list[FileAssessment], config: dict, context: s
         thresholds = {**thresholds, **context_thresholds}
 
     for assessment in assessments:
-        if assessment.cohesion.value < thresholds["cohesion"]["min"]:
+        cohesion_min = _get_threshold(thresholds["cohesion"], "min")
+        if assessment.cohesion.value < cohesion_min:
             print(
                 f"❌ {assessment.file_path}: Cohesion {assessment.cohesion.value} "
-                f"< {thresholds['cohesion']['min']}",
+                f"< {cohesion_min}",
                 file=sys.stderr
             )
             return 11
 
-        if assessment.coupling.value < thresholds["coupling"]["min"]:
+        coupling_min = _get_threshold(thresholds["coupling"], "min")
+        if assessment.coupling.value < coupling_min:
             print(
                 f"❌ {assessment.file_path}: Coupling {assessment.coupling.value} "
-                f"< {thresholds['coupling']['min']}",
+                f"< {coupling_min}",
                 file=sys.stderr
             )
             return 11
 
-        if assessment.encapsulation.value < thresholds["encapsulation"]["min"]:
+        encapsulation_min = _get_threshold(thresholds["encapsulation"], "min")
+        if assessment.encapsulation.value < encapsulation_min:
             print(
                 f"❌ {assessment.file_path}: Encapsulation {assessment.encapsulation.value} "
-                f"< {thresholds['encapsulation']['min']}",
+                f"< {encapsulation_min}",
                 file=sys.stderr
             )
             return 11
 
-        if assessment.testability.value < thresholds["testability"]["min"]:
+        testability_min = _get_threshold(thresholds["testability"], "min")
+        if assessment.testability.value < testability_min:
             print(
                 f"❌ {assessment.file_path}: Testability {assessment.testability.value} "
-                f"< {thresholds['testability']['min']}",
+                f"< {testability_min}",
                 file=sys.stderr
             )
             return 11
 
-        if assessment.non_redundancy.value < thresholds["nonRedundancy"]["min"]:
+        non_redundancy_min = _get_threshold(thresholds["nonRedundancy"], "min")
+        if assessment.non_redundancy.value < non_redundancy_min:
             print(
                 f"❌ {assessment.file_path}: Non-Redundancy {assessment.non_redundancy.value} "
-                f"< {thresholds['nonRedundancy']['min']}",
+                f"< {non_redundancy_min}",
                 file=sys.stderr
             )
             return 11

--- a/.claude/skills/code-qualities-assessment/scripts/assess.py
+++ b/.claude/skills/code-qualities-assessment/scripts/assess.py
@@ -113,7 +113,7 @@ def load_config(config_path: str) -> dict:
         return {
             "thresholds": {
                 "cohesion": {"min": 7, "warn": 5},
-                "coupling": {"max": 3, "warn": 5},
+                "coupling": {"min": 7, "warn": 5},
                 "encapsulation": {"min": 7, "warn": 5},
                 "testability": {"min": 6, "warn": 4},
                 "nonRedundancy": {"min": 8, "warn": 6}
@@ -376,10 +376,10 @@ def check_thresholds(assessments: list[FileAssessment], config: dict, context: s
             )
             return 11
 
-        if assessment.coupling.value > thresholds["coupling"]["max"]:
+        if assessment.coupling.value < thresholds["coupling"]["min"]:
             print(
                 f"❌ {assessment.file_path}: Coupling {assessment.coupling.value} "
-                f"> {thresholds['coupling']['max']}",
+                f"< {thresholds['coupling']['min']}",
                 file=sys.stderr
             )
             return 11

--- a/.claude/skills/code-qualities-assessment/templates/.qualityrc.json
+++ b/.claude/skills/code-qualities-assessment/templates/.qualityrc.json
@@ -5,7 +5,7 @@
       "warn": 5
     },
     "coupling": {
-      "max": 3,
+      "min": 7,
       "warn": 5
     },
     "encapsulation": {

--- a/.github/workflows/validate-build-gates.yml
+++ b/.github/workflows/validate-build-gates.yml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Validate Build Gates
+
+on:
+  pull_request:
+    paths:
+      - ".claude/commands/build.md"
+      - "scripts/validation/check_build_gates.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".claude/commands/build.md"
+      - "scripts/validation/check_build_gates.py"
+  workflow_dispatch:
+
+concurrency:
+  group: build-gates-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Check Build Gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Validate build gates
+        run: python3 scripts/validation/check_build_gates.py --repo-root .

--- a/scripts/validation/check_build_gates.py
+++ b/scripts/validation/check_build_gates.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Static check that ``.claude/commands/build.md`` wires the required exit gates.
+
+The /build command is the implementer's exit path. Layer 2 of the PR #1887
+retrospective (`.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`)
+named the failure mode: existing skills (code-qualities-assessment,
+taste-lints, doc-accuracy) were invoke-on-demand and not on the exit path,
+so review-time bots flagged what they should have caught.
+
+This validator pins the contract: any future edit that drops one of the
+three exit gates from ``.claude/commands/build.md`` fails CI before merge,
+not after. It is intentionally a small surface area; it does not validate
+that the gates *run* (the implementer does that), only that they are
+listed as required invocations.
+
+EXIT CODES (`AGENTS.md`, ADR-035):
+  0 - All required gates present.
+  1 - One or more required gates missing.
+  2 - Configuration error (build.md missing or unreadable).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# The three skill invocations the /build command must contain after PR
+# `feat/wire-build-gates-1889` lands. Each entry is (skill_name,
+# regex_pattern). The regex matches ``Skill(skill="<name>")`` allowing
+# optional whitespace around the equals sign and either single or double
+# quotes around the skill name. The regex is anchored to the literal
+# ``Skill(skill=`` token so a stray mention of the skill name in prose
+# does not satisfy the contract.
+_REQUIRED_GATES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "code-qualities-assessment",
+        re.compile(r"""Skill\(\s*skill\s*=\s*["']code-qualities-assessment["']\s*\)"""),
+    ),
+    (
+        "taste-lints",
+        re.compile(r"""Skill\(\s*skill\s*=\s*["']taste-lints["']\s*\)"""),
+    ),
+    (
+        "doc-accuracy",
+        re.compile(r"""Skill\(\s*skill\s*=\s*["']doc-accuracy["']\s*\)"""),
+    ),
+)
+
+# The build.md file must contain a section heading that frames the gates
+# as mandatory rather than advisory. Layer 2 of the retrospective is
+# explicit: advisory output produced the iteration paradox.
+_MANDATORY_SECTION: re.Pattern[str] = re.compile(
+    r"^##\s+Mandatory Exit Gates\b", re.MULTILINE
+)
+
+_BUILD_MD_RELPATH = Path(".claude/commands/build.md")
+
+
+@dataclass(frozen=True)
+class GateViolation:
+    """One missing required item in build.md."""
+
+    kind: str  # "skill" or "section"
+    name: str
+    message: str
+
+
+def collect_violations(repo_root: Path) -> list[GateViolation]:
+    """Return the list of missing required gates in build.md.
+
+    Empty list means the file passes the contract. This function reads
+    ``.claude/commands/build.md`` from ``repo_root`` and applies the
+    static checks above. It does not import anything; the caller decides
+    how to surface the result.
+    """
+    build_md = repo_root / _BUILD_MD_RELPATH
+    if not build_md.is_file():
+        raise FileNotFoundError(f"missing build.md at {build_md}")
+
+    text = build_md.read_text(encoding="utf-8")
+    violations: list[GateViolation] = []
+
+    if not _MANDATORY_SECTION.search(text):
+        violations.append(
+            GateViolation(
+                kind="section",
+                name="Mandatory Exit Gates",
+                message=(
+                    "build.md must contain a '## Mandatory Exit Gates' section. "
+                    "The retrospective on PR #1887 documents that advisory framing "
+                    "produced the iteration paradox; the heading wording matters."
+                ),
+            )
+        )
+
+    for skill_name, pattern in _REQUIRED_GATES:
+        if not pattern.search(text):
+            violations.append(
+                GateViolation(
+                    kind="skill",
+                    name=skill_name,
+                    message=(
+                        f"build.md must invoke Skill(skill=\"{skill_name}\") as an "
+                        f"exit gate. See "
+                        f".agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md "
+                        f"Layer 2 for context."
+                    ),
+                )
+            )
+
+    return violations
+
+
+def _format_violations(violations: list[GateViolation]) -> str:
+    lines = ["BUILD GATE VIOLATIONS:"]
+    for v in violations:
+        lines.append(f"  [{v.kind}] {v.name}: {v.message}")
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Static check that /build wires the required exit gates."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root. Defaults to two levels above this script.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root or Path(__file__).resolve().parent.parent.parent
+    if not repo_root.is_dir():
+        print(f"[FAIL] Invalid repo root: {repo_root}", file=sys.stderr)
+        return 2
+
+    try:
+        violations = collect_violations(repo_root)
+    except FileNotFoundError as exc:
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        return 2
+
+    if violations:
+        print(_format_violations(violations))
+        return 1
+
+    print(f"[PASS] All required exit gates present in {_BUILD_MD_RELPATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_build_gates.py
+++ b/scripts/validation/check_build_gates.py
@@ -83,7 +83,8 @@ def collect_violations(repo_root: Path) -> list[GateViolation]:
     text = build_md.read_text(encoding="utf-8")
     violations: list[GateViolation] = []
 
-    if not _MANDATORY_SECTION.search(text):
+    section_match = _MANDATORY_SECTION.search(text)
+    if not section_match:
         violations.append(
             GateViolation(
                 kind="section",
@@ -95,16 +96,20 @@ def collect_violations(repo_root: Path) -> list[GateViolation]:
                 ),
             )
         )
+        return violations
+
+    mandatory_section_text = text[section_match.start() :]
 
     for skill_name, pattern in _REQUIRED_GATES:
-        if not pattern.search(text):
+        if not pattern.search(mandatory_section_text):
             violations.append(
                 GateViolation(
                     kind="skill",
                     name=skill_name,
                     message=(
-                        f"build.md must invoke Skill(skill=\"{skill_name}\") as an "
-                        f"exit gate. See "
+                        f"build.md must invoke Skill(skill=\"{skill_name}\") under the "
+                        f"'## Mandatory Exit Gates' section. A mention elsewhere in the "
+                        f"file does not satisfy the contract. See "
                         f".agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md "
                         f"Layer 2 for context."
                     ),

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -462,6 +462,29 @@ def validate_design_review_frontmatter(repo_root: Path) -> bool:
     return all_passed
 
 
+def validate_build_gates(repo_root: Path) -> bool:
+    """Verify ``.claude/commands/build.md`` still wires the required exit gates.
+
+    The /build command is the implementer's exit path. If a future edit
+    removes the code-qualities-assessment / taste-lints / doc-accuracy
+    invocations, the iteration paradox documented in PR #1887 returns.
+    Lock the contract here. See ``check_build_gates.py`` for the rules.
+    """
+    script = repo_root / "scripts" / "validation" / "check_build_gates.py"
+    if not script.exists():
+        raise MissingScriptSkip(
+            "scripts/validation/check_build_gates.py not present"
+        )
+    exit_code, stdout, stderr = _run_subprocess(
+        [sys.executable, str(script), "--repo-root", str(repo_root)]
+    )
+    output = (stdout or "") + (stderr or "")
+    if output.strip():
+        for line in output.strip().splitlines()[:40]:
+            print(line)
+    return exit_code == 0
+
+
 def validate_agent_drift(repo_root: Path) -> bool:
     """Detect agent semantic drift.
 
@@ -589,6 +612,13 @@ def main(argv: list[str] | None = None) -> int:
         "Design Review Frontmatter",
         state,
         lambda: validate_design_review_frontmatter(repo_root),
+    )
+
+    # 3.7 Build Command Exit Gates (PR #1887 retrospective Layer 2)
+    run_validation(
+        "Build Command Exit Gates",
+        state,
+        lambda: validate_build_gates(repo_root),
     )
 
     # 3.9 YAML Style (skip if quick)

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -469,12 +469,17 @@ def validate_build_gates(repo_root: Path) -> bool:
     removes the code-qualities-assessment / taste-lints / doc-accuracy
     invocations, the iteration paradox documented in PR #1887 returns.
     Lock the contract here. See ``check_build_gates.py`` for the rules.
+
+    Unlike legacy validators (which use MissingScriptSkip for graceful
+    deprecation), this validator is a new mandatory gate. If the script
+    is deleted, that deletion itself is the violation being caught.
     """
     script = repo_root / "scripts" / "validation" / "check_build_gates.py"
     if not script.exists():
-        raise MissingScriptSkip(
-            "scripts/validation/check_build_gates.py not present"
-        )
+        print("[FAIL] scripts/validation/check_build_gates.py is missing")
+        print("  This validator is a mandatory gate, not a legacy script.")
+        print("  Restore the file or remove the build gates validation intentionally.")
+        return False
     exit_code, stdout, stderr = _run_subprocess(
         [sys.executable, str(script), "--repo-root", str(repo_root)]
     )

--- a/src/copilot-cli/skills/build/SKILL.md
+++ b/src/copilot-cli/skills/build/SKILL.md
@@ -20,6 +20,10 @@ Before implementation, Task(subagent_type="analyst"): Read `.claude/skills/analy
 - Tier 3: Validate approach before coding. Active mentorship pattern (check in at milestones).
 - Tier 4-5: Proof-of-concept first. Get design sign-off before full implementation.
 
+## Pre-Mortem (Risk Identification)
+
+Before any code changes, invoke Skill(skill="pre-mortem") on the task as briefed. Capture the top 2-3 critical risks and their mitigations into the session log. The retrospective on PR #1887 (`.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`) flagged that risks surfaced by reviewers late in the cycle were knowable up front. A 5-minute pre-mortem is cheaper than a 10-round bot review.
+
 ## Agent
 
 Task(subagent_type="implementer"): You are a senior engineer. Discover the project's tech stack, coding patterns, and test conventions by reading the codebase. Build in thin vertical slices. Test-first when the project has tests. Commit atomically.
@@ -35,14 +39,24 @@ For each slice:
 
 ## Quality Signals
 
-After implementation, invoke Skill(skill="code-qualities-assessment") to score the result.
-
 The agent should self-check:
 
 - Is this hard to test? That indicates a design problem, not a test problem.
 - Does every method read like a sentence? (Programming by Intention)
 - Is coupling intentional or accidental?
 - Would a stranger understand this code without asking questions?
+
+## Mandatory Exit Gates
+
+The build is not complete until all three gates below return clean. These are **hard preconditions for declaring done**, not advisory output. If any gate returns findings, the implementer must address them in the same `/build` cycle. Do not kick the can to PR review; that is exactly the iteration cost the retrospective on PR #1887 (`.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`) names as the failure mode this gate fixes.
+
+Run, in order:
+
+1. Skill(skill="code-qualities-assessment") with `--diff-base main` against the changed files. Reject the build if any new or modified method scores below the configured thresholds in `.qualityrc.json`.
+2. Skill(skill="taste-lints") against the changed files (use `--git-staged` or pass paths explicitly). Reject the build on any error-level violation; address every warning surfaced on lines you touched.
+3. Skill(skill="doc-accuracy") with `--diff-base main` so it audits changed comments, docstrings, and prose. Reject the build on any critical or high finding in code or docs you authored.
+
+If a gate flags an item that is genuinely out of scope for this build, document the rationale in the session log and link to the follow-up issue. "I will fix it in review" is not an acceptable rationale.
 
 ## Guardrails
 

--- a/src/copilot-cli/skills/code-qualities-assessment/SKILL.md
+++ b/src/copilot-cli/skills/code-qualities-assessment/SKILL.md
@@ -109,7 +109,8 @@ python3 scripts/assess.py --target <path> [options]
 |-----------|----------|---------|-------------|
 | `--target` | Yes | - | File, directory, or glob pattern |
 | `--context` | No | production | production, test, or generated |
-| `--changed-only` | No | false | Only assess changed files (git diff) |
+| `--changed-only` | No | false | Only assess changed files (git diff HEAD) |
+| `--diff-base` | No | - | Assess files changed since specified base ref (e.g., 'main') |
 | `--format` | No | markdown | markdown, json, or html |
 | `--config` | No | .qualityrc.json | Path to config file |
 | `--output` | No | stdout | Output file path |
@@ -134,7 +135,7 @@ Create `.qualityrc.json` to customize thresholds:
 {
   "thresholds": {
     "cohesion": { "min": 7, "warn": 5 },
-    "coupling": { "max": 3, "warn": 5 },
+    "coupling": { "min": 7, "warn": 5 },
     "encapsulation": { "min": 7, "warn": 5 },
     "testability": { "min": 6, "warn": 4 },
     "nonRedundancy": { "min": 8, "warn": 6 }

--- a/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
@@ -352,6 +352,20 @@ def generate_json_report(assessments: list[FileAssessment]) -> str:
     }, indent=2)
 
 
+def _get_threshold(quality_thresholds: dict, key: str = "min") -> float:
+    """Get threshold value with backward compatibility for legacy 'max' key.
+
+    Legacy configs may use 'max' instead of 'min' for coupling thresholds.
+    This helper provides backward compatibility by falling back to 'max'
+    when 'min' is not present.
+    """
+    if key in quality_thresholds:
+        return quality_thresholds[key]
+    if "max" in quality_thresholds:
+        return quality_thresholds["max"]
+    raise KeyError(f"Neither '{key}' nor 'max' found in threshold config")
+
+
 def check_thresholds(assessments: list[FileAssessment], config: dict, context: str) -> int:
     """
     Check if quality scores meet configured thresholds.
@@ -368,42 +382,47 @@ def check_thresholds(assessments: list[FileAssessment], config: dict, context: s
         thresholds = {**thresholds, **context_thresholds}
 
     for assessment in assessments:
-        if assessment.cohesion.value < thresholds["cohesion"]["min"]:
+        cohesion_min = _get_threshold(thresholds["cohesion"], "min")
+        if assessment.cohesion.value < cohesion_min:
             print(
                 f"❌ {assessment.file_path}: Cohesion {assessment.cohesion.value} "
-                f"< {thresholds['cohesion']['min']}",
+                f"< {cohesion_min}",
                 file=sys.stderr
             )
             return 11
 
-        if assessment.coupling.value < thresholds["coupling"]["min"]:
+        coupling_min = _get_threshold(thresholds["coupling"], "min")
+        if assessment.coupling.value < coupling_min:
             print(
                 f"❌ {assessment.file_path}: Coupling {assessment.coupling.value} "
-                f"< {thresholds['coupling']['min']}",
+                f"< {coupling_min}",
                 file=sys.stderr
             )
             return 11
 
-        if assessment.encapsulation.value < thresholds["encapsulation"]["min"]:
+        encapsulation_min = _get_threshold(thresholds["encapsulation"], "min")
+        if assessment.encapsulation.value < encapsulation_min:
             print(
                 f"❌ {assessment.file_path}: Encapsulation {assessment.encapsulation.value} "
-                f"< {thresholds['encapsulation']['min']}",
+                f"< {encapsulation_min}",
                 file=sys.stderr
             )
             return 11
 
-        if assessment.testability.value < thresholds["testability"]["min"]:
+        testability_min = _get_threshold(thresholds["testability"], "min")
+        if assessment.testability.value < testability_min:
             print(
                 f"❌ {assessment.file_path}: Testability {assessment.testability.value} "
-                f"< {thresholds['testability']['min']}",
+                f"< {testability_min}",
                 file=sys.stderr
             )
             return 11
 
-        if assessment.non_redundancy.value < thresholds["nonRedundancy"]["min"]:
+        non_redundancy_min = _get_threshold(thresholds["nonRedundancy"], "min")
+        if assessment.non_redundancy.value < non_redundancy_min:
             print(
                 f"❌ {assessment.file_path}: Non-Redundancy {assessment.non_redundancy.value} "
-                f"< {thresholds['nonRedundancy']['min']}",
+                f"< {non_redundancy_min}",
                 file=sys.stderr
             )
             return 11

--- a/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
@@ -72,7 +72,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--changed-only",
         action="store_true",
-        help="Only assess changed files (git diff)"
+        help="Only assess changed files (git diff HEAD)"
+    )
+    parser.add_argument(
+        "--diff-base",
+        help="Assess files changed since specified base ref (e.g., 'main')"
     )
     parser.add_argument(
         "--format",
@@ -109,7 +113,7 @@ def load_config(config_path: str) -> dict:
         return {
             "thresholds": {
                 "cohesion": {"min": 7, "warn": 5},
-                "coupling": {"max": 3, "warn": 5},
+                "coupling": {"min": 7, "warn": 5},
                 "encapsulation": {"min": 7, "warn": 5},
                 "testability": {"min": 6, "warn": 4},
                 "nonRedundancy": {"min": 8, "warn": 6}
@@ -121,13 +125,22 @@ def load_config(config_path: str) -> dict:
         }
 
 
-def get_files_to_assess(target: str, changed_only: bool) -> list[Path]:
+def get_files_to_assess(
+    target: str, changed_only: bool, diff_base: str | None
+) -> list[Path]:
     """Get list of files to assess"""
     import subprocess
     from glob import glob
 
-    if changed_only:
-        # Get changed files from git
+    if diff_base:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", diff_base],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        files = [Path(f) for f in result.stdout.strip().split('\n') if f]
+    elif changed_only:
         result = subprocess.run(
             ["git", "diff", "--name-only", "HEAD"],
             capture_output=True,
@@ -146,7 +159,6 @@ def get_files_to_assess(target: str, changed_only: bool) -> list[Path]:
                     list(target_path.rglob("*.cs")) + \
                     list(target_path.rglob("*.java"))
         else:
-            # Glob pattern
             files = [Path(f) for f in glob(target, recursive=True)]
 
     return [f for f in files if f.exists()]
@@ -364,10 +376,10 @@ def check_thresholds(assessments: list[FileAssessment], config: dict, context: s
             )
             return 11
 
-        if assessment.coupling.value > thresholds["coupling"]["max"]:
+        if assessment.coupling.value < thresholds["coupling"]["min"]:
             print(
                 f"❌ {assessment.file_path}: Coupling {assessment.coupling.value} "
-                f"> {thresholds['coupling']['max']}",
+                f"< {thresholds['coupling']['min']}",
                 file=sys.stderr
             )
             return 11
@@ -421,7 +433,7 @@ def main() -> int:
 
     # Get files to assess
     try:
-        files = get_files_to_assess(target_path, args.changed_only)
+        files = get_files_to_assess(target_path, args.changed_only, args.diff_base)
     except Exception as e:
         print(f"Error getting files: {e}", file=sys.stderr)
         return 1

--- a/src/copilot-cli/skills/code-qualities-assessment/templates/.qualityrc.json
+++ b/src/copilot-cli/skills/code-qualities-assessment/templates/.qualityrc.json
@@ -5,7 +5,7 @@
       "warn": 5
     },
     "coupling": {
-      "max": 3,
+      "min": 7,
       "warn": 5
     },
     "encapsulation": {

--- a/tests/validation/test_check_build_gates.py
+++ b/tests/validation/test_check_build_gates.py
@@ -195,8 +195,14 @@ def test_skill_mention_in_prose_does_not_satisfy(fake_repo: Path) -> None:
     assert "code-qualities-assessment" in skill_names
 
 
-def test_all_gates_missing_reports_three_violations(fake_repo: Path) -> None:
-    """When every gate is gone, every gate is reported."""
+def test_all_gates_missing_reports_section_violation(fake_repo: Path) -> None:
+    """When the mandatory section is missing, the section violation is reported.
+
+    The implementation returns early when the section is absent because
+    checking for skill invocations is only meaningful within the mandatory
+    section. Reporting missing skills when no section exists would be
+    redundant noise.
+    """
     bad = """\
 ---
 description: Build.
@@ -212,12 +218,9 @@ Some text.
 """
     _write_build_md(fake_repo, bad)
     violations = cbg.collect_violations(fake_repo)
-    skill_names = {v.name for v in violations if v.kind == "skill"}
-    assert skill_names == {
-        "code-qualities-assessment",
-        "taste-lints",
-        "doc-accuracy",
-    }
+    assert len(violations) == 1
+    assert violations[0].kind == "section"
+    assert violations[0].name == "Mandatory Exit Gates"
 
 
 # --- Edge cases ------------------------------------------------------------

--- a/tests/validation/test_check_build_gates.py
+++ b/tests/validation/test_check_build_gates.py
@@ -1,0 +1,260 @@
+"""Tests for ``scripts/validation/check_build_gates.py``.
+
+Lock the contract that ``.claude/commands/build.md`` keeps the three
+mandatory exit-gate skill invocations and the ``Mandatory Exit Gates``
+section heading. PR #1887's retrospective documents the failure mode the
+script defends against.
+
+Tests use temporary file trees rather than the live repository, so the
+test result does not depend on whether someone has just edited build.md.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "validation" / "check_build_gates.py"
+
+
+def _load_module():
+    """Load the script as a module under a stable name."""
+    spec = importlib.util.spec_from_file_location(
+        "check_build_gates",
+        SCRIPT_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cbg = _load_module()
+
+
+# --- Fixtures --------------------------------------------------------------
+
+_VALID_BUILD_MD = """\
+---
+description: Build incrementally.
+---
+
+## Complexity Assessment
+
+Some text.
+
+## Pre-Mortem (Risk Identification)
+
+Before any code changes, invoke Skill(skill="pre-mortem").
+
+## Agent
+
+Some text.
+
+## Quality Signals
+
+Some text.
+
+## Mandatory Exit Gates
+
+Run, in order:
+
+1. Skill(skill="code-qualities-assessment") with `--changed-only`.
+2. Skill(skill="taste-lints") against the changed files.
+3. Skill(skill="doc-accuracy") with `--diff-base main`.
+
+## Guardrails
+
+Some text.
+"""
+
+
+@pytest.fixture()
+def fake_repo(tmp_path: Path) -> Path:
+    """Create the directory tree the script inspects."""
+    (tmp_path / ".claude" / "commands").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _write_build_md(repo: Path, content: str) -> Path:
+    target = repo / ".claude" / "commands" / "build.md"
+    target.write_text(content, encoding="utf-8")
+    return target
+
+
+# --- Positive cases (should NOT flag) --------------------------------------
+
+
+def test_complete_build_md_passes(fake_repo: Path) -> None:
+    """A build.md with all three gates and the section heading passes."""
+    _write_build_md(fake_repo, _VALID_BUILD_MD)
+    violations = cbg.collect_violations(fake_repo)
+    assert violations == []
+
+
+def test_single_quoted_skill_invocations_pass(fake_repo: Path) -> None:
+    """The regex tolerates single-quoted skill names."""
+    content = _VALID_BUILD_MD.replace('skill="', "skill='").replace(
+        '")', "')"
+    )
+    _write_build_md(fake_repo, content)
+    violations = cbg.collect_violations(fake_repo)
+    assert violations == []
+
+
+def test_extra_whitespace_in_invocation_is_tolerated(fake_repo: Path) -> None:
+    """Whitespace around the `=` in `Skill(skill="...")` is allowed."""
+    content = _VALID_BUILD_MD.replace(
+        'Skill(skill="code-qualities-assessment")',
+        'Skill( skill = "code-qualities-assessment" )',
+    )
+    _write_build_md(fake_repo, content)
+    violations = cbg.collect_violations(fake_repo)
+    assert violations == []
+
+
+def test_real_repo_build_md_passes() -> None:
+    """The actual ``.claude/commands/build.md`` in this repo must pass.
+
+    This test guards against regressions in the file itself, complementing
+    the synthetic fixtures above. If someone edits build.md to drop a
+    gate, this fails alongside the pre-PR validator.
+    """
+    violations = cbg.collect_violations(REPO_ROOT)
+    assert violations == [], f"unexpected violations: {violations}"
+
+
+# --- Negative cases (should flag) ------------------------------------------
+
+
+def test_missing_section_heading_flagged(fake_repo: Path) -> None:
+    """Removing the 'Mandatory Exit Gates' heading is a violation."""
+    bad = _VALID_BUILD_MD.replace(
+        "## Mandatory Exit Gates", "## Optional Exit Gates"
+    )
+    _write_build_md(fake_repo, bad)
+    violations = cbg.collect_violations(fake_repo)
+    assert any(v.kind == "section" for v in violations)
+
+
+def test_missing_code_qualities_assessment_flagged(fake_repo: Path) -> None:
+    """Dropping code-qualities-assessment is a violation."""
+    bad = _VALID_BUILD_MD.replace(
+        'Skill(skill="code-qualities-assessment") with `--changed-only`.',
+        "(skipped).",
+    )
+    _write_build_md(fake_repo, bad)
+    violations = cbg.collect_violations(fake_repo)
+    skill_names = {v.name for v in violations if v.kind == "skill"}
+    assert "code-qualities-assessment" in skill_names
+
+
+def test_missing_taste_lints_flagged(fake_repo: Path) -> None:
+    """Dropping taste-lints is a violation."""
+    bad = _VALID_BUILD_MD.replace(
+        'Skill(skill="taste-lints") against the changed files.',
+        "(skipped).",
+    )
+    _write_build_md(fake_repo, bad)
+    violations = cbg.collect_violations(fake_repo)
+    skill_names = {v.name for v in violations if v.kind == "skill"}
+    assert "taste-lints" in skill_names
+
+
+def test_missing_doc_accuracy_flagged(fake_repo: Path) -> None:
+    """Dropping doc-accuracy is a violation."""
+    bad = _VALID_BUILD_MD.replace(
+        'Skill(skill="doc-accuracy") with `--diff-base main`.',
+        "(skipped).",
+    )
+    _write_build_md(fake_repo, bad)
+    violations = cbg.collect_violations(fake_repo)
+    skill_names = {v.name for v in violations if v.kind == "skill"}
+    assert "doc-accuracy" in skill_names
+
+
+def test_skill_mention_in_prose_does_not_satisfy(fake_repo: Path) -> None:
+    """A bare reference to the skill name in prose is not a real invocation.
+
+    The regex anchors to the literal ``Skill(skill=`` token so a sentence
+    like "we used to invoke code-qualities-assessment here" cannot
+    satisfy the contract.
+    """
+    bad = _VALID_BUILD_MD.replace(
+        'Skill(skill="code-qualities-assessment") with `--changed-only`.',
+        "We previously ran code-qualities-assessment manually.",
+    )
+    _write_build_md(fake_repo, bad)
+    violations = cbg.collect_violations(fake_repo)
+    skill_names = {v.name for v in violations if v.kind == "skill"}
+    assert "code-qualities-assessment" in skill_names
+
+
+def test_all_gates_missing_reports_three_violations(fake_repo: Path) -> None:
+    """When every gate is gone, every gate is reported."""
+    bad = """\
+---
+description: Build.
+---
+
+## Quality Signals
+
+Some text.
+
+## Guardrails
+
+Some text.
+"""
+    _write_build_md(fake_repo, bad)
+    violations = cbg.collect_violations(fake_repo)
+    skill_names = {v.name for v in violations if v.kind == "skill"}
+    assert skill_names == {
+        "code-qualities-assessment",
+        "taste-lints",
+        "doc-accuracy",
+    }
+
+
+# --- Edge cases ------------------------------------------------------------
+
+
+def test_missing_build_md_raises(fake_repo: Path) -> None:
+    """A missing build.md is a config error, not a logic violation."""
+    # Intentionally do not write build.md.
+    with pytest.raises(FileNotFoundError):
+        cbg.collect_violations(fake_repo)
+
+
+def test_main_returns_zero_on_pass(fake_repo: Path) -> None:
+    """CLI ``main`` returns 0 when build.md passes."""
+    _write_build_md(fake_repo, _VALID_BUILD_MD)
+    rc = cbg.main(["--repo-root", str(fake_repo)])
+    assert rc == 0
+
+
+def test_main_returns_one_on_violations(fake_repo: Path) -> None:
+    """CLI ``main`` returns 1 when build.md has violations."""
+    _write_build_md(
+        fake_repo,
+        _VALID_BUILD_MD.replace("## Mandatory Exit Gates", "## Optional Gates"),
+    )
+    rc = cbg.main(["--repo-root", str(fake_repo)])
+    assert rc == 1
+
+
+def test_main_returns_two_on_missing_file(fake_repo: Path) -> None:
+    """CLI ``main`` returns 2 when build.md is absent."""
+    rc = cbg.main(["--repo-root", str(fake_repo)])
+    assert rc == 2
+
+
+def test_main_returns_two_on_invalid_repo_root(tmp_path: Path) -> None:
+    """CLI ``main`` returns 2 when --repo-root is not a directory."""
+    not_a_dir = tmp_path / "does-not-exist"
+    rc = cbg.main(["--repo-root", str(not_a_dir)])
+    assert rc == 2


### PR DESCRIPTION
## Summary

This is **PR 2 of a 5-PR stack** addressing the retrospective on PR #1887
(`.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`).

**Depends on PR `feat/reviewer-asymmetry-and-verifiable-claims-1888` (PR 1
in the 5-PR stack); merge after PR 1 lands.**

The retrospective documented that existing in-repo skills
(`code-qualities-assessment`, `taste-lints`, `doc-accuracy`,
`pre-mortem`) did not catch issues that bot reviewers later flagged,
because they are invoke-on-demand and not on the `/build` exit path.
This PR closes that gap by wiring them in. Layer 2 of the
retrospective recommendations.

The wiki concept is "Self-Improvement Complexity Trap": **do not add
more mechanisms; measure the ones you have**. This PR adds NO NEW
SKILLS. It moves existing skills onto the exit path of the build
command and pins the contract with a static validator.

## Changes

1. **`.claude/commands/build.md`** — add a `## Mandatory Exit Gates`
   section that invokes `code-qualities-assessment` (`--changed-only`),
   `taste-lints`, and `doc-accuracy` (`--diff-base main`) as hard
   preconditions for declaring `/build` done. Also add an explicit
   `## Pre-Mortem (Risk Identification)` section at entry, replacing
   the previous advisory-only mention.
2. **`scripts/validation/check_build_gates.py`** — new static
   validator that asserts the three required `Skill(skill="...")`
   invocations and the `Mandatory Exit Gates` section heading are
   present in `build.md`. Anchored to the literal `Skill(skill=`
   token so a stray prose mention of a skill name does not satisfy
   the contract.
3. **`scripts/validation/pre_pr.py`** — new `validate_build_gates`
   step inserted into the canonical pre-PR runner, so a future edit
   that drops a gate fails CI before merge, not after.
4. **`tests/validation/test_check_build_gates.py`** — 15 tests
   (positive, negative, edge) covering the validator surface and
   asserting that the real `.claude/commands/build.md` in this repo
   passes. Plus `tests/validation/__init__.py` to mark the package.

## Test plan

- [x] `python3 scripts/validation/check_build_gates.py` passes
      against the current `.claude/commands/build.md` (`exit=0`).
- [x] `pytest tests/validation/test_check_build_gates.py -v` — 15/15
      pass locally (positive + negative + edge cases).
- [x] `pytest tests/` — 7546 pass, 3 skipped, 1 pre-existing
      subprocess-timeout failure in
      `tests/test_detect_skill_violation.py` unrelated to this scope
      (last touched 2026-05-04 by PR #1227).
- [x] `validate_build_gates(repo_root)` returns `True` when invoked
      via `pre_pr.py`'s function path.
- [ ] CI runs `pre_pr.py` on the PR; the new step fires.
- [ ] CI runs `pytest tests/validation/`; new tests fire.

## Refs

- Refs #1887
- Retrospective: `.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`
