### PR TITLE
feat(build,skills): Hook Maturity Model for push guards (Refs #1887 retro Layer 5)

### DIFF
--- a/.agents/telemetry/README.md
+++ b/.agents/telemetry/README.md
@@ -1,0 +1,47 @@
+# Push Guard Telemetry
+
+EVENT lines from the push guards (M2/M3/M4/M5 and friends) land here. The
+canonical schema is one JSON object per line; one JSONL file per guard per
+week. The aggregator (`build/scripts/aggregate_guard_intercepts.py`) and
+classifier (`build/scripts/classify_guard_maturity.py`) read these.
+
+## Event contract
+
+Every push guard built on `push_guard_base.py` emits structured lines on
+stderr:
+
+```text
+EVENT={"guard": "<name>", "code": "E_<NAME>", "outcome": "block"|"fail_open", ...}
+```
+
+The `outcome` field distinguishes a real intercept (`block`) from a
+framework-permitted bypass (`fail_open`). Each event also records
+`violations`, `matched_files`, and `changed_files` for blocks, and
+`reason` plus `detail` for fail-opens. See `.claude/hooks/PreToolUse/push_guard_base.py`
+for the source of truth.
+
+## Persistence
+
+The production wiring is **TBD**. Today the aggregator can read either:
+
+1. A directory of `*.jsonl` files in this folder. Each line must contain
+   the JSON object emitted after the `EVENT=` prefix (one event per
+   line, no other content).
+2. STDIN piped from a one-shot capture script.
+
+A follow-up will land the production capture pipeline (likely a
+post-push hook that tees the EVENT lines into the canonical file). Until
+then this directory exists so the aggregator has a stable read target
+and can be exercised by tests using fixtures.
+
+## Naming convention
+
+`push-guard-events-YYYY-WW.jsonl` (ISO week). One file rolls per week
+and never gets edited in place.
+
+## Privacy
+
+These events contain guard names, error codes, file counts, and
+fail-open reasons. No file paths, no commit SHAs, no PII. Safe to keep
+in the repository if needed; safer to keep out of git and rebuild from
+the event log.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     },
     {
       "name": "project-toolkit",
-      "description": "Complete project development toolkit: 23 agents, 23 slash commands, 35 lifecycle hooks, and 69 reusable skills for Claude Code workflows",
+      "description": "Complete project development toolkit: 23 agents, 23 slash commands, 35 lifecycle hooks, and 70 reusable skills for Claude Code workflows",
       "source": "./.claude"
     }
   ]

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -47,3 +47,9 @@ The agent should self-check:
 - No code without understanding the existing patterns first.
 - Favor delegation over inheritance. A makes B, or A uses B. Never both.
 - Three similar lines beat a premature abstraction.
+
+## Optional Final Gate: Guard Maturity Report
+
+Optionally invoke Skill(skill="guard-maturity") at the end of the build to print the Hook Maturity Model report for the push guards. This gate is **informational at landing**; promote it to mandatory after 30 days of real telemetry have accumulated in `.agents/telemetry/`. Until then, an empty report is expected and not a failure.
+
+Rationale: the retrospective on PR #1887 (`.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`) flagged that 95+ crystallized hooks earlier accumulated without measurement. The build flow surfaces the maturity report so contributors see the cost of new guards alongside the work they are landing. See `docs/guard-maturity-runbook.md` for how to read the output.

--- a/.claude/skills/guard-maturity/SKILL.md
+++ b/.claude/skills/guard-maturity/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: guard-maturity
+version: 1.0.0
+model: claude-haiku-4-5
+description: Classify push guards by Hook Maturity Model tier. Aggregates EVENT lines emitted by push_guard_base.py and assigns each guard a tier (Budding, Growing, Mature, Proficient, Inert, Harmful) based on age, intercept count, and fitness derived from block rate. Use to decide when to promote a new guard, when to prune dead weight, and when to remove a harmful one. Triggers `guard maturity report`, `classify push guards`, `hook maturity tiers`.
+license: MIT
+---
+
+# Guard Maturity
+
+Hook Maturity Model fitness scoring for the push guards (M2/M3/M4/M5
+and any future siblings built on `push_guard_base.py`).
+
+The retrospective on PR #1887 (`.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`)
+flagged that 95+ crystallized hooks earlier accumulated without
+measurement. This skill is the measurement: real intercept counts feed
+real tier assignments, and the tier dictates whether a guard gets kept,
+promoted, or pruned.
+
+## When to use
+
+- **Periodic review** (recommended every 30 days once telemetry is
+  flowing): run the report, prune Inert guards, promote Proficient
+  ones, remove Harmful ones immediately.
+- **Before adding a new guard**: confirm no existing guard already
+  covers the case at a higher tier.
+- **Pre-release**: include the report in the release notes so the team
+  can see which guards are paying for themselves.
+
+## What it does
+
+1. Calls `python3 build/scripts/aggregate_guard_intercepts.py` against
+   `.agents/telemetry/` (or stdin if no telemetry has landed yet).
+2. Pipes the JSON summary into
+   `python3 build/scripts/classify_guard_maturity.py`.
+3. Prints a table (one row per guard) sorted by tier severity:
+   `Harmful` first, then `Inert`, then `Budding`, `Growing`, `Mature`,
+   `Proficient`.
+
+## Tier definitions
+
+| Tier | Age | Intercepts | Fitness | Action |
+|---|---|---|---|---|
+| Harmful | any | ≥1 | < -0.02 | Remove immediately |
+| Proficient | ≥60 days | ≥10 | ≥ +0.02 | Promote, keep watching |
+| Mature | ≥30 days | ≥5 | ≥ 0 | Keep, low review |
+| Growing | 14-30 days | ≥1 | any | Adolescent, hold |
+| Inert | ≥30 days | 0 | n/a | Prune candidate |
+| Budding | <14 days | any | any | New, anything goes |
+
+Fitness is `block_rate - 0.5` (centered). The full rationale lives in
+the classifier's module docstring.
+
+## Quick start
+
+```bash
+# Default: read .agents/telemetry/*.jsonl, classify, print report.
+python3 build/scripts/aggregate_guard_intercepts.py \
+  --guard markdown-lint --guard manifest-count --guard pr-description --guard session-log \
+  | python3 build/scripts/classify_guard_maturity.py
+```
+
+The `--guard` flags ensure that guards which have NEVER fired still
+appear in the report (otherwise an Inert guard with zero events would
+silently drop out of the summary).
+
+## Production wiring
+
+The capture pipeline that writes to `.agents/telemetry/` is TBD; the
+push guards already emit the right `EVENT=` lines on stderr per
+`.claude/hooks/PreToolUse/push_guard_base.py`. Until the pipeline lands,
+you can capture events ad-hoc:
+
+```bash
+git push 2>&1 | tee /tmp/push.log
+grep '^EVENT=' /tmp/push.log >> .agents/telemetry/$(date +push-guard-events-%G-%V).jsonl
+```
+
+Then run the aggregator + classifier as above.
+
+## See also
+
+- `docs/guard-maturity-runbook.md` (how to read the report and what
+  action each tier suggests).
+- `.claude/hooks/PreToolUse/push_guard_base.py` (the EVENT contract
+  this skill consumes).
+- `.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`
+  (Phase 5 action items, Layer 5 of the iteration-paradox stack).

--- a/.claude/skills/guard-maturity/scripts/run_report.py
+++ b/.claude/skills/guard-maturity/scripts/run_report.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Run the guard maturity report end-to-end.
+
+Thin wrapper around the two build/scripts:
+
+1. ``aggregate_guard_intercepts.py``
+2. ``classify_guard_maturity.py``
+
+Output is a human-readable table printed to stdout, plus the raw JSON
+report on stderr (so a caller can capture it with ``2>``).
+
+The wrapper keeps logic out of the SKILL.md prose (the skill should
+describe what to do; the script should do it). All tier and fitness
+math lives in the classifier; this file is presentation only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+AGGREGATE = REPO_ROOT / "build" / "scripts" / "aggregate_guard_intercepts.py"
+CLASSIFY = REPO_ROOT / "build" / "scripts" / "classify_guard_maturity.py"
+
+# Severity sort: Harmful first (act now), then Inert (prune), then the
+# happy tiers. Within a tier, sort by intercepts descending so the
+# loudest guards float to the top.
+TIER_ORDER = {
+    "Harmful": 0,
+    "Inert": 1,
+    "Budding": 2,
+    "Growing": 3,
+    "Mature": 4,
+    "Proficient": 5,
+}
+
+
+def _run_aggregate(known_guards: list[str], source: str | None) -> dict:
+    cmd = [sys.executable, str(AGGREGATE)]
+    for g in known_guards:
+        cmd.extend(["--guard", g])
+    if source:
+        cmd.extend(["--source", source])
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(proc.returncode)
+    return json.loads(proc.stdout)
+
+
+def _run_classify(summary: dict, treat_unseen_as_inert: bool) -> dict:
+    cmd = [sys.executable, str(CLASSIFY)]
+    if treat_unseen_as_inert:
+        cmd.append("--treat-unseen-as-inert")
+    proc = subprocess.run(
+        cmd,
+        input=json.dumps(summary),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(proc.returncode)
+    return json.loads(proc.stdout)
+
+
+def _format_table(report: dict) -> str:
+    rows = sorted(
+        report.values(),
+        key=lambda r: (TIER_ORDER.get(r["tier"], 99), -r["intercepts"], r["guard"]),
+    )
+    if not rows:
+        return "(no guards in report)\n"
+    header = f"{'tier':<11} {'guard':<22} {'intercepts':>10} {'fitness':>8} {'age_days':>9}"
+    lines = [header, "-" * len(header)]
+    for r in rows:
+        age = r.get("days_since_first_event")
+        age_s = f"{age:.1f}" if isinstance(age, (int, float)) else "n/a"
+        lines.append(
+            f"{r['tier']:<11} {r['guard']:<22} {r['intercepts']:>10} "
+            f"{r['fitness']:>+7.2f} {age_s:>9}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the guard maturity report (aggregate + classify).",
+    )
+    parser.add_argument(
+        "--guard",
+        action="append",
+        default=[
+            "markdown-lint",
+            "manifest-count",
+            "pr-description",
+            "session-log",
+        ],
+        help=("Guard name to include even with zero events. Repeatable. "
+              "Defaults cover M2-M5."),
+    )
+    parser.add_argument(
+        "--source",
+        default=None,
+        help="Override telemetry source path (file or directory).",
+    )
+    parser.add_argument(
+        "--treat-unseen-as-inert",
+        action="store_true",
+        help="Mark guards with no events as Inert instead of Budding.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit raw JSON instead of the human-readable table.",
+    )
+    args = parser.parse_args(argv)
+
+    summary = _run_aggregate(args.guard, args.source)
+    report = _run_classify(summary, args.treat_unseen_as_inert)
+
+    if args.json:
+        json.dump(report, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(_format_table(report))
+        # Stash the raw JSON on stderr so callers can capture both.
+        json.dump(report, sys.stderr, indent=2, sort_keys=True)
+        sys.stderr.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/scripts/aggregate_guard_intercepts.py
+++ b/build/scripts/aggregate_guard_intercepts.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Aggregate push-guard EVENT lines into a per-guard summary.
+
+Consumes telemetry written by ``push_guard_base.py`` (one JSON object
+per line, ``EVENT=`` prefix optional) and emits a JSON summary keyed by
+guard name. The summary feeds ``classify_guard_maturity.py``.
+
+Sources:
+
+1. Directory (default ``.agents/telemetry/*.jsonl``).
+2. STDIN piped from a one-shot ``git push 2>&1`` capture.
+3. Explicit ``--source <file_or_dir>``.
+
+Aggregator is lenient: malformed lines are skipped with a stderr
+warning, never raised. ``--guard <name>`` lets a caller include a guard
+in the output even when it had zero events (so the classifier can mark
+it Inert).
+
+Per-guard summary fields: total_events, blocks, fail_opens, block_rate,
+fail_open_rate, first_event, last_event, days_since_first_event,
+days_since_last_event.
+
+Hook Maturity Model fitness is computed downstream; this script stays
+pure aggregation so its output is cacheable and replayable.
+
+Exit codes (per AGENTS.md):
+    0 = ok
+    1 = logic error (no events and no --guard)
+    2 = config error (bad --now or unreadable --source)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_SOURCE = REPO_ROOT / ".agents" / "telemetry"
+EVENT_PREFIX = "EVENT="
+
+
+def _parse_event_line(line: str) -> dict | None:
+    """Return parsed event dict or None for malformed input."""
+    raw = line.strip()
+    if not raw:
+        return None
+    if raw.startswith(EVENT_PREFIX):
+        raw = raw[len(EVENT_PREFIX):]
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if "guard" not in payload or "outcome" not in payload:
+        return None
+    return payload
+
+
+def _events_from_path(source: Path) -> list[tuple[dict, datetime]]:
+    """Yield (event, timestamp) tuples from a file or directory."""
+    files: list[Path] = []
+    if source.is_dir():
+        files.extend(sorted(source.glob("*.jsonl")))
+    elif source.is_file():
+        files.append(source)
+    else:
+        print(f"warning: source not found: {source}", file=sys.stderr)
+        return []
+    out: list[tuple[dict, datetime]] = []
+    for fp in files:
+        try:
+            mtime = datetime.fromtimestamp(fp.stat().st_mtime, tz=timezone.utc)
+        except OSError:
+            mtime = datetime.now(tz=timezone.utc)
+        try:
+            with fp.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    event = _parse_event_line(line)
+                    if event is None:
+                        continue
+                    ts = _event_timestamp(event, mtime)
+                    out.append((event, ts))
+        except OSError as exc:
+            print(f"warning: cannot read {fp}: {exc}", file=sys.stderr)
+            continue
+    return out
+
+
+def _events_from_stdin() -> list[tuple[dict, datetime]]:
+    """Read EVENT= lines from stdin; non-event lines are ignored."""
+    if sys.stdin.isatty():
+        return []
+    now = datetime.now(tz=timezone.utc)
+    out: list[tuple[dict, datetime]] = []
+    for line in sys.stdin:
+        if EVENT_PREFIX not in line:
+            continue
+        idx = line.find(EVENT_PREFIX)
+        event = _parse_event_line(line[idx:])
+        if event is None:
+            continue
+        out.append((event, _event_timestamp(event, now)))
+    return out
+
+
+def _event_timestamp(event: dict, fallback: datetime) -> datetime:
+    raw = event.get("timestamp")
+    if not isinstance(raw, str):
+        return fallback
+    try:
+        # Accept both Z-suffix and +00:00 ISO forms.
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return fallback
+
+
+def aggregate(events: list[tuple[dict, datetime]], extra_guards: list[str], now: datetime) -> dict:
+    """Reduce events to per-guard summary."""
+    summary: dict[str, dict] = {}
+    for guard in extra_guards:
+        summary.setdefault(guard, _empty_summary(guard))
+    for event, ts in events:
+        guard = event.get("guard")
+        if not isinstance(guard, str) or not guard:
+            continue
+        s = summary.setdefault(guard, _empty_summary(guard))
+        s["total_events"] += 1
+        outcome = event.get("outcome")
+        if outcome == "block":
+            s["blocks"] += 1
+        elif outcome == "fail_open":
+            s["fail_opens"] += 1
+        if s["_first_dt"] is None or ts < s["_first_dt"]:
+            s["_first_dt"] = ts
+        if s["_last_dt"] is None or ts > s["_last_dt"]:
+            s["_last_dt"] = ts
+    for s in summary.values():
+        _finalize_summary(s, now)
+    return summary
+
+
+def _empty_summary(guard: str) -> dict:
+    return {
+        "guard": guard,
+        "total_events": 0,
+        "blocks": 0,
+        "fail_opens": 0,
+        "block_rate": 0.0,
+        "fail_open_rate": 0.0,
+        "first_event": None,
+        "last_event": None,
+        "days_since_first_event": None,
+        "days_since_last_event": None,
+        "_first_dt": None,
+        "_last_dt": None,
+    }
+
+
+def _finalize_summary(s: dict, now: datetime) -> None:
+    total = s["total_events"]
+    if total > 0:
+        s["block_rate"] = s["blocks"] / total
+        s["fail_open_rate"] = s["fail_opens"] / total
+    first_dt = s.pop("_first_dt")
+    last_dt = s.pop("_last_dt")
+    if first_dt is not None:
+        s["first_event"] = first_dt.isoformat()
+        s["days_since_first_event"] = max(0.0, (now - first_dt).total_seconds() / 86400.0)
+    if last_dt is not None:
+        s["last_event"] = last_dt.isoformat()
+        s["days_since_last_event"] = max(0.0, (now - last_dt).total_seconds() / 86400.0)
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Aggregate push-guard EVENT lines into a per-guard summary.",
+    )
+    parser.add_argument(
+        "--source",
+        default=None,
+        help=("File or directory of EVENT JSONL. Defaults to "
+              ".agents/telemetry/ when present, else stdin."),
+    )
+    parser.add_argument(
+        "--stdin",
+        action="store_true",
+        help="Read EVENT= lines from stdin (overrides --source).",
+    )
+    parser.add_argument(
+        "--guard",
+        action="append",
+        default=[],
+        help=("Include this guard name in the output even if it had zero "
+              "events. Repeatable. Useful for marking Inert guards."),
+    )
+    parser.add_argument(
+        "--now",
+        default=None,
+        help=("Override 'now' for age math (ISO 8601). Used by tests so "
+              "fixtures produce stable output."),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_argparser()
+    args = parser.parse_args(argv)
+
+    if args.now:
+        try:
+            now = datetime.fromisoformat(args.now.replace("Z", "+00:00"))
+        except ValueError:
+            print(f"error: invalid --now: {args.now}", file=sys.stderr)
+            return 2
+    else:
+        now = datetime.now(tz=timezone.utc)
+
+    if args.stdin:
+        events = _events_from_stdin()
+    elif args.source:
+        events = _events_from_path(Path(args.source))
+    elif DEFAULT_SOURCE.exists():
+        events = _events_from_path(DEFAULT_SOURCE)
+    elif not sys.stdin.isatty():
+        events = _events_from_stdin()
+    else:
+        print(
+            f"warning: default telemetry source not found: {DEFAULT_SOURCE}; "
+            "no events to aggregate (use --source or --stdin).",
+            file=sys.stderr,
+        )
+        events = []
+
+    summary = aggregate(events, args.guard, now)
+    if not summary:
+        print(
+            "error: no guards found and no --guard listed; nothing to summarize.",
+            file=sys.stderr,
+        )
+        return 1
+    json.dump(summary, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write(os.linesep)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/scripts/classify_guard_maturity.py
+++ b/build/scripts/classify_guard_maturity.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Classify push guards into Hook Maturity Model tiers.
+
+Consumes the JSON output of ``aggregate_guard_intercepts.py`` and assigns
+each guard one of six tiers based on age, intercept volume, and a fitness
+signal derived from block rate.
+
+Tiers (evaluated in order; first match wins):
+
+- ``Harmful``: any age, ≥1 intercept, fitness < ``-0.02``. Remove
+  immediately. A guard that mostly fails open or that catches things it
+  should not is doing harm; it normalizes bypass.
+- ``Proficient``: ≥60 days since first event, ≥10 intercepts, fitness
+  ≥ ``+0.02``. Promote and keep.
+- ``Mature``: ≥30 days since first event, ≥5 intercepts, fitness ≥ 0.
+  Keep and watch.
+- ``Inert``: ≥30 days since first event, 0 intercepts. Prune candidate.
+  Either no real diff has tripped it, or the validator is too narrow to
+  fire.
+- ``Growing``: 14-30 days since first event, ≥1 intercept. Adolescent;
+  too young for promotion, too productive to drop.
+- ``Budding``: <14 days since first event. New, anything goes.
+
+A guard with no events at all but listed by ``--guard`` falls into
+``Budding`` if its days-since-first-event is null (never seen) and
+``--treat-unseen-as-inert`` is false; pass that flag to mark guards
+that have been registered for some time as Inert when their first event
+is null. The default is conservative: a guard that has never fired
+might just be brand new.
+
+Fitness rationale: in this codebase a guard EITHER blocks (catches a
+real or precautionary issue) OR fails open (the framework or the
+validator could not run; see ``push_guard_base.py``'s contract).
+``block_rate`` therefore measures "how often did the guard do its job
+when it had the chance". Block rate alone is not a fitness *delta*: a
+guard that always blocks may be too noisy. The classifier maps block
+rate to a centered fitness value:
+
+    fitness = block_rate - 0.5
+
+So a guard that blocks half the time has fitness 0 (neutral); blocking
+much more often is positive (doing real work); blocking far less than
+half is negative (mostly noise / fail-opens). Thresholds use ``±0.02``
+to capture meaningful positive or negative signal without rounding
+small samples to zero.
+
+Future work: the wiki's Hook Maturity Model concept references a
+fitness score derived from "true positive vs noisy positive" signals
+that this codebase does not capture today. When per-event ground-truth
+labels exist, swap the fitness formula in ``compute_fitness`` without
+changing the threshold table.
+
+Exit codes (per AGENTS.md):
+    0 = ok
+    1 = logic error (input not parseable)
+    2 = config error (bad --source path)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Tier thresholds. Modify here to adjust policy; tests pin the canonical
+# transitions so a change here is intentional.
+HARMFUL_FITNESS_MAX = -0.02
+PROFICIENT_FITNESS_MIN = 0.02
+PROFICIENT_AGE_DAYS = 60.0
+PROFICIENT_INTERCEPTS = 10
+MATURE_AGE_DAYS = 30.0
+MATURE_INTERCEPTS = 5
+INERT_AGE_DAYS = 30.0
+GROWING_AGE_MIN_DAYS = 14.0
+
+
+def compute_fitness(block_rate: float) -> float:
+    """Map block rate to a centered fitness signal.
+
+    See module docstring for the choice. Centered on 0.5 so a balanced
+    guard reads as neutral; positive values reward catching, negative
+    values penalize fail-open dominance.
+    """
+    return block_rate - 0.5
+
+
+def classify_one(summary: dict, treat_unseen_as_inert: bool = False) -> str:
+    """Return the tier for a single guard summary.
+
+    The summary shape matches ``aggregate_guard_intercepts.py`` output:
+    keys ``total_events``, ``blocks``, ``fail_opens``, ``block_rate``,
+    ``days_since_first_event``.
+    """
+    intercepts = int(summary.get("blocks", 0)) + int(summary.get("fail_opens", 0))
+    block_rate = float(summary.get("block_rate", 0.0))
+    fitness = compute_fitness(block_rate)
+    age = summary.get("days_since_first_event")
+
+    # Harmful first: a known-bad guard at any age is a remove-on-sight.
+    if intercepts >= 1 and fitness < HARMFUL_FITNESS_MAX:
+        return "Harmful"
+
+    if age is None:
+        # Never observed firing.
+        if treat_unseen_as_inert:
+            return "Inert"
+        return "Budding"
+
+    # Inert: been around long enough to fire, never did. Prune candidate.
+    if age >= INERT_AGE_DAYS and intercepts == 0:
+        return "Inert"
+
+    # Proficient: mature, productive, positive fitness.
+    if (age >= PROFICIENT_AGE_DAYS
+            and intercepts >= PROFICIENT_INTERCEPTS
+            and fitness >= PROFICIENT_FITNESS_MIN):
+        return "Proficient"
+
+    # Mature: settled and net-positive.
+    if (age >= MATURE_AGE_DAYS
+            and intercepts >= MATURE_INTERCEPTS
+            and fitness >= 0):
+        return "Mature"
+
+    # Growing: adolescent age, has fired at least once.
+    if GROWING_AGE_MIN_DAYS <= age < INERT_AGE_DAYS and intercepts >= 1:
+        return "Growing"
+
+    # Budding: too young to assess, or in a quiet patch.
+    return "Budding"
+
+
+def classify(summaries: dict, treat_unseen_as_inert: bool = False) -> dict:
+    """Classify every guard summary; return name -> {tier, fitness, ...}."""
+    out: dict = {}
+    for name, s in summaries.items():
+        block_rate = float(s.get("block_rate", 0.0))
+        intercepts = int(s.get("blocks", 0)) + int(s.get("fail_opens", 0))
+        out[name] = {
+            "guard": name,
+            "tier": classify_one(s, treat_unseen_as_inert=treat_unseen_as_inert),
+            "fitness": compute_fitness(block_rate),
+            "intercepts": intercepts,
+            "blocks": int(s.get("blocks", 0)),
+            "fail_opens": int(s.get("fail_opens", 0)),
+            "block_rate": block_rate,
+            "days_since_first_event": s.get("days_since_first_event"),
+            "days_since_last_event": s.get("days_since_last_event"),
+        }
+    return out
+
+
+def _build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Classify push guards by Hook Maturity Model tier.",
+    )
+    parser.add_argument(
+        "--source",
+        default=None,
+        help="Path to aggregator JSON output. Defaults to stdin.",
+    )
+    parser.add_argument(
+        "--treat-unseen-as-inert",
+        action="store_true",
+        help=("Mark guards with null days_since_first_event as Inert "
+              "instead of Budding. Use after enough wall-clock time has "
+              "passed to expect at least one event."),
+    )
+    return parser
+
+
+def _load_input(path_arg: str | None) -> dict:
+    if path_arg:
+        return json.loads(Path(path_arg).read_text(encoding="utf-8"))
+    if sys.stdin.isatty():
+        raise ValueError("no --source and no stdin")
+    return json.loads(sys.stdin.read())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_argparser()
+    args = parser.parse_args(argv)
+    try:
+        summaries = _load_input(args.source)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: cannot read aggregator JSON: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(summaries, dict):
+        print("error: aggregator JSON must be an object keyed by guard name.",
+              file=sys.stderr)
+        return 1
+    classified = classify(summaries, treat_unseen_as_inert=args.treat_unseen_as_inert)
+    json.dump(classified, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/guard-maturity-runbook.md
+++ b/docs/guard-maturity-runbook.md
@@ -1,0 +1,125 @@
+# Guard Maturity Runbook
+
+How to read the guard maturity report and what to do with it.
+
+The push guards built on `.claude/hooks/PreToolUse/push_guard_base.py`
+(M2 markdown lint, M3 manifest count, M4 session log, M5 PR description,
+and any future siblings) emit structured `EVENT={...}` lines on stderr
+for every block and every fail-open. The Hook Maturity Model classifies
+each guard into one of six tiers based on age, intercept count, and a
+fitness signal derived from block rate.
+
+This runbook tells you what to do with the report.
+
+## Generating the report
+
+```bash
+# From the repo root.
+python3 build/scripts/aggregate_guard_intercepts.py \
+  --guard markdown-lint --guard manifest-count \
+  --guard pr-description --guard session-log \
+  | python3 build/scripts/classify_guard_maturity.py
+```
+
+Or via the skill wrapper that reads the same telemetry source and
+prints a sorted human-readable table:
+
+```bash
+python3 .claude/skills/guard-maturity/scripts/run_report.py
+```
+
+The wrapper prints the table on stdout and the raw JSON on stderr, so
+both can be captured.
+
+## Reading the report
+
+Each row is one guard. Columns:
+
+| Column | Meaning |
+|---|---|
+| `tier` | Hook Maturity Model classification |
+| `guard` | Guard name (matches `EVENT.guard`) |
+| `intercepts` | Total events: blocks + fail-opens |
+| `fitness` | `block_rate - 0.5`. Positive = catching real issues; negative = mostly fail-opens or noise |
+| `age_days` | Days since the first observed event for this guard |
+
+The classifier sorts by tier severity (Harmful first, Inert second,
+then Budding, Growing, Mature, Proficient). Within a tier it sorts by
+intercept count descending. Read top-down.
+
+## What to do per tier
+
+| Tier | Threshold | Action | Why |
+|---|---|---|---|
+| **Harmful** | any age, ≥1 intercept, fitness < -0.02 | **Remove now**. Open an issue, delete the guard, send a PR. | A guard that fails open more than it blocks normalizes bypass. Other guards lose credibility. |
+| **Inert** | ≥30 days, 0 intercepts | **Prune candidate**. Confirm via grep that the guard's globs have not matched any pushed file in the window, then remove. | A guard that has not fired for a month is paying nothing for the cognitive load it imposes on contributors. |
+| **Budding** | <14 days | **Hold**. Watch the next two weeks. | Too young to score. Most new guards land here. |
+| **Growing** | 14-30 days, ≥1 intercept | **Hold**. Re-evaluate at 30 days. | Adolescent. The guard fires; we do not yet know whether the catches are real. |
+| **Mature** | ≥30 days, ≥5 intercepts, fitness ≥ 0 | **Keep**. Periodic review only. | The guard is settled and net-positive. Leave it alone. |
+| **Proficient** | ≥60 days, ≥10 intercepts, fitness ≥ +0.02 | **Promote**. Add to the canonical guard list in PR templates and onboarding docs. Cite as evidence when reviewing related guards. | The guard catches real issues regularly. Other contributors should know it exists. |
+
+## When to prune vs promote
+
+Prune (move to Inert -> remove) when:
+
+- Age is ≥30 days **and** intercepts is 0 across the whole telemetry
+  window. Confirm by inspecting the source telemetry; an empty file is
+  not the same as zero events.
+- The guard's globs have demonstrably not matched any pushed file in
+  the last 30 days. Run a quick grep over the canonical event log
+  before deleting; if globs match but no events exist, the guard's
+  validator may be silently fail-opening, in which case the right move
+  is **fix**, not **prune**.
+
+Promote (move from Mature to Proficient) when:
+
+- Age is ≥60 days **and** intercepts is ≥10 **and** fitness is
+  ≥ +0.02. Promotion is a formal step: update the PR template and
+  onboarding docs to reference the guard.
+
+Remove (Harmful) immediately when:
+
+- Fitness is < -0.02 with at least one intercept. The guard is teaching
+  contributors to ignore push guards. Removing a Harmful guard is
+  always cheaper than letting it normalize bypass.
+
+## Fitness in detail
+
+`fitness = block_rate - 0.5`
+
+| block_rate | fitness | Reading |
+|---|---|---|
+| 1.0 | +0.5 | Always blocks. Possibly noisy; check matched_files counts. |
+| 0.7 | +0.2 | Mostly blocks. Healthy. |
+| 0.5 | 0.0 | Half blocks, half fail-opens. Neutral. |
+| 0.3 | -0.2 | Mostly fail-opens. Investigate root cause. |
+| 0.0 | -0.5 | Always fails open. Harmful by definition. |
+
+The +/-0.02 threshold for Harmful and Proficient guards small samples
+from being labeled either way on a single noisy event.
+
+When the codebase gains true positive vs noisy positive labels per
+event, swap the formula in `compute_fitness()` without changing the
+threshold table.
+
+## Cadence
+
+- Weekly: glance at the report. Promote anything Proficient. Open an
+  issue for anything Harmful.
+- Every 30 days: full pass. Prune Inert guards. Re-evaluate Growing
+  guards.
+- Before adding a new guard: run the report. Confirm no existing guard
+  already covers the case at a higher tier than the new one would
+  arrive at.
+
+## Why this exists
+
+The retrospective on PR #1887
+(`.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`)
+documents that 95+ crystallized hooks earlier accumulated without
+measurement. Each hook adds cognitive load on contributors and execution
+cost on every push. Without a fitness scorecard, hooks accumulate as
+dead weight.
+
+The Hook Maturity Model is the scorecard. This runbook is how you act
+on it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 license = {text = "MIT"}
 
 dependencies = [
-    "anthropic==0.97.0",
+    "anthropic==0.99.0",
     "markdown-it-py>=4.0.0",
     "python-frontmatter==1.1.0",
     "PyYAML==6.0.3",

--- a/src/copilot-cli/skills/build/SKILL.md
+++ b/src/copilot-cli/skills/build/SKILL.md
@@ -50,3 +50,9 @@ The agent should self-check:
 - No code without understanding the existing patterns first.
 - Favor delegation over inheritance. A makes B, or A uses B. Never both.
 - Three similar lines beat a premature abstraction.
+
+## Optional Final Gate: Guard Maturity Report
+
+Optionally invoke Skill(skill="guard-maturity") at the end of the build to print the Hook Maturity Model report for the push guards. This gate is **informational at landing**; promote it to mandatory after 30 days of real telemetry have accumulated in `.agents/telemetry/`. Until then, an empty report is expected and not a failure.
+
+Rationale: the retrospective on PR #1887 (`.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`) flagged that 95+ crystallized hooks earlier accumulated without measurement. The build flow surfaces the maturity report so contributors see the cost of new guards alongside the work they are landing. See `docs/guard-maturity-runbook.md` for how to read the output.

--- a/src/copilot-cli/skills/guard-maturity/SKILL.md
+++ b/src/copilot-cli/skills/guard-maturity/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: guard-maturity
+version: 1.0.0
+model: claude-haiku-4-5
+description: Classify push guards by Hook Maturity Model tier. Aggregates EVENT lines emitted by push_guard_base.py and assigns each guard a tier (Budding, Growing, Mature, Proficient, Inert, Harmful) based on age, intercept count, and fitness derived from block rate. Use to decide when to promote a new guard, when to prune dead weight, and when to remove a harmful one. Triggers `guard maturity report`, `classify push guards`, `hook maturity tiers`.
+license: MIT
+---
+
+# Guard Maturity
+
+Hook Maturity Model fitness scoring for the push guards (M2/M3/M4/M5
+and any future siblings built on `push_guard_base.py`).
+
+The retrospective on PR #1887 (`.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`)
+flagged that 95+ crystallized hooks earlier accumulated without
+measurement. This skill is the measurement: real intercept counts feed
+real tier assignments, and the tier dictates whether a guard gets kept,
+promoted, or pruned.
+
+## When to use
+
+- **Periodic review** (recommended every 30 days once telemetry is
+  flowing): run the report, prune Inert guards, promote Proficient
+  ones, remove Harmful ones immediately.
+- **Before adding a new guard**: confirm no existing guard already
+  covers the case at a higher tier.
+- **Pre-release**: include the report in the release notes so the team
+  can see which guards are paying for themselves.
+
+## What it does
+
+1. Calls `python3 build/scripts/aggregate_guard_intercepts.py` against
+   `.agents/telemetry/` (or stdin if no telemetry has landed yet).
+2. Pipes the JSON summary into
+   `python3 build/scripts/classify_guard_maturity.py`.
+3. Prints a table (one row per guard) sorted by tier severity:
+   `Harmful` first, then `Inert`, then `Budding`, `Growing`, `Mature`,
+   `Proficient`.
+
+## Tier definitions
+
+| Tier | Age | Intercepts | Fitness | Action |
+|---|---|---|---|---|
+| Harmful | any | ≥1 | < -0.02 | Remove immediately |
+| Proficient | ≥60 days | ≥10 | ≥ +0.02 | Promote, keep watching |
+| Mature | ≥30 days | ≥5 | ≥ 0 | Keep, low review |
+| Growing | 14-30 days | ≥1 | any | Adolescent, hold |
+| Inert | ≥30 days | 0 | n/a | Prune candidate |
+| Budding | <14 days | any | any | New, anything goes |
+
+Fitness is `block_rate - 0.5` (centered). The full rationale lives in
+the classifier's module docstring.
+
+## Quick start
+
+```bash
+# Default: read .agents/telemetry/*.jsonl, classify, print report.
+python3 build/scripts/aggregate_guard_intercepts.py \
+  --guard markdown-lint --guard manifest-count --guard pr-description --guard session-log \
+  | python3 build/scripts/classify_guard_maturity.py
+```
+
+The `--guard` flags ensure that guards which have NEVER fired still
+appear in the report (otherwise an Inert guard with zero events would
+silently drop out of the summary).
+
+## Production wiring
+
+The capture pipeline that writes to `.agents/telemetry/` is TBD; the
+push guards already emit the right `EVENT=` lines on stderr per
+`.claude/hooks/PreToolUse/push_guard_base.py`. Until the pipeline lands,
+you can capture events ad-hoc:
+
+```bash
+git push 2>&1 | tee /tmp/push.log
+grep '^EVENT=' /tmp/push.log >> .agents/telemetry/$(date +push-guard-events-%G-%V).jsonl
+```
+
+Then run the aggregator + classifier as above.
+
+## See also
+
+- `docs/guard-maturity-runbook.md` (how to read the report and what
+  action each tier suggests).
+- `.claude/hooks/PreToolUse/push_guard_base.py` (the EVENT contract
+  this skill consumes).
+- `.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`
+  (Phase 5 action items, Layer 5 of the iteration-paradox stack).

--- a/src/copilot-cli/skills/guard-maturity/scripts/run_report.py
+++ b/src/copilot-cli/skills/guard-maturity/scripts/run_report.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Run the guard maturity report end-to-end.
+
+Thin wrapper around the two build/scripts:
+
+1. ``aggregate_guard_intercepts.py``
+2. ``classify_guard_maturity.py``
+
+Output is a human-readable table printed to stdout, plus the raw JSON
+report on stderr (so a caller can capture it with ``2>``).
+
+The wrapper keeps logic out of the SKILL.md prose (the skill should
+describe what to do; the script should do it). All tier and fitness
+math lives in the classifier; this file is presentation only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+AGGREGATE = REPO_ROOT / "build" / "scripts" / "aggregate_guard_intercepts.py"
+CLASSIFY = REPO_ROOT / "build" / "scripts" / "classify_guard_maturity.py"
+
+# Severity sort: Harmful first (act now), then Inert (prune), then the
+# happy tiers. Within a tier, sort by intercepts descending so the
+# loudest guards float to the top.
+TIER_ORDER = {
+    "Harmful": 0,
+    "Inert": 1,
+    "Budding": 2,
+    "Growing": 3,
+    "Mature": 4,
+    "Proficient": 5,
+}
+
+
+def _run_aggregate(known_guards: list[str], source: str | None) -> dict:
+    cmd = [sys.executable, str(AGGREGATE)]
+    for g in known_guards:
+        cmd.extend(["--guard", g])
+    if source:
+        cmd.extend(["--source", source])
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(proc.returncode)
+    return json.loads(proc.stdout)
+
+
+def _run_classify(summary: dict, treat_unseen_as_inert: bool) -> dict:
+    cmd = [sys.executable, str(CLASSIFY)]
+    if treat_unseen_as_inert:
+        cmd.append("--treat-unseen-as-inert")
+    proc = subprocess.run(
+        cmd,
+        input=json.dumps(summary),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(proc.returncode)
+    return json.loads(proc.stdout)
+
+
+def _format_table(report: dict) -> str:
+    rows = sorted(
+        report.values(),
+        key=lambda r: (TIER_ORDER.get(r["tier"], 99), -r["intercepts"], r["guard"]),
+    )
+    if not rows:
+        return "(no guards in report)\n"
+    header = f"{'tier':<11} {'guard':<22} {'intercepts':>10} {'fitness':>8} {'age_days':>9}"
+    lines = [header, "-" * len(header)]
+    for r in rows:
+        age = r.get("days_since_first_event")
+        age_s = f"{age:.1f}" if isinstance(age, (int, float)) else "n/a"
+        lines.append(
+            f"{r['tier']:<11} {r['guard']:<22} {r['intercepts']:>10} "
+            f"{r['fitness']:>+7.2f} {age_s:>9}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the guard maturity report (aggregate + classify).",
+    )
+    parser.add_argument(
+        "--guard",
+        action="append",
+        default=[
+            "markdown-lint",
+            "manifest-count",
+            "pr-description",
+            "session-log",
+        ],
+        help=("Guard name to include even with zero events. Repeatable. "
+              "Defaults cover M2-M5."),
+    )
+    parser.add_argument(
+        "--source",
+        default=None,
+        help="Override telemetry source path (file or directory).",
+    )
+    parser.add_argument(
+        "--treat-unseen-as-inert",
+        action="store_true",
+        help="Mark guards with no events as Inert instead of Budding.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit raw JSON instead of the human-readable table.",
+    )
+    args = parser.parse_args(argv)
+
+    summary = _run_aggregate(args.guard, args.source)
+    report = _run_classify(summary, args.treat_unseen_as_inert)
+
+    if args.json:
+        json.dump(report, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(_format_table(report))
+        # Stash the raw JSON on stderr so callers can capture both.
+        json.dump(report, sys.stderr, indent=2, sort_keys=True)
+        sys.stderr.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/build_scripts/test_aggregate_guard_intercepts.py
+++ b/tests/build_scripts/test_aggregate_guard_intercepts.py
@@ -1,0 +1,225 @@
+"""Tests for build/scripts/aggregate_guard_intercepts.py.
+
+Synthetic event-log fixtures only; no live telemetry. Covers:
+
+- Directory and file source modes
+- STDIN mode via the script's argparse path
+- Malformed lines silently skipped
+- ``--guard`` injection of zero-event guards
+- Time math for ``days_since_*`` fields with ``--now`` override
+- Block / fail-open separation in counts and rates
+
+Negative tests cover unreadable sources, bad JSON, and bad ``--now``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "build" / "scripts"))
+
+import aggregate_guard_intercepts as agi  # noqa: E402
+
+_FIXED_NOW = "2026-05-05T00:00:00+00:00"
+
+
+def _write_jsonl(path: Path, events: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(e) for e in events) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _block(guard: str, ts: str) -> dict:
+    return {
+        "guard": guard,
+        "code": f"E_{guard.upper().replace('-', '_')}",
+        "outcome": "block",
+        "violations": 1,
+        "matched_files": 1,
+        "changed_files": 3,
+        "timestamp": ts,
+    }
+
+
+def _fail_open(guard: str, ts: str) -> dict:
+    return {
+        "guard": guard,
+        "code": f"E_{guard.upper().replace('-', '_')}",
+        "outcome": "fail_open",
+        "reason": "exception",
+        "detail": "boom",
+        "timestamp": ts,
+    }
+
+
+# ---------------------------------------------------------------------
+# Happy-path tests
+# ---------------------------------------------------------------------
+
+def test_aggregates_blocks_and_fail_opens_per_guard(tmp_path, capsys):
+    log = tmp_path / "events.jsonl"
+    _write_jsonl(log, [
+        _block("markdown-lint", "2026-04-25T10:00:00+00:00"),
+        _fail_open("markdown-lint", "2026-05-01T10:00:00+00:00"),
+        _block("manifest-count", "2026-05-04T10:00:00+00:00"),
+    ])
+    rc = agi.main(["--source", str(log), "--now", _FIXED_NOW])
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    out = json.loads(captured.out)
+    assert set(out.keys()) == {"markdown-lint", "manifest-count"}
+    md = out["markdown-lint"]
+    assert md["total_events"] == 2
+    assert md["blocks"] == 1
+    assert md["fail_opens"] == 1
+    assert md["block_rate"] == 0.5
+    assert md["fail_open_rate"] == 0.5
+    mc = out["manifest-count"]
+    assert mc["total_events"] == 1
+    assert mc["blocks"] == 1
+    assert mc["fail_opens"] == 0
+    assert mc["block_rate"] == 1.0
+
+
+def test_directory_source_picks_up_all_jsonl(tmp_path, capsys):
+    (tmp_path / "wk-a.jsonl").write_text(
+        json.dumps(_block("g1", "2026-05-01T00:00:00+00:00")) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "wk-b.jsonl").write_text(
+        json.dumps(_fail_open("g1", "2026-05-04T00:00:00+00:00")) + "\n",
+        encoding="utf-8",
+    )
+    rc = agi.main(["--source", str(tmp_path), "--now", _FIXED_NOW])
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    out = json.loads(captured.out)
+    g = out["g1"]
+    assert g["blocks"] == 1
+    assert g["fail_opens"] == 1
+    assert g["days_since_first_event"] > g["days_since_last_event"]
+
+
+def test_event_prefix_is_stripped(tmp_path, capsys):
+    log = tmp_path / "raw.jsonl"
+    log.write_text(
+        f"EVENT={json.dumps(_block('g1', '2026-05-01T00:00:00+00:00'))}\n",
+        encoding="utf-8",
+    )
+    rc = agi.main(["--source", str(log), "--now", _FIXED_NOW])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert json.loads(captured.out)["g1"]["blocks"] == 1
+
+
+def test_explicit_guard_listed_with_zero_events(tmp_path, capsys):
+    log = tmp_path / "events.jsonl"
+    _write_jsonl(log, [_block("seen", "2026-05-01T00:00:00+00:00")])
+    rc = agi.main(["--source", str(log), "--guard", "unseen", "--now", _FIXED_NOW])
+    captured = capsys.readouterr()
+    assert rc == 0
+    out = json.loads(captured.out)
+    assert "unseen" in out
+    assert out["unseen"]["total_events"] == 0
+    assert out["unseen"]["days_since_first_event"] is None
+
+
+def test_stdin_mode_reads_event_lines(monkeypatch, capsys):
+    payload = (
+        "stderr noise\n"
+        f"EVENT={json.dumps(_block('g1', '2026-05-01T00:00:00+00:00'))}\n"
+        "more noise\n"
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+    # io.StringIO has no isatty; force False via patch.
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False, raising=False)
+    rc = agi.main(["--stdin", "--now", _FIXED_NOW])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert json.loads(captured.out)["g1"]["blocks"] == 1
+
+
+def test_age_computation_uses_now_override(tmp_path, capsys):
+    log = tmp_path / "events.jsonl"
+    _write_jsonl(log, [_block("g1", "2026-05-01T00:00:00+00:00")])
+    rc = agi.main(["--source", str(log), "--now", "2026-05-08T00:00:00+00:00"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    g = json.loads(captured.out)["g1"]
+    assert g["days_since_first_event"] == pytest.approx(7.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------
+# Lenience: malformed input
+# ---------------------------------------------------------------------
+
+def test_malformed_lines_are_skipped(tmp_path, capsys):
+    log = tmp_path / "events.jsonl"
+    log.write_text(
+        "\n".join([
+            "not json at all",
+            "{not: valid}",
+            "[]",  # not a dict
+            "{}",  # missing required keys
+            json.dumps({"guard": "g1"}),  # missing outcome
+            json.dumps(_block("g1", "2026-05-01T00:00:00+00:00")),
+        ]) + "\n",
+        encoding="utf-8",
+    )
+    rc = agi.main(["--source", str(log), "--now", _FIXED_NOW])
+    captured = capsys.readouterr()
+    assert rc == 0
+    out = json.loads(captured.out)
+    assert out["g1"]["total_events"] == 1
+
+
+# ---------------------------------------------------------------------
+# Negative tests
+# ---------------------------------------------------------------------
+
+def test_no_events_and_no_guard_returns_logic_error(tmp_path, capsys):
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("", encoding="utf-8")
+    rc = agi.main(["--source", str(empty), "--now", _FIXED_NOW])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "nothing to summarize" in captured.err
+
+
+def test_bad_now_returns_config_error(tmp_path, capsys):
+    log = tmp_path / "events.jsonl"
+    _write_jsonl(log, [_block("g1", "2026-05-01T00:00:00+00:00")])
+    rc = agi.main(["--source", str(log), "--now", "not-a-date"])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "invalid --now" in captured.err
+
+
+def test_missing_source_warns_and_falls_through(tmp_path, capsys):
+    missing = tmp_path / "does-not-exist"
+    rc = agi.main(["--source", str(missing), "--now", _FIXED_NOW])
+    captured = capsys.readouterr()
+    # No events, no guards -> logic error 1.
+    assert rc == 1
+    assert "source not found" in captured.err
+
+
+def test_event_without_guard_is_skipped(tmp_path, capsys):
+    log = tmp_path / "events.jsonl"
+    log.write_text(
+        json.dumps({"guard": "", "outcome": "block"}) + "\n"
+        + json.dumps(_block("g1", "2026-05-01T00:00:00+00:00")) + "\n",
+        encoding="utf-8",
+    )
+    rc = agi.main(["--source", str(log), "--now", _FIXED_NOW])
+    captured = capsys.readouterr()
+    assert rc == 0
+    out = json.loads(captured.out)
+    assert "g1" in out and "" not in out

--- a/tests/build_scripts/test_classify_guard_maturity.py
+++ b/tests/build_scripts/test_classify_guard_maturity.py
@@ -1,0 +1,207 @@
+"""Tests for build/scripts/classify_guard_maturity.py.
+
+Pin every Hook Maturity Model tier transition. Each test exercises a
+single tier; together they cover all six (Budding, Growing, Mature,
+Proficient, Inert, Harmful) plus the order-sensitive "Harmful wins
+over everything" precedence rule.
+
+Negative tests cover bad input shapes, unreadable files, and the CLI
+parsing of stdin.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "build" / "scripts"))
+
+import classify_guard_maturity as cgm  # noqa: E402
+
+
+def _summary(
+    *,
+    blocks: int = 0,
+    fail_opens: int = 0,
+    age: float | None = None,
+    last_age: float | None = None,
+) -> dict:
+    total = blocks + fail_opens
+    return {
+        "guard": "test-guard",
+        "total_events": total,
+        "blocks": blocks,
+        "fail_opens": fail_opens,
+        "block_rate": (blocks / total) if total else 0.0,
+        "fail_open_rate": (fail_opens / total) if total else 0.0,
+        "first_event": None,
+        "last_event": None,
+        "days_since_first_event": age,
+        "days_since_last_event": last_age if last_age is not None else age,
+    }
+
+
+# ---------------------------------------------------------------------
+# Single-guard tier tests (all six tiers)
+# ---------------------------------------------------------------------
+
+def test_budding_under_14_days_any_intercepts():
+    s = _summary(blocks=2, age=5.0)
+    assert cgm.classify_one(s) == "Budding"
+
+
+def test_budding_when_age_is_null_default_unseen():
+    s = _summary(blocks=0, age=None)
+    assert cgm.classify_one(s) == "Budding"
+
+
+def test_growing_14_to_30_days_with_intercepts():
+    s = _summary(blocks=1, age=20.0)
+    assert cgm.classify_one(s) == "Growing"
+
+
+def test_growing_lower_bound_at_14_days():
+    s = _summary(blocks=1, age=14.0)
+    assert cgm.classify_one(s) == "Growing"
+
+
+def test_mature_30_plus_days_5_plus_intercepts_neutral_fitness():
+    # Block rate exactly 0.5 -> fitness exactly 0.0, which qualifies for
+    # Mature (fitness >= 0).
+    s = _summary(blocks=3, fail_opens=3, age=45.0)
+    assert cgm.classify_one(s) == "Mature"
+
+
+def test_proficient_60_plus_days_10_plus_intercepts_positive_fitness():
+    # 10 blocks, 0 fail_opens -> block_rate 1.0 -> fitness 0.5.
+    s = _summary(blocks=10, age=90.0)
+    assert cgm.classify_one(s) == "Proficient"
+
+
+def test_inert_30_plus_days_zero_intercepts():
+    s = _summary(blocks=0, fail_opens=0, age=45.0)
+    assert cgm.classify_one(s) == "Inert"
+
+
+def test_harmful_negative_fitness_at_any_age():
+    # All fail-opens -> block_rate 0.0 -> fitness -0.5.
+    s = _summary(fail_opens=3, age=2.0)
+    assert cgm.classify_one(s) == "Harmful"
+
+
+def test_harmful_precedence_beats_proficient():
+    # 60 days, 10 intercepts, but all are fail-opens -> Harmful first.
+    s = _summary(fail_opens=10, age=90.0)
+    assert cgm.classify_one(s) == "Harmful"
+
+
+def test_treat_unseen_as_inert_flips_null_age_to_inert():
+    s = _summary(blocks=0, age=None)
+    assert cgm.classify_one(s, treat_unseen_as_inert=True) == "Inert"
+
+
+# ---------------------------------------------------------------------
+# Edge transitions and boundary semantics
+# ---------------------------------------------------------------------
+
+def test_proficient_just_misses_intercept_count_falls_back_to_mature():
+    # 60+ days, 9 intercepts (< 10), positive fitness -> Mature.
+    s = _summary(blocks=9, age=70.0)
+    assert cgm.classify_one(s) == "Mature"
+
+
+def test_mature_just_misses_intercept_count_falls_back_to_growing():
+    # 30+ days, 4 intercepts (< 5), positive fitness -> falls into the
+    # Growing band only if age < 30. At 30 days exactly with <5 intercepts,
+    # we hit none of (Inert, Proficient, Mature, Growing) and land on Budding.
+    s = _summary(blocks=4, age=30.0)
+    assert cgm.classify_one(s) == "Budding"
+
+
+def test_growing_at_exactly_30_days_drops_to_budding_quiet_patch():
+    s = _summary(blocks=1, age=30.0)
+    # 30 days exact: not Inert (intercepts > 0), not Mature (intercepts < 5),
+    # not Growing (age >= 30 limit), so it lands in Budding's catch-all.
+    assert cgm.classify_one(s) == "Budding"
+
+
+def test_fitness_centered_on_block_rate():
+    assert cgm.compute_fitness(0.0) == -0.5
+    assert cgm.compute_fitness(0.5) == 0.0
+    assert cgm.compute_fitness(1.0) == 0.5
+
+
+# ---------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------
+
+def test_cli_classifies_aggregator_output_via_stdin(monkeypatch, capsys):
+    summaries = {
+        "g1": _summary(blocks=10, age=90.0),
+        "g2": _summary(fail_opens=3, age=10.0),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(summaries)))
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False, raising=False)
+    rc = cgm.main([])
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    out = json.loads(captured.out)
+    assert out["g1"]["tier"] == "Proficient"
+    assert out["g2"]["tier"] == "Harmful"
+
+
+def test_cli_reads_source_file(tmp_path, capsys):
+    payload = {"g1": _summary(blocks=10, age=90.0)}
+    src = tmp_path / "agg.json"
+    src.write_text(json.dumps(payload), encoding="utf-8")
+    rc = cgm.main(["--source", str(src)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert json.loads(captured.out)["g1"]["tier"] == "Proficient"
+
+
+def test_cli_treat_unseen_as_inert_flag_propagates(tmp_path, capsys):
+    payload = {"g1": _summary(blocks=0, age=None)}
+    src = tmp_path / "agg.json"
+    src.write_text(json.dumps(payload), encoding="utf-8")
+    rc = cgm.main(["--source", str(src), "--treat-unseen-as-inert"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert json.loads(captured.out)["g1"]["tier"] == "Inert"
+
+
+# ---------------------------------------------------------------------
+# Negative tests
+# ---------------------------------------------------------------------
+
+def test_cli_bad_source_returns_config_error(tmp_path, capsys):
+    rc = cgm.main(["--source", str(tmp_path / "missing.json")])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "cannot read aggregator JSON" in captured.err
+
+
+def test_cli_non_object_input_returns_logic_error(tmp_path, capsys):
+    src = tmp_path / "agg.json"
+    src.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    rc = cgm.main(["--source", str(src)])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "must be an object" in captured.err
+
+
+def test_classify_pure_function_returns_dict_per_guard():
+    summaries = {
+        "g1": _summary(blocks=10, age=90.0),
+        "g2": _summary(blocks=0, age=45.0),
+    }
+    out = cgm.classify(summaries)
+    assert out["g1"]["tier"] == "Proficient"
+    assert out["g2"]["tier"] == "Inert"
+    assert "fitness" in out["g1"]
+    assert "intercepts" in out["g2"]

--- a/uv.lock
+++ b/uv.lock
@@ -35,7 +35,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = "==0.97.0" },
+    { name = "anthropic", specifier = "==0.99.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.9.4" },
     { name = "markdown-it-py", specifier = ">=4.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.20.2" },
@@ -63,7 +63,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.97.0"
+version = "0.99.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -75,9 +75,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/93/f66ea8bfe39f2e6bb9da8e27fa5457ad2520e8f7612dfc547b17fad55c4d/anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be", size = 669502, upload-time = "2026-04-23T20:52:34.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/c9/e8a3a1caeab575e80551b30b084096b5a430abc52739a526a1daaadd038c/anthropic-0.99.0.tar.gz", hash = "sha256:16f41e00f215ed2d193b146be3dd567c4319c32ed3af6c8725d68ba875257c1c", size = 727239, upload-time = "2026-05-05T16:03:07.986Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b6/8e851369fa661ad0fef2ae6266bf3b7d52b78ccf011720058f4adaca59e2/anthropic-0.97.0-py3-none-any.whl", hash = "sha256:8a1a472dfabcfc0c52ff6a3eecf724ac7e07107a2f6e2367be55ceb42f5d5613", size = 662126, upload-time = "2026-04-23T20:52:32.377Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/d0917506744e1707cf55659a57f1e3ff952eda5636df0ffffe3e884b7c61/anthropic-0.99.0-py3-none-any.whl", hash = "sha256:c44469b746ab2ef19a4c52dcbdb98e17bc95c60bebdd18ec40d76d2d23592b49", size = 700564, upload-time = "2026-05-05T16:03:06.059Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds the **Hook Maturity Model** to the push guards (M2/M3/M4/M5) so they earn a fitness score from real intercepts instead of accumulating as unmeasured weight. This is **Layer 5** of the 5-layer remediation derived from the PR #1887 retrospective at `.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`.

The retrospective notes the repo previously accumulated 95+ crystallized hooks without effectiveness measurement, and the new push guards risk the same pattern. The wiki concept "Hook Maturity Model" defines a 6-tier schema (Budding / Growing / Mature / Proficient / Inert / Harmful) scored on age, intercept count, and fitness delta. The push guards already emit structured `EVENT={"guard": ..., "outcome": "block"|"fail_open", ...}` lines on stderr per `push_guard_base.py`; this PR builds the aggregator and tier classifier on top of that contract.

Depends on PR `feat/evidence-standards-implementer-1890` (PR 3 of the 5-PR stack derived from the PR #1887 retrospective).

Refs #1887

## Changes

1. **`build/scripts/aggregate_guard_intercepts.py`** (new, 252 lines, stdlib only) — reads `.agents/telemetry/push-guard-events.jsonl` (or stdin) and outputs per-guard summary: name, total intercepts (block + fail_open), block rate, fail-open rate, days-since-first-event, days-since-last-event.
2. **`build/scripts/classify_guard_maturity.py`** (new, 200 lines, stdlib only) — applies Hook Maturity Model thresholds: Budding (0-14d), Growing (14-30d, ≥1 intercept), Mature (30+d, ≥5, fitness ≥ 0), Proficient (60+d, ≥10, fitness ≥ +0.02), Inert (30+d, 0 intercepts), Harmful (any age, intercepts, fitness < -0.02). Fitness = `block_rate - 0.5` (centered so 50/50 reads as neutral).
3. **`.claude/skills/guard-maturity/`** (new) — thin skill wrapper around the two build/scripts. `Skill(skill="guard-maturity")` prints a maturity report.
4. **`tests/build_scripts/test_aggregate_guard_intercepts.py`** + **`tests/build_scripts/test_classify_guard_maturity.py`** — 31 tests pinning all 6 tier transitions with positive, negative, edge cases.
5. **`docs/guard-maturity-runbook.md`** (new) — operator runbook: how to read the report, when to prune vs promote, what action each tier suggests.
6. **`.agents/telemetry/`** (new) — placeholder directory with `.gitkeep` and `README.md` documenting the EVENT contract.
7. **`.claude/commands/build.md`** — appends an *optional* (informational) "Guard Maturity Report" gate. Comment notes: "promote to mandatory after 30 days of real telemetry".
8. **`.claude-plugin/marketplace.json`** — count bump 69 → 70 for the new skill.
9. **`src/copilot-cli/skills/{build,guard-maturity}/...`** — regenerated copilot-cli artifacts.

## Design notes

- **Fitness formula choice**: `block_rate - 0.5`. Centered so 50/50 reads as neutral; positive rewards real catches. Documented in classifier docstring as today's mapping; the threshold table is policy that survives a future formula swap.
- **Production telemetry pipeline TBD**: aggregator reads from `.agents/telemetry/` directory or stdin. Per the brief, this PR is not blocked on the pipeline change; it ships the consumer.
- **Optional gate, not mandatory**: guard-maturity is informational at landing because the guards need ~30 days in production before scores are meaningful. The brief explicitly called this out.

## Test plan

- [x] `pytest tests/build_scripts/test_aggregate_guard_intercepts.py tests/build_scripts/test_classify_guard_maturity.py` — 31/31 pass
- [x] All 6 Hook Maturity Model tier transitions pinned with positive/negative/edge cases
- [x] `python3 build/scripts/validate_marketplace_counts.py` — counts in sync
- [x] No new dependencies; stdlib only
- [ ] CI green on this PR (pending)

## Stack position

PR 4 of 5-PR stack derived from PR #1887 retrospective. Base = `feat/evidence-standards-implementer-1890` (PR 3). Predecessors: PR #1894 (Layer 1 + 3), PR #1895 (Layer 2), PR #1897 (Layer 4). Successor: PR 5 = `feat/pr-review-dispatchable-1892` (Layer 6).
