### PR TITLE
refactor(commands): dispatchable /pr-review completion gate (Refs #1887 retro Layer 6)

### DIFF
--- a/.agents/architecture/ADR-059-pr-review-completion-gate-dispatcher.md
+++ b/.agents/architecture/ADR-059-pr-review-completion-gate-dispatcher.md
@@ -1,0 +1,77 @@
+# ADR-059: /pr-review Completion Gate Dispatcher and pass_when DSL
+
+## Status
+
+Proposed
+
+## Date
+
+2026-05-08
+
+## Context
+
+PR #1887 introduced a /pr-review completion gate as a narrative checklist:
+the agent reviewed the PR, then claimed verdicts like "0 unresolved threads"
+inline. The retrospective at
+`.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md` records four
+times the gate was satisfied while review threads were unresolved. The
+failure mode is named "Reporting-Without-Acting Anti-Pattern" (Layer 6 in
+the retrospective): an audit output that asserts state instead of measuring
+it produces the same wrong answer on retry.
+
+## Decision
+
+1. Replace the narrative completion gate with a dispatcher.
+   `.claude/skills/github/scripts/pr/run_completion_gate.py` reads
+   `pr-review-config.yaml`, runs each criterion's command, parses its
+   stdout as JSON, evaluates `pass_when`, and prints a per-criterion table.
+   Exit 0 if all pass, 1 if any fail, 2 on usage.
+
+2. Define a small `pass_when` DSL: dotted-path resolution, literals
+   (integers, `true`, `false`, `null`, double-quoted strings), `==`/`!=`
+   comparisons, `AND`/`OR` composition (left-to-right, no parentheses).
+   AND/OR evaluate left-to-right with equal precedence; atoms are pure
+   lookups with no side effects, so the evaluation order does not affect
+   correctness.
+
+3. Provide `pass_when_python` as an escape hatch. Evaluated with `eval`
+   against an empty `__builtins__` dict. NOT a sandbox (Python class
+   hierarchy remains reachable). Acceptable because the config file is
+   repo-controlled and `--config` is locked to the repo root.
+
+4. Fail closed by default. `fail_open` defaults to false.
+
+5. Lock `--config` to the repo root via `validate_safe_path` (CWE-22).
+
+6. Make `fetched_pages_complete` a Published Language across verifiers.
+
+## Rationale
+
+### Alternatives Considered
+
+| Alternative | Pros | Cons | Why Not Chosen |
+|-------------|------|------|----------------|
+| Keep narrative gate | No new code | Same failure mode | Root cause unaddressed |
+| Policy engine (OPA) | Mature | Heavy dependency | Overkill for 3 criteria |
+| Python-only (no DSL) | One mechanism | Every criterion is eval | DSL keeps common case safe |
+| DSL-only (no eval) | No eval surface | Limits future logic | Escape hatch is rare |
+
+## Consequences
+
+### Positive
+
+- Verdicts are functions of verifier output, not agent narration
+- Pagination cliffs surface via `fetched_pages_complete`
+- New criteria are config-only changes
+
+### Negative
+
+- DSL is not parens-aware
+- `pass_when_python` is an eval surface
+- Adding operators requires parser changes
+
+## References
+
+- `.agents/retrospective/2026-05-05-pr-1887-iteration-paradox.md`
+- `.claude/skills/github/scripts/pr/run_completion_gate.py`
+- PR #1898

--- a/.agents/architecture/ADR-059-pr-review-completion-gate-dispatcher.md
+++ b/.agents/architecture/ADR-059-pr-review-completion-gate-dispatcher.md
@@ -69,6 +69,15 @@ it produces the same wrong answer on retry.
 - DSL is not parens-aware
 - `pass_when_python` is an eval surface
 - Adding operators requires parser changes
+- **PR-branch trust boundary**: when `/pr-review` runs after
+  `gh pr checkout`, the config it reads is the PR branch's copy. A
+  malicious PR can change `completion_criteria.command` or
+  `pass_when_python` and the dispatcher will execute it. This is the
+  same trust a reviewer extends by running tests/linters on a PR
+  branch, but more direct. Mitigations documented in the dispatcher
+  docstring and the `/pr-review` workflow; structural hardening
+  (loading config from `main` or refusing to run on divergence) is
+  deferred as follow-up. Surfaced by CodeRabbit review on PR #1898.
 
 ## References
 

--- a/.agents/critique/ADR-059-debate-log.md
+++ b/.agents/critique/ADR-059-debate-log.md
@@ -1,0 +1,16 @@
+# ADR-059 Debate Log
+
+## Date: 2026-05-08
+
+## Participants
+- architect agent (primary reviewer)
+
+## Verdict: Accept
+
+Architect reviewed the proposed ADR-059 for the /pr-review completion
+gate dispatcher. No P0 or P1 issues. The DSL grammar matches the
+implementation. Trust model is accurately described. Alternatives
+considered are reasonable. Template compliance confirmed.
+
+P2 observation: AND/OR evaluation order clarification added to the ADR
+text.

--- a/.claude/commands/pr-review-config.yaml
+++ b/.claude/commands/pr-review-config.yaml
@@ -55,11 +55,15 @@ error_recovery:
 # the source of truth; the criterion passes only when its `pass_when`
 # expression evaluates true against that JSON. A criterion fails closed
 # (passed=false) on any of:
-#   - non-zero exit code with non-JSON stdout
-#   - JSON stdout that does not contain the required fields
+#   - command failed to run (FileNotFoundError, timeout)
+#   - command exited non-zero (any non-zero status, regardless of stdout)
+#   - command stdout is not a JSON object
 #   - pass_when evaluating false
-# unless `fail_open: true` is set, in which case the criterion passes on
-# command/parse error (it still fails on a clean false from pass_when).
+# `fail_open: true` flips the dispatch-error cases (command/timeout,
+# non-zero exit, non-JSON stdout) to pass. It does NOT flip the
+# pass_when-false case, and a *broken* pass_when expression (DSL syntax
+# error or pass_when_python lambda exception) always fails closed; that
+# is a config bug, not a verifier outage.
 #
 # This replaces the prior narrative criteria (e.g. "0 unresolved threads")
 # whose verdict was claimed by the agent. The agent now dispatches and

--- a/.claude/commands/pr-review-config.yaml
+++ b/.claude/commands/pr-review-config.yaml
@@ -49,31 +49,51 @@ error_recovery:
   - scenario: "Merge conflict"
     action: "Log conflict, skip cleanup, report for manual resolution"
 
+# Completion criteria are dispatchable.
+#
+# Each criterion runs an external command. The command's stdout JSON is
+# the source of truth; the criterion passes only when its `pass_when`
+# expression evaluates true against that JSON. A criterion fails closed
+# (passed=false) on any of:
+#   - non-zero exit code with non-JSON stdout
+#   - JSON stdout that does not contain the required fields
+#   - pass_when evaluating false
+# unless `fail_open: true` is set, in which case the criterion passes on
+# command/parse error (it still fails on a clean false from pass_when).
+#
+# This replaces the prior narrative criteria (e.g. "0 unresolved threads")
+# whose verdict was claimed by the agent. The agent now dispatches and
+# reports; the verifier's output IS the verdict.
+#
+# pass_when DSL (handled by run_completion_gate.py):
+#   * dotted path access:    stdout-json.field, stdout-json.nested.field
+#   * literals:              integers, true, false, null, "double-quoted"
+#   * comparison operators:  ==, !=
+#   * boolean composition:   AND, OR (left-to-right; no parens)
+#
+# Fields:
+#   name           Human-readable criterion title.
+#   verification   Currently only "command" is supported.
+#   command        Shell command template; {pr} is substituted with the PR number.
+#   pass_when      DSL expression evaluated against the parsed stdout JSON.
+#   pass_when_python  (Optional) Python lambda escape hatch when DSL is too narrow.
+#   fail_open      (Optional, default false) Treat dispatch errors as a pass.
 completion_criteria:
-  - criterion: "All review comments addressed"
-    verification: "Each review thread has reply + resolution"
-    required: true
-  - criterion: "All PR comments acknowledged"
-    verification: "Each PR comment has acknowledgment (reply or reaction)"
-    required: true
-  - criterion: "No new comments"
-    verification: "Re-check after 45s wait returned 0 new"
-    required: true
-  - criterion: "CI checks pass"
-    verification: "get_pr_checks AllPassing = true (or failures acknowledged)"
-    required: true
-  - criterion: "No unresolved threads"
-    verification: "GraphQL query for unresolved reviewThreads = 0"
-    required: true
-  - criterion: "Merge eligible"
-    verification: "mergeable=MERGEABLE, no conflicts with base"
-    required: true
-  - criterion: "PR not merged"
-    verification: "test_pr_merged exit code 0"
-    required: true
-  - criterion: "Commits pushed"
-    verification: "git status shows up to date with origin"
-    required: true
+  - name: "All review threads resolved"
+    verification: "command"
+    command: "python3 .claude/skills/github/scripts/pr/get_unresolved_review_threads.py --pull-request {pr}"
+    pass_when: "stdout-json.unresolved_count == 0 AND stdout-json.fetched_pages_complete == true"
+    fail_open: false
+  - name: "PR is ready to merge (CI green, no conflicts)"
+    verification: "command"
+    command: "python3 .claude/skills/github/scripts/pr/test_pr_merge_ready.py --pull-request {pr}"
+    pass_when: "stdout-json.CanMerge == true AND stdout-json.CIPassing == true AND stdout-json.fetched_pages_complete == true AND stdout-json.UnresolvedThreads == 0"
+    fail_open: false
+  - name: "PR is not already merged"
+    verification: "command"
+    command: "python3 .claude/skills/github/scripts/pr/test_pr_merged.py --pull-request {pr}"
+    pass_when: "stdout-json.merged == false"
+    fail_open: false
 
 failure_handling:
   - type: "Session validation fails"
@@ -119,8 +139,13 @@ thread_resolution:
 invocation_limits:
   all_open_max_prs: 5
   all_open_overflow_action: "Report the PR numbers of the remaining open PRs and instruct the user to process them by specifying those numbers explicitly in a new command (re-running with all-open will re-process the same first N PRs)"
-  completion_gate_max_retries: 3
-  completion_gate_overflow_action: "Escalate to user with summary of which criteria are still failing and recommended fixes"
+  # The completion gate is no longer retried in a loop. A failing
+  # criterion produces the same wrong answer when looped, by definition;
+  # the workflow halts and surfaces the failing command's output instead.
+  # These fields are retained for backward compatibility with the schema
+  # validator but are not consulted by the new dispatchable gate.
+  completion_gate_max_retries: 0
+  completion_gate_overflow_action: "Halt and surface failing criterion output; do not loop"
 
 output_constraints:
   per_pr_max_response_tokens: 4096

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -91,6 +91,10 @@ When the dispatcher exits 1, surface the failing criterion's `name`, `command`, 
 
 `fail_open: false` (the default for every criterion in this config) means a verifier that errors or returns malformed output also fails the gate. A verifier that cannot verify is not evidence that the criterion holds.
 
+### Trust boundary on the PR branch
+
+When `/pr-review` runs after `gh pr checkout`, the dispatcher reads `pr-review-config.yaml` from the PR's working tree. A malicious PR can change `completion_criteria.command` or `pass_when_python` and the dispatcher will execute it. Before invoking `/pr-review` on a PR that you do not control, INSPECT the diff for any change to `.claude/commands/pr-review-config.yaml`. The same caution applies to any test/lint/build a reviewer runs on a PR branch; this gate just makes the execution path explicit. Hardening (loading the config from `main` or refusing to run on divergence) is tracked as a follow-up to PR #1898.
+
 ## Related Memories
 
 See `related_memories` in config for Serena memories to consult during PR review.

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -76,7 +76,19 @@ Replying does NOT resolve threads. Use `add_thread_reply_resolve` or separate `r
 
 ## Completion Gate
 
-ALL criteria from `completion_criteria` in config must pass before claiming completion. If ANY fails, loop back up to `invocation_limits.completion_gate_max_retries` times (default: 3) from config. If criteria still fail after the maximum retries, execute `invocation_limits.completion_gate_overflow_action` and halt. See `failure_handling` and `error_recovery` in config for recovery actions.
+The completion gate is dispatchable: each criterion in `completion_criteria` runs an external verification command, and the command's stdout JSON is the source of truth for the verdict. Run the dispatcher exactly once per PR:
+
+```bash
+python3 .claude/skills/github/scripts/pr/run_completion_gate.py \
+    --config .claude/commands/pr-review-config.yaml \
+    --pull-request {pr}
+```
+
+The dispatcher exits 0 if every criterion passes, 1 if any criterion fails. On failure, do NOT loop. Looping on a failing verifier produces the same wrong answer; the retry-on-failure behavior was the wrong design and has been removed (see retrospective `2026-05-05-pr-1887-iteration-paradox.md`, Layer 6: Reporting-Without-Acting Anti-Pattern).
+
+When the dispatcher exits 1, surface the failing criterion's name, command, and parsed output, then halt. Do not claim completion. Do not re-run the gate hoping for a different answer. Investigate the underlying failure and address it; once addressed, the gate may be re-run.
+
+`fail_open: false` (the default for every criterion in this config) means a verifier that errors or returns malformed output also fails the gate. A verifier that cannot verify is not evidence that the criterion holds.
 
 ## Related Memories
 

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -81,12 +81,13 @@ The completion gate is dispatchable: each criterion in `completion_criteria` run
 ```bash
 python3 .claude/skills/github/scripts/pr/run_completion_gate.py \
     --config .claude/commands/pr-review-config.yaml \
-    --pull-request {pr}
+    --pull-request {pr} \
+    --json
 ```
 
-The dispatcher exits 0 if every criterion passes, 1 if any criterion fails. On failure, do NOT loop. Looping on a failing verifier produces the same wrong answer; the retry-on-failure behavior was the wrong design and has been removed (see retrospective `2026-05-05-pr-1887-iteration-paradox.md`, Layer 6: Reporting-Without-Acting Anti-Pattern).
+The dispatcher exits 0 if every criterion passes, 1 if any criterion fails, 2 on a config error. On failure, do NOT loop. Looping on a failing verifier produces the same wrong answer; the retry-on-failure behavior was the wrong design and has been removed (see retrospective `2026-05-05-pr-1887-iteration-paradox.md`, Layer 6: Reporting-Without-Acting Anti-Pattern).
 
-When the dispatcher exits 1, surface the failing criterion's name, command, and parsed output, then halt. Do not claim completion. Do not re-run the gate hoping for a different answer. Investigate the underlying failure and address it; once addressed, the gate may be re-run.
+When the dispatcher exits 1, surface the failing criterion's `name`, `command`, `reason`, and a stdout/stderr excerpt from the JSON output, then halt. Do not claim completion. Do not re-run the gate hoping for a different answer. Investigate the underlying failure and address it; once addressed, the gate may be re-run. The `--json` mode emits the verifier evidence inline; the table mode (default) prints the same fields below each FAIL row.
 
 `fail_open: false` (the default for every criterion in this config) means a verifier that errors or returns malformed output also fails the gate. A verifier that cannot verify is not evidence that the criterion holds.
 

--- a/.claude/hooks/PreToolUse/invoke_correction_applier.py
+++ b/.claude/hooks/PreToolUse/invoke_correction_applier.py
@@ -215,7 +215,8 @@ def main() -> int:
         for source, text in shown:
             lines.append(f"- [{source}] {text}")
 
-        print("\n".join(lines))
+        # Output to stderr (advisory), not stdout (which must be valid JSON or empty)
+        print("\n".join(lines), file=sys.stderr)
     except Exception as exc:
         print(f"[{hook_name}] Error (fail-open): {exc}", file=sys.stderr)
     return 0

--- a/.claude/skills/github/scripts/pr/get_unresolved_review_threads.py
+++ b/.claude/skills/github/scripts/pr/get_unresolved_review_threads.py
@@ -108,7 +108,13 @@ def fetch_unresolved_threads_paginated(
     cursor: str | None = None
     fetched_pages_complete = False
 
-    for _ in range(_MAX_PAGES):
+    # ``page_index`` tracks the page count for diagnostic messages. Per
+    # Copilot review: the prior implementation used
+    # ``len(all_unresolved)`` in the error message, which is the number
+    # of threads collected so far, not the page index. They are the same
+    # only by coincidence (when each page contains zero or one
+    # unresolved thread). An explicit counter avoids the misreport.
+    for page_index in range(1, _MAX_PAGES + 1):
         variables: dict = {
             "owner": owner,
             "name": repo,
@@ -121,7 +127,7 @@ def fetch_unresolved_threads_paginated(
             data = gh_graphql(_QUERY, variables)
         except RuntimeError as exc:
             print(
-                f"Failed to query review threads (page {len(all_unresolved)}+): {exc}",
+                f"Failed to query review threads (page {page_index}): {exc}",
                 file=sys.stderr,
             )
             return all_unresolved, False

--- a/.claude/skills/github/scripts/pr/get_unresolved_review_threads.py
+++ b/.claude/skills/github/scripts/pr/get_unresolved_review_threads.py
@@ -1,8 +1,26 @@
 #!/usr/bin/env python3
 """Get unresolved review threads for a GitHub Pull Request.
 
-Thin wrapper around the get_unresolved_review_threads helper in github_core.api.
 Uses GitHub GraphQL API to query review thread resolution status.
+Paginates ``reviewThreads`` to exhaustion so a 100-thread cliff cannot
+silently mask unresolved threads (this masking failure was documented
+in retrospective 2026-05-05-pr-1887-iteration-paradox.md).
+
+Output is a JSON object with:
+
+    {
+      "success": true,
+      "pull_request": <int>,
+      "unresolved_count": <int>,
+      "fetched_pages_complete": <bool>,
+      "threads": [<thread>, ...]
+    }
+
+The ``fetched_pages_complete`` flag is true only when pagination ran to
+``hasNextPage == false``. The /pr-review completion gate's pass_when
+expression requires this flag to be true alongside ``unresolved_count
+== 0``: a partial fetch that happens to return zero unresolved threads
+is not evidence that zero unresolved threads exist.
 
 Part of the "Acknowledged vs Resolved" lifecycle model:
 NEW -> ACKNOWLEDGED (eyes reaction) -> REPLIED -> RESOLVED (thread marked resolved)
@@ -41,9 +59,96 @@ if _lib_dir not in sys.path:
 from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     error_and_exit,
-    get_unresolved_review_threads,
+    gh_graphql,
     resolve_repo_params,
 )
+
+# Safety net: cap pages so a runaway PR cannot pin the script forever.
+# 50 pages * 100 threads/page = 5,000 unresolved threads; well past any
+# realistic PR. If exceeded, we fall back to fetched_pages_complete=False.
+_MAX_PAGES = 50
+
+_QUERY = """\
+query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+        pullRequest(number: $prNumber) {
+            reviewThreads(first: 100, after: $cursor) {
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+                nodes {
+                    id
+                    isResolved
+                    comments(first: 1) {
+                        nodes {
+                            databaseId
+                        }
+                    }
+                }
+            }
+        }
+    }
+}"""
+
+
+def fetch_unresolved_threads_paginated(
+    owner: str, repo: str, pull_request: int,
+) -> tuple[list[dict], bool]:
+    """Fetch unresolved review threads, paginating to exhaustion.
+
+    Returns a tuple ``(threads, fetched_pages_complete)``. The flag is
+    True only when the underlying GraphQL pagination terminated normally
+    (``hasNextPage`` was false on the last page). Pagination errors,
+    page-cap exhaustion, or query failures yield False; the caller MUST
+    treat False as "we cannot prove there are no more unresolved
+    threads".
+    """
+    all_unresolved: list[dict] = []
+    cursor: str | None = None
+    fetched_pages_complete = False
+
+    for _ in range(_MAX_PAGES):
+        variables: dict = {
+            "owner": owner,
+            "name": repo,
+            "prNumber": pull_request,
+        }
+        if cursor:
+            variables["cursor"] = cursor
+
+        try:
+            data = gh_graphql(_QUERY, variables)
+        except RuntimeError as exc:
+            print(
+                f"Failed to query review threads (page {len(all_unresolved)}+): {exc}",
+                file=sys.stderr,
+            )
+            return all_unresolved, False
+
+        repo_data = data.get("repository") or {}
+        pr_data = repo_data.get("pullRequest")
+        if pr_data is None:
+            return all_unresolved, False
+        review_threads = pr_data.get("reviewThreads")
+        if review_threads is None:
+            return all_unresolved, False
+
+        nodes = review_threads.get("nodes", []) or []
+        for node in nodes:
+            if not node.get("isResolved", True):
+                all_unresolved.append(node)
+
+        page_info = review_threads.get("pageInfo", {}) or {}
+        if not page_info.get("hasNextPage", False):
+            fetched_pages_complete = True
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            # hasNextPage was true but no cursor; treat as incomplete.
+            return all_unresolved, False
+
+    return all_unresolved, fetched_pages_complete
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -68,8 +173,20 @@ def main(argv: list[str] | None = None) -> int:
     resolved = resolve_repo_params(args.owner, args.repo)
     owner, repo = resolved.owner, resolved.repo
 
-    threads = get_unresolved_review_threads(owner, repo, args.pull_request)
-    print(json.dumps(threads, indent=2))
+    threads, fetched_pages_complete = fetch_unresolved_threads_paginated(
+        owner, repo, args.pull_request,
+    )
+
+    output = {
+        "success": True,
+        "pull_request": args.pull_request,
+        "owner": owner,
+        "repo": repo,
+        "unresolved_count": len(threads),
+        "fetched_pages_complete": fetched_pages_complete,
+        "threads": threads,
+    }
+    print(json.dumps(output, indent=2))
     return 0
 
 

--- a/.claude/skills/github/scripts/pr/get_unresolved_review_threads.py
+++ b/.claude/skills/github/scripts/pr/get_unresolved_review_threads.py
@@ -25,11 +25,18 @@ is not evidence that zero unresolved threads exist.
 Part of the "Acknowledged vs Resolved" lifecycle model:
 NEW -> ACKNOWLEDGED (eyes reaction) -> REPLIED -> RESOLVED (thread marked resolved)
 
-Exit codes follow ADR-035:
-    0 - Success
+Exit codes follow ADR-035, with one deliberate deviation noted below:
+    0 - Snapshot returned (may be incomplete; see ``fetched_pages_complete``)
     2 - Config/usage error (invalid parameters)
-    3 - External error (API failure)
     4 - Auth error
+
+API/pagination failures do NOT exit 3. They return 0 with
+``success: false`` and ``fetched_pages_complete: false`` so the
+/pr-review completion gate's ``pass_when`` (which requires
+``fetched_pages_complete == true``) remains the single source of
+truth for the verdict. Mixing exit-3 with the JSON-flag contract
+would force every consumer to handle two failure surfaces; one
+surface is enough.
 """
 
 from __future__ import annotations

--- a/.claude/skills/github/scripts/pr/get_unresolved_review_threads.py
+++ b/.claude/skills/github/scripts/pr/get_unresolved_review_threads.py
@@ -177,8 +177,14 @@ def main(argv: list[str] | None = None) -> int:
         owner, repo, args.pull_request,
     )
 
+    # ``success`` reflects whether the *snapshot* is trustworthy. When
+    # pagination cannot prove completeness (an underlying GraphQL error
+    # or a missing ``endCursor``), the count and threads are at best a
+    # lower bound; the dispatcher's pass_when (which requires
+    # ``fetched_pages_complete == true``) already fails closed in that
+    # case, but emitting ``success: true`` would lie to other consumers.
     output = {
-        "success": True,
+        "success": fetched_pages_complete,
         "pull_request": args.pull_request,
         "owner": owner,
         "repo": repo,

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -101,15 +101,23 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# Resolve the project root so ``scripts.utils.path_validation`` is
-# importable. The dispatcher lives at
-# ``<repo>/.claude/skills/github/scripts/pr/run_completion_gate.py``,
-# so ``parents[4]`` (i.e. five levels up from the file) is the repo
-# root. The same lookup pattern is used by other Python scripts in the
-# repo (e.g. validate_pr_review_config.py at scripts/, which uses
-# ``parent.parent``).
-_SCRIPT_DIR = Path(__file__).resolve().parent
-_PROJECT_ROOT = _SCRIPT_DIR.parents[4]
+# Resolve the project root by walking up to find the ``scripts/``
+# package. A fixed ``parents[N]`` index works for the canonical
+# ``.claude/skills/.../pr/`` location but breaks for the
+# ``src/copilot-cli/skills/.../pr/`` mirror (one extra ``src/`` level)
+# and would break again for any future deployed install. The walk
+# resolves the right root regardless of where the script lives.
+def _resolve_project_root() -> Path:
+    here = Path(__file__).resolve().parent
+    for ancestor in (here, *here.parents):
+        if (ancestor / "scripts" / "utils" / "path_validation.py").is_file():
+            return ancestor
+    # Fall back to the original heuristic if the marker is missing
+    # (e.g. when the script is bundled without the scripts/ tree).
+    return Path(__file__).resolve().parents[4]
+
+
+_PROJECT_ROOT = _resolve_project_root()
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -94,6 +94,9 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from scripts.utils.path_validation import validate_safe_path  # noqa: E402
 
+# PyYAML is a hard dependency for this script. The rest of the codebase
+# already requires PyYAML; matching that is simpler than maintaining a
+# stdlib-only loader and avoids the schema-drift risk of a partial parser.
 try:
     import yaml  # type: ignore[import-untyped]
     _HAVE_YAML = True
@@ -108,29 +111,41 @@ except ImportError:  # pragma: no cover - exercised when PyYAML missing
 
 
 _DEFAULT_CONFIG_PATH = (
-    Path(__file__).resolve().parents[4] / "commands" / "pr-review-config.yaml"
+    _PROJECT_ROOT / ".claude" / "commands" / "pr-review-config.yaml"
 )
 
 
+class ConfigError(Exception):
+    """Schema or load error in the completion-gate config.
+
+    Raised by :func:`_load_config` and :func:`_evaluate_criterion` to
+    distinguish a config bug (which the dispatcher exits 2 for, per
+    ADR-035) from a criterion that legitimately failed (exit 1).
+    """
+
+
 def _load_config(path: Path) -> dict:
-    """Load a YAML config file. Raises on parse failure or missing file."""
+    """Load a YAML config file. Raises ConfigError on any failure mode."""
     if not path.is_file():
-        raise FileNotFoundError(f"Config file not found: {path}")
-
-    text = path.read_text(encoding="utf-8")
-
-    if _HAVE_YAML:
+        raise ConfigError(f"Config file not found: {path}")
+    if not _HAVE_YAML:
+        raise ConfigError(
+            "PyYAML is required to parse the completion-gate config; "
+            "install it via `pip install pyyaml`.",
+        )
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ConfigError(f"Cannot read config {path}: {exc}") from exc
+    try:
         data = yaml.safe_load(text)  # type: ignore[union-attr]
-        if not isinstance(data, dict):
-            raise ValueError(
-                f"Config root must be a mapping, got {type(data).__name__}"
-            )
-        return data
-
-    raise RuntimeError(
-        "PyYAML is required to parse the completion-gate config; "
-        "install it via `pip install pyyaml`."
-    )
+    except yaml.YAMLError as exc:  # type: ignore[union-attr]
+        raise ConfigError(f"Cannot parse config {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ConfigError(
+            f"Config root must be a mapping, got {type(data).__name__}",
+        )
+    return data
 
 
 # ---------------------------------------------------------------------------
@@ -197,12 +212,17 @@ def _eval_atom(data: dict, atom: list[str]) -> bool:
 def _eval_pass_when(data: dict, expr: str) -> bool:
     """Evaluate a pass_when expression against parsed stdout-json data.
 
-    Tokens are split on whitespace (literals must not contain spaces).
-    Atoms are joined left-to-right with ``AND`` / ``OR`` connectives;
-    AND and OR have equal precedence and evaluate strictly in order
-    (no parentheses). Short-circuiting follows the connective.
+    Tokens are split with ``shlex.split(posix=False)`` so double-quoted
+    string literals stay intact (``"PR merged"`` remains one token, not
+    two). Atoms are joined left-to-right with ``AND`` / ``OR``
+    connectives; AND and OR have equal precedence and evaluate strictly
+    in order (no parentheses). Atoms are pure dict lookups, so the
+    evaluation order does not affect correctness.
     """
-    tokens = expr.split()
+    try:
+        tokens = shlex.split(expr, posix=False)
+    except ValueError as exc:
+        raise ValueError(f"pass_when tokenization failed: {exc}") from exc
     if not tokens:
         raise ValueError("pass_when expression is empty")
 
@@ -300,14 +320,70 @@ def _parse_stdout_json(stdout: str) -> dict | None:
     return None
 
 
+def _validate_criterion_schema(criterion: dict) -> tuple[str, str, str | None, str | None]:
+    """Schema-check one criterion. Raises ConfigError on any violation.
+
+    Returns ``(name, command, pass_when, pass_when_python)``.
+
+    Schema rules (mirror scripts/validate_pr_review_config.py):
+      * ``verification`` must be ``"command"`` (only kind supported).
+      * ``command`` must be a non-empty string.
+      * Exactly one of ``pass_when`` / ``pass_when_python`` must be set
+        (Copilot review feedback: both-set is ambiguous).
+    """
+    if not isinstance(criterion, dict):
+        raise ConfigError(f"criterion is not a mapping: {criterion!r}")
+
+    name = criterion.get("name", "<unnamed>")
+    verification = criterion.get("verification", "command")
+    if verification != "command":
+        raise ConfigError(
+            f"criterion {name!r}: unsupported verification kind "
+            f"{verification!r} (expected 'command')",
+        )
+    cmd_template = criterion.get("command", "")
+    if not cmd_template:
+        raise ConfigError(f"criterion {name!r}: missing command")
+
+    pass_when = criterion.get("pass_when")
+    pass_when_python = criterion.get("pass_when_python")
+    if pass_when and pass_when_python:
+        raise ConfigError(
+            f"criterion {name!r}: pass_when and pass_when_python are "
+            f"mutually exclusive; specify exactly one",
+        )
+    if not pass_when and not pass_when_python:
+        raise ConfigError(
+            f"criterion {name!r}: missing pass_when or pass_when_python",
+        )
+    return name, cmd_template, pass_when, pass_when_python
+
+
 def _evaluate_criterion(criterion: dict, pr_number: int) -> dict:
     """Run one criterion's command and evaluate its pass_when expression.
 
     Returns a dict with: name, passed (bool), reason (str), command (str),
-    exit_code (int|None), parsed (bool).
+    exit_code (int|None), parsed (bool), stdout (str), stderr (str).
+
+    Raises :class:`ConfigError` on any schema violation; the caller
+    (``main``) translates that to exit 2 per ADR-035. Once the schema
+    check passes, the function never raises: command failures, malformed
+    output, and broken pass_when expressions are all reported as a
+    failed criterion (with ``fail_open`` honored where applicable).
+
+    Failure semantics:
+      * Command not found / timeout / non-zero exit -> dispatch error;
+        ``passed = fail_open``.
+      * Stdout is not a JSON object -> dispatch error;
+        ``passed = fail_open``.
+      * pass_when raises (DSL syntax error, bad literal, broken lambda)
+        -> evaluator failure; ``passed = False`` regardless of
+        ``fail_open``. A verifier that ran successfully but whose
+        contract cannot be evaluated is a config bug, not a verifier
+        outage; masking it with ``fail_open`` would let a typo silently
+        green the gate.
     """
-    name = criterion.get("name", "<unnamed>")
-    verification = criterion.get("verification", "command")
+    name, cmd_template, pass_when, pass_when_python = _validate_criterion_schema(criterion)
     fail_open = bool(criterion.get("fail_open", False))
 
     result: dict = {
@@ -317,18 +393,9 @@ def _evaluate_criterion(criterion: dict, pr_number: int) -> dict:
         "command": "",
         "exit_code": None,
         "parsed": False,
+        "stdout": "",
+        "stderr": "",
     }
-
-    if verification != "command":
-        result["reason"] = (
-            f"unsupported verification kind: {verification!r}"
-        )
-        return result
-
-    cmd_template = criterion.get("command", "")
-    if not cmd_template:
-        result["reason"] = "criterion has no command"
-        return result
 
     argv = _format_command(cmd_template, pr_number)
     result["command"] = " ".join(argv)
@@ -347,30 +414,38 @@ def _evaluate_criterion(criterion: dict, pr_number: int) -> dict:
         return result
 
     result["exit_code"] = proc.returncode
+    result["stdout"] = proc.stdout
+    result["stderr"] = proc.stderr
+
+    if proc.returncode != 0:
+        result["reason"] = (
+            f"command exited non-zero ({proc.returncode}); "
+            f"fail_open={fail_open}; stderr={proc.stderr.strip()[:200]!r}"
+        )
+        result["passed"] = fail_open
+        return result
+
     parsed = _parse_stdout_json(proc.stdout)
     if parsed is None:
         result["reason"] = (
-            f"command stdout is not a JSON object "
-            f"(exit={proc.returncode}); fail_open={fail_open}"
+            f"command stdout is not a JSON object; fail_open={fail_open}"
         )
         result["passed"] = fail_open
         return result
 
     result["parsed"] = True
 
-    pass_when = criterion.get("pass_when")
-    pass_when_python = criterion.get("pass_when_python")
     try:
         if pass_when_python:
             verdict = _eval_pass_when_python(parsed, pass_when_python)
-        elif pass_when:
-            verdict = _eval_pass_when(parsed, pass_when)
         else:
-            result["reason"] = "criterion has no pass_when expression"
-            return result
+            verdict = _eval_pass_when(parsed, pass_when)
     except (ValueError, SyntaxError, TypeError, KeyError, NameError, AttributeError) as exc:
-        result["reason"] = f"pass_when error: {exc}; fail_open={fail_open}"
-        result["passed"] = fail_open
+        # A broken pass_when expression is a config bug, not a verifier
+        # outage. fail_open does NOT apply: masking a typo with a
+        # green gate would defeat the dispatcher's purpose.
+        result["reason"] = f"pass_when error (fails closed): {exc}"
+        result["passed"] = False
         return result
 
     result["passed"] = verdict
@@ -448,30 +523,35 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         config = _load_config(config_path)
-    except (FileNotFoundError, ValueError, RuntimeError) as exc:
+    except ConfigError as exc:
         print(f"Failed to load config {config_path}: {exc}", file=sys.stderr)
         return 2
 
     criteria = config.get("completion_criteria")
+    # Reject anything other than a list. The previous ``if not criteria``
+    # accepted a dict that is non-empty, which would silently iterate the
+    # dict's keys (CodeRabbit review feedback).
+    if not isinstance(criteria, list):
+        print(
+            f"completion_criteria must be a list, got "
+            f"{type(criteria).__name__}",
+            file=sys.stderr,
+        )
+        return 2
     if not criteria:
         print("No completion_criteria in config", file=sys.stderr)
         return 2
 
     rows: list[dict] = []
-    for criterion in criteria:
-        if not isinstance(criterion, dict):
-            rows.append(
-                {
-                    "name": "<malformed>",
-                    "passed": False,
-                    "reason": f"criterion is not a mapping: {criterion!r}",
-                    "command": "",
-                    "exit_code": None,
-                    "parsed": False,
-                }
-            )
-            continue
-        rows.append(_evaluate_criterion(criterion, args.pull_request))
+    try:
+        for criterion in criteria:
+            rows.append(_evaluate_criterion(criterion, args.pull_request))
+    except ConfigError as exc:
+        # Schema bug in a criterion: exit 2 per ADR-035, do not pretend
+        # the gate ran. Distinguishes a malformed config from a verifier
+        # legitimately reporting failure.
+        print(f"Config error in completion_criteria: {exc}", file=sys.stderr)
+        return 2
 
     if args.json:
         print(

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -52,6 +52,28 @@ in-repo, in-tree, and reviewed alongside this script. Do not extend
 this dispatcher to load config from network input or user-supplied
 absolute paths.
 
+PR-branch trust boundary
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the dispatcher is invoked by ``/pr-review`` after checking out a
+PR branch (via ``gh pr checkout``), the config it reads is the PR
+branch's copy of ``pr-review-config.yaml`` -- NOT the trusted version
+on ``main``. A malicious PR can edit ``completion_criteria.command``
+or ``pass_when_python`` to execute arbitrary code on the reviewer's
+machine. ``validate_safe_path`` keeps the file inside the repo; it
+does NOT make the file trusted.
+
+This is the same trust the reviewer extends by running tests or
+linters on a PR branch, but the surface here is more direct: the
+dispatcher *will* run whatever command appears in the config.
+Reviewers SHOULD inspect any change to ``pr-review-config.yaml`` in
+the PR diff before invoking ``/pr-review`` on it. A future hardening
+(see CodeRabbit review on PR #1898) is to load the config from a
+trusted source (e.g. ``git show main:...``) instead of the working
+tree, or to refuse to run if the working-tree config diverges from
+``main``. Both options are deferred as follow-up work because they
+require restructuring the workflow's config-resolution path.
+
 Substitution
 ------------
 

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -36,6 +36,33 @@ parsed stdout-json dict and must return a truthy/falsy value. This is
 provided as an escape hatch when a criterion's logic does not fit the
 DSL; prefer ``pass_when`` where possible.
 
+Trust model
+-----------
+
+This dispatcher executes ``command`` strings and ``pass_when_python``
+lambdas read from the YAML config. The config path MUST be controlled
+by the repository, never user-supplied beyond the validated default.
+Path traversal protection: ``--config`` is canonicalised and rejected
+unless it lives under the repository root via
+``scripts.utils.path_validation.validate_safe_path``. The
+``pass_when_python`` evaluator runs ``eval`` with an empty
+``__builtins__`` dict; this is NOT a sandbox (Python's class hierarchy
+remains reachable) and is only acceptable because the config is
+in-repo, in-tree, and reviewed alongside this script. Do not extend
+this dispatcher to load config from network input or user-supplied
+absolute paths.
+
+Substitution
+------------
+
+Only ``{pr}`` is substituted into ``command`` templates, and the
+substituted value is the integer ``--pull-request`` argument validated
+by argparse (``type=int``) plus a positivity check. Other ``{...}``
+slots present in the surrounding ``pr-review-config.yaml`` (for
+example ``{thread_id}`` or ``{body}`` in the thread-resolution scripts)
+belong to other consumers and are not handled here. Future maintainers
+extending this dispatcher must re-validate every new slot they add.
+
 Exit codes follow ADR-035:
     0 - All criteria passed
     1 - At least one criterion failed (or had an evaluation error)
@@ -53,10 +80,20 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# stdlib YAML loader is not available; we use a tiny inline loader for the
-# narrow shape we need. PyYAML is preferred when present (matches the rest
-# of the codebase), but standard library only is the contract for this
-# script. The loader handles enough of YAML to parse pr-review-config.yaml.
+# Resolve the project root so ``scripts.utils.path_validation`` is
+# importable. The dispatcher lives at
+# ``<repo>/.claude/skills/github/scripts/pr/run_completion_gate.py``,
+# so ``parents[4]`` (i.e. five levels up from the file) is the repo
+# root. The same lookup pattern is used by other Python scripts in the
+# repo (e.g. validate_pr_review_config.py at scripts/, which uses
+# ``parent.parent``).
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_PROJECT_ROOT = _SCRIPT_DIR.parents[4]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.utils.path_validation import validate_safe_path  # noqa: E402
+
 try:
     import yaml  # type: ignore[import-untyped]
     _HAVE_YAML = True
@@ -206,12 +243,23 @@ def _eval_pass_when_python(data: dict, expr: str) -> bool:
 
     The expression must be a single ``lambda d: ...`` form. The lambda
     receives the parsed stdout-json dict.
+
+    Security: this function calls ``eval``. The empty ``__builtins__``
+    dict does NOT sandbox the expression (Python's class hierarchy is
+    still reachable). The trust model lives in the module docstring:
+    the config that supplies ``expr`` MUST be repo-controlled. Reject
+    obviously malformed expressions before eval to keep the surface
+    visible to maintainers.
     """
+    if not isinstance(expr, str):
+        raise ValueError("pass_when_python must be a string")
     expr = expr.strip()
     if not expr.startswith("lambda"):
         raise ValueError(
             "pass_when_python must be a lambda expression"
         )
+    if "\n" in expr or "\r" in expr:
+        raise ValueError("pass_when_python must be a single line")
     func = eval(expr, {"__builtins__": {}}, {})  # noqa: S307
     if not callable(func):
         raise ValueError("pass_when_python did not yield a callable")
@@ -224,7 +272,16 @@ def _eval_pass_when_python(data: dict, expr: str) -> bool:
 
 
 def _format_command(template: str, pr_number: int) -> list[str]:
-    """Render a command template with ``{pr}`` substitution and split it."""
+    """Render a command template with ``{pr}`` substitution and split it.
+
+    ``pr_number`` MUST be an int. The CLI is the only validated entry
+    point: argparse coerces ``--pull-request`` to int and ``main``
+    rejects non-positive values before this function is reached. This
+    assertion documents that contract for any future caller and
+    forecloses CWE-78 via stringly-typed PR identifiers.
+    """
+    if not isinstance(pr_number, int) or isinstance(pr_number, bool):
+        raise TypeError(f"pr_number must be int, got {type(pr_number).__name__}")
     rendered = template.replace("{pr}", str(pr_number))
     return shlex.split(rendered)
 
@@ -380,7 +437,15 @@ def main(argv: list[str] | None = None) -> int:
         print("Pull request number must be positive.", file=sys.stderr)
         return 2
 
-    config_path = Path(args.config)
+    try:
+        config_path = validate_safe_path(args.config, _PROJECT_ROOT)
+    except (FileNotFoundError, ValueError) as exc:
+        print(
+            f"Refusing to load config from unsafe path {args.config!r}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
     try:
         config = _load_config(config_path)
     except (FileNotFoundError, ValueError, RuntimeError) as exc:

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -73,7 +73,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import shlex
 import subprocess
 import sys
@@ -327,9 +326,13 @@ def _validate_criterion_schema(criterion: dict) -> tuple[str, str, str | None, s
 
     Schema rules (mirror scripts/validate_pr_review_config.py):
       * ``verification`` must be ``"command"`` (only kind supported).
-      * ``command`` must be a non-empty string.
-      * Exactly one of ``pass_when`` / ``pass_when_python`` must be set
-        (Copilot review feedback: both-set is ambiguous).
+      * ``command`` must be a non-empty string. Bot review feedback:
+        if YAML parses ``command`` as a list (e.g. due to indentation),
+        ``_format_command`` would crash later; catch the type error here.
+      * ``fail_open``, when present, must be a real bool. Truthy
+        non-bools (``"yes"``, ``1``) silently change gate behavior;
+        reject them at schema time.
+      * Exactly one of ``pass_when`` / ``pass_when_python`` must be set.
     """
     if not isinstance(criterion, dict):
         raise ConfigError(f"criterion is not a mapping: {criterion!r}")
@@ -342,8 +345,16 @@ def _validate_criterion_schema(criterion: dict) -> tuple[str, str, str | None, s
             f"{verification!r} (expected 'command')",
         )
     cmd_template = criterion.get("command", "")
-    if not cmd_template:
-        raise ConfigError(f"criterion {name!r}: missing command")
+    if not isinstance(cmd_template, str) or not cmd_template:
+        raise ConfigError(
+            f"criterion {name!r}: command must be a non-empty string "
+            f"(got {type(cmd_template).__name__})",
+        )
+    if "fail_open" in criterion and not isinstance(criterion["fail_open"], bool):
+        raise ConfigError(
+            f"criterion {name!r}: fail_open must be a boolean "
+            f"(got {type(criterion['fail_open']).__name__})",
+        )
 
     pass_when = criterion.get("pass_when")
     pass_when_python = criterion.get("pass_when_python")
@@ -384,7 +395,9 @@ def _evaluate_criterion(criterion: dict, pr_number: int) -> dict:
         green the gate.
     """
     name, cmd_template, pass_when, pass_when_python = _validate_criterion_schema(criterion)
-    fail_open = bool(criterion.get("fail_open", False))
+    # Schema check above already proved this is a real bool (or absent);
+    # no permissive truthiness coercion here.
+    fail_open = criterion.get("fail_open", False)
 
     result: dict = {
         "name": name,
@@ -440,10 +453,18 @@ def _evaluate_criterion(criterion: dict, pr_number: int) -> dict:
             verdict = _eval_pass_when_python(parsed, pass_when_python)
         else:
             verdict = _eval_pass_when(parsed, pass_when)
-    except (ValueError, SyntaxError, TypeError, KeyError, NameError, AttributeError) as exc:
+    except Exception as exc:  # noqa: BLE001
         # A broken pass_when expression is a config bug, not a verifier
         # outage. fail_open does NOT apply: masking a typo with a
         # green gate would defeat the dispatcher's purpose.
+        #
+        # Catching ``Exception`` (broad) is intentional: a
+        # ``pass_when_python`` lambda body can raise anything
+        # (``ZeroDivisionError``, ``IndexError``, custom domain
+        # exceptions). Per CodeRabbit review, the prior tight-list
+        # catch (ValueError, KeyError, ...) let those leak through.
+        # ``KeyboardInterrupt`` and ``SystemExit`` are NOT caught
+        # because they inherit from ``BaseException``.
         result["reason"] = f"pass_when error (fails closed): {exc}"
         result["passed"] = False
         return result
@@ -463,7 +484,13 @@ def _evaluate_criterion(criterion: dict, pr_number: int) -> dict:
 
 
 def _print_table(rows: list[dict]) -> None:
-    """Print a per-criterion result table to stdout."""
+    """Print a per-criterion result table to stdout.
+
+    For failing rows, also prints the verifier's command and a short
+    excerpt of stdout/stderr so the operator can triage without re-running
+    the verifier separately. Per CodeRabbit review feedback: an operator
+    reading the table should see the same evidence the JSON consumer sees.
+    """
     print()
     print("Completion Gate Results")
     print("=" * 60)
@@ -472,8 +499,19 @@ def _print_table(rows: list[dict]) -> None:
     for row in rows:
         marker = "PASS" if row["passed"] else "FAIL"
         print(f"{marker:<6} {row['name']:<48}")
-        if not row["passed"] and row["reason"]:
-            print(f"       reason: {row['reason']}")
+        if not row["passed"]:
+            if row.get("reason"):
+                print(f"       reason: {row['reason']}")
+            if row.get("command"):
+                print(f"       command: {row['command']}")
+            stdout_excerpt = (row.get("stdout") or "").strip()
+            if stdout_excerpt:
+                excerpt = stdout_excerpt.splitlines()[0][:200]
+                print(f"       stdout: {excerpt}")
+            stderr_excerpt = (row.get("stderr") or "").strip()
+            if stderr_excerpt:
+                excerpt = stderr_excerpt.splitlines()[0][:200]
+                print(f"       stderr: {excerpt}")
     print("-" * 60)
 
 

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Run the /pr-review completion gate against a pull request.
+
+Reads completion_criteria from a config YAML, dispatches each criterion's
+verification command, parses the resulting JSON, and evaluates the
+``pass_when`` expression. Prints a per-criterion result table. Exits 0 if
+every criterion passes, 1 if any criterion fails.
+
+This replaces the prior narrative completion gate where the agent claimed
+verdicts like "0 unresolved threads". Each verdict is now produced by an
+external command whose JSON output IS the source of truth. The script
+dispatches; it does not narrate.
+
+The ``pass_when`` mini-DSL supports:
+
+  * dotted path access:        ``stdout-json.unresolved_count``
+  * literals:                  integers, ``true``, ``false``, ``null``,
+                               and double-quoted strings
+  * comparison operators:      ``==``, ``!=``
+  * boolean composition:       ``AND``, ``OR`` (left-to-right; no parens)
+
+The ``stdout-json`` prefix denotes the parsed JSON object on the
+command's stdout. Any other dotted prefix is treated as a literal lookup
+into the same object (so ``stdout-json.x`` and ``x`` are equivalent).
+
+Each criterion may set ``fail_open: true`` to treat dispatch errors
+(non-zero exit, non-JSON stdout) as a pass. Default is ``fail_open:
+false``: if the command misbehaves, the criterion fails closed. This
+matches the retrospective's "Reporting-Without-Acting Anti-Pattern"
+guidance: a verifier that cannot verify must not be silently treated as
+having verified.
+
+If the DSL is insufficient, a criterion may instead specify
+``pass_when_python: "lambda d: <expr>"``. The expression receives the
+parsed stdout-json dict and must return a truthy/falsy value. This is
+provided as an escape hatch when a criterion's logic does not fit the
+DSL; prefer ``pass_when`` where possible.
+
+Exit codes follow ADR-035:
+    0 - All criteria passed
+    1 - At least one criterion failed (or had an evaluation error)
+    2 - Config/usage error (config missing, malformed, or no criteria)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# stdlib YAML loader is not available; we use a tiny inline loader for the
+# narrow shape we need. PyYAML is preferred when present (matches the rest
+# of the codebase), but standard library only is the contract for this
+# script. The loader handles enough of YAML to parse pr-review-config.yaml.
+try:
+    import yaml  # type: ignore[import-untyped]
+    _HAVE_YAML = True
+except ImportError:  # pragma: no cover - exercised when PyYAML missing
+    yaml = None  # type: ignore[assignment]
+    _HAVE_YAML = False
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_CONFIG_PATH = (
+    Path(__file__).resolve().parents[4] / "commands" / "pr-review-config.yaml"
+)
+
+
+def _load_config(path: Path) -> dict:
+    """Load a YAML config file. Raises on parse failure or missing file."""
+    if not path.is_file():
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    text = path.read_text(encoding="utf-8")
+
+    if _HAVE_YAML:
+        data = yaml.safe_load(text)  # type: ignore[union-attr]
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Config root must be a mapping, got {type(data).__name__}"
+            )
+        return data
+
+    raise RuntimeError(
+        "PyYAML is required to parse the completion-gate config; "
+        "install it via `pip install pyyaml`."
+    )
+
+
+# ---------------------------------------------------------------------------
+# pass_when DSL
+# ---------------------------------------------------------------------------
+
+
+def _resolve_path(data: dict, path: str) -> Any:
+    """Resolve a dotted path against a parsed-stdout dict.
+
+    The leading segment may be ``stdout-json`` (or absent); both refer to
+    the dict itself. Returns ``None`` if any segment is missing, so the
+    caller can compare against ``null`` literals.
+    """
+    segments = path.split(".")
+    if segments and segments[0] == "stdout-json":
+        segments = segments[1:]
+
+    cur: Any = data
+    for seg in segments:
+        if isinstance(cur, dict) and seg in cur:
+            cur = cur[seg]
+        else:
+            return None
+    return cur
+
+
+def _parse_literal(token: str) -> Any:
+    """Parse a single DSL literal: int, bool, null, or quoted string."""
+    if token == "true":
+        return True
+    if token == "false":
+        return False
+    if token == "null":
+        return None
+    if (
+        len(token) >= 2
+        and token[0] == '"'
+        and token[-1] == '"'
+    ):
+        return token[1:-1]
+    try:
+        return int(token)
+    except ValueError as exc:
+        raise ValueError(f"Unrecognized literal in pass_when: {token!r}") from exc
+
+
+def _eval_atom(data: dict, atom: list[str]) -> bool:
+    """Evaluate a 3-token atom: ``<path> <op> <literal>``."""
+    if len(atom) != 3:
+        raise ValueError(
+            f"pass_when atom must have 3 tokens, got {atom!r}"
+        )
+    path, op, literal_tok = atom
+    actual = _resolve_path(data, path)
+    expected = _parse_literal(literal_tok)
+    if op == "==":
+        return actual == expected
+    if op == "!=":
+        return actual != expected
+    raise ValueError(f"Unsupported pass_when operator: {op!r}")
+
+
+def _eval_pass_when(data: dict, expr: str) -> bool:
+    """Evaluate a pass_when expression against parsed stdout-json data.
+
+    Tokens are split on whitespace (literals must not contain spaces).
+    Atoms are joined left-to-right with ``AND`` / ``OR`` connectives;
+    AND and OR have equal precedence and evaluate strictly in order
+    (no parentheses). Short-circuiting follows the connective.
+    """
+    tokens = expr.split()
+    if not tokens:
+        raise ValueError("pass_when expression is empty")
+
+    result: bool | None = None
+    pending_op: str | None = None
+    i = 0
+    while i < len(tokens):
+        atom = tokens[i:i + 3]
+        i += 3
+        atom_value = _eval_atom(data, atom)
+
+        if result is None:
+            result = atom_value
+        elif pending_op == "AND":
+            result = result and atom_value
+        elif pending_op == "OR":
+            result = result or atom_value
+        else:
+            raise ValueError(
+                f"Missing AND/OR connective before atom {atom!r}"
+            )
+
+        if i >= len(tokens):
+            break
+
+        pending_op = tokens[i]
+        if pending_op not in ("AND", "OR"):
+            raise ValueError(
+                f"Expected AND/OR, got {pending_op!r}"
+            )
+        i += 1
+
+    return bool(result)
+
+
+def _eval_pass_when_python(data: dict, expr: str) -> bool:
+    """Evaluate a pass_when_python expression. Escape hatch only.
+
+    The expression must be a single ``lambda d: ...`` form. The lambda
+    receives the parsed stdout-json dict.
+    """
+    expr = expr.strip()
+    if not expr.startswith("lambda"):
+        raise ValueError(
+            "pass_when_python must be a lambda expression"
+        )
+    func = eval(expr, {"__builtins__": {}}, {})  # noqa: S307
+    if not callable(func):
+        raise ValueError("pass_when_python did not yield a callable")
+    return bool(func(data))
+
+
+# ---------------------------------------------------------------------------
+# Criterion dispatch
+# ---------------------------------------------------------------------------
+
+
+def _format_command(template: str, pr_number: int) -> list[str]:
+    """Render a command template with ``{pr}`` substitution and split it."""
+    rendered = template.replace("{pr}", str(pr_number))
+    return shlex.split(rendered)
+
+
+def _parse_stdout_json(stdout: str) -> dict | None:
+    """Return parsed JSON dict from stdout or None if unparseable."""
+    text = stdout.strip()
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(parsed, dict):
+        return parsed
+    return None
+
+
+def _evaluate_criterion(criterion: dict, pr_number: int) -> dict:
+    """Run one criterion's command and evaluate its pass_when expression.
+
+    Returns a dict with: name, passed (bool), reason (str), command (str),
+    exit_code (int|None), parsed (bool).
+    """
+    name = criterion.get("name", "<unnamed>")
+    verification = criterion.get("verification", "command")
+    fail_open = bool(criterion.get("fail_open", False))
+
+    result: dict = {
+        "name": name,
+        "passed": False,
+        "reason": "",
+        "command": "",
+        "exit_code": None,
+        "parsed": False,
+    }
+
+    if verification != "command":
+        result["reason"] = (
+            f"unsupported verification kind: {verification!r}"
+        )
+        return result
+
+    cmd_template = criterion.get("command", "")
+    if not cmd_template:
+        result["reason"] = "criterion has no command"
+        return result
+
+    argv = _format_command(cmd_template, pr_number)
+    result["command"] = " ".join(argv)
+
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        result["reason"] = f"command failed to run: {exc}"
+        result["passed"] = fail_open
+        return result
+
+    result["exit_code"] = proc.returncode
+    parsed = _parse_stdout_json(proc.stdout)
+    if parsed is None:
+        result["reason"] = (
+            f"command stdout is not a JSON object "
+            f"(exit={proc.returncode}); fail_open={fail_open}"
+        )
+        result["passed"] = fail_open
+        return result
+
+    result["parsed"] = True
+
+    pass_when = criterion.get("pass_when")
+    pass_when_python = criterion.get("pass_when_python")
+    try:
+        if pass_when_python:
+            verdict = _eval_pass_when_python(parsed, pass_when_python)
+        elif pass_when:
+            verdict = _eval_pass_when(parsed, pass_when)
+        else:
+            result["reason"] = "criterion has no pass_when expression"
+            return result
+    except (ValueError, SyntaxError, TypeError, KeyError, NameError, AttributeError) as exc:
+        result["reason"] = f"pass_when error: {exc}; fail_open={fail_open}"
+        result["passed"] = fail_open
+        return result
+
+    result["passed"] = verdict
+    if not verdict:
+        result["reason"] = (
+            f"pass_when evaluated false; stdout-json keys: "
+            f"{sorted(parsed.keys())}"
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _print_table(rows: list[dict]) -> None:
+    """Print a per-criterion result table to stdout."""
+    print()
+    print("Completion Gate Results")
+    print("=" * 60)
+    print(f"{'PASS':<6} {'CRITERION':<48}")
+    print("-" * 60)
+    for row in rows:
+        marker = "PASS" if row["passed"] else "FAIL"
+        print(f"{marker:<6} {row['name']:<48}")
+        if not row["passed"] and row["reason"]:
+            print(f"       reason: {row['reason']}")
+    print("-" * 60)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the /pr-review completion gate.",
+    )
+    parser.add_argument(
+        "--config",
+        default=str(_DEFAULT_CONFIG_PATH),
+        help="Path to pr-review-config.yaml",
+    )
+    parser.add_argument(
+        "--pull-request",
+        type=int,
+        required=True,
+        help="Pull request number",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a single JSON object rather than the human table",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.pull_request <= 0:
+        print("Pull request number must be positive.", file=sys.stderr)
+        return 2
+
+    config_path = Path(args.config)
+    try:
+        config = _load_config(config_path)
+    except (FileNotFoundError, ValueError, RuntimeError) as exc:
+        print(f"Failed to load config {config_path}: {exc}", file=sys.stderr)
+        return 2
+
+    criteria = config.get("completion_criteria")
+    if not criteria:
+        print("No completion_criteria in config", file=sys.stderr)
+        return 2
+
+    rows: list[dict] = []
+    for criterion in criteria:
+        if not isinstance(criterion, dict):
+            rows.append(
+                {
+                    "name": "<malformed>",
+                    "passed": False,
+                    "reason": f"criterion is not a mapping: {criterion!r}",
+                    "command": "",
+                    "exit_code": None,
+                    "parsed": False,
+                }
+            )
+            continue
+        rows.append(_evaluate_criterion(criterion, args.pull_request))
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "pull_request": args.pull_request,
+                    "all_passed": all(r["passed"] for r in rows),
+                    "criteria": rows,
+                },
+                indent=2,
+            )
+        )
+    else:
+        _print_table(rows)
+
+    return 0 if all(r["passed"] for r in rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/github/scripts/pr/run_completion_gate.py
+++ b/.claude/skills/github/scripts/pr/run_completion_gate.py
@@ -275,6 +275,14 @@ def _eval_pass_when(data: dict, expr: str) -> bool:
                 f"Expected AND/OR, got {pending_op!r}"
             )
         i += 1
+        # Per Copilot review: a trailing connective with no atom after
+        # it (e.g. ``x == 1 AND``) silently passed before because the
+        # outer loop checked ``i < len(tokens)`` only at the top. Catch
+        # it explicitly: an AND/OR must be followed by another atom.
+        if i >= len(tokens):
+            raise ValueError(
+                f"pass_when ends with dangling connective {pending_op!r}",
+            )
 
     return bool(result)
 
@@ -359,8 +367,23 @@ def _validate_criterion_schema(criterion: dict) -> tuple[str, str, str | None, s
     if not isinstance(criterion, dict):
         raise ConfigError(f"criterion is not a mapping: {criterion!r}")
 
-    name = criterion.get("name", "<unnamed>")
-    verification = criterion.get("verification", "command")
+    # Per Copilot review: presence-with-default lets a missing or
+    # wrong-typed ``name``/``verification`` slip through. Require them
+    # explicitly and type-check ``name`` so the validator and the
+    # dispatcher reject the same configs.
+    if "name" not in criterion:
+        raise ConfigError("criterion missing required field: name")
+    name = criterion["name"]
+    if not isinstance(name, str) or not name.strip():
+        raise ConfigError(
+            f"criterion: name must be a non-empty string "
+            f"(got {type(name).__name__})",
+        )
+    if "verification" not in criterion:
+        raise ConfigError(
+            f"criterion {name!r}: missing required field: verification",
+        )
+    verification = criterion["verification"]
     if verification != "command":
         raise ConfigError(
             f"criterion {name!r}: unsupported verification kind "
@@ -380,6 +403,21 @@ def _validate_criterion_schema(criterion: dict) -> tuple[str, str, str | None, s
 
     pass_when = criterion.get("pass_when")
     pass_when_python = criterion.get("pass_when_python")
+    # Type-check both expression fields when present. The validator
+    # already does this; mirror it here so a config that bypasses
+    # the standalone validator (direct dispatcher invocation) cannot
+    # smuggle a non-string into the eval/DSL paths.
+    for field, value in (
+        ("pass_when", pass_when),
+        ("pass_when_python", pass_when_python),
+    ):
+        if field in criterion and (
+            not isinstance(value, str) or not value.strip()
+        ):
+            raise ConfigError(
+                f"criterion {name!r}: {field} must be a non-empty string "
+                f"(got {type(value).__name__})",
+            )
     if pass_when and pass_when_python:
         raise ConfigError(
             f"criterion {name!r}: pass_when and pass_when_python are "

--- a/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -19,6 +19,15 @@ A name whose only conclusion is CANCELLED carries no opinion and does not
 block. The PR #1887 retrospective records four false-FAIL reports caused
 by counting CANCELLED debounce rows as failed required checks.
 
+The output JSON includes a ``fetched_pages_complete`` field that is true
+only when both ``reviewThreads`` and ``statusCheckRollup.contexts`` were
+returned in their entirety by the inline GraphQL query. The /pr-review
+completion gate's pass_when expression requires this flag to be true; a
+partial fetch that happens to find no failing checks is not evidence
+that no failing checks exist. This addresses the pagination-cliff
+masking failure documented in retrospective
+2026-05-05-pr-1887-iteration-paradox.md.
+
 Exit codes follow ADR-035:
     0 - PR is ready to merge
     1 - PR is not ready to merge
@@ -91,6 +100,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
                         statusCheckRollup {
                             state
                             contexts(first: 100) {
+                                totalCount
                                 nodes {
                                     ... on CheckRun {
                                         __typename
@@ -460,8 +470,16 @@ def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
 def _evaluate_review_threads(
     pr: dict, ignore_threads: bool, reasons: list[str],
     owner: str, repo: str, pr_number: int,
-) -> tuple[int, int]:
-    """Count unresolved threads and append reason; return (unresolved, total).
+) -> tuple[int, int, bool]:
+    """Count unresolved threads and append reason.
+
+    Returns ``(unresolved, total, pages_complete)``. ``pages_complete`` is
+    True when the inline ``reviewThreads(first: 100)`` page returned every
+    thread (``totalCount <= len(nodes)``); False when the page truncated.
+    The flag is purely about the inline GraphQL response: even if the
+    paginated fallback below produces an exact ``unresolved`` count, a
+    truncated inline page means the snapshot is partial and the
+    /pr-review completion gate fails closed via ``fetched_pages_complete``.
 
     The merge-ready GraphQL query embeds a ``reviewThreads(first: 100)``
     inline page to keep the round-trip cheap. When ``totalCount`` exceeds
@@ -472,10 +490,11 @@ def _evaluate_review_threads(
     fires when the page is incomplete, so the fast path stays cheap.
     """
     if ignore_threads:
-        return 0, 0
+        return 0, 0, True
     threads = pr.get("reviewThreads", {})
     total_threads = threads.get("totalCount", 0)
     nodes = threads.get("nodes", [])
+    pages_complete = total_threads <= len(nodes)
 
     if total_threads > len(nodes):
         # Calculate inline count as a lower bound before the paginated call.
@@ -501,7 +520,7 @@ def _evaluate_review_threads(
 
     if unresolved_count > 0:
         reasons.append(f"{unresolved_count} unresolved review thread(s)")
-    return unresolved_count, total_threads
+    return unresolved_count, total_threads, pages_complete
 
 
 def _evaluate_ci_checks(
@@ -509,11 +528,17 @@ def _evaluate_ci_checks(
     ignore_ci: bool,
     include_non_required: bool,
     reasons: list[str],
-) -> tuple[list[str], list[str], list[str], list[str], int, bool, int]:
+) -> tuple[list[str], list[str], list[str], list[str], int, bool, int, bool]:
     """Classify rollup contexts and append CI reasons.
 
     Returns ``(failed_required, pending_required, failed_non_required,
-    pending_non_required, passed_checks, ci_passing, rollup_rows)``.
+    pending_non_required, passed_checks, ci_passing, rollup_rows,
+    pages_complete)``. ``pages_complete`` is True when the inline
+    ``contexts(first: 100)`` page returned every status context
+    (``totalCount <= len(nodes)``); False when the page truncated. A
+    truncated context page can hide a failing required check, so the
+    /pr-review completion gate fails closed via ``fetched_pages_complete``
+    rather than trusting a partial snapshot.
     """
     failed_required: list[str] = []
     pending_required: list[str] = []
@@ -523,17 +548,23 @@ def _evaluate_ci_checks(
     passed_checks = 0
     ci_passing = True
     rollup_rows = 0
+    pages_complete = True
 
     if ignore_ci:
         return (failed_required, pending_required, failed_non_required,
-                pending_non_required, passed_checks, ci_passing, rollup_rows)
+                pending_non_required, passed_checks, ci_passing,
+                rollup_rows, pages_complete)
 
     commits = pr.get("commits", {}).get("nodes", [])
     if commits:
         rollup = commits[0].get("commit", {}).get("statusCheckRollup")
         if rollup:
-            contexts = rollup.get("contexts", {}).get("nodes", []) or []
+            contexts_obj = rollup.get("contexts", {}) or {}
+            total_contexts = contexts_obj.get("totalCount")
+            contexts = contexts_obj.get("nodes", []) or []
             rollup_rows = len(contexts)
+            if total_contexts is not None:
+                pages_complete = total_contexts <= len(contexts)
             _classify_check_contexts(
                 contexts,
                 failed_required=failed_required,
@@ -554,7 +585,8 @@ def _evaluate_ci_checks(
         failed_non_required, pending_non_required, include_non_required,
     )
     return (failed_required, pending_required, failed_non_required,
-            pending_non_required, passed_checks, ci_passing, rollup_rows)
+            pending_non_required, passed_checks, ci_passing,
+            rollup_rows, pages_complete)
 
 
 def _append_ci_reasons(
@@ -627,15 +659,16 @@ def check_merge_readiness(
 
     reasons: list[str] = []
     mergeable = _evaluate_pr_state(pr, reasons)
-    unresolved_count, total_threads = _evaluate_review_threads(
+    unresolved_count, total_threads, threads_pages_complete = _evaluate_review_threads(
         pr, ignore_threads, reasons, owner, repo, pr_number,
     )
     (failed_required, pending_required, failed_non_required,
      pending_non_required, passed_checks, ci_passing,
-     rollup_rows) = _evaluate_ci_checks(
+     rollup_rows, contexts_pages_complete) = _evaluate_ci_checks(
         pr, ignore_ci, include_non_required, reasons,
     )
     can_merge = len(reasons) == 0
+    fetched_pages_complete = threads_pages_complete and contexts_pages_complete
     _emit_merge_ready_log(
         pr_number, owner, repo, rollup_rows,
         failed_required + pending_required
@@ -661,6 +694,7 @@ def check_merge_readiness(
         "PassedChecks": passed_checks,
         "CIPassing": ci_passing,
         "IncludeNonRequired": include_non_required,
+        "fetched_pages_complete": fetched_pages_complete,
         "Reasons": reasons,
     }
 

--- a/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -78,6 +78,50 @@ from github_core.api import (  # noqa: E402
 # GraphQL query
 # ---------------------------------------------------------------------------
 
+# Cap on context pagination loops. A PR with more than 5000 status
+# contexts (50 pages * 100 per page) is far past anything operational;
+# refuse to spin forever and surface the truncation as
+# fetched_pages_complete=False.
+_CONTEXTS_MAX_PAGES = 50
+
+
+# Follow-up query used when the merge-ready inline page truncates the
+# contexts list. Re-fetches the same commit by SHA and pages contexts
+# from the cursor returned by the previous call.
+_CONTEXTS_PAGE_QUERY = """\
+query($owner: String!, $repo: String!, $oid: GitObjectID!, $number: Int!, $cursor: String!) {
+    repository(owner: $owner, name: $repo) {
+        object(oid: $oid) {
+            ... on Commit {
+                statusCheckRollup {
+                    contexts(first: 100, after: $cursor) {
+                        pageInfo {
+                            hasNextPage
+                            endCursor
+                        }
+                        nodes {
+                            ... on CheckRun {
+                                __typename
+                                name
+                                status
+                                conclusion
+                                isRequired(pullRequestNumber: $number)
+                            }
+                            ... on StatusContext {
+                                __typename
+                                context
+                                state
+                                isRequired(pullRequestNumber: $number)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}"""
+
+
 _MERGE_READY_QUERY = """\
 query($owner: String!, $repo: String!, $number: Int!) {
     repository(owner: $owner, name: $repo) {
@@ -97,10 +141,15 @@ query($owner: String!, $repo: String!, $number: Int!) {
             commits(last: 1) {
                 nodes {
                     commit {
+                        oid
                         statusCheckRollup {
                             state
                             contexts(first: 100) {
                                 totalCount
+                                pageInfo {
+                                    hasNextPage
+                                    endCursor
+                                }
                                 nodes {
                                     ... on CheckRun {
                                         __typename
@@ -523,22 +572,71 @@ def _evaluate_review_threads(
     return unresolved_count, total_threads, pages_complete
 
 
+def _paginate_contexts(
+    owner: str, repo: str, pr_number: int, oid: str, start_cursor: str | None,
+) -> tuple[list[dict], bool]:
+    """Fetch remaining status-check contexts by cursor pagination.
+
+    Returns ``(extra_nodes, pages_complete)``. The boolean is True only
+    when the GraphQL pagination terminated normally (``hasNextPage``
+    was false on the last page) and the cap was not exhausted.
+    """
+    extras: list[dict] = []
+    cursor = start_cursor
+    if not cursor:
+        return extras, False
+    for _ in range(_CONTEXTS_MAX_PAGES):
+        try:
+            data = gh_graphql(
+                _CONTEXTS_PAGE_QUERY,
+                {
+                    "owner": owner, "repo": repo, "oid": oid,
+                    "number": pr_number, "cursor": cursor,
+                },
+            )
+        except RuntimeError as exc:
+            logger.warning(
+                "op=merge_ready_contexts_paginate_error pr=%d oid=%s err=%s",
+                pr_number, oid, safe_log_str(str(exc)),
+            )
+            return extras, False
+        commit_obj = (data.get("repository") or {}).get("object") or {}
+        rollup = commit_obj.get("statusCheckRollup") or {}
+        contexts_obj = rollup.get("contexts") or {}
+        nodes = contexts_obj.get("nodes") or []
+        extras.extend(nodes)
+        page_info = contexts_obj.get("pageInfo") or {}
+        if not page_info.get("hasNextPage", False):
+            return extras, True
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            return extras, False
+    return extras, False
+
+
 def _evaluate_ci_checks(
     pr: dict,
     ignore_ci: bool,
     include_non_required: bool,
     reasons: list[str],
+    owner: str = "", repo: str = "", pr_number: int = 0,
 ) -> tuple[list[str], list[str], list[str], list[str], int, bool, int, bool]:
     """Classify rollup contexts and append CI reasons.
 
     Returns ``(failed_required, pending_required, failed_non_required,
     pending_non_required, passed_checks, ci_passing, rollup_rows,
-    pages_complete)``. ``pages_complete`` is True when the inline
-    ``contexts(first: 100)`` page returned every status context
-    (``totalCount <= len(nodes)``); False when the page truncated. A
-    truncated context page can hide a failing required check, so the
-    /pr-review completion gate fails closed via ``fetched_pages_complete``
-    rather than trusting a partial snapshot.
+    pages_complete)``. ``pages_complete`` is True when every status
+    context on the latest commit was retrieved (either the inline
+    first:100 page was complete, or paginated follow-up calls exhausted
+    the list). False when truncation could not be resolved (paginate
+    hit the cap, or a follow-up GraphQL error). A truncated snapshot
+    can hide a failing required check, so the /pr-review completion
+    gate fails closed via ``fetched_pages_complete``.
+
+    ``owner``, ``repo``, and ``pr_number`` are required for the
+    paginated follow-up but default to empty/zero for backward
+    compatibility with callers that only need the inline-page slice
+    (e.g. unit tests that supply a synthetic PR dict).
     """
     failed_required: list[str] = []
     pending_required: list[str] = []
@@ -557,14 +655,40 @@ def _evaluate_ci_checks(
 
     commits = pr.get("commits", {}).get("nodes", [])
     if commits:
-        rollup = commits[0].get("commit", {}).get("statusCheckRollup")
+        commit_obj = commits[0].get("commit", {}) or {}
+        oid = commit_obj.get("oid", "")
+        rollup = commit_obj.get("statusCheckRollup")
         if rollup:
             contexts_obj = rollup.get("contexts", {}) or {}
             total_contexts = contexts_obj.get("totalCount")
-            contexts = contexts_obj.get("nodes", []) or []
-            rollup_rows = len(contexts)
-            if total_contexts is not None:
+            contexts = list(contexts_obj.get("nodes", []) or [])
+            page_info = contexts_obj.get("pageInfo") or {}
+
+            # Inline first:100 page truncated. Paginate to keep the
+            # snapshot exact, mirroring the threads-side fallback in
+            # _evaluate_review_threads. If pagination fails or hits
+            # the cap, pages_complete stays False so the gate fails
+            # closed even if the partial set looks clean.
+            if (
+                page_info.get("hasNextPage", False)
+                and owner and repo and pr_number and oid
+            ):
+                logger.info(
+                    "op=merge_ready_contexts_paginating pr=%d total=%s "
+                    "inline_nodes=%d",
+                    pr_number, total_contexts, len(contexts),
+                )
+                extras, ok = _paginate_contexts(
+                    owner, repo, pr_number, oid,
+                    page_info.get("endCursor"),
+                )
+                contexts.extend(extras)
+                if not ok:
+                    pages_complete = False
+            elif total_contexts is not None:
                 pages_complete = total_contexts <= len(contexts)
+
+            rollup_rows = len(contexts)
             _classify_check_contexts(
                 contexts,
                 failed_required=failed_required,
@@ -666,6 +790,7 @@ def check_merge_readiness(
      pending_non_required, passed_checks, ci_passing,
      rollup_rows, contexts_pages_complete) = _evaluate_ci_checks(
         pr, ignore_ci, include_non_required, reasons,
+        owner=owner, repo=repo, pr_number=pr_number,
     )
     can_merge = len(reasons) == 0
     fetched_pages_complete = threads_pages_complete and contexts_pages_complete

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -94,6 +94,10 @@ python3 .claude/skills/github/scripts/pr/run_completion_gate.py \
 
 Exit 0 = all criteria passed; exit 1 = at least one failed; exit 2 = config error. On failure, do NOT loop. The retry-on-failure behavior was the wrong design and has been removed (see retrospective `2026-05-05-pr-1887-iteration-paradox.md`, Layer 6: Reporting-Without-Acting Anti-Pattern). Surface the failing criterion's `name`, `command`, `reason`, and stdout/stderr excerpt from the JSON output, then halt. The default table mode prints the same fields below each FAIL row.
 
+### Trust boundary on the PR branch
+
+When `/pr-review` runs after `gh pr checkout`, the dispatcher reads `pr-review-config.yaml` from the PR's working tree. A malicious PR can change `completion_criteria.command` or `pass_when_python` and the dispatcher will execute it. Before invoking `/pr-review` on a PR that you do not control, INSPECT the diff for any change to `.claude/commands/pr-review-config.yaml`. Hardening (loading the config from `main` or refusing to run on divergence) is tracked as a follow-up to PR #1898.
+
 ## Related Memories
 
 See `related_memories` in config for Serena memories to consult during PR review.

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -83,7 +83,15 @@ Replying does NOT resolve threads. Use `add_thread_reply` then `resolve_thread` 
 
 ## Completion Gate
 
-ALL criteria from `completion_criteria` in config must pass before claiming completion. If ANY fails, loop back. See `failure_handling` and `error_recovery` in config for recovery actions.
+The completion gate is dispatchable. Each criterion in `completion_criteria` runs an external command, and the command's stdout JSON drives the verdict via the `pass_when` expression. Run the dispatcher exactly once per PR:
+
+```bash
+python3 .claude/skills/github/scripts/pr/run_completion_gate.py \
+    --config .claude/commands/pr-review-config.yaml \
+    --pull-request {pr}
+```
+
+Exit 0 = all criteria passed; exit 1 = at least one failed. On failure, do NOT loop. The retry-on-failure behavior was the wrong design and has been removed (see retrospective `2026-05-05-pr-1887-iteration-paradox.md`, Layer 6: Reporting-Without-Acting Anti-Pattern). Surface the failing criterion's name and command output, then halt.
 
 ## Related Memories
 

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -88,10 +88,11 @@ The completion gate is dispatchable. Each criterion in `completion_criteria` run
 ```bash
 python3 .claude/skills/github/scripts/pr/run_completion_gate.py \
     --config .claude/commands/pr-review-config.yaml \
-    --pull-request {pr}
+    --pull-request {pr} \
+    --json
 ```
 
-Exit 0 = all criteria passed; exit 1 = at least one failed. On failure, do NOT loop. The retry-on-failure behavior was the wrong design and has been removed (see retrospective `2026-05-05-pr-1887-iteration-paradox.md`, Layer 6: Reporting-Without-Acting Anti-Pattern). Surface the failing criterion's name and command output, then halt.
+Exit 0 = all criteria passed; exit 1 = at least one failed; exit 2 = config error. On failure, do NOT loop. The retry-on-failure behavior was the wrong design and has been removed (see retrospective `2026-05-05-pr-1887-iteration-paradox.md`, Layer 6: Reporting-Without-Acting Anti-Pattern). Surface the failing criterion's `name`, `command`, `reason`, and stdout/stderr excerpt from the JSON output, then halt. The default table mode prints the same fields below each FAIL row.
 
 ## Related Memories
 

--- a/scripts/validate_pr_review_config.py
+++ b/scripts/validate_pr_review_config.py
@@ -76,7 +76,12 @@ CLAUDE_CODE_ONLY_KEYS = [
 
 REQUIRED_SCRIPT_SECTIONS = ["claude_code", "copilot"]
 
-COMPLETION_CRITERIA_FIELDS = ["criterion", "verification", "required"]
+# Each completion criterion is a dispatchable verification: a command whose
+# stdout JSON drives a pass_when expression. The agent no longer narrates
+# verdicts; the command output IS the verdict. See pr-review-config.yaml
+# header comments for the pass_when DSL.
+COMPLETION_CRITERIA_REQUIRED_FIELDS = ["name", "verification", "command"]
+COMPLETION_CRITERIA_PASS_FIELDS = ["pass_when", "pass_when_python"]
 ERROR_RECOVERY_FIELDS = ["scenario", "action"]
 CHECK_FAILURE_FIELDS = ["check_type", "action"]
 FAILURE_HANDLING_FIELDS = ["type", "action"]
@@ -112,11 +117,33 @@ def validate_config(config: dict) -> list[str]:
 
     if "completion_criteria" in config:
         for i, item in enumerate(config["completion_criteria"]):
-            for field in COMPLETION_CRITERIA_FIELDS:
+            if not isinstance(item, dict):
+                errors.append(
+                    f"completion_criteria[{i}] must be a mapping"
+                )
+                continue
+            for field in COMPLETION_CRITERIA_REQUIRED_FIELDS:
                 if field not in item:
                     errors.append(
                         f"completion_criteria[{i}] missing field: {field}"
                     )
+            # Exactly one of pass_when / pass_when_python must be set.
+            if not any(f in item for f in COMPLETION_CRITERIA_PASS_FIELDS):
+                errors.append(
+                    f"completion_criteria[{i}] missing field: pass_when "
+                    f"(or pass_when_python)"
+                )
+            verification = item.get("verification")
+            if verification is not None and verification != "command":
+                errors.append(
+                    f"completion_criteria[{i}].verification must be "
+                    f"'command' (got {verification!r})"
+                )
+            fail_open = item.get("fail_open")
+            if fail_open is not None and not isinstance(fail_open, bool):
+                errors.append(
+                    f"completion_criteria[{i}].fail_open must be a boolean"
+                )
 
     if "error_recovery" in config:
         for i, item in enumerate(config["error_recovery"]):

--- a/scripts/validate_pr_review_config.py
+++ b/scripts/validate_pr_review_config.py
@@ -128,10 +128,21 @@ def validate_config(config: dict) -> list[str]:
                         f"completion_criteria[{i}] missing field: {field}"
                     )
             # Exactly one of pass_when / pass_when_python must be set.
-            if not any(f in item for f in COMPLETION_CRITERIA_PASS_FIELDS):
+            # Both-set is ambiguous because the dispatcher silently picks
+            # pass_when_python first; reject it at validation time so
+            # the ambiguity never reaches runtime.
+            present = [
+                f for f in COMPLETION_CRITERIA_PASS_FIELDS if f in item
+            ]
+            if not present:
                 errors.append(
                     f"completion_criteria[{i}] missing field: pass_when "
                     f"(or pass_when_python)"
+                )
+            elif len(present) > 1:
+                errors.append(
+                    f"completion_criteria[{i}] has both pass_when and "
+                    f"pass_when_python; specify exactly one"
                 )
             verification = item.get("verification")
             if verification is not None and verification != "command":

--- a/scripts/validate_pr_review_config.py
+++ b/scripts/validate_pr_review_config.py
@@ -159,6 +159,31 @@ def validate_config(config: dict) -> list[str]:
                 errors.append(
                     f"completion_criteria[{i}].fail_open must be a boolean"
                 )
+            # Per Copilot review: presence is not enough; reject empty
+            # or wrong-typed values that would slip past the dispatcher
+            # only to crash later.
+            if "name" in item and (
+                not isinstance(item["name"], str) or not item["name"].strip()
+            ):
+                errors.append(
+                    f"completion_criteria[{i}].name must be a non-empty string"
+                )
+            if "command" in item and (
+                not isinstance(item["command"], str)
+                or not item["command"].strip()
+            ):
+                errors.append(
+                    f"completion_criteria[{i}].command must be a non-empty string"
+                )
+            for field in ("pass_when", "pass_when_python"):
+                if field in item and (
+                    not isinstance(item[field], str)
+                    or not item[field].strip()
+                ):
+                    errors.append(
+                        f"completion_criteria[{i}].{field} must be a "
+                        f"non-empty string"
+                    )
 
     if "error_recovery" in config:
         for i, item in enumerate(config["error_recovery"]):

--- a/scripts/validate_pr_review_config.py
+++ b/scripts/validate_pr_review_config.py
@@ -115,7 +115,22 @@ def validate_config(config: dict) -> list[str]:
                             f"Missing script in scripts.{section}: {script_key}"
                         )
 
-    if "completion_criteria" in config:
+    completion_criteria = config.get("completion_criteria")
+    if completion_criteria is not None and not isinstance(
+        completion_criteria, list,
+    ):
+        # Per Copilot review: if YAML parses ``completion_criteria`` as
+        # a mapping or string, the per-element loop would iterate
+        # keys/chars and emit a noisy series of "must be a mapping"
+        # errors. Reject the container shape with a single clear
+        # message and skip per-criterion validation. Other sections of
+        # the config still get validated below. Mirrors the
+        # dispatcher's behavior.
+        errors.append(
+            f"completion_criteria must be a list "
+            f"(got {type(completion_criteria).__name__})"
+        )
+    elif "completion_criteria" in config:
         for i, item in enumerate(config["completion_criteria"]):
             if not isinstance(item, dict):
                 errors.append(

--- a/scripts/validate_pr_review_config.py
+++ b/scripts/validate_pr_review_config.py
@@ -131,8 +131,12 @@ def validate_config(config: dict) -> list[str]:
             # Both-set is ambiguous because the dispatcher silently picks
             # pass_when_python first; reject it at validation time so
             # the ambiguity never reaches runtime.
+            # Check both key presence AND truthiness: a key with null or ""
+            # passes `f in item` but fails the dispatcher's `if not pass_when`
+            # check at runtime. Matching truthiness here ensures the validator
+            # rejects configs that would fail at dispatch time.
             present = [
-                f for f in COMPLETION_CRITERIA_PASS_FIELDS if f in item
+                f for f in COMPLETION_CRITERIA_PASS_FIELDS if item.get(f)
             ]
             if not present:
                 errors.append(

--- a/src/copilot-cli/hooks/preToolUse/invoke_correction_applier__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/preToolUse/invoke_correction_applier__Bash_f620ca.py
@@ -358,7 +358,8 @@ def _original_main(stdin_bytes):
             for source, text in shown:
                 lines.append(f"- [{source}] {text}")
 
-            print("\n".join(lines))
+            # Output to stderr (advisory), not stdout (which must be valid JSON or empty)
+            print("\n".join(lines), file=sys.stderr)
         except Exception as exc:
             print(f"[{hook_name}] Error (fail-open): {exc}", file=sys.stderr)
         return 0

--- a/src/copilot-cli/skills/github/scripts/pr/get_unresolved_review_threads.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_unresolved_review_threads.py
@@ -108,7 +108,13 @@ def fetch_unresolved_threads_paginated(
     cursor: str | None = None
     fetched_pages_complete = False
 
-    for _ in range(_MAX_PAGES):
+    # ``page_index`` tracks the page count for diagnostic messages. Per
+    # Copilot review: the prior implementation used
+    # ``len(all_unresolved)`` in the error message, which is the number
+    # of threads collected so far, not the page index. They are the same
+    # only by coincidence (when each page contains zero or one
+    # unresolved thread). An explicit counter avoids the misreport.
+    for page_index in range(1, _MAX_PAGES + 1):
         variables: dict = {
             "owner": owner,
             "name": repo,
@@ -121,7 +127,7 @@ def fetch_unresolved_threads_paginated(
             data = gh_graphql(_QUERY, variables)
         except RuntimeError as exc:
             print(
-                f"Failed to query review threads (page {len(all_unresolved)}+): {exc}",
+                f"Failed to query review threads (page {page_index}): {exc}",
                 file=sys.stderr,
             )
             return all_unresolved, False

--- a/src/copilot-cli/skills/github/scripts/pr/get_unresolved_review_threads.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_unresolved_review_threads.py
@@ -1,8 +1,26 @@
 #!/usr/bin/env python3
 """Get unresolved review threads for a GitHub Pull Request.
 
-Thin wrapper around the get_unresolved_review_threads helper in github_core.api.
 Uses GitHub GraphQL API to query review thread resolution status.
+Paginates ``reviewThreads`` to exhaustion so a 100-thread cliff cannot
+silently mask unresolved threads (this masking failure was documented
+in retrospective 2026-05-05-pr-1887-iteration-paradox.md).
+
+Output is a JSON object with:
+
+    {
+      "success": true,
+      "pull_request": <int>,
+      "unresolved_count": <int>,
+      "fetched_pages_complete": <bool>,
+      "threads": [<thread>, ...]
+    }
+
+The ``fetched_pages_complete`` flag is true only when pagination ran to
+``hasNextPage == false``. The /pr-review completion gate's pass_when
+expression requires this flag to be true alongside ``unresolved_count
+== 0``: a partial fetch that happens to return zero unresolved threads
+is not evidence that zero unresolved threads exist.
 
 Part of the "Acknowledged vs Resolved" lifecycle model:
 NEW -> ACKNOWLEDGED (eyes reaction) -> REPLIED -> RESOLVED (thread marked resolved)
@@ -41,9 +59,96 @@ if _lib_dir not in sys.path:
 from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     error_and_exit,
-    get_unresolved_review_threads,
+    gh_graphql,
     resolve_repo_params,
 )
+
+# Safety net: cap pages so a runaway PR cannot pin the script forever.
+# 50 pages * 100 threads/page = 5,000 unresolved threads; well past any
+# realistic PR. If exceeded, we fall back to fetched_pages_complete=False.
+_MAX_PAGES = 50
+
+_QUERY = """\
+query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+        pullRequest(number: $prNumber) {
+            reviewThreads(first: 100, after: $cursor) {
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+                nodes {
+                    id
+                    isResolved
+                    comments(first: 1) {
+                        nodes {
+                            databaseId
+                        }
+                    }
+                }
+            }
+        }
+    }
+}"""
+
+
+def fetch_unresolved_threads_paginated(
+    owner: str, repo: str, pull_request: int,
+) -> tuple[list[dict], bool]:
+    """Fetch unresolved review threads, paginating to exhaustion.
+
+    Returns a tuple ``(threads, fetched_pages_complete)``. The flag is
+    True only when the underlying GraphQL pagination terminated normally
+    (``hasNextPage`` was false on the last page). Pagination errors,
+    page-cap exhaustion, or query failures yield False; the caller MUST
+    treat False as "we cannot prove there are no more unresolved
+    threads".
+    """
+    all_unresolved: list[dict] = []
+    cursor: str | None = None
+    fetched_pages_complete = False
+
+    for _ in range(_MAX_PAGES):
+        variables: dict = {
+            "owner": owner,
+            "name": repo,
+            "prNumber": pull_request,
+        }
+        if cursor:
+            variables["cursor"] = cursor
+
+        try:
+            data = gh_graphql(_QUERY, variables)
+        except RuntimeError as exc:
+            print(
+                f"Failed to query review threads (page {len(all_unresolved)}+): {exc}",
+                file=sys.stderr,
+            )
+            return all_unresolved, False
+
+        repo_data = data.get("repository") or {}
+        pr_data = repo_data.get("pullRequest")
+        if pr_data is None:
+            return all_unresolved, False
+        review_threads = pr_data.get("reviewThreads")
+        if review_threads is None:
+            return all_unresolved, False
+
+        nodes = review_threads.get("nodes", []) or []
+        for node in nodes:
+            if not node.get("isResolved", True):
+                all_unresolved.append(node)
+
+        page_info = review_threads.get("pageInfo", {}) or {}
+        if not page_info.get("hasNextPage", False):
+            fetched_pages_complete = True
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            # hasNextPage was true but no cursor; treat as incomplete.
+            return all_unresolved, False
+
+    return all_unresolved, fetched_pages_complete
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -68,8 +173,26 @@ def main(argv: list[str] | None = None) -> int:
     resolved = resolve_repo_params(args.owner, args.repo)
     owner, repo = resolved.owner, resolved.repo
 
-    threads = get_unresolved_review_threads(owner, repo, args.pull_request)
-    print(json.dumps(threads, indent=2))
+    threads, fetched_pages_complete = fetch_unresolved_threads_paginated(
+        owner, repo, args.pull_request,
+    )
+
+    # ``success`` reflects whether the *snapshot* is trustworthy. When
+    # pagination cannot prove completeness (an underlying GraphQL error
+    # or a missing ``endCursor``), the count and threads are at best a
+    # lower bound; the dispatcher's pass_when (which requires
+    # ``fetched_pages_complete == true``) already fails closed in that
+    # case, but emitting ``success: true`` would lie to other consumers.
+    output = {
+        "success": fetched_pages_complete,
+        "pull_request": args.pull_request,
+        "owner": owner,
+        "repo": repo,
+        "unresolved_count": len(threads),
+        "fetched_pages_complete": fetched_pages_complete,
+        "threads": threads,
+    }
+    print(json.dumps(output, indent=2))
     return 0
 
 

--- a/src/copilot-cli/skills/github/scripts/pr/get_unresolved_review_threads.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_unresolved_review_threads.py
@@ -25,11 +25,18 @@ is not evidence that zero unresolved threads exist.
 Part of the "Acknowledged vs Resolved" lifecycle model:
 NEW -> ACKNOWLEDGED (eyes reaction) -> REPLIED -> RESOLVED (thread marked resolved)
 
-Exit codes follow ADR-035:
-    0 - Success
+Exit codes follow ADR-035, with one deliberate deviation noted below:
+    0 - Snapshot returned (may be incomplete; see ``fetched_pages_complete``)
     2 - Config/usage error (invalid parameters)
-    3 - External error (API failure)
     4 - Auth error
+
+API/pagination failures do NOT exit 3. They return 0 with
+``success: false`` and ``fetched_pages_complete: false`` so the
+/pr-review completion gate's ``pass_when`` (which requires
+``fetched_pages_complete == true``) remains the single source of
+truth for the verdict. Mixing exit-3 with the JSON-flag contract
+would force every consumer to handle two failure surfaces; one
+surface is enough.
 """
 
 from __future__ import annotations

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -101,15 +101,23 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# Resolve the project root so ``scripts.utils.path_validation`` is
-# importable. The dispatcher lives at
-# ``<repo>/.claude/skills/github/scripts/pr/run_completion_gate.py``,
-# so ``parents[4]`` (i.e. five levels up from the file) is the repo
-# root. The same lookup pattern is used by other Python scripts in the
-# repo (e.g. validate_pr_review_config.py at scripts/, which uses
-# ``parent.parent``).
-_SCRIPT_DIR = Path(__file__).resolve().parent
-_PROJECT_ROOT = _SCRIPT_DIR.parents[4]
+# Resolve the project root by walking up to find the ``scripts/``
+# package. A fixed ``parents[N]`` index works for the canonical
+# ``.claude/skills/.../pr/`` location but breaks for the
+# ``src/copilot-cli/skills/.../pr/`` mirror (one extra ``src/`` level)
+# and would break again for any future deployed install. The walk
+# resolves the right root regardless of where the script lives.
+def _resolve_project_root() -> Path:
+    here = Path(__file__).resolve().parent
+    for ancestor in (here, *here.parents):
+        if (ancestor / "scripts" / "utils" / "path_validation.py").is_file():
+            return ancestor
+    # Fall back to the original heuristic if the marker is missing
+    # (e.g. when the script is bundled without the scripts/ tree).
+    return Path(__file__).resolve().parents[4]
+
+
+_PROJECT_ROOT = _resolve_project_root()
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -52,6 +52,28 @@ in-repo, in-tree, and reviewed alongside this script. Do not extend
 this dispatcher to load config from network input or user-supplied
 absolute paths.
 
+PR-branch trust boundary
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the dispatcher is invoked by ``/pr-review`` after checking out a
+PR branch (via ``gh pr checkout``), the config it reads is the PR
+branch's copy of ``pr-review-config.yaml`` -- NOT the trusted version
+on ``main``. A malicious PR can edit ``completion_criteria.command``
+or ``pass_when_python`` to execute arbitrary code on the reviewer's
+machine. ``validate_safe_path`` keeps the file inside the repo; it
+does NOT make the file trusted.
+
+This is the same trust the reviewer extends by running tests or
+linters on a PR branch, but the surface here is more direct: the
+dispatcher *will* run whatever command appears in the config.
+Reviewers SHOULD inspect any change to ``pr-review-config.yaml`` in
+the PR diff before invoking ``/pr-review`` on it. A future hardening
+(see CodeRabbit review on PR #1898) is to load the config from a
+trusted source (e.g. ``git show main:...``) instead of the working
+tree, or to refuse to run if the working-tree config diverges from
+``main``. Both options are deferred as follow-up work because they
+require restructuring the workflow's config-resolution path.
+
 Substitution
 ------------
 
@@ -81,13 +103,13 @@ from typing import Any
 
 # Resolve the project root so ``scripts.utils.path_validation`` is
 # importable. The dispatcher lives at
-# ``<repo>/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py``,
-# so ``parents[5]`` (i.e. six levels up from the file) is the repo
+# ``<repo>/.claude/skills/github/scripts/pr/run_completion_gate.py``,
+# so ``parents[4]`` (i.e. five levels up from the file) is the repo
 # root. The same lookup pattern is used by other Python scripts in the
 # repo (e.g. validate_pr_review_config.py at scripts/, which uses
 # ``parent.parent``).
 _SCRIPT_DIR = Path(__file__).resolve().parent
-_PROJECT_ROOT = _SCRIPT_DIR.parents[5]
+_PROJECT_ROOT = _SCRIPT_DIR.parents[4]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -1,0 +1,574 @@
+#!/usr/bin/env python3
+"""Run the /pr-review completion gate against a pull request.
+
+Reads completion_criteria from a config YAML, dispatches each criterion's
+verification command, parses the resulting JSON, and evaluates the
+``pass_when`` expression. Prints a per-criterion result table. Exits 0 if
+every criterion passes, 1 if any criterion fails.
+
+This replaces the prior narrative completion gate where the agent claimed
+verdicts like "0 unresolved threads". Each verdict is now produced by an
+external command whose JSON output IS the source of truth. The script
+dispatches; it does not narrate.
+
+The ``pass_when`` mini-DSL supports:
+
+  * dotted path access:        ``stdout-json.unresolved_count``
+  * literals:                  integers, ``true``, ``false``, ``null``,
+                               and double-quoted strings
+  * comparison operators:      ``==``, ``!=``
+  * boolean composition:       ``AND``, ``OR`` (left-to-right; no parens)
+
+The ``stdout-json`` prefix denotes the parsed JSON object on the
+command's stdout. Any other dotted prefix is treated as a literal lookup
+into the same object (so ``stdout-json.x`` and ``x`` are equivalent).
+
+Each criterion may set ``fail_open: true`` to treat dispatch errors
+(non-zero exit, non-JSON stdout) as a pass. Default is ``fail_open:
+false``: if the command misbehaves, the criterion fails closed. This
+matches the retrospective's "Reporting-Without-Acting Anti-Pattern"
+guidance: a verifier that cannot verify must not be silently treated as
+having verified.
+
+If the DSL is insufficient, a criterion may instead specify
+``pass_when_python: "lambda d: <expr>"``. The expression receives the
+parsed stdout-json dict and must return a truthy/falsy value. This is
+provided as an escape hatch when a criterion's logic does not fit the
+DSL; prefer ``pass_when`` where possible.
+
+Trust model
+-----------
+
+This dispatcher executes ``command`` strings and ``pass_when_python``
+lambdas read from the YAML config. The config path MUST be controlled
+by the repository, never user-supplied beyond the validated default.
+Path traversal protection: ``--config`` is canonicalised and rejected
+unless it lives under the repository root via
+``scripts.utils.path_validation.validate_safe_path``. The
+``pass_when_python`` evaluator runs ``eval`` with an empty
+``__builtins__`` dict; this is NOT a sandbox (Python's class hierarchy
+remains reachable) and is only acceptable because the config is
+in-repo, in-tree, and reviewed alongside this script. Do not extend
+this dispatcher to load config from network input or user-supplied
+absolute paths.
+
+Substitution
+------------
+
+Only ``{pr}`` is substituted into ``command`` templates, and the
+substituted value is the integer ``--pull-request`` argument validated
+by argparse (``type=int``) plus a positivity check. Other ``{...}``
+slots present in the surrounding ``pr-review-config.yaml`` (for
+example ``{thread_id}`` or ``{body}`` in the thread-resolution scripts)
+belong to other consumers and are not handled here. Future maintainers
+extending this dispatcher must re-validate every new slot they add.
+
+Exit codes follow ADR-035:
+    0 - All criteria passed
+    1 - At least one criterion failed (or had an evaluation error)
+    2 - Config/usage error (config missing, malformed, or no criteria)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# Resolve the project root so ``scripts.utils.path_validation`` is
+# importable. The dispatcher lives at
+# ``<repo>/.claude/skills/github/scripts/pr/run_completion_gate.py``,
+# so ``parents[4]`` (i.e. five levels up from the file) is the repo
+# root. The same lookup pattern is used by other Python scripts in the
+# repo (e.g. validate_pr_review_config.py at scripts/, which uses
+# ``parent.parent``).
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_PROJECT_ROOT = _SCRIPT_DIR.parents[4]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.utils.path_validation import validate_safe_path  # noqa: E402
+
+# PyYAML is a hard dependency for this script. The rest of the codebase
+# already requires PyYAML; matching that is simpler than maintaining a
+# stdlib-only loader and avoids the schema-drift risk of a partial parser.
+try:
+    import yaml  # type: ignore[import-untyped]
+    _HAVE_YAML = True
+except ImportError:  # pragma: no cover - exercised when PyYAML missing
+    yaml = None  # type: ignore[assignment]
+    _HAVE_YAML = False
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_CONFIG_PATH = (
+    _PROJECT_ROOT / ".claude" / "commands" / "pr-review-config.yaml"
+)
+
+
+class ConfigError(Exception):
+    """Schema or load error in the completion-gate config.
+
+    Raised by :func:`_load_config` and :func:`_evaluate_criterion` to
+    distinguish a config bug (which the dispatcher exits 2 for, per
+    ADR-035) from a criterion that legitimately failed (exit 1).
+    """
+
+
+def _load_config(path: Path) -> dict:
+    """Load a YAML config file. Raises ConfigError on any failure mode."""
+    if not path.is_file():
+        raise ConfigError(f"Config file not found: {path}")
+    if not _HAVE_YAML:
+        raise ConfigError(
+            "PyYAML is required to parse the completion-gate config; "
+            "install it via `pip install pyyaml`.",
+        )
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ConfigError(f"Cannot read config {path}: {exc}") from exc
+    try:
+        data = yaml.safe_load(text)  # type: ignore[union-attr]
+    except yaml.YAMLError as exc:  # type: ignore[union-attr]
+        raise ConfigError(f"Cannot parse config {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ConfigError(
+            f"Config root must be a mapping, got {type(data).__name__}",
+        )
+    return data
+
+
+# ---------------------------------------------------------------------------
+# pass_when DSL
+# ---------------------------------------------------------------------------
+
+
+def _resolve_path(data: dict, path: str) -> Any:
+    """Resolve a dotted path against a parsed-stdout dict.
+
+    The leading segment may be ``stdout-json`` (or absent); both refer to
+    the dict itself. Returns ``None`` if any segment is missing, so the
+    caller can compare against ``null`` literals.
+    """
+    segments = path.split(".")
+    if segments and segments[0] == "stdout-json":
+        segments = segments[1:]
+
+    cur: Any = data
+    for seg in segments:
+        if isinstance(cur, dict) and seg in cur:
+            cur = cur[seg]
+        else:
+            return None
+    return cur
+
+
+def _parse_literal(token: str) -> Any:
+    """Parse a single DSL literal: int, bool, null, or quoted string."""
+    if token == "true":
+        return True
+    if token == "false":
+        return False
+    if token == "null":
+        return None
+    if (
+        len(token) >= 2
+        and token[0] == '"'
+        and token[-1] == '"'
+    ):
+        return token[1:-1]
+    try:
+        return int(token)
+    except ValueError as exc:
+        raise ValueError(f"Unrecognized literal in pass_when: {token!r}") from exc
+
+
+def _eval_atom(data: dict, atom: list[str]) -> bool:
+    """Evaluate a 3-token atom: ``<path> <op> <literal>``."""
+    if len(atom) != 3:
+        raise ValueError(
+            f"pass_when atom must have 3 tokens, got {atom!r}"
+        )
+    path, op, literal_tok = atom
+    actual = _resolve_path(data, path)
+    expected = _parse_literal(literal_tok)
+    if op == "==":
+        return actual == expected
+    if op == "!=":
+        return actual != expected
+    raise ValueError(f"Unsupported pass_when operator: {op!r}")
+
+
+def _eval_pass_when(data: dict, expr: str) -> bool:
+    """Evaluate a pass_when expression against parsed stdout-json data.
+
+    Tokens are split with ``shlex.split(posix=False)`` so double-quoted
+    string literals stay intact (``"PR merged"`` remains one token, not
+    two). Atoms are joined left-to-right with ``AND`` / ``OR``
+    connectives; AND and OR have equal precedence and evaluate strictly
+    in order (no parentheses). Atoms are pure dict lookups, so the
+    evaluation order does not affect correctness.
+    """
+    try:
+        tokens = shlex.split(expr, posix=False)
+    except ValueError as exc:
+        raise ValueError(f"pass_when tokenization failed: {exc}") from exc
+    if not tokens:
+        raise ValueError("pass_when expression is empty")
+
+    result: bool | None = None
+    pending_op: str | None = None
+    i = 0
+    while i < len(tokens):
+        atom = tokens[i:i + 3]
+        i += 3
+        atom_value = _eval_atom(data, atom)
+
+        if result is None:
+            result = atom_value
+        elif pending_op == "AND":
+            result = result and atom_value
+        elif pending_op == "OR":
+            result = result or atom_value
+        else:
+            raise ValueError(
+                f"Missing AND/OR connective before atom {atom!r}"
+            )
+
+        if i >= len(tokens):
+            break
+
+        pending_op = tokens[i]
+        if pending_op not in ("AND", "OR"):
+            raise ValueError(
+                f"Expected AND/OR, got {pending_op!r}"
+            )
+        i += 1
+
+    return bool(result)
+
+
+def _eval_pass_when_python(data: dict, expr: str) -> bool:
+    """Evaluate a pass_when_python expression. Escape hatch only.
+
+    The expression must be a single ``lambda d: ...`` form. The lambda
+    receives the parsed stdout-json dict.
+
+    Security: this function calls ``eval``. The empty ``__builtins__``
+    dict does NOT sandbox the expression (Python's class hierarchy is
+    still reachable). The trust model lives in the module docstring:
+    the config that supplies ``expr`` MUST be repo-controlled. Reject
+    obviously malformed expressions before eval to keep the surface
+    visible to maintainers.
+    """
+    if not isinstance(expr, str):
+        raise ValueError("pass_when_python must be a string")
+    expr = expr.strip()
+    if not expr.startswith("lambda"):
+        raise ValueError(
+            "pass_when_python must be a lambda expression"
+        )
+    if "\n" in expr or "\r" in expr:
+        raise ValueError("pass_when_python must be a single line")
+    func = eval(expr, {"__builtins__": {}}, {})  # noqa: S307
+    if not callable(func):
+        raise ValueError("pass_when_python did not yield a callable")
+    return bool(func(data))
+
+
+# ---------------------------------------------------------------------------
+# Criterion dispatch
+# ---------------------------------------------------------------------------
+
+
+def _format_command(template: str, pr_number: int) -> list[str]:
+    """Render a command template with ``{pr}`` substitution and split it.
+
+    ``pr_number`` MUST be an int. The CLI is the only validated entry
+    point: argparse coerces ``--pull-request`` to int and ``main``
+    rejects non-positive values before this function is reached. This
+    assertion documents that contract for any future caller and
+    forecloses CWE-78 via stringly-typed PR identifiers.
+    """
+    if not isinstance(pr_number, int) or isinstance(pr_number, bool):
+        raise TypeError(f"pr_number must be int, got {type(pr_number).__name__}")
+    rendered = template.replace("{pr}", str(pr_number))
+    return shlex.split(rendered)
+
+
+def _parse_stdout_json(stdout: str) -> dict | None:
+    """Return parsed JSON dict from stdout or None if unparseable."""
+    text = stdout.strip()
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(parsed, dict):
+        return parsed
+    return None
+
+
+def _validate_criterion_schema(criterion: dict) -> tuple[str, str, str | None, str | None]:
+    """Schema-check one criterion. Raises ConfigError on any violation.
+
+    Returns ``(name, command, pass_when, pass_when_python)``.
+
+    Schema rules (mirror scripts/validate_pr_review_config.py):
+      * ``verification`` must be ``"command"`` (only kind supported).
+      * ``command`` must be a non-empty string.
+      * Exactly one of ``pass_when`` / ``pass_when_python`` must be set
+        (Copilot review feedback: both-set is ambiguous).
+    """
+    if not isinstance(criterion, dict):
+        raise ConfigError(f"criterion is not a mapping: {criterion!r}")
+
+    name = criterion.get("name", "<unnamed>")
+    verification = criterion.get("verification", "command")
+    if verification != "command":
+        raise ConfigError(
+            f"criterion {name!r}: unsupported verification kind "
+            f"{verification!r} (expected 'command')",
+        )
+    cmd_template = criterion.get("command", "")
+    if not cmd_template:
+        raise ConfigError(f"criterion {name!r}: missing command")
+
+    pass_when = criterion.get("pass_when")
+    pass_when_python = criterion.get("pass_when_python")
+    if pass_when and pass_when_python:
+        raise ConfigError(
+            f"criterion {name!r}: pass_when and pass_when_python are "
+            f"mutually exclusive; specify exactly one",
+        )
+    if not pass_when and not pass_when_python:
+        raise ConfigError(
+            f"criterion {name!r}: missing pass_when or pass_when_python",
+        )
+    return name, cmd_template, pass_when, pass_when_python
+
+
+def _evaluate_criterion(criterion: dict, pr_number: int) -> dict:
+    """Run one criterion's command and evaluate its pass_when expression.
+
+    Returns a dict with: name, passed (bool), reason (str), command (str),
+    exit_code (int|None), parsed (bool), stdout (str), stderr (str).
+
+    Raises :class:`ConfigError` on any schema violation; the caller
+    (``main``) translates that to exit 2 per ADR-035. Once the schema
+    check passes, the function never raises: command failures, malformed
+    output, and broken pass_when expressions are all reported as a
+    failed criterion (with ``fail_open`` honored where applicable).
+
+    Failure semantics:
+      * Command not found / timeout / non-zero exit -> dispatch error;
+        ``passed = fail_open``.
+      * Stdout is not a JSON object -> dispatch error;
+        ``passed = fail_open``.
+      * pass_when raises (DSL syntax error, bad literal, broken lambda)
+        -> evaluator failure; ``passed = False`` regardless of
+        ``fail_open``. A verifier that ran successfully but whose
+        contract cannot be evaluated is a config bug, not a verifier
+        outage; masking it with ``fail_open`` would let a typo silently
+        green the gate.
+    """
+    name, cmd_template, pass_when, pass_when_python = _validate_criterion_schema(criterion)
+    fail_open = bool(criterion.get("fail_open", False))
+
+    result: dict = {
+        "name": name,
+        "passed": False,
+        "reason": "",
+        "command": "",
+        "exit_code": None,
+        "parsed": False,
+        "stdout": "",
+        "stderr": "",
+    }
+
+    argv = _format_command(cmd_template, pr_number)
+    result["command"] = " ".join(argv)
+
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        result["reason"] = f"command failed to run: {exc}"
+        result["passed"] = fail_open
+        return result
+
+    result["exit_code"] = proc.returncode
+    result["stdout"] = proc.stdout
+    result["stderr"] = proc.stderr
+
+    if proc.returncode != 0:
+        result["reason"] = (
+            f"command exited non-zero ({proc.returncode}); "
+            f"fail_open={fail_open}; stderr={proc.stderr.strip()[:200]!r}"
+        )
+        result["passed"] = fail_open
+        return result
+
+    parsed = _parse_stdout_json(proc.stdout)
+    if parsed is None:
+        result["reason"] = (
+            f"command stdout is not a JSON object; fail_open={fail_open}"
+        )
+        result["passed"] = fail_open
+        return result
+
+    result["parsed"] = True
+
+    try:
+        if pass_when_python:
+            verdict = _eval_pass_when_python(parsed, pass_when_python)
+        else:
+            verdict = _eval_pass_when(parsed, pass_when)
+    except (ValueError, SyntaxError, TypeError, KeyError, NameError, AttributeError) as exc:
+        # A broken pass_when expression is a config bug, not a verifier
+        # outage. fail_open does NOT apply: masking a typo with a
+        # green gate would defeat the dispatcher's purpose.
+        result["reason"] = f"pass_when error (fails closed): {exc}"
+        result["passed"] = False
+        return result
+
+    result["passed"] = verdict
+    if not verdict:
+        result["reason"] = (
+            f"pass_when evaluated false; stdout-json keys: "
+            f"{sorted(parsed.keys())}"
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _print_table(rows: list[dict]) -> None:
+    """Print a per-criterion result table to stdout."""
+    print()
+    print("Completion Gate Results")
+    print("=" * 60)
+    print(f"{'PASS':<6} {'CRITERION':<48}")
+    print("-" * 60)
+    for row in rows:
+        marker = "PASS" if row["passed"] else "FAIL"
+        print(f"{marker:<6} {row['name']:<48}")
+        if not row["passed"] and row["reason"]:
+            print(f"       reason: {row['reason']}")
+    print("-" * 60)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the /pr-review completion gate.",
+    )
+    parser.add_argument(
+        "--config",
+        default=str(_DEFAULT_CONFIG_PATH),
+        help="Path to pr-review-config.yaml",
+    )
+    parser.add_argument(
+        "--pull-request",
+        type=int,
+        required=True,
+        help="Pull request number",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a single JSON object rather than the human table",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.pull_request <= 0:
+        print("Pull request number must be positive.", file=sys.stderr)
+        return 2
+
+    try:
+        config_path = validate_safe_path(args.config, _PROJECT_ROOT)
+    except (FileNotFoundError, ValueError) as exc:
+        print(
+            f"Refusing to load config from unsafe path {args.config!r}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        config = _load_config(config_path)
+    except ConfigError as exc:
+        print(f"Failed to load config {config_path}: {exc}", file=sys.stderr)
+        return 2
+
+    criteria = config.get("completion_criteria")
+    # Reject anything other than a list. The previous ``if not criteria``
+    # accepted a dict that is non-empty, which would silently iterate the
+    # dict's keys (CodeRabbit review feedback).
+    if not isinstance(criteria, list):
+        print(
+            f"completion_criteria must be a list, got "
+            f"{type(criteria).__name__}",
+            file=sys.stderr,
+        )
+        return 2
+    if not criteria:
+        print("No completion_criteria in config", file=sys.stderr)
+        return 2
+
+    rows: list[dict] = []
+    try:
+        for criterion in criteria:
+            rows.append(_evaluate_criterion(criterion, args.pull_request))
+    except ConfigError as exc:
+        # Schema bug in a criterion: exit 2 per ADR-035, do not pretend
+        # the gate ran. Distinguishes a malformed config from a verifier
+        # legitimately reporting failure.
+        print(f"Config error in completion_criteria: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "pull_request": args.pull_request,
+                    "all_passed": all(r["passed"] for r in rows),
+                    "criteria": rows,
+                },
+                indent=2,
+            )
+        )
+    else:
+        _print_table(rows)
+
+    return 0 if all(r["passed"] for r in rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -73,7 +73,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import shlex
 import subprocess
 import sys
@@ -327,9 +326,13 @@ def _validate_criterion_schema(criterion: dict) -> tuple[str, str, str | None, s
 
     Schema rules (mirror scripts/validate_pr_review_config.py):
       * ``verification`` must be ``"command"`` (only kind supported).
-      * ``command`` must be a non-empty string.
-      * Exactly one of ``pass_when`` / ``pass_when_python`` must be set
-        (Copilot review feedback: both-set is ambiguous).
+      * ``command`` must be a non-empty string. Bot review feedback:
+        if YAML parses ``command`` as a list (e.g. due to indentation),
+        ``_format_command`` would crash later; catch the type error here.
+      * ``fail_open``, when present, must be a real bool. Truthy
+        non-bools (``"yes"``, ``1``) silently change gate behavior;
+        reject them at schema time.
+      * Exactly one of ``pass_when`` / ``pass_when_python`` must be set.
     """
     if not isinstance(criterion, dict):
         raise ConfigError(f"criterion is not a mapping: {criterion!r}")
@@ -342,8 +345,16 @@ def _validate_criterion_schema(criterion: dict) -> tuple[str, str, str | None, s
             f"{verification!r} (expected 'command')",
         )
     cmd_template = criterion.get("command", "")
-    if not cmd_template:
-        raise ConfigError(f"criterion {name!r}: missing command")
+    if not isinstance(cmd_template, str) or not cmd_template:
+        raise ConfigError(
+            f"criterion {name!r}: command must be a non-empty string "
+            f"(got {type(cmd_template).__name__})",
+        )
+    if "fail_open" in criterion and not isinstance(criterion["fail_open"], bool):
+        raise ConfigError(
+            f"criterion {name!r}: fail_open must be a boolean "
+            f"(got {type(criterion['fail_open']).__name__})",
+        )
 
     pass_when = criterion.get("pass_when")
     pass_when_python = criterion.get("pass_when_python")
@@ -384,7 +395,9 @@ def _evaluate_criterion(criterion: dict, pr_number: int) -> dict:
         green the gate.
     """
     name, cmd_template, pass_when, pass_when_python = _validate_criterion_schema(criterion)
-    fail_open = bool(criterion.get("fail_open", False))
+    # Schema check above already proved this is a real bool (or absent);
+    # no permissive truthiness coercion here.
+    fail_open = criterion.get("fail_open", False)
 
     result: dict = {
         "name": name,
@@ -440,10 +453,18 @@ def _evaluate_criterion(criterion: dict, pr_number: int) -> dict:
             verdict = _eval_pass_when_python(parsed, pass_when_python)
         else:
             verdict = _eval_pass_when(parsed, pass_when)
-    except (ValueError, SyntaxError, TypeError, KeyError, NameError, AttributeError) as exc:
+    except Exception as exc:  # noqa: BLE001
         # A broken pass_when expression is a config bug, not a verifier
         # outage. fail_open does NOT apply: masking a typo with a
         # green gate would defeat the dispatcher's purpose.
+        #
+        # Catching ``Exception`` (broad) is intentional: a
+        # ``pass_when_python`` lambda body can raise anything
+        # (``ZeroDivisionError``, ``IndexError``, custom domain
+        # exceptions). Per CodeRabbit review, the prior tight-list
+        # catch (ValueError, KeyError, ...) let those leak through.
+        # ``KeyboardInterrupt`` and ``SystemExit`` are NOT caught
+        # because they inherit from ``BaseException``.
         result["reason"] = f"pass_when error (fails closed): {exc}"
         result["passed"] = False
         return result
@@ -463,7 +484,13 @@ def _evaluate_criterion(criterion: dict, pr_number: int) -> dict:
 
 
 def _print_table(rows: list[dict]) -> None:
-    """Print a per-criterion result table to stdout."""
+    """Print a per-criterion result table to stdout.
+
+    For failing rows, also prints the verifier's command and a short
+    excerpt of stdout/stderr so the operator can triage without re-running
+    the verifier separately. Per CodeRabbit review feedback: an operator
+    reading the table should see the same evidence the JSON consumer sees.
+    """
     print()
     print("Completion Gate Results")
     print("=" * 60)
@@ -472,8 +499,19 @@ def _print_table(rows: list[dict]) -> None:
     for row in rows:
         marker = "PASS" if row["passed"] else "FAIL"
         print(f"{marker:<6} {row['name']:<48}")
-        if not row["passed"] and row["reason"]:
-            print(f"       reason: {row['reason']}")
+        if not row["passed"]:
+            if row.get("reason"):
+                print(f"       reason: {row['reason']}")
+            if row.get("command"):
+                print(f"       command: {row['command']}")
+            stdout_excerpt = (row.get("stdout") or "").strip()
+            if stdout_excerpt:
+                excerpt = stdout_excerpt.splitlines()[0][:200]
+                print(f"       stdout: {excerpt}")
+            stderr_excerpt = (row.get("stderr") or "").strip()
+            if stderr_excerpt:
+                excerpt = stderr_excerpt.splitlines()[0][:200]
+                print(f"       stderr: {excerpt}")
     print("-" * 60)
 
 

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -82,13 +82,13 @@ from typing import Any
 
 # Resolve the project root so ``scripts.utils.path_validation`` is
 # importable. The dispatcher lives at
-# ``<repo>/.claude/skills/github/scripts/pr/run_completion_gate.py``,
-# so ``parents[4]`` (i.e. five levels up from the file) is the repo
+# ``<repo>/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py``,
+# so ``parents[5]`` (i.e. six levels up from the file) is the repo
 # root. The same lookup pattern is used by other Python scripts in the
 # repo (e.g. validate_pr_review_config.py at scripts/, which uses
 # ``parent.parent``).
 _SCRIPT_DIR = Path(__file__).resolve().parent
-_PROJECT_ROOT = _SCRIPT_DIR.parents[4]
+_PROJECT_ROOT = _SCRIPT_DIR.parents[5]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 

--- a/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
+++ b/src/copilot-cli/skills/github/scripts/pr/run_completion_gate.py
@@ -275,6 +275,14 @@ def _eval_pass_when(data: dict, expr: str) -> bool:
                 f"Expected AND/OR, got {pending_op!r}"
             )
         i += 1
+        # Per Copilot review: a trailing connective with no atom after
+        # it (e.g. ``x == 1 AND``) silently passed before because the
+        # outer loop checked ``i < len(tokens)`` only at the top. Catch
+        # it explicitly: an AND/OR must be followed by another atom.
+        if i >= len(tokens):
+            raise ValueError(
+                f"pass_when ends with dangling connective {pending_op!r}",
+            )
 
     return bool(result)
 
@@ -359,8 +367,23 @@ def _validate_criterion_schema(criterion: dict) -> tuple[str, str, str | None, s
     if not isinstance(criterion, dict):
         raise ConfigError(f"criterion is not a mapping: {criterion!r}")
 
-    name = criterion.get("name", "<unnamed>")
-    verification = criterion.get("verification", "command")
+    # Per Copilot review: presence-with-default lets a missing or
+    # wrong-typed ``name``/``verification`` slip through. Require them
+    # explicitly and type-check ``name`` so the validator and the
+    # dispatcher reject the same configs.
+    if "name" not in criterion:
+        raise ConfigError("criterion missing required field: name")
+    name = criterion["name"]
+    if not isinstance(name, str) or not name.strip():
+        raise ConfigError(
+            f"criterion: name must be a non-empty string "
+            f"(got {type(name).__name__})",
+        )
+    if "verification" not in criterion:
+        raise ConfigError(
+            f"criterion {name!r}: missing required field: verification",
+        )
+    verification = criterion["verification"]
     if verification != "command":
         raise ConfigError(
             f"criterion {name!r}: unsupported verification kind "
@@ -380,6 +403,21 @@ def _validate_criterion_schema(criterion: dict) -> tuple[str, str, str | None, s
 
     pass_when = criterion.get("pass_when")
     pass_when_python = criterion.get("pass_when_python")
+    # Type-check both expression fields when present. The validator
+    # already does this; mirror it here so a config that bypasses
+    # the standalone validator (direct dispatcher invocation) cannot
+    # smuggle a non-string into the eval/DSL paths.
+    for field, value in (
+        ("pass_when", pass_when),
+        ("pass_when_python", pass_when_python),
+    ):
+        if field in criterion and (
+            not isinstance(value, str) or not value.strip()
+        ):
+            raise ConfigError(
+                f"criterion {name!r}: {field} must be a non-empty string "
+                f"(got {type(value).__name__})",
+            )
     if pass_when and pass_when_python:
         raise ConfigError(
             f"criterion {name!r}: pass_when and pass_when_python are "

--- a/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -19,6 +19,15 @@ A name whose only conclusion is CANCELLED carries no opinion and does not
 block. The PR #1887 retrospective records four false-FAIL reports caused
 by counting CANCELLED debounce rows as failed required checks.
 
+The output JSON includes a ``fetched_pages_complete`` field that is true
+only when both ``reviewThreads`` and ``statusCheckRollup.contexts`` were
+returned in their entirety by the inline GraphQL query. The /pr-review
+completion gate's pass_when expression requires this flag to be true; a
+partial fetch that happens to find no failing checks is not evidence
+that no failing checks exist. This addresses the pagination-cliff
+masking failure documented in retrospective
+2026-05-05-pr-1887-iteration-paradox.md.
+
 Exit codes follow ADR-035:
     0 - PR is ready to merge
     1 - PR is not ready to merge
@@ -91,6 +100,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
                         statusCheckRollup {
                             state
                             contexts(first: 100) {
+                                totalCount
                                 nodes {
                                     ... on CheckRun {
                                         __typename
@@ -460,8 +470,16 @@ def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
 def _evaluate_review_threads(
     pr: dict, ignore_threads: bool, reasons: list[str],
     owner: str, repo: str, pr_number: int,
-) -> tuple[int, int]:
-    """Count unresolved threads and append reason; return (unresolved, total).
+) -> tuple[int, int, bool]:
+    """Count unresolved threads and append reason.
+
+    Returns ``(unresolved, total, pages_complete)``. ``pages_complete`` is
+    True when the inline ``reviewThreads(first: 100)`` page returned every
+    thread (``totalCount <= len(nodes)``); False when the page truncated.
+    The flag is purely about the inline GraphQL response: even if the
+    paginated fallback below produces an exact ``unresolved`` count, a
+    truncated inline page means the snapshot is partial and the
+    /pr-review completion gate fails closed via ``fetched_pages_complete``.
 
     The merge-ready GraphQL query embeds a ``reviewThreads(first: 100)``
     inline page to keep the round-trip cheap. When ``totalCount`` exceeds
@@ -472,10 +490,11 @@ def _evaluate_review_threads(
     fires when the page is incomplete, so the fast path stays cheap.
     """
     if ignore_threads:
-        return 0, 0
+        return 0, 0, True
     threads = pr.get("reviewThreads", {})
     total_threads = threads.get("totalCount", 0)
     nodes = threads.get("nodes", [])
+    pages_complete = total_threads <= len(nodes)
 
     if total_threads > len(nodes):
         # Calculate inline count as a lower bound before the paginated call.
@@ -501,7 +520,7 @@ def _evaluate_review_threads(
 
     if unresolved_count > 0:
         reasons.append(f"{unresolved_count} unresolved review thread(s)")
-    return unresolved_count, total_threads
+    return unresolved_count, total_threads, pages_complete
 
 
 def _evaluate_ci_checks(
@@ -509,11 +528,17 @@ def _evaluate_ci_checks(
     ignore_ci: bool,
     include_non_required: bool,
     reasons: list[str],
-) -> tuple[list[str], list[str], list[str], list[str], int, bool, int]:
+) -> tuple[list[str], list[str], list[str], list[str], int, bool, int, bool]:
     """Classify rollup contexts and append CI reasons.
 
     Returns ``(failed_required, pending_required, failed_non_required,
-    pending_non_required, passed_checks, ci_passing, rollup_rows)``.
+    pending_non_required, passed_checks, ci_passing, rollup_rows,
+    pages_complete)``. ``pages_complete`` is True when the inline
+    ``contexts(first: 100)`` page returned every status context
+    (``totalCount <= len(nodes)``); False when the page truncated. A
+    truncated context page can hide a failing required check, so the
+    /pr-review completion gate fails closed via ``fetched_pages_complete``
+    rather than trusting a partial snapshot.
     """
     failed_required: list[str] = []
     pending_required: list[str] = []
@@ -523,17 +548,23 @@ def _evaluate_ci_checks(
     passed_checks = 0
     ci_passing = True
     rollup_rows = 0
+    pages_complete = True
 
     if ignore_ci:
         return (failed_required, pending_required, failed_non_required,
-                pending_non_required, passed_checks, ci_passing, rollup_rows)
+                pending_non_required, passed_checks, ci_passing,
+                rollup_rows, pages_complete)
 
     commits = pr.get("commits", {}).get("nodes", [])
     if commits:
         rollup = commits[0].get("commit", {}).get("statusCheckRollup")
         if rollup:
-            contexts = rollup.get("contexts", {}).get("nodes", []) or []
+            contexts_obj = rollup.get("contexts", {}) or {}
+            total_contexts = contexts_obj.get("totalCount")
+            contexts = contexts_obj.get("nodes", []) or []
             rollup_rows = len(contexts)
+            if total_contexts is not None:
+                pages_complete = total_contexts <= len(contexts)
             _classify_check_contexts(
                 contexts,
                 failed_required=failed_required,
@@ -554,7 +585,8 @@ def _evaluate_ci_checks(
         failed_non_required, pending_non_required, include_non_required,
     )
     return (failed_required, pending_required, failed_non_required,
-            pending_non_required, passed_checks, ci_passing, rollup_rows)
+            pending_non_required, passed_checks, ci_passing,
+            rollup_rows, pages_complete)
 
 
 def _append_ci_reasons(
@@ -627,15 +659,16 @@ def check_merge_readiness(
 
     reasons: list[str] = []
     mergeable = _evaluate_pr_state(pr, reasons)
-    unresolved_count, total_threads = _evaluate_review_threads(
+    unresolved_count, total_threads, threads_pages_complete = _evaluate_review_threads(
         pr, ignore_threads, reasons, owner, repo, pr_number,
     )
     (failed_required, pending_required, failed_non_required,
      pending_non_required, passed_checks, ci_passing,
-     rollup_rows) = _evaluate_ci_checks(
+     rollup_rows, contexts_pages_complete) = _evaluate_ci_checks(
         pr, ignore_ci, include_non_required, reasons,
     )
     can_merge = len(reasons) == 0
+    fetched_pages_complete = threads_pages_complete and contexts_pages_complete
     _emit_merge_ready_log(
         pr_number, owner, repo, rollup_rows,
         failed_required + pending_required
@@ -661,6 +694,7 @@ def check_merge_readiness(
         "PassedChecks": passed_checks,
         "CIPassing": ci_passing,
         "IncludeNonRequired": include_non_required,
+        "fetched_pages_complete": fetched_pages_complete,
         "Reasons": reasons,
     }
 

--- a/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -78,6 +78,50 @@ from github_core.api import (  # noqa: E402
 # GraphQL query
 # ---------------------------------------------------------------------------
 
+# Cap on context pagination loops. A PR with more than 5000 status
+# contexts (50 pages * 100 per page) is far past anything operational;
+# refuse to spin forever and surface the truncation as
+# fetched_pages_complete=False.
+_CONTEXTS_MAX_PAGES = 50
+
+
+# Follow-up query used when the merge-ready inline page truncates the
+# contexts list. Re-fetches the same commit by SHA and pages contexts
+# from the cursor returned by the previous call.
+_CONTEXTS_PAGE_QUERY = """\
+query($owner: String!, $repo: String!, $oid: GitObjectID!, $number: Int!, $cursor: String!) {
+    repository(owner: $owner, name: $repo) {
+        object(oid: $oid) {
+            ... on Commit {
+                statusCheckRollup {
+                    contexts(first: 100, after: $cursor) {
+                        pageInfo {
+                            hasNextPage
+                            endCursor
+                        }
+                        nodes {
+                            ... on CheckRun {
+                                __typename
+                                name
+                                status
+                                conclusion
+                                isRequired(pullRequestNumber: $number)
+                            }
+                            ... on StatusContext {
+                                __typename
+                                context
+                                state
+                                isRequired(pullRequestNumber: $number)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}"""
+
+
 _MERGE_READY_QUERY = """\
 query($owner: String!, $repo: String!, $number: Int!) {
     repository(owner: $owner, name: $repo) {
@@ -97,10 +141,15 @@ query($owner: String!, $repo: String!, $number: Int!) {
             commits(last: 1) {
                 nodes {
                     commit {
+                        oid
                         statusCheckRollup {
                             state
                             contexts(first: 100) {
                                 totalCount
+                                pageInfo {
+                                    hasNextPage
+                                    endCursor
+                                }
                                 nodes {
                                     ... on CheckRun {
                                         __typename
@@ -523,22 +572,71 @@ def _evaluate_review_threads(
     return unresolved_count, total_threads, pages_complete
 
 
+def _paginate_contexts(
+    owner: str, repo: str, pr_number: int, oid: str, start_cursor: str | None,
+) -> tuple[list[dict], bool]:
+    """Fetch remaining status-check contexts by cursor pagination.
+
+    Returns ``(extra_nodes, pages_complete)``. The boolean is True only
+    when the GraphQL pagination terminated normally (``hasNextPage``
+    was false on the last page) and the cap was not exhausted.
+    """
+    extras: list[dict] = []
+    cursor = start_cursor
+    if not cursor:
+        return extras, False
+    for _ in range(_CONTEXTS_MAX_PAGES):
+        try:
+            data = gh_graphql(
+                _CONTEXTS_PAGE_QUERY,
+                {
+                    "owner": owner, "repo": repo, "oid": oid,
+                    "number": pr_number, "cursor": cursor,
+                },
+            )
+        except RuntimeError as exc:
+            logger.warning(
+                "op=merge_ready_contexts_paginate_error pr=%d oid=%s err=%s",
+                pr_number, oid, safe_log_str(str(exc)),
+            )
+            return extras, False
+        commit_obj = (data.get("repository") or {}).get("object") or {}
+        rollup = commit_obj.get("statusCheckRollup") or {}
+        contexts_obj = rollup.get("contexts") or {}
+        nodes = contexts_obj.get("nodes") or []
+        extras.extend(nodes)
+        page_info = contexts_obj.get("pageInfo") or {}
+        if not page_info.get("hasNextPage", False):
+            return extras, True
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            return extras, False
+    return extras, False
+
+
 def _evaluate_ci_checks(
     pr: dict,
     ignore_ci: bool,
     include_non_required: bool,
     reasons: list[str],
+    owner: str = "", repo: str = "", pr_number: int = 0,
 ) -> tuple[list[str], list[str], list[str], list[str], int, bool, int, bool]:
     """Classify rollup contexts and append CI reasons.
 
     Returns ``(failed_required, pending_required, failed_non_required,
     pending_non_required, passed_checks, ci_passing, rollup_rows,
-    pages_complete)``. ``pages_complete`` is True when the inline
-    ``contexts(first: 100)`` page returned every status context
-    (``totalCount <= len(nodes)``); False when the page truncated. A
-    truncated context page can hide a failing required check, so the
-    /pr-review completion gate fails closed via ``fetched_pages_complete``
-    rather than trusting a partial snapshot.
+    pages_complete)``. ``pages_complete`` is True when every status
+    context on the latest commit was retrieved (either the inline
+    first:100 page was complete, or paginated follow-up calls exhausted
+    the list). False when truncation could not be resolved (paginate
+    hit the cap, or a follow-up GraphQL error). A truncated snapshot
+    can hide a failing required check, so the /pr-review completion
+    gate fails closed via ``fetched_pages_complete``.
+
+    ``owner``, ``repo``, and ``pr_number`` are required for the
+    paginated follow-up but default to empty/zero for backward
+    compatibility with callers that only need the inline-page slice
+    (e.g. unit tests that supply a synthetic PR dict).
     """
     failed_required: list[str] = []
     pending_required: list[str] = []
@@ -557,14 +655,40 @@ def _evaluate_ci_checks(
 
     commits = pr.get("commits", {}).get("nodes", [])
     if commits:
-        rollup = commits[0].get("commit", {}).get("statusCheckRollup")
+        commit_obj = commits[0].get("commit", {}) or {}
+        oid = commit_obj.get("oid", "")
+        rollup = commit_obj.get("statusCheckRollup")
         if rollup:
             contexts_obj = rollup.get("contexts", {}) or {}
             total_contexts = contexts_obj.get("totalCount")
-            contexts = contexts_obj.get("nodes", []) or []
-            rollup_rows = len(contexts)
-            if total_contexts is not None:
+            contexts = list(contexts_obj.get("nodes", []) or [])
+            page_info = contexts_obj.get("pageInfo") or {}
+
+            # Inline first:100 page truncated. Paginate to keep the
+            # snapshot exact, mirroring the threads-side fallback in
+            # _evaluate_review_threads. If pagination fails or hits
+            # the cap, pages_complete stays False so the gate fails
+            # closed even if the partial set looks clean.
+            if (
+                page_info.get("hasNextPage", False)
+                and owner and repo and pr_number and oid
+            ):
+                logger.info(
+                    "op=merge_ready_contexts_paginating pr=%d total=%s "
+                    "inline_nodes=%d",
+                    pr_number, total_contexts, len(contexts),
+                )
+                extras, ok = _paginate_contexts(
+                    owner, repo, pr_number, oid,
+                    page_info.get("endCursor"),
+                )
+                contexts.extend(extras)
+                if not ok:
+                    pages_complete = False
+            elif total_contexts is not None:
                 pages_complete = total_contexts <= len(contexts)
+
+            rollup_rows = len(contexts)
             _classify_check_contexts(
                 contexts,
                 failed_required=failed_required,
@@ -666,6 +790,7 @@ def check_merge_readiness(
      pending_non_required, passed_checks, ci_passing,
      rollup_rows, contexts_pages_complete) = _evaluate_ci_checks(
         pr, ignore_ci, include_non_required, reasons,
+        owner=owner, repo=repo, pr_number=pr_number,
     )
     can_merge = len(reasons) == 0
     fetched_pages_complete = threads_pages_complete and contexts_pages_complete

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -78,7 +78,19 @@ Replying does NOT resolve threads. Use `add_thread_reply_resolve` or separate `r
 
 ## Completion Gate
 
-ALL criteria from `completion_criteria` in config must pass before claiming completion. If ANY fails, loop back up to `invocation_limits.completion_gate_max_retries` times (default: 3) from config. If criteria still fail after the maximum retries, execute `invocation_limits.completion_gate_overflow_action` and halt. See `failure_handling` and `error_recovery` in config for recovery actions.
+The completion gate is dispatchable: each criterion in `completion_criteria` runs an external verification command, and the command's stdout JSON is the source of truth for the verdict. Run the dispatcher exactly once per PR:
+
+```bash
+python3 .claude/skills/github/scripts/pr/run_completion_gate.py \
+    --config .claude/commands/pr-review-config.yaml \
+    --pull-request {pr}
+```
+
+The dispatcher exits 0 if every criterion passes, 1 if any criterion fails. On failure, do NOT loop. Looping on a failing verifier produces the same wrong answer; the retry-on-failure behavior was the wrong design and has been removed (see retrospective `2026-05-05-pr-1887-iteration-paradox.md`, Layer 6: Reporting-Without-Acting Anti-Pattern).
+
+When the dispatcher exits 1, surface the failing criterion's name, command, and parsed output, then halt. Do not claim completion. Do not re-run the gate hoping for a different answer. Investigate the underlying failure and address it; once addressed, the gate may be re-run.
+
+`fail_open: false` (the default for every criterion in this config) means a verifier that errors or returns malformed output also fails the gate. A verifier that cannot verify is not evidence that the criterion holds.
 
 ## Related Memories
 

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -93,6 +93,10 @@ When the dispatcher exits 1, surface the failing criterion's `name`, `command`, 
 
 `fail_open: false` (the default for every criterion in this config) means a verifier that errors or returns malformed output also fails the gate. A verifier that cannot verify is not evidence that the criterion holds.
 
+### Trust boundary on the PR branch
+
+When `/pr-review` runs after `gh pr checkout`, the dispatcher reads `pr-review-config.yaml` from the PR's working tree. A malicious PR can change `completion_criteria.command` or `pass_when_python` and the dispatcher will execute it. Before invoking `/pr-review` on a PR that you do not control, INSPECT the diff for any change to `.claude/commands/pr-review-config.yaml`. The same caution applies to any test/lint/build a reviewer runs on a PR branch; this gate just makes the execution path explicit. Hardening (loading the config from `main` or refusing to run on divergence) is tracked as a follow-up to PR #1898.
+
 ## Related Memories
 
 See `related_memories` in config for Serena memories to consult during PR review.

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -83,12 +83,13 @@ The completion gate is dispatchable: each criterion in `completion_criteria` run
 ```bash
 python3 .claude/skills/github/scripts/pr/run_completion_gate.py \
     --config .claude/commands/pr-review-config.yaml \
-    --pull-request {pr}
+    --pull-request {pr} \
+    --json
 ```
 
-The dispatcher exits 0 if every criterion passes, 1 if any criterion fails. On failure, do NOT loop. Looping on a failing verifier produces the same wrong answer; the retry-on-failure behavior was the wrong design and has been removed (see retrospective `2026-05-05-pr-1887-iteration-paradox.md`, Layer 6: Reporting-Without-Acting Anti-Pattern).
+The dispatcher exits 0 if every criterion passes, 1 if any criterion fails, 2 on a config error. On failure, do NOT loop. Looping on a failing verifier produces the same wrong answer; the retry-on-failure behavior was the wrong design and has been removed (see retrospective `2026-05-05-pr-1887-iteration-paradox.md`, Layer 6: Reporting-Without-Acting Anti-Pattern).
 
-When the dispatcher exits 1, surface the failing criterion's name, command, and parsed output, then halt. Do not claim completion. Do not re-run the gate hoping for a different answer. Investigate the underlying failure and address it; once addressed, the gate may be re-run.
+When the dispatcher exits 1, surface the failing criterion's `name`, `command`, `reason`, and a stdout/stderr excerpt from the JSON output, then halt. Do not claim completion. Do not re-run the gate hoping for a different answer. Investigate the underlying failure and address it; once addressed, the gate may be re-run. The `--json` mode emits the verifier evidence inline; the table mode (default) prints the same fields below each FAIL row.
 
 `fail_open: false` (the default for every criterion in this config) means a verifier that errors or returns malformed output also fails the gate. A verifier that cannot verify is not evidence that the criterion holds.
 

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -178,6 +178,23 @@ class TestPassWhenDsl:
                 'stdout-json.x == "unterminated',
             )
 
+    def test_dangling_and_connective_rejected(self):
+        # Per Copilot review: ``x == 1 AND`` (with no atom after AND)
+        # silently passed before because the loop checked ``i < len``
+        # only at the top.
+        with pytest.raises(ValueError, match="dangling connective"):
+            _dispatcher._eval_pass_when(
+                {"x": 1},
+                "stdout-json.x == 1 AND",
+            )
+
+    def test_dangling_or_connective_rejected(self):
+        with pytest.raises(ValueError, match="dangling connective"):
+            _dispatcher._eval_pass_when(
+                {"x": 1},
+                "stdout-json.x == 0 OR",
+            )
+
 
 # ---------------------------------------------------------------------------
 # Dispatcher integration tests
@@ -886,6 +903,64 @@ class TestSchemaTypeChecks:
         )
         assert rc == 2
         assert "fail_open must be a boolean" in capsys.readouterr().err
+
+    def test_pass_when_as_list_rejected(self, repo_root, tmp_path, capsys):
+        # Per Copilot review: pass_when must also be type-checked, not
+        # just present. A list-valued pass_when (YAML indentation) would
+        # crash the DSL tokenizer later.
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Listy",
+                    "verification": "command",
+                    "command": "echo ignored",
+                    "pass_when": ["stdout-json.x == 0"],
+                },
+            ],
+        )
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "1"],
+        )
+        assert rc == 2
+        assert "pass_when must be a non-empty string" in capsys.readouterr().err
+
+    def test_missing_name_rejected(self, repo_root, tmp_path, capsys):
+        # Per Copilot review: name was previously defaulted to <unnamed>
+        # which could silently slip past. The dispatcher now mirrors the
+        # validator and requires it explicitly.
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "verification": "command",
+                    "command": "echo ignored",
+                    "pass_when": "stdout-json.x == 0",
+                },
+            ],
+        )
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "1"],
+        )
+        assert rc == 2
+        assert "missing required field: name" in capsys.readouterr().err
+
+    def test_missing_verification_rejected(self, repo_root, tmp_path, capsys):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "No-verification",
+                    "command": "echo ignored",
+                    "pass_when": "stdout-json.x == 0",
+                },
+            ],
+        )
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "1"],
+        )
+        assert rc == 2
+        assert "missing required field: verification" in capsys.readouterr().err
 
 
 class TestPassWhenPythonBroadException:

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -57,6 +57,19 @@ def _make_proc(stdout: str = "", stderr: str = "", returncode: int = 0):
     )
 
 
+@pytest.fixture
+def repo_root(tmp_path, monkeypatch):
+    """Treat tmp_path as the repo root so validate_safe_path accepts configs.
+
+    The dispatcher locks ``--config`` to paths under ``_PROJECT_ROOT`` to
+    block path traversal (CWE-22). Tests need to write throwaway configs
+    in tmp_path; monkeypatching the resolved root preserves the
+    production guard while keeping the tests hermetic.
+    """
+    monkeypatch.setattr(_dispatcher, "_PROJECT_ROOT", tmp_path)
+    return tmp_path
+
+
 def _write_config(tmp_path: Path, criteria: list[dict]) -> Path:
     """Write a minimal config YAML with only completion_criteria.
 
@@ -158,7 +171,7 @@ class TestPassWhenDsl:
 class TestRunCompletionGate:
     """End-to-end main() exercises with mocked subprocess.run."""
 
-    def test_all_pass_exits_zero(self, tmp_path, capsys):
+    def test_all_pass_exits_zero(self, repo_root, tmp_path, capsys):
         config_path = _write_config(
             tmp_path,
             [
@@ -207,7 +220,7 @@ class TestRunCompletionGate:
         assert result["all_passed"] is True
         assert all(c["passed"] for c in result["criteria"])
 
-    def test_one_fail_exits_one(self, tmp_path, capsys):
+    def test_one_fail_exits_one(self, repo_root, tmp_path, capsys):
         config_path = _write_config(
             tmp_path,
             [
@@ -242,7 +255,7 @@ class TestRunCompletionGate:
         assert "pass_when evaluated false" in result["criteria"][0]["reason"]
 
     def test_command_error_fails_closed_when_fail_open_false(
-        self, tmp_path, capsys,
+        self, repo_root, tmp_path, capsys,
     ):
         config_path = _write_config(
             tmp_path,
@@ -274,7 +287,7 @@ class TestRunCompletionGate:
         assert result["criteria"][0]["passed"] is False
         assert "command failed to run" in result["criteria"][0]["reason"]
 
-    def test_command_error_passes_when_fail_open_true(self, tmp_path, capsys):
+    def test_command_error_passes_when_fail_open_true(self, repo_root, tmp_path, capsys):
         config_path = _write_config(
             tmp_path,
             [
@@ -304,7 +317,7 @@ class TestRunCompletionGate:
         result = json.loads(capsys.readouterr().out)
         assert result["criteria"][0]["passed"] is True
 
-    def test_malformed_json_fails_closed(self, tmp_path, capsys):
+    def test_malformed_json_fails_closed(self, repo_root, tmp_path, capsys):
         config_path = _write_config(
             tmp_path,
             [
@@ -335,7 +348,7 @@ class TestRunCompletionGate:
         assert result["criteria"][0]["passed"] is False
         assert "not a JSON object" in result["criteria"][0]["reason"]
 
-    def test_missing_config_returns_two(self, tmp_path):
+    def test_missing_config_returns_two(self, repo_root, tmp_path):
         rc = _dispatcher.main(
             [
                 "--config", str(tmp_path / "does-not-exist.yaml"),
@@ -345,7 +358,7 @@ class TestRunCompletionGate:
         )
         assert rc == 2
 
-    def test_negative_pr_returns_two(self, tmp_path):
+    def test_negative_pr_returns_two(self, repo_root, tmp_path):
         config_path = _write_config(
             tmp_path,
             [
@@ -362,7 +375,7 @@ class TestRunCompletionGate:
         )
         assert rc == 2
 
-    def test_pr_substitution(self, tmp_path):
+    def test_pr_substitution(self, repo_root, tmp_path):
         config_path = _write_config(
             tmp_path,
             [
@@ -395,7 +408,7 @@ class TestRunCompletionGate:
         # The {pr} placeholder must have been substituted before tokenizing.
         assert "1234" in " ".join(captured["argv"])
 
-    def test_pass_when_python_escape_hatch(self, tmp_path):
+    def test_pass_when_python_escape_hatch(self, repo_root, tmp_path):
         config_path = _write_config(
             tmp_path,
             [
@@ -422,3 +435,247 @@ class TestRunCompletionGate:
             )
 
         assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Negative branch coverage: rejection paths in the dispatcher.
+# These exercise branches that the production-code review identified as
+# reachable but untested. Each test covers one branch so that a future
+# regression localizes the failure.
+# ---------------------------------------------------------------------------
+
+
+class TestPassWhenDslNegativeBranches:
+    """Cover error-path branches of the pass_when DSL evaluator."""
+
+    def test_empty_expression_raises(self):
+        with pytest.raises(ValueError):
+            _dispatcher._eval_pass_when({}, "")
+
+    def test_missing_connective_between_atoms_raises(self):
+        # "a == 0 b == 1" lacks AND/OR between the two atoms; the parser
+        # should reject rather than silently accept.
+        with pytest.raises(ValueError):
+            _dispatcher._eval_pass_when(
+                {"a": 0, "b": 1},
+                "stdout-json.a == 0 stdout-json.b == 1",
+            )
+
+
+class TestPassWhenPythonNegativeBranches:
+    """Cover the eval-rejection paths in _eval_pass_when_python.
+
+    These branches are security-relevant: they bound the surface that
+    the eval call will accept. AGENTS.md sets the security-critical
+    coverage floor at 100%; missing these branches violates that floor.
+    """
+
+    def test_non_string_rejected(self):
+        with pytest.raises(ValueError, match="must be a string"):
+            _dispatcher._eval_pass_when_python({}, 123)  # type: ignore[arg-type]
+
+    def test_non_lambda_rejected(self):
+        with pytest.raises(ValueError, match="must be a lambda"):
+            _dispatcher._eval_pass_when_python({}, "1 + 1")
+
+    def test_multiline_rejected(self):
+        with pytest.raises(ValueError, match="single line"):
+            _dispatcher._eval_pass_when_python(
+                {}, "lambda d: d\n.get('x')",
+            )
+
+    def test_non_callable_result_rejected(self):
+        # A lambda that yields a non-callable value (defensive guard for
+        # a future expression form that does not produce a function).
+        # `lambda d: 1` is callable, so we exercise the guard via the
+        # boolean coercion: the function must be a callable in the
+        # is-checked sense. We force the result to a non-callable by
+        # supplying a degenerate expression that startswith "lambda" but
+        # whose body is parsed as something other than a function.
+        # Python forbids that at parse-time, so this branch is reached
+        # only via the ``isinstance(expr, str)`` + ``startswith`` path.
+        # The only way to exercise the ``not callable(func)`` line is to
+        # call _eval_pass_when_python with an expression that compiles
+        # but produces a non-callable. None such exists for ``lambda``,
+        # so we confirm the guard via direct unit-style exercise: feed
+        # a value that bypasses the startswith check by patching it.
+        with patch.object(
+            _dispatcher, "eval", return_value=42, create=True,
+        ):
+            with pytest.raises(ValueError, match="did not yield a callable"):
+                _dispatcher._eval_pass_when_python({}, "lambda d: True")
+
+
+class TestDispatcherCriterionRejectionPaths:
+    """Reachable production branches in _evaluate_criterion that the
+    earlier tests did not cover.
+    """
+
+    def test_unsupported_verification_kind(self, repo_root, tmp_path, capsys):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Bogus",
+                    "verification": "magic",
+                    "command": "echo ignored",
+                    "pass_when": "stdout-json.x == 0",
+                },
+            ],
+        )
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "1", "--json"],
+        )
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert result["criteria"][0]["passed"] is False
+        assert "unsupported verification" in result["criteria"][0]["reason"]
+
+    def test_missing_command_field(self, repo_root, tmp_path, capsys):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "No-cmd",
+                    "verification": "command",
+                    "pass_when": "stdout-json.x == 0",
+                },
+            ],
+        )
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "1", "--json"],
+        )
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert "no command" in result["criteria"][0]["reason"]
+
+    def test_missing_pass_when_expression(self, repo_root, tmp_path, capsys):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "No-expr",
+                    "verification": "command",
+                    "command": "echo ignored",
+                },
+            ],
+        )
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            return_value=_make_proc(stdout=json.dumps({"x": 0})),
+        ):
+            rc = _dispatcher.main(
+                ["--config", str(config_path), "--pull-request", "1", "--json"],
+            )
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert "no pass_when expression" in result["criteria"][0]["reason"]
+
+    def test_timeout_fails_closed_when_fail_open_false(
+        self, repo_root, tmp_path, capsys,
+    ):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Slow",
+                    "verification": "command",
+                    "command": "sleep 9999",
+                    "pass_when": "stdout-json.x == 0",
+                    "fail_open": False,
+                },
+            ],
+        )
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            side_effect=subprocess.TimeoutExpired(cmd=["sleep"], timeout=1),
+        ):
+            rc = _dispatcher.main(
+                ["--config", str(config_path), "--pull-request", "1", "--json"],
+            )
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert result["criteria"][0]["passed"] is False
+        assert "command failed to run" in result["criteria"][0]["reason"]
+
+    def test_timeout_passes_when_fail_open_true(
+        self, repo_root, tmp_path, capsys,
+    ):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Lenient",
+                    "verification": "command",
+                    "command": "sleep 9999",
+                    "pass_when": "stdout-json.x == 0",
+                    "fail_open": True,
+                },
+            ],
+        )
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            side_effect=subprocess.TimeoutExpired(cmd=["sleep"], timeout=1),
+        ):
+            rc = _dispatcher.main(
+                ["--config", str(config_path), "--pull-request", "1", "--json"],
+            )
+        assert rc == 0
+
+
+class TestDispatcherMainRejectionPaths:
+    """Reachable branches in main() that earlier tests did not cover."""
+
+    def test_empty_completion_criteria_returns_two(
+        self, repo_root, tmp_path, capsys,
+    ):
+        config_path = _write_config(tmp_path, [])
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "1"],
+        )
+        assert rc == 2
+        assert "No completion_criteria" in capsys.readouterr().err
+
+    def test_malformed_criterion_not_a_mapping(
+        self, repo_root, tmp_path, capsys,
+    ):
+        # YAML parses "- foo" as a list element of type str, not dict.
+        # Write the config directly to exercise the "not isinstance dict"
+        # branch in main().
+        config_path = tmp_path / "pr-review-config.yaml"
+        config_path.write_text(
+            "completion_criteria:\n  - 'this is a string, not a mapping'\n",
+            encoding="utf-8",
+        )
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "1", "--json"],
+        )
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert result["criteria"][0]["name"] == "<malformed>"
+        assert "not a mapping" in result["criteria"][0]["reason"]
+
+    def test_path_traversal_rejected(self, tmp_path):
+        # No repo_root fixture: --config points outside the production
+        # _PROJECT_ROOT (which is the actual repo root); the dispatcher
+        # MUST reject with exit 2 before reading the file.
+        outside = tmp_path / "evil.yaml"
+        outside.write_text("completion_criteria: []\n", encoding="utf-8")
+        rc = _dispatcher.main(
+            ["--config", str(outside), "--pull-request", "1"],
+        )
+        assert rc == 2
+
+
+class TestFormatCommandTypeGuard:
+    """The integer assertion in _format_command bounds CWE-78 risk."""
+
+    def test_string_pr_number_rejected(self):
+        with pytest.raises(TypeError, match="pr_number must be int"):
+            _dispatcher._format_command("echo {pr}", "1; rm -rf /")  # type: ignore[arg-type]
+
+    def test_bool_pr_number_rejected(self):
+        # bools are int subclasses in Python; the guard rejects them
+        # explicitly so a downstream caller cannot smuggle True/False.
+        with pytest.raises(TypeError, match="pr_number must be int"):
+            _dispatcher._format_command("echo {pr}", True)  # type: ignore[arg-type]

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -661,7 +661,7 @@ class TestDispatcherCriterionRejectionPaths:
             ["--config", str(config_path), "--pull-request", "1", "--json"],
         )
         assert rc == 2
-        assert "missing command" in capsys.readouterr().err
+        assert "command must be a non-empty string" in capsys.readouterr().err
 
     def test_missing_pass_when_expression(self, repo_root, tmp_path, capsys):
         config_path = _write_config(
@@ -841,3 +841,147 @@ class TestFormatCommandTypeGuard:
         # explicitly so a downstream caller cannot smuggle True/False.
         with pytest.raises(TypeError, match="pr_number must be int"):
             _dispatcher._format_command("echo {pr}", True)  # type: ignore[arg-type]
+
+
+class TestSchemaTypeChecks:
+    """Per Copilot review: tighten value-type checks in
+    _validate_criterion_schema so YAML quirks (lists where strings are
+    expected, ``"yes"`` instead of ``true``) surface as ConfigError
+    rather than crashing later in the dispatch path.
+    """
+
+    def test_command_as_list_rejected(self, repo_root, tmp_path, capsys):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Listy",
+                    "verification": "command",
+                    "command": ["echo", "ignored"],
+                    "pass_when": "stdout-json.x == 0",
+                },
+            ],
+        )
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "1"],
+        )
+        assert rc == 2
+        assert "command must be a non-empty string" in capsys.readouterr().err
+
+    def test_fail_open_string_yes_rejected(self, repo_root, tmp_path, capsys):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Trickier",
+                    "verification": "command",
+                    "command": "echo ignored",
+                    "pass_when": "stdout-json.x == 0",
+                    "fail_open": "yes",
+                },
+            ],
+        )
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "1"],
+        )
+        assert rc == 2
+        assert "fail_open must be a boolean" in capsys.readouterr().err
+
+
+class TestPassWhenPythonBroadException:
+    """Per CodeRabbit: a pass_when_python lambda body can raise anything
+    (ZeroDivisionError, IndexError, custom exceptions). The dispatcher
+    must catch all of them and fail closed.
+    """
+
+    def test_zero_division_in_lambda_fails_closed(
+        self, repo_root, tmp_path, capsys,
+    ):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Divides",
+                    "verification": "command",
+                    "command": "echo ignored",
+                    "pass_when_python": "lambda d: 1 / 0",
+                    "fail_open": True,  # MUST be ignored (config bug)
+                },
+            ],
+        )
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            return_value=_make_proc(stdout=json.dumps({"x": 0})),
+        ):
+            rc = _dispatcher.main(
+                ["--config", str(config_path), "--pull-request", "1", "--json"],
+            )
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert result["criteria"][0]["passed"] is False
+        assert "fails closed" in result["criteria"][0]["reason"]
+
+    def test_index_error_in_lambda_fails_closed(
+        self, repo_root, tmp_path, capsys,
+    ):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "OutOfBounds",
+                    "verification": "command",
+                    "command": "echo ignored",
+                    "pass_when_python": "lambda d: d['items'][5] == 'x'",
+                    "fail_open": True,
+                },
+            ],
+        )
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            return_value=_make_proc(stdout=json.dumps({"items": []})),
+        ):
+            rc = _dispatcher.main(
+                ["--config", str(config_path), "--pull-request", "1", "--json"],
+            )
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert "fails closed" in result["criteria"][0]["reason"]
+
+
+class TestTableModeShowsEvidence:
+    """Per CodeRabbit: the non-JSON path also needs to surface the
+    verifier's command and stdout/stderr so an operator triaging from
+    the terminal output has the same evidence the JSON consumer sees.
+    """
+
+    def test_failing_row_shows_command_and_output(
+        self, repo_root, tmp_path, capsys,
+    ):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "ShowMe",
+                    "verification": "command",
+                    "command": "echo evidence",
+                    "pass_when": "stdout-json.unresolved_count == 99",
+                },
+            ],
+        )
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            return_value=_make_proc(
+                stdout=json.dumps({"unresolved_count": 0}),
+                stderr="warning from verifier",
+                returncode=0,
+            ),
+        ):
+            rc = _dispatcher.main(
+                ["--config", str(config_path), "--pull-request", "1"],
+            )
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "FAIL   ShowMe" in out
+        assert "command:" in out
+        assert "stdout:" in out
+        assert "warning from verifier" in out

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -162,6 +162,22 @@ class TestPassWhenDsl:
             data, "stdout-json.outer.inner == 42",
         ) is True
 
+    def test_quoted_string_with_space_stays_intact(self):
+        # Per Gemini review: previous expr.split() broke on
+        # ``"PR merged"``, splitting it into ``['"PR', 'merged"']``. The
+        # shlex.split tokenizer keeps the literal as a single token.
+        data = {"label": "PR merged"}
+        assert _dispatcher._eval_pass_when(
+            data, 'stdout-json.label == "PR merged"',
+        ) is True
+
+    def test_unbalanced_quotes_rejected(self):
+        with pytest.raises(ValueError, match="tokenization failed"):
+            _dispatcher._eval_pass_when(
+                {"x": 1},
+                'stdout-json.x == "unterminated',
+            )
+
 
 # ---------------------------------------------------------------------------
 # Dispatcher integration tests
@@ -348,6 +364,103 @@ class TestRunCompletionGate:
         assert result["criteria"][0]["passed"] is False
         assert "not a JSON object" in result["criteria"][0]["reason"]
 
+    def test_non_zero_exit_treated_as_dispatch_error(
+        self, repo_root, tmp_path, capsys,
+    ):
+        # Per Copilot review: a non-zero verifier exit is a dispatch
+        # error, not a "the verifier ran fine, parse its stdout"
+        # success path. Verifier output may be a stale snapshot; trust
+        # the exit code first.
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Crashy",
+                    "verification": "command",
+                    "command": "false",
+                    "pass_when": "stdout-json.x == 0",
+                    "fail_open": False,
+                },
+            ],
+        )
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            return_value=_make_proc(
+                stdout=json.dumps({"x": 0}),
+                stderr="something went wrong",
+                returncode=3,
+            ),
+        ):
+            rc = _dispatcher.main(
+                ["--config", str(config_path), "--pull-request", "1", "--json"],
+            )
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert result["criteria"][0]["passed"] is False
+        assert "exited non-zero" in result["criteria"][0]["reason"]
+        # Verifier output is preserved in the result for triage:
+        assert result["criteria"][0]["stderr"] == "something went wrong"
+
+    def test_broken_pass_when_fails_closed_even_when_fail_open_true(
+        self, repo_root, tmp_path, capsys,
+    ):
+        # Per CodeRabbit review: a broken pass_when expression is a
+        # config bug, not a verifier outage. fail_open MUST NOT mask
+        # it; otherwise a typo in the gate definition silently greens
+        # the gate.
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Broken expr",
+                    "verification": "command",
+                    "command": "echo {}",
+                    "pass_when": "stdout-json.x !@# 0",  # nonsense op
+                    "fail_open": True,  # MUST be ignored for this case
+                },
+            ],
+        )
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            return_value=_make_proc(stdout=json.dumps({"x": 0})),
+        ):
+            rc = _dispatcher.main(
+                ["--config", str(config_path), "--pull-request", "1", "--json"],
+            )
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert result["criteria"][0]["passed"] is False
+        assert "fails closed" in result["criteria"][0]["reason"]
+
+    def test_verifier_stdout_preserved_in_result(
+        self, repo_root, tmp_path, capsys,
+    ):
+        # Per CodeRabbit review: the result row must include the
+        # verifier's stdout/stderr so the failing criterion can be
+        # debugged from the gate output alone.
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Verbose",
+                    "verification": "command",
+                    "command": "echo ignored",
+                    "pass_when": "stdout-json.unresolved_count == 99",
+                },
+            ],
+        )
+        verifier_out = json.dumps({"unresolved_count": 0})
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            return_value=_make_proc(stdout=verifier_out, returncode=0),
+        ):
+            rc = _dispatcher.main(
+                ["--config", str(config_path), "--pull-request", "1", "--json"],
+            )
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert result["criteria"][0]["stdout"] == verifier_out
+
     def test_missing_config_returns_two(self, repo_root, tmp_path):
         rc = _dispatcher.main(
             [
@@ -512,6 +625,10 @@ class TestDispatcherCriterionRejectionPaths:
     """
 
     def test_unsupported_verification_kind(self, repo_root, tmp_path, capsys):
+        # Schema bug: verification kind unknown. Per CodeRabbit review
+        # feedback, malformed criteria are config errors (exit 2), not
+        # gate failures (exit 1). Distinguishes a typo from a verifier
+        # legitimately reporting a problem.
         config_path = _write_config(
             tmp_path,
             [
@@ -526,10 +643,8 @@ class TestDispatcherCriterionRejectionPaths:
         rc = _dispatcher.main(
             ["--config", str(config_path), "--pull-request", "1", "--json"],
         )
-        assert rc == 1
-        result = json.loads(capsys.readouterr().out)
-        assert result["criteria"][0]["passed"] is False
-        assert "unsupported verification" in result["criteria"][0]["reason"]
+        assert rc == 2
+        assert "unsupported verification" in capsys.readouterr().err
 
     def test_missing_command_field(self, repo_root, tmp_path, capsys):
         config_path = _write_config(
@@ -545,9 +660,8 @@ class TestDispatcherCriterionRejectionPaths:
         rc = _dispatcher.main(
             ["--config", str(config_path), "--pull-request", "1", "--json"],
         )
-        assert rc == 1
-        result = json.loads(capsys.readouterr().out)
-        assert "no command" in result["criteria"][0]["reason"]
+        assert rc == 2
+        assert "missing command" in capsys.readouterr().err
 
     def test_missing_pass_when_expression(self, repo_root, tmp_path, capsys):
         config_path = _write_config(
@@ -560,16 +674,35 @@ class TestDispatcherCriterionRejectionPaths:
                 },
             ],
         )
-        with patch.object(
-            _dispatcher.subprocess, "run",
-            return_value=_make_proc(stdout=json.dumps({"x": 0})),
-        ):
-            rc = _dispatcher.main(
-                ["--config", str(config_path), "--pull-request", "1", "--json"],
-            )
-        assert rc == 1
-        result = json.loads(capsys.readouterr().out)
-        assert "no pass_when expression" in result["criteria"][0]["reason"]
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "1", "--json"],
+        )
+        assert rc == 2
+        assert "missing pass_when" in capsys.readouterr().err
+
+    def test_pass_when_and_pass_when_python_both_set_rejected(
+        self, repo_root, tmp_path, capsys,
+    ):
+        # Per Copilot review: both-set is ambiguous because the
+        # dispatcher silently picks pass_when_python first. Reject at
+        # schema time so the ambiguity never reaches runtime.
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Both",
+                    "verification": "command",
+                    "command": "echo ignored",
+                    "pass_when": "stdout-json.x == 0",
+                    "pass_when_python": "lambda d: d['x'] == 0",
+                },
+            ],
+        )
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "1", "--json"],
+        )
+        assert rc == 2
+        assert "mutually exclusive" in capsys.readouterr().err
 
     def test_timeout_fails_closed_when_fail_open_false(
         self, repo_root, tmp_path, capsys,
@@ -640,8 +773,8 @@ class TestDispatcherMainRejectionPaths:
         self, repo_root, tmp_path, capsys,
     ):
         # YAML parses "- foo" as a list element of type str, not dict.
-        # Write the config directly to exercise the "not isinstance dict"
-        # branch in main().
+        # CodeRabbit review feedback: a non-mapping criterion is a
+        # config bug, not a gate result. Exit 2.
         config_path = tmp_path / "pr-review-config.yaml"
         config_path.write_text(
             "completion_criteria:\n  - 'this is a string, not a mapping'\n",
@@ -650,10 +783,39 @@ class TestDispatcherMainRejectionPaths:
         rc = _dispatcher.main(
             ["--config", str(config_path), "--pull-request", "1", "--json"],
         )
-        assert rc == 1
-        result = json.loads(capsys.readouterr().out)
-        assert result["criteria"][0]["name"] == "<malformed>"
-        assert "not a mapping" in result["criteria"][0]["reason"]
+        assert rc == 2
+        assert "not a mapping" in capsys.readouterr().err
+
+    def test_completion_criteria_not_a_list_rejected(
+        self, repo_root, tmp_path, capsys,
+    ):
+        # Per CodeRabbit: a dict in this slot would be silently iterated
+        # as keys. Reject explicitly.
+        config_path = tmp_path / "pr-review-config.yaml"
+        config_path.write_text(
+            "completion_criteria:\n  some_key: some_value\n",
+            encoding="utf-8",
+        )
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "1"],
+        )
+        assert rc == 2
+        assert "must be a list" in capsys.readouterr().err
+
+    def test_unreadable_config_returns_two(
+        self, repo_root, tmp_path, capsys,
+    ):
+        # Per CodeRabbit: yaml.YAMLError must be caught and exit 2.
+        config_path = tmp_path / "pr-review-config.yaml"
+        config_path.write_text(
+            "this is not: valid: yaml: at: all:\n  - [unbalanced",
+            encoding="utf-8",
+        )
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "1"],
+        )
+        assert rc == 2
+        assert "Failed to load config" in capsys.readouterr().err
 
     def test_path_traversal_rejected(self, tmp_path):
         # No repo_root fixture: --config points outside the production

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -1,0 +1,424 @@
+"""Tests for the dispatchable /pr-review completion gate.
+
+Covers run_completion_gate.py at .claude/skills/github/scripts/pr/.
+
+Each test case constructs a synthetic config and stubs subprocess.run so
+the criterion's command does not actually shell out. We assert on:
+
+  * exit code (0 if all pass, 1 if any fail, 2 on usage)
+  * per-criterion verdicts visible in --json output
+  * fail_open semantics: command error -> pass when fail_open=true,
+    fail when fail_open=false
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = (
+    _REPO_ROOT
+    / ".claude"
+    / "skills"
+    / "github"
+    / "scripts"
+    / "pr"
+    / "run_completion_gate.py"
+)
+
+
+def _import_dispatcher():
+    """Import the dispatcher module from its file path."""
+    spec = importlib.util.spec_from_file_location(
+        "run_completion_gate", _SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["run_completion_gate"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_dispatcher = _import_dispatcher()
+
+
+def _make_proc(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+def _write_config(tmp_path: Path, criteria: list[dict]) -> Path:
+    """Write a minimal config YAML with only completion_criteria.
+
+    Uses JSON syntax (which is valid YAML) so PyYAML parses it without
+    needing block-style indentation gymnastics in the test source.
+    """
+    config = {"completion_criteria": criteria}
+    path = tmp_path / "pr-review-config.yaml"
+    path.write_text(json.dumps(config), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# pass_when DSL unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestPassWhenDsl:
+    """Direct exercise of the pass_when expression evaluator."""
+
+    def test_simple_int_eq_passes(self):
+        data = {"unresolved_count": 0}
+        assert _dispatcher._eval_pass_when(
+            data, "stdout-json.unresolved_count == 0",
+        ) is True
+
+    def test_simple_int_eq_fails(self):
+        data = {"unresolved_count": 3}
+        assert _dispatcher._eval_pass_when(
+            data, "stdout-json.unresolved_count == 0",
+        ) is False
+
+    def test_bool_eq_true(self):
+        data = {"fetched_pages_complete": True}
+        assert _dispatcher._eval_pass_when(
+            data, "stdout-json.fetched_pages_complete == true",
+        ) is True
+
+    def test_bool_eq_false_with_false_literal(self):
+        data = {"merged": False}
+        assert _dispatcher._eval_pass_when(
+            data, "stdout-json.merged == false",
+        ) is True
+
+    def test_neq_operator(self):
+        data = {"state": "OPEN"}
+        assert _dispatcher._eval_pass_when(
+            data, 'stdout-json.state != "CLOSED"',
+        ) is True
+
+    def test_and_composition_both_true(self):
+        data = {"unresolved_count": 0, "fetched_pages_complete": True}
+        expr = (
+            "stdout-json.unresolved_count == 0 "
+            "AND stdout-json.fetched_pages_complete == true"
+        )
+        assert _dispatcher._eval_pass_when(data, expr) is True
+
+    def test_and_composition_one_false(self):
+        data = {"unresolved_count": 0, "fetched_pages_complete": False}
+        expr = (
+            "stdout-json.unresolved_count == 0 "
+            "AND stdout-json.fetched_pages_complete == true"
+        )
+        assert _dispatcher._eval_pass_when(data, expr) is False
+
+    def test_or_composition_one_true(self):
+        data = {"unresolved_count": 5, "ignore_threads": True}
+        expr = (
+            "stdout-json.unresolved_count == 0 "
+            "OR stdout-json.ignore_threads == true"
+        )
+        assert _dispatcher._eval_pass_when(data, expr) is True
+
+    def test_missing_path_returns_none(self):
+        data: dict = {}
+        # null literal compares equal to a missing path
+        assert _dispatcher._eval_pass_when(
+            data, "stdout-json.nope == null",
+        ) is True
+
+    def test_unsupported_op_raises(self):
+        data = {"x": 1}
+        with pytest.raises(ValueError):
+            _dispatcher._eval_pass_when(data, "stdout-json.x > 0")
+
+    def test_dotted_nested_path(self):
+        data = {"outer": {"inner": 42}}
+        assert _dispatcher._eval_pass_when(
+            data, "stdout-json.outer.inner == 42",
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunCompletionGate:
+    """End-to-end main() exercises with mocked subprocess.run."""
+
+    def test_all_pass_exits_zero(self, tmp_path, capsys):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "All threads resolved",
+                    "verification": "command",
+                    "command": "echo ignored",
+                    "pass_when": (
+                        "stdout-json.unresolved_count == 0 "
+                        "AND stdout-json.fetched_pages_complete == true"
+                    ),
+                    "fail_open": False,
+                },
+                {
+                    "name": "Not merged",
+                    "verification": "command",
+                    "command": "echo ignored",
+                    "pass_when": "stdout-json.merged == false",
+                    "fail_open": False,
+                },
+            ],
+        )
+
+        responses = [
+            _make_proc(
+                stdout=json.dumps(
+                    {"unresolved_count": 0, "fetched_pages_complete": True},
+                ),
+            ),
+            _make_proc(stdout=json.dumps({"merged": False})),
+        ]
+
+        with patch.object(
+            _dispatcher.subprocess, "run", side_effect=responses,
+        ):
+            rc = _dispatcher.main(
+                [
+                    "--config", str(config_path),
+                    "--pull-request", "1234",
+                    "--json",
+                ],
+            )
+
+        assert rc == 0
+        result = json.loads(capsys.readouterr().out)
+        assert result["all_passed"] is True
+        assert all(c["passed"] for c in result["criteria"])
+
+    def test_one_fail_exits_one(self, tmp_path, capsys):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "All threads resolved",
+                    "verification": "command",
+                    "command": "echo ignored",
+                    "pass_when": "stdout-json.unresolved_count == 0",
+                    "fail_open": False,
+                },
+            ],
+        )
+
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            return_value=_make_proc(
+                stdout=json.dumps({"unresolved_count": 3}),
+            ),
+        ):
+            rc = _dispatcher.main(
+                [
+                    "--config", str(config_path),
+                    "--pull-request", "1234",
+                    "--json",
+                ],
+            )
+
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert result["all_passed"] is False
+        assert result["criteria"][0]["passed"] is False
+        assert "pass_when evaluated false" in result["criteria"][0]["reason"]
+
+    def test_command_error_fails_closed_when_fail_open_false(
+        self, tmp_path, capsys,
+    ):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Strict",
+                    "verification": "command",
+                    "command": "this-command-does-not-exist",
+                    "pass_when": "stdout-json.x == 0",
+                    "fail_open": False,
+                },
+            ],
+        )
+
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            side_effect=FileNotFoundError("nope"),
+        ):
+            rc = _dispatcher.main(
+                [
+                    "--config", str(config_path),
+                    "--pull-request", "1234",
+                    "--json",
+                ],
+            )
+
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert result["criteria"][0]["passed"] is False
+        assert "command failed to run" in result["criteria"][0]["reason"]
+
+    def test_command_error_passes_when_fail_open_true(self, tmp_path, capsys):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Lenient",
+                    "verification": "command",
+                    "command": "this-command-does-not-exist",
+                    "pass_when": "stdout-json.x == 0",
+                    "fail_open": True,
+                },
+            ],
+        )
+
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            side_effect=FileNotFoundError("nope"),
+        ):
+            rc = _dispatcher.main(
+                [
+                    "--config", str(config_path),
+                    "--pull-request", "1234",
+                    "--json",
+                ],
+            )
+
+        assert rc == 0
+        result = json.loads(capsys.readouterr().out)
+        assert result["criteria"][0]["passed"] is True
+
+    def test_malformed_json_fails_closed(self, tmp_path, capsys):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Bad output",
+                    "verification": "command",
+                    "command": "echo not-json",
+                    "pass_when": "stdout-json.x == 0",
+                    "fail_open": False,
+                },
+            ],
+        )
+
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            return_value=_make_proc(stdout="not-json", returncode=0),
+        ):
+            rc = _dispatcher.main(
+                [
+                    "--config", str(config_path),
+                    "--pull-request", "1234",
+                    "--json",
+                ],
+            )
+
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert result["criteria"][0]["passed"] is False
+        assert "not a JSON object" in result["criteria"][0]["reason"]
+
+    def test_missing_config_returns_two(self, tmp_path):
+        rc = _dispatcher.main(
+            [
+                "--config", str(tmp_path / "does-not-exist.yaml"),
+                "--pull-request", "1234",
+                "--json",
+            ],
+        )
+        assert rc == 2
+
+    def test_negative_pr_returns_two(self, tmp_path):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "x",
+                    "verification": "command",
+                    "command": "echo {}",
+                    "pass_when": "stdout-json.x == 0",
+                },
+            ],
+        )
+        rc = _dispatcher.main(
+            ["--config", str(config_path), "--pull-request", "-1"],
+        )
+        assert rc == 2
+
+    def test_pr_substitution(self, tmp_path):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "echo PR",
+                    "verification": "command",
+                    "command": 'echo {"pr": {pr}}',
+                    "pass_when": "stdout-json.pr == 1234",
+                    "fail_open": False,
+                },
+            ],
+        )
+
+        captured: dict = {}
+
+        def fake_run(argv, **_kw):
+            captured["argv"] = argv
+            return _make_proc(stdout=json.dumps({"pr": 1234}))
+
+        with patch.object(_dispatcher.subprocess, "run", side_effect=fake_run):
+            rc = _dispatcher.main(
+                [
+                    "--config", str(config_path),
+                    "--pull-request", "1234",
+                    "--json",
+                ],
+            )
+
+        assert rc == 0
+        # The {pr} placeholder must have been substituted before tokenizing.
+        assert "1234" in " ".join(captured["argv"])
+
+    def test_pass_when_python_escape_hatch(self, tmp_path):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "name": "Python hatch",
+                    "verification": "command",
+                    "command": "echo ignored",
+                    "pass_when_python": "lambda d: d.get('x', 0) > 0",
+                    "fail_open": False,
+                },
+            ],
+        )
+
+        with patch.object(
+            _dispatcher.subprocess, "run",
+            return_value=_make_proc(stdout=json.dumps({"x": 7})),
+        ):
+            rc = _dispatcher.main(
+                [
+                    "--config", str(config_path),
+                    "--pull-request", "1",
+                    "--json",
+                ],
+            )
+
+        assert rc == 0

--- a/tests/test_get_unresolved_review_threads.py
+++ b/tests/test_get_unresolved_review_threads.py
@@ -193,6 +193,10 @@ class TestMain:
         # fetched_pages_complete flag drive the pass/fail decision.
         assert output["fetched_pages_complete"] is False
         assert output["unresolved_count"] == 0
+        # Per Copilot review: success must mirror fetched_pages_complete
+        # so other consumers do not treat an incomplete snapshot as a
+        # success-shaped reply.
+        assert output["success"] is False
 
     def test_missing_cursor_marks_incomplete(self, capsys):
         # hasNextPage true but endCursor absent: cannot continue, must
@@ -215,3 +219,4 @@ class TestMain:
         assert rc == 0
         output = json.loads(capsys.readouterr().out)
         assert output["fetched_pages_complete"] is False
+        assert output["success"] is False

--- a/tests/test_get_unresolved_review_threads.py
+++ b/tests/test_get_unresolved_review_threads.py
@@ -1,4 +1,10 @@
-"""Tests for get_unresolved_review_threads.py skill script."""
+"""Tests for get_unresolved_review_threads.py skill script.
+
+The script now emits a JSON object with ``unresolved_count`` and
+``fetched_pages_complete``. Pagination is handled in the script (not by
+the api.py helper) so the explicit completeness flag can drive the
+/pr-review completion gate's pass_when expression.
+"""
 
 from __future__ import annotations
 
@@ -34,6 +40,25 @@ def _import_script(name: str):
 _mod = _import_script("get_unresolved_review_threads")
 main = _mod.main
 build_parser = _mod.build_parser
+
+
+def _page(
+    *, nodes: list[dict], has_next: bool, end_cursor: str | None = None,
+) -> dict:
+    """Build a synthetic GraphQL response page for the reviewThreads query."""
+    return {
+        "repository": {
+            "pullRequest": {
+                "reviewThreads": {
+                    "pageInfo": {
+                        "hasNextPage": has_next,
+                        "endCursor": end_cursor,
+                    },
+                    "nodes": nodes,
+                },
+            },
+        },
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -73,7 +98,7 @@ class TestMain:
                 main(["--pull-request", "1"])
             assert exc.value.code == 4
 
-    def test_negative_pr_exits_1(self):
+    def test_negative_pr_exits_2(self):
         with patch(
             "get_unresolved_review_threads.assert_gh_authenticated",
         ), patch(
@@ -84,34 +109,109 @@ class TestMain:
                 main(["--pull-request", "-1"])
             assert exc.value.code == 2
 
-    def test_success_outputs_json(self, capsys):
-        threads = [{"id": "t1", "isResolved": False}]
+    def test_single_page_complete(self, capsys):
+        nodes = [{"id": "t1", "isResolved": False}]
         with patch(
             "get_unresolved_review_threads.assert_gh_authenticated",
         ), patch(
             "get_unresolved_review_threads.resolve_repo_params",
             return_value=RepoInfo(owner="o", repo="r"),
         ), patch(
-            "get_unresolved_review_threads.get_unresolved_review_threads",
-            return_value=threads,
+            "get_unresolved_review_threads.gh_graphql",
+            return_value=_page(nodes=nodes, has_next=False),
         ):
             rc = main(["--pull-request", "42"])
         assert rc == 0
         output = json.loads(capsys.readouterr().out)
-        assert len(output) == 1
-        assert output[0]["id"] == "t1"
+        assert output["unresolved_count"] == 1
+        assert output["fetched_pages_complete"] is True
+        assert output["threads"][0]["id"] == "t1"
 
-    def test_empty_threads(self, capsys):
+    def test_zero_threads_complete(self, capsys):
         with patch(
             "get_unresolved_review_threads.assert_gh_authenticated",
         ), patch(
             "get_unresolved_review_threads.resolve_repo_params",
             return_value=RepoInfo(owner="o", repo="r"),
         ), patch(
-            "get_unresolved_review_threads.get_unresolved_review_threads",
-            return_value=[],
+            "get_unresolved_review_threads.gh_graphql",
+            return_value=_page(nodes=[], has_next=False),
         ):
             rc = main(["--pull-request", "1"])
         assert rc == 0
         output = json.loads(capsys.readouterr().out)
-        assert output == []
+        assert output["unresolved_count"] == 0
+        assert output["fetched_pages_complete"] is True
+        assert output["threads"] == []
+
+    def test_multipage_aggregates_only_unresolved(self, capsys):
+        page1 = _page(
+            nodes=[
+                {"id": "t1", "isResolved": True},
+                {"id": "t2", "isResolved": False},
+            ],
+            has_next=True,
+            end_cursor="cur-a",
+        )
+        page2 = _page(
+            nodes=[
+                {"id": "t3", "isResolved": False},
+                {"id": "t4", "isResolved": True},
+            ],
+            has_next=False,
+        )
+        with patch(
+            "get_unresolved_review_threads.assert_gh_authenticated",
+        ), patch(
+            "get_unresolved_review_threads.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "get_unresolved_review_threads.gh_graphql",
+            side_effect=[page1, page2],
+        ):
+            rc = main(["--pull-request", "42"])
+        assert rc == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output["unresolved_count"] == 2
+        assert {t["id"] for t in output["threads"]} == {"t2", "t3"}
+        assert output["fetched_pages_complete"] is True
+
+    def test_graphql_error_marks_incomplete(self, capsys):
+        with patch(
+            "get_unresolved_review_threads.assert_gh_authenticated",
+        ), patch(
+            "get_unresolved_review_threads.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "get_unresolved_review_threads.gh_graphql",
+            side_effect=RuntimeError("transport failed"),
+        ):
+            rc = main(["--pull-request", "42"])
+        assert rc == 0
+        output = json.loads(capsys.readouterr().out)
+        # On API failure we still exit 0 and let the gate's
+        # fetched_pages_complete flag drive the pass/fail decision.
+        assert output["fetched_pages_complete"] is False
+        assert output["unresolved_count"] == 0
+
+    def test_missing_cursor_marks_incomplete(self, capsys):
+        # hasNextPage true but endCursor absent: cannot continue, must
+        # report incomplete rather than silently truncate.
+        page1 = _page(
+            nodes=[{"id": "t1", "isResolved": False}],
+            has_next=True,
+            end_cursor=None,
+        )
+        with patch(
+            "get_unresolved_review_threads.assert_gh_authenticated",
+        ), patch(
+            "get_unresolved_review_threads.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "get_unresolved_review_threads.gh_graphql",
+            return_value=page1,
+        ):
+            rc = main(["--pull-request", "42"])
+        assert rc == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output["fetched_pages_complete"] is False

--- a/tests/test_invoke_correction_applier.py
+++ b/tests/test_invoke_correction_applier.py
@@ -251,8 +251,10 @@ class TestMainOutputPath:
             result = main()
             assert result == 0
             captured = capsys.readouterr()
-            assert "Self-Improving Agent" in captured.out
-            assert "pnpm" in captured.out
+            # Advisory text now goes to stderr (commit 92df3875: stdout
+            # must be valid JSON or empty for hook payloads).
+            assert "Self-Improving Agent" in captured.err
+            assert "pnpm" in captured.err
 
     @patch("invoke_correction_applier.skip_if_consumer_repo", return_value=False)
     @patch(

--- a/tests/test_test_pr_merge_ready.py
+++ b/tests/test_test_pr_merge_ready.py
@@ -471,3 +471,148 @@ class TestMain:
         ):
             rc = main(["--pull-request", "42"])
         assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: fetched_pages_complete pagination cliff signal
+#
+# The /pr-review completion gate's pass_when expression requires the
+# script's output to include fetched_pages_complete=true. A partial fetch
+# that happens to find no failing checks is not evidence that no failing
+# checks exist; the flag exists so the gate can fail closed in that case.
+# ---------------------------------------------------------------------------
+
+
+def _pr_payload_with_totals(
+    *,
+    review_threads_total: int = 0,
+    review_threads_nodes: list[dict] | None = None,
+    contexts_total: int = 0,
+    contexts_nodes: list[dict] | None = None,
+) -> dict:
+    """Synthetic GraphQL payload that exercises the totalCount-vs-nodes check."""
+    return {
+        "repository": {
+            "pullRequest": {
+                "number": 1,
+                "state": "OPEN",
+                "isDraft": False,
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "reviewThreads": {
+                    "totalCount": review_threads_total,
+                    "nodes": review_threads_nodes or [],
+                },
+                "commits": {
+                    "nodes": [
+                        {
+                            "commit": {
+                                "statusCheckRollup": {
+                                    "state": "SUCCESS",
+                                    "contexts": {
+                                        "totalCount": contexts_total,
+                                        "nodes": contexts_nodes or [],
+                                    },
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+    }
+
+
+class TestFetchedPagesCompleteFlag:
+    def test_complete_within_first_page(self):
+        payload = _pr_payload_with_totals(
+            review_threads_total=2,
+            review_threads_nodes=[
+                {"id": "t1", "isResolved": True},
+                {"id": "t2", "isResolved": True},
+            ],
+            contexts_total=1,
+            contexts_nodes=[
+                {
+                    "__typename": "CheckRun",
+                    "name": "ci",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "isRequired": True,
+                },
+            ],
+        )
+        with patch("test_pr_merge_ready.gh_graphql", return_value=payload):
+            result = check_merge_readiness("o", "r", 1)
+        assert result["fetched_pages_complete"] is True
+        assert result["CanMerge"] is True
+
+    def test_incomplete_when_more_threads_than_returned(self):
+        # totalCount > len(nodes): GitHub has more threads than we fetched.
+        payload = _pr_payload_with_totals(
+            review_threads_total=150,
+            review_threads_nodes=[
+                {"id": f"t{i}", "isResolved": True} for i in range(100)
+            ],
+            contexts_total=1,
+            contexts_nodes=[
+                {
+                    "__typename": "CheckRun",
+                    "name": "ci",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "isRequired": True,
+                },
+            ],
+        )
+        with patch("test_pr_merge_ready.gh_graphql", return_value=payload):
+            result = check_merge_readiness("o", "r", 1)
+        assert result["fetched_pages_complete"] is False
+
+    def test_incomplete_when_more_contexts_than_returned(self):
+        payload = _pr_payload_with_totals(
+            review_threads_total=0,
+            review_threads_nodes=[],
+            contexts_total=200,
+            contexts_nodes=[
+                {
+                    "__typename": "CheckRun",
+                    "name": f"ci-{i}",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "isRequired": True,
+                }
+                for i in range(100)
+            ],
+        )
+        with patch("test_pr_merge_ready.gh_graphql", return_value=payload):
+            result = check_merge_readiness("o", "r", 1)
+        assert result["fetched_pages_complete"] is False
+
+    def test_complete_with_failing_required_check(self):
+        payload = _pr_payload_with_totals(
+            review_threads_total=0,
+            contexts_total=2,
+            contexts_nodes=[
+                {
+                    "__typename": "CheckRun",
+                    "name": "ci",
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                    "isRequired": True,
+                },
+                {
+                    "__typename": "CheckRun",
+                    "name": "lint",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "isRequired": True,
+                },
+            ],
+        )
+        with patch("test_pr_merge_ready.gh_graphql", return_value=payload):
+            result = check_merge_readiness("o", "r", 1)
+        assert result["fetched_pages_complete"] is True
+        assert result["CIPassing"] is False
+        assert "ci" in result["FailedRequiredChecks"]
+        assert result["CanMerge"] is False

--- a/tests/test_test_pr_merge_ready.py
+++ b/tests/test_test_pr_merge_ready.py
@@ -589,6 +589,140 @@ class TestFetchedPagesCompleteFlag:
             result = check_merge_readiness("o", "r", 1)
         assert result["fetched_pages_complete"] is False
 
+    def test_pagination_resolves_truncation(self):
+        # Inline page is truncated (totalCount=150 > 100 nodes) AND
+        # hasNextPage=True with a real cursor: the script paginates
+        # the remainder via a follow-up query and reports
+        # fetched_pages_complete=True. This is the live-PR scenario:
+        # accumulated CI runs grow past the inline 100-cap.
+        first_page_nodes = [
+            {
+                "__typename": "CheckRun",
+                "name": f"ci-{i}",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "isRequired": False,
+            }
+            for i in range(100)
+        ]
+        merge_ready_payload = {
+            "repository": {
+                "pullRequest": {
+                    "number": 1,
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "reviewThreads": {"totalCount": 0, "nodes": []},
+                    "commits": {
+                        "nodes": [
+                            {
+                                "commit": {
+                                    "oid": "abc123",
+                                    "statusCheckRollup": {
+                                        "state": "SUCCESS",
+                                        "contexts": {
+                                            "totalCount": 150,
+                                            "pageInfo": {
+                                                "hasNextPage": True,
+                                                "endCursor": "cursor-1",
+                                            },
+                                            "nodes": first_page_nodes,
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        }
+        # Follow-up page: 50 more contexts, hasNextPage=False.
+        followup_payload = {
+            "repository": {
+                "object": {
+                    "statusCheckRollup": {
+                        "contexts": {
+                            "pageInfo": {
+                                "hasNextPage": False,
+                                "endCursor": None,
+                            },
+                            "nodes": [
+                                {
+                                    "__typename": "CheckRun",
+                                    "name": f"ci-{i}",
+                                    "status": "COMPLETED",
+                                    "conclusion": "SUCCESS",
+                                    "isRequired": False,
+                                }
+                                for i in range(100, 150)
+                            ],
+                        },
+                    },
+                },
+            },
+        }
+        with patch(
+            "test_pr_merge_ready.gh_graphql",
+            side_effect=[merge_ready_payload, followup_payload],
+        ):
+            result = check_merge_readiness("o", "r", 1)
+        assert result["fetched_pages_complete"] is True
+        assert result["CIPassing"] is True
+        assert result["CanMerge"] is True
+
+    def test_pagination_failure_keeps_incomplete(self):
+        # Same setup but the follow-up call raises RuntimeError. The
+        # script must report fetched_pages_complete=False (fail closed).
+        first_page_nodes = [
+            {
+                "__typename": "CheckRun",
+                "name": f"ci-{i}",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "isRequired": False,
+            }
+            for i in range(100)
+        ]
+        merge_ready_payload = {
+            "repository": {
+                "pullRequest": {
+                    "number": 1, "state": "OPEN", "isDraft": False,
+                    "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN",
+                    "reviewThreads": {"totalCount": 0, "nodes": []},
+                    "commits": {
+                        "nodes": [
+                            {
+                                "commit": {
+                                    "oid": "abc123",
+                                    "statusCheckRollup": {
+                                        "state": "SUCCESS",
+                                        "contexts": {
+                                            "totalCount": 150,
+                                            "pageInfo": {
+                                                "hasNextPage": True,
+                                                "endCursor": "cursor-1",
+                                            },
+                                            "nodes": first_page_nodes,
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        }
+        with patch(
+            "test_pr_merge_ready.gh_graphql",
+            side_effect=[
+                merge_ready_payload,
+                RuntimeError("transport failed"),
+            ],
+        ):
+            result = check_merge_readiness("o", "r", 1)
+        assert result["fetched_pages_complete"] is False
+
     def test_complete_with_failing_required_check(self):
         payload = _pr_payload_with_totals(
             review_threads_total=0,

--- a/tests/test_validate_pr_review_config.py
+++ b/tests/test_validate_pr_review_config.py
@@ -45,7 +45,13 @@ VALID_CONFIG: dict = {
         {"scenario": "PR not found", "action": "Skip"},
     ],
     "completion_criteria": [
-        {"criterion": "All comments addressed", "verification": "Check threads", "required": True},
+        {
+            "name": "All comments addressed",
+            "verification": "command",
+            "command": "python3 script.py --pull-request {pr}",
+            "pass_when": "stdout-json.unresolved_count == 0",
+            "fail_open": False,
+        },
     ],
     "failure_handling": [
         {"type": "Merge conflicts", "action": "Resolve"},
@@ -100,9 +106,48 @@ class TestValidateConfig:
 
     def test_missing_completion_criteria_field(self) -> None:
         config = copy.deepcopy(VALID_CONFIG)
-        del config["completion_criteria"][0]["required"]
+        del config["completion_criteria"][0]["name"]
         errors = validate_config(config)
-        assert any("completion_criteria[0] missing field: required" in e for e in errors)
+        assert any("completion_criteria[0] missing field: name" in e for e in errors)
+
+    def test_missing_completion_criteria_pass_when(self) -> None:
+        # Either pass_when or pass_when_python must be present.
+        config = copy.deepcopy(VALID_CONFIG)
+        del config["completion_criteria"][0]["pass_when"]
+        errors = validate_config(config)
+        assert any(
+            "completion_criteria[0] missing field: pass_when" in e
+            for e in errors
+        )
+
+    def test_completion_criteria_pass_when_python_accepted(self) -> None:
+        # pass_when_python is the documented escape hatch when the DSL is
+        # too narrow; using it instead of pass_when must validate cleanly.
+        config = copy.deepcopy(VALID_CONFIG)
+        del config["completion_criteria"][0]["pass_when"]
+        config["completion_criteria"][0]["pass_when_python"] = (
+            "lambda d: d.get('x', 0) == 0"
+        )
+        errors = validate_config(config)
+        assert errors == []
+
+    def test_completion_criteria_verification_must_be_command(self) -> None:
+        config = copy.deepcopy(VALID_CONFIG)
+        config["completion_criteria"][0]["verification"] = "narrative"
+        errors = validate_config(config)
+        assert any(
+            "completion_criteria[0].verification must be 'command'" in e
+            for e in errors
+        )
+
+    def test_completion_criteria_fail_open_must_be_bool(self) -> None:
+        config = copy.deepcopy(VALID_CONFIG)
+        config["completion_criteria"][0]["fail_open"] = "yes"
+        errors = validate_config(config)
+        assert any(
+            "completion_criteria[0].fail_open must be a boolean" in e
+            for e in errors
+        )
 
     def test_missing_error_recovery_field(self) -> None:
         config = copy.deepcopy(VALID_CONFIG)

--- a/tests/test_validate_pr_review_config.py
+++ b/tests/test_validate_pr_review_config.py
@@ -147,7 +147,7 @@ class TestValidateConfig:
     def test_completion_criteria_null_pass_when_rejected(self) -> None:
         # YAML `pass_when:` with no value yields None. The key exists
         # but the value is falsy. The validator must reject this so it
-        # matches the dispatcher's truthiness check (bug fix).
+        # matches the dispatcher's truthiness check.
         config = copy.deepcopy(VALID_CONFIG)
         config["completion_criteria"][0]["pass_when"] = None
         errors = validate_config(config)
@@ -157,15 +157,42 @@ class TestValidateConfig:
         )
 
     def test_completion_criteria_empty_pass_when_rejected(self) -> None:
-        # YAML `pass_when: ""` yields an empty string. The key exists
-        # but the value is falsy. The validator must reject this so it
-        # matches the dispatcher's truthiness check (bug fix).
+        # YAML `pass_when: ""` yields an empty string. Now caught by
+        # both the truthiness check (missing field) and the type check
+        # (must be a non-empty string).
         config = copy.deepcopy(VALID_CONFIG)
         config["completion_criteria"][0]["pass_when"] = ""
         errors = validate_config(config)
         assert any(
             "completion_criteria[0] missing field: pass_when" in e
             for e in errors
+        )
+
+    def test_completion_criteria_command_must_be_string(self) -> None:
+        # Per Copilot review: presence is not enough. A YAML config that
+        # parses ``command`` as a list (indentation slip-up) would only
+        # crash later in the dispatcher; reject at validation time.
+        config = copy.deepcopy(VALID_CONFIG)
+        config["completion_criteria"][0]["command"] = ["echo", "ignored"]
+        errors = validate_config(config)
+        assert any(
+            "command must be a non-empty string" in e for e in errors
+        )
+
+    def test_completion_criteria_pass_when_must_be_nonempty_string(self) -> None:
+        config = copy.deepcopy(VALID_CONFIG)
+        config["completion_criteria"][0]["pass_when"] = ""
+        errors = validate_config(config)
+        assert any(
+            "pass_when must be a non-empty string" in e for e in errors
+        )
+
+    def test_completion_criteria_name_must_be_nonempty_string(self) -> None:
+        config = copy.deepcopy(VALID_CONFIG)
+        config["completion_criteria"][0]["name"] = "   "
+        errors = validate_config(config)
+        assert any(
+            "name must be a non-empty string" in e for e in errors
         )
 
     def test_completion_criteria_verification_must_be_command(self) -> None:

--- a/tests/test_validate_pr_review_config.py
+++ b/tests/test_validate_pr_review_config.py
@@ -144,6 +144,30 @@ class TestValidateConfig:
             "both pass_when and pass_when_python" in e for e in errors
         )
 
+    def test_completion_criteria_null_pass_when_rejected(self) -> None:
+        # YAML `pass_when:` with no value yields None. The key exists
+        # but the value is falsy. The validator must reject this so it
+        # matches the dispatcher's truthiness check (bug fix).
+        config = copy.deepcopy(VALID_CONFIG)
+        config["completion_criteria"][0]["pass_when"] = None
+        errors = validate_config(config)
+        assert any(
+            "completion_criteria[0] missing field: pass_when" in e
+            for e in errors
+        )
+
+    def test_completion_criteria_empty_pass_when_rejected(self) -> None:
+        # YAML `pass_when: ""` yields an empty string. The key exists
+        # but the value is falsy. The validator must reject this so it
+        # matches the dispatcher's truthiness check (bug fix).
+        config = copy.deepcopy(VALID_CONFIG)
+        config["completion_criteria"][0]["pass_when"] = ""
+        errors = validate_config(config)
+        assert any(
+            "completion_criteria[0] missing field: pass_when" in e
+            for e in errors
+        )
+
     def test_completion_criteria_verification_must_be_command(self) -> None:
         config = copy.deepcopy(VALID_CONFIG)
         config["completion_criteria"][0]["verification"] = "narrative"

--- a/tests/test_validate_pr_review_config.py
+++ b/tests/test_validate_pr_review_config.py
@@ -195,6 +195,25 @@ class TestValidateConfig:
             "name must be a non-empty string" in e for e in errors
         )
 
+    def test_completion_criteria_must_be_list_not_dict(self) -> None:
+        # Per Copilot review: a YAML-parsed dict would have iterated
+        # keys/chars and emitted noisy per-key "must be a mapping"
+        # errors. The validator now rejects the container shape with a
+        # single clear error message.
+        config = copy.deepcopy(VALID_CONFIG)
+        config["completion_criteria"] = {"key": "value"}
+        errors = validate_config(config)
+        # Single, clear error about the container; not a swarm.
+        container_errors = [
+            e for e in errors if "completion_criteria must be a list" in e
+        ]
+        assert len(container_errors) == 1
+        # And no per-element noise:
+        per_element_errors = [
+            e for e in errors if e.startswith("completion_criteria[")
+        ]
+        assert per_element_errors == []
+
     def test_completion_criteria_verification_must_be_command(self) -> None:
         config = copy.deepcopy(VALID_CONFIG)
         config["completion_criteria"][0]["verification"] = "narrative"

--- a/tests/test_validate_pr_review_config.py
+++ b/tests/test_validate_pr_review_config.py
@@ -131,6 +131,19 @@ class TestValidateConfig:
         errors = validate_config(config)
         assert errors == []
 
+    def test_completion_criteria_both_pass_when_fields_rejected(self) -> None:
+        # Per Copilot review: both-set is ambiguous because the
+        # dispatcher silently picks pass_when_python first. The
+        # validator must reject it before runtime.
+        config = copy.deepcopy(VALID_CONFIG)
+        config["completion_criteria"][0]["pass_when_python"] = (
+            "lambda d: True"
+        )
+        errors = validate_config(config)
+        assert any(
+            "both pass_when and pass_when_python" in e for e in errors
+        )
+
     def test_completion_criteria_verification_must_be_command(self) -> None:
         config = copy.deepcopy(VALID_CONFIG)
         config["completion_criteria"][0]["verification"] = "narrative"


### PR DESCRIPTION
## Summary

Inverts the `/pr-review` completion gate from a narrative checklist (where the agent claimed verdicts like "0 unresolved threads") into a dispatcher that runs each criterion's verification command and treats the command's stdout JSON AS the verdict (Reporting-Without-Acting Anti-Pattern, Layer 6 of PR #1887's retrospective).

## Background

PR #1887's gate was satisfied four times while review threads were unresolved. The wiki concept is "Reporting-Without-Acting Anti-Pattern": audit outputs should be structured as dispatchable tasks, not narrative reports. Each gate criterion should produce a verification *call* whose result *is* the verdict, not a narrative claim about state.

## Changes

1. **`.claude/commands/pr-review-config.yaml`** rewrites `completion_criteria` as dispatchable objects: `name`, `verification` (always `command` for now), `command` (with `{pr}` substitution), `pass_when` (DSL expression), `fail_open` (default false). Three live criteria: all-threads-resolved, merge-ready, not-already-merged. The retry loop fields are retained for backward-compat schema validation but no longer consulted; `completion_gate_max_retries` is set to 0 to make the no-loop policy self-documenting.

2. **`.claude/commands/pr-review.md`** Workflow's "Completion Gate" section now invokes `run_completion_gate.py` exactly once per PR. On exit-1 the workflow halts and surfaces the failing criterion's name and command output. The retry-on-failure behavior was the wrong design and is removed: looping on a failing verifier produces the same wrong answer.

3. **`.claude/skills/github/scripts/pr/run_completion_gate.py`** (NEW) reads `--config` (defaults to pr-review-config.yaml) and `--pull-request <n>`, dispatches each criterion's command, parses stdout JSON, evaluates `pass_when` (or `pass_when_python`), prints a per-criterion table, exits 0 if all pass / 1 if any fail.

4. **Tests** for the dispatcher at `tests/skills/github/test_run_completion_gate.py`: all-pass, one-fail (closed), command-error fail-closed when `fail_open: false`, command-error pass when `fail_open: true`, malformed JSON output (fail-closed), missing config (returns 2), negative PR (returns 2), `{pr}` substitution, `pass_when_python` escape hatch. Plus DSL unit tests covering literals, AND/OR composition, missing-path nulls, unsupported operators, and dotted-path nesting.

5. **`.claude/skills/github/scripts/pr/get_unresolved_review_threads.py`** Output reshaped to a JSON object with `unresolved_count`, `fetched_pages_complete`, and `threads`. Pagination is in the script (50-page cap; hasNextPage drives the loop). The completion gate's `pass_when` for this criterion requires `fetched_pages_complete == true`; a partial fetch that happens to return zero unresolved threads is no longer reportable as a green signal. This script keeps its own loop because the helper in api.py returns an empty list on both success-with-zero-threads and RuntimeError, which cannot expose the cliff. Tests cover GraphQL error path returning incomplete and missing endCursor on hasNextPage=true returning incomplete.

6. **`.claude/skills/github/scripts/pr/test_pr_merge_ready.py`** Adds `totalCount` to `statusCheckRollup.contexts`; computes `fetched_pages_complete` by comparing each `totalCount` against the count of returned nodes. The merge-ready criterion's `pass_when` now requires `fetched_pages_complete == true` alongside `CIPassing == true` and `UnresolvedThreads == 0`. The flag tracks inline-page completeness, separate from the unresolved-count fallback that paginates when threads truncate (preserved so unresolved counts stay exact).

## pass_when DSL

Tiny by design (~50 LoC of evaluator). Standard library only.

| Form | Example |
|---|---|
| dotted path | `stdout-json.unresolved_count` |
| nested path | `stdout-json.outer.inner` |
| literals | integers, `true`, `false`, `null`, `"double-quoted"` |
| comparison | `==`, `!=` |
| composition | `AND`, `OR` (left-to-right; no parens) |

The `stdout-json.` prefix is optional. A missing path resolves to null, so `stdout-json.field == null` is a valid presence-check.

When the DSL is too narrow, a criterion may use `pass_when_python: "lambda d: <expr>"` instead. The lambda receives the parsed stdout-json dict.

`fail_open` defaults to false. A verifier that errors, returns malformed output, or whose `pass_when` raises fails the criterion closed. This is intentional: a verifier that cannot verify is not evidence that the criterion holds.

## Validator + tests

`scripts/validate_pr_review_config.py` is updated to the new schema: `name`, `verification`, `command` are required; one of `pass_when` / `pass_when_python` is required; `verification` must equal `"command"`; `fail_open` must be a boolean when present. The existing `tests/test_validate_pr_review_config.py` is updated and four new schema-rule tests added.

## Test plan

- [x] `python3 -m pytest tests/skills/github/test_run_completion_gate.py tests/test_get_unresolved_review_threads.py tests/test_test_pr_merge_ready.py tests/test_validate_pr_review_config.py -x` (102 passed)
- [x] `python3 scripts/validate_pr_review_config.py` exits 0 on the live config
- [ ] `python3 .claude/skills/github/scripts/pr/run_completion_gate.py --pull-request <PR>` runs end-to-end against a real PR
- [ ] Required CI checks green or pending

## Rebase note

Originally opened against `feat/hook-maturity-push-guards-1891` (now merged via PR #1897). Rebased onto `main` and retargeted; `test_pr_merge_ready.py` changes were re-applied to the refactored sergeant-orchestrator structure that landed in #1897 (helper functions `_evaluate_review_threads` and `_evaluate_ci_checks` now return a `pages_complete` flag).

Refs #1887

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
