### PR TITLE
docs(tests): align q1_aspirational docstring with code

### DIFF
--- a/tests/commands/step0_parser.py
+++ b/tests/commands/step0_parser.py
@@ -105,7 +105,7 @@ def q1_aspirational(answer: str) -> bool:
     """REQ-006-04 operational test: any one of three conditions makes Q1 aspirational.
 
     Three conditions; any one fires:
-    1. No specific named entity (person, team name, system, ticket, file).
+    1. Fewer than three specific named entities (person, team name, system, ticket, file).
     2. Future tense or conditional mood about demand existence.
     3. Generic category appearing WITHOUT a specific named entity (so
        "the team would benefit" fires; "Alice on the Payments team"

--- a/tests/commands/step0_parser.py
+++ b/tests/commands/step0_parser.py
@@ -108,8 +108,10 @@ def q1_aspirational(answer: str) -> bool:
     1. Fewer than three specific named entities (person, team name, system, ticket, file).
     2. Future tense or conditional mood about demand existence.
     3. Generic category appearing WITHOUT a specific named entity (so
-       "the team would benefit" fires; "Alice on the Payments team"
-       does not, because Alice + Payments team is a specific entity).
+       "the team would benefit" fires; "Bleu team, Delos team, and
+       Calc team escalated #1700" does not, because four specific
+       entities (three teams + one ticket) satisfy the >= 3 threshold
+       in condition 1 and the named-entity check in condition 3).
 
     Restored generic-category condition #3 per Copilot PR #1931 comments
     3213975262 + 3213984488 (round-4 finding): the round-1 simplification


### PR DESCRIPTION
## Summary

Aligns docstring of `q1_aspirational` in `tests/commands/step0_parser.py` with implementation. Condition 1 said "no specific named entity" (count == 0); code at line 142 implements `named_entity_count < 3`. Updated docstring to "Fewer than three specific named entities" matching the code and the existing test `test_one_named_requester_fails_three_or_more_rule` at `tests/commands/test_spec_step0.py:438`.

### What

- One-line docstring update on `q1_aspirational`. No code behavior change.

### Why

PR #1931 review comment from `devin-ai-integration[bot]` (id `3214039743`) flagged the drift. Inline comments at lines 138-141 already document the intentional change to `< 3`, but the docstring header was missed during round-4 review.

Fixes the documentation contract for anyone reading the function before writing new tests.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #1931 | Follow-up comment on merged PR |
| **Comment** | https://github.com/rjmurillo/ai-agents/pull/1931#discussion_r3214039743 | devin-ai-integration[bot] suggestion |

## Type of Change

- [x] Documentation update (docstring alignment)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: trivial doc fix, low scrutiny, low urgency.

## Test plan

- [x] `uv run python3 -m pytest tests/commands/ -q` — 65 passed
- [x] `uv run python3 -m pytest tests/commands/test_spec_step0.py::TestQ1Aspirational -v` — 11 passed
- [x] `uv run python3 .claude/skills/security-scan/scripts/scan_vulnerabilities.py tests/commands/step0_parser.py` — 0 vulnerabilities
- [x] `uv run python3 .claude/skills/taste-lints/scripts/taste_lints.py tests/commands/step0_parser.py` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/rjmurillo/ai-agents/pull/1941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->