### PR TITLE
refactor(agent-registry): drop AGENTS.md catalog cross-check

### DIFF
--- a/scripts/validation/agent_registry.py
+++ b/scripts/validation/agent_registry.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Parse and validate agent definitions from src/claude/*.md against AGENTS.md.
+"""Parse and validate agent definitions from src/claude/*.md.
 
-Parses YAML frontmatter from agent markdown files and validates
-each definition against the canonical agent catalog in AGENTS.md.
+Parses YAML frontmatter from agent markdown files and validates each
+definition (required fields, allowed model, no duplicate names).
 
 Exit codes follow ADR-035:
     0 - Success: all agents valid
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -34,16 +33,6 @@ _REQUIRED_FIELDS = ("name", "description", "model")
 # Allowed model values
 _VALID_MODELS = frozenset({"opus", "sonnet", "haiku"})
 
-# Pattern for extracting agent rows from AGENTS.md markdown table
-_AGENT_TABLE_ROW = re.compile(
-    r"^\|\s*(?P<name>[\w-]+)\s*\|[^|]*\|\s*(?P<model>opus|sonnet|haiku)\s*\|",
-)
-
-# Pattern for pipe-delimited agent entries: |name: purpose (model)
-_AGENT_PIPE_ENTRY = re.compile(
-    r"(?P<name>[\w-]+):\s*[^(|]+(?:\((?P<model>opus|sonnet|haiku)\))?"
-)
-
 
 @dataclass(frozen=True)
 class AgentDefinition:
@@ -54,14 +43,6 @@ class AgentDefinition:
     model: str
     argument_hint: str
     file_path: Path
-
-
-@dataclass
-class CatalogEntry:
-    """Expected agent from AGENTS.md catalog."""
-
-    name: str
-    model: str
 
 
 @dataclass
@@ -124,84 +105,16 @@ def parse_agent_files(agent_dir: Path) -> tuple[list[AgentDefinition], list[str]
     return agents, errors
 
 
-def parse_catalog(agents_md_path: Path) -> list[CatalogEntry]:
-    """Parse the agent catalog from AGENTS.md.
-
-    Supports both markdown table format and pipe-delimited format.
-    Table format: | name | purpose | model |
-    Pipe format: |name: purpose (model)|name2: purpose2
-    """
-    content = agents_md_path.read_text(encoding="utf-8")
-    entries: list[CatalogEntry] = []
-    seen_names: set[str] = set()
-    in_agents_section = False
-
-    for line in content.splitlines():
-        # Track when we enter/leave the Agents section
-        if line.startswith("## Agents"):
-            in_agents_section = True
-            continue
-        if in_agents_section and line.startswith("## "):
-            in_agents_section = False
-            continue
-
-        # Try table row format first
-        m = _AGENT_TABLE_ROW.match(line)
-        if m:
-            name = m.group("name")
-            if name not in seen_names:
-                seen_names.add(name)
-                entries.append(CatalogEntry(name=name, model=m.group("model")))
-            else:
-                logger.debug(
-                    "Skipping duplicate agent %r (model=%s, format=table)",
-                    name,
-                    m.group("model"),
-                )
-            continue
-
-        # Try pipe-delimited format (only in Agents section)
-        if in_agents_section and line.startswith("|"):
-            for m in _AGENT_PIPE_ENTRY.finditer(line):
-                name = m.group("name")
-                model = m.group("model") or "sonnet"
-                if name not in seen_names:
-                    seen_names.add(name)
-                    entries.append(CatalogEntry(name=name, model=model))
-                else:
-                    logger.debug(
-                        "Skipping duplicate agent %r (model=%s, format=pipe)",
-                        name,
-                        model,
-                    )
-
-    return entries
-
-
-def validate(
-    agents: list[AgentDefinition],
-    catalog: list[CatalogEntry],
-) -> ValidationResult:
-    """Validate parsed agents against the canonical catalog.
+def validate(agents: list[AgentDefinition]) -> ValidationResult:
+    """Validate parsed agents.
 
     Checks:
     - Required frontmatter fields present
     - Model value is valid (opus, sonnet, haiku)
-    - Every catalog agent has a corresponding file
-    - Model assignments match between file and catalog
-    - No duplicate agent names in parsed files
-    - Catalog is not empty when agents exist (prevents silent skip of catalog validation)
+    - No duplicate agent names across parsed files
     """
     result = ValidationResult()
-    catalog_by_name = {e.name: e for e in catalog}
     agents_by_name: dict[str, AgentDefinition] = {}
-
-    if len(catalog) == 0 and len(agents) > 0:
-        result.errors.append(
-            f"Catalog is empty but {len(agents)} agent(s) found; "
-            "catalog validation would be silently skipped. "
-            "Ensure the catalog file contains a '## Agents' section with agent entries."
-        )
 
     for agent in agents:
         # Duplicate check
@@ -227,48 +140,19 @@ def validate(
                 f"invalid model '{agent.model}', expected one of {sorted(_VALID_MODELS)}"
             )
 
-        # Model match against catalog
-        if agent.name in catalog_by_name:
-            expected_model = catalog_by_name[agent.name].model
-            if agent.model and agent.model != expected_model:
-                result.errors.append(
-                    f"Agent '{agent.name}' ({agent.file_path.name}): "
-                    f"model '{agent.model}' does not match catalog '{expected_model}'"
-                )
-
-    # Missing agents: in catalog but no file
-    for entry in catalog:
-        if entry.name not in agents_by_name:
-            result.warnings.append(
-                f"Catalog agent '{entry.name}' has no definition file in src/claude/"
-            )
-
-    # Extra agents: file exists but not in catalog
-    for name in agents_by_name:
-        if name not in catalog_by_name:
-            result.warnings.append(
-                f"Agent '{name}' has a definition file but is not in the AGENTS.md catalog"
-            )
-
     return result
 
 
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point for agent registry validation."""
     parser = argparse.ArgumentParser(
-        description="Parse and validate agent registry against AGENTS.md catalog.",
+        description="Parse and validate agent definitions in src/claude/.",
     )
     parser.add_argument(
         "--agent-dir",
         type=Path,
         default=Path("src/claude"),
         help="Directory containing agent markdown files (default: src/claude)",
-    )
-    parser.add_argument(
-        "--catalog",
-        type=Path,
-        default=Path("AGENTS.md"),
-        help="Path to AGENTS.md with canonical agent catalog (default: AGENTS.md)",
     )
     parser.add_argument(
         "--json",
@@ -281,19 +165,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: agent directory not found: {args.agent_dir}", file=sys.stderr)
         return 2
 
-    if not args.catalog.is_file():
-        print(f"Error: catalog file not found: {args.catalog}", file=sys.stderr)
-        return 2
-
     agents, parsing_errors = parse_agent_files(args.agent_dir)
-
-    try:
-        catalog = parse_catalog(args.catalog)
-    except OSError as e:
-        print(f"Error reading catalog file {args.catalog}: {e}", file=sys.stderr)
-        return 2
-
-    result = validate(agents, catalog)
+    result = validate(agents)
     result.errors.extend(parsing_errors)
 
     if args.json:
@@ -303,7 +176,6 @@ def main(argv: list[str] | None = None) -> int:
             json.dumps(
                 {
                     "agents_parsed": len(agents),
-                    "catalog_entries": len(catalog),
                     "errors": result.errors,
                     "warnings": result.warnings,
                     "ok": result.ok,
@@ -312,7 +184,7 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
     else:
-        print(f"Parsed {len(agents)} agents, {len(catalog)} catalog entries")
+        print(f"Parsed {len(agents)} agents")
         for err in result.errors:
             print(f"  ERROR: {err}")
         for warn in result.warnings:

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -2,9 +2,8 @@
 
 Covers:
 - Frontmatter parsing from agent markdown files
-- Catalog table extraction from AGENTS.md
-- Validation: required fields, model values, model mismatches, duplicates
-- Integration: real src/claude/ files against real AGENTS.md
+- Validation: required fields, model values, duplicates
+- Integration: real src/claude/ files
 """
 
 from __future__ import annotations
@@ -16,11 +15,9 @@ import pytest
 
 from scripts.validation.agent_registry import (
     AgentDefinition,
-    CatalogEntry,
     ValidationResult,
     parse_agent_file,
     parse_agent_files,
-    parse_catalog,
     validate,
 )
 
@@ -30,7 +27,6 @@ from scripts.validation.agent_registry import (
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 AGENT_DIR = REPO_ROOT / "src" / "claude"
-AGENTS_MD = REPO_ROOT / "AGENTS.md"
 
 
 @pytest.fixture()
@@ -196,47 +192,6 @@ class TestParseAgentFiles:
 
 
 # ---------------------------------------------------------------------------
-# Unit: parse_catalog
-# ---------------------------------------------------------------------------
-
-
-class TestParseCatalog:
-    def test_extracts_agents_from_table(self, tmp_path: Path) -> None:
-        catalog_path = tmp_path / "AGENTS.md"
-        catalog_path.write_text(
-            textwrap.dedent("""\
-            # AGENTS.md
-
-            ## Agent Catalog
-
-            | Agent | Purpose | Model |
-            |-------|---------|-------|
-            | orchestrator | Task coordination | opus |
-            | analyst | Research | sonnet |
-            | memory | Context retrieval | haiku |
-
-            Some other content.
-            """),
-            encoding="utf-8",
-        )
-        entries = parse_catalog(catalog_path)
-        assert len(entries) == 3
-        by_name = {e.name: e.model for e in entries}
-        assert by_name["orchestrator"] == "opus"
-        assert by_name["analyst"] == "sonnet"
-        assert by_name["memory"] == "haiku"
-
-    def test_ignores_non_table_lines(self, tmp_path: Path) -> None:
-        catalog_path = tmp_path / "AGENTS.md"
-        catalog_path.write_text(
-            "# No table here\nJust text.\n",
-            encoding="utf-8",
-        )
-        entries = parse_catalog(catalog_path)
-        assert entries == []
-
-
-# ---------------------------------------------------------------------------
 # Unit: validate
 # ---------------------------------------------------------------------------
 
@@ -246,26 +201,15 @@ class TestValidate:
         agents = [
             AgentDefinition("a1", "Desc", "sonnet", "hint", Path("a1.md")),
         ]
-        catalog = [CatalogEntry("a1", "sonnet")]
-        result = validate(agents, catalog)
+        result = validate(agents)
         assert result.ok
         assert result.errors == []
-
-    def test_model_mismatch(self) -> None:
-        agents = [
-            AgentDefinition("a1", "Desc", "haiku", "hint", Path("a1.md")),
-        ]
-        catalog = [CatalogEntry("a1", "opus")]
-        result = validate(agents, catalog)
-        assert not result.ok
-        assert any("model 'haiku' does not match catalog 'opus'" in e for e in result.errors)
 
     def test_invalid_model(self) -> None:
         agents = [
             AgentDefinition("a1", "Desc", "gpt4", "hint", Path("a1.md")),
         ]
-        catalog = [CatalogEntry("a1", "sonnet")]
-        result = validate(agents, catalog)
+        result = validate(agents)
         assert not result.ok
         assert any("invalid model 'gpt4'" in e for e in result.errors)
 
@@ -273,8 +217,7 @@ class TestValidate:
         agents = [
             AgentDefinition("a1", "", "sonnet", "", Path("a1.md")),
         ]
-        catalog = [CatalogEntry("a1", "sonnet")]
-        result = validate(agents, catalog)
+        result = validate(agents)
         assert not result.ok
         assert any("missing required field 'description'" in e for e in result.errors)
 
@@ -283,35 +226,9 @@ class TestValidate:
             AgentDefinition("a1", "Desc1", "sonnet", "", Path("a1.md")),
             AgentDefinition("a1", "Desc2", "sonnet", "", Path("a1_copy.md")),
         ]
-        catalog = [CatalogEntry("a1", "sonnet")]
-        result = validate(agents, catalog)
+        result = validate(agents)
         assert not result.ok
         assert any("Duplicate agent name 'a1'" in e for e in result.errors)
-
-    def test_missing_from_catalog_warns(self) -> None:
-        agents: list[AgentDefinition] = []
-        catalog = [CatalogEntry("missing-agent", "sonnet")]
-        result = validate(agents, catalog)
-        assert result.ok  # Warnings do not fail
-        assert any("missing-agent" in w for w in result.warnings)
-
-    def test_extra_agent_warns(self) -> None:
-        agents = [
-            AgentDefinition("extra", "Desc", "sonnet", "", Path("extra.md")),
-        ]
-        catalog = [CatalogEntry("other-agent", "sonnet")]
-        result = validate(agents, catalog)
-        assert result.ok  # Warnings do not fail
-        assert any("extra" in w for w in result.warnings)
-
-    def test_empty_catalog_with_agents_fails(self) -> None:
-        agents = [
-            AgentDefinition("agent1", "Desc", "sonnet", "", Path("agent1.md")),
-        ]
-        catalog: list[CatalogEntry] = []
-        result = validate(agents, catalog)
-        assert not result.ok
-        assert any("Catalog is empty" in e for e in result.errors)
 
 
 # ---------------------------------------------------------------------------
@@ -320,7 +237,6 @@ class TestValidate:
 
 
 @pytest.mark.skipif(not AGENT_DIR.is_dir(), reason="src/claude/ not found")
-@pytest.mark.skipif(not AGENTS_MD.is_file(), reason="AGENTS.md not found")
 class TestIntegration:
     def test_parse_real_agents(self) -> None:
         agents, _errors = parse_agent_files(AGENT_DIR)
@@ -331,15 +247,9 @@ class TestIntegration:
         assert "implementer" in names
 
     def test_validate_real_agents_runs_without_crash(self) -> None:
-        """Verify validation completes and returns structured results.
-
-        Does not assert zero errors because pre-existing model drift
-        between agent files and AGENTS.md is a known condition.
-        The validator correctly detects this drift.
-        """
+        """Verify validation completes and returns structured results."""
         agents, _errors = parse_agent_files(AGENT_DIR)
-        catalog = parse_catalog(AGENTS_MD)
-        result = validate(agents, catalog)
+        result = validate(agents)
         assert isinstance(result, ValidationResult)
         assert isinstance(result.errors, list)
         assert isinstance(result.warnings, list)


### PR DESCRIPTION
## Summary

### What

Removes the AGENTS.md agent-catalog cross-check from the agent-registry
validator and its tests. The catalog branch compared agent definition files
against a hand-maintained roster in AGENTS.md's `## Agents` section. PR #2035
removed that section because the harness loads agent definitions and their
frontmatter directly, and the validator is not wired into any workflow,
hook, or pre-PR runner.

A late commit in #2035 (bbb9cf8) turned an empty catalog into a hard error,
which causes the validator to always exit 1 against the post-#2035
AGENTS.md. This PR removes the catalog surface entirely instead of leaving
a no-op that bots and future readers can mistake for active enforcement.

### Why

The catalog branch became vestigial after #2035, and the late-added
empty-catalog error broke the validator's exit code without adding
real protection. Removing the surface is cheaper than maintaining a
dead code path that's actively misleading.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| Related | Refs #2035 | Original AGENTS.md workspace-budget PR that removed `## Agents` |
| Related | Refs #2034 | Workspace per-file budget issue (already fixed by #2035) |

No `Closes #` / `Fixes #` keyword: this is a follow-up cleanup after two
already-merged PRs; there is no open issue this PR resolves.

## Changes

| File | Change |
|------|--------|
| `scripts/validation/agent_registry.py` | Drop `CatalogEntry`, `parse_catalog`, catalog-related regexes, the `--catalog` CLI flag, the empty-catalog error, and the catalog comparison branch in `validate()`. Keep the duplicate-name, required-field, and valid-model checks. |
| `tests/test_agent_registry.py` | Drop `TestParseCatalog` and the catalog-only `TestValidate` cases (model mismatch, missing-from-catalog warn, extra-agent warn, empty-catalog-with-agents-fails). Keep duplicate, required-field, invalid-model, and integration coverage on the parse-and-validate path that remains. |

## Type of Change

- [x] Refactor (no functional change to active code paths; removes
      vestigial surface area)
- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] CI/build

## Testing

- [x] `python3 scripts/validation/agent_registry.py` exits 0 against
      current AGENTS.md (was 1 on main).
- [x] `pytest tests/test_agent_registry.py` passes 13/13 in a non-root
      environment (the upstream chmod-as-root test gating was unrelated
      to this PR; CI runs as a non-root user).
- [x] Local pre-push: all phases pass (lint, build, tests, security
      governance, drift detection).

## Notes for Reviewers

The PR author of #2035 stated in two review threads on that PR that the
catalog branch in `agent_registry.py` "is therefore a no-op against
AGENTS.md by design" and that cleaning up the vestigial CLI default was
"out of scope" for the workspace-budget fix. This PR follows up on that
explicit design decision.