### PR TITLE
ci(deps): auto-approve and auto-merge dependabot/renovate PRs

### DIFF
--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -20,9 +20,11 @@ permissions:
 jobs:
   dependabot:
     name: Dependabot (GitHub Actions and Python)
+    # All approval and merge calls use the GH_ACTIONS_PR_WRITE PAT. The job
+    # GITHUB_TOKEN keeps the workflow-level read-only stance for least
+    # privilege under pull_request_target.
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     runs-on: ubuntu-24.04-arm
     if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     steps:
@@ -47,21 +49,29 @@ jobs:
 
   renovate:
     name: Renovate
+    # Approval uses the GH_ACTIONS_PR_WRITE PAT. The job GITHUB_TOKEN keeps
+    # the workflow-level read-only stance for least privilege under
+    # pull_request_target.
     permissions:
-      pull-requests: write
+      contents: read
     runs-on: ubuntu-24.04-arm
     if: github.actor == 'renovate[bot]'
     # Renovate handles auto-merge decisions via platformAutomerge and
     # per-package automerge rules in renovate.json. This workflow only
     # provides the required approval for non-major updates. Major-version
     # bumps are excluded from auto-approval and require manual review.
+    # Major detection reads the 'renovate-major' label that renovate.json
+    # 'major.addLabels' applies on major PRs. Label-based detection is
+    # reliable; PR title regex was not (no marker configured upstream).
     steps:
       - name: Detect major update
         id: detect-major
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          GH_TOKEN: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          if printf '%s' "$PR_TITLE" | grep -qiE '\(major\)'; then
+          labels=$(gh pr view "$PR_URL" --json labels --jq '[.labels[].name] | join(",")')
+          if printf '%s' "$labels" | grep -q '\brenovate-major\b'; then
             echo "is_major=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_major=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -41,7 +41,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_ACTIONS_PR_WRITE }}
 
       - name: Enable auto-merge for non-major updates
-        if: steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'
+        if: steps.dependabot-metadata.outputs.update-type != '' && steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -1,0 +1,75 @@
+name: Auto-Approve and Auto-Merge Bot PRs
+
+# Auto-approves and enables auto-merge on non-major dependency updates from
+# Dependabot and Renovate so dependency PR debt does not accumulate.
+#
+# Major version bumps are excluded from auto-approval and require manual
+# review. Uses the GH_ACTIONS_PR_WRITE PAT so approvals come from a real
+# user identity that satisfies branch ruleset requirements.
+#
+# Security: all PR-supplied values (html_url, title) are passed via env and
+# referenced as quoted shell variables, never interpolated into run blocks.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dependabot:
+    name: Dependabot (GitHub Actions and Python)
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-24.04-arm
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    steps:
+      - name: Fetch metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GH_ACTIONS_PR_WRITE }}"
+
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+
+      - name: Enable auto-merge for non-major updates
+        if: steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+
+  renovate:
+    name: Renovate
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-24.04-arm
+    if: github.actor == 'renovate[bot]'
+    # Renovate handles auto-merge decisions via platformAutomerge and
+    # per-package automerge rules in renovate.json. This workflow only
+    # provides the required approval for non-major updates. Major-version
+    # bumps are excluded from auto-approval and require manual review.
+    steps:
+      - name: Detect major update
+        id: detect-major
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if printf '%s' "$PR_TITLE" | grep -qiE '\(major\)'; then
+            echo "is_major=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_major=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Approve PR
+        if: steps.detect-major.outputs.is_major != 'true'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,23 @@
+# Dependency Review Action
+#
+# Scans dependency manifest changes in pull requests and surfaces
+# known-vulnerable versions of declared or updated packages. When this
+# workflow is marked required, PRs introducing known-vulnerable packages
+# are blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,8 @@
   "patch": {
     "automerge": true
   },
+  "major": {
+    "addLabels": ["renovate-major"]
+  },
   "platformAutomerge": true
 }


### PR DESCRIPTION
## Summary

- Adds `dependency-review.yml`: runs `actions/dependency-review-action` on every PR; blocks known-vulnerable package introductions.
- Adds `dependabot-approve-and-auto-merge.yml`: auto-approves Dependabot and Renovate PRs and enables squash auto-merge for non-major updates. Major bumps stay manual.
- Pattern mirrored from [rjmurillo/moq.analyzers](https://github.com/rjmurillo/moq.analyzers/blob/main/.github/workflows/dependabot-approve-and-auto-merge.yml). Goal: stop dependency PR debt from piling up.

## Pre-merge setup required

- **Secret**: `GH_ACTIONS_PR_WRITE` (PAT with `repo` + `workflow` scopes) must exist in repo secrets. Without it, the approve and auto-merge steps will fail with auth errors. Approvals from `GITHUB_TOKEN` would not satisfy branch rulesets that require non-bot approvers, which is why a PAT is used.
- **Repo settings**: "Allow auto-merge" must be enabled under Settings, General, Pull Requests.

## Security review

- All PR-supplied values (`html_url`, `title`) are read into `env:` and referenced as quoted shell variables. No direct `${{ github.event.pull_request.* }}` interpolation inside `run:` blocks.
- All Actions pinned to commit SHAs per universal rule.
- Runs on `ubuntu-24.04-arm` per ADR-025.
- `pull_request_target` is gated by `github.actor == 'dependabot[bot]'` and `github.actor == 'renovate[bot]'` so the elevated context only fires for the intended bots.

## Behavior

| Bot | Non-major update | Major update |
|---|---|---|
| Dependabot | Approve + squash auto-merge | Approve only (manual merge) |
| Renovate   | Approve (auto-merge handled by `renovate.json`) | No approval (manual review) |

## Test plan

- [ ] Confirm `GH_ACTIONS_PR_WRITE` exists; if not, add it before merge so the workflow does not fail-closed on the first dependabot PR.
- [ ] Confirm "Allow auto-merge" is enabled in repo settings.
- [ ] After merge, observe the next dependabot PR to verify approve and auto-merge fires.
- [ ] Confirm a major-version dependabot PR (if any in queue) is approved but NOT auto-merged.

Refs: dependency PR backlog reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
