### PR TITLE
fix(hooks): add audit trail for auto-retrospective Stop hook (Fixes #2062)

### DIFF
--- a/.claude/hooks/Stop/invoke_auto_retrospective.py
+++ b/.claude/hooks/Stop/invoke_auto_retrospective.py
@@ -534,29 +534,38 @@ def main() -> int:
 
     try:
         retro_path = generate_retrospective(project_dir, today)
-        if retro_path:
-            update_retro_index(project_dir, today, retro_path.name)
-            write_audit_log(
-                project_dir,
-                "created",
-                retro_filename=retro_path.name,
-            )
-        else:
-            write_audit_log(
-                project_dir,
-                "failed",
-                skip_reason="generate_retrospective returned None",
-            )
     except Exception as e:
-        # Broad catch preserves fail-open contract; surface to stderr.
         print(
-            f"[hook-error] invoke_auto_retrospective main: {type(e).__name__}: {e}",
+            f"[hook-error] invoke_auto_retrospective generate: {type(e).__name__}: {e}",
             file=sys.stderr,
         )
         write_audit_log(
             project_dir,
             "failed",
             skip_reason=f"{type(e).__name__}: {e}",
+        )
+        return 0
+
+    if not retro_path:
+        write_audit_log(
+            project_dir,
+            "failed",
+            skip_reason="generate_retrospective returned None",
+        )
+        return 0
+
+    write_audit_log(
+        project_dir,
+        "created",
+        retro_filename=retro_path.name,
+    )
+
+    try:
+        update_retro_index(project_dir, today, retro_path.name)
+    except Exception as e:
+        print(
+            f"[hook-error] invoke_auto_retrospective index: {type(e).__name__}: {e}",
+            file=sys.stderr,
         )
 
     return 0

--- a/.claude/hooks/Stop/invoke_auto_retrospective.py
+++ b/.claude/hooks/Stop/invoke_auto_retrospective.py
@@ -349,9 +349,18 @@ def write_audit_log(
 ) -> None:
     """Append a per-hook JSONL audit record for this run.
 
-    Mirrors the audit pattern in ``invoke_false_completion_gate.write_audit_log``
-    so operators can correlate retro creation with completion-gate decisions
-    in the same ``.hook-state/`` tree.
+    Canonical source: ``.claude/hooks/PreToolUse/invoke_false_completion_gate.py``
+    (function ``write_audit_log``, lines 191-234). Quoted contract:
+
+    - Audit root is ``project_dir / ".agents" / ".hook-state"``.
+    - Skip silently when ``.agents/`` does not exist (consumer-repo guard).
+    - JSONL line carries ``schema=1``, ``timestamp`` (ISO-8601 UTC),
+      ``hook`` (function-local hook id), and per-hook payload fields.
+    - File handle is taken with ``open(audit_file, "a", encoding="utf-8")``
+      and serialized through the shared ``_lock_file`` / ``_unlock_file``
+      helpers when available.
+    - Errors writing the audit log are swallowed and surfaced to stderr
+      to preserve fail-open behavior.
 
     Per Issue #2062 acceptance, records land at::
 
@@ -367,10 +376,22 @@ def write_audit_log(
     - ``skip_reason``: human-readable explanation when status is ``skipped``
       or ``failed``; empty string for ``created``.
 
-    Error tolerance: any OSError writing the audit file is swallowed and
-    surfaced to stderr to preserve the Stop hook's fail-open contract.
-    Consumer repos (no ``.agents/`` dir) skip silently so we never create
-    state outside the project's own working set.
+    Stricter/looser/different than canonical:
+
+    - Subdirectory: writes under ``.hook-state/auto-retrospective/`` instead
+      of the canonical's flat ``.hook-state/`` so retro audit files do not
+      collide with completion-gate audit files. The canonical writes a
+      single ``audit-{date}.jsonl`` per day; this hook namespaces by hook.
+    - Exception scope: catches ``Exception`` rather than the canonical's
+      ``OSError``. The Stop-hook fail-open contract requires resilience
+      against unexpected runtime errors (``TypeError``, ``ValueError``,
+      JSON-serialization edge cases) in addition to disk errors, while
+      still letting ``BaseException`` (``KeyboardInterrupt``,
+      ``SystemExit``) propagate. Refs PR #2077 gemini-code-assist review.
+    - Payload shape: ``status`` / ``retro_filename`` / ``skip_reason``
+      fields replace the canonical's ``command`` / ``decision`` / ``reason``
+      / ``session_id`` / ``tool_use_id``; the two hooks log different
+      events and the field names track each event's domain.
     """
     try:
         agents_dir = project_dir / ".agents"
@@ -396,7 +417,11 @@ def write_audit_log(
             finally:
                 if _unlock_file is not None:
                     _unlock_file(f)
-    except OSError as e:
+    except Exception as e:
+        # Broader than canonical's OSError: see docstring "Stricter/looser/
+        # different than canonical". Preserves Stop hook's fail-open contract
+        # against unexpected runtime errors (e.g. TypeError, ValueError) while
+        # still letting BaseException (KeyboardInterrupt, SystemExit) escape.
         print(
             f"[hook-error] invoke_auto_retrospective audit: {type(e).__name__}: {e}",
             file=sys.stderr,

--- a/.claude/hooks/Stop/invoke_auto_retrospective.py
+++ b/.claude/hooks/Stop/invoke_auto_retrospective.py
@@ -20,6 +20,7 @@ import os
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, cast
 
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
 if _plugin_root:
@@ -101,7 +102,9 @@ def _pick_same_day_retro(retro_dir: Path, today: str) -> Path | None:
             mtime = candidate.stat().st_mtime
         except OSError:
             continue
-        if mtime > best_mtime or (mtime == best_mtime and (best is None or candidate.name > best.name)):
+        if mtime > best_mtime or (
+            mtime == best_mtime and (best is None or candidate.name > best.name)
+        ):
             best_mtime = mtime
             best = candidate
 
@@ -161,10 +164,10 @@ def find_recent_session_file(sessions_dir: Path, today_only: bool = False) -> Pa
         return _find_recent_session_fallback(sessions_dir, today_only=today_only)
 
     # Use shared utility for standard "prefer today, fall back to yesterday" logic
-    return _get_recent_session_log(str(sessions_dir))
+    return cast(Path | None, _get_recent_session_log(str(sessions_dir)))
 
 
-def _coerce_to_list_fallback(value) -> list:
+def _coerce_to_list_fallback(value: object) -> list[Any]:
     """Fallback normalizer when hook_utilities is unavailable."""
     if value is None:
         return []
@@ -186,7 +189,7 @@ def _coerce_to_list_fallback(value) -> list:
     return []
 
 
-def coerce_to_list(value) -> list:
+def coerce_to_list(value: object) -> list[Any]:
     """Normalize work/outcomes to a list, regardless of session schema shape.
 
     Session logs in this repo have used several shapes over time:
@@ -196,11 +199,11 @@ def coerce_to_list(value) -> list:
     - bare strings (rare)
     """
     if _coerce_to_list is not None:
-        return _coerce_to_list(value)
+        return cast(list[Any], _coerce_to_list(value))
     return _coerce_to_list_fallback(value)
 
 
-def _format_work_item_fallback(item: dict) -> str:
+def _format_work_item_fallback(item: dict[str, Any]) -> str:
     """Fallback formatter when hook_utilities is unavailable."""
     if "action" in item:
         parts = []
@@ -217,7 +220,7 @@ def _format_work_item_fallback(item: dict) -> str:
     return str(item)
 
 
-def format_work_item(item: dict) -> str:
+def format_work_item(item: dict[str, Any]) -> str:
     """Format a work item dict into a human-readable string.
 
     Supports multiple session schemas:
@@ -225,11 +228,11 @@ def format_work_item(item: dict) -> str:
     - Legacy: {'description': '...'} or {'task': '...'}
     """
     if _format_work_item is not None:
-        return _format_work_item(item)
+        return cast(str, _format_work_item(item))
     return _format_work_item_fallback(item)
 
 
-def _extract_work_outcomes(data) -> tuple[list, list]:
+def _extract_work_outcomes(data: object) -> tuple[list[Any], list[Any]]:
     """Pull work and outcomes from session data, supporting workLog and work shapes."""
     if not isinstance(data, dict):
         return [], []
@@ -304,7 +307,8 @@ def generate_retrospective(project_dir: Path, today: str) -> Path | None:
                             session_context += f"- {outcome.get('result', str(outcome))}\n"
             except Exception as e:
                 print(
-                    f"[hook-error] invoke_auto_retrospective generate_retrospective: {type(e).__name__}: {e}",
+                    "[hook-error] invoke_auto_retrospective generate_retrospective: "
+                    f"{type(e).__name__}: {e}",
                     file=sys.stderr,
                 )
 
@@ -335,6 +339,68 @@ def generate_retrospective(project_dir: Path, today: str) -> Path | None:
 
     retro_path.write_text(content, encoding="utf-8")
     return retro_path
+
+
+def write_audit_log(
+    project_dir: Path,
+    status: str,
+    retro_filename: str = "",
+    skip_reason: str = "",
+) -> None:
+    """Append a per-hook JSONL audit record for this run.
+
+    Mirrors the audit pattern in ``invoke_false_completion_gate.write_audit_log``
+    so operators can correlate retro creation with completion-gate decisions
+    in the same ``.hook-state/`` tree.
+
+    Per Issue #2062 acceptance, records land at::
+
+        .agents/.hook-state/auto-retrospective/{YYYY-MM-DD}.jsonl
+
+    Schema (forward-compat ``schema: 1``):
+
+    - ``timestamp``: ISO-8601 UTC of the record.
+    - ``hook``: always ``"invoke_auto_retrospective"`` for cross-hook joins.
+    - ``status``: ``created`` | ``skipped`` | ``failed``.
+    - ``retro_filename``: basename of the retro file when known (created or
+      re-discovered on the skip-because-exists path), else empty string.
+    - ``skip_reason``: human-readable explanation when status is ``skipped``
+      or ``failed``; empty string for ``created``.
+
+    Error tolerance: any OSError writing the audit file is swallowed and
+    surfaced to stderr to preserve the Stop hook's fail-open contract.
+    Consumer repos (no ``.agents/`` dir) skip silently so we never create
+    state outside the project's own working set.
+    """
+    try:
+        agents_dir = project_dir / ".agents"
+        if not agents_dir.is_dir():
+            return  # Consumer repo: skip silently to avoid creating .agents/
+        audit_dir = agents_dir / ".hook-state" / "auto-retrospective"
+        audit_dir.mkdir(parents=True, exist_ok=True)
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        audit_file = audit_dir / f"{today}.jsonl"
+        entry = json.dumps({
+            "schema": 1,
+            "timestamp": datetime.now(tz=UTC).isoformat(),
+            "hook": "invoke_auto_retrospective",
+            "status": status,
+            "retro_filename": retro_filename,
+            "skip_reason": skip_reason,
+        })
+        with open(audit_file, "a", encoding="utf-8") as f:
+            if _lock_file is not None:
+                _lock_file(f)
+            try:
+                f.write(entry + "\n")
+            finally:
+                if _unlock_file is not None:
+                    _unlock_file(f)
+    except OSError as e:
+        print(
+            f"[hook-error] invoke_auto_retrospective audit: {type(e).__name__}: {e}",
+            file=sys.stderr,
+        )
 
 
 def update_retro_index(project_dir: Path, today: str, filename: str) -> None:
@@ -408,6 +474,13 @@ def main() -> int:
 
     # Bypass
     if os.environ.get("SKIP_AUTO_RETRO", "").lower() == "true":
+        project_dir = get_project_directory()
+        if project_dir:
+            write_audit_log(
+                project_dir,
+                "skipped",
+                skip_reason="SKIP_AUTO_RETRO=true",
+            )
         return 0
 
     project_dir = get_project_directory()
@@ -428,15 +501,23 @@ def main() -> int:
     # when mtimes match or stat fails. This keeps index repair predictable
     # across runs.
     if has_retro_today(retro_dir, today):
+        existing_name = ""
         try:
             existing = _pick_same_day_retro(retro_dir, today)
             if existing is not None:
+                existing_name = existing.name
                 update_retro_index(project_dir, today, existing.name)
         except Exception as e:
             print(
                 f"[hook-error] invoke_auto_retrospective index-repair: {type(e).__name__}: {e}",
                 file=sys.stderr,
             )
+        write_audit_log(
+            project_dir,
+            "skipped",
+            retro_filename=existing_name,
+            skip_reason="retro already exists today",
+        )
         return 0
 
     # Skip trivial sessions. is_trivial_session() prefers today's session log
@@ -444,17 +525,38 @@ def main() -> int:
     # when no today-prefixed session exists (cross-midnight continuation).
     # Mirrors the same precedence used by hook_utilities.get_recent_session_log.
     if is_trivial_session(project_dir):
+        write_audit_log(
+            project_dir,
+            "skipped",
+            skip_reason="trivial session",
+        )
         return 0
 
     try:
         retro_path = generate_retrospective(project_dir, today)
         if retro_path:
             update_retro_index(project_dir, today, retro_path.name)
+            write_audit_log(
+                project_dir,
+                "created",
+                retro_filename=retro_path.name,
+            )
+        else:
+            write_audit_log(
+                project_dir,
+                "failed",
+                skip_reason="generate_retrospective returned None",
+            )
     except Exception as e:
         # Broad catch preserves fail-open contract; surface to stderr.
         print(
             f"[hook-error] invoke_auto_retrospective main: {type(e).__name__}: {e}",
             file=sys.stderr,
+        )
+        write_audit_log(
+            project_dir,
+            "failed",
+            skip_reason=f"{type(e).__name__}: {e}",
         )
 
     return 0

--- a/src/copilot-cli/hooks/sessionEnd/invoke_auto_retrospective.py
+++ b/src/copilot-cli/hooks/sessionEnd/invoke_auto_retrospective.py
@@ -534,29 +534,38 @@ def main() -> int:
 
     try:
         retro_path = generate_retrospective(project_dir, today)
-        if retro_path:
-            update_retro_index(project_dir, today, retro_path.name)
-            write_audit_log(
-                project_dir,
-                "created",
-                retro_filename=retro_path.name,
-            )
-        else:
-            write_audit_log(
-                project_dir,
-                "failed",
-                skip_reason="generate_retrospective returned None",
-            )
     except Exception as e:
-        # Broad catch preserves fail-open contract; surface to stderr.
         print(
-            f"[hook-error] invoke_auto_retrospective main: {type(e).__name__}: {e}",
+            f"[hook-error] invoke_auto_retrospective generate: {type(e).__name__}: {e}",
             file=sys.stderr,
         )
         write_audit_log(
             project_dir,
             "failed",
             skip_reason=f"{type(e).__name__}: {e}",
+        )
+        return 0
+
+    if not retro_path:
+        write_audit_log(
+            project_dir,
+            "failed",
+            skip_reason="generate_retrospective returned None",
+        )
+        return 0
+
+    write_audit_log(
+        project_dir,
+        "created",
+        retro_filename=retro_path.name,
+    )
+
+    try:
+        update_retro_index(project_dir, today, retro_path.name)
+    except Exception as e:
+        print(
+            f"[hook-error] invoke_auto_retrospective index: {type(e).__name__}: {e}",
+            file=sys.stderr,
         )
 
     return 0

--- a/src/copilot-cli/hooks/sessionEnd/invoke_auto_retrospective.py
+++ b/src/copilot-cli/hooks/sessionEnd/invoke_auto_retrospective.py
@@ -349,9 +349,18 @@ def write_audit_log(
 ) -> None:
     """Append a per-hook JSONL audit record for this run.
 
-    Mirrors the audit pattern in ``invoke_false_completion_gate.write_audit_log``
-    so operators can correlate retro creation with completion-gate decisions
-    in the same ``.hook-state/`` tree.
+    Canonical source: ``.claude/hooks/PreToolUse/invoke_false_completion_gate.py``
+    (function ``write_audit_log``, lines 191-234). Quoted contract:
+
+    - Audit root is ``project_dir / ".agents" / ".hook-state"``.
+    - Skip silently when ``.agents/`` does not exist (consumer-repo guard).
+    - JSONL line carries ``schema=1``, ``timestamp`` (ISO-8601 UTC),
+      ``hook`` (function-local hook id), and per-hook payload fields.
+    - File handle is taken with ``open(audit_file, "a", encoding="utf-8")``
+      and serialized through the shared ``_lock_file`` / ``_unlock_file``
+      helpers when available.
+    - Errors writing the audit log are swallowed and surfaced to stderr
+      to preserve fail-open behavior.
 
     Per Issue #2062 acceptance, records land at::
 
@@ -367,10 +376,22 @@ def write_audit_log(
     - ``skip_reason``: human-readable explanation when status is ``skipped``
       or ``failed``; empty string for ``created``.
 
-    Error tolerance: any OSError writing the audit file is swallowed and
-    surfaced to stderr to preserve the Stop hook's fail-open contract.
-    Consumer repos (no ``.agents/`` dir) skip silently so we never create
-    state outside the project's own working set.
+    Stricter/looser/different than canonical:
+
+    - Subdirectory: writes under ``.hook-state/auto-retrospective/`` instead
+      of the canonical's flat ``.hook-state/`` so retro audit files do not
+      collide with completion-gate audit files. The canonical writes a
+      single ``audit-{date}.jsonl`` per day; this hook namespaces by hook.
+    - Exception scope: catches ``Exception`` rather than the canonical's
+      ``OSError``. The Stop-hook fail-open contract requires resilience
+      against unexpected runtime errors (``TypeError``, ``ValueError``,
+      JSON-serialization edge cases) in addition to disk errors, while
+      still letting ``BaseException`` (``KeyboardInterrupt``,
+      ``SystemExit``) propagate. Refs PR #2077 gemini-code-assist review.
+    - Payload shape: ``status`` / ``retro_filename`` / ``skip_reason``
+      fields replace the canonical's ``command`` / ``decision`` / ``reason``
+      / ``session_id`` / ``tool_use_id``; the two hooks log different
+      events and the field names track each event's domain.
     """
     try:
         agents_dir = project_dir / ".agents"
@@ -396,7 +417,11 @@ def write_audit_log(
             finally:
                 if _unlock_file is not None:
                     _unlock_file(f)
-    except OSError as e:
+    except Exception as e:
+        # Broader than canonical's OSError: see docstring "Stricter/looser/
+        # different than canonical". Preserves Stop hook's fail-open contract
+        # against unexpected runtime errors (e.g. TypeError, ValueError) while
+        # still letting BaseException (KeyboardInterrupt, SystemExit) escape.
         print(
             f"[hook-error] invoke_auto_retrospective audit: {type(e).__name__}: {e}",
             file=sys.stderr,

--- a/src/copilot-cli/hooks/sessionEnd/invoke_auto_retrospective.py
+++ b/src/copilot-cli/hooks/sessionEnd/invoke_auto_retrospective.py
@@ -20,6 +20,7 @@ import os
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, cast
 
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
 if _plugin_root:
@@ -101,7 +102,9 @@ def _pick_same_day_retro(retro_dir: Path, today: str) -> Path | None:
             mtime = candidate.stat().st_mtime
         except OSError:
             continue
-        if mtime > best_mtime or (mtime == best_mtime and (best is None or candidate.name > best.name)):
+        if mtime > best_mtime or (
+            mtime == best_mtime and (best is None or candidate.name > best.name)
+        ):
             best_mtime = mtime
             best = candidate
 
@@ -161,10 +164,10 @@ def find_recent_session_file(sessions_dir: Path, today_only: bool = False) -> Pa
         return _find_recent_session_fallback(sessions_dir, today_only=today_only)
 
     # Use shared utility for standard "prefer today, fall back to yesterday" logic
-    return _get_recent_session_log(str(sessions_dir))
+    return cast(Path | None, _get_recent_session_log(str(sessions_dir)))
 
 
-def _coerce_to_list_fallback(value) -> list:
+def _coerce_to_list_fallback(value: object) -> list[Any]:
     """Fallback normalizer when hook_utilities is unavailable."""
     if value is None:
         return []
@@ -186,7 +189,7 @@ def _coerce_to_list_fallback(value) -> list:
     return []
 
 
-def coerce_to_list(value) -> list:
+def coerce_to_list(value: object) -> list[Any]:
     """Normalize work/outcomes to a list, regardless of session schema shape.
 
     Session logs in this repo have used several shapes over time:
@@ -196,11 +199,11 @@ def coerce_to_list(value) -> list:
     - bare strings (rare)
     """
     if _coerce_to_list is not None:
-        return _coerce_to_list(value)
+        return cast(list[Any], _coerce_to_list(value))
     return _coerce_to_list_fallback(value)
 
 
-def _format_work_item_fallback(item: dict) -> str:
+def _format_work_item_fallback(item: dict[str, Any]) -> str:
     """Fallback formatter when hook_utilities is unavailable."""
     if "action" in item:
         parts = []
@@ -217,7 +220,7 @@ def _format_work_item_fallback(item: dict) -> str:
     return str(item)
 
 
-def format_work_item(item: dict) -> str:
+def format_work_item(item: dict[str, Any]) -> str:
     """Format a work item dict into a human-readable string.
 
     Supports multiple session schemas:
@@ -225,11 +228,11 @@ def format_work_item(item: dict) -> str:
     - Legacy: {'description': '...'} or {'task': '...'}
     """
     if _format_work_item is not None:
-        return _format_work_item(item)
+        return cast(str, _format_work_item(item))
     return _format_work_item_fallback(item)
 
 
-def _extract_work_outcomes(data) -> tuple[list, list]:
+def _extract_work_outcomes(data: object) -> tuple[list[Any], list[Any]]:
     """Pull work and outcomes from session data, supporting workLog and work shapes."""
     if not isinstance(data, dict):
         return [], []
@@ -304,7 +307,8 @@ def generate_retrospective(project_dir: Path, today: str) -> Path | None:
                             session_context += f"- {outcome.get('result', str(outcome))}\n"
             except Exception as e:
                 print(
-                    f"[hook-error] invoke_auto_retrospective generate_retrospective: {type(e).__name__}: {e}",
+                    "[hook-error] invoke_auto_retrospective generate_retrospective: "
+                    f"{type(e).__name__}: {e}",
                     file=sys.stderr,
                 )
 
@@ -335,6 +339,68 @@ def generate_retrospective(project_dir: Path, today: str) -> Path | None:
 
     retro_path.write_text(content, encoding="utf-8")
     return retro_path
+
+
+def write_audit_log(
+    project_dir: Path,
+    status: str,
+    retro_filename: str = "",
+    skip_reason: str = "",
+) -> None:
+    """Append a per-hook JSONL audit record for this run.
+
+    Mirrors the audit pattern in ``invoke_false_completion_gate.write_audit_log``
+    so operators can correlate retro creation with completion-gate decisions
+    in the same ``.hook-state/`` tree.
+
+    Per Issue #2062 acceptance, records land at::
+
+        .agents/.hook-state/auto-retrospective/{YYYY-MM-DD}.jsonl
+
+    Schema (forward-compat ``schema: 1``):
+
+    - ``timestamp``: ISO-8601 UTC of the record.
+    - ``hook``: always ``"invoke_auto_retrospective"`` for cross-hook joins.
+    - ``status``: ``created`` | ``skipped`` | ``failed``.
+    - ``retro_filename``: basename of the retro file when known (created or
+      re-discovered on the skip-because-exists path), else empty string.
+    - ``skip_reason``: human-readable explanation when status is ``skipped``
+      or ``failed``; empty string for ``created``.
+
+    Error tolerance: any OSError writing the audit file is swallowed and
+    surfaced to stderr to preserve the Stop hook's fail-open contract.
+    Consumer repos (no ``.agents/`` dir) skip silently so we never create
+    state outside the project's own working set.
+    """
+    try:
+        agents_dir = project_dir / ".agents"
+        if not agents_dir.is_dir():
+            return  # Consumer repo: skip silently to avoid creating .agents/
+        audit_dir = agents_dir / ".hook-state" / "auto-retrospective"
+        audit_dir.mkdir(parents=True, exist_ok=True)
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        audit_file = audit_dir / f"{today}.jsonl"
+        entry = json.dumps({
+            "schema": 1,
+            "timestamp": datetime.now(tz=UTC).isoformat(),
+            "hook": "invoke_auto_retrospective",
+            "status": status,
+            "retro_filename": retro_filename,
+            "skip_reason": skip_reason,
+        })
+        with open(audit_file, "a", encoding="utf-8") as f:
+            if _lock_file is not None:
+                _lock_file(f)
+            try:
+                f.write(entry + "\n")
+            finally:
+                if _unlock_file is not None:
+                    _unlock_file(f)
+    except OSError as e:
+        print(
+            f"[hook-error] invoke_auto_retrospective audit: {type(e).__name__}: {e}",
+            file=sys.stderr,
+        )
 
 
 def update_retro_index(project_dir: Path, today: str, filename: str) -> None:
@@ -408,6 +474,13 @@ def main() -> int:
 
     # Bypass
     if os.environ.get("SKIP_AUTO_RETRO", "").lower() == "true":
+        project_dir = get_project_directory()
+        if project_dir:
+            write_audit_log(
+                project_dir,
+                "skipped",
+                skip_reason="SKIP_AUTO_RETRO=true",
+            )
         return 0
 
     project_dir = get_project_directory()
@@ -428,15 +501,23 @@ def main() -> int:
     # when mtimes match or stat fails. This keeps index repair predictable
     # across runs.
     if has_retro_today(retro_dir, today):
+        existing_name = ""
         try:
             existing = _pick_same_day_retro(retro_dir, today)
             if existing is not None:
+                existing_name = existing.name
                 update_retro_index(project_dir, today, existing.name)
         except Exception as e:
             print(
                 f"[hook-error] invoke_auto_retrospective index-repair: {type(e).__name__}: {e}",
                 file=sys.stderr,
             )
+        write_audit_log(
+            project_dir,
+            "skipped",
+            retro_filename=existing_name,
+            skip_reason="retro already exists today",
+        )
         return 0
 
     # Skip trivial sessions. is_trivial_session() prefers today's session log
@@ -444,17 +525,38 @@ def main() -> int:
     # when no today-prefixed session exists (cross-midnight continuation).
     # Mirrors the same precedence used by hook_utilities.get_recent_session_log.
     if is_trivial_session(project_dir):
+        write_audit_log(
+            project_dir,
+            "skipped",
+            skip_reason="trivial session",
+        )
         return 0
 
     try:
         retro_path = generate_retrospective(project_dir, today)
         if retro_path:
             update_retro_index(project_dir, today, retro_path.name)
+            write_audit_log(
+                project_dir,
+                "created",
+                retro_filename=retro_path.name,
+            )
+        else:
+            write_audit_log(
+                project_dir,
+                "failed",
+                skip_reason="generate_retrospective returned None",
+            )
     except Exception as e:
         # Broad catch preserves fail-open contract; surface to stderr.
         print(
             f"[hook-error] invoke_auto_retrospective main: {type(e).__name__}: {e}",
             file=sys.stderr,
+        )
+        write_audit_log(
+            project_dir,
+            "failed",
+            skip_reason=f"{type(e).__name__}: {e}",
         )
 
     return 0

--- a/tests/test_auto_retrospective.py
+++ b/tests/test_auto_retrospective.py
@@ -8,6 +8,7 @@ import unittest
 from datetime import UTC, datetime
 from io import StringIO
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent / ".claude" / "hooks" / "Stop"))
@@ -41,7 +42,9 @@ class TestAutoRetrospective(unittest.TestCase):
             existing.write_text("# Already exists")
 
             with patch("sys.stdin", StringIO("")):
-                with patch.object(invoke_auto_retrospective, "get_project_directory", return_value=tmp_path):
+                with patch.object(
+                    invoke_auto_retrospective, "get_project_directory", return_value=tmp_path
+                ):
                     result = invoke_auto_retrospective.main()
                     self.assertEqual(result, 0)
                     # No new file created
@@ -59,7 +62,9 @@ class TestAutoRetrospective(unittest.TestCase):
             session.write_text(json.dumps({"work": [], "outcomes": []}))
 
             with patch("sys.stdin", StringIO("")):
-                with patch.object(invoke_auto_retrospective, "get_project_directory", return_value=tmp_path):
+                with patch.object(
+                    invoke_auto_retrospective, "get_project_directory", return_value=tmp_path
+                ):
                     result = invoke_auto_retrospective.main()
                     self.assertEqual(result, 0)
 
@@ -77,7 +82,9 @@ class TestAutoRetrospective(unittest.TestCase):
             }))
 
             with patch("sys.stdin", StringIO("")):
-                with patch.object(invoke_auto_retrospective, "get_project_directory", return_value=tmp_path):
+                with patch.object(
+                    invoke_auto_retrospective, "get_project_directory", return_value=tmp_path
+                ):
                     result = invoke_auto_retrospective.main()
                     self.assertEqual(result, 0)
 
@@ -96,7 +103,11 @@ class TestAutoRetrospective(unittest.TestCase):
     def test_fail_open_on_os_error(self):
         """OSError should not crash the hook."""
         with patch("sys.stdin", StringIO("")):
-            with patch.object(invoke_auto_retrospective, "get_project_directory", return_value=Path("/nonexistent/path")):
+            with patch.object(
+                invoke_auto_retrospective,
+                "get_project_directory",
+                return_value=Path("/nonexistent/path"),
+            ):
                 result = invoke_auto_retrospective.main()
                 self.assertEqual(result, 0)
 
@@ -113,7 +124,9 @@ class TestAutoRetrospective(unittest.TestCase):
             # docs/retros/INDEX.md intentionally missing
 
             with patch("sys.stdin", StringIO("")):
-                with patch.object(invoke_auto_retrospective, "get_project_directory", return_value=tmp_path):
+                with patch.object(
+                    invoke_auto_retrospective, "get_project_directory", return_value=tmp_path
+                ):
                     result = invoke_auto_retrospective.main()
                     self.assertEqual(result, 0)
                     index = tmp_path / "docs" / "retros" / "INDEX.md"
@@ -125,8 +138,12 @@ class TestAutoRetrospective(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             today = "2026-04-20"
-            invoke_auto_retrospective.update_retro_index(tmp_path, today, "2026-04-20-auto-retro.md")
-            invoke_auto_retrospective.update_retro_index(tmp_path, today, "2026-04-20-auto-retro.md")
+            invoke_auto_retrospective.update_retro_index(
+                tmp_path, today, "2026-04-20-auto-retro.md"
+            )
+            invoke_auto_retrospective.update_retro_index(
+                tmp_path, today, "2026-04-20-auto-retro.md"
+            )
             index = tmp_path / "docs" / "retros" / "INDEX.md"
             content = index.read_text()
             self.assertEqual(content.count("2026-04-20-auto-retro.md"), 1)
@@ -167,6 +184,215 @@ class TestAutoRetrospective(unittest.TestCase):
             third = invoke_auto_retrospective._pick_same_day_retro(retro_dir, today)
             self.assertEqual(first, second)
             self.assertEqual(second, third)
+
+
+class TestAutoRetrospectiveAudit(unittest.TestCase):
+    """Audit-trail JSONL coverage for Issue #2062."""
+
+    @staticmethod
+    def _read_audit_records(project_dir: Path) -> list[dict[str, Any]]:
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        audit_file = (
+            project_dir / ".agents" / ".hook-state" / "auto-retrospective" / f"{today}.jsonl"
+        )
+        if not audit_file.exists():
+            return []
+        records = []
+        for line in audit_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            records.append(json.loads(line))
+        return records
+
+    def _assert_record_shape(self, record: dict[str, Any]) -> None:
+        """Audit records carry every field the acceptance criteria requires."""
+        self.assertIn("timestamp", record)
+        self.assertIn("status", record)
+        self.assertIn("retro_filename", record)
+        self.assertIn("skip_reason", record)
+        self.assertEqual(record.get("hook"), "invoke_auto_retrospective")
+        self.assertEqual(record.get("schema"), 1)
+        # Timestamp is a valid ISO 8601 string.
+        datetime.fromisoformat(record["timestamp"])
+
+    def test_audit_created_path(self):
+        """A nontrivial session writes a 'created' audit record with filename."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / ".agents").mkdir()
+            sessions_dir = tmp_path / ".agents" / "sessions"
+            sessions_dir.mkdir(parents=True)
+            today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+            session = sessions_dir / f"{today}-session-01.json"
+            session.write_text(json.dumps({
+                "work": ["Implemented audit trail"],
+                "outcomes": ["Audit log emitted"],
+            }))
+
+            with patch("sys.stdin", StringIO("")), patch.object(
+                invoke_auto_retrospective, "get_project_directory", return_value=tmp_path
+            ):
+                result = invoke_auto_retrospective.main()
+                self.assertEqual(result, 0)
+
+            records = self._read_audit_records(tmp_path)
+            self.assertEqual(len(records), 1)
+            self._assert_record_shape(records[0])
+            self.assertEqual(records[0]["status"], "created")
+            self.assertTrue(records[0]["retro_filename"].endswith("-auto-retro.md"))
+            self.assertIn(today, records[0]["retro_filename"])
+            self.assertEqual(records[0]["skip_reason"], "")
+
+    def test_audit_skipped_trivial_session(self):
+        """A trivial session emits a 'skipped' record with skip_reason."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / ".agents").mkdir()
+            sessions_dir = tmp_path / ".agents" / "sessions"
+            sessions_dir.mkdir(parents=True)
+            today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+            session = sessions_dir / f"{today}-session-01.json"
+            session.write_text(json.dumps({"work": [], "outcomes": []}))
+
+            with patch("sys.stdin", StringIO("")), patch.object(
+                invoke_auto_retrospective, "get_project_directory", return_value=tmp_path
+            ):
+                result = invoke_auto_retrospective.main()
+                self.assertEqual(result, 0)
+
+            records = self._read_audit_records(tmp_path)
+            self.assertEqual(len(records), 1)
+            self._assert_record_shape(records[0])
+            self.assertEqual(records[0]["status"], "skipped")
+            self.assertEqual(records[0]["skip_reason"], "trivial session")
+            self.assertEqual(records[0]["retro_filename"], "")
+
+    def test_audit_skipped_existing_retro(self):
+        """An existing retro emits a 'skipped' record naming the existing file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / ".agents").mkdir()
+            retro_dir = tmp_path / ".agents" / "retrospective"
+            retro_dir.mkdir(parents=True)
+            today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+            existing = retro_dir / f"{today}-manual-retro.md"
+            existing.write_text("# Already exists")
+
+            with patch("sys.stdin", StringIO("")), patch.object(
+                invoke_auto_retrospective, "get_project_directory", return_value=tmp_path
+            ):
+                result = invoke_auto_retrospective.main()
+                self.assertEqual(result, 0)
+
+            records = self._read_audit_records(tmp_path)
+            self.assertEqual(len(records), 1)
+            self._assert_record_shape(records[0])
+            self.assertEqual(records[0]["status"], "skipped")
+            self.assertEqual(records[0]["skip_reason"], "retro already exists today")
+            self.assertEqual(records[0]["retro_filename"], existing.name)
+
+    def test_audit_skipped_bypass_env(self):
+        """SKIP_AUTO_RETRO=true emits a 'skipped' record citing the env var."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / ".agents").mkdir()
+
+            with patch.dict("os.environ", {"SKIP_AUTO_RETRO": "true"}):
+                with patch("sys.stdin", StringIO("")), patch.object(
+                    invoke_auto_retrospective, "get_project_directory", return_value=tmp_path
+                ):
+                    result = invoke_auto_retrospective.main()
+                    self.assertEqual(result, 0)
+
+            records = self._read_audit_records(tmp_path)
+            self.assertEqual(len(records), 1)
+            self._assert_record_shape(records[0])
+            self.assertEqual(records[0]["status"], "skipped")
+            self.assertEqual(records[0]["skip_reason"], "SKIP_AUTO_RETRO=true")
+
+    def test_audit_failed_path(self):
+        """An exception during generation emits a 'failed' record."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / ".agents").mkdir()
+            sessions_dir = tmp_path / ".agents" / "sessions"
+            sessions_dir.mkdir(parents=True)
+            today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+            session = sessions_dir / f"{today}-session-01.json"
+            session.write_text(json.dumps({
+                "work": ["force-failure"],
+                "outcomes": ["ok"],
+            }))
+
+            def _explode(*_args, **_kwargs):
+                raise RuntimeError("synthetic failure")
+
+            with patch("sys.stdin", StringIO("")), patch.object(
+                invoke_auto_retrospective, "get_project_directory", return_value=tmp_path
+            ), patch.object(
+                invoke_auto_retrospective, "generate_retrospective", side_effect=_explode
+            ):
+                result = invoke_auto_retrospective.main()
+                # Fail-open: still returns 0 even though generation threw.
+                self.assertEqual(result, 0)
+
+            records = self._read_audit_records(tmp_path)
+            self.assertEqual(len(records), 1)
+            self._assert_record_shape(records[0])
+            self.assertEqual(records[0]["status"], "failed")
+            self.assertIn("RuntimeError", records[0]["skip_reason"])
+            self.assertIn("synthetic failure", records[0]["skip_reason"])
+
+    def test_audit_write_tolerates_missing_agents_dir(self):
+        """write_audit_log silently no-ops when .agents/ is absent (consumer repo)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            # Intentionally do NOT create .agents/.
+            invoke_auto_retrospective.write_audit_log(
+                tmp_path, "skipped", skip_reason="consumer repo guard"
+            )
+            self.assertFalse((tmp_path / ".agents").exists())
+
+    def test_audit_write_tolerates_unwritable_audit_dir(self):
+        """write_audit_log swallows OSError and never propagates to the hook."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / ".agents").mkdir()
+
+            def _raise_oserror(*_args, **_kwargs):
+                raise OSError("simulated read-only filesystem")
+
+            # Patch Path.mkdir to simulate an unwritable .hook-state directory.
+            with patch("pathlib.Path.mkdir", side_effect=_raise_oserror):
+                # Must not raise; the hook's fail-open contract depends on this.
+                invoke_auto_retrospective.write_audit_log(
+                    tmp_path, "created", retro_filename="x.md"
+                )
+
+    def test_audit_record_is_valid_jsonl(self):
+        """Every audit line is valid JSON; lines are newline-delimited."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / ".agents").mkdir()
+
+            # Write three records back-to-back.
+            for i in range(3):
+                invoke_auto_retrospective.write_audit_log(
+                    tmp_path, "skipped", skip_reason=f"run {i}"
+                )
+
+            today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+            audit_file = (
+                tmp_path / ".agents" / ".hook-state" / "auto-retrospective" / f"{today}.jsonl"
+            )
+            self.assertTrue(audit_file.exists())
+            lines = audit_file.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 3)
+            for i, line in enumerate(lines):
+                record = json.loads(line)  # must parse
+                self.assertEqual(record["status"], "skipped")
+                self.assertEqual(record["skip_reason"], f"run {i}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #2062

## Summary
Adds per-hook JSONL audit-trail to invoke_auto_retrospective.py (Stop hook), mirroring the audit pattern in invoke_false_completion_gate.py.

Each Stop hook invocation now appends one record to:
`.agents/.hook-state/auto-retrospective/{YYYY-MM-DD}.jsonl`

Fields: schema, timestamp (ISO-8601 UTC), hook, status (created|skipped|failed), retro_filename, skip_reason.

Mirrored in both Stop hook copies (.claude/hooks and src/copilot-cli/hooks).

## Tests
tests/test_auto_retrospective.py: 8 new cases cover created, three skipped paths (trivial/existing/bypass-env), failed path, edge cases (missing .agents/, unwritable audit dir), and JSONL well-formedness.

Refs PR #1763 (CodeRabbit thread PRRT_kwDOQoWRls59lbeE), Issue #1703, ADR-008.
