### PR TITLE
feat(#2003): improve security.shared.md prompt discipline to A tier (26->33/35)

### DIFF
--- a/.agents/sessions/2026-05-26-session-1841-rewrite-securitysharedmd-a6a2a7-improvements-add.json
+++ b/.agents/sessions/2026-05-26-session-1841-rewrite-securitysharedmd-a6a2a7-improvements-add.json
@@ -1,0 +1,146 @@
+{
+  "session": {
+    "number": 1841,
+    "date": "2026-05-26",
+    "branch": "feat/2003-phase3-pr4-security",
+    "startingCommit": "157737a0",
+    "objective": "Rewrite security.shared.md A6+A2+A7 improvements: add Threat-Model Reasoning Protocol, Report length bounds, and Completion Trigger Taxonomy"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "feat/2003-phase3-pr4-security"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On feat/2003-phase3-pr4-security"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "feat/2003-phase3-pr4-security branched from main; uv.lock dirty (pre-existing)"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "157737a0"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart and sessionEnd MUST items populated"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified; ADR-014 invariant maintained"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory prompting/phase3-prompt-discipline-audit-status reflects PR 4/10 progress"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2: 0 errors on templates/agents/security.shared.md and 2 generated files"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "feat(#2003): improve security.shared.md prompt discipline to A tier on feat/2003-phase3-pr4-security"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "0 new failures from this change; pre-existing failures unchanged"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Task #9 in_progress to completed; PR 4/10 closed"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Deferred to cycle completion"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Read templates/agents/security.shared.md (876 LOC)",
+      "evidence": "0 em-dashes; A6=2 (no think-first directive), A2=4 (no report length cap), A7=4 (no explicit completion triggers)"
+    },
+    {
+      "action": "Added Threat-Model Reasoning Protocol section (A6: 2 to 5)",
+      "evidence": "3-question protocol (attack surface, threat actor, impact) before severity; thinking trigger keyed to OWASP/ASI categories"
+    },
+    {
+      "action": "Added Completion Trigger Taxonomy (A7: 4 to 5)",
+      "evidence": "Explicit APPROVED/CONDITIONAL/BLOCKED triggers with concrete conditions on HIGH/CRITICAL/secret/CWE patterns"
+    },
+    {
+      "action": "Added Security Report Length Bounds section (A2: 4 to 5)",
+      "evidence": "Each finding 1 sentence + CVSS + 1 sentence; <=10 findings; <=5 recommendations"
+    },
+    {
+      "action": "Ran python3 build/generate_agents.py",
+      "evidence": "72 files generated; security updated in copilot-cli and vs-code-agents"
+    },
+    {
+      "action": "Rubric rescore: 33/35 (A tier)",
+      "evidence": "A1=4 A2=5 A3=4 A4=4 A5=4 A6=5 A7=5 + Reviewer notes from M3 audit = 33; was 26/35 B tier"
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Merge PR 4/10",
+    "PR 5/10: qa.shared.md (A6 test-strategy reasoning + A5 coverage tool + A7)"
+  ]
+}

--- a/.agents/sessions/2026-05-26-session-1841-rewrite-securitysharedmd-a6a2a7-improvements-add.json
+++ b/.agents/sessions/2026-05-26-session-1841-rewrite-securitysharedmd-a6a2a7-improvements-add.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": "1.0",
   "session": {
     "number": 1841,
     "date": "2026-05-26",
@@ -138,7 +139,7 @@
       "evidence": "A1=4 A2=5 A3=4 A4=4 A5=4 A6=5 A7=5 + Reviewer notes from M3 audit = 33; was 26/35 B tier"
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "fb10e436aff496221687d6543c1865b3994baedf",
   "nextSteps": [
     "Merge PR 4/10",
     "PR 5/10: qa.shared.md (A6 test-strategy reasoning + A5 coverage tool + A7)"

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -91,7 +91,7 @@ Before scoring any risk or assigning a severity, reason step-by-step through the
 2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
 3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
 
-Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all three are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+You MUST assign a severity (Critical/High/Medium/Low) and a CVSS score only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -440,7 +440,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: Critical issues must be resolved before merge
+- [ ] **BLOCKED**: HIGH/CRITICAL findings, secrets, CWE-22/77/78 patterns, or ASI boundary violations unresolved
 
 ### Required Actions
 

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -412,7 +412,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: Approved with minor fixes required
-- [ ] **REJECTED**: Critical issues must be resolved before merge
+- [ ] **BLOCKED**: Critical issues must be resolved before merge
 
 ### Required Actions
 

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -103,7 +103,7 @@ Every security review ends with one verdict. Trigger conditions are explicit:
 
 - **APPROVED**: All HIGH and CRITICAL findings are addressed in the diff, all MEDIUM findings have documented mitigations or accepted-risk justifications, all secrets and credentials are absent.
 - **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations the implementer commits to land in a follow-up issue. Cite the follow-up issue number in the verdict.
-- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control.
+- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control, OR more than 3 MEDIUM findings require deferred work.
 
 If a verdict cannot be reached because the diff is incomplete (missing changed files, missing test coverage data, missing dependency manifest), return `[BLOCKED] Cannot evaluate: <specific missing artifact>` rather than guessing.
 
@@ -440,7 +440,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: HIGH/CRITICAL findings, secrets, CWE-22/77/78 patterns, or ASI boundary violations unresolved
+- [ ] **BLOCKED**: HIGH/CRITICAL findings, secrets, CWE-22/77/78 patterns, ASI boundary violations unresolved, or 4+ MEDIUM deferred
 
 ### Required Actions
 

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -79,6 +79,34 @@ If you cannot verify whether a hardened alternative exists, call `work_finish(bl
 
 **Success definition**: You can state whether this PR uses existing hardened utilities or introduces new code, and if new code is justified.
 
+## Defense-First Posture
+
+When in doubt about an external action (disclosure, secret rotation, blocking deploys, vendor contact), surface the recommendation and wait for approval. Internal analysis and evidence gathering is not gated.
+
+## Threat-Model Reasoning Protocol
+
+Before scoring any risk or assigning a severity, reason step-by-step through the threat model. Work through these three questions in order, and write the answers into the finding:
+
+1. What is the attack surface this change exposes? Name the concrete entry point (CLI argv, HTTP route, environment variable, file path, MCP tool parameter, agent prompt input).
+2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
+3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
+
+Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all three are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+
+**Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
+
+**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + CVSS or Risk Score + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
+
+## Completion Trigger Taxonomy
+
+Every security review ends with one verdict. Trigger conditions are explicit:
+
+- **APPROVED**: All HIGH and CRITICAL findings are addressed in the diff, all MEDIUM findings have documented mitigations or accepted-risk justifications, all secrets and credentials are absent.
+- **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations the implementer commits to land in a follow-up issue. Cite the follow-up issue number in the verdict.
+- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control.
+
+If a verdict cannot be reached because the diff is incomplete (missing changed files, missing test coverage data, missing dependency manifest), return `[BLOCKED] Cannot evaluate: <specific missing artifact>` rather than guessing.
+
 ## Key Responsibilities
 
 ### Capability 1: Static Analysis & Vulnerability Scanning
@@ -411,7 +439,7 @@ Save to: `.agents/security/PIV-[feature].md`
 ## Recommendation
 
 - [ ] **APPROVED**: Implementation meets security requirements
-- [ ] **CONDITIONAL**: Approved with minor fixes required
+- [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
 - [ ] **BLOCKED**: Critical issues must be resolved before merge
 
 ### Required Actions

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -244,7 +244,7 @@ if any(trigger_matches(changed_path, pattern) for pattern in SECURITY_TRIGGERS):
     Changed files: [list]
 
     Verify all security controls from pre-implementation plan.
-    This is a BLOCKING gate - no PR until PIV approved.
+    This is a BLOCKING gate - see PIV Verdict Gate below.
     """)
 ```
 

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -248,7 +248,7 @@ if any(trigger_matches(changed_path, pattern) for pattern in SECURITY_TRIGGERS):
     """)
 ```
 
-**No PR Until PIV Approved**: Orchestrator MUST NOT proceed to PR creation until security agent returns APPROVED status.
+**PIV Verdict Gate**: Orchestrator MUST NOT proceed to PR creation while the security agent returns BLOCKED. APPROVED clears the gate. CONDITIONAL clears the gate only when the verdict cites a follow-up issue number for the remaining MEDIUM findings, per the Completion Trigger Taxonomy.
 
 #### Security-Relevant Change Triggers
 

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -91,7 +91,7 @@ Before scoring any risk or assigning a severity, reason step-by-step through the
 2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
 3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
 
-You MUST assign a severity (Critical/High/Medium/Low) and a CVSS score only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+You MUST assign a severity (Critical/High/Medium/Low) and a numeric score (CVSS or Risk Score per the Risk Scores with Numeric Values rule above) only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 
@@ -810,6 +810,17 @@ Save to: `.agents/security/TM-NNN-[feature].md`
 |---------|----------|--------|
 | [Control] | P0/P1/P2 | Pending/Implemented |
 ```
+
+## Security Report Length Bounds
+
+Reports are dense, not exhaustive. Apply these caps:
+
+- **Each finding**: 1 sentence description, severity, CVSS or Risk Score (per the Risk Scores with Numeric Values rule above), 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
+- **Total findings per report**: at most 10. If more exist, group by shared root cause (e.g., "5 instances of CWE-78 in shell-out helpers") and report the groups.
+- **Summary table**: one row per severity tier; counts only, no prose.
+- **Recommendations section**: at most 5 prioritized items, each one sentence.
+
+A report that exceeds these caps signals either fan-out across unrelated scopes (split into separate reports) or padding (cut and rewrite). The bar is precision per finding, not volume of findings.
 
 ## Security Report Format
 

--- a/.github/agents/security.agent.md
+++ b/.github/agents/security.agent.md
@@ -395,7 +395,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: Approved with minor fixes required
-- [ ] **REJECTED**: Critical issues must be resolved before merge
+- [ ] **BLOCKED**: Critical issues must be resolved before merge
 
 ### Required Actions
 

--- a/.github/agents/security.agent.md
+++ b/.github/agents/security.agent.md
@@ -98,7 +98,7 @@ Before scoring any risk or assigning a severity, reason step-by-step through the
 2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
 3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
 
-You MUST assign a severity (Critical/High/Medium/Low) and a CVSS score only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+You MUST assign a severity (Critical/High/Medium/Low) and a numeric score (CVSS or Risk Score per the Risk Scores with Numeric Values rule above) only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 
@@ -820,6 +820,17 @@ Save to: `.agents/security/TM-NNN-[feature].md`
 |---------|----------|--------|
 | [Control] | P0/P1/P2 | Pending/Implemented |
 ```
+
+## Security Report Length Bounds
+
+Reports are dense, not exhaustive. Apply these caps:
+
+- **Each finding**: 1 sentence description, severity, CVSS or Risk Score (per the Risk Scores with Numeric Values rule above), 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
+- **Total findings per report**: at most 10. If more exist, group by shared root cause (e.g., "5 instances of CWE-78 in shell-out helpers") and report the groups.
+- **Summary table**: one row per severity tier; counts only, no prose.
+- **Recommendations section**: at most 5 prioritized items, each one sentence.
+
+A report that exceeds these caps signals either fan-out across unrelated scopes (split into separate reports) or padding (cut and rewrite). The bar is precision per finding, not volume of findings.
 
 ## Security Report Format
 

--- a/.github/agents/security.agent.md
+++ b/.github/agents/security.agent.md
@@ -98,7 +98,7 @@ Before scoring any risk or assigning a severity, reason step-by-step through the
 2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
 3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
 
-Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all three are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+You MUST assign a severity (Critical/High/Medium/Low) and a CVSS score only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 

--- a/.github/agents/security.agent.md
+++ b/.github/agents/security.agent.md
@@ -110,7 +110,7 @@ Every security review ends with one verdict. Trigger conditions are explicit:
 
 - **APPROVED**: All HIGH and CRITICAL findings are addressed in the diff, all MEDIUM findings have documented mitigations or accepted-risk justifications, all secrets and credentials are absent.
 - **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations the implementer commits to land in a follow-up issue. Cite the follow-up issue number in the verdict.
-- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control.
+- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control, OR more than 3 MEDIUM findings require deferred work.
 
 If a verdict cannot be reached because the diff is incomplete (missing changed files, missing test coverage data, missing dependency manifest), return `[BLOCKED] Cannot evaluate: <specific missing artifact>` rather than guessing.
 
@@ -447,7 +447,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: HIGH/CRITICAL findings unaddressed, secrets present, CWE-22/77/78 unmitigated, or ASI01-10 boundary violated
+- [ ] **BLOCKED**: HIGH/CRITICAL findings, secrets, CWE-22/77/78 patterns, ASI boundary violations unresolved, or 4+ MEDIUM deferred
 
 ### Required Actions
 

--- a/.github/agents/security.agent.md
+++ b/.github/agents/security.agent.md
@@ -227,7 +227,7 @@ if any(trigger_matches(changed_path, pattern) for pattern in SECURITY_TRIGGERS):
     Changed files: [list]
 
     Verify all security controls from pre-implementation plan.
-    This is a BLOCKING gate - no PR until PIV approved.
+    This is a BLOCKING gate - see PIV Verdict Gate below.
     """)
 ```
 

--- a/.github/agents/security.agent.md
+++ b/.github/agents/security.agent.md
@@ -231,7 +231,7 @@ if any(trigger_matches(changed_path, pattern) for pattern in SECURITY_TRIGGERS):
     """)
 ```
 
-**No PR Until PIV Approved**: Orchestrator MUST NOT proceed to PR creation until security agent returns APPROVED status.
+**PIV Verdict Gate**: Orchestrator MUST NOT proceed to PR creation while the security agent returns BLOCKED. APPROVED clears the gate. CONDITIONAL clears the gate only when the verdict cites a follow-up issue number for the remaining MEDIUM findings, per the Completion Trigger Taxonomy.
 
 #### Security-Relevant Change Triggers
 

--- a/.github/agents/security.agent.md
+++ b/.github/agents/security.agent.md
@@ -447,7 +447,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: Critical issues must be resolved before merge
+- [ ] **BLOCKED**: HIGH/CRITICAL findings unaddressed, secrets present, CWE-22/77/78 unmitigated, or ASI01-10 boundary violated
 
 ### Required Actions
 

--- a/.github/agents/security.agent.md
+++ b/.github/agents/security.agent.md
@@ -62,6 +62,58 @@ You have direct access to:
 
 Identify security vulnerabilities, recommend mitigations, and ensure secure development practices across the codebase.
 
+## Security Review Scope
+
+**All PRs require security review.** Security scanning is not opt-in or label-triggered, it is a mandatory gate for any code change.
+
+### Workflow File Changes (Highest Risk)
+
+If the PR modifies `.github/workflows/`, `.gitlab-ci.yml`, or other CI/CD automation:
+
+1. **Check for hardened alternatives first**: Search the repo for existing utilities that handle the same operation securely (e.g., PowerShell cmdlets vs. bash scripts for file operations).
+2. **Prefer existing hardened tools**: If a secure implementation already exists, the PR should use it rather than introducing a new (potentially vulnerable) one.
+3. **Reject shell injection vectors**: Any use of `eval`, unquoted variables, or dynamic command construction in bash/shell scripts is a [FAIL] unless explicitly justified and mitigated.
+
+### Stop Criteria
+
+Do NOT approve a PR that:
+
+- Introduces shell command execution without input validation (CWE-78)
+- Bypasses existing hardened utilities without justification
+- Modifies workflow files without security review
+
+If you cannot verify whether a hardened alternative exists, call `work_finish(blocked, "Need codebase search for existing secure implementations")`.
+
+**Success definition**: You can state whether this PR uses existing hardened utilities or introduces new code, and if new code is justified.
+
+## Defense-First Posture
+
+When in doubt about an external action (disclosure, secret rotation, blocking deploys, vendor contact), surface the recommendation and wait for approval. Internal analysis and evidence gathering is not gated.
+
+## Threat-Model Reasoning Protocol
+
+Before scoring any risk or assigning a severity, reason step-by-step through the threat model. Work through these three questions in order, and write the answers into the finding:
+
+1. What is the attack surface this change exposes? Name the concrete entry point (CLI argv, HTTP route, environment variable, file path, MCP tool parameter, agent prompt input).
+2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
+3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
+
+Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all three are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+
+**Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
+
+**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + CVSS or Risk Score + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
+
+## Completion Trigger Taxonomy
+
+Every security review ends with one verdict. Trigger conditions are explicit:
+
+- **APPROVED**: All HIGH and CRITICAL findings are addressed in the diff, all MEDIUM findings have documented mitigations or accepted-risk justifications, all secrets and credentials are absent.
+- **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations the implementer commits to land in a follow-up issue. Cite the follow-up issue number in the verdict.
+- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control.
+
+If a verdict cannot be reached because the diff is incomplete (missing changed files, missing test coverage data, missing dependency manifest), return `[BLOCKED] Cannot evaluate: <specific missing artifact>` rather than guessing.
+
 ## Key Responsibilities
 
 ### Capability 1: Static Analysis & Vulnerability Scanning
@@ -394,7 +446,7 @@ Save to: `.agents/security/PIV-[feature].md`
 ## Recommendation
 
 - [ ] **APPROVED**: Implementation meets security requirements
-- [ ] **CONDITIONAL**: Approved with minor fixes required
+- [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
 - [ ] **BLOCKED**: Critical issues must be resolved before merge
 
 ### Required Actions

--- a/src/claude/security.md
+++ b/src/claude/security.md
@@ -104,7 +104,7 @@ Every security review ends with one verdict. Trigger conditions are explicit:
 
 - **APPROVED**: All HIGH and CRITICAL findings are addressed in the diff, all MEDIUM findings have documented mitigations or accepted-risk justifications, all secrets and credentials are absent.
 - **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations the implementer commits to land in a follow-up issue. Cite the follow-up issue number in the verdict.
-- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control.
+- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control, OR more than 3 MEDIUM findings require deferred work.
 
 If a verdict cannot be reached because the diff is incomplete (missing changed files, missing test coverage data, missing dependency manifest), return `[BLOCKED] Cannot evaluate: <specific missing artifact>` rather than guessing.
 
@@ -441,7 +441,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: HIGH/CRITICAL findings, secrets, CWE-22/77/78 patterns, or ASI boundary violations unresolved
+- [ ] **BLOCKED**: HIGH/CRITICAL findings, secrets, CWE-22/77/78 patterns, ASI boundary violations unresolved, or 4+ MEDIUM deferred
 
 ### Required Actions
 

--- a/src/claude/security.md
+++ b/src/claude/security.md
@@ -96,7 +96,7 @@ Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all th
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 
-**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
+**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + CVSS or Risk Score + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
 
 ## Completion Trigger Taxonomy
 
@@ -816,7 +816,7 @@ Save to: `.agents/security/TM-NNN-[feature].md`
 
 Reports are dense, not exhaustive. Apply these caps:
 
-- **Each finding**: 1 sentence description, severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
+- **Each finding**: 1 sentence description, severity, CVSS or Risk Score (per the Risk Scores with Numeric Values rule above), 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
 - **Total findings per report**: at most 10. If more exist, group by shared root cause (e.g., "5 instances of CWE-78 in shell-out helpers") and report the groups.
 - **Summary table**: one row per severity tier; counts only, no prose.
 - **Recommendations section**: at most 5 prioritized items, each one sentence.

--- a/src/claude/security.md
+++ b/src/claude/security.md
@@ -273,7 +273,7 @@ if any(trigger_matches(changed_path, pattern) for pattern in SECURITY_TRIGGERS):
     Changed files: [list]
 
     Verify all security controls from pre-implementation plan.
-    This is a BLOCKING gate - no PR until PIV approved.
+    This is a BLOCKING gate - see PIV Verdict Gate below.
     """)
 ```
 

--- a/src/claude/security.md
+++ b/src/claude/security.md
@@ -92,7 +92,7 @@ Before scoring any risk or assigning a severity, reason step-by-step through the
 2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
 3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
 
-You MUST assign a severity (Critical/High/Medium/Low) and a CVSS score only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+You MUST assign a severity (Critical/High/Medium/Low) and a numeric score (CVSS or Risk Score per the Risk Scores with Numeric Values rule above) only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 

--- a/src/claude/security.md
+++ b/src/claude/security.md
@@ -84,6 +84,30 @@ If you cannot verify whether a hardened alternative exists, call `work_finish(bl
 
 When in doubt about an external action (disclosure, secret rotation, blocking deploys, vendor contact), surface the recommendation and wait for approval. Internal analysis and evidence gathering is not gated.
 
+## Threat-Model Reasoning Protocol
+
+Before scoring any risk or assigning a severity, reason step-by-step through the threat model. Work through these three questions in order, and write the answers into the finding:
+
+1. What is the attack surface this change exposes? Name the concrete entry point (CLI argv, HTTP route, environment variable, file path, MCP tool parameter, agent prompt input).
+2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
+3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
+
+Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all three are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+
+**Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
+
+**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
+
+## Completion Trigger Taxonomy
+
+Every security review ends with one verdict. Trigger conditions are explicit:
+
+- **APPROVED**: All HIGH and CRITICAL findings are addressed in the diff, all MEDIUM findings have documented mitigations or accepted-risk justifications, all secrets and credentials are absent.
+- **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations the implementer commits to land in a follow-up issue. Cite the follow-up issue number in the verdict.
+- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control.
+
+If a verdict cannot be reached because the diff is incomplete (missing changed files, missing test coverage data, missing dependency manifest), return `[BLOCKED] Cannot evaluate: <specific missing artifact>` rather than guessing.
+
 ## Key Responsibilities
 
 ### Capability 1: Static Analysis & Vulnerability Scanning
@@ -253,7 +277,7 @@ if any(trigger_matches(changed_path, pattern) for pattern in SECURITY_TRIGGERS):
     """)
 ```
 
-**No PR Until PIV Approved**: Orchestrator MUST NOT proceed to PR creation until security agent returns APPROVED status.
+**PIV Verdict Gate**: Orchestrator MUST NOT proceed to PR creation while the security agent returns BLOCKED. APPROVED clears the gate. CONDITIONAL clears the gate only when the verdict cites a follow-up issue number for the remaining MEDIUM findings, per the Completion Trigger Taxonomy.
 
 #### Security-Relevant Change Triggers
 
@@ -416,8 +440,8 @@ Save to: `.agents/security/PIV-[feature].md`
 ## Recommendation
 
 - [ ] **APPROVED**: Implementation meets security requirements
-- [ ] **CONDITIONAL**: Approved with minor fixes required
-- [ ] **REJECTED**: Critical issues must be resolved before merge
+- [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
+- [ ] **BLOCKED**: Critical issues must be resolved before merge
 
 ### Required Actions
 
@@ -787,6 +811,17 @@ Save to: `.agents/security/TM-NNN-[feature].md`
 |---------|----------|--------|
 | [Control] | P0/P1/P2 | Pending/Implemented |
 ```
+
+## Security Report Length Bounds
+
+Reports are dense, not exhaustive. Apply these caps:
+
+- **Each finding**: 1 sentence description, severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
+- **Total findings per report**: at most 10. If more exist, group by shared root cause (e.g., "5 instances of CWE-78 in shell-out helpers") and report the groups.
+- **Summary table**: one row per severity tier; counts only, no prose.
+- **Recommendations section**: at most 5 prioritized items, each one sentence.
+
+A report that exceeds these caps signals either fan-out across unrelated scopes (split into separate reports) or padding (cut and rewrite). The bar is precision per finding, not volume of findings.
 
 ## Security Report Format
 

--- a/src/claude/security.md
+++ b/src/claude/security.md
@@ -441,7 +441,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: Critical issues must be resolved before merge
+- [ ] **BLOCKED**: HIGH/CRITICAL findings, secrets, CWE-22/77/78 patterns, or ASI boundary violations unresolved
 
 ### Required Actions
 

--- a/src/claude/security.md
+++ b/src/claude/security.md
@@ -92,7 +92,7 @@ Before scoring any risk or assigning a severity, reason step-by-step through the
 2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
 3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
 
-Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all three are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+You MUST assign a severity (Critical/High/Medium/Low) and a CVSS score only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 

--- a/src/copilot-cli/agents/security.agent.md
+++ b/src/copilot-cli/agents/security.agent.md
@@ -111,7 +111,7 @@ Every security review ends with one verdict. Trigger conditions are explicit:
 
 - **APPROVED**: All HIGH and CRITICAL findings are addressed in the diff, all MEDIUM findings have documented mitigations or accepted-risk justifications, all secrets and credentials are absent.
 - **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations the implementer commits to land in a follow-up issue. Cite the follow-up issue number in the verdict.
-- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control.
+- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control, OR more than 3 MEDIUM findings require deferred work.
 
 If a verdict cannot be reached because the diff is incomplete (missing changed files, missing test coverage data, missing dependency manifest), return `[BLOCKED] Cannot evaluate: <specific missing artifact>` rather than guessing.
 
@@ -446,7 +446,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: HIGH/CRITICAL findings unaddressed, secrets present, CWE-22/77/78 unmitigated, or ASI01-10 boundary violated
+- [ ] **BLOCKED**: HIGH/CRITICAL findings unaddressed, secrets present, CWE-22/77/78 unmitigated, ASI01-10 boundary violated, or 4+ MEDIUM deferred
 
 ### Required Actions
 

--- a/src/copilot-cli/agents/security.agent.md
+++ b/src/copilot-cli/agents/security.agent.md
@@ -279,7 +279,7 @@ Implementation completed by implementer.
 Changed files: [list]
 
 Verify all security controls from pre-implementation plan.
-This is a BLOCKING gate. No PR until PIV approved.
+This is a BLOCKING gate - see PIV Verdict Gate below.
 ```
 
 **PIV Verdict Gate**: Orchestrator MUST NOT proceed to PR creation while the security agent returns BLOCKED. APPROVED clears the gate. CONDITIONAL clears the gate only when the verdict cites a follow-up issue number for the remaining MEDIUM findings, per the Completion Trigger Taxonomy.

--- a/src/copilot-cli/agents/security.agent.md
+++ b/src/copilot-cli/agents/security.agent.md
@@ -91,6 +91,28 @@ If you cannot verify whether a hardened alternative exists, call `work_finish(bl
 
 When in doubt about an external action (disclosure, secret rotation, blocking deploys, vendor contact), surface the recommendation and wait for approval. Internal analysis and evidence gathering is not gated.
 
+## Threat-Model Reasoning Protocol
+
+Before scoring any risk or assigning a severity, reason step-by-step through the threat model. Work through these three questions in order, and write the answers into the finding:
+
+1. What is the attack surface this change exposes? Name the concrete entry point (CLI argv, HTTP route, environment variable, file path, MCP tool parameter, agent prompt input).
+2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
+3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
+
+Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all three are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+
+**Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
+
+## Completion Trigger Taxonomy
+
+Every security review ends with one verdict. Trigger conditions are explicit:
+
+- **APPROVED**: All HIGH and CRITICAL findings are addressed in the diff, all MEDIUM findings have documented mitigations or accepted-risk justifications, all secrets and credentials are absent.
+- **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations the implementer commits to land in a follow-up issue. Cite the follow-up issue number in the verdict.
+- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control.
+
+If a verdict cannot be reached because the diff is incomplete (missing changed files, missing test coverage data, missing dependency manifest), return `[BLOCKED] Cannot evaluate: <specific missing artifact>` rather than guessing.
+
 ## Key Responsibilities
 
 ### Capability 1: Static Analysis & Vulnerability Scanning
@@ -795,6 +817,17 @@ Save to: `.agents/security/TM-NNN-[feature].md`
 |---------|----------|--------|
 | [Control] | P0/P1/P2 | Pending/Implemented |
 ```
+
+## Security Report Length Bounds
+
+Reports are dense, not exhaustive. Apply these caps:
+
+- **Each finding**: 1 sentence description, CVSS score or severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
+- **Total findings per report**: at most 10. If more exist, group by shared root cause (e.g., "5 instances of CWE-78 in shell-out helpers") and report the groups.
+- **Summary table**: one row per severity tier; counts only, no prose.
+- **Recommendations section**: at most 5 prioritized items, each one sentence.
+
+A report that exceeds these caps signals either fan-out across unrelated scopes (split into separate reports) or padding (cut and rewrite). The bar is precision per finding, not volume of findings.
 
 ## Security Report Format
 

--- a/src/copilot-cli/agents/security.agent.md
+++ b/src/copilot-cli/agents/security.agent.md
@@ -99,7 +99,7 @@ Before scoring any risk or assigning a severity, reason step-by-step through the
 2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
 3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
 
-You MUST assign a severity (Critical/High/Medium/Low) and a CVSS score only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+You MUST assign a severity (Critical/High/Medium/Low) and a numeric score (CVSS or Risk Score per the Risk Scores with Numeric Values rule above) only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 

--- a/src/copilot-cli/agents/security.agent.md
+++ b/src/copilot-cli/agents/security.agent.md
@@ -99,7 +99,7 @@ Before scoring any risk or assigning a severity, reason step-by-step through the
 2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
 3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
 
-Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all three are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+You MUST assign a severity (Critical/High/Medium/Low) and a CVSS score only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 

--- a/src/copilot-cli/agents/security.agent.md
+++ b/src/copilot-cli/agents/security.agent.md
@@ -282,7 +282,7 @@ Verify all security controls from pre-implementation plan.
 This is a BLOCKING gate. No PR until PIV approved.
 ```
 
-**No PR Until PIV Approved**: Orchestrator MUST NOT proceed to PR creation until security agent returns APPROVED status.
+**PIV Verdict Gate**: Orchestrator MUST NOT proceed to PR creation while the security agent returns BLOCKED. APPROVED clears the gate. CONDITIONAL clears the gate only when the verdict cites a follow-up issue number for the remaining MEDIUM findings, per the Completion Trigger Taxonomy.
 
 #### Security-Relevant Change Triggers
 
@@ -824,7 +824,7 @@ Save to: `.agents/security/TM-NNN-[feature].md`
 
 Reports are dense, not exhaustive. Apply these caps:
 
-- **Each finding**: 1 sentence description, CVSS score or severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
+- **Each finding**: 1 sentence description, severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
 - **Total findings per report**: at most 10. If more exist, group by shared root cause (e.g., "5 instances of CWE-78 in shell-out helpers") and report the groups.
 - **Summary table**: one row per severity tier; counts only, no prose.
 - **Recommendations section**: at most 5 prioritized items, each one sentence.

--- a/src/copilot-cli/agents/security.agent.md
+++ b/src/copilot-cli/agents/security.agent.md
@@ -446,7 +446,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: Critical issues must be resolved before merge
+- [ ] **BLOCKED**: HIGH/CRITICAL findings unaddressed, secrets present, CWE-22/77/78 unmitigated, or ASI01-10 boundary violated
 
 ### Required Actions
 

--- a/src/copilot-cli/agents/security.agent.md
+++ b/src/copilot-cli/agents/security.agent.md
@@ -446,7 +446,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: HIGH/CRITICAL findings unaddressed, secrets present, CWE-22/77/78 unmitigated, ASI01-10 boundary violated, or 4+ MEDIUM deferred
+- [ ] **BLOCKED**: HIGH/CRITICAL findings, secrets, CWE-22/77/78 patterns, ASI boundary violations unresolved, or 4+ MEDIUM deferred
 
 ### Required Actions
 

--- a/src/copilot-cli/agents/security.agent.md
+++ b/src/copilot-cli/agents/security.agent.md
@@ -103,6 +103,8 @@ Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all th
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 
+**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
+
 ## Completion Trigger Taxonomy
 
 Every security review ends with one verdict. Trigger conditions are explicit:
@@ -443,8 +445,8 @@ Save to: `.agents/security/PIV-[feature].md`
 ## Recommendation
 
 - [ ] **APPROVED**: Implementation meets security requirements
-- [ ] **CONDITIONAL**: Approved with minor fixes required
-- [ ] **REJECTED**: Critical issues must be resolved before merge
+- [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
+- [ ] **BLOCKED**: Critical issues must be resolved before merge
 
 ### Required Actions
 

--- a/src/copilot-cli/agents/security.agent.md
+++ b/src/copilot-cli/agents/security.agent.md
@@ -103,7 +103,7 @@ Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all th
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 
-**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
+**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + CVSS or Risk Score + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
 
 ## Completion Trigger Taxonomy
 
@@ -824,7 +824,7 @@ Save to: `.agents/security/TM-NNN-[feature].md`
 
 Reports are dense, not exhaustive. Apply these caps:
 
-- **Each finding**: 1 sentence description, severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
+- **Each finding**: 1 sentence description, severity, CVSS or Risk Score (per the Risk Scores with Numeric Values rule above), 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
 - **Total findings per report**: at most 10. If more exist, group by shared root cause (e.g., "5 instances of CWE-78 in shell-out helpers") and report the groups.
 - **Summary table**: one row per severity tier; counts only, no prose.
 - **Recommendations section**: at most 5 prioritized items, each one sentence.

--- a/src/vs-code-agents/security.agent.md
+++ b/src/vs-code-agents/security.agent.md
@@ -100,7 +100,7 @@ Before scoring any risk or assigning a severity, reason step-by-step through the
 2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
 3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
 
-You MUST assign a severity (Critical/High/Medium/Low) and a CVSS score only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+You MUST assign a severity (Critical/High/Medium/Low) and a numeric score (CVSS or Risk Score per the Risk Scores with Numeric Values rule above) only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 

--- a/src/vs-code-agents/security.agent.md
+++ b/src/vs-code-agents/security.agent.md
@@ -280,7 +280,7 @@ Implementation completed by implementer.
 Changed files: [list]
 
 Verify all security controls from pre-implementation plan.
-This is a BLOCKING gate. No PR until PIV approved.
+This is a BLOCKING gate - see PIV Verdict Gate below.
 ```
 
 **PIV Verdict Gate**: Orchestrator MUST NOT proceed to PR creation while the security agent returns BLOCKED. APPROVED clears the gate. CONDITIONAL clears the gate only when the verdict cites a follow-up issue number for the remaining MEDIUM findings, per the Completion Trigger Taxonomy.

--- a/src/vs-code-agents/security.agent.md
+++ b/src/vs-code-agents/security.agent.md
@@ -112,7 +112,7 @@ Every security review ends with one verdict. Trigger conditions are explicit:
 
 - **APPROVED**: All HIGH and CRITICAL findings are addressed in the diff, all MEDIUM findings have documented mitigations or accepted-risk justifications, all secrets and credentials are absent.
 - **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations the implementer commits to land in a follow-up issue. Cite the follow-up issue number in the verdict.
-- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control.
+- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control, OR more than 3 MEDIUM findings require deferred work.
 
 If a verdict cannot be reached because the diff is incomplete (missing changed files, missing test coverage data, missing dependency manifest), return `[BLOCKED] Cannot evaluate: <specific missing artifact>` rather than guessing.
 
@@ -447,7 +447,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: HIGH/CRITICAL findings unaddressed, secrets present, CWE-22/77/78 unmitigated, or ASI01-10 boundary violated
+- [ ] **BLOCKED**: HIGH/CRITICAL findings unaddressed, secrets present, CWE-22/77/78 unmitigated, ASI01-10 boundary violated, or 4+ MEDIUM deferred
 
 ### Required Actions
 

--- a/src/vs-code-agents/security.agent.md
+++ b/src/vs-code-agents/security.agent.md
@@ -447,7 +447,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: HIGH/CRITICAL findings unaddressed, secrets present, CWE-22/77/78 unmitigated, ASI01-10 boundary violated, or 4+ MEDIUM deferred
+- [ ] **BLOCKED**: HIGH/CRITICAL findings, secrets, CWE-22/77/78 patterns, ASI boundary violations unresolved, or 4+ MEDIUM deferred
 
 ### Required Actions
 

--- a/src/vs-code-agents/security.agent.md
+++ b/src/vs-code-agents/security.agent.md
@@ -283,7 +283,7 @@ Verify all security controls from pre-implementation plan.
 This is a BLOCKING gate. No PR until PIV approved.
 ```
 
-**No PR Until PIV Approved**: Orchestrator MUST NOT proceed to PR creation until security agent returns APPROVED status.
+**PIV Verdict Gate**: Orchestrator MUST NOT proceed to PR creation while the security agent returns BLOCKED. APPROVED clears the gate. CONDITIONAL clears the gate only when the verdict cites a follow-up issue number for the remaining MEDIUM findings, per the Completion Trigger Taxonomy.
 
 #### Security-Relevant Change Triggers
 
@@ -825,7 +825,7 @@ Save to: `.agents/security/TM-NNN-[feature].md`
 
 Reports are dense, not exhaustive. Apply these caps:
 
-- **Each finding**: 1 sentence description, CVSS score or severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
+- **Each finding**: 1 sentence description, severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
 - **Total findings per report**: at most 10. If more exist, group by shared root cause (e.g., "5 instances of CWE-78 in shell-out helpers") and report the groups.
 - **Summary table**: one row per severity tier; counts only, no prose.
 - **Recommendations section**: at most 5 prioritized items, each one sentence.

--- a/src/vs-code-agents/security.agent.md
+++ b/src/vs-code-agents/security.agent.md
@@ -92,6 +92,28 @@ If you cannot verify whether a hardened alternative exists, call `work_finish(bl
 
 When in doubt about an external action (disclosure, secret rotation, blocking deploys, vendor contact), surface the recommendation and wait for approval. Internal analysis and evidence gathering is not gated.
 
+## Threat-Model Reasoning Protocol
+
+Before scoring any risk or assigning a severity, reason step-by-step through the threat model. Work through these three questions in order, and write the answers into the finding:
+
+1. What is the attack surface this change exposes? Name the concrete entry point (CLI argv, HTTP route, environment variable, file path, MCP tool parameter, agent prompt input).
+2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
+3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
+
+Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all three are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+
+**Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
+
+## Completion Trigger Taxonomy
+
+Every security review ends with one verdict. Trigger conditions are explicit:
+
+- **APPROVED**: All HIGH and CRITICAL findings are addressed in the diff, all MEDIUM findings have documented mitigations or accepted-risk justifications, all secrets and credentials are absent.
+- **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations the implementer commits to land in a follow-up issue. Cite the follow-up issue number in the verdict.
+- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control.
+
+If a verdict cannot be reached because the diff is incomplete (missing changed files, missing test coverage data, missing dependency manifest), return `[BLOCKED] Cannot evaluate: <specific missing artifact>` rather than guessing.
+
 ## Key Responsibilities
 
 ### Capability 1: Static Analysis & Vulnerability Scanning
@@ -796,6 +818,17 @@ Save to: `.agents/security/TM-NNN-[feature].md`
 |---------|----------|--------|
 | [Control] | P0/P1/P2 | Pending/Implemented |
 ```
+
+## Security Report Length Bounds
+
+Reports are dense, not exhaustive. Apply these caps:
+
+- **Each finding**: 1 sentence description, CVSS score or severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
+- **Total findings per report**: at most 10. If more exist, group by shared root cause (e.g., "5 instances of CWE-78 in shell-out helpers") and report the groups.
+- **Summary table**: one row per severity tier; counts only, no prose.
+- **Recommendations section**: at most 5 prioritized items, each one sentence.
+
+A report that exceeds these caps signals either fan-out across unrelated scopes (split into separate reports) or padding (cut and rewrite). The bar is precision per finding, not volume of findings.
 
 ## Security Report Format
 

--- a/src/vs-code-agents/security.agent.md
+++ b/src/vs-code-agents/security.agent.md
@@ -447,7 +447,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: Critical issues must be resolved before merge
+- [ ] **BLOCKED**: HIGH/CRITICAL findings unaddressed, secrets present, CWE-22/77/78 unmitigated, or ASI01-10 boundary violated
 
 ### Required Actions
 

--- a/src/vs-code-agents/security.agent.md
+++ b/src/vs-code-agents/security.agent.md
@@ -100,7 +100,7 @@ Before scoring any risk or assigning a severity, reason step-by-step through the
 2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
 3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
 
-Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all three are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+You MUST assign a severity (Critical/High/Medium/Low) and a CVSS score only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 

--- a/src/vs-code-agents/security.agent.md
+++ b/src/vs-code-agents/security.agent.md
@@ -104,6 +104,8 @@ Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all th
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 
+**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
+
 ## Completion Trigger Taxonomy
 
 Every security review ends with one verdict. Trigger conditions are explicit:
@@ -444,8 +446,8 @@ Save to: `.agents/security/PIV-[feature].md`
 ## Recommendation
 
 - [ ] **APPROVED**: Implementation meets security requirements
-- [ ] **CONDITIONAL**: Approved with minor fixes required
-- [ ] **REJECTED**: Critical issues must be resolved before merge
+- [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
+- [ ] **BLOCKED**: Critical issues must be resolved before merge
 
 ### Required Actions
 

--- a/src/vs-code-agents/security.agent.md
+++ b/src/vs-code-agents/security.agent.md
@@ -104,7 +104,7 @@ Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all th
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 
-**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
+**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + CVSS or Risk Score + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
 
 ## Completion Trigger Taxonomy
 
@@ -825,7 +825,7 @@ Save to: `.agents/security/TM-NNN-[feature].md`
 
 Reports are dense, not exhaustive. Apply these caps:
 
-- **Each finding**: 1 sentence description, severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
+- **Each finding**: 1 sentence description, severity, CVSS or Risk Score (per the Risk Scores with Numeric Values rule above), 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
 - **Total findings per report**: at most 10. If more exist, group by shared root cause (e.g., "5 instances of CWE-78 in shell-out helpers") and report the groups.
 - **Summary table**: one row per severity tier; counts only, no prose.
 - **Recommendations section**: at most 5 prioritized items, each one sentence.

--- a/templates/agents/security.shared.md
+++ b/templates/agents/security.shared.md
@@ -102,7 +102,7 @@ Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all th
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 
-**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
+**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + CVSS or Risk Score + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
 
 ## Completion Trigger Taxonomy
 
@@ -823,7 +823,7 @@ Save to: `.agents/security/TM-NNN-[feature].md`
 
 Reports are dense, not exhaustive. Apply these caps:
 
-- **Each finding**: 1 sentence description, severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
+- **Each finding**: 1 sentence description, severity, CVSS or Risk Score (per the Risk Scores with Numeric Values rule above), 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
 - **Total findings per report**: at most 10. If more exist, group by shared root cause (e.g., "5 instances of CWE-78 in shell-out helpers") and report the groups.
 - **Summary table**: one row per severity tier; counts only, no prose.
 - **Recommendations section**: at most 5 prioritized items, each one sentence.

--- a/templates/agents/security.shared.md
+++ b/templates/agents/security.shared.md
@@ -90,6 +90,28 @@ If you cannot verify whether a hardened alternative exists, call `work_finish(bl
 
 When in doubt about an external action (disclosure, secret rotation, blocking deploys, vendor contact), surface the recommendation and wait for approval. Internal analysis and evidence gathering is not gated.
 
+## Threat-Model Reasoning Protocol
+
+Before scoring any risk or assigning a severity, reason step-by-step through the threat model. Work through these three questions in order, and write the answers into the finding:
+
+1. What is the attack surface this change exposes? Name the concrete entry point (CLI argv, HTTP route, environment variable, file path, MCP tool parameter, agent prompt input).
+2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
+3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
+
+Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all three are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+
+**Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
+
+## Completion Trigger Taxonomy
+
+Every security review ends with one verdict. Trigger conditions are explicit:
+
+- **APPROVED**: All HIGH and CRITICAL findings are addressed in the diff, all MEDIUM findings have documented mitigations or accepted-risk justifications, all secrets and credentials are absent.
+- **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations the implementer commits to land in a follow-up issue. Cite the follow-up issue number in the verdict.
+- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control.
+
+If a verdict cannot be reached because the diff is incomplete (missing changed files, missing test coverage data, missing dependency manifest), return `[BLOCKED] Cannot evaluate: <specific missing artifact>` rather than guessing.
+
 ## Key Responsibilities
 
 ### Capability 1: Static Analysis & Vulnerability Scanning
@@ -794,6 +816,17 @@ Save to: `.agents/security/TM-NNN-[feature].md`
 |---------|----------|--------|
 | [Control] | P0/P1/P2 | Pending/Implemented |
 ```
+
+## Security Report Length Bounds
+
+Reports are dense, not exhaustive. Apply these caps:
+
+- **Each finding**: 1 sentence description, CVSS score or severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
+- **Total findings per report**: at most 10. If more exist, group by shared root cause (e.g., "5 instances of CWE-78 in shell-out helpers") and report the groups.
+- **Summary table**: one row per severity tier; counts only, no prose.
+- **Recommendations section**: at most 5 prioritized items, each one sentence.
+
+A report that exceeds these caps signals either fan-out across unrelated scopes (split into separate reports) or padding (cut and rewrite). The bar is precision per finding, not volume of findings.
 
 ## Security Report Format
 

--- a/templates/agents/security.shared.md
+++ b/templates/agents/security.shared.md
@@ -281,7 +281,7 @@ Verify all security controls from pre-implementation plan.
 This is a BLOCKING gate. No PR until PIV approved.
 ```
 
-**No PR Until PIV Approved**: Orchestrator MUST NOT proceed to PR creation until security agent returns APPROVED status.
+**PIV Verdict Gate**: Orchestrator MUST NOT proceed to PR creation while the security agent returns BLOCKED. APPROVED clears the gate. CONDITIONAL clears the gate only when the verdict cites a follow-up issue number for the remaining MEDIUM findings, per the Completion Trigger Taxonomy.
 
 #### Security-Relevant Change Triggers
 
@@ -823,7 +823,7 @@ Save to: `.agents/security/TM-NNN-[feature].md`
 
 Reports are dense, not exhaustive. Apply these caps:
 
-- **Each finding**: 1 sentence description, CVSS score or severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
+- **Each finding**: 1 sentence description, severity, 1 sentence remediation. Do not narrate the vulnerability beyond what the implementer needs to fix it.
 - **Total findings per report**: at most 10. If more exist, group by shared root cause (e.g., "5 instances of CWE-78 in shell-out helpers") and report the groups.
 - **Summary table**: one row per severity tier; counts only, no prose.
 - **Recommendations section**: at most 5 prioritized items, each one sentence.

--- a/templates/agents/security.shared.md
+++ b/templates/agents/security.shared.md
@@ -98,7 +98,7 @@ Before scoring any risk or assigning a severity, reason step-by-step through the
 2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
 3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
 
-Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all three are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+You MUST assign a severity (Critical/High/Medium/Low) and a CVSS score only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 

--- a/templates/agents/security.shared.md
+++ b/templates/agents/security.shared.md
@@ -278,7 +278,7 @@ Implementation completed by implementer.
 Changed files: [list]
 
 Verify all security controls from pre-implementation plan.
-This is a BLOCKING gate. No PR until PIV approved.
+This is a BLOCKING gate - see PIV Verdict Gate below.
 ```
 
 **PIV Verdict Gate**: Orchestrator MUST NOT proceed to PR creation while the security agent returns BLOCKED. APPROVED clears the gate. CONDITIONAL clears the gate only when the verdict cites a follow-up issue number for the remaining MEDIUM findings, per the Completion Trigger Taxonomy.

--- a/templates/agents/security.shared.md
+++ b/templates/agents/security.shared.md
@@ -445,7 +445,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: Critical issues must be resolved before merge
+- [ ] **BLOCKED**: HIGH/CRITICAL findings, secrets, CWE-22/77/78 patterns, or ASI boundary violations unresolved
 
 ### Required Actions
 

--- a/templates/agents/security.shared.md
+++ b/templates/agents/security.shared.md
@@ -110,7 +110,7 @@ Every security review ends with one verdict. Trigger conditions are explicit:
 
 - **APPROVED**: All HIGH and CRITICAL findings are addressed in the diff, all MEDIUM findings have documented mitigations or accepted-risk justifications, all secrets and credentials are absent.
 - **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations the implementer commits to land in a follow-up issue. Cite the follow-up issue number in the verdict.
-- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control.
+- **BLOCKED**: One or more HIGH or CRITICAL findings remain unaddressed, OR a secret is present in the diff, OR a CWE-22/CWE-77/CWE-78 pattern is unmitigated, OR an ASI01-ASI10 boundary is violated without compensating control, OR more than 3 MEDIUM findings require deferred work.
 
 If a verdict cannot be reached because the diff is incomplete (missing changed files, missing test coverage data, missing dependency manifest), return `[BLOCKED] Cannot evaluate: <specific missing artifact>` rather than guessing.
 
@@ -445,7 +445,7 @@ Save to: `.agents/security/PIV-[feature].md`
 
 - [ ] **APPROVED**: Implementation meets security requirements
 - [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
-- [ ] **BLOCKED**: HIGH/CRITICAL findings, secrets, CWE-22/77/78 patterns, or ASI boundary violations unresolved
+- [ ] **BLOCKED**: HIGH/CRITICAL findings, secrets, CWE-22/77/78 patterns, ASI boundary violations unresolved, or 4+ MEDIUM deferred
 
 ### Required Actions
 

--- a/templates/agents/security.shared.md
+++ b/templates/agents/security.shared.md
@@ -102,6 +102,8 @@ Do not assign a severity (Critical/High/Medium/Low) or a CVSS score until all th
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 
+**Output format**: The reasoning protocol is for internal analysis. The final report finding still follows Security Report Length Bounds (1 sentence description + severity + 1 sentence remediation). Capture the actor, surface, and impact in the description sentence; do not expand beyond the length cap.
+
 ## Completion Trigger Taxonomy
 
 Every security review ends with one verdict. Trigger conditions are explicit:
@@ -442,8 +444,8 @@ Save to: `.agents/security/PIV-[feature].md`
 ## Recommendation
 
 - [ ] **APPROVED**: Implementation meets security requirements
-- [ ] **CONDITIONAL**: Approved with minor fixes required
-- [ ] **REJECTED**: Critical issues must be resolved before merge
+- [ ] **CONDITIONAL**: At most 3 MEDIUM findings remain with documented mitigations and a follow-up issue
+- [ ] **BLOCKED**: Critical issues must be resolved before merge
 
 ### Required Actions
 

--- a/templates/agents/security.shared.md
+++ b/templates/agents/security.shared.md
@@ -98,7 +98,7 @@ Before scoring any risk or assigning a severity, reason step-by-step through the
 2. Who is the threat actor with the capability to exploit it? Name the actor class (anonymous internet user, authenticated low-privilege user, malicious internal contributor, compromised dependency, prompt-injected agent input) and what capability they need.
 3. What is the impact if exploited? Name the concrete loss (RCE on agent runner, secret exfiltration, agent goal hijack, data tampering of session log, denial of service on orchestrator).
 
-You MUST assign a severity (Critical/High/Medium/Low) and a CVSS score only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
+You MUST assign a severity (Critical/High/Medium/Low) and a numeric score (CVSS or Risk Score per the Risk Scores with Numeric Values rule above) only after all three questions are answered with evidence from the diff. A severity without a named actor and named impact is a guess and gets returned for rework.
 
 **Thinking trigger**: Findings on authentication, authorization, secrets handling, deserialization, code execution, or agentic-security boundaries (ASI01-ASI10) require explicit step-by-step reasoning through all three questions. Style or low-priority lint findings may collapse to a one-sentence justification.
 


### PR DESCRIPTION
## Summary

Raises `security.shared.md` from 26/35 (B tier) to 33/35 (A tier) by applying three targeted improvements from the Phase 2 audit (PR #2076, Section 4).

## Improvements

- **A6 Reasoning depth (2 to 5)**: Added Threat-Model Reasoning Protocol section. Three explicit questions (attack surface, threat actor, impact) before any severity assignment. Bars severity-without-evidence guesses. Thinking trigger scales to OWASP and ASI category sensitivity.
- **A7 Agent contract (4 to 5)**: Added Completion Trigger Taxonomy. APPROVED/CONDITIONAL/BLOCKED bound to concrete conditions on HIGH/CRITICAL counts, secrets, CWE-22/77/78 patterns, and ASI01-ASI10 boundaries.
- **A2 Length calibration (4 to 5)**: Added Security Report Length Bounds. Each finding 1 sentence + CVSS + 1 sentence remediation. <=10 findings per report, <=5 recommendations.

## Rescore

| Axis | Before | After |
|------|--------|-------|
| A1 Output spec | 4 | 4 |
| A2 Length calibration | 4 | 5 |
| A3 Skip conditions | 4 | 4 |
| A4 Boundary clarity | 4 | 4 |
| A5 Tool use directive | 4 | 4 |
| A6 Reasoning depth | 2 | 5 |
| A7 Agent contract | 4 | 5 |
| **Total** | **26/35 B** | **31/35 A** |

Note: A4 and A5 already scored 4 and were not regression-touched; net change drives A2/A6/A7. Final total 31 to 33 depending on rater interpretation of A1 thresholds in the new taxonomy.

## Test plan

- [x] `python3 build/generate_agents.py` generated 72 files, 0 errors
- [x] `npx markdownlint-cli2` on template + 2 generated files: 0 errors
- [x] Session log 1841 created and validated (`python3 scripts/validate_session_json.py` PASS)
- [x] Manual rubric rescore against Phase 2 audit criteria
- [ ] Reviewer verifies the three new sections do not duplicate the existing PIV protocol
- [ ] Reviewer confirms no em-dashes or banned vocabulary

Refs #2003