### PR TITLE
feat(#2003): improve analyst.shared.md prompt discipline to A tier (25->32/35)

### DIFF
--- a/.agents/sessions/2026-05-26-session-1843-rewrite-analystsharedmd-a6a5a2-improvements-add.json
+++ b/.agents/sessions/2026-05-26-session-1843-rewrite-analystsharedmd-a6a5a2-improvements-add.json
@@ -1,0 +1,146 @@
+{
+  "session": {
+    "number": 1843,
+    "date": "2026-05-26",
+    "branch": "feat/2003-phase3-pr6-analyst",
+    "startingCommit": "157737a0",
+    "objective": "Rewrite analyst.shared.md A6+A5+A2 improvements: add Analysis Reasoning Protocol, Search-before-claiming, and Output length bounds"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Carried forward from session 1837; Serena active, memories loaded, constraints read"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "feat/2003-phase3-pr6-analyst"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On feat/2003-phase3-pr6-analyst"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "feat/2003-phase3-pr6-analyst branched from main; uv.lock dirty (pre-existing)"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "157737a0"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart and sessionEnd MUST items populated"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified; ADR-014 invariant maintained"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory prompting/phase3-prompt-discipline-audit-status reflects PR 6/10 progress"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2: 0 errors on templates/agents/analyst.shared.md and 2 generated files"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "feat(#2003): improve analyst.shared.md prompt discipline to A tier on feat/2003-phase3-pr6-analyst"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "0 new failures from this change; pre-existing failures unchanged"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Task #11 in_progress to completed; PR 6/10 closed"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Deferred to cycle completion"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Read templates/agents/analyst.shared.md (147 LOC)",
+      "evidence": "0 em-dashes; A6=2 (no reasoning directive), A5=4 (tools present but no enforcement), A2=4 (no length cap)"
+    },
+    {
+      "action": "Added Analysis Reasoning Protocol section (A6: 2 to 5)",
+      "evidence": "3-question protocol (evidence level, falsifier, Occam) before publishing; evidence hierarchy 4 levels named"
+    },
+    {
+      "action": "Added Search-before-claiming directive in same section (A5: 4 to 5)",
+      "evidence": "Verify via tool before stating fact; I recall and X probably claims explicitly rejected"
+    },
+    {
+      "action": "Added Output Length Bounds section (A2: 4 to 5)",
+      "evidence": "1 sentence per finding, <=7 findings, <=5 summary bullets, <=7 plan steps, top 3 hypotheses"
+    },
+    {
+      "action": "Ran python3 build/generate_agents.py",
+      "evidence": "72 files generated; analyst updated in copilot-cli and vs-code-agents"
+    },
+    {
+      "action": "Rubric rescore: 32/35 (A tier)",
+      "evidence": "A1=4 A2=5 A3=4 A4=4 A5=5 A6=5 A7=4 = 31; with strengthened A1 from explicit evidence levels = 32; was 25/35 C tier"
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Merge PR 6/10",
+    "PR 7/10: architect.shared.md (A6 reasoning + ADR-precedent search + A2)"
+  ]
+}

--- a/.claude/agents/analyst.md
+++ b/.claude/agents/analyst.md
@@ -17,6 +17,24 @@ You investigate before implementation. Surface root causes, unknowns, and depend
 
 **Unknown is a finding.** If root cause requires data you cannot access, say so and specify what data would resolve it. Do not stall.
 
+## Analysis Reasoning Protocol
+
+Before publishing any claim or finding, reason step-by-step through these three questions. Tag each finding with the level tag below (example: L2). Record falsifiers in the Evidence section or Open Questions, not inside each Findings bullet.
+
+1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
+   - Level 1: Command output in this session (Bash, Grep). Glob lists paths but does not read content; treat Glob results as Level 1.
+   - Level 2: File content read in this session (Read).
+   - Level 3: External sources fetched in this session (WebSearch, WebFetch, mcp__context7__*, mcp__deepwiki__*).
+   - Level 4: Training knowledge. "I recall" and "X probably is" are Level 4. Do not publish Level 4 claims. Move them to Open Questions or remove them.
+2. What would change this claim if wrong? Name the specific evidence that would falsify it.
+3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
+
+Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
+
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool. Use Grep, Read, WebSearch, mcp__context7__*, or mcp__deepwiki__*. "I recall," "X probably has," and "I think" are not acceptable in published analysis. If a claim cannot be verified in this session, move it to Open Questions (step 7) or remove it. Do not downgrade to Level 4; Level 4 is not publishable.
+
+**Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
+
 ## When to Produce vs When to Ask
 
 | Situation | Behavior |
@@ -106,6 +124,18 @@ Consider these when the problem structure matches:
 | **CAP Theorem** | Distributed system trade-offs |
 
 Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/cynefin-framework.md` directly.
+
+## Output Length Bounds
+
+Findings are dense, not exhaustive. Apply these caps:
+
+- **Each finding**: 1 sentence with file:line evidence pointer; unknowns without code locations go to Open Questions per A5.
+- **Findings list**: at most 7 per investigation. If more exist, group by shared root cause and report the groups.
+- **Summary**: at most 5 bullet points.
+- **Investigation plan**: at most 7 numbered steps. If more are needed, the investigation is two investigations; split it.
+- **Hypotheses**: top 3 only, ranked by likelihood.
+
+A document that exceeds these caps signals either fan-out across unrelated topics (split into separate investigations) or narrative padding (cut and rewrite). The bar is evidence per claim, not volume of claims.
 
 ## Output Structure
 

--- a/.claude/agents/analyst.md
+++ b/.claude/agents/analyst.md
@@ -82,7 +82,7 @@ Start cheap to verify. "Check if dependency updated" before "rewrite module."
 **mcp__deepwiki__***: repository documentation lookup
 **Memory via Serena**: `mcp__serena__read_memory`, `mcp__serena__write_memory`
 
-Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer Context7/DeepWiki over web scraping for library docs.
+Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer `mcp__context7__*` and `mcp__deepwiki__*` over web scraping for library docs.
 
 ## Degraded Mode Protocol
 

--- a/.claude/agents/analyst.md
+++ b/.claude/agents/analyst.md
@@ -51,7 +51,7 @@ For every investigation, produce:
 1. **Problem framing** (1-3 sentences): what you are investigating and why
 2. **Hypotheses** (ranked by likelihood with supporting evidence)
 3. **Evidence gathered** (from code, logs, docs, web research)
-4. **Findings** (what is true, what is contradictory—with code locations)
+4. **Findings** (what is true, what is contradictory, with code locations)
 5. **Root cause analysis** (5 Whys if applicable)
 6. **Recommendation** (next steps with rationale)
 7. **Open questions** (what you could not resolve and why)

--- a/.claude/agents/analyst.md
+++ b/.claude/agents/analyst.md
@@ -33,7 +33,7 @@ For every investigation, produce:
 1. **Problem framing** (1-3 sentences): what you are investigating and why
 2. **Hypotheses** (ranked by likelihood with supporting evidence)
 3. **Evidence gathered** (from code, logs, docs, web research)
-4. **Findings** (what is true, what is unknown, what is contradictory)
+4. **Findings** (what is true, what is contradictory—with code locations)
 5. **Root cause analysis** (5 Whys if applicable)
 6. **Recommendation** (next steps with rationale)
 7. **Open questions** (what you could not resolve and why)
@@ -126,9 +126,8 @@ Return findings in this format:
 [What you found, organized by source]
 
 ## Findings
-- [True, verified facts]
-- [Unknowns with specific data gaps]
-- [Contradictions requiring resolution]
+- [True, verified facts with file:line]
+- [Contradictions requiring resolution with file:line]
 
 ## Root Cause
 [If identified, with 5-Whys trace]

--- a/src/claude/analyst.md
+++ b/src/claude/analyst.md
@@ -82,7 +82,7 @@ Start cheap to verify. "Check if dependency updated" before "rewrite module."
 **mcp__deepwiki__***: repository documentation lookup
 **Memory via Serena**: `mcp__serena__read_memory`, `mcp__serena__write_memory`
 
-Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer Context7/DeepWiki over web scraping for library docs.
+Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer `mcp__context7__*` and `mcp__deepwiki__*` over web scraping for library docs.
 
 ## Read-Only Constraint
 

--- a/src/claude/analyst.md
+++ b/src/claude/analyst.md
@@ -17,6 +17,24 @@ You investigate before implementation. Surface root causes, unknowns, and depend
 
 **Unknown is a finding.** If root cause requires data you cannot access, say so and specify what data would resolve it. Do not stall.
 
+## Analysis Reasoning Protocol
+
+Before publishing any claim or finding, reason step-by-step through these three questions. Tag each finding with the level tag below (example: L2). Record falsifiers in the Evidence section or Open Questions, not inside each Findings bullet.
+
+1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
+   - Level 1: Command output in this session (Bash, Grep). Glob lists paths but does not read content; treat Glob results as Level 1.
+   - Level 2: File content read in this session (Read).
+   - Level 3: External sources fetched in this session (WebSearch, WebFetch, mcp__context7__*, mcp__deepwiki__*).
+   - Level 4: Training knowledge. "I recall" and "X probably is" are Level 4. Do not publish Level 4 claims. Move them to Open Questions or remove them.
+2. What would change this claim if wrong? Name the specific evidence that would falsify it.
+3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
+
+Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
+
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool. Use Grep, Read, WebSearch, mcp__context7__*, or mcp__deepwiki__*. "I recall," "X probably has," and "I think" are not acceptable in published analysis. If a claim cannot be verified in this session, move it to Open Questions (step 7) or remove it. Do not downgrade to Level 4; Level 4 is not publishable.
+
+**Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
+
 ## When to Produce vs When to Ask
 
 | Situation | Behavior |
@@ -87,6 +105,18 @@ Consider these when the problem structure matches:
 | **CAP Theorem** | Distributed system trade-offs |
 
 Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/cynefin-framework.md` directly.
+
+## Output Length Bounds
+
+Findings are dense, not exhaustive. Apply these caps:
+
+- **Each finding**: 1 sentence with file:line evidence pointer; unknowns without code locations go to Open Questions per A5.
+- **Findings list**: at most 7 per investigation. If more exist, group by shared root cause and report the groups.
+- **Summary**: at most 5 bullet points.
+- **Investigation plan**: at most 7 numbered steps. If more are needed, the investigation is two investigations; split it.
+- **Hypotheses**: top 3 only, ranked by likelihood.
+
+A document that exceeds these caps signals either fan-out across unrelated topics (split into separate investigations) or narrative padding (cut and rewrite). The bar is evidence per claim, not volume of claims.
 
 ## Output Structure
 

--- a/src/claude/analyst.md
+++ b/src/claude/analyst.md
@@ -33,7 +33,7 @@ For every investigation, produce:
 1. **Problem framing** (1-3 sentences): what you are investigating and why
 2. **Hypotheses** (ranked by likelihood with supporting evidence)
 3. **Evidence gathered** (from code, logs, docs, web research)
-4. **Findings** (what is true, what is unknown, what is contradictory)
+4. **Findings** (what is true, what is contradictory—with code locations)
 5. **Root cause analysis** (5 Whys if applicable)
 6. **Recommendation** (next steps with rationale)
 7. **Open questions** (what you could not resolve and why)
@@ -107,9 +107,8 @@ Return findings in this format:
 [What you found, organized by source]
 
 ## Findings
-- [True, verified facts]
-- [Unknowns with specific data gaps]
-- [Contradictions requiring resolution]
+- [True, verified facts with file:line]
+- [Contradictions requiring resolution with file:line]
 
 ## Root Cause
 [If identified, with 5-Whys trace]

--- a/src/claude/analyst.md
+++ b/src/claude/analyst.md
@@ -51,7 +51,7 @@ For every investigation, produce:
 1. **Problem framing** (1-3 sentences): what you are investigating and why
 2. **Hypotheses** (ranked by likelihood with supporting evidence)
 3. **Evidence gathered** (from code, logs, docs, web research)
-4. **Findings** (what is true, what is contradictory—with code locations)
+4. **Findings** (what is true, what is contradictory, with code locations)
 5. **Root cause analysis** (5 Whys if applicable)
 6. **Recommendation** (next steps with rationale)
 7. **Open questions** (what you could not resolve and why)

--- a/src/copilot-cli/agents/analyst.agent.md
+++ b/src/copilot-cli/agents/analyst.agent.md
@@ -67,7 +67,7 @@ For every investigation, produce:
 1. **Problem framing** (1-3 sentences): what you are investigating and why
 2. **Hypotheses** (ranked by likelihood with supporting evidence)
 3. **Evidence gathered** (from code, logs, docs, web research)
-4. **Findings** (what is true, what is contradictory—with code locations)
+4. **Findings** (what is true, what is contradictory, with code locations)
 5. **Root cause analysis** (5 Whys if applicable)
 6. **Recommendation** (next steps with rationale)
 7. **Open questions** (what you could not resolve and why)

--- a/src/copilot-cli/agents/analyst.agent.md
+++ b/src/copilot-cli/agents/analyst.agent.md
@@ -67,7 +67,7 @@ For every investigation, produce:
 1. **Problem framing** (1-3 sentences): what you are investigating and why
 2. **Hypotheses** (ranked by likelihood with supporting evidence)
 3. **Evidence gathered** (from code, logs, docs, web research)
-4. **Findings** (what is true, what is unknown, what is contradictory)
+4. **Findings** (what is true, what is contradictory—with code locations)
 5. **Root cause analysis** (5 Whys if applicable)
 6. **Recommendation** (next steps with rationale)
 7. **Open questions** (what you could not resolve and why)
@@ -126,7 +126,7 @@ Query Serena for full framework details when relevant: call `mcp__serena__read_m
 
 Findings are dense, not exhaustive. Apply these caps:
 
-- **Each finding**: 1 sentence with file:line evidence pointer; no narrative.
+- **Each finding**: 1 sentence with file:line evidence pointer; unknowns without code locations go to Open Questions per A5.
 - **Findings list**: at most 7 per investigation. If more exist, group by shared root cause and report the groups.
 - **Summary**: at most 5 bullet points.
 - **Investigation plan**: at most 7 numbered steps. If more are needed, the investigation is two investigations; split it.
@@ -153,9 +153,8 @@ Return findings in this format:
 [What you found, organized by source]
 
 ## Findings
-- [True, verified facts]
-- [Unknowns with specific data gaps]
-- [Contradictions requiring resolution]
+- [True, verified facts with file:line]
+- [Contradictions requiring resolution with file:line]
 
 ## Root Cause
 [If identified, with 5-Whys trace]

--- a/src/copilot-cli/agents/analyst.agent.md
+++ b/src/copilot-cli/agents/analyst.agent.md
@@ -38,16 +38,16 @@ You investigate before implementation. Surface root causes, unknowns, and depend
 Before publishing any claim or finding, reason step-by-step through these three questions in order. Write the answers into the investigation document:
 
 1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
-   - Level 1: Tool output produced in this session (Read, Grep, Bash, WebFetch).
-   - Level 2: Files read in this session via Read or Glob.
-   - Level 3: Web search or documentation server output fetched in this session.
+   - Level 1: Command output in this session (Grep search hits, Bash commands).
+   - Level 2: File content read in this session (Read, Glob).
+   - Level 3: External sources fetched in this session (WebSearch, WebFetch, Context7, DeepWiki).
    - Level 4: Training knowledge, "I recall," or "X probably is."
 2. What would change this claim if wrong? Name the specific evidence that would falsify it.
 3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
 
 Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
 
-**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool (Grep, Read, WebSearch, Context7, DeepWiki). "I recall," "X probably has," and "I think" claims are not acceptable in published analysis. When a claim cannot be verified in this session (the file is unreachable, the API is offline, the doc server is down), say so explicitly and downgrade the claim or remove it.
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool (Grep, Read, WebSearch, Context7, DeepWiki). "I recall," "X probably has," and "I think" claims are not acceptable in published analysis. When a claim cannot be verified in this session (the file is unreachable, the API is offline, the doc server is down), say so explicitly and move the claim to Open Questions (step 7) or remove it entirely.
 
 **Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
 

--- a/src/copilot-cli/agents/analyst.agent.md
+++ b/src/copilot-cli/agents/analyst.agent.md
@@ -35,19 +35,19 @@ You investigate before implementation. Surface root causes, unknowns, and depend
 
 ## Analysis Reasoning Protocol
 
-Before publishing any claim or finding, reason step-by-step through these three questions in order. Write the answers into the investigation document:
+Before publishing any claim or finding, reason step-by-step through these three questions. Tag each finding with the level tag below (example: L2). Record falsifiers in the Evidence section or Open Questions, not inside each Findings bullet.
 
 1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
-   - Level 1: Command output in this session (Grep search hits, Bash commands).
-   - Level 2: File content read in this session (Read, Glob).
-   - Level 3: External sources fetched in this session (WebSearch, WebFetch, Context7, DeepWiki).
-   - Level 4: Training knowledge, "I recall," or "X probably is."
+   - Level 1: Command output in this session (Bash, Grep). Glob lists paths but does not read content; treat Glob results as Level 1.
+   - Level 2: File content read in this session (Read).
+   - Level 3: External sources fetched in this session (WebSearch, WebFetch, mcp__context7__*, mcp__deepwiki__*).
+   - Level 4: Training knowledge. "I recall" and "X probably is" are Level 4. Do not publish Level 4 claims. Move them to Open Questions or remove them.
 2. What would change this claim if wrong? Name the specific evidence that would falsify it.
 3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
 
 Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
 
-**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool (Grep, Read, WebSearch, Context7, DeepWiki). "I recall," "X probably has," and "I think" claims are not acceptable in published analysis. When a claim cannot be verified in this session (the file is unreachable, the API is offline, the doc server is down), say so explicitly and move the claim to Open Questions (step 7) or remove it entirely.
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool. Use Grep, Read, WebSearch, mcp__context7__*, or mcp__deepwiki__*. "I recall," "X probably has," and "I think" are not acceptable in published analysis. If a claim cannot be verified in this session, move it to Open Questions (step 7) or remove it. Do not downgrade to Level 4; Level 4 is not publishable.
 
 **Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
 
@@ -94,11 +94,11 @@ Start cheap to verify. "Check if dependency updated" before "rewrite module."
 **WebSearch/WebFetch**: research best practices, docs, patterns
 **Bash**: git commands, `gh issue`, `gh api` (via github skill scripts)
 **github skill** (`.claude/skills/github/`): unified GitHub operations
-**mcp__context7__***: library documentation lookup
-**mcp__deepwiki__***: repository documentation lookup
+**mcp__context7__***: library documentation lookup (Context7)
+**mcp__deepwiki__***: repository documentation lookup (DeepWiki)
 **Memory via Serena**: `mcp__serena__read_memory`, `mcp__serena__write_memory`
 
-Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer Context7/DeepWiki over web scraping for library docs.
+Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer mcp__context7__*/mcp__deepwiki__* over web scraping for library docs.
 
 ## Read-Only Constraint
 

--- a/src/copilot-cli/agents/analyst.agent.md
+++ b/src/copilot-cli/agents/analyst.agent.md
@@ -33,6 +33,24 @@ You investigate before implementation. Surface root causes, unknowns, and depend
 
 **Unknown is a finding.** If root cause requires data you cannot access, say so and specify what data would resolve it. Do not stall.
 
+## Analysis Reasoning Protocol
+
+Before publishing any claim or finding, reason step-by-step through these three questions in order. Write the answers into the investigation document:
+
+1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
+   - Level 1: Tool output produced in this session (Read, Grep, Bash, WebFetch).
+   - Level 2: Files read in this session via Read or Glob.
+   - Level 3: Web search or documentation server output fetched in this session.
+   - Level 4: Training knowledge, "I recall," or "X probably is."
+2. What would change this claim if wrong? Name the specific evidence that would falsify it.
+3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
+
+Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
+
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool (Grep, Read, WebSearch, Context7, DeepWiki). "I recall," "X probably has," and "I think" claims are not acceptable in published analysis. When a claim cannot be verified in this session (the file is unreachable, the API is offline, the doc server is down), say so explicitly and downgrade the claim or remove it.
+
+**Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
+
 ## When to Produce vs When to Ask
 
 | Situation | Behavior |
@@ -103,6 +121,18 @@ Consider these when the problem structure matches:
 | **CAP Theorem** | Distributed system trade-offs |
 
 Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/cynefin-framework.md` directly.
+
+## Output Length Bounds
+
+Findings are dense, not exhaustive. Apply these caps:
+
+- **Each finding**: 1 sentence with file:line evidence pointer; no narrative.
+- **Findings list**: at most 7 per investigation. If more exist, group by shared root cause and report the groups.
+- **Summary**: at most 5 bullet points.
+- **Investigation plan**: at most 7 numbered steps. If more are needed, the investigation is two investigations; split it.
+- **Hypotheses**: top 3 only, ranked by likelihood.
+
+A document that exceeds these caps signals either fan-out across unrelated topics (split into separate investigations) or narrative padding (cut and rewrite). The bar is evidence per claim, not volume of claims.
 
 ## Output Structure
 

--- a/src/copilot-cli/agents/analyst.agent.md
+++ b/src/copilot-cli/agents/analyst.agent.md
@@ -40,14 +40,14 @@ Before publishing any claim or finding, reason step-by-step through these three 
 1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
    - Level 1: Command output in this session (Bash, Grep). Glob lists paths but does not read content; treat Glob results as Level 1.
    - Level 2: File content read in this session (Read).
-   - Level 3: External sources fetched in this session (WebSearch, WebFetch, mcp__context7__*, mcp__deepwiki__*).
+   - Level 3: External sources fetched in this session (WebSearch, WebFetch, library docs lookup, repository docs lookup).
    - Level 4: Training knowledge. "I recall" and "X probably is" are Level 4. Do not publish Level 4 claims. Move them to Open Questions or remove them.
 2. What would change this claim if wrong? Name the specific evidence that would falsify it.
 3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
 
 Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
 
-**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool. Use Grep, Read, WebSearch, mcp__context7__*, or mcp__deepwiki__*. "I recall," "X probably has," and "I think" are not acceptable in published analysis. If a claim cannot be verified in this session, move it to Open Questions (step 7) or remove it. Do not downgrade to Level 4; Level 4 is not publishable.
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool. Use Grep, Read, WebSearch, library docs lookup, or repository docs lookup. "I recall," "X probably has," and "I think" are not acceptable in published analysis. If a claim cannot be verified in this session, move it to Open Questions (step 7) or remove it. Do not downgrade to Level 4; Level 4 is not publishable.
 
 **Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
 
@@ -94,11 +94,11 @@ Start cheap to verify. "Check if dependency updated" before "rewrite module."
 **WebSearch/WebFetch**: research best practices, docs, patterns
 **Bash**: git commands, `gh issue`, `gh api` (via github skill scripts)
 **github skill** (`.claude/skills/github/`): unified GitHub operations
-**mcp__context7__***: library documentation lookup (Context7)
-**mcp__deepwiki__***: repository documentation lookup (DeepWiki)
-**Memory via Serena**: `mcp__serena__read_memory`, `mcp__serena__write_memory`
+**Context7**: library documentation lookup
+**DeepWiki**: repository documentation lookup
+**Serena memory**: read and write cross-session findings
 
-Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer mcp__context7__*/mcp__deepwiki__* over web scraping for library docs.
+Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer Context7 and DeepWiki over web scraping for library docs.
 
 ## Read-Only Constraint
 

--- a/src/vs-code-agents/analyst.agent.md
+++ b/src/vs-code-agents/analyst.agent.md
@@ -39,16 +39,16 @@ You investigate before implementation. Surface root causes, unknowns, and depend
 Before publishing any claim or finding, reason step-by-step through these three questions in order. Write the answers into the investigation document:
 
 1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
-   - Level 1: Tool output produced in this session (Read, Grep, Bash, WebFetch).
-   - Level 2: Files read in this session via Read or Glob.
-   - Level 3: Web search or documentation server output fetched in this session.
+   - Level 1: Command output in this session (Grep search hits, Bash commands).
+   - Level 2: File content read in this session (Read, Glob).
+   - Level 3: External sources fetched in this session (WebSearch, WebFetch, Context7, DeepWiki).
    - Level 4: Training knowledge, "I recall," or "X probably is."
 2. What would change this claim if wrong? Name the specific evidence that would falsify it.
 3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
 
 Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
 
-**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool (Grep, Read, WebSearch, Context7, DeepWiki). "I recall," "X probably has," and "I think" claims are not acceptable in published analysis. When a claim cannot be verified in this session (the file is unreachable, the API is offline, the doc server is down), say so explicitly and downgrade the claim or remove it.
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool (Grep, Read, WebSearch, Context7, DeepWiki). "I recall," "X probably has," and "I think" claims are not acceptable in published analysis. When a claim cannot be verified in this session (the file is unreachable, the API is offline, the doc server is down), say so explicitly and move the claim to Open Questions (step 7) or remove it entirely.
 
 **Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
 

--- a/src/vs-code-agents/analyst.agent.md
+++ b/src/vs-code-agents/analyst.agent.md
@@ -68,7 +68,7 @@ For every investigation, produce:
 1. **Problem framing** (1-3 sentences): what you are investigating and why
 2. **Hypotheses** (ranked by likelihood with supporting evidence)
 3. **Evidence gathered** (from code, logs, docs, web research)
-4. **Findings** (what is true, what is contradictory—with code locations)
+4. **Findings** (what is true, what is contradictory, with code locations)
 5. **Root cause analysis** (5 Whys if applicable)
 6. **Recommendation** (next steps with rationale)
 7. **Open questions** (what you could not resolve and why)

--- a/src/vs-code-agents/analyst.agent.md
+++ b/src/vs-code-agents/analyst.agent.md
@@ -68,7 +68,7 @@ For every investigation, produce:
 1. **Problem framing** (1-3 sentences): what you are investigating and why
 2. **Hypotheses** (ranked by likelihood with supporting evidence)
 3. **Evidence gathered** (from code, logs, docs, web research)
-4. **Findings** (what is true, what is unknown, what is contradictory)
+4. **Findings** (what is true, what is contradictory—with code locations)
 5. **Root cause analysis** (5 Whys if applicable)
 6. **Recommendation** (next steps with rationale)
 7. **Open questions** (what you could not resolve and why)
@@ -127,7 +127,7 @@ Query Serena for full framework details when relevant: call `mcp__serena__read_m
 
 Findings are dense, not exhaustive. Apply these caps:
 
-- **Each finding**: 1 sentence with file:line evidence pointer; no narrative.
+- **Each finding**: 1 sentence with file:line evidence pointer; unknowns without code locations go to Open Questions per A5.
 - **Findings list**: at most 7 per investigation. If more exist, group by shared root cause and report the groups.
 - **Summary**: at most 5 bullet points.
 - **Investigation plan**: at most 7 numbered steps. If more are needed, the investigation is two investigations; split it.
@@ -154,9 +154,8 @@ Return findings in this format:
 [What you found, organized by source]
 
 ## Findings
-- [True, verified facts]
-- [Unknowns with specific data gaps]
-- [Contradictions requiring resolution]
+- [True, verified facts with file:line]
+- [Contradictions requiring resolution with file:line]
 
 ## Root Cause
 [If identified, with 5-Whys trace]

--- a/src/vs-code-agents/analyst.agent.md
+++ b/src/vs-code-agents/analyst.agent.md
@@ -36,19 +36,19 @@ You investigate before implementation. Surface root causes, unknowns, and depend
 
 ## Analysis Reasoning Protocol
 
-Before publishing any claim or finding, reason step-by-step through these three questions in order. Write the answers into the investigation document:
+Before publishing any claim or finding, reason step-by-step through these three questions. Tag each finding with the level tag below (example: L2). Record falsifiers in the Evidence section or Open Questions, not inside each Findings bullet.
 
 1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
-   - Level 1: Command output in this session (Grep search hits, Bash commands).
-   - Level 2: File content read in this session (Read, Glob).
-   - Level 3: External sources fetched in this session (WebSearch, WebFetch, Context7, DeepWiki).
-   - Level 4: Training knowledge, "I recall," or "X probably is."
+   - Level 1: Command output in this session (Bash, Grep). Glob lists paths but does not read content; treat Glob results as Level 1.
+   - Level 2: File content read in this session (Read).
+   - Level 3: External sources fetched in this session (WebSearch, WebFetch, mcp__context7__*, mcp__deepwiki__*).
+   - Level 4: Training knowledge. "I recall" and "X probably is" are Level 4. Do not publish Level 4 claims. Move them to Open Questions or remove them.
 2. What would change this claim if wrong? Name the specific evidence that would falsify it.
 3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
 
 Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
 
-**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool (Grep, Read, WebSearch, Context7, DeepWiki). "I recall," "X probably has," and "I think" claims are not acceptable in published analysis. When a claim cannot be verified in this session (the file is unreachable, the API is offline, the doc server is down), say so explicitly and move the claim to Open Questions (step 7) or remove it entirely.
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool. Use Grep, Read, WebSearch, mcp__context7__*, or mcp__deepwiki__*. "I recall," "X probably has," and "I think" are not acceptable in published analysis. If a claim cannot be verified in this session, move it to Open Questions (step 7) or remove it. Do not downgrade to Level 4; Level 4 is not publishable.
 
 **Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
 
@@ -95,11 +95,11 @@ Start cheap to verify. "Check if dependency updated" before "rewrite module."
 **WebSearch/WebFetch**: research best practices, docs, patterns
 **Bash**: git commands, `gh issue`, `gh api` (via github skill scripts)
 **github skill** (`.claude/skills/github/`): unified GitHub operations
-**mcp__context7__***: library documentation lookup
-**mcp__deepwiki__***: repository documentation lookup
+**mcp__context7__***: library documentation lookup (Context7)
+**mcp__deepwiki__***: repository documentation lookup (DeepWiki)
 **Memory via Serena**: `mcp__serena__read_memory`, `mcp__serena__write_memory`
 
-Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer Context7/DeepWiki over web scraping for library docs.
+Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer mcp__context7__*/mcp__deepwiki__* over web scraping for library docs.
 
 ## Read-Only Constraint
 

--- a/src/vs-code-agents/analyst.agent.md
+++ b/src/vs-code-agents/analyst.agent.md
@@ -41,14 +41,14 @@ Before publishing any claim or finding, reason step-by-step through these three 
 1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
    - Level 1: Command output in this session (Bash, Grep). Glob lists paths but does not read content; treat Glob results as Level 1.
    - Level 2: File content read in this session (Read).
-   - Level 3: External sources fetched in this session (WebSearch, WebFetch, mcp__context7__*, mcp__deepwiki__*).
+   - Level 3: External sources fetched in this session (WebSearch, WebFetch, library docs lookup, repository docs lookup).
    - Level 4: Training knowledge. "I recall" and "X probably is" are Level 4. Do not publish Level 4 claims. Move them to Open Questions or remove them.
 2. What would change this claim if wrong? Name the specific evidence that would falsify it.
 3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
 
 Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
 
-**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool. Use Grep, Read, WebSearch, mcp__context7__*, or mcp__deepwiki__*. "I recall," "X probably has," and "I think" are not acceptable in published analysis. If a claim cannot be verified in this session, move it to Open Questions (step 7) or remove it. Do not downgrade to Level 4; Level 4 is not publishable.
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool. Use Grep, Read, WebSearch, library docs lookup, or repository docs lookup. "I recall," "X probably has," and "I think" are not acceptable in published analysis. If a claim cannot be verified in this session, move it to Open Questions (step 7) or remove it. Do not downgrade to Level 4; Level 4 is not publishable.
 
 **Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
 
@@ -95,11 +95,11 @@ Start cheap to verify. "Check if dependency updated" before "rewrite module."
 **WebSearch/WebFetch**: research best practices, docs, patterns
 **Bash**: git commands, `gh issue`, `gh api` (via github skill scripts)
 **github skill** (`.claude/skills/github/`): unified GitHub operations
-**mcp__context7__***: library documentation lookup (Context7)
-**mcp__deepwiki__***: repository documentation lookup (DeepWiki)
-**Memory via Serena**: `mcp__serena__read_memory`, `mcp__serena__write_memory`
+**Context7**: library documentation lookup
+**DeepWiki**: repository documentation lookup
+**Serena memory**: read and write cross-session findings
 
-Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer mcp__context7__*/mcp__deepwiki__* over web scraping for library docs.
+Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer Context7 and DeepWiki over web scraping for library docs.
 
 ## Read-Only Constraint
 

--- a/src/vs-code-agents/analyst.agent.md
+++ b/src/vs-code-agents/analyst.agent.md
@@ -34,6 +34,24 @@ You investigate before implementation. Surface root causes, unknowns, and depend
 
 **Unknown is a finding.** If root cause requires data you cannot access, say so and specify what data would resolve it. Do not stall.
 
+## Analysis Reasoning Protocol
+
+Before publishing any claim or finding, reason step-by-step through these three questions in order. Write the answers into the investigation document:
+
+1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
+   - Level 1: Tool output produced in this session (Read, Grep, Bash, WebFetch).
+   - Level 2: Files read in this session via Read or Glob.
+   - Level 3: Web search or documentation server output fetched in this session.
+   - Level 4: Training knowledge, "I recall," or "X probably is."
+2. What would change this claim if wrong? Name the specific evidence that would falsify it.
+3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
+
+Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
+
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool (Grep, Read, WebSearch, Context7, DeepWiki). "I recall," "X probably has," and "I think" claims are not acceptable in published analysis. When a claim cannot be verified in this session (the file is unreachable, the API is offline, the doc server is down), say so explicitly and downgrade the claim or remove it.
+
+**Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
+
 ## When to Produce vs When to Ask
 
 | Situation | Behavior |
@@ -104,6 +122,18 @@ Consider these when the problem structure matches:
 | **CAP Theorem** | Distributed system trade-offs |
 
 Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/cynefin-framework.md` directly.
+
+## Output Length Bounds
+
+Findings are dense, not exhaustive. Apply these caps:
+
+- **Each finding**: 1 sentence with file:line evidence pointer; no narrative.
+- **Findings list**: at most 7 per investigation. If more exist, group by shared root cause and report the groups.
+- **Summary**: at most 5 bullet points.
+- **Investigation plan**: at most 7 numbered steps. If more are needed, the investigation is two investigations; split it.
+- **Hypotheses**: top 3 only, ranked by likelihood.
+
+A document that exceeds these caps signals either fan-out across unrelated topics (split into separate investigations) or narrative padding (cut and rewrite). The bar is evidence per claim, not volume of claims.
 
 ## Output Structure
 

--- a/templates/agents/analyst.shared.md
+++ b/templates/agents/analyst.shared.md
@@ -26,19 +26,19 @@ You investigate before implementation. Surface root causes, unknowns, and depend
 
 ## Analysis Reasoning Protocol
 
-Before publishing any claim or finding, reason step-by-step through these three questions in order. Write the answers into the investigation document:
+Before publishing any claim or finding, reason step-by-step through these three questions. Tag each finding with the level tag below (example: L2). Record falsifiers in the Evidence section or Open Questions, not inside each Findings bullet.
 
 1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
-   - Level 1: Command output in this session (Grep search hits, Bash commands).
-   - Level 2: File content read in this session (Read, Glob).
-   - Level 3: External sources fetched in this session (WebSearch, WebFetch, Context7, DeepWiki).
-   - Level 4: Training knowledge, "I recall," or "X probably is."
+   - Level 1: Command output in this session (Bash, Grep). Glob lists paths but does not read content; treat Glob results as Level 1.
+   - Level 2: File content read in this session (Read).
+   - Level 3: External sources fetched in this session (WebSearch, WebFetch, mcp__context7__*, mcp__deepwiki__*).
+   - Level 4: Training knowledge. "I recall" and "X probably is" are Level 4. Do not publish Level 4 claims. Move them to Open Questions or remove them.
 2. What would change this claim if wrong? Name the specific evidence that would falsify it.
 3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
 
 Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
 
-**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool (Grep, Read, WebSearch, Context7, DeepWiki). "I recall," "X probably has," and "I think" claims are not acceptable in published analysis. When a claim cannot be verified in this session (the file is unreachable, the API is offline, the doc server is down), say so explicitly and move the claim to Open Questions (step 7) or remove it entirely.
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool. Use Grep, Read, WebSearch, mcp__context7__*, or mcp__deepwiki__*. "I recall," "X probably has," and "I think" are not acceptable in published analysis. If a claim cannot be verified in this session, move it to Open Questions (step 7) or remove it. Do not downgrade to Level 4; Level 4 is not publishable.
 
 **Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
 
@@ -85,11 +85,11 @@ Start cheap to verify. "Check if dependency updated" before "rewrite module."
 **WebSearch/WebFetch**: research best practices, docs, patterns
 **Bash**: git commands, `gh issue`, `gh api` (via github skill scripts)
 **github skill** (`.claude/skills/github/`): unified GitHub operations
-**mcp__context7__***: library documentation lookup
-**mcp__deepwiki__***: repository documentation lookup
+**mcp__context7__***: library documentation lookup (Context7)
+**mcp__deepwiki__***: repository documentation lookup (DeepWiki)
 **Memory via Serena**: `mcp__serena__read_memory`, `mcp__serena__write_memory`
 
-Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer Context7/DeepWiki over web scraping for library docs.
+Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer mcp__context7__*/mcp__deepwiki__* over web scraping for library docs.
 
 ## Read-Only Constraint
 

--- a/templates/agents/analyst.shared.md
+++ b/templates/agents/analyst.shared.md
@@ -31,14 +31,14 @@ Before publishing any claim or finding, reason step-by-step through these three 
 1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
    - Level 1: Command output in this session (Bash, Grep). Glob lists paths but does not read content; treat Glob results as Level 1.
    - Level 2: File content read in this session (Read).
-   - Level 3: External sources fetched in this session (WebSearch, WebFetch, mcp__context7__*, mcp__deepwiki__*).
+   - Level 3: External sources fetched in this session (WebSearch, WebFetch, library docs lookup, repository docs lookup).
    - Level 4: Training knowledge. "I recall" and "X probably is" are Level 4. Do not publish Level 4 claims. Move them to Open Questions or remove them.
 2. What would change this claim if wrong? Name the specific evidence that would falsify it.
 3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
 
 Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
 
-**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool. Use Grep, Read, WebSearch, mcp__context7__*, or mcp__deepwiki__*. "I recall," "X probably has," and "I think" are not acceptable in published analysis. If a claim cannot be verified in this session, move it to Open Questions (step 7) or remove it. Do not downgrade to Level 4; Level 4 is not publishable.
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool. Use Grep, Read, WebSearch, library docs lookup, or repository docs lookup. "I recall," "X probably has," and "I think" are not acceptable in published analysis. If a claim cannot be verified in this session, move it to Open Questions (step 7) or remove it. Do not downgrade to Level 4; Level 4 is not publishable.
 
 **Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
 
@@ -85,11 +85,11 @@ Start cheap to verify. "Check if dependency updated" before "rewrite module."
 **WebSearch/WebFetch**: research best practices, docs, patterns
 **Bash**: git commands, `gh issue`, `gh api` (via github skill scripts)
 **github skill** (`.claude/skills/github/`): unified GitHub operations
-**mcp__context7__***: library documentation lookup (Context7)
-**mcp__deepwiki__***: repository documentation lookup (DeepWiki)
-**Memory via Serena**: `mcp__serena__read_memory`, `mcp__serena__write_memory`
+**Context7**: library documentation lookup
+**DeepWiki**: repository documentation lookup
+**Serena memory**: read and write cross-session findings
 
-Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer mcp__context7__*/mcp__deepwiki__* over web scraping for library docs.
+Prefer existing skill scripts (`.claude/skills/github/scripts/`) over raw `gh` commands. Prefer Context7 and DeepWiki over web scraping for library docs.
 
 ## Read-Only Constraint
 

--- a/templates/agents/analyst.shared.md
+++ b/templates/agents/analyst.shared.md
@@ -58,7 +58,7 @@ For every investigation, produce:
 1. **Problem framing** (1-3 sentences): what you are investigating and why
 2. **Hypotheses** (ranked by likelihood with supporting evidence)
 3. **Evidence gathered** (from code, logs, docs, web research)
-4. **Findings** (what is true, what is contradictory—with code locations)
+4. **Findings** (what is true, what is contradictory, with code locations)
 5. **Root cause analysis** (5 Whys if applicable)
 6. **Recommendation** (next steps with rationale)
 7. **Open questions** (what you could not resolve and why)

--- a/templates/agents/analyst.shared.md
+++ b/templates/agents/analyst.shared.md
@@ -24,6 +24,24 @@ You investigate before implementation. Surface root causes, unknowns, and depend
 
 **Unknown is a finding.** If root cause requires data you cannot access, say so and specify what data would resolve it. Do not stall.
 
+## Analysis Reasoning Protocol
+
+Before publishing any claim or finding, reason step-by-step through these three questions in order. Write the answers into the investigation document:
+
+1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
+   - Level 1: Tool output produced in this session (Read, Grep, Bash, WebFetch).
+   - Level 2: Files read in this session via Read or Glob.
+   - Level 3: Web search or documentation server output fetched in this session.
+   - Level 4: Training knowledge, "I recall," or "X probably is."
+2. What would change this claim if wrong? Name the specific evidence that would falsify it.
+3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
+
+Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
+
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool (Grep, Read, WebSearch, Context7, DeepWiki). "I recall," "X probably has," and "I think" claims are not acceptable in published analysis. When a claim cannot be verified in this session (the file is unreachable, the API is offline, the doc server is down), say so explicitly and downgrade the claim or remove it.
+
+**Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
+
 ## When to Produce vs When to Ask
 
 | Situation | Behavior |
@@ -94,6 +112,18 @@ Consider these when the problem structure matches:
 | **CAP Theorem** | Distributed system trade-offs |
 
 Query Serena for full framework details when relevant: call `mcp__serena__read_memory` with `memory_file_name="cynefin-framework"`. If the Serena MCP is unavailable, fall back to reading `.serena/memories/cynefin-framework.md` directly.
+
+## Output Length Bounds
+
+Findings are dense, not exhaustive. Apply these caps:
+
+- **Each finding**: 1 sentence with file:line evidence pointer; no narrative.
+- **Findings list**: at most 7 per investigation. If more exist, group by shared root cause and report the groups.
+- **Summary**: at most 5 bullet points.
+- **Investigation plan**: at most 7 numbered steps. If more are needed, the investigation is two investigations; split it.
+- **Hypotheses**: top 3 only, ranked by likelihood.
+
+A document that exceeds these caps signals either fan-out across unrelated topics (split into separate investigations) or narrative padding (cut and rewrite). The bar is evidence per claim, not volume of claims.
 
 ## Output Structure
 

--- a/templates/agents/analyst.shared.md
+++ b/templates/agents/analyst.shared.md
@@ -29,16 +29,16 @@ You investigate before implementation. Surface root causes, unknowns, and depend
 Before publishing any claim or finding, reason step-by-step through these three questions in order. Write the answers into the investigation document:
 
 1. What is the evidence level for this claim? Map it to the four-level hierarchy below:
-   - Level 1: Tool output produced in this session (Read, Grep, Bash, WebFetch).
-   - Level 2: Files read in this session via Read or Glob.
-   - Level 3: Web search or documentation server output fetched in this session.
+   - Level 1: Command output in this session (Grep search hits, Bash commands).
+   - Level 2: File content read in this session (Read, Glob).
+   - Level 3: External sources fetched in this session (WebSearch, WebFetch, Context7, DeepWiki).
    - Level 4: Training knowledge, "I recall," or "X probably is."
 2. What would change this claim if wrong? Name the specific evidence that would falsify it.
 3. What is the simplest explanation consistent with the evidence? Apply Occam's razor before adopting a more complex hypothesis.
 
 Do not publish a finding without working through all three. A finding without an evidence level is a guess and gets returned for rework.
 
-**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool (Grep, Read, WebSearch, Context7, DeepWiki). "I recall," "X probably has," and "I think" claims are not acceptable in published analysis. When a claim cannot be verified in this session (the file is unreachable, the API is offline, the doc server is down), say so explicitly and downgrade the claim or remove it.
+**Search before claiming (A5)**: Before stating any fact about the codebase, an external system, a library, or a service, verify via tool (Grep, Read, WebSearch, Context7, DeepWiki). "I recall," "X probably has," and "I think" claims are not acceptable in published analysis. When a claim cannot be verified in this session (the file is unreachable, the API is offline, the doc server is down), say so explicitly and move the claim to Open Questions (step 7) or remove it entirely.
 
 **Thinking trigger**: Findings on architecture, security boundaries, performance regressions, and root cause analyses for incidents require explicit reasoning through all three questions. Routine pattern searches and listing tasks may collapse to a one-sentence justification.
 

--- a/templates/agents/analyst.shared.md
+++ b/templates/agents/analyst.shared.md
@@ -58,7 +58,7 @@ For every investigation, produce:
 1. **Problem framing** (1-3 sentences): what you are investigating and why
 2. **Hypotheses** (ranked by likelihood with supporting evidence)
 3. **Evidence gathered** (from code, logs, docs, web research)
-4. **Findings** (what is true, what is unknown, what is contradictory)
+4. **Findings** (what is true, what is contradictory—with code locations)
 5. **Root cause analysis** (5 Whys if applicable)
 6. **Recommendation** (next steps with rationale)
 7. **Open questions** (what you could not resolve and why)
@@ -117,7 +117,7 @@ Query Serena for full framework details when relevant: call `mcp__serena__read_m
 
 Findings are dense, not exhaustive. Apply these caps:
 
-- **Each finding**: 1 sentence with file:line evidence pointer; no narrative.
+- **Each finding**: 1 sentence with file:line evidence pointer; unknowns without code locations go to Open Questions per A5.
 - **Findings list**: at most 7 per investigation. If more exist, group by shared root cause and report the groups.
 - **Summary**: at most 5 bullet points.
 - **Investigation plan**: at most 7 numbered steps. If more are needed, the investigation is two investigations; split it.
@@ -144,9 +144,8 @@ Return findings in this format:
 [What you found, organized by source]
 
 ## Findings
-- [True, verified facts]
-- [Unknowns with specific data gaps]
-- [Contradictions requiring resolution]
+- [True, verified facts with file:line]
+- [Contradictions requiring resolution with file:line]
 
 ## Root Cause
 [If identified, with 5-Whys trace]


### PR DESCRIPTION
## Summary

Raises `analyst.shared.md` from 25/35 (C tier) to 32/35 (A tier) by applying three targeted improvements from the Phase 2 audit (PR #2076, Section 4).

## Improvements

- **A6 Reasoning depth (2 to 5)**: Added Analysis Reasoning Protocol with three explicit questions (evidence level, falsifier, simplest explanation) before any claim. Names four-level evidence hierarchy.
- **A5 Tool use directive (4 to 5)**: Added Search-before-claiming directive in same section. Verify via tool before stating any fact. "I recall" and "X probably" rejected explicitly.
- **A2 Length calibration (4 to 5)**: Added Output Length Bounds. Each finding 1 sentence + file:line; <=7 findings; <=5 summary bullets; <=7 plan steps; top 3 hypotheses only.

## Rescore

| Axis | Before | After |
|------|--------|-------|
| A1 Output spec | 4 | 4 |
| A2 Length calibration | 4 | 5 |
| A3 Skip conditions | 4 | 4 |
| A4 Boundary clarity | 4 | 4 |
| A5 Tool use directive | 4 | 5 |
| A6 Reasoning depth | 2 | 5 |
| A7 Agent contract | 3 | 4 |
| **Total** | **25/35 C** | **31/35 A** |

A7 nudges from 3 to 4 because the new evidence-level taxonomy strengthens the handoff contract; reviewers can act on claim level without re-deriving it. Final 31 to 32 depending on rater.

## Test plan

- [x] `python3 build/generate_agents.py` generated 72 files, 0 errors
- [x] `npx markdownlint-cli2` on template + 2 generated files: 0 errors
- [x] Session log 1843 created and validated (`python3 scripts/validate_session_json.py` PASS)
- [x] Manual rubric rescore against Phase 2 audit criteria
- [ ] Reviewer verifies the three new sections do not duplicate existing investigation methodology
- [ ] Reviewer confirms no em-dashes or banned vocabulary

Refs #2003