### PR TITLE
fix(#2094): resync .claude/agents install copies (qa, architect, implementer)

### DIFF
--- a/.agents/sessions/2026-05-26-session-1849-install-parity-landed-resync.json
+++ b/.agents/sessions/2026-05-26-session-1849-install-parity-landed-resync.json
@@ -1,0 +1,156 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 1849,
+    "date": "2026-05-26",
+    "branch": "fix/install-parity-resync-landed-drift",
+    "startingCommit": "cb285ebe",
+    "objective": "Resync the .claude/agents/ install copies of qa, architect, and implementer with the canonical Claude variant in src/claude/. PR #2087, PR #2089, and PR #2084 updated templates and src/* but left the Claude Code self-host install copies stale. Preserves Claude-specific addenda (Step 5 in qa, ADR Exception/Degraded Mode in architect, Test rigor checklist in implementer) via a 3-way merge against the pre-template-change base. Refs #2094."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "mcp__serena tools available; memory architecture/install-parity already on disk from session 1848"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Initial instructions loaded; ADR-007 enforcer hook ran on session start"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md auto-loaded by context_loader hook"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Inspected .claude/skills/github/scripts/pr/ before invoking PR scripts"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md, CLAUDE.md, and build/AGENTS.md loaded; clarified canonical-vs-install model"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "REQ-003-010 read inline; ADR-035 exit codes; em-dash prohibition observed in merge resolutions"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Reused architecture/install-parity memory from session 1848"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git checkout -b fix/install-parity-resync-landed-drift from main"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/install-parity-resync-landed-drift"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Verified clean main state before branching"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "cb285ebe (current main HEAD)"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST items satisfied; resync landed for qa, architect, implementer"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md untouched (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Reused existing architecture/install-parity memory from session 1848; the resync execution applies the same model documented there"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "npx markdownlint-cli2 on each modified .claude/agents/*.md produced 0 errors"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "See endingCommit"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "validate_install_parity.py --files .claude/agents/{qa,architect,implementer}.md returned OK (asymmetric resync rule applies)"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Task 5 moved to in_progress then completed at session end"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Retrospective deferred; resync rationale captured in PR body and issue #2094"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "timestamp": "2026-05-26T17:00:00Z",
+      "action": "Investigated landed drift. PR #2087 (qa), PR #2089 (architect), PR #2084 (implementer) all updated templates and src/* but skipped .claude/agents/. PR #2083 (orchestrator) is broader: it also missed src/claude/orchestrator.md, so the resync there needs a manual template-content-application step, deferred to a follow-up.",
+      "files": []
+    },
+    {
+      "timestamp": "2026-05-26T17:15:00Z",
+      "action": "Initial attempt was a flat overwrite (cp src/claude/X.md .claude/agents/X.md). Aborted because the diff showed substantive Claude-specific addenda would be lost: Step 5 (PR Description Validation) in qa, ADR Exception/Degraded Mode in architect, Test rigor checklist in implementer.",
+      "files": []
+    },
+    {
+      "timestamp": "2026-05-26T17:30:00Z",
+      "action": "Switched to a 3-way merge approach: base = src/claude/X.md from the commit before the template PR, theirs = src/claude/X.md current, ours = .claude/agents/X.md current. git merge-file --diff3 applied the template's new content while preserving the install copy's local addenda.",
+      "files": [
+        ".claude/agents/qa.md",
+        ".claude/agents/architect.md",
+        ".claude/agents/implementer.md"
+      ]
+    },
+    {
+      "timestamp": "2026-05-26T17:45:00Z",
+      "action": "qa.md had two conflict regions (new template sections inserted at the same location, gate count change from 4 to 5). Resolved by taking theirs for the new sections and integrating the 5-gates phrasing into the new threshold table.",
+      "files": [
+        ".claude/agents/qa.md"
+      ]
+    },
+    {
+      "timestamp": "2026-05-26T17:55:00Z",
+      "action": "Verified Claude addenda survived merge: Step 5 present in qa, Degraded Mode in architect, Test rigor checklist in implementer. Validator allows the diff under the asymmetric resync rule (touched set is entirely install members of SHARED_AGENT groups).",
+      "files": []
+    }
+  ],
+  "endingCommit": "PENDING",
+  "nextSteps": [
+    "Open PR for this resync referencing #2094.",
+    "Follow-up PR for orchestrator: PR #2083 also missed src/claude/orchestrator.md so the resync needs to apply the template's Reasoning Protocol additions to both src/claude/ and .claude/agents/ together. Outside the scope of this single-side install resync.",
+    "Follow-up issue for .github/agents/ structural divergence (different format, model field, tool naming). Separate from this PR.",
+    "Once PR #2095 lands, this resync is the first real exercise of the asymmetric carve-out; treat its CI run as a validation of the validator."
+  ]
+}

--- a/.agents/sessions/2026-05-26-session-1849-install-parity-landed-resync.json
+++ b/.agents/sessions/2026-05-26-session-1849-install-parity-landed-resync.json
@@ -144,9 +144,21 @@
       "timestamp": "2026-05-26T17:55:00Z",
       "action": "Verified Claude addenda survived merge: Step 5 present in qa, Degraded Mode in architect, Test rigor checklist in implementer. Validator allows the diff under the asymmetric resync rule (touched set is entirely install members of SHARED_AGENT groups).",
       "files": []
+    },
+    {
+      "timestamp": "2026-05-26T19:30:00Z",
+      "action": "PR feedback cycle: addressed 4 unresolved threads (gemini false-positive on generated-file edit; copilot regex bracket placeholder in architect; copilot endingCommit PENDING; copilot duplicated coverage commands in qa). Fixed via template edit + regenerate. Ran pytest tests/build_scripts/: 361 passed in 1.32s. Ran detect_agent_drift.py: 22 OK, 1 pre-existing (merge-resolver), 3 no-counterpart.",
+      "files": [
+        "templates/agents/architect.shared.md",
+        "templates/agents/qa.shared.md",
+        "src/claude/architect.md",
+        "src/claude/qa.md",
+        ".claude/agents/architect.md",
+        ".claude/agents/qa.md"
+      ]
     }
   ],
-  "endingCommit": "PENDING",
+  "endingCommit": "0f81a522",
   "nextSteps": [
     "Open PR for this resync referencing #2094.",
     "Follow-up PR for orchestrator: PR #2083 also missed src/claude/orchestrator.md so the resync needs to apply the template's Reasoning Protocol additions to both src/claude/ and .claude/agents/ together. Outside the scope of this single-side install resync.",

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -48,6 +48,30 @@ You have direct access to:
 
 Maintain system architecture as single source of truth. Conduct reviews across three phases: pre-planning, plan/analysis, and post-implementation.
 
+## Architecture Reasoning Protocol
+
+Before recommending any design or approving any ADR, reason step-by-step through these three questions in order. Write the answers into the ADR or design review:
+
+1. What ADRs already govern this area? Run `git grep -i -- "[topic]" .agents/architecture/` (replacing `[topic]` with keywords relevant to the change) and read every ADR whose title or scope overlaps the change. A recommendation that ignores an existing binding ADR is incomplete and will be returned for rework.
+2. Which quality attributes does this design serve, and which does it sacrifice? Name the explicit trade. Every architecture choice trades one quality for another; designs that claim to win on all axes are designs that have not been examined.
+3. What is the top failure mode of the chosen approach? Name the concrete way this design fails in two years, under load, with the team grown, or when the next ADR supersedes a foundational assumption.
+
+Do not recommend before working through all three. A recommendation without an ADR-precedent search, a named trade-off, and a named failure mode is a guess.
+
+**ADR-precedent search (A5)**: Before drafting any new ADR, search the existing ADR catalog for prior decisions in the same area. Cite ADR numbers and quote the relevant sections in the new ADR's `Decision Drivers` or `Strategic Considerations` section. If a prior ADR is being superseded, set the new ADR's status to `accepted` (note the supersession in the Context section) and update the prior ADR's status to `superseded by ADR-NNNN` (where `NNNN` is the new ADR's 4-digit number) in the same change. Designs that ignore precedent get returned.
+
+**Thinking trigger**: New ADRs, design reviews on cross-cutting concerns (transport, persistence, agent runtime, session protocol), and any change to a binding constraint require explicit reasoning through all three questions. Documentation-only ADRs (renumbering, format adjustments) may collapse to a one-sentence justification.
+
+## Ask Before vs Proceed With Default
+
+| Situation | Behavior |
+|-----------|----------|
+| Quality-attribute trade is named, alternative explored, failure mode flagged | **Proceed** with the design and document the trade |
+| Two binding ADRs conflict on the chosen approach | **Ask** the orchestrator which ADR is authoritative before drafting |
+| Stakeholders (decision-makers, consulted, informed) cannot be identified | **Ask** before drafting; an ADR without stakeholders fails Definition of Ready |
+| Required investment is unknown (effort, dependencies, lock-in) | **Investigate** first; route to analyst, then return |
+| Conventional pattern applies and the change is bounded | **Proceed** with the conventional pattern; cite the precedent ADR |
+
 ## Key Responsibilities
 
 1. **Maintain** master architecture document (`system-architecture.md`)
@@ -101,7 +125,7 @@ Save to: `.agents/planning/impact-analysis-architecture-[feature].md`
 
 | ADR | Status | Notes |
 |-----|--------|-------|
-| ADR-NNN | Aligns / Conflicts / Not Applicable | [Details] |
+| ADR-NNNN | Aligns / Conflicts / Not Applicable | [Details] |
 
 ## Required Patterns
 
@@ -209,7 +233,7 @@ Save to: `.agents/architecture/ADR-NNNN-[decision-name].md`
 
 ```markdown
 ---
-status: "{proposed | rejected | accepted | deprecated | superseded by ADR-NNN}"
+status: "{proposed | rejected | accepted | deprecated | superseded by ADR-NNNN}"
 date: {YYYY-MM-DD when the decision was last updated}
 decision-makers: {list everyone involved in the decision}
 consulted: {list everyone whose opinions are sought; two-way communication}
@@ -460,6 +484,19 @@ Design review enforcement happens in two checks:
 
 - `scripts/validation/pre_pr.py` validates required frontmatter fields (including `status`) and rejects PRs when fields are missing or invalid.
 - `synthesis-panel-gate.yml` parses frontmatter via `.github/scripts/check_design_review_gate.py` and blocks PRs when the verdict is NEEDS_CHANGES, FAIL, or REJECTED.
+
+## ADR and Design Review Length Bounds
+
+Architecture documents are dense, not exhaustive. Apply these caps:
+
+- **ADR Context and Problem Statement**: at most 3 sentences. Link to the deeper context; do not inline it.
+- **ADR Considered Options**: at most 5 options. If more were genuinely considered, group and report the groups; if not, list the three to five that actually competed.
+- **ADR Pros and Cons per option**: at most 4 bullets per option, matching the embedded MADR 4.0 template above (typically 2 good, 1 neutral, 1 bad; the final option may collapse to 1 good plus 1 bad). The reader needs the trade, not a thesis.
+- **Design Review Executive Summary**: at most 3 sentences.
+- **Design Review Issues table**: at most 7 items per priority tier. Group when more exist.
+- **Design Review Recommendations**: at most 5 prioritized items, each one sentence.
+
+A document that exceeds these caps signals either fan-out across unrelated decisions (split into separate ADRs) or padding (cut and rewrite). The bar is decision clarity per word, not volume.
 
 ## Architecture Review Process
 

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -52,7 +52,7 @@ Maintain system architecture as single source of truth. Conduct reviews across t
 
 Before recommending any design or approving any ADR, reason step-by-step through these three questions in order. Write the answers into the ADR or design review:
 
-1. What ADRs already govern this area? Run `git grep -i -- "[topic]" .agents/architecture/` (replacing `[topic]` with keywords relevant to the change) and read every ADR whose title or scope overlaps the change. A recommendation that ignores an existing binding ADR is incomplete and will be returned for rework.
+1. What ADRs already govern this area? Run `git grep -F -i -- "<topic>" .agents/architecture/` (replacing `<topic>` with keywords relevant to the change; the `-F` forces fixed-string matching so brackets and other regex metacharacters are safe) and read every ADR whose title or scope overlaps the change. A recommendation that ignores an existing binding ADR is incomplete and will be returned for rework.
 2. Which quality attributes does this design serve, and which does it sacrifice? Name the explicit trade. Every architecture choice trades one quality for another; designs that claim to win on all axes are designs that have not been examined.
 3. What is the top failure mode of the chosen approach? Name the concrete way this design fails in two years, under load, with the team grown, or when the next ADR supersedes a foundational assumption.
 

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -94,6 +94,21 @@ Read these files in order:
 
 **Rationale**: Past retrospectives document agents skipping CLAUDE.md, AGENTS.md, and HANDOFF.md before acting. This produced drift and inverted sources of truth (see .agents/retrospective/2025-12-15-drift-detection-disaster.md). Explicit stop criteria, fallbacks, and a success definition prevent recurrence. This section is BLOCKING. Strategic memory is optional optimization; project documentation is mandatory.
 
+## Plan Validation Protocol
+
+Before writing a single line of code, work through these four questions in order:
+
+1. What does the plan specify? Quote the acceptance criteria verbatim from the plan file, not from memory.
+2. What adjacent code will this touch? Read related files for patterns now, not during implementation.
+3. What are the top two failure modes for this change? Name them before touching any file.
+4. What is the smallest implementation that satisfies the criteria without adding speculation?
+
+Do not proceed past step 1 until you can answer it from the plan. If the plan has no acceptance criteria, stop and return `[BLOCKED] Plan missing acceptance criteria: <plan file path>`.
+
+**Thinking trigger**: Tasks that modify more than one file, change a public interface, or touch security boundaries require explicit step-by-step reasoning through all four questions. Single-file config changes and trivial additions do not.
+
+**Ask before proceeding when**: the stated change scope expands to files outside the plan. **Proceed with documented defaults when**: naming conventions are undocumented, test framework conventions are not explicit, import ordering is not specified.
+
 ## Core Behavior
 
 **Implement what is in front of you.** If the task is clear, start producing code. If context is missing, state what you need and proceed with reasonable defaults flagged as assumptions. Do not refuse to work because additional strategic memories could be loaded. Strategic memory lookup is optional optimization.
@@ -271,7 +286,15 @@ If a tool or service is unavailable, do not halt on first failure or retry indef
 
 You cannot delegate. Return to orchestrator with:
 
-1. **Completion status**: [COMPLETE] / [BLOCKED] / [SECURITY_FLAG] / [NEEDS_DECOMPOSITION]
+1. **Completion status**: [COMPLETE] / [BLOCKED] / [SECURITY_FLAG] / [NEEDS_DECOMPOSITION] / [NEEDS_DESIGN_REVIEW]
+
+**Failure-mode trigger conditions:**
+
+- `[BLOCKED]`: Plan missing, acceptance criteria absent, or conflicting constraints not resolvable without human input.
+- `[SECURITY_FLAG]`: Encountered CWE/OWASP surface (path traversal, injection, auth boundary, secrets) that requires security agent review before proceeding.
+- `[NEEDS_DECOMPOSITION]`: Task is XL complexity or touches more than 5 files; return an estimated breakdown.
+- `[NEEDS_DESIGN_REVIEW]`: Implementation reveals a pattern conflict or ADR ambiguity; do not guess, escalate.
+
 2. **Confidence**: HIGH / MEDIUM / LOW with reasoning
 3. **Files changed** (with brief description)
 4. **Tests added** (count + coverage delta)

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -74,13 +74,7 @@ Before designing any test or scoring any coverage report, work through these thr
 
 Do not write a test without answering all three. A test whose name reads "test_function_X" with no behavior in the name signals the first question was skipped.
 
-**Coverage tool directive (A5)**: Before asserting any coverage claim, run the coverage tool against the diff. Do not rely on memory or test counts. The canonical invocations per stack are in `.agents/governance/TESTING-RIGOR.md`; copy the relevant line, run it, paste the output line with the coverage percentage into the report. A coverage claim without a tool-run-this-session is a guess and gets returned for rework.
-
-- Python: `python3 -m coverage run --source=<dir> -m pytest && python3 -m coverage report -m --include='<file>' --fail-under=<target>`
-- Go: `go test -cover -coverprofile=cover.out ./... && go tool cover -func=cover.out`
-- Node/JS/TS: `c8 --100 npm test` or `jest --coverage --coverageThreshold='{"global":{"lines":<target>}}'`
-- C#/.NET: `dotnet test --collect:"XPlat Code Coverage"` with `coverlet.runsettings` thresholds
-- PowerShell: `Invoke-Pester -CodeCoverage <files> -CodeCoverageOutputFile cov.xml`
+**Coverage tool directive (A5)**: Before asserting any coverage claim, run the coverage tool against the diff. Do not rely on memory or test counts. The canonical invocations per stack live in `.agents/governance/TESTING-RIGOR.md` (section "Verify Before Commit"). Copy the line for the stack you changed, run it, paste the output line with the coverage percentage into the report. A coverage claim without a tool-run-this-session is a guess and gets returned for rework. Do not inline the commands here, the governance file is the single source of truth.
 
 **Thinking trigger**: New features, security-relevant changes, regression fixes, and any change that touches authentication, persistence, or external I/O require explicit step-by-step reasoning through all three questions before tests are designed. Style or trivial doc-only diffs may collapse to a one-sentence justification.
 

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -62,6 +62,53 @@ You have direct access to:
 
 **Passing tests are path to goal, not goal itself.** If tests pass but users hit bugs, QA failed. Approach testing from user perspective.
 
+Validation is not passing a test suite. Validation is verifying what was supposed to be built actually got built. If something was supposed to happen and it did not, that is a validation failure. If something was built incorrectly, that is a validation failure.
+
+## Test Strategy Reasoning Protocol
+
+Before designing any test or scoring any coverage report, work through these three questions in order. Write the answers into the test strategy document or the test report:
+
+1. What behavior does this test verify? Name the specific input-to-observable-output relationship, not "the function works."
+2. What are the negative cases? List invalid input, boundary values, type errors, race conditions, and authorization failures the test must reject.
+3. What is the minimum test that proves correctness? A test that triples in size to add assertions that do not change with the input is padding; cut it.
+
+Do not write a test without answering all three. A test whose name reads "test_function_X" with no behavior in the name signals the first question was skipped.
+
+**Coverage tool directive (A5)**: Before asserting any coverage claim, run the coverage tool against the diff. Do not rely on memory or test counts. The canonical invocations per stack are in `.agents/governance/TESTING-RIGOR.md`; copy the relevant line, run it, paste the output line with the coverage percentage into the report. A coverage claim without a tool-run-this-session is a guess and gets returned for rework.
+
+- Python: `python3 -m coverage run --source=<dir> -m pytest && python3 -m coverage report -m --include='<file>' --fail-under=<target>`
+- Go: `go test -cover -coverprofile=cover.out ./... && go tool cover -func=cover.out`
+- Node/JS/TS: `c8 --100 npm test` or `jest --coverage --coverageThreshold='{"global":{"lines":<target>}}'`
+- C#/.NET: `dotnet test --collect:"XPlat Code Coverage"` with `coverlet.runsettings` thresholds
+- PowerShell: `Invoke-Pester -CodeCoverage <files> -CodeCoverageOutputFile cov.xml`
+
+**Thinking trigger**: New features, security-relevant changes, regression fixes, and any change that touches authentication, persistence, or external I/O require explicit step-by-step reasoning through all three questions before tests are designed. Style or trivial doc-only diffs may collapse to a one-sentence justification.
+
+## Completeness Verification (Mandatory)
+
+Before reporting validation results, verify completeness independently. Format checks alone do not verify scope.
+
+1. **What was promised?** Check the original issue, task description, or orchestrator delegation for the deliverable list.
+2. **What was delivered?** List actual files created, modified, or functions implemented.
+3. **Compare**: If the promise was "update all 49 templates" and only 16 exist, validation = FAIL regardless of whether those 16 are correct.
+
+**Validation checks both correctness AND completeness.**
+
+Format your report:
+
+```text
+Promised: [list from issue/delegation]
+Delivered: [list from workspace]
+Gap: [missing items, if any]
+Result: PASS | FAIL
+```
+
+If you cannot independently verify what was promised (no issue, no task description, no delegation record), call `work_finish(blocked, "Cannot verify completeness without requirements")`.
+
+**Success definition**: You can state exactly what was promised, what was delivered, and whether they match. If you cannot, you have NOT completed validation.
+
+**Rationale**: Past incident: an agent stopped at 16 of 49 planned files and reported "Validation: PASSED" because the validation script checked format only, not count. Explicit completeness verification prevents this failure mode (false completion reporting).
+
 ## Key Responsibilities
 
 1. **Read roadmaps** before designing tests
@@ -519,11 +566,27 @@ Specific fixes required:
 
 ### Verdict Decision Logic
 
-| Condition | Verdict |
-|-----------|---------|
-| All 5 gates PASS | APPROVED |
-| Any gate FAIL | BLOCKED |
-| Coverage < minimum but > 60% AND no other failures | CONDITIONAL (document gap, proceed with warning) |
+Numeric thresholds are explicit. Do not interpolate.
+
+| Condition | Verdict | Trigger |
+|-----------|---------|---------|
+| All 5 gates PASS, line coverage >=80%, branch coverage >=70%, new-code coverage >=80% | APPROVED | All gates green |
+| Coverage in 70-79% (line) or 60-69% (branch) AND no other gate fails | CONDITIONAL | Document gap, cite follow-up issue, proceed with warning |
+| Any gate FAIL, OR line coverage <70%, OR branch coverage <60%, OR new-code coverage <70% | BLOCKED | Specify failing gate and missing threshold by number |
+| Cannot run coverage tool, missing CI environment, missing test infrastructure | BLOCKED | Return `[BLOCKED] Cannot evaluate: <specific missing artifact>` |
+
+A CONDITIONAL verdict must cite the follow-up issue number that will close the gap. A BLOCKED verdict must name the failing gate and the numeric value that triggered it. Verdicts without these are returned for rework.
+
+## QA Report Length Bounds
+
+Reports are dense, not exhaustive. Apply these caps:
+
+- **Summary table**: one row per gate; status only, no prose in the same column.
+- **Issues table**: at most 10 issues per report. If more exist, group by shared root cause and report the groups.
+- **Recommendations**: at most 5 prioritized items, each one sentence.
+- **Coverage evidence**: paste the single coverage-tool output line, not the full report.
+
+A report that exceeds these caps signals either fan-out across unrelated test suites (split into separate reports) or padding (cut and rewrite). The bar is precision per finding, not volume.
 
 ---
 

--- a/src/claude/architect.md
+++ b/src/claude/architect.md
@@ -51,7 +51,7 @@ Maintain system architecture as single source of truth. Conduct reviews across t
 
 Before recommending any design or approving any ADR, reason step-by-step through these three questions in order. Write the answers into the ADR or design review:
 
-1. What ADRs already govern this area? Run `git grep -i -- "[topic]" .agents/architecture/` (replacing `[topic]` with keywords relevant to the change) and read every ADR whose title or scope overlaps the change. A recommendation that ignores an existing binding ADR is incomplete and will be returned for rework.
+1. What ADRs already govern this area? Run `git grep -F -i -- "<topic>" .agents/architecture/` (replacing `<topic>` with keywords relevant to the change; the `-F` forces fixed-string matching so brackets and other regex metacharacters are safe) and read every ADR whose title or scope overlaps the change. A recommendation that ignores an existing binding ADR is incomplete and will be returned for rework.
 2. Which quality attributes does this design serve, and which does it sacrifice? Name the explicit trade. Every architecture choice trades one quality for another; designs that claim to win on all axes are designs that have not been examined.
 3. What is the top failure mode of the chosen approach? Name the concrete way this design fails in two years, under load, with the team grown, or when the next ADR supersedes a foundational assumption.
 

--- a/src/claude/qa.md
+++ b/src/claude/qa.md
@@ -75,13 +75,7 @@ Before designing any test or scoring any coverage report, work through these thr
 
 Do not write a test without answering all three. A test whose name reads "test_function_X" with no behavior in the name signals the first question was skipped.
 
-**Coverage tool directive (A5)**: Before asserting any coverage claim, run the coverage tool against the diff. Do not rely on memory or test counts. The canonical invocations per stack are in `.agents/governance/TESTING-RIGOR.md`; copy the relevant line, run it, paste the output line with the coverage percentage into the report. A coverage claim without a tool-run-this-session is a guess and gets returned for rework.
-
-- Python: `python3 -m coverage run --source=<dir> -m pytest && python3 -m coverage report -m --include='<file>' --fail-under=<target>`
-- Go: `go test -cover -coverprofile=cover.out ./... && go tool cover -func=cover.out`
-- Node/JS/TS: `c8 --100 npm test` or `jest --coverage --coverageThreshold='{"global":{"lines":<target>}}'`
-- C#/.NET: `dotnet test --collect:"XPlat Code Coverage"` with `coverlet.runsettings` thresholds
-- PowerShell: `Invoke-Pester -CodeCoverage <files> -CodeCoverageOutputFile cov.xml`
+**Coverage tool directive (A5)**: Before asserting any coverage claim, run the coverage tool against the diff. Do not rely on memory or test counts. The canonical invocations per stack live in `.agents/governance/TESTING-RIGOR.md` (section "Verify Before Commit"). Copy the line for the stack you changed, run it, paste the output line with the coverage percentage into the report. A coverage claim without a tool-run-this-session is a guess and gets returned for rework. Do not inline the commands here, the governance file is the single source of truth.
 
 **Thinking trigger**: New features, security-relevant changes, regression fixes, and any change that touches authentication, persistence, or external I/O require explicit step-by-step reasoning through all three questions before tests are designed. Style or trivial doc-only diffs may collapse to a one-sentence justification.
 

--- a/src/copilot-cli/agents/architect.agent.md
+++ b/src/copilot-cli/agents/architect.agent.md
@@ -71,7 +71,7 @@ Maintain system architecture as single source of truth. Conduct reviews across t
 
 Before recommending any design or approving any ADR, reason step-by-step through these three questions in order. Write the answers into the ADR or design review:
 
-1. What ADRs already govern this area? Run `git grep -i -- "[topic]" .agents/architecture/` (replacing `[topic]` with keywords relevant to the change) and read every ADR whose title or scope overlaps the change. A recommendation that ignores an existing binding ADR is incomplete and will be returned for rework.
+1. What ADRs already govern this area? Run `git grep -F -i -- "<topic>" .agents/architecture/` (replacing `<topic>` with keywords relevant to the change; the `-F` forces fixed-string matching so brackets and other regex metacharacters are safe) and read every ADR whose title or scope overlaps the change. A recommendation that ignores an existing binding ADR is incomplete and will be returned for rework.
 2. Which quality attributes does this design serve, and which does it sacrifice? Name the explicit trade. Every architecture choice trades one quality for another; designs that claim to win on all axes are designs that have not been examined.
 3. What is the top failure mode of the chosen approach? Name the concrete way this design fails in two years, under load, with the team grown, or when the next ADR supersedes a foundational assumption.
 

--- a/src/copilot-cli/agents/qa.agent.md
+++ b/src/copilot-cli/agents/qa.agent.md
@@ -69,13 +69,7 @@ Before designing any test or scoring any coverage report, work through these thr
 
 Do not write a test without answering all three. A test whose name reads "test_function_X" with no behavior in the name signals the first question was skipped.
 
-**Coverage tool directive (A5)**: Before asserting any coverage claim, run the coverage tool against the diff. Do not rely on memory or test counts. The canonical invocations per stack are in `.agents/governance/TESTING-RIGOR.md`; copy the relevant line, run it, paste the output line with the coverage percentage into the report. A coverage claim without a tool-run-this-session is a guess and gets returned for rework.
-
-- Python: `python3 -m coverage run --source=<dir> -m pytest && python3 -m coverage report -m --include='<file>' --fail-under=<target>`
-- Go: `go test -cover -coverprofile=cover.out ./... && go tool cover -func=cover.out`
-- Node/JS/TS: `c8 --100 npm test` or `jest --coverage --coverageThreshold='{"global":{"lines":<target>}}'`
-- C#/.NET: `dotnet test --collect:"XPlat Code Coverage"` with `coverlet.runsettings` thresholds
-- PowerShell: `Invoke-Pester -CodeCoverage <files> -CodeCoverageOutputFile cov.xml`
+**Coverage tool directive (A5)**: Before asserting any coverage claim, run the coverage tool against the diff. Do not rely on memory or test counts. The canonical invocations per stack live in `.agents/governance/TESTING-RIGOR.md` (section "Verify Before Commit"). Copy the line for the stack you changed, run it, paste the output line with the coverage percentage into the report. A coverage claim without a tool-run-this-session is a guess and gets returned for rework. Do not inline the commands here, the governance file is the single source of truth.
 
 **Thinking trigger**: New features, security-relevant changes, regression fixes, and any change that touches authentication, persistence, or external I/O require explicit step-by-step reasoning through all three questions before tests are designed. Style or trivial doc-only diffs may collapse to a one-sentence justification.
 

--- a/src/vs-code-agents/architect.agent.md
+++ b/src/vs-code-agents/architect.agent.md
@@ -72,7 +72,7 @@ Maintain system architecture as single source of truth. Conduct reviews across t
 
 Before recommending any design or approving any ADR, reason step-by-step through these three questions in order. Write the answers into the ADR or design review:
 
-1. What ADRs already govern this area? Run `git grep -i -- "[topic]" .agents/architecture/` (replacing `[topic]` with keywords relevant to the change) and read every ADR whose title or scope overlaps the change. A recommendation that ignores an existing binding ADR is incomplete and will be returned for rework.
+1. What ADRs already govern this area? Run `git grep -F -i -- "<topic>" .agents/architecture/` (replacing `<topic>` with keywords relevant to the change; the `-F` forces fixed-string matching so brackets and other regex metacharacters are safe) and read every ADR whose title or scope overlaps the change. A recommendation that ignores an existing binding ADR is incomplete and will be returned for rework.
 2. Which quality attributes does this design serve, and which does it sacrifice? Name the explicit trade. Every architecture choice trades one quality for another; designs that claim to win on all axes are designs that have not been examined.
 3. What is the top failure mode of the chosen approach? Name the concrete way this design fails in two years, under load, with the team grown, or when the next ADR supersedes a foundational assumption.
 

--- a/src/vs-code-agents/qa.agent.md
+++ b/src/vs-code-agents/qa.agent.md
@@ -70,13 +70,7 @@ Before designing any test or scoring any coverage report, work through these thr
 
 Do not write a test without answering all three. A test whose name reads "test_function_X" with no behavior in the name signals the first question was skipped.
 
-**Coverage tool directive (A5)**: Before asserting any coverage claim, run the coverage tool against the diff. Do not rely on memory or test counts. The canonical invocations per stack are in `.agents/governance/TESTING-RIGOR.md`; copy the relevant line, run it, paste the output line with the coverage percentage into the report. A coverage claim without a tool-run-this-session is a guess and gets returned for rework.
-
-- Python: `python3 -m coverage run --source=<dir> -m pytest && python3 -m coverage report -m --include='<file>' --fail-under=<target>`
-- Go: `go test -cover -coverprofile=cover.out ./... && go tool cover -func=cover.out`
-- Node/JS/TS: `c8 --100 npm test` or `jest --coverage --coverageThreshold='{"global":{"lines":<target>}}'`
-- C#/.NET: `dotnet test --collect:"XPlat Code Coverage"` with `coverlet.runsettings` thresholds
-- PowerShell: `Invoke-Pester -CodeCoverage <files> -CodeCoverageOutputFile cov.xml`
+**Coverage tool directive (A5)**: Before asserting any coverage claim, run the coverage tool against the diff. Do not rely on memory or test counts. The canonical invocations per stack live in `.agents/governance/TESTING-RIGOR.md` (section "Verify Before Commit"). Copy the line for the stack you changed, run it, paste the output line with the coverage percentage into the report. A coverage claim without a tool-run-this-session is a guess and gets returned for rework. Do not inline the commands here, the governance file is the single source of truth.
 
 **Thinking trigger**: New features, security-relevant changes, regression fixes, and any change that touches authentication, persistence, or external I/O require explicit step-by-step reasoning through all three questions before tests are designed. Style or trivial doc-only diffs may collapse to a one-sentence justification.
 

--- a/templates/agents/architect.shared.md
+++ b/templates/agents/architect.shared.md
@@ -69,7 +69,7 @@ Maintain system architecture as single source of truth. Conduct reviews across t
 
 Before recommending any design or approving any ADR, reason step-by-step through these three questions in order. Write the answers into the ADR or design review:
 
-1. What ADRs already govern this area? Run `git grep -i -- "[topic]" .agents/architecture/` (replacing `[topic]` with keywords relevant to the change) and read every ADR whose title or scope overlaps the change. A recommendation that ignores an existing binding ADR is incomplete and will be returned for rework.
+1. What ADRs already govern this area? Run `git grep -F -i -- "<topic>" .agents/architecture/` (replacing `<topic>` with keywords relevant to the change; the `-F` forces fixed-string matching so brackets and other regex metacharacters are safe) and read every ADR whose title or scope overlaps the change. A recommendation that ignores an existing binding ADR is incomplete and will be returned for rework.
 2. Which quality attributes does this design serve, and which does it sacrifice? Name the explicit trade. Every architecture choice trades one quality for another; designs that claim to win on all axes are designs that have not been examined.
 3. What is the top failure mode of the chosen approach? Name the concrete way this design fails in two years, under load, with the team grown, or when the next ADR supersedes a foundational assumption.
 

--- a/templates/agents/qa.shared.md
+++ b/templates/agents/qa.shared.md
@@ -68,13 +68,7 @@ Before designing any test or scoring any coverage report, work through these thr
 
 Do not write a test without answering all three. A test whose name reads "test_function_X" with no behavior in the name signals the first question was skipped.
 
-**Coverage tool directive (A5)**: Before asserting any coverage claim, run the coverage tool against the diff. Do not rely on memory or test counts. The canonical invocations per stack are in `.agents/governance/TESTING-RIGOR.md`; copy the relevant line, run it, paste the output line with the coverage percentage into the report. A coverage claim without a tool-run-this-session is a guess and gets returned for rework.
-
-- Python: `python3 -m coverage run --source=<dir> -m pytest && python3 -m coverage report -m --include='<file>' --fail-under=<target>`
-- Go: `go test -cover -coverprofile=cover.out ./... && go tool cover -func=cover.out`
-- Node/JS/TS: `c8 --100 npm test` or `jest --coverage --coverageThreshold='{"global":{"lines":<target>}}'`
-- C#/.NET: `dotnet test --collect:"XPlat Code Coverage"` with `coverlet.runsettings` thresholds
-- PowerShell: `Invoke-Pester -CodeCoverage <files> -CodeCoverageOutputFile cov.xml`
+**Coverage tool directive (A5)**: Before asserting any coverage claim, run the coverage tool against the diff. Do not rely on memory or test counts. The canonical invocations per stack live in `.agents/governance/TESTING-RIGOR.md` (section "Verify Before Commit"). Copy the line for the stack you changed, run it, paste the output line with the coverage percentage into the report. A coverage claim without a tool-run-this-session is a guess and gets returned for rework. Do not inline the commands here, the governance file is the single source of truth.
 
 **Thinking trigger**: New features, security-relevant changes, regression fixes, and any change that touches authentication, persistence, or external I/O require explicit step-by-step reasoning through all three questions before tests are designed. Style or trivial doc-only diffs may collapse to a one-sentence justification.
 


### PR DESCRIPTION
## Summary

Brings the hand-maintained Claude Code install copies back in line with the canonical Claude variant after three recent template PRs landed without updating them.

Refs #2094.

## What was drifted

| Agent | Anchor PR | Stale on `main` since |
|---|---|---|
| qa | PR #2087 | 2026-05-26 |
| architect | PR #2089 | 2026-05-26 |
| implementer | PR #2084 | 2026-05-26 |

The anchor PRs each added new prompt content (Test Strategy Reasoning Protocol, Coverage tool directive, Completeness Verification, ADR Reasoning Protocol, etc.) to the shared template and the three vendored copies under the published src tree, but skipped the Claude Code install copy.

## What this PR does

Three-way merge per agent:

- base = the canonical Claude variant at the commit BEFORE the anchor PR
- theirs = the canonical Claude variant current
- ours = the Claude Code install copy current

`git merge-file --diff3` applies the template's new content while preserving the install copy's local addenda. The install copies are hand-maintained for Claude Code self-host of THIS repo; they accumulate Claude-specific blocks over time that should survive a template update.

## Claude addenda preserved (verified by grep)

- qa keeps the "Step 5: PR Description Validation" section
- architect keeps the ADR Exception review block and the Degraded Mode Protocol section
- implementer keeps the cross-language test rigor checklist

## Out of scope

- **Orchestrator**: PR #2083 missed the canonical Claude variant itself (not just the install copy). The Reasoning Protocol additions never landed in the Claude source. Fixing this needs a manual port from the template, not a merge from a stale canonical. Tracked as a follow-up on #2094.
- **Copilot install side**: those files use a different GitHub Copilot self-host format that does not map mechanically to the vendored Copilot tree. Needs a separate decision. Tracked on #2094.

## Validator interaction

This PR is the first exercise of the asymmetric carve-out added in PR #2095. The validator now allows a diff whose touched set is entirely install members of a SHARED_AGENT group, because that shape is the catch-up resync the validator's existence motivates.

## Conflict resolution detail

qa had two conflict regions, both real:

1. The template's new Test Strategy Reasoning Protocol and Completeness Verification sections went into the same slot the install copy had been silently missing. Resolved by taking theirs.
2. The Verdict Decision Logic table changed from "All 4 gates PASS" (template's pre-PR base) to a numeric threshold table with "4 gates" in theirs. The install copy had "All 5 gates PASS" because it has Step 5. Resolved by taking the new threshold table and updating the gate count to 5.

## Test plan

- [x] markdownlint-cli2 reports 0 errors across all three modified files
- [x] Validator reports clean against this diff
- [x] Post-merge grep confirms all three Claude-specific blocks survived
- [ ] CI runs (waiting on PR #2095 to merge so the validator step exists in main)
