### PR TITLE
fix(skills): add list_issues.py and fix guard mapping (#2110)

### DIFF
--- a/.claude/hooks/PreToolUse/invoke_skill_first_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_skill_first_guard.py
@@ -119,8 +119,11 @@ SKILL_MAPPINGS: dict[str, dict[str, dict[str, str]]] = {
             ),
         },
         "list": {
-            "script": "get_issue_context.py",
-            "example": "python3 .claude/skills/github/scripts/issue/get_issue_context.py",
+            "script": "list_issues.py",
+            "example": (
+                "python3 .claude/skills/github/scripts/issue/"
+                "list_issues.py --state open --label bug"
+            ),
         },
     },
 }

--- a/.claude/skills/github/scripts/issue/list_issues.py
+++ b/.claude/skills/github/scripts/issue/list_issues.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""List GitHub Issues with optional filters.
+
+Enumerates issues in a repository with filtering capabilities:
+- State (open, closed, all)
+- Labels (comma-separated or single label)
+- Author
+- Assignee
+- Search query
+- Result limit
+
+Returns a JSON array with issue metadata for downstream processing.
+
+Mirrors the PR-side ``get_pull_requests.py`` precedent so the
+``invoke_skill_first_guard.py`` ``issue.list`` mapping resolves to a
+script that can actually list issues (see issue #2110).
+
+Exit codes follow ADR-035:
+    0 - Success
+    2 - Config / argument error
+    3 - External error (API failure)
+    4 - Auth error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+_plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_workspace = os.environ.get("GITHUB_WORKSPACE")
+if _plugin_root:
+    _lib_dir = os.path.join(_plugin_root, "lib")
+elif _workspace:
+    _lib_dir = os.path.join(_workspace, ".claude", "lib")
+else:
+    _lib_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "lib")
+    )
+if not os.path.isdir(_lib_dir):
+    print(f"Plugin lib directory not found: {_lib_dir}", file=sys.stderr)
+    sys.exit(2)  # Config error per ADR-035
+if _lib_dir not in sys.path:
+    sys.path.insert(0, _lib_dir)
+
+from github_core.api import (  # noqa: E402
+    assert_gh_authenticated,
+    error_and_exit,
+    resolve_repo_params,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="List GitHub Issues with optional filters.",
+    )
+    parser.add_argument("--owner", default="", help="Repository owner")
+    parser.add_argument("--repo", default="", help="Repository name")
+    parser.add_argument(
+        "--state", choices=["open", "closed", "all"], default="open",
+        help="Issue state filter (default: open)",
+    )
+    parser.add_argument(
+        "--label", default="",
+        help="Filter by label(s). Comma-separated for multiple.",
+    )
+    parser.add_argument(
+        "--author", default="", help="Filter by issue author username",
+    )
+    parser.add_argument(
+        "--assignee", default="",
+        help="Filter by assignee username (use '@me' for self).",
+    )
+    parser.add_argument(
+        "--search", default="",
+        help="GitHub search query (e.g. 'fix auth is:open'). "
+             "When used, --state/--label/--author/--assignee are ignored.",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=30,
+        help="Max number of issues to return (1-1000, default: 30)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if not 1 <= args.limit <= 1000:
+        error_and_exit("Limit must be between 1 and 1000.", 2)
+
+    assert_gh_authenticated()
+    resolved = resolve_repo_params(args.owner, args.repo)
+    owner, repo = resolved.owner, resolved.repo
+    repo_flag = f"{owner}/{repo}"
+
+    list_args = [
+        "gh", "issue", "list",
+        "--repo", repo_flag,
+        "--limit", str(args.limit),
+        "--json", "number,title,state,labels,assignees,author,url,createdAt,updatedAt",
+    ]
+
+    if args.search:
+        # gh issue list --search ignores --state, --label, --author,
+        # --assignee. Only pass --search to avoid misleading behavior.
+        list_args.extend(["--search", args.search])
+    else:
+        if args.state != "all":
+            list_args.extend(["--state", args.state])
+
+        if args.label:
+            labels = [lbl.strip() for lbl in args.label.split(",") if lbl.strip()]
+            for lbl in labels:
+                list_args.extend(["--label", lbl])
+
+        if args.author:
+            list_args.extend(["--author", args.author])
+
+        if args.assignee:
+            list_args.extend(["--assignee", args.assignee])
+
+    result = subprocess.run(
+        list_args, capture_output=True, text=True, timeout=30, check=False,
+    )
+
+    if result.returncode != 0:
+        error_and_exit(
+            f"Failed to list issues: {result.stderr or result.stdout}", 3,
+        )
+
+    issues = json.loads(result.stdout)
+
+    output = [
+        {
+            "number": i.get("number"),
+            "title": i.get("title"),
+            "state": i.get("state"),
+            "labels": [lbl.get("name") for lbl in i.get("labels", [])],
+            "assignees": [a.get("login") for a in i.get("assignees", [])],
+            "author": (i.get("author") or {}).get("login"),
+            "url": i.get("url"),
+            "createdAt": i.get("createdAt"),
+            "updatedAt": i.get("updatedAt"),
+        }
+        for i in issues
+    ]
+
+    print(json.dumps(output, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/github/scripts/issue/list_issues.py
+++ b/.claude/skills/github/scripts/issue/list_issues.py
@@ -144,6 +144,11 @@ def main(argv: list[str] | None = None) -> int:
     except (json.JSONDecodeError, ValueError) as exc:
         error_and_exit(f"Failed to parse JSON response from gh: {exc}", 3)
 
+    if not isinstance(issues, list):
+        error_and_exit(
+            f"Expected a JSON array from gh, got {type(issues).__name__}.", 3,
+        )
+
     output = [
         {
             "number": i.get("number"),

--- a/.claude/skills/github/scripts/issue/list_issues.py
+++ b/.claude/skills/github/scripts/issue/list_issues.py
@@ -109,8 +109,10 @@ def main(argv: list[str] | None = None) -> int:
         # --assignee. Only pass --search to avoid misleading behavior.
         list_args.extend(["--search", args.search])
     else:
-        if args.state != "all":
-            list_args.extend(["--state", args.state])
+        # Forward every state, including 'all'. Omitting --state makes
+        # gh fall back to its open-only default, which silently drops
+        # closed issues when the caller asked for --state all.
+        list_args.extend(["--state", args.state])
 
         if args.label:
             labels = [lbl.strip() for lbl in args.label.split(",") if lbl.strip()]
@@ -123,30 +125,47 @@ def main(argv: list[str] | None = None) -> int:
         if args.assignee:
             list_args.extend(["--assignee", args.assignee])
 
-    result = subprocess.run(
-        list_args, capture_output=True, text=True, timeout=30, check=False,
-    )
+    try:
+        result = subprocess.run(
+            list_args, capture_output=True, text=True, timeout=30, check=False,
+        )
+    except subprocess.TimeoutExpired:
+        error_and_exit("Timed out waiting for gh issue list.", 3)
+    except FileNotFoundError:
+        error_and_exit("gh CLI not found on PATH.", 3)
 
     if result.returncode != 0:
         error_and_exit(
             f"Failed to list issues: {result.stderr or result.stdout}", 3,
         )
 
-    issues = json.loads(result.stdout)
+    try:
+        issues = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
+        error_and_exit(f"Failed to parse JSON response from gh: {exc}", 3)
 
     output = [
         {
             "number": i.get("number"),
             "title": i.get("title"),
             "state": i.get("state"),
-            "labels": [lbl.get("name") for lbl in i.get("labels", [])],
-            "assignees": [a.get("login") for a in i.get("assignees", [])],
+            "labels": [
+                lbl.get("name")
+                for lbl in (i.get("labels") or [])
+                if isinstance(lbl, dict)
+            ],
+            "assignees": [
+                a.get("login")
+                for a in (i.get("assignees") or [])
+                if isinstance(a, dict)
+            ],
             "author": (i.get("author") or {}).get("login"),
             "url": i.get("url"),
             "createdAt": i.get("createdAt"),
             "updatedAt": i.get("updatedAt"),
         }
         for i in issues
+        if isinstance(i, dict)
     ]
 
     print(json.dumps(output, indent=2))

--- a/.claude/skills/github/scripts/issue/list_issues.py
+++ b/.claude/skills/github/scripts/issue/list_issues.py
@@ -109,8 +109,7 @@ def main(argv: list[str] | None = None) -> int:
         # --assignee. Only pass --search to avoid misleading behavior.
         list_args.extend(["--search", args.search])
     else:
-        if args.state != "all":
-            list_args.extend(["--state", args.state])
+        list_args.extend(["--state", args.state])
 
         if args.label:
             labels = [lbl.strip() for lbl in args.label.split(",") if lbl.strip()]

--- a/.claude/skills/github/scripts/issue/list_issues.py
+++ b/.claude/skills/github/scripts/issue/list_issues.py
@@ -109,7 +109,8 @@ def main(argv: list[str] | None = None) -> int:
         # --assignee. Only pass --search to avoid misleading behavior.
         list_args.extend(["--search", args.search])
     else:
-        list_args.extend(["--state", args.state])
+        if args.state != "all":
+            list_args.extend(["--state", args.state])
 
         if args.label:
             labels = [lbl.strip() for lbl in args.label.split(",") if lbl.strip()]

--- a/src/copilot-cli/hooks/preToolUse/invoke_skill_first_guard__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/preToolUse/invoke_skill_first_guard__Bash_f620ca.py
@@ -262,8 +262,11 @@ def _original_main(stdin_bytes):
                 ),
             },
             "list": {
-                "script": "get_issue_context.py",
-                "example": "python3 .claude/skills/github/scripts/issue/get_issue_context.py",
+                "script": "list_issues.py",
+                "example": (
+                    "python3 .claude/skills/github/scripts/issue/"
+                    "list_issues.py --state open --label bug"
+                ),
             },
         },
     }

--- a/src/copilot-cli/skills/github/scripts/issue/list_issues.py
+++ b/src/copilot-cli/skills/github/scripts/issue/list_issues.py
@@ -144,6 +144,11 @@ def main(argv: list[str] | None = None) -> int:
     except (json.JSONDecodeError, ValueError) as exc:
         error_and_exit(f"Failed to parse JSON response from gh: {exc}", 3)
 
+    if not isinstance(issues, list):
+        error_and_exit(
+            f"Expected a JSON array from gh, got {type(issues).__name__}.", 3,
+        )
+
     output = [
         {
             "number": i.get("number"),

--- a/src/copilot-cli/skills/github/scripts/issue/list_issues.py
+++ b/src/copilot-cli/skills/github/scripts/issue/list_issues.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""List GitHub Issues with optional filters.
+
+Enumerates issues in a repository with filtering capabilities:
+- State (open, closed, all)
+- Labels (comma-separated or single label)
+- Author
+- Assignee
+- Search query
+- Result limit
+
+Returns a JSON array with issue metadata for downstream processing.
+
+Mirrors the PR-side ``get_pull_requests.py`` precedent so the
+``invoke_skill_first_guard.py`` ``issue.list`` mapping resolves to a
+script that can actually list issues (see issue #2110).
+
+Exit codes follow ADR-035:
+    0 - Success
+    2 - Config / argument error
+    3 - External error (API failure)
+    4 - Auth error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+_plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_workspace = os.environ.get("GITHUB_WORKSPACE")
+if _plugin_root:
+    _lib_dir = os.path.join(_plugin_root, "lib")
+elif _workspace:
+    _lib_dir = os.path.join(_workspace, ".claude", "lib")
+else:
+    _lib_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "lib")
+    )
+if not os.path.isdir(_lib_dir):
+    print(f"Plugin lib directory not found: {_lib_dir}", file=sys.stderr)
+    sys.exit(2)  # Config error per ADR-035
+if _lib_dir not in sys.path:
+    sys.path.insert(0, _lib_dir)
+
+from github_core.api import (  # noqa: E402
+    assert_gh_authenticated,
+    error_and_exit,
+    resolve_repo_params,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="List GitHub Issues with optional filters.",
+    )
+    parser.add_argument("--owner", default="", help="Repository owner")
+    parser.add_argument("--repo", default="", help="Repository name")
+    parser.add_argument(
+        "--state", choices=["open", "closed", "all"], default="open",
+        help="Issue state filter (default: open)",
+    )
+    parser.add_argument(
+        "--label", default="",
+        help="Filter by label(s). Comma-separated for multiple.",
+    )
+    parser.add_argument(
+        "--author", default="", help="Filter by issue author username",
+    )
+    parser.add_argument(
+        "--assignee", default="",
+        help="Filter by assignee username (use '@me' for self).",
+    )
+    parser.add_argument(
+        "--search", default="",
+        help="GitHub search query (e.g. 'fix auth is:open'). "
+             "When used, --state/--label/--author/--assignee are ignored.",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=30,
+        help="Max number of issues to return (1-1000, default: 30)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if not 1 <= args.limit <= 1000:
+        error_and_exit("Limit must be between 1 and 1000.", 2)
+
+    assert_gh_authenticated()
+    resolved = resolve_repo_params(args.owner, args.repo)
+    owner, repo = resolved.owner, resolved.repo
+    repo_flag = f"{owner}/{repo}"
+
+    list_args = [
+        "gh", "issue", "list",
+        "--repo", repo_flag,
+        "--limit", str(args.limit),
+        "--json", "number,title,state,labels,assignees,author,url,createdAt,updatedAt",
+    ]
+
+    if args.search:
+        # gh issue list --search ignores --state, --label, --author,
+        # --assignee. Only pass --search to avoid misleading behavior.
+        list_args.extend(["--search", args.search])
+    else:
+        # Forward every state, including 'all'. Omitting --state makes
+        # gh fall back to its open-only default, which silently drops
+        # closed issues when the caller asked for --state all.
+        list_args.extend(["--state", args.state])
+
+        if args.label:
+            labels = [lbl.strip() for lbl in args.label.split(",") if lbl.strip()]
+            for lbl in labels:
+                list_args.extend(["--label", lbl])
+
+        if args.author:
+            list_args.extend(["--author", args.author])
+
+        if args.assignee:
+            list_args.extend(["--assignee", args.assignee])
+
+    try:
+        result = subprocess.run(
+            list_args, capture_output=True, text=True, timeout=30, check=False,
+        )
+    except subprocess.TimeoutExpired:
+        error_and_exit("Timed out waiting for gh issue list.", 3)
+    except FileNotFoundError:
+        error_and_exit("gh CLI not found on PATH.", 3)
+
+    if result.returncode != 0:
+        error_and_exit(
+            f"Failed to list issues: {result.stderr or result.stdout}", 3,
+        )
+
+    try:
+        issues = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
+        error_and_exit(f"Failed to parse JSON response from gh: {exc}", 3)
+
+    output = [
+        {
+            "number": i.get("number"),
+            "title": i.get("title"),
+            "state": i.get("state"),
+            "labels": [
+                lbl.get("name")
+                for lbl in (i.get("labels") or [])
+                if isinstance(lbl, dict)
+            ],
+            "assignees": [
+                a.get("login")
+                for a in (i.get("assignees") or [])
+                if isinstance(a, dict)
+            ],
+            "author": (i.get("author") or {}).get("login"),
+            "url": i.get("url"),
+            "createdAt": i.get("createdAt"),
+            "updatedAt": i.get("updatedAt"),
+        }
+        for i in issues
+        if isinstance(i, dict)
+    ]
+
+    print(json.dumps(output, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_list_issues.py
+++ b/tests/test_list_issues.py
@@ -169,7 +169,9 @@ class TestMain:
         assert "--assignee" in cmd
         assert "@me" in cmd
 
-    def test_state_all_omits_state_flag(self):
+    def test_state_all_forwards_state_flag(self):
+        # gh issue list defaults to open-only when --state is omitted,
+        # so --state all must be forwarded to actually return all states.
         with patch(
             "list_issues.assert_gh_authenticated",
         ), patch(
@@ -181,7 +183,8 @@ class TestMain:
         ) as mock_run:
             main(["--state", "all"])
         cmd = mock_run.call_args[0][0]
-        assert "--state" not in cmd
+        assert "--state" in cmd
+        assert "all" in cmd
 
     def test_search_filter_ignores_other_flags(self, capsys):
         issues = [_issue(5, "Fix auth bug")]
@@ -220,6 +223,94 @@ class TestMain:
             with pytest.raises(SystemExit) as exc:
                 main([])
             assert exc.value.code == 3
+
+    def test_timeout_exits_3(self):
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=30),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main([])
+            assert exc.value.code == 3
+
+    def test_gh_missing_exits_3(self):
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=FileNotFoundError("gh"),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main([])
+            assert exc.value.code == 3
+
+    def test_malformed_json_exits_3(self):
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout="not json", rc=0),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main([])
+            assert exc.value.code == 3
+
+    def test_non_dict_items_skipped(self, capsys):
+        # gh should never return scalars, but a malformed response must
+        # not crash on attribute access.
+        payload = [_issue(1, "Good"), "garbage", None, 42]
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout=json.dumps(payload), rc=0),
+        ):
+            rc = main([])
+        assert rc == 0
+        output = json.loads(capsys.readouterr().out)
+        assert len(output) == 1
+        assert output[0]["number"] == 1
+
+    def test_null_labels_and_assignees_handled(self, capsys):
+        payload = [{
+            "number": 7,
+            "title": "Null lists",
+            "state": "OPEN",
+            "labels": None,
+            "assignees": None,
+            "author": {"login": "alice"},
+            "url": "https://github.com/o/r/issues/7",
+            "createdAt": None,
+            "updatedAt": None,
+        }]
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout=json.dumps(payload), rc=0),
+        ):
+            rc = main([])
+        assert rc == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output[0]["labels"] == []
+        assert output[0]["assignees"] == []
 
     def test_empty_results(self, capsys):
         with patch(

--- a/tests/test_list_issues.py
+++ b/tests/test_list_issues.py
@@ -1,0 +1,336 @@
+"""Tests for list_issues.py skill script (issue #2110)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.github_core.api import RepoInfo
+
+# ---------------------------------------------------------------------------
+# Import the script via importlib (not a package)
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / ".claude" / "skills" / "github" / "scripts" / "issue"
+)
+
+
+def _import_script(name: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS_DIR / f"{name}.py")
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _import_script("list_issues")
+main = _mod.main
+build_parser = _mod.build_parser
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _completed(stdout: str = "", stderr: str = "", rc: int = 0):
+    return subprocess.CompletedProcess(args=[], returncode=rc, stdout=stdout, stderr=stderr)
+
+
+def _issue(
+    number=1,
+    title="Issue",
+    state="OPEN",
+    labels=None,
+    assignees=None,
+    author="alice",
+):
+    return {
+        "number": number,
+        "title": title,
+        "state": state,
+        "labels": [{"name": n} for n in (labels or [])],
+        "assignees": [{"login": a} for a in (assignees or [])],
+        "author": {"login": author},
+        "url": f"https://github.com/o/r/issues/{number}",
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-02T00:00:00Z",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_parser
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    def test_defaults(self):
+        args = build_parser().parse_args([])
+        assert args.state == "open"
+        assert args.limit == 30
+        assert args.label == ""
+        assert args.assignee == ""
+
+    def test_all_filters(self):
+        args = build_parser().parse_args([
+            "--state", "closed",
+            "--label", "bug,P1",
+            "--author", "alice",
+            "--assignee", "bob",
+            "--limit", "100",
+        ])
+        assert args.state == "closed"
+        assert args.label == "bug,P1"
+        assert args.author == "alice"
+        assert args.assignee == "bob"
+        assert args.limit == 100
+
+    def test_invalid_state_rejected(self):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["--state", "bogus"])
+
+
+# ---------------------------------------------------------------------------
+# Tests: main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_not_authenticated_exits_4(self):
+        with patch(
+            "list_issues.assert_gh_authenticated",
+            side_effect=SystemExit(4),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main([])
+            assert exc.value.code == 4
+
+    def test_success_open_issues(self, capsys):
+        issues = [
+            _issue(1, "First", labels=["bug"], assignees=["alice"]),
+            _issue(2, "Second"),
+        ]
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout=json.dumps(issues), rc=0),
+        ):
+            rc = main([])
+        assert rc == 0
+        output = json.loads(capsys.readouterr().out)
+        assert len(output) == 2
+        assert output[0]["number"] == 1
+        assert output[0]["labels"] == ["bug"]
+        assert output[0]["assignees"] == ["alice"]
+        assert output[0]["author"] == "alice"
+
+    def test_label_filter_passes_each_label(self):
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout="[]", rc=0),
+        ) as mock_run:
+            rc = main(["--label", "bug,P1"])
+        assert rc == 0
+        cmd = mock_run.call_args[0][0]
+        # Each label gets its own --label flag.
+        assert cmd.count("--label") == 2
+        assert "bug" in cmd and "P1" in cmd
+
+    def test_assignee_filter_passed(self):
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout="[]", rc=0),
+        ) as mock_run:
+            main(["--assignee", "@me"])
+        cmd = mock_run.call_args[0][0]
+        assert "--assignee" in cmd
+        assert "@me" in cmd
+
+    def test_state_all_omits_state_flag(self):
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout="[]", rc=0),
+        ) as mock_run:
+            main(["--state", "all"])
+        cmd = mock_run.call_args[0][0]
+        assert "--state" not in cmd
+
+    def test_search_filter_ignores_other_flags(self, capsys):
+        issues = [_issue(5, "Fix auth bug")]
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout=json.dumps(issues), rc=0),
+        ) as mock_run:
+            rc = main(["--search", "fix auth", "--label", "bug", "--state", "open"])
+        assert rc == 0
+        cmd = mock_run.call_args[0][0]
+        assert "--search" in cmd
+        assert "fix auth" in cmd
+        assert "--label" not in cmd
+        assert "--author" not in cmd
+        # --state is implicit-default 'open' here but must not be forwarded
+        # when --search is set, since gh would ignore it anyway.
+        assert "--state" not in cmd
+        output = json.loads(capsys.readouterr().out)
+        assert len(output) == 1
+
+    def test_api_error_exits_3(self):
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(rc=1, stderr="API error"),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main([])
+            assert exc.value.code == 3
+
+    def test_empty_results(self, capsys):
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout="[]", rc=0),
+        ):
+            rc = main([])
+        assert rc == 0
+        assert json.loads(capsys.readouterr().out) == []
+
+    def test_invalid_limit_exits_2(self):
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main(["--limit", "0"])
+            assert exc.value.code == 2
+
+    def test_missing_author_login_handled(self, capsys):
+        # Defensive: gh sometimes returns a null author (deleted user).
+        issues = [{
+            "number": 9,
+            "title": "Orphan",
+            "state": "OPEN",
+            "labels": [],
+            "assignees": [],
+            "author": None,
+            "url": "https://github.com/o/r/issues/9",
+            "createdAt": None,
+            "updatedAt": None,
+        }]
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout=json.dumps(issues), rc=0),
+        ):
+            rc = main([])
+        assert rc == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output[0]["author"] is None
+
+
+# ---------------------------------------------------------------------------
+# Regression: invoke_skill_first_guard 'issue.list' mapping (#2110)
+# ---------------------------------------------------------------------------
+
+
+class TestIssueListGuardMapping:
+    """Guard's issue.list mapping must point at a list-capable script
+    whose example command parses without requiring extra args."""
+
+    def test_mapping_targets_list_issues_script(self):
+        guard_path = (
+            Path(__file__).resolve().parents[1]
+            / ".claude" / "hooks" / "PreToolUse" / "invoke_skill_first_guard.py"
+        )
+        # Use a unique module name to avoid polluting the canonical
+        # 'invoke_skill_first_guard' entry that other test modules import
+        # with sys.path manipulation + @patch on the canonical name.
+        spec = importlib.util.spec_from_file_location(
+            "_isfg_mapping_probe", guard_path,
+        )
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["_isfg_mapping_probe"] = mod
+        spec.loader.exec_module(mod)
+
+        mapping = mod.SKILL_MAPPINGS["issue"]["list"]
+        assert mapping["script"] == "list_issues.py"
+        # The mapped script must exist on disk.
+        script = _SCRIPTS_DIR / mapping["script"]
+        assert script.exists(), f"missing {script}"
+        # The example must reference the same script.
+        assert mapping["script"] in mapping["example"]
+
+    def test_example_command_parses_without_error(self):
+        # Strip the leading 'python3 .claude/...script' prefix and verify
+        # the remaining argv is accepted by build_parser without exit.
+        guard_path = (
+            Path(__file__).resolve().parents[1]
+            / ".claude" / "hooks" / "PreToolUse" / "invoke_skill_first_guard.py"
+        )
+        spec = importlib.util.spec_from_file_location(
+            "invoke_skill_first_guard_v2", guard_path,
+        )
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["invoke_skill_first_guard_v2"] = mod
+        spec.loader.exec_module(mod)
+
+        example = mod.SKILL_MAPPINGS["issue"]["list"]["example"]
+        # Drop 'python3 <path>' prefix; keep the rest as argv.
+        tokens = example.split()
+        # Find script token (ends with .py).
+        script_idx = next(
+            i for i, t in enumerate(tokens) if t.endswith(".py")
+        )
+        argv = tokens[script_idx + 1:]
+        # Must not raise SystemExit.
+        args = build_parser().parse_args(argv)
+        assert args.state == "open"
+        assert args.label == "bug"

--- a/tests/test_list_issues.py
+++ b/tests/test_list_issues.py
@@ -266,6 +266,24 @@ class TestMain:
                 main([])
             assert exc.value.code == 3
 
+    @pytest.mark.parametrize("payload", ["null", "{}", "42", '"text"'])
+    def test_non_list_root_exits_3(self, payload):
+        # gh should always return a JSON array; a non-list root (null,
+        # object, scalar) must map to ADR-035 exit code 3, not crash or
+        # silently emit an empty list.
+        with patch(
+            "list_issues.assert_gh_authenticated",
+        ), patch(
+            "list_issues.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout=payload, rc=0),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main([])
+            assert exc.value.code == 3
+
     def test_non_dict_items_skipped(self, capsys):
         # gh should never return scalars, but a malformed response must
         # not crash on attribute access.


### PR DESCRIPTION
Fixes #2110

## Summary

The skill-first guard mapped the issue-list command to a script that requires `--issue` and cannot enumerate issues. The redirect target exited with a usage error, so agents worked around the guard with raw API calls, defeating the skill-first intent.

## Changes

- Add `.claude/skills/github/scripts/issue/list_issues.py` mirroring the PR-side list-issues precedent. Supports `--state`, `--label` (comma-separated, repeated per gh), `--author`, `--assignee`, `--search`, `--limit`, `--owner`/`--repo`. Emits JSON. Exit codes per ADR-035 (0/2/3/4). Maps gh timeout, missing-binary, and malformed-JSON failures to external-error exit code 3. Guards non-dict items and null label/assignee lists. Forwards `--state all` so closed issues are returned.
- Repoint the `issue.list` mapping in `invoke_skill_first_guard.py` at the new script with a corrected example command.
- Add `tests/test_list_issues.py` (20 tests): parser defaults, all filters, every error exit code (timeout, missing gh, malformed JSON, API error), search-mode flag suppression, label fan-out, `--state all` forwarding, non-dict and null-list handling, null-author handling, and a regression test asserting the guard mapping targets the new script and that its example argv parses without SystemExit.
- Regenerate the Copilot CLI mirror copies so they reflect the fixed source: `src/copilot-cli/skills/github/scripts/issue/list_issues.py` and `src/copilot-cli/hooks/preToolUse/invoke_skill_first_guard__Bash_f620ca.py`.

## Acceptance

- [x] `issue.list` guard mapping points at a script that lists issues
- [x] Script supports filtering by label, state, assignee; emits JSON
- [x] Guard example command runs without a usage error (regression test enforces this)
- [x] Error paths (timeout, missing gh, malformed JSON) map to ADR-035 exit code 3
- [x] 20/20 tests pass in `test_list_issues.py`
