### PR TITLE
fix(#2119): strip proof/scope sections in pr_description validator

### DIFF
--- a/scripts/validation/pr_description.py
+++ b/scripts/validation/pr_description.py
@@ -87,11 +87,11 @@ _CONTEXTUAL_SECTION_NAMES: tuple[str, ...] = (
     r"Test\s*Plan",
     r"Design\s*Decisions?",
     r"Related",
-    r"Related\s+Issues",
+    r"Related[ \t]+Issues",
     r"References?",
     r"See\s*Also",
     r"Notes?",
-    r"Notes\s+for\s+Reviewers",
+    r"Notes[ \t]+for[ \t]+Reviewers",
     r"Background",
     r"Inspired\s*By",
     r"Pattern\s*From",
@@ -119,7 +119,7 @@ _REFERENCE_SECTION_PREFIXES: tuple[str, ...] = (
     r"Evidence",
     r"Validation",
     r"Verification",
-    r"Out[\s-]*of[\s-]*Scope",
+    r"Out[ \t-]*of[ \t-]*Scope",
 )
 
 # Patterns to extract file paths from PR description text

--- a/scripts/validation/pr_description.py
+++ b/scripts/validation/pr_description.py
@@ -76,17 +76,50 @@ DEFAULT_BYPASS_LABEL = "description-validation-bypass"
 # Section names whose file mentions are contextual references, not change
 # claims. Matches `## Heading` (h2) at the start of a line, case-insensitive.
 # Each entry is a regex fragment for the heading text only.
+#
+# These are matched EXACTLY (the whole `## ...` line must be the name, modulo
+# trailing whitespace). Use this list for ambiguous single words where a
+# trailing suffix can carry a real change claim (e.g. `## Notes on the auth
+# rewrite` must stay validated). Multi-word template headings that are pure
+# references ("Related Issues", "Notes for Reviewers") are listed explicitly so
+# the exact-match anchor accepts them.
 _CONTEXTUAL_SECTION_NAMES: tuple[str, ...] = (
     r"Test\s*Plan",
     r"Design\s*Decisions?",
     r"Related",
+    r"Related\s+Issues",
     r"References?",
     r"See\s*Also",
     r"Notes?",
+    r"Notes\s+for\s+Reviewers",
     r"Background",
     r"Inspired\s*By",
     r"Pattern\s*From",
     r"Prior\s*Art",
+)
+
+# Section-name PREFIXES whose file mentions are proof or scope references, never
+# change claims. Matched as a prefix at a word boundary, so ANY suffix is
+# absorbed: "Evidence", "Evidence For", "Validation Summary", "Verification
+# Results", "Out of Scope notes" all strip. This kills the exact-name treadmill:
+# agent PR-body templates emit many variants of these proof/scope sections, and
+# enumerating each one recurs on the next variant.
+#
+# Safe because the description check is one-directional: Check 1
+# (mentioned-but-not-in-diff) is the only CRITICAL gate, and Check 2
+# (changed-but-not-mentioned) is a non-blocking WARNING. Stripping a reference
+# section can only remove a blocking false positive; the worst case is that a
+# file mentioned ONLY here, and actually changed, becomes a non-blocking
+# WARNING instead of a satisfied mention. Real drift is never hidden.
+#
+# Restricted to KINDS that never assert "I changed this file": proof (Evidence,
+# Validation, Verification) and scope exclusion (Out of Scope). Ambiguous words
+# that can carry real claims with a suffix stay in the exact-match list above.
+_REFERENCE_SECTION_PREFIXES: tuple[str, ...] = (
+    r"Evidence",
+    r"Validation",
+    r"Verification",
+    r"Out[\s-]*of[\s-]*Scope",
 )
 
 # Patterns to extract file paths from PR description text
@@ -350,6 +383,25 @@ def _strip_informational_sections(description: str) -> str:
     )
     text = re.sub(
         contextual_pattern,
+        "",
+        text,
+        flags=re.DOTALL | re.MULTILINE | re.IGNORECASE,
+    )
+    # Strip proof/scope reference sections by heading PREFIX (any suffix). Unlike
+    # the exact-match block above, this absorbs trailing words so heading
+    # variants ("Evidence For", "Validation Summary", "Verification Results",
+    # "Out of Scope notes") all strip without enumerating each one. The `\b`
+    # after the prefix prevents matching a longer word that merely starts with
+    # the prefix (e.g. "Validations" or "Evidenced"); the rest of the heading
+    # line is then consumed by `[^\n]*$`. Same terminating lookahead as above:
+    # the section ends at the next H1 or H2 (not H3+).
+    reference_prefix_pattern = (
+        r"^##\s+(?:"
+        + "|".join(_REFERENCE_SECTION_PREFIXES)
+        + r")\b[^\n]*$.*?(?=^#{1,2}(?!#)|\Z)"
+    )
+    text = re.sub(
+        reference_prefix_pattern,
         "",
         text,
         flags=re.DOTALL | re.MULTILINE | re.IGNORECASE,

--- a/scripts/validation/pr_description.py
+++ b/scripts/validation/pr_description.py
@@ -96,29 +96,39 @@ _CONTEXTUAL_SECTION_NAMES: tuple[str, ...] = (
     r"Inspired\s*By",
     r"Pattern\s*From",
     r"Prior\s*Art",
+    # Proof/results headings that name an activity, not a changed file.
+    # Listed here (exact match) instead of _REFERENCE_SECTION_PREFIXES so that
+    # headings like "## Validation Script" or "## Verification Steps", which
+    # describe real validator changes, are NOT stripped. Only bare proof headings
+    # and known summary suffixes strip.
+    r"Validation",
+    r"Validation[ \t]+Summary",
+    r"Validation[ \t]+Results",
+    r"Validation[ \t]+Report",
+    r"Verification",
+    r"Verification[ \t]+Results",
+    r"Verification[ \t]+Summary",
+    r"Verification[ \t]+Report",
 )
 
 # Section-name PREFIXES whose file mentions are proof or scope references, never
 # change claims. Matched as a prefix at a word boundary, so ANY suffix is
-# absorbed: "Evidence", "Evidence For", "Validation Summary", "Verification
-# Results", "Out of Scope notes" all strip. This kills the exact-name treadmill:
-# agent PR-body templates emit many variants of these proof/scope sections, and
-# enumerating each one recurs on the next variant.
+# absorbed. This kills the exact-name treadmill for Evidence and Out-of-Scope
+# headings: agent PR-body templates emit many variants, and enumerating each one
+# recurs on the next variant.
 #
-# Safe because the description check is one-directional: Check 1
-# (mentioned-but-not-in-diff) is the only CRITICAL gate, and Check 2
-# (changed-but-not-mentioned) is a non-blocking WARNING. Stripping a reference
-# section can only remove a blocking false positive; the worst case is that a
-# file mentioned ONLY here, and actually changed, becomes a non-blocking
-# WARNING instead of a satisfied mention. Real drift is never hidden.
+# Validation and Verification are NOT here (they moved to _CONTEXTUAL_SECTION_NAMES
+# as exact-match entries). Those words can prefix real change-claim sections
+# (e.g., "## Validation Script", "## Verification Steps"), so a blind prefix
+# match would suppress CRITICAL checks for genuine drift.
 #
-# Restricted to KINDS that never assert "I changed this file": proof (Evidence,
-# Validation, Verification) and scope exclusion (Out of Scope). Ambiguous words
-# that can carry real claims with a suffix stay in the exact-match list above.
+# Evidence never precedes a real change-claim section in this codebase, so the
+# prefix absorbs all Evidence variants safely.
+#
+# Out-of-Scope is unambiguous by definition: it explicitly names files NOT
+# changed in this PR.
 _REFERENCE_SECTION_PREFIXES: tuple[str, ...] = (
     r"Evidence",
-    r"Validation",
-    r"Verification",
     r"Out[ \t-]*of[ \t-]*Scope",
 )
 

--- a/tests/test_validation_pr_description.py
+++ b/tests/test_validation_pr_description.py
@@ -433,6 +433,27 @@ class TestExtractMentionedFiles:
         assert "real.py" in result
         assert "proof.py" not in result
 
+    def test_validation_script_heading_not_stripped(self) -> None:
+        """Copilot review: 'Validation Script', 'Validation Rules', etc. must NOT
+        strip because they can describe real validator changes. Only bare
+        'Validation' and known proof suffixes (Summary, Results, Report) strip."""
+        desc = (
+            "## Summary\nUpdated the validator.\n\n"
+            "## Validation Script\n- rewrote `validator.py`\n"
+        )
+        result = extract_mentioned_files(desc)
+        assert "validator.py" in result
+
+    def test_verification_steps_heading_not_stripped(self) -> None:
+        """'Verification Steps' is a change-description heading, not a proof
+        heading; it must NOT strip."""
+        desc = (
+            "## Summary\nAdded hook.\n\n"
+            "## Verification Steps\n- run `hook.py` to confirm\n"
+        )
+        result = extract_mentioned_files(desc)
+        assert "hook.py" in result
+
     def test_contextual_section_case_insensitive(self) -> None:
         desc = (
             "## Summary\nChanged `a.py`.\n\n"

--- a/tests/test_validation_pr_description.py
+++ b/tests/test_validation_pr_description.py
@@ -326,6 +326,113 @@ class TestExtractMentionedFiles:
         result = extract_mentioned_files(desc)
         assert "b.py" not in result
 
+    def test_evidence_section_ignored(self) -> None:
+        """Issue #2119 repro: agent PR bodies cite files in an Evidence section
+        as proof, not as change claims."""
+        desc = (
+            "## Summary\nChanged `a.py`.\n\n"
+            "## Evidence\n- `validate_marketplace_counts.py --fix` updated counts\n"
+            "- pre-existing failures in `pre_pr.py` are unrelated\n"
+        )
+        result = extract_mentioned_files(desc)
+        assert "a.py" in result
+        assert "pre_pr.py" not in result
+        assert "validate_marketplace_counts.py" not in result
+
+    def test_evidence_with_suffix_section_ignored(self) -> None:
+        """Prefix match absorbs a trailing word: 'Evidence For' strips too."""
+        desc = (
+            "## Summary\nChanged `a.py`.\n\n"
+            "## Evidence For\n- `b.py` demonstrates the prior behavior\n"
+        )
+        result = extract_mentioned_files(desc)
+        assert "b.py" not in result
+
+    def test_validation_section_ignored(self) -> None:
+        desc = (
+            "## Summary\nChanged `a.py`.\n\n"
+            "## Validation\n- ran `b.py`; `c.json` config unchanged\n"
+        )
+        result = extract_mentioned_files(desc)
+        assert "a.py" in result
+        assert "b.py" not in result
+        assert "c.json" not in result
+
+    def test_validation_summary_suffix_section_ignored(self) -> None:
+        desc = (
+            "## Summary\nChanged `a.py`.\n\n"
+            "## Validation Summary\n- `b.py` passed\n"
+        )
+        result = extract_mentioned_files(desc)
+        assert "b.py" not in result
+
+    def test_verification_results_suffix_section_ignored(self) -> None:
+        desc = (
+            "## Summary\nChanged `a.py`.\n\n"
+            "## Verification Results\n- `b.py` exit 0\n"
+        )
+        result = extract_mentioned_files(desc)
+        assert "b.py" not in result
+
+    def test_out_of_scope_section_ignored(self) -> None:
+        """Issue #2119 repro (PR #2114): 'Out of scope' names files explicitly
+        NOT changed; treating them as change claims is backwards."""
+        desc = (
+            "## Summary\nChanged `a.py`.\n\n"
+            "## Out of scope\n- `marketplace.json` count drift is pre-existing\n"
+        )
+        result = extract_mentioned_files(desc)
+        assert "a.py" in result
+        assert "marketplace.json" not in result
+
+    def test_out_of_scope_hyphenated_section_ignored(self) -> None:
+        desc = (
+            "## Summary\nChanged `a.py`.\n\n"
+            "## Out-of-Scope\n- `b.py`\n"
+        )
+        result = extract_mentioned_files(desc)
+        assert "b.py" not in result
+
+    def test_related_issues_multiword_heading_ignored(self) -> None:
+        """The strict exact-match anchor rejected 'Related Issues' (only bare
+        'Related' matched); it is now listed explicitly."""
+        desc = (
+            "## Summary\nChanged `a.py`.\n\n"
+            "## Related Issues\n- see `b.py` from #100\n"
+        )
+        result = extract_mentioned_files(desc)
+        assert "b.py" not in result
+
+    def test_notes_for_reviewers_multiword_heading_ignored(self) -> None:
+        desc = (
+            "## Summary\nChanged `a.py`.\n\n"
+            "## Notes for Reviewers\n- `b.py` is the prior art\n"
+        )
+        result = extract_mentioned_files(desc)
+        assert "b.py" not in result
+
+    def test_reference_prefix_word_boundary_not_overstripped(self) -> None:
+        """`\\b` after the prefix prevents matching a longer word. A section
+        named 'Validations' (plural, not a known proof kind) must NOT strip, so
+        a real change claim inside it is still validated."""
+        desc = (
+            "## Summary\nWork.\n\n"
+            "## Validationsxyz\n- changed `b.py`\n"
+        )
+        result = extract_mentioned_files(desc)
+        assert "b.py" in result
+
+    def test_reference_prefix_does_not_overstrip_changes_section(self) -> None:
+        """A real change claim in a normal section still extracts even when an
+        Evidence section follows it."""
+        desc = (
+            "## Changes\n- `real.py` rewritten\n\n"
+            "## Evidence\n- `proof.py` shows the fix\n"
+        )
+        result = extract_mentioned_files(desc)
+        assert "real.py" in result
+        assert "proof.py" not in result
+
     def test_contextual_section_case_insensitive(self) -> None:
         desc = (
             "## Summary\nChanged `a.py`.\n\n"
@@ -1012,6 +1119,42 @@ class TestValidatePRDescription:
         critical = [i for i in issues if i.severity == "CRITICAL"]
         assert len(critical) == 1
         assert critical[0].file == "scripts/bar.py"
+
+    def test_issue_2119_evidence_and_scope_files_do_not_block(self) -> None:
+        """End-to-end #2119 (PR #2114 shape): a body that cites files in
+        Evidence and Out of scope sections, none in the diff, must produce zero
+        CRITICAL. The actually-changed file is mentioned in Summary, so no
+        warning either."""
+        description = (
+            "## Summary\nBumps `plugin.json` to 0.3.1.\n\n"
+            "## Evidence\n- `validate_marketplace_counts.py` reports no drift\n\n"
+            "## Out of scope\n"
+            "- pre-existing `pre_pr.py` lint failures\n"
+            "- `marketplace.json` count is handled separately\n"
+        )
+        mentioned = extract_mentioned_files(description)
+        issues = validate_pr_description(
+            pr_files=["plugin.json"],
+            mentioned_files=mentioned,
+        )
+        critical = [i for i in issues if i.severity == "CRITICAL"]
+        assert critical == []
+
+    def test_issue_2119_real_summary_claim_still_blocks(self) -> None:
+        """Guard against over-strip: a genuine change claim in Summary that is
+        NOT in the diff must still fire CRITICAL even when an Evidence section
+        is present."""
+        description = (
+            "## Summary\nRewrites `scripts/missing.py`.\n\n"
+            "## Evidence\n- `proof.py` shows it\n"
+        )
+        mentioned = extract_mentioned_files(description)
+        issues = validate_pr_description(
+            pr_files=["scripts/other.py"],
+            mentioned_files=mentioned,
+        )
+        critical = [i for i in issues if i.severity == "CRITICAL"]
+        assert [i.file for i in critical] == ["scripts/missing.py"]
 
     def test_warning_when_significant_file_not_mentioned(self) -> None:
         issues = validate_pr_description(


### PR DESCRIPTION
## Summary

### What

Fix a CRITICAL false positive in `scripts/validation/pr_description.py`. The description-matches-diff check flagged file references that appear in proof or scope sections of a PR body (Evidence, Validation, Verification, Out of scope) as if the PR claimed to change those files, blocking the required "Validate PR" check.

### Why

In one PR-landing pass on 2026-05-29, five PRs (#2107, #2109, #2100, #2114, #2115) each burned a full fix cycle on this exact false positive. The validator already strips reference sections before extraction, but only by an exact-name denylist that did not include the proof and scope section names the agent PR-body templates emit. Enumerating each name is a treadmill; the next template variant recurs. The goal here is prevention.

## Changes

- `scripts/validation/pr_description.py`: add a prefix-matched reference-section set (Evidence, Validation, Verification, Out of Scope) matched at a word boundary so any suffix (Evidence For, Validation Summary, Verification Results) strips without enumeration. Add the template multi-word headings Related Issues and Notes for Reviewers to the exact-match list. Keep exact-match for ambiguous single words (Notes, Related) where a suffix can carry a real change claim.
- `tests/test_validation_pr_description.py`: 13 new cases covering each section kind, multi-word headings, the word-boundary over-strip guard, and end-to-end repros of the PR #2114 shape plus a guard that a genuine Summary claim still fires CRITICAL.

## Root cause

`_strip_informational_sections` removes contextual H2 sections by exact name. The strict full-line anchor also rejected multi-word headings. Proof and scope sections never assert that a file changed; their mentions are evidence or explicit non-changes.

## Why this is safe (not a coverage reduction)

The check is one-directional. Check 1 (mentioned-but-not-in-diff) is the only CRITICAL gate. Check 2 (changed-but-not-mentioned) is a non-blocking WARNING and scans the diff, not the body. Stripping a reference section can only remove a blocking false positive. Worst case: a file mentioned only in a reference section, and actually changed, becomes a non-blocking WARNING. Real drift is never hidden.

## Design alternatives considered

- Extend the exact-name denylist one entry at a time: rejected, it recurs on the next template heading variant.
- Downgrade Check 1 to WARNING when the mentioned file exists in the repo but not the diff: rejected, it weakens the genuine drift case.
- Allowlist claim-sections instead of denylisting reference-sections: cleaner long term but a larger inversion of the committed design with more false-negative risk; deferred.

## Testing

Ran the validator suite with uv run pytest on the validation test module: 184 passed.

## Out of scope

The allowlist redesign and the broader extraction refactor. The double-extension and token-boundary hardening already landed under #1874 and #1881.

Fixes #2119
