### PR TITLE
feat(validation): require changed workflows to pass a local run before push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -239,6 +239,7 @@ CHANGED_PY_CANONICAL=$(echo "$CHANGED_PY" \
     || true)
 CHANGED_PS=$(echo "$CHANGED_FILES" | grep -E '\.(ps1|psm1)$' || true)
 CHANGED_WORKFLOWS=$(echo "$CHANGED_FILES" | grep -E '^\.github/workflows/.*\.ya?ml$' || true)
+CHANGED_ACTIONS=$(echo "$CHANGED_FILES" | grep -E '^\.github/actions/.*\.ya?ml$' || true)
 CHANGED_YAML=$(echo "$CHANGED_FILES" | grep -E '\.ya?ml$' || true)
 CHANGED_TEMPLATES=$(echo "$CHANGED_FILES" | grep -E '^templates/' || true)
 CHANGED_SESSIONS=$(echo "$CHANGED_FILES" | grep -E '^\.agents/sessions/' || true)
@@ -515,7 +516,10 @@ else
 fi
 
 # 8a. Workflow validation (validate_workflows.py) - BLOCKING
-if [ -n "$CHANGED_WORKFLOWS" ]; then
+# validate_workflows.py validates both .github/workflows/ and .github/actions/ files
+# for SHA-pinning, expression-injection, and YAML structure. Use both CHANGED_WORKFLOWS
+# (for Section 8 local-run gate) and CHANGED_ACTIONS (for action definitions) here.
+if [ -n "$CHANGED_WORKFLOWS" ] || [ -n "$CHANGED_ACTIONS" ]; then
     VALIDATE_WORKFLOWS_SCRIPT="$REPO_ROOT/scripts/validate_workflows.py"
 
     if [ -L "$VALIDATE_WORKFLOWS_SCRIPT" ]; then
@@ -528,6 +532,11 @@ if [ -n "$CHANGED_WORKFLOWS" ]; then
                 [ -L "$file" ] && continue
                 [ -f "$file" ] && WF_FILES+=("$file")
             done <<< "$CHANGED_WORKFLOWS"
+            while IFS= read -r file; do
+                [ -z "$file" ] && continue
+                [ -L "$file" ] && continue
+                [ -f "$file" ] && WF_FILES+=("$file")
+            done <<< "$CHANGED_ACTIONS"
 
             if [ ${#WF_FILES[@]} -gt 0 ]; then
                 VALIDATE_OUTPUT=$(mktemp)
@@ -551,7 +560,7 @@ if [ -n "$CHANGED_WORKFLOWS" ]; then
         record_skip "Workflow validation (script not found)"
     fi
 else
-    record_skip "Workflow validation (no workflow files changed)"
+    record_skip "Workflow validation (no workflow or action files changed)"
 fi
 
 # 9. YAML style (yamllint) - Non-blocking warnings

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -470,8 +470,16 @@ fi
 # SKIP_WORKFLOW_LOCAL_TEST=true.
 if [ -n "$CHANGED_WORKFLOWS" ]; then
     WF_LOCAL_SCRIPT="$REPO_ROOT/scripts/validation/run_workflow_local_test.py"
-    if [ -L "$WF_LOCAL_SCRIPT" ]; then
-        record_warn "Workflow local-run script is a symlink (skipping)"
+    # Fail closed: the gate exists to REQUIRE a local run. A missing, symlinked,
+    # or unrunnable validator MUST block the push, not silently skip it. The only
+    # escape is the documented, audible bypass.
+    WF_BYPASS=$(printf '%s' "${SKIP_WORKFLOW_LOCAL_TEST:-}" | tr '[:upper:]' '[:lower:]')
+    if [ "$WF_BYPASS" = "true" ] || [ "$WF_BYPASS" = "1" ]; then
+        record_warn "Workflow local run BYPASSED (SKIP_WORKFLOW_LOCAL_TEST set)"
+    elif [ -L "$WF_LOCAL_SCRIPT" ]; then
+        record_fail "Workflow local-run script is a symlink; refusing to skip the gate"
+        echo_info "  Restore scripts/validation/run_workflow_local_test.py, or set"
+        echo_info "  SKIP_WORKFLOW_LOCAL_TEST=true to bypass an unrunnable workflow."
     elif [ -f "$WF_LOCAL_SCRIPT" ] && set_python_cmd; then
         WF_FILES=()
         while IFS= read -r file; do
@@ -487,16 +495,12 @@ if [ -n "$CHANGED_WORKFLOWS" ]; then
                 > "$WF_LOCAL_OUTPUT" 2>&1
             WF_LOCAL_RC=$?
             if [ $WF_LOCAL_RC -eq 0 ]; then
-                if grep -q "BYPASSED" "$WF_LOCAL_OUTPUT" 2>/dev/null; then
-                    cat "$WF_LOCAL_OUTPUT"
-                    record_warn "Workflow local run BYPASSED (SKIP_WORKFLOW_LOCAL_TEST=true)"
-                else
-                    record_pass "Workflow local run (actionlint+act, ${#WF_FILES[@]} files)"
-                fi
+                record_pass "Workflow local run (actionlint+act, ${#WF_FILES[@]} files)"
             elif [ $WF_LOCAL_RC -eq 3 ]; then
                 cat "$WF_LOCAL_OUTPUT"
                 record_fail "Workflow local run: required tool unavailable"
-                echo_info "  Install actionlint + Docker, or set"
+                echo_info "  Install actionlint, the gh act extension"
+                echo_info "  (gh extension install nektos/gh-act), and Docker, or set"
                 echo_info "  SKIP_WORKFLOW_LOCAL_TEST=true to bypass an unrunnable workflow."
             else
                 cat "$WF_LOCAL_OUTPUT"
@@ -509,7 +513,10 @@ if [ -n "$CHANGED_WORKFLOWS" ]; then
             record_skip "Workflow local run (no accessible files)"
         fi
     else
-        record_skip "Workflow local run (script or Python unavailable)"
+        record_fail "Workflow local run: validator script or Python unavailable"
+        echo_info "  Install Python 3 and restore"
+        echo_info "  scripts/validation/run_workflow_local_test.py, or set"
+        echo_info "  SKIP_WORKFLOW_LOCAL_TEST=true to bypass an unrunnable workflow."
     fi
 else
     record_skip "Workflow local run (no workflow files changed)"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -238,7 +238,7 @@ CHANGED_PY_CANONICAL=$(echo "$CHANGED_PY" \
     | grep -Ev '^src/copilot-cli/skills/' \
     || true)
 CHANGED_PS=$(echo "$CHANGED_FILES" | grep -E '\.(ps1|psm1)$' || true)
-CHANGED_WORKFLOWS=$(echo "$CHANGED_FILES" | grep -E '^\.github/(workflows|actions)/.*\.ya?ml$' || true)
+CHANGED_WORKFLOWS=$(echo "$CHANGED_FILES" | grep -E '^\.github/workflows/.*\.ya?ml$' || true)
 CHANGED_YAML=$(echo "$CHANGED_FILES" | grep -E '\.ya?ml$' || true)
 CHANGED_TEMPLATES=$(echo "$CHANGED_FILES" | grep -E '^templates/' || true)
 CHANGED_SESSIONS=$(echo "$CHANGED_FILES" | grep -E '^\.agents/sessions/' || true)
@@ -486,7 +486,12 @@ if [ -n "$CHANGED_WORKFLOWS" ]; then
                 > "$WF_LOCAL_OUTPUT" 2>&1
             WF_LOCAL_RC=$?
             if [ $WF_LOCAL_RC -eq 0 ]; then
-                record_pass "Workflow local run (actionlint+act, ${#WF_FILES[@]} files)"
+                if grep -q "BYPASSED" "$WF_LOCAL_OUTPUT" 2>/dev/null; then
+                    cat "$WF_LOCAL_OUTPUT"
+                    record_warn "Workflow local run BYPASSED (SKIP_WORKFLOW_LOCAL_TEST=true)"
+                else
+                    record_pass "Workflow local run (actionlint+act, ${#WF_FILES[@]} files)"
+                fi
             elif [ $WF_LOCAL_RC -eq 3 ]; then
                 cat "$WF_LOCAL_OUTPUT"
                 record_fail "Workflow local run: required tool unavailable"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -457,9 +457,21 @@ else
     record_skip "Python type check (no .py files changed)"
 fi
 
-# 8. Workflow YAML (actionlint) - BLOCKING
+# 8. Workflow local-run gate (actionlint + gh act dry-run + full run) - BLOCKING
+#
+# Belt and suspenders: a changed .github/workflows file MUST pass actionlint,
+# then `gh act -n` (dry-run graph), then a full `gh act` run before the push is
+# allowed. Delegates to scripts/validation/run_workflow_local_test.py so the
+# stage logic is unit-tested (ADR-006). Exit 3 means a required tool
+# (actionlint, gh act, Docker) is unavailable; that blocks too, because the
+# point of this gate is to REQUIRE the local run. A workflow that genuinely
+# cannot run under act (secrets, ARM-only runner) is bypassed, audibly, with
+# SKIP_WORKFLOW_LOCAL_TEST=true.
 if [ -n "$CHANGED_WORKFLOWS" ]; then
-    if command -v actionlint &> /dev/null; then
+    WF_LOCAL_SCRIPT="$REPO_ROOT/scripts/validation/run_workflow_local_test.py"
+    if [ -L "$WF_LOCAL_SCRIPT" ]; then
+        record_warn "Workflow local-run script is a symlink (skipping)"
+    elif [ -f "$WF_LOCAL_SCRIPT" ] && set_python_cmd; then
         WF_FILES=()
         while IFS= read -r file; do
             [ -z "$file" ] && continue
@@ -468,24 +480,33 @@ if [ -n "$CHANGED_WORKFLOWS" ]; then
         done <<< "$CHANGED_WORKFLOWS"
 
         if [ ${#WF_FILES[@]} -gt 0 ]; then
-            ACTIONLINT_OUTPUT=$(mktemp)
-            if actionlint "${WF_FILES[@]}" > "$ACTIONLINT_OUTPUT" 2>&1; then
-                rm -f "$ACTIONLINT_OUTPUT"
-                record_pass "Workflow YAML/actionlint (${#WF_FILES[@]} files)"
+            WF_LOCAL_OUTPUT=$(mktemp)
+            TEMP_FILES+=("$WF_LOCAL_OUTPUT")
+            "${PYTHON_CMD[@]}" "$WF_LOCAL_SCRIPT" --files "${WF_FILES[@]}" \
+                > "$WF_LOCAL_OUTPUT" 2>&1
+            WF_LOCAL_RC=$?
+            if [ $WF_LOCAL_RC -eq 0 ]; then
+                record_pass "Workflow local run (actionlint+act, ${#WF_FILES[@]} files)"
+            elif [ $WF_LOCAL_RC -eq 3 ]; then
+                cat "$WF_LOCAL_OUTPUT"
+                record_fail "Workflow local run: required tool unavailable"
+                echo_info "  Install actionlint + Docker, or set"
+                echo_info "  SKIP_WORKFLOW_LOCAL_TEST=true to bypass an unrunnable workflow."
             else
-                echo_info "  actionlint issues:"
-                head -10 "$ACTIONLINT_OUTPUT"
-                rm -f "$ACTIONLINT_OUTPUT"
-                record_fail "Workflow YAML/actionlint"
+                cat "$WF_LOCAL_OUTPUT"
+                record_fail "Workflow local run failed (exit $WF_LOCAL_RC)"
+                echo_info "  Make the workflow pass locally, or set"
+                echo_info "  SKIP_WORKFLOW_LOCAL_TEST=true if it cannot run under act."
             fi
+            rm -f "$WF_LOCAL_OUTPUT"
         else
-            record_skip "Workflow YAML (no accessible files)"
+            record_skip "Workflow local run (no accessible files)"
         fi
     else
-        record_skip "Workflow YAML (actionlint not installed)"
+        record_skip "Workflow local run (script or Python unavailable)"
     fi
 else
-    record_skip "Workflow YAML (no workflow files changed)"
+    record_skip "Workflow local run (no workflow files changed)"
 fi
 
 # 8a. Workflow validation (validate_workflows.py) - BLOCKING

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Read first, reason second. Pre-training last resort.
 
 ## Boundaries
 
-**Always**: Python new scripts (ADR-042)|Verify branch|Update Serena|Check skills|Assign issues|PR template|Atomic commits (≤5 files)|Scoped lint|Pin Actions to SHA|`gh act` locally
+**Always**: Python new scripts (ADR-042)|Verify branch|Update Serena|Check skills|Assign issues|PR template|Atomic commits (≤5 files)|Scoped lint|Pin Actions to SHA|Changed `.github/workflows/` MUST pass local run before push (actionlint + `gh act` dry-run + full; enforced by pre-push, bypass `SKIP_WORKFLOW_LOCAL_TEST=true`)
 **Ask First**: Architecture changes|New ADRs|Breaking changes|Security-sensitive
 **Autonomy Guardrail**: Internal+reversible (read,edit,memory): act|External/Irreversible: confirm|Ambiguous: act minimal, flag rest
 **Never**: Commit secrets|Update HANDOFF.md|Use bash|Skip validation|Logic in YAML (ADR-006)|Raw gh when skills exist|Force push|Skip hooks|Internal refs in src/|Scratch in working tree (use `$TMPDIR`/`mktemp`)|Resolve security threads without fixing underlying vulnerability (CWE/OWASP/CVE) in code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Read first, reason second. Pre-training last resort.
 
 ## Boundaries
 
-**Always**: Python new scripts (ADR-042)|Verify branch|Update Serena|Check skills|Assign issues|PR template|Atomic commits (≤5 files)|Scoped lint|Pin Actions to SHA|Changed `.github/workflows/` MUST pass local run before push (actionlint + `gh act` dry-run + full; enforced by pre-push, bypass `SKIP_WORKFLOW_LOCAL_TEST=true`)
+**Always**: Python new scripts (ADR-042)|Verify branch|Update Serena|Check skills|Assign issues|PR template|Atomic commits (≤5 files)|Scoped lint|Pin Actions to SHA|Run changed workflows locally pre-push (`SKIP_WORKFLOW_LOCAL_TEST=true` bypass)
 **Ask First**: Architecture changes|New ADRs|Breaking changes|Security-sensitive
 **Autonomy Guardrail**: Internal+reversible (read,edit,memory): act|External/Irreversible: confirm|Ambiguous: act minimal, flag rest
 **Never**: Commit secrets|Update HANDOFF.md|Use bash|Skip validation|Logic in YAML (ADR-006)|Raw gh when skills exist|Force push|Skip hooks|Internal refs in src/|Scratch in working tree (use `$TMPDIR`/`mktemp`)|Resolve security threads without fixing underlying vulnerability (CWE/OWASP/CVE) in code

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -838,6 +838,58 @@ def validate_install_parity(repo_root: Path) -> bool:
     return exit_code == 0
 
 
+def validate_workflow_local_run(repo_root: Path) -> bool:
+    """Shift-left tier of the workflow local-run gate (actionlint + act -n).
+
+    Runs the fast stages of ``scripts/validation/run_workflow_local_test.py``
+    (``--no-full``) over the changed ``.github/workflows`` files. The full
+    ``gh act`` execution stage is reserved for the pre-push hook so pre_pr stays
+    fast and does not require a running Docker daemon.
+
+    Contract: pass when no workflow changed or all run stages pass. A stage
+    failure (exit 1) blocks. A missing local tool (exit 3) does NOT block here,
+    because the pre-push gate is the authoritative enforcer; pre_pr only warns
+    so a contributor without actionlint installed is not stopped pre-PR.
+    """
+    script = repo_root / "scripts" / "validation" / "run_workflow_local_test.py"
+    if not script.exists():
+        raise MissingScriptSkip("run_workflow_local_test.py not present")
+
+    base_ref = _resolve_branch_base_ref(repo_root)
+    if not base_ref:
+        print("[WARN] workflow local-run: base ref unresolved; skipping.")
+        return True
+
+    diff_code, diff_out, _ = _run_subprocess(
+        ["git", "-C", str(repo_root), "diff", "--name-only", f"{base_ref}...HEAD"]
+    )
+    if diff_code != 0:
+        print("[WARN] workflow local-run: git diff failed; skipping.")
+        return True
+    changed = [
+        line
+        for line in diff_out.splitlines()
+        if line.startswith(".github/workflows/") and line.endswith((".yml", ".yaml"))
+    ]
+    if not changed:
+        print("No changed workflow files; nothing to run locally.")
+        return True
+
+    cmd = [sys.executable, str(script), "--no-full", "--files", *changed]
+    exit_code, stdout, stderr = _run_subprocess(cmd)
+    output = (stdout or "") + (stderr or "")
+    if output.strip():
+        for line in output.strip().splitlines()[:80]:
+            print(line)
+    if exit_code == 3:
+        print(
+            "[WARN] workflow local-run tools unavailable locally; the pre-push "
+            "hook enforces the full gate (actionlint + gh act)."
+        )
+        return True
+    return exit_code == 0
+
+
 def validate_command_bundle_coverage(repo_root: Path) -> bool:
     """SPEC-005 advisory check: each lifecycle command invokes its bundled skills.
 
@@ -1056,6 +1108,13 @@ def main(argv: list[str] | None = None) -> int:
         "Install Parity (agents and rules)",
         state,
         lambda: validate_install_parity(repo_root),
+    )
+
+    # 6d. Workflow Local Run (actionlint + gh act dry-run for changed workflows)
+    run_validation(
+        "Workflow Local Run",
+        state,
+        lambda: validate_workflow_local_run(repo_root),
     )
 
     # 7. Command-Skill Bundle Coverage (advisory by default; SPEC-005 AC-14)

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -869,7 +869,9 @@ def validate_workflow_local_run(repo_root: Path) -> bool:
     changed = [
         line
         for line in diff_out.splitlines()
-        if line.startswith(".github/workflows/") and line.endswith((".yml", ".yaml"))
+        if line.startswith(".github/workflows/")
+        and line.endswith((".yml", ".yaml"))
+        and (repo_root / line).is_file()
     ]
     if not changed:
         print("No changed workflow files; nothing to run locally.")

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -847,9 +847,12 @@ def validate_workflow_local_run(repo_root: Path) -> bool:
     fast and does not require a running Docker daemon.
 
     Contract: pass when no workflow changed or all run stages pass. A stage
-    failure (exit 1) blocks. A missing local tool (exit 3) does NOT block here,
-    because the pre-push gate is the authoritative enforcer; pre_pr only warns
-    so a contributor without actionlint installed is not stopped pre-PR.
+    failure (exit 1) blocks. A configuration error (exit 2: a path that escapes
+    the repo root, or a missing repo root) also blocks, because the inputs are
+    wrong and a clean run cannot be trusted. A missing local tool (exit 3) does
+    NOT block here, because the pre-push gate is the authoritative enforcer;
+    pre_pr only warns so a contributor without actionlint installed is not
+    stopped pre-PR.
     """
     script = repo_root / "scripts" / "validation" / "run_workflow_local_test.py"
     if not script.exists():

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -880,7 +880,18 @@ def validate_workflow_local_run(repo_root: Path) -> bool:
         print("No changed workflow files; nothing to run locally.")
         return True
 
-    cmd = [sys.executable, str(script), "--no-full", "--files", *changed]
+    # Pass the known repo_root explicitly so containment and path resolution
+    # validate against this checkout, not the script's path-derived default
+    # (robust to symlinked checkouts).
+    cmd = [
+        sys.executable,
+        str(script),
+        "--repo-root",
+        str(repo_root),
+        "--no-full",
+        "--files",
+        *changed,
+    ]
     exit_code, stdout, stderr = _run_subprocess(cmd)
     output = (stdout or "") + (stderr or "")
     if output.strip():

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -293,6 +293,8 @@ def run_local_test(
 def _format_text(report: Report) -> str:
     if report.bypassed:
         return f"workflow-local-test: BYPASSED ({report.note})"
+    if report.exit_code == 2:
+        return f"workflow-local-test: CONFIG ERROR\n  {report.note}"
     if report.exit_code == 3:
         return f"workflow-local-test: TOOL UNAVAILABLE\n  {report.note}"
     if report.exit_code == 0:

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -97,6 +97,12 @@ def _docker_ready() -> bool:
     return rc == 0
 
 
+def _gh_act_available() -> bool:
+    """True when the ``gh act`` extension is installed."""
+    rc, _, _ = _run(["gh", "act", "--help"], timeout=20)
+    return rc == 0
+
+
 def _run(cmd: list[str], *, timeout: int, cwd: Path | None = None) -> tuple[int, str, str]:
     """Run a command. Returns (exit_code, stdout, stderr); -1 on spawn error."""
     try:
@@ -197,6 +203,13 @@ def run_local_test(
     if not _have("gh"):
         report.exit_code = 3
         report.note = f"gh CLI not installed. Install it or set {_BYPASS_ENV}=true."
+        return report
+    if not _gh_act_available():
+        report.exit_code = 3
+        report.note = (
+            "gh act extension not installed. Install it via "
+            f"'gh extension install nektos/gh-act' or set {_BYPASS_ENV}=true."
+        )
         return report
 
     s2 = _act_dryrun_stage(files, repo_root)

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -218,6 +218,13 @@ def run_local_test(
             note=f"{_BYPASS_ENV} set; local workflow run skipped (logged).",
         )
 
+    # Precondition: repo_root must exist. A direct caller (the tests, the
+    # pre-PR runner) that passes a missing root is a configuration error
+    # (exit 2), not a stage failure (exit 1). main() checks this too; the
+    # check lives here so every caller of run_local_test gets the contract.
+    if not repo_root.is_dir():
+        return Report(exit_code=2, note=f"repo root not found: {repo_root}")
+
     files, path_error = _select_workflow_files(workflow_files, repo_root)
     if path_error is not None:
         return Report(exit_code=2, note=path_error)

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -272,10 +272,14 @@ def run_local_test(
     if full:
         if not _docker_ready():
             report.exit_code = 3
+            if not _have("docker"):
+                cause = "Docker is not installed"
+            else:
+                cause = "the Docker daemon is not running"
             report.note = (
-                "Docker daemon not available; the full gh act run cannot "
-                f"execute. Start Docker or set {_BYPASS_ENV}=true to bypass an "
-                "unrunnable workflow (or pass --no-full for the lint+dry-run tier)."
+                f"{cause}; the full gh act run cannot execute. Install/start "
+                f"Docker or set {_BYPASS_ENV}=true to bypass an unrunnable "
+                "workflow (or pass --no-full for the lint+dry-run tier)."
             )
             return report
         s3 = _act_full_stage(files, repo_root)

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -58,6 +58,18 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 _BYPASS_ENV = "SKIP_WORKFLOW_LOCAL_TEST"
 
+# Truthy values for the bypass env. Matches the repo convention for boolean
+# env flags (see BUNDLE_CHECK_ENFORCED in scripts/validation/pre_pr.py, which
+# accepts "1" and "true").
+_TRUTHY = {"1", "true"}
+
+# Only GitHub Actions workflow files can run under ``gh act``. Custom actions
+# under ``.github/actions/`` and any other path are filtered out before the act
+# stages so a caller that over-collects (the pre-push hook globs changed files)
+# does not hand a non-runnable path to ``gh act``.
+_WORKFLOW_PREFIX = ".github/workflows/"
+_WORKFLOW_SUFFIXES = (".yml", ".yaml")
+
 # Per-stage timeouts (seconds). The full act run pulls images and executes
 # composite actions, so it gets the largest budget.
 _ACTIONLINT_TIMEOUT = 60
@@ -121,6 +133,35 @@ def _run(cmd: list[str], *, timeout: int, cwd: Path | None = None) -> tuple[int,
     return proc.returncode, proc.stdout, proc.stderr
 
 
+def _select_workflow_files(
+    workflow_files: Sequence[str], repo_root: Path
+) -> tuple[list[str], str | None]:
+    """Resolve, contain, and filter the candidate files.
+
+    Returns ``(files, error)``. ``files`` are repo-relative workflow paths safe
+    to hand to ``actionlint`` and ``gh act``. ``error`` is non-None when a path
+    escapes ``repo_root`` (CWE-22 path traversal); the caller maps that to a
+    configuration error (exit 2).
+
+    Containment uses ``Path.resolve()`` + ``is_relative_to`` rather than a
+    string prefix check, so symlinks and ``..`` segments cannot smuggle a path
+    outside the repository. Non-workflow paths (custom actions, unrelated YAML)
+    are dropped silently because only ``.github/workflows`` files run under act.
+    """
+    root = repo_root.resolve()
+    selected: list[str] = []
+    for candidate in workflow_files:
+        if not candidate:
+            continue
+        resolved = (root / candidate).resolve()
+        if not resolved.is_relative_to(root):
+            return [], f"path escapes repository root: {candidate}"
+        rel = resolved.relative_to(root).as_posix()
+        if rel.startswith(_WORKFLOW_PREFIX) and rel.endswith(_WORKFLOW_SUFFIXES):
+            selected.append(rel)
+    return selected, None
+
+
 # --- Stages --------------------------------------------------------------
 
 
@@ -170,14 +211,16 @@ def run_local_test(
     as exit 3 so the caller can decide how loudly to block. A clean run over
     zero files is exit 0.
     """
-    if os.environ.get(_BYPASS_ENV, "").lower() == "true":
+    if os.environ.get(_BYPASS_ENV, "").strip().lower() in _TRUTHY:
         return Report(
             exit_code=0,
             bypassed=True,
-            note=f"{_BYPASS_ENV}=true; local workflow run skipped (logged).",
+            note=f"{_BYPASS_ENV} set; local workflow run skipped (logged).",
         )
 
-    files = [f for f in workflow_files if f]
+    files, path_error = _select_workflow_files(workflow_files, repo_root)
+    if path_error is not None:
+        return Report(exit_code=2, note=path_error)
     if not files:
         return Report(exit_code=0, note="no workflow files to test")
 

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Local-run gate for changed GitHub Actions workflows (ADR-006 module).
+
+Policy (Issue tracked in PR): a changed file under ``.github/workflows/`` MUST
+be exercised locally and pass before the push is allowed. The pre-push hook and
+the pre-PR runner delegate here so the YAML stays out of shell logic and the
+behavior is unit-tested.
+
+Belt-and-suspenders, three ordered stages per the repository owner's decision.
+Stages run in order and short-circuit on the first failure:
+
+    1. actionlint            static analysis (syntax, action refs, exprs)
+    2. gh act -n             dry-run: job graph, step wiring, resolvable uses
+    3. gh act (full)         real execution in Docker
+
+Why all three: actionlint catches what never reaches a runner; the dry-run
+catches graph/wiring errors without spending minutes; the full run catches
+logic that only fails at execution time (the class of defect that slipped
+through static checks in PR #2120's CI runner).
+
+Tool / environment gaps are reported, not silently skipped: a missing
+actionlint, gh act, or Docker daemon yields exit 3 (external) so the caller can
+block with an actionable message. A documented bypass exists for workflows that
+genuinely cannot run under act (secrets, ARM-only runners): set
+``SKIP_WORKFLOW_LOCAL_TEST=true``; the bypass is logged, not hidden.
+
+CLI
+---
+
+::
+
+    python3 scripts/validation/run_workflow_local_test.py --files .github/workflows/x.yml
+    python3 scripts/validation/run_workflow_local_test.py --files x.yml --no-full
+    python3 scripts/validation/run_workflow_local_test.py --files x.yml --format json
+
+EXIT CODES (per ADR-035, exit-code contract in AGENTS.md)
+---------------------------------------------------------
+
+0 - all stages passed (or no workflow files, or bypassed)
+1 - a stage ran and failed (block the push)
+2 - configuration error (bad args, repo root absent)
+3 - a required tool is unavailable (actionlint, gh act, or Docker)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+_BYPASS_ENV = "SKIP_WORKFLOW_LOCAL_TEST"
+
+# Per-stage timeouts (seconds). The full act run pulls images and executes
+# composite actions, so it gets the largest budget.
+_ACTIONLINT_TIMEOUT = 60
+_ACT_DRYRUN_TIMEOUT = 120
+_ACT_FULL_TIMEOUT = 600
+
+
+@dataclass
+class StageResult:
+    """Outcome of one stage for one (or all) workflow file(s)."""
+
+    stage: str
+    ok: bool
+    detail: str = ""
+
+
+@dataclass
+class Report:
+    """Aggregate result. ``exit_code`` follows the module contract."""
+
+    exit_code: int
+    stages: list[StageResult] = field(default_factory=list)
+    bypassed: bool = False
+    note: str = ""
+
+
+# --- Tool detection (mockable seams) -------------------------------------
+
+
+def _have(tool: str) -> bool:
+    return shutil.which(tool) is not None
+
+
+def _docker_ready() -> bool:
+    """True when a Docker daemon answers. ``gh act`` cannot run without it."""
+    rc, _, _ = _run(["docker", "info"], timeout=20)
+    return rc == 0
+
+
+def _run(cmd: list[str], *, timeout: int, cwd: Path | None = None) -> tuple[int, str, str]:
+    """Run a command. Returns (exit_code, stdout, stderr); -1 on spawn error."""
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return -1, "", f"command not found: {cmd[0]}"
+    except (OSError, subprocess.SubprocessError) as exc:
+        return -1, "", f"{type(exc).__name__}: {exc}"
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+# --- Stages --------------------------------------------------------------
+
+
+def _actionlint_stage(files: Sequence[str], repo_root: Path) -> StageResult:
+    rc, out, err = _run(["actionlint", *files], timeout=_ACTIONLINT_TIMEOUT, cwd=repo_root)
+    if rc == 0:
+        return StageResult("actionlint", True)
+    return StageResult("actionlint", False, (out + err).strip()[:4000])
+
+
+def _act_dryrun_stage(files: Sequence[str], repo_root: Path) -> StageResult:
+    for wf in files:
+        rc, out, err = _run(
+            ["gh", "act", "-n", "-W", wf], timeout=_ACT_DRYRUN_TIMEOUT, cwd=repo_root
+        )
+        if rc != 0:
+            return StageResult(
+                "gh act -n", False, f"{wf}:\n{(out + err).strip()[:4000]}"
+            )
+    return StageResult("gh act -n", True)
+
+
+def _act_full_stage(files: Sequence[str], repo_root: Path) -> StageResult:
+    for wf in files:
+        rc, out, err = _run(
+            ["gh", "act", "-W", wf], timeout=_ACT_FULL_TIMEOUT, cwd=repo_root
+        )
+        if rc != 0:
+            return StageResult(
+                "gh act (full)", False, f"{wf}:\n{(out + err).strip()[:4000]}"
+            )
+    return StageResult("gh act (full)", True)
+
+
+# --- Orchestration -------------------------------------------------------
+
+
+def run_local_test(
+    workflow_files: Sequence[str],
+    repo_root: Path,
+    *,
+    full: bool = True,
+) -> Report:
+    """Run the ordered stages over ``workflow_files`` and return a Report.
+
+    Short-circuits on the first failing stage. Reports a tool/environment gap
+    as exit 3 so the caller can decide how loudly to block. A clean run over
+    zero files is exit 0.
+    """
+    if os.environ.get(_BYPASS_ENV, "").lower() == "true":
+        return Report(
+            exit_code=0,
+            bypassed=True,
+            note=f"{_BYPASS_ENV}=true; local workflow run skipped (logged).",
+        )
+
+    files = [f for f in workflow_files if f]
+    if not files:
+        return Report(exit_code=0, note="no workflow files to test")
+
+    report = Report(exit_code=0)
+
+    # Stage 1: actionlint.
+    if not _have("actionlint"):
+        report.exit_code = 3
+        report.note = (
+            "actionlint not installed. Install it "
+            "(https://github.com/rhysd/actionlint) or set "
+            f"{_BYPASS_ENV}=true to bypass for an unrunnable workflow."
+        )
+        return report
+    s1 = _actionlint_stage(files, repo_root)
+    report.stages.append(s1)
+    if not s1.ok:
+        report.exit_code = 1
+        return report
+
+    # Stage 2 (dry-run) needs gh act but not a running Docker daemon: act -n
+    # only plans the run.
+    if not _have("gh"):
+        report.exit_code = 3
+        report.note = f"gh CLI not installed. Install it or set {_BYPASS_ENV}=true."
+        return report
+
+    s2 = _act_dryrun_stage(files, repo_root)
+    report.stages.append(s2)
+    if not s2.ok:
+        report.exit_code = 1
+        return report
+
+    # Stage 3 (full run) executes in Docker, so it needs a live daemon.
+    if full:
+        if not _docker_ready():
+            report.exit_code = 3
+            report.note = (
+                "Docker daemon not available; the full gh act run cannot "
+                f"execute. Start Docker or set {_BYPASS_ENV}=true to bypass an "
+                "unrunnable workflow (or pass --no-full for the lint+dry-run tier)."
+            )
+            return report
+        s3 = _act_full_stage(files, repo_root)
+        report.stages.append(s3)
+        if not s3.ok:
+            report.exit_code = 1
+            return report
+
+    return report
+
+
+# --- Output --------------------------------------------------------------
+
+
+def _format_text(report: Report) -> str:
+    if report.bypassed:
+        return f"workflow-local-test: BYPASSED ({report.note})"
+    if report.exit_code == 3:
+        return f"workflow-local-test: TOOL UNAVAILABLE\n  {report.note}"
+    if report.exit_code == 0:
+        passed = ", ".join(s.stage for s in report.stages) or report.note
+        return f"workflow-local-test: OK ({passed})"
+    lines = ["workflow-local-test: FAIL"]
+    for s in report.stages:
+        mark = "ok" if s.ok else "FAIL"
+        lines.append(f"  [{mark}] {s.stage}")
+        if not s.ok and s.detail:
+            for line in s.detail.splitlines()[:40]:
+                lines.append(f"      {line}")
+    return "\n".join(lines)
+
+
+def _format_json(report: Report) -> str:
+    return json.dumps(
+        {
+            "exit_code": report.exit_code,
+            "bypassed": report.bypassed,
+            "note": report.note,
+            "stages": [
+                {"stage": s.stage, "ok": s.ok, "detail": s.detail} for s in report.stages
+            ],
+        },
+        indent=2,
+        sort_keys=True,
+    )
+
+
+# --- CLI -----------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Run changed GitHub Actions workflows locally before push.",
+    )
+    p.add_argument(
+        "--files",
+        nargs="*",
+        default=None,
+        help="Workflow file paths to test (relative to repo root).",
+    )
+    p.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Override repo root (default: derived from script path).",
+    )
+    p.add_argument(
+        "--no-full",
+        action="store_true",
+        help="Skip the full gh act execution stage (actionlint + dry-run only).",
+    )
+    p.add_argument("--format", choices=("text", "json"), default="text")
+    return p
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    repo_root = (args.repo_root or _REPO_ROOT).resolve()
+    if not repo_root.is_dir():
+        print(f"error: repo root not found: {repo_root}", file=sys.stderr)
+        return 2
+
+    files = args.files if args.files is not None else []
+    report = run_local_test(files, repo_root, full=not args.no_full)
+
+    if args.format == "json":
+        print(_format_json(report))
+    else:
+        print(_format_text(report))
+    return report.exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -1,0 +1,211 @@
+"""Tests for scripts/validation/run_workflow_local_test.py.
+
+Covers the belt-and-suspenders gate: stage ordering and short-circuit,
+tool/Docker gaps -> exit 3, bypass env, --no-full, and CLI exit codes. All
+external commands (actionlint, gh act, docker) are mocked; no Docker required.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "validation"))
+
+import run_workflow_local_test as w  # noqa: E402
+
+WF = ".github/workflows/x.yml"
+
+
+@pytest.fixture
+def all_tools(monkeypatch):
+    """Pretend actionlint, gh, and Docker are all available."""
+    monkeypatch.setattr(w, "_have", lambda tool: True)
+    monkeypatch.setattr(w, "_docker_ready", lambda: True)
+    monkeypatch.delenv(w._BYPASS_ENV, raising=False)
+
+
+def _ok(stage):
+    return w.StageResult(stage, True)
+
+
+def _fail(stage):
+    return w.StageResult(stage, False, "boom")
+
+
+# --- bypass / empty ------------------------------------------------------
+
+
+def test_bypass_env_short_circuits(monkeypatch, tmp_path):
+    monkeypatch.setenv(w._BYPASS_ENV, "true")
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 0
+    assert r.bypassed is True
+
+
+def test_no_files_passes(all_tools, tmp_path):
+    r = w.run_local_test([], tmp_path)
+    assert r.exit_code == 0
+    assert r.stages == []
+
+
+# --- tool / docker gaps --------------------------------------------------
+
+
+def test_actionlint_missing_is_exit_3(monkeypatch, tmp_path):
+    monkeypatch.setattr(w, "_have", lambda tool: tool != "actionlint")
+    monkeypatch.delenv(w._BYPASS_ENV, raising=False)
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 3
+    assert "actionlint" in r.note
+
+
+def test_gh_missing_is_exit_3(monkeypatch, tmp_path):
+    monkeypatch.setattr(w, "_have", lambda tool: tool == "actionlint")
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.delenv(w._BYPASS_ENV, raising=False)
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 3
+    assert "gh" in r.note
+
+
+def test_docker_down_is_exit_3_for_full(all_tools, monkeypatch, tmp_path):
+    # Dry-run passes (no daemon needed); the full stage needs Docker -> exit 3.
+    monkeypatch.setattr(w, "_docker_ready", lambda: False)
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 3
+    assert "Docker" in r.note
+
+
+def test_no_full_does_not_require_docker(all_tools, monkeypatch, tmp_path):
+    monkeypatch.setattr(w, "_docker_ready", lambda: False)
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
+    r = w.run_local_test([WF], tmp_path, full=False)
+    assert r.exit_code == 0
+
+
+# --- stage ordering + short-circuit --------------------------------------
+
+
+def test_actionlint_failure_blocks_and_skips_act(all_tools, monkeypatch, tmp_path):
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _fail("actionlint"))
+    called = {"act": False}
+
+    def _act(f, r):
+        called["act"] = True
+        return _ok("gh act -n")
+
+    monkeypatch.setattr(w, "_act_dryrun_stage", _act)
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 1
+    assert called["act"] is False  # short-circuit before act
+
+
+def test_dryrun_failure_blocks_and_skips_full(all_tools, monkeypatch, tmp_path):
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _fail("gh act -n"))
+    called = {"full": False}
+
+    def _full(f, r):
+        called["full"] = True
+        return _ok("gh act (full)")
+
+    monkeypatch.setattr(w, "_act_full_stage", _full)
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 1
+    assert called["full"] is False
+
+
+def test_full_failure_blocks(all_tools, monkeypatch, tmp_path):
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
+    monkeypatch.setattr(w, "_act_full_stage", lambda f, r: _fail("gh act (full)"))
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 1
+    assert [s.stage for s in r.stages] == ["actionlint", "gh act -n", "gh act (full)"]
+
+
+def test_all_stages_pass(all_tools, monkeypatch, tmp_path):
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
+    monkeypatch.setattr(w, "_act_full_stage", lambda f, r: _ok("gh act (full)"))
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 0
+    assert len(r.stages) == 3
+
+
+def test_no_full_skips_execution_stage(all_tools, monkeypatch, tmp_path):
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
+    called = {"full": False}
+
+    def _full(f, r):
+        called["full"] = True
+        return _ok("gh act (full)")
+
+    monkeypatch.setattr(w, "_act_full_stage", _full)
+    r = w.run_local_test([WF], tmp_path, full=False)
+    assert r.exit_code == 0
+    assert called["full"] is False
+    assert [s.stage for s in r.stages] == ["actionlint", "gh act -n"]
+
+
+# --- stage internals (subprocess mocked) ---------------------------------
+
+
+def test_actionlint_stage_passes_files(monkeypatch, tmp_path):
+    seen = {}
+
+    def fake_run(cmd, *, timeout, cwd=None):
+        seen["cmd"] = cmd
+        return 0, "", ""
+
+    monkeypatch.setattr(w, "_run", fake_run)
+    res = w._actionlint_stage([WF, "y.yml"], tmp_path)
+    assert res.ok is True
+    assert seen["cmd"] == ["actionlint", WF, "y.yml"]
+
+
+def test_act_dryrun_stage_runs_each_file_and_stops_on_failure(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(cmd, *, timeout, cwd=None):
+        calls.append(cmd[-1])
+        return (1, "", "bad") if cmd[-1] == "a.yml" else (0, "", "")
+
+    monkeypatch.setattr(w, "_run", fake_run)
+    res = w._act_dryrun_stage(["a.yml", "b.yml"], tmp_path)
+    assert res.ok is False
+    assert calls == ["a.yml"]  # stopped after first failure
+
+
+# --- CLI -----------------------------------------------------------------
+
+
+def test_cli_exit_code_propagates(all_tools, monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _fail("actionlint"))
+    rc = w.main(["--files", WF, "--repo-root", str(tmp_path)])
+    assert rc == 1
+    assert "FAIL" in capsys.readouterr().out
+
+
+def test_cli_json(all_tools, monkeypatch, capsys, tmp_path):
+    import json
+
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
+    rc = w.main(["--files", WF, "--repo-root", str(tmp_path), "--no-full", "--format", "json"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["exit_code"] == 0
+
+
+def test_cli_bad_repo_root(capsys):
+    rc = w.main(["--files", WF, "--repo-root", "/no/such/xyz"])
+    assert rc == 2
+    assert "repo root not found" in capsys.readouterr().err

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -149,12 +149,26 @@ def test_gh_act_extension_missing_is_exit_3(monkeypatch, tmp_path):
 
 def test_docker_down_is_exit_3_for_full(all_tools, monkeypatch, tmp_path):
     # Dry-run passes (no daemon needed); the full stage needs Docker -> exit 3.
+    # docker is installed but the daemon is down -> "not running" note.
     monkeypatch.setattr(w, "_docker_ready", lambda: False)
     monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
     monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
     r = w.run_local_test([WF], tmp_path)
     assert r.exit_code == 3
-    assert "Docker" in r.note
+    assert "daemon is not running" in r.note
+
+
+def test_docker_not_installed_is_exit_3_with_distinct_note(monkeypatch, tmp_path):
+    # docker binary absent -> "not installed" note, distinct from daemon-down.
+    monkeypatch.setattr(w, "_have", lambda tool: tool != "docker")
+    monkeypatch.setattr(w, "_gh_act_available", lambda: True)
+    monkeypatch.setattr(w, "_docker_ready", lambda: False)
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
+    monkeypatch.delenv(w._BYPASS_ENV, raising=False)
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 3
+    assert "Docker is not installed" in r.note
 
 
 def test_no_full_does_not_require_docker(all_tools, monkeypatch, tmp_path):

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -79,6 +79,15 @@ def test_absolute_path_outside_repo_is_exit_2(all_tools, tmp_path):
     assert "escapes repository root" in r.note
 
 
+def test_missing_repo_root_is_exit_2(all_tools, tmp_path):
+    # A direct caller passing a non-existent repo_root is a config error (2),
+    # not a stage failure (1). Matches main()'s repo-root check.
+    missing = tmp_path / "does" / "not" / "exist"
+    r = w.run_local_test([WF], missing)
+    assert r.exit_code == 2
+    assert "repo root not found" in r.note
+
+
 def test_non_workflow_paths_are_filtered_out(all_tools, monkeypatch, tmp_path):
     # Custom actions and unrelated YAML never run under gh act; they drop out
     # and, with nothing left to test, the run is a clean no-op.

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -13,7 +13,9 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-sys.path.insert(0, str(REPO_ROOT / "scripts" / "validation"))
+_VALIDATION_DIR = str(REPO_ROOT / "scripts" / "validation")
+if _VALIDATION_DIR not in sys.path:
+    sys.path.insert(0, _VALIDATION_DIR)
 
 import run_workflow_local_test as w  # noqa: E402
 
@@ -22,7 +24,7 @@ WF = ".github/workflows/x.yml"
 
 @pytest.fixture
 def all_tools(monkeypatch):
-    """Pretend actionlint, gh, the gh-act extension, and Docker are available."""
+    """Pretend actionlint, gh, the gh act extension, and Docker are available."""
     monkeypatch.setattr(w, "_have", lambda tool: True)
     monkeypatch.setattr(w, "_gh_act_available", lambda: True)
     monkeypatch.setattr(w, "_docker_ready", lambda: True)
@@ -47,10 +49,62 @@ def test_bypass_env_short_circuits(monkeypatch, tmp_path):
     assert r.bypassed is True
 
 
+def test_bypass_env_accepts_one(monkeypatch, tmp_path):
+    # Matches the repo convention: boolean env flags accept "1" and "true".
+    monkeypatch.setenv(w._BYPASS_ENV, "1")
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 0
+    assert r.bypassed is True
+
+
 def test_no_files_passes(all_tools, tmp_path):
     r = w.run_local_test([], tmp_path)
     assert r.exit_code == 0
     assert r.stages == []
+
+
+# --- path containment (CWE-22) + workflow filtering ----------------------
+
+
+def test_path_traversal_is_exit_2(all_tools, tmp_path):
+    # A path that escapes repo_root must be rejected as a config error, not run.
+    r = w.run_local_test(["../../etc/passwd"], tmp_path)
+    assert r.exit_code == 2
+    assert "escapes repository root" in r.note
+
+
+def test_absolute_path_outside_repo_is_exit_2(all_tools, tmp_path):
+    r = w.run_local_test(["/etc/passwd"], tmp_path)
+    assert r.exit_code == 2
+    assert "escapes repository root" in r.note
+
+
+def test_non_workflow_paths_are_filtered_out(all_tools, monkeypatch, tmp_path):
+    # Custom actions and unrelated YAML never run under gh act; they drop out
+    # and, with nothing left to test, the run is a clean no-op.
+    r = w.run_local_test(
+        [".github/actions/foo/action.yml", "README.md"], tmp_path
+    )
+    assert r.exit_code == 0
+    assert r.note == "no workflow files to test"
+
+
+def test_select_workflow_files_keeps_only_workflows(tmp_path):
+    selected, err = w._select_workflow_files(
+        [
+            ".github/workflows/ci.yml",
+            ".github/workflows/release.yaml",
+            ".github/actions/build/action.yml",
+            "docs/x.yml",
+            "",
+        ],
+        tmp_path,
+    )
+    assert err is None
+    assert selected == [
+        ".github/workflows/ci.yml",
+        ".github/workflows/release.yaml",
+    ]
 
 
 # --- tool / docker gaps --------------------------------------------------
@@ -74,6 +128,7 @@ def test_gh_missing_is_exit_3(monkeypatch, tmp_path):
 
 
 def test_gh_act_extension_missing_is_exit_3(monkeypatch, tmp_path):
+    # gh is present but the act extension is not -> exit 3 before dry-run.
     monkeypatch.setattr(w, "_have", lambda tool: True)
     monkeypatch.setattr(w, "_gh_act_available", lambda: False)
     monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -22,8 +22,9 @@ WF = ".github/workflows/x.yml"
 
 @pytest.fixture
 def all_tools(monkeypatch):
-    """Pretend actionlint, gh, and Docker are all available."""
+    """Pretend actionlint, gh, the gh-act extension, and Docker are available."""
     monkeypatch.setattr(w, "_have", lambda tool: True)
+    monkeypatch.setattr(w, "_gh_act_available", lambda: True)
     monkeypatch.setattr(w, "_docker_ready", lambda: True)
     monkeypatch.delenv(w._BYPASS_ENV, raising=False)
 
@@ -70,6 +71,16 @@ def test_gh_missing_is_exit_3(monkeypatch, tmp_path):
     r = w.run_local_test([WF], tmp_path)
     assert r.exit_code == 3
     assert "gh" in r.note
+
+
+def test_gh_act_extension_missing_is_exit_3(monkeypatch, tmp_path):
+    monkeypatch.setattr(w, "_have", lambda tool: True)
+    monkeypatch.setattr(w, "_gh_act_available", lambda: False)
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.delenv(w._BYPASS_ENV, raising=False)
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 3
+    assert "gh act extension" in r.note
 
 
 def test_docker_down_is_exit_3_for_full(all_tools, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Closes the structural gap behind PR #2120: nothing forced a changed workflow to be run locally before push. A two-dot-vs-merge-base defect in #2120's CI runner reached the branch and was caught only because a reviewer asked whether it had been tested locally.

This makes the ci-scripts rule executable. When a a workflow YAML file changes, a pre-push gate runs a belt-and-suspenders local check, ordered, short-circuit on first failure:

1. `actionlint` (static)
2. `gh act -n` (dry-run graph)
3. full `gh act` execution

Closes #2122.

## Design (ADR-006 thin workflow)

- `scripts/validation/run_workflow_local_test.py`: the staged logic, unit-tested. Docker is required only for the full stage; the dry-run tier needs none. Exit codes: 0 ok, 1 stage failed, 2 config, 3 tool/daemon unavailable.
- `.githooks/pre-push` Section 8: delegates to the module, full run, BLOCKING. Replaces the prior actionlint-only block that skipped silently when actionlint was absent.
- `scripts/validation/pre_pr.py`: shift-left tier (`--no-full`: actionlint + dry-run) for fast feedback without Docker; full run stays at push.

## Enforcement vs escape hatch

Tool/Docker gaps return exit 3 and **block** at pre-push, because the point is to require the run. A workflow that genuinely cannot run under act (secrets, ARM-only runners) is bypassed audibly: `SKIP_WORKFLOW_LOCAL_TEST=true` (logged, not hidden). pre_pr only warns on missing local tools, since pre-push is the authoritative enforcer.

## Local verification

- 16 pytest cases (mocked actionlint/act/docker): stage order, short-circuit, tool/daemon gaps, bypass, `--no-full`, CLI.
- Exercised the module against a real workflow: tool-gap path returns exit 3 with guidance; the real `gh act -n` dry-run stage passes.
- pre_pr wrapper verified (no workflow changed -> pass); `bash -n` clean on pre-push.

## Flags

- This PR changes no workflow file, so its own gate self-skips on push. The gate is exercised by the tests + direct module runs above.
- actionlint is not installed in this environment; the gate correctly reports that as exit 3 (blocking) rather than passing silently. Contributors need actionlint + Docker, or the bypass.

Refs #2120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
