### PR TITLE
chore(commands): rename autofix-pr command to pr-autofix

### DIFF
--- a/.claude/commands/pr-autofix.md
+++ b/.claude/commands/pr-autofix.md
@@ -3,7 +3,7 @@ description: Autonomous PR monitor and fixer per docs/autonomous-pr-monitor.md. 
 allowed-tools: Bash, Read, Edit, Write, Skill
 ---
 
-# /autofix-pr
+# /pr-autofix
 
 Autonomous PR monitor and fixer. Implements the protocol from
 `docs/autonomous-pr-monitor.md`.
@@ -12,7 +12,7 @@ Autonomous PR monitor and fixer. Implements the protocol from
 
 | Trigger phrase | Operation |
 |----------------|-----------|
-| `autofix-pr` | Triage all open PRs by tier and act |
+| `pr-autofix` | Triage all open PRs by tier and act |
 | `autofix this pr` | Single-PR mode on the current branch's open PR |
 | `monitor open prs` | Periodic triage without merging |
 | `auto-merge ready prs` | Tier 1 only: enable auto-merge on land-ready PRs |


### PR DESCRIPTION
## Summary

Renames the `autofix-pr` command to `pr-autofix` so the project slash command no longer collides with Claude Code's built-in `/autofix-pr` command. The command is now invoked as `/pr-autofix`.

## Change

Single file (`git mv` + two in-file edits), now at `.claude/commands/pr-autofix.md`:

- File renamed from the former `autofix-pr` command to `pr-autofix`
- H1 title `# /autofix-pr` -> `# /pr-autofix`
- Triggers-table command keyword `autofix-pr` -> `pr-autofix`

Natural-language trigger phrases (`autofix this pr`, `monitor open prs`, `auto-merge ready prs`, `address pr feedback`) are unchanged.

## Out of scope

The copilot-cli skill at `src/copilot-cli/skills/autofix-pr/` is a separate harness with no Claude Code built-in to collide with, so it is intentionally left as-is. Historical session logs, retros, and memories that mention `autofix-pr` are immutable records and are not edited.

Fixes #2137
