### PR TITLE
chore(plugin): bump claude plugin to 0.3.3 after pr-autofix rename

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": { "name": "rjmurillo" }
 }


### PR DESCRIPTION
# Pull Request

## Summary

### What

Bumps the `project-toolkit` (claude) plugin manifest from `0.3.2` to `0.3.3`.

### Why

PR #2138 renamed the `autofix-pr` command to `pr-autofix` under `.claude/commands/`, a source dir owned by the claude plugin, but merged without incrementing the plugin version. The `validate-plugin-version-bump` gate requires a strictly greater semver when a plugin's source files change, otherwise existing installs do not re-sync the renamed command. This bump closes that consistency gap.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #2137 | Rename /autofix-pr command to /pr-autofix |

## Changes

- `.claude/.claude-plugin/plugin.json`: `version` `0.3.2` -> `0.3.3`

## Type of Change

- [x] Infrastructure/CI change

## Reviewer Expectations

**Review kind / scrutiny / urgency**: rubber stamp, low, no rush

**Focus areas**: Single-line semver bump to re-sync the claude plugin after the `pr-autofix` rename merged without a version increment.

## Testing

Deliverables in this PR:

- [x] No testing required (configuration only)

Validated locally: `python3 scripts/validation/run_plugin_version_bump_ci.py` reports `plugin-version-bump: OK`.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

## Author Pre-flight

- [x] Pre-PR validation passed (plugin version-bump gate green locally)
- [x] Self-review completed
- [x] No new warnings introduced

## Related Issues

Refs #2137
