### PR TITLE
docs(agents): route memory lookup through the memory skill, not list_memories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,11 +17,11 @@ Read first, reason second. Pre-training last resort.
 
 **Memory lookup**: use the `memory` skill, don't hand-roll:
 
-1. **Primary**: `python3 .claude/skills/memory/scripts/search_memory.py "<query>"` (Serena-first + Forgetful, ranked, token-bounded ~2K). Returns the right `*-index`/atomic file; then `read_memory` it.
+1. **Primary**: `python3 .claude/skills/memory/scripts/search_memory.py "<query>"`. Keyword-ranks Serena memory names (Serena-first), augments with Forgetful when it is reachable, and flags large memories by token estimate. Returns the relevant `*-index`; `read_memory` it, then follow its links to the atomic file.
 2. **Deep context** before planning: delegate to `context-retrieval` agent. Human CLI: `/memory-search`.
-3. **Raw fallback** (scripting): guess `read_memory("<intuitive-name>")` (miss = cheap "not found", not a list) → domain `*-index` → `read_memory("memory-index")`. NEVER bare `list_memories` (800+ files, ~73KB); `topic="<dir>"` filters by namespace folder only, not keywords.
+3. **Raw fallback** (scripting): guess `read_memory("<intuitive-name>")` (miss = cheap "not found", not a list) then domain `*-index` then `read_memory("memory-index")`. Prefer these name/index lookups over a bare `list_memories`.
 
-On add: update the `*-index` so the next agent finds it by name. Atomic files + indexes are deliberate (no embeddings; filename = activation vocab): see `memory-token-efficiency`, `memory-size-001-decomposition-thresholds`. Do NOT consolidate atomic memories to cheapen listing; it breaks discovery + cross-links.
+On add: update the `*-index` so the next agent finds it by name. Atomic files + indexes are deliberate (no embeddings; filename = activation vocab): see `.serena/memories/memory/memory-token-efficiency.md`, `.serena/memories/memory/memory-size-001-decomposition-thresholds.md`. Do NOT consolidate atomic memories to cheapen listing; it breaks discovery + cross-links.
 
 ## Session Gates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,14 @@ Read first, reason second. Pre-training last resort.
 |Protocol: `.agents/SESSION-PROTOCOL.md`
 |Skills: `.claude/skills/{name}/SKILL.md`
 
-**Memory lookup**: NEVER bare `list_memories` (800+ atomic files, ~73KB/call). Filter by namespace: `list_memories(topic="<dir>")` where `<dir>` is the top-level folder prefix (`git`, `adr`, `memory`, `pr-review`); it matches the directory, not arbitrary keywords (so `topic="git-hooks"` is empty, `topic="git"` returns `git/git-hooks-*`). Or read a `*-index` registry then `read_memory` the one file. Atomic files + index is deliberate (no embeddings; name = activation vocab): see `memory-token-efficiency`, `memory-size-001-decomposition-thresholds`. Do NOT consolidate atomic memories to cheapen listing; it breaks discovery + cross-links.
+**Memory lookup** (cheapest → last resort; never start with `list_memories`):
+
+1. **Guess + read**: `read_memory("<intuitive-name>")` directly. Names are activation-vocab by design (aim >80% hit); a miss returns a cheap "not found" string, not a list.
+2. **Index-first** (unknown exact name): read the domain router `skills-<domain>-index` / `<domain>/...-index` (small), then `read_memory` the linked file.
+3. **Root router** (domain unclear): `read_memory("memory-index")` (keyword → file table).
+4. **Last resort only**: `list_memories(topic="<dir>")` (namespace = top folder like `git`/`adr`, not keywords), then bare `list_memories` (800+ files, ~73KB).
+
+When adding a memory, update its `*-index` so the next agent finds it by name. Atomic files + indexes are deliberate (no embeddings; filename = activation vocab): see `memory-token-efficiency`, `memory-size-001-decomposition-thresholds`. Do NOT consolidate atomic memories to cheapen listing; it breaks discovery + cross-links.
 
 ## Session Gates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,14 +15,13 @@ Read first, reason second. Pre-training last resort.
 |Protocol: `.agents/SESSION-PROTOCOL.md`
 |Skills: `.claude/skills/{name}/SKILL.md`
 
-**Memory lookup** (cheapest → last resort; never start with `list_memories`):
+**Memory lookup**: use the `memory` skill, don't hand-roll:
 
-1. **Guess + read**: `read_memory("<intuitive-name>")` directly. Names are activation-vocab by design (aim >80% hit); a miss returns a cheap "not found" string, not a list.
-2. **Index-first** (unknown exact name): read the domain router `skills-<domain>-index` / `<domain>/...-index` (small), then `read_memory` the linked file.
-3. **Root router** (domain unclear): `read_memory("memory-index")` (keyword → file table).
-4. **Last resort only**: `list_memories(topic="<dir>")` (namespace = top folder like `git`/`adr`, not keywords), then bare `list_memories` (800+ files, ~73KB).
+1. **Primary**: `python3 .claude/skills/memory/scripts/search_memory.py "<query>"` (Serena-first + Forgetful, ranked, token-bounded ~2K). Returns the right `*-index`/atomic file; then `read_memory` it.
+2. **Deep context** before planning: delegate to `context-retrieval` agent. Human CLI: `/memory-search`.
+3. **Raw fallback** (scripting): guess `read_memory("<intuitive-name>")` (miss = cheap "not found", not a list) → domain `*-index` → `read_memory("memory-index")`. NEVER bare `list_memories` (800+ files, ~73KB); `topic="<dir>"` filters by namespace folder only, not keywords.
 
-When adding a memory, update its `*-index` so the next agent finds it by name. Atomic files + indexes are deliberate (no embeddings; filename = activation vocab): see `memory-token-efficiency`, `memory-size-001-decomposition-thresholds`. Do NOT consolidate atomic memories to cheapen listing; it breaks discovery + cross-links.
+On add: update the `*-index` so the next agent finds it by name. Atomic files + indexes are deliberate (no embeddings; filename = activation vocab): see `memory-token-efficiency`, `memory-size-001-decomposition-thresholds`. Do NOT consolidate atomic memories to cheapen listing; it breaks discovery + cross-links.
 
 ## Session Gates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ Read first, reason second. Pre-training last resort.
 |Protocol: `.agents/SESSION-PROTOCOL.md`
 |Skills: `.claude/skills/{name}/SKILL.md`
 
+**Memory lookup**: NEVER bare `list_memories` (800+ atomic files, ~73KB/call). Filter by namespace: `list_memories(topic="<dir>")` where `<dir>` is the top-level folder prefix (`git`, `adr`, `memory`, `pr-review`); it matches the directory, not arbitrary keywords (so `topic="git-hooks"` is empty, `topic="git"` returns `git/git-hooks-*`). Or read a `*-index` registry then `read_memory` the one file. Atomic files + index is deliberate (no embeddings; name = activation vocab): see `memory-token-efficiency`, `memory-size-001-decomposition-thresholds`. Do NOT consolidate atomic memories to cheapen listing; it breaks discovery + cross-links.
+
 ## Session Gates
 
 **Start**: Init Serena|Read HANDOFF.md + latest issue handoff + Verify-on-Resume|Session log|Search memories|Verify git


### PR DESCRIPTION
## Summary

Documents the correct memory-lookup protocol in `AGENTS.md` (loaded every session via the Claude @import chain) so agents stop hand-rolling `list_memories`.

With 800+ atomic Serena memory files, a bare `list_memories` returns ~73KB and burns tokens every call. `list_memories(topic=...)` only filters by namespace directory prefix (e.g. `git`), not keywords, so a topic miss falls back to a full list anyway. The repository already solves this; the guidance just was not where every agent reads it.

## Change

New "Memory lookup" block in the Retrieval-Led Reasoning section, ordered skill-first:

1. **Primary**: `search_memory.py "<query>"` (memory skill: Serena-first + Forgetful, ranked, token-bounded ~2K).
2. **Deep context**: `context-retrieval` agent; `/memory-search` for humans.
3. **Raw fallback only**: guess `read_memory("<name>")` (a miss is a cheap "not found", not a list) then domain `*-index` then `memory-index`. Never bare `list_memories`.

Plus: update the `*-index` when adding a memory; do not consolidate atomic memories to cheapen listing (breaks discovery + cross-links). Rationale cited from `memory-token-efficiency` and `memory-size-001-decomposition-thresholds`.

## Scope

`AGENTS.md` only, +8 lines. Documentation; no code or behavior change.

Fixes #2145
