### PR TITLE
feat(hooks): idempotent git-hooks installer with local drift gate

### DIFF
--- a/.serena/memories/git/git-hooks-005-relative-hookspath-worktrees.md
+++ b/.serena/memories/git/git-hooks-005-relative-hookspath-worktrees.md
@@ -1,0 +1,53 @@
+# Skill-Git-005: Relative core.hooksPath, never absolute (worktree-safe)
+
+**Statement**: Set `core.hooksPath` to the relative value `.githooks`, never an absolute path. Relative resolves per-worktree to each tree's own checked-out hooks; absolute silently bypasses guards in every `git worktree`.
+
+**Context**: Installing/enforcing the repository's `.githooks/` (pre-commit, pre-push, including the plugin version-bump gate from #2118). Diagnosed during PR #2138/#2136 work when a clone was found with `core.hooksPath = /abs/path/.git/hooks` (the empty default dir), so no guard ran locally and un-bumped plugin PRs reached merge.
+
+**Evidence**:
+
+- `core.hooksPath` is stored once in the shared `.git/config` and inherited by every worktree.
+- githooks(5): before running a hook, git sets cwd to the work-tree root. A **relative** `core.hooksPath` therefore resolves against the current worktree root, so each worktree runs its OWN `.githooks/`. Verified empirically: a throwaway `git worktree add` reported `core.hooksPath=.githooks` and found its own executable `pre-push`.
+- An **absolute** value (e.g. `/home/.../.git/hooks`) overrides `.githooks` AND makes every worktree run the main repo's empty hooks dir, bypassing all guards. This is the footgun.
+- Nothing local can self-detect a wrong/absent `hooksPath`: if hooks are off, no guard runs to notice. Only a CI **required** check is non-bypassable.
+
+**Atomicity**: 90%
+
+**Tag**: critical
+
+**Impact**: 9/10 (silent guard bypass across all worktrees)
+
+**Created**: 2026-05-30
+
+**Validation Count**: 1 (diagnosed live, PR #2138/#2136)
+
+**Failure Count**: 0
+
+**Category**: Git
+
+## Anti-Pattern
+
+```bash
+# WRONG: absolute path. Overrides .githooks and breaks every worktree.
+git config core.hooksPath "$(pwd)/.git/hooks"
+git config core.hooksPath /home/user/repo/.git/hooks
+```
+
+## Correct Pattern
+
+```bash
+# RIGHT: relative. Self-configures the main tree and every worktree.
+git config core.hooksPath .githooks
+# Or the idempotent installer (also verifies executability + flags stale shims):
+python3 scripts/install_git_hooks.py
+# Verify without mutating (wired into scripts/validation/pre_pr.py, skipped under CI):
+python3 scripts/install_git_hooks.py --check
+```
+
+## Related
+
+- `scripts/install_git_hooks.py` (installer + `--check`)
+- `scripts/validation/pre_pr.py::validate_git_hooks_installed` (local drift gate, CI-skipped)
+- `CONTRIBUTING.md` setup step 6 + Pre-Commit Hooks section
+- `.githooks/pre-push` (the guards being protected; version-bump section ~line 741)
+- The separate merge-gate half: add `Validate Plugin Version Bump` to ruleset required checks (governance change).

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -58,7 +58,7 @@
 [Tooling and Patterns]
 |utility script markdown fence PathInfo security pattern: [skills-utilities-index](skills-utilities-index.md) (183)
 |edit file read search replace text operation: [patterns/edit-001-read-before-edit-pattern](patterns/edit-001-read-before-edit-pattern.md) (464), [patterns/edit-002-unique-context-for-edit-matching](patterns/edit-002-unique-context-for-edit-matching.md) (368)
-|git hook pre-commit autofix cross-language grep TOCTOU: [skills-git-hooks-index](skills-git-hooks-index.md) (325)
+|git hook pre-commit autofix cross-language grep TOCTOU: [skills-git-hooks-index](skills-git-hooks-index.md) (368)
 |git branch merge conflict checkout cleanup workflow resolution worktree: [skills-git-index](skills-git-index.md) (287)
 |git branch switch checkout file state verification lost: [git/git-004-branch-switch-file-verification](git/git-004-branch-switch-file-verification.md) (851)
 |lost code recovery investigation unmerged branch orphaned: [session/recovery-001-lost-code-investigation](session/recovery-001-lost-code-investigation.md) (552)

--- a/.serena/memories/skills-git-hooks-index.md
+++ b/.serena/memories/skills-git-hooks-index.md
@@ -10,3 +10,4 @@
 | branch recovery main commit mistake reset origin HEAD | [git/git-hooks-002-branch-recovery-procedure](git/git-hooks-002-branch-recovery-procedure.md) |
 | branch name validation pattern feat fix chore docs reject pre-commit mismatch declared | [git/git-hooks-004-branch-name-validation](git/git-hooks-004-branch-name-validation.md) |
 | pre-commit hook bypass no-verify protocol enforcement fix-errors | [git/git-hooks-fix-hook-errors-never-bypass](git/git-hooks-fix-hook-errors-never-bypass.md) |
+| core.hooksPath relative absolute worktree githooks install bypass guard footgun | [git/git-hooks-005-relative-hookspath-worktrees](git/git-hooks-005-relative-hookspath-worktrees.md) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Thank you for your interest in contributing to this project. This guide explains
 3. **Install Python 3.14.x** (see Prerequisites above)
 4. **Set up Python environment**: `uv venv && uv pip install -e ".[dev]"`
 5. Configure Git for cross-platform development (see [Git Configuration](#git-configuration) below)
-6. Set up git hooks (pre-commit + pre-push): `git config core.hooksPath .githooks`
+6. Set up git hooks (pre-commit + pre-push): `python3 scripts/install_git_hooks.py` (idempotent: sets `core.hooksPath`, verifies the hooks are executable, and flags a stale `.git/hooks/pre-push` shim; the bare `git config core.hooksPath .githooks` also works)
 7. Make your changes following the guidelines below
 8. Submit a pull request
 
@@ -505,8 +505,19 @@ In rare cases (e.g., emergency hotfix), you may need to skip drift detection:
 Enable automated validation on commits:
 
 ```bash
-git config core.hooksPath .githooks
+python3 scripts/install_git_hooks.py
 ```
+
+This points `core.hooksPath` at `.githooks`, verifies the hook scripts are
+executable, and warns about a legacy `.git/hooks/pre-push` shim that would
+otherwise shadow the canonical hook. Because `core.hooksPath` is stored in the
+shared `.git/config` as the relative path `.githooks`, every `git worktree`
+inherits it and runs its own checked-out hooks automatically; no per-worktree
+setup is needed. The equivalent one-liner is `git config core.hooksPath .githooks`.
+
+`pre_pr.py` runs `install_git_hooks.py --check` as a local gate, so a desynced
+`core.hooksPath` (for example, a clone left on an absolute `.git/hooks` path)
+is caught before push instead of silently bypassing the pre-push guards.
 
 The pre-commit hook automatically runs checks including, depending on staged files:
 

--- a/scripts/install_git_hooks.py
+++ b/scripts/install_git_hooks.py
@@ -73,13 +73,19 @@ def get_hooks_path(repo_root: Path) -> str | None:
 
 
 def hooks_path_points_at_canonical(repo_root: Path, value: str | None) -> bool:
-    """True if ``value`` resolves to the repo's ``.githooks`` directory."""
+    """True if ``value`` is a relative path resolving to ``.githooks``.
+
+    Absolute paths are rejected even if they resolve to ``.githooks``, because
+    they break worktrees: secondary worktrees do not get per-tree hook
+    resolution when an absolute path is written to the shared ``.git/config``.
+    """
     if not value:
         return False
-    canonical = (repo_root / HOOKS_DIR_NAME).resolve()
     candidate = Path(value)
-    if not candidate.is_absolute():
-        candidate = (repo_root / candidate)
+    if candidate.is_absolute():
+        return False
+    canonical = (repo_root / HOOKS_DIR_NAME).resolve()
+    candidate = repo_root / candidate
     try:
         return candidate.resolve() == canonical
     except OSError:

--- a/scripts/install_git_hooks.py
+++ b/scripts/install_git_hooks.py
@@ -71,6 +71,26 @@ def find_repo_root(start: Path) -> Path | None:
     return Path(top) if top else None
 
 
+def get_git_common_dir(repo_root: Path) -> Path | None:
+    """Return the shared git directory (common dir) for this repository.
+
+    For a regular checkout, this is the same as ``.git``. For a linked worktree,
+    this returns the main repository's ``.git`` directory, which is where shared
+    config (including ``core.hooksPath``) should be written so all worktrees
+    inherit the setting.
+    """
+    result = _run_git(["rev-parse", "--git-common-dir"], cwd=repo_root)
+    if result.returncode != 0:
+        return None
+    common = result.stdout.strip()
+    if not common:
+        return None
+    common_path = Path(common)
+    if not common_path.is_absolute():
+        common_path = repo_root / common_path
+    return common_path.resolve()
+
+
 def get_hooks_path(repo_root: Path) -> str | None:
     """Return the configured ``core.hooksPath`` value, or None if unset."""
     result = _run_git(["config", "--get", "core.hooksPath"], cwd=repo_root)
@@ -101,9 +121,20 @@ def hooks_path_points_at_canonical(repo_root: Path, value: str | None) -> bool:
 
 
 def set_hooks_path(repo_root: Path) -> bool:
-    """Point ``core.hooksPath`` at ``.githooks``. Return True on success."""
+    """Point ``core.hooksPath`` at ``.githooks`` in the shared repository config.
+
+    Uses ``--file`` targeting the shared config so linked worktrees inherit the
+    setting. Without this, ``git config`` from a linked worktree writes to the
+    worktree's private config, leaving other worktrees (including the primary
+    checkout) with an unset ``core.hooksPath``.
+    """
+    common_dir = get_git_common_dir(repo_root)
+    if common_dir is None:
+        return False
+    shared_config = common_dir / "config"
     result = _run_git(
-        ["config", "core.hooksPath", HOOKS_DIR_NAME], cwd=repo_root
+        ["config", "--file", str(shared_config), "core.hooksPath", HOOKS_DIR_NAME],
+        cwd=repo_root,
     )
     return result.returncode == 0
 

--- a/scripts/install_git_hooks.py
+++ b/scripts/install_git_hooks.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Install the canonical git hooks for this repository.
+
+The repository ships its enforced hooks under ``.githooks/`` (pre-commit,
+pre-push). Git only runs them when ``core.hooksPath`` points at that directory.
+A fresh clone defaults to ``.git/hooks`` instead, so the pre-push guards
+(workflow validation, plugin version-bump gate, Python tests) never run locally
+and bad pushes slip through to CI.
+
+This script sets ``core.hooksPath`` to ``.githooks`` (idempotent), verifies the
+hook scripts exist and are executable, and warns about a legacy
+``.git/hooks/pre-push`` shim that would otherwise be shadowed.
+
+Canonical mechanism documented in ``docs/technical-guardrails.md`` and
+``scripts/bootstrap-vm.sh`` (``git config core.hooksPath .githooks``).
+
+Modes:
+
+* default: configure ``core.hooksPath`` and verify hooks.
+* ``--check``: verify only, never mutate. Exit non-zero if not configured or
+  hooks are missing. Useful for a setup assertion.
+
+Exit codes (per AGENTS.md): 0 ok, 1 logic (hooks missing/not executable or
+``--check`` found misconfiguration), 2 config (not a git repo / no .githooks),
+3 external (a git command failed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+HOOKS_DIR_NAME = ".githooks"
+# Hook files that must be present and executable for enforcement to work.
+REQUIRED_HOOKS = ("pre-commit", "pre-push")
+
+EXIT_OK = 0
+EXIT_LOGIC = 1
+EXIT_CONFIG = 2
+EXIT_EXTERNAL = 3
+
+
+def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run a git command, capturing output. Raises on a missing git binary."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def find_repo_root(start: Path) -> Path | None:
+    """Return the git work-tree root containing ``start``, or None."""
+    result = _run_git(["rev-parse", "--show-toplevel"], cwd=start)
+    if result.returncode != 0:
+        return None
+    top = result.stdout.strip()
+    return Path(top) if top else None
+
+
+def get_hooks_path(repo_root: Path) -> str | None:
+    """Return the configured ``core.hooksPath`` value, or None if unset."""
+    result = _run_git(["config", "--get", "core.hooksPath"], cwd=repo_root)
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def hooks_path_points_at_canonical(repo_root: Path, value: str | None) -> bool:
+    """True if ``value`` resolves to the repo's ``.githooks`` directory."""
+    if not value:
+        return False
+    canonical = (repo_root / HOOKS_DIR_NAME).resolve()
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        candidate = (repo_root / candidate)
+    try:
+        return candidate.resolve() == canonical
+    except OSError:
+        return False
+
+
+def set_hooks_path(repo_root: Path) -> bool:
+    """Point ``core.hooksPath`` at ``.githooks``. Return True on success."""
+    result = _run_git(
+        ["config", "core.hooksPath", HOOKS_DIR_NAME], cwd=repo_root
+    )
+    return result.returncode == 0
+
+
+def verify_hooks(repo_root: Path) -> list[str]:
+    """Return a list of problems with the ``.githooks`` directory.
+
+    Empty list means every required hook exists and is executable.
+    """
+    problems: list[str] = []
+    hooks_dir = repo_root / HOOKS_DIR_NAME
+    if not hooks_dir.is_dir():
+        problems.append(f"missing hooks directory: {hooks_dir}")
+        return problems
+    for name in REQUIRED_HOOKS:
+        hook = hooks_dir / name
+        if not hook.is_file():
+            problems.append(f"missing hook: {hook}")
+            continue
+        mode = hook.stat().st_mode
+        if not mode & stat.S_IXUSR:
+            problems.append(f"hook not executable: {hook}")
+    return problems
+
+
+def detect_legacy_shim(repo_root: Path) -> Path | None:
+    """Return the path to a legacy ``.git/hooks/pre-push`` shim if present.
+
+    Once ``core.hooksPath`` points at ``.githooks`` this file is shadowed and
+    never runs, so a stale copy is a foot-gun worth flagging.
+    """
+    legacy = repo_root / ".git" / "hooks" / "pre-push"
+    return legacy if legacy.is_file() else None
+
+
+def _print(message: str, *, quiet: bool) -> None:
+    if not quiet:
+        print(message)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify configuration without modifying anything.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress success output (errors still print to stderr).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Override repo root detection (mainly for tests).",
+    )
+    return parser
+
+
+def _print_problems(problems: list[str]) -> None:
+    for problem in problems:
+        print(f"error: {problem}", file=sys.stderr)
+
+
+def _run_check(
+    repo_root: Path, *, configured: bool, current: str | None, quiet: bool
+) -> int:
+    if not configured:
+        print(
+            "error: core.hooksPath is not set to "
+            f"{HOOKS_DIR_NAME} (current: {current or 'unset'}); "
+            "run scripts/install_git_hooks.py",
+            file=sys.stderr,
+        )
+        return EXIT_LOGIC
+    problems = verify_hooks(repo_root)
+    if problems:
+        _print_problems(problems)
+        return EXIT_LOGIC
+    _print(
+        f"OK: core.hooksPath -> {HOOKS_DIR_NAME}, hooks present", quiet=quiet
+    )
+    return EXIT_OK
+
+
+def _run_install(
+    repo_root: Path, *, configured: bool, current: str | None, quiet: bool
+) -> int:
+    if configured:
+        _print(
+            f"core.hooksPath already set to {HOOKS_DIR_NAME}", quiet=quiet
+        )
+    elif not set_hooks_path(repo_root):
+        print("error: failed to set core.hooksPath", file=sys.stderr)
+        return EXIT_EXTERNAL
+    else:
+        _print(
+            f"set core.hooksPath -> {HOOKS_DIR_NAME} (was: {current or 'unset'})",
+            quiet=quiet,
+        )
+
+    problems = verify_hooks(repo_root)
+    if problems:
+        _print_problems(problems)
+        return EXIT_LOGIC
+
+    legacy = detect_legacy_shim(repo_root)
+    if legacy is not None:
+        _print(
+            f"warning: legacy hook {legacy} is now shadowed by "
+            f"{HOOKS_DIR_NAME}/pre-push and will not run; "
+            "delete it to avoid confusion",
+            quiet=quiet,
+        )
+
+    _print("git hooks installed", quiet=quiet)
+    return EXIT_OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    start = Path(args.repo_root) if args.repo_root else Path.cwd()
+    repo_root = find_repo_root(start)
+    if repo_root is None:
+        print(f"error: not a git repository: {start}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    if not (repo_root / HOOKS_DIR_NAME).is_dir():
+        print(
+            f"error: {HOOKS_DIR_NAME}/ not found under {repo_root}; "
+            "this does not look like the ai-agents repo",
+            file=sys.stderr,
+        )
+        return EXIT_CONFIG
+
+    current = get_hooks_path(repo_root)
+    configured = hooks_path_points_at_canonical(repo_root, current)
+
+    if args.check:
+        return _run_check(
+            repo_root, configured=configured, current=current, quiet=args.quiet
+        )
+    return _run_install(
+        repo_root, configured=configured, current=current, quiet=args.quiet
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_git_hooks.py
+++ b/scripts/install_git_hooks.py
@@ -28,6 +28,7 @@ Exit codes (per AGENTS.md): 0 ok, 1 logic (hooks missing/not executable or
 from __future__ import annotations
 
 import argparse
+import os
 import stat
 import subprocess
 import sys
@@ -44,13 +45,20 @@ EXIT_EXTERNAL = 3
 
 
 def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
-    """Run a git command, capturing output. Raises on a missing git binary."""
+    """Run a git command, capturing output. Raises on a missing git binary.
+
+    Uses ``-C`` and strips ``GIT_DIR``/``GIT_WORK_TREE`` from the environment
+    so that git always operates on the specified ``cwd``, ignoring any
+    repository override variables the caller may have inherited.
+    """
+    env = {k: v for k, v in os.environ.items() if k not in ("GIT_DIR", "GIT_WORK_TREE")}
     return subprocess.run(
-        ["git", *args],
+        ["git", "-C", str(cwd), *args],
         cwd=str(cwd),
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
 
 

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -883,6 +883,39 @@ def validate_plugin_version_bump(repo_root: Path) -> bool:
     )
 
 
+def validate_git_hooks_installed(repo_root: Path) -> bool:
+    """Fail when the local clone is not wired to run the canonical githooks.
+
+    Delegates to ``scripts/install_git_hooks.py --check``, which verifies that
+    ``core.hooksPath`` resolves to ``.githooks`` and the hook scripts exist and
+    are executable. A clone left on the default ``.git/hooks`` (or pointed at an
+    absolute path) silently bypasses every pre-push guard, including the plugin
+    version-bump gate, so drift here is a hard local failure.
+
+    Skipped under CI: a CI checkout neither has nor should have
+    ``core.hooksPath`` set to ``.githooks`` (the guards run as workflow steps,
+    not local hooks), so the check is irrelevant there.
+    """
+    if os.environ.get("GITHUB_ACTIONS") or os.environ.get("CI"):
+        raise MissingScriptSkip("git hooks check skipped under CI")
+    script = repo_root / "scripts" / "install_git_hooks.py"
+    if not script.exists():
+        raise MissingScriptSkip("install_git_hooks.py not present")
+    exit_code, stdout, stderr = _run_subprocess(
+        [sys.executable, str(script), "--check", "--repo-root", str(repo_root)]
+    )
+    if stdout.strip():
+        print(stdout.strip())
+    if stderr.strip():
+        print(stderr.strip())
+    if exit_code != 0:
+        print(
+            "[FAIL] Local git hooks are not installed. "
+            "Run: python3 scripts/install_git_hooks.py"
+        )
+    return exit_code == 0
+
+
 def validate_workflow_local_run(repo_root: Path) -> bool:
     """Shift-left tier of the workflow local-run gate (actionlint + act -n).
 
@@ -1176,6 +1209,14 @@ def main(argv: list[str] | None = None) -> int:
         "Plugin Version Bump",
         state,
         lambda: validate_plugin_version_bump(repo_root),
+    )
+
+    # 6d. Git Hooks Installed (local clone must run the canonical .githooks;
+    # a desynced hooksPath bypasses the pre-push guards). Skipped under CI.
+    run_validation(
+        "Git Hooks Installed",
+        state,
+        lambda: validate_git_hooks_installed(repo_root),
     )
 
     # 6d. Workflow Local Run (actionlint + gh act dry-run for changed workflows)

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -896,7 +896,10 @@ def validate_git_hooks_installed(repo_root: Path) -> bool:
     ``core.hooksPath`` set to ``.githooks`` (the guards run as workflow steps,
     not local hooks), so the check is irrelevant there.
     """
-    if os.environ.get("GITHUB_ACTIONS") or os.environ.get("CI"):
+    if (
+        os.environ.get("GITHUB_ACTIONS", "").lower() in ("true", "1")
+        or os.environ.get("CI", "").lower() in ("true", "1")
+    ):
         raise MissingScriptSkip("git hooks check skipped under CI")
     script = repo_root / "scripts" / "install_git_hooks.py"
     if not script.exists():

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -903,7 +903,13 @@ def validate_git_hooks_installed(repo_root: Path) -> bool:
         raise MissingScriptSkip("git hooks check skipped under CI")
     script = repo_root / "scripts" / "install_git_hooks.py"
     if not script.exists():
-        raise MissingScriptSkip("install_git_hooks.py not present")
+        print(
+            "[ERROR] install_git_hooks.py absent; the git-hooks gate cannot "
+            "run. Hard failure: the gate is the point of registering "
+            "this validator.",
+            file=sys.stderr,
+        )
+        return False
     exit_code, stdout, stderr = _run_subprocess(
         [sys.executable, str(script), "--check", "--repo-root", str(repo_root)]
     )

--- a/tests/test_install_git_hooks.py
+++ b/tests/test_install_git_hooks.py
@@ -1,0 +1,132 @@
+"""Tests for scripts/install_git_hooks.py."""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import install_git_hooks as igh  # noqa: E402
+
+
+def _make_hook(path: Path, *, executable: bool = True) -> None:
+    path.write_text("#!/bin/bash\nexit 0\n")
+    if executable:
+        path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
+
+
+def _init_repo(root: Path, *, with_hooks: bool = True) -> Path:
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    if with_hooks:
+        hooks = root / ".githooks"
+        hooks.mkdir()
+        for name in igh.REQUIRED_HOOKS:
+            _make_hook(hooks / name)
+    return root
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    return _init_repo(tmp_path / "repo")
+
+
+def _hooks_path(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "config", "--get", "core.hooksPath"],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip()
+
+
+# --- happy path -----------------------------------------------------------
+
+
+def test_sets_hooks_path(repo: Path) -> None:
+    assert igh.main(["--repo-root", str(repo)]) == igh.EXIT_OK
+    assert _hooks_path(repo) == igh.HOOKS_DIR_NAME
+
+
+def test_idempotent_second_run(repo: Path) -> None:
+    assert igh.main(["--repo-root", str(repo)]) == igh.EXIT_OK
+    # Second run must not fail and must keep the value.
+    assert igh.main(["--repo-root", str(repo)]) == igh.EXIT_OK
+    assert _hooks_path(repo) == igh.HOOKS_DIR_NAME
+
+
+def test_check_passes_after_install(repo: Path) -> None:
+    igh.main(["--repo-root", str(repo)])
+    assert igh.main(["--repo-root", str(repo), "--check"]) == igh.EXIT_OK
+
+
+# --- check mode (non-mutating) -------------------------------------------
+
+
+def test_check_fails_when_unconfigured(repo: Path) -> None:
+    # Not installed yet -> logic failure, and config left untouched.
+    assert igh.main(["--repo-root", str(repo), "--check"]) == igh.EXIT_LOGIC
+    assert _hooks_path(repo) == ""
+
+
+# --- negative / edge cases -----------------------------------------------
+
+
+def test_not_a_git_repo(tmp_path: Path) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert igh.main(["--repo-root", str(plain)]) == igh.EXIT_CONFIG
+
+
+def test_missing_githooks_dir(tmp_path: Path) -> None:
+    root = _init_repo(tmp_path / "norepo", with_hooks=False)
+    assert igh.main(["--repo-root", str(root)]) == igh.EXIT_CONFIG
+
+
+def test_hook_not_executable_is_logic_error(repo: Path) -> None:
+    pre_push = repo / ".githooks" / "pre-push"
+    pre_push.chmod(pre_push.stat().st_mode & ~stat.S_IXUSR & ~stat.S_IXGRP)
+    assert igh.main(["--repo-root", str(repo)]) == igh.EXIT_LOGIC
+
+
+def test_legacy_shim_warning(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    legacy = repo / ".git" / "hooks"
+    legacy.mkdir(parents=True, exist_ok=True)
+    _make_hook(legacy / "pre-push")
+    assert igh.main(["--repo-root", str(repo)]) == igh.EXIT_OK
+    out = capsys.readouterr().out
+    assert "shadowed" in out
+
+
+def test_quiet_suppresses_success_output(
+    repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert igh.main(["--repo-root", str(repo), "--quiet"]) == igh.EXIT_OK
+    assert capsys.readouterr().out == ""
+
+
+# --- unit: canonical path resolution -------------------------------------
+
+
+def test_points_at_canonical_relative(repo: Path) -> None:
+    assert igh.hooks_path_points_at_canonical(repo, ".githooks") is True
+
+
+def test_points_at_canonical_absolute(repo: Path) -> None:
+    abs_path = str((repo / ".githooks").resolve())
+    assert igh.hooks_path_points_at_canonical(repo, abs_path) is True
+
+
+def test_points_at_canonical_rejects_default(repo: Path) -> None:
+    assert igh.hooks_path_points_at_canonical(repo, ".git/hooks") is False
+
+
+def test_points_at_canonical_rejects_none(repo: Path) -> None:
+    assert igh.hooks_path_points_at_canonical(repo, None) is False

--- a/tests/test_install_git_hooks.py
+++ b/tests/test_install_git_hooks.py
@@ -121,7 +121,8 @@ def test_points_at_canonical_relative(repo: Path) -> None:
 
 def test_points_at_canonical_absolute(repo: Path) -> None:
     abs_path = str((repo / ".githooks").resolve())
-    assert igh.hooks_path_points_at_canonical(repo, abs_path) is True
+    # Absolute paths are drift that breaks worktrees - must be rejected.
+    assert igh.hooks_path_points_at_canonical(repo, abs_path) is False
 
 
 def test_points_at_canonical_rejects_default(repo: Path) -> None:

--- a/tests/test_validation_pre_pr.py
+++ b/tests/test_validation_pre_pr.py
@@ -726,22 +726,16 @@ class TestValidateGitHooksInstalled:
                 mock_run.return_value = (0, "OK", "")
                 assert validate_git_hooks_installed(tmp_path) is True
 
-    def test_missing_script_raises_skip(self, tmp_path: Path) -> None:
+    def test_missing_script_fails_closed(self, tmp_path: Path) -> None:
         import os
 
-        import pytest
-
-        from scripts.validation.pre_pr import (
-            MissingScriptSkip,
-            validate_git_hooks_installed,
-        )
+        from scripts.validation.pre_pr import validate_git_hooks_installed
 
         with patch.dict("os.environ", {}, clear=False):
             os.environ.pop("GITHUB_ACTIONS", None)
             os.environ.pop("CI", None)
-            # tmp_path has no scripts/install_git_hooks.py
-            with pytest.raises(MissingScriptSkip):
-                validate_git_hooks_installed(tmp_path)
+            # tmp_path has no scripts/install_git_hooks.py; expect hard failure
+            assert validate_git_hooks_installed(tmp_path) is False
 
     def test_passes_when_check_exits_zero(self, tmp_path: Path) -> None:
         import os

--- a/tests/test_validation_pre_pr.py
+++ b/tests/test_validation_pre_pr.py
@@ -706,6 +706,26 @@ class TestValidateGitHooksInstalled:
             with pytest.raises(MissingScriptSkip):
                 validate_git_hooks_installed(tmp_path)
 
+    def test_not_skipped_when_ci_is_false(self, tmp_path: Path) -> None:
+        """CI=false or CI=0 should NOT skip the check (they are non-truthy)."""
+        import os
+
+        from scripts.validation.pre_pr import (
+            MissingScriptSkip,
+            validate_git_hooks_installed,
+        )
+
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "scripts" / "install_git_hooks.py").write_text("# stub\n")
+        env = {"CI": "false"}
+        with patch.dict("os.environ", env, clear=False):
+            os.environ.pop("GITHUB_ACTIONS", None)
+            with patch(
+                "scripts.validation.pre_pr._run_subprocess"
+            ) as mock_run:
+                mock_run.return_value = (0, "OK", "")
+                assert validate_git_hooks_installed(tmp_path) is True
+
     def test_missing_script_raises_skip(self, tmp_path: Path) -> None:
         import os
 

--- a/tests/test_validation_pre_pr.py
+++ b/tests/test_validation_pre_pr.py
@@ -667,3 +667,90 @@ class TestValidateDashProhibition:
             # No file at tmp_path/doc.md (working tree). Function should
             # still detect the violation because it reads HEAD content.
             assert validate_dash_prohibition(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# validate_git_hooks_installed
+# ---------------------------------------------------------------------------
+
+
+class TestValidateGitHooksInstalled:
+    """The local-githooks gate delegates to install_git_hooks.py --check."""
+
+    def test_skipped_under_github_actions(self, tmp_path: Path) -> None:
+        import pytest
+
+        from scripts.validation.pre_pr import (
+            MissingScriptSkip,
+            validate_git_hooks_installed,
+        )
+
+        with patch.dict("os.environ", {"GITHUB_ACTIONS": "true"}, clear=False):
+            with pytest.raises(MissingScriptSkip):
+                validate_git_hooks_installed(tmp_path)
+
+    def test_skipped_under_ci(self, tmp_path: Path) -> None:
+        import pytest
+
+        from scripts.validation.pre_pr import (
+            MissingScriptSkip,
+            validate_git_hooks_installed,
+        )
+
+        env = {"CI": "1"}
+        with patch.dict("os.environ", env, clear=False):
+            # Ensure GITHUB_ACTIONS does not mask the CI branch.
+            import os
+
+            os.environ.pop("GITHUB_ACTIONS", None)
+            with pytest.raises(MissingScriptSkip):
+                validate_git_hooks_installed(tmp_path)
+
+    def test_missing_script_raises_skip(self, tmp_path: Path) -> None:
+        import os
+
+        import pytest
+
+        from scripts.validation.pre_pr import (
+            MissingScriptSkip,
+            validate_git_hooks_installed,
+        )
+
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("GITHUB_ACTIONS", None)
+            os.environ.pop("CI", None)
+            # tmp_path has no scripts/install_git_hooks.py
+            with pytest.raises(MissingScriptSkip):
+                validate_git_hooks_installed(tmp_path)
+
+    def test_passes_when_check_exits_zero(self, tmp_path: Path) -> None:
+        import os
+
+        from scripts.validation.pre_pr import validate_git_hooks_installed
+
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "scripts" / "install_git_hooks.py").write_text("# stub\n")
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("GITHUB_ACTIONS", None)
+            os.environ.pop("CI", None)
+            with patch(
+                "scripts.validation.pre_pr._run_subprocess"
+            ) as mock_run:
+                mock_run.return_value = (0, "OK", "")
+                assert validate_git_hooks_installed(tmp_path) is True
+
+    def test_fails_when_check_exits_nonzero(self, tmp_path: Path) -> None:
+        import os
+
+        from scripts.validation.pre_pr import validate_git_hooks_installed
+
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "scripts" / "install_git_hooks.py").write_text("# stub\n")
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("GITHUB_ACTIONS", None)
+            os.environ.pop("CI", None)
+            with patch(
+                "scripts.validation.pre_pr._run_subprocess"
+            ) as mock_run:
+                mock_run.return_value = (1, "", "core.hooksPath not set")
+                assert validate_git_hooks_installed(tmp_path) is False


### PR DESCRIPTION
## Summary

Adds an idempotent git-hooks installer and a local pre-PR drift gate so contributors (and worktrees) cannot silently run with `core.hooksPath` unset or pointing at a stale absolute path.

## Problem

`core.hooksPath` is configured per-clone. A fresh clone, or a `git worktree add`, has no affordance to run a setup hook on entry, so hooks silently do not fire until someone notices a guard that should have blocked a push did not. CONTRIBUTING.md documents the manual step, but documentation does not enforce.

## Change

- `scripts/install_git_hooks.py` (new): idempotent installer. Sets a **relative** `core.hooksPath` (`.githooks`) so the same config works across the main clone and every worktree. `--check` mode reports drift without mutating.
- `scripts/validation/pre_pr.py`: new step 6d `validate_git_hooks_installed()` runs `install_git_hooks.py --check`. Skips under CI (hooks are not the CI execution model); hard-fails locally on drift.
- `CONTRIBUTING.md`: document the installer and the worktree rationale.
- Memory: capture the relative-hooksPath worktree footgun for future sessions.

## Tests

- `tests/test_install_git_hooks.py` (new, 13 tests): idempotency, relative-path assertion, drift detection, check vs install modes.
- `tests/test_validation_pre_pr.py`: 5 added cases for the new gate (CI skip, local drift fail, clean pass).

## Stacking

Based on #2149 (the autofix-pr generated-rename fix) so the build-pipeline staleness gate sees a clean generated tree. GitHub will retarget this PR to `main` automatically when #2149 merges.

Fixes #2144
