### PR TITLE
fix(agents): unblock main CI (workspace budget + generated-file staleness)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "author": { "name": "rjmurillo" }
 }

--- a/.claude/skills/memory/SKILL.md
+++ b/.claude/skills/memory/SKILL.md
@@ -140,6 +140,8 @@ This skill implements [progressive disclosure principles](../../../.agents/analy
 | **Details** | `mcp__serena__read_memory` | ~500-10K tokens | After index confirms relevance |
 | **Deep Dive** | Follow cross-references | Variable | For complete understanding |
 
+**Routing**: `search_memory.py "<q>"` keyword-ranks Serena memory names (Serena-first, augments with Forgetful when reachable, flags large memories by token estimate) and returns the relevant `*-index`; `read_memory` it, then follow its links to the atomic file. Raw fallback when scripting: guess `read_memory("<intuitive-name>")` (a miss is a cheap "not found", not a list), then the domain `*-index`, then `read_memory("memory-index")`. Prefer these name/index lookups over a bare `list_memories`. On add: update the `*-index` so the next agent finds it by name. Atomic files plus indexes are deliberate (no embeddings; filename is the activation vocabulary): do NOT consolidate atomic memories to cheapen listing, it breaks discovery and cross-links.
+
 ### Token Cost Visibility
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,18 +10,10 @@ Read first, reason second. Pre-training last resort.
 
 |APIs: Context7, DeepWiki, WebSearch
 |Constraints: `.agents/governance/PROJECT-CONSTRAINTS.md`
-|Patterns: Serena `mcp__serena__read_memory`
+|Memory: `memory` skill; not bare `list_memories`
 |ADRs: `.agents/architecture/ADR-*.md`
 |Protocol: `.agents/SESSION-PROTOCOL.md`
 |Skills: `.claude/skills/{name}/SKILL.md`
-
-**Memory lookup**: use the `memory` skill, don't hand-roll:
-
-1. **Primary**: `python3 .claude/skills/memory/scripts/search_memory.py "<query>"`. Keyword-ranks Serena memory names (Serena-first), augments with Forgetful when it is reachable, and flags large memories by token estimate. Returns the relevant `*-index`; `read_memory` it, then follow its links to the atomic file.
-2. **Deep context** before planning: delegate to `context-retrieval` agent. Human CLI: `/memory-search`.
-3. **Raw fallback** (scripting): guess `read_memory("<intuitive-name>")` (miss = cheap "not found", not a list) then domain `*-index` then `read_memory("memory-index")`. Prefer these name/index lookups over a bare `list_memories`.
-
-On add: update the `*-index` so the next agent finds it by name. Atomic files + indexes are deliberate (no embeddings; filename = activation vocab): see `.serena/memories/memory/memory-token-efficiency.md`, `.serena/memories/memory/memory-size-001-decomposition-thresholds.md`. Do NOT consolidate atomic memories to cheapen listing; it breaks discovery + cross-links.
 
 ## Session Gates
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "24 agent definitions, 81 reusable skills, 34 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": { "name": "rjmurillo" }
 }

--- a/src/copilot-cli/skills/memory/SKILL.md
+++ b/src/copilot-cli/skills/memory/SKILL.md
@@ -140,6 +140,8 @@ This skill implements [progressive disclosure principles](../../../.agents/analy
 | **Details** | `mcp__serena__read_memory` | ~500-10K tokens | After index confirms relevance |
 | **Deep Dive** | Follow cross-references | Variable | For complete understanding |
 
+**Routing**: `search_memory.py "<q>"` keyword-ranks Serena memory names (Serena-first, augments with Forgetful when reachable, flags large memories by token estimate) and returns the relevant `*-index`; `read_memory` it, then follow its links to the atomic file. Raw fallback when scripting: guess `read_memory("<intuitive-name>")` (a miss is a cheap "not found", not a list), then the domain `*-index`, then `read_memory("memory-index")`. Prefer these name/index lookups over a bare `list_memories`. On add: update the `*-index` so the next agent finds it by name. Atomic files plus indexes are deliberate (no embeddings; filename is the activation vocabulary): do NOT consolidate atomic memories to cheapen listing, it breaks discovery and cross-links.
+
 ### Token Cost Visibility
 
 ```bash

--- a/src/copilot-cli/skills/pr-autofix/SKILL.md
+++ b/src/copilot-cli/skills/pr-autofix/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: autofix-pr
+name: pr-autofix
 description: Autonomous PR monitor and fixer per docs/autonomous-pr-monitor.md. Triages open PRs by tier, addresses thread feedback, fixes CI failures, and enables auto-merge when the 4-condition Ready-to-Merge gate passes.
 allowed-tools: Bash, Read, Edit, Write, Skill
 user-invocable: true
 ---
 
-# /autofix-pr
+# /pr-autofix
 
 Autonomous PR monitor and fixer. Implements the protocol from
 `docs/autonomous-pr-monitor.md`.
@@ -14,7 +14,7 @@ Autonomous PR monitor and fixer. Implements the protocol from
 
 | Trigger phrase | Operation |
 |----------------|-----------|
-| `autofix-pr` | Triage all open PRs by tier and act |
+| `pr-autofix` | Triage all open PRs by tier and act |
 | `autofix this pr` | Single-PR mode on the current branch's open PR |
 | `monitor open prs` | Periodic triage without merging |
 | `auto-merge ready prs` | Tier 1 only: enable auto-merge on land-ready PRs |


### PR DESCRIPTION
## Summary

Unblocks `Run Python Tests` and `build_all` staleness on `main`, which were red on the default branch and therefore failing CI on every open PR.

Two independent main-branch breakages, both fixed here:

1. **Workspace-budget regression.** PR #2146 added a memory-lookup block to the root workspace context, growing it from 2982 to 4065 bytes and exceeding the 3000-byte per-file workspace budget. Because the budget test runs against the merged tree, this broke `Run Python Tests` for the whole PR queue. Fix: compress the always-on guidance to a single Retrieval-Led Reasoning bullet and relocate the full routing detail into the memory skill, where actionable detail belongs. The root context is back to 2987 bytes; both budget enforcers pass (22 tests).

2. **Generated-file staleness.** The `autofix-pr` to `pr-autofix` command rename (#2142) committed the source and bumped the claude plugin, but never regenerated the Copilot skill mirror, leaving the old mirror tracked and the new mirror absent. This tripped the generated-files staleness check on every branch. Fix: regenerate the mirror (rename) and bump both plugin manifests.

## Changes

- Compress memory-routing guidance in the root workspace context to a one-line pointer.
- Move the routing detail (index-first lookup, index-on-add, naming-as-vocabulary) into the memory skill.
- Reconcile the Copilot skill mirrors and bump the claude and copilot plugin versions.

## Validation

- Workspace-budget validator: PASS
- Budget pytest suites: 22 passed
- Generated-files staleness check: clean

Refs #2145
