### PR TITLE
chore(memory): add eval-harness + build-model skill sidecar learnings

### DIFF
--- a/.serena/memories/agent-prompt-optimization-observations.md
+++ b/.serena/memories/agent-prompt-optimization-observations.md
@@ -1,7 +1,7 @@
 # Skill Sidecar Learnings: agent-prompt-optimization
 
-**Last Updated**: 2026-04-11
-**Sessions Analyzed**: 1 (feat/agent-prompt-optimization branch)
+**Last Updated**: 2026-05-30
+**Sessions Analyzed**: 2 (feat/agent-prompt-optimization; wiki-rubric audit #2126/#2136)
 **Related**: knowledge-integration-observations.md (PR #1614, same refs pattern but for skills)
 
 ## Constraints (HIGH confidence)
@@ -100,6 +100,16 @@ These sections appear in most/all agents and are candidates for extraction to sh
 
 Slimming these out saved 40-89% per agent without any capability loss.
 
+### Ground agent/skill changes in evals; prove effectiveness, do not assume
+
+Before filing improvement issues, dedup against ALL open issues (`gh issue list`). Ground proposed changes in the committed eval baseline (`evals/baseline-report.md`) + triage docs (`evals/agent-triage.md`, `evals/skill-triage.md`). After editing, PROVE effectiveness: (a) regression-run every edited eval-able agent vs its committed baseline delta, and (b) author NEW fixtures for behaviours the existing harness does not measure. Most description/safety edits are non-regression-only against the verdict-recall harness; the real signal needs new behavioural fixtures.
+
+**Source**: user — "check for issues already filed so we don't get dupes", "the items need to have their evals run to determine if the edits are effective". (2026-05-30)
+
+### Delegate, do not re-embed another skill's framework
+
+When a skill body re-implements another skill's framework (e.g. `programming-advisor` Steps 5/9 duplicated `buy-vs-build-framework`'s decision matrix in weaker scriptless prose), replace it with a delegation, not a copy. Check the tier: tactical ("use a library vs glue code") vs strategic ("build/buy/partner/defer with multi-year TCO"). Reciprocal SKIP clauses: each artifact owns only its own side; verify both sides landed. (#2140/#2141, 2026-05-30)
+
 ## Edge Cases (MED confidence)
 
 ### Tagging eval prompts with Cynefin classification
@@ -129,9 +139,16 @@ This is THE fundamental distinction for knowledge placement. Skills can afford r
 
 **Implication**: Use skills for reusable capability packages. Use agents for persona definitions. Never conflate.
 
+### New eval fixtures: score behaviour via regex, not the verdict token
+
+The agent-vs-baseline harness (`scripts/eval/eval-agent-vs-baseline.py`) forces the first output token to `IDENTIFY|OK|ESCALATE`. Specialized agents use IDENTIFY vs ESCALATE inconsistently for "I found a problem" (verdict-vocabulary confound, baseline-report followup #1). New fixtures must score the agent-specific BEHAVIOURAL marker via a regex the naive baseline will not emit (e.g. security cites the ASI taxonomy `ASI0\d`; qa says "claim, not evidence" / "reconciliation block"), NOT the verdict token. Also: obvious injections / easy routing SATURATE (the naive baseline already resists/disambiguates), so fixtures need agent-specific markers or harder adversarial inputs to discriminate. Custom eval scripts must call `_anthropic_api.call_api` (urllib transport); the `anthropic` SDK is NOT installed in this repo.
+
+**Source**: new injection (security F011-F016) + evidence (qa Q009-Q012) fixtures; my first pass wrongly asserted ESCALATE while agents said IDENTIFY -> false 0.50. Recalibrated to regex -> security agent 1.000 vs baseline 0.333 SIG-POS. (2026-05-30)
+
 ## Notes for Review (LOW confidence)
 
 - Consider whether task-decomposer, milestone-planner, roadmap would also benefit from the same slim pattern even though they scored above 3.5 baseline
 - Research whether "produce when you can, ask when you must" template should be extracted into a shared agent fragment referenced by all ask-first agents
 - Investigate whether the 4.0 floor we achieved post-slim is actually a ceiling imposed by the LLM-as-judge scoring framework rather than the actual agents
 - Consider publishing eval-agents.py with Cynefin-aware scoring as a reusable tool for other agent-based projects
+- The Workflow tool silently dropped a large nested `args` key (a `clusters` array) on one run; inline big config (cluster/page lists, rubrics) as `const` in the script body rather than passing via `args`. (2026-05-30)

--- a/.serena/memories/ci-infrastructure-observations.md
+++ b/.serena/memories/ci-infrastructure-observations.md
@@ -1,7 +1,7 @@
 # Skill Sidecar Learnings: CI Infrastructure
 
-**Last Updated**: 2026-03-04
-**Sessions Analyzed**: 1
+**Last Updated**: 2026-05-30
+**Sessions Analyzed**: 2
 
 ## Constraints (HIGH confidence)
 
@@ -11,6 +11,12 @@
 
 - After major cleanup operations (file deletions, merges from main), update the PR description before pushing. The `pr_description.py` CI validator checks that files mentioned in the description match the actual diff. Stale descriptions cause `DESCRIPTION_RESULT: FAIL`. (PR #1361, 2026-03-04)
 - Virtual environment tools (`uv run python`) should be first priority in Python detection functions like `set_python_cmd()`, before system `python3`/`python`/`py` fallbacks. System Python often lacks project dependencies (pytest, etc.) that live in the virtual environment. See `.githooks/pre-push:110`. (PR #1361, 2026-03-04)
+
+## Edge Cases (MED confidence)
+
+- Agent multi-platform sibling model (ADR-036): a SHARED_AGENT's hand-maintained siblings are `templates/agents/<n>.shared.md` + `src/claude/<n>.md` + `.claude/agents/<n>.md` + `.github/agents/<n>.agent.md`; `build/scripts/validate_install_parity.py` requires they move together. `.github/agents/*.agent.md` is hand-curated (different body+frontmatter from the copilot mirror), NOT generated. If you edit any sibling of an agent that LACKS its `.github` copy, parity fails ("missing required sibling"). Either create the `.github` variant or revert that agent. Hit on `issue-feature-review` (no `.github` copy at main). (wiki-rubric audit #2126/#2136, 2026-05-30)
+- Agent/skill generators: use `python3 build/generate_agents.py` (writes only `src/copilot-cli/agents` + `src/vs-code-agents`) and `python3 build/scripts/build_all.py` (regenerates all mirrors incl. `src/copilot-cli/skills`). Docs' `pwsh build/Generate-Agents.ps1` is STALE/absent. Drift detector is `build/scripts/detect_agent_drift.py` (src/claude vs src/vs-code, 80% threshold; weekly cron, opens an issue, NOT a blocking PR gate). `build_all.py --check` reporting "STALENESS DETECTED" just means your regen output is uncommitted; it is idempotent and clears once committed. `.claude/agents` and `.github/agents` are hand-synced (no install script). (wiki-rubric audit, 2026-05-30)
+- `validate-skill.py` (SkillForge) has a CWE-22 cwd path guard: it rejects target paths outside the current working dir. To validate an `origin/main` worktree copy, `cd` INTO the worktree first. It is local-pre-commit-hook only (not wired into any CI workflow), and `core.hooksPath` may point at `.git/hooks` so it may not even run on commit. ~16 skills fail its structural checks (missing Process/Verification sections) on origin/main; ALWAYS diff validator output against an origin/main worktree before "fixing" pre-existing failures as if they were your regression. (wiki-rubric audit, 2026-05-30)
 
 ## Notes for Review (LOW confidence)
 

--- a/.serena/memories/eval-harness-observations.md
+++ b/.serena/memories/eval-harness-observations.md
@@ -1,0 +1,26 @@
+# Skill Sidecar Learnings: Eval Harness
+
+**Last Updated**: 2026-05-30
+**Sessions Analyzed**: 1 (wiki-rubric audit #2126/#2136)
+**Related**: agent-prompt-optimization-observations.md (fixture-design-for-effectiveness lesson lives there)
+
+## Constraints (HIGH confidence)
+
+- Run one agent's eval: `python3 scripts/eval/eval-agent-vs-baseline.py --agent <name> --fixtures evals/<name>-spike/fixtures --n-runs 3 --model claude-sonnet-4-6` from repo root. `ANTHROPIC_API_KEY` is read from env or `.env`. The agent-under-test "variant" is `templates/agents/<name>.shared.md` (read as the system prompt); baseline prompt is fixed "Review the following input." `--dry-run` validates fixtures + prints the plan with ZERO spend (the only no-API path; no `--mock` exists).
+- Custom eval scripts MUST use the repo's own transport `from _anthropic_api import call_api` (urllib-based, `scripts/eval/_anthropic_api.py`). `import anthropic` FAILS — the SDK is not installed. The main harness works because it uses `call_api`, not the SDK. (Bug hit: `eval_skill_router.py` rc=3 "SDK not installed".)
+
+## Preferences (MED confidence)
+
+- Fixture format: JSON, one per file in `evals/<name>-spike/fixtures/*.json`. Fields: `schemaVersion` (must be 1), `id` (unique across corpus), `input`, `provenance` (`synthetic|public-cve|paraphrased-from-public`), `assertions` (each `{"kind":"verdict","expected_value":"IDENTIFY|OK|ESCALATE"}` OR `{"kind":"regex","pattern":"..."}`; never both on one assertion), `tags`. Validated by `FixtureValidator` (`_eval_agent_types.py`). No manifest/registry; the runner globs `fixtures/*.json`.
+- Reports: `evals/<name>-spike/reports/<RUN_ID>/report.json` (+ `REPORT.md`); per-call records in `runs/<RUN_ID>/runs.jsonl` (the agent's actual output is the `raw_response` field). `report.json` carries `agent_recall`, `baseline_recall`, `recall_delta`, `bootstrap_ci_95`, `per_fixture_pass_rates`, and `*_sha` provenance. To detect regression after a prompt edit: re-run the SAME fixtures, compare new `recall_delta`/CI to the committed baseline report (comparable only when `fixture_set_sha` matches). The harness has NO built-in diff command.
+- Cost ~$0.40-1.40 per agent at `--n-runs 3` (calls = n_runs x fixtures x 2 variants). Flakiness halt: if >30% of fixtures are intra-run-variant flaky, the runner emits informational metrics and exits non-zero (ADR-058) — a delta with flaky=true is directional, not significant.
+
+## Edge Cases (MED confidence)
+
+- DEFERRED agents (no `templates/agents/<name>.shared.md`): the harness cannot load the variant, so it cannot eval them. context-retrieval, quality-auditor, spec-generator are DEFERRED. To eval them you must first author the `.shared.md` template + a spike.
+- Two skill eval systems exist: knowledge-integration (`scripts/eval/eval-knowledge-integration.py`, prompts in `tests/evals/skills/*.json`) and agent-vs-baseline. A true skill ROUTER/trigger eval (does query X load skill Y?) does NOT exist; author one if needed (`eval_skill_router.py` was a first attempt — compares before/after skill descriptions on disambiguation queries).
+- `validate-skill.py` (SkillForge) has a CWE-22 cwd path guard — it rejects targets outside cwd; `cd` into a worktree to validate its copy. See `mem:ci-infrastructure-observations` for the build/parity/drift model.
+
+## Notes for Review (LOW confidence)
+
+- The verdict-vocabulary confound (harness forces IDENTIFY|OK|ESCALATE) is the single biggest measurement-noise source; fixture-design workaround (score behavioural regex, not verdict token) is documented in agent-prompt-optimization-observations.md.

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -76,6 +76,7 @@
 
 [Retrospective and Learning]
 |retrospective learning session failure skill persistence extract artifact: [skills-retrospective-index](skills-retrospective-index.md) (376), [retrospective/retrospective-artifact-efficiency-pattern](retrospective/retrospective-artifact-efficiency-pattern.md) (986)
+|skill sidecar observations learnings eval-harness fixtures build-model parity drift prompt-optimization ci-infrastructure: [agent-prompt-optimization-observations](agent-prompt-optimization-observations.md) (1960), [eval-harness-observations](eval-harness-observations.md) (543), [ci-infrastructure-observations](ci-infrastructure-observations.md) (568)
 
 [Memory and Context]
 |serena token efficiency symbolic tools cache memory read search: [skills-serena-index](skills-serena-index.md) (284)


### PR DESCRIPTION
Skill-sidecar learnings captured via `/reflect` after the agents/skills wiki-rubric audit session (epic #2126 / PR #2136, follow-ups #2140 / #2141).

## What's captured
- `.serena/memories/eval-harness-observations.md` (new)
- `.serena/memories/ci-infrastructure-observations.md`
- `.serena/memories/agent-prompt-optimization-observations.md`
- `.serena/memories/memory-index.md`

## Notes
- eval-harness-observations (new): how to run the agent-vs-baseline eval, the urllib transport used because the anthropic SDK is not installed, fixture JSON schema, report/regression mechanics, cost, DEFERRED agents, and the two skill-eval systems.
- ci-infrastructure-observations: ADR-036 multi-platform sibling / install-parity model (the github agents tree is a hand-maintained parity sibling), the real generators (not the stale PowerShell), agent drift detection, the validate-skill cwd guard, and always diff validator output against an origin/main worktree before "fixing" pre-existing failures.
- agent-prompt-optimization-observations: prove edit effectiveness with evals (dedup issues first, regression-run plus author new behavioural fixtures); delegate rather than re-embed another skill's framework; score new fixtures by behavioural regex, not the verdict token.
- memory-index: indexes the three sidecars under Retrospective and Learning.

memory-index has no automated generator; it is hand-curated and validated by the memory index validator (ADR-017). Root-level observation sidecars were previously un-indexed; this PR adds the three touched here so they are discoverable per the reflect skill's design.

## Validation
`python3 scripts/validation/memory_index.py --ci` passed (303 files indexed, 0 missing, no broken refs).

Docs and learnings only: no code or agent/skill behaviour changes.

Refs #2126
