### PR TITLE
fix(pr-scripts): normalize unresolved review-thread output shape (#2012)

### DIFF
--- a/.agents/sessions/2026-05-31-session-1857-fix-issue-2012-normalize-get_unresolved_review_threads.json
+++ b/.agents/sessions/2026-05-31-session-1857-fix-issue-2012-normalize-get_unresolved_review_threads.json
@@ -1,0 +1,127 @@
+{
+  "session": {
+    "number": 1857,
+    "date": "2026-05-31",
+    "branch": "fix/2012-thread-shape-consistency",
+    "startingCommit": "e6fa83a93",
+    "objective": "Fix issue 2012: normalize get_unresolved_review_threads output to canonical flat thread shape shared with get_pr_review_threads"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "mcp__serena__initial_instructions activated project ai-agents; symbolic tools (get_symbols_overview, find_symbol) used to read the pr scripts"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read Serena Instructions Manual via initial_instructions before code work"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-injected at session start and reviewed (read-only per ADR-014)"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Skill catalog listed in session context; session-init and session-end skills invoked"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "usage-mandatory guidance reviewed; Serena-first and skill-first routing followed"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".claude/rules/*.md loaded via CLAUDE.md imports; AGENTS.md boundaries and canonical-source-mirror rule applied to the dual-synced github_core lib"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory index loaded; github-skill and pr-review memories consulted for thread-shape contract"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2012-thread-shape-consistency"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Isolated worktree at /tmp/wt-2012 on fix/2012-thread-shape-consistency off origin/main"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status verified clean before edits; main checkout left untouched"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "e6fa83a93"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All Start MUST gates complete; work landed across 4 atomic commits; 208 unit tests pass"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Wrote Serena memory workflow/worktree-session-init-writes-to-main"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint run via pre_pr.py; this PR changes zero markdown files"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Work head da8abdf3e; session log committed last"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "pre_pr.py: plugin-version-bump was the only diff-caused failure and now re-passes; markdown, agent-drift, and git-hooks failures are pre-existing repo and environment state outside this diff; 208 unit tests pass"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Tracked in workLog and nextSteps"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "task": "Resolve issue #2012: get_unresolved_review_threads emitted raw GraphQL per-thread nodes that disagreed with get_pr_review_threads flat shape, crashing consumers",
+      "outcome": "Added canonical transform_review_thread to scripts/github_core/api.py (single source of truth), made both pr scripts use it, enriched the unresolved GraphQL query and added --include-comments. Verified no consumer reads the old per-thread shape (wait_for_unresolved_zero reads only top-level keys).",
+      "evidence": "208 tests pass (uv run pytest); live run against PR 2155 emits flat shape with no crash; sync_plugin_lib + build_all regenerate .claude/lib and src/copilot-cli copies"
+    }
+  ],
+  "endingCommit": "da8abdf3e9ee06ff5d6848a24e2df67cb9199441",
+  "nextSteps": [
+    "Open PR with Fixes #2012",
+    "Continue session-1858 for issue #2048; verify and close issue #2007"
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "author": { "name": "rjmurillo" }
 }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": { "name": "rjmurillo" }
 }

--- a/.claude/lib/github_core/__init__.py
+++ b/.claude/lib/github_core/__init__.py
@@ -27,6 +27,7 @@ from .api import (  # noqa: F401
     is_gh_authenticated,
     resolve_repo_params,
     safe_log_str,
+    transform_review_thread,
     update_issue_comment,
 )
 from .bot_config import (  # noqa: F401
@@ -85,6 +86,7 @@ __all__ = [
     "is_safe_file_path",
     "resolve_repo_params",
     "safe_log_str",
+    "transform_review_thread",
     "update_issue_comment",
     "write_skill_error",
     "write_skill_output",

--- a/.claude/lib/github_core/api.py
+++ b/.claude/lib/github_core/api.py
@@ -57,6 +57,59 @@ def filter_unresolved_threads(thread_nodes: list[dict]) -> list[dict]:
     """
     return [t for t in thread_nodes if not t.get("isResolved", True)]
 
+
+def transform_review_thread(thread: dict, include_comments: bool = False) -> dict:
+    """Transform a raw GraphQL review-thread node into the canonical flat shape.
+
+    Single authoritative definition (DRY) of the review-thread output shape
+    shared by ``get_pr_review_threads.py`` and
+    ``get_unresolved_review_threads.py``. A consumer that reads one script's
+    ``threads`` list can read the other's without a shape branch, which is the
+    bug this consolidates: the lighter unresolved script previously emitted raw
+    GraphQL nodes (``{"id", "isResolved", "comments": {"nodes": [...]}}``) while
+    the richer script emitted this flat shape, so ``thread["comments"][-1]``
+    crashed against one and worked against the other.
+
+    ``include_comments`` controls whether the full comment list is materialized.
+    When False (the cheap-probe default), ``comments`` is None and only the
+    ``first_comment_*`` fields are populated; the caller still pays for one
+    comment per thread in its GraphQL query, never the whole conversation.
+    """
+    comments_nodes = thread.get("comments", {}).get("nodes", [])
+    first = comments_nodes[0] if comments_nodes else None
+
+    result: dict = {
+        "thread_id": thread.get("id"),
+        "is_resolved": thread.get("isResolved", False),
+        "is_outdated": thread.get("isOutdated", False),
+        "path": thread.get("path"),
+        "line": thread.get("line"),
+        "start_line": thread.get("startLine"),
+        "diff_side": thread.get("diffSide"),
+        "comment_count": thread.get("comments", {}).get("totalCount", 0),
+        "first_comment_id": first.get("databaseId") if first else None,
+        "first_comment_author": (
+            first.get("author", {}).get("login") if first and first.get("author") else None
+        ),
+        "first_comment_body": first.get("body") if first else None,
+        "first_comment_created_at": first.get("createdAt") if first else None,
+        "comments": None,
+    }
+
+    if include_comments:
+        result["comments"] = [
+            {
+                "id": c.get("databaseId"),
+                "author": c.get("author", {}).get("login") if c.get("author") else None,
+                "body": c.get("body"),
+                "created_at": c.get("createdAt"),
+            }
+            for c in comments_nodes
+        ]
+
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Result types
 # ---------------------------------------------------------------------------

--- a/.claude/lib/github_core/api.py
+++ b/.claude/lib/github_core/api.py
@@ -75,7 +75,8 @@ def transform_review_thread(thread: dict, include_comments: bool = False) -> dic
     ``first_comment_*`` fields are populated; the caller still pays for one
     comment per thread in its GraphQL query, never the whole conversation.
     """
-    comments_nodes = thread.get("comments", {}).get("nodes", [])
+    comments_data = thread.get("comments") or {}
+    comments_nodes = comments_data.get("nodes") or []
     first = comments_nodes[0] if comments_nodes else None
 
     result: dict = {
@@ -86,7 +87,7 @@ def transform_review_thread(thread: dict, include_comments: bool = False) -> dic
         "line": thread.get("line"),
         "start_line": thread.get("startLine"),
         "diff_side": thread.get("diffSide"),
-        "comment_count": thread.get("comments", {}).get("totalCount", 0),
+        "comment_count": comments_data.get("totalCount", 0),
         "first_comment_id": first.get("databaseId") if first else None,
         "first_comment_author": (
             first.get("author", {}).get("login") if first and first.get("author") else None

--- a/.claude/skills/github/scripts/pr/get_pr_review_threads.py
+++ b/.claude/skills/github/scripts/pr/get_pr_review_threads.py
@@ -50,6 +50,7 @@ from github_core.api import (  # noqa: E402
     filter_unresolved_threads,
     gh_graphql,
     resolve_repo_params,
+    transform_review_thread,
 )
 
 # Page size for the reviewThreads connection. GitHub GraphQL caps connection
@@ -290,40 +291,14 @@ def _collect_all_threads(
 
 
 def _transform_thread(thread: dict, include_comments: bool) -> dict:
-    """Transform a raw GraphQL thread node into the output format."""
-    comments_nodes = thread.get("comments", {}).get("nodes", [])
-    first = comments_nodes[0] if comments_nodes else None
+    """Transform a raw GraphQL thread node into the canonical flat shape.
 
-    result: dict = {
-        "thread_id": thread.get("id"),
-        "is_resolved": thread.get("isResolved", False),
-        "is_outdated": thread.get("isOutdated", False),
-        "path": thread.get("path"),
-        "line": thread.get("line"),
-        "start_line": thread.get("startLine"),
-        "diff_side": thread.get("diffSide"),
-        "comment_count": thread.get("comments", {}).get("totalCount", 0),
-        "first_comment_id": first.get("databaseId") if first else None,
-        "first_comment_author": (
-            first.get("author", {}).get("login") if first and first.get("author") else None
-        ),
-        "first_comment_body": first.get("body") if first else None,
-        "first_comment_created_at": first.get("createdAt") if first else None,
-        "comments": None,
-    }
-
-    if include_comments:
-        result["comments"] = [
-            {
-                "id": c.get("databaseId"),
-                "author": c.get("author", {}).get("login") if c.get("author") else None,
-                "body": c.get("body"),
-                "created_at": c.get("createdAt"),
-            }
-            for c in comments_nodes
-        ]
-
-    return result
+    Thin wrapper over ``github_core.api.transform_review_thread`` (DRY). The
+    shape lives in one place so this script and ``get_unresolved_review_threads.py``
+    cannot drift. Kept as a named function because the test suite imports it
+    directly.
+    """
+    return transform_review_thread(thread, include_comments)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/.claude/skills/github/scripts/pr/get_unresolved_review_threads.py
+++ b/.claude/skills/github/scripts/pr/get_unresolved_review_threads.py
@@ -16,6 +16,14 @@ Output is a JSON object with:
       "threads": [<thread>, ...]
     }
 
+Each ``thread`` uses the canonical flat shape produced by
+``github_core.api.transform_review_thread`` (``thread_id``, ``is_resolved``,
+``path``, ``line``, ``first_comment_*``, ``comments``). It is identical to the
+shape emitted by ``get_pr_review_threads.py`` so a consumer can read either
+script's ``threads`` without a shape branch. Pass ``--include-comments`` to
+materialize the full per-thread comment list; by default ``comments`` is null
+and only the ``first_comment_*`` fields are populated.
+
 The ``fetched_pages_complete`` flag is true only when pagination ran to
 ``hasNextPage == false``. The /pr-review completion gate's pass_when
 expression requires this flag to be true alongside ``unresolved_count
@@ -68,6 +76,7 @@ from github_core.api import (  # noqa: E402
     error_and_exit,
     gh_graphql,
     resolve_repo_params,
+    transform_review_thread,
 )
 
 # Safety net: cap pages so a runaway PR cannot pin the script forever.
@@ -75,8 +84,12 @@ from github_core.api import (  # noqa: E402
 # realistic PR. If exceeded, we fall back to fetched_pages_complete=False.
 _MAX_PAGES = 50
 
+# Node selection mirrors the fields consumed by
+# ``github_core.api.transform_review_thread`` so the emitted ``threads`` share
+# the canonical flat shape with get_pr_review_threads.py. ``$commentsLimit`` is
+# 1 by default (cheap unresolved-count probe) and 50 under --include-comments.
 _QUERY = """\
-query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
+query($owner: String!, $name: String!, $prNumber: Int!, $commentsLimit: Int!, $cursor: String) {
     repository(owner: $owner, name: $name) {
         pullRequest(number: $prNumber) {
             reviewThreads(first: 100, after: $cursor) {
@@ -87,9 +100,18 @@ query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
                 nodes {
                     id
                     isResolved
-                    comments(first: 1) {
+                    isOutdated
+                    path
+                    line
+                    startLine
+                    diffSide
+                    comments(first: $commentsLimit) {
+                        totalCount
                         nodes {
                             databaseId
+                            body
+                            author { login }
+                            createdAt
                         }
                     }
                 }
@@ -100,16 +122,18 @@ query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
 
 
 def fetch_unresolved_threads_paginated(
-    owner: str, repo: str, pull_request: int,
+    owner: str, repo: str, pull_request: int, comments_limit: int = 1,
 ) -> tuple[list[dict], bool]:
     """Fetch unresolved review threads, paginating to exhaustion.
 
-    Returns a tuple ``(threads, fetched_pages_complete)``. The flag is
-    True only when the underlying GraphQL pagination terminated normally
-    (``hasNextPage`` was false on the last page). Pagination errors,
-    page-cap exhaustion, or query failures yield False; the caller MUST
-    treat False as "we cannot prove there are no more unresolved
-    threads".
+    Returns a tuple ``(threads, fetched_pages_complete)`` of raw GraphQL
+    nodes. ``comments_limit`` is forwarded to the query's
+    ``comments(first: ...)`` selection: 1 for the cheap probe, higher when
+    the caller wants the full comment list. The flag is True only when the
+    underlying GraphQL pagination terminated normally (``hasNextPage`` was
+    false on the last page). Pagination errors, page-cap exhaustion, or
+    query failures yield False; the caller MUST treat False as "we cannot
+    prove there are no more unresolved threads".
     """
     all_unresolved: list[dict] = []
     cursor: str | None = None
@@ -126,6 +150,7 @@ def fetch_unresolved_threads_paginated(
             "owner": owner,
             "name": repo,
             "prNumber": pull_request,
+            "commentsLimit": comments_limit,
         }
         if cursor:
             variables["cursor"] = cursor
@@ -173,6 +198,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--pull-request", type=int, required=True, help="Pull request number",
     )
+    parser.add_argument(
+        "--include-comments", action="store_true",
+        help="Include the full comment list in each thread (not just the first)",
+    )
     return parser
 
 
@@ -186,9 +215,16 @@ def main(argv: list[str] | None = None) -> int:
     resolved = resolve_repo_params(args.owner, args.repo)
     owner, repo = resolved.owner, resolved.repo
 
-    threads, fetched_pages_complete = fetch_unresolved_threads_paginated(
-        owner, repo, args.pull_request,
+    # Mirror get_pr_review_threads.py: 1 comment for the cheap probe, 50 when
+    # the caller wants the whole conversation.
+    comments_limit = 50 if args.include_comments else 1
+
+    nodes, fetched_pages_complete = fetch_unresolved_threads_paginated(
+        owner, repo, args.pull_request, comments_limit,
     )
+    threads = [
+        transform_review_thread(node, args.include_comments) for node in nodes
+    ]
 
     # ``success`` reflects whether the *snapshot* is trustworthy. When
     # pagination cannot prove completeness (an underlying GraphQL error

--- a/scripts/github_core/__init__.py
+++ b/scripts/github_core/__init__.py
@@ -27,6 +27,7 @@ from scripts.github_core.api import (  # noqa: F401
     is_gh_authenticated,
     resolve_repo_params,
     safe_log_str,
+    transform_review_thread,
     update_issue_comment,
 )
 from scripts.github_core.bot_config import (  # noqa: F401
@@ -85,6 +86,7 @@ __all__ = [
     "is_safe_file_path",
     "resolve_repo_params",
     "safe_log_str",
+    "transform_review_thread",
     "update_issue_comment",
     "write_skill_error",
     "write_skill_output",

--- a/scripts/github_core/api.py
+++ b/scripts/github_core/api.py
@@ -57,6 +57,59 @@ def filter_unresolved_threads(thread_nodes: list[dict]) -> list[dict]:
     """
     return [t for t in thread_nodes if not t.get("isResolved", True)]
 
+
+def transform_review_thread(thread: dict, include_comments: bool = False) -> dict:
+    """Transform a raw GraphQL review-thread node into the canonical flat shape.
+
+    Single authoritative definition (DRY) of the review-thread output shape
+    shared by ``get_pr_review_threads.py`` and
+    ``get_unresolved_review_threads.py``. A consumer that reads one script's
+    ``threads`` list can read the other's without a shape branch, which is the
+    bug this consolidates: the lighter unresolved script previously emitted raw
+    GraphQL nodes (``{"id", "isResolved", "comments": {"nodes": [...]}}``) while
+    the richer script emitted this flat shape, so ``thread["comments"][-1]``
+    crashed against one and worked against the other.
+
+    ``include_comments`` controls whether the full comment list is materialized.
+    When False (the cheap-probe default), ``comments`` is None and only the
+    ``first_comment_*`` fields are populated; the caller still pays for one
+    comment per thread in its GraphQL query, never the whole conversation.
+    """
+    comments_nodes = thread.get("comments", {}).get("nodes", [])
+    first = comments_nodes[0] if comments_nodes else None
+
+    result: dict = {
+        "thread_id": thread.get("id"),
+        "is_resolved": thread.get("isResolved", False),
+        "is_outdated": thread.get("isOutdated", False),
+        "path": thread.get("path"),
+        "line": thread.get("line"),
+        "start_line": thread.get("startLine"),
+        "diff_side": thread.get("diffSide"),
+        "comment_count": thread.get("comments", {}).get("totalCount", 0),
+        "first_comment_id": first.get("databaseId") if first else None,
+        "first_comment_author": (
+            first.get("author", {}).get("login") if first and first.get("author") else None
+        ),
+        "first_comment_body": first.get("body") if first else None,
+        "first_comment_created_at": first.get("createdAt") if first else None,
+        "comments": None,
+    }
+
+    if include_comments:
+        result["comments"] = [
+            {
+                "id": c.get("databaseId"),
+                "author": c.get("author", {}).get("login") if c.get("author") else None,
+                "body": c.get("body"),
+                "created_at": c.get("createdAt"),
+            }
+            for c in comments_nodes
+        ]
+
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Result types
 # ---------------------------------------------------------------------------

--- a/scripts/github_core/api.py
+++ b/scripts/github_core/api.py
@@ -75,7 +75,8 @@ def transform_review_thread(thread: dict, include_comments: bool = False) -> dic
     ``first_comment_*`` fields are populated; the caller still pays for one
     comment per thread in its GraphQL query, never the whole conversation.
     """
-    comments_nodes = thread.get("comments", {}).get("nodes", [])
+    comments_data = thread.get("comments") or {}
+    comments_nodes = comments_data.get("nodes") or []
     first = comments_nodes[0] if comments_nodes else None
 
     result: dict = {
@@ -86,7 +87,7 @@ def transform_review_thread(thread: dict, include_comments: bool = False) -> dic
         "line": thread.get("line"),
         "start_line": thread.get("startLine"),
         "diff_side": thread.get("diffSide"),
-        "comment_count": thread.get("comments", {}).get("totalCount", 0),
+        "comment_count": comments_data.get("totalCount", 0),
         "first_comment_id": first.get("databaseId") if first else None,
         "first_comment_author": (
             first.get("author", {}).get("login") if first and first.get("author") else None

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "24 agent definitions, 82 reusable skills, 51 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "author": { "name": "rjmurillo" }
 }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "24 agent definitions, 82 reusable skills, 51 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "author": { "name": "rjmurillo" }
 }

--- a/src/copilot-cli/lib/github_core/__init__.py
+++ b/src/copilot-cli/lib/github_core/__init__.py
@@ -27,6 +27,7 @@ from .api import (  # noqa: F401
     is_gh_authenticated,
     resolve_repo_params,
     safe_log_str,
+    transform_review_thread,
     update_issue_comment,
 )
 from .bot_config import (  # noqa: F401
@@ -85,6 +86,7 @@ __all__ = [
     "is_safe_file_path",
     "resolve_repo_params",
     "safe_log_str",
+    "transform_review_thread",
     "update_issue_comment",
     "write_skill_error",
     "write_skill_output",

--- a/src/copilot-cli/lib/github_core/api.py
+++ b/src/copilot-cli/lib/github_core/api.py
@@ -57,6 +57,59 @@ def filter_unresolved_threads(thread_nodes: list[dict]) -> list[dict]:
     """
     return [t for t in thread_nodes if not t.get("isResolved", True)]
 
+
+def transform_review_thread(thread: dict, include_comments: bool = False) -> dict:
+    """Transform a raw GraphQL review-thread node into the canonical flat shape.
+
+    Single authoritative definition (DRY) of the review-thread output shape
+    shared by ``get_pr_review_threads.py`` and
+    ``get_unresolved_review_threads.py``. A consumer that reads one script's
+    ``threads`` list can read the other's without a shape branch, which is the
+    bug this consolidates: the lighter unresolved script previously emitted raw
+    GraphQL nodes (``{"id", "isResolved", "comments": {"nodes": [...]}}``) while
+    the richer script emitted this flat shape, so ``thread["comments"][-1]``
+    crashed against one and worked against the other.
+
+    ``include_comments`` controls whether the full comment list is materialized.
+    When False (the cheap-probe default), ``comments`` is None and only the
+    ``first_comment_*`` fields are populated; the caller still pays for one
+    comment per thread in its GraphQL query, never the whole conversation.
+    """
+    comments_nodes = thread.get("comments", {}).get("nodes", [])
+    first = comments_nodes[0] if comments_nodes else None
+
+    result: dict = {
+        "thread_id": thread.get("id"),
+        "is_resolved": thread.get("isResolved", False),
+        "is_outdated": thread.get("isOutdated", False),
+        "path": thread.get("path"),
+        "line": thread.get("line"),
+        "start_line": thread.get("startLine"),
+        "diff_side": thread.get("diffSide"),
+        "comment_count": thread.get("comments", {}).get("totalCount", 0),
+        "first_comment_id": first.get("databaseId") if first else None,
+        "first_comment_author": (
+            first.get("author", {}).get("login") if first and first.get("author") else None
+        ),
+        "first_comment_body": first.get("body") if first else None,
+        "first_comment_created_at": first.get("createdAt") if first else None,
+        "comments": None,
+    }
+
+    if include_comments:
+        result["comments"] = [
+            {
+                "id": c.get("databaseId"),
+                "author": c.get("author", {}).get("login") if c.get("author") else None,
+                "body": c.get("body"),
+                "created_at": c.get("createdAt"),
+            }
+            for c in comments_nodes
+        ]
+
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Result types
 # ---------------------------------------------------------------------------

--- a/src/copilot-cli/lib/github_core/api.py
+++ b/src/copilot-cli/lib/github_core/api.py
@@ -75,7 +75,8 @@ def transform_review_thread(thread: dict, include_comments: bool = False) -> dic
     ``first_comment_*`` fields are populated; the caller still pays for one
     comment per thread in its GraphQL query, never the whole conversation.
     """
-    comments_nodes = thread.get("comments", {}).get("nodes", [])
+    comments_data = thread.get("comments") or {}
+    comments_nodes = comments_data.get("nodes") or []
     first = comments_nodes[0] if comments_nodes else None
 
     result: dict = {
@@ -86,7 +87,7 @@ def transform_review_thread(thread: dict, include_comments: bool = False) -> dic
         "line": thread.get("line"),
         "start_line": thread.get("startLine"),
         "diff_side": thread.get("diffSide"),
-        "comment_count": thread.get("comments", {}).get("totalCount", 0),
+        "comment_count": comments_data.get("totalCount", 0),
         "first_comment_id": first.get("databaseId") if first else None,
         "first_comment_author": (
             first.get("author", {}).get("login") if first and first.get("author") else None

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_review_threads.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_review_threads.py
@@ -50,6 +50,7 @@ from github_core.api import (  # noqa: E402
     filter_unresolved_threads,
     gh_graphql,
     resolve_repo_params,
+    transform_review_thread,
 )
 
 # Page size for the reviewThreads connection. GitHub GraphQL caps connection
@@ -290,40 +291,14 @@ def _collect_all_threads(
 
 
 def _transform_thread(thread: dict, include_comments: bool) -> dict:
-    """Transform a raw GraphQL thread node into the output format."""
-    comments_nodes = thread.get("comments", {}).get("nodes", [])
-    first = comments_nodes[0] if comments_nodes else None
+    """Transform a raw GraphQL thread node into the canonical flat shape.
 
-    result: dict = {
-        "thread_id": thread.get("id"),
-        "is_resolved": thread.get("isResolved", False),
-        "is_outdated": thread.get("isOutdated", False),
-        "path": thread.get("path"),
-        "line": thread.get("line"),
-        "start_line": thread.get("startLine"),
-        "diff_side": thread.get("diffSide"),
-        "comment_count": thread.get("comments", {}).get("totalCount", 0),
-        "first_comment_id": first.get("databaseId") if first else None,
-        "first_comment_author": (
-            first.get("author", {}).get("login") if first and first.get("author") else None
-        ),
-        "first_comment_body": first.get("body") if first else None,
-        "first_comment_created_at": first.get("createdAt") if first else None,
-        "comments": None,
-    }
-
-    if include_comments:
-        result["comments"] = [
-            {
-                "id": c.get("databaseId"),
-                "author": c.get("author", {}).get("login") if c.get("author") else None,
-                "body": c.get("body"),
-                "created_at": c.get("createdAt"),
-            }
-            for c in comments_nodes
-        ]
-
-    return result
+    Thin wrapper over ``github_core.api.transform_review_thread`` (DRY). The
+    shape lives in one place so this script and ``get_unresolved_review_threads.py``
+    cannot drift. Kept as a named function because the test suite imports it
+    directly.
+    """
+    return transform_review_thread(thread, include_comments)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/copilot-cli/skills/github/scripts/pr/get_unresolved_review_threads.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_unresolved_review_threads.py
@@ -16,6 +16,14 @@ Output is a JSON object with:
       "threads": [<thread>, ...]
     }
 
+Each ``thread`` uses the canonical flat shape produced by
+``github_core.api.transform_review_thread`` (``thread_id``, ``is_resolved``,
+``path``, ``line``, ``first_comment_*``, ``comments``). It is identical to the
+shape emitted by ``get_pr_review_threads.py`` so a consumer can read either
+script's ``threads`` without a shape branch. Pass ``--include-comments`` to
+materialize the full per-thread comment list; by default ``comments`` is null
+and only the ``first_comment_*`` fields are populated.
+
 The ``fetched_pages_complete`` flag is true only when pagination ran to
 ``hasNextPage == false``. The /pr-review completion gate's pass_when
 expression requires this flag to be true alongside ``unresolved_count
@@ -68,6 +76,7 @@ from github_core.api import (  # noqa: E402
     error_and_exit,
     gh_graphql,
     resolve_repo_params,
+    transform_review_thread,
 )
 
 # Safety net: cap pages so a runaway PR cannot pin the script forever.
@@ -75,8 +84,12 @@ from github_core.api import (  # noqa: E402
 # realistic PR. If exceeded, we fall back to fetched_pages_complete=False.
 _MAX_PAGES = 50
 
+# Node selection mirrors the fields consumed by
+# ``github_core.api.transform_review_thread`` so the emitted ``threads`` share
+# the canonical flat shape with get_pr_review_threads.py. ``$commentsLimit`` is
+# 1 by default (cheap unresolved-count probe) and 50 under --include-comments.
 _QUERY = """\
-query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
+query($owner: String!, $name: String!, $prNumber: Int!, $commentsLimit: Int!, $cursor: String) {
     repository(owner: $owner, name: $name) {
         pullRequest(number: $prNumber) {
             reviewThreads(first: 100, after: $cursor) {
@@ -87,9 +100,18 @@ query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
                 nodes {
                     id
                     isResolved
-                    comments(first: 1) {
+                    isOutdated
+                    path
+                    line
+                    startLine
+                    diffSide
+                    comments(first: $commentsLimit) {
+                        totalCount
                         nodes {
                             databaseId
+                            body
+                            author { login }
+                            createdAt
                         }
                     }
                 }
@@ -100,16 +122,18 @@ query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
 
 
 def fetch_unresolved_threads_paginated(
-    owner: str, repo: str, pull_request: int,
+    owner: str, repo: str, pull_request: int, comments_limit: int = 1,
 ) -> tuple[list[dict], bool]:
     """Fetch unresolved review threads, paginating to exhaustion.
 
-    Returns a tuple ``(threads, fetched_pages_complete)``. The flag is
-    True only when the underlying GraphQL pagination terminated normally
-    (``hasNextPage`` was false on the last page). Pagination errors,
-    page-cap exhaustion, or query failures yield False; the caller MUST
-    treat False as "we cannot prove there are no more unresolved
-    threads".
+    Returns a tuple ``(threads, fetched_pages_complete)`` of raw GraphQL
+    nodes. ``comments_limit`` is forwarded to the query's
+    ``comments(first: ...)`` selection: 1 for the cheap probe, higher when
+    the caller wants the full comment list. The flag is True only when the
+    underlying GraphQL pagination terminated normally (``hasNextPage`` was
+    false on the last page). Pagination errors, page-cap exhaustion, or
+    query failures yield False; the caller MUST treat False as "we cannot
+    prove there are no more unresolved threads".
     """
     all_unresolved: list[dict] = []
     cursor: str | None = None
@@ -126,6 +150,7 @@ def fetch_unresolved_threads_paginated(
             "owner": owner,
             "name": repo,
             "prNumber": pull_request,
+            "commentsLimit": comments_limit,
         }
         if cursor:
             variables["cursor"] = cursor
@@ -173,6 +198,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--pull-request", type=int, required=True, help="Pull request number",
     )
+    parser.add_argument(
+        "--include-comments", action="store_true",
+        help="Include the full comment list in each thread (not just the first)",
+    )
     return parser
 
 
@@ -186,9 +215,16 @@ def main(argv: list[str] | None = None) -> int:
     resolved = resolve_repo_params(args.owner, args.repo)
     owner, repo = resolved.owner, resolved.repo
 
-    threads, fetched_pages_complete = fetch_unresolved_threads_paginated(
-        owner, repo, args.pull_request,
+    # Mirror get_pr_review_threads.py: 1 comment for the cheap probe, 50 when
+    # the caller wants the whole conversation.
+    comments_limit = 50 if args.include_comments else 1
+
+    nodes, fetched_pages_complete = fetch_unresolved_threads_paginated(
+        owner, repo, args.pull_request, comments_limit,
     )
+    threads = [
+        transform_review_thread(node, args.include_comments) for node in nodes
+    ]
 
     # ``success`` reflects whether the *snapshot* is trustworthy. When
     # pagination cannot prove completeness (an underlying GraphQL error

--- a/tests/test_get_unresolved_review_threads.py
+++ b/tests/test_get_unresolved_review_threads.py
@@ -1,9 +1,15 @@
 """Tests for get_unresolved_review_threads.py skill script.
 
-The script now emits a JSON object with ``unresolved_count`` and
+The script emits a JSON object with ``unresolved_count`` and
 ``fetched_pages_complete``. Pagination is handled in the script (not by
 the api.py helper) so the explicit completeness flag can drive the
 /pr-review completion gate's pass_when expression.
+
+Per issue #2012, each entry in ``threads`` is normalized through
+``github_core.api.transform_review_thread`` into the canonical flat shape
+(``thread_id``, ``is_resolved``, ``path``, ``first_comment_*``, ``comments``)
+so it matches get_pr_review_threads.py and no consumer crashes on a shape
+mismatch.
 """
 
 from __future__ import annotations
@@ -82,6 +88,16 @@ class TestBuildParser:
         assert args.owner == "myorg"
         assert args.repo == "myrepo"
 
+    def test_include_comments_defaults_false(self):
+        args = build_parser().parse_args(["--pull-request", "1"])
+        assert args.include_comments is False
+
+    def test_include_comments_flag(self):
+        args = build_parser().parse_args(
+            ["--pull-request", "1", "--include-comments"],
+        )
+        assert args.include_comments is True
+
 
 # ---------------------------------------------------------------------------
 # Tests: main
@@ -125,7 +141,9 @@ class TestMain:
         output = json.loads(capsys.readouterr().out)
         assert output["unresolved_count"] == 1
         assert output["fetched_pages_complete"] is True
-        assert output["threads"][0]["id"] == "t1"
+        # #2012: thread is the canonical flat shape, so the id key is
+        # ``thread_id`` (snake_case), not the raw GraphQL ``id``.
+        assert output["threads"][0]["thread_id"] == "t1"
 
     def test_zero_threads_complete(self, capsys):
         with patch(
@@ -173,7 +191,7 @@ class TestMain:
         assert rc == 0
         output = json.loads(capsys.readouterr().out)
         assert output["unresolved_count"] == 2
-        assert {t["id"] for t in output["threads"]} == {"t2", "t3"}
+        assert {t["thread_id"] for t in output["threads"]} == {"t2", "t3"}
         assert output["fetched_pages_complete"] is True
 
     def test_graphql_error_marks_incomplete(self, capsys):
@@ -220,3 +238,110 @@ class TestMain:
         output = json.loads(capsys.readouterr().out)
         assert output["fetched_pages_complete"] is False
         assert output["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: canonical flat thread shape (#2012)
+# ---------------------------------------------------------------------------
+
+# A realistic unresolved node as returned by the enriched GraphQL query.
+_RICH_NODE = {
+    "id": "PRRT_kwDO_x",
+    "isResolved": False,
+    "isOutdated": False,
+    "path": ".githooks/pre-push",
+    "line": 1068,
+    "startLine": None,
+    "diffSide": "RIGHT",
+    "comments": {
+        "totalCount": 2,
+        "nodes": [
+            {
+                "databaseId": 3216327001,
+                "body": "first note",
+                "author": {"login": "alice"},
+                "createdAt": "2026-05-01T00:00:00Z",
+            },
+            {
+                "databaseId": 3216327045,
+                "body": "last note",
+                "author": {"login": "bob"},
+                "createdAt": "2026-05-02T00:00:00Z",
+            },
+        ],
+    },
+}
+
+
+def _run_with_node(node: dict, argv: list[str], capsys) -> dict:
+    """Run main() with a single-page response containing ``node``."""
+    with patch(
+        "get_unresolved_review_threads.assert_gh_authenticated",
+    ), patch(
+        "get_unresolved_review_threads.resolve_repo_params",
+        return_value=RepoInfo(owner="o", repo="r"),
+    ), patch(
+        "get_unresolved_review_threads.gh_graphql",
+        return_value=_page(nodes=[node], has_next=False),
+    ):
+        rc = main(argv)
+    assert rc == 0
+    return json.loads(capsys.readouterr().out)
+
+
+class TestThreadShape:
+    """The unresolved script must emit the same flat shape as the rich one."""
+
+    _CANONICAL_KEYS = {
+        "thread_id",
+        "is_resolved",
+        "is_outdated",
+        "path",
+        "line",
+        "start_line",
+        "diff_side",
+        "comment_count",
+        "first_comment_id",
+        "first_comment_author",
+        "first_comment_body",
+        "first_comment_created_at",
+        "comments",
+    }
+
+    def test_default_shape_has_canonical_keys(self, capsys):
+        output = _run_with_node(_RICH_NODE, ["--pull-request", "42"], capsys)
+        thread = output["threads"][0]
+        assert set(thread.keys()) == self._CANONICAL_KEYS
+        assert thread["thread_id"] == "PRRT_kwDO_x"
+        assert thread["is_resolved"] is False
+        assert thread["path"] == ".githooks/pre-push"
+        assert thread["line"] == 1068
+        assert thread["comment_count"] == 2
+        # Without --include-comments the list is not materialized.
+        assert thread["comments"] is None
+        # ... but the first comment metadata is always present.
+        assert thread["first_comment_author"] == "alice"
+        assert thread["first_comment_body"] == "first note"
+
+    def test_include_comments_materializes_flat_list(self, capsys):
+        output = _run_with_node(
+            _RICH_NODE, ["--pull-request", "42", "--include-comments"], capsys,
+        )
+        thread = output["threads"][0]
+        assert isinstance(thread["comments"], list)
+        assert len(thread["comments"]) == 2
+        # This is the exact idiom that crashed in issue #2012: asking the
+        # unresolved script for the last comment's author. It now works.
+        assert thread["comments"][-1]["author"] == "bob"
+        assert thread["comments"][-1]["body"] == "last note"
+        assert thread["comments"][0]["id"] == 3216327001
+
+    def test_matches_rich_script_transform(self, capsys):
+        """The unresolved output is identical to transform_review_thread."""
+        from scripts.github_core.api import transform_review_thread
+
+        output = _run_with_node(
+            _RICH_NODE, ["--pull-request", "42", "--include-comments"], capsys,
+        )
+        expected = transform_review_thread(_RICH_NODE, include_comments=True)
+        assert output["threads"][0] == expected


### PR DESCRIPTION
## Summary

### What

`get_unresolved_review_threads.py` now emits the same canonical flat thread shape as `get_pr_review_threads.py`. Both scripts route every thread through one shared helper, `transform_review_thread`.

### Why

The lighter unresolved script emitted raw GraphQL nodes (`{id, isResolved, comments:{nodes:[...]}}`) while the richer script emitted a flat shape (`thread_id`, `is_resolved`, `path`, `first_comment_*`, `comments`). A consumer asking the unresolved script for `thread["comments"][-1]` hit `KeyError`. The workaround was to call the heavier script every time, doubling API cost and defeating the cheap-probe purpose of the lighter one (issue #2012).

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2012 | get_unresolved_review_threads thread shape inconsistent with get_pr_review_threads |

## Changes

- Add `transform_review_thread()` to `scripts/github_core/api.py` (exported from `scripts/github_core/__init__.py`) as the single source of truth for the review-thread output shape, beside the existing count and filter helpers.
- `get_pr_review_threads.py`: the thread transform is now a thin wrapper over the shared helper (behavior-preserving; the test suite imports it directly, so the name and signature are kept).
- `get_unresolved_review_threads.py`: enrich the GraphQL query with the fields the shape needs, add `--include-comments` (1 comment by default for the cheap probe, 50 when set), and transform each node before output.
- Top-level keys (`unresolved_count`, `fetched_pages_complete`, `success`) are unchanged. The unresolved-zero poller and the `/pr-review` completion gate read only those top-level keys, so they are unaffected.
- Regenerate the vendored copilot-cli copies and the synced `.claude/lib` copy; bump both plugin manifests (#2118).

### Files changed

- `scripts/github_core/api.py`, `scripts/github_core/__init__.py`
- `.claude/lib/github_core/api.py`, `.claude/lib/github_core/__init__.py`
- `.claude/skills/github/scripts/pr/get_unresolved_review_threads.py`, `.claude/skills/github/scripts/pr/get_pr_review_threads.py`
- `tests/test_get_unresolved_review_threads.py`
- `src/copilot-cli/lib/github_core/api.py`, `src/copilot-cli/lib/github_core/__init__.py`
- `src/copilot-cli/skills/github/scripts/pr/get_unresolved_review_threads.py`, `src/copilot-cli/skills/github/scripts/pr/get_pr_review_threads.py`
- `.claude/.claude-plugin/plugin.json`, `src/copilot-cli/.claude-plugin/plugin.json`

## Testing

- The unresolved-threads, pr-review-threads, and github_core suites all pass under uv run pytest (208 passed).
- New tests assert the canonical key set, that `--include-comments` materializes the comment list, and that the exact last-comment idiom from the issue now works.
- A live run against PR #2155 emits the flat shape with no crash.

## Notes for Reviewers

DRY decision: the thread shape lives in one place now so the two scripts cannot drift. The alternative (documenting and duplicating the transform) was rejected because the function was being copied verbatim.

The synced `.claude/lib` and copilot-cli copies are regenerated output from the canonical sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
