### PR TITLE
fix(merge-ready): gate CanMerge on mergeStateStatus=BEHIND (#2157)

### DIFF
--- a/.agents/sessions/2026-05-31-session-1858-fix-issue-2157-gate-canmerge.json
+++ b/.agents/sessions/2026-05-31-session-1858-fix-issue-2157-gate-canmerge.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": "1.0",
   "session": {
     "number": 1858,
     "date": "2026-05-31",
@@ -98,7 +99,7 @@
       "validationPassed": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "29 unit tests pass; plugin-version-bump passes (0.4.5/0.4.14); only pre-existing markdown/agent-drift/git-hooks environment failures remain, outside this diff"
+        "Evidence": "29 unit tests pass; plugin-version-bump passes (0.4.8/0.4.17); only pre-existing markdown/agent-drift/git-hooks environment failures remain, outside this diff"
       },
       "tasksUpdated": {
         "level": "SHOULD",

--- a/.agents/sessions/2026-05-31-session-1858-fix-issue-2157-gate-canmerge.json
+++ b/.agents/sessions/2026-05-31-session-1858-fix-issue-2157-gate-canmerge.json
@@ -1,0 +1,127 @@
+{
+  "session": {
+    "number": 1858,
+    "date": "2026-05-31",
+    "branch": "fix/merge-ready-mergestate-gate",
+    "startingCommit": "e6fa83a93",
+    "objective": "Fix issue 2157: gate CanMerge on mergeStateStatus BEHIND in test_pr_merge_ready, keep BLOCKED non-blocking"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "mcp__serena__initial_instructions activated project ai-agents; symbolic tools used earlier this session"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read Serena Instructions Manual via initial_instructions"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-injected at session start and reviewed (read-only per ADR-014)"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "github and session-init skill scripts invoked (new_issue.py, post_issue_comment.py, new_session_log.py, build_all.py)"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Skill-first and Serena-first routing followed; raw gh blocked by guard and replaced with skill scripts"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".claude/rules/*.md loaded via CLAUDE.md imports; AGENTS.md boundaries applied (atomic commits, plugin bump, worktree isolation)"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory index loaded; wrote decision-merge-ready-blocked-vs-behind"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/merge-ready-mergestate-gate"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Isolated worktree at /tmp/wt-mr on fix/merge-ready-mergestate-gate off origin/main"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status verified; only the 3 intended source files plus plugin manifests changed"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "e6fa83a93"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All Start MUST gates complete; work landed across 2 atomic commits; 29 unit tests pass"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Wrote Serena memory decision-merge-ready-blocked-vs-behind"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint covered by pre_pr.py; this PR changes zero markdown files"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Work head a7880e0e2; session log committed last"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "29 unit tests pass; plugin-version-bump passes (0.4.5/0.4.14); only pre-existing markdown/agent-drift/git-hooks environment failures remain, outside this diff"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Tracked in workLog and nextSteps"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "task": "Issue #2157: test_pr_merge_ready CanMerge ignored mergeStateStatus, so a branch BEHIND base passed as ready (residual of closed #2048)",
+      "outcome": "Added a BEHIND gate to _evaluate_pr_state; BLOCKED stays non-blocking (auto-merge-on-approval) and is surfaced via MergeStateStatus. Filed issue #2157, logged the BLOCKED-vs-BEHIND decision to Serena.",
+      "evidence": "29 unit tests pass (2 new: BEHIND blocks, BLOCKED stays ready); build_all regenerates the copilot-cli copy; plugin manifests bumped"
+    }
+  ],
+  "endingCommit": "a7880e0e22bbf3f267d5950e7b6b4d747ffb0182",
+  "nextSteps": [
+    "Open PR with Fixes #2157",
+    "Proceed to issue #2013 (extract_session_episode defaults/overwrite) per user-selected batch"
+  ]
+}

--- a/.agents/sessions/2026-05-31-session-1858-fix-issue-2157-gate-canmerge.json
+++ b/.agents/sessions/2026-05-31-session-1858-fix-issue-2157-gate-canmerge.json
@@ -99,7 +99,7 @@
       "validationPassed": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "29 unit tests pass; plugin-version-bump passes (0.4.8/0.4.17); only pre-existing markdown/agent-drift/git-hooks environment failures remain, outside this diff"
+        "Evidence": "29 unit tests pass; plugin-version-bump passes for both manifests (exact versions in the plugin.json diff); only pre-existing markdown/agent-drift/git-hooks environment failures remain, outside this diff"
       },
       "tasksUpdated": {
         "level": "SHOULD",

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.4.3",
+  "version": "0.4.5",
   "author": { "name": "rjmurillo" }
 }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "author": { "name": "rjmurillo" }
 }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "author": { "name": "rjmurillo" }
 }

--- a/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -525,7 +525,7 @@ def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
     elif mergeable == "UNKNOWN":
         reasons.append("Merge status is being calculated")
     if pr.get("mergeStateStatus") == "BEHIND":
-        reasons.append("Branch is behind base; update against main before merging")
+        reasons.append("Branch is behind base; update against the base branch before merging")
     return mergeable
 
 

--- a/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -503,7 +503,18 @@ def _fetch_pr_data(owner: str, repo: str, pr_number: int, op_start: float) -> di
 
 
 def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
-    """Append draft/state/merge-conflict reasons; return mergeable string."""
+    """Append draft/state/merge-conflict reasons; return mergeable string.
+
+    Also gates on ``mergeStateStatus == BEHIND`` (issue #2157): a branch
+    behind its base cannot land, and this repo does not auto-update it on
+    auto-merge (issue #2048 concrete failure), so it must block. ``DRAFT``,
+    ``DIRTY``, and ``UNKNOWN`` are already covered by the ``isDraft`` and
+    ``mergeable`` checks. ``BLOCKED`` is intentionally NOT blocked: it
+    usually means "awaiting required review", which is exactly when enabling
+    auto-merge is the correct action; it stays surfaced via the
+    ``MergeStateStatus`` output field. See decision note
+    ``decision-merge-ready-blocked-vs-behind``.
+    """
     if pr["state"] != "OPEN":
         reasons.append(f"PR is {pr['state'].lower()}, not open")
     if pr.get("isDraft"):
@@ -513,6 +524,8 @@ def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
         reasons.append("PR has merge conflicts")
     elif mergeable == "UNKNOWN":
         reasons.append("Merge status is being calculated")
+    if pr.get("mergeStateStatus") == "BEHIND":
+        reasons.append("Branch is behind base; update against main before merging")
     return mergeable
 
 

--- a/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -512,8 +512,7 @@ def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
     ``mergeable`` checks. ``BLOCKED`` is intentionally NOT blocked: it
     usually means "awaiting required review", which is exactly when enabling
     auto-merge is the correct action; it stays surfaced via the
-    ``MergeStateStatus`` output field. See decision note
-    ``decision-merge-ready-blocked-vs-behind``.
+    ``MergeStateStatus`` output field.
     """
     if pr["state"] != "OPEN":
         reasons.append(f"PR is {pr['state'].lower()}, not open")

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "24 agent definitions, 82 reusable skills, 51 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "author": { "name": "rjmurillo" }
 }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "24 agent definitions, 82 reusable skills, 51 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.4.12",
+  "version": "0.4.14",
   "author": { "name": "rjmurillo" }
 }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "24 agent definitions, 82 reusable skills, 51 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "author": { "name": "rjmurillo" }
 }

--- a/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -525,7 +525,7 @@ def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
     elif mergeable == "UNKNOWN":
         reasons.append("Merge status is being calculated")
     if pr.get("mergeStateStatus") == "BEHIND":
-        reasons.append("Branch is behind base; update against main before merging")
+        reasons.append("Branch is behind base; update against the base branch before merging")
     return mergeable
 
 

--- a/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -503,7 +503,18 @@ def _fetch_pr_data(owner: str, repo: str, pr_number: int, op_start: float) -> di
 
 
 def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
-    """Append draft/state/merge-conflict reasons; return mergeable string."""
+    """Append draft/state/merge-conflict reasons; return mergeable string.
+
+    Also gates on ``mergeStateStatus == BEHIND`` (issue #2157): a branch
+    behind its base cannot land, and this repo does not auto-update it on
+    auto-merge (issue #2048 concrete failure), so it must block. ``DRAFT``,
+    ``DIRTY``, and ``UNKNOWN`` are already covered by the ``isDraft`` and
+    ``mergeable`` checks. ``BLOCKED`` is intentionally NOT blocked: it
+    usually means "awaiting required review", which is exactly when enabling
+    auto-merge is the correct action; it stays surfaced via the
+    ``MergeStateStatus`` output field. See decision note
+    ``decision-merge-ready-blocked-vs-behind``.
+    """
     if pr["state"] != "OPEN":
         reasons.append(f"PR is {pr['state'].lower()}, not open")
     if pr.get("isDraft"):
@@ -513,6 +524,8 @@ def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
         reasons.append("PR has merge conflicts")
     elif mergeable == "UNKNOWN":
         reasons.append("Merge status is being calculated")
+    if pr.get("mergeStateStatus") == "BEHIND":
+        reasons.append("Branch is behind base; update against main before merging")
     return mergeable
 
 

--- a/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -512,8 +512,7 @@ def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
     ``mergeable`` checks. ``BLOCKED`` is intentionally NOT blocked: it
     usually means "awaiting required review", which is exactly when enabling
     auto-merge is the correct action; it stays surfaced via the
-    ``MergeStateStatus`` output field. See decision note
-    ``decision-merge-ready-blocked-vs-behind``.
+    ``MergeStateStatus`` output field.
     """
     if pr["state"] != "OPEN":
         reasons.append(f"PR is {pr['state'].lower()}, not open")

--- a/tests/test_test_pr_merge_ready.py
+++ b/tests/test_test_pr_merge_ready.py
@@ -127,6 +127,30 @@ class TestCheckMergeReadiness:
         assert result["CanMerge"] is False
         assert any("conflict" in r.lower() for r in result["Reasons"])
 
+    def test_behind_branch_not_ready(self):
+        # issue #2157: a branch behind base cannot land and is not auto-updated
+        # by auto-merge in this repo, so CanMerge must be False even when CI
+        # passes and threads are clean.
+        pr_data = json.loads(json.dumps(_OPEN_PR))
+        pr_data["repository"]["pullRequest"]["mergeStateStatus"] = "BEHIND"
+        with patch("test_pr_merge_ready.gh_graphql", return_value=pr_data):
+            result = check_merge_readiness("o", "r", 42)
+        assert result["CanMerge"] is False
+        assert result["MergeStateStatus"] == "BEHIND"
+        assert any("behind" in r.lower() for r in result["Reasons"])
+
+    def test_blocked_state_still_ready(self):
+        # issue #2157: BLOCKED usually means "awaiting required review", which
+        # is exactly when enabling auto-merge is correct. It must NOT block
+        # CanMerge; it is surfaced via MergeStateStatus for the agent.
+        pr_data = json.loads(json.dumps(_OPEN_PR))
+        pr_data["repository"]["pullRequest"]["mergeStateStatus"] = "BLOCKED"
+        with patch("test_pr_merge_ready.gh_graphql", return_value=pr_data):
+            result = check_merge_readiness("o", "r", 42)
+        assert result["CanMerge"] is True
+        assert result["MergeStateStatus"] == "BLOCKED"
+        assert result["Reasons"] == []
+
     def test_unresolved_threads(self):
         pr_data = json.loads(json.dumps(_OPEN_PR))
         pr_data["repository"]["pullRequest"]["reviewThreads"] = {


### PR DESCRIPTION
## Summary

### What

The merge-ready gate now treats a branch behind its base as not ready. `test_pr_merge_ready.py` adds one condition: when `mergeStateStatus` is `BEHIND`, `CanMerge` is `False`.

### Why

`CanMerge` previously ignored `mergeStateStatus`. A PR with passing CI and clean threads but a branch behind `main` reported `CanMerge=True`, the autonomous monitor enabled auto-merge, and the PR did not land (issue #2048 concrete failure on PR #2044). This repo does not auto-update a behind branch on auto-merge, so the branch must be updated first. This is the residual code-enforcement gap behind closed issue #2048.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2157 | CanMerge ignores mergeStateStatus=BEHIND |

## Changes

- `test_pr_merge_ready.py`: the PR-state evaluator appends a blocking reason when `mergeStateStatus == "BEHIND"`. DRAFT, DIRTY (conflicts), and UNKNOWN were already covered by the existing draft and mergeable checks.
- BLOCKED is intentionally non-blocking (awaiting required review is exactly when auto-merge should be enabled); it stays surfaced via the `MergeStateStatus` output field. Reasoning in Serena note `decision-merge-ready-blocked-vs-behind`.
- Tests added in `tests/test_test_pr_merge_ready.py`: BEHIND blocks, BLOCKED stays ready.
- Regenerate the copilot-cli copy; bump both plugin manifests (#2118), stacking above PR #2156.

## Testing

- The merge-ready suite passes under uv run pytest (29 passed, 2 new). Existing fixtures use CLEAN, so the change breaks none of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
