### PR TITLE
fix(review): security prompt emits VERDICT on the first line (#2006)

### DIFF
--- a/.agents/sessions/2026-05-31-session-1859-fix-issue-2006-security-review.json
+++ b/.agents/sessions/2026-05-31-session-1859-fix-issue-2006-security-review.json
@@ -1,0 +1,128 @@
+{
+  "session": {
+    "number": 1859,
+    "date": "2026-05-31",
+    "branch": "fix/2006-security-verdict-first",
+    "startingCommit": "e6fa83a93",
+    "objective": "Fix issue 2006: security review prompt emits VERDICT on first line so truncated reviews stay parseable, add regression test"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "mcp__serena__initial_instructions activated project ai-agents; symbolic tools used earlier this session"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read Serena Instructions Manual via initial_instructions"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-injected at session start and reviewed (read-only per ADR-014)"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "github and session-init skill scripts invoked; generate_pr_quality_prompts and build_all used for prompt regeneration"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Skill-first and Serena-first routing followed; raw gh replaced with skill scripts"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".claude/rules/*.md loaded via CLAUDE.md imports; security.md rule (security-sensitive change) and templates.md (regenerate after edit) applied"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory index loaded; pr-review verdict-token memories consulted"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2006-security-verdict-first"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Isolated worktree at /tmp/wt-2006 on fix/2006-security-verdict-first off origin/main"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status verified; only the canonical prompt, its generated CI prompt, the copilot copy, and the test changed"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "e6fa83a93"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All Start MUST gates complete; work landed across 3 atomic commits; 230 ai-review tests and 48 generator tests pass"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory updated this session (workflow/worktree-session-init-writes-to-main, decision-merge-ready-blocked-vs-behind)"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 run on the one linted markdown file (.github/prompts) reports 0 errors; the two skills markdown files are excluded by config"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Work head f1b593996; session log committed last"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "230 ai-review tests, 48 generator tests pass; plugin-version-bump and install-parity pass; only pre-existing markdown, agent-drift, and git-hooks environment failures remain, outside this diff"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Tracked in workLog and nextSteps"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "task": "Issue #2006: security review verdict was a final line; output-budget truncation dropped it, parser fell through to NEEDS_REVIEW and blocked a substantively-PASS PR",
+      "outcome": "Reworded the canonical security axis prompt to emit a single VERDICT line FIRST (truncation-robust), removed the trailing duplicate, regenerated the CI prompt and copilot copy, and added a regression test against the captured PR #2004 truncated output. Parser unchanged per issue scope.",
+      "evidence": "230 ai-review tests pass (3 new in TestSecurityTruncationRegression); 48 generator tests pass; generated prompts match canonical (no drift)"
+    }
+  ],
+  "endingCommit": "f1b5939968a631863e7b587fcc271d5617db7706",
+  "nextSteps": [
+    "Open PR with Fixes #2006",
+    "Security agent reviews this prompt change in CI (security-sensitive)",
+    "Possible follow-up: apply the same VERDICT-first pattern to the other axis prompts (analyst, architect, qa, devops, roadmap)"
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": { "name": "rjmurillo" }
 }

--- a/.claude/skills/review/references/security.md
+++ b/.claude/skills/review/references/security.md
@@ -107,7 +107,8 @@ After the verdict block, provide the supporting analysis in this format:
 ### Verdict
 
 Choose the verdict by highest-severity finding (do not emit a second
-`VERDICT:` line here; the verdict on the first line is canonical):
+`VERDICT:` line here; if multiple verdict lines appear, `extract_verdict`
+returns the last match, which may differ from your intended leading verdict):
 
 - `PASS` - No security issues found
 - `WARN` - Minor issues that don't block merge
@@ -213,6 +214,8 @@ The response MUST begin with a single line (the first line) matching the regex
 `(?m)^\s*(?i:(?:Final\s+)?Verdict):\s*\[?(PASS|WARN|CRITICAL_FAIL|REJECTED|FAIL|NEEDS_REVIEW|NON_COMPLIANT|COMPLIANT|PARTIAL|UNKNOWN)(?![|A-Z_])\]?` (label is case-insensitive; tokens are case-sensitive uppercase). Emit it once, at the start, so it survives output truncation (issue #2006).
 This line is parsed by `extract_verdict` in
 `.claude/lib/ai_review_common/verdict.py` and consumed by `merge_verdicts`
-when `/review` aggregates across all axes.
+when `/review` aggregates across all axes. Note: `extract_verdict` returns
+the last match if multiple verdict lines appear; emit exactly one verdict
+line to avoid ambiguity between the leading verdict and any later occurrences.
 
 Refs REQ-008-01, REQ-008-05 (issue #1934).

--- a/.claude/skills/review/references/security.md
+++ b/.claude/skills/review/references/security.md
@@ -87,6 +87,17 @@ output budget can truncate a long review; a leading verdict is still read by
 the gate when the findings below are cut off (issue #2006). Emit exactly ONE
 `VERDICT:` line in the whole response.
 
+The `VERDICT:` line MUST contain only the token. The CI parser is anchored to
+the end of the line, so any trailing explanation after the token makes the line
+fail to match. Put all explanation on the `MESSAGE:` line. When the `VERDICT:`
+line does not match, the gate falls back to the `verdict` field in the JSON
+block below, and only if that is also missing does it default to
+`NEEDS_REVIEW`. Because the verdict is emitted first but the parser never
+revisits it, compute it from the completed analysis: the leading verdict MUST
+equal the highest-severity finding and MUST match the `verdict` field in the
+JSON block. Keeping the two in agreement means an optimistic early verdict
+cannot slip through when the JSON fallback is the value actually used.
+
 ```text
 VERDICT: [PASS|WARN|CRITICAL_FAIL]
 MESSAGE: [Brief explanation]

--- a/.claude/skills/review/references/security.md
+++ b/.claude/skills/review/references/security.md
@@ -81,7 +81,18 @@ For changes to:
 
 ## Output Requirements
 
-Provide your analysis in this format:
+Emit the verdict as the FIRST line of your response, before any analysis.
+Determine it from the highest-severity finding, then state it up front. The
+output budget can truncate a long review; a leading verdict is still read by
+the gate when the findings below are cut off (issue #2006). Emit exactly ONE
+`VERDICT:` line in the whole response.
+
+```text
+VERDICT: [PASS|WARN|CRITICAL_FAIL]
+MESSAGE: [Brief explanation]
+```
+
+After the verdict block, provide the supporting analysis in this format:
 
 ### Findings
 
@@ -95,16 +106,12 @@ Provide your analysis in this format:
 
 ### Verdict
 
-Choose ONE verdict:
+Choose the verdict by highest-severity finding (do not emit a second
+`VERDICT:` line here; the verdict on the first line is canonical):
 
-- `VERDICT: PASS` - No security issues found
-- `VERDICT: WARN` - Minor issues that don't block merge
-- `VERDICT: CRITICAL_FAIL` - Security vulnerabilities that MUST be fixed
-
-```text
-VERDICT: [PASS|WARN|CRITICAL_FAIL]
-MESSAGE: [Brief explanation]
-```
+- `PASS` - No security issues found
+- `WARN` - Minor issues that don't block merge
+- `CRITICAL_FAIL` - Security vulnerabilities that MUST be fixed
 
 ## Verdict Thresholds
 
@@ -202,8 +209,8 @@ object):
   findings list (any `critical` severity -> CRITICAL_FAIL; any `high` ->
   WARN; otherwise PASS).
 
-The response MUST contain a final line matching the regex
-`(?m)^\s*(?i:(?:Final\s+)?Verdict):\s*\[?(PASS|WARN|CRITICAL_FAIL|REJECTED|FAIL|NEEDS_REVIEW|NON_COMPLIANT|COMPLIANT|PARTIAL|UNKNOWN)(?![|A-Z_])\]?` (label is case-insensitive; tokens are case-sensitive uppercase).
+The response MUST begin with a single line (the first line) matching the regex
+`(?m)^\s*(?i:(?:Final\s+)?Verdict):\s*\[?(PASS|WARN|CRITICAL_FAIL|REJECTED|FAIL|NEEDS_REVIEW|NON_COMPLIANT|COMPLIANT|PARTIAL|UNKNOWN)(?![|A-Z_])\]?` (label is case-insensitive; tokens are case-sensitive uppercase). Emit it once, at the start, so it survives output truncation (issue #2006).
 This line is parsed by `extract_verdict` in
 `.claude/lib/ai_review_common/verdict.py` and consumed by `merge_verdicts`
 when `/review` aggregates across all axes.

--- a/.github/prompts/pr-quality-gate-security.md
+++ b/.github/prompts/pr-quality-gate-security.md
@@ -84,6 +84,17 @@ output budget can truncate a long review; a leading verdict is still read by
 the gate when the findings below are cut off (issue #2006). Emit exactly ONE
 `VERDICT:` line in the whole response.
 
+The `VERDICT:` line MUST contain only the token. The CI parser is anchored to
+the end of the line, so any trailing explanation after the token makes the line
+fail to match. Put all explanation on the `MESSAGE:` line. When the `VERDICT:`
+line does not match, the gate falls back to the `verdict` field in the JSON
+block below, and only if that is also missing does it default to
+`NEEDS_REVIEW`. Because the verdict is emitted first but the parser never
+revisits it, compute it from the completed analysis: the leading verdict MUST
+equal the highest-severity finding and MUST match the `verdict` field in the
+JSON block. Keeping the two in agreement means an optimistic early verdict
+cannot slip through when the JSON fallback is the value actually used.
+
 ```text
 VERDICT: [PASS|WARN|CRITICAL_FAIL]
 MESSAGE: [Brief explanation]

--- a/.github/prompts/pr-quality-gate-security.md
+++ b/.github/prompts/pr-quality-gate-security.md
@@ -78,7 +78,18 @@ For changes to:
 
 ## Output Requirements
 
-Provide your analysis in this format:
+Emit the verdict as the FIRST line of your response, before any analysis.
+Determine it from the highest-severity finding, then state it up front. The
+output budget can truncate a long review; a leading verdict is still read by
+the gate when the findings below are cut off (issue #2006). Emit exactly ONE
+`VERDICT:` line in the whole response.
+
+```text
+VERDICT: [PASS|WARN|CRITICAL_FAIL]
+MESSAGE: [Brief explanation]
+```
+
+After the verdict block, provide the supporting analysis in this format:
 
 ### Findings
 
@@ -92,16 +103,12 @@ Provide your analysis in this format:
 
 ### Verdict
 
-Choose ONE verdict:
+Choose the verdict by highest-severity finding (do not emit a second
+`VERDICT:` line here; the verdict on the first line is canonical):
 
-- `VERDICT: PASS` - No security issues found
-- `VERDICT: WARN` - Minor issues that don't block merge
-- `VERDICT: CRITICAL_FAIL` - Security vulnerabilities that MUST be fixed
-
-```text
-VERDICT: [PASS|WARN|CRITICAL_FAIL]
-MESSAGE: [Brief explanation]
-```
+- `PASS` - No security issues found
+- `WARN` - Minor issues that don't block merge
+- `CRITICAL_FAIL` - Security vulnerabilities that MUST be fixed
 
 ## Verdict Thresholds
 
@@ -199,8 +206,8 @@ object):
   findings list (any `critical` severity -> CRITICAL_FAIL; any `high` ->
   WARN; otherwise PASS).
 
-The response MUST contain a final line matching the regex
-`(?m)^\s*(?i:(?:Final\s+)?Verdict):\s*\[?(PASS|WARN|CRITICAL_FAIL|REJECTED|FAIL|NEEDS_REVIEW|NON_COMPLIANT|COMPLIANT|PARTIAL|UNKNOWN)(?![|A-Z_])\]?` (label is case-insensitive; tokens are case-sensitive uppercase).
+The response MUST begin with a single line (the first line) matching the regex
+`(?m)^\s*(?i:(?:Final\s+)?Verdict):\s*\[?(PASS|WARN|CRITICAL_FAIL|REJECTED|FAIL|NEEDS_REVIEW|NON_COMPLIANT|COMPLIANT|PARTIAL|UNKNOWN)(?![|A-Z_])\]?` (label is case-insensitive; tokens are case-sensitive uppercase). Emit it once, at the start, so it survives output truncation (issue #2006).
 This line is parsed by `extract_verdict` in
 `.claude/lib/ai_review_common/verdict.py` and consumed by `merge_verdicts`
 when `/review` aggregates across all axes.

--- a/.github/prompts/pr-quality-gate-security.md
+++ b/.github/prompts/pr-quality-gate-security.md
@@ -104,7 +104,8 @@ After the verdict block, provide the supporting analysis in this format:
 ### Verdict
 
 Choose the verdict by highest-severity finding (do not emit a second
-`VERDICT:` line here; the verdict on the first line is canonical):
+`VERDICT:` line here; if multiple verdict lines appear, `extract_verdict`
+returns the last match, which may differ from your intended leading verdict):
 
 - `PASS` - No security issues found
 - `WARN` - Minor issues that don't block merge
@@ -210,6 +211,8 @@ The response MUST begin with a single line (the first line) matching the regex
 `(?m)^\s*(?i:(?:Final\s+)?Verdict):\s*\[?(PASS|WARN|CRITICAL_FAIL|REJECTED|FAIL|NEEDS_REVIEW|NON_COMPLIANT|COMPLIANT|PARTIAL|UNKNOWN)(?![|A-Z_])\]?` (label is case-insensitive; tokens are case-sensitive uppercase). Emit it once, at the start, so it survives output truncation (issue #2006).
 This line is parsed by `extract_verdict` in
 `.claude/lib/ai_review_common/verdict.py` and consumed by `merge_verdicts`
-when `/review` aggregates across all axes.
+when `/review` aggregates across all axes. Note: `extract_verdict` returns
+the last match if multiple verdict lines appear; emit exactly one verdict
+line to avoid ambiguity between the leading verdict and any later occurrences.
 
 Refs REQ-008-01, REQ-008-05 (issue #1934).

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-toolkit",
   "description": "24 agent definitions, 82 reusable skills, 51 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "author": { "name": "rjmurillo" }
 }

--- a/src/copilot-cli/skills/review/references/security.md
+++ b/src/copilot-cli/skills/review/references/security.md
@@ -81,7 +81,18 @@ For changes to:
 
 ## Output Requirements
 
-Provide your analysis in this format:
+Emit the verdict as the FIRST line of your response, before any analysis.
+Determine it from the highest-severity finding, then state it up front. The
+output budget can truncate a long review; a leading verdict is still read by
+the gate when the findings below are cut off (issue #2006). Emit exactly ONE
+`VERDICT:` line in the whole response.
+
+```text
+VERDICT: [PASS|WARN|CRITICAL_FAIL]
+MESSAGE: [Brief explanation]
+```
+
+After the verdict block, provide the supporting analysis in this format:
 
 ### Findings
 
@@ -95,16 +106,12 @@ Provide your analysis in this format:
 
 ### Verdict
 
-Choose ONE verdict:
+Choose the verdict by highest-severity finding (do not emit a second
+`VERDICT:` line here; the verdict on the first line is canonical):
 
-- `VERDICT: PASS` - No security issues found
-- `VERDICT: WARN` - Minor issues that don't block merge
-- `VERDICT: CRITICAL_FAIL` - Security vulnerabilities that MUST be fixed
-
-```text
-VERDICT: [PASS|WARN|CRITICAL_FAIL]
-MESSAGE: [Brief explanation]
-```
+- `PASS` - No security issues found
+- `WARN` - Minor issues that don't block merge
+- `CRITICAL_FAIL` - Security vulnerabilities that MUST be fixed
 
 ## Verdict Thresholds
 
@@ -202,8 +209,8 @@ object):
   findings list (any `critical` severity -> CRITICAL_FAIL; any `high` ->
   WARN; otherwise PASS).
 
-The response MUST contain a final line matching the regex
-`(?m)^\s*(?i:(?:Final\s+)?Verdict):\s*\[?(PASS|WARN|CRITICAL_FAIL|REJECTED|FAIL|NEEDS_REVIEW|NON_COMPLIANT|COMPLIANT|PARTIAL|UNKNOWN)(?![|A-Z_])\]?` (label is case-insensitive; tokens are case-sensitive uppercase).
+The response MUST begin with a single line (the first line) matching the regex
+`(?m)^\s*(?i:(?:Final\s+)?Verdict):\s*\[?(PASS|WARN|CRITICAL_FAIL|REJECTED|FAIL|NEEDS_REVIEW|NON_COMPLIANT|COMPLIANT|PARTIAL|UNKNOWN)(?![|A-Z_])\]?` (label is case-insensitive; tokens are case-sensitive uppercase). Emit it once, at the start, so it survives output truncation (issue #2006).
 This line is parsed by `extract_verdict` in
 `.claude/lib/ai_review_common/verdict.py` and consumed by `merge_verdicts`
 when `/review` aggregates across all axes.

--- a/src/copilot-cli/skills/review/references/security.md
+++ b/src/copilot-cli/skills/review/references/security.md
@@ -87,6 +87,17 @@ output budget can truncate a long review; a leading verdict is still read by
 the gate when the findings below are cut off (issue #2006). Emit exactly ONE
 `VERDICT:` line in the whole response.
 
+The `VERDICT:` line MUST contain only the token. The CI parser is anchored to
+the end of the line, so any trailing explanation after the token makes the line
+fail to match. Put all explanation on the `MESSAGE:` line. When the `VERDICT:`
+line does not match, the gate falls back to the `verdict` field in the JSON
+block below, and only if that is also missing does it default to
+`NEEDS_REVIEW`. Because the verdict is emitted first but the parser never
+revisits it, compute it from the completed analysis: the leading verdict MUST
+equal the highest-severity finding and MUST match the `verdict` field in the
+JSON block. Keeping the two in agreement means an optimistic early verdict
+cannot slip through when the JSON fallback is the value actually used.
+
 ```text
 VERDICT: [PASS|WARN|CRITICAL_FAIL]
 MESSAGE: [Brief explanation]
@@ -107,7 +118,8 @@ After the verdict block, provide the supporting analysis in this format:
 ### Verdict
 
 Choose the verdict by highest-severity finding (do not emit a second
-`VERDICT:` line here; the verdict on the first line is canonical):
+`VERDICT:` line here; if multiple verdict lines appear, `extract_verdict`
+returns the last match, which may differ from your intended leading verdict):
 
 - `PASS` - No security issues found
 - `WARN` - Minor issues that don't block merge
@@ -213,6 +225,8 @@ The response MUST begin with a single line (the first line) matching the regex
 `(?m)^\s*(?i:(?:Final\s+)?Verdict):\s*\[?(PASS|WARN|CRITICAL_FAIL|REJECTED|FAIL|NEEDS_REVIEW|NON_COMPLIANT|COMPLIANT|PARTIAL|UNKNOWN)(?![|A-Z_])\]?` (label is case-insensitive; tokens are case-sensitive uppercase). Emit it once, at the start, so it survives output truncation (issue #2006).
 This line is parsed by `extract_verdict` in
 `.claude/lib/ai_review_common/verdict.py` and consumed by `merge_verdicts`
-when `/review` aggregates across all axes.
+when `/review` aggregates across all axes. Note: `extract_verdict` returns
+the last match if multiple verdict lines appear; emit exactly one verdict
+line to avoid ambiguity between the leading verdict and any later occurrences.
 
 Refs REQ-008-01, REQ-008-05 (issue #1934).

--- a/tests/test_ai_review.py
+++ b/tests/test_ai_review.py
@@ -13,6 +13,7 @@ import pytest
 from scripts.ai_review_common import (
     assert_environment_variables,
     convert_to_json_escaped,
+    extract_verdict,
     format_collapsible_section,
     format_markdown_table_row,
     format_verdict_alert,
@@ -1222,3 +1223,51 @@ class TestJSONParsingIntegration:
         for inp in malicious:
             get_labels_from_ai_output(inp)
             get_milestone_from_ai_output(inp)
+
+
+# ---------------------------------------------------------------------------
+# Regression: security review output truncation (#2006)
+# ---------------------------------------------------------------------------
+
+# Captured from PR #2004's Security Review (run 25642461341): four PASS findings,
+# then output stopped mid-sentence during the 4th finding with NO verdict line.
+# With the verdict at the END, truncation drops it and the parser cannot recover
+# the verdict, so the CI action falls through to NEEDS_REVIEW and blocks the PR.
+_TRUNCATED_SECURITY_OUTPUT = (
+    "#### 1. Path Traversal Prevention - [PASS]\n"
+    "realpath() before startswith() check (CWE-22)\n\n"
+    "#### 2. Path Containment - [PASS]\n"
+    "validates path is within repo root\n\n"
+    "#### 3. Subprocess Security - [PASS]\n"
+    "All subprocess calls use list-based argv and explicit timeout=\n\n"
+    "#### 4. Exception Handling - [PASS]\n"
+    "**Location**: complete_session_log.py:383-399\n"
+    "The broad `except Exception`"
+)
+
+
+class TestSecurityTruncationRegression:
+    """#2006: the security prompt now emits the VERDICT on the first line, so a
+    review truncated by the output budget is still parseable."""
+
+    def test_trailing_verdict_lost_to_truncation_is_unparseable(self):
+        # Old shape: the verdict was a final line, so truncation leaves no
+        # ``Verdict:`` line. extract_verdict returns UNKNOWN, mirroring the CI
+        # action's fall-through to NEEDS_REVIEW (both mean "no verdict found").
+        assert extract_verdict(_TRUNCATED_SECURITY_OUTPUT) == "UNKNOWN"
+
+    def test_leading_verdict_survives_truncation(self):
+        # New shape (#2006): VERDICT first. Even when the findings below are cut
+        # off, the verdict is recovered by both verdict parsers.
+        leading = (
+            "VERDICT: PASS\nMESSAGE: No security issues found\n\n"
+            + _TRUNCATED_SECURITY_OUTPUT
+        )
+        assert extract_verdict(leading) == "PASS"
+        assert get_verdict(leading) == "PASS"
+
+    def test_single_leading_verdict_is_canonical(self):
+        # One leading verdict means the last-match-wins parsers return it
+        # unambiguously; there is no trailing duplicate to be truncated away.
+        leading = "VERDICT: CRITICAL_FAIL\nMESSAGE: SQL injection at db.py:12\n\nfindings"
+        assert extract_verdict(leading) == "CRITICAL_FAIL"


### PR DESCRIPTION
## Summary

### What

The security review prompt now emits the `VERDICT:` line as the FIRST line of the response (a single occurrence), instead of requiring it as the final line.

### Why

The security agent ran past its output budget mid-findings on PR #2004 (run 25642461341): it emitted four `[PASS]` findings, then output stopped mid-sentence with no `VERDICT:` line. The CI parser found no verdict and fell through to `NEEDS_REVIEW`, which is blocking, so a PR whose review was substantively PASS on every dimension was blocked twice. A leading verdict survives truncation.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2006 | Security agent output truncation produces false NEEDS_REVIEW |

## Changes

- `.claude/skills/review/references/security.md` (canonical security axis prompt): emit exactly one `VERDICT:` line first, before the findings; removed the trailing duplicate verdict block so there is a single verdict line. Updated the "MUST contain a final line" instruction to "MUST begin with a single line".
- Regenerated `.github/prompts/pr-quality-gate-security.md` (CI prompt) and the copilot-cli copy.
- No parser change (the issue scopes the parser change to proposal #3, not chosen). `extract_verdict` (last-match) and the ai-review action's sed parser (last match wins) both return the single leading verdict.

## Testing

- `tests/test_ai_review.py` adds `TestSecurityTruncationRegression`: a leading verdict is recovered from the captured PR #2004 truncated output (`extract_verdict` and `get_verdict` both return PASS), and the old trailing-verdict shape is unparseable (`extract_verdict` returns UNKNOWN, mirroring the CI NEEDS_REVIEW fall-through).
- 230 ai-review tests and 48 generator tests pass; generated prompts match canonical (no drift).

## Notes for Reviewers

This is a security-sensitive prompt change; the security agent reviews it in CI. The anchoring tradeoff (verdict stated before the detailed findings) is the explicit tradeoff in the issue's proposal #2, chosen as the cheapest robust fix. The same VERDICT-first pattern could be applied to the other axis prompts (analyst, architect, qa, devops, roadmap) as a follow-up; this PR scopes to security, the axis with reproduced evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
