### PR TITLE
fix(workflows): isolate post-pr-retrospective agent failure (#2015)

### DIFF
--- a/.github/workflows/post-pr-retrospective.yml
+++ b/.github/workflows/post-pr-retrospective.yml
@@ -222,7 +222,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # Pin to SHA matches claude.yml and rjmurillo-bot.yml.
-      # https://github.com/anthropics/claude-code-action/releases/tag/v1.0.103
+      # https://github.com/anthropics/claude-code-action/releases/tag/v1.0.133
       #
       # Failure isolation (Issue #2015):
       #   This workflow is async, best-effort, and never blocks merge (see the

--- a/.github/workflows/post-pr-retrospective.yml
+++ b/.github/workflows/post-pr-retrospective.yml
@@ -223,7 +223,23 @@ jobs:
 
       # Pin to SHA matches claude.yml and rjmurillo-bot.yml.
       # https://github.com/anthropics/claude-code-action/releases/tag/v1.0.103
+      #
+      # Failure isolation (Issue #2015):
+      #   This workflow is async, best-effort, and never blocks merge (see the
+      #   header and the "Async by design" hard constraint in the prompt). The
+      #   agent run depends on the CLAUDE_CODE_OAUTH_TOKEN secret and on the
+      #   Anthropic API. When the token is expired or the API is unavailable,
+      #   the action returns a hard error (observed: "401 Invalid authentication
+      #   credentials"). Without continue-on-error, that one transient or
+      #   credential failure paints the "Run retrospective agent" check red on
+      #   every PR, training contributors to treat the check as expected-red and
+      #   eroding signal across the rest of the CI fleet.
+      #   continue-on-error: true keeps the failure observable as a step
+      #   annotation while letting the check report success, matching the
+      #   best-effort contract. The annotation, not a red check, is the signal a
+      #   maintainer acts on (for example, to rotate the OAuth token).
       - name: Run retrospective via Claude Code
+        continue-on-error: true
         uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/tests/workflows/test_post_pr_retrospective.py
+++ b/tests/workflows/test_post_pr_retrospective.py
@@ -25,6 +25,7 @@ _AGENT_STEP_NAME = "Run retrospective via Claude Code"
 _ACTION_REF = (
     "anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251"
 )
+_OAUTH_TOKEN_EXPR = "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
 
 
 def _load_workflow() -> dict[str, Any]:
@@ -95,8 +96,9 @@ class TestAgentStepFailureIsolation:
         assert step is not None
         # Act
         uses = step.get("uses", "")
-        # Assert: failure isolation must not regress the SHA pin
-        assert uses.startswith(_ACTION_REF)
+        # Assert: exact pin so a path change (owner/repo/path@ref) is caught,
+        # not just the prefix
+        assert uses == _ACTION_REF
 
     def test_agent_step_still_wires_oauth_token(self) -> None:
         # Arrange
@@ -105,10 +107,10 @@ class TestAgentStepFailureIsolation:
         assert step is not None
         # Act
         step_with = step.get("with")
-        step_with = {} if step_with is None else step_with
-        token = step_with.get("claude_code_oauth_token", "")
         # Assert: the token wiring is unchanged by the isolation fix
-        assert "CLAUDE_CODE_OAUTH_TOKEN" in token
+        assert isinstance(step_with, dict)
+        token = step_with.get("claude_code_oauth_token", "")
+        assert token == _OAUTH_TOKEN_EXPR
 
 
 class TestFailureIsolationDetectionNegative:

--- a/tests/workflows/test_post_pr_retrospective.py
+++ b/tests/workflows/test_post_pr_retrospective.py
@@ -35,8 +35,12 @@ def _load_workflow() -> dict[str, Any]:
 
 def _find_step(workflow: dict[str, Any], step_name: str) -> dict[str, Any] | None:
     """Return the first step matching step_name across all jobs, or None."""
-    for job in workflow.get("jobs", {}).values():
-        for step in job.get("steps", []):
+    jobs = workflow.get("jobs")
+    jobs = {} if jobs is None else jobs
+    for job in jobs.values():
+        steps = job.get("steps")
+        steps = [] if steps is None else steps
+        for step in steps:
             if step.get("name") == step_name:
                 return step
     return None
@@ -90,7 +94,9 @@ class TestAgentStepFailureIsolation:
         step = _find_step(workflow, _AGENT_STEP_NAME)
         assert step is not None
         # Act
-        token = step.get("with", {}).get("claude_code_oauth_token", "")
+        step_with = step.get("with")
+        step_with = {} if step_with is None else step_with
+        token = step_with.get("claude_code_oauth_token", "")
         # Assert: the token wiring is unchanged by the isolation fix
         assert "CLAUDE_CODE_OAUTH_TOKEN" in token
 

--- a/tests/workflows/test_post_pr_retrospective.py
+++ b/tests/workflows/test_post_pr_retrospective.py
@@ -1,0 +1,164 @@
+"""Tests for the Post-PR Retrospective workflow failure isolation (Issue #2015).
+
+The retrospective workflow is async, best-effort, and never blocks merge. Its
+agent step depends on the CLAUDE_CODE_OAUTH_TOKEN secret and the Anthropic API.
+When the token is expired or the API is unavailable, the action returns a hard
+error (observed root cause for #2015: "401 Invalid authentication credentials").
+
+Without continue-on-error on the agent step, that one failure paints the
+"Run retrospective agent" check red on every PR. These tests pin the contract
+that the agent step is failure-isolated so a credential or API outage degrades
+to a step annotation, not a red check.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "post-pr-retrospective.yml"
+
+_AGENT_STEP_NAME = "Run retrospective via Claude Code"
+_ACTION_REF = (
+    "anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251"
+)
+
+
+def _load_workflow() -> dict[str, Any]:
+    """Parse the workflow YAML into a dict."""
+    with _WORKFLOW_PATH.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _find_step(workflow: dict[str, Any], step_name: str) -> dict[str, Any] | None:
+    """Return the first step matching step_name across all jobs, or None."""
+    for job in workflow.get("jobs", {}).values():
+        for step in job.get("steps", []):
+            if step.get("name") == step_name:
+                return step
+    return None
+
+
+class TestWorkflowFile:
+    def test_workflow_file_exists(self) -> None:
+        # Arrange / Act / Assert
+        assert _WORKFLOW_PATH.is_file()
+
+    def test_workflow_parses_as_yaml(self) -> None:
+        # Arrange / Act
+        workflow = _load_workflow()
+        # Assert
+        assert isinstance(workflow, dict)
+        assert "jobs" in workflow
+
+
+class TestAgentStepFailureIsolation:
+    def test_agent_step_is_present(self) -> None:
+        # Arrange
+        workflow = _load_workflow()
+        # Act
+        step = _find_step(workflow, _AGENT_STEP_NAME)
+        # Assert
+        assert step is not None, f"missing agent step named {_AGENT_STEP_NAME!r}"
+
+    def test_agent_step_is_failure_isolated(self) -> None:
+        # Arrange
+        workflow = _load_workflow()
+        step = _find_step(workflow, _AGENT_STEP_NAME)
+        assert step is not None
+        # Act
+        continue_on_error = step.get("continue-on-error")
+        # Assert: best-effort async step must not fail the check (Issue #2015)
+        assert continue_on_error is True
+
+    def test_agent_step_keeps_sha_pinned_action(self) -> None:
+        # Arrange
+        workflow = _load_workflow()
+        step = _find_step(workflow, _AGENT_STEP_NAME)
+        assert step is not None
+        # Act
+        uses = step.get("uses", "")
+        # Assert: failure isolation must not regress the SHA pin
+        assert uses.startswith(_ACTION_REF)
+
+    def test_agent_step_still_wires_oauth_token(self) -> None:
+        # Arrange
+        workflow = _load_workflow()
+        step = _find_step(workflow, _AGENT_STEP_NAME)
+        assert step is not None
+        # Act
+        token = step.get("with", {}).get("claude_code_oauth_token", "")
+        # Assert: the token wiring is unchanged by the isolation fix
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in token
+
+
+class TestFailureIsolationDetectionNegative:
+    """Negative coverage: the assertion catches a non-isolated step.
+
+    Builds an in-memory workflow whose agent step lacks continue-on-error and
+    confirms the failure-isolation predicate the real test relies on would flag
+    it. This guards against the predicate silently passing on a regression.
+    """
+
+    def test_missing_continue_on_error_is_detected(self) -> None:
+        # Arrange: a workflow shaped like the real one but without isolation
+        workflow: dict[str, Any] = {
+            "jobs": {
+                "retrospective": {
+                    "steps": [
+                        {"name": _AGENT_STEP_NAME, "uses": _ACTION_REF},
+                    ]
+                }
+            }
+        }
+        step = _find_step(workflow, _AGENT_STEP_NAME)
+        assert step is not None
+        # Act
+        continue_on_error = step.get("continue-on-error")
+        # Assert: predicate correctly reports the step is NOT isolated
+        assert continue_on_error is not True
+
+    def test_explicit_false_continue_on_error_is_detected(self) -> None:
+        # Arrange: continue-on-error present but set to False
+        workflow: dict[str, Any] = {
+            "jobs": {
+                "retrospective": {
+                    "steps": [
+                        {
+                            "name": _AGENT_STEP_NAME,
+                            "uses": _ACTION_REF,
+                            "continue-on-error": False,
+                        },
+                    ]
+                }
+            }
+        }
+        step = _find_step(workflow, _AGENT_STEP_NAME)
+        assert step is not None
+        # Act
+        continue_on_error = step.get("continue-on-error")
+        # Assert
+        assert continue_on_error is not True
+
+
+class TestStepLookupEdgeCases:
+    def test_find_step_returns_none_when_absent(self) -> None:
+        # Arrange
+        workflow: dict[str, Any] = {
+            "jobs": {"only": {"steps": [{"name": "something else"}]}}
+        }
+        # Act
+        step = _find_step(workflow, _AGENT_STEP_NAME)
+        # Assert
+        assert step is None
+
+    def test_find_step_handles_job_with_no_steps(self) -> None:
+        # Arrange: a job missing the steps key must not raise
+        workflow: dict[str, Any] = {"jobs": {"empty": {}}}
+        # Act
+        step = _find_step(workflow, _AGENT_STEP_NAME)
+        # Assert
+        assert step is None

--- a/tests/workflows/test_post_pr_retrospective.py
+++ b/tests/workflows/test_post_pr_retrospective.py
@@ -30,18 +30,28 @@ _ACTION_REF = (
 def _load_workflow() -> dict[str, Any]:
     """Parse the workflow YAML into a dict."""
     with _WORKFLOW_PATH.open(encoding="utf-8") as handle:
-        return yaml.safe_load(handle)
+        loaded = yaml.safe_load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError(
+            f"Expected {_WORKFLOW_PATH} to parse as a mapping, "
+            f"got {type(loaded).__name__}"
+        )
+    return loaded
 
 
 def _find_step(workflow: dict[str, Any], step_name: str) -> dict[str, Any] | None:
     """Return the first step matching step_name across all jobs, or None."""
     jobs = workflow.get("jobs")
-    jobs = {} if jobs is None else jobs
+    if not isinstance(jobs, dict):
+        return None
     for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
         steps = job.get("steps")
-        steps = [] if steps is None else steps
+        if not isinstance(steps, list):
+            continue
         for step in steps:
-            if step.get("name") == step_name:
+            if isinstance(step, dict) and step.get("name") == step_name:
                 return step
     return None
 


### PR DESCRIPTION
## Summary

The `Run retrospective agent` check (workflow `post-pr-retrospective.yml`) fails on every PR. This PR fixes the false-red signal by isolating the agent step's failure, and documents the underlying root cause, which is an owner action (secret rotation) that cannot land in code.

## Root cause (with log evidence, secrets redacted)

The Claude Code action authenticates against the Anthropic API and receives a hard 401. The `CLAUDE_CODE_OAUTH_TOKEN` repository secret is expired or invalid.

From run 26727704230 (most recent failure):

```
{
  "type": "result",
  "subtype": "success",
  "is_error": true,
  "duration_ms": 2167,
  "num_turns": 1,
  "total_cost_usd": 0,
  "permission_denials_count": 0
}
##[error]Action failed with error: SDK execution error: Error: Claude Code returned an error result: Failed to authenticate. API Error: 401 Invalid authentication credentials
```

Confirmed identical 401 on four sampled runs: 26727704230, 26727114460, 26725875980, 26723375899. Every retro run in the last 30 (oldest 2026-05-30, newest 2026-05-31) concluded `failure`.

The secret is not globally expired in a way I can repair: the sibling claude.yml and rjmurillo-bot.yml use the same `CLAUDE_CODE_OAUTH_TOKEN`. But every recent claude.yml run skipped its API-calling job (`claude-response`, gated on a `@claude` trigger that did not match), so the token was never exercised there. `post-pr-retrospective.yml` is the only workflow that calls the API unconditionally on every PR close, which is why it is the only one surfacing the 401. The workflow YAML itself is correct: the action is SHA pinned and the token is wired the same way as claude.yml.

## Decision: keep + fix the false-red, plus required owner action

Per the issue's three options (keep+fix, keep+replace, remove), the verdict is keep + fix:

1. The workflow is the intended source for `.agents/retrospective/`. Removing it would drop the capability; the right move is to restore it once the secret is valid.
2. The repairable defect in code is failure isolation. The workflow is async, best-effort, and never blocks merge (stated in its header and in the prompt's "Async by design" hard constraint). Yet the agent step had no `continue-on-error`, so any credential or API failure painted the check red on every PR. That is the exact harm the issue names.
3. `continue-on-error: true` on the agent step converts a credential or API failure into a step annotation, not a red check. This fixes the failure class (transient or credential failures painting red), not just the current expired-token instance.

### Required owner action (cannot land in code)

Rotate the `CLAUDE_CODE_OAUTH_TOKEN` repository secret. After rotation, a closed-PR event (or a `workflow_dispatch` of `post-pr-retrospective.yml`) should produce a successful agent run that writes a retrospective artifact. The failure-isolation change in this PR makes the check green regardless; the annotation is the signal a maintainer uses to confirm the token is healthy.

## Change per file

- `.github/workflows/post-pr-retrospective.yml`: add `continue-on-error: true` to the `Run retrospective via Claude Code` step, with a header comment documenting the failure-isolation rationale and the secret-owner action. No untrusted input interpolation added; the existing safe handling of PR fields is unchanged.
- `tests/workflows/test_post_pr_retrospective.py`: new pytest module that parses the workflow YAML and pins the failure-isolation contract. Positive (the agent step has `continue-on-error: true`, keeps its SHA pin, keeps its token wiring), negative (a constructed non-isolated step is detected, including an explicit `false`), and edge cases (step lookup returns `None` when absent or when a job has no steps).

## Validation
- `uv run pytest tests/workflows/test_post_pr_retrospective.py -v`: 10 passed.
- Regression check: removed `continue-on-error` from the workflow, ran `test_agent_step_is_failure_isolated`, it FAILED (`assert None is True`), restored the file, re-ran, it PASSED. Proves the test is load-bearing, not a tautology.
- `uv run pytest tests/test_validate_workflows.py -q`: 16 passed.
- `python3 scripts/validate_workflows.py`: exit 0, all validations passed. The `166 lines` ADR-006 advisory is a pre-existing warning shared by many workflows, not introduced by this change and not a blocking error.
- YAML parse sanity: `python3 -c "import yaml; yaml.safe_load(...)"` parses cleanly; jobs are `prepare`, `retrospective`.
- Dash check: no em or en dashes in either changed file.
- Local `act` run not performed: `act` is not installed in this environment (`SKIP_WORKFLOW_LOCAL_TEST` bypass per AGENTS.md). Structural validation via `validate_workflows.py` and PyYAML parsing covered the YAML correctness.

Fixes #2015