### PR TITLE
feat(cli): add --target flag and copilot instruction-block append

### DIFF
--- a/packages/ai-agents-cli/src/cli.ts
+++ b/packages/ai-agents-cli/src/cli.ts
@@ -7,11 +7,13 @@ import { FsBundleSource } from "./io/bundle-source-fs.js";
 import { FsTargetEmitter } from "./target/emitter-fs.js";
 import { init } from "./init.js";
 import { mergeClaudeMd } from "./target/merge-claude-md.js";
+import { mergeCopilotInstructions } from "./target/merge-copilot-instructions.js";
 import { writeAgentsMd } from "./target/write-agents-md.js";
 import { writeVersionPin } from "./target/version-pin.js";
-import type { BundleEntry, TargetContext } from "./types.js";
+import { TARGETS, type BundleEntry, type Target, type TargetContext } from "./types.js";
 
 const VERSION = "0.1.0";
+const DEFAULT_TARGET: Target = "claude";
 
 export interface RunInitOptions {
   targetDir: string;
@@ -19,6 +21,31 @@ export interface RunInitOptions {
   dryRun: boolean;
   assetsDir: string;
   version: string;
+  target?: Target;
+}
+
+// Append the inline harness block to the instruction file(s) the target selects.
+async function writeTargetBlocks(
+  targetDir: string,
+  target: Target,
+  dryRun: boolean,
+): Promise<void> {
+  if (target === "claude" || target === "both") {
+    await mergeClaudeMd(targetDir, dryRun);
+  }
+  if (target === "copilot" || target === "both") {
+    await mergeCopilotInstructions(targetDir, dryRun);
+  }
+}
+
+// Reject any --target value outside the known set with a clear, typed error.
+export function parseTarget(value: string): Target {
+  if ((TARGETS as readonly string[]).includes(value)) {
+    return value as Target;
+  }
+  throw new Error(
+    `Invalid --target "${value}". Expected one of: ${TARGETS.join(", ")}.`,
+  );
 }
 
 // Exported for tests: wires the vendoring pipeline end-to-end.
@@ -43,7 +70,11 @@ export async function runInit(opts: RunInitOptions): Promise<number> {
   if (code !== 0) return code;
 
   if (!opts.dryRun) {
-    await mergeClaudeMd(target.targetDir, opts.dryRun);
+    await writeTargetBlocks(
+      target.targetDir,
+      opts.target ?? DEFAULT_TARGET,
+      opts.dryRun,
+    );
     await writeAgentsMd(target.targetDir, opts.dryRun);
     await writeVersionPin(
       target.targetDir,
@@ -69,6 +100,7 @@ async function main(): Promise<number> {
     options: {
       force: { type: "boolean", default: false },
       "dry-run": { type: "boolean", default: false },
+      target: { type: "string", default: DEFAULT_TARGET },
       yes: { type: "boolean", short: "y", default: false },
       help: { type: "boolean", short: "h", default: false },
       version: { type: "boolean", default: false },
@@ -93,6 +125,8 @@ async function main(): Promise<number> {
         "Options:",
         "  --force       Overwrite existing files that diverge from snapshot",
         "  --dry-run     Show what would be written without touching disk",
+        "  --target T    Instruction file(s) to update: claude, copilot, or both",
+        "                (default: claude)",
         "  -y, --yes     Skip confirmation prompts",
         "  -h, --help    Show this help message",
         "  --version     Print the CLI version and exit",
@@ -113,8 +147,17 @@ async function main(): Promise<number> {
   const force = values.force ?? false;
   const dryRun = values["dry-run"] ?? false;
 
+  let target: Target;
+  try {
+    target = parseTarget(values.target ?? DEFAULT_TARGET);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`${message}\n`);
+    return 2;
+  }
+
   process.stdout.write(
-    `ai-agents init: target=${targetDir} force=${force} dryRun=${dryRun}\n`,
+    `ai-agents init: dir=${targetDir} target=${target} force=${force} dryRun=${dryRun}\n`,
   );
 
   return runInit({
@@ -123,6 +166,7 @@ async function main(): Promise<number> {
     dryRun,
     assetsDir: resolveAssetsDir(),
     version: VERSION,
+    target,
   });
 }
 

--- a/packages/ai-agents-cli/src/cli.ts
+++ b/packages/ai-agents-cli/src/cli.ts
@@ -38,7 +38,7 @@ async function writeTargetBlocks(
   }
 }
 
-// Reject any --target value outside the known set with a clear, typed error.
+// Reject any --target value outside the known set with a clear error message.
 export function parseTarget(value: string): Target {
   if ((TARGETS as readonly string[]).includes(value)) {
     return value as Target;

--- a/packages/ai-agents-cli/src/target/append-marker-block.ts
+++ b/packages/ai-agents-cli/src/target/append-marker-block.ts
@@ -15,6 +15,14 @@ export async function appendMarkerBlock(
   block: string,
   dryRun: boolean,
 ): Promise<void> {
+  if (!block.includes(BEGIN_MARKER) || !block.includes(END_MARKER)) {
+    throw new Error(
+      "appendMarkerBlock requires the block to contain both " +
+        `${BEGIN_MARKER} and ${END_MARKER}; the idempotency check relies on ` +
+        "them.",
+    );
+  }
+
   if (dryRun) return;
 
   const dir = dirname(filePath);
@@ -39,7 +47,9 @@ export async function appendMarkerBlock(
 
   let blockToWrite = block;
   if (detectedCrlf) {
-    blockToWrite = blockToWrite.replace(/\n/g, "\r\n");
+    // Match optional CR so a block already using CRLF does not become
+    // corrupted \r\r\n line endings.
+    blockToWrite = blockToWrite.replace(/\r?\n/g, "\r\n");
   }
 
   let result: string;

--- a/packages/ai-agents-cli/src/target/append-marker-block.ts
+++ b/packages/ai-agents-cli/src/target/append-marker-block.ts
@@ -1,0 +1,64 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export const BEGIN_MARKER = "<!-- ai-agents:begin -->";
+export const END_MARKER = "<!-- ai-agents:end -->";
+
+// Append a marker-delimited block to a markdown instruction file, preserving
+// existing content and CRLF line endings. Idempotent: a file that already
+// contains both markers is left untouched. The dry-run guard writes nothing.
+//
+// Shared by the CLAUDE.md (claude target) and copilot-instructions.md
+// (copilot target) writers so the CRLF and idempotency rules live in one place.
+export async function appendMarkerBlock(
+  filePath: string,
+  block: string,
+  dryRun: boolean,
+): Promise<void> {
+  if (dryRun) return;
+
+  const dir = dirname(filePath);
+  await mkdir(dir, { recursive: true });
+
+  let existing = "";
+  let detectedCrlf = false;
+  try {
+    const raw = await readFile(filePath);
+    existing = raw.toString("utf-8");
+    detectedCrlf = existing.includes("\r\n");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+    // File does not exist yet, proceed with empty existing content
+  }
+
+  if (existing.includes(BEGIN_MARKER) && existing.includes(END_MARKER)) {
+    return;
+  }
+
+  let blockToWrite = block;
+  if (detectedCrlf) {
+    blockToWrite = blockToWrite.replace(/\n/g, "\r\n");
+  }
+
+  let result: string;
+  if (existing.length === 0) {
+    result = blockToWrite + "\n";
+  } else {
+    const lineEnding = detectedCrlf ? "\r\n" : "\n";
+    const trimmed = existing.endsWith(lineEnding)
+      ? existing
+      : existing + lineEnding;
+    result = trimmed + lineEnding + blockToWrite + lineEnding;
+  }
+
+  if (detectedCrlf) {
+    // Equivalent to /(?<!\r)\n/g but avoids negative lookbehind for
+    // broader engine compatibility: match optional CR + LF and
+    // unconditionally rewrite to CRLF (\r\n is an identity, \n is fixed).
+    result = result.replace(/\r?\n/g, "\r\n");
+  }
+
+  await writeFile(filePath, result, "utf-8");
+}

--- a/packages/ai-agents-cli/src/target/merge-copilot-instructions.ts
+++ b/packages/ai-agents-cli/src/target/merge-copilot-instructions.ts
@@ -5,15 +5,15 @@ import {
   appendMarkerBlock,
 } from "./append-marker-block.js";
 
-const GENERIC_BLOCK = `${BEGIN_MARKER}
+const COPILOT_BLOCK = `${BEGIN_MARKER}
 # ai-agents Harness
 
 Vendored by [@rjmurillo/ai-agents](https://github.com/rjmurillo/ai-agents).
 
 ## Skill Routing
 
-When your request matches an available skill, invoke it using the Skill tool
-as your FIRST action. Skills provide specialized workflows.
+When your request matches an available skill, invoke it as your FIRST action.
+Skills provide specialized workflows.
 
 Key routing:
 - Bugs, errors -> /analyze
@@ -35,7 +35,7 @@ Key routing:
 
 ## Agents
 
-Use the Task tool with specialized agents:
+Delegate to specialized agents:
 - orchestrator: multi-step coordination
 - analyst: research and investigation
 - architect: design and ADRs
@@ -44,10 +44,10 @@ Use the Task tool with specialized agents:
 - qa: testing and verification
 ${END_MARKER}`;
 
-export async function mergeClaudeMd(
+export async function mergeCopilotInstructions(
   targetDir: string,
   dryRun: boolean,
 ): Promise<void> {
-  const filePath = join(targetDir, "CLAUDE.md");
-  await appendMarkerBlock(filePath, GENERIC_BLOCK, dryRun);
+  const filePath = join(targetDir, ".github", "copilot-instructions.md");
+  await appendMarkerBlock(filePath, COPILOT_BLOCK, dryRun);
 }

--- a/packages/ai-agents-cli/src/types.ts
+++ b/packages/ai-agents-cli/src/types.ts
@@ -1,3 +1,10 @@
+// Which harness instruction file(s) the inline block is appended to.
+// "claude" writes CLAUDE.md, "copilot" writes .github/copilot-instructions.md,
+// "both" writes both.
+export type Target = "claude" | "copilot" | "both";
+
+export const TARGETS: readonly Target[] = ["claude", "copilot", "both"];
+
 export interface BundleEntry {
   readonly relativePath: string;
   readonly size: number;

--- a/packages/ai-agents-cli/tests/cli.test.ts
+++ b/packages/ai-agents-cli/tests/cli.test.ts
@@ -32,6 +32,7 @@ describe("CLI init (integration)", () => {
     expect(output).toContain("Usage: ai-agents init");
     expect(output).toContain("--force");
     expect(output).toContain("--dry-run");
+    expect(output).toContain("--target");
   });
 
   test("unknown command exits with error", async () => {
@@ -43,5 +44,34 @@ describe("CLI init (integration)", () => {
     await proc.exited;
     expect(proc.exitCode).not.toBe(0);
     expect(stderr).toContain("Unknown command");
+  });
+
+  test("init reports the selected target in its startup line", async () => {
+    // The CLI prints the resolved target before vendoring runs. We assert the
+    // log line and the dry-run no-write contract, not the exit code: the exit
+    // code depends on the bundle/assets dir existing, which is a packaging
+    // concern outside this flag's behavior.
+    const proc = Bun.spawn(
+      ["bun", "run", "src/cli.ts", "init", testDir, "--dry-run", "--target", "copilot"],
+      { cwd: join(import.meta.dir, ".."), stdout: "pipe" },
+    );
+    const output = await new Response(proc.stdout).text();
+    await proc.exited;
+    expect(output).toContain("target=copilot");
+    // dry-run touches nothing on disk
+    await expect(
+      access(join(testDir, ".github", "copilot-instructions.md")),
+    ).rejects.toThrow();
+  });
+
+  test("init --target with an invalid value exits with config error", async () => {
+    const proc = Bun.spawn(
+      ["bun", "run", "src/cli.ts", "init", testDir, "--target", "gemini"],
+      { cwd: join(import.meta.dir, ".."), stderr: "pipe" },
+    );
+    const stderr = await new Response(proc.stderr).text();
+    await proc.exited;
+    expect(proc.exitCode).toBe(2);
+    expect(stderr).toContain('Invalid --target "gemini"');
   });
 });

--- a/packages/ai-agents-cli/tests/merge-copilot-instructions.test.ts
+++ b/packages/ai-agents-cli/tests/merge-copilot-instructions.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, readFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mergeCopilotInstructions } from "../src/target/merge-copilot-instructions.js";
+
+const BEGIN_MARKER = "<!-- ai-agents:begin -->";
+const END_MARKER = "<!-- ai-agents:end -->";
+const REL_PATH = [".github", "copilot-instructions.md"] as const;
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "merge-copilot-"));
+});
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+function instructionsPath(): string {
+  return join(testDir, ...REL_PATH);
+}
+
+describe("mergeCopilotInstructions", () => {
+  test("creates .github/copilot-instructions.md when file does not exist", async () => {
+    await mergeCopilotInstructions(testDir, false);
+
+    const content = await readFile(instructionsPath(), "utf-8");
+    expect(content).toContain(BEGIN_MARKER);
+    expect(content).toContain(END_MARKER);
+    expect(content).toContain("ai-agents Harness");
+  });
+
+  test("appends block to existing instructions file", async () => {
+    await mkdir(join(testDir, ".github"), { recursive: true });
+    const existing = "# Repo Copilot Rules\n\nExisting guidance here.\n";
+    await writeFile(instructionsPath(), existing);
+
+    await mergeCopilotInstructions(testDir, false);
+
+    const content = await readFile(instructionsPath(), "utf-8");
+    expect(content).toStartWith("# Repo Copilot Rules");
+    expect(content).toContain(BEGIN_MARKER);
+    expect(content).toContain(END_MARKER);
+  });
+
+  test("idempotent: does not duplicate block on re-run", async () => {
+    await mergeCopilotInstructions(testDir, false);
+    await mergeCopilotInstructions(testDir, false);
+
+    const content = await readFile(instructionsPath(), "utf-8");
+    const beginCount = content.split(BEGIN_MARKER).length - 1;
+    expect(beginCount).toBe(1);
+  });
+
+  test("preserves CRLF line endings", async () => {
+    await mkdir(join(testDir, ".github"), { recursive: true });
+    const existing = "# Rules\r\n\r\nSome content.\r\n";
+    await writeFile(instructionsPath(), existing);
+
+    await mergeCopilotInstructions(testDir, false);
+
+    const content = await readFile(instructionsPath(), "utf-8");
+    expect(content).toContain("\r\n");
+    // No orphaned LF (one not preceded by CR) precedes the marker block.
+    for (let i = 0; i < content.length; i++) {
+      if (content[i] === "\n" && content[i - 1] !== "\r") {
+        const rest = content.slice(i);
+        expect(rest.includes("<!-- ai-agents")).toBe(false);
+      }
+    }
+  });
+
+  test("handles missing trailing newline", async () => {
+    await mkdir(join(testDir, ".github"), { recursive: true });
+    const existing = "# Rules\n\nNo trailing newline";
+    await writeFile(instructionsPath(), existing);
+
+    await mergeCopilotInstructions(testDir, false);
+
+    const content = await readFile(instructionsPath(), "utf-8");
+    expect(content).toContain(BEGIN_MARKER);
+    expect(content).toContain("No trailing newline");
+  });
+
+  test("dry run writes nothing", async () => {
+    await mergeCopilotInstructions(testDir, true);
+
+    try {
+      await readFile(instructionsPath());
+      expect(true).toBe(false);
+    } catch (err: any) {
+      expect(err.code).toBe("ENOENT");
+    }
+  });
+});

--- a/packages/ai-agents-cli/tests/parse-target.test.ts
+++ b/packages/ai-agents-cli/tests/parse-target.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from "bun:test";
+import { parseTarget } from "../src/cli.js";
+
+describe("parseTarget", () => {
+  test("accepts claude", () => {
+    expect(parseTarget("claude")).toBe("claude");
+  });
+
+  test("accepts copilot", () => {
+    expect(parseTarget("copilot")).toBe("copilot");
+  });
+
+  test("accepts both", () => {
+    expect(parseTarget("both")).toBe("both");
+  });
+
+  test("rejects an unknown target", () => {
+    expect(() => parseTarget("gemini")).toThrow(/Invalid --target "gemini"/);
+  });
+
+  test("rejects an empty target", () => {
+    expect(() => parseTarget("")).toThrow(/Invalid --target/);
+  });
+
+  test("is case-sensitive: Claude is not claude", () => {
+    expect(() => parseTarget("Claude")).toThrow(/Invalid --target "Claude"/);
+  });
+
+  test("error message lists the valid targets", () => {
+    expect(() => parseTarget("none")).toThrow(/claude, copilot, both/);
+  });
+});

--- a/packages/ai-agents-cli/tests/run-init-target.test.ts
+++ b/packages/ai-agents-cli/tests/run-init-target.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, mkdir, writeFile, access } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runInit } from "../src/cli.js";
+
+let assetsDir: string;
+let targetDir: string;
+
+beforeEach(async () => {
+  assetsDir = await mkdtemp(join(tmpdir(), "run-init-target-assets-"));
+  targetDir = await mkdtemp(join(tmpdir(), "run-init-target-dir-"));
+
+  await mkdir(join(assetsDir, "agents"), { recursive: true });
+  await writeFile(join(assetsDir, "agents", "implementer.md"), "# implementer\n");
+});
+
+afterEach(async () => {
+  await rm(assetsDir, { recursive: true, force: true });
+  await rm(targetDir, { recursive: true, force: true });
+});
+
+function claudePath(): string {
+  return join(targetDir, "CLAUDE.md");
+}
+
+function copilotPath(): string {
+  return join(targetDir, ".github", "copilot-instructions.md");
+}
+
+describe("runInit --target dispatch", () => {
+  test("claude target writes CLAUDE.md and not copilot instructions", async () => {
+    const code = await runInit({
+      targetDir,
+      force: false,
+      dryRun: false,
+      assetsDir,
+      version: "0.1.0",
+      target: "claude",
+    });
+
+    expect(code).toBe(0);
+    await access(claudePath());
+    await expect(access(copilotPath())).rejects.toThrow();
+  });
+
+  test("copilot target writes copilot instructions and not CLAUDE.md", async () => {
+    const code = await runInit({
+      targetDir,
+      force: false,
+      dryRun: false,
+      assetsDir,
+      version: "0.1.0",
+      target: "copilot",
+    });
+
+    expect(code).toBe(0);
+    await access(copilotPath());
+    await expect(access(claudePath())).rejects.toThrow();
+  });
+
+  test("both target writes CLAUDE.md and copilot instructions", async () => {
+    const code = await runInit({
+      targetDir,
+      force: false,
+      dryRun: false,
+      assetsDir,
+      version: "0.1.0",
+      target: "both",
+    });
+
+    expect(code).toBe(0);
+    await access(claudePath());
+    await access(copilotPath());
+  });
+
+  test("omitted target defaults to claude", async () => {
+    const code = await runInit({
+      targetDir,
+      force: false,
+      dryRun: false,
+      assetsDir,
+      version: "0.1.0",
+    });
+
+    expect(code).toBe(0);
+    await access(claudePath());
+    await expect(access(copilotPath())).rejects.toThrow();
+  });
+
+  test("dry-run with both target writes neither instruction file", async () => {
+    const code = await runInit({
+      targetDir,
+      force: false,
+      dryRun: true,
+      assetsDir,
+      version: "0.1.0",
+      target: "both",
+    });
+
+    expect(code).toBe(0);
+    await expect(access(claudePath())).rejects.toThrow();
+    await expect(access(copilotPath())).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Completes the Stage 2 CLI deliverable in `packages/ai-agents-cli/`. Adds a `--target {claude,copilot,both}` option to the `ai-agents init` command and a copilot instruction-block writer that mirrors the existing CLAUDE.md block pattern. With this, an operator can vendor the harness and pick which instruction file gets the inline block: CLAUDE.md (claude), .github/copilot-instructions.md (copilot), or both.

The current `main` state ships neither the `Target` type nor the copilot emitter that issue #2060 references (PR #1645 never landed), so this builds both from the established Stage 1 pattern in `src/target/merge-claude-md.ts`.

## Change per file

- `src/types.ts`: add the `Target` union (`"claude" | "copilot" | "both"`) and a `TARGETS` constant for validation.
- `src/target/append-marker-block.ts` (new): extract the shared marker-block append logic (CRLF handling, idempotency, dry-run guard) from merge-claude-md so both writers use one implementation. DRY at the knowledge level: the CRLF and idempotency rules live in one place.
- `src/target/merge-claude-md.ts`: refactor to call appendMarkerBlock. Pure structural change, no behavior change. The 6 existing merge-claude-md tests still pass.
- `src/target/merge-copilot-instructions.ts` (new): append the inline harness block to .github/copilot-instructions.md, mirroring the CLAUDE.md block.
- `src/cli.ts`: add the `--target` option (default `claude`, preserving current behavior), validate it via `parseTarget` (typed error, exits with config code 2 on an unknown value), dispatch to the matching writer through `writeTargetBlocks`, and update help text plus the startup log line. `runInit` takes an optional `target` and defaults to `claude` so existing callers keep working.
- `tests/parse-target.test.ts` (new): positive (each valid value), negative (unknown, empty), edge (case-sensitive).
- `tests/merge-copilot-instructions.test.ts` (new): create, append, idempotent, CRLF preservation, missing trailing newline, dry-run.
- `tests/run-init-target.test.ts` (new): each target value writes the correct file(s); omitted target defaults to claude; dry-run with `both` writes neither file.
- `tests/cli.test.ts`: assert `--target` appears in help, the startup line reports the selected target, and an invalid target exits with code 2.

## Notes for Reviewers
- The package `typecheck` script (`tsc --noEmit`) fails on the unmodified `main` baseline too: TypeScript 6.0.3 with @types/node 25.x is not wired through tsconfig.json `types`, so `process`, `Buffer`, and `node:*` resolve as errors across all files including untouched ones. This is a pre-existing toolchain mismatch, not a regression from this change, and is left out of scope. The canonical package check (`bun test`) passes. Flagging so it can be fixed separately.
- src/target/write-agents-md.ts (not in this changeset) contains 3 em-dashes in its embedded stub content (lines 13 to 15). Out of scope for this PR; worth a follow-up to bring it in line with the repo dash prohibition.

## Fixes

Fixes #2060

## Testing

- `cd packages/ai-agents-cli && bun test`
- Result: 60 pass, 0 fail, 111 expect() calls, 12 files. Baseline before this change was 40 pass across 9 files. The `init failed ... bundle/assets` line in output is expected: the CLI integration tests run against a worktree with no shipped bundle, and the assertions account for that (they check the startup log line and the dry-run no-write contract, not the exit code).