### PR TITLE
fix(agents): compress AGENTS.md under workspace per-file cap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,25 +10,25 @@ Read first, reason second. Pre-training last resort.
 
 |APIs: Context7, DeepWiki, WebSearch
 |Constraints: `.agents/governance/PROJECT-CONSTRAINTS.md`
-|Memory: `memory` skill; not bare `list_memories`
+|Memory: `memory` skill, not `list_memories`
 |ADRs: `.agents/architecture/ADR-*.md`
 |Protocol: `.agents/SESSION-PROTOCOL.md`
 |Skills: `.claude/skills/{name}/SKILL.md`
-|Generators (edit source, not output): `.agents/governance/GENERATOR-FILES.md`
+|Generators (edit source): `.agents/governance/GENERATOR-FILES.md`
 
 ## Session Gates
 
 **Start**: Init Serena|Read HANDOFF.md + latest issue handoff + Verify-on-Resume|Session log|Search memories|Verify git
 **Mid**: `Commit X/20 (ADR-008)`|Warn at 15+
 **Pre-PR**: `python3 scripts/validation/pre_pr.py`|No BLOCKING|Security scan|Style: `.gemini/styleguide.md`
-**End**: Complete log|Preserve HANDOFF.md|Issue handoff (template) if open|Update Serena|Lint|Commit|Validate JSON
+**End**: Complete log|Preserve HANDOFF.md|Issue handoff if open|Update Serena|Lint|Commit|Validate JSON
 
 ## Boundaries
 
-**Always**: Python new scripts (ADR-042)|Verify branch|Update Serena|Check skills|Assign issues|PR template|Atomic commits (≤5 files)|Scoped lint|Pin Actions to SHA|Run changed workflows locally pre-push (`SKIP_WORKFLOW_LOCAL_TEST=true` bypass)|Bump `plugin.json` (semver) on plugin source change (#2118)
+**Always**: Python new scripts (ADR-042)|Verify branch|Update Serena|Check skills|Assign issues|PR template|Atomic commits (≤5 files)|Scoped lint|Pin Actions to SHA|Run changed workflows pre-push (`SKIP_WORKFLOW_LOCAL_TEST=true` bypass)|Bump `plugin.json` (semver) on plugin source change
 **Ask First**: Architecture changes|New ADRs|Breaking changes|Security-sensitive
 **Autonomy Guardrail**: Internal+reversible (read,edit,memory): act|External/Irreversible: confirm|Ambiguous: act minimal, flag rest
-**Never**: Commit secrets|Update HANDOFF.md|Use bash|Skip validation|Logic in YAML (ADR-006)|Raw gh when skills exist|Force push|Skip hooks|Internal refs in src/|Scratch in working tree (use `$TMPDIR`/`mktemp`)|Resolve security threads without fixing underlying vulnerability (CWE/OWASP/CVE) in code
+**Never**: Commit secrets|Update HANDOFF.md|Use bash|Skip validation|Logic in YAML (ADR-006)|Raw gh when skills exist|Force push|Skip hooks|Internal refs in src/|Scratch in working tree (`$TMPDIR`/`mktemp`)|Resolve security threads without fixing the vulnerability (CWE/OWASP/CVE) in code
 
 ## Context Type Decision
 
@@ -43,11 +43,11 @@ Knowledge → passive context (@imports). Actions → skills.
 |Session: session-init, session-end|CI fix: session-log-fixer|Push: /push-pr
 |Security: security-detection|Quality: analyze|Learn: reflect
 |Lifecycle: /spec, /plan, /build, /test, /review, /ship
-|New capability (Context/module/scanner/validator/pipeline): run buy-vs-build-framework Quick tier min BEFORE spec-generator|Skip: bug fixes, doc-only, refactors w/o new capability, already-approved extensions
+|New capability (Context/module/scanner/validator/pipeline): run buy-vs-build-framework Quick tier BEFORE spec-generator|Skip: bug fixes, doc-only, refactors w/o new capability, approved extensions
 
 ### ADR Review (BLOCKING)
 
-Any `ADR-*.md` or `SESSION-PROTOCOL.md` create/edit fires adr-review skill.
+Any `ADR-*.md` or `SESSION-PROTOCOL.md` create/edit fires adr-review.
 
 ## Standards
 
@@ -55,7 +55,7 @@ Commits: `<type>(<scope>): <desc>` + `Co-Authored-By:`
 Exit codes: 0=ok|1=logic|2=config|3=external|4=auth
 Coverage: 100% security|80% business|60% docs
 Tests: `tests/`|`.claude/skills/<name>/tests/`|`.agents/security/benchmarks/`
-Tests (BLOCKING): pos+neg+edge|every branch|mock I/O|CLI argv exits. See `.agents/governance/TESTING-RIGOR.md`.
+Tests (BLOCKING): pos+neg+edge|every branch|mock I/O|CLI argv exits. See `.agents/governance/TESTING-RIGOR.md`
 
 ## Stack
 


### PR DESCRIPTION
## Summary

PR #2174 added a generator-files index line to AGENTS.md, pushing it from 2987 to 3066 bytes, past the 3000-byte per-file workspace budget. `test_repo_workspace_files_within_budget` now fails on main, blocking the "Run Python Tests" check for every open PR that merges main.

This compresses AGENTS.md to 2992 bytes by trimming filler words from the boundary, skill-first, and gate lines. No reference path was removed.

## Validation

- `python3 scripts/validate_workspace_budget.py` passes: AGENTS.md 2992 bytes [OK], total 5954 / 6600.
- `pytest tests/test_validate_workspace_budget.py` 19 passed.
- `build/scripts/validate_install_parity.py` OK (AGENTS.md is blocklisted from parity groups; no mirror regen needed).

Refs #1921
