### PR TITLE
fix(evals): replace prohibited em-dashes in eval test comments

### DIFF
--- a/tests/evals/test_eval_agent_vs_baseline.py
+++ b/tests/evals/test_eval_agent_vs_baseline.py
@@ -1309,7 +1309,7 @@ class TestReportAggregatorRecall:
         assert result.error_count == 1
 
     def test_recall_uses_assertion_count_not_fixture_count(self):
-        # One fixture, two assertions on the same response — recall denom
+        # One fixture, two assertions on the same response, so the recall denom
         # MUST be the assertion count (2), not the fixture count (1).
         record = RunRecord(
             fixture_id="F001",
@@ -2532,7 +2532,7 @@ class TestPerFixtureHaltThreshold:
         assert '"fixtures_with_errors": 1' in captured.err
         assert '"executed_fixtures": 5' in captured.err
         # Per-record values are also logged so operators can correlate; the
-        # per-record fraction here is well below 10% — proving the halt
+        # per-record fraction here is well below 10%, proving the halt
         # fired on the per-fixture rule, not the per-record one.
         assert '"error_count": 1' in captured.err
         assert '"executed_records": 30' in captured.err


### PR DESCRIPTION
## Summary

`tests/evals/test_eval_agent_vs_baseline.py` carried two U+2014 (em-dash) characters in code comments. The file lives under `tests/evals/`, which is not the exempt prefix (`tests/hooks/fixtures/`), so the dashes violate `.claude/rules/universal.md` MUST NOT entry 5 (Refs #1923). Bot reviewers flag every occurrence, costing a thread per dash on every PR that touches the file.

This change replaces both em-dashes with commas. No test logic changes: the diff is two comment lines only (2 insertions, 2 deletions).

## Per-file change

`tests/evals/test_eval_agent_vs_baseline.py`:
- Line 1312 (comment in `test_recall_uses_assertion_count_not_fixture_count`): `same response - recall denom` becomes `same response, so the recall denom`. Em-dash replaced with a comma plus a connective so the sentence still reads.
- Line 2535 (comment in `test_one_error_in_one_of_five_fixtures_halts_per_fixture`): `well below 10% - proving the halt` becomes `well below 10%, proving the halt`. Em-dash replaced with a comma.

## Dash-guard coverage gap (investigation, no guard change)

The task asked whether the dash-guard SHOULD cover `tests/evals/` and whether a real coverage gap let these dashes in. There is a gap, but it is NOT a prefix problem, and I did not change the guard.

Root cause: both enforcement points scan markdown only.
- `.githooks/pre-commit` (lines 336 to 352) iterates `STAGED_MD_FILES`, which is restricted to `*.md`. Python files are never scanned by the dash block.
- `scripts/validation/pre_pr.py:validate_dash_prohibition` calls `_branch_markdown_files`, which filters `if p.endswith(".md")` (line 370). Python files are excluded from the branch-wide scan.

The exempt prefix `tests/hooks/fixtures/` in `_VENDORED_PREFIXES` (pre_pr.py line 331) and in the pre-commit `case` (line 342) is correct and does not need adjustment. `tests/evals/` is not exempted; it simply never reaches the dash check because the check filters on file extension `.md`.

Why I did not fix it here: widening the scan from `*.md` to also cover `*.py` is a multi-line behavior change across two files (`.githooks/pre-commit` and `scripts/validation/pre_pr.py`) plus their test suites. The rule text in `universal.md` MUST NOT entry 5 already binds "code comments" and "any authored text", so the intent covers `.py`, but the enforcement does not. That widening is its own work-item with its own tests, not a one-line prefix correction, so it stays out of scope per the task guardrail. Flagging it here for a follow-up issue.

Fixes #2192

## Testing

- `grep -nP '[\x{2013}\x{2014}]' tests/evals/test_eval_agent_vs_baseline.py` -> exit 1 (zero matches) after the edit. Before the edit it returned 2 lines (1312, 2535).
- `uv run pytest tests/evals/test_eval_agent_vs_baseline.py --collect-only -q` -> 145 tests collected, exit 0. The file still parses and collects.
- `git diff` confirms only two comment lines changed; no assertions, fixtures, or production code touched.