### PR TITLE
fix(hooks): make episode extraction non-destructive in pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1249,9 +1249,12 @@ if [ -n "$STAGED_SESSION_LOG" ]; then
             echo_warning "Skipping episode extraction: script path is a symlink"
         elif [ -f "$EPISODE_EXTRACT_SCRIPT" ]; then
             if set_python_cmd; then
-                # Run episode extraction
+                # Run episode extraction (non-destructive: merge over any existing
+                # episode instead of overwriting it). --preserve read-modify-writes
+                # the existing episode, keeping richer prior data (issue #2193).
+                # --force remains available for an intentional manual overwrite.
                 # Guard against set -e aborting the hook on non-blocking extraction failures
-                EXTRACT_OUTPUT=$("${PYTHON_CMD[@]}" "$EPISODE_EXTRACT_SCRIPT" "$STAGED_SESSION_LOG" --force 2>&1 || true)
+                EXTRACT_OUTPUT=$("${PYTHON_CMD[@]}" "$EPISODE_EXTRACT_SCRIPT" "$STAGED_SESSION_LOG" --preserve 2>&1 || true)
                 EXTRACT_EXIT=$?
 
                 if [ $EXTRACT_EXIT -eq 0 ]; then


### PR DESCRIPTION
## Summary

The pre-commit episode-extraction step invoked `extract_session_episode.py` with `--force`, silently overwriting any existing episode for a session each time a commit touched a session log (issue #2193). PR #2170 already added a non-destructive `--preserve` mode to the extractor (read-modify-write merge that keeps richer prior data and writes a fresh episode when none exists), but the hook still called `--force`. This change switches the hook to `--preserve`, closing the remaining gap.

## Scope note

The original work-item asked to ADD a `--preserve` flag to the extractor script plus tests. That flag already exists on `main`: PR #2170 (commit 6abb3b32b) shipped `--preserve` with merge semantics, made `--force`/`--preserve` mutually exclusive, and added test coverage. Re-implementing it would duplicate and conflict with the merged version, so this change is reduced to the one genuine remaining fix: the pre-commit invocation.

## Per-file change

- `.githooks/pre-commit`: episode-extraction invocation switched from `--force` to `--preserve` (line ~1254). `--force` remains available for an intentional manual overwrite. Added a comment explaining the non-destructive intent and the issue reference.

## Behavior

- New session (no existing episode): `--preserve` writes a fresh episode, exit 0. Common path unchanged.
- Re-commit on an existing session: `--preserve` merges fresh extraction over the existing episode without dropping curated content, exit 0. No more silent clobber.
- Corrupt or unreadable existing episode: `--preserve` exits non-zero; the hook already treats extractor non-zero exits as non-blocking (warning, commit proceeds), and the manual-recovery hint still points to `--force`.

## Overlap with PR #2170

PR #2170 (branch `fix/2036-json-episode-extractor`) is merged to `main` and owns `extract_session_episode.py`, including the `--preserve` implementation this hook relies on. This change does not touch that file, so there is no conflict.

Fixes #2193

## Testing

- `uv run python -m pytest .claude/skills/memory/tests/test_extract_session_episode.py` -> 63 passed (the merged #2170 suite covers exists-merge, force-overwrite, not-exists-write, and `--force`/`--preserve` mutual exclusion).
- Functional CLI check of the merged extractor (the behavior the hook now invokes): `--preserve` with no existing episode wrote a fresh file (exit 0); `--preserve` with an existing episode merged non-destructively (exit 0); `--force --preserve` rejected (exit 2).
- `bash -n .githooks/pre-commit` -> syntax OK.
- `uv run python build/scripts/build_all.py --check` -> exit 0, no generation drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)