### PR TITLE
ci(pytest): add report-only ruff lint step

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -100,6 +100,20 @@ jobs:
           enable-pester: false
           enable-git-hooks: false
 
+      # Issue #2194: ruff is configured in pyproject.toml ([tool.ruff]) but no CI
+      # workflow ran it. The repository has a pre-existing backlog of 2026 ruff
+      # findings (measured 2026-06-01 with ruff>=0.15.14), so this step is
+      # report-only (continue-on-error: true). It annotates the PR diff with
+      # findings via --output-format=github without blocking merges. Flip to a
+      # blocking gate (drop continue-on-error) once the backlog reaches zero.
+      # See pyproject.toml for the lint config; the invocation matches the
+      # baseline command `ruff check .`. ruff is installed via the
+      # setup-code-env action (uv pip install --system -e ".[dev]").
+      - name: Run ruff (report-only)
+        if: steps.should-run.outputs.skip != 'true'
+        continue-on-error: true
+        run: ruff check . --output-format=github
+
       - name: Run pytest
         if: steps.should-run.outputs.skip != 'true'
         run: |

--- a/tests/workflows/test_pytest_ruff_step.py
+++ b/tests/workflows/test_pytest_ruff_step.py
@@ -26,9 +26,27 @@ def _load_workflow() -> dict[str, Any]:
         return yaml.safe_load(handle)
 
 
+def _steps_from_workflow(workflow: Any) -> list[dict[str, Any]]:
+    if not isinstance(workflow, dict):
+        return []
+
+    jobs = workflow.get("jobs") or {}
+    if not isinstance(jobs, dict):
+        return []
+
+    test_job = jobs.get("test") or {}
+    if not isinstance(test_job, dict):
+        return []
+
+    steps = test_job.get("steps") or []
+    if not isinstance(steps, list):
+        return []
+
+    return [step for step in steps if isinstance(step, dict)]
+
+
 def _test_job_steps() -> list[dict[str, Any]]:
-    workflow = _load_workflow()
-    return workflow["jobs"]["test"]["steps"]
+    return _steps_from_workflow(_load_workflow())
 
 
 def _find_ruff_step() -> dict[str, Any] | None:
@@ -37,6 +55,31 @@ def _find_ruff_step() -> dict[str, Any] | None:
         if isinstance(run, str) and "ruff check" in run:
             return step
     return None
+
+
+class TestWorkflowStepExtraction:
+    """Edge: malformed workflow shapes produce no steps instead of errors."""
+
+    def test_missing_or_null_workflow_sections_return_empty_steps(self) -> None:
+        assert _steps_from_workflow(None) == []
+        assert _steps_from_workflow({"jobs": None}) == []
+        assert _steps_from_workflow({"jobs": {"test": None}}) == []
+        assert _steps_from_workflow({"jobs": {"test": {"steps": None}}}) == []
+
+    def test_non_mapping_steps_are_ignored(self) -> None:
+        workflow = {
+            "jobs": {
+                "test": {
+                    "steps": [
+                        "not-a-step",
+                        {"name": "Run ruff", "run": "ruff check . --output-format=github"},
+                    ]
+                }
+            }
+        }
+        assert _steps_from_workflow(workflow) == [
+            {"name": "Run ruff", "run": "ruff check . --output-format=github"}
+        ]
 
 
 class TestRuffStepPresence:

--- a/tests/workflows/test_pytest_ruff_step.py
+++ b/tests/workflows/test_pytest_ruff_step.py
@@ -1,0 +1,93 @@
+"""Contract tests for the report-only ruff step in pytest.yml (Issue #2194).
+
+The repository carries a pre-existing backlog of ruff findings (2026 as of
+2026-06-01), so the CI ruff step is deliberately report-only
+(`continue-on-error: true`) and must not block merges. These tests pin that
+contract so a later edit cannot silently turn the step into a blocking gate, or
+drop the gating/skip condition, without a test failing first.
+
+When the backlog reaches zero and the step is promoted to a blocking gate, the
+report-only assertions here are expected to change in the same PR that drops
+`continue-on-error`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "pytest.yml"
+
+
+def _load_workflow() -> dict[str, Any]:
+    with _WORKFLOW.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _test_job_steps() -> list[dict[str, Any]]:
+    workflow = _load_workflow()
+    return workflow["jobs"]["test"]["steps"]
+
+
+def _find_ruff_step() -> dict[str, Any] | None:
+    for step in _test_job_steps():
+        run = step.get("run")
+        if isinstance(run, str) and "ruff check" in run:
+            return step
+    return None
+
+
+class TestRuffStepPresence:
+    """Positive: the ruff step exists and runs the canonical invocation."""
+
+    def test_workflow_file_exists(self) -> None:
+        assert _WORKFLOW.is_file()
+
+    def test_ruff_step_present_in_test_job(self) -> None:
+        assert _find_ruff_step() is not None
+
+    def test_ruff_step_runs_canonical_invocation(self) -> None:
+        step = _find_ruff_step()
+        assert step is not None
+        # Matches the baseline command `ruff check .`; CI adds GitHub
+        # annotations via --output-format=github.
+        assert step["run"].strip() == "ruff check . --output-format=github"
+
+
+class TestRuffStepIsReportOnly:
+    """Negative: the step must not block merges while the backlog is non-zero."""
+
+    def test_ruff_step_is_continue_on_error(self) -> None:
+        step = _find_ruff_step()
+        assert step is not None
+        assert step.get("continue-on-error") is True
+
+    def test_no_other_test_step_runs_ruff_as_a_gate(self) -> None:
+        """No additional ruff invocation in the test job lacks continue-on-error."""
+        gating = [
+            step
+            for step in _test_job_steps()
+            if isinstance(step.get("run"), str)
+            and "ruff check" in step["run"]
+            and step.get("continue-on-error") is not True
+        ]
+        assert gating == []
+
+
+class TestRuffStepGating:
+    """Edge: the step honors the existing skip gate and carries no injection surface."""
+
+    def test_ruff_step_gated_by_skip_condition(self) -> None:
+        step = _find_ruff_step()
+        assert step is not None
+        # Reuses the same gate every other step in the test job uses so the
+        # ruff step is skipped when no Python files changed.
+        assert step.get("if") == "steps.should-run.outputs.skip != 'true'"
+
+    def test_ruff_step_has_no_untrusted_interpolation(self) -> None:
+        """The run command must not interpolate untrusted GitHub event data."""
+        step = _find_ruff_step()
+        assert step is not None
+        assert "${{" not in step["run"]


### PR DESCRIPTION
## Summary

ruff is configured in `pyproject.toml` (`[tool.ruff]`, `ruff>=0.15.14`) but no CI workflow ran it. This adds a ruff lint step to the Python CI workflow.

Baseline measured first (the deciding factor): `ruff check .` reports **2026 findings** across the repo as of 2026-06-01. Top rules: E501 (504), ANN001 (297), ANN202 (277), UP032 (225), N806 (181), I001 (141), F401 (89), UP006 (80). A blocking gate would fail every PR, so the step is **report-only** (`continue-on-error: true`). It annotates the PR diff with findings via `--output-format=github` and never blocks a merge.

## Per-file change

- `.github/workflows/pytest.yml`: new "Run ruff (report-only)" step in the existing `test` job, placed after `setup-code-env` (which installs `.[dev]` and verifies ruff is on PATH) and before pytest. The step reuses the same `steps.should-run.outputs.skip != 'true'` gate as every other step in the job, so it is skipped when no Python files changed. Command is a single static invocation (`ruff check . --output-format=github`), keeping logic out of YAML (ADR-006) and carrying no untrusted GitHub event interpolation. No new `uses:` references, so no SHA pinning needed.
- `tests/workflows/test_pytest_ruff_step.py`: contract tests that parse `pytest.yml` and pin the report-only design: step present in the test job, runs the canonical `ruff check .` invocation, has `continue-on-error: true`, no second ungated ruff invocation, honors the skip gate, and contains no `${{ }}` interpolation in the run command.

## Remediation plan

The 2026 findings stay visible as PR annotations under report-only mode. Remediate the backlog incrementally (autofixable first: `ruff check . --fix` resolves 630 of them, mostly I001 import sorting and F401 unused imports). When the count reaches zero, promote the step to a blocking gate by dropping `continue-on-error: true`. The contract test `test_ruff_step_is_continue_on_error` is the tripwire that forces that change to be deliberate and reviewed; it is expected to change in the same PR that flips the gate.

Fixes #2194

## Testing

- `uvx ruff check .` (baseline measurement): 2026 findings, exit code 1. Confirmed the exact CI invocation `ruff check . --output-format=github` runs and emits GitHub-format annotations.
- `uvx --with pyyaml --from pytest pytest tests/workflows/test_pytest_ruff_step.py -v`: 7 passed.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pytest.yml'))"`: parses cleanly; ruff step has `continue-on-error: True` and the expected skip gate.
- Dash scan on both changed files: no em or en dashes.