### PR TITLE
docs(governance): register canonical code-quality and code-review-norms sources

### DIFF
--- a/.agents/governance/code-quality.md
+++ b/.agents/governance/code-quality.md
@@ -1,0 +1,244 @@
+# Code Quality
+
+**Status**: Canonical Source for code quality norms
+
+This file is the harness-neutral canonical source for baseline code quality in this
+repository. It sets the standard for any code you write or change, regardless of
+which harness (Claude Code, Copilot, Cortex, Factory Droid) is running. It merges
+the everyday fundamentals from Robert Martin's _Clean Code_ and Steve McConnell's
+_Code Complete_.
+
+Apply these rules on every edit. They override stylistic preferences but defer to
+project conventions in `AGENTS.md`, `.editorconfig`, and `.markdownlint-cli2.yaml`.
+
+The harness-scoped rule at `.claude/rules/code-quality.md` carries the same substance
+for Claude Code agents and adds the worked examples. When the two disagree, this file
+wins on the norm; the rule file wins on Claude-specific mechanics.
+
+## Naming
+
+Names are documentation. A reader who knows nothing about the change should
+understand the code from the names alone.
+
+- Choose intention-revealing names. `daysSinceLastLogin` beats `d` or `delta`.
+- Use pronounceable, searchable names. `customerCount` beats `cc`.
+- Drop abbreviations and Hungarian prefixes. `userList` beats `usrLst`.
+- Use one word per concept across the whole codebase. Pick `fetch`, `get`, or
+  `retrieve` and stay with it.
+- Names track scope. Short names fit short scopes. Long names fit long-lived classes
+  and public APIs.
+- Class names are nouns. Method names are verbs. Boolean methods read as predicates:
+  `isReady`, `hasChildren`, `canCommit`.
+- Avoid disinformation. Do not call something `accountList` if it is a `Set`.
+- Mirror the domain. If the team says "tenant," do not write `customer` in code.
+
+When you find yourself writing a comment to explain a name, rename instead.
+
+## Functions
+
+Functions are the core unit of design. Keep them small, single-purpose, and easy to
+test.
+
+- Functions should do one thing. If you can describe the function as "X and Y," split
+  it.
+- Prefer 20 lines or fewer. The project ceiling is 60. Past that, extract.
+- Aim for cyclomatic complexity of 10 or lower. Past that, extract or use
+  table-driven logic.
+- Limit parameters to three. Prefer two. Zero is best. Bundle related parameters into
+  a parameter object.
+- Avoid flag arguments. A boolean argument means the function does two things. Split
+  it into `renderTextual()` and `renderHtml()`.
+- Output parameters are confusing. Return a value, a tuple, or a small record.
+- One level of abstraction per function. A high-level orchestrator should not parse
+  strings; a parser should not log analytics.
+- Apply the Stepdown Rule. Read top to bottom: each function calls the next level of
+  detail.
+- No side effects beyond the function's name. `validatePassword(user)` should not also
+  log the user in.
+
+If a function is hard to name, it does too much. Split it.
+
+## Guard Clauses Over Deep Nesting
+
+Deep `if`/`else` trees hide intent. Use early returns to flatten control flow. Bail on
+the unhappy path first. Keep the happy path on the leftmost indent level. This pattern
+also localizes preconditions next to the inputs they check.
+
+## Delete Dead Code
+
+Commented-out code rots. Remove it. The version control history is the archive.
+
+- Delete unreachable branches, unused imports, and stale parameters.
+- Delete TODOs that have outlived their context. Open an issue if the work still
+  matters.
+- Delete commented-out blocks. If you are unsure, run a search across the repo first;
+  then delete.
+- Delete unused public APIs once you confirm no internal callers exist. External
+  consumers belong behind a deprecation notice.
+
+A reader trusts the code in front of them. Dead code teaches readers to distrust
+everything they read.
+
+## Code Smell Detection
+
+Treat smells as evidence, not verdicts. They flag places worth a closer look.
+
+- **Long Method**: extract until each method fits one screen.
+- **Large Class**: split by responsibility.
+- **Long Parameter List**: introduce a parameter object or builder.
+- **Duplicate Code**: extract a function or use a shared helper. The Rule of Three:
+  duplicate twice, refactor on the third occurrence.
+- **Feature Envy**: a method that uses another class's data more than its own belongs
+  on that other class.
+- **Data Clumps**: the same group of fields traveling together usually wants to be a
+  type.
+- **Primitive Obsession**: replace `string customerId` with a `CustomerId` type when
+  the value carries rules.
+- **Switch Statements on Type**: replace with polymorphism or a strategy table.
+- **Shotgun Surgery**: one logical change touching many files signals weak cohesion.
+  Consolidate the responsibility.
+- **Comments Explaining What**: rename or extract until the comment becomes redundant.
+  Reserve comments for _why_.
+
+When you smell something, name it explicitly in the PR description so reviewers can see
+your reasoning.
+
+## SOLID
+
+SOLID protects code from change-driven decay. Apply at the unit boundary.
+
+- **Single Responsibility**: a class has one reason to change.
+- **Open/Closed**: open to extension, closed to modification.
+- **Liskov Substitution**: subtypes must be usable wherever the parent is used. Prefer
+  composition.
+- **Interface Segregation**: clients should not depend on methods they do not use.
+- **Dependency Inversion**: depend on abstractions, not concretes.
+
+Apply SOLID where change is likely. Premature abstraction is its own smell.
+
+## Test Readability
+
+Tests are first-class code. They document behavior. Treat them with the same care.
+
+- Use the Arrange/Act/Assert structure. One blank line between sections.
+- One behavior per test. A failing test should localize the bug.
+- Names describe the behavior, not the method. `creditsAccountWhenBalanceIsPositive`
+  beats `testCredit1`.
+- Prefer Given/When/Then phrasing for integration tests.
+- Build inputs with named factories or builders.
+- Assert on outcomes, not internals.
+- Keep test data minimal. Each value in the setup should matter to the assertion.
+- Tests should fail for one reason.
+
+If you cannot write a test, the design is wrong. Fix the design first.
+
+## Defensive Programming
+
+Assume bad input can reach your function. Decide where to catch it, then catch it once.
+
+- Validate inputs at the boundary. Internal functions trust their callers; public APIs
+  do not.
+- Use assertions for conditions that should be impossible. Use exceptions for
+  conditions that are merely invalid.
+- Fail fast. A function with a contract violation should raise on the first detection,
+  not log and continue.
+- Check pre-conditions, then post-conditions. Document both in the function header.
+- Treat all external data as hostile until validated: HTTP request bodies, environment
+  variables, file contents, database rows from older schemas.
+- Never trust user-supplied identifiers as authorization. Re-check ownership inside the
+  function.
+- Choose one error-handling strategy per layer: exceptions, result types, or sentinel
+  values. Mixing them inside one layer creates ambiguity.
+- Log enough context to reconstruct the failure: input identifiers, user, request id.
+  Never log secrets, tokens, or full PII.
+
+Defensive code should not become paranoid code. If two callers already validated the
+input, a third check is noise.
+
+## Table-Driven Logic
+
+When branching grows past three or four cases, replace conditional code with a table.
+
+- Map known inputs to outputs in a dictionary or array.
+- Add a default case for unknown inputs. Decide explicitly: raise, log, or fall back.
+- Tables make changes localized. Adding a new case is a one-line edit, not a new
+  branch.
+- Tables make tests parametrize cleanly. Each row becomes one test case.
+
+Use table-driven logic for command dispatch, status transitions, validation rules, and
+feature flags. Avoid it when the cases differ in structure, not just data; polymorphism
+fits better there.
+
+## Variable Scope and Lifetime
+
+Minimize the distance between a variable's declaration and its last use.
+
+- Declare variables at the smallest scope that satisfies their use.
+- Initialize at the point of declaration. Avoid declared-then-assigned-later patterns.
+- Prefer immutability. Reassignment is a smell unless the loop variable is the point.
+- Reduce live variables.
+- Avoid global mutable state. Where you cannot, document the invariants and guard the
+  writers.
+- Pull constants out of methods only when they are reused.
+
+A short scope is easier to reason about. A short scope makes refactoring safe.
+
+## Comments
+
+Code explains _what_. Comments explain _why_.
+
+- Write comments when the rationale would surprise a peer reader: a hidden invariant, a
+  workaround for a vendor bug, a non-obvious performance choice.
+- Do not narrate the code.
+- Do not date-stamp or sign comments. Git already records that.
+- Reference issues and ADRs when the rationale lives elsewhere.
+- Update or delete comments when the code under them changes. A wrong comment is worse
+  than no comment.
+
+If you must comment to explain a function, the function probably wants a better name or
+a smaller body.
+
+## Error Handling
+
+Errors are part of the contract. Handle them with the same care as the happy path.
+
+- Define what each function does on failure: returns, raises, or both.
+- Do not swallow exceptions. If you catch one, you have a reason; record the reason in
+  code or in a log.
+- Wrap low-level errors with domain-meaningful types at the boundary so callers do not
+  depend on infrastructure details.
+- Use `try`/`finally` (or its language equivalent) for resource cleanup. Prefer
+  language constructs (`with`, `using`, `defer`) when available.
+- Never use exceptions for normal control flow. They are slow and hide intent.
+- Re-raise to preserve the stack. A new exception with no cause loses the trail.
+
+A function that fails predictably is easier to operate than one that succeeds
+unpredictably.
+
+## Quick Self-Review
+
+Before you mark work complete, walk this list:
+
+- [ ] Names tell the reader what the code does without comments.
+- [ ] Each function does one thing. Cyclomatic complexity is 10 or lower. Length is 60
+      lines or fewer.
+- [ ] No commented-out code. No dead branches.
+- [ ] Guard clauses are at the top. The happy path is on the leftmost column.
+- [ ] Inputs are validated at the boundary, not at every layer.
+- [ ] Long branching uses tables when shapes match; polymorphism when they do not.
+- [ ] Tests describe behavior, follow Arrange/Act/Assert, and would catch a regression.
+- [ ] Variables live in the narrowest scope that satisfies their use.
+- [ ] Comments explain _why_; the code explains _what_.
+- [ ] Errors are typed, traced, and logged without secrets.
+- [ ] Mandatory security patterns (CWE-22 path traversal, CWE-78 command injection,
+      authentication and authorization boundaries, secret handling) are checked.
+
+If you cannot check a box, fix it before requesting review. The cost of a fix grows
+after the merge.
+
+## References
+
+- `.claude/rules/code-quality.md`. Claude Code harness-scoped version with worked
+  examples.
+- `AGENTS.md`. Boundaries and standards.
+- `.agents/governance/code-review-norms.md`. How reviewers apply these standards.

--- a/.agents/governance/code-review-norms.md
+++ b/.agents/governance/code-review-norms.md
@@ -1,0 +1,50 @@
+# Code Review Norms
+
+**Status**: Canonical Source for code review culture
+
+This file is the single canonical source for the code review norms in this repository.
+It is harness-neutral. Templates, skills, and agent prompts that need to cite review
+culture link here; they do not restate the content.
+
+These norms were inlined in `.github/PULL_REQUEST_TEMPLATE.md`'s `Notes for Reviewers`
+block until they were extracted here so there is one authority instead of a copy that
+drifts. The PR template now links to this file and keeps a render-safe summary that
+points back here for authority.
+
+## Norms
+
+- **Assume competence and goodwill.** A "bad" PR usually means one party has
+  information the other does not.
+- **Explain _why_, not just _what_.** "This is wrong because..." beats "this is wrong."
+- **Approve once the change improves overall code health.** Perfect is not the bar.
+- **Target reply within ~1 business day.** If you cannot, leave a comment saying when
+  you can.
+- **Prefer "Approve with suggestions"** for minor issues, especially across timezones.
+- **Authors: address every comment** by adopting, deferring (with a tracking issue), or
+  pushing back with reasoning. Silence is not resolution.
+
+## Comment Severity Prefixes
+
+Authors triage by prefix. Reviewers prefix every comment so the author knows whether it
+blocks merge.
+
+| Prefix | Meaning |
+|---|---|
+| `Nit:` | Minor / style; do not block on it |
+| `Optional:` | Worth considering; author may defer |
+| `FYI:` | Future thought; no action needed |
+| _(no prefix)_ | Must address before merge |
+
+## Relationship to Other Sources
+
+- The quality standards reviewers apply live in `.agents/governance/code-quality.md`.
+- The review priorities ordering (security, correctness, exit codes, test coverage,
+  style) lives in `.gemini/styleguide.md` under "Code Review Priorities."
+- Security review is always-on and cannot be skipped; see
+  `.agents/governance/SECURITY-REVIEW-PROTOCOL.md`.
+
+## References
+
+- `.github/PULL_REQUEST_TEMPLATE.md`. Renders a summary of these norms and links here.
+- `.agents/governance/code-quality.md`. The standards reviewers enforce.
+- `.gemini/styleguide.md`. Routing index and review priorities.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -8,6 +8,8 @@
 
 | Topic | Source |
 |-------|--------|
+| Code quality | [`.agents/governance/code-quality.md`](../.agents/governance/code-quality.md) (canonical) |
+| Code review norms | [`.agents/governance/code-review-norms.md`](../.agents/governance/code-review-norms.md) (canonical) |
 | PowerShell standards | [`scripts/AGENTS.md`](../scripts/AGENTS.md) (canonical) |
 | Exit codes | [`ADR-035`](../.agents/architecture/ADR-035-exit-code-standardization.md) in `.agents/architecture/` |
 | Output schemas | [`ADR-028`](../.agents/architecture/ADR-028-powershell-output-schema-consistency.md) in `.agents/architecture/` |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,14 @@
 Code review norms for this repo: assume competence and goodwill on both sides.
 Authors: provide context, satisfy preconditions, state expectations.
 Reviewers: explain *why*, reply within ~1 business day, prefer "approve with
-suggestions" for minor issues. The "Notes for Reviewers" section near the
-bottom of this template renders the full norms; see also
+suggestions" for minor issues. Canonical norms:
+[.agents/governance/code-review-norms.md](https://github.com/rjmurillo/ai-agents/blob/main/.agents/governance/code-review-norms.md).
+Canonical code quality standards:
+[.agents/governance/code-quality.md](https://github.com/rjmurillo/ai-agents/blob/main/.agents/governance/code-quality.md).
+Both are registered in
 [.gemini/styleguide.md](https://github.com/rjmurillo/ai-agents/blob/main/.gemini/styleguide.md).
+The "Notes for Reviewers" section near the bottom renders a summary that links
+back to the canonical file for authority.
 -->
 
 ## Summary
@@ -132,7 +137,7 @@ substance, not on catching what tooling already catches.
 - [ ] Builds locally (or N/A)
 - [ ] Pre-PR validation passed (`python3 scripts/validation/pre_pr.py`; pass `--quick` to skip slow validations or `--skip-tests` for very fast iterations)
 - [ ] Lint and formatting clean (scoped to changed files)
-- [ ] Code follows project style guidelines ([.gemini/styleguide.md](https://github.com/rjmurillo/ai-agents/blob/main/.gemini/styleguide.md))
+- [ ] Code follows project style guidelines ([.gemini/styleguide.md](https://github.com/rjmurillo/ai-agents/blob/main/.gemini/styleguide.md)) and code quality standards ([.agents/governance/code-quality.md](https://github.com/rjmurillo/ai-agents/blob/main/.agents/governance/code-quality.md))
 - [ ] Self-review completed (read the diff as if you did not write it)
 - [ ] Comments added only where the *why* is non-obvious
 - [ ] Documentation updated (if applicable)
@@ -142,6 +147,8 @@ substance, not on catching what tooling already catches.
 
 <details>
 <summary>Review norms (expand)</summary>
+
+Canonical source: [.agents/governance/code-review-norms.md](https://github.com/rjmurillo/ai-agents/blob/main/.agents/governance/code-review-norms.md). The summary below is for convenience; the canonical file is authoritative.
 
 - **Assume competence and goodwill.** A "bad" PR usually means one party has information the other does not.
 - **Explain *why*, not just *what*.** "This is wrong because..." beats "this is wrong."

--- a/tests/test_canonical_sources_registration.py
+++ b/tests/test_canonical_sources_registration.py
@@ -1,0 +1,148 @@
+"""Regression tests for code-quality and code-review-norms canonical sources.
+
+Issue #1863 registered two harness-neutral canonical sources:
+
+- ``.agents/governance/code-quality.md``
+- ``.agents/governance/code-review-norms.md``
+
+Both are listed in the ``.gemini/styleguide.md`` Canonical Sources table and
+referenced from ``.github/PULL_REQUEST_TEMPLATE.md``. These tests pin that
+contract so a future edit cannot silently drop a canonical file, point the
+routing table at a path that does not exist, or move the canonical files under a
+harness-scoped tree (``.claude/``, ``.github/instructions/``).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+CODE_QUALITY = REPO_ROOT / ".agents/governance/code-quality.md"
+CODE_REVIEW_NORMS = REPO_ROOT / ".agents/governance/code-review-norms.md"
+STYLEGUIDE = REPO_ROOT / ".gemini/styleguide.md"
+PR_TEMPLATE = REPO_ROOT / ".github/PULL_REQUEST_TEMPLATE.md"
+
+# Relative-from-.gemini paths exactly as they appear in the styleguide table.
+STYLEGUIDE_ROWS = (
+    ("Code quality", "../.agents/governance/code-quality.md"),
+    ("Code review norms", "../.agents/governance/code-review-norms.md"),
+)
+
+# Repo-root-relative paths exactly as they appear in PR template links.
+PR_TEMPLATE_REFS = (
+    ".agents/governance/code-quality.md",
+    ".agents/governance/code-review-norms.md",
+)
+
+# Harness-scoped prefixes that disqualify a canonical source per the issue
+# Acceptance: each row "points to a file that is harness-neutral".
+HARNESS_SCOPED_PREFIXES = (".claude/", ".github/instructions/")
+
+
+def test_code_quality_canonical_file_exists() -> None:
+    """The harness-neutral code-quality canonical source exists and is non-empty."""
+    assert CODE_QUALITY.exists(), f"Missing canonical source at {CODE_QUALITY}"
+    assert CODE_QUALITY.read_text(encoding="utf-8").strip(), "code-quality.md is empty"
+
+
+def test_code_review_norms_canonical_file_exists() -> None:
+    """The harness-neutral code-review-norms canonical source exists and is non-empty."""
+    assert CODE_REVIEW_NORMS.exists(), f"Missing canonical source at {CODE_REVIEW_NORMS}"
+    assert CODE_REVIEW_NORMS.read_text(encoding="utf-8").strip(), (
+        "code-review-norms.md is empty"
+    )
+
+
+@pytest.mark.parametrize("path", (CODE_QUALITY, CODE_REVIEW_NORMS))
+def test_canonical_sources_are_harness_neutral(path: Path) -> None:
+    """Canonical files live outside harness-scoped trees.
+
+    A canonical source under ``.claude/`` or ``.github/instructions/`` is only
+    loaded by one harness and reintroduces the drift the issue closed.
+    """
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    for bad in HARNESS_SCOPED_PREFIXES:
+        assert not rel.startswith(bad), (
+            f"{rel} is harness-scoped ({bad}). Canonical sources must be neutral."
+        )
+
+
+@pytest.mark.parametrize(("topic", "rel_path"), STYLEGUIDE_ROWS)
+def test_styleguide_table_row_points_to_existing_file(topic: str, rel_path: str) -> None:
+    """Each new Canonical Sources row exists in the table and resolves to a real file."""
+    styleguide_text = STYLEGUIDE.read_text(encoding="utf-8")
+    assert f"]({rel_path})" in styleguide_text, (
+        f"styleguide.md has no Canonical Sources row linking {rel_path} for '{topic}'."
+    )
+    # Resolve the relative-from-.gemini link to a real path on disk.
+    resolved = (STYLEGUIDE.parent / rel_path).resolve()
+    assert resolved.exists(), (
+        f"styleguide.md row for '{topic}' points at {rel_path}, which does not resolve "
+        f"to an existing file ({resolved})."
+    )
+
+
+def test_styleguide_rows_are_in_canonical_sources_table() -> None:
+    """The new rows sit inside the Canonical Sources table, not elsewhere in the doc.
+
+    Edge case: a link could appear in prose far from the table and still satisfy a
+    naive substring check. Anchor the rows to the table region between the
+    'Canonical Sources' heading and the next top-level section.
+    """
+    text = STYLEGUIDE.read_text(encoding="utf-8")
+    start = text.find("## Canonical Sources")
+    assert start != -1, "styleguide.md lost its '## Canonical Sources' heading."
+    end = text.find("\n## ", start + 1)
+    table_region = text[start:] if end == -1 else text[start:end]
+    for topic, rel_path in STYLEGUIDE_ROWS:
+        assert f"| {topic} |" in table_region, (
+            f"Row '{topic}' is not inside the Canonical Sources table."
+        )
+        assert rel_path in table_region, (
+            f"Link {rel_path} is not inside the Canonical Sources table."
+        )
+
+
+@pytest.mark.parametrize("ref", PR_TEMPLATE_REFS)
+def test_pr_template_references_canonical_paths(ref: str) -> None:
+    """The PR template links the canonical governance paths, not just the routing index."""
+    template_text = PR_TEMPLATE.read_text(encoding="utf-8")
+    assert ref in template_text, (
+        f"PULL_REQUEST_TEMPLATE.md must reference {ref}. Acceptance requires the "
+        "template to point at the canonical paths."
+    )
+
+
+def test_pr_template_norms_summary_defers_to_canonical() -> None:
+    """The template's inlined norms summary names the canonical file as authoritative.
+
+    The norms live in exactly one canonical file. The template keeps a render-safe
+    summary, so it must explicitly defer authority to the canonical source to avoid
+    becoming a second source of truth.
+    """
+    template_text = PR_TEMPLATE.read_text(encoding="utf-8")
+    review_norms_link = ".agents/governance/code-review-norms.md"
+    # The summary block must cite the canonical file as the source of truth.
+    assert re.search(
+        r"[Cc]anonical source:.*code-review-norms\.md", template_text
+    ), (
+        "The Review norms summary must name code-review-norms.md as the canonical "
+        "source so the template is a mirror, not a competing authority."
+    )
+    assert review_norms_link in template_text
+
+
+def test_canonical_files_cross_reference_each_other() -> None:
+    """The two canonical files link to each other so a reader can navigate the pair."""
+    quality_text = CODE_QUALITY.read_text(encoding="utf-8")
+    norms_text = CODE_REVIEW_NORMS.read_text(encoding="utf-8")
+    assert "code-review-norms.md" in quality_text, (
+        "code-quality.md should reference code-review-norms.md."
+    )
+    assert "code-quality.md" in norms_text, (
+        "code-review-norms.md should reference code-quality.md."
+    )

--- a/tests/test_canonical_sources_registration.py
+++ b/tests/test_canonical_sources_registration.py
@@ -128,7 +128,9 @@ def test_pr_template_norms_summary_defers_to_canonical() -> None:
     review_norms_link = ".agents/governance/code-review-norms.md"
     # The summary block must cite the canonical file as the source of truth.
     assert re.search(
-        r"[Cc]anonical source:.*code-review-norms\.md", template_text
+        rf"canonical source:.*(?<![\w/]){re.escape(review_norms_link)}(?!\w)",
+        template_text,
+        re.IGNORECASE,
     ), (
         "The Review norms summary must name code-review-norms.md as the canonical "
         "source so the template is a mirror, not a competing authority."


### PR DESCRIPTION
## Summary

### What

Registers two harness-neutral canonical sources so future templates, skills, and agents that cite code quality or code review norms have one authoritative destination instead of parallel harness-scoped copies that drift.

### Why

Issue #1863 asks for canonical source registration. This PR implements the registration and template-wiring portion while leaving the broader audit out of scope.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #1863 | Register canonical sources |

## Changes

- Added `.agents/governance/code-quality.md` as the canonical baseline for code quality.
- Added `.agents/governance/code-review-norms.md` as the canonical baseline for review culture and severity prefixes.
- Updated `.gemini/styleguide.md` to register both canonical source rows.
- Updated `.github/PULL_REQUEST_TEMPLATE.md` to link the canonical sources and make its review norms summary a mirror.
- Added `tests/test_canonical_sources_registration.py` to pin the registration contract and path-resolution behavior.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted governance documentation review, standard scrutiny, no rush

**Focus areas**: canonical source registration and PR template source-of-truth wording

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Validation run:

- venv python pytest for tests/test_canonical_sources_registration.py -> 11 passed.
- venv python pytest for tests/evals/test_no_unicode_dashes.py and tests/test_canonical_sources_registration.py -> 20 passed.
- npx markdownlint-cli2 for .github/PULL_REQUEST_TEMPLATE.md -> 0 errors.
- Manual check for U+2014 and U+2013 across all five changed files: none found.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR
- [ ] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [ ] Security patterns applied

**Files requiring security review:** none

### Review Agents Consulted

- [x] No AI agent review needed
- [ ] Security agent
- [ ] Architecture agent
- [ ] QA agent
- [ ] Other: 

## Author Pre-flight Checklist

- [x] PR scope is focused and reviewable
- [x] Code follows project style guidelines ([.gemini/styleguide.md](https://github.com/rjmurillo/ai-agents/blob/main/.gemini/styleguide.md)) and code quality standards ([.agents/governance/code-quality.md](https://github.com/rjmurillo/ai-agents/blob/main/.agents/governance/code-quality.md))
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the why is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Refs #1863
