### PR TITLE
feat(validation): pre-PR spec-vs-code contradiction detector (#1920)

### DIFF
--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -779,15 +779,17 @@ def validate_spec_contradiction(repo_root: Path) -> bool:
         print("[WARNING] spec_contradiction.py not found (skipping)")
         return True
 
-    exit_code, stdout, stderr = _run_subprocess(
-        [
-            sys.executable,
-            str(script),
-            "--repo-root",
-            str(repo_root),
-            "--advisory",
-        ]
-    )
+    base_ref = _resolve_branch_base_ref(repo_root)
+    cmd = [
+        sys.executable,
+        str(script),
+        "--repo-root",
+        str(repo_root),
+        "--advisory",
+    ]
+    if base_ref:
+        cmd.extend(["--base", base_ref])
+    exit_code, stdout, stderr = _run_subprocess(cmd)
     if stdout.strip():
         print(stdout.strip())
     if stderr.strip():

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -12,6 +12,7 @@ Validation sequence:
     5. Design Review Frontmatter (validate DESIGN-REVIEW YAML frontmatter)
     6. Build Command Exit Gates (PR #1887 retrospective Layer 2)
     7. Canonical Citation Check (heuristic mirror-claim citation; soft warn)
+    7b. Spec Contradiction Check (PR/issue vs committed frontmatter; advisory)
     8. YAML Style (check YAML style with yamllint) [skip if --quick]
     9. Path Normalization (check for absolute paths) [skip if --quick, requires PS1]
    10. Planning Artifacts (validate planning consistency) [skip if --quick, requires PS1]
@@ -760,6 +761,43 @@ def validate_canonical_citations(repo_root: Path) -> bool:
     return exit_code == 0
 
 
+def validate_spec_contradiction(repo_root: Path) -> bool:
+    """Advisory check for PR-description vs linked-issue vs code contradictions.
+
+    Wraps ``scripts/validation/spec_contradiction.py`` in ``--advisory`` mode,
+    so a heuristic false positive never blocks the local pre-PR cycle. The
+    script catches the PR #1897 round-7 loop locally (Issue #1894 claimed
+    ``model_tier: sonnet`` while the committed agent frontmatter shipped
+    ``model: opus``), which CI's "Validate Spec Coverage" gate surfaced only
+    after each push. Always returns True; the WARN output is the signal.
+
+    See Issue #1920 and the retrospective at
+    ``.agents/retrospective/2026-05-08-pr-1897-confident-incorrectness-recurrence.md``.
+    """
+    script = repo_root / "scripts" / "validation" / "spec_contradiction.py"
+    if not script.exists():
+        print("[WARNING] spec_contradiction.py not found (skipping)")
+        return True
+
+    exit_code, stdout, stderr = _run_subprocess(
+        [
+            sys.executable,
+            str(script),
+            "--repo-root",
+            str(repo_root),
+            "--advisory",
+        ]
+    )
+    if stdout.strip():
+        print(stdout.strip())
+    if stderr.strip():
+        print(stderr.strip(), file=sys.stderr)
+    # Advisory: the wrapped script already exits 0 under --advisory, so any
+    # non-zero exit here is a config error (e.g. could not resolve repo). Do
+    # not block the pre-PR cycle on it; surface the output and pass.
+    return True
+
+
 def validate_agent_drift(repo_root: Path) -> bool:
     """Detect agent semantic drift.
 
@@ -1172,6 +1210,15 @@ def main(argv: list[str] | None = None) -> int:
         "Em/en-dash Prohibition",
         state,
         lambda: validate_dash_prohibition(repo_root),
+    )
+
+    # 3.87 Spec Contradiction Check (advisory; Issue #1920). Catches the
+    # PR #1897 round-7 loop (linked issue claims one model tier, committed
+    # agent frontmatter ships another) locally instead of after each push.
+    run_validation(
+        "Spec Contradiction Check",
+        state,
+        lambda: validate_spec_contradiction(repo_root),
     )
 
     # 3.9 YAML Style (skip if quick)

--- a/scripts/validation/spec_contradiction.py
+++ b/scripts/validation/spec_contradiction.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Flag contradictions between a PR description, its linked issues, and code.
+
+The "Validate Spec Coverage" CI check reads the PR description, the linked
+issue text, and the implementation as a single spec, then fails on
+contradiction. PR #1897 round-7 hit that gate: Issue #1894 still claimed
+``model_tier: sonnet`` for the implementer while the committed agent
+frontmatter shipped ``model: opus`` (user override). Three rounds of
+code-only fixes did not move the gate; one PR-description update closed it.
+CI surfaced the failure roughly 90 seconds after each push. This check
+catches the same contradiction locally in seconds.
+
+The check fetches the current branch's PR body via the gh CLI, extracts the
+linked-issue references (``Closes/Fixes/Resolves/Implements #N``), fetches
+each linked issue body, then compares two classes of load-bearing claim
+against the committed agent frontmatter:
+
+  1. Model tier: a spec text saying ``model: sonnet`` (or ``model_tier:
+     sonnet``) contradicts a committed agent file whose frontmatter declares
+     ``model: opus``.
+  2. Numeric threshold: a spec text saying ``model: 3`` style key-value pair
+     contradicts the same committed key with a different value.
+
+The comparison target is the committed frontmatter, parsed from the agent
+markdown files changed on the branch. The agent frontmatter ``model:`` field
+is documented in ADR-002 (agent model selection); valid tiers are
+``opus``, ``sonnet``, and ``haiku``.
+
+Detection is heuristic. This is a shift-left tool, not a substitute for the
+CI gate. False positives are tolerable (the author reads the WARN and moves
+on); a false negative reintroduces the round-7 loop.
+
+EXIT CODES (ADR-035):
+  0 - Success (no contradictions found, OR --advisory downgraded a finding,
+      OR no PR / no gh / no linked issues so nothing to compare)
+  1 - Logic error: one or more contradictions found (only when NOT --advisory)
+  2 - Config error (could not resolve repo owner/name)
+
+Stricter/looser/different than canonical:
+  This check does NOT mirror a single canonical regex. The model-tier token
+  set ``{opus, sonnet, haiku}`` is taken from the agent frontmatter contract
+  documented in ADR-002, not copied from another validator. The numeric
+  threshold comparison is novel to this check. The only shared contract is
+  the ADR-035 exit-code table (0 ok, 1 logic, 2 config), quoted above
+  verbatim from ``.agents/architecture/ADR-035-exit-code-standardization.md``.
+  This check is LOOSER than the "Validate Spec Coverage" CI gate: it inspects
+  only the model-tier and numeric-threshold axes, where that gate reads the
+  whole spec. It is also advisory when invoked from ``pre_pr.py`` (the
+  ``--advisory`` flag downgrades exit 1 to 0) so a heuristic false positive
+  never blocks the local pre-PR cycle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.github_core.api import RepoInfo  # noqa: E402
+
+# Valid model tiers per ADR-002 (agent model selection). A spec text that
+# names one tier while the committed agent frontmatter names another is the
+# canonical PR #1897 round-7 contradiction.
+MODEL_TIERS: frozenset[str] = frozenset({"opus", "sonnet", "haiku"})
+
+# Issue-linking keywords. GitHub closes an issue on merge for the first three;
+# "Implements" and "Spec" are project conventions that still point at a spec
+# issue. Case-insensitive, followed by an optional colon and a `#<number>`.
+_ISSUE_LINK_RE: re.Pattern[str] = re.compile(
+    r"\b(?:closes|fixes|resolves|implements|refs?|spec)\b\s*:?\s*#(\d+)",
+    re.IGNORECASE,
+)
+
+# Model-tier claim in spec text. Matches `model: sonnet`, `model_tier: opus`,
+# `model-tier = haiku`, with optional surrounding backticks or quotes. The
+# captured tier is normalized to lowercase by the caller.
+_MODEL_CLAIM_RE: re.Pattern[str] = re.compile(
+    r"\bmodel(?:[_-]?tier)?\b\s*[:=]\s*[`'\"]?(opus|sonnet|haiku)[`'\"]?",
+    re.IGNORECASE,
+)
+
+# Numeric `key: N` claim in spec text. The key is a simple identifier; the
+# value is an integer. Used to flag a spec threshold that disagrees with the
+# committed frontmatter value of the same key.
+_NUMERIC_CLAIM_RE: re.Pattern[str] = re.compile(
+    r"\b([a-z][a-z0-9_]{2,})\b\s*[:=]\s*(\d+)\b",
+    re.IGNORECASE,
+)
+
+# Numeric keys worth comparing. A blanket numeric compare would flag prose
+# like "version 2" against unrelated frontmatter; restrict to keys that carry
+# a threshold meaning in this codebase.
+_NUMERIC_KEYS: frozenset[str] = frozenset(
+    {"priority", "timeout", "max_retries", "threshold", "version", "complexity"}
+)
+
+
+@dataclass(frozen=True)
+class Contradiction:
+    """One detected mismatch between a spec claim and committed code.
+
+    `axis` is "model-tier" or "numeric"; `claimed` is the value found in the
+    PR or issue text; `committed` is the value found in the agent frontmatter;
+    `source` names where the claim came from (e.g. "issue #1894").
+    """
+
+    axis: str
+    key: str
+    claimed: str
+    committed: str
+    file: str
+    source: str
+
+
+def get_repo_info() -> RepoInfo:
+    """Parse owner/repo from the git remote origin URL.
+
+    Raises RuntimeError on failure so the caller can map it to exit code 2.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        raise RuntimeError("Could not determine git remote origin") from exc
+
+    if result.returncode != 0:
+        raise RuntimeError("Could not determine git remote origin")
+
+    remote_url = result.stdout.strip()
+    match = re.search(r"github\.com[:/]([^/]+)/([^/.]+)", remote_url)
+    if not match:
+        raise RuntimeError(
+            f"Could not parse GitHub owner/repo from remote URL: {remote_url}"
+        )
+    return RepoInfo(owner=match.group(1), repo=match.group(2))
+
+
+def fetch_current_pr_body(owner: str, repo: str) -> str | None:
+    """Return the open PR body for the current branch, or None.
+
+    Returns None (never raises) when gh is absent, no PR exists for the
+    current branch, or gh fails. A missing PR is the common pre-PR case and
+    must not crash the local cycle.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh", "pr", "view",
+                "--json", "body",
+                "-q", ".body",
+                "--repo", f"{owner}/{repo}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    body = result.stdout.strip()
+    return body or None
+
+
+def fetch_issue_body(issue_number: int, owner: str, repo: str) -> str | None:
+    """Return the body of a linked issue, or None on any failure."""
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "view", str(issue_number),
+                "--json", "body",
+                "-q", ".body",
+                "--repo", f"{owner}/{repo}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    body = result.stdout.strip()
+    return body or None
+
+
+def extract_linked_issues(pr_body: str) -> list[int]:
+    """Return unique linked issue numbers from a PR body, in first-seen order."""
+    seen: set[int] = set()
+    ordered: list[int] = []
+    for match in _ISSUE_LINK_RE.finditer(pr_body or ""):
+        number = int(match.group(1))
+        if number not in seen:
+            seen.add(number)
+            ordered.append(number)
+    return ordered
+
+
+def extract_model_claims(text: str) -> set[str]:
+    """Return the set of model tiers (lowercase) claimed in spec text."""
+    return {m.group(1).lower() for m in _MODEL_CLAIM_RE.finditer(text or "")}
+
+
+def extract_numeric_claims(text: str) -> dict[str, set[int]]:
+    """Return numeric `key -> {values}` claims for the comparison key set."""
+    claims: dict[str, set[int]] = {}
+    for match in _NUMERIC_CLAIM_RE.finditer(text or ""):
+        key = match.group(1).lower()
+        if key not in _NUMERIC_KEYS:
+            continue
+        claims.setdefault(key, set()).add(int(match.group(2)))
+    return claims
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    """Parse a flat YAML frontmatter block into a string-keyed dict.
+
+    Minimal parser: only the top-level ``key: value`` pairs in the leading
+    ``---`` fenced block. Nested mappings (e.g. ``metadata:``) are skipped.
+    Mirrors the lightweight approach used by
+    ``scripts/validation/pre_pr.py:_parse_yaml_frontmatter`` (top-level keys
+    only, no external YAML dependency); this copy stops at the first nested
+    block and does not coerce booleans or integers because the comparison
+    here is string-based.
+    """
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    block = text[4:end]
+    result: dict[str, str] = {}
+    for line in block.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        # Skip nested entries (indented) and block openers (`key:` with no value).
+        if line[0] in (" ", "\t"):
+            continue
+        colon = line.find(":")
+        if colon == -1:
+            continue
+        key = line[:colon].strip()
+        value = line[colon + 1 :].strip()
+        if not value:
+            continue
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        result[key] = value
+    return result
+
+
+def find_contradictions(
+    spec_text: str,
+    source_label: str,
+    frontmatter_files: dict[str, str],
+) -> list[Contradiction]:
+    """Compare spec claims against committed frontmatter; return mismatches.
+
+    Args:
+        spec_text: combined PR body + linked issue text (one source).
+        source_label: human label for `spec_text` (e.g. "issue #1894").
+        frontmatter_files: relpath -> committed file text (agent markdown).
+    """
+    contradictions: list[Contradiction] = []
+    claimed_tiers = extract_model_claims(spec_text)
+    claimed_numeric = extract_numeric_claims(spec_text)
+
+    for relpath, file_text in frontmatter_files.items():
+        front = parse_frontmatter(file_text)
+
+        committed_model = front.get("model", "").lower()
+        if committed_model in MODEL_TIERS and claimed_tiers:
+            for tier in sorted(claimed_tiers):
+                if tier != committed_model:
+                    contradictions.append(
+                        Contradiction(
+                            axis="model-tier",
+                            key="model",
+                            claimed=tier,
+                            committed=committed_model,
+                            file=relpath,
+                            source=source_label,
+                        )
+                    )
+
+        for key, values in claimed_numeric.items():
+            committed_raw = front.get(key, "")
+            if not committed_raw.isdigit():
+                continue
+            committed_value = int(committed_raw)
+            for claimed_value in sorted(values):
+                if claimed_value != committed_value:
+                    contradictions.append(
+                        Contradiction(
+                            axis="numeric",
+                            key=key,
+                            claimed=str(claimed_value),
+                            committed=str(committed_value),
+                            file=relpath,
+                            source=source_label,
+                        )
+                    )
+
+    return contradictions
+
+
+def _changed_agent_files(repo_root: Path, base_ref: str) -> dict[str, str]:
+    """Return committed markdown files changed on the branch with frontmatter.
+
+    Reads each path from the HEAD blob (``git show HEAD:<path>``) rather than
+    the working tree so the scan matches the committed state the CI gate sees.
+    Restricted to files that begin with a ``---`` frontmatter fence.
+    """
+    diff = subprocess.run(
+        [
+            "git", "-C", str(repo_root), "diff",
+            "--name-only", "--diff-filter=ACMR", f"{base_ref}...HEAD",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if diff.returncode != 0:
+        return {}
+    files: dict[str, str] = {}
+    for relpath in diff.stdout.splitlines():
+        if not relpath.endswith(".md"):
+            continue
+        show = subprocess.run(
+            ["git", "-C", str(repo_root), "show", f"HEAD:{relpath}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if show.returncode != 0:
+            continue
+        if show.stdout.startswith("---"):
+            files[relpath] = show.stdout
+    return files
+
+
+def _resolve_base_ref(repo_root: Path) -> str | None:
+    """Resolve the branch base ref, trying upstream then origin/main."""
+    for ref in ("@{u}", "refs/remotes/origin/HEAD", "origin/main"):
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--verify", "--quiet", ref],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return ref
+    return None
+
+
+def collect_contradictions(
+    repo_root: Path, owner: str, repo: str
+) -> list[Contradiction]:
+    """Fetch PR + linked issues, diff agent frontmatter, return contradictions.
+
+    Returns an empty list (not an error) when there is no PR, no gh, no linked
+    issues, or no changed agent files. Those are the common pre-PR states and
+    mean "nothing to compare", not "contradiction found".
+    """
+    pr_body = fetch_current_pr_body(owner, repo)
+    if pr_body is None:
+        return []
+
+    base_ref = _resolve_base_ref(repo_root)
+    if base_ref is None:
+        return []
+    frontmatter_files = _changed_agent_files(repo_root, base_ref)
+    if not frontmatter_files:
+        return []
+
+    contradictions: list[Contradiction] = []
+    contradictions.extend(
+        find_contradictions(pr_body, "PR description", frontmatter_files)
+    )
+    for issue_number in extract_linked_issues(pr_body):
+        issue_body = fetch_issue_body(issue_number, owner, repo)
+        if issue_body is None:
+            continue
+        contradictions.extend(
+            find_contradictions(
+                issue_body, f"issue #{issue_number}", frontmatter_files
+            )
+        )
+    return contradictions
+
+
+def format_report(contradictions: list[Contradiction]) -> str:
+    """Render a human-readable report of contradictions."""
+    if not contradictions:
+        return "[PASS] No spec-vs-code contradictions detected."
+    lines = [
+        f"[WARN] {len(contradictions)} spec-vs-code contradiction(s) detected:",
+    ]
+    for c in contradictions:
+        lines.append(
+            f"  - {c.file}: spec ({c.source}) claims {c.key}={c.claimed!r} "
+            f"but committed frontmatter has {c.key}={c.committed!r} "
+            f"(axis: {c.axis})"
+        )
+    lines.append(
+        "  Fix: update the PR description and linked issue to match the "
+        "committed value, or change the committed value to match the spec."
+    )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser with env var defaults."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Flag contradictions between a PR description, its linked "
+            "issues, and committed agent frontmatter."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(_PROJECT_ROOT),
+        help="Repository root (default: inferred from this script's path)",
+    )
+    parser.add_argument(
+        "--owner",
+        default=os.environ.get("REPO_OWNER", ""),
+        help="Repository owner (env: REPO_OWNER, or inferred from git remote)",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("REPO_NAME", ""),
+        help="Repository name (env: REPO_NAME, or inferred from git remote)",
+    )
+    parser.add_argument(
+        "--advisory",
+        action="store_true",
+        default=os.environ.get("SPEC_CONTRADICTION_ADVISORY", "").lower()
+        in ("1", "true"),
+        help=(
+            "Advisory mode: print findings but always exit 0 "
+            "(env: SPEC_CONTRADICTION_ADVISORY). Used by pre_pr.py."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns an ADR-035 exit code."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    owner: str = args.owner
+    repo: str = args.repo
+
+    if not owner or not repo:
+        try:
+            info = get_repo_info()
+        except RuntimeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+        owner = owner or info.owner
+        repo = repo or info.repo
+
+    contradictions = collect_contradictions(repo_root, owner, repo)
+    print(format_report(contradictions))
+
+    if contradictions and not args.advisory:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/validation/spec_contradiction.py
+++ b/scripts/validation/spec_contradiction.py
@@ -64,7 +64,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from scripts.github_core.api import RepoInfo  # noqa: E402
+from scripts.github_core.api import resolve_repo_params  # noqa: E402
 
 # Valid model tiers per ADR-002 (agent model selection). A spec text that
 # names one tier while the committed agent frontmatter names another is the
@@ -118,33 +118,6 @@ class Contradiction:
     committed: str
     file: str
     source: str
-
-
-def get_repo_info() -> RepoInfo:
-    """Parse owner/repo from the git remote origin URL.
-
-    Raises RuntimeError on failure so the caller can map it to exit code 2.
-    """
-    try:
-        result = subprocess.run(
-            ["git", "remote", "get-url", "origin"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
-        raise RuntimeError("Could not determine git remote origin") from exc
-
-    if result.returncode != 0:
-        raise RuntimeError("Could not determine git remote origin")
-
-    remote_url = result.stdout.strip()
-    match = re.search(r"github\.com[:/]([^/]+)/([^/.]+)", remote_url)
-    if not match:
-        raise RuntimeError(
-            f"Could not parse GitHub owner/repo from remote URL: {remote_url}"
-        )
-    return RepoInfo(owner=match.group(1), repo=match.group(2))
 
 
 def fetch_current_pr_body(owner: str, repo: str) -> str | None:
@@ -255,6 +228,17 @@ def parse_frontmatter(text: str) -> dict[str, str]:
         value = line[colon + 1 :].strip()
         if not value:
             continue
+        # Strip inline YAML comments (e.g. "model: opus  # override") so the
+        # trailing comment is not captured as part of the value, which would
+        # cause silent false negatives. Mirrors
+        # scripts/validation/pre_pr.py:_parse_yaml_frontmatter (only strip when
+        # the value does not open with a quote; cut at the first "#").
+        if value[0] not in ('"', "'"):
+            comment_pos = value.find("#")
+            if comment_pos > 0:
+                value = value[:comment_pos].strip()
+                if not value:
+                    continue
         if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
             value = value[1:-1]
         result[key] = value
@@ -366,19 +350,24 @@ def _resolve_base_ref(repo_root: Path) -> str | None:
 
 
 def collect_contradictions(
-    repo_root: Path, owner: str, repo: str
+    repo_root: Path, owner: str, repo: str, base_ref: str | None = None
 ) -> list[Contradiction]:
     """Fetch PR + linked issues, diff agent frontmatter, return contradictions.
 
     Returns an empty list (not an error) when there is no PR, no gh, no linked
     issues, or no changed agent files. Those are the common pre-PR states and
     mean "nothing to compare", not "contradiction found".
+
+    When ``base_ref`` is provided (e.g. a value resolved by pre_pr.py's
+    ``_resolve_branch_base_ref``) it is used as the diff base. Otherwise the
+    base ref is resolved locally via ``_resolve_base_ref``.
     """
     pr_body = fetch_current_pr_body(owner, repo)
     if pr_body is None:
         return []
 
-    base_ref = _resolve_base_ref(repo_root)
+    if base_ref is None:
+        base_ref = _resolve_base_ref(repo_root)
     if base_ref is None:
         return []
     frontmatter_files = _changed_agent_files(repo_root, base_ref)
@@ -454,6 +443,15 @@ def build_parser() -> argparse.ArgumentParser:
             "(env: SPEC_CONTRADICTION_ADVISORY). Used by pre_pr.py."
         ),
     )
+    parser.add_argument(
+        "--base",
+        default=None,
+        help=(
+            "Base ref to diff committed agent frontmatter against "
+            "(e.g. origin/main). When omitted, resolved locally from the "
+            "branch upstream, origin/HEAD, then origin/main."
+        ),
+    )
     return parser
 
 
@@ -466,16 +464,16 @@ def main(argv: list[str] | None = None) -> int:
     owner: str = args.owner
     repo: str = args.repo
 
-    if not owner or not repo:
-        try:
-            info = get_repo_info()
-        except RuntimeError as exc:
-            print(f"Error: {exc}", file=sys.stderr)
-            return 2
-        owner = owner or info.owner
-        repo = repo or info.repo
+    try:
+        info = resolve_repo_params(owner, repo)
+    except SystemExit:
+        return 2
+    owner = info.owner
+    repo = info.repo
 
-    contradictions = collect_contradictions(repo_root, owner, repo)
+    contradictions = collect_contradictions(
+        repo_root, owner, repo, base_ref=args.base
+    )
     print(format_report(contradictions))
 
     if contradictions and not args.advisory:

--- a/tests/validation/test_spec_contradiction.py
+++ b/tests/validation/test_spec_contradiction.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SCRIPT_PATH = REPO_ROOT / "scripts" / "validation" / "spec_contradiction.py"
@@ -136,6 +137,21 @@ def test_parse_frontmatter_no_fence_returns_empty():
     assert sc.parse_frontmatter(_NO_FRONTMATTER) == {}
 
 
+def test_parse_frontmatter_strips_inline_comment():
+    # A trailing YAML comment must not be captured as part of the value, or
+    # the model tier goes unrecognized and the contradiction is missed.
+    text = "---\nname: helper\nmodel: opus  # per ADR-002 override\n---\n"
+    front = sc.parse_frontmatter(text)
+    assert front["model"] == "opus"
+
+
+def test_parse_frontmatter_keeps_hash_inside_quotes():
+    # A '#' inside a quoted value is literal content, not a comment leader.
+    text = '---\nlabel: "a # b"\n---\n'
+    front = sc.parse_frontmatter(text)
+    assert front["label"] == "a # b"
+
+
 # --- find_contradictions (the core comparison) -----------------------------
 
 
@@ -157,6 +173,13 @@ def test_find_contradictions_no_flag_when_tiers_agree():
     spec = "The implementer uses model: opus."
     files = {"src/claude/implementer.md": _OPUS_AGENT}
     assert sc.find_contradictions(spec, "PR description", files) == []
+
+
+def test_find_contradictions_no_flag_when_sonnet_agrees():
+    # Spec and committed frontmatter both name the sonnet tier: no contradiction.
+    spec = "The helper uses model_tier: sonnet per the spec."
+    files = {"src/claude/helper.md": _SONNET_AGENT}
+    assert sc.find_contradictions(spec, "issue #1", files) == []
 
 
 def test_find_contradictions_no_claim_no_flag():
@@ -301,10 +324,12 @@ def test_collect_contradictions_issue_fetch_failure_skipped(monkeypatch):
 
 
 def test_main_advisory_exits_zero_on_contradiction(monkeypatch, capsys):
-    monkeypatch.setattr(sc, "get_repo_info", lambda: sc.RepoInfo("o", "r"))
+    monkeypatch.setattr(
+        sc, "resolve_repo_params", lambda owner="", repo="": SimpleNamespace(owner="o", repo="r")
+    )
     c = sc.Contradiction("model-tier", "model", "sonnet", "opus", "f.md", "issue #1")
     monkeypatch.setattr(
-        sc, "collect_contradictions", lambda root, owner, repo: [c]
+        sc, "collect_contradictions", lambda root, owner, repo, base_ref=None: [c]
     )
     code = sc.main(["--advisory"])
     assert code == 0
@@ -312,28 +337,51 @@ def test_main_advisory_exits_zero_on_contradiction(monkeypatch, capsys):
 
 
 def test_main_strict_exits_one_on_contradiction(monkeypatch, capsys):
-    monkeypatch.setattr(sc, "get_repo_info", lambda: sc.RepoInfo("o", "r"))
+    monkeypatch.setattr(
+        sc, "resolve_repo_params", lambda owner="", repo="": SimpleNamespace(owner="o", repo="r")
+    )
     c = sc.Contradiction("model-tier", "model", "sonnet", "opus", "f.md", "issue #1")
     monkeypatch.setattr(
-        sc, "collect_contradictions", lambda root, owner, repo: [c]
+        sc, "collect_contradictions", lambda root, owner, repo, base_ref=None: [c]
     )
     code = sc.main([])
     assert code == 1
 
 
 def test_main_exits_zero_when_clean(monkeypatch, capsys):
-    monkeypatch.setattr(sc, "get_repo_info", lambda: sc.RepoInfo("o", "r"))
-    monkeypatch.setattr(sc, "collect_contradictions", lambda root, owner, repo: [])
+    monkeypatch.setattr(
+        sc, "resolve_repo_params", lambda owner="", repo="": SimpleNamespace(owner="o", repo="r")
+    )
+    monkeypatch.setattr(
+        sc, "collect_contradictions", lambda root, owner, repo, base_ref=None: []
+    )
     code = sc.main([])
     assert code == 0
     assert "[PASS]" in capsys.readouterr().out
 
 
 def test_main_config_error_when_repo_unresolvable(monkeypatch):
-    def _raise() -> sc.RepoInfo:
-        raise RuntimeError("Could not determine git remote origin")
+    def _raise(owner: str = "", repo: str = ""):
+        # resolve_repo_params raises SystemExit on unresolvable/invalid input.
+        raise SystemExit(2)
 
-    monkeypatch.setattr(sc, "get_repo_info", _raise)
+    monkeypatch.setattr(sc, "resolve_repo_params", _raise)
     # No --owner/--repo provided, so the script must resolve and fail with 2.
     code = sc.main([])
     assert code == 2
+
+
+def test_main_passes_base_to_collect(monkeypatch):
+    monkeypatch.setattr(
+        sc, "resolve_repo_params", lambda owner="", repo="": SimpleNamespace(owner="o", repo="r")
+    )
+    seen: dict[str, str | None] = {}
+
+    def _capture(root, owner, repo, base_ref=None):
+        seen["base_ref"] = base_ref
+        return []
+
+    monkeypatch.setattr(sc, "collect_contradictions", _capture)
+    code = sc.main(["--base", "origin/release"])
+    assert code == 0
+    assert seen["base_ref"] == "origin/release"

--- a/tests/validation/test_spec_contradiction.py
+++ b/tests/validation/test_spec_contradiction.py
@@ -1,0 +1,339 @@
+"""Tests for scripts/validation/spec_contradiction.py.
+
+Covers the Issue #1920 shift-left check that flags contradictions between a
+PR description, its linked issues, and the committed agent frontmatter. The
+canonical regression is the PR #1897 round-7 loop: Issue #1894 claimed
+``model_tier: sonnet`` while the committed implementer frontmatter shipped
+``model: opus``.
+
+gh CLI and git I/O are mocked at the subprocess boundary (monkeypatching the
+module's ``fetch_*`` and ``_changed_agent_files`` seams) so the tests never
+touch the network or the live repository state.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "validation" / "spec_contradiction.py"
+
+
+def _load_module():
+    """Load the script as a module under a stable name."""
+    spec = importlib.util.spec_from_file_location("spec_contradiction", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sc = _load_module()
+
+
+# --- Frontmatter fixtures --------------------------------------------------
+
+_OPUS_AGENT = """---
+name: implementer
+description: Ships code.
+model: opus
+metadata:
+  tier: builder
+---
+
+# Implementer
+"""
+
+_SONNET_AGENT = """---
+name: helper
+model: sonnet
+---
+
+# Helper
+"""
+
+_NO_FRONTMATTER = "# Just a heading\n\nNo frontmatter here.\n"
+
+
+# --- extract_linked_issues -------------------------------------------------
+
+
+def test_extract_linked_issues_finds_all_keywords():
+    body = (
+        "Closes #1894\n"
+        "Fixes #100\n"
+        "Resolves: #200\n"
+        "Implements #300\n"
+        "Refs #400\n"
+    )
+    assert sc.extract_linked_issues(body) == [1894, 100, 200, 300, 400]
+
+
+def test_extract_linked_issues_deduplicates_preserving_order():
+    body = "Fixes #5 and also closes #5 and resolves #7"
+    assert sc.extract_linked_issues(body) == [5, 7]
+
+
+def test_extract_linked_issues_empty_when_no_refs():
+    assert sc.extract_linked_issues("No issue links here.") == []
+
+
+def test_extract_linked_issues_handles_none():
+    assert sc.extract_linked_issues("") == []
+
+
+# --- extract_model_claims --------------------------------------------------
+
+
+def test_extract_model_claims_matches_tier_variants():
+    text = "model: sonnet and model_tier: opus and model-tier = haiku"
+    assert sc.extract_model_claims(text) == {"sonnet", "opus", "haiku"}
+
+
+def test_extract_model_claims_normalizes_case_and_backticks():
+    text = "`model: Sonnet`"
+    assert sc.extract_model_claims(text) == {"sonnet"}
+
+
+def test_extract_model_claims_empty_when_no_tier():
+    assert sc.extract_model_claims("model: gpt-4 is unsupported") == set()
+
+
+# --- extract_numeric_claims ------------------------------------------------
+
+
+def test_extract_numeric_claims_only_known_keys():
+    text = "priority: 2 and version: 5 and unrelated: 99"
+    claims = sc.extract_numeric_claims(text)
+    assert claims == {"priority": {2}, "version": {5}}
+
+
+def test_extract_numeric_claims_collects_multiple_values():
+    text = "timeout: 30 then later timeout = 60"
+    assert sc.extract_numeric_claims(text) == {"timeout": {30, 60}}
+
+
+# --- parse_frontmatter -----------------------------------------------------
+
+
+def test_parse_frontmatter_top_level_keys():
+    front = sc.parse_frontmatter(_OPUS_AGENT)
+    assert front["name"] == "implementer"
+    assert front["model"] == "opus"
+
+
+def test_parse_frontmatter_skips_nested_block():
+    # `metadata:` opens a nested block; `tier:` is indented and must be skipped.
+    front = sc.parse_frontmatter(_OPUS_AGENT)
+    assert "tier" not in front
+    assert "metadata" not in front
+
+
+def test_parse_frontmatter_no_fence_returns_empty():
+    assert sc.parse_frontmatter(_NO_FRONTMATTER) == {}
+
+
+# --- find_contradictions (the core comparison) -----------------------------
+
+
+def test_find_contradictions_flags_sonnet_spec_vs_opus_code():
+    """PR #1897 regression: spec says sonnet, committed code is opus."""
+    spec = "The implementer uses model_tier: sonnet per the spec."
+    files = {"src/claude/implementer.md": _OPUS_AGENT}
+    found = sc.find_contradictions(spec, "issue #1894", files)
+    assert len(found) == 1
+    c = found[0]
+    assert c.axis == "model-tier"
+    assert c.claimed == "sonnet"
+    assert c.committed == "opus"
+    assert c.file == "src/claude/implementer.md"
+    assert c.source == "issue #1894"
+
+
+def test_find_contradictions_no_flag_when_tiers_agree():
+    spec = "The implementer uses model: opus."
+    files = {"src/claude/implementer.md": _OPUS_AGENT}
+    assert sc.find_contradictions(spec, "PR description", files) == []
+
+
+def test_find_contradictions_no_claim_no_flag():
+    spec = "This PR refactors logging. No model tier mentioned."
+    files = {"src/claude/implementer.md": _OPUS_AGENT}
+    assert sc.find_contradictions(spec, "PR description", files) == []
+
+
+def test_find_contradictions_skips_files_without_model_frontmatter():
+    spec = "model: sonnet"
+    files = {"docs/readme.md": _NO_FRONTMATTER}
+    assert sc.find_contradictions(spec, "PR description", files) == []
+
+
+def test_find_contradictions_numeric_threshold_mismatch():
+    spec = "Set priority: 1 in the spec."
+    agent = "---\nname: a\nmodel: opus\npriority: 2\n---\n"
+    files = {"src/claude/a.md": agent}
+    found = sc.find_contradictions(spec, "PR description", files)
+    numeric = [c for c in found if c.axis == "numeric"]
+    assert len(numeric) == 1
+    assert numeric[0].key == "priority"
+    assert numeric[0].claimed == "1"
+    assert numeric[0].committed == "2"
+
+
+def test_find_contradictions_numeric_agrees_no_flag():
+    spec = "priority: 2"
+    agent = "---\nname: a\nmodel: opus\npriority: 2\n---\n"
+    files = {"src/claude/a.md": agent}
+    found = sc.find_contradictions(spec, "PR description", files)
+    assert [c for c in found if c.axis == "numeric"] == []
+
+
+# --- format_report ---------------------------------------------------------
+
+
+def test_format_report_pass_message():
+    assert "[PASS]" in sc.format_report([])
+
+
+def test_format_report_lists_contradictions():
+    c = sc.Contradiction(
+        axis="model-tier",
+        key="model",
+        claimed="sonnet",
+        committed="opus",
+        file="src/claude/implementer.md",
+        source="issue #1894",
+    )
+    report = sc.format_report([c])
+    assert "[WARN]" in report
+    assert "implementer.md" in report
+    assert "issue #1894" in report
+    assert "sonnet" in report
+    assert "opus" in report
+
+
+# --- collect_contradictions (mocked gh + git seams) ------------------------
+
+
+def test_collect_contradictions_no_pr_returns_empty(monkeypatch):
+    monkeypatch.setattr(sc, "fetch_current_pr_body", lambda owner, repo: None)
+    result = sc.collect_contradictions(REPO_ROOT, "o", "r")
+    assert result == []
+
+
+def test_collect_contradictions_no_changed_files_returns_empty(monkeypatch):
+    monkeypatch.setattr(
+        sc, "fetch_current_pr_body", lambda owner, repo: "Fixes #1894"
+    )
+    monkeypatch.setattr(sc, "_resolve_base_ref", lambda repo_root: "origin/main")
+    monkeypatch.setattr(sc, "_changed_agent_files", lambda repo_root, base: {})
+    assert sc.collect_contradictions(REPO_ROOT, "o", "r") == []
+
+
+def test_collect_contradictions_full_regression_flow(monkeypatch):
+    """End-to-end PR #1897 scenario with all I/O mocked.
+
+    PR body links Issue #1894; the issue body claims sonnet; the committed
+    implementer frontmatter is opus. The check must surface one contradiction
+    sourced from the issue.
+    """
+    monkeypatch.setattr(
+        sc,
+        "fetch_current_pr_body",
+        lambda owner, repo: "This PR ships the implementer. Fixes #1894.",
+    )
+    monkeypatch.setattr(sc, "_resolve_base_ref", lambda repo_root: "origin/main")
+    monkeypatch.setattr(
+        sc,
+        "_changed_agent_files",
+        lambda repo_root, base: {"src/claude/implementer.md": _OPUS_AGENT},
+    )
+    monkeypatch.setattr(
+        sc,
+        "fetch_issue_body",
+        lambda number, owner, repo: "Spec: the implementer must use model_tier: sonnet.",
+    )
+
+    result = sc.collect_contradictions(REPO_ROOT, "o", "r")
+    assert len(result) == 1
+    assert result[0].source == "issue #1894"
+    assert result[0].claimed == "sonnet"
+    assert result[0].committed == "opus"
+
+
+def test_collect_contradictions_pr_body_claim_flagged(monkeypatch):
+    """A contradiction in the PR body itself (not just the issue) is flagged."""
+    monkeypatch.setattr(
+        sc,
+        "fetch_current_pr_body",
+        lambda owner, repo: "The implementer uses model: sonnet.",
+    )
+    monkeypatch.setattr(sc, "_resolve_base_ref", lambda repo_root: "origin/main")
+    monkeypatch.setattr(
+        sc,
+        "_changed_agent_files",
+        lambda repo_root, base: {"src/claude/implementer.md": _OPUS_AGENT},
+    )
+    result = sc.collect_contradictions(REPO_ROOT, "o", "r")
+    assert any(c.source == "PR description" for c in result)
+
+
+def test_collect_contradictions_issue_fetch_failure_skipped(monkeypatch):
+    """An unreachable linked issue is skipped, not fatal."""
+    monkeypatch.setattr(
+        sc, "fetch_current_pr_body", lambda owner, repo: "Fixes #1894"
+    )
+    monkeypatch.setattr(sc, "_resolve_base_ref", lambda repo_root: "origin/main")
+    monkeypatch.setattr(
+        sc,
+        "_changed_agent_files",
+        lambda repo_root, base: {"src/claude/implementer.md": _OPUS_AGENT},
+    )
+    monkeypatch.setattr(sc, "fetch_issue_body", lambda number, owner, repo: None)
+    # PR body has no model claim and the only issue is unreachable, so no flag.
+    assert sc.collect_contradictions(REPO_ROOT, "o", "r") == []
+
+
+# --- main (exit codes; ADR-035) --------------------------------------------
+
+
+def test_main_advisory_exits_zero_on_contradiction(monkeypatch, capsys):
+    monkeypatch.setattr(sc, "get_repo_info", lambda: sc.RepoInfo("o", "r"))
+    c = sc.Contradiction("model-tier", "model", "sonnet", "opus", "f.md", "issue #1")
+    monkeypatch.setattr(
+        sc, "collect_contradictions", lambda root, owner, repo: [c]
+    )
+    code = sc.main(["--advisory"])
+    assert code == 0
+    assert "[WARN]" in capsys.readouterr().out
+
+
+def test_main_strict_exits_one_on_contradiction(monkeypatch, capsys):
+    monkeypatch.setattr(sc, "get_repo_info", lambda: sc.RepoInfo("o", "r"))
+    c = sc.Contradiction("model-tier", "model", "sonnet", "opus", "f.md", "issue #1")
+    monkeypatch.setattr(
+        sc, "collect_contradictions", lambda root, owner, repo: [c]
+    )
+    code = sc.main([])
+    assert code == 1
+
+
+def test_main_exits_zero_when_clean(monkeypatch, capsys):
+    monkeypatch.setattr(sc, "get_repo_info", lambda: sc.RepoInfo("o", "r"))
+    monkeypatch.setattr(sc, "collect_contradictions", lambda root, owner, repo: [])
+    code = sc.main([])
+    assert code == 0
+    assert "[PASS]" in capsys.readouterr().out
+
+
+def test_main_config_error_when_repo_unresolvable(monkeypatch):
+    def _raise() -> sc.RepoInfo:
+        raise RuntimeError("Could not determine git remote origin")
+
+    monkeypatch.setattr(sc, "get_repo_info", _raise)
+    # No --owner/--repo provided, so the script must resolve and fail with 2.
+    code = sc.main([])
+    assert code == 2


### PR DESCRIPTION
## Summary

Adds a shift-left check that flags contradictions between a PR description, its linked issues, and the committed agent frontmatter. This catches the PR #1897 round-7 loop locally in seconds instead of after each push: Issue #1894 still claimed `model_tier: sonnet` for the implementer while the committed agent frontmatter shipped `model: opus`, and the "Validate Spec Coverage" CI gate surfaced that contradiction roughly 90 seconds after each push.

## Per-file changes

- `scripts/validation/spec_contradiction.py` (new): fetches the current branch PR body via the gh CLI, extracts `Closes/Fixes/Resolves/Implements/Refs #N` issue references, fetches each linked issue body, then compares two classes of load-bearing claim against the committed agent frontmatter changed on the branch (read from the HEAD blob via `git show`, base resolved via `@{u}` then `origin/HEAD` then `origin/main`): model tier (opus, sonnet, haiku per ADR-002) and numeric thresholds for a fixed key set. Exit codes follow ADR-035 (0 ok, 1 logic, 2 config); a `--advisory` flag downgrades exit 1 to 0 for the pre_pr wiring. Returns an empty result (not an error) when there is no PR, no gh, no linked issues, or no changed agent files.
- `tests/validation/test_spec_contradiction.py` (new): 29 cases covering positive, negative, and edge paths. Mocks gh and git at the `fetch_*` and `_changed_agent_files` seams, including the full PR #1897 regression flow (PR links Issue #1894, issue body claims sonnet, committed frontmatter is opus, one contradiction surfaced and sourced from the issue) and the ADR-035 exit-code matrix (advisory exit 0, strict exit 1, clean exit 0, config error exit 2).
- `scripts/validation/pre_pr.py` (wiring): adds `validate_spec_contradiction`, an advisory step that runs the new script with `--advisory`, prints the WARN output, and always returns True so a heuristic false positive never blocks the local pre-PR cycle. Registered after the Canonical Citation Check.

## Canonical source mirror

Per the canonical-source-mirror rule (.claude/rules canonical-source-mirror), the script docstring includes a "Stricter/looser/different than canonical" section. This check does not mirror a single canonical regex. The only shared contract is the ADR-035 exit-code table, quoted verbatim from ADR-035 (exit-code standardization). The model-tier token set `{opus, sonnet, haiku}` is taken from the ADR-002 agent frontmatter contract. The check is looser than the "Validate Spec Coverage" CI gate (only the model-tier and numeric axes) and advisory when invoked from pre_pr.

## Acceptance criteria

- Pre_pr step detects PR-description vs code contradictions on the model-tier axis: yes.
- Detection includes linked-issue text, not only the PR description: yes (PR body plus each linked issue body).
- Integrated into pre_pr.py so the existing pre-PR cycle catches it: yes (advisory step).
- Regression test using the PR #1897 round-7 contradiction: yes (`test_collect_contradictions_full_regression_flow`).

Fixes #1920

## Testing

- `uv run python -m pytest tests/validation/test_spec_contradiction.py -q` => 29 passed in 0.12s.
- `uv run python -m pytest tests/validation/ -q` => 122 passed (no regression in the validation suite).
- `uv run python scripts/validation/spec_contradiction.py --advisory` => `[PASS] No spec-vs-code contradictions detected.`, exit 0.
- `uv run python scripts/validation/pre_pr.py --quick --skip-tests` => the new "Spec Contradiction Check" step runs and passes.
- `uvx ruff check` on the new files => clean (the one remaining N818 finding on `MissingScriptSkip` pre-exists on origin/main and is unrelated).
- `uvx mypy scripts/validation/spec_contradiction.py` => Success: no issues found.
- No U+2014 or U+2013 in any changed file.
