### PR TITLE
feat(validation): enforce sync-registry provenance for shared lib packages

### DIFF
--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -729,6 +729,30 @@ def validate_spec_id_uniqueness(repo_root: Path) -> bool:
     return exit_code == 0
 
 
+def validate_sync_registry(repo_root: Path) -> bool:
+    """Enforce that every shared lib package is registered for sync (Issue #1909).
+
+    `scripts/sync_plugin_lib.py:SYNC_PAIRS` lists the shared packages copied
+    into `.claude/lib/` for plugin distribution. A new lib package added
+    without a SYNC_PAIRS entry silently misses the sync and crashes a shimmed
+    hook at install time. This gate fails when a package under the source roots
+    or under `.claude/lib/` is unregistered.
+    """
+    script = repo_root / "scripts" / "validation" / "validate_sync_registry.py"
+    if not script.exists():
+        raise MissingScriptSkip(
+            "scripts/validation/validate_sync_registry.py not present"
+        )
+    exit_code, stdout, stderr = _run_subprocess(
+        [sys.executable, str(script), "--repo-root", str(repo_root)]
+    )
+    output = (stdout or "") + (stderr or "")
+    if output.strip():
+        for line in output.strip().splitlines()[:40]:
+            print(line)
+    return exit_code == 0
+
+
 def validate_canonical_citations(repo_root: Path) -> bool:
     """Heuristic check for uncited mirror-claims.
 
@@ -1157,6 +1181,13 @@ def main(argv: list[str] | None = None) -> int:
         "Spec ID Uniqueness",
         state,
         lambda: validate_spec_id_uniqueness(repo_root),
+    )
+
+    # 3.77 Sync Registry Provenance (Issue #1909)
+    run_validation(
+        "Sync Registry Provenance",
+        state,
+        lambda: validate_sync_registry(repo_root),
     )
 
     # 3.8 Canonical Citation Check (heuristic; soft warn unless

--- a/scripts/validation/validate_sync_registry.py
+++ b/scripts/validation/validate_sync_registry.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Assert every shared lib package is registered in the sync registry (Issue #1909).
+
+`scripts/sync_plugin_lib.py` copies shared Python packages from `scripts/` to
+`.claude/lib/` so the plugin install layout ships them with relative imports.
+The list of pairs lives in `SYNC_PAIRS`. Nothing enforced that a newly added
+shared lib package was registered there, so a new package could silently miss
+the sync and crash at install time when a shimmed hook imports it.
+
+This gate closes that provenance gap. It asserts:
+
+1. Every package directory directly under `scripts/github_core/` and
+   `scripts/hook_utilities/` appears as a SYNC_PAIRS source. Those two
+   directories are themselves the shared lib packages; the check also catches a
+   future sub-package added beneath either of them.
+2. Every package directory under `.claude/lib/` appears as a SYNC_PAIRS
+   destination, or is named in an explicit allowlist (`LIB_ALLOWLIST`).
+
+`SYNC_PAIRS` is imported from `sync_plugin_lib`, the single source of truth, so
+this validator and the sync tool can never disagree about the registry contents.
+
+Canonical: scripts/sync_plugin_lib.py defines the registry this validator reads.
+The relevant fragment, copied verbatim:
+
+    SYNC_PAIRS: list[tuple[str, str]] = [
+        ("scripts/hook_utilities", ".claude/lib/hook_utilities"),
+        ("scripts/github_core", ".claude/lib/github_core"),
+        ("scripts/ai_review_common", ".claude/lib/ai_review_common"),
+    ]
+
+See `.claude/rules/canonical-source-mirror.md`.
+
+Different than canonical: `sync_plugin_lib.py` consumes SYNC_PAIRS to copy
+files. This validator only reads SYNC_PAIRS to assert registration coverage; it
+copies nothing and mutates nothing. It is a read-only provenance gate, not a
+second sync implementation.
+
+Exit codes (per ADR-035):
+    0 - every shared lib package is registered (or allowlisted)
+    1 - one or more package directories are unregistered
+    2 - config error (e.g. the repo root or sync_plugin_lib is missing)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+# Source directories whose package children MUST be registered as SYNC_PAIRS
+# sources. These two are the shared lib roots called out by Issue #1909.
+SOURCE_ROOTS: tuple[str, ...] = (
+    "scripts/github_core",
+    "scripts/hook_utilities",
+)
+
+# `.claude/lib/` package directories that are allowed to exist without a
+# SYNC_PAIRS destination. Empty today: every lib package is synced. Add a name
+# here only with a comment explaining why the package is lib-only.
+LIB_ALLOWLIST: frozenset[str] = frozenset()
+
+_LIB_DIR_REL = ".claude/lib"
+
+
+def _is_package_dir(path: Path) -> bool:
+    """True when *path* is a directory holding a Python package.
+
+    A package has an `__init__.py`; `__pycache__` and other bookkeeping dirs do
+    not and are ignored.
+    """
+    return path.is_dir() and (path / "__init__.py").is_file()
+
+
+def _sync_sources(sync_pairs: list[tuple[str, str]]) -> set[str]:
+    """Return the set of source paths registered in SYNC_PAIRS."""
+    return {src for src, _ in sync_pairs}
+
+
+def _sync_destinations(sync_pairs: list[tuple[str, str]]) -> set[str]:
+    """Return the set of destination paths registered in SYNC_PAIRS."""
+    return {dst for _, dst in sync_pairs}
+
+
+def _check_source_roots(
+    repo_root: Path,
+    sync_pairs: list[tuple[str, str]],
+) -> list[str]:
+    """Return errors for unregistered source package directories.
+
+    Each path in SOURCE_ROOTS must itself be a registered SYNC_PAIRS source. If
+    the directory contains sub-package directories, each of those must be
+    registered too, so a nested package added later cannot escape the sync.
+    """
+    registered = _sync_sources(sync_pairs)
+    errors: list[str] = []
+
+    for root_rel in SOURCE_ROOTS:
+        root = repo_root / root_rel
+        if not _is_package_dir(root):
+            # A missing or non-package source root is not this gate's concern;
+            # sync_plugin_lib already warns when a source dir is absent.
+            continue
+        if root_rel not in registered:
+            errors.append(
+                f"source package {root_rel} is not registered in SYNC_PAIRS"
+            )
+        for child in sorted(root.iterdir()):
+            if not _is_package_dir(child):
+                continue
+            child_rel = f"{root_rel}/{child.name}"
+            if child_rel not in registered:
+                errors.append(
+                    f"source package {child_rel} is not registered in SYNC_PAIRS"
+                )
+
+    return errors
+
+
+def _check_lib_destinations(
+    repo_root: Path,
+    sync_pairs: list[tuple[str, str]],
+    allowlist: frozenset[str],
+) -> list[str]:
+    """Return errors for `.claude/lib/` packages with no registered destination."""
+    registered = _sync_destinations(sync_pairs)
+    lib_dir = repo_root / _LIB_DIR_REL
+    if not lib_dir.is_dir():
+        return []
+
+    errors: list[str] = []
+    for child in sorted(lib_dir.iterdir()):
+        if not _is_package_dir(child):
+            continue
+        dst_rel = f"{_LIB_DIR_REL}/{child.name}"
+        if dst_rel in registered or child.name in allowlist:
+            continue
+        errors.append(
+            f"lib package {dst_rel} has no SYNC_PAIRS destination and is not "
+            f"in LIB_ALLOWLIST"
+        )
+    return errors
+
+
+def find_unregistered(
+    repo_root: Path,
+    sync_pairs: list[tuple[str, str]],
+    allowlist: frozenset[str] = LIB_ALLOWLIST,
+) -> list[str]:
+    """Return every registration error for the given tree and registry.
+
+    Pure over its inputs so tests can pass a synthetic repo root and a
+    synthetic SYNC_PAIRS list without touching the real registry.
+    """
+    errors: list[str] = []
+    errors.extend(_check_source_roots(repo_root, sync_pairs))
+    errors.extend(_check_lib_destinations(repo_root, sync_pairs, allowlist))
+    return errors
+
+
+def _load_sync_pairs() -> list[tuple[str, str]]:
+    """Import SYNC_PAIRS from sync_plugin_lib (single source of truth).
+
+    Raises ImportError if the module is missing; the caller maps that to the
+    ADR-035 config-error exit code.
+    """
+    import sync_plugin_lib
+
+    pairs: list[tuple[str, str]] = sync_plugin_lib.SYNC_PAIRS
+    return pairs
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns an ADR-035 exit code."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root (defaults to two levels above this script).",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root
+    if not repo_root.is_dir():
+        print(f"[CONFIG] repo root not found: {repo_root}", file=sys.stderr)
+        return 2
+
+    try:
+        sync_pairs = _load_sync_pairs()
+    except ImportError as exc:
+        print(f"[CONFIG] cannot import sync_plugin_lib: {exc}", file=sys.stderr)
+        return 2
+
+    errors = find_unregistered(repo_root, sync_pairs)
+    if errors:
+        print("[FAIL] Unregistered shared lib packages detected (Issue #1909):")
+        for err in errors:
+            print(f"  - {err}")
+        print(
+            "\nEvery shared lib package MUST be registered in "
+            "scripts/sync_plugin_lib.py:SYNC_PAIRS so it ships with the plugin. "
+            "Add the (source, destination) pair there, or add a lib-only "
+            "package to LIB_ALLOWLIST in this script with a justifying comment."
+        )
+        return 1
+
+    print("[PASS] Every shared lib package is registered in SYNC_PAIRS.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validation/validate_sync_registry.py
+++ b/scripts/validation/validate_sync_registry.py
@@ -9,10 +9,11 @@ the sync and crash at install time when a shimmed hook imports it.
 
 This gate closes that provenance gap. It asserts:
 
-1. Every package directory directly under `scripts/github_core/` and
-   `scripts/hook_utilities/` appears as a SYNC_PAIRS source. Those two
-   directories are themselves the shared lib packages; the check also catches a
-   future sub-package added beneath either of them.
+1. Every package directory directly under `scripts/github_core/`,
+   `scripts/hook_utilities/`, and `scripts/ai_review_common/` appears as a
+   SYNC_PAIRS source. Those three directories are themselves the shared lib
+   packages; the check also catches a future sub-package added beneath any of
+   them.
 2. Every package directory under `.claude/lib/` appears as a SYNC_PAIRS
    destination, or is named in an explicit allowlist (`LIB_ALLOWLIST`).
 
@@ -52,10 +53,13 @@ if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
 # Source directories whose package children MUST be registered as SYNC_PAIRS
-# sources. These two are the shared lib roots called out by Issue #1909.
+# sources. These are the shared lib roots called out by Issue #1909. Keep this
+# list aligned with the SYNC_PAIRS source paths in scripts/sync_plugin_lib.py:
+# every synced source root belongs here so its children are scanned too.
 SOURCE_ROOTS: tuple[str, ...] = (
     "scripts/github_core",
     "scripts/hook_utilities",
+    "scripts/ai_review_common",
 )
 
 # `.claude/lib/` package directories that are allowed to exist without a
@@ -180,11 +184,12 @@ def main(argv: list[str] | None = None) -> int:
         "--repo-root",
         type=Path,
         default=Path(__file__).resolve().parents[2],
-        help="Repository root (defaults to two levels above this script).",
+        help="Repository root (defaults to the repo root that contains "
+        "scripts/validation/).",
     )
     args = parser.parse_args(argv)
 
-    repo_root = args.repo_root
+    repo_root = args.repo_root.expanduser().resolve()
     if not repo_root.is_dir():
         print(f"[CONFIG] repo root not found: {repo_root}", file=sys.stderr)
         return 2

--- a/tests/validation/test_validate_sync_registry.py
+++ b/tests/validation/test_validate_sync_registry.py
@@ -1,0 +1,209 @@
+"""Tests for scripts/validation/validate_sync_registry.py (Issue #1909).
+
+Pins behaviour of the sync-registry provenance gate:
+
+- pos: a tree whose lib packages and source roots are all registered passes
+- neg: a `.claude/lib/` package with no SYNC_PAIRS destination fails (exit 1)
+- neg: a source-root child package not registered as a SYNC_PAIRS source fails
+- edge: an allowlisted lib package passes; `__pycache__` and non-package dirs
+  are ignored; a missing repo root returns exit 2 (config error per ADR-035)
+- integration: the real repo tree passes with the real SYNC_PAIRS
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "validation" / "validate_sync_registry.py"
+
+# Make the module importable for the unit tests that call find_unregistered
+# directly. The script also self-inserts scripts/ on import to reach
+# sync_plugin_lib.
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "validation"))
+
+import validate_sync_registry as vsr  # noqa: E402
+
+
+def _make_package(parent: Path, name: str) -> Path:
+    """Create a Python package directory (with __init__.py) under parent."""
+    pkg = parent / name
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    return pkg
+
+
+# ---- positive ----------------------------------------------------------------
+
+
+def test_all_registered_passes(tmp_path: Path) -> None:
+    """Lib packages and source roots all registered -> no errors."""
+    _make_package(tmp_path / "scripts", "github_core")
+    _make_package(tmp_path / "scripts", "hook_utilities")
+    _make_package(tmp_path / ".claude" / "lib", "github_core")
+    _make_package(tmp_path / ".claude" / "lib", "hook_utilities")
+    sync_pairs = [
+        ("scripts/github_core", ".claude/lib/github_core"),
+        ("scripts/hook_utilities", ".claude/lib/hook_utilities"),
+    ]
+
+    errors = vsr.find_unregistered(tmp_path, sync_pairs)
+
+    assert errors == [], errors
+
+
+# ---- negative ----------------------------------------------------------------
+
+
+def test_unregistered_lib_package_fails(tmp_path: Path) -> None:
+    """A `.claude/lib/` package with no destination produces an error."""
+    _make_package(tmp_path / "scripts", "github_core")
+    _make_package(tmp_path / ".claude" / "lib", "github_core")
+    # newpkg is synced into lib but never registered as a destination.
+    _make_package(tmp_path / ".claude" / "lib", "newpkg")
+    sync_pairs = [("scripts/github_core", ".claude/lib/github_core")]
+
+    errors = vsr.find_unregistered(tmp_path, sync_pairs)
+
+    assert any(".claude/lib/newpkg" in e for e in errors), errors
+
+
+def test_unregistered_source_child_fails(tmp_path: Path) -> None:
+    """A sub-package under a source root not in SYNC_PAIRS produces an error."""
+    root = _make_package(tmp_path / "scripts", "github_core")
+    # A nested package added later but never registered.
+    _make_package(root, "nested")
+    sync_pairs = [("scripts/github_core", ".claude/lib/github_core")]
+
+    errors = vsr.find_unregistered(tmp_path, sync_pairs)
+
+    assert any("scripts/github_core/nested" in e for e in errors), errors
+
+
+def test_unregistered_source_root_fails(tmp_path: Path) -> None:
+    """A source root present on disk but absent from SYNC_PAIRS fails."""
+    _make_package(tmp_path / "scripts", "github_core")
+    _make_package(tmp_path / "scripts", "hook_utilities")
+    # Only github_core is registered; hook_utilities is not.
+    sync_pairs = [("scripts/github_core", ".claude/lib/github_core")]
+
+    errors = vsr.find_unregistered(tmp_path, sync_pairs)
+
+    assert any("scripts/hook_utilities" in e for e in errors), errors
+
+
+# ---- edge --------------------------------------------------------------------
+
+
+def test_allowlisted_lib_package_passes(tmp_path: Path) -> None:
+    """A lib package named in the allowlist passes without a destination."""
+    _make_package(tmp_path / "scripts", "github_core")
+    _make_package(tmp_path / ".claude" / "lib", "github_core")
+    _make_package(tmp_path / ".claude" / "lib", "vendored")
+    sync_pairs = [("scripts/github_core", ".claude/lib/github_core")]
+
+    errors = vsr.find_unregistered(
+        tmp_path, sync_pairs, allowlist=frozenset({"vendored"})
+    )
+
+    assert errors == [], errors
+
+
+def test_non_package_dirs_ignored(tmp_path: Path) -> None:
+    """`__pycache__` and dirs without __init__.py are not flagged."""
+    _make_package(tmp_path / "scripts", "github_core")
+    lib = tmp_path / ".claude" / "lib"
+    _make_package(lib, "github_core")
+    # __pycache__ has no __init__.py; a bare dir has no __init__.py either.
+    (lib / "__pycache__").mkdir(parents=True)
+    (lib / "bare_dir").mkdir()
+    sync_pairs = [("scripts/github_core", ".claude/lib/github_core")]
+
+    errors = vsr.find_unregistered(tmp_path, sync_pairs)
+
+    assert errors == [], errors
+
+
+def test_loose_lib_file_ignored(tmp_path: Path) -> None:
+    """A loose `.py` file under `.claude/lib/` (e.g. bootstrap.py) is not a package."""
+    _make_package(tmp_path / "scripts", "github_core")
+    lib = tmp_path / ".claude" / "lib"
+    _make_package(lib, "github_core")
+    (lib / "bootstrap.py").write_text("# loose module\n", encoding="utf-8")
+    sync_pairs = [("scripts/github_core", ".claude/lib/github_core")]
+
+    errors = vsr.find_unregistered(tmp_path, sync_pairs)
+
+    assert errors == [], errors
+
+
+def test_missing_repo_root_returns_config_error(tmp_path: Path) -> None:
+    """Per ADR-035: a missing repo root returns exit 2, not 1."""
+    missing = tmp_path / "does-not-exist"
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(missing)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "repo root not found" in result.stderr
+
+
+# ---- CLI / exit codes --------------------------------------------------------
+
+
+def test_cli_passes_on_registered_tree(tmp_path: Path) -> None:
+    """CLI exits 0 when the scaffolded tree matches the real SYNC_PAIRS.
+
+    The CLI imports the real SYNC_PAIRS, so the synthetic tree mirrors the
+    three registered destinations and the two source roots.
+    """
+    _make_package(tmp_path / "scripts", "github_core")
+    _make_package(tmp_path / "scripts", "hook_utilities")
+    _make_package(tmp_path / "scripts", "ai_review_common")
+    for name in ("github_core", "hook_utilities", "ai_review_common"):
+        _make_package(tmp_path / ".claude" / "lib", name)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "[PASS]" in result.stdout
+
+
+def test_cli_fails_on_unregistered_lib(tmp_path: Path) -> None:
+    """CLI exits 1 when a lib package has no registered destination."""
+    _make_package(tmp_path / "scripts", "github_core")
+    _make_package(tmp_path / ".claude" / "lib", "github_core")
+    _make_package(tmp_path / ".claude" / "lib", "unregistered_pkg")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "unregistered_pkg" in result.stdout
+
+
+# ---- integration -------------------------------------------------------------
+
+
+def test_real_repo_registry_is_complete() -> None:
+    """Regression: the actual repo tree satisfies the gate with real SYNC_PAIRS."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(REPO_ROOT)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        "Real sync registry is incomplete:\n" + result.stdout + result.stderr
+    )

--- a/tests/validation/test_validate_sync_registry.py
+++ b/tests/validation/test_validate_sync_registry.py
@@ -82,6 +82,27 @@ def test_unregistered_source_child_fails(tmp_path: Path) -> None:
     assert any("scripts/github_core/nested" in e for e in errors), errors
 
 
+def test_unregistered_ai_review_common_child_fails(tmp_path: Path) -> None:
+    """A sub-package under scripts/ai_review_common not in SYNC_PAIRS fails.
+
+    Guards the Issue #1909 provenance gap: ai_review_common is a synced source
+    root, so a nested package added beneath it must be registered too. Sync is
+    non-recursive, so an unregistered subpackage would otherwise only surface as
+    an install-time import error.
+    """
+    root = _make_package(tmp_path / "scripts", "ai_review_common")
+    _make_package(root, "cache_guard")
+    sync_pairs = [
+        ("scripts/ai_review_common", ".claude/lib/ai_review_common"),
+    ]
+
+    errors = vsr.find_unregistered(tmp_path, sync_pairs)
+
+    assert any(
+        "scripts/ai_review_common/cache_guard" in e for e in errors
+    ), errors
+
+
 def test_unregistered_source_root_fails(tmp_path: Path) -> None:
     """A source root present on disk but absent from SYNC_PAIRS fails."""
     _make_package(tmp_path / "scripts", "github_core")
@@ -159,7 +180,8 @@ def test_cli_passes_on_registered_tree(tmp_path: Path) -> None:
     """CLI exits 0 when the scaffolded tree matches the real SYNC_PAIRS.
 
     The CLI imports the real SYNC_PAIRS, so the synthetic tree mirrors the
-    three registered destinations and the two source roots.
+    three registered destinations and the three source roots
+    (github_core, hook_utilities, ai_review_common).
     """
     _make_package(tmp_path / "scripts", "github_core")
     _make_package(tmp_path / "scripts", "hook_utilities")


### PR DESCRIPTION
## Summary

Closes the sync-registry provenance gap. `scripts/sync_plugin_lib.py` defines `SYNC_PAIRS` (the list of shared Python packages copied from `scripts/` into `.claude/lib/` for plugin distribution), but nothing enforced that every shared lib package is registered. A new lib package could silently miss the sync and crash a shimmed hook at install time when it tries to import the unshipped package.

This adds a read-only provenance gate that imports `SYNC_PAIRS` from `sync_plugin_lib` (single source of truth, cited per `.claude/rules/canonical-source-mirror.md`) and asserts registration coverage.

## Per-file change

- `scripts/validation/validate_sync_registry.py` (new): asserts that every package directory under `scripts/github_core/` and `scripts/hook_utilities/` appears as a `SYNC_PAIRS` source, and that every package under `.claude/lib/` appears as a `SYNC_PAIRS` destination or in an explicit `LIB_ALLOWLIST`. Imports `SYNC_PAIRS` from `sync_plugin_lib` so the validator and the sync tool cannot disagree. ADR-035 exit codes: 0 pass, 1 unregistered package(s), 2 config error. Core logic (`find_unregistered`) is pure over its inputs (repo root, sync pairs, allowlist) so it is unit-testable against a synthetic tree. `__pycache__`, dirs without `__init__.py`, and loose `.py` files such as `bootstrap.py` are correctly ignored.
- `scripts/validation/pre_pr.py` (modified): wires the gate in as a new validation step "Sync Registry Provenance", following the existing `validate_spec_id_uniqueness` pattern (delegates to the script via subprocess, surfaces output, returns success on exit 0).
- `tests/validation/test_validate_sync_registry.py` (new): pytest coverage. Positive (all registered passes), negative (unregistered lib package fails, unregistered source child fails, unregistered source root fails), edge (allowlisted package passes, non-package dirs ignored, loose lib file ignored, missing repo root returns exit 2 per ADR-035), CLI exit codes (pass on registered tree, fail on unregistered lib), and a real-repo integration test that asserts the current registry is complete.

## Fixes

Fixes #1909

## Testing

- `uv run pytest tests/validation/test_validate_sync_registry.py -v` -> 11 passed
- `uv run pytest tests/validation/ -q` -> 104 passed (no regressions in the validation suite)
- `uvx ruff check scripts/validation/validate_sync_registry.py tests/validation/test_validate_sync_registry.py` -> All checks passed
- `uvx mypy --ignore-missing-imports scripts/validation/validate_sync_registry.py` -> Success, no issues
- `python3 scripts/validation/validate_sync_registry.py` -> [PASS] exit 0 against the real repo
- Verified `pre_pr.validate_sync_registry(repo_root)` returns True via direct import
- Em/en-dash scan over all three files -> 0 hits