### PR TITLE
fix(build): commit copilot cache_guard mirror, restore build reproducibility

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "25 agent definitions, 81 reusable skills, 52 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/lib/ai_review_common/cache_guard.py
+++ b/src/copilot-cli/lib/ai_review_common/cache_guard.py
@@ -1,0 +1,100 @@
+"""Canonical: scripts/ai_review_common/cache_guard.py. Sync via scripts/sync_plugin_lib.py."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+_AGENT_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+NON_CACHEABLE_VERDICTS = frozenset({"NEEDS_REVIEW"})
+
+
+class CacheGuardConfigError(ValueError):
+    """Raised when the cache guard receives invalid configuration."""
+
+
+def validate_agent_name(agent: str) -> str:
+    """Return a safe agent name or raise for invalid path input."""
+    if not _AGENT_PATTERN.fullmatch(agent):
+        raise CacheGuardConfigError(
+            f"Invalid agent name: {agent}. Must match '^[a-zA-Z0-9_-]+$'."
+        )
+    return agent
+
+
+def skip_cache_reason(verdict: str, infra_failure: str) -> str | None:
+    """Return a skip reason when review output must not be cached."""
+    if infra_failure == "true":
+        return "infrastructure failure"
+    if not verdict:
+        return "empty verdict (truncated or malformed AI output)"
+    if verdict in NON_CACHEABLE_VERDICTS:
+        return "verdict is NEEDS_REVIEW (malformed AI output)"
+    return None
+
+
+def append_github_output(output_path: Path, key: str, value: str) -> None:
+    """Append one GitHub Actions output value."""
+    with output_path.open("a", encoding="utf-8") as output_file:
+        output_file.write(f"{key}={value}\n")
+
+
+def populate_cache(
+    *,
+    agent: str,
+    verdict: str,
+    findings: str,
+    infra_failure: str,
+    github_output: Path,
+    cache_root: Path = Path("ai-review-cache"),
+) -> bool:
+    """Populate the review cache only when the verdict is structurally valid."""
+    safe_agent = validate_agent_name(agent)
+
+    reason = skip_cache_reason(verdict, infra_failure)
+    if reason is not None:
+        append_github_output(github_output, "cache_populated", "false")
+        print(f"Skipping cache save: {reason}")
+        return False
+
+    cache_dir = cache_root / safe_agent
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "verdict.txt").write_text(verdict, encoding="utf-8")
+    (cache_dir / "findings.txt").write_text(findings, encoding="utf-8")
+    (cache_dir / "infrastructure-failure.txt").write_text(
+        infra_failure or "false",
+        encoding="utf-8",
+    )
+    append_github_output(github_output, "cache_populated", "true")
+    print(f"Populated cache directory for {safe_agent}")
+    return True
+
+
+def main() -> int:
+    """Run from GitHub Actions."""
+    github_output = os.environ.get("GITHUB_OUTPUT", "").strip()
+    if not github_output:
+        print("::error::GITHUB_OUTPUT is required", file=sys.stderr)
+        return 2
+
+    try:
+        populate_cache(
+            agent=os.environ.get("AGENT", ""),
+            verdict=os.environ.get("VERDICT", ""),
+            findings=os.environ.get("FINDINGS", ""),
+            infra_failure=os.environ.get("INFRA_FAILURE", ""),
+            github_output=Path(github_output),
+        )
+    except CacheGuardConfigError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"::error::Failed to populate review cache: {exc}", file=sys.stderr)
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

A prior merge added the ai-review cache-guard module and its `.claude` lib mirror but never committed the generated copilot lib mirror. As a result, the build pipeline became non-reproducible on `main`: every build emits an uncommitted copilot mirror file.

The agent-drift-detection workflow only validates generated agent markdown, so it does not catch lib-mirror drift. That gap let the incomplete mirror land. Filed as issue #2222.

## Changes (3 files)

- `src/copilot-cli/lib/ai_review_common/cache_guard.py` (new): the generated copilot mirror, byte-identical to the already-merged canonical and `.claude` lib copies.
- `.claude/.claude-plugin/plugin.json`: version bump to 0.5.11.
- `src/copilot-cli/.claude-plugin/plugin.json`: version bump to 0.5.11 (parity).

## Validation

- The build check mode exits 0 (reproducible after this commit).
- The plugin-lib sync check passes.
- The cache-guard workflow tests pass (7 of 7).

Refs #2195
