### PR TITLE
fix(eval): acceptance gate blocks regressions, not zero-improvement edits

### DIFF
--- a/.agents/architecture/ADR-057-prompt-behavioral-evaluation.md
+++ b/.agents/architecture/ADR-057-prompt-behavioral-evaluation.md
@@ -75,11 +75,23 @@ Each evaluation consists of:
 
 ### Acceptance Gate
 
-A prompt change passes behavioral evaluation when all three criteria hold:
+The gate blocks regressions. It does not mandate an improvement on every edit. A prompt change passes behavioral evaluation when these criteria hold:
 
 1. `after_score >= before_score` (no regression on existing scenarios)
-2. Any scenario the change targets moves from fail to pass
-3. No scenario flips from pass to fail without explicit justification in the PR. Intentional trade-offs are acceptable when the PR documents the rationale.
+2. No scenario flips from pass to fail without explicit justification in the PR. Intentional trade-offs are acceptable when the PR documents the rationale.
+3. Flakiness on any scenario stays at or below the 40% block threshold.
+
+A change that targets a failing scenario SHOULD move it from fail to pass. This is recorded as `has_improvement` and surfaced in the gate output, but it is not a hard pass requirement (see the 2026-06-01 relaxation note below).
+
+#### Acceptance Gate Relaxation (2026-06-01, Issue #2197)
+
+The original gate required `has_improvement` (at least one fail-to-pass flip, or `before_score == 1.0`) as a hard pass condition. This structurally blocked any legitimate change to a prompt whose base ref already had a failing scenario. Example: a documentation-consistency edit to `.claude/commands/spec.md` introduces no behavioral change and no regression, but pre-existing scenarios D13 and D14 fail on `main` (`before_score` 5/7 < 1.0). With zero fail-to-pass flips, `has_improvement` was false and the gate returned FAIL even though the change regressed nothing.
+
+That outcome contradicts the gate's stated purpose: regression prevention (Decision Driver 2), not a mandate that every edit improve a score. The criterion "any scenario the change targets moves from fail to pass" was always conditional on the change targeting a scenario; it was never meant to apply to changes that target no scenario.
+
+Relaxation: `has_improvement` is dropped as a hard pass requirement in `eval-prompt-change.py acceptance_gate()`. The gate now passes when `no_regression AND no_unexplained_regressions AND no_high_flakiness` hold (plus the security-critical 100%-pass requirement when applicable). `has_improvement` is still computed and reported in the gate criteria for visibility.
+
+Regression blocking is preserved. A real pass-to-fail flip drops `after_score` below `before_score` (fails `no_regression`) and records the scenario in `regressions` (fails `no_unexplained_regressions`), so the gate still returns FAIL. The security-critical 100%-pass requirement is untouched: a security-critical run below 100% pass rate still blocks regardless of improvement state.
 
 #### Security-Critical Prompt Tier
 

--- a/.agents/architecture/ADR-057-prompt-behavioral-evaluation.md
+++ b/.agents/architecture/ADR-057-prompt-behavioral-evaluation.md
@@ -78,7 +78,7 @@ Each evaluation consists of:
 The gate blocks regressions. It does not mandate an improvement on every edit. A prompt change passes behavioral evaluation when these criteria hold:
 
 1. `after_score >= before_score` (no regression on existing scenarios)
-2. No scenario flips from pass to fail without explicit justification in the PR. Intentional trade-offs are acceptable when the PR documents the rationale.
+2. No scenario flips from pass to fail. Every pass-to-fail flip is recorded in `regressions` and blocks the gate automatically; the automated gate has no mechanism to accept a "justified" regression. Landing a deliberate trade-off requires a human override (admin merge) with the rationale documented in the PR, not a gate bypass.
 3. Flakiness on any scenario stays at or below the 40% block threshold.
 
 A change that targets a failing scenario SHOULD move it from fail to pass. This is recorded as `has_improvement` and surfaced in the gate output, but it is not a hard pass requirement (see the 2026-06-01 relaxation note below).
@@ -91,7 +91,7 @@ That outcome contradicts the gate's stated purpose: regression prevention (Decis
 
 Relaxation: `has_improvement` is dropped as a hard pass requirement in `eval-prompt-change.py acceptance_gate()`. The gate now passes when `no_regression AND no_unexplained_regressions AND no_high_flakiness` hold (plus the security-critical 100%-pass requirement when applicable). `has_improvement` is still computed and reported in the gate criteria for visibility.
 
-Regression blocking is preserved. A real pass-to-fail flip drops `after_score` below `before_score` (fails `no_regression`) and records the scenario in `regressions` (fails `no_unexplained_regressions`), so the gate still returns FAIL. The security-critical 100%-pass requirement is untouched: a security-critical run below 100% pass rate still blocks regardless of improvement state.
+Regression blocking is preserved. Every pass-to-fail flip records the scenario in `regressions`, so `no_unexplained_regressions` fails and the gate returns FAIL. This holds even when an offsetting improvement keeps `after_score` flat (so `no_regression` stays true): the `regressions` list, not the score delta, is the authoritative block signal. The security-critical 100%-pass requirement is untouched: a security-critical run below 100% pass rate still blocks regardless of improvement state.
 
 #### Security-Critical Prompt Tier
 

--- a/scripts/eval/eval-prompt-change.py
+++ b/scripts/eval/eval-prompt-change.py
@@ -75,6 +75,11 @@ DEFAULT_RUNS = 3
 SECURITY_RUNS = 5
 FLAKINESS_BLOCK_THRESHOLD = 0.4
 
+# Criteria reported for human/JSON consumers but NOT part of the pass/fail
+# decision. They are surfaced for context only; the gate verdict never depends
+# on them. Keep this in sync with the comment on `has_improvement` and ADR-057.
+NON_GATING_CRITERIA = frozenset({"has_improvement"})
+
 
 # ---------------------------------------------------------------------------
 # Scenario loading and validation
@@ -470,9 +475,11 @@ def acceptance_gate(
     no_high_flakiness = len(high_flakiness_scenarios) == 0
 
     # A non-regressing change passes even with zero improvements. A real
-    # regression still fails: a pass->fail flip drops after_score below
-    # before_score (no_regression=False) and populates regressions
-    # (no_unexplained_regressions=False).
+    # regression still fails: any pass->fail flip populates `regressions`, so
+    # no_unexplained_regressions=False blocks the change. This holds even when
+    # an offsetting improvement keeps after_score flat (no_regression stays
+    # True); the regressions list, not the score delta, is the authoritative
+    # block signal.
     passed = (no_regression and no_unexplained_regressions
               and no_high_flakiness)
     if security_critical:
@@ -640,8 +647,13 @@ def _print_gate_summary(gate: dict[str, Any]) -> None:
           f"Delta: {gate['delta']:+.0%}", file=sys.stderr)
     print("  Criteria:", file=sys.stderr)
     for criterion, passed in gate["criteria"].items():
-        mark = "PASS" if passed else "FAIL"
-        print(f"    {criterion}: {mark}", file=sys.stderr)
+        if criterion in NON_GATING_CRITERIA:
+            value = "yes" if passed else "no"
+            print(f"    {criterion}: {value} (informational, non-gating)",
+                  file=sys.stderr)
+        else:
+            mark = "PASS" if passed else "FAIL"
+            print(f"    {criterion}: {mark}", file=sys.stderr)
 
     if gate["improvements"]:
         print(f"  Improvements: {gate['improvements']}", file=sys.stderr)

--- a/scripts/eval/eval-prompt-change.py
+++ b/scripts/eval/eval-prompt-change.py
@@ -407,14 +407,22 @@ def acceptance_gate(
     comparison: dict[str, Any],
     security_critical: bool = False,
 ) -> dict[str, Any]:
-    """Apply ADR-057 three-criteria acceptance gate.
+    """Apply the ADR-057 acceptance gate.
 
-    Criteria:
-    1. after_score >= before_score (no regression)
-    2. Any targeted scenario moves from fail to pass
-    3. No scenario flips pass->fail without justification
+    The gate exists to block REGRESSIONS, not to mandate an improvement on
+    every edit. A change passes when it does not regress behavior:
 
-    Security-critical tier: all runs must pass (100% pass rate).
+    1. after_score >= before_score (no regression on existing scenarios)
+    2. No scenario flips pass->fail (no unexplained regression)
+    3. Flakiness on any scenario stays at or below the block threshold
+
+    has_improvement is computed and reported for visibility, but it is NOT
+    a hard pass requirement. Requiring an improvement on every edit
+    structurally blocked legitimate documentation-consistency changes whenever
+    a pre-existing scenario already failed on the base ref (before_score < 1.0
+    with zero targeted improvements). See ADR-057 (2026-06-01 relaxation note).
+
+    Security-critical tier: all runs must pass (100% pass rate). Unchanged.
     """
     before_results = comparison["before_results"]
     after_results = comparison["after_results"]
@@ -422,7 +430,6 @@ def acceptance_gate(
     # Criterion 1: no regression
     no_regression = comparison["after_score"] >= comparison["before_score"]
 
-    # Criterion 2: at least one improvement (or no failures to begin with)
     improvements = []
     regressions = []
     flaky_scenarios = []
@@ -436,9 +443,12 @@ def acceptance_gate(
         if a.get("flaky"):
             flaky_scenarios.append(sid)
 
+    # Informational only: whether the change moved any scenario fail->pass, or
+    # the base ref already passed everything. NOT a gating requirement (see
+    # the docstring and ADR-057).
     has_improvement = len(improvements) > 0 or comparison["before_score"] == 1.0
 
-    # Criterion 3: no unexplained regressions
+    # Criterion 2: no unexplained regressions
     no_unexplained_regressions = len(regressions) == 0
 
     # Security-critical: require 100% pass rate across all runs
@@ -449,7 +459,7 @@ def acceptance_gate(
                 security_pass = False
                 break
 
-    # Criterion 4: flakiness threshold (ADR-057 enforced)
+    # Criterion 3: flakiness threshold (ADR-057 enforced)
     high_flakiness_scenarios = []
     for a in after_results:
         if a.get("flaky") and a["runs"] > 1:
@@ -459,8 +469,12 @@ def acceptance_gate(
 
     no_high_flakiness = len(high_flakiness_scenarios) == 0
 
-    passed = (no_regression and has_improvement
-              and no_unexplained_regressions and no_high_flakiness)
+    # A non-regressing change passes even with zero improvements. A real
+    # regression still fails: a pass->fail flip drops after_score below
+    # before_score (no_regression=False) and populates regressions
+    # (no_unexplained_regressions=False).
+    passed = (no_regression and no_unexplained_regressions
+              and no_high_flakiness)
     if security_critical:
         passed = passed and security_pass
 

--- a/tests/eval/test_eval_prompt_change.py
+++ b/tests/eval/test_eval_prompt_change.py
@@ -792,14 +792,58 @@ class TestAcceptanceGate:
         assert gate["passed"] is True
         assert "S1" in gate["improvements"]
 
-    def test_no_improvement_below_one_fails(self):
+    def test_no_improvement_no_regression_passes(self):
+        # Issue #2197: a no-delta change that does not regress PASSES even when
+        # pre-existing scenarios fail on the base ref (before_score < 1.0 with
+        # zero improvements). has_improvement is reported but is not gating.
+        # This reverses the old test_no_improvement_below_one_fails assertion:
+        # the gate now blocks regressions, not edits that fail to improve.
         before = [self._r("S1", False), self._r("S2", False)]
         after = [self._r("S1", False), self._r("S2", False)]
         comp = self._comparison(before, after)
         comp["delta"] = 0.0
         gate = eval_mod.acceptance_gate(comp)
-        assert gate["passed"] is False
+        assert gate["passed"] is True
+        assert gate["verdict"] == "PASS"
+        assert gate["criteria"]["no_regression"] is True
+        assert gate["criteria"]["no_unexplained_regressions"] is True
+        # has_improvement remains informational and False here.
         assert gate["criteria"]["has_improvement"] is False
+
+    def test_partial_base_failure_no_delta_passes(self):
+        # Issue #2197 regression repro: base ref has 5/7 passing (D13/D14 fail),
+        # a doc-consistency edit changes nothing. before_score == after_score,
+        # no regression, zero improvements. Must PASS, not block.
+        before = [
+            self._r("D1", True), self._r("D6", True), self._r("D7", True),
+            self._r("D9", True), self._r("D12", True),
+            self._r("D13", False), self._r("D14", False),
+        ]
+        after = [
+            self._r("D1", True), self._r("D6", True), self._r("D7", True),
+            self._r("D9", True), self._r("D12", True),
+            self._r("D13", False), self._r("D14", False),
+        ]
+        comp = self._comparison(before, after)
+        comp["delta"] = 0.0
+        gate = eval_mod.acceptance_gate(comp)
+        assert gate["passed"] is True
+        assert gate["improvements"] == []
+        assert gate["regressions"] == []
+
+    def test_fail_introducing_change_still_fails(self):
+        # A change that flips a passing scenario to fail must still FAIL the
+        # gate: after_score < before_score and the regression is recorded.
+        before = [self._r("S1", True), self._r("S2", True), self._r("S3", False)]
+        after = [self._r("S1", True), self._r("S2", False), self._r("S3", False)]
+        comp = self._comparison(before, after)
+        comp["delta"] = -1 / 3
+        gate = eval_mod.acceptance_gate(comp)
+        assert gate["passed"] is False
+        assert gate["verdict"] == "FAIL"
+        assert gate["criteria"]["no_regression"] is False
+        assert gate["criteria"]["no_unexplained_regressions"] is False
+        assert "S2" in gate["regressions"]
 
     def test_security_critical_requires_100_percent(self):
         before = [self._r("S1", True, pass_rate=1.0, runs=5)]
@@ -818,6 +862,30 @@ class TestAcceptanceGate:
         gate = eval_mod.acceptance_gate(comp, security_critical=True)
         assert gate["passed"] is True
         assert gate["criteria"]["security_all_runs_pass"] is True
+
+    def test_security_critical_no_improvement_full_pass_passes(self):
+        # Issue #2197: the relaxation does not weaken the security tier. A
+        # security-critical change with zero improvements still PASSES when it
+        # does not regress and every run passes (100% pass rate preserved).
+        before = [self._r("S1", True, pass_rate=1.0, runs=5)]
+        after = [self._r("S1", True, pass_rate=1.0, runs=5)]
+        comp = self._comparison(before, after, before_score=1.0, after_score=1.0)
+        comp["delta"] = 0.0
+        gate = eval_mod.acceptance_gate(comp, security_critical=True)
+        assert gate["passed"] is True
+        assert gate["criteria"]["security_all_runs_pass"] is True
+
+    def test_security_critical_partial_pass_still_blocks(self):
+        # Issue #2197: even with no regression (before==after score), a run
+        # that does not reach 100% pass rate MUST still block under the
+        # security tier. The 100%-pass requirement is untouched.
+        before = [self._r("S1", True, pass_rate=1.0, runs=5)]
+        after = [self._r("S1", True, pass_rate=0.6, runs=5)]
+        comp = self._comparison(before, after, before_score=1.0, after_score=1.0)
+        comp["delta"] = 0.0
+        gate = eval_mod.acceptance_gate(comp, security_critical=True)
+        assert gate["passed"] is False
+        assert gate["criteria"]["security_all_runs_pass"] is False
 
     def test_high_flakiness_fails_gate(self):
         # 30% pass rate => fail rate 70% > 40% threshold => blocked
@@ -1074,8 +1142,8 @@ class TestMainCLI:
         ])
         with pytest.raises(SystemExit) as exc:
             eval_mod.main()
-        # Gate passes because before==after==1.0 satisfies has_improvement
-        # via the before_score==1.0 clause
+        # Gate passes because before==after==1.0: no regression, no flip
+        # pass->fail (Issue #2197: improvement is not a hard requirement)
         assert exc.value.code == 0
         result = json.loads(out_path.read_text())
         assert result["gate"]["verdict"] == "PASS"


### PR DESCRIPTION
## Summary

The ADR-057 acceptance gate in `scripts/eval/eval-prompt-change.py` required `has_improvement` (at least one fail-to-pass flip, or `before_score == 1.0`) as a hard pass condition. This structurally blocked any legitimate change to a prompt whose base ref already had a failing scenario. Concrete repro: a documentation-consistency edit to a command prompt (the spec command, .claude/commands path) introduces no behavioral change and no regression, but pre-existing scenarios D13 and D14 fail on `main` (`before_score` 5/7 < 1.0). With zero fail-to-pass flips, `has_improvement` was false and the gate returned FAIL even though the change regressed nothing.

That contradicts the gate's stated purpose: regression prevention (ADR-057 Decision Driver 2), not a mandate that every edit improve a score. This relaxes the gate so a non-regressing change passes even with zero improvements, while real regressions still fail and the security-critical 100%-pass path is untouched.

## Per-file changes

- `scripts/eval/eval-prompt-change.py`: in `acceptance_gate()`, dropped `has_improvement` from the hard `passed` condition. The gate now passes when `no_regression AND no_unexplained_regressions AND no_high_flakiness` hold (plus `security_pass` when `security_critical`). `has_improvement` is still computed and reported in `gate["criteria"]` for visibility. Updated the docstring and the criterion-numbering comments. No change to the security-critical 100%-pass-rate logic.
- `tests/eval/test_eval_prompt_change.py`: rewrote `test_no_improvement_below_one_fails` into `test_no_improvement_no_regression_passes` (deliberate behavior change, documented in the test comment). Added `test_partial_base_failure_no_delta_passes` (the D13/D14 5-of-7 repro), `test_fail_introducing_change_still_fails` (regression still FAILs), `test_security_critical_no_improvement_full_pass_passes`, and `test_security_critical_partial_pass_still_blocks` (security 100%-pass requirement unchanged). Updated one stale comment in `test_full_run_exits_zero_on_pass`.
- `.agents/architecture/ADR-057-prompt-behavioral-evaluation.md`: relaxed the Acceptance Gate criteria wording (improvement is now SHOULD when the change targets a failing scenario, not a hard MUST) and added a dated subsection "Acceptance Gate Relaxation (2026-06-01, Issue #2197)" documenting the failure, the rationale, and the preserved regression-blocking and security behavior.

Fixes #2197

## Testing

- `uv run pytest tests/eval/` -> 167 passed (95 in `test_eval_prompt_change.py`).
- Targeted gate tests verified: `test_no_improvement_no_regression_passes`, `test_partial_base_failure_no_delta_passes`, `test_fail_introducing_change_still_fails`, `test_improvement_satisfies_gate`, `test_regression_fails_gate`, `test_security_critical_requires_100_percent`, `test_security_critical_no_improvement_full_pass_passes`, `test_security_critical_partial_pass_still_blocks` -> all pass.
- `ruff check scripts/eval/eval-prompt-change.py tests/eval/test_eval_prompt_change.py` -> All checks passed.
- Ran the security-scan skill (scan_vulnerabilities) on the changed script -> No vulnerabilities found.
- No em/en dashes in any changed file (verified with a U+2013/U+2014 grep, 0 hits each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
