### PR TITLE
docs(analysis): classify monolith sections for issue 1769 Phase 1 audit

### DIFF
--- a/.agents/analysis/1769-monolith-section-classification.md
+++ b/.agents/analysis/1769-monolith-section-classification.md
@@ -51,6 +51,11 @@ are template/example content, are excluded):
 | `phase-execution.md` | `.agents/planning/**,.agents/sessions/**` | `normal` |
 | `governance-agents.md` | `.agents/governance/**` | `high` |
 
+Phase 2 must treat internal-only globs as Claude rule scopes, not portable mirror
+scopes. `build/scripts/generate_rules.py` strips `.agents/` and `.serena/` when
+it emits Copilot instruction mirrors, and all-internal scopes can collapse to
+`applyTo: "**"` in generated outputs.
+
 `governance-agents.md` avoids colliding with the existing `.claude/rules/governance.md`,
 which already scopes `.agents/governance/**` for governance-file edit rules. The
 new rule carries the agent quality-gate and conflict-resolution directives.

--- a/.agents/analysis/1769-monolith-section-classification.md
+++ b/.agents/analysis/1769-monolith-section-classification.md
@@ -103,9 +103,9 @@ owner. The steering files and their scopes:
 | Impact Analysis (Agent Prompt Changes) | KEEP-IN-STEERING | Agent-prompt-change impact overlaps `agent-prompts.md` (`src/claude/**`); pointer only |
 | Commit Message Format | KEEP-IN-STEERING | Conventional-commit + Co-Authored-By rule already in `.claude/rules/universal.md` (`**`, `critical`); do not duplicate |
 | Markdown Formatting Standards | KEEP-IN-STEERING | `documentation.md` (`**/*.md`) is authoritative for markdown linting |
-| Session Log Template | PATH-SCOPED-RULE | `session-protocol.md` (`.agents/sessions/**`); JSON template lives with session rules |
-| HANDOFF.md Template | PATH-SCOPED-RULE | `memory-handoff.md` (`.agents/**`) |
-| Recommended Agent Workflows | PATH-SCOPED-RULE | `workflow-routing.md` |
+| Notes for Next Session | PATH-SCOPED-RULE | `memory-handoff.md`; session carry-forward guidance |
+| Session History | PATH-SCOPED-RULE | `session-protocol.md`; session log history belongs with session rules |
+| Files to Review | PATH-SCOPED-RULE | `memory-handoff.md`; context retrieval order and handoff dependencies |
 | Agent Invocation Reference | PATH-SCOPED-RULE | `agent-catalog.md`; delegation syntax |
 | Skill System | KEEP-IN-STEERING | `claude-skills.md` (`.claude/skills/**`) is authoritative for skill standards |
 | Traceability Rules | PATH-SCOPED-RULE | `memory-handoff.md`; cross-reference + entity-link requirements |

--- a/.agents/analysis/1769-monolith-section-classification.md
+++ b/.agents/analysis/1769-monolith-section-classification.md
@@ -1,0 +1,163 @@
+# Monolith Section Classification: .agents/*.md Extraction
+
+> **Issue**: #1769 (Phase 1 audit)
+> **Date**: 2026-06-01
+> **Scope**: Every top-level `##` section in the three always-loaded monoliths
+> **Method**: Static section inventory (fence-aware) + steering overlap check
+
+## Summary
+
+Phase 1 of #1769 is an audit only. It maps every top-level `##` section in the
+three monolith instruction files to one of three destinations and does NOT move
+any content. Content moves happen in later phases.
+
+Destinations:
+
+- **KEEP-IN-STEERING**: content already lives in an `.agents/steering/*.md` file.
+  Per decision D6, the steering file stays authoritative and the section is not
+  re-extracted into a rule.
+- **ALWAYS-LOAD-RULE**: universal safety invariant. Lands in the one always-load
+  rule (`agent-boundaries.md`, `applyTo: "**"`, `priority: critical`).
+- **PATH-SCOPED-RULE**: loads only when a matching path is touched. Lands in one
+  of the six path-scoped rule files with an `applyTo:` glob.
+
+Frontmatter follows the repo convention (`applyTo:` + `priority:`), NOT the
+issue's stale `paths:`/`alwaysApply:` keys. See the binding decision comment on
+#1769 (2026-05-31): when the issue was filed, `.claude/rules/` held 1 file and
+no generator. Main now has ~29 rule files and `build/scripts/generate_rules.py`,
+which generates BOTH `.github/instructions/` and `src/copilot-cli/instructions/`
+from `.claude/rules/`. Phase 2 authors rules and runs the generator; it does not
+hand-author the Copilot mirror.
+
+Section counts measured fence-aware (headings inside fenced code blocks, which
+are template/example content, are excluded):
+
+| Monolith | Top-level `##` sections | Lines |
+|----------|-------------------------|-------|
+| `AGENT-SYSTEM.md` | 13 | 1989 |
+| `AGENT-INSTRUCTIONS.md` | 18 | 824 |
+| `SESSION-PROTOCOL.md` | 16 | 1191 |
+| **Total** | **47** | **4004** |
+
+## Target Rule Files (Phase 2)
+
+| Rule file | `applyTo:` | `priority:` |
+|-----------|------------|-------------|
+| `agent-boundaries.md` | `**` | `critical` |
+| `session-protocol.md` | `.agents/sessions/**` | `high` |
+| `agent-catalog.md` | `templates/agents/**,src/claude/**,.claude/agents/**` | `high` |
+| `memory-handoff.md` | `.agents/**,.serena/**` | `normal` |
+| `workflow-routing.md` | `templates/**,.agents/planning/**` | `normal` |
+| `phase-execution.md` | `.agents/planning/**,.agents/sessions/**` | `normal` |
+| `governance-agents.md` | `.agents/governance/**` | `high` |
+
+`governance-agents.md` avoids colliding with the existing `.claude/rules/governance.md`,
+which already scopes `.agents/governance/**` for governance-file edit rules. The
+new rule carries the agent quality-gate and conflict-resolution directives.
+
+## Steering Overlap Reference (D6)
+
+A section maps to KEEP-IN-STEERING only when its content already has a steering
+owner. The steering files and their scopes:
+
+| Steering file | `applyTo:` |
+|---------------|------------|
+| `agent-prompts.md` | `src/claude/**/*.md,.github/copilot-instructions.md` |
+| `claude-skills.md` | `.claude/skills/**` |
+| `documentation.md` | `**/*.md` (excl. `src/claude/**`, steering) |
+| `powershell-patterns.md` | `**/*.ps1,**/*.psm1` |
+| `security-practices.md` | `**/Auth/**,*.env*,**/*.secrets.*,.github/workflows/**,.githooks/**` |
+| `testing-approach.md` | `**/*.Tests.ps1` |
+
+## AGENT-SYSTEM.md (13 sections, 1989 lines)
+
+| `##` Section | Lines | Classification | Target / glob |
+|--------------|-------|----------------|---------------|
+| 1. Executive Summary | 33 | PATH-SCOPED-RULE | `agent-catalog.md` (`templates/agents/**,src/claude/**,.claude/agents/**`); compress to system-purpose preamble |
+| 2. Agent Catalog | 744 | PATH-SCOPED-RULE | `agent-catalog.md`; compress 20-agent prose to a table + per-agent key constraints (D7) |
+| 2.5 Agent Tier Hierarchy | 149 | PATH-SCOPED-RULE | `agent-catalog.md`; tier table + escalation rule |
+| 3. Workflow Patterns | 282 | PATH-SCOPED-RULE | `workflow-routing.md` (`templates/**,.agents/planning/**`); canonical workflow source is `src/claude/orchestrator.md`, keep pointer |
+| 4. Routing Heuristics | 37 | PATH-SCOPED-RULE | `workflow-routing.md` |
+| 5. Memory and Handoff System | 100 | PATH-SCOPED-RULE | `memory-handoff.md` (`.agents/**,.serena/**`) |
+| 6. Parallel Execution | 296 | PATH-SCOPED-RULE | `workflow-routing.md`; compress voting/parallel-readiness detail |
+| 7. Steering System | 71 | KEEP-IN-STEERING | `.agents/steering/README.md` is authoritative for steering mechanics; leave a pointer only |
+| 8. Quality Gates | 42 | PATH-SCOPED-RULE | `governance-agents.md` (`.agents/governance/**`); critic/QA gate rules |
+| 9. Conflict Resolution | 43 | PATH-SCOPED-RULE | `governance-agents.md`; agent-disagreement + blocker-report rules |
+| 10. Quick Reference Tables | 40 | PATH-SCOPED-RULE | `agent-catalog.md`; workflow-selection + model-assignment tables |
+| 11. Extension Points | 91 | KEEP-IN-STEERING | Adding-agents / adding-steering / adding-workflows mechanics overlap `agent-prompts.md` + `steering/README.md`; keep a pointer, do not duplicate |
+| 12. Appendix | 53 | PATH-SCOPED-RULE | `memory-handoff.md`; entity-naming + relation-type tables drive memory writes |
+
+## AGENT-INSTRUCTIONS.md (18 sections, 824 lines)
+
+| `##` Section | Classification | Target / glob |
+|--------------|----------------|---------------|
+| Agent System Overview | PATH-SCOPED-RULE | `agent-catalog.md`; pointer + one-paragraph overview |
+| Quick Start Checklist | ALWAYS-LOAD-RULE | `agent-boundaries.md` (`**`, `critical`); pre-work safety steps |
+| Document Hierarchy | PATH-SCOPED-RULE | `agent-catalog.md`; which doc owns what |
+| Phase Execution Protocol | PATH-SCOPED-RULE | `phase-execution.md` (`.agents/planning/**,.agents/sessions/**`) |
+| Impact Analysis (Agent Prompt Changes) | KEEP-IN-STEERING | Agent-prompt-change impact overlaps `agent-prompts.md` (`src/claude/**`); pointer only |
+| Commit Message Format | KEEP-IN-STEERING | Conventional-commit + Co-Authored-By rule already in `.claude/rules/universal.md` (`**`, `critical`); do not duplicate |
+| Markdown Formatting Standards | KEEP-IN-STEERING | `documentation.md` (`**/*.md`) is authoritative for markdown linting |
+| Session Log Template | PATH-SCOPED-RULE | `session-protocol.md` (`.agents/sessions/**`); JSON template lives with session rules |
+| HANDOFF.md Template | PATH-SCOPED-RULE | `memory-handoff.md` (`.agents/**`) |
+| Recommended Agent Workflows | PATH-SCOPED-RULE | `workflow-routing.md` |
+| Agent Invocation Reference | PATH-SCOPED-RULE | `agent-catalog.md`; delegation syntax |
+| Skill System | KEEP-IN-STEERING | `claude-skills.md` (`.claude/skills/**`) is authoritative for skill standards |
+| Traceability Rules | PATH-SCOPED-RULE | `memory-handoff.md`; cross-reference + entity-link requirements |
+| Steering System | KEEP-IN-STEERING | `steering/README.md` authoritative; pointer only |
+| Critical Reminders | ALWAYS-LOAD-RULE | `agent-boundaries.md`; DO / DO-NOT safety invariants |
+| Emergency Recovery | ALWAYS-LOAD-RULE | `agent-boundaries.md`; recovery steps must be reachable from any path |
+| Related Documents | KEEP-IN-STEERING | Pointer list; stays as a pointer block in the slimmed monolith |
+| Lessons Learned | PATH-SCOPED-RULE | `memory-handoff.md`; feeds memory/retro, scope to `.agents/**` |
+
+## SESSION-PROTOCOL.md (16 sections, 1191 lines)
+
+| `##` Section | Classification | Target / glob |
+|--------------|----------------|---------------|
+| RFC 2119 Key Words | ALWAYS-LOAD-RULE | `agent-boundaries.md`; requirement-keyword definitions bind every session |
+| Protocol Enforcement Model | PATH-SCOPED-RULE | `session-protocol.md` (`.agents/sessions/**`); trust vs verification model |
+| Session Start Protocol | PATH-SCOPED-RULE | `session-protocol.md` |
+| Session Start Checklist | PATH-SCOPED-RULE | `session-protocol.md` |
+| Session Mid Protocol | PATH-SCOPED-RULE | `session-protocol.md`; commit-count monitoring |
+| Tier-Based Coordination (BLOCKING for multi-agent sessions) | PATH-SCOPED-RULE | `workflow-routing.md`; multi-agent tier coordination per ADR-009 |
+| Session End Protocol | PATH-SCOPED-RULE | `session-protocol.md` |
+| Session End Checklist | PATH-SCOPED-RULE | `session-protocol.md` |
+| Session Log Template | PATH-SCOPED-RULE | `session-protocol.md`; JSON schema at `.agents/schemas/session-log.schema.json` |
+| Unattended Execution Protocol | PATH-SCOPED-RULE | `session-protocol.md`; autonomous-operation rules |
+| Violation Handling | PATH-SCOPED-RULE | `session-protocol.md` |
+| Validation Tooling | PATH-SCOPED-RULE | `session-protocol.md`; `scripts/validation/` + validator commands |
+| Cross-Reference: Other Documents | KEEP-IN-STEERING | Pointer block; stays in slimmed monolith |
+| Rationale for RFC 2119 | KEEP-IN-STEERING | Rationale prose; collapse into a pointer, not a rule directive |
+| ADR Cross-Reference | KEEP-IN-STEERING | Pointer to governing ADRs; stays in slimmed monolith |
+| Related Documents | KEEP-IN-STEERING | Pointer block; stays in slimmed monolith |
+
+## Tallies
+
+| Classification | Count |
+|----------------|-------|
+| ALWAYS-LOAD-RULE | 4 |
+| PATH-SCOPED-RULE | 33 |
+| KEEP-IN-STEERING | 10 |
+| **Total sections** | **47** |
+
+ALWAYS-LOAD sections (the only content entering `agent-boundaries.md`):
+
+- AGENT-INSTRUCTIONS `Quick Start Checklist`
+- AGENT-INSTRUCTIONS `Critical Reminders`
+- AGENT-INSTRUCTIONS `Emergency Recovery`
+- SESSION-PROTOCOL `RFC 2119 Key Words`
+
+## Notes and Caveats for Phase 2
+
+- This is a static section map. Phase 2 MUST re-read each section before moving
+  it, because line counts shift as content compresses.
+- KEEP-IN-STEERING does not mean "delete." The slimmed monolith keeps a one-line
+  pointer to the steering owner so existing `read()` references stay valid (D1).
+- Two KEEP-IN-STEERING calls route to existing `.claude/rules/` files, not
+  steering: `Commit Message Format` is already in `universal.md`, and markdown
+  standards are owned by `documentation.md` steering. Phase 2 MUST NOT duplicate
+  either into a new rule.
+- `agent-boundaries.md` must stay under 100 lines. The four always-load sections
+  above total well over that in raw form; Phase 2 compresses them to invariant
+  bullets, dropping prose and examples.
+- No content was moved in this PR. This document is the only file added.

--- a/.agents/analysis/1769-monolith-section-classification.md
+++ b/.agents/analysis/1769-monolith-section-classification.md
@@ -52,9 +52,9 @@ are template/example content, are excluded):
 | `governance-agents.md` | `.agents/governance/**` | `high` |
 
 Phase 2 must treat internal-only globs as Claude rule scopes, not portable mirror
-scopes. `build/scripts/generate_rules.py` strips `.agents/` and `.serena/` when
-it emits Copilot instruction mirrors, and all-internal scopes can collapse to
-`applyTo: "**"` in generated outputs.
+scopes. `build/scripts/generate_rules.py` strips `.agents/`, `.claude/`, and
+`.serena/` when it emits Copilot instruction mirrors, and all-internal scopes can
+collapse to `applyTo: "**"` in generated outputs.
 
 `governance-agents.md` avoids colliding with the existing `.claude/rules/governance.md`,
 which already scopes `.agents/governance/**` for governance-file edit rules. The

--- a/tests/test_monolith_section_classification.py
+++ b/tests/test_monolith_section_classification.py
@@ -16,6 +16,7 @@ sections, so ``top_level_sections`` skips them.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -32,29 +33,47 @@ MONOLITHS = (
 
 
 def top_level_sections(text: str) -> list[str]:
-    """Return titles of fence-aware top-level ``## `` headings.
-
-    A line that toggles a fenced code block (``` or ~~~) flips fence state, and
-    any ``## `` line while inside a fence is treated as content, not a heading.
-    """
+    """Return titles of fence-aware top-level ``## `` headings."""
     titles: list[str] = []
-    in_fence = False
+    active_fence: str | None = None
     for line in text.split("\n"):
         stripped = line.strip()
-        if stripped.startswith("```") or stripped.startswith("~~~"):
-            in_fence = not in_fence
+        fence_marker = stripped[:3]
+        if fence_marker in ("```", "~~~"):
+            if active_fence is None:
+                active_fence = fence_marker
+            elif active_fence == fence_marker:
+                active_fence = None
             continue
-        if not in_fence and line.startswith("## "):
+        if active_fence is None and line.startswith("## "):
             titles.append(line[3:].strip())
     return titles
+
+
+def audit_mentions_section(audit_text: str, monolith_name: str, title: str) -> bool:
+    """Return whether a section title appears in the monolith's table block."""
+    monolith_heading = f"## {monolith_name}"
+    next_monolith_heading = r"\n## [A-Z][A-Z-]+\.md"
+    block_match = re.search(
+        rf"^{re.escape(monolith_heading)}.*?(?={next_monolith_heading}|\Z)",
+        audit_text,
+        flags=re.M | re.S,
+    )
+    if block_match is None:
+        return False
+    title_cell = re.escape(title)
+    title_pattern = rf"^\|\s*(?:\d+\.\s*)?{title_cell}\s*\|"
+    return re.search(title_pattern, block_match[0], re.M) is not None
 
 
 def test_top_level_sections_skips_fenced_headings() -> None:
     text = (
         "## Real One\n"
+        "~~~\n"
         "```\n"
         "## Fenced Not A Section\n"
         "```\n"
+        "~~~\n"
         "## Real Two\n"
     )
     assert top_level_sections(text) == ["Real One", "Real Two"]
@@ -79,7 +98,11 @@ def test_every_monolith_section_is_classified(monolith: Path) -> None:
     audit_text = ANALYSIS_DOC.read_text(encoding="utf-8")
     sections = top_level_sections(monolith.read_text(encoding="utf-8"))
     assert sections, f"no top-level sections found in {monolith.name}"
-    missing = [title for title in sections if title not in audit_text]
+    missing = [
+        title
+        for title in sections
+        if not audit_mentions_section(audit_text, monolith.name, title)
+    ]
     assert not missing, (
         f"{monolith.name} sections absent from the classification doc: {missing}"
     )
@@ -90,6 +113,7 @@ def test_audit_records_total_section_count() -> None:
         len(top_level_sections(path.read_text(encoding="utf-8"))) for path in MONOLITHS
     )
     audit_text = ANALYSIS_DOC.read_text(encoding="utf-8")
-    assert f"**{total}**" in audit_text, (
+    total_row = rf"^\|\s*\*\*Total\*\*\s*\|\s*\*\*{total}\*\*\s*\|"
+    assert re.search(total_row, audit_text, re.M), (
         f"audit total tally must state {total} sections"
     )

--- a/tests/test_monolith_section_classification.py
+++ b/tests/test_monolith_section_classification.py
@@ -35,17 +35,19 @@ MONOLITHS = (
 def top_level_sections(text: str) -> list[str]:
     """Return titles of fence-aware top-level ``## `` headings."""
     titles: list[str] = []
-    active_fence: str | None = None
+    active_fence: tuple[str, int] | None = None
     for line in text.split("\n"):
         stripped = line.strip()
-        fence_marker = stripped[:3]
-        if fence_marker in ("```", "~~~"):
-            if active_fence is None:
-                active_fence = fence_marker
-            elif active_fence == fence_marker:
+        if active_fence is None and stripped.startswith(("```", "~~~")):
+            marker = stripped[0]
+            active_fence = (marker, len(stripped) - len(stripped.lstrip(marker)))
+            continue
+        if active_fence is not None:
+            marker, minimum_length = active_fence
+            if stripped.startswith(marker * minimum_length) and set(stripped) == {marker}:
                 active_fence = None
             continue
-        if active_fence is None and line.startswith("## "):
+        if line.startswith("## "):
             titles.append(line[3:].strip())
     return titles
 
@@ -74,6 +76,18 @@ def test_top_level_sections_skips_fenced_headings() -> None:
         "## Fenced Not A Section\n"
         "```\n"
         "~~~\n"
+        "## Real Two\n"
+    )
+    assert top_level_sections(text) == ["Real One", "Real Two"]
+
+
+def test_top_level_sections_requires_bare_closing_fence() -> None:
+    text = (
+        "## Real One\n"
+        "```\n"
+        "```text\n"
+        "## Fenced Not A Section\n"
+        "```\n"
         "## Real Two\n"
     )
     assert top_level_sections(text) == ["Real One", "Real Two"]

--- a/tests/test_monolith_section_classification.py
+++ b/tests/test_monolith_section_classification.py
@@ -1,0 +1,95 @@
+"""Audit-completeness checks for issue #1769 Phase 1.
+
+The classification document at
+``.agents/analysis/1769-monolith-section-classification.md`` maps every
+top-level ``##`` section in the three always-loaded monolith instruction files
+to a destination. These tests pin the audit's core invariant: no monolith
+section is silently dropped from the classification.
+
+The failure mode this guards against: a future edit adds a new ``##`` section
+to a monolith, and a stale audit no longer covers it. The test fails until the
+audit is updated.
+
+Headings inside fenced code blocks are template or example content, not real
+sections, so ``top_level_sections`` skips them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+ANALYSIS_DOC = (
+    PROJECT_ROOT / ".agents" / "analysis" / "1769-monolith-section-classification.md"
+)
+MONOLITHS = (
+    PROJECT_ROOT / ".agents" / "AGENT-SYSTEM.md",
+    PROJECT_ROOT / ".agents" / "AGENT-INSTRUCTIONS.md",
+    PROJECT_ROOT / ".agents" / "SESSION-PROTOCOL.md",
+)
+
+
+def top_level_sections(text: str) -> list[str]:
+    """Return titles of fence-aware top-level ``## `` headings.
+
+    A line that toggles a fenced code block (``` or ~~~) flips fence state, and
+    any ``## `` line while inside a fence is treated as content, not a heading.
+    """
+    titles: list[str] = []
+    in_fence = False
+    for line in text.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if not in_fence and line.startswith("## "):
+            titles.append(line[3:].strip())
+    return titles
+
+
+def test_top_level_sections_skips_fenced_headings() -> None:
+    text = (
+        "## Real One\n"
+        "```\n"
+        "## Fenced Not A Section\n"
+        "```\n"
+        "## Real Two\n"
+    )
+    assert top_level_sections(text) == ["Real One", "Real Two"]
+
+
+def test_top_level_sections_ignores_deeper_headings() -> None:
+    text = "## Top\n### Sub\n#### Deeper\n## Top Two\n"
+    assert top_level_sections(text) == ["Top", "Top Two"]
+
+
+def test_top_level_sections_empty_when_no_headings() -> None:
+    assert top_level_sections("no headings here\njust prose\n") == []
+
+
+def test_analysis_doc_exists() -> None:
+    assert ANALYSIS_DOC.is_file(), f"missing audit doc: {ANALYSIS_DOC}"
+
+
+@pytest.mark.parametrize("monolith", MONOLITHS, ids=lambda p: p.name)
+def test_every_monolith_section_is_classified(monolith: Path) -> None:
+    assert monolith.is_file(), f"missing monolith: {monolith}"
+    audit_text = ANALYSIS_DOC.read_text(encoding="utf-8")
+    sections = top_level_sections(monolith.read_text(encoding="utf-8"))
+    assert sections, f"no top-level sections found in {monolith.name}"
+    missing = [title for title in sections if title not in audit_text]
+    assert not missing, (
+        f"{monolith.name} sections absent from the classification doc: {missing}"
+    )
+
+
+def test_audit_records_total_section_count() -> None:
+    total = sum(
+        len(top_level_sections(path.read_text(encoding="utf-8"))) for path in MONOLITHS
+    )
+    audit_text = ANALYSIS_DOC.read_text(encoding="utf-8")
+    assert f"**{total}**" in audit_text, (
+        f"audit total tally must state {total} sections"
+    )


### PR DESCRIPTION
## Summary

Phase 1 of #1769 is an audit only. This PR maps every top-level `##` section in the three always-loaded monolith instruction files to a destination and posts the classification as an issue comment. No content is moved; that happens in later phases.

Per the binding decision comment on #1769 (2026-05-31), the audit uses the repo's current `applyTo:` and `priority:` frontmatter convention, not the stale `paths:` and `alwaysApply:` keys from the issue D-table. Main already has many rule files plus the current generator, so Phase 2 will author rules and run generated mirrors rather than hand-authoring Copilot output.

Section counts (fence-aware, so headings inside fenced code blocks are excluded as template content):

| Monolith | Sections | Lines |
|----------|----------|-------|
| AGENT-SYSTEM.md | 13 | 1989 |
| AGENT-INSTRUCTIONS.md | 18 | 824 |
| SESSION-PROTOCOL.md | 16 | 1191 |
| Total | 47 | 4004 |

Classification tallies: ALWAYS-LOAD-RULE 4, PATH-SCOPED-RULE 33, KEEP-IN-STEERING 10.

The classification table was also posted as an issue comment (id 4598828416, idempotent marker).

## Per-file change

- `.agents/analysis/1769-monolith-section-classification.md` (new): full section-to-destination map for all three monoliths, the 7 target rule files with their `applyTo:` globs and `priority:`, steering-overlap reference (D6), tallies, and Phase 2 caveats.
- `tests/test_monolith_section_classification.py` (new): 9 pytest cases. Positive (each monolith's sections all appear in the audit, parametrized per file), negative (no headings yields empty), and edge (fenced `##` headings skipped, deeper `###` ignored, info-string fence content does not close an active fence). Includes exact row matching so duplicate section names cannot hide missing classifications.

## Testing

- `python -m pytest -q tests/test_monolith_section_classification.py` passed: 9 tests.
- `python -m ruff check tests/test_monolith_section_classification.py` passed.
- Diff dash check passed: no em or en dashes in added lines.
- Local markdown link check passed for the audit doc.

Fixes #1769