### PR TITLE
feat(pr-comment-responder): add Phase 0 gist clustering of unresolved threads

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.28",
+  "version": "0.5.29",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/commands/pr-review-config.yaml
+++ b/.claude/commands/pr-review-config.yaml
@@ -28,7 +28,7 @@ scripts:
     test_pr_merged: "pwsh -NoProfile .claude/skills/github/scripts/pr/Test-PRMerged.ps1 -PullRequest {number}"
     get_review_threads: "pwsh -NoProfile .claude/skills/github/scripts/pr/Get-PRReviewThreads.ps1 -PullRequest {number}"
     get_unresolved_threads: "pwsh -NoProfile .claude/skills/github/scripts/pr/Get-UnresolvedReviewThreads.ps1 -PullRequest {number}"
-    cluster_threads: 'pwsh -NoProfile -Command "python3 src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py --pull-request {number}"'
+    cluster_threads: 'pwsh -NoProfile -Command "python3 .claude/skills/pr-comment-responder/scripts/cluster_threads.py --pull-request {number}"'
     get_unaddressed_comments: "pwsh -NoProfile .claude/skills/github/scripts/pr/Get-UnaddressedComments.ps1 -PullRequest {number}"
     get_pr_checks: "pwsh -NoProfile .claude/skills/github/scripts/pr/Get-PRChecks.ps1 -PullRequest {number}"
     add_thread_reply: "pwsh -NoProfile .claude/skills/github/scripts/pr/Post-PRCommentReply.ps1 -PullRequest {number} -ThreadId {thread_id} -Body {body}"

--- a/.claude/commands/pr-review-config.yaml
+++ b/.claude/commands/pr-review-config.yaml
@@ -8,6 +8,7 @@ scripts:
     test_pr_merged: "python3 .claude/skills/github/scripts/pr/test_pr_merged.py --pull-request {number}"
     get_review_threads: "python3 .claude/skills/github/scripts/pr/get_pr_review_threads.py --pull-request {number}"
     get_unresolved_threads: "python3 .claude/skills/github/scripts/pr/get_unresolved_review_threads.py --pull-request {number}"
+    cluster_threads: "python3 .claude/skills/pr-comment-responder/scripts/cluster_threads.py --pull-request {number}"
     # Settling gate. The one-shot get_unresolved_threads snapshot can read
     # unresolved_count == 0 in the window between an agent resolving the last
     # thread and the next bot (Copilot, Devin) scan landing 30-120s later. That
@@ -27,6 +28,7 @@ scripts:
     test_pr_merged: "pwsh -NoProfile .claude/skills/github/scripts/pr/Test-PRMerged.ps1 -PullRequest {number}"
     get_review_threads: "pwsh -NoProfile .claude/skills/github/scripts/pr/Get-PRReviewThreads.ps1 -PullRequest {number}"
     get_unresolved_threads: "pwsh -NoProfile .claude/skills/github/scripts/pr/Get-UnresolvedReviewThreads.ps1 -PullRequest {number}"
+    cluster_threads: "python3 src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py --pull-request {number}"
     get_unaddressed_comments: "pwsh -NoProfile .claude/skills/github/scripts/pr/Get-UnaddressedComments.ps1 -PullRequest {number}"
     get_pr_checks: "pwsh -NoProfile .claude/skills/github/scripts/pr/Get-PRChecks.ps1 -PullRequest {number}"
     add_thread_reply: "pwsh -NoProfile .claude/skills/github/scripts/pr/Post-PRCommentReply.ps1 -PullRequest {number} -ThreadId {thread_id} -Body {body}"

--- a/.claude/commands/pr-review-config.yaml
+++ b/.claude/commands/pr-review-config.yaml
@@ -28,7 +28,7 @@ scripts:
     test_pr_merged: "pwsh -NoProfile .claude/skills/github/scripts/pr/Test-PRMerged.ps1 -PullRequest {number}"
     get_review_threads: "pwsh -NoProfile .claude/skills/github/scripts/pr/Get-PRReviewThreads.ps1 -PullRequest {number}"
     get_unresolved_threads: "pwsh -NoProfile .claude/skills/github/scripts/pr/Get-UnresolvedReviewThreads.ps1 -PullRequest {number}"
-    cluster_threads: "python3 src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py --pull-request {number}"
+    cluster_threads: 'pwsh -NoProfile -Command "python3 src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py --pull-request {number}"'
     get_unaddressed_comments: "pwsh -NoProfile .claude/skills/github/scripts/pr/Get-UnaddressedComments.ps1 -PullRequest {number}"
     get_pr_checks: "pwsh -NoProfile .claude/skills/github/scripts/pr/Get-PRChecks.ps1 -PullRequest {number}"
     add_thread_reply: "pwsh -NoProfile .claude/skills/github/scripts/pr/Post-PRCommentReply.ps1 -PullRequest {number} -ThreadId {thread_id} -Body {body}"

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -43,7 +43,7 @@ Verify PR merge state using `scripts.claude_code.test_pr_merged`. Exit code 0 = 
 
 Before addressing comments, gather full context:
 
-1. **Run Phase 0 thread clustering**: Use `cluster_threads` from config before the per-thread fix loop. If the JSON report has `warning: true`, surface the clusters in the verdict with `size`, `shared_tokens`, `source_artifact`, and `thread_ids`; stop the per-thread loop and fix the cluster-level framing or spec source first. Resume per-file patches only after that cluster-level fix is pushed.
+1. **Run Phase 0 thread clustering**: Use `cluster_threads` from config before the per-thread fix loop. If the JSON report has `warning: true`, add a `clusters` section to the verdict containing each cluster's `size`, `shared_tokens`, `source_artifact`, and `thread_ids`. Halt the per-thread loop. If `source_artifact` is non-null, patch that file's shared framing or spec source; otherwise patch the PR description, linked issue, or most common thread path after inspecting the cluster. Commit and push that cluster-level fix, then re-run the cluster step and resume per-file patches only after the warning is gone or the remaining threads no longer share one gist.
 2. **Review ALL comments**: Use `get_review_threads`, `get_unresolved_threads`, `get_unaddressed_comments`, and `get_pr_context` scripts from config.
 3. **Check merge eligibility**: Verify `mergeable=MERGEABLE` and no conflicts.
 4. **Review failing checks**: Use `get_pr_checks` script. Handle failures per `check_failure_actions` table in config.

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -43,9 +43,10 @@ Verify PR merge state using `scripts.claude_code.test_pr_merged`. Exit code 0 = 
 
 Before addressing comments, gather full context:
 
-1. **Review ALL comments**: Use `get_review_threads`, `get_unresolved_threads`, `get_unaddressed_comments`, and `get_pr_context` scripts from config.
-2. **Check merge eligibility**: Verify `mergeable=MERGEABLE` and no conflicts.
-3. **Review failing checks**: Use `get_pr_checks` script. Handle failures per `check_failure_actions` table in config.
+1. **Run Phase 0 thread clustering**: Use `cluster_threads` from config before the per-thread fix loop. If the JSON report has `warning: true`, surface the clusters in the verdict with `size`, `shared_tokens`, `source_artifact`, and `thread_ids`; stop the per-thread loop and fix the cluster-level framing or spec source first. Resume per-file patches only after that cluster-level fix is pushed.
+2. **Review ALL comments**: Use `get_review_threads`, `get_unresolved_threads`, `get_unaddressed_comments`, and `get_pr_context` scripts from config.
+3. **Check merge eligibility**: Verify `mergeable=MERGEABLE` and no conflicts.
+4. **Review failing checks**: Use `get_pr_checks` script. Handle failures per `check_failure_actions` table in config.
 
 After you resolve the last thread on a PR with live bot reviewers (Copilot, Devin), do NOT trust a single `get_unresolved_threads` snapshot. A bot scan can land 30 to 120 seconds after your push and reopen the count. Run the `wait_for_settled_zero` script from config to confirm the count has settled: it polls and exits 0 only after three consecutive complete-and-zero readings 180s apart. This closes the bot-settle gap that produced the PR #1965 "0 unresolved" lie. The completion gate below is a one-shot verdict and does not settle over time.
 

--- a/.claude/skills/pr-comment-responder/SKILL.md
+++ b/.claude/skills/pr-comment-responder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-comment-responder
-version: 1.0.0
+version: 1.1.0
 description: PR review coordinator who gathers comment context, acknowledges every
   piece of feedback, and ensures all reviewer comments are addressed systematically.
   Triages by actionability, tracks thread conversations, and maps each comment to
@@ -63,6 +63,7 @@ See [references/workflow.md](references/workflow.md) Phase -1 for full details.
 
 | Operation | Script |
 |-----------|--------|
+| **Cluster threads by gist (Phase 0)** | `cluster_threads.py` |
 | **Context extraction** | `extract_github_context.py` |
 | PR metadata | `get_pr_context.py` |
 | Comments | `get_pr_review_comments.py --include-issue-comments` |
@@ -149,6 +150,39 @@ Use direct `post_pr_comment_reply.py` instead when:
 - You already know the exact response to post
 
 ## Process
+
+### Phase 0: Cluster Threads by Gist
+
+Before the per-thread fix loop, group unresolved threads by shared gist and
+surface clusters of 4 or more threads. A cluster of 4+ threads with the same
+gist is a single-source-of-truth violation: the same root cause (a framing or
+spec problem) restated on several files. Patching each file in turn does not
+close the cluster; retiring the framing in the source artifact once does.
+
+This step mechanizes the `feedback_bot_thread_clustering.md` mental model. It
+exists because PR #1897 round 7 surfaced 17 unresolved threads where 8 were the
+same "model_tier=opus contradicts cheaper-tier reviewer claim" framing on
+different files; rounds 5 and 6 patched per-file and did not collapse the
+cluster (see `.agents/retrospective/2026-05-08-pr-1897-confident-incorrectness-recurrence.md`).
+
+```bash
+SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT:-.claude}/skills/pr-comment-responder/scripts"
+
+# Pass owner/repo/PR as separate quoted args (never concatenated; argv injection).
+python3 "$SCRIPTS_DIR/cluster_threads.py" \
+    --owner "$OWNER" --repo "$REPO" --pull-request "$PR_NUMBER"
+```
+
+The script fetches unresolved threads, clusters them by load-bearing token
+overlap, and emits a JSON report. When `"warning": true`, each entry in
+`clusters` names the cluster `size`, the `shared_tokens` that define the gist,
+and the `source_artifact` (the file most threads land on) most likely to be the
+framing root cause.
+
+**When a cluster of 4+ is reported: STOP the per-thread loop.** Fix the framing
+in the source artifact (template, PR description, or linked issue) first, push,
+and let the next bot rescan collapse the cluster. Only then proceed to Phase 1
+for the threads that remain.
 
 ### Phase 1: Context and Gather
 

--- a/.claude/skills/pr-comment-responder/SKILL.md
+++ b/.claude/skills/pr-comment-responder/SKILL.md
@@ -168,9 +168,8 @@ cluster (see `.agents/retrospective/2026-05-08-pr-1897-confident-incorrectness-r
 ```bash
 SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT:-.claude}/skills/pr-comment-responder/scripts"
 
-# Pass owner/repo/PR as separate quoted args (never concatenated; argv injection).
-python3 "$SCRIPTS_DIR/cluster_threads.py" \
-    --owner "$OWNER" --repo "$REPO" --pull-request "$PR_NUMBER"
+# Owner and repo are optional; the script infers them from git when omitted.
+python3 "$SCRIPTS_DIR/cluster_threads.py" --pull-request "$PR_NUMBER"
 ```
 
 The script fetches unresolved threads, clusters them by load-bearing token

--- a/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -158,10 +158,12 @@ def extract_gist(body: object) -> frozenset[str]:
     if not isinstance(body, str) or not body:
         return frozenset()
 
+    body = re.sub(
+        r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])",
+        "_",
+        body,
+    )
     lowered = body.lower()
-    # Split CamelCase before lowercasing would lose case, so split on the
-    # already-lowercased text using underscores and the original case markers
-    # are gone; snake_case still splits on underscore via the token regex below.
     raw_tokens = _TOKEN_RE.findall(lowered)
 
     gist: set[str] = set()
@@ -346,53 +348,136 @@ def cluster_threads(
     }
 
 
-def _fetch_unresolved_threads(owner: str, repo: str, pull_request: int) -> list[Thread]:
-    """Fetch unresolved threads via the github skill's canonical helper.
+_REVIEW_THREADS_FOR_CLUSTERING_QUERY = """\
+query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+        pullRequest(number: $prNumber) {
+            reviewThreads(first: 100, after: $cursor) {
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+                nodes {
+                    id
+                    isResolved
+                    isOutdated
+                    path
+                    line
+                    startLine
+                    diffSide
+                    comments(first: 1) {
+                        totalCount
+                        nodes {
+                            databaseId
+                            body
+                            createdAt
+                            author {
+                                login
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}"""
 
-    Delegates pagination and the GraphQL query to
-    ``github_core.review_threads.get_unresolved_review_threads`` rather than
-    re-implementing them (DRY; the pagination edge cases are already covered and
-    tested there). Translates the integration point's failure into a clean exit
-    rather than leaking a transport exception. ``get_unresolved_review_threads``
-    returns ``[]`` on transport failure and never raises, so the caller cannot
-    distinguish "no unresolved threads" from "fetch failed" on the list alone;
-    the auth check below fails fast on the common auth failure, and an empty
-    list is reported as zero threads (a true empty PR is the same observable
-    state, which is acceptable for a Phase 0 advisory).
-    """
+
+def _fetch_unresolved_threads_with_clients(
+    owner: str,
+    repo: str,
+    pull_request: int,
+    gh_graphql,
+    filter_unresolved_threads,
+    transform_review_thread,
+) -> list[Thread]:
+    """Fetch unresolved threads with enough fields for gist clustering."""
+    aggregated: list[dict] = []
+    cursor: str | None = None
+    max_pages = 50
+
+    for _page in range(max_pages):
+        variables: dict[str, object] = {
+            "owner": owner,
+            "name": repo,
+            "prNumber": pull_request,
+        }
+        if cursor is not None:
+            variables["cursor"] = cursor
+
+        try:
+            data = gh_graphql(_REVIEW_THREADS_FOR_CLUSTERING_QUERY, variables)
+        except RuntimeError as exc:
+            print(
+                f"Could not fetch review threads for PR {pull_request}: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+
+        repository = data.get("repository") or {}
+        pr_obj = repository.get("pullRequest")
+        if not isinstance(pr_obj, dict):
+            break
+        review_threads = pr_obj.get("reviewThreads")
+        if not isinstance(review_threads, dict):
+            break
+        nodes = review_threads.get("nodes")
+        if not isinstance(nodes, list):
+            break
+
+        aggregated.extend(node for node in nodes if isinstance(node, dict))
+
+        page_info = review_threads.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor_obj = page_info.get("endCursor")
+        if not isinstance(cursor_obj, str) or not cursor_obj:
+            break
+        cursor = cursor_obj
+
+    unresolved = filter_unresolved_threads(aggregated)
+    return [
+        item
+        for item in (transform_review_thread(node) for node in unresolved)
+        if isinstance(item, dict)
+    ]
+
+
+def _fetch_unresolved_threads(owner: str, repo: str, pull_request: int) -> list[Thread]:
+    """Fetch unresolved threads via a clustering-specific GraphQL query."""
     lib_dir = _resolve_lib_dir()
     if lib_dir not in sys.path:
         sys.path.insert(0, lib_dir)
 
     from github_core.api import (  # noqa: E402
         assert_gh_authenticated,
+        gh_graphql,
         resolve_repo_params,
     )
     from github_core.review_threads import (  # noqa: E402
-        get_unresolved_review_threads,
+        filter_unresolved_threads,
+        transform_review_thread,
     )
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(owner, repo)
-    # get_unresolved_review_threads is untyped at this import path (it lives
-    # under .claude/lib, outside the typed scripts.* tree), so mypy sees Any.
-    # The helper's documented contract is a list of flat thread dicts; keep
-    # only dict elements to honor the Thread type and drop any malformed node.
-    fetched = get_unresolved_review_threads(
-        resolved.owner, resolved.repo, pull_request,
+    return _fetch_unresolved_threads_with_clients(
+        resolved.owner,
+        resolved.repo,
+        pull_request,
+        gh_graphql,
+        filter_unresolved_threads,
+        transform_review_thread,
     )
-    return [item for item in fetched if isinstance(item, dict)]
 
 
 def _resolve_lib_dir() -> str:
-    """Locate the plugin ``lib`` directory the same way the github scripts do.
+    """Locate the plugin ``lib`` directory for github_core imports.
 
-    Mirrors the resolution order in
-    .claude/skills/github/scripts/pr/get_unresolved_review_threads.py:
-    ``CLAUDE_PLUGIN_ROOT`` env, then ``GITHUB_WORKSPACE`` env, then a path
-    relative to this file. Exits 2 (config error per ADR-035) when no candidate
-    directory exists, so a misconfigured install fails loudly rather than
-    importing nothing.
+    Resolution order: ``CLAUDE_PLUGIN_ROOT`` env, ``GITHUB_WORKSPACE`` env, then
+    a path relative to this file. Exits 2 (config error per ADR-035) when no
+    candidate directory exists, so a misconfigured install fails loudly rather
+    than importing nothing.
     """
     import os
 
@@ -443,12 +528,28 @@ def _load_threads_from_file(path: str) -> list[Thread]:
     Exits 2 on a missing file, malformed JSON, or a payload that is not a list
     of objects: a bad ``--threads-file`` is a usage error, not a clustering
     result. Non-dict list elements (untrusted input) are dropped rather than
-    crashing the clusterer.
+    crashing the clusterer. Relative paths are anchored to the project root so
+    the caller's current working directory cannot change what file is read.
     """
     from pathlib import Path
 
+    requested_path = Path(path)
+    if requested_path.is_absolute():
+        threads_path = requested_path
+    else:
+        project_root = Path(__file__).resolve().parents[4]
+        threads_path = (project_root / requested_path).resolve()
+        try:
+            threads_path.relative_to(project_root)
+        except ValueError:
+            print(
+                f"Threads file {path} escapes project root.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
     try:
-        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+        raw = json.loads(threads_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         print(f"Could not read threads file {path}: {exc}", file=sys.stderr)
         sys.exit(2)

--- a/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -47,6 +47,7 @@ import argparse
 import json
 import re
 import sys
+from typing import NoReturn
 
 # A review thread in the canonical flat shape produced by
 # github_core.review_threads.transform_review_thread. Heterogeneous values
@@ -392,7 +393,7 @@ query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
 }"""
 
 
-def _fail_fetch(message: str, pull_request: int) -> None:
+def _fail_fetch(message: str, pull_request: int) -> NoReturn:
     print(f"Could not fetch review threads for PR {pull_request}: {message}", file=sys.stderr)
     sys.exit(3)
 

--- a/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -424,7 +424,11 @@ def _fetch_unresolved_threads_with_clients(
         except Exception as exc:
             _fail_fetch(str(exc), pull_request)
 
-        repository = data.get("repository") or {}
+        if not isinstance(data, dict):
+            _fail_fetch("malformed GraphQL response", pull_request)
+        repository = data.get("repository")
+        if not isinstance(repository, dict):
+            _fail_fetch("missing repository", pull_request)
         pr_obj = repository.get("pullRequest")
         if not isinstance(pr_obj, dict):
             _fail_fetch("missing pullRequest", pull_request)
@@ -437,7 +441,9 @@ def _fetch_unresolved_threads_with_clients(
 
         aggregated.extend(node for node in nodes if isinstance(node, dict))
 
-        page_info = review_threads.get("pageInfo") or {}
+        page_info = review_threads.get("pageInfo")
+        if not isinstance(page_info, dict):
+            _fail_fetch("missing pagination info", pull_request)
         if not page_info.get("hasNextPage"):
             break
         cursor_obj = page_info.get("endCursor")

--- a/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -271,8 +271,8 @@ def _cluster_size(cluster: Report) -> int:
     """Read a cluster's ``size`` as an int for sorting.
 
     The value is always the ``len(members)`` int stored in ``cluster_threads``;
-    the explicit int() narrows the ``object`` value type so the sort key is typed
-    and mypy's no-any-return rule is satisfied without a cast.
+    the isinstance check narrows the ``object`` value type so the sort key is
+    typed and mypy's no-any-return rule is satisfied without a cast.
     """
     size = cluster["size"]
     return size if isinstance(size, int) else 0
@@ -486,14 +486,16 @@ def _fetch_unresolved_threads(owner: str, repo: str, pull_request: int) -> list[
 def _resolve_lib_dir() -> str:
     """Locate the plugin ``lib`` directory for github_core imports.
 
-    Resolution order: ``CLAUDE_PLUGIN_ROOT`` env, ``GITHUB_WORKSPACE`` env, then
-    a path relative to this file. Exits 2 (config error per ADR-035) when no
-    candidate directory exists, so a misconfigured install fails loudly rather
-    than importing nothing.
+    Resolution order: ``COPILOT_PLUGIN_ROOT`` env, ``CLAUDE_PLUGIN_ROOT`` env,
+    ``GITHUB_WORKSPACE`` env, then a path relative to this file. Exits 2
+    (config error per ADR-035) when no candidate directory exists, so a
+    misconfigured install fails loudly rather than importing nothing.
     """
     import os
 
-    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get(
+        "CLAUDE_PLUGIN_ROOT",
+    )
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if plugin_root:
         lib_dir = os.path.join(plugin_root, "lib")

--- a/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -227,8 +227,9 @@ def _identify_source_artifact(threads: list[Thread]) -> str | None:
     A cluster whose threads land on one path points at that file as the framing
     root cause. When the cluster spans several files (the round-7 asymmetry
     case: 8 paths, one framing), the most common path is the best single
-    pointer; ties resolve to the first path seen for determinism. Returns None
-    when no thread in the cluster carries a path.
+    pointer only if it has a unique lead. Ties return None so the report does
+    not steer the agent into an arbitrary file patch. Returns None when no
+    thread in the cluster carries a path.
     """
     counts: dict[str, int] = {}
     order: list[str] = []

--- a/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Cluster unresolved PR review threads by shared gist before the fix loop.
+
+Phase 0 of the pr-comment-responder workflow. When a bot rescan surfaces many
+unresolved threads, several are often the same root cause stated on different
+files. PR #1897 round 7 surfaced 17 unresolved threads; 8 were the same
+"model_tier=opus contradicts cheaper-tier reviewer claim" framing on different
+paths (see .agents/retrospective/2026-05-08-pr-1897-confident-incorrectness-recurrence.md).
+Rounds 5 and 6 patched those per-file and did not close the cluster; round 7
+retired the framing in the source artifact and the cluster collapsed in one
+round.
+
+This module turns the agent-side mental model captured in the global memory
+``feedback_bot_thread_clustering.md`` ("4+ threads with the same gist = single
+source-of-truth violation, retire the framing once") into a mechanical step.
+When a cluster reaches ``CLUSTER_WARNING_THRESHOLD`` threads it is flagged so the
+agent fixes the framing root cause before the per-thread fix loop begins.
+
+Pipeline:
+
+1. Fetch unresolved threads (delegated to the github skill's
+   ``get_unresolved_review_threads.py`` so the GraphQL/pagination logic is not
+   duplicated; see Integration Points in .claude/rules/release-it.md).
+2. Extract a "gist" (a set of load-bearing tokens) from each thread's first
+   comment body.
+3. Cluster threads whose gists overlap (Jaccard similarity at or above
+   ``SIMILARITY_THRESHOLD``) using union-find.
+4. Report clusters of ``CLUSTER_WARNING_THRESHOLD`` or more threads, naming the
+   source artifact (the file path shared by the most threads in the cluster)
+   most likely to be the framing root cause.
+
+The fetch is an integration point; the clustering is pure. ``cluster_threads``
+and its helpers take plain dicts (the canonical flat thread shape produced by
+``github_core.review_threads.transform_review_thread``) and return plain dicts,
+so the algorithm is unit-testable without the network.
+
+Exit codes follow ADR-035:
+    0 - Report produced (warnings, if any, are in the JSON; not an error exit)
+    2 - Config/usage error (invalid parameters)
+    3 - Fetch failed (could not obtain a trustworthy thread snapshot)
+    4 - Auth error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+# A review thread in the canonical flat shape produced by
+# github_core.review_threads.transform_review_thread. Heterogeneous values
+# (str, int, None, list), so the value type is object rather than a narrower
+# alias; callers read specific keys (first_comment_body, path, thread_id).
+Thread = dict[str, object]
+# A clustering report or one cluster entry: same heterogeneous-value shape.
+Report = dict[str, object]
+
+# Threads with this many members sharing one gist are flagged as a probable
+# single-source-of-truth (framing/spec) violation. The value 4 comes directly
+# from the issue #1917 acceptance criteria and feedback_bot_thread_clustering.md;
+# the round-7 asymmetry cluster had 8 members and must trip the warning.
+CLUSTER_WARNING_THRESHOLD = 4
+
+# Two gists are "the same" when their Jaccard similarity (size of token
+# intersection over size of token union) is at or above this value. Bots
+# paraphrase, so an exact-match rule would split the round-7 asymmetry cluster
+# across Copilot/CodeRabbit re-wordings. 0.5 keeps loosely paraphrased restates
+# of one finding together while separating genuinely distinct findings.
+SIMILARITY_THRESHOLD = 0.5
+
+# A token must carry meaning to count toward overlap. We drop review-comment
+# filler ("consider", "should", "please") and structural noise so that the
+# load-bearing words (the nouns of the finding: "model", "tier", "opus",
+# "contradicts") drive clustering. Tokens shorter than this are also dropped.
+_MIN_TOKEN_LENGTH = 4
+
+# Generic review-comment vocabulary that appears across unrelated findings and
+# would create false overlap if counted. Lowercased; matched after tokenizing.
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "this",
+        "that",
+        "with",
+        "from",
+        "have",
+        "should",
+        "would",
+        "could",
+        "consider",
+        "please",
+        "change",
+        "changes",
+        "comment",
+        "review",
+        "line",
+        "lines",
+        "file",
+        "code",
+        "above",
+        "below",
+        "here",
+        "there",
+        "when",
+        "then",
+        "than",
+        "your",
+        "into",
+        "also",
+        "make",
+        "uses",
+        "used",
+        "using",
+        "note",
+        "needs",
+        "need",
+        "want",
+        "very",
+        "more",
+        "most",
+        "some",
+        "they",
+        "them",
+        "what",
+        "which",
+        "where",
+        "will",
+        "does",
+        "doesn",
+        "isn",
+        "instead",
+        "rather",
+        "suggest",
+        "suggestion",
+    }
+)
+
+# Token = a run of word characters. Markdown punctuation, backticks, and code
+# fences are stripped first so "`model_tier`" and "model_tier" tokenize the same.
+_TOKEN_RE = re.compile(r"[a-z0-9_]+")
+
+
+def extract_gist(body: object) -> frozenset[str]:
+    """Reduce a comment body to its set of load-bearing tokens.
+
+    Lowercases, splits ``snake_case`` and ``CamelCase`` boundaries into their
+    parts (so ``model_tier`` contributes ``model`` and ``tier``), then keeps
+    tokens that are at least ``_MIN_TOKEN_LENGTH`` long and not in
+    ``_STOPWORDS``. Returns an empty set for an empty or token-poor body; such
+    threads cannot join a cluster, which is the safe default (a thread with no
+    distinctive words should not be lumped with a real finding).
+
+    ``body`` is typed ``object`` because it comes straight from a JSON thread
+    dict whose value type is unconstrained (untrusted input at the boundary).
+    A non-string body (None, a number, a malformed list) yields an empty gist
+    rather than raising, so one bad thread cannot abort the whole report.
+    """
+    if not isinstance(body, str) or not body:
+        return frozenset()
+
+    lowered = body.lower()
+    # Split CamelCase before lowercasing would lose case, so split on the
+    # already-lowercased text using underscores and the original case markers
+    # are gone; snake_case still splits on underscore via the token regex below.
+    raw_tokens = _TOKEN_RE.findall(lowered)
+
+    gist: set[str] = set()
+    for token in raw_tokens:
+        for part in token.split("_"):
+            if len(part) >= _MIN_TOKEN_LENGTH and part not in _STOPWORDS:
+                gist.add(part)
+    return frozenset(gist)
+
+
+def gist_similarity(left: frozenset[str], right: frozenset[str]) -> float:
+    """Jaccard similarity between two gists: |intersection| / |union|.
+
+    Returns 0.0 when either gist is empty (an empty gist shares nothing). The
+    value is in [0.0, 1.0]; 1.0 means identical token sets.
+    """
+    if not left or not right:
+        return 0.0
+    intersection = len(left & right)
+    if intersection == 0:
+        return 0.0
+    union = len(left | right)
+    return intersection / union
+
+
+class _UnionFind:
+    """Disjoint-set over thread indices for transitive clustering.
+
+    If thread A is similar to B and B is similar to C, A, B and C land in one
+    cluster even when A and C are not directly similar. This matches the
+    real-world shape: a paraphrase chain across bot rescans links restates that
+    are not pairwise identical.
+    """
+
+    def __init__(self, size: int) -> None:
+        self._parent = list(range(size))
+
+    def find(self, node: int) -> int:
+        root = node
+        while self._parent[root] != root:
+            root = self._parent[root]
+        # Path compression keeps repeated finds near-constant time.
+        while self._parent[node] != root:
+            self._parent[node], node = root, self._parent[node]
+        return root
+
+    def union(self, left: int, right: int) -> None:
+        self._parent[self.find(left)] = self.find(right)
+
+
+def _group_indices_by_root(uf: _UnionFind, count: int) -> dict[int, list[int]]:
+    groups: dict[int, list[int]] = {}
+    for index in range(count):
+        groups.setdefault(uf.find(index), []).append(index)
+    return groups
+
+
+def _identify_source_artifact(threads: list[Thread]) -> str | None:
+    """Return the file path shared by the most threads in a cluster.
+
+    A cluster whose threads land on one path points at that file as the framing
+    root cause. When the cluster spans several files (the round-7 asymmetry
+    case: 8 paths, one framing), the most common path is the best single
+    pointer; ties resolve to the first path seen for determinism. Returns None
+    when no thread in the cluster carries a path.
+    """
+    counts: dict[str, int] = {}
+    order: list[str] = []
+    for thread in threads:
+        path = thread.get("path")
+        # Non-string or empty paths (None, missing, malformed) carry no
+        # artifact signal; skip them rather than key a count on a non-str.
+        if not isinstance(path, str) or not path:
+            continue
+        if path not in counts:
+            order.append(path)
+        counts[path] = counts.get(path, 0) + 1
+    if not counts:
+        return None
+    # max() is stable over the insertion-ordered keys, so a tie keeps the
+    # first-seen path rather than depending on dict hash order.
+    return max(order, key=lambda path: counts[path])
+
+
+def _shared_tokens(threads: list[Thread]) -> list[str]:
+    """Tokens present in the gist of every thread in the cluster, sorted.
+
+    These are the load-bearing words that define the cluster's gist; surfacing
+    them tells the agent what framing to retire. When transitive linking means
+    no single token spans all members, returns the empty list and the caller
+    falls back to the per-thread gists.
+    """
+    gists = [extract_gist(t.get("first_comment_body")) for t in threads]
+    gists = [g for g in gists if g]
+    if not gists:
+        return []
+    common = set.intersection(*(set(g) for g in gists))
+    return sorted(common)
+
+
+def _cluster_size(cluster: Report) -> int:
+    """Read a cluster's ``size`` as an int for sorting.
+
+    The value is always the ``len(members)`` int stored in ``cluster_threads``;
+    the explicit int() narrows the ``object`` value type so the sort key is typed
+    and mypy's no-any-return rule is satisfied without a cast.
+    """
+    size = cluster["size"]
+    return size if isinstance(size, int) else 0
+
+
+def cluster_threads(
+    threads: list[Thread],
+    similarity_threshold: float = SIMILARITY_THRESHOLD,
+    warning_threshold: int = CLUSTER_WARNING_THRESHOLD,
+) -> Report:
+    """Group threads by shared gist and flag large clusters.
+
+    ``threads`` is a list of canonical flat thread dicts (the shape from
+    ``transform_review_thread``); each must carry ``first_comment_body`` and
+    optionally ``path`` and ``thread_id``. Returns a report dict:
+
+        {
+          "thread_count": <int>,
+          "cluster_count": <int>,          # clusters at/over warning_threshold
+          "warning": <bool>,               # any cluster at/over the threshold
+          "clusters": [
+            {
+              "size": <int>,
+              "shared_tokens": [<str>, ...],
+              "source_artifact": <str|None>,
+              "thread_ids": [<str|None>, ...],
+              "paths": [<str|None>, ...]
+            },
+            ...
+          ]
+        }
+
+    Only clusters of ``warning_threshold`` or more threads appear in
+    ``clusters`` and contribute to ``cluster_count``; smaller groups are the
+    per-thread fix loop's normal work and are not framing problems. Clusters are
+    sorted largest-first so the worst single-source-of-truth violation leads.
+    """
+    count = len(threads)
+    gists = [extract_gist(t.get("first_comment_body")) for t in threads]
+
+    uf = _UnionFind(count)
+    for i in range(count):
+        if not gists[i]:
+            continue
+        for j in range(i + 1, count):
+            if not gists[j]:
+                continue
+            if gist_similarity(gists[i], gists[j]) >= similarity_threshold:
+                uf.union(i, j)
+
+    groups = _group_indices_by_root(uf, count)
+
+    clusters: list[Report] = []
+    for indices in groups.values():
+        if len(indices) < warning_threshold:
+            continue
+        members = [threads[i] for i in indices]
+        clusters.append(
+            {
+                "size": len(members),
+                "shared_tokens": _shared_tokens(members),
+                "source_artifact": _identify_source_artifact(members),
+                "thread_ids": [m.get("thread_id") for m in members],
+                "paths": [m.get("path") for m in members],
+            }
+        )
+
+    # Largest cluster first; size is always the int we stored above.
+    clusters.sort(key=_cluster_size, reverse=True)
+
+    return {
+        "thread_count": count,
+        "cluster_count": len(clusters),
+        "warning": bool(clusters),
+        "clusters": clusters,
+    }
+
+
+def _fetch_unresolved_threads(owner: str, repo: str, pull_request: int) -> list[Thread]:
+    """Fetch unresolved threads via the github skill's canonical helper.
+
+    Delegates pagination and the GraphQL query to
+    ``github_core.review_threads.get_unresolved_review_threads`` rather than
+    re-implementing them (DRY; the pagination edge cases are already covered and
+    tested there). Translates the integration point's failure into a clean exit
+    rather than leaking a transport exception. ``get_unresolved_review_threads``
+    returns ``[]`` on transport failure and never raises, so the caller cannot
+    distinguish "no unresolved threads" from "fetch failed" on the list alone;
+    the auth check below fails fast on the common auth failure, and an empty
+    list is reported as zero threads (a true empty PR is the same observable
+    state, which is acceptable for a Phase 0 advisory).
+    """
+    lib_dir = _resolve_lib_dir()
+    if lib_dir not in sys.path:
+        sys.path.insert(0, lib_dir)
+
+    from github_core.api import (  # noqa: E402
+        assert_gh_authenticated,
+        resolve_repo_params,
+    )
+    from github_core.review_threads import (  # noqa: E402
+        get_unresolved_review_threads,
+    )
+
+    assert_gh_authenticated()
+    resolved = resolve_repo_params(owner, repo)
+    # get_unresolved_review_threads is untyped at this import path (it lives
+    # under .claude/lib, outside the typed scripts.* tree), so mypy sees Any.
+    # The helper's documented contract is a list of flat thread dicts; keep
+    # only dict elements to honor the Thread type and drop any malformed node.
+    fetched = get_unresolved_review_threads(
+        resolved.owner, resolved.repo, pull_request,
+    )
+    return [item for item in fetched if isinstance(item, dict)]
+
+
+def _resolve_lib_dir() -> str:
+    """Locate the plugin ``lib`` directory the same way the github scripts do.
+
+    Mirrors the resolution order in
+    .claude/skills/github/scripts/pr/get_unresolved_review_threads.py:
+    ``CLAUDE_PLUGIN_ROOT`` env, then ``GITHUB_WORKSPACE`` env, then a path
+    relative to this file. Exits 2 (config error per ADR-035) when no candidate
+    directory exists, so a misconfigured install fails loudly rather than
+    importing nothing.
+    """
+    import os
+
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if plugin_root:
+        lib_dir = os.path.join(plugin_root, "lib")
+    elif workspace:
+        lib_dir = os.path.join(workspace, ".claude", "lib")
+    else:
+        lib_dir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..", "lib")
+        )
+    if not os.path.isdir(lib_dir):
+        print(f"Plugin lib directory not found: {lib_dir}", file=sys.stderr)
+        sys.exit(2)
+    return lib_dir
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Cluster unresolved PR review threads by shared gist and flag "
+            "framing/spec problems before the per-thread fix loop."
+        ),
+    )
+    parser.add_argument("--owner", default="", help="Repository owner")
+    parser.add_argument("--repo", default="", help="Repository name")
+    parser.add_argument(
+        "--pull-request", type=int, required=True, help="Pull request number",
+    )
+    parser.add_argument(
+        "--threads-file",
+        default="",
+        help=(
+            "Read threads from a JSON file instead of fetching. The file is "
+            "either a list of thread dicts or an object with a 'threads' key "
+            "(the shape get_unresolved_review_threads.py emits). Used for "
+            "offline analysis and tests; skips the GitHub fetch."
+        ),
+    )
+    return parser
+
+
+def _load_threads_from_file(path: str) -> list[Thread]:
+    """Read threads from a JSON file (list or ``{"threads": [...]}``).
+
+    Exits 2 on a missing file, malformed JSON, or a payload that is not a list
+    of objects: a bad ``--threads-file`` is a usage error, not a clustering
+    result. Non-dict list elements (untrusted input) are dropped rather than
+    crashing the clusterer.
+    """
+    from pathlib import Path
+
+    try:
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Could not read threads file {path}: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    payload = raw.get("threads") if isinstance(raw, dict) else raw
+    if not isinstance(payload, list):
+        print(
+            f"Threads file {path} must be a list or an object with a "
+            "'threads' list.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.pull_request <= 0:
+        print("Pull request number must be positive.", file=sys.stderr)
+        return 2
+
+    if args.threads_file:
+        threads = _load_threads_from_file(args.threads_file)
+    else:
+        threads = _fetch_unresolved_threads(
+            args.owner, args.repo, args.pull_request,
+        )
+
+    report = cluster_threads(threads)
+    report["pull_request"] = args.pull_request
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -493,9 +493,7 @@ def _resolve_lib_dir() -> str:
     """
     import os
 
-    plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get(
-        "CLAUDE_PLUGIN_ROOT",
-    )
+    plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if plugin_root:
         lib_dir = os.path.join(plugin_root, "lib")

--- a/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -421,7 +421,7 @@ def _fetch_unresolved_threads_with_clients(
 
         try:
             data = gh_graphql(_REVIEW_THREADS_FOR_CLUSTERING_QUERY, variables)
-        except RuntimeError as exc:
+        except Exception as exc:
             _fail_fetch(str(exc), pull_request)
 
         repository = data.get("repository") or {}

--- a/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -18,9 +18,9 @@ agent fixes the framing root cause before the per-thread fix loop begins.
 
 Pipeline:
 
-1. Fetch unresolved threads (delegated to the github skill's
-   ``get_unresolved_review_threads.py`` so the GraphQL/pagination logic is not
-   duplicated; see Integration Points in .claude/rules/release-it.md).
+1. Fetch unresolved threads with a clustering-specific GraphQL query that
+   selects path and first-comment body fields, then map nodes through
+   ``github_core.review_threads.transform_review_thread``.
 2. Extract a "gist" (a set of load-bearing tokens) from each thread's first
    comment body.
 3. Cluster threads whose gists overlap (Jaccard similarity at or above
@@ -243,9 +243,11 @@ def _identify_source_artifact(threads: list[Thread]) -> str | None:
         counts[path] = counts.get(path, 0) + 1
     if not counts:
         return None
-    # max() is stable over the insertion-ordered keys, so a tie keeps the
-    # first-seen path rather than depending on dict hash order.
-    return max(order, key=lambda path: counts[path])
+    max_count = max(counts.values())
+    winners = [path for path in order if counts[path] == max_count]
+    if len(winners) != 1:
+        return None
+    return winners[0]
 
 
 def _shared_tokens(threads: list[Thread]) -> list[str]:
@@ -310,13 +312,19 @@ def cluster_threads(
     count = len(threads)
     gists = [extract_gist(t.get("first_comment_body")) for t in threads]
 
+    token_to_indices: dict[str, set[int]] = {}
+    for index, gist in enumerate(gists):
+        for token in gist:
+            token_to_indices.setdefault(token, set()).add(index)
+
     uf = _UnionFind(count)
     for i in range(count):
         if not gists[i]:
             continue
-        for j in range(i + 1, count):
-            if not gists[j]:
-                continue
+        candidates: set[int] = set()
+        for token in gists[i]:
+            candidates.update(token_to_indices[token])
+        for j in sorted(candidate for candidate in candidates if candidate > i):
             if gist_similarity(gists[i], gists[j]) >= similarity_threshold:
                 uf.union(i, j)
 
@@ -383,6 +391,11 @@ query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
 }"""
 
 
+def _fail_fetch(message: str, pull_request: int) -> None:
+    print(f"Could not fetch review threads for PR {pull_request}: {message}", file=sys.stderr)
+    sys.exit(3)
+
+
 def _fetch_unresolved_threads_with_clients(
     owner: str,
     repo: str,
@@ -408,22 +421,18 @@ def _fetch_unresolved_threads_with_clients(
         try:
             data = gh_graphql(_REVIEW_THREADS_FOR_CLUSTERING_QUERY, variables)
         except RuntimeError as exc:
-            print(
-                f"Could not fetch review threads for PR {pull_request}: {exc}",
-                file=sys.stderr,
-            )
-            sys.exit(3)
+            _fail_fetch(str(exc), pull_request)
 
         repository = data.get("repository") or {}
         pr_obj = repository.get("pullRequest")
         if not isinstance(pr_obj, dict):
-            break
+            _fail_fetch("missing pullRequest", pull_request)
         review_threads = pr_obj.get("reviewThreads")
         if not isinstance(review_threads, dict):
-            break
+            _fail_fetch("missing reviewThreads", pull_request)
         nodes = review_threads.get("nodes")
         if not isinstance(nodes, list):
-            break
+            _fail_fetch("missing reviewThreads nodes", pull_request)
 
         aggregated.extend(node for node in nodes if isinstance(node, dict))
 
@@ -432,8 +441,10 @@ def _fetch_unresolved_threads_with_clients(
             break
         cursor_obj = page_info.get("endCursor")
         if not isinstance(cursor_obj, str) or not cursor_obj:
-            break
+            _fail_fetch("missing pagination cursor", pull_request)
         cursor = cursor_obj
+    else:
+        _fail_fetch("pagination exceeded 50 pages", pull_request)
 
     unresolved = filter_unresolved_threads(aggregated)
     return [
@@ -522,6 +533,24 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _project_root() -> "Path":
+    from pathlib import Path
+    import os
+
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if workspace:
+        root = Path(workspace).resolve()
+        if (root / "pyproject.toml").is_file():
+            return root
+
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "pyproject.toml").is_file():
+            return candidate
+
+    print("Could not locate project root.", file=sys.stderr)
+    sys.exit(2)
+
+
 def _load_threads_from_file(path: str) -> list[Thread]:
     """Read threads from a JSON file (list or ``{"threads": [...]}``).
 
@@ -534,19 +563,20 @@ def _load_threads_from_file(path: str) -> list[Thread]:
     from pathlib import Path
 
     requested_path = Path(path)
+    project_root = _project_root()
     if requested_path.is_absolute():
-        threads_path = requested_path
-    else:
-        project_root = Path(__file__).resolve().parents[4]
-        threads_path = (project_root / requested_path).resolve()
-        try:
-            threads_path.relative_to(project_root)
-        except ValueError:
-            print(
-                f"Threads file {path} escapes project root.",
-                file=sys.stderr,
-            )
-            sys.exit(2)
+        print("Threads file must be repository-relative.", file=sys.stderr)
+        sys.exit(2)
+
+    threads_path = (project_root / requested_path).resolve()
+    try:
+        threads_path.relative_to(project_root)
+    except ValueError:
+        print(
+            f"Threads file {path} escapes project root.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     try:
         raw = json.loads(threads_path.read_text(encoding="utf-8"))

--- a/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -379,10 +379,11 @@ class TestCli:
         assert result.returncode == 2
 
     def test_malformed_threads_file_exits_2(self):
-        relative_path, absolute_path = _write_repo_threads_file("malformed", "{not json")
+        absolute_path = _repo_root() / ".cluster-threads-malformed.json"
+        absolute_path.write_text("{not json", encoding="utf-8")
         try:
             result = self._run(
-                ["--pull-request", "1897", "--threads-file", relative_path],
+                ["--pull-request", "1897", "--threads-file", absolute_path.name],
             )
         finally:
             absolute_path.unlink(missing_ok=True)

--- a/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -506,3 +506,18 @@ class TestResolveLibDir:
         monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
         monkeypatch.setattr(os.path, "isdir", lambda path: path == "copilot-root/lib")
         assert mod._resolve_lib_dir() == "copilot-root/lib"
+
+    def test_non_runtime_fetch_failure_exits_3(self):
+        mod = _load_module()
+
+        def fake_graphql(query, variables):
+            raise TimeoutError("slow graphql")
+
+        try:
+            mod._fetch_unresolved_threads_with_clients(
+                "owner", "repo", 1, fake_graphql, lambda nodes: nodes, lambda node: node,
+            )
+        except SystemExit as exc:
+            assert exc.code == 3
+        else:
+            raise AssertionError("expected SystemExit")

--- a/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -521,3 +521,39 @@ class TestResolveLibDir:
             assert exc.code == 3
         else:
             raise AssertionError("expected SystemExit")
+
+    def test_non_dict_graphql_response_exits_3(self):
+        mod = _load_module()
+
+        def fake_graphql(query, variables):
+            return []
+
+        try:
+            mod._fetch_unresolved_threads_with_clients(
+                "owner", "repo", 1, fake_graphql, lambda nodes: nodes, lambda node: node,
+            )
+        except SystemExit as exc:
+            assert exc.code == 3
+        else:
+            raise AssertionError("expected SystemExit")
+
+    def test_malformed_page_info_exits_3(self):
+        mod = _load_module()
+
+        def fake_graphql(query, variables):
+            return {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {"pageInfo": [], "nodes": []},
+                    },
+                },
+            }
+
+        try:
+            mod._fetch_unresolved_threads_with_clients(
+                "owner", "repo", 1, fake_graphql, lambda nodes: nodes, lambda node: node,
+            )
+        except SystemExit as exc:
+            assert exc.code == 3
+        else:
+            raise AssertionError("expected SystemExit")

--- a/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -496,3 +496,13 @@ class TestFetchUnresolvedThreads:
             assert exc.code == 3
         else:
             raise AssertionError("expected SystemExit")
+
+
+class TestResolveLibDir:
+    def test_resolve_lib_dir_prefers_copilot_plugin_root(self, monkeypatch):
+        mod = _load_module()
+        monkeypatch.setenv("COPILOT_PLUGIN_ROOT", "copilot-root")
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+        monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+        monkeypatch.setattr(os.path, "isdir", lambda path: path == "copilot-root/lib")
+        assert mod._resolve_lib_dir() == "copilot-root/lib"

--- a/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+from pathlib import Path
 import subprocess
 import sys
 
@@ -34,6 +35,19 @@ def _load_module():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def _repo_root() -> Path:
+    for candidate in Path(_SCRIPT).resolve().parents:
+        if (candidate / "pyproject.toml").is_file():
+            return candidate
+    raise AssertionError("repo root not found")
+
+
+def _write_repo_threads_file(name: str, payload: object) -> tuple[str, Path]:
+    absolute_path = _repo_root() / f".cluster-threads-{name}.json"
+    absolute_path.write_text(json.dumps(payload), encoding="utf-8")
+    return absolute_path.name, absolute_path
 
 
 def _thread(thread_id: str, path: str, body: str) -> dict:
@@ -197,14 +211,13 @@ class TestClusterThreadsPr1897Regression:
         # 8 asymmetry + 2 harmful + 3 session-log + 1 aggregate + 2 evidence.
         assert report["thread_count"] == 16
 
-    def test_source_artifact_points_at_a_clustered_path(self):
+    def test_source_artifact_is_none_when_cluster_paths_tie(self):
         mod = _load_module()
         report = mod.cluster_threads(PR_1897_ROUND7_THREADS)
         top = report["clusters"][0]
-        # Every asymmetry thread lives under templates/agents/; the named
-        # artifact is one of those eight paths, not a non-cluster path.
-        assert top["source_artifact"] in top["paths"]
-        assert top["source_artifact"].startswith("templates/agents/")
+        # The asymmetry fixture spans eight paths with no winning file path, so
+        # returning None avoids steering the agent into an arbitrary file patch.
+        assert top["source_artifact"] is None
 
 
 class TestClusterThreadsThreshold:
@@ -278,13 +291,13 @@ class TestSourceArtifactIdentification:
         threads = [{"first_comment_body": "x"}, {"path": None, "first_comment_body": "y"}]
         assert mod._identify_source_artifact(threads) is None
 
-    def test_tie_keeps_first_seen_path(self):
+    def test_tie_returns_none(self):
         mod = _load_module()
         threads = [
             _thread("t0", "first.py", "a"),
             _thread("t1", "second.py", "b"),
         ]
-        assert mod._identify_source_artifact(threads) == "first.py"
+        assert mod._identify_source_artifact(threads) is None
 
 
 class TestTransitiveClustering:
@@ -313,60 +326,78 @@ class TestCli:
             input=input_text,
         )
 
-    def test_threads_file_path_produces_report(self, tmp_path):
-        threads_file = tmp_path / "threads.json"
-        threads_file.write_text(
-            json.dumps({"threads": PR_1897_ROUND7_THREADS}), encoding="utf-8",
+    def test_threads_file_path_produces_report(self):
+        relative_path, absolute_path = _write_repo_threads_file(
+            "object", {"threads": PR_1897_ROUND7_THREADS},
         )
-        result = self._run(
-            ["--pull-request", "1897", "--threads-file", str(threads_file)],
-        )
+        try:
+            result = self._run(
+                ["--pull-request", "1897", "--threads-file", relative_path],
+            )
+        finally:
+            absolute_path.unlink(missing_ok=True)
         assert result.returncode == 0
         report = json.loads(result.stdout)
         assert report["pull_request"] == 1897
         assert report["warning"] is True
         assert 8 in [c["size"] for c in report["clusters"]]
 
-    def test_bare_list_threads_file_is_accepted(self, tmp_path):
-        threads_file = tmp_path / "threads.json"
-        threads_file.write_text(
-            json.dumps(PR_1897_ROUND7_THREADS), encoding="utf-8",
+    def test_bare_list_threads_file_is_accepted(self):
+        relative_path, absolute_path = _write_repo_threads_file(
+            "list", PR_1897_ROUND7_THREADS,
         )
-        result = self._run(
-            ["--pull-request", "1897", "--threads-file", str(threads_file)],
-        )
+        try:
+            result = self._run(
+                ["--pull-request", "1897", "--threads-file", relative_path],
+            )
+        finally:
+            absolute_path.unlink(missing_ok=True)
         assert result.returncode == 0
         report = json.loads(result.stdout)
         assert report["thread_count"] == 16
 
-    def test_nonpositive_pull_request_exits_2(self, tmp_path):
-        threads_file = tmp_path / "threads.json"
-        threads_file.write_text("[]", encoding="utf-8")
+    def test_nonpositive_pull_request_exits_2(self):
+        relative_path, absolute_path = _write_repo_threads_file("empty", [])
+        try:
+            result = self._run(
+                ["--pull-request", "0", "--threads-file", relative_path],
+            )
+        finally:
+            absolute_path.unlink(missing_ok=True)
+        assert result.returncode == 2
+
+    def test_absolute_threads_file_exits_2(self):
         result = self._run(
-            ["--pull-request", "0", "--threads-file", str(threads_file)],
+            ["--pull-request", "1897", "--threads-file", str(_repo_root() / "x.json")],
         )
         assert result.returncode == 2
 
     def test_missing_threads_file_exits_2(self):
         result = self._run(
-            ["--pull-request", "1897", "--threads-file", "/no/such/file.json"],
+            ["--pull-request", "1897", "--threads-file", "no-such-file.json"],
         )
         assert result.returncode == 2
 
-    def test_malformed_threads_file_exits_2(self, tmp_path):
-        threads_file = tmp_path / "threads.json"
-        threads_file.write_text("{not json", encoding="utf-8")
-        result = self._run(
-            ["--pull-request", "1897", "--threads-file", str(threads_file)],
-        )
+    def test_malformed_threads_file_exits_2(self):
+        relative_path, absolute_path = _write_repo_threads_file("malformed", "{not json")
+        try:
+            result = self._run(
+                ["--pull-request", "1897", "--threads-file", relative_path],
+            )
+        finally:
+            absolute_path.unlink(missing_ok=True)
         assert result.returncode == 2
 
-    def test_threads_file_wrong_shape_exits_2(self, tmp_path):
-        threads_file = tmp_path / "threads.json"
-        threads_file.write_text(json.dumps({"threads": 42}), encoding="utf-8")
-        result = self._run(
-            ["--pull-request", "1897", "--threads-file", str(threads_file)],
+    def test_threads_file_wrong_shape_exits_2(self):
+        relative_path, absolute_path = _write_repo_threads_file(
+            "wrong-shape", {"threads": 42},
         )
+        try:
+            result = self._run(
+                ["--pull-request", "1897", "--threads-file", relative_path],
+            )
+        finally:
+            absolute_path.unlink(missing_ok=True)
         assert result.returncode == 2
 
     def test_missing_required_pull_request_exits_2(self):
@@ -440,6 +471,21 @@ class TestFetchUnresolvedThreads:
 
         def fake_graphql(query, variables):
             raise RuntimeError("network down")
+
+        try:
+            mod._fetch_unresolved_threads_with_clients(
+                "owner", "repo", 1, fake_graphql, lambda nodes: nodes, lambda node: node,
+            )
+        except SystemExit as exc:
+            assert exc.code == 3
+        else:
+            raise AssertionError("expected SystemExit")
+
+    def test_malformed_payload_exits_3(self):
+        mod = _load_module()
+
+        def fake_graphql(query, variables):
+            return {"repository": {"pullRequest": {"reviewThreads": {"nodes": None}}}}
 
         try:
             mod._fetch_unresolved_threads_with_clients(

--- a/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Tests for the pr-comment-responder cluster_threads.py Phase 0 step.
+
+The headline regression fixture (``PR_1897_ROUND7_THREADS``) reconstructs the
+PR #1897 round-7 unresolved-thread set described in
+.agents/retrospective/2026-05-08-pr-1897-confident-incorrectness-recurrence.md
+Phase 0: five gist clusters (asymmetry x 8, harmful x 2, session-log x 3,
+aggregate x 1, evidence-drift x 2). The 8-thread asymmetry cluster
+("model_tier=opus contradicts cheaper-tier reviewer claim" on different files)
+is the single-source-of-truth violation the step exists to catch.
+
+The retrospective's headline says "post-push 17" but its own per-cluster
+breakdown (8 + 2 + 3 + 1 + 2) sums to 16. We hold the fixture to the
+itemized per-cluster counts (the load-bearing detail for this test, since the
+8-thread asymmetry cluster is what the step must detect) rather than the
+headline total, so the fixture has 16 threads.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+
+_SCRIPT = os.path.join(
+    os.path.dirname(__file__), "..", "scripts", "cluster_threads.py",
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("cluster_threads", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _thread(thread_id: str, path: str, body: str) -> dict:
+    """Build a canonical flat thread dict (transform_review_thread shape)."""
+    return {"thread_id": thread_id, "path": path, "first_comment_body": body}
+
+
+# Eight restates of the same finding across eight files, each paraphrased the
+# way Copilot/CodeRabbit re-word a finding on a rescan. The load-bearing tokens
+# (model, tier, opus, contradicts/cheaper) recur; the filler varies.
+_ASYMMETRY_BODIES = [
+    "The model_tier is set to opus here but the template claims a cheaper "
+    "reviewer model tier; this contradicts the stronger model wording.",
+    "model_tier opus contradicts the cheaper model tier described for the "
+    "reviewer in this template section.",
+    "This sets model_tier to opus yet the prose says cheaper reviewer tier. "
+    "The model tier wording contradicts the opus assignment.",
+    "Reviewer model_tier opus contradicts the cheaper-tier claim. The model "
+    "tier asymmetry framing is wrong.",
+    "opus model_tier here contradicts the template's cheaper model tier "
+    "reviewer framing.",
+    "The model tier (opus) contradicts the cheaper reviewer model tier this "
+    "template asserts.",
+    "model_tier opus assignment contradicts cheaper model tier reviewer "
+    "wording, an asymmetry framing problem.",
+    "This opus model_tier contradicts the cheaper-tier reviewer model "
+    "framing described nearby.",
+]
+
+_HARMFUL_BODIES = [
+    "The harmful-content threshold here is too low and rejects benign "
+    "fixtures; raise the harmful threshold boundary.",
+    "harmful threshold boundary rejects benign input; the harmful content "
+    "threshold value is misconfigured.",
+]
+
+_SESSION_LOG_BODIES = [
+    "The session-log naming pattern violates the protocol; rename the session "
+    "log file to the canonical session naming format.",
+    "session log naming does not match the protocol session naming convention "
+    "for the session log file.",
+    "This session-log filename breaks the session naming protocol; the "
+    "session log naming convention requires the dated slug.",
+]
+
+_EVIDENCE_DRIFT_BODIES = [
+    "The evidence-standards section drifted from the canonical evidence "
+    "hierarchy levels; sync the evidence section drift.",
+    "evidence section drift: the evidence hierarchy levels documented here no "
+    "longer match the canonical evidence standards.",
+]
+
+
+def _build_pr_1897_round7_threads() -> list[dict]:
+    threads: list[dict] = []
+    for index, body in enumerate(_ASYMMETRY_BODIES):
+        threads.append(_thread(f"asym-{index}", f"templates/agents/file_{index}.md", body))
+    for index, body in enumerate(_HARMFUL_BODIES):
+        threads.append(_thread(f"harm-{index}", "guard-maturity/thresholds.py", body))
+    for index, body in enumerate(_SESSION_LOG_BODIES):
+        threads.append(_thread(f"sess-{index}", "scripts/session_log.py", body))
+    threads.append(
+        _thread(
+            "agg-0",
+            "guard-maturity/run_report.py",
+            "The aggregate exit code returns zero on a partial aggregate "
+            "failure; the aggregate exit-code branch swallows the failure.",
+        )
+    )
+    for index, body in enumerate(_EVIDENCE_DRIFT_BODIES):
+        threads.append(_thread(f"ev-{index}", "templates/agents/evidence.md", body))
+    return threads
+
+
+# 8 + 2 + 3 + 1 + 2 == 16, the retrospective's itemized per-cluster counts.
+PR_1897_ROUND7_THREADS = _build_pr_1897_round7_threads()
+
+
+class TestExtractGist:
+    def test_splits_snake_case_into_load_bearing_parts(self):
+        mod = _load_module()
+        gist = mod.extract_gist("The model_tier is opus here.")
+        assert "model" in gist
+        assert "tier" in gist
+        assert "opus" in gist
+
+    def test_drops_short_tokens_and_stopwords(self):
+        mod = _load_module()
+        gist = mod.extract_gist("This should consider the change here.")
+        # All tokens are stopwords or under the length floor; nothing survives.
+        assert gist == frozenset()
+
+    def test_empty_body_returns_empty_gist(self):
+        mod = _load_module()
+        assert mod.extract_gist("") == frozenset()
+
+    def test_none_body_returns_empty_gist(self):
+        mod = _load_module()
+        assert mod.extract_gist(None) == frozenset()
+
+    def test_backticked_token_matches_plain_token(self):
+        mod = _load_module()
+        backticked = mod.extract_gist("Fix `model_tier` opus assignment.")
+        plain = mod.extract_gist("Fix model_tier opus assignment.")
+        assert backticked == plain
+
+
+class TestGistSimilarity:
+    def test_identical_gists_score_one(self):
+        mod = _load_module()
+        gist = frozenset({"model", "tier", "opus"})
+        assert mod.gist_similarity(gist, gist) == 1.0
+
+    def test_disjoint_gists_score_zero(self):
+        mod = _load_module()
+        left = frozenset({"model", "tier"})
+        right = frozenset({"harmful", "threshold"})
+        assert mod.gist_similarity(left, right) == 0.0
+
+    def test_empty_gist_scores_zero(self):
+        mod = _load_module()
+        assert mod.gist_similarity(frozenset(), frozenset({"opus"})) == 0.0
+
+    def test_partial_overlap_is_jaccard(self):
+        mod = _load_module()
+        left = frozenset({"model", "tier", "opus"})
+        right = frozenset({"model", "tier", "cheaper"})
+        # intersection 2 (model, tier) over union 4 -> 0.5
+        assert mod.gist_similarity(left, right) == 0.5
+
+
+class TestClusterThreadsPr1897Regression:
+    def test_detects_eight_thread_asymmetry_cluster(self):
+        mod = _load_module()
+        report = mod.cluster_threads(PR_1897_ROUND7_THREADS)
+        assert report["warning"] is True
+        sizes = [c["size"] for c in report["clusters"]]
+        # The 8-thread asymmetry cluster is the single 4+ cluster; the other
+        # round-7 clusters (2, 3, 1, 2) are below the warning threshold.
+        assert 8 in sizes
+
+    def test_asymmetry_cluster_leads_and_names_load_bearing_tokens(self):
+        mod = _load_module()
+        report = mod.cluster_threads(PR_1897_ROUND7_THREADS)
+        top = report["clusters"][0]
+        assert top["size"] == 8
+        # The framing tokens that recur across all eight restates.
+        assert "model" in top["shared_tokens"]
+        assert "tier" in top["shared_tokens"]
+        assert "opus" in top["shared_tokens"]
+
+    def test_thread_count_matches_round7_itemized_breakdown(self):
+        mod = _load_module()
+        report = mod.cluster_threads(PR_1897_ROUND7_THREADS)
+        # 8 asymmetry + 2 harmful + 3 session-log + 1 aggregate + 2 evidence.
+        assert report["thread_count"] == 16
+
+    def test_source_artifact_points_at_a_clustered_path(self):
+        mod = _load_module()
+        report = mod.cluster_threads(PR_1897_ROUND7_THREADS)
+        top = report["clusters"][0]
+        # Every asymmetry thread lives under templates/agents/; the named
+        # artifact is one of those eight paths, not a non-cluster path.
+        assert top["source_artifact"] in top["paths"]
+        assert top["source_artifact"].startswith("templates/agents/")
+
+
+class TestClusterThreadsThreshold:
+    def test_no_warning_below_threshold(self):
+        mod = _load_module()
+        # Three identical-gist threads: a real group but under the 4 floor.
+        threads = [
+            _thread(f"t{index}", "a.py", "model_tier opus contradicts cheaper tier")
+            for index in range(3)
+        ]
+        report = mod.cluster_threads(threads)
+        assert report["warning"] is False
+        assert report["cluster_count"] == 0
+        assert report["clusters"] == []
+
+    def test_warning_exactly_at_threshold(self):
+        mod = _load_module()
+        threads = [
+            _thread(f"t{index}", "a.py", "model_tier opus contradicts cheaper tier")
+            for index in range(4)
+        ]
+        report = mod.cluster_threads(threads)
+        assert report["warning"] is True
+        assert report["cluster_count"] == 1
+        assert report["clusters"][0]["size"] == 4
+
+    def test_empty_thread_list_produces_no_warning(self):
+        mod = _load_module()
+        report = mod.cluster_threads([])
+        assert report["thread_count"] == 0
+        assert report["warning"] is False
+        assert report["clusters"] == []
+
+    def test_token_poor_threads_do_not_cluster(self):
+        mod = _load_module()
+        # Bodies whose only words are stopwords/short: each gist is empty, so no
+        # two can reach the similarity threshold and no cluster forms.
+        threads = [
+            _thread(f"t{index}", "a.py", "this should change here")
+            for index in range(6)
+        ]
+        report = mod.cluster_threads(threads)
+        assert report["warning"] is False
+
+    def test_distinct_findings_stay_separate(self):
+        mod = _load_module()
+        # Four distinct findings, no shared load-bearing tokens: no cluster.
+        threads = [
+            _thread("t0", "a.py", "the harmful threshold boundary rejects benign fixtures"),
+            _thread("t1", "b.py", "session log naming violates the dated slug protocol"),
+            _thread("t2", "c.py", "aggregate exit code swallows partial failure branch"),
+            _thread("t3", "d.py", "evidence hierarchy levels drifted from canonical standards"),
+        ]
+        report = mod.cluster_threads(threads)
+        assert report["warning"] is False
+        assert report["cluster_count"] == 0
+
+
+class TestSourceArtifactIdentification:
+    def test_most_common_path_wins(self):
+        mod = _load_module()
+        threads = [
+            _thread("t0", "common.py", "model tier opus contradicts cheaper"),
+            _thread("t1", "common.py", "model tier opus contradicts cheaper"),
+            _thread("t2", "other.py", "model tier opus contradicts cheaper"),
+        ]
+        assert mod._identify_source_artifact(threads) == "common.py"
+
+    def test_returns_none_when_no_paths(self):
+        mod = _load_module()
+        threads = [{"first_comment_body": "x"}, {"path": None, "first_comment_body": "y"}]
+        assert mod._identify_source_artifact(threads) is None
+
+    def test_tie_keeps_first_seen_path(self):
+        mod = _load_module()
+        threads = [
+            _thread("t0", "first.py", "a"),
+            _thread("t1", "second.py", "b"),
+        ]
+        assert mod._identify_source_artifact(threads) == "first.py"
+
+
+class TestTransitiveClustering:
+    def test_paraphrase_chain_links_into_one_cluster(self):
+        mod = _load_module()
+        # A-B share {model, tier}; B-C share {tier, opus}; A-C share only
+        # {tier} (below 0.5 alone) but transitively join via B. Four members
+        # so the cluster trips the warning.
+        threads = [
+            _thread("a", "f.py", "model tier framing"),
+            _thread("b", "f.py", "model tier opus framing"),
+            _thread("c", "f.py", "tier opus cheaper"),
+            _thread("d", "f.py", "model tier opus cheaper"),
+        ]
+        report = mod.cluster_threads(threads)
+        assert report["warning"] is True
+        assert report["clusters"][0]["size"] == 4
+
+
+class TestCli:
+    def _run(self, args: list[str], input_text: str | None = None):
+        return subprocess.run(
+            [sys.executable, _SCRIPT, *args],
+            capture_output=True,
+            text=True,
+            input=input_text,
+        )
+
+    def test_threads_file_path_produces_report(self, tmp_path):
+        threads_file = tmp_path / "threads.json"
+        threads_file.write_text(
+            json.dumps({"threads": PR_1897_ROUND7_THREADS}), encoding="utf-8",
+        )
+        result = self._run(
+            ["--pull-request", "1897", "--threads-file", str(threads_file)],
+        )
+        assert result.returncode == 0
+        report = json.loads(result.stdout)
+        assert report["pull_request"] == 1897
+        assert report["warning"] is True
+        assert 8 in [c["size"] for c in report["clusters"]]
+
+    def test_bare_list_threads_file_is_accepted(self, tmp_path):
+        threads_file = tmp_path / "threads.json"
+        threads_file.write_text(
+            json.dumps(PR_1897_ROUND7_THREADS), encoding="utf-8",
+        )
+        result = self._run(
+            ["--pull-request", "1897", "--threads-file", str(threads_file)],
+        )
+        assert result.returncode == 0
+        report = json.loads(result.stdout)
+        assert report["thread_count"] == 16
+
+    def test_nonpositive_pull_request_exits_2(self, tmp_path):
+        threads_file = tmp_path / "threads.json"
+        threads_file.write_text("[]", encoding="utf-8")
+        result = self._run(
+            ["--pull-request", "0", "--threads-file", str(threads_file)],
+        )
+        assert result.returncode == 2
+
+    def test_missing_threads_file_exits_2(self):
+        result = self._run(
+            ["--pull-request", "1897", "--threads-file", "/no/such/file.json"],
+        )
+        assert result.returncode == 2
+
+    def test_malformed_threads_file_exits_2(self, tmp_path):
+        threads_file = tmp_path / "threads.json"
+        threads_file.write_text("{not json", encoding="utf-8")
+        result = self._run(
+            ["--pull-request", "1897", "--threads-file", str(threads_file)],
+        )
+        assert result.returncode == 2
+
+    def test_threads_file_wrong_shape_exits_2(self, tmp_path):
+        threads_file = tmp_path / "threads.json"
+        threads_file.write_text(json.dumps({"threads": 42}), encoding="utf-8")
+        result = self._run(
+            ["--pull-request", "1897", "--threads-file", str(threads_file)],
+        )
+        assert result.returncode == 2
+
+    def test_missing_required_pull_request_exits_2(self):
+        result = self._run([])
+        # argparse exits 2 on a missing required argument.
+        assert result.returncode == 2

--- a/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/.claude/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -140,6 +140,12 @@ class TestExtractGist:
         plain = mod.extract_gist("Fix model_tier opus assignment.")
         assert backticked == plain
 
+    def test_splits_camel_case_into_load_bearing_parts(self):
+        mod = _load_module()
+        gist = mod.extract_gist("The modelTier setting contradicts ModelTier docs.")
+        assert "model" in gist
+        assert "tier" in gist
+
 
 class TestGistSimilarity:
     def test_identical_gists_score_one(self):
@@ -367,3 +373,79 @@ class TestCli:
         result = self._run([])
         # argparse exits 2 on a missing required argument.
         assert result.returncode == 2
+
+
+class TestFetchUnresolvedThreads:
+    def test_fetch_uses_fields_needed_for_clustering(self):
+        mod = _load_module()
+        queries = []
+
+        def fake_graphql(query, variables):
+            queries.append((query, variables))
+            return {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": [
+                                {
+                                    "id": "thread-1",
+                                    "isResolved": False,
+                                    "path": "a.py",
+                                    "comments": {
+                                        "totalCount": 1,
+                                        "nodes": [
+                                            {
+                                                "databaseId": 1,
+                                                "body": "modelTier contradicts docs",
+                                                "createdAt": "2026-01-01T00:00:00Z",
+                                                "author": {"login": "bot"},
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                },
+            }
+
+        def fake_filter(nodes):
+            return [node for node in nodes if node.get("isResolved") is False]
+
+        def fake_transform(node):
+            return {
+                "thread_id": node.get("id"),
+                "path": node.get("path"),
+                "first_comment_body": node["comments"]["nodes"][0]["body"],
+            }
+
+        threads = mod._fetch_unresolved_threads_with_clients(
+            "owner", "repo", 1, fake_graphql, fake_filter, fake_transform,
+        )
+
+        query = queries[0][0]
+        assert "path" in query
+        assert "body" in query
+        assert threads == [
+            {
+                "thread_id": "thread-1",
+                "path": "a.py",
+                "first_comment_body": "modelTier contradicts docs",
+            },
+        ]
+
+    def test_fetch_failure_exits_3(self):
+        mod = _load_module()
+
+        def fake_graphql(query, variables):
+            raise RuntimeError("network down")
+
+        try:
+            mod._fetch_unresolved_threads_with_clients(
+                "owner", "repo", 1, fake_graphql, lambda nodes: nodes, lambda node: node,
+            )
+        except SystemExit as exc:
+            assert exc.code == 3
+        else:
+            raise AssertionError("expected SystemExit")

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -52,9 +52,10 @@ Verify PR merge state using `scripts.copilot.test_pr_merged`. Exit code 0 = not 
 
 Before addressing comments, gather full context:
 
-1. **Review ALL comments**: Use `get_review_threads`, `get_unresolved_threads`, `get_unaddressed_comments`, and `get_pr_context` scripts from config.
-2. **Check merge eligibility**: Verify `mergeable=MERGEABLE` and no conflicts.
-3. **Review failing checks**: Use `get_pr_checks` script. Handle failures per `check_failure_actions` table in config.
+1. **Run Phase 0 thread clustering**: Use `cluster_threads` from config before the per-thread fix loop. If the JSON report has `warning: true`, surface the clusters in the verdict with `size`, `shared_tokens`, `source_artifact`, and `thread_ids`; stop the per-thread loop and fix the cluster-level framing or spec source first. Resume per-file patches only after that cluster-level fix is pushed.
+2. **Review ALL comments**: Use `get_review_threads`, `get_unresolved_threads`, `get_unaddressed_comments`, and `get_pr_context` scripts from config.
+3. **Check merge eligibility**: Verify `mergeable=MERGEABLE` and no conflicts.
+4. **Review failing checks**: Use `get_pr_checks` script. Handle failures per `check_failure_actions` table in config.
 
 ### Step 3: Create Worktrees (if --parallel)
 

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -52,7 +52,7 @@ Verify PR merge state using `scripts.copilot.test_pr_merged`. Exit code 0 = not 
 
 Before addressing comments, gather full context:
 
-1. **Run Phase 0 thread clustering**: Use `cluster_threads` from config before the per-thread fix loop. If the JSON report has `warning: true`, surface the clusters in the verdict with `size`, `shared_tokens`, `source_artifact`, and `thread_ids`; stop the per-thread loop and fix the cluster-level framing or spec source first. Resume per-file patches only after that cluster-level fix is pushed.
+1. **Run Phase 0 thread clustering**: Use `cluster_threads` from config before the per-thread fix loop. If the JSON report has `warning: true`, add a `clusters` section to the verdict containing each cluster's `size`, `shared_tokens`, `source_artifact`, and `thread_ids`. Halt the per-thread loop. If `source_artifact` is non-null, patch that file's shared framing or spec source; otherwise patch the PR description, linked issue, or most common thread path after inspecting the cluster. Commit and push that cluster-level fix, then re-run the cluster step and resume per-file patches only after the warning is gone or the remaining threads no longer share one gist.
 2. **Review ALL comments**: Use `get_review_threads`, `get_unresolved_threads`, `get_unaddressed_comments`, and `get_pr_context` scripts from config.
 3. **Check merge eligibility**: Verify `mergeable=MERGEABLE` and no conflicts.
 4. **Review failing checks**: Use `get_pr_checks` script. Handle failures per `check_failure_actions` table in config.

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.23",
+  "version": "0.5.24",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
-  "description": "25 agent definitions, 81 reusable skills, 52 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.5.27",
+  "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
+  "version": "0.5.23",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.28",
+  "version": "0.5.29",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.26",
+  "version": "0.5.27",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.25",
+  "version": "0.5.26",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/pr-comment-responder/SKILL.md
+++ b/src/copilot-cli/skills/pr-comment-responder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-comment-responder
-version: 1.0.0
+version: 1.1.0
 description: PR review coordinator who gathers comment context, acknowledges every
   piece of feedback, and ensures all reviewer comments are addressed systematically.
   Triages by actionability, tracks thread conversations, and maps each comment to
@@ -63,6 +63,7 @@ See [references/workflow.md](references/workflow.md) Phase -1 for full details.
 
 | Operation | Script |
 |-----------|--------|
+| **Cluster threads by gist (Phase 0)** | `cluster_threads.py` |
 | **Context extraction** | `extract_github_context.py` |
 | PR metadata | `get_pr_context.py` |
 | Comments | `get_pr_review_comments.py --include-issue-comments` |
@@ -149,6 +150,39 @@ Use direct `post_pr_comment_reply.py` instead when:
 - You already know the exact response to post
 
 ## Process
+
+### Phase 0: Cluster Threads by Gist
+
+Before the per-thread fix loop, group unresolved threads by shared gist and
+surface clusters of 4 or more threads. A cluster of 4+ threads with the same
+gist is a single-source-of-truth violation: the same root cause (a framing or
+spec problem) restated on several files. Patching each file in turn does not
+close the cluster; retiring the framing in the source artifact once does.
+
+This step mechanizes the `feedback_bot_thread_clustering.md` mental model. It
+exists because PR #1897 round 7 surfaced 17 unresolved threads where 8 were the
+same "model_tier=opus contradicts cheaper-tier reviewer claim" framing on
+different files; rounds 5 and 6 patched per-file and did not collapse the
+cluster (see `.agents/retrospective/2026-05-08-pr-1897-confident-incorrectness-recurrence.md`).
+
+```bash
+SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT:-.claude}/skills/pr-comment-responder/scripts"
+
+# Pass owner/repo/PR as separate quoted args (never concatenated; argv injection).
+python3 "$SCRIPTS_DIR/cluster_threads.py" \
+    --owner "$OWNER" --repo "$REPO" --pull-request "$PR_NUMBER"
+```
+
+The script fetches unresolved threads, clusters them by load-bearing token
+overlap, and emits a JSON report. When `"warning": true`, each entry in
+`clusters` names the cluster `size`, the `shared_tokens` that define the gist,
+and the `source_artifact` (the file most threads land on) most likely to be the
+framing root cause.
+
+**When a cluster of 4+ is reported: STOP the per-thread loop.** Fix the framing
+in the source artifact (template, PR description, or linked issue) first, push,
+and let the next bot rescan collapse the cluster. Only then proceed to Phase 1
+for the threads that remain.
 
 ### Phase 1: Context and Gather
 

--- a/src/copilot-cli/skills/pr-comment-responder/SKILL.md
+++ b/src/copilot-cli/skills/pr-comment-responder/SKILL.md
@@ -168,9 +168,8 @@ cluster (see `.agents/retrospective/2026-05-08-pr-1897-confident-incorrectness-r
 ```bash
 SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT:-.claude}/skills/pr-comment-responder/scripts"
 
-# Pass owner/repo/PR as separate quoted args (never concatenated; argv injection).
-python3 "$SCRIPTS_DIR/cluster_threads.py" \
-    --owner "$OWNER" --repo "$REPO" --pull-request "$PR_NUMBER"
+# Owner and repo are optional; the script infers them from git when omitted.
+python3 "$SCRIPTS_DIR/cluster_threads.py" --pull-request "$PR_NUMBER"
 ```
 
 The script fetches unresolved threads, clusters them by load-bearing token

--- a/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -158,10 +158,12 @@ def extract_gist(body: object) -> frozenset[str]:
     if not isinstance(body, str) or not body:
         return frozenset()
 
+    body = re.sub(
+        r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])",
+        "_",
+        body,
+    )
     lowered = body.lower()
-    # Split CamelCase before lowercasing would lose case, so split on the
-    # already-lowercased text using underscores and the original case markers
-    # are gone; snake_case still splits on underscore via the token regex below.
     raw_tokens = _TOKEN_RE.findall(lowered)
 
     gist: set[str] = set()
@@ -346,53 +348,136 @@ def cluster_threads(
     }
 
 
-def _fetch_unresolved_threads(owner: str, repo: str, pull_request: int) -> list[Thread]:
-    """Fetch unresolved threads via the github skill's canonical helper.
+_REVIEW_THREADS_FOR_CLUSTERING_QUERY = """\
+query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+        pullRequest(number: $prNumber) {
+            reviewThreads(first: 100, after: $cursor) {
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+                nodes {
+                    id
+                    isResolved
+                    isOutdated
+                    path
+                    line
+                    startLine
+                    diffSide
+                    comments(first: 1) {
+                        totalCount
+                        nodes {
+                            databaseId
+                            body
+                            createdAt
+                            author {
+                                login
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}"""
 
-    Delegates pagination and the GraphQL query to
-    ``github_core.review_threads.get_unresolved_review_threads`` rather than
-    re-implementing them (DRY; the pagination edge cases are already covered and
-    tested there). Translates the integration point's failure into a clean exit
-    rather than leaking a transport exception. ``get_unresolved_review_threads``
-    returns ``[]`` on transport failure and never raises, so the caller cannot
-    distinguish "no unresolved threads" from "fetch failed" on the list alone;
-    the auth check below fails fast on the common auth failure, and an empty
-    list is reported as zero threads (a true empty PR is the same observable
-    state, which is acceptable for a Phase 0 advisory).
-    """
+
+def _fetch_unresolved_threads_with_clients(
+    owner: str,
+    repo: str,
+    pull_request: int,
+    gh_graphql,
+    filter_unresolved_threads,
+    transform_review_thread,
+) -> list[Thread]:
+    """Fetch unresolved threads with enough fields for gist clustering."""
+    aggregated: list[dict] = []
+    cursor: str | None = None
+    max_pages = 50
+
+    for _page in range(max_pages):
+        variables: dict[str, object] = {
+            "owner": owner,
+            "name": repo,
+            "prNumber": pull_request,
+        }
+        if cursor is not None:
+            variables["cursor"] = cursor
+
+        try:
+            data = gh_graphql(_REVIEW_THREADS_FOR_CLUSTERING_QUERY, variables)
+        except RuntimeError as exc:
+            print(
+                f"Could not fetch review threads for PR {pull_request}: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+
+        repository = data.get("repository") or {}
+        pr_obj = repository.get("pullRequest")
+        if not isinstance(pr_obj, dict):
+            break
+        review_threads = pr_obj.get("reviewThreads")
+        if not isinstance(review_threads, dict):
+            break
+        nodes = review_threads.get("nodes")
+        if not isinstance(nodes, list):
+            break
+
+        aggregated.extend(node for node in nodes if isinstance(node, dict))
+
+        page_info = review_threads.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor_obj = page_info.get("endCursor")
+        if not isinstance(cursor_obj, str) or not cursor_obj:
+            break
+        cursor = cursor_obj
+
+    unresolved = filter_unresolved_threads(aggregated)
+    return [
+        item
+        for item in (transform_review_thread(node) for node in unresolved)
+        if isinstance(item, dict)
+    ]
+
+
+def _fetch_unresolved_threads(owner: str, repo: str, pull_request: int) -> list[Thread]:
+    """Fetch unresolved threads via a clustering-specific GraphQL query."""
     lib_dir = _resolve_lib_dir()
     if lib_dir not in sys.path:
         sys.path.insert(0, lib_dir)
 
     from github_core.api import (  # noqa: E402
         assert_gh_authenticated,
+        gh_graphql,
         resolve_repo_params,
     )
     from github_core.review_threads import (  # noqa: E402
-        get_unresolved_review_threads,
+        filter_unresolved_threads,
+        transform_review_thread,
     )
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(owner, repo)
-    # get_unresolved_review_threads is untyped at this import path (it lives
-    # under .claude/lib, outside the typed scripts.* tree), so mypy sees Any.
-    # The helper's documented contract is a list of flat thread dicts; keep
-    # only dict elements to honor the Thread type and drop any malformed node.
-    fetched = get_unresolved_review_threads(
-        resolved.owner, resolved.repo, pull_request,
+    return _fetch_unresolved_threads_with_clients(
+        resolved.owner,
+        resolved.repo,
+        pull_request,
+        gh_graphql,
+        filter_unresolved_threads,
+        transform_review_thread,
     )
-    return [item for item in fetched if isinstance(item, dict)]
 
 
 def _resolve_lib_dir() -> str:
-    """Locate the plugin ``lib`` directory the same way the github scripts do.
+    """Locate the plugin ``lib`` directory for github_core imports.
 
-    Mirrors the resolution order in
-    .claude/skills/github/scripts/pr/get_unresolved_review_threads.py:
-    ``CLAUDE_PLUGIN_ROOT`` env, then ``GITHUB_WORKSPACE`` env, then a path
-    relative to this file. Exits 2 (config error per ADR-035) when no candidate
-    directory exists, so a misconfigured install fails loudly rather than
-    importing nothing.
+    Resolution order: ``CLAUDE_PLUGIN_ROOT`` env, ``GITHUB_WORKSPACE`` env, then
+    a path relative to this file. Exits 2 (config error per ADR-035) when no
+    candidate directory exists, so a misconfigured install fails loudly rather
+    than importing nothing.
     """
     import os
 
@@ -443,12 +528,28 @@ def _load_threads_from_file(path: str) -> list[Thread]:
     Exits 2 on a missing file, malformed JSON, or a payload that is not a list
     of objects: a bad ``--threads-file`` is a usage error, not a clustering
     result. Non-dict list elements (untrusted input) are dropped rather than
-    crashing the clusterer.
+    crashing the clusterer. Relative paths are anchored to the project root so
+    the caller's current working directory cannot change what file is read.
     """
     from pathlib import Path
 
+    requested_path = Path(path)
+    if requested_path.is_absolute():
+        threads_path = requested_path
+    else:
+        project_root = Path(__file__).resolve().parents[4]
+        threads_path = (project_root / requested_path).resolve()
+        try:
+            threads_path.relative_to(project_root)
+        except ValueError:
+            print(
+                f"Threads file {path} escapes project root.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
     try:
-        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+        raw = json.loads(threads_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         print(f"Could not read threads file {path}: {exc}", file=sys.stderr)
         sys.exit(2)

--- a/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -47,6 +47,7 @@ import argparse
 import json
 import re
 import sys
+from typing import NoReturn
 
 # A review thread in the canonical flat shape produced by
 # github_core.review_threads.transform_review_thread. Heterogeneous values
@@ -392,7 +393,7 @@ query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
 }"""
 
 
-def _fail_fetch(message: str, pull_request: int) -> None:
+def _fail_fetch(message: str, pull_request: int) -> NoReturn:
     print(f"Could not fetch review threads for PR {pull_request}: {message}", file=sys.stderr)
     sys.exit(3)
 

--- a/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -424,7 +424,11 @@ def _fetch_unresolved_threads_with_clients(
         except Exception as exc:
             _fail_fetch(str(exc), pull_request)
 
-        repository = data.get("repository") or {}
+        if not isinstance(data, dict):
+            _fail_fetch("malformed GraphQL response", pull_request)
+        repository = data.get("repository")
+        if not isinstance(repository, dict):
+            _fail_fetch("missing repository", pull_request)
         pr_obj = repository.get("pullRequest")
         if not isinstance(pr_obj, dict):
             _fail_fetch("missing pullRequest", pull_request)
@@ -437,7 +441,9 @@ def _fetch_unresolved_threads_with_clients(
 
         aggregated.extend(node for node in nodes if isinstance(node, dict))
 
-        page_info = review_threads.get("pageInfo") or {}
+        page_info = review_threads.get("pageInfo")
+        if not isinstance(page_info, dict):
+            _fail_fetch("missing pagination info", pull_request)
         if not page_info.get("hasNextPage"):
             break
         cursor_obj = page_info.get("endCursor")

--- a/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -271,8 +271,8 @@ def _cluster_size(cluster: Report) -> int:
     """Read a cluster's ``size`` as an int for sorting.
 
     The value is always the ``len(members)`` int stored in ``cluster_threads``;
-    the explicit int() narrows the ``object`` value type so the sort key is typed
-    and mypy's no-any-return rule is satisfied without a cast.
+    the isinstance check narrows the ``object`` value type so the sort key is
+    typed and mypy's no-any-return rule is satisfied without a cast.
     """
     size = cluster["size"]
     return size if isinstance(size, int) else 0
@@ -486,14 +486,16 @@ def _fetch_unresolved_threads(owner: str, repo: str, pull_request: int) -> list[
 def _resolve_lib_dir() -> str:
     """Locate the plugin ``lib`` directory for github_core imports.
 
-    Resolution order: ``CLAUDE_PLUGIN_ROOT`` env, ``GITHUB_WORKSPACE`` env, then
-    a path relative to this file. Exits 2 (config error per ADR-035) when no
-    candidate directory exists, so a misconfigured install fails loudly rather
-    than importing nothing.
+    Resolution order: ``COPILOT_PLUGIN_ROOT`` env, ``CLAUDE_PLUGIN_ROOT`` env,
+    ``GITHUB_WORKSPACE`` env, then a path relative to this file. Exits 2
+    (config error per ADR-035) when no candidate directory exists, so a
+    misconfigured install fails loudly rather than importing nothing.
     """
     import os
 
-    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get(
+        "CLAUDE_PLUGIN_ROOT",
+    )
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if plugin_root:
         lib_dir = os.path.join(plugin_root, "lib")

--- a/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -227,8 +227,9 @@ def _identify_source_artifact(threads: list[Thread]) -> str | None:
     A cluster whose threads land on one path points at that file as the framing
     root cause. When the cluster spans several files (the round-7 asymmetry
     case: 8 paths, one framing), the most common path is the best single
-    pointer; ties resolve to the first path seen for determinism. Returns None
-    when no thread in the cluster carries a path.
+    pointer only if it has a unique lead. Ties return None so the report does
+    not steer the agent into an arbitrary file patch. Returns None when no
+    thread in the cluster carries a path.
     """
     counts: dict[str, int] = {}
     order: list[str] = []

--- a/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Cluster unresolved PR review threads by shared gist before the fix loop.
+
+Phase 0 of the pr-comment-responder workflow. When a bot rescan surfaces many
+unresolved threads, several are often the same root cause stated on different
+files. PR #1897 round 7 surfaced 17 unresolved threads; 8 were the same
+"model_tier=opus contradicts cheaper-tier reviewer claim" framing on different
+paths (see .agents/retrospective/2026-05-08-pr-1897-confident-incorrectness-recurrence.md).
+Rounds 5 and 6 patched those per-file and did not close the cluster; round 7
+retired the framing in the source artifact and the cluster collapsed in one
+round.
+
+This module turns the agent-side mental model captured in the global memory
+``feedback_bot_thread_clustering.md`` ("4+ threads with the same gist = single
+source-of-truth violation, retire the framing once") into a mechanical step.
+When a cluster reaches ``CLUSTER_WARNING_THRESHOLD`` threads it is flagged so the
+agent fixes the framing root cause before the per-thread fix loop begins.
+
+Pipeline:
+
+1. Fetch unresolved threads (delegated to the github skill's
+   ``get_unresolved_review_threads.py`` so the GraphQL/pagination logic is not
+   duplicated; see Integration Points in .claude/rules/release-it.md).
+2. Extract a "gist" (a set of load-bearing tokens) from each thread's first
+   comment body.
+3. Cluster threads whose gists overlap (Jaccard similarity at or above
+   ``SIMILARITY_THRESHOLD``) using union-find.
+4. Report clusters of ``CLUSTER_WARNING_THRESHOLD`` or more threads, naming the
+   source artifact (the file path shared by the most threads in the cluster)
+   most likely to be the framing root cause.
+
+The fetch is an integration point; the clustering is pure. ``cluster_threads``
+and its helpers take plain dicts (the canonical flat thread shape produced by
+``github_core.review_threads.transform_review_thread``) and return plain dicts,
+so the algorithm is unit-testable without the network.
+
+Exit codes follow ADR-035:
+    0 - Report produced (warnings, if any, are in the JSON; not an error exit)
+    2 - Config/usage error (invalid parameters)
+    3 - Fetch failed (could not obtain a trustworthy thread snapshot)
+    4 - Auth error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+# A review thread in the canonical flat shape produced by
+# github_core.review_threads.transform_review_thread. Heterogeneous values
+# (str, int, None, list), so the value type is object rather than a narrower
+# alias; callers read specific keys (first_comment_body, path, thread_id).
+Thread = dict[str, object]
+# A clustering report or one cluster entry: same heterogeneous-value shape.
+Report = dict[str, object]
+
+# Threads with this many members sharing one gist are flagged as a probable
+# single-source-of-truth (framing/spec) violation. The value 4 comes directly
+# from the issue #1917 acceptance criteria and feedback_bot_thread_clustering.md;
+# the round-7 asymmetry cluster had 8 members and must trip the warning.
+CLUSTER_WARNING_THRESHOLD = 4
+
+# Two gists are "the same" when their Jaccard similarity (size of token
+# intersection over size of token union) is at or above this value. Bots
+# paraphrase, so an exact-match rule would split the round-7 asymmetry cluster
+# across Copilot/CodeRabbit re-wordings. 0.5 keeps loosely paraphrased restates
+# of one finding together while separating genuinely distinct findings.
+SIMILARITY_THRESHOLD = 0.5
+
+# A token must carry meaning to count toward overlap. We drop review-comment
+# filler ("consider", "should", "please") and structural noise so that the
+# load-bearing words (the nouns of the finding: "model", "tier", "opus",
+# "contradicts") drive clustering. Tokens shorter than this are also dropped.
+_MIN_TOKEN_LENGTH = 4
+
+# Generic review-comment vocabulary that appears across unrelated findings and
+# would create false overlap if counted. Lowercased; matched after tokenizing.
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "this",
+        "that",
+        "with",
+        "from",
+        "have",
+        "should",
+        "would",
+        "could",
+        "consider",
+        "please",
+        "change",
+        "changes",
+        "comment",
+        "review",
+        "line",
+        "lines",
+        "file",
+        "code",
+        "above",
+        "below",
+        "here",
+        "there",
+        "when",
+        "then",
+        "than",
+        "your",
+        "into",
+        "also",
+        "make",
+        "uses",
+        "used",
+        "using",
+        "note",
+        "needs",
+        "need",
+        "want",
+        "very",
+        "more",
+        "most",
+        "some",
+        "they",
+        "them",
+        "what",
+        "which",
+        "where",
+        "will",
+        "does",
+        "doesn",
+        "isn",
+        "instead",
+        "rather",
+        "suggest",
+        "suggestion",
+    }
+)
+
+# Token = a run of word characters. Markdown punctuation, backticks, and code
+# fences are stripped first so "`model_tier`" and "model_tier" tokenize the same.
+_TOKEN_RE = re.compile(r"[a-z0-9_]+")
+
+
+def extract_gist(body: object) -> frozenset[str]:
+    """Reduce a comment body to its set of load-bearing tokens.
+
+    Lowercases, splits ``snake_case`` and ``CamelCase`` boundaries into their
+    parts (so ``model_tier`` contributes ``model`` and ``tier``), then keeps
+    tokens that are at least ``_MIN_TOKEN_LENGTH`` long and not in
+    ``_STOPWORDS``. Returns an empty set for an empty or token-poor body; such
+    threads cannot join a cluster, which is the safe default (a thread with no
+    distinctive words should not be lumped with a real finding).
+
+    ``body`` is typed ``object`` because it comes straight from a JSON thread
+    dict whose value type is unconstrained (untrusted input at the boundary).
+    A non-string body (None, a number, a malformed list) yields an empty gist
+    rather than raising, so one bad thread cannot abort the whole report.
+    """
+    if not isinstance(body, str) or not body:
+        return frozenset()
+
+    lowered = body.lower()
+    # Split CamelCase before lowercasing would lose case, so split on the
+    # already-lowercased text using underscores and the original case markers
+    # are gone; snake_case still splits on underscore via the token regex below.
+    raw_tokens = _TOKEN_RE.findall(lowered)
+
+    gist: set[str] = set()
+    for token in raw_tokens:
+        for part in token.split("_"):
+            if len(part) >= _MIN_TOKEN_LENGTH and part not in _STOPWORDS:
+                gist.add(part)
+    return frozenset(gist)
+
+
+def gist_similarity(left: frozenset[str], right: frozenset[str]) -> float:
+    """Jaccard similarity between two gists: |intersection| / |union|.
+
+    Returns 0.0 when either gist is empty (an empty gist shares nothing). The
+    value is in [0.0, 1.0]; 1.0 means identical token sets.
+    """
+    if not left or not right:
+        return 0.0
+    intersection = len(left & right)
+    if intersection == 0:
+        return 0.0
+    union = len(left | right)
+    return intersection / union
+
+
+class _UnionFind:
+    """Disjoint-set over thread indices for transitive clustering.
+
+    If thread A is similar to B and B is similar to C, A, B and C land in one
+    cluster even when A and C are not directly similar. This matches the
+    real-world shape: a paraphrase chain across bot rescans links restates that
+    are not pairwise identical.
+    """
+
+    def __init__(self, size: int) -> None:
+        self._parent = list(range(size))
+
+    def find(self, node: int) -> int:
+        root = node
+        while self._parent[root] != root:
+            root = self._parent[root]
+        # Path compression keeps repeated finds near-constant time.
+        while self._parent[node] != root:
+            self._parent[node], node = root, self._parent[node]
+        return root
+
+    def union(self, left: int, right: int) -> None:
+        self._parent[self.find(left)] = self.find(right)
+
+
+def _group_indices_by_root(uf: _UnionFind, count: int) -> dict[int, list[int]]:
+    groups: dict[int, list[int]] = {}
+    for index in range(count):
+        groups.setdefault(uf.find(index), []).append(index)
+    return groups
+
+
+def _identify_source_artifact(threads: list[Thread]) -> str | None:
+    """Return the file path shared by the most threads in a cluster.
+
+    A cluster whose threads land on one path points at that file as the framing
+    root cause. When the cluster spans several files (the round-7 asymmetry
+    case: 8 paths, one framing), the most common path is the best single
+    pointer; ties resolve to the first path seen for determinism. Returns None
+    when no thread in the cluster carries a path.
+    """
+    counts: dict[str, int] = {}
+    order: list[str] = []
+    for thread in threads:
+        path = thread.get("path")
+        # Non-string or empty paths (None, missing, malformed) carry no
+        # artifact signal; skip them rather than key a count on a non-str.
+        if not isinstance(path, str) or not path:
+            continue
+        if path not in counts:
+            order.append(path)
+        counts[path] = counts.get(path, 0) + 1
+    if not counts:
+        return None
+    # max() is stable over the insertion-ordered keys, so a tie keeps the
+    # first-seen path rather than depending on dict hash order.
+    return max(order, key=lambda path: counts[path])
+
+
+def _shared_tokens(threads: list[Thread]) -> list[str]:
+    """Tokens present in the gist of every thread in the cluster, sorted.
+
+    These are the load-bearing words that define the cluster's gist; surfacing
+    them tells the agent what framing to retire. When transitive linking means
+    no single token spans all members, returns the empty list and the caller
+    falls back to the per-thread gists.
+    """
+    gists = [extract_gist(t.get("first_comment_body")) for t in threads]
+    gists = [g for g in gists if g]
+    if not gists:
+        return []
+    common = set.intersection(*(set(g) for g in gists))
+    return sorted(common)
+
+
+def _cluster_size(cluster: Report) -> int:
+    """Read a cluster's ``size`` as an int for sorting.
+
+    The value is always the ``len(members)`` int stored in ``cluster_threads``;
+    the explicit int() narrows the ``object`` value type so the sort key is typed
+    and mypy's no-any-return rule is satisfied without a cast.
+    """
+    size = cluster["size"]
+    return size if isinstance(size, int) else 0
+
+
+def cluster_threads(
+    threads: list[Thread],
+    similarity_threshold: float = SIMILARITY_THRESHOLD,
+    warning_threshold: int = CLUSTER_WARNING_THRESHOLD,
+) -> Report:
+    """Group threads by shared gist and flag large clusters.
+
+    ``threads`` is a list of canonical flat thread dicts (the shape from
+    ``transform_review_thread``); each must carry ``first_comment_body`` and
+    optionally ``path`` and ``thread_id``. Returns a report dict:
+
+        {
+          "thread_count": <int>,
+          "cluster_count": <int>,          # clusters at/over warning_threshold
+          "warning": <bool>,               # any cluster at/over the threshold
+          "clusters": [
+            {
+              "size": <int>,
+              "shared_tokens": [<str>, ...],
+              "source_artifact": <str|None>,
+              "thread_ids": [<str|None>, ...],
+              "paths": [<str|None>, ...]
+            },
+            ...
+          ]
+        }
+
+    Only clusters of ``warning_threshold`` or more threads appear in
+    ``clusters`` and contribute to ``cluster_count``; smaller groups are the
+    per-thread fix loop's normal work and are not framing problems. Clusters are
+    sorted largest-first so the worst single-source-of-truth violation leads.
+    """
+    count = len(threads)
+    gists = [extract_gist(t.get("first_comment_body")) for t in threads]
+
+    uf = _UnionFind(count)
+    for i in range(count):
+        if not gists[i]:
+            continue
+        for j in range(i + 1, count):
+            if not gists[j]:
+                continue
+            if gist_similarity(gists[i], gists[j]) >= similarity_threshold:
+                uf.union(i, j)
+
+    groups = _group_indices_by_root(uf, count)
+
+    clusters: list[Report] = []
+    for indices in groups.values():
+        if len(indices) < warning_threshold:
+            continue
+        members = [threads[i] for i in indices]
+        clusters.append(
+            {
+                "size": len(members),
+                "shared_tokens": _shared_tokens(members),
+                "source_artifact": _identify_source_artifact(members),
+                "thread_ids": [m.get("thread_id") for m in members],
+                "paths": [m.get("path") for m in members],
+            }
+        )
+
+    # Largest cluster first; size is always the int we stored above.
+    clusters.sort(key=_cluster_size, reverse=True)
+
+    return {
+        "thread_count": count,
+        "cluster_count": len(clusters),
+        "warning": bool(clusters),
+        "clusters": clusters,
+    }
+
+
+def _fetch_unresolved_threads(owner: str, repo: str, pull_request: int) -> list[Thread]:
+    """Fetch unresolved threads via the github skill's canonical helper.
+
+    Delegates pagination and the GraphQL query to
+    ``github_core.review_threads.get_unresolved_review_threads`` rather than
+    re-implementing them (DRY; the pagination edge cases are already covered and
+    tested there). Translates the integration point's failure into a clean exit
+    rather than leaking a transport exception. ``get_unresolved_review_threads``
+    returns ``[]`` on transport failure and never raises, so the caller cannot
+    distinguish "no unresolved threads" from "fetch failed" on the list alone;
+    the auth check below fails fast on the common auth failure, and an empty
+    list is reported as zero threads (a true empty PR is the same observable
+    state, which is acceptable for a Phase 0 advisory).
+    """
+    lib_dir = _resolve_lib_dir()
+    if lib_dir not in sys.path:
+        sys.path.insert(0, lib_dir)
+
+    from github_core.api import (  # noqa: E402
+        assert_gh_authenticated,
+        resolve_repo_params,
+    )
+    from github_core.review_threads import (  # noqa: E402
+        get_unresolved_review_threads,
+    )
+
+    assert_gh_authenticated()
+    resolved = resolve_repo_params(owner, repo)
+    # get_unresolved_review_threads is untyped at this import path (it lives
+    # under .claude/lib, outside the typed scripts.* tree), so mypy sees Any.
+    # The helper's documented contract is a list of flat thread dicts; keep
+    # only dict elements to honor the Thread type and drop any malformed node.
+    fetched = get_unresolved_review_threads(
+        resolved.owner, resolved.repo, pull_request,
+    )
+    return [item for item in fetched if isinstance(item, dict)]
+
+
+def _resolve_lib_dir() -> str:
+    """Locate the plugin ``lib`` directory the same way the github scripts do.
+
+    Mirrors the resolution order in
+    .claude/skills/github/scripts/pr/get_unresolved_review_threads.py:
+    ``CLAUDE_PLUGIN_ROOT`` env, then ``GITHUB_WORKSPACE`` env, then a path
+    relative to this file. Exits 2 (config error per ADR-035) when no candidate
+    directory exists, so a misconfigured install fails loudly rather than
+    importing nothing.
+    """
+    import os
+
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if plugin_root:
+        lib_dir = os.path.join(plugin_root, "lib")
+    elif workspace:
+        lib_dir = os.path.join(workspace, ".claude", "lib")
+    else:
+        lib_dir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..", "lib")
+        )
+    if not os.path.isdir(lib_dir):
+        print(f"Plugin lib directory not found: {lib_dir}", file=sys.stderr)
+        sys.exit(2)
+    return lib_dir
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Cluster unresolved PR review threads by shared gist and flag "
+            "framing/spec problems before the per-thread fix loop."
+        ),
+    )
+    parser.add_argument("--owner", default="", help="Repository owner")
+    parser.add_argument("--repo", default="", help="Repository name")
+    parser.add_argument(
+        "--pull-request", type=int, required=True, help="Pull request number",
+    )
+    parser.add_argument(
+        "--threads-file",
+        default="",
+        help=(
+            "Read threads from a JSON file instead of fetching. The file is "
+            "either a list of thread dicts or an object with a 'threads' key "
+            "(the shape get_unresolved_review_threads.py emits). Used for "
+            "offline analysis and tests; skips the GitHub fetch."
+        ),
+    )
+    return parser
+
+
+def _load_threads_from_file(path: str) -> list[Thread]:
+    """Read threads from a JSON file (list or ``{"threads": [...]}``).
+
+    Exits 2 on a missing file, malformed JSON, or a payload that is not a list
+    of objects: a bad ``--threads-file`` is a usage error, not a clustering
+    result. Non-dict list elements (untrusted input) are dropped rather than
+    crashing the clusterer.
+    """
+    from pathlib import Path
+
+    try:
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Could not read threads file {path}: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    payload = raw.get("threads") if isinstance(raw, dict) else raw
+    if not isinstance(payload, list):
+        print(
+            f"Threads file {path} must be a list or an object with a "
+            "'threads' list.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.pull_request <= 0:
+        print("Pull request number must be positive.", file=sys.stderr)
+        return 2
+
+    if args.threads_file:
+        threads = _load_threads_from_file(args.threads_file)
+    else:
+        threads = _fetch_unresolved_threads(
+            args.owner, args.repo, args.pull_request,
+        )
+
+    report = cluster_threads(threads)
+    report["pull_request"] = args.pull_request
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -493,9 +493,7 @@ def _resolve_lib_dir() -> str:
     """
     import os
 
-    plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get(
-        "CLAUDE_PLUGIN_ROOT",
-    )
+    plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if plugin_root:
         lib_dir = os.path.join(plugin_root, "lib")

--- a/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -421,7 +421,7 @@ def _fetch_unresolved_threads_with_clients(
 
         try:
             data = gh_graphql(_REVIEW_THREADS_FOR_CLUSTERING_QUERY, variables)
-        except RuntimeError as exc:
+        except Exception as exc:
             _fail_fetch(str(exc), pull_request)
 
         repository = data.get("repository") or {}

--- a/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
@@ -18,9 +18,9 @@ agent fixes the framing root cause before the per-thread fix loop begins.
 
 Pipeline:
 
-1. Fetch unresolved threads (delegated to the github skill's
-   ``get_unresolved_review_threads.py`` so the GraphQL/pagination logic is not
-   duplicated; see Integration Points in .claude/rules/release-it.md).
+1. Fetch unresolved threads with a clustering-specific GraphQL query that
+   selects path and first-comment body fields, then map nodes through
+   ``github_core.review_threads.transform_review_thread``.
 2. Extract a "gist" (a set of load-bearing tokens) from each thread's first
    comment body.
 3. Cluster threads whose gists overlap (Jaccard similarity at or above
@@ -243,9 +243,11 @@ def _identify_source_artifact(threads: list[Thread]) -> str | None:
         counts[path] = counts.get(path, 0) + 1
     if not counts:
         return None
-    # max() is stable over the insertion-ordered keys, so a tie keeps the
-    # first-seen path rather than depending on dict hash order.
-    return max(order, key=lambda path: counts[path])
+    max_count = max(counts.values())
+    winners = [path for path in order if counts[path] == max_count]
+    if len(winners) != 1:
+        return None
+    return winners[0]
 
 
 def _shared_tokens(threads: list[Thread]) -> list[str]:
@@ -310,13 +312,19 @@ def cluster_threads(
     count = len(threads)
     gists = [extract_gist(t.get("first_comment_body")) for t in threads]
 
+    token_to_indices: dict[str, set[int]] = {}
+    for index, gist in enumerate(gists):
+        for token in gist:
+            token_to_indices.setdefault(token, set()).add(index)
+
     uf = _UnionFind(count)
     for i in range(count):
         if not gists[i]:
             continue
-        for j in range(i + 1, count):
-            if not gists[j]:
-                continue
+        candidates: set[int] = set()
+        for token in gists[i]:
+            candidates.update(token_to_indices[token])
+        for j in sorted(candidate for candidate in candidates if candidate > i):
             if gist_similarity(gists[i], gists[j]) >= similarity_threshold:
                 uf.union(i, j)
 
@@ -383,6 +391,11 @@ query($owner: String!, $name: String!, $prNumber: Int!, $cursor: String) {
 }"""
 
 
+def _fail_fetch(message: str, pull_request: int) -> None:
+    print(f"Could not fetch review threads for PR {pull_request}: {message}", file=sys.stderr)
+    sys.exit(3)
+
+
 def _fetch_unresolved_threads_with_clients(
     owner: str,
     repo: str,
@@ -408,22 +421,18 @@ def _fetch_unresolved_threads_with_clients(
         try:
             data = gh_graphql(_REVIEW_THREADS_FOR_CLUSTERING_QUERY, variables)
         except RuntimeError as exc:
-            print(
-                f"Could not fetch review threads for PR {pull_request}: {exc}",
-                file=sys.stderr,
-            )
-            sys.exit(3)
+            _fail_fetch(str(exc), pull_request)
 
         repository = data.get("repository") or {}
         pr_obj = repository.get("pullRequest")
         if not isinstance(pr_obj, dict):
-            break
+            _fail_fetch("missing pullRequest", pull_request)
         review_threads = pr_obj.get("reviewThreads")
         if not isinstance(review_threads, dict):
-            break
+            _fail_fetch("missing reviewThreads", pull_request)
         nodes = review_threads.get("nodes")
         if not isinstance(nodes, list):
-            break
+            _fail_fetch("missing reviewThreads nodes", pull_request)
 
         aggregated.extend(node for node in nodes if isinstance(node, dict))
 
@@ -432,8 +441,10 @@ def _fetch_unresolved_threads_with_clients(
             break
         cursor_obj = page_info.get("endCursor")
         if not isinstance(cursor_obj, str) or not cursor_obj:
-            break
+            _fail_fetch("missing pagination cursor", pull_request)
         cursor = cursor_obj
+    else:
+        _fail_fetch("pagination exceeded 50 pages", pull_request)
 
     unresolved = filter_unresolved_threads(aggregated)
     return [
@@ -522,6 +533,24 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _project_root() -> "Path":
+    from pathlib import Path
+    import os
+
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if workspace:
+        root = Path(workspace).resolve()
+        if (root / "pyproject.toml").is_file():
+            return root
+
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "pyproject.toml").is_file():
+            return candidate
+
+    print("Could not locate project root.", file=sys.stderr)
+    sys.exit(2)
+
+
 def _load_threads_from_file(path: str) -> list[Thread]:
     """Read threads from a JSON file (list or ``{"threads": [...]}``).
 
@@ -534,19 +563,20 @@ def _load_threads_from_file(path: str) -> list[Thread]:
     from pathlib import Path
 
     requested_path = Path(path)
+    project_root = _project_root()
     if requested_path.is_absolute():
-        threads_path = requested_path
-    else:
-        project_root = Path(__file__).resolve().parents[4]
-        threads_path = (project_root / requested_path).resolve()
-        try:
-            threads_path.relative_to(project_root)
-        except ValueError:
-            print(
-                f"Threads file {path} escapes project root.",
-                file=sys.stderr,
-            )
-            sys.exit(2)
+        print("Threads file must be repository-relative.", file=sys.stderr)
+        sys.exit(2)
+
+    threads_path = (project_root / requested_path).resolve()
+    try:
+        threads_path.relative_to(project_root)
+    except ValueError:
+        print(
+            f"Threads file {path} escapes project root.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     try:
         raw = json.loads(threads_path.read_text(encoding="utf-8"))

--- a/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -379,10 +379,11 @@ class TestCli:
         assert result.returncode == 2
 
     def test_malformed_threads_file_exits_2(self):
-        relative_path, absolute_path = _write_repo_threads_file("malformed", "{not json")
+        absolute_path = _repo_root() / ".cluster-threads-malformed.json"
+        absolute_path.write_text("{not json", encoding="utf-8")
         try:
             result = self._run(
-                ["--pull-request", "1897", "--threads-file", relative_path],
+                ["--pull-request", "1897", "--threads-file", absolute_path.name],
             )
         finally:
             absolute_path.unlink(missing_ok=True)

--- a/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -506,3 +506,18 @@ class TestResolveLibDir:
         monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
         monkeypatch.setattr(os.path, "isdir", lambda path: path == "copilot-root/lib")
         assert mod._resolve_lib_dir() == "copilot-root/lib"
+
+    def test_non_runtime_fetch_failure_exits_3(self):
+        mod = _load_module()
+
+        def fake_graphql(query, variables):
+            raise TimeoutError("slow graphql")
+
+        try:
+            mod._fetch_unresolved_threads_with_clients(
+                "owner", "repo", 1, fake_graphql, lambda nodes: nodes, lambda node: node,
+            )
+        except SystemExit as exc:
+            assert exc.code == 3
+        else:
+            raise AssertionError("expected SystemExit")

--- a/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -521,3 +521,39 @@ class TestResolveLibDir:
             assert exc.code == 3
         else:
             raise AssertionError("expected SystemExit")
+
+    def test_non_dict_graphql_response_exits_3(self):
+        mod = _load_module()
+
+        def fake_graphql(query, variables):
+            return []
+
+        try:
+            mod._fetch_unresolved_threads_with_clients(
+                "owner", "repo", 1, fake_graphql, lambda nodes: nodes, lambda node: node,
+            )
+        except SystemExit as exc:
+            assert exc.code == 3
+        else:
+            raise AssertionError("expected SystemExit")
+
+    def test_malformed_page_info_exits_3(self):
+        mod = _load_module()
+
+        def fake_graphql(query, variables):
+            return {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {"pageInfo": [], "nodes": []},
+                    },
+                },
+            }
+
+        try:
+            mod._fetch_unresolved_threads_with_clients(
+                "owner", "repo", 1, fake_graphql, lambda nodes: nodes, lambda node: node,
+            )
+        except SystemExit as exc:
+            assert exc.code == 3
+        else:
+            raise AssertionError("expected SystemExit")

--- a/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -496,3 +496,13 @@ class TestFetchUnresolvedThreads:
             assert exc.code == 3
         else:
             raise AssertionError("expected SystemExit")
+
+
+class TestResolveLibDir:
+    def test_resolve_lib_dir_prefers_copilot_plugin_root(self, monkeypatch):
+        mod = _load_module()
+        monkeypatch.setenv("COPILOT_PLUGIN_ROOT", "copilot-root")
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+        monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+        monkeypatch.setattr(os.path, "isdir", lambda path: path == "copilot-root/lib")
+        assert mod._resolve_lib_dir() == "copilot-root/lib"

--- a/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+from pathlib import Path
 import subprocess
 import sys
 
@@ -34,6 +35,19 @@ def _load_module():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def _repo_root() -> Path:
+    for candidate in Path(_SCRIPT).resolve().parents:
+        if (candidate / "pyproject.toml").is_file():
+            return candidate
+    raise AssertionError("repo root not found")
+
+
+def _write_repo_threads_file(name: str, payload: object) -> tuple[str, Path]:
+    absolute_path = _repo_root() / f".cluster-threads-{name}.json"
+    absolute_path.write_text(json.dumps(payload), encoding="utf-8")
+    return absolute_path.name, absolute_path
 
 
 def _thread(thread_id: str, path: str, body: str) -> dict:
@@ -197,14 +211,13 @@ class TestClusterThreadsPr1897Regression:
         # 8 asymmetry + 2 harmful + 3 session-log + 1 aggregate + 2 evidence.
         assert report["thread_count"] == 16
 
-    def test_source_artifact_points_at_a_clustered_path(self):
+    def test_source_artifact_is_none_when_cluster_paths_tie(self):
         mod = _load_module()
         report = mod.cluster_threads(PR_1897_ROUND7_THREADS)
         top = report["clusters"][0]
-        # Every asymmetry thread lives under templates/agents/; the named
-        # artifact is one of those eight paths, not a non-cluster path.
-        assert top["source_artifact"] in top["paths"]
-        assert top["source_artifact"].startswith("templates/agents/")
+        # The asymmetry fixture spans eight paths with no winning file path, so
+        # returning None avoids steering the agent into an arbitrary file patch.
+        assert top["source_artifact"] is None
 
 
 class TestClusterThreadsThreshold:
@@ -278,13 +291,13 @@ class TestSourceArtifactIdentification:
         threads = [{"first_comment_body": "x"}, {"path": None, "first_comment_body": "y"}]
         assert mod._identify_source_artifact(threads) is None
 
-    def test_tie_keeps_first_seen_path(self):
+    def test_tie_returns_none(self):
         mod = _load_module()
         threads = [
             _thread("t0", "first.py", "a"),
             _thread("t1", "second.py", "b"),
         ]
-        assert mod._identify_source_artifact(threads) == "first.py"
+        assert mod._identify_source_artifact(threads) is None
 
 
 class TestTransitiveClustering:
@@ -313,60 +326,78 @@ class TestCli:
             input=input_text,
         )
 
-    def test_threads_file_path_produces_report(self, tmp_path):
-        threads_file = tmp_path / "threads.json"
-        threads_file.write_text(
-            json.dumps({"threads": PR_1897_ROUND7_THREADS}), encoding="utf-8",
+    def test_threads_file_path_produces_report(self):
+        relative_path, absolute_path = _write_repo_threads_file(
+            "object", {"threads": PR_1897_ROUND7_THREADS},
         )
-        result = self._run(
-            ["--pull-request", "1897", "--threads-file", str(threads_file)],
-        )
+        try:
+            result = self._run(
+                ["--pull-request", "1897", "--threads-file", relative_path],
+            )
+        finally:
+            absolute_path.unlink(missing_ok=True)
         assert result.returncode == 0
         report = json.loads(result.stdout)
         assert report["pull_request"] == 1897
         assert report["warning"] is True
         assert 8 in [c["size"] for c in report["clusters"]]
 
-    def test_bare_list_threads_file_is_accepted(self, tmp_path):
-        threads_file = tmp_path / "threads.json"
-        threads_file.write_text(
-            json.dumps(PR_1897_ROUND7_THREADS), encoding="utf-8",
+    def test_bare_list_threads_file_is_accepted(self):
+        relative_path, absolute_path = _write_repo_threads_file(
+            "list", PR_1897_ROUND7_THREADS,
         )
-        result = self._run(
-            ["--pull-request", "1897", "--threads-file", str(threads_file)],
-        )
+        try:
+            result = self._run(
+                ["--pull-request", "1897", "--threads-file", relative_path],
+            )
+        finally:
+            absolute_path.unlink(missing_ok=True)
         assert result.returncode == 0
         report = json.loads(result.stdout)
         assert report["thread_count"] == 16
 
-    def test_nonpositive_pull_request_exits_2(self, tmp_path):
-        threads_file = tmp_path / "threads.json"
-        threads_file.write_text("[]", encoding="utf-8")
+    def test_nonpositive_pull_request_exits_2(self):
+        relative_path, absolute_path = _write_repo_threads_file("empty", [])
+        try:
+            result = self._run(
+                ["--pull-request", "0", "--threads-file", relative_path],
+            )
+        finally:
+            absolute_path.unlink(missing_ok=True)
+        assert result.returncode == 2
+
+    def test_absolute_threads_file_exits_2(self):
         result = self._run(
-            ["--pull-request", "0", "--threads-file", str(threads_file)],
+            ["--pull-request", "1897", "--threads-file", str(_repo_root() / "x.json")],
         )
         assert result.returncode == 2
 
     def test_missing_threads_file_exits_2(self):
         result = self._run(
-            ["--pull-request", "1897", "--threads-file", "/no/such/file.json"],
+            ["--pull-request", "1897", "--threads-file", "no-such-file.json"],
         )
         assert result.returncode == 2
 
-    def test_malformed_threads_file_exits_2(self, tmp_path):
-        threads_file = tmp_path / "threads.json"
-        threads_file.write_text("{not json", encoding="utf-8")
-        result = self._run(
-            ["--pull-request", "1897", "--threads-file", str(threads_file)],
-        )
+    def test_malformed_threads_file_exits_2(self):
+        relative_path, absolute_path = _write_repo_threads_file("malformed", "{not json")
+        try:
+            result = self._run(
+                ["--pull-request", "1897", "--threads-file", relative_path],
+            )
+        finally:
+            absolute_path.unlink(missing_ok=True)
         assert result.returncode == 2
 
-    def test_threads_file_wrong_shape_exits_2(self, tmp_path):
-        threads_file = tmp_path / "threads.json"
-        threads_file.write_text(json.dumps({"threads": 42}), encoding="utf-8")
-        result = self._run(
-            ["--pull-request", "1897", "--threads-file", str(threads_file)],
+    def test_threads_file_wrong_shape_exits_2(self):
+        relative_path, absolute_path = _write_repo_threads_file(
+            "wrong-shape", {"threads": 42},
         )
+        try:
+            result = self._run(
+                ["--pull-request", "1897", "--threads-file", relative_path],
+            )
+        finally:
+            absolute_path.unlink(missing_ok=True)
         assert result.returncode == 2
 
     def test_missing_required_pull_request_exits_2(self):
@@ -440,6 +471,21 @@ class TestFetchUnresolvedThreads:
 
         def fake_graphql(query, variables):
             raise RuntimeError("network down")
+
+        try:
+            mod._fetch_unresolved_threads_with_clients(
+                "owner", "repo", 1, fake_graphql, lambda nodes: nodes, lambda node: node,
+            )
+        except SystemExit as exc:
+            assert exc.code == 3
+        else:
+            raise AssertionError("expected SystemExit")
+
+    def test_malformed_payload_exits_3(self):
+        mod = _load_module()
+
+        def fake_graphql(query, variables):
+            return {"repository": {"pullRequest": {"reviewThreads": {"nodes": None}}}}
 
         try:
             mod._fetch_unresolved_threads_with_clients(

--- a/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Tests for the pr-comment-responder cluster_threads.py Phase 0 step.
+
+The headline regression fixture (``PR_1897_ROUND7_THREADS``) reconstructs the
+PR #1897 round-7 unresolved-thread set described in
+.agents/retrospective/2026-05-08-pr-1897-confident-incorrectness-recurrence.md
+Phase 0: five gist clusters (asymmetry x 8, harmful x 2, session-log x 3,
+aggregate x 1, evidence-drift x 2). The 8-thread asymmetry cluster
+("model_tier=opus contradicts cheaper-tier reviewer claim" on different files)
+is the single-source-of-truth violation the step exists to catch.
+
+The retrospective's headline says "post-push 17" but its own per-cluster
+breakdown (8 + 2 + 3 + 1 + 2) sums to 16. We hold the fixture to the
+itemized per-cluster counts (the load-bearing detail for this test, since the
+8-thread asymmetry cluster is what the step must detect) rather than the
+headline total, so the fixture has 16 threads.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+
+_SCRIPT = os.path.join(
+    os.path.dirname(__file__), "..", "scripts", "cluster_threads.py",
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("cluster_threads", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _thread(thread_id: str, path: str, body: str) -> dict:
+    """Build a canonical flat thread dict (transform_review_thread shape)."""
+    return {"thread_id": thread_id, "path": path, "first_comment_body": body}
+
+
+# Eight restates of the same finding across eight files, each paraphrased the
+# way Copilot/CodeRabbit re-word a finding on a rescan. The load-bearing tokens
+# (model, tier, opus, contradicts/cheaper) recur; the filler varies.
+_ASYMMETRY_BODIES = [
+    "The model_tier is set to opus here but the template claims a cheaper "
+    "reviewer model tier; this contradicts the stronger model wording.",
+    "model_tier opus contradicts the cheaper model tier described for the "
+    "reviewer in this template section.",
+    "This sets model_tier to opus yet the prose says cheaper reviewer tier. "
+    "The model tier wording contradicts the opus assignment.",
+    "Reviewer model_tier opus contradicts the cheaper-tier claim. The model "
+    "tier asymmetry framing is wrong.",
+    "opus model_tier here contradicts the template's cheaper model tier "
+    "reviewer framing.",
+    "The model tier (opus) contradicts the cheaper reviewer model tier this "
+    "template asserts.",
+    "model_tier opus assignment contradicts cheaper model tier reviewer "
+    "wording, an asymmetry framing problem.",
+    "This opus model_tier contradicts the cheaper-tier reviewer model "
+    "framing described nearby.",
+]
+
+_HARMFUL_BODIES = [
+    "The harmful-content threshold here is too low and rejects benign "
+    "fixtures; raise the harmful threshold boundary.",
+    "harmful threshold boundary rejects benign input; the harmful content "
+    "threshold value is misconfigured.",
+]
+
+_SESSION_LOG_BODIES = [
+    "The session-log naming pattern violates the protocol; rename the session "
+    "log file to the canonical session naming format.",
+    "session log naming does not match the protocol session naming convention "
+    "for the session log file.",
+    "This session-log filename breaks the session naming protocol; the "
+    "session log naming convention requires the dated slug.",
+]
+
+_EVIDENCE_DRIFT_BODIES = [
+    "The evidence-standards section drifted from the canonical evidence "
+    "hierarchy levels; sync the evidence section drift.",
+    "evidence section drift: the evidence hierarchy levels documented here no "
+    "longer match the canonical evidence standards.",
+]
+
+
+def _build_pr_1897_round7_threads() -> list[dict]:
+    threads: list[dict] = []
+    for index, body in enumerate(_ASYMMETRY_BODIES):
+        threads.append(_thread(f"asym-{index}", f"templates/agents/file_{index}.md", body))
+    for index, body in enumerate(_HARMFUL_BODIES):
+        threads.append(_thread(f"harm-{index}", "guard-maturity/thresholds.py", body))
+    for index, body in enumerate(_SESSION_LOG_BODIES):
+        threads.append(_thread(f"sess-{index}", "scripts/session_log.py", body))
+    threads.append(
+        _thread(
+            "agg-0",
+            "guard-maturity/run_report.py",
+            "The aggregate exit code returns zero on a partial aggregate "
+            "failure; the aggregate exit-code branch swallows the failure.",
+        )
+    )
+    for index, body in enumerate(_EVIDENCE_DRIFT_BODIES):
+        threads.append(_thread(f"ev-{index}", "templates/agents/evidence.md", body))
+    return threads
+
+
+# 8 + 2 + 3 + 1 + 2 == 16, the retrospective's itemized per-cluster counts.
+PR_1897_ROUND7_THREADS = _build_pr_1897_round7_threads()
+
+
+class TestExtractGist:
+    def test_splits_snake_case_into_load_bearing_parts(self):
+        mod = _load_module()
+        gist = mod.extract_gist("The model_tier is opus here.")
+        assert "model" in gist
+        assert "tier" in gist
+        assert "opus" in gist
+
+    def test_drops_short_tokens_and_stopwords(self):
+        mod = _load_module()
+        gist = mod.extract_gist("This should consider the change here.")
+        # All tokens are stopwords or under the length floor; nothing survives.
+        assert gist == frozenset()
+
+    def test_empty_body_returns_empty_gist(self):
+        mod = _load_module()
+        assert mod.extract_gist("") == frozenset()
+
+    def test_none_body_returns_empty_gist(self):
+        mod = _load_module()
+        assert mod.extract_gist(None) == frozenset()
+
+    def test_backticked_token_matches_plain_token(self):
+        mod = _load_module()
+        backticked = mod.extract_gist("Fix `model_tier` opus assignment.")
+        plain = mod.extract_gist("Fix model_tier opus assignment.")
+        assert backticked == plain
+
+
+class TestGistSimilarity:
+    def test_identical_gists_score_one(self):
+        mod = _load_module()
+        gist = frozenset({"model", "tier", "opus"})
+        assert mod.gist_similarity(gist, gist) == 1.0
+
+    def test_disjoint_gists_score_zero(self):
+        mod = _load_module()
+        left = frozenset({"model", "tier"})
+        right = frozenset({"harmful", "threshold"})
+        assert mod.gist_similarity(left, right) == 0.0
+
+    def test_empty_gist_scores_zero(self):
+        mod = _load_module()
+        assert mod.gist_similarity(frozenset(), frozenset({"opus"})) == 0.0
+
+    def test_partial_overlap_is_jaccard(self):
+        mod = _load_module()
+        left = frozenset({"model", "tier", "opus"})
+        right = frozenset({"model", "tier", "cheaper"})
+        # intersection 2 (model, tier) over union 4 -> 0.5
+        assert mod.gist_similarity(left, right) == 0.5
+
+
+class TestClusterThreadsPr1897Regression:
+    def test_detects_eight_thread_asymmetry_cluster(self):
+        mod = _load_module()
+        report = mod.cluster_threads(PR_1897_ROUND7_THREADS)
+        assert report["warning"] is True
+        sizes = [c["size"] for c in report["clusters"]]
+        # The 8-thread asymmetry cluster is the single 4+ cluster; the other
+        # round-7 clusters (2, 3, 1, 2) are below the warning threshold.
+        assert 8 in sizes
+
+    def test_asymmetry_cluster_leads_and_names_load_bearing_tokens(self):
+        mod = _load_module()
+        report = mod.cluster_threads(PR_1897_ROUND7_THREADS)
+        top = report["clusters"][0]
+        assert top["size"] == 8
+        # The framing tokens that recur across all eight restates.
+        assert "model" in top["shared_tokens"]
+        assert "tier" in top["shared_tokens"]
+        assert "opus" in top["shared_tokens"]
+
+    def test_thread_count_matches_round7_itemized_breakdown(self):
+        mod = _load_module()
+        report = mod.cluster_threads(PR_1897_ROUND7_THREADS)
+        # 8 asymmetry + 2 harmful + 3 session-log + 1 aggregate + 2 evidence.
+        assert report["thread_count"] == 16
+
+    def test_source_artifact_points_at_a_clustered_path(self):
+        mod = _load_module()
+        report = mod.cluster_threads(PR_1897_ROUND7_THREADS)
+        top = report["clusters"][0]
+        # Every asymmetry thread lives under templates/agents/; the named
+        # artifact is one of those eight paths, not a non-cluster path.
+        assert top["source_artifact"] in top["paths"]
+        assert top["source_artifact"].startswith("templates/agents/")
+
+
+class TestClusterThreadsThreshold:
+    def test_no_warning_below_threshold(self):
+        mod = _load_module()
+        # Three identical-gist threads: a real group but under the 4 floor.
+        threads = [
+            _thread(f"t{index}", "a.py", "model_tier opus contradicts cheaper tier")
+            for index in range(3)
+        ]
+        report = mod.cluster_threads(threads)
+        assert report["warning"] is False
+        assert report["cluster_count"] == 0
+        assert report["clusters"] == []
+
+    def test_warning_exactly_at_threshold(self):
+        mod = _load_module()
+        threads = [
+            _thread(f"t{index}", "a.py", "model_tier opus contradicts cheaper tier")
+            for index in range(4)
+        ]
+        report = mod.cluster_threads(threads)
+        assert report["warning"] is True
+        assert report["cluster_count"] == 1
+        assert report["clusters"][0]["size"] == 4
+
+    def test_empty_thread_list_produces_no_warning(self):
+        mod = _load_module()
+        report = mod.cluster_threads([])
+        assert report["thread_count"] == 0
+        assert report["warning"] is False
+        assert report["clusters"] == []
+
+    def test_token_poor_threads_do_not_cluster(self):
+        mod = _load_module()
+        # Bodies whose only words are stopwords/short: each gist is empty, so no
+        # two can reach the similarity threshold and no cluster forms.
+        threads = [
+            _thread(f"t{index}", "a.py", "this should change here")
+            for index in range(6)
+        ]
+        report = mod.cluster_threads(threads)
+        assert report["warning"] is False
+
+    def test_distinct_findings_stay_separate(self):
+        mod = _load_module()
+        # Four distinct findings, no shared load-bearing tokens: no cluster.
+        threads = [
+            _thread("t0", "a.py", "the harmful threshold boundary rejects benign fixtures"),
+            _thread("t1", "b.py", "session log naming violates the dated slug protocol"),
+            _thread("t2", "c.py", "aggregate exit code swallows partial failure branch"),
+            _thread("t3", "d.py", "evidence hierarchy levels drifted from canonical standards"),
+        ]
+        report = mod.cluster_threads(threads)
+        assert report["warning"] is False
+        assert report["cluster_count"] == 0
+
+
+class TestSourceArtifactIdentification:
+    def test_most_common_path_wins(self):
+        mod = _load_module()
+        threads = [
+            _thread("t0", "common.py", "model tier opus contradicts cheaper"),
+            _thread("t1", "common.py", "model tier opus contradicts cheaper"),
+            _thread("t2", "other.py", "model tier opus contradicts cheaper"),
+        ]
+        assert mod._identify_source_artifact(threads) == "common.py"
+
+    def test_returns_none_when_no_paths(self):
+        mod = _load_module()
+        threads = [{"first_comment_body": "x"}, {"path": None, "first_comment_body": "y"}]
+        assert mod._identify_source_artifact(threads) is None
+
+    def test_tie_keeps_first_seen_path(self):
+        mod = _load_module()
+        threads = [
+            _thread("t0", "first.py", "a"),
+            _thread("t1", "second.py", "b"),
+        ]
+        assert mod._identify_source_artifact(threads) == "first.py"
+
+
+class TestTransitiveClustering:
+    def test_paraphrase_chain_links_into_one_cluster(self):
+        mod = _load_module()
+        # A-B share {model, tier}; B-C share {tier, opus}; A-C share only
+        # {tier} (below 0.5 alone) but transitively join via B. Four members
+        # so the cluster trips the warning.
+        threads = [
+            _thread("a", "f.py", "model tier framing"),
+            _thread("b", "f.py", "model tier opus framing"),
+            _thread("c", "f.py", "tier opus cheaper"),
+            _thread("d", "f.py", "model tier opus cheaper"),
+        ]
+        report = mod.cluster_threads(threads)
+        assert report["warning"] is True
+        assert report["clusters"][0]["size"] == 4
+
+
+class TestCli:
+    def _run(self, args: list[str], input_text: str | None = None):
+        return subprocess.run(
+            [sys.executable, _SCRIPT, *args],
+            capture_output=True,
+            text=True,
+            input=input_text,
+        )
+
+    def test_threads_file_path_produces_report(self, tmp_path):
+        threads_file = tmp_path / "threads.json"
+        threads_file.write_text(
+            json.dumps({"threads": PR_1897_ROUND7_THREADS}), encoding="utf-8",
+        )
+        result = self._run(
+            ["--pull-request", "1897", "--threads-file", str(threads_file)],
+        )
+        assert result.returncode == 0
+        report = json.loads(result.stdout)
+        assert report["pull_request"] == 1897
+        assert report["warning"] is True
+        assert 8 in [c["size"] for c in report["clusters"]]
+
+    def test_bare_list_threads_file_is_accepted(self, tmp_path):
+        threads_file = tmp_path / "threads.json"
+        threads_file.write_text(
+            json.dumps(PR_1897_ROUND7_THREADS), encoding="utf-8",
+        )
+        result = self._run(
+            ["--pull-request", "1897", "--threads-file", str(threads_file)],
+        )
+        assert result.returncode == 0
+        report = json.loads(result.stdout)
+        assert report["thread_count"] == 16
+
+    def test_nonpositive_pull_request_exits_2(self, tmp_path):
+        threads_file = tmp_path / "threads.json"
+        threads_file.write_text("[]", encoding="utf-8")
+        result = self._run(
+            ["--pull-request", "0", "--threads-file", str(threads_file)],
+        )
+        assert result.returncode == 2
+
+    def test_missing_threads_file_exits_2(self):
+        result = self._run(
+            ["--pull-request", "1897", "--threads-file", "/no/such/file.json"],
+        )
+        assert result.returncode == 2
+
+    def test_malformed_threads_file_exits_2(self, tmp_path):
+        threads_file = tmp_path / "threads.json"
+        threads_file.write_text("{not json", encoding="utf-8")
+        result = self._run(
+            ["--pull-request", "1897", "--threads-file", str(threads_file)],
+        )
+        assert result.returncode == 2
+
+    def test_threads_file_wrong_shape_exits_2(self, tmp_path):
+        threads_file = tmp_path / "threads.json"
+        threads_file.write_text(json.dumps({"threads": 42}), encoding="utf-8")
+        result = self._run(
+            ["--pull-request", "1897", "--threads-file", str(threads_file)],
+        )
+        assert result.returncode == 2
+
+    def test_missing_required_pull_request_exits_2(self):
+        result = self._run([])
+        # argparse exits 2 on a missing required argument.
+        assert result.returncode == 2

--- a/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
+++ b/src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
@@ -140,6 +140,12 @@ class TestExtractGist:
         plain = mod.extract_gist("Fix model_tier opus assignment.")
         assert backticked == plain
 
+    def test_splits_camel_case_into_load_bearing_parts(self):
+        mod = _load_module()
+        gist = mod.extract_gist("The modelTier setting contradicts ModelTier docs.")
+        assert "model" in gist
+        assert "tier" in gist
+
 
 class TestGistSimilarity:
     def test_identical_gists_score_one(self):
@@ -367,3 +373,79 @@ class TestCli:
         result = self._run([])
         # argparse exits 2 on a missing required argument.
         assert result.returncode == 2
+
+
+class TestFetchUnresolvedThreads:
+    def test_fetch_uses_fields_needed_for_clustering(self):
+        mod = _load_module()
+        queries = []
+
+        def fake_graphql(query, variables):
+            queries.append((query, variables))
+            return {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": [
+                                {
+                                    "id": "thread-1",
+                                    "isResolved": False,
+                                    "path": "a.py",
+                                    "comments": {
+                                        "totalCount": 1,
+                                        "nodes": [
+                                            {
+                                                "databaseId": 1,
+                                                "body": "modelTier contradicts docs",
+                                                "createdAt": "2026-01-01T00:00:00Z",
+                                                "author": {"login": "bot"},
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                },
+            }
+
+        def fake_filter(nodes):
+            return [node for node in nodes if node.get("isResolved") is False]
+
+        def fake_transform(node):
+            return {
+                "thread_id": node.get("id"),
+                "path": node.get("path"),
+                "first_comment_body": node["comments"]["nodes"][0]["body"],
+            }
+
+        threads = mod._fetch_unresolved_threads_with_clients(
+            "owner", "repo", 1, fake_graphql, fake_filter, fake_transform,
+        )
+
+        query = queries[0][0]
+        assert "path" in query
+        assert "body" in query
+        assert threads == [
+            {
+                "thread_id": "thread-1",
+                "path": "a.py",
+                "first_comment_body": "modelTier contradicts docs",
+            },
+        ]
+
+    def test_fetch_failure_exits_3(self):
+        mod = _load_module()
+
+        def fake_graphql(query, variables):
+            raise RuntimeError("network down")
+
+        try:
+            mod._fetch_unresolved_threads_with_clients(
+                "owner", "repo", 1, fake_graphql, lambda nodes: nodes, lambda node: node,
+            )
+        except SystemExit as exc:
+            assert exc.code == 3
+        else:
+            raise AssertionError("expected SystemExit")

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -45,7 +45,7 @@ Verify PR merge state using `scripts.claude_code.test_pr_merged`. Exit code 0 = 
 
 Before addressing comments, gather full context:
 
-1. **Run Phase 0 thread clustering**: Use `cluster_threads` from config before the per-thread fix loop. If the JSON report has `warning: true`, surface the clusters in the verdict with `size`, `shared_tokens`, `source_artifact`, and `thread_ids`; stop the per-thread loop and fix the cluster-level framing or spec source first. Resume per-file patches only after that cluster-level fix is pushed.
+1. **Run Phase 0 thread clustering**: Use `cluster_threads` from config before the per-thread fix loop. If the JSON report has `warning: true`, add a `clusters` section to the verdict containing each cluster's `size`, `shared_tokens`, `source_artifact`, and `thread_ids`. Halt the per-thread loop. If `source_artifact` is non-null, patch that file's shared framing or spec source; otherwise patch the PR description, linked issue, or most common thread path after inspecting the cluster. Commit and push that cluster-level fix, then re-run the cluster step and resume per-file patches only after the warning is gone or the remaining threads no longer share one gist.
 2. **Review ALL comments**: Use `get_review_threads`, `get_unresolved_threads`, `get_unaddressed_comments`, and `get_pr_context` scripts from config.
 3. **Check merge eligibility**: Verify `mergeable=MERGEABLE` and no conflicts.
 4. **Review failing checks**: Use `get_pr_checks` script. Handle failures per `check_failure_actions` table in config.

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -45,9 +45,10 @@ Verify PR merge state using `scripts.claude_code.test_pr_merged`. Exit code 0 = 
 
 Before addressing comments, gather full context:
 
-1. **Review ALL comments**: Use `get_review_threads`, `get_unresolved_threads`, `get_unaddressed_comments`, and `get_pr_context` scripts from config.
-2. **Check merge eligibility**: Verify `mergeable=MERGEABLE` and no conflicts.
-3. **Review failing checks**: Use `get_pr_checks` script. Handle failures per `check_failure_actions` table in config.
+1. **Run Phase 0 thread clustering**: Use `cluster_threads` from config before the per-thread fix loop. If the JSON report has `warning: true`, surface the clusters in the verdict with `size`, `shared_tokens`, `source_artifact`, and `thread_ids`; stop the per-thread loop and fix the cluster-level framing or spec source first. Resume per-file patches only after that cluster-level fix is pushed.
+2. **Review ALL comments**: Use `get_review_threads`, `get_unresolved_threads`, `get_unaddressed_comments`, and `get_pr_context` scripts from config.
+3. **Check merge eligibility**: Verify `mergeable=MERGEABLE` and no conflicts.
+4. **Review failing checks**: Use `get_pr_checks` script. Handle failures per `check_failure_actions` table in config.
 
 After you resolve the last thread on a PR with live bot reviewers (Copilot, Devin), do NOT trust a single `get_unresolved_threads` snapshot. A bot scan can land 30 to 120 seconds after your push and reopen the count. Run the `wait_for_settled_zero` script from config to confirm the count has settled: it polls and exits 0 only after three consecutive complete-and-zero readings 180s apart. This closes the bot-settle gap that produced the PR #1965 "0 unresolved" lie. The completion gate below is a one-shot verdict and does not settle over time.
 

--- a/tests/skills/pr-comment-responder/test_cluster_threads.py
+++ b/tests/skills/pr-comment-responder/test_cluster_threads.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""CI-collected wrapper for the pr-comment-responder cluster tests."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SKILL_TEST = (
+    _REPO_ROOT
+    / ".claude"
+    / "skills"
+    / "pr-comment-responder"
+    / "tests"
+    / "test_cluster_threads.py"
+)
+
+spec = importlib.util.spec_from_file_location("pr_comment_responder_cluster_tests", _SKILL_TEST)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+for name, value in vars(module).items():
+    if name.startswith("Test") or name.startswith("test_"):
+        globals()[name] = value


### PR DESCRIPTION
## Summary

Adds Phase 0 gist clustering to pr-comment-responder and wires it into /pr-review command dispatch before the per-thread fix loop. When the cluster report finds 4 or more unresolved threads with the same gist, /pr-review must surface the cluster in the verdict, stop per-file patching, and fix the cluster-level framing or spec source first.

Fixes #1917

## Changed files

- .claude/.claude-plugin/plugin.json
- .claude/commands/pr-review-config.yaml
- .claude/commands/pr-review.md
- .claude/skills/pr-comment-responder/SKILL.md
- .claude/skills/pr-comment-responder/scripts/cluster_threads.py
- .claude/skills/pr-comment-responder/tests/test_cluster_threads.py
- .github/prompts/pr-review.prompt.md
- src/copilot-cli/.claude-plugin/plugin.json
- src/copilot-cli/skills/pr-comment-responder/SKILL.md
- src/copilot-cli/skills/pr-comment-responder/scripts/cluster_threads.py
- src/copilot-cli/skills/pr-comment-responder/tests/test_cluster_threads.py
- src/copilot-cli/skills/pr-review/SKILL.md
- tests/skills/pr-comment-responder/test_cluster_threads.py

## Details

- The cluster fetch now includes path and first-comment body fields required for live gist clustering.
- CamelCase and snake_case tokens both normalize into load-bearing gist terms.
- Relative threads-file inputs anchor to the project root.
- The command flow exposes and runs Phase 0 before the per-thread fix loop.
- Copilot skill and command mirrors were regenerated from Claude canonical sources.

## Testing

- TMPDIR set inside the worktree, uv run pytest -q for the cluster tests and command config tests, 91 passed.
- CI-collected cluster wrapper and plugin path tests passed locally.
- Live cluster report for PR 2237 exited 0.
- Skill mirror generation exited 0.
- Full generated-files check exited 0.
- PR description validation was rerun after this description update.


Validation refresh: commit-limit-bypass label applied.
