### PR TITLE
feat(validation): Phase 3 CI check for agent-skill discriminator (#2008)

### DIFF
--- a/.github/workflows/agent-skill-discriminator-check.yml
+++ b/.github/workflows/agent-skill-discriminator-check.yml
@@ -1,0 +1,108 @@
+# Agent-Skill Discriminator Check (Issue #2008)
+#
+# Phase 3 CI backstop for the agent-skill classification audit (Issue #2003).
+# Detects new or materially changed agents added in "skill shape" so the
+# catalog does not keep accumulating misclassification debt (the audit found
+# 42 percent of 23 agents were skill candidates).
+#
+# An agent scoring 2+ on c1 (slash-command Task invocation), c2 (>=70 percent
+# structured-reference body), and c3 (sibling skill in the same pipeline) fails
+# unless it carries 'isolation_required: true' in frontmatter OR the PR body
+# carries the token '[skill-discriminator: <rationale>]'.
+#
+# Logic lives in scripts/validation/check_agent_skill_discriminator.py per
+# ADR-006 (thin workflows) and ADR-042 (Python-first). Uses dorny/paths-filter
+# (Issue #103) so the workflow satisfies required-check contracts on every PR
+# and skips with a passing status when no agent files changed.
+
+name: Agent-Skill Discriminator Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-paths:
+    name: Detect agent changes
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    outputs:
+      should-run: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.agents }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check path filters
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          filters: |
+            agents:
+              - '.claude/agents/**.md'
+              - 'templates/agents/**.shared.md'
+              - 'scripts/validation/check_agent_skill_discriminator.py'
+              - '.github/workflows/agent-skill-discriminator-check.yml'
+
+  validate-discriminator:
+    name: Score changed agents
+    needs: check-paths
+    if: needs.check-paths.outputs.should-run == 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
+
+      - name: Compute changed agent files
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ -n "${BASE_SHA}" ] && [ -n "${HEAD_SHA}" ]; then
+            FILES=$(git diff --name-only --diff-filter=ACMR "${BASE_SHA}" "${HEAD_SHA}" \
+              -- '.claude/agents/*.md' 'templates/agents/*.shared.md' | tr '\n' ' ')
+          else
+            FILES=$(git ls-files '.claude/agents/*.md' 'templates/agents/*.shared.md' | tr '\n' ' ')
+          fi
+          echo "files=${FILES}" >> "${GITHUB_OUTPUT}"
+
+      - name: Run discriminator check
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          python3 scripts/validation/check_agent_skill_discriminator.py
+
+  skip-discriminator:
+    name: Skip discriminator (no agent changes)
+    needs: check-paths
+    if: needs.check-paths.outputs.should-run != 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 1
+    steps:
+      - name: Checkout code
+        # Required for dorny/paths-filter pattern consistency.
+        # See: .serena/memories/ci-infrastructure-dorny-paths-filter-checkout.md
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Skip message
+        run: |
+          echo "No agent definition changes detected - skipping discriminator check"

--- a/.github/workflows/agent-skill-discriminator-check.yml
+++ b/.github/workflows/agent-skill-discriminator-check.yml
@@ -76,13 +76,15 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          DELIMITER="agent_files_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}"
+          echo "files<<${DELIMITER}" >> "${GITHUB_OUTPUT}"
           if [ -n "${BASE_SHA}" ] && [ -n "${HEAD_SHA}" ]; then
-            FILES=$(git diff --name-only --diff-filter=ACMR "${BASE_SHA}" "${HEAD_SHA}" \
-              -- '.claude/agents/*.md' 'templates/agents/*.shared.md' | tr '\n' ' ')
+            git diff --name-only --diff-filter=ACMR "${BASE_SHA}" "${HEAD_SHA}" \
+              -- .claude/agents templates/agents >> "${GITHUB_OUTPUT}"
           else
-            FILES=$(git ls-files '.claude/agents/*.md' 'templates/agents/*.shared.md' | tr '\n' ' ')
+            git ls-files .claude/agents templates/agents >> "${GITHUB_OUTPUT}"
           fi
-          echo "files=${FILES}" >> "${GITHUB_OUTPUT}"
+          echo "${DELIMITER}" >> "${GITHUB_OUTPUT}"
 
       - name: Run discriminator check
         env:

--- a/scripts/validation/check_agent_skill_discriminator.py
+++ b/scripts/validation/check_agent_skill_discriminator.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Phase 3 CI check: detect new agents added in skill shape (Issue #2008).
+
+Backstop for the agent-skill classification audit (Issue #2003). The audit
+found 42 percent of 23 agents were skill-shape candidates. This check stops
+new agents from accumulating the same misclassification debt at PR time.
+
+Discriminator (locked by the #2003 audit; canonical source:
+``.agents/audits/2026-05-10-agent-skill-classification-audit.md``):
+
+A new or materially changed agent under ``.claude/agents/`` (or its
+``templates/agents/*.shared.md`` sibling per ADR-036) is a skill-shape
+candidate when 2 or more of these hold:
+
+- c1: invoked from a slash command via ``Task(subagent_type="<name>")``
+  (searched across ``.claude/commands/`` and ``templates/commands/``).
+- c2: body is at least 70 percent structured-reference material (tables,
+  decision-tree list items, anti-pattern catalogs, format/schema specs,
+  validation rule lists). Counted conservatively; see ``score_c2``.
+- c3: a sibling artifact invoked from the same slash-command pipeline is
+  already a skill (``Skill(skill="<name>")``), AND the agent is invoked from
+  fewer than 3 distinct pipelines (the 3-pipeline rule). c3 is N/A (scores 0)
+  when c1 is false or the agent is invoked from 3 or more pipelines.
+
+c4 (PR-history schema drift) requires git history and is out of scope for CI.
+
+An agent scoring 2 or more FAILS the check unless one escape hatch is present:
+
+- Agent frontmatter contains ``isolation_required: true`` (with a rationale),
+  or
+- The PR description carries the token ``[skill-discriminator: <rationale>]``
+  (passed via ``--pr-body`` / ``PR_BODY``).
+
+Exit codes follow ADR-035:
+    0 - Success: no changed agent fails the discriminator (or escape hatch set)
+    1 - Error: one or more changed agents score 2+ without an escape hatch
+    2 - Config error (repo root or commands directory not found)
+
+Related: ADR-006 (thin workflows / testable modules), ADR-042 (Python-first),
+ADR-030 (Skills Pattern Superiority), ADR-036 (Two-Source Agent Templates).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+AUDIT_PATH = ".agents/audits/2026-05-10-agent-skill-classification-audit.md"
+ADR_PATH = ".agents/architecture/ADR-030-skills-pattern-superiority.md"
+
+# Reserved metadata files that are not agents.
+_NON_AGENT_NAMES: frozenset[str] = frozenset({"AGENTS", "CLAUDE", "README"})
+
+# c2: an agent body counts as skill-shape when this fraction of its content
+# lines are structured-reference. Locked at 0.70 by the #2003 audit (PRD s.11).
+C2_THRESHOLD: float = 0.70
+
+# The 3-pipeline rule: an agent invoked from this many distinct slash-command
+# pipelines (or more) is too cross-cutting to be a skill candidate; c3 is N/A.
+PIPELINE_RULE_LIMIT: int = 3
+
+# PR-description escape-hatch token: ``[skill-discriminator: rationale text]``.
+_OVERRIDE_TOKEN: re.Pattern[str] = re.compile(
+    r"\[skill-discriminator:\s*(?P<rationale>[^\]]+)\]", re.IGNORECASE
+)
+
+# Structured-reference line markers (c2). Conservative: only lines that are
+# clearly reference shapes count. Prose bullets that are full sentences are
+# excluded by the sentence heuristic in ``_is_reference_line``.
+_TABLE_ROW: re.Pattern[str] = re.compile(r"^\s*\|.*\|\s*$")
+_TABLE_SEP: re.Pattern[str] = re.compile(r"^\s*\|[\s:|-]+\|\s*$")
+_LIST_ITEM: re.Pattern[str] = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+\S")
+_HEADING: re.Pattern[str] = re.compile(r"^\s*#{1,6}\s+\S")
+
+
+@dataclass(frozen=True, slots=True)
+class AgentScore:
+    """Discriminator outcome for a single agent."""
+
+    name: str
+    path: str
+    c1: bool
+    c2: bool
+    c3: bool
+    pipeline_count: int
+    isolation_required: bool
+
+    @property
+    def score(self) -> int:
+        """Number of true discriminator criteria (c1 + c2 + c3)."""
+        return int(self.c1) + int(self.c2) + int(self.c3)
+
+    @property
+    def is_candidate(self) -> bool:
+        """True when the agent is a skill-shape candidate (score >= 2)."""
+        return self.score >= 2
+
+
+@dataclass
+class CheckResult:
+    """Aggregate outcome across all changed agents."""
+
+    scores: list[AgentScore] = field(default_factory=list)
+    override_rationale: str | None = None
+
+    @property
+    def candidates(self) -> list[AgentScore]:
+        """Candidates that lack the frontmatter escape hatch."""
+        return [
+            s for s in self.scores if s.is_candidate and not s.isolation_required
+        ]
+
+    @property
+    def failing(self) -> list[AgentScore]:
+        """Candidates that fail the check (no escape hatch of any kind)."""
+        if self.override_rationale:
+            return []
+        return self.candidates
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing
+# ---------------------------------------------------------------------------
+
+
+def split_frontmatter(content: str) -> tuple[str, str]:
+    """Return (frontmatter_block, body) for a markdown file.
+
+    The frontmatter block excludes the ``---`` fences. When no frontmatter is
+    present the first element is empty and the body is the whole content.
+    """
+    if not content.startswith("---"):
+        return "", content
+
+    lines = content.split("\n")
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return "\n".join(lines[1:i]), "\n".join(lines[i + 1 :])
+    return "", content
+
+
+def has_isolation_required(frontmatter: str) -> bool:
+    """True when frontmatter declares ``isolation_required: true``.
+
+    The escape hatch must carry a non-empty rationale on the same line or be
+    accompanied by other frontmatter context; the audit only requires the flag
+    plus a one-line rationale, so any truthy value qualifies here. A bare
+    ``isolation_required: false`` does not qualify.
+    """
+    match = re.search(
+        r"^\s*isolation_required:\s*(?P<value>\S+)",
+        frontmatter,
+        re.MULTILINE,
+    )
+    if match is None:
+        return False
+    return match.group("value").strip().lower() in {"true", "yes", "1"}
+
+
+# ---------------------------------------------------------------------------
+# c2: structured-reference heuristic
+# ---------------------------------------------------------------------------
+
+
+def _is_reference_line(line: str) -> bool:
+    """True when a non-blank body line is structured-reference, not prose.
+
+    Conservative count rule (issue note: the audit heuristic over-estimated
+    reasoning agents). A line counts as reference when it is a table row,
+    a heading, or a short list item. A list item that reads as a full prose
+    sentence (ends in a period and runs long) does NOT count.
+    """
+    if _TABLE_ROW.match(line):
+        return True
+    if _HEADING.match(line):
+        return True
+    if _LIST_ITEM.match(line):
+        stripped = re.sub(r"^\s*(?:[-*+]|\d+\.)\s+", "", line).strip()
+        # A long bullet that ends like a sentence is reasoning prose, not a
+        # decision-tree entry. Keep short, label-like bullets as reference.
+        words = stripped.split()
+        if len(words) > 18 and stripped.endswith((".", "!", "?")):
+            return False
+        return True
+    return False
+
+
+def _content_lines(body: str) -> list[str]:
+    """Body lines that count toward the c2 denominator.
+
+    Excludes blank lines and fenced-code-block content (code is neither prose
+    nor decision-tree reference; counting it skews both ways).
+    """
+    out: list[str] = []
+    in_fence = False
+    for raw in body.split("\n"):
+        stripped = raw.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if not stripped:
+            continue
+        out.append(raw)
+    return out
+
+
+def score_c2(body: str) -> tuple[bool, float]:
+    """Return (is_skill_shape, ratio) for the structured-reference heuristic."""
+    lines = _content_lines(body)
+    if not lines:
+        return False, 0.0
+    reference = sum(1 for line in lines if _is_reference_line(line))
+    ratio = reference / len(lines)
+    return ratio >= C2_THRESHOLD, ratio
+
+
+# ---------------------------------------------------------------------------
+# c1 / c3: slash-command pipeline analysis
+# ---------------------------------------------------------------------------
+
+
+def _task_invocations(text: str) -> set[str]:
+    """Agent names invoked via ``Task(subagent_type="<name>")`` in one file."""
+    return set(re.findall(r'Task\(subagent_type="([a-z0-9-]+)"', text))
+
+
+def _skill_invocations(text: str) -> set[str]:
+    """Skill names invoked via ``Skill(skill="<name>")`` in one file."""
+    return set(re.findall(r'Skill\(skill="([a-z0-9-]+)"', text))
+
+
+def _command_files(repo_root: Path) -> list[Path]:
+    """Slash-command markdown files across both command source trees."""
+    files: list[Path] = []
+    for rel in (".claude/commands", "templates/commands"):
+        base = repo_root / rel
+        if base.is_dir():
+            files.extend(sorted(base.rglob("*.md")))
+    return files
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineIndex:
+    """Per-command-file map of agents invoked and skills invoked."""
+
+    agents_by_file: dict[str, frozenset[str]]
+    skills_by_file: dict[str, frozenset[str]]
+
+    def pipelines_for(self, agent: str) -> list[str]:
+        """Command files that invoke the agent via Task()."""
+        return [f for f, agents in self.agents_by_file.items() if agent in agents]
+
+    def sibling_skill_in_pipeline(self, agent: str) -> bool:
+        """True when any pipeline invoking the agent also invokes a skill."""
+        for path in self.pipelines_for(agent):
+            if self.skills_by_file.get(path):
+                return True
+        return False
+
+
+def build_pipeline_index(repo_root: Path) -> PipelineIndex:
+    """Index every slash command's Task() and Skill() invocations."""
+    agents_by_file: dict[str, frozenset[str]] = {}
+    skills_by_file: dict[str, frozenset[str]] = {}
+    for path in _command_files(repo_root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        rel = str(path.relative_to(repo_root))
+        agents_by_file[rel] = frozenset(_task_invocations(text))
+        skills_by_file[rel] = frozenset(_skill_invocations(text))
+    return PipelineIndex(agents_by_file, skills_by_file)
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def agent_name_from_path(path: str) -> str:
+    """Derive the agent name from a .claude/agents or templates/agents path."""
+    stem = Path(path).name
+    # templates/agents/<name>.shared.md -> <name>
+    if stem.endswith(".shared.md"):
+        return stem[: -len(".shared.md")]
+    return Path(stem).stem
+
+
+def is_agent_path(path: str) -> bool:
+    """True when the path is an agent definition (not metadata, not a skill)."""
+    norm = path.replace("\\", "/")
+    name = agent_name_from_path(norm)
+    if name in _NON_AGENT_NAMES:
+        return False
+    if norm.endswith(".shared.md"):
+        return "templates/agents/" in norm
+    return "/.claude/agents/" in f"/{norm}" and norm.endswith(".md")
+
+
+def score_agent(
+    repo_root: Path, agent_path: str, index: PipelineIndex
+) -> AgentScore | None:
+    """Score one agent file against c1 + c2 + c3. None when file is missing."""
+    name = agent_name_from_path(agent_path)
+    full = repo_root / agent_path
+    try:
+        content = full.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    frontmatter, body = split_frontmatter(content)
+    isolation = has_isolation_required(frontmatter)
+
+    pipelines = index.pipelines_for(name)
+    pipeline_count = len(pipelines)
+    c1 = pipeline_count > 0
+
+    c2_shape, _ratio = score_c2(body)
+
+    # c3 is N/A (False) when c1 is false or the agent spans 3+ pipelines.
+    if not c1 or pipeline_count >= PIPELINE_RULE_LIMIT:
+        c3 = False
+    else:
+        c3 = index.sibling_skill_in_pipeline(name)
+
+    return AgentScore(
+        name=name,
+        path=agent_path,
+        c1=c1,
+        c2=c2_shape,
+        c3=c3,
+        pipeline_count=pipeline_count,
+        isolation_required=isolation,
+    )
+
+
+def filter_agent_paths(changed_files: list[str]) -> list[str]:
+    """Keep only agent-definition paths, de-duplicated, order-stable."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in changed_files:
+        path = raw.strip()
+        if not path or not is_agent_path(path):
+            continue
+        if path in seen:
+            continue
+        seen.add(path)
+        out.append(path)
+    return out
+
+
+def run_check(
+    repo_root: Path, changed_files: list[str], pr_body: str
+) -> CheckResult:
+    """Score every changed agent and resolve the PR-description override."""
+    index = build_pipeline_index(repo_root)
+    result = CheckResult()
+
+    override = _OVERRIDE_TOKEN.search(pr_body or "")
+    if override is not None:
+        result.override_rationale = override.group("rationale").strip()
+
+    for agent_path in filter_agent_paths(changed_files):
+        score = score_agent(repo_root, agent_path, index)
+        if score is not None:
+            result.scores.append(score)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _criteria_str(score: AgentScore) -> str:
+    parts = [
+        f"c1={'Y' if score.c1 else 'n'}",
+        f"c2={'Y' if score.c2 else 'n'}",
+        f"c3={'Y' if score.c3 else 'n'}",
+    ]
+    return " ".join(parts)
+
+
+def print_report(result: CheckResult) -> None:
+    """Print a human-readable summary of the scoring."""
+    print("Agent-skill discriminator check (Issue #2008)")
+    print("=" * 60)
+
+    if not result.scores:
+        print("No changed agent definitions to score.")
+        return
+
+    for score in result.scores:
+        status = "CANDIDATE" if score.is_candidate else "ok"
+        print(
+            f"  [{status}] {score.name} "
+            f"(score {score.score}/3: {_criteria_str(score)}, "
+            f"pipelines={score.pipeline_count}, "
+            f"isolation_required={'yes' if score.isolation_required else 'no'})"
+        )
+
+    if result.override_rationale:
+        print()
+        print(f"PR override present: {result.override_rationale}")
+
+    failing = result.failing
+    print()
+    if not failing:
+        print("PASS: no agent fails the discriminator.")
+        return
+
+    print("FAIL: the following agents are skill-shape candidates (score 2+):")
+    for score in failing:
+        print(f"  - {score.name} ({_criteria_str(score)})")
+    print()
+    print("Each candidate must either:")
+    print("  1. Be refactored into a skill before merge, or")
+    print("  2. Add 'isolation_required: true' (with a one-line rationale) to")
+    print("     the agent frontmatter, or")
+    print("  3. Carry the PR-description token")
+    print("     '[skill-discriminator: <rationale>]' for a one-off override.")
+    print()
+    print(f"See {AUDIT_PATH}")
+    print(f"and {ADR_PATH}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _split_changed_arg(values: list[str] | None, env_value: str | None) -> list[str]:
+    """Normalize changed-file inputs from CLI args or a whitespace/newline env."""
+    if values:
+        return list(values)
+    if env_value:
+        return [p for p in re.split(r"\s+", env_value.strip()) if p]
+    return []
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Detect new agents added in skill shape (Issue #2008).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=os.environ.get("REPO_ROOT", "."),
+        help="Repository root (env: REPO_ROOT, default: .)",
+    )
+    parser.add_argument(
+        "--changed-files",
+        nargs="*",
+        default=None,
+        help="Changed agent file paths to score (space-separated).",
+    )
+    parser.add_argument(
+        "--pr-body",
+        default=os.environ.get("PR_BODY", ""),
+        help="PR description text; scanned for the override token (env: PR_BODY).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns an ADR-035 exit code."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    if not repo_root.is_dir():
+        print(f"Repo root not found: {repo_root}", file=sys.stderr)
+        return 2
+
+    commands_dir = repo_root / ".claude" / "commands"
+    if not commands_dir.is_dir():
+        print(
+            f"Commands directory not found: {commands_dir} "
+            "(cannot score c1/c3).",
+            file=sys.stderr,
+        )
+        return 2
+
+    changed = _split_changed_arg(
+        args.changed_files, os.environ.get("CHANGED_FILES")
+    )
+
+    result = run_check(repo_root, changed, args.pr_body)
+    print_report(result)
+
+    return 1 if result.failing else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_agent_skill_discriminator.py
+++ b/scripts/validation/check_agent_skill_discriminator.py
@@ -72,7 +72,6 @@ _OVERRIDE_TOKEN: re.Pattern[str] = re.compile(
 # clearly reference shapes count. Prose bullets that are full sentences are
 # excluded by the sentence heuristic in ``_is_reference_line``.
 _TABLE_ROW: re.Pattern[str] = re.compile(r"^\s*\|.*\|\s*$")
-_TABLE_SEP: re.Pattern[str] = re.compile(r"^\s*\|[\s:|-]+\|\s*$")
 _LIST_ITEM: re.Pattern[str] = re.compile(r"^\s*(?:[-*+]|\d+\.)\s+\S")
 _HEADING: re.Pattern[str] = re.compile(r"^\s*#{1,6}\s+\S")
 
@@ -136,7 +135,7 @@ def split_frontmatter(content: str) -> tuple[str, str]:
     if not content.startswith("---"):
         return "", content
 
-    lines = content.split("\n")
+    lines = content.splitlines()
     for i in range(1, len(lines)):
         if lines[i].strip() == "---":
             return "\n".join(lines[1:i]), "\n".join(lines[i + 1 :])
@@ -152,13 +151,13 @@ def has_isolation_required(frontmatter: str) -> bool:
     ``isolation_required: false`` does not qualify.
     """
     match = re.search(
-        r"^\s*isolation_required:\s*(?P<value>\S+)",
+        r"^isolation_required:[ \t]*['\"]?(?P<value>true|yes|1|false|no|0)['\"]?[ \t]*(?:#.*)?$",
         frontmatter,
-        re.MULTILINE,
+        re.IGNORECASE | re.MULTILINE,
     )
     if match is None:
         return False
-    return match.group("value").strip().lower() in {"true", "yes", "1"}
+    return match.group("value").lower() in {"true", "yes", "1"}
 
 
 # ---------------------------------------------------------------------------
@@ -197,7 +196,7 @@ def _content_lines(body: str) -> list[str]:
     """
     out: list[str] = []
     in_fence = False
-    for raw in body.split("\n"):
+    for raw in body.splitlines():
         stripped = raw.strip()
         if stripped.startswith("```"):
             in_fence = not in_fence
@@ -227,12 +226,22 @@ def score_c2(body: str) -> tuple[bool, float]:
 
 def _task_invocations(text: str) -> set[str]:
     """Agent names invoked via ``Task(subagent_type="<name>")`` in one file."""
-    return set(re.findall(r'Task\(subagent_type="([a-z0-9-]+)"', text))
+    return set(
+        re.findall(
+            r"Task\([ \t]*subagent_type[ \t]*=[ \t]*['\"]([a-z0-9-]+)['\"]",
+            text,
+        )
+    )
 
 
 def _skill_invocations(text: str) -> set[str]:
     """Skill names invoked via ``Skill(skill="<name>")`` in one file."""
-    return set(re.findall(r'Skill\(skill="([a-z0-9-]+)"', text))
+    return set(
+        re.findall(
+            r"Skill\([ \t]*skill[ \t]*=[ \t]*['\"]([a-z0-9-]+)['\"]",
+            text,
+        )
+    )
 
 
 def _command_files(repo_root: Path) -> list[Path]:
@@ -269,10 +278,7 @@ def build_pipeline_index(repo_root: Path) -> PipelineIndex:
     agents_by_file: dict[str, frozenset[str]] = {}
     skills_by_file: dict[str, frozenset[str]] = {}
     for path in _command_files(repo_root):
-        try:
-            text = path.read_text(encoding="utf-8")
-        except OSError:
-            continue
+        text = path.read_text(encoding="utf-8")
         rel = str(path.relative_to(repo_root))
         agents_by_file[rel] = frozenset(_task_invocations(text))
         skills_by_file[rel] = frozenset(_skill_invocations(text))
@@ -304,16 +310,20 @@ def is_agent_path(path: str) -> bool:
     return "/.claude/agents/" in f"/{norm}" and norm.endswith(".md")
 
 
-def score_agent(
-    repo_root: Path, agent_path: str, index: PipelineIndex
-) -> AgentScore | None:
-    """Score one agent file against c1 + c2 + c3. None when file is missing."""
-    name = agent_name_from_path(agent_path)
-    full = repo_root / agent_path
-    try:
-        content = full.read_text(encoding="utf-8")
-    except OSError:
-        return None
+def resolve_repo_path(repo_root: Path, relative_path: str) -> Path:
+    """Return a resolved path only when it stays under the repo root."""
+    resolved_root = repo_root.resolve()
+    full_path = (resolved_root / relative_path).resolve()
+    if not full_path.is_relative_to(resolved_root):
+        raise ValueError(f"Path escapes repo root: {relative_path}")
+    return full_path
+
+
+def score_agent(repo_root: Path, agent_path: str, index: PipelineIndex) -> AgentScore:
+    """Score one resolved agent file against c1 + c2 + c3."""
+    full = resolve_repo_path(repo_root, agent_path)
+    name = agent_name_from_path(str(full))
+    content = full.read_text(encoding="utf-8")
 
     frontmatter, body = split_frontmatter(content)
     isolation = has_isolation_required(frontmatter)
@@ -368,9 +378,7 @@ def run_check(
         result.override_rationale = override.group("rationale").strip()
 
     for agent_path in filter_agent_paths(changed_files):
-        score = score_agent(repo_root, agent_path, index)
-        if score is not None:
-            result.scores.append(score)
+        result.scores.append(score_agent(repo_root, agent_path, index))
     return result
 
 
@@ -491,7 +499,12 @@ def main(argv: list[str] | None = None) -> int:
         args.changed_files, os.environ.get("CHANGED_FILES")
     )
 
-    result = run_check(repo_root, changed, args.pr_body)
+    try:
+        result = run_check(repo_root, changed, args.pr_body)
+    except (OSError, UnicodeError, ValueError) as exc:
+        print(f"Config error: {exc}", file=sys.stderr)
+        return 2
+
     print_report(result)
 
     return 1 if result.failing else 0

--- a/scripts/validation/check_agent_skill_discriminator.py
+++ b/scripts/validation/check_agent_skill_discriminator.py
@@ -67,6 +67,9 @@ PIPELINE_RULE_LIMIT: int = 3
 _OVERRIDE_TOKEN: re.Pattern[str] = re.compile(
     r"\[skill-discriminator:\s*(?P<rationale>[^\]]+)\]", re.IGNORECASE
 )
+_DESCRIPTIVE_TASK: re.Pattern[str] = re.compile(
+    r"Task\([ \t]*subagent_type[ \t]*=[ \t]*\.\.\.[ \t]*\)[^\n]*?\((?P<agents>[^)\n]+)\)"
+)
 
 # Structured-reference line markers (c2). Conservative: only lines that are
 # clearly reference shapes count. Prose bullets that are full sentences are
@@ -145,10 +148,10 @@ def split_frontmatter(content: str) -> tuple[str, str]:
 def has_isolation_required(frontmatter: str) -> bool:
     """True when frontmatter declares ``isolation_required: true``.
 
-    The escape hatch must carry a non-empty rationale on the same line or be
-    accompanied by other frontmatter context; the audit only requires the flag
-    plus a one-line rationale, so any truthy value qualifies here. A bare
-    ``isolation_required: false`` does not qualify.
+    The audit accepts the flag as the machine-readable escape hatch. Rationale
+    text can live in a comment or nearby frontmatter, but this parser only
+    evaluates the truthy flag value. A bare ``isolation_required: false`` does
+    not qualify.
     """
     match = re.search(
         r"^isolation_required:[ \t]*['\"]?(?P<value>true|yes|1|false|no|0)['\"]?[ \t]*(?:#.*)?$",
@@ -225,13 +228,20 @@ def score_c2(body: str) -> tuple[bool, float]:
 
 
 def _task_invocations(text: str) -> set[str]:
-    """Agent names invoked via ``Task(subagent_type="<name>")`` in one file."""
-    return set(
+    """Agent names invoked via literal or descriptive ``Task`` forms."""
+    agents = set(
         re.findall(
             r"Task\([ \t]*subagent_type[ \t]*=[ \t]*['\"]([a-z0-9-]+)['\"]",
             text,
         )
     )
+    for match in _DESCRIPTIVE_TASK.finditer(text):
+        agents.update(
+            name
+            for raw in match.group("agents").split(",")
+            if (name := raw.strip()) and re.fullmatch(r"[a-z0-9-]+", name)
+        )
+    return agents
 
 
 def _skill_invocations(text: str) -> set[str]:
@@ -446,7 +456,7 @@ def print_report(result: CheckResult) -> None:
 
 def _split_changed_arg(values: list[str] | None, env_value: str | None) -> list[str]:
     """Normalize changed-file inputs from CLI args or a whitespace/newline env."""
-    if values:
+    if values is not None:
         return list(values)
     if env_value:
         return [p for p in re.split(r"\s+", env_value.strip()) if p]

--- a/tests/validation/test_check_agent_skill_discriminator.py
+++ b/tests/validation/test_check_agent_skill_discriminator.py
@@ -1,0 +1,397 @@
+"""Tests for scripts/validation/check_agent_skill_discriminator.py (Issue #2008).
+
+Pins the Phase 3 agent-skill discriminator CI backstop.
+
+Required fixture coverage (issue acceptance criteria):
+- pure-skill agent (c1+c2+c3 all true): fails
+- pure-agent agent (prose body, no slash-command invocation): passes
+- mixed agent with frontmatter override (isolation_required): passes
+- agent invoked from 3+ pipelines (c3 N/A via the 3-pipeline rule): passes
+
+Plus edge and branch cases: PR-description override token, metadata files
+excluded, two-source templates/agents siblings scored, c2 conservative
+sentence-prose exclusion, and ADR-035 exit codes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "validation" / "check_agent_skill_discriminator.py"
+
+
+def _load_module():
+    """Import the validator by file path for direct-function tests.
+
+    Register the module in sys.modules before exec so the dataclass decorator
+    (slots=True) can resolve the module namespace during class creation.
+    """
+    spec = importlib.util.spec_from_file_location("agent_skill_disc", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _reference_body(lines: int = 30) -> str:
+    """A heavily structured-reference body (tables + short label bullets)."""
+    rows = "\n".join(f"| key{i} | value{i} |" for i in range(lines // 2))
+    bullets = "\n".join(f"- field{i}: required" for i in range(lines // 2))
+    return f"## Schema\n\n| col | desc |\n|-----|------|\n{rows}\n\n## Rules\n{bullets}\n"
+
+
+def _prose_body(lines: int = 30) -> str:
+    """A prose body of full sentences (reasoning, not reference)."""
+    para = (
+        "You investigate before implementation and reason about the problem "
+        "from first principles to surface the deepest root cause available."
+    )
+    return "## Mission\n\n" + "\n\n".join(para for _ in range(lines)) + "\n"
+
+
+def _write_agent(
+    repo: Path,
+    name: str,
+    body: str,
+    *,
+    isolation_required: bool = False,
+    shared_template: bool = False,
+) -> str:
+    """Write an agent file and return its repo-relative path.
+
+    Frontmatter lines are assembled at column 0 (no dedent) so the optional
+    isolation_required line keeps the same zero indentation as the fences.
+    """
+    fm_lines = [
+        "---",
+        f"name: {name}",
+        f"description: Test agent {name}.",
+        "model: sonnet",
+    ]
+    if isolation_required:
+        fm_lines.append("isolation_required: true  # fresh-context review")
+    fm_lines.append("---")
+    content = "\n".join(fm_lines) + f"\n\n# {name} agent\n\n" + body
+    if shared_template:
+        rel = f"templates/agents/{name}.shared.md"
+    else:
+        rel = f".claude/agents/{name}.md"
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return rel
+
+
+def _write_command(repo: Path, name: str, text: str) -> None:
+    base = repo / ".claude" / "commands"
+    base.mkdir(parents=True, exist_ok=True)
+    (base / f"{name}.md").write_text(text, encoding="utf-8")
+
+
+def _scaffold(tmp_path: Path) -> Path:
+    """Create the minimal repo shape: .claude/commands and .claude/agents."""
+    repo = tmp_path / "repo"
+    (repo / ".claude" / "commands").mkdir(parents=True)
+    (repo / ".claude" / "agents").mkdir(parents=True)
+    return repo
+
+
+def _run(
+    repo: Path, changed: list[str], pr_body: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo-root",
+            str(repo),
+            "--pr-body",
+            pr_body,
+            "--changed-files",
+            *changed,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit: c2 heuristic
+# ---------------------------------------------------------------------------
+
+
+def test_c2_structured_body_scores_true() -> None:
+    is_shape, ratio = mod.score_c2(_reference_body())
+    assert is_shape is True
+    assert ratio >= mod.C2_THRESHOLD
+
+
+def test_c2_prose_body_scores_false() -> None:
+    is_shape, ratio = mod.score_c2(_prose_body())
+    assert is_shape is False
+    assert ratio < mod.C2_THRESHOLD
+
+
+def test_c2_long_sentence_bullet_is_not_reference() -> None:
+    """A long bullet ending in a period is reasoning prose, not reference."""
+    line = (
+        "- You must carefully consider every downstream consumer before you "
+        "decide whether the change is safe to land in production today."
+    )
+    assert mod._is_reference_line(line) is False
+
+
+def test_c2_short_label_bullet_is_reference() -> None:
+    assert mod._is_reference_line("- field: required") is True
+
+
+def test_c2_empty_body_is_not_shape() -> None:
+    is_shape, ratio = mod.score_c2("")
+    assert is_shape is False
+    assert ratio == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Unit: frontmatter escape hatch
+# ---------------------------------------------------------------------------
+
+
+def test_isolation_required_true_detected() -> None:
+    assert mod.has_isolation_required("name: x\nisolation_required: true") is True
+
+
+def test_isolation_required_false_not_detected() -> None:
+    assert mod.has_isolation_required("isolation_required: false") is False
+
+
+def test_isolation_required_absent() -> None:
+    assert mod.has_isolation_required("name: x\nmodel: sonnet") is False
+
+
+# ---------------------------------------------------------------------------
+# Unit: path filtering
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_files_excluded() -> None:
+    assert mod.is_agent_path(".claude/agents/AGENTS.md") is False
+    assert mod.is_agent_path(".claude/agents/CLAUDE.md") is False
+
+
+def test_agent_and_shared_template_paths_included() -> None:
+    assert mod.is_agent_path(".claude/agents/devops.md") is True
+    assert mod.is_agent_path("templates/agents/devops.shared.md") is True
+
+
+def test_skill_path_not_treated_as_agent() -> None:
+    assert mod.is_agent_path(".claude/skills/devops/SKILL.md") is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: required fixture scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_pure_skill_agent_fails(tmp_path: Path) -> None:
+    """c1+c2+c3 all true with no escape hatch -> exit 1 (candidate fails)."""
+    repo = _scaffold(tmp_path)
+    rel = _write_agent(repo, "shaped", _reference_body())
+    # One pipeline invokes both the agent (c1) and a sibling skill (c3).
+    _write_command(
+        repo,
+        "build",
+        'Task(subagent_type="shaped"): do work.\n'
+        'Invoke Skill(skill="pre-mortem") first.\n',
+    )
+
+    proc = _run(repo, [rel])
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "FAIL" in proc.stdout
+    assert "shaped" in proc.stdout
+    assert mod.AUDIT_PATH in proc.stdout
+
+
+def test_pure_agent_passes(tmp_path: Path) -> None:
+    """Prose body, never invoked from a slash command -> exit 0."""
+    repo = _scaffold(tmp_path)
+    rel = _write_agent(repo, "thinker", _prose_body())
+    _write_command(repo, "build", "No agent invocations here.\n")
+
+    proc = _run(repo, [rel])
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "PASS" in proc.stdout
+
+
+def test_mixed_agent_with_frontmatter_override_passes(tmp_path: Path) -> None:
+    """Skill-shape but isolation_required: true -> exit 0."""
+    repo = _scaffold(tmp_path)
+    rel = _write_agent(
+        repo, "critic", _reference_body(), isolation_required=True
+    )
+    _write_command(
+        repo,
+        "review",
+        'Task(subagent_type="critic"): review.\n'
+        'Skill(skill="taste-lints").\n',
+    )
+
+    proc = _run(repo, [rel])
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "PASS" in proc.stdout
+    assert "isolation_required=yes" in proc.stdout
+
+
+def test_three_pipeline_agent_passes_via_c3_na(tmp_path: Path) -> None:
+    """Agent invoked from 3+ pipelines: c3 is N/A, score caps at 2 only if c1+c2.
+
+    With c1 (true) + c2 (true) the score is 2, which would normally fail. The
+    3-pipeline rule forces c3 to N/A (False), so the cross-cutting agent that
+    is genuinely orchestrated from many commands does not trip on c3. To keep
+    it below the failing threshold the body must not also be skill-shape, OR
+    the agent uses an override. Here we prove c3 is suppressed: a 3-pipeline
+    agent whose only signals are c1 and c3-eligible siblings scores 1 (c1),
+    not 2, because c3 is N/A.
+    """
+    repo = _scaffold(tmp_path)
+    rel = _write_agent(repo, "analyst", _prose_body())
+    for cmd in ("build", "plan", "review"):
+        _write_command(
+            repo,
+            cmd,
+            'Task(subagent_type="analyst"): investigate.\n'
+            'Skill(skill="memory").\n',
+        )
+
+    proc = _run(repo, [rel])
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    # c1 true, c2 false (prose), c3 N/A => score 1.
+    assert "score 1/3" in proc.stdout
+    assert "pipelines=3" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Integration: PR-description override
+# ---------------------------------------------------------------------------
+
+
+def test_pr_description_override_token_passes(tmp_path: Path) -> None:
+    """A skill-shape candidate passes when the PR body carries the token."""
+    repo = _scaffold(tmp_path)
+    rel = _write_agent(repo, "shaped", _reference_body())
+    _write_command(
+        repo,
+        "build",
+        'Task(subagent_type="shaped"): do work.\n'
+        'Skill(skill="pre-mortem").\n',
+    )
+
+    proc = _run(
+        repo,
+        [rel],
+        pr_body="Adds shaped. [skill-discriminator: one-off, ships with skill next PR]",
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "PR override present" in proc.stdout
+    assert "PASS" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Integration: two-source (ADR-036) shared template
+# ---------------------------------------------------------------------------
+
+
+def test_shared_template_sibling_scored(tmp_path: Path) -> None:
+    """A templates/agents/*.shared.md change is scored by agent name."""
+    repo = _scaffold(tmp_path)
+    rel = _write_agent(
+        repo, "devops", _reference_body(), shared_template=True
+    )
+    _write_command(
+        repo,
+        "ship",
+        'Task(subagent_type="devops"): release.\n'
+        'Skill(skill="pipeline-validator").\n',
+    )
+
+    proc = _run(repo, [rel])
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "devops" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Integration: no changed agents and exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_no_changed_agents_passes(tmp_path: Path) -> None:
+    repo = _scaffold(tmp_path)
+    _write_command(repo, "build", "nothing.\n")
+    proc = _run(repo, [])
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "No changed agent definitions" in proc.stdout
+
+
+def test_non_agent_changed_files_ignored(tmp_path: Path) -> None:
+    repo = _scaffold(tmp_path)
+    _write_command(repo, "build", "nothing.\n")
+    (repo / "README.md").write_text("# readme\n", encoding="utf-8")
+    proc = _run(repo, ["README.md", ".claude/agents/AGENTS.md"])
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "No changed agent definitions" in proc.stdout
+
+
+def test_missing_repo_root_is_config_error(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(missing)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 2
+
+
+def test_missing_commands_dir_is_config_error(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / ".claude").mkdir(parents=True)
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(repo)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 2
+
+
+def test_changed_files_via_env(tmp_path: Path, monkeypatch) -> None:
+    """CHANGED_FILES env var feeds the file list (workflow path)."""
+    repo = _scaffold(tmp_path)
+    rel = _write_agent(repo, "shaped", _reference_body())
+    _write_command(
+        repo,
+        "build",
+        'Task(subagent_type="shaped"): work.\nSkill(skill="pre-mortem").\n',
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(repo)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**__import__("os").environ, "CHANGED_FILES": rel},
+    )
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "shaped" in proc.stdout

--- a/tests/validation/test_check_agent_skill_discriminator.py
+++ b/tests/validation/test_check_agent_skill_discriminator.py
@@ -165,6 +165,21 @@ def test_c2_empty_body_is_not_shape() -> None:
     assert ratio == 0.0
 
 
+def test_frontmatter_and_body_split_handle_crlf() -> None:
+    frontmatter, body = mod.split_frontmatter(
+        "---\r\nname: x\r\n---\r\nbody line\r\n"
+    )
+    assert frontmatter == "name: x"
+    assert body == "body line"
+
+
+def test_content_lines_handle_crlf() -> None:
+    assert mod._content_lines("alpha\r\n\r\n```\r\nignored\r\n```\r\nbeta\r\n") == [
+        "alpha",
+        "beta",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Unit: frontmatter escape hatch
 # ---------------------------------------------------------------------------
@@ -172,6 +187,16 @@ def test_c2_empty_body_is_not_shape() -> None:
 
 def test_isolation_required_true_detected() -> None:
     assert mod.has_isolation_required("name: x\nisolation_required: true") is True
+
+
+def test_isolation_required_allows_quotes_and_trailing_comment() -> None:
+    frontmatter = "name: x\nisolation_required: 'yes'  # fresh context needed"
+    assert mod.has_isolation_required(frontmatter) is True
+
+
+def test_isolation_required_ignores_prose_mentions() -> None:
+    frontmatter = "description: isolation_required: true belongs in docs"
+    assert mod.has_isolation_required(frontmatter) is False
 
 
 def test_isolation_required_false_not_detected() -> None:
@@ -199,6 +224,17 @@ def test_agent_and_shared_template_paths_included() -> None:
 
 def test_skill_path_not_treated_as_agent() -> None:
     assert mod.is_agent_path(".claude/skills/devops/SKILL.md") is False
+
+
+# ---------------------------------------------------------------------------
+# Unit: pipeline invocation parsing
+# ---------------------------------------------------------------------------
+
+
+def test_invocation_parsing_allows_spaces_and_single_quotes() -> None:
+    text = "Task( subagent_type = 'analyst')\nSkill( skill = 'memory')\n"
+    assert mod._task_invocations(text) == {"analyst"}
+    assert mod._skill_invocations(text) == {"memory"}
 
 
 # ---------------------------------------------------------------------------
@@ -375,6 +411,35 @@ def test_missing_commands_dir_is_config_error(tmp_path: Path) -> None:
         check=False,
     )
     assert proc.returncode == 2
+
+
+def test_missing_changed_agent_is_config_error(tmp_path: Path) -> None:
+    repo = _scaffold(tmp_path)
+    _write_command(repo, "build", 'Task( subagent_type = "ghost").\n')
+
+    proc = _run(repo, [".claude/agents/ghost.md"])
+    assert proc.returncode == 2
+    assert "Config error" in proc.stderr
+
+
+def test_changed_agent_path_traversal_is_config_error(tmp_path: Path) -> None:
+    repo = _scaffold(tmp_path)
+    _write_command(repo, "build", 'Task(subagent_type="evil").\n')
+
+    proc = _run(repo, ["../outside/.claude/agents/evil.md"])
+    assert proc.returncode == 2
+    assert "escapes repo root" in proc.stderr
+
+
+def test_unreadable_command_file_is_config_error(tmp_path: Path) -> None:
+    repo = _scaffold(tmp_path)
+    rel = _write_agent(repo, "shaped", _reference_body())
+    broken = repo / ".claude" / "commands" / "broken.md"
+    broken.symlink_to(repo / "missing-command.md")
+
+    proc = _run(repo, [rel])
+    assert proc.returncode == 2
+    assert "Config error" in proc.stderr
 
 
 def test_changed_files_via_env(tmp_path: Path, monkeypatch) -> None:

--- a/tests/validation/test_check_agent_skill_discriminator.py
+++ b/tests/validation/test_check_agent_skill_discriminator.py
@@ -237,6 +237,21 @@ def test_invocation_parsing_allows_spaces_and_single_quotes() -> None:
     assert mod._skill_invocations(text) == {"memory"}
 
 
+def test_invocation_parsing_detects_descriptive_agent_list() -> None:
+    text = (
+        "Task(subagent_type=...) agent "
+        "(analyst, architect, qa, security, devops, roadmap)"
+    )
+    assert mod._task_invocations(text) == {
+        "analyst",
+        "architect",
+        "qa",
+        "security",
+        "devops",
+        "roadmap",
+    }
+
+
 # ---------------------------------------------------------------------------
 # Integration: required fixture scenarios
 # ---------------------------------------------------------------------------
@@ -440,6 +455,10 @@ def test_unreadable_command_file_is_config_error(tmp_path: Path) -> None:
     proc = _run(repo, [rel])
     assert proc.returncode == 2
     assert "Config error" in proc.stderr
+
+
+def test_empty_changed_files_cli_arg_overrides_env() -> None:
+    assert mod._split_changed_arg([], ".claude/agents/shaped.md") == []
 
 
 def test_changed_files_via_env(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Adds the Phase 3 CI backstop from the agent-skill classification audit (#2003). New or materially changed agents that match skill shape are flagged at PR time so the catalog stops accumulating the misclassification debt the audit quantified at 42% of 23 agents.

The check scores each changed agent against the discriminator locked by the #2003 audit:

- c1: invoked from a slash command via `Task(subagent_type="<name>")` (searched across `.claude/commands/` and `templates/commands/`).
- c2: body is >=70% structured-reference (tables, decision-tree bullets, headings). Counted conservatively; a long sentence-shaped bullet is treated as prose, not reference, per the audit note that the heuristic over-estimated reasoning agents.
- c3: a sibling skill is invoked in the same pipeline (`Skill(skill="<name>")`), AND the agent spans fewer than 3 pipelines (the 3-pipeline rule). c3 is N/A when c1 is false or the agent spans 3+ pipelines.

An agent scoring 2+ FAILS unless one escape hatch is present: `isolation_required: true` in agent frontmatter, or `[skill-discriminator: <rationale>]` in the PR description. c4 (PR-history schema drift) is out of scope for CI per the issue.

Verified against current main: the validator flags exactly the audit's skill / context-fork-skill verdicts (architect, devops, implementer, milestone-planner, qa, security, task-decomposer) and passes keep-as-agent ones (analyst via 3-pipeline c3 N/A, critic via prose body). Those 7 are pre-existing debt the audit already tracks for Phase 2; the check only fires on agents a PR actually adds or changes, so normal PRs pass.

## Per-file changes

- `scripts/validation/check_agent_skill_discriminator.py` (new): the scoring validator. Pure functions for c2 heuristic and frontmatter parsing; a `PipelineIndex` that maps each slash command to the agents and skills it invokes; `run_check` resolves the override and scores every changed agent. ADR-035 exit codes (0 ok, 1 candidate-without-hatch, 2 config error). Reads changed files from `--changed-files` or `CHANGED_FILES` and the PR body from `--pr-body` or `PR_BODY`. Hardened path validation, CRLF parsing, quoted frontmatter values, invocation regexes, and unreadable-file errors.
- `.github/workflows/agent-skill-discriminator-check.yml` (new): thin workflow (ADR-006). Runs on PRs touching agent definition paths or shared agent templates. Uses `dorny/paths-filter` so it satisfies the required-status contract on every PR and skips with a passing status otherwise. Computes the changed agent set from the base..head diff and passes it plus the PR body to the validator through env vars only. Writes changed paths through a multiline GitHub output block. All actions SHA-pinned to versions already used elsewhere in the repo.
- `tests/validation/test_check_agent_skill_discriminator.py` (new): 32 tests covering the four required fixtures (pure-skill fails, pure-agent passes, mixed+override passes, 3-pipeline passes via c3 N/A), the PR-description override token, shared-template sibling scoring, the conservative c2 heuristic, metadata-file exclusion, CRLF handling, path traversal, unreadable inputs, descriptive c1 forms, explicit empty changed-file args, and the 0/1/2 exit codes.

## Testing

- `$SHARED/.venv/bin/python -m pytest tests/validation/ -q` -> 170 passed in 1.26s
- `$SHARED/.venv/bin/ruff check scripts/validation/check_agent_skill_discriminator.py tests/validation/test_check_agent_skill_discriminator.py` -> All checks passed
- Dash diff check -> no prohibited dash bytes in added lines
- Workflow local-test runner reported actionlint/act tool gap (exit 2); direct workflow execution was not available in this environment.

Fixes #2008

