### PR TITLE
feat(lib): vendor-portable path resolver plus CI gate (#2050 Phase 1)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/lib/paths.py
+++ b/.claude/lib/paths.py
@@ -8,9 +8,8 @@ policies every skill needs so no script hard-codes an upstream-only path.
 Two policies:
 
 - `resolve_skill_resource(skill, relpath)` is the READ path. It locates a
-  file that ships inside the plugin (a reference doc, a helper script). The
-  candidate order mirrors the `/review` skill's documented "Path resolution
-  (harness-agnostic)" section in `.claude/skills/review/SKILL.md`:
+  file that ships inside the plugin (a reference doc, a helper script). This
+  helper uses this local candidate order:
     1. `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>` when CLAUDE_PLUGIN_ROOT
        is set by the harness.
     2. `.claude/skills/<skill>/<relpath>` resolved from the current working
@@ -27,17 +26,19 @@ Two policies:
   overridable by the `AI_AGENTS_ARTIFACT_ROOT` environment variable so a
   consumer can redirect every skill's output to one place.
 
-Stricter/looser/different than canonical:
-  The read-path candidate order is a strict mirror of the `/review` skill's
-  three-candidate chain (CLAUDE_PLUGIN_ROOT, `.claude/`, plugin-root-relative)
-  with the verbatim contract preserved. The write path is new (the `/review`
-  skill has no write artifact), modeled on `/spec` Step 0 writing
+Relationship to existing skills:
+  The read path uses a three-location fallback like `/review`, but the
+  environment variable and concrete resource paths are local to this helper.
+  `/review` documents `CLAUDE_SKILL_DIR` for its first candidate. This helper
+  uses `CLAUDE_PLUGIN_ROOT` because packaged plugin installs expose the plugin
+  root, not one skill directory. The write path is new (the `/review` skill has
+  no write artifact), modeled on `/spec` Step 0 writing
   `.agents/metrics/STEP-0-METRICS.md` lazily under the consumer cwd. The
   AI_AGENTS_ARTIFACT_ROOT override is added so the consumer, not the skill,
   owns the artifact location.
 
-Canonical read-path pattern: `.claude/skills/review/SKILL.md`,
-section "Path resolution (harness-agnostic)". Plugin-root marker reuse:
+Related sources: `.claude/skills/review/SKILL.md`, section "Path resolution
+(harness-agnostic)". Plugin-root marker reuse:
 `.claude/lib/bootstrap.py::resolve_plugin_lib_dir` (CLAUDE_PLUGIN_ROOT then
 the `.claude-plugin/plugin.json` walk-up). This file is a sibling write-path
 resolver to that read-path resolver per the Issue #2050 batch decision.
@@ -86,6 +87,17 @@ def _normalize_relpath(relpath: str | Path) -> Path:
     return rel
 
 
+def _normalize_skill_name(skill: str) -> str:
+    """Reject skill names that escape the skills directory."""
+    name = skill.strip()
+    if not name:
+        raise ValueError("skill must be a non-empty name")
+    rel = _normalize_relpath(name)
+    if len(rel.parts) != 1:
+        raise ValueError("skill must be a single directory name")
+    return rel.as_posix()
+
+
 def resolve_skill_resource(skill: str, relpath: str | Path) -> Path | None:
     """Resolve a read-only resource shipped inside a skill.
 
@@ -108,21 +120,20 @@ def resolve_skill_resource(skill: str, relpath: str | Path) -> Path | None:
         ValueError: When skill is empty or relpath is absolute or escapes
             the skill directory with `..`.
     """
-    if not skill or not skill.strip():
-        raise ValueError("skill must be a non-empty name")
+    skill_name = _normalize_skill_name(skill)
     rel = _normalize_relpath(relpath)
 
     candidates: list[Path] = []
 
     plugin_env = os.environ.get("CLAUDE_PLUGIN_ROOT")
     if plugin_env:
-        candidates.append(Path(plugin_env).resolve() / "skills" / skill / rel)
+        candidates.append(Path(plugin_env).resolve() / "skills" / skill_name / rel)
 
-    candidates.append(Path.cwd() / ".claude" / "skills" / skill / rel)
+    candidates.append(Path.cwd() / ".claude" / "skills" / skill_name / rel)
 
     install_root = _plugin_install_root()
     if install_root is not None:
-        candidates.append(install_root / "skills" / skill / rel)
+        candidates.append(install_root / "skills" / skill_name / rel)
 
     for candidate in candidates:
         if candidate.is_file():

--- a/.claude/lib/paths.py
+++ b/.claude/lib/paths.py
@@ -71,6 +71,8 @@ def _normalize_relpath(relpath: str | Path) -> Path:
     so raise rather than resolve it.
     """
     rel = Path(relpath)
+    if str(rel) == ".":
+        raise ValueError(f"relpath must not be empty or '.': {relpath!r}")
     if rel.is_absolute():
         raise ValueError(f"relpath must be relative, got absolute: {relpath!r}")
     if ".." in rel.parts:

--- a/.claude/lib/paths.py
+++ b/.claude/lib/paths.py
@@ -10,8 +10,8 @@ Two policies:
 - `resolve_skill_resource(skill, relpath)` is the READ path. It locates a
   file that ships inside the plugin (a reference doc, a helper script). This
   helper uses this local candidate order:
-    1. `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>` when CLAUDE_PLUGIN_ROOT
-       is set by the harness.
+    1. `${COPILOT_PLUGIN_ROOT}/skills/<skill>/<relpath>` or
+       `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>` when set by the harness.
     2. `.claude/skills/<skill>/<relpath>` resolved from the current working
        directory (Claude Code project layout).
     3. `skills/<skill>/<relpath>` resolved relative to the plugin install
@@ -30,9 +30,9 @@ Relationship to existing skills:
   The read path uses a three-location fallback like `/review`, but the
   environment variable and concrete resource paths are local to this helper.
   `/review` documents `CLAUDE_SKILL_DIR` for its first candidate. This helper
-  uses `CLAUDE_PLUGIN_ROOT` because packaged plugin installs expose the plugin
-  root, not one skill directory. The write path is new (the `/review` skill has
-  no write artifact), modeled on `/spec` Step 0 writing
+  uses `COPILOT_PLUGIN_ROOT` or `CLAUDE_PLUGIN_ROOT` because packaged plugin
+  installs expose the plugin root, not one skill directory. The write path is
+  new (the `/review` skill has no write artifact), modeled on `/spec` Step 0 writing
   `.agents/metrics/STEP-0-METRICS.md` lazily under the consumer cwd. The
   AI_AGENTS_ARTIFACT_ROOT override is added so the consumer, not the skill,
   owns the artifact location.
@@ -50,6 +50,11 @@ import os
 from pathlib import Path
 
 _PLUGIN_MARKER = Path(".claude-plugin") / "plugin.json"
+
+
+def _plugin_root_env() -> str | None:
+    """Return the harness-provided plugin root, if any."""
+    return os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
 
 
 def _plugin_install_root() -> Path | None:
@@ -95,7 +100,8 @@ def resolve_skill_resource(skill: str, relpath: str | Path) -> Path | None:
     """Resolve a read-only resource shipped inside a skill.
 
     Tries each candidate in order and returns the first that exists:
-      1. `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>`
+      1. `${COPILOT_PLUGIN_ROOT}/skills/<skill>/<relpath>` or
+         `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>`
       2. `<cwd>/.claude/skills/<skill>/<relpath>`
       3. `<plugin install root>/skills/<skill>/<relpath>`
 
@@ -118,7 +124,7 @@ def resolve_skill_resource(skill: str, relpath: str | Path) -> Path | None:
 
     candidates: list[Path] = []
 
-    plugin_env = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    plugin_env = _plugin_root_env()
     if plugin_env:
         candidates.append(Path(plugin_env).resolve() / "skills" / skill_name / rel)
 

--- a/.claude/lib/paths.py
+++ b/.claude/lib/paths.py
@@ -53,16 +53,7 @@ _PLUGIN_MARKER = Path(".claude-plugin") / "plugin.json"
 
 
 def _plugin_install_root() -> Path | None:
-    """Return the plugin install root, or None when no marker is found.
-
-    Prefers CLAUDE_PLUGIN_ROOT. Otherwise walks up from this file looking
-    for the `.claude-plugin/plugin.json` manifest marker, the same marker
-    `bootstrap.resolve_plugin_lib_dir` uses.
-    """
-    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
-    if plugin_root:
-        return Path(plugin_root).resolve()
-
+    """Return the marker-discovered plugin install root, or None."""
     cur = Path(__file__).resolve().parent
     while True:
         if (cur / _PLUGIN_MARKER).is_file():

--- a/.claude/lib/paths.py
+++ b/.claude/lib/paths.py
@@ -1,0 +1,165 @@
+"""Vendor-portable path resolution for skill scripts (Issue #2050).
+
+Skills that ship in a vendored plugin install (Copilot CLI and similar
+harnesses) cannot assume the consumer repo has a `.claude/` directory or
+the upstream `.agents/` tree. This module centralizes the two resolution
+policies every skill needs so no script hard-codes an upstream-only path.
+
+Two policies:
+
+- `resolve_skill_resource(skill, relpath)` is the READ path. It locates a
+  file that ships inside the plugin (a reference doc, a helper script). The
+  candidate order mirrors the `/review` skill's documented "Path resolution
+  (harness-agnostic)" section in `.claude/skills/review/SKILL.md`:
+    1. `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>` when CLAUDE_PLUGIN_ROOT
+       is set by the harness.
+    2. `.claude/skills/<skill>/<relpath>` resolved from the current working
+       directory (Claude Code project layout).
+    3. `skills/<skill>/<relpath>` resolved relative to the plugin install
+       root discovered by walking up from this file to the
+       `.claude-plugin/plugin.json` marker (vendored install).
+  Returns the first candidate that exists, else None. Read-only: it never
+  creates anything.
+
+- `resolve_artifact_root(subdir)` is the WRITE path. Skills write artifacts
+  to a consumer-side location, defaulting to `<cwd>/.agents/<subdir>`. The
+  directory is created lazily (parents=True, exist_ok=True). The root is
+  overridable by the `AI_AGENTS_ARTIFACT_ROOT` environment variable so a
+  consumer can redirect every skill's output to one place.
+
+Stricter/looser/different than canonical:
+  The read-path candidate order is a strict mirror of the `/review` skill's
+  three-candidate chain (CLAUDE_PLUGIN_ROOT, `.claude/`, plugin-root-relative)
+  with the verbatim contract preserved. The write path is new (the `/review`
+  skill has no write artifact), modeled on `/spec` Step 0 writing
+  `.agents/metrics/STEP-0-METRICS.md` lazily under the consumer cwd. The
+  AI_AGENTS_ARTIFACT_ROOT override is added so the consumer, not the skill,
+  owns the artifact location.
+
+Canonical read-path pattern: `.claude/skills/review/SKILL.md`,
+section "Path resolution (harness-agnostic)". Plugin-root marker reuse:
+`.claude/lib/bootstrap.py::resolve_plugin_lib_dir` (CLAUDE_PLUGIN_ROOT then
+the `.claude-plugin/plugin.json` walk-up). This file is a sibling write-path
+resolver to that read-path resolver per the Issue #2050 batch decision.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_PLUGIN_MARKER = Path(".claude-plugin") / "plugin.json"
+
+
+def _plugin_install_root() -> Path | None:
+    """Return the plugin install root, or None when no marker is found.
+
+    Prefers CLAUDE_PLUGIN_ROOT. Otherwise walks up from this file looking
+    for the `.claude-plugin/plugin.json` manifest marker, the same marker
+    `bootstrap.resolve_plugin_lib_dir` uses.
+    """
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        return Path(plugin_root).resolve()
+
+    cur = Path(__file__).resolve().parent
+    while True:
+        if (cur / _PLUGIN_MARKER).is_file():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+
+
+def _normalize_relpath(relpath: str | Path) -> Path:
+    """Reject absolute paths and parent-escapes in a skill relative path.
+
+    A skill resource path is always relative to the skill directory. An
+    absolute path or a `..` segment is a caller bug and a traversal risk,
+    so raise rather than resolve it.
+    """
+    rel = Path(relpath)
+    if rel.is_absolute():
+        raise ValueError(f"relpath must be relative, got absolute: {relpath!r}")
+    if ".." in rel.parts:
+        raise ValueError(f"relpath must not contain '..': {relpath!r}")
+    return rel
+
+
+def resolve_skill_resource(skill: str, relpath: str | Path) -> Path | None:
+    """Resolve a read-only resource shipped inside a skill.
+
+    Tries each candidate in order and returns the first that exists:
+      1. `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>`
+      2. `<cwd>/.claude/skills/<skill>/<relpath>`
+      3. `<plugin install root>/skills/<skill>/<relpath>`
+
+    Args:
+        skill: Skill directory name (for example "review").
+        relpath: Path of the resource within the skill directory, relative
+            (for example "references/analyst.md"). Must not be absolute or
+            contain a `..` segment.
+
+    Returns:
+        The resolved absolute Path of the first existing candidate, or None
+        when no candidate exists.
+
+    Raises:
+        ValueError: When skill is empty or relpath is absolute or escapes
+            the skill directory with `..`.
+    """
+    if not skill or not skill.strip():
+        raise ValueError("skill must be a non-empty name")
+    rel = _normalize_relpath(relpath)
+
+    candidates: list[Path] = []
+
+    plugin_env = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_env:
+        candidates.append(Path(plugin_env).resolve() / "skills" / skill / rel)
+
+    candidates.append(Path.cwd() / ".claude" / "skills" / skill / rel)
+
+    install_root = _plugin_install_root()
+    if install_root is not None:
+        candidates.append(install_root / "skills" / skill / rel)
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+
+    return None
+
+
+def resolve_artifact_root(subdir: str | Path) -> Path:
+    """Resolve and create the write directory for a skill artifact.
+
+    The default root is `<cwd>/.agents`, overridable by the
+    `AI_AGENTS_ARTIFACT_ROOT` environment variable. The returned directory
+    (`<root>/<subdir>`) is created lazily with parents.
+
+    Args:
+        subdir: Artifact subdirectory under the artifact root (for example
+            "analysis" or "metrics"). Must not be absolute or escape the
+            root with `..`.
+
+    Returns:
+        The resolved absolute Path of the created `<root>/<subdir>`.
+
+    Raises:
+        ValueError: When subdir is empty, absolute, or contains `..`.
+        OSError: When the directory cannot be created.
+    """
+    if not str(subdir).strip():
+        raise ValueError("subdir must be non-empty")
+    sub = _normalize_relpath(subdir)
+
+    override = os.environ.get("AI_AGENTS_ARTIFACT_ROOT")
+    if override and override.strip():
+        root = Path(override).expanduser()
+    else:
+        root = Path.cwd() / ".agents"
+
+    target = (root / sub).resolve()
+    target.mkdir(parents=True, exist_ok=True)
+    return target

--- a/scripts/validation/check_vendor_portability.py
+++ b/scripts/validation/check_vendor_portability.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Fail CI when a vendor-shipped script hard-codes an upstream-only path.
+
+Issue #2050: skills in a vendored plugin install hard-code paths
+(`.agents/`, `.claude/lib/`) that exist only in the upstream
+`rjmurillo/ai-agents` checkout. In a consumer repo those paths do not
+exist, so the skill fails or degrades silently. The fix (Phase 1) ships a
+`.claude/lib/paths.py` helper with `resolve_artifact_root` (write path) and
+`resolve_skill_resource` (read path). This check stops NEW scripts from
+hard-coding those paths instead of routing through the helper.
+
+What it flags:
+  A Python file under a scanned skill-scripts root that contains a string
+  literal with `.agents/` or `.claude/lib/` AND does not import the
+  portability helper (`paths`, exposing `resolve_artifact_root` /
+  `resolve_skill_resource`). A file that imports the helper is assumed to
+  resolve paths through it; the literal is then the documented lazy default
+  or prose, not a hard-coded dependency.
+
+Baseline ratchet:
+  131 files across 30+ skills already hard-code these paths (Issue #2050).
+  Phase 1 does not migrate them. To gate regressions without forcing that
+  migration now, the current offenders are recorded in a baseline file
+  (see BASELINE_PATH). Files in the baseline are reported as known debt but
+  do not fail the check. A NEW offender not in the baseline fails. Run with
+  `--update-baseline` to regenerate the baseline after an intentional change
+  (for example, after migrating a file off the baseline).
+
+EXIT CODES (ADR-035):
+  0 - Success: no new offenders (baseline-listed debt is allowed); OR
+      no scan roots present (vendor install without `.claude/skills` is
+      benign here, prints `[SKIP] no scan roots present`); OR
+      `--update-baseline` wrote the baseline.
+  1 - One or more NEW offenders found (not in the baseline).
+  2 - Configuration error (repo root or baseline path invalid).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Upstream-only path prefixes that break in a vendored consumer repo.
+# `.claude/skills/` is intentionally NOT flagged: the `/review` pattern
+# resolves skill resources via the helper's `.claude/skills/...` candidate,
+# so a reference to it inside the helper or via the helper is correct.
+_BANNED_PATH = re.compile(r"\.agents/|\.claude/lib/")
+
+# Indicators that a file routes paths through the portability helper.
+# Any of these substrings exempts the file (it is presumed to use the
+# helper's lazy-default / candidate resolution rather than a hard-coded dep).
+_HELPER_TOKENS: tuple[str, ...] = (
+    "import paths",
+    "from paths import",
+    "resolve_artifact_root",
+    "resolve_skill_resource",
+)
+
+# Directories scanned for vendor-shipped scripts.
+_SCAN_ROOTS: tuple[str, ...] = (".claude/skills",)
+
+# Baseline of known pre-existing offenders, relative to repo root, one
+# POSIX path per line. Comments (`#`) and blank lines are ignored.
+BASELINE_FILENAME = "vendor_portability_baseline.txt"
+
+
+@dataclass
+class Offender:
+    """A scanned file that hard-codes a banned path without the helper."""
+
+    relpath: str
+    line: int
+    excerpt: str
+
+
+def baseline_path(repo_root: Path) -> Path:
+    """Return the baseline file path co-located with this script."""
+    return repo_root / "scripts" / "validation" / BASELINE_FILENAME
+
+
+def load_baseline(path: Path) -> set[str]:
+    """Load the baseline allowlist of known offenders (POSIX relpaths)."""
+    if not path.is_file():
+        return set()
+    entries: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        entries.add(line)
+    return entries
+
+
+def scan_roots(repo_root: Path) -> list[Path]:
+    """Return the scan-root directories that exist under repo_root."""
+    return [repo_root / r for r in _SCAN_ROOTS if (repo_root / r).is_dir()]
+
+
+def _routes_through_helper(content: str) -> bool:
+    """True when the file imports or calls the portability helper."""
+    return any(token in content for token in _HELPER_TOKENS)
+
+
+def _first_banned_line(content: str) -> tuple[int, str] | None:
+    """Return (1-based line number, stripped line) of the first banned path."""
+    for idx, line in enumerate(content.splitlines(), start=1):
+        if _BANNED_PATH.search(line):
+            return idx, line.strip()
+    return None
+
+
+def collect_offenders(repo_root: Path) -> list[Offender]:
+    """Find files that hard-code a banned path without the helper.
+
+    A file is an offender when it contains a banned path AND does not route
+    through the portability helper. The portability helper itself
+    (`.claude/lib/paths.py`) lives outside the scan roots, so it is never
+    scanned.
+    """
+    offenders: list[Offender] = []
+    for root in scan_roots(repo_root):
+        for py_file in sorted(root.rglob("*.py")):
+            if "__pycache__" in py_file.parts:
+                continue
+            try:
+                content = py_file.read_text(encoding="utf-8")
+            except OSError, UnicodeDecodeError:
+                continue
+            if not _BANNED_PATH.search(content):
+                continue
+            if _routes_through_helper(content):
+                continue
+            hit = _first_banned_line(content)
+            if hit is None:
+                continue
+            line_no, excerpt = hit
+            relpath = py_file.relative_to(repo_root).as_posix()
+            offenders.append(Offender(relpath, line_no, excerpt))
+    return offenders
+
+
+def split_offenders(
+    offenders: list[Offender],
+    baseline: set[str],
+) -> tuple[list[Offender], list[Offender]]:
+    """Partition offenders into (new, known) by baseline membership."""
+    new: list[Offender] = []
+    known: list[Offender] = []
+    for off in offenders:
+        (known if off.relpath in baseline else new).append(off)
+    return new, known
+
+
+def format_report(new: list[Offender], known: list[Offender]) -> str:
+    """Format a human-readable report."""
+    lines: list[str] = []
+    if not new:
+        lines.append("[PASS] No new vendor-portability offenders.")
+        if known:
+            lines.append(
+                f"       {len(known)} known offender(s) tracked in the baseline "
+                "(Issue #2050 migration debt)."
+            )
+        return "\n".join(lines) + "\n"
+
+    lines.append(f"[FAIL] {len(new)} new vendor-portability offender(s) found.")
+    lines.append("")
+    lines.append(
+        "These files hard-code an upstream-only path (.agents/ or "
+        ".claude/lib/) and do not route through the portability helper."
+    )
+    lines.append(
+        "Use .claude/lib/paths.py: resolve_artifact_root() for write paths, "
+        "resolve_skill_resource() for read paths. See Issue #2050."
+    )
+    lines.append("")
+    for off in new:
+        lines.append(f"  - {off.relpath}:{off.line}")
+        lines.append(f"      {off.excerpt!r}")
+    lines.append("")
+    lines.append(
+        "If this offender is intentional and cannot be made portable, add it "
+        "to scripts/validation/vendor_portability_baseline.txt with a comment "
+        "or run --update-baseline."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_baseline(path: Path, offenders: list[Offender]) -> None:
+    """Write the baseline file from the current offender set."""
+    header = [
+        "# Vendor-portability baseline (Issue #2050).",
+        "# Pre-existing scripts that hard-code .agents/ or .claude/lib/ paths.",
+        "# check_vendor_portability.py allows these but fails on NEW offenders.",
+        "# Regenerate: python3 scripts/validation/check_vendor_portability.py --update-baseline",
+        "",
+    ]
+    body = sorted({off.relpath for off in offenders})
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(header + body) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Fail CI on new hard-coded upstream-only paths in skills.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (defaults to the script's grandparent).",
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Regenerate the baseline from the current offenders, then exit 0.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns an ADR-035 exit code."""
+    args = parse_args(argv)
+
+    repo_root = args.repo_root
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parent.parent.parent
+
+    if not repo_root.is_dir():
+        print(f"[FAIL] repo root not found: {repo_root}", file=sys.stderr)
+        return 2
+
+    roots = scan_roots(repo_root)
+    if not roots:
+        print("[SKIP] no scan roots present (.claude/skills).")
+        return 0
+
+    offenders = collect_offenders(repo_root)
+
+    bpath = baseline_path(repo_root)
+    if args.update_baseline:
+        try:
+            write_baseline(bpath, offenders)
+        except OSError as exc:
+            print(f"[FAIL] cannot write baseline {bpath}: {exc}", file=sys.stderr)
+            return 2
+        print(f"[OK] wrote baseline: {bpath} ({len(offenders)} entr(ies))")
+        return 0
+
+    baseline = load_baseline(bpath)
+    new, known = split_offenders(offenders, baseline)
+    print(format_report(new, known))
+    return 1 if new else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_vendor_portability.py
+++ b/scripts/validation/check_vendor_portability.py
@@ -10,12 +10,12 @@ exist, so the skill fails or degrades silently. The fix (Phase 1) ships a
 hard-coding those paths instead of routing through the helper.
 
 What it flags:
-  A Python file under a scanned skill-scripts root that contains a string
-  literal with `.agents/` or `.claude/lib/` AND does not import the
+  A Python file under a scanned skill-scripts root that contains a non-docstring
+  string literal with `.agents/` or `.claude/lib/` AND does not import the
   portability helper (`paths`, exposing `resolve_artifact_root` /
   `resolve_skill_resource`). A file that imports the helper is assumed to
   resolve paths through it; the literal is then the documented lazy default
-  or prose, not a hard-coded dependency.
+  or prose, not a hard-coded dependency. Comments and docstrings are ignored.
 
 Baseline ratchet:
   131 files across 30+ skills already hard-code these paths (Issue #2050).
@@ -38,8 +38,11 @@ EXIT CODES (ADR-035):
 from __future__ import annotations
 
 import argparse
+import ast
+import io
 import re
 import sys
+import tokenize
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -104,11 +107,50 @@ def _routes_through_helper(content: str) -> bool:
     return any(token in content for token in _HELPER_TOKENS)
 
 
+def _docstring_lines(content: str) -> set[int]:
+    """Return line numbers occupied by module, class, and function docstrings."""
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        return set()
+
+    lines: set[int] = set()
+    nodes: list[ast.AST] = [tree]
+    nodes.extend(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef)
+    )
+    for node in nodes:
+        body = getattr(node, "body", [])
+        if not body:
+            continue
+        first = body[0]
+        if not (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            continue
+        start = first.lineno
+        end = getattr(first, "end_lineno", start)
+        lines.update(range(start, end + 1))
+    return lines
+
+
 def _first_banned_line(content: str) -> tuple[int, str] | None:
-    """Return (1-based line number, stripped line) of the first banned path."""
-    for idx, line in enumerate(content.splitlines(), start=1):
-        if _BANNED_PATH.search(line):
-            return idx, line.strip()
+    """Return the first banned path in a non-docstring string literal."""
+    doc_lines = _docstring_lines(content)
+    reader = io.StringIO(content).readline
+    try:
+        tokens = tokenize.generate_tokens(reader)
+        for token in tokens:
+            if token.type != tokenize.STRING or token.start[0] in doc_lines:
+                continue
+            if _BANNED_PATH.search(token.string):
+                return token.start[0], token.line.strip()
+    except tokenize.TokenError:
+        return None
     return None
 
 
@@ -127,9 +169,7 @@ def collect_offenders(repo_root: Path) -> list[Offender]:
                 continue
             try:
                 content = py_file.read_text(encoding="utf-8")
-            except OSError, UnicodeDecodeError:
-                continue
-            if not _BANNED_PATH.search(content):
+            except (OSError, UnicodeDecodeError):
                 continue
             if _routes_through_helper(content):
                 continue

--- a/scripts/validation/check_vendor_portability.py
+++ b/scripts/validation/check_vendor_portability.py
@@ -21,7 +21,7 @@ Baseline ratchet:
   131 files across 30+ skills already hard-code these paths (Issue #2050).
   Phase 1 does not migrate them. To gate regressions without forcing that
   migration now, the current offenders are recorded in a baseline file
-  (see BASELINE_PATH). Files in the baseline are reported as known debt but
+  (see `baseline_path()`). Files in the baseline are reported as known debt but
   do not fail the check. A NEW offender not in the baseline fails. Run with
   `--update-baseline` to regenerate the baseline after an intentional change
   (for example, after migrating a file off the baseline).

--- a/scripts/validation/check_vendor_portability.py
+++ b/scripts/validation/check_vendor_portability.py
@@ -52,14 +52,9 @@ from pathlib import Path
 # so a reference to it inside the helper or via the helper is correct.
 _BANNED_PATH = re.compile(r"\.agents/|\.claude/lib/")
 
-# Indicators that a file routes paths through the portability helper.
-# Any of these substrings exempts the file (it is presumed to use the
-# helper's lazy-default / candidate resolution rather than a hard-coded dep).
-_HELPER_TOKENS: tuple[str, ...] = (
-    "import paths",
-    "from paths import",
-    "resolve_artifact_root",
-    "resolve_skill_resource",
+# Helper function names exposed by .claude/lib/paths.py.
+_HELPER_FUNCTIONS: frozenset[str] = frozenset(
+    {"resolve_artifact_root", "resolve_skill_resource"}
 )
 
 # Directories scanned for vendor-shipped scripts.
@@ -103,8 +98,20 @@ def scan_roots(repo_root: Path) -> list[Path]:
 
 
 def _routes_through_helper(content: str) -> bool:
-    """True when the file imports or calls the portability helper."""
-    return any(token in content for token in _HELPER_TOKENS)
+    """True when the file imports the portability helper."""
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        return False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(alias.name == "paths" for alias in node.names):
+                return True
+        if isinstance(node, ast.ImportFrom) and node.module == "paths":
+            if any(alias.name in _HELPER_FUNCTIONS for alias in node.names):
+                return True
+    return False
 
 
 def _docstring_lines(content: str) -> set[int]:

--- a/scripts/validation/check_vendor_portability.py
+++ b/scripts/validation/check_vendor_portability.py
@@ -11,7 +11,8 @@ hard-coding those paths instead of routing through the helper.
 
 What it flags:
   A Python file under a scanned skill-scripts root that contains a non-docstring
-  string literal with `.agents/` or `.claude/lib/` AND does not import the
+  string literal or f-string text with `.agents`, `.agents/`, `.agents\\`,
+  `.claude/lib`, or `.claude\\lib` AND does not import and use the
   portability helper (`paths`, exposing `resolve_artifact_root` /
   `resolve_skill_resource`). A file that imports the helper is assumed to
   resolve paths through it; the literal is then the documented lazy default
@@ -50,7 +51,10 @@ from pathlib import Path
 # `.claude/skills/` is intentionally NOT flagged: the `/review` pattern
 # resolves skill resources via the helper's `.claude/skills/...` candidate,
 # so a reference to it inside the helper or via the helper is correct.
-_BANNED_PATH = re.compile(r"\.agents/|\.claude/lib/")
+_BANNED_PATH = re.compile(r"\.agents(?:[\\/]+|['\"]|$)|\.claude[\\/]+lib(?:[\\/]+|['\"]|$)")
+_STRING_TOKEN_TYPES = {tokenize.STRING}
+if hasattr(tokenize, "FSTRING_MIDDLE"):
+    _STRING_TOKEN_TYPES.add(tokenize.FSTRING_MIDDLE)
 
 # Helper function names exposed by .claude/lib/paths.py.
 _HELPER_FUNCTIONS: frozenset[str] = frozenset(
@@ -98,19 +102,32 @@ def scan_roots(repo_root: Path) -> list[Path]:
 
 
 def _routes_through_helper(content: str) -> bool:
-    """True when the file imports the portability helper."""
+    """True when the file imports and uses the portability helper."""
     try:
         tree = ast.parse(content)
     except SyntaxError:
         return False
 
+    paths_aliases: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
-            if any(alias.name == "paths" for alias in node.names):
-                return True
+            for alias in node.names:
+                if alias.name == "paths":
+                    paths_aliases.add(alias.asname or "paths")
         if isinstance(node, ast.ImportFrom) and node.module == "paths":
             if any(alias.name in _HELPER_FUNCTIONS for alias in node.names):
                 return True
+
+    if not paths_aliases:
+        return False
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute):
+            continue
+        if node.attr not in _HELPER_FUNCTIONS:
+            continue
+        if isinstance(node.value, ast.Name) and node.value.id in paths_aliases:
+            return True
     return False
 
 
@@ -152,7 +169,7 @@ def _first_banned_line(content: str) -> tuple[int, str] | None:
     try:
         tokens = tokenize.generate_tokens(reader)
         for token in tokens:
-            if token.type != tokenize.STRING or token.start[0] in doc_lines:
+            if token.type not in _STRING_TOKEN_TYPES or token.start[0] in doc_lines:
                 continue
             if _BANNED_PATH.search(token.string):
                 return token.start[0], token.line.strip()

--- a/scripts/validation/vendor_portability_baseline.txt
+++ b/scripts/validation/vendor_portability_baseline.txt
@@ -1,0 +1,35 @@
+# Vendor-portability baseline (Issue #2050).
+# Pre-existing scripts that hard-code .agents/ or .claude/lib/ paths.
+# check_vendor_portability.py allows these but fails on NEW offenders.
+# Regenerate with: python3 scripts/validation/check_vendor_portability.py --update-baseline
+
+.claude/skills/adr-review/scripts/detect_adr_changes.py
+.claude/skills/chaos-experiment/scripts/generate_experiment.py
+.claude/skills/chaos-experiment/scripts/validate_experiment.py
+.claude/skills/chestertons-fence/scripts/investigate.py
+.claude/skills/context-optimizer/scripts/analyze_skill_placement.py
+.claude/skills/context-optimizer/scripts/compress_markdown_content.py
+.claude/skills/context-optimizer/scripts/extract_and_index.py
+.claude/skills/github/scripts/pr/new_pr.py
+.claude/skills/github/scripts/pr/wait_for_unresolved_zero.py
+.claude/skills/golden-principles/scripts/scan_principles.py
+.claude/skills/memory/scripts/extract_session_episode.py
+.claude/skills/memory/scripts/update_causal_graph.py
+.claude/skills/merge-resolver/scripts/resolve_pr_conflicts.py
+.claude/skills/merge-resolver/tests/test_resolve_pr_conflicts.py
+.claude/skills/metrics/collect_metrics.py
+.claude/skills/orphan-ref-validator/scripts/envelope.py
+.claude/skills/orphan-ref-validator/scripts/scan.py
+.claude/skills/orphan-ref-validator/tests/test_scan.py
+.claude/skills/security-scan/scripts/scan_vulnerabilities.py
+.claude/skills/session-end/scripts/complete_session_log.py
+.claude/skills/session-end/scripts/rework_warning.py
+.claude/skills/session-init/scripts/new_session_log.py
+.claude/skills/session/scripts/test_investigation_eligibility.py
+.claude/skills/session/tests/test_session_eligibility.py
+.claude/skills/spec-generator/scripts/validate_spec_frontmatter.py
+.claude/skills/spec-generator/tests/test_validate_spec_frontmatter.py
+.claude/skills/steering-matcher/get_applicable_steering.py
+.claude/skills/steering-matcher/scripts/get_applicable_steering.py
+.claude/skills/threat-modeling/scripts/generate_threat_matrix.py
+.claude/skills/threat-modeling/scripts/validate_threat_model.py

--- a/scripts/validation/vendor_portability_baseline.txt
+++ b/scripts/validation/vendor_portability_baseline.txt
@@ -1,34 +1,34 @@
 # Vendor-portability baseline (Issue #2050).
 # Pre-existing scripts that hard-code .agents/ or .claude/lib/ paths.
 # check_vendor_portability.py allows these but fails on NEW offenders.
-# Regenerate with: python3 scripts/validation/check_vendor_portability.py --update-baseline
+# Regenerate: python3 scripts/validation/check_vendor_portability.py --update-baseline
 
 .claude/skills/adr-review/scripts/detect_adr_changes.py
+.claude/skills/adr-review/tests/test_detect_adr_changes.py
 .claude/skills/chaos-experiment/scripts/generate_experiment.py
 .claude/skills/chaos-experiment/scripts/validate_experiment.py
 .claude/skills/chestertons-fence/scripts/investigate.py
-.claude/skills/context-optimizer/scripts/analyze_skill_placement.py
-.claude/skills/context-optimizer/scripts/compress_markdown_content.py
-.claude/skills/context-optimizer/scripts/extract_and_index.py
 .claude/skills/github/scripts/pr/new_pr.py
-.claude/skills/github/scripts/pr/wait_for_unresolved_zero.py
 .claude/skills/golden-principles/scripts/scan_principles.py
+.claude/skills/memory/memory_core/reflexion_memory.py
 .claude/skills/memory/scripts/extract_session_episode.py
+.claude/skills/memory/scripts/test_memory_health.py
 .claude/skills/memory/scripts/update_causal_graph.py
+.claude/skills/memory/tests/test_memory_health.py
 .claude/skills/merge-resolver/scripts/resolve_pr_conflicts.py
 .claude/skills/merge-resolver/tests/test_resolve_pr_conflicts.py
 .claude/skills/metrics/collect_metrics.py
-.claude/skills/orphan-ref-validator/scripts/envelope.py
 .claude/skills/orphan-ref-validator/scripts/scan.py
-.claude/skills/orphan-ref-validator/tests/test_scan.py
+.claude/skills/quality-grades/scripts/grade_domains.py
 .claude/skills/security-scan/scripts/scan_vulnerabilities.py
 .claude/skills/session-end/scripts/complete_session_log.py
 .claude/skills/session-end/scripts/rework_warning.py
+.claude/skills/session-end/tests/test_complete_session_log.py
 .claude/skills/session-init/scripts/new_session_log.py
+.claude/skills/session-init/scripts/new_session_log_json.py
+.claude/skills/session-init/tests/test_session_init.py
 .claude/skills/session/scripts/test_investigation_eligibility.py
 .claude/skills/session/tests/test_session_eligibility.py
-.claude/skills/spec-generator/scripts/validate_spec_frontmatter.py
-.claude/skills/spec-generator/tests/test_validate_spec_frontmatter.py
 .claude/skills/steering-matcher/get_applicable_steering.py
 .claude/skills/steering-matcher/scripts/get_applicable_steering.py
 .claude/skills/threat-modeling/scripts/generate_threat_matrix.py

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "25 agent definitions, 81 reusable skills, 52 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "25 agent definitions, 81 reusable skills, 52 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "25 agent definitions, 81 reusable skills, 52 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/lib/paths.py
+++ b/src/copilot-cli/lib/paths.py
@@ -8,9 +8,8 @@ policies every skill needs so no script hard-codes an upstream-only path.
 Two policies:
 
 - `resolve_skill_resource(skill, relpath)` is the READ path. It locates a
-  file that ships inside the plugin (a reference doc, a helper script). The
-  candidate order mirrors the `/review` skill's documented "Path resolution
-  (harness-agnostic)" section in `.claude/skills/review/SKILL.md`:
+  file that ships inside the plugin (a reference doc, a helper script). This
+  helper uses this local candidate order:
     1. `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>` when CLAUDE_PLUGIN_ROOT
        is set by the harness.
     2. `.claude/skills/<skill>/<relpath>` resolved from the current working
@@ -27,17 +26,19 @@ Two policies:
   overridable by the `AI_AGENTS_ARTIFACT_ROOT` environment variable so a
   consumer can redirect every skill's output to one place.
 
-Stricter/looser/different than canonical:
-  The read-path candidate order is a strict mirror of the `/review` skill's
-  three-candidate chain (CLAUDE_PLUGIN_ROOT, `.claude/`, plugin-root-relative)
-  with the verbatim contract preserved. The write path is new (the `/review`
-  skill has no write artifact), modeled on `/spec` Step 0 writing
+Relationship to existing skills:
+  The read path uses a three-location fallback like `/review`, but the
+  environment variable and concrete resource paths are local to this helper.
+  `/review` documents `CLAUDE_SKILL_DIR` for its first candidate. This helper
+  uses `CLAUDE_PLUGIN_ROOT` because packaged plugin installs expose the plugin
+  root, not one skill directory. The write path is new (the `/review` skill has
+  no write artifact), modeled on `/spec` Step 0 writing
   `.agents/metrics/STEP-0-METRICS.md` lazily under the consumer cwd. The
   AI_AGENTS_ARTIFACT_ROOT override is added so the consumer, not the skill,
   owns the artifact location.
 
-Canonical read-path pattern: `.claude/skills/review/SKILL.md`,
-section "Path resolution (harness-agnostic)". Plugin-root marker reuse:
+Related sources: `.claude/skills/review/SKILL.md`, section "Path resolution
+(harness-agnostic)". Plugin-root marker reuse:
 `.claude/lib/bootstrap.py::resolve_plugin_lib_dir` (CLAUDE_PLUGIN_ROOT then
 the `.claude-plugin/plugin.json` walk-up). This file is a sibling write-path
 resolver to that read-path resolver per the Issue #2050 batch decision.
@@ -86,6 +87,17 @@ def _normalize_relpath(relpath: str | Path) -> Path:
     return rel
 
 
+def _normalize_skill_name(skill: str) -> str:
+    """Reject skill names that escape the skills directory."""
+    name = skill.strip()
+    if not name:
+        raise ValueError("skill must be a non-empty name")
+    rel = _normalize_relpath(name)
+    if len(rel.parts) != 1:
+        raise ValueError("skill must be a single directory name")
+    return rel.as_posix()
+
+
 def resolve_skill_resource(skill: str, relpath: str | Path) -> Path | None:
     """Resolve a read-only resource shipped inside a skill.
 
@@ -108,21 +120,20 @@ def resolve_skill_resource(skill: str, relpath: str | Path) -> Path | None:
         ValueError: When skill is empty or relpath is absolute or escapes
             the skill directory with `..`.
     """
-    if not skill or not skill.strip():
-        raise ValueError("skill must be a non-empty name")
+    skill_name = _normalize_skill_name(skill)
     rel = _normalize_relpath(relpath)
 
     candidates: list[Path] = []
 
     plugin_env = os.environ.get("CLAUDE_PLUGIN_ROOT")
     if plugin_env:
-        candidates.append(Path(plugin_env).resolve() / "skills" / skill / rel)
+        candidates.append(Path(plugin_env).resolve() / "skills" / skill_name / rel)
 
-    candidates.append(Path.cwd() / ".claude" / "skills" / skill / rel)
+    candidates.append(Path.cwd() / ".claude" / "skills" / skill_name / rel)
 
     install_root = _plugin_install_root()
     if install_root is not None:
-        candidates.append(install_root / "skills" / skill / rel)
+        candidates.append(install_root / "skills" / skill_name / rel)
 
     for candidate in candidates:
         if candidate.is_file():

--- a/src/copilot-cli/lib/paths.py
+++ b/src/copilot-cli/lib/paths.py
@@ -71,6 +71,8 @@ def _normalize_relpath(relpath: str | Path) -> Path:
     so raise rather than resolve it.
     """
     rel = Path(relpath)
+    if str(rel) == ".":
+        raise ValueError(f"relpath must not be empty or '.': {relpath!r}")
     if rel.is_absolute():
         raise ValueError(f"relpath must be relative, got absolute: {relpath!r}")
     if ".." in rel.parts:

--- a/src/copilot-cli/lib/paths.py
+++ b/src/copilot-cli/lib/paths.py
@@ -10,8 +10,8 @@ Two policies:
 - `resolve_skill_resource(skill, relpath)` is the READ path. It locates a
   file that ships inside the plugin (a reference doc, a helper script). This
   helper uses this local candidate order:
-    1. `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>` when CLAUDE_PLUGIN_ROOT
-       is set by the harness.
+    1. `${COPILOT_PLUGIN_ROOT}/skills/<skill>/<relpath>` or
+       `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>` when set by the harness.
     2. `.claude/skills/<skill>/<relpath>` resolved from the current working
        directory (Claude Code project layout).
     3. `skills/<skill>/<relpath>` resolved relative to the plugin install
@@ -30,9 +30,9 @@ Relationship to existing skills:
   The read path uses a three-location fallback like `/review`, but the
   environment variable and concrete resource paths are local to this helper.
   `/review` documents `CLAUDE_SKILL_DIR` for its first candidate. This helper
-  uses `CLAUDE_PLUGIN_ROOT` because packaged plugin installs expose the plugin
-  root, not one skill directory. The write path is new (the `/review` skill has
-  no write artifact), modeled on `/spec` Step 0 writing
+  uses `COPILOT_PLUGIN_ROOT` or `CLAUDE_PLUGIN_ROOT` because packaged plugin
+  installs expose the plugin root, not one skill directory. The write path is
+  new (the `/review` skill has no write artifact), modeled on `/spec` Step 0 writing
   `.agents/metrics/STEP-0-METRICS.md` lazily under the consumer cwd. The
   AI_AGENTS_ARTIFACT_ROOT override is added so the consumer, not the skill,
   owns the artifact location.
@@ -50,6 +50,11 @@ import os
 from pathlib import Path
 
 _PLUGIN_MARKER = Path(".claude-plugin") / "plugin.json"
+
+
+def _plugin_root_env() -> str | None:
+    """Return the harness-provided plugin root, if any."""
+    return os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
 
 
 def _plugin_install_root() -> Path | None:
@@ -95,7 +100,8 @@ def resolve_skill_resource(skill: str, relpath: str | Path) -> Path | None:
     """Resolve a read-only resource shipped inside a skill.
 
     Tries each candidate in order and returns the first that exists:
-      1. `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>`
+      1. `${COPILOT_PLUGIN_ROOT}/skills/<skill>/<relpath>` or
+         `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>`
       2. `<cwd>/.claude/skills/<skill>/<relpath>`
       3. `<plugin install root>/skills/<skill>/<relpath>`
 
@@ -118,7 +124,7 @@ def resolve_skill_resource(skill: str, relpath: str | Path) -> Path | None:
 
     candidates: list[Path] = []
 
-    plugin_env = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    plugin_env = _plugin_root_env()
     if plugin_env:
         candidates.append(Path(plugin_env).resolve() / "skills" / skill_name / rel)
 

--- a/src/copilot-cli/lib/paths.py
+++ b/src/copilot-cli/lib/paths.py
@@ -53,16 +53,7 @@ _PLUGIN_MARKER = Path(".claude-plugin") / "plugin.json"
 
 
 def _plugin_install_root() -> Path | None:
-    """Return the plugin install root, or None when no marker is found.
-
-    Prefers CLAUDE_PLUGIN_ROOT. Otherwise walks up from this file looking
-    for the `.claude-plugin/plugin.json` manifest marker, the same marker
-    `bootstrap.resolve_plugin_lib_dir` uses.
-    """
-    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
-    if plugin_root:
-        return Path(plugin_root).resolve()
-
+    """Return the marker-discovered plugin install root, or None."""
     cur = Path(__file__).resolve().parent
     while True:
         if (cur / _PLUGIN_MARKER).is_file():

--- a/src/copilot-cli/lib/paths.py
+++ b/src/copilot-cli/lib/paths.py
@@ -1,0 +1,165 @@
+"""Vendor-portable path resolution for skill scripts (Issue #2050).
+
+Skills that ship in a vendored plugin install (Copilot CLI and similar
+harnesses) cannot assume the consumer repo has a `.claude/` directory or
+the upstream `.agents/` tree. This module centralizes the two resolution
+policies every skill needs so no script hard-codes an upstream-only path.
+
+Two policies:
+
+- `resolve_skill_resource(skill, relpath)` is the READ path. It locates a
+  file that ships inside the plugin (a reference doc, a helper script). The
+  candidate order mirrors the `/review` skill's documented "Path resolution
+  (harness-agnostic)" section in `.claude/skills/review/SKILL.md`:
+    1. `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>` when CLAUDE_PLUGIN_ROOT
+       is set by the harness.
+    2. `.claude/skills/<skill>/<relpath>` resolved from the current working
+       directory (Claude Code project layout).
+    3. `skills/<skill>/<relpath>` resolved relative to the plugin install
+       root discovered by walking up from this file to the
+       `.claude-plugin/plugin.json` marker (vendored install).
+  Returns the first candidate that exists, else None. Read-only: it never
+  creates anything.
+
+- `resolve_artifact_root(subdir)` is the WRITE path. Skills write artifacts
+  to a consumer-side location, defaulting to `<cwd>/.agents/<subdir>`. The
+  directory is created lazily (parents=True, exist_ok=True). The root is
+  overridable by the `AI_AGENTS_ARTIFACT_ROOT` environment variable so a
+  consumer can redirect every skill's output to one place.
+
+Stricter/looser/different than canonical:
+  The read-path candidate order is a strict mirror of the `/review` skill's
+  three-candidate chain (CLAUDE_PLUGIN_ROOT, `.claude/`, plugin-root-relative)
+  with the verbatim contract preserved. The write path is new (the `/review`
+  skill has no write artifact), modeled on `/spec` Step 0 writing
+  `.agents/metrics/STEP-0-METRICS.md` lazily under the consumer cwd. The
+  AI_AGENTS_ARTIFACT_ROOT override is added so the consumer, not the skill,
+  owns the artifact location.
+
+Canonical read-path pattern: `.claude/skills/review/SKILL.md`,
+section "Path resolution (harness-agnostic)". Plugin-root marker reuse:
+`.claude/lib/bootstrap.py::resolve_plugin_lib_dir` (CLAUDE_PLUGIN_ROOT then
+the `.claude-plugin/plugin.json` walk-up). This file is a sibling write-path
+resolver to that read-path resolver per the Issue #2050 batch decision.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_PLUGIN_MARKER = Path(".claude-plugin") / "plugin.json"
+
+
+def _plugin_install_root() -> Path | None:
+    """Return the plugin install root, or None when no marker is found.
+
+    Prefers CLAUDE_PLUGIN_ROOT. Otherwise walks up from this file looking
+    for the `.claude-plugin/plugin.json` manifest marker, the same marker
+    `bootstrap.resolve_plugin_lib_dir` uses.
+    """
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        return Path(plugin_root).resolve()
+
+    cur = Path(__file__).resolve().parent
+    while True:
+        if (cur / _PLUGIN_MARKER).is_file():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+
+
+def _normalize_relpath(relpath: str | Path) -> Path:
+    """Reject absolute paths and parent-escapes in a skill relative path.
+
+    A skill resource path is always relative to the skill directory. An
+    absolute path or a `..` segment is a caller bug and a traversal risk,
+    so raise rather than resolve it.
+    """
+    rel = Path(relpath)
+    if rel.is_absolute():
+        raise ValueError(f"relpath must be relative, got absolute: {relpath!r}")
+    if ".." in rel.parts:
+        raise ValueError(f"relpath must not contain '..': {relpath!r}")
+    return rel
+
+
+def resolve_skill_resource(skill: str, relpath: str | Path) -> Path | None:
+    """Resolve a read-only resource shipped inside a skill.
+
+    Tries each candidate in order and returns the first that exists:
+      1. `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/<relpath>`
+      2. `<cwd>/.claude/skills/<skill>/<relpath>`
+      3. `<plugin install root>/skills/<skill>/<relpath>`
+
+    Args:
+        skill: Skill directory name (for example "review").
+        relpath: Path of the resource within the skill directory, relative
+            (for example "references/analyst.md"). Must not be absolute or
+            contain a `..` segment.
+
+    Returns:
+        The resolved absolute Path of the first existing candidate, or None
+        when no candidate exists.
+
+    Raises:
+        ValueError: When skill is empty or relpath is absolute or escapes
+            the skill directory with `..`.
+    """
+    if not skill or not skill.strip():
+        raise ValueError("skill must be a non-empty name")
+    rel = _normalize_relpath(relpath)
+
+    candidates: list[Path] = []
+
+    plugin_env = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_env:
+        candidates.append(Path(plugin_env).resolve() / "skills" / skill / rel)
+
+    candidates.append(Path.cwd() / ".claude" / "skills" / skill / rel)
+
+    install_root = _plugin_install_root()
+    if install_root is not None:
+        candidates.append(install_root / "skills" / skill / rel)
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+
+    return None
+
+
+def resolve_artifact_root(subdir: str | Path) -> Path:
+    """Resolve and create the write directory for a skill artifact.
+
+    The default root is `<cwd>/.agents`, overridable by the
+    `AI_AGENTS_ARTIFACT_ROOT` environment variable. The returned directory
+    (`<root>/<subdir>`) is created lazily with parents.
+
+    Args:
+        subdir: Artifact subdirectory under the artifact root (for example
+            "analysis" or "metrics"). Must not be absolute or escape the
+            root with `..`.
+
+    Returns:
+        The resolved absolute Path of the created `<root>/<subdir>`.
+
+    Raises:
+        ValueError: When subdir is empty, absolute, or contains `..`.
+        OSError: When the directory cannot be created.
+    """
+    if not str(subdir).strip():
+        raise ValueError("subdir must be non-empty")
+    sub = _normalize_relpath(subdir)
+
+    override = os.environ.get("AI_AGENTS_ARTIFACT_ROOT")
+    if override and override.strip():
+        root = Path(override).expanduser()
+    else:
+        root = Path.cwd() / ".agents"
+
+    target = (root / sub).resolve()
+    target.mkdir(parents=True, exist_ok=True)
+    return target

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -47,6 +47,7 @@ def paths():
 @pytest.fixture(autouse=True)
 def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure neither env var leaks in from the runner's environment."""
+    monkeypatch.delenv("COPILOT_PLUGIN_ROOT", raising=False)
     monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
     monkeypatch.delenv("AI_AGENTS_ARTIFACT_ROOT", raising=False)
 
@@ -99,6 +100,26 @@ def test_skill_resource_env_beats_cwd(
     result = paths.resolve_skill_resource("review", "x.md")
 
     assert result == env_target.resolve()
+
+
+def test_skill_resource_prefers_copilot_plugin_root(
+    paths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    copilot_root = tmp_path / "copilot"
+    claude_root = tmp_path / "claude"
+    copilot_target = copilot_root / "skills" / "review" / "x.md"
+    claude_target = claude_root / "skills" / "review" / "x.md"
+    copilot_target.parent.mkdir(parents=True)
+    claude_target.parent.mkdir(parents=True)
+    copilot_target.write_text("copilot", encoding="utf-8")
+    claude_target.write_text("claude", encoding="utf-8")
+    monkeypatch.setenv("COPILOT_PLUGIN_ROOT", str(copilot_root))
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(claude_root))
+    monkeypatch.chdir(tmp_path)
+
+    result = paths.resolve_skill_resource("review", "x.md")
+
+    assert result == copilot_target.resolve()
 
 
 def test_skill_resource_env_miss_falls_back_to_install_root(

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -101,6 +101,19 @@ def test_skill_resource_env_beats_cwd(
     assert result == env_target.resolve()
 
 
+def test_skill_resource_env_miss_falls_back_to_install_root(
+    paths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+    monkeypatch.chdir(tmp_path)
+
+    result = paths.resolve_skill_resource("review", "SKILL.md")
+
+    assert result == (REPO_ROOT / ".claude" / "skills" / "review" / "SKILL.md").resolve()
+
+
 def test_skill_resource_accepts_path_relpath(
     paths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,229 @@
+"""Tests for the vendor-portable path helper at .claude/lib/paths.py.
+
+Issue #2050. Covers both resolution policies:
+
+resolve_skill_resource (read path):
+  - CLAUDE_PLUGIN_ROOT candidate wins when the file exists there
+  - .claude/skills/<skill>/<rel> candidate (Claude project layout)
+  - plugin-install-root candidate (walk-up to .claude-plugin/plugin.json)
+  - candidate order (env beats cwd beats install-root)
+  - returns None when no candidate exists
+  - rejects empty skill, absolute relpath, and `..` traversal
+
+resolve_artifact_root (write path):
+  - default <cwd>/.agents/<subdir>, created lazily
+  - AI_AGENTS_ARTIFACT_ROOT override
+  - idempotent when the directory already exists
+  - rejects empty subdir, absolute subdir, and `..` traversal
+
+The module lives outside any importable package, so it is loaded directly
+via importlib.util (same approach as tests/test_bootstrap.py).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PATHS_MODULE = REPO_ROOT / ".claude" / "lib" / "paths.py"
+
+
+def _load_paths():
+    spec = importlib.util.spec_from_file_location("paths_under_test", PATHS_MODULE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def paths():
+    return _load_paths()
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure neither env var leaks in from the runner's environment."""
+    monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+    monkeypatch.delenv("AI_AGENTS_ARTIFACT_ROOT", raising=False)
+
+
+# --- resolve_skill_resource: positive -------------------------------------
+
+
+def test_skill_resource_prefers_plugin_root_env(
+    paths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plugin_root = tmp_path / "plugin"
+    target = plugin_root / "skills" / "review" / "references" / "analyst.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("axis", encoding="utf-8")
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+    monkeypatch.chdir(tmp_path)
+
+    result = paths.resolve_skill_resource("review", "references/analyst.md")
+
+    assert result == target.resolve()
+
+
+def test_skill_resource_claude_project_layout(
+    paths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / ".claude" / "skills" / "review" / "references" / "qa.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("axis", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    result = paths.resolve_skill_resource("review", "references/qa.md")
+
+    assert result == target.resolve()
+
+
+def test_skill_resource_env_beats_cwd(
+    paths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Both candidates exist; CLAUDE_PLUGIN_ROOT must win.
+    plugin_root = tmp_path / "plugin"
+    env_target = plugin_root / "skills" / "review" / "x.md"
+    env_target.parent.mkdir(parents=True)
+    env_target.write_text("env", encoding="utf-8")
+    cwd_target = tmp_path / ".claude" / "skills" / "review" / "x.md"
+    cwd_target.parent.mkdir(parents=True)
+    cwd_target.write_text("cwd", encoding="utf-8")
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(plugin_root))
+    monkeypatch.chdir(tmp_path)
+
+    result = paths.resolve_skill_resource("review", "x.md")
+
+    assert result == env_target.resolve()
+
+
+def test_skill_resource_accepts_path_relpath(
+    paths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / ".claude" / "skills" / "memory" / "scripts" / "s.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("# s", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    result = paths.resolve_skill_resource("memory", Path("scripts/s.py"))
+
+    assert result == target.resolve()
+
+
+# --- resolve_skill_resource: negative / edge -------------------------------
+
+
+def test_skill_resource_returns_none_when_missing(
+    paths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = paths.resolve_skill_resource("nope", "references/missing.md")
+
+    assert result is None
+
+
+def test_skill_resource_rejects_empty_skill(paths) -> None:
+    with pytest.raises(ValueError):
+        paths.resolve_skill_resource("", "references/x.md")
+
+
+def test_skill_resource_rejects_blank_skill(paths) -> None:
+    with pytest.raises(ValueError):
+        paths.resolve_skill_resource("   ", "references/x.md")
+
+
+def test_skill_resource_rejects_absolute_relpath(paths) -> None:
+    with pytest.raises(ValueError):
+        paths.resolve_skill_resource("review", "/etc/passwd")
+
+
+def test_skill_resource_rejects_parent_traversal(paths) -> None:
+    with pytest.raises(ValueError):
+        paths.resolve_skill_resource("review", "../../secrets.md")
+
+
+# --- resolve_artifact_root: positive ---------------------------------------
+
+
+def test_artifact_root_default_under_cwd(
+    paths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = paths.resolve_artifact_root("analysis")
+
+    expected = (tmp_path / ".agents" / "analysis").resolve()
+    assert result == expected
+    assert result.is_dir()
+
+
+def test_artifact_root_creates_nested_subdir(
+    paths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = paths.resolve_artifact_root("sessions/logs")
+
+    assert result == (tmp_path / ".agents" / "sessions" / "logs").resolve()
+    assert result.is_dir()
+
+
+def test_artifact_root_env_override(paths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    override = tmp_path / "custom_root"
+    monkeypatch.setenv("AI_AGENTS_ARTIFACT_ROOT", str(override))
+    monkeypatch.chdir(tmp_path)
+
+    result = paths.resolve_artifact_root("metrics")
+
+    assert result == (override / "metrics").resolve()
+    assert result.is_dir()
+    # Default location must NOT be used when the override is set.
+    assert not (tmp_path / ".agents" / "metrics").exists()
+
+
+def test_artifact_root_idempotent_when_exists(
+    paths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    first = paths.resolve_artifact_root("analysis")
+    marker = first / "keep.txt"
+    marker.write_text("data", encoding="utf-8")
+
+    second = paths.resolve_artifact_root("analysis")
+
+    assert second == first
+    assert marker.read_text(encoding="utf-8") == "data"
+
+
+# --- resolve_artifact_root: negative / edge --------------------------------
+
+
+def test_artifact_root_blank_override_falls_back_to_default(
+    paths, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AI_AGENTS_ARTIFACT_ROOT", "   ")
+    monkeypatch.chdir(tmp_path)
+
+    result = paths.resolve_artifact_root("analysis")
+
+    assert result == (tmp_path / ".agents" / "analysis").resolve()
+
+
+def test_artifact_root_rejects_empty_subdir(paths) -> None:
+    with pytest.raises(ValueError):
+        paths.resolve_artifact_root("")
+
+
+def test_artifact_root_rejects_absolute_subdir(paths) -> None:
+    with pytest.raises(ValueError):
+        paths.resolve_artifact_root("/var/tmp/evil")
+
+
+def test_artifact_root_rejects_parent_traversal(paths) -> None:
+    with pytest.raises(ValueError):
+        paths.resolve_artifact_root("../escape")

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -160,6 +160,11 @@ def test_skill_resource_rejects_skill_parent_traversal(paths) -> None:
         paths.resolve_skill_resource("../escape", "secret.md")
 
 
+def test_skill_resource_rejects_dot_skill(paths) -> None:
+    with pytest.raises(ValueError):
+        paths.resolve_skill_resource(".", "secret.md")
+
+
 def test_skill_resource_rejects_absolute_relpath(paths) -> None:
     with pytest.raises(ValueError):
         paths.resolve_skill_resource("review", "/etc/passwd")
@@ -240,6 +245,11 @@ def test_artifact_root_blank_override_falls_back_to_default(
 def test_artifact_root_rejects_empty_subdir(paths) -> None:
     with pytest.raises(ValueError):
         paths.resolve_artifact_root("")
+
+
+def test_artifact_root_rejects_dot_subdir(paths) -> None:
+    with pytest.raises(ValueError):
+        paths.resolve_artifact_root(".")
 
 
 def test_artifact_root_rejects_absolute_subdir(paths) -> None:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -137,6 +137,16 @@ def test_skill_resource_rejects_blank_skill(paths) -> None:
         paths.resolve_skill_resource("   ", "references/x.md")
 
 
+def test_skill_resource_rejects_absolute_skill(paths) -> None:
+    with pytest.raises(ValueError):
+        paths.resolve_skill_resource("/etc", "passwd")
+
+
+def test_skill_resource_rejects_skill_parent_traversal(paths) -> None:
+    with pytest.raises(ValueError):
+        paths.resolve_skill_resource("../escape", "secret.md")
+
+
 def test_skill_resource_rejects_absolute_relpath(paths) -> None:
     with pytest.raises(ValueError):
         paths.resolve_skill_resource("review", "/etc/passwd")

--- a/tests/validation/test_check_vendor_portability.py
+++ b/tests/validation/test_check_vendor_portability.py
@@ -74,6 +74,19 @@ def test_script_routing_through_helper_is_exempt(fake_repo: Path) -> None:
     assert offenders == []
 
 
+def test_script_using_paths_module_helper_is_exempt(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/foo/scripts/portable_module.py",
+        "import paths\n\nroot = paths.resolve_artifact_root('analysis')\n"
+        "default = '.agents'\n",
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert offenders == []
+
+
 def test_comments_with_upstream_paths_are_not_offenders(fake_repo: Path) -> None:
     _write(
         fake_repo,
@@ -126,6 +139,58 @@ def test_import_pathspec_does_not_exempt_offender(fake_repo: Path) -> None:
 
     assert len(offenders) == 1
     assert offenders[0].relpath == ".claude/skills/bar/scripts/pathspec_bad.py"
+
+
+def test_unused_paths_import_does_not_exempt_offender(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/bar/scripts/unused_paths.py",
+        "import paths\n\nout = '.agents/analysis/x.md'\n",
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert len(offenders) == 1
+    assert offenders[0].relpath == ".claude/skills/bar/scripts/unused_paths.py"
+
+
+def test_standalone_agents_segment_is_offender(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/bar/scripts/standalone.py",
+        "out = os.path.join('.agents', 'analysis', 'x.md')\n",
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert len(offenders) == 1
+    assert offenders[0].relpath == ".claude/skills/bar/scripts/standalone.py"
+
+
+def test_windows_claude_lib_path_is_offender(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/bar/scripts/windows.py",
+        r"spec = '.claude\\lib\\paths.py'" + "\n",
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert len(offenders) == 1
+    assert offenders[0].relpath == ".claude/skills/bar/scripts/windows.py"
+
+
+def test_fstring_agents_path_is_offender(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/bar/scripts/fstring.py",
+        "out = f'.agents/{subdir}/x.md'\n",
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert len(offenders) == 1
+    assert offenders[0].relpath == ".claude/skills/bar/scripts/fstring.py"
 
 
 def test_hardcoded_claude_lib_path_is_offender(fake_repo: Path) -> None:

--- a/tests/validation/test_check_vendor_portability.py
+++ b/tests/validation/test_check_vendor_portability.py
@@ -115,6 +115,19 @@ def test_hardcoded_agents_path_is_offender(fake_repo: Path) -> None:
     assert ".agents/" in offenders[0].excerpt
 
 
+def test_import_pathspec_does_not_exempt_offender(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/bar/scripts/pathspec_bad.py",
+        "import pathspec\n\nout = '.agents/analysis/x.md'\n",
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert len(offenders) == 1
+    assert offenders[0].relpath == ".claude/skills/bar/scripts/pathspec_bad.py"
+
+
 def test_hardcoded_claude_lib_path_is_offender(fake_repo: Path) -> None:
     _write(
         fake_repo,

--- a/tests/validation/test_check_vendor_portability.py
+++ b/tests/validation/test_check_vendor_portability.py
@@ -1,0 +1,236 @@
+"""Tests for scripts/validation/check_vendor_portability.py.
+
+Issue #2050. The check fails CI when a vendor-shipped skill script
+hard-codes an upstream-only path (.agents/ or .claude/lib/) without
+routing through the portability helper, unless the offender is recorded
+in the baseline. Tests use temporary file trees rather than the live
+repo so the result is independent of how clean the repo happens to be.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "validation" / "check_vendor_portability.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_vendor_portability", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cvp = _load_module()
+
+
+def _write(repo: Path, relpath: str, content: str) -> Path:
+    target = repo / relpath
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    return target
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """Create the scan root the script inspects."""
+    (tmp_path / ".claude" / "skills").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+# --- collect_offenders: positive (clean) -----------------------------------
+
+
+def test_clean_script_is_not_an_offender(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/foo/scripts/clean.py",
+        "from pathlib import Path\n\nx = Path('output.json')\n",
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert offenders == []
+
+
+def test_script_routing_through_helper_is_exempt(fake_repo: Path) -> None:
+    # References .agents/ but imports the helper, so it is presumed portable.
+    _write(
+        fake_repo,
+        ".claude/skills/foo/scripts/portable.py",
+        "from paths import resolve_artifact_root\n\n"
+        "root = resolve_artifact_root('analysis')  # default <cwd>/.agents/\n",
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert offenders == []
+
+
+# --- collect_offenders: negative (offending) -------------------------------
+
+
+def test_hardcoded_agents_path_is_offender(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/bar/scripts/bad.py",
+        "from pathlib import Path\n\nout = Path('.agents/analysis/x.md')\n",
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert len(offenders) == 1
+    assert offenders[0].relpath == ".claude/skills/bar/scripts/bad.py"
+    assert ".agents/" in offenders[0].excerpt
+
+
+def test_hardcoded_claude_lib_path_is_offender(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/baz/scripts/bad.py",
+        "spec = '.claude/lib/ai_review_common/verdict.py'\n",
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert len(offenders) == 1
+    assert offenders[0].relpath == ".claude/skills/baz/scripts/bad.py"
+
+
+def test_offender_line_number_points_at_first_hit(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/bar/scripts/bad.py",
+        "import os\n\n\nout = '.agents/sessions/log.json'\n",
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert offenders[0].line == 4
+
+
+# --- baseline ratchet ------------------------------------------------------
+
+
+def test_baselined_offender_does_not_fail(fake_repo: Path) -> None:
+    rel = ".claude/skills/bar/scripts/bad.py"
+    _write(fake_repo, rel, "out = '.agents/analysis/x.md'\n")
+    offenders = cvp.collect_offenders(fake_repo)
+
+    new, known = cvp.split_offenders(offenders, {rel})
+
+    assert new == []
+    assert len(known) == 1
+
+
+def test_new_offender_outside_baseline_fails(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/bar/scripts/new_bad.py",
+        "out = '.agents/analysis/x.md'\n",
+    )
+    offenders = cvp.collect_offenders(fake_repo)
+
+    new, known = cvp.split_offenders(offenders, {".claude/skills/old/x.py"})
+
+    assert len(new) == 1
+    assert known == []
+
+
+def test_load_baseline_ignores_comments_and_blanks(tmp_path: Path) -> None:
+    bpath = tmp_path / "baseline.txt"
+    bpath.write_text(
+        "# header comment\n\n.claude/skills/a/x.py\n  # indented comment\n.claude/skills/b/y.py\n",
+        encoding="utf-8",
+    )
+
+    entries = cvp.load_baseline(bpath)
+
+    assert entries == {".claude/skills/a/x.py", ".claude/skills/b/y.py"}
+
+
+def test_load_baseline_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert cvp.load_baseline(tmp_path / "nope.txt") == set()
+
+
+# --- main / CLI exit codes -------------------------------------------------
+
+
+def test_main_passes_when_no_offenders(fake_repo: Path) -> None:
+    _write(fake_repo, ".claude/skills/foo/scripts/clean.py", "x = 1\n")
+
+    rc = cvp.main(["--repo-root", str(fake_repo)])
+
+    assert rc == 0
+
+
+def test_main_fails_on_new_offender(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/bar/scripts/bad.py",
+        "out = '.agents/analysis/x.md'\n",
+    )
+
+    rc = cvp.main(["--repo-root", str(fake_repo)])
+
+    assert rc == 1
+
+
+def test_main_passes_when_offender_in_baseline(fake_repo: Path) -> None:
+    rel = ".claude/skills/bar/scripts/bad.py"
+    _write(fake_repo, rel, "out = '.agents/analysis/x.md'\n")
+    bpath = cvp.baseline_path(fake_repo)
+    bpath.parent.mkdir(parents=True, exist_ok=True)
+    bpath.write_text(rel + "\n", encoding="utf-8")
+
+    rc = cvp.main(["--repo-root", str(fake_repo)])
+
+    assert rc == 0
+
+
+def test_main_update_baseline_writes_offenders(fake_repo: Path) -> None:
+    rel = ".claude/skills/bar/scripts/bad.py"
+    _write(fake_repo, rel, "out = '.agents/analysis/x.md'\n")
+
+    rc = cvp.main(["--repo-root", str(fake_repo), "--update-baseline"])
+
+    assert rc == 0
+    written = cvp.load_baseline(cvp.baseline_path(fake_repo))
+    assert written == {rel}
+
+
+def test_main_skips_when_no_scan_root(tmp_path: Path) -> None:
+    # No .claude/skills directory present.
+    rc = cvp.main(["--repo-root", str(tmp_path)])
+
+    assert rc == 0
+
+
+def test_main_config_error_on_missing_repo_root(tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist"
+
+    rc = cvp.main(["--repo-root", str(missing)])
+
+    assert rc == 2
+
+
+# --- edge: pycache excluded, baselined-then-removed --------------------------
+
+
+def test_pycache_files_are_skipped(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/foo/scripts/__pycache__/bad.py",
+        "out = '.agents/analysis/x.md'\n",
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert offenders == []

--- a/tests/validation/test_check_vendor_portability.py
+++ b/tests/validation/test_check_vendor_portability.py
@@ -74,6 +74,30 @@ def test_script_routing_through_helper_is_exempt(fake_repo: Path) -> None:
     assert offenders == []
 
 
+def test_comments_with_upstream_paths_are_not_offenders(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/foo/scripts/comment.py",
+        "# writes to .agents/analysis when running upstream\nvalue = 'safe'\n",
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert offenders == []
+
+
+def test_docstrings_with_upstream_paths_are_not_offenders(fake_repo: Path) -> None:
+    _write(
+        fake_repo,
+        ".claude/skills/foo/scripts/docstring.py",
+        '"""Mentions .claude/lib/paths.py in prose."""\n\nvalue = "safe"\n',
+    )
+
+    offenders = cvp.collect_offenders(fake_repo)
+
+    assert offenders == []
+
+
 # --- collect_offenders: negative (offending) -------------------------------
 
 


### PR DESCRIPTION
## Summary

Phase 1 of the vendor-portability epic. Skills shipped in a vendored plugin install can fail when they depend on upstream-only paths. This PR adds the reusable path resolver plus a CI ratchet that blocks new hard-coded upstream path usage while leaving the existing migration debt for later phases.

Refs #2050

## SpecificationReferences

- Issue #2050

## TypeOfChange

- New library helper
- New validation gate
- Tests

## Changes

- `.claude/lib/paths.py`: adds `resolve_skill_resource(skill, relpath)` for read-only skill resources and `resolve_artifact_root(subdir)` for write artifacts. Both reject absolute paths and parent traversal. The skill name is also validated against absolute paths, parent traversal, and multi-segment names.
- `src/copilot-cli/lib/paths.py`: Copilot plugin copy of the path resolver.
- `scripts/validation/check_vendor_portability.py`: adds the vendor-portability CI gate. It tokenizes Python files, ignores comments and docstrings, and fails on new non-docstring string literals that hard-code upstream-only paths without using the helper.
- `scripts/validation/vendor_portability_baseline.txt`: records known existing offenders so the new gate can ratchet without forcing the full migration in this phase.
- `tests/test_paths.py`: covers read-path lookup order, artifact root creation, traversal rejection, and skill-name traversal rejection.
- `tests/validation/test_check_vendor_portability.py`: covers clean scripts, offenders, helper exemptions, comment and docstring ignores, baseline behavior, CLI exit codes, and pycache skip behavior.
- `.claude/.claude-plugin/plugin.json`, `src/copilot-cli/.claude-plugin/plugin.json`: patch bumps for changed packaged plugin content.

## Testing

- `$VENV -m pytest tests/test_paths.py tests/validation/test_check_vendor_portability.py -q --basetemp=$WT/.pytest-tmp/pytest` -> 47 passed.
- `$SHARED/.venv/bin/ruff check .claude/lib/paths.py scripts/validation/check_vendor_portability.py src/copilot-cli/lib/paths.py tests/test_paths.py tests/validation/test_check_vendor_portability.py` -> passed.
- `$VENV scripts/validation/check_vendor_portability.py` -> passed.
- `$VENV $SHARED/scripts/sync_plugin_lib.py --check` -> passed.
- `$VENV $SHARED/build/scripts/validate_plugin_manifests.py` -> passed.
- Dash check on `git diff origin/main...HEAD` -> no prohibited dash bytes.