### PR TITLE
feat(skills): add retrospective skill contract (PR 1 of N, #2080)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/retrospective/SKILL.md
+++ b/.claude/skills/retrospective/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: retrospective
+version: 0.1.0
+model: claude-sonnet-4-6
+description: Extract learnings from a session or task through structured retrospective frameworks. Gathers evidence, runs Five Whys and fishbone diagnosis, scores atomicity, and writes a canonical retrospective artifact. Use to turn execution experience into institutional knowledge. Do NOT use for in-conversation correction capture (use the reflect skill).
+license: MIT
+metadata:
+  domains: [retrospective, learning-extraction, root-cause-analysis, continuous-improvement]
+  type: workflow
+  inputs: [scope-description, session-log, git-history]
+  outputs: [retrospective-markdown-file]
+  adr: ADR-008, ADR-017, ADR-037
+---
+
+# Retrospective
+
+Turn execution experience into institutional knowledge. This skill orchestrates a fixed
+Phase 0 through Phase 5 workflow that gathers evidence, generates insights, diagnoses root
+causes, decides actions, scores atomicity, and persists learnings. The long-form rubrics
+live verbatim in `references/`; this file is the orchestration contract.
+
+This skill replaces the former `retrospective` agent (`.claude/agents/retrospective.md`).
+Lifecycle hooks can invoke a skill but not an agent, so the retrospective workflow moves
+here to be callable from `Skill("retrospective")`, from `/retro fill <date>` (Issue #2079),
+and from the Stop-hook auto-retrospective path
+(`.claude/hooks/Stop/invoke_auto_retrospective.py`).
+
+## Triggers
+
+| Trigger Phrase | Operation |
+|----------------|-----------|
+| `run a retrospective` | Full Phase 0..5 workflow over the given scope |
+| `retro fill` | Fill an unfilled auto-retro skeleton for a date |
+| `extract learnings from this session` | Phase 0..4 over the current session |
+| `diagnose this failure` | Phase 0..2 root-cause analysis, then stop |
+| `what did we learn` | Phase 4 atomicity-scored learning extraction |
+
+---
+
+## When to Use
+
+| Situation | Use This Skill? |
+|-----------|-----------------|
+| Session ended with meaningful work and you want learnings persisted | Yes |
+| An unfilled auto-retro skeleton exists in `.agents/retrospective/` | Yes (fill it) |
+| Diagnosing why a task failed (Five Whys, fishbone) | Yes |
+| Capturing a single in-conversation correction ("no", "wrong") | No, use `reflect` |
+| Saving a quick checkpoint with no analysis | No, use `session-end` |
+
+The output artifact is a Markdown file. The Learning Extraction Template in
+`references/learning-template.md` defines the exact structure. Save to
+`.agents/retrospective/YYYY-MM-DD-[scope].md`. When filling an auto-retro skeleton, write
+to the existing `YYYY-MM-DD-auto-retro.md` file produced by the Stop hook.
+
+---
+
+## Inputs
+
+| Input | Source | Required |
+|-------|--------|----------|
+| Scope | User argument (session, task, date, PR) | Yes |
+| Session log | `.agents/sessions/` most recent for the period | When available |
+| Git history | `git log` over the period | When available |
+| GitHub activity | PRs and issues for the period (via the `github` skill) | Optional enrichment |
+
+Treat the session log as the system of record for what happened. Git history and GitHub
+activity are derived evidence that corroborate or extend it. When a source is unavailable,
+degrade gracefully: produce the artifact from the evidence you have and mark the missing
+sections, never substitute invented data.
+
+---
+
+## Process
+
+The workflow is six sequential phases. Phase 0 gathers facts. Phases 1 and 2 interpret them.
+Phase 3 decides actions. Phase 4 extracts and scores learnings. Phase 5 persists them. Each
+phase links to the rubric and template it uses. Run them in order; do not interpret before
+you observe.
+
+### Phase 0: Data Gathering
+
+Gather facts before interpretation. Observation precedes diagnosis.
+
+- Run the **4-Step Debrief** (Observe, Respond, Analyze, Apply): see
+  [frameworks.md, 4-Step Debrief](references/frameworks.md#activity-4-step-debrief).
+- Build the **Execution Trace** chronology: see
+  [frameworks.md, Execution Trace Analysis](references/frameworks.md#activity-execution-trace-analysis).
+- Run **Outcome Classification** (Mad, Sad, Glad): see
+  [frameworks.md, Outcome Classification](references/frameworks.md#activity-outcome-classification).
+
+Evidence sources: the most recent session log under `.agents/sessions/`, `git log` for the
+period, and optional GitHub activity through the `github` skill. Do not use raw `gh`.
+
+### Phase 1: Generate Insights
+
+Make meaning from data. Look past symptoms to find causes.
+
+- **Five Whys** is mandatory for every failure: see
+  [frameworks.md, Five Whys](references/frameworks.md#activity-five-whys).
+- **Fishbone Analysis** for complex failures with multiple contributing factors: see
+  [frameworks.md, Fishbone Analysis](references/frameworks.md#activity-fishbone-analysis).
+- **Force Field Analysis** when a pattern recurs despite knowing better: see
+  [frameworks.md, Force Field Analysis](references/frameworks.md#activity-force-field-analysis).
+- **Patterns and Shifts** for multi-session trends: see
+  [frameworks.md, Patterns and Shifts](references/frameworks.md#activity-patterns-and-shifts).
+- **Learning Matrix** for quick categorization when short on time: see
+  [frameworks.md, Learning Matrix](references/frameworks.md#activity-learning-matrix).
+
+### Phase 2: Diagnosis
+
+Prioritize findings for action. Diagnostic priority order: critical error patterns, success
+analysis, near misses, efficiency opportunities, skill gaps, traceability health. The full
+priority order, traceability metrics, and diagnosis template live in
+[diagnosis-and-actions.md, Diagnosis](references/diagnosis-and-actions.md#diagnosis).
+
+For each root cause that Five Whys surfaces, store a root-cause pattern for future
+prevention: see
+[diagnosis-and-actions.md, Root Cause Pattern Management](references/diagnosis-and-actions.md#root-cause-pattern-management).
+
+If the work touched diagnosis or action classification, stop here for the `diagnose this
+failure` trigger; otherwise continue to Phase 3.
+
+### Phase 3: Decide What to Do
+
+Move from insights to action.
+
+- **Action Classification** (Keep, Drop, Add, Modify): see
+  [diagnosis-and-actions.md, Action Classification](references/diagnosis-and-actions.md#activity-action-classification).
+- **SMART Validation** of every proposed learning before storage: see
+  [diagnosis-and-actions.md, SMART Validation](references/diagnosis-and-actions.md#activity-smart-validation).
+- **Dependency Ordering** of the resulting actions: see
+  [diagnosis-and-actions.md, Dependency Ordering](references/diagnosis-and-actions.md#dependency-ordering).
+
+### Phase 4: Learning Extraction
+
+Transform insights into stored knowledge. Score every learning 0 to 100 percent for
+atomicity and reject vague statements. The scoring rubric, quality thresholds, worked
+examples, and evidence-based tagging live in
+[diagnosis-and-actions.md, Atomicity Scoring](references/diagnosis-and-actions.md#atomicity-scoring).
+
+Assemble the artifact using the byte-exact
+[Learning Extraction Template](references/learning-template.md). Save to
+`.agents/retrospective/YYYY-MM-DD-[scope].md`. When filling an auto-retro skeleton, overwrite
+the placeholder sections in the existing `YYYY-MM-DD-auto-retro.md` and remove the UNFILLED
+banner.
+
+### Phase 5: Persist and Close
+
+Persist learnings to memory and evaluate the retrospective itself.
+
+- Persist learnings with atomicity at or above 70 percent to Serena memory (ADR-037). Search
+  for existing patterns before creating new entries to avoid duplicates: see
+  [diagnosis-and-actions.md, Memory Protocol](references/diagnosis-and-actions.md#memory-protocol).
+- Close with **+/Delta**, **ROTI**, and **Helped, Hindered, Hypothesis**: see
+  [frameworks.md, Closing Activities](references/frameworks.md#closing-activities).
+- Route any P0 or P1 delta item to a GitHub issue through the `github` skill; store P2 and P3
+  items in backlog memory.
+
+---
+
+## Success Criteria
+
+Before the retrospective is complete, confirm:
+
+- [ ] One Markdown file exists at `.agents/retrospective/YYYY-MM-DD-[scope].md` (or the
+  existing auto-retro skeleton was filled and its UNFILLED banner removed).
+- [ ] The artifact structure matches the
+  [Learning Extraction Template](references/learning-template.md) byte-for-byte, with
+  placeholders filled.
+- [ ] Every extracted learning carries an atomicity score and an evidence reference.
+- [ ] Learnings at or above 70 percent atomicity are persisted to Serena memory, or the
+  memory write failure is noted in the artifact.
+
+---
+
+## Boundaries
+
+- This skill reads evidence and writes one artifact plus memory entries. It does not open PRs
+  itself; it routes delta items to the `github` skill.
+- Memory and GitHub are integration points. A failed memory call degrades to a documented
+  fallback (write the artifact, note the memory write failed), never a silent context loss.
+- Keep entry points thin. The Stop hook and `/retro fill` parse inputs and call this skill;
+  they do not re-implement the workflow.
+
+---
+
+## References
+
+- [frameworks.md](references/frameworks.md): Phase 0, 1, and closing activity rubrics
+  (4-Step Debrief, Execution Trace, Outcome Classification, Five Whys, Fishbone, Force Field,
+  Patterns and Shifts, Learning Matrix, +/Delta, ROTI, Helped/Hindered/Hypothesis).
+- [diagnosis-and-actions.md](references/diagnosis-and-actions.md): Phase 2, 3, 4, and 5
+  rubrics (diagnosis priority and traceability, root-cause patterns, action classification,
+  SMART validation, atomicity scoring, evidence-based tagging, memory protocol).
+- [learning-template.md](references/learning-template.md): the byte-exact Learning Extraction
+  Template that the output artifact must match.
+- `.claude/agents/retrospective.md`: the source agent body these references were lifted from
+  (canonical source for the rubrics; retired once the skill ships).

--- a/.claude/skills/retrospective/references/diagnosis-and-actions.md
+++ b/.claude/skills/retrospective/references/diagnosis-and-actions.md
@@ -1,0 +1,360 @@
+# Diagnosis, Actions, and Persistence
+
+Phase 2 (Diagnosis), Phase 3 (Decide What to Do), Phase 4 (Atomicity Scoring and tagging),
+Root Cause Pattern Management, and the Memory Protocol. The rubrics below are lifted verbatim
+from the canonical source agent body at `.claude/agents/retrospective.md` (the original
+Phase 2, Phase 3, Phase 4, "Root Cause Pattern Management", and "Memory Protocol" sections).
+Keep them byte-for-byte; the SKILL.md orchestration links to the headings here.
+
+---
+
+## Diagnosis
+
+Prioritize findings for action.
+
+### Diagnostic Priority Order
+
+1. **Critical Error Patterns** - Failures that blocked progress
+2. **Success Analysis** - Strategies that contributed to outcomes
+3. **Near Misses** - Things that almost failed but recovered
+4. **Efficiency Opportunities** - Ways to do same thing better
+5. **Skill Gaps** - Missing capabilities identified
+6. **Traceability Health** - Spec layer coherence metrics
+
+### Traceability Metrics
+
+When the session involves specification artifacts (requirements, designs, tasks), evaluate spec layer health:
+
+**Run validation:**
+
+```powershell
+pwsh scripts/Validate-Traceability.ps1 
+```
+
+**Metrics to capture:**
+
+| Metric | Description | Target |
+|--------|-------------|--------|
+| Valid Chains | Complete REQ -> DESIGN -> TASK traces | 100% of designs |
+| Orphaned REQs | Requirements with no implementing design | 0 |
+| Orphaned Designs | Designs with no implementing tasks | 0 |
+| Broken References | References to non-existent specs | 0 |
+| Untraced Tasks | Tasks without design reference | 0 |
+
+**Template:**
+
+````markdown
+## Traceability Health
+
+### Current State
+
+| Metric | Count | Status |
+|--------|-------|--------|
+| Requirements | [N] | - |
+| Designs | [N] | - |
+| Tasks | [N] | - |
+| Valid Chains | [N] | [PASS/WARN/FAIL] |
+| Errors | [N] | [PASS/FAIL] |
+| Warnings | [N] | [PASS/WARN] |
+
+### Issues Found
+
+#### Errors (Blocking)
+- [List broken references, untraced tasks]
+
+#### Warnings (Non-Blocking)
+- [List orphaned specs]
+
+### Remediation Actions
+
+| Issue | Fix | Owner |
+|-------|-----|-------|
+| [Issue] | [Action] | [spec-generator/milestone-planner] |
+````
+
+**Integration with Learning Extraction:**
+
+Traceability failures are skill gaps. Extract learnings:
+
+- If broken reference: "Verify spec IDs exist before adding to related field"
+- If orphaned REQ: "Create design specs when requirements are approved"
+- If untraced task: "Add related field to task front matter during creation"
+
+### Diagnosis Template
+
+````markdown
+## Diagnostic Analysis
+
+### Outcome
+[Success | Partial Success | Failure]
+
+### What Happened
+[Concrete description of actual execution]
+
+### Root Cause Analysis
+- **If Success**: What strategies contributed?
+- **If Failure**: Where exactly did it fail? Why?
+
+### Evidence
+[Specific tools, steps, error messages, metrics]
+
+### Priority Classification
+| Finding | Priority | Category | Evidence |
+|---------|----------|----------|----------|
+| [Finding] | P0/P1/P2 | [Critical/Success/NearMiss/Efficiency/Gap] | [Ref] |
+````
+
+---
+
+## Activity: Action Classification
+
+Adapted from Keep/Drop/Add. Categorize what to do with findings.
+
+| Category | Agent Action | Criteria |
+|----------|--------------|----------|
+| **Keep** | TAG as helpful, increase validation count | Worked, should continue |
+| **Drop** | REMOVE or TAG as harmful | Failed, should stop |
+| **Add** | ADD new skill | Novel learning, no existing pattern |
+| **Modify** | UPDATE existing skill | Refinement to existing pattern |
+
+**Template:**
+
+````markdown
+## Action Classification
+
+### Keep (TAG as helpful)
+| Finding | Skill ID | Validation Count |
+|---------|----------|------------------|
+| [Finding] | [Skill-XXX] | [N+1] |
+
+### Drop (REMOVE or TAG as harmful)
+| Finding | Skill ID | Reason |
+|---------|----------|--------|
+| [Finding] | [Skill-XXX] | [Why removing] |
+
+### Add (New skill)
+| Finding | Proposed Skill ID | Statement |
+|---------|-------------------|-----------|
+| [Finding] | [Skill-Category-NNN] | [Atomic statement] |
+
+### Modify (UPDATE existing)
+| Finding | Skill ID | Current | Proposed |
+|---------|----------|---------|----------|
+| [Finding] | [Skill-XXX] | [Current text] | [New text] |
+````
+
+## Activity: SMART Validation
+
+Validate every learning before storage. Reinforces atomicity.
+
+| Criterion | Skill Requirement | Check |
+|-----------|-------------------|-------|
+| **Specific** | One atomic concept, no compound statements | No "and", "also" |
+| **Measurable** | Has evidence, can be validated | Has execution reference |
+| **Attainable** | Within agent capability | Technically feasible |
+| **Relevant** | Applies to actual execution scenarios | Has trigger condition |
+| **Timely** | Clear when to apply | Has context/timing |
+
+**Validation Template:**
+
+````markdown
+## SMART Validation
+
+### Proposed Skill
+**Statement:** [The skill text]
+
+### Validation
+| Criterion | Pass? | Evidence |
+|-----------|-------|----------|
+| Specific | Y/N | [One concept or multiple?] |
+| Measurable | Y/N | [Can we verify it worked?] |
+| Attainable | Y/N | [Is this technically possible?] |
+| Relevant | Y/N | [Does it apply to real scenarios?] |
+| Timely | Y/N | [Is trigger condition clear?] |
+
+### Result
+- [ ] All criteria pass: Accept skill
+- [ ] Some criteria fail: Refine skill
+- [ ] Multiple criteria fail: Reject skill
+````
+
+## Dependency Ordering
+
+Order actions based on dependencies.
+
+**Template:**
+
+````markdown
+## Action Sequence
+
+| Order | Action | Depends On | Blocks |
+|-------|--------|------------|--------|
+| 1 | [First action] | None | [Actions 2, 3] |
+| 2 | [Second action] | [Action 1] | [Action 4] |
+| 3 | [Third action] | [Action 1] | None |
+````
+
+---
+
+## Atomicity Scoring
+
+All learnings scored 0-100%.
+
+| Factor | Adjustment |
+|--------|------------|
+| Compound statements ("and", "also") | -15% each |
+| Vague terms ("generally", "sometimes") | -20% each |
+| Length > 15 words | -5% per extra word |
+| Missing metrics/evidence | -25% |
+| No actionable guidance | -30% |
+
+### Quality Thresholds
+
+| Score | Quality | Action |
+|-------|---------|--------|
+| 95-100% | Excellent | Add to skillbook |
+| 70-94% | Good | Add with refinement |
+| 40-69% | Needs Work | Refine before adding |
+| <40% | Rejected | Too vague |
+
+### Examples
+
+**Bad (35%)**: "The caching strategy was effective"
+
+- Vague "effective" (-20%)
+- No specifics (-25%)
+- Not actionable (-30%)
+
+**Good (92%)**: "Redis cache with 5-min TTL reduced API calls by 73% for user profiles"
+
+- Specific tool (Redis)
+- Exact config (5-min TTL)
+- Measurable outcome (73%)
+- Clear context (user profiles)
+
+### Evidence-Based Tagging
+
+| Tag | Meaning | Evidence Required |
+|-----|---------|-------------------|
+| **helpful** | Contributed to success | Specific positive execution |
+| **harmful** | Caused failure | Specific negative execution |
+| **neutral** | No measurable impact | Use without effect |
+
+---
+
+## Root Cause Pattern Management
+
+After Five Whys analysis identifies root causes, systematically store patterns for future prevention.
+
+### Root Cause Categories
+
+Standard categories based on common failure modes:
+
+| Category | Description | Examples |
+|----------|-------------|----------|
+| **Cross-Cutting Concerns** | Issues affecting multiple components | Missing input validation, inconsistent error handling |
+| **Fail-Safe Design** | Missing defensive patterns | No fallbacks, unhandled edge cases |
+| **Test-Implementation Drift** | Tests don't match actual behavior | Mocks diverge from reality, stale fixtures |
+| **Premature Validation** | Validating before data is complete | Checking state too early, race conditions |
+| **Context Loss** | Information not preserved | Missing handoff data, dropped session state |
+| **Skill Gap** | Missing capability | No existing pattern for scenario |
+
+### Memory Storage Pattern
+
+Store root cause entities for future pattern matching:
+
+**Create root cause memory:**
+
+```text
+mcp__serena__write_memory
+memory_file_name: "rootcause-{category}-{nnn}"
+content: "# Root Cause: {Category} #{NNN}\n\n**Description**: [What failed and why]\n**Frequency**: [How often this occurs]\n**Impact**: [Severity when it occurs]\n**Detection**: [How to identify this pattern]\n**Prevention**: [How to avoid it]\n**Source**: [PR/Issue/Session reference]\n\n## Related\n- Prevention skill: [skill-file-name]\n- Incident: [incident-ref]\n- Category: [category-name]"
+```
+
+### Failure Prevention Matrix
+
+Maintain cumulative statistics across sessions:
+
+````markdown
+## Failure Prevention Matrix
+
+| Root Cause Category | Incidents | Prevention Skills | Last Occurrence | Trend |
+|---------------------|-----------|-------------------|-----------------|-------|
+| Cross-Cutting Concerns | [N] | Skill-Val-001, Skill-Val-002 | [PR/Session ref] | [Up/Down/Stable] |
+| Fail-Safe Design | [N] | Skill-Safe-001 | [PR/Session ref] | [Up/Down/Stable] |
+| Test-Implementation Drift | [N] | Skill-Test-001 | [PR/Session ref] | [Up/Down/Stable] |
+| Premature Validation | [N] | Skill-Val-003 | [PR/Session ref] | [Up/Down/Stable] |
+| Context Loss | [N] | Skill-Ctx-001 | [PR/Session ref] | [Up/Down/Stable] |
+| Skill Gap | [N] | [New skills added] | [PR/Session ref] | [Up/Down/Stable] |
+````
+
+### Root Cause Pattern Template
+
+Add to retrospective artifact when Five Whys identifies root cause:
+
+````markdown
+## Root Cause Pattern
+
+**Pattern ID**: RootCause-{Category}-{NNN}
+**Category**: [Cross-Cutting | Fail-Safe | Test-Implementation Drift | Premature | Context | Skill-Gap]
+
+### Description
+[What failed and why - from Five Whys analysis]
+
+### Detection Signals
+- [Signal 1]: How to recognize this pattern early
+- [Signal 2]: Warning signs before failure
+
+### Prevention Skill
+**Skill ID**: Skill-{Category}-{NNN}
+**Statement**: [Atomic prevention strategy]
+**Application**: [When and how to apply]
+
+### Evidence
+- **Incident**: [PR/Issue/Session reference]
+- **Root Cause Path**: [Five Whys chain summary]
+- **Resolution**: [What fixed it]
+
+### Relations
+- **Prevents by**: [Prevention skill ID]
+- **Similar to**: [Related root cause patterns]
+- **Supersedes**: [Older patterns this replaces]
+````
+
+---
+
+## Memory Protocol
+
+Use Memory Router for search and Serena tools for persistence (ADR-037):
+
+**Search for existing patterns (before creating new):**
+
+```bash
+uv run python .claude/skills/memory/scripts/search_memory.py --query "{domain} {description} skill patterns"
+```
+
+**Create new skills:**
+
+```text
+mcp__serena__write_memory
+memory_file_name: "{domain}-{description}"
+content: "# Skill: {Description}\n\n**Statement**: [Skill statement with context and evidence]\n\n**Evidence**: [Source reference]\n\n## Details\n\n..."
+```
+
+**Update existing skills (add observations):**
+
+```text
+mcp__serena__edit_memory
+memory_file_name: "[skill-file-name]"
+content: "[Updated content with new observation appended]"
+```
+
+> **Fallback**: If Memory Router unavailable, read `.serena/memories/` directly with Read tool.
+
+**Deduplication Query:**
+
+```bash
+uv run python .claude/skills/memory/scripts/search_memory.py --query "rootcause {Category} {Keywords from description}"
+```
+
+If similar pattern exists (>70% similarity), UPDATE existing entity instead of creating new one.

--- a/.claude/skills/retrospective/references/frameworks.md
+++ b/.claude/skills/retrospective/references/frameworks.md
@@ -1,0 +1,484 @@
+# Retrospective Frameworks
+
+Phase 0 (Data Gathering), Phase 1 (Generate Insights), and the closing activities. The
+rubrics below are lifted verbatim from the canonical source agent body at
+`.claude/agents/retrospective.md` (the original Phase 0, Phase 1, and Phase 6 sections).
+Keep them byte-for-byte; the SKILL.md orchestration links to the activity headings here.
+
+---
+
+## Phase 0: Data Gathering
+
+Gather facts before interpretation. Observation precedes diagnosis.
+
+### Activity: 4-Step Debrief
+
+Separate observation from interpretation.
+
+| Step | Human Version | Agent Version | Output |
+|------|---------------|---------------|--------|
+| 1. Observe | "What did you see and hear?" | What tools called, outputs produced, errors occurred | Facts only |
+| 2. Respond | "What surprised you? Where were you challenged?" | Where did agents pivot, retry, escalate, or block? | Reactions |
+| 3. Analyze | "What insight do you have?" | What patterns emerge about agent behavior? | Interpretations |
+| 4. Apply | "What would you do differently?" | What skill updates or process changes follow? | Actions |
+
+**Template:**
+
+````markdown
+## 4-Step Debrief
+
+### Step 1: Observe (Facts Only)
+- Tool calls: [List with timestamps]
+- Outputs: [What was produced]
+- Errors: [What failed]
+- Duration: [Time spent]
+
+### Step 2: Respond (Reactions)
+- Pivots: [Where did flow change?]
+- Retries: [What was attempted multiple times?]
+- Escalations: [What required human input?]
+- Blocks: [What stopped progress?]
+
+### Step 3: Analyze (Interpretations)
+- Patterns: [What recurring behaviors?]
+- Anomalies: [What was unexpected?]
+- Correlations: [What happened together?]
+
+### Step 4: Apply (Actions)
+- Skills to update: [List]
+- Process changes: [List]
+- Context to preserve: [List]
+````
+
+### Activity: Execution Trace Analysis
+
+Adapted from Timeline activity. Create a chronological picture of agent execution.
+
+**Purpose:** See the full sequence. Identify where things stalled, accelerated, or went wrong.
+
+**Steps:**
+
+1. Extract execution sequence from logs, tool calls, and outputs
+2. Arrange events chronologically
+3. Mark significant events: starts, completions, failures, pivots
+4. Annotate with energy indicators (high activity, stalled, blocked)
+5. Look for patterns across the timeline
+
+**Template:**
+
+````markdown
+## Execution Trace
+
+| Time | Agent | Action | Outcome | Energy |
+|------|-------|--------|---------|--------|
+| T+0 | orchestrator | Route to analyst | Success | High |
+| T+1 | analyst | Research API | Success | High |
+| T+2 | analyst | Search memory | Empty result | Medium |
+| T+3 | analyst | Retry with broader query | Success | Medium |
+| ... | ... | ... | ... | ... |
+
+### Timeline Patterns
+- [Pattern 1]: [Description]
+- [Pattern 2]: [Description]
+
+### Energy Shifts
+- High to Low at: [Point] - Reason: [Why]
+- Stall points: [List]
+````
+
+### Activity: Outcome Classification
+
+Adapted from Mad Sad Glad. Classify execution outcomes by emotional valence.
+
+| Category | Agent Meaning | Examples |
+|----------|---------------|----------|
+| **Mad (Blocked)** | Failures that stopped progress | Errors, timeouts, missing dependencies |
+| **Sad (Suboptimal)** | Worked but poorly | Slow, inefficient, required retries |
+| **Glad (Success)** | Worked as intended | Clean execution, good outcomes |
+
+**Template:**
+
+````markdown
+## Outcome Classification
+
+### Mad (Blocked/Failed)
+- [Event]: [Why it blocked progress]
+
+### Sad (Suboptimal)
+- [Event]: [Why it was inefficient]
+
+### Glad (Success)
+- [Event]: [What made it work well]
+
+### Distribution
+- Mad: [N] events
+- Sad: [N] events
+- Glad: [N] events
+- Success Rate: [%]
+````
+
+---
+
+## Phase 1: Generate Insights
+
+Make meaning from data. Look past symptoms to find causes.
+
+### Activity: Five Whys
+
+Mandatory for all failures. Ask "Why?" until you reach root cause.
+
+**Purpose:** Discover underlying conditions that contribute to an issue.
+
+**Process:**
+
+1. State the problem
+2. Ask "Why did this happen?"
+3. For each answer, ask "Why?" again
+4. Repeat until you reach something outside agent control or a fixable root cause
+5. Stop at 5 levels or when cause is actionable
+
+**Template:**
+
+````markdown
+## Five Whys Analysis
+
+**Problem:** [Statement of what went wrong]
+
+**Q1:** Why did [problem] occur?
+**A1:** [Answer]
+
+**Q2:** Why did [A1] happen?
+**A2:** [Answer]
+
+**Q3:** Why did [A2] happen?
+**A3:** [Answer]
+
+**Q4:** Why did [A3] happen?
+**A4:** [Answer]
+
+**Q5:** Why did [A4] happen?
+**A5:** [Answer]
+
+**Root Cause:** [The actual underlying issue]
+**Actionable Fix:** [What can be changed]
+````
+
+**Example:**
+
+````markdown
+**Problem:** Implementer produced code that failed tests
+
+**Q1:** Why did the code fail tests?
+**A1:** The method signature didn't match the interface
+
+**Q2:** Why didn't the signature match?
+**A2:** Implementer didn't read the interface definition
+
+**Q3:** Why didn't implementer read the interface?
+**A3:** The plan didn't specify which interface to implement
+
+**Q4:** Why didn't the plan specify?
+**A4:** Analyst didn't identify the interface in research
+
+**Q5:** Why didn't analyst identify it?
+**A5:** Search query was too narrow
+
+**Root Cause:** Insufficient research scope
+**Actionable Fix:** Add interface discovery to analyst checklist
+````
+
+### Activity: Fishbone Analysis
+
+Use for complex failures with multiple contributing factors.
+
+**Purpose:** Look past symptoms to identify root causes across categories.
+
+**Agent-Specific Categories:**
+
+| Category | What It Covers |
+|----------|----------------|
+| **Prompt** | Instructions, context, framing, ambiguity |
+| **Tools** | Tool selection, tool usage, tool failures |
+| **Context** | Missing information, stale context, memory gaps |
+| **Dependencies** | External services, APIs, file system state |
+| **Sequence** | Agent routing, handoff issues, ordering problems |
+| **State** | Accumulated errors, drift, context pollution |
+
+**Template:**
+
+````markdown
+## Fishbone Analysis
+
+**Problem:** [Head of fish - the issue being analyzed]
+
+### Category: Prompt
+- [Contributing factor]
+- [Contributing factor]
+
+### Category: Tools
+- [Contributing factor]
+
+### Category: Context
+- [Contributing factor]
+
+### Category: Dependencies
+- [Contributing factor]
+
+### Category: Sequence
+- [Contributing factor]
+
+### Category: State
+- [Contributing factor]
+
+### Cross-Category Patterns
+Items appearing in multiple categories (likely root causes):
+- [Pattern]: Appears in [Category A] and [Category B]
+
+### Controllable vs Uncontrollable
+| Factor | Controllable? | Action |
+|--------|---------------|--------|
+| [Factor] | Yes | [Fix] |
+| [Factor] | No | [Mitigate] |
+````
+
+### Activity: Force Field Analysis
+
+Use when a pattern keeps recurring despite "knowing better."
+
+**Purpose:** Identify what drives change and what restrains it.
+
+**Template:**
+
+````markdown
+## Force Field Analysis
+
+**Desired State:** [What we want to achieve]
+**Current State:** [What happens now]
+
+### Driving Forces (Supporting Change)
+| Factor | Strength (1-5) | How to Strengthen |
+|--------|----------------|-------------------|
+| [Factor] | [N] | [Action] |
+
+### Restraining Forces (Blocking Change)
+| Factor | Strength (1-5) | How to Reduce |
+|--------|----------------|---------------|
+| [Factor] | [N] | [Action] |
+
+### Force Balance
+- Total Driving: [Sum]
+- Total Restraining: [Sum]
+- Net: [Driving - Restraining]
+
+### Recommended Strategy
+- [ ] Strengthen: [Driving factor]
+- [ ] Reduce: [Restraining factor]
+- [ ] Accept: [Factor outside control]
+````
+
+### Activity: Patterns and Shifts
+
+Use for multi-session or multi-execution analysis. Look for trends.
+
+**Purpose:** Find connections between facts and feelings across executions.
+
+**Template:**
+
+````markdown
+## Patterns and Shifts
+
+### Recurring Patterns
+| Pattern | Frequency | Impact | Category |
+|---------|-----------|--------|----------|
+| [Pattern] | [N times] | [H/M/L] | [Success/Failure/Efficiency] |
+
+### Shifts Detected
+| Shift | When | Before | After | Cause |
+|-------|------|--------|-------|-------|
+| [Shift name] | [Session/Time] | [Previous state] | [New state] | [Why] |
+
+### Pattern Questions
+- How do these patterns contribute to current issues?
+- What do these shifts tell us about trajectory?
+- Which patterns should we reinforce?
+- Which patterns should we break?
+````
+
+### Activity: Learning Matrix
+
+Quick categorization of insights. Use when short on time.
+
+**Categories:**
+
+| Quadrant | Icon | Question |
+|----------|------|----------|
+| Top-Left | :) | What did we do well that we want to continue? |
+| Top-Right | :( | What would we like to change? |
+| Bottom-Left | Idea | What new ideas have come up? |
+| Bottom-Right | Invest | What improvements should we invest in? |
+
+**Template:**
+
+````markdown
+## Learning Matrix
+
+### :) Continue (What worked)
+- [Item]
+
+### :( Change (What didn't work)
+- [Item]
+
+### Idea (New approaches)
+- [Item]
+
+### Invest (Long-term improvements)
+- [Item]
+
+### Priority Items
+Top items from each quadrant:
+1. [Item from Continue to reinforce]
+2. [Item from Change to fix]
+3. [Item from Ideas to try]
+````
+
+---
+
+## Closing Activities
+
+Evaluate the retrospective itself. Continuous improvement.
+
+### Activity: +/Delta
+
+Quick self-assessment of the retrospective process.
+
+| Category | Questions |
+|----------|-----------|
+| **+ (Keep)** | What worked in this analysis? What activities produced useful insights? |
+| **Delta (Change)** | What took too long? What activities yielded nothing? What should be skipped? |
+
+**Template:**
+
+````markdown
+## +/Delta
+
+### + Keep
+- [What worked well in this retrospective]
+
+### Delta Change
+- [What should be different next time]
+
+### Backlog Candidates
+| Delta Item | Priority | Action |
+|------------|----------|--------|
+| [Item] | P0/P1/P2/P3 | Issue/Memory/Skip |
+````
+
+### Activity: Delta Triage
+
+Process Delta items to capture actionable improvements. Delta items represent change requests that should not be forgotten.
+
+**Actionable Delta Categories:**
+
+| Category | Description | Examples |
+|----------|-------------|----------|
+| **Missing Documentation** | Gaps in guides, READMEs, or inline comments | "Agent didn't know about X script" |
+| **Tool/Script Awareness** | Existing tools that agents fail to discover | "Should have used Y instead of Z" |
+| **Process Improvements** | Workflow or protocol changes | "Need earlier validation step" |
+| **Feature Requests** | New capabilities needed | "Add automated X detection" |
+
+**Triage Protocol:**
+
+1. **Review each Delta item** from the +/Delta output
+2. **Classify as actionable** if it matches a category above
+3. **Assign priority** based on impact and frequency:
+   - **P0**: Blocks core functionality, recurring failures
+   - **P1**: Significant impact, affects multiple sessions
+   - **P2**: Normal improvement, would help efficiency
+   - **P3**: Nice-to-have, low frequency
+4. **Route to destination**:
+   - **P0/P1**: Create GitHub issue immediately (use the `github` skill)
+   - **P2/P3**: Store in backlog memory for future triage
+   - **Skip**: Not actionable or duplicate of existing item
+
+**Delta Triage Template:**
+
+````markdown
+## Delta Triage
+
+### Actionable Items Identified
+
+| Delta Item | Category | Priority | Destination | Reference |
+|------------|----------|----------|-------------|-----------|
+| [Item from Delta] | [Missing Docs/Tool Gap/Process/Feature] | P0/P1/P2/P3 | Issue #N / Memory / Skip | [Link] |
+
+### Issues Created
+
+| Issue | Title | Priority | Labels |
+|-------|-------|----------|--------|
+| #[N] | [Title] | P0/P1 | enhancement, source:retrospective |
+
+### Backlog Items Stored
+
+| Item | Priority | Memory File |
+|------|----------|-------------|
+| [Item] | P2/P3 | backlog/retro-YYYY-MM-DD-items.md |
+
+### Skipped Items
+
+| Item | Reason |
+|------|--------|
+| [Item] | [Duplicate of #X / Not actionable / Already addressed] |
+````
+
+### Activity: ROTI (Return on Time Invested)
+
+Measure if retrospective was worth the effort.
+
+| Score | Meaning | Action |
+|-------|---------|--------|
+| 0 | No benefit, wasted cycles | Stop this retrospective pattern |
+| 1 | Break-even | Continue with modifications |
+| 2 | Benefit > effort | Keep pattern |
+| 3 | High return | Document as best practice |
+| 4 | Exceptional | Extract into reusable template |
+
+**Template:**
+
+````markdown
+## ROTI Assessment
+
+**Score**: [0-4]
+
+**Benefits Received**:
+- [Benefit 1]
+- [Benefit 2]
+
+**Time Invested**: [Duration]
+
+**Verdict**: [Continue | Modify | Stop]
+````
+
+### Activity: Helped, Hindered, Hypothesis
+
+Meta-learning about the retrospective process.
+
+| Category | Questions |
+|----------|-----------|
+| **Helped** | What data, tools, or context made analysis easier? |
+| **Hindered** | What was missing, broken, or unclear? |
+| **Hypothesis** | What should be tried next time to improve? |
+
+**Template:**
+
+````markdown
+## Helped, Hindered, Hypothesis
+
+### Helped
+- [What made this retrospective effective]
+
+### Hindered
+- [What got in the way]
+
+### Hypothesis
+- [Experiment to try next retrospective]
+````

--- a/.claude/skills/retrospective/references/learning-template.md
+++ b/.claude/skills/retrospective/references/learning-template.md
@@ -1,0 +1,100 @@
+# Learning Extraction Template
+
+The byte-exact retrospective artifact structure. Lifted verbatim from the canonical source
+agent body at `.claude/agents/retrospective.md` (Phase 4, "Learning Extraction Template",
+original lines 696-789). The output artifact MUST match this template, modulo filled
+placeholders. Do not reword the headings or table columns; downstream readers and the
+auto-retro skeleton-fill path depend on the exact shape.
+
+Save to: `.agents/retrospective/YYYY-MM-DD-[scope].md`
+
+````markdown
+# Retrospective: [Scope]
+
+## Session Info
+- **Date**: YYYY-MM-DD
+- **Agents**: [List]
+- **Task Type**: [Feature | Bug | Research]
+- **Outcome**: [Success | Partial | Failure]
+
+## Phase 0: Data Gathering
+[4-Step Debrief output]
+[Execution Trace output]
+[Outcome Classification output]
+
+## Phase 1: Insights Generated
+[Five Whys output if failure]
+[Fishbone output if complex]
+[Patterns and Shifts output]
+[Learning Matrix output]
+
+## Phase 2: Diagnosis
+
+### Successes (Tag: helpful)
+| Strategy | Evidence | Impact | Atomicity |
+|----------|----------|--------|-----------|
+| [Strategy] | [Outcome] | [1-10] | [%] |
+
+### Failures (Tag: harmful)
+| Strategy | Error Type | Root Cause | Prevention | Atomicity |
+|----------|------------|------------|------------|-----------|
+| [Strategy] | [Type] | [Cause] | [Fix] | [%] |
+
+### Near Misses
+| What Almost Failed | Recovery | Learning |
+|--------------------|----------|----------|
+| [Situation] | [Save] | [Takeaway] |
+
+## Phase 3: Decisions
+
+### Action Classification
+[Keep/Drop/Add/Modify table]
+
+### SMART Validation
+[Validation for each new skill]
+
+### Action Sequence
+[Ordered actions with dependencies]
+
+## Phase 4: Extracted Learnings
+
+### Learning 1
+- **Statement**: [Atomic - max 15 words]
+- **Atomicity Score**: [%]
+- **Evidence**: [Execution detail]
+- **Skill Operation**: ADD | UPDATE | TAG | REMOVE
+- **Target Skill ID**: [If UPDATE/TAG/REMOVE]
+
+## Skillbook Updates
+
+### ADD
+```json
+{
+  "skill_id": "{domain}-{description}",
+  "statement": "[Atomic]",
+  "context": "[When to apply]",
+  "evidence": "[Source]",
+  "atomicity": [%]
+}
+```
+
+### UPDATE
+
+| Skill ID | Current | Proposed | Why |
+|----------|---------|----------|-----|
+
+### TAG
+
+| Skill ID | Tag | Evidence | Impact |
+|----------|-----|----------|--------|
+
+### REMOVE
+
+| Skill ID | Reason | Evidence |
+|----------|--------|----------|
+
+## Deduplication Check
+
+| New Skill | Most Similar | Similarity | Decision |
+|-----------|--------------|------------|----------|
+````

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "25 agent definitions, 81 reusable skills, 52 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "25 agent definitions, 81 reusable skills, 52 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/retrospective/SKILL.md
+++ b/src/copilot-cli/skills/retrospective/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: retrospective
+version: 0.1.0
+model: claude-sonnet-4-6
+description: Extract learnings from a session or task through structured retrospective frameworks. Gathers evidence, runs Five Whys and fishbone diagnosis, scores atomicity, and writes a canonical retrospective artifact. Use to turn execution experience into institutional knowledge. Do NOT use for in-conversation correction capture (use the reflect skill).
+license: MIT
+metadata:
+  domains: [retrospective, learning-extraction, root-cause-analysis, continuous-improvement]
+  type: workflow
+  inputs: [scope-description, session-log, git-history]
+  outputs: [retrospective-markdown-file]
+  adr: ADR-008, ADR-017, ADR-037
+---
+
+# Retrospective
+
+Turn execution experience into institutional knowledge. This skill orchestrates a fixed
+Phase 0 through Phase 5 workflow that gathers evidence, generates insights, diagnoses root
+causes, decides actions, scores atomicity, and persists learnings. The long-form rubrics
+live verbatim in `references/`; this file is the orchestration contract.
+
+This skill replaces the former `retrospective` agent (`.claude/agents/retrospective.md`).
+Lifecycle hooks can invoke a skill but not an agent, so the retrospective workflow moves
+here to be callable from `Skill("retrospective")`, from `/retro fill <date>` (Issue #2079),
+and from the Stop-hook auto-retrospective path
+(`.claude/hooks/Stop/invoke_auto_retrospective.py`).
+
+## Triggers
+
+| Trigger Phrase | Operation |
+|----------------|-----------|
+| `run a retrospective` | Full Phase 0..5 workflow over the given scope |
+| `retro fill` | Fill an unfilled auto-retro skeleton for a date |
+| `extract learnings from this session` | Phase 0..4 over the current session |
+| `diagnose this failure` | Phase 0..2 root-cause analysis, then stop |
+| `what did we learn` | Phase 4 atomicity-scored learning extraction |
+
+---
+
+## When to Use
+
+| Situation | Use This Skill? |
+|-----------|-----------------|
+| Session ended with meaningful work and you want learnings persisted | Yes |
+| An unfilled auto-retro skeleton exists in `.agents/retrospective/` | Yes (fill it) |
+| Diagnosing why a task failed (Five Whys, fishbone) | Yes |
+| Capturing a single in-conversation correction ("no", "wrong") | No, use `reflect` |
+| Saving a quick checkpoint with no analysis | No, use `session-end` |
+
+The output artifact is a Markdown file. The Learning Extraction Template in
+`references/learning-template.md` defines the exact structure. Save to
+`.agents/retrospective/YYYY-MM-DD-[scope].md`. When filling an auto-retro skeleton, write
+to the existing `YYYY-MM-DD-auto-retro.md` file produced by the Stop hook.
+
+---
+
+## Inputs
+
+| Input | Source | Required |
+|-------|--------|----------|
+| Scope | User argument (session, task, date, PR) | Yes |
+| Session log | `.agents/sessions/` most recent for the period | When available |
+| Git history | `git log` over the period | When available |
+| GitHub activity | PRs and issues for the period (via the `github` skill) | Optional enrichment |
+
+Treat the session log as the system of record for what happened. Git history and GitHub
+activity are derived evidence that corroborate or extend it. When a source is unavailable,
+degrade gracefully: produce the artifact from the evidence you have and mark the missing
+sections, never substitute invented data.
+
+---
+
+## Process
+
+The workflow is six sequential phases. Phase 0 gathers facts. Phases 1 and 2 interpret them.
+Phase 3 decides actions. Phase 4 extracts and scores learnings. Phase 5 persists them. Each
+phase links to the rubric and template it uses. Run them in order; do not interpret before
+you observe.
+
+### Phase 0: Data Gathering
+
+Gather facts before interpretation. Observation precedes diagnosis.
+
+- Run the **4-Step Debrief** (Observe, Respond, Analyze, Apply): see
+  [frameworks.md, 4-Step Debrief](references/frameworks.md#activity-4-step-debrief).
+- Build the **Execution Trace** chronology: see
+  [frameworks.md, Execution Trace Analysis](references/frameworks.md#activity-execution-trace-analysis).
+- Run **Outcome Classification** (Mad, Sad, Glad): see
+  [frameworks.md, Outcome Classification](references/frameworks.md#activity-outcome-classification).
+
+Evidence sources: the most recent session log under `.agents/sessions/`, `git log` for the
+period, and optional GitHub activity through the `github` skill. Do not use raw `gh`.
+
+### Phase 1: Generate Insights
+
+Make meaning from data. Look past symptoms to find causes.
+
+- **Five Whys** is mandatory for every failure: see
+  [frameworks.md, Five Whys](references/frameworks.md#activity-five-whys).
+- **Fishbone Analysis** for complex failures with multiple contributing factors: see
+  [frameworks.md, Fishbone Analysis](references/frameworks.md#activity-fishbone-analysis).
+- **Force Field Analysis** when a pattern recurs despite knowing better: see
+  [frameworks.md, Force Field Analysis](references/frameworks.md#activity-force-field-analysis).
+- **Patterns and Shifts** for multi-session trends: see
+  [frameworks.md, Patterns and Shifts](references/frameworks.md#activity-patterns-and-shifts).
+- **Learning Matrix** for quick categorization when short on time: see
+  [frameworks.md, Learning Matrix](references/frameworks.md#activity-learning-matrix).
+
+### Phase 2: Diagnosis
+
+Prioritize findings for action. Diagnostic priority order: critical error patterns, success
+analysis, near misses, efficiency opportunities, skill gaps, traceability health. The full
+priority order, traceability metrics, and diagnosis template live in
+[diagnosis-and-actions.md, Diagnosis](references/diagnosis-and-actions.md#diagnosis).
+
+For each root cause that Five Whys surfaces, store a root-cause pattern for future
+prevention: see
+[diagnosis-and-actions.md, Root Cause Pattern Management](references/diagnosis-and-actions.md#root-cause-pattern-management).
+
+If the work touched diagnosis or action classification, stop here for the `diagnose this
+failure` trigger; otherwise continue to Phase 3.
+
+### Phase 3: Decide What to Do
+
+Move from insights to action.
+
+- **Action Classification** (Keep, Drop, Add, Modify): see
+  [diagnosis-and-actions.md, Action Classification](references/diagnosis-and-actions.md#activity-action-classification).
+- **SMART Validation** of every proposed learning before storage: see
+  [diagnosis-and-actions.md, SMART Validation](references/diagnosis-and-actions.md#activity-smart-validation).
+- **Dependency Ordering** of the resulting actions: see
+  [diagnosis-and-actions.md, Dependency Ordering](references/diagnosis-and-actions.md#dependency-ordering).
+
+### Phase 4: Learning Extraction
+
+Transform insights into stored knowledge. Score every learning 0 to 100 percent for
+atomicity and reject vague statements. The scoring rubric, quality thresholds, worked
+examples, and evidence-based tagging live in
+[diagnosis-and-actions.md, Atomicity Scoring](references/diagnosis-and-actions.md#atomicity-scoring).
+
+Assemble the artifact using the byte-exact
+[Learning Extraction Template](references/learning-template.md). Save to
+`.agents/retrospective/YYYY-MM-DD-[scope].md`. When filling an auto-retro skeleton, overwrite
+the placeholder sections in the existing `YYYY-MM-DD-auto-retro.md` and remove the UNFILLED
+banner.
+
+### Phase 5: Persist and Close
+
+Persist learnings to memory and evaluate the retrospective itself.
+
+- Persist learnings with atomicity at or above 70 percent to Serena memory (ADR-037). Search
+  for existing patterns before creating new entries to avoid duplicates: see
+  [diagnosis-and-actions.md, Memory Protocol](references/diagnosis-and-actions.md#memory-protocol).
+- Close with **+/Delta**, **ROTI**, and **Helped, Hindered, Hypothesis**: see
+  [frameworks.md, Closing Activities](references/frameworks.md#closing-activities).
+- Route any P0 or P1 delta item to a GitHub issue through the `github` skill; store P2 and P3
+  items in backlog memory.
+
+---
+
+## Success Criteria
+
+Before the retrospective is complete, confirm:
+
+- [ ] One Markdown file exists at `.agents/retrospective/YYYY-MM-DD-[scope].md` (or the
+  existing auto-retro skeleton was filled and its UNFILLED banner removed).
+- [ ] The artifact structure matches the
+  [Learning Extraction Template](references/learning-template.md) byte-for-byte, with
+  placeholders filled.
+- [ ] Every extracted learning carries an atomicity score and an evidence reference.
+- [ ] Learnings at or above 70 percent atomicity are persisted to Serena memory, or the
+  memory write failure is noted in the artifact.
+
+---
+
+## Boundaries
+
+- This skill reads evidence and writes one artifact plus memory entries. It does not open PRs
+  itself; it routes delta items to the `github` skill.
+- Memory and GitHub are integration points. A failed memory call degrades to a documented
+  fallback (write the artifact, note the memory write failed), never a silent context loss.
+- Keep entry points thin. The Stop hook and `/retro fill` parse inputs and call this skill;
+  they do not re-implement the workflow.
+
+---
+
+## References
+
+- [frameworks.md](references/frameworks.md): Phase 0, 1, and closing activity rubrics
+  (4-Step Debrief, Execution Trace, Outcome Classification, Five Whys, Fishbone, Force Field,
+  Patterns and Shifts, Learning Matrix, +/Delta, ROTI, Helped/Hindered/Hypothesis).
+- [diagnosis-and-actions.md](references/diagnosis-and-actions.md): Phase 2, 3, 4, and 5
+  rubrics (diagnosis priority and traceability, root-cause patterns, action classification,
+  SMART validation, atomicity scoring, evidence-based tagging, memory protocol).
+- [learning-template.md](references/learning-template.md): the byte-exact Learning Extraction
+  Template that the output artifact must match.
+- `.claude/agents/retrospective.md`: the source agent body these references were lifted from
+  (canonical source for the rubrics; retired once the skill ships).

--- a/src/copilot-cli/skills/retrospective/references/diagnosis-and-actions.md
+++ b/src/copilot-cli/skills/retrospective/references/diagnosis-and-actions.md
@@ -1,0 +1,360 @@
+# Diagnosis, Actions, and Persistence
+
+Phase 2 (Diagnosis), Phase 3 (Decide What to Do), Phase 4 (Atomicity Scoring and tagging),
+Root Cause Pattern Management, and the Memory Protocol. The rubrics below are lifted verbatim
+from the canonical source agent body at `.claude/agents/retrospective.md` (the original
+Phase 2, Phase 3, Phase 4, "Root Cause Pattern Management", and "Memory Protocol" sections).
+Keep them byte-for-byte; the SKILL.md orchestration links to the headings here.
+
+---
+
+## Diagnosis
+
+Prioritize findings for action.
+
+### Diagnostic Priority Order
+
+1. **Critical Error Patterns** - Failures that blocked progress
+2. **Success Analysis** - Strategies that contributed to outcomes
+3. **Near Misses** - Things that almost failed but recovered
+4. **Efficiency Opportunities** - Ways to do same thing better
+5. **Skill Gaps** - Missing capabilities identified
+6. **Traceability Health** - Spec layer coherence metrics
+
+### Traceability Metrics
+
+When the session involves specification artifacts (requirements, designs, tasks), evaluate spec layer health:
+
+**Run validation:**
+
+```powershell
+pwsh scripts/Validate-Traceability.ps1 
+```
+
+**Metrics to capture:**
+
+| Metric | Description | Target |
+|--------|-------------|--------|
+| Valid Chains | Complete REQ -> DESIGN -> TASK traces | 100% of designs |
+| Orphaned REQs | Requirements with no implementing design | 0 |
+| Orphaned Designs | Designs with no implementing tasks | 0 |
+| Broken References | References to non-existent specs | 0 |
+| Untraced Tasks | Tasks without design reference | 0 |
+
+**Template:**
+
+````markdown
+## Traceability Health
+
+### Current State
+
+| Metric | Count | Status |
+|--------|-------|--------|
+| Requirements | [N] | - |
+| Designs | [N] | - |
+| Tasks | [N] | - |
+| Valid Chains | [N] | [PASS/WARN/FAIL] |
+| Errors | [N] | [PASS/FAIL] |
+| Warnings | [N] | [PASS/WARN] |
+
+### Issues Found
+
+#### Errors (Blocking)
+- [List broken references, untraced tasks]
+
+#### Warnings (Non-Blocking)
+- [List orphaned specs]
+
+### Remediation Actions
+
+| Issue | Fix | Owner |
+|-------|-----|-------|
+| [Issue] | [Action] | [spec-generator/milestone-planner] |
+````
+
+**Integration with Learning Extraction:**
+
+Traceability failures are skill gaps. Extract learnings:
+
+- If broken reference: "Verify spec IDs exist before adding to related field"
+- If orphaned REQ: "Create design specs when requirements are approved"
+- If untraced task: "Add related field to task front matter during creation"
+
+### Diagnosis Template
+
+````markdown
+## Diagnostic Analysis
+
+### Outcome
+[Success | Partial Success | Failure]
+
+### What Happened
+[Concrete description of actual execution]
+
+### Root Cause Analysis
+- **If Success**: What strategies contributed?
+- **If Failure**: Where exactly did it fail? Why?
+
+### Evidence
+[Specific tools, steps, error messages, metrics]
+
+### Priority Classification
+| Finding | Priority | Category | Evidence |
+|---------|----------|----------|----------|
+| [Finding] | P0/P1/P2 | [Critical/Success/NearMiss/Efficiency/Gap] | [Ref] |
+````
+
+---
+
+## Activity: Action Classification
+
+Adapted from Keep/Drop/Add. Categorize what to do with findings.
+
+| Category | Agent Action | Criteria |
+|----------|--------------|----------|
+| **Keep** | TAG as helpful, increase validation count | Worked, should continue |
+| **Drop** | REMOVE or TAG as harmful | Failed, should stop |
+| **Add** | ADD new skill | Novel learning, no existing pattern |
+| **Modify** | UPDATE existing skill | Refinement to existing pattern |
+
+**Template:**
+
+````markdown
+## Action Classification
+
+### Keep (TAG as helpful)
+| Finding | Skill ID | Validation Count |
+|---------|----------|------------------|
+| [Finding] | [Skill-XXX] | [N+1] |
+
+### Drop (REMOVE or TAG as harmful)
+| Finding | Skill ID | Reason |
+|---------|----------|--------|
+| [Finding] | [Skill-XXX] | [Why removing] |
+
+### Add (New skill)
+| Finding | Proposed Skill ID | Statement |
+|---------|-------------------|-----------|
+| [Finding] | [Skill-Category-NNN] | [Atomic statement] |
+
+### Modify (UPDATE existing)
+| Finding | Skill ID | Current | Proposed |
+|---------|----------|---------|----------|
+| [Finding] | [Skill-XXX] | [Current text] | [New text] |
+````
+
+## Activity: SMART Validation
+
+Validate every learning before storage. Reinforces atomicity.
+
+| Criterion | Skill Requirement | Check |
+|-----------|-------------------|-------|
+| **Specific** | One atomic concept, no compound statements | No "and", "also" |
+| **Measurable** | Has evidence, can be validated | Has execution reference |
+| **Attainable** | Within agent capability | Technically feasible |
+| **Relevant** | Applies to actual execution scenarios | Has trigger condition |
+| **Timely** | Clear when to apply | Has context/timing |
+
+**Validation Template:**
+
+````markdown
+## SMART Validation
+
+### Proposed Skill
+**Statement:** [The skill text]
+
+### Validation
+| Criterion | Pass? | Evidence |
+|-----------|-------|----------|
+| Specific | Y/N | [One concept or multiple?] |
+| Measurable | Y/N | [Can we verify it worked?] |
+| Attainable | Y/N | [Is this technically possible?] |
+| Relevant | Y/N | [Does it apply to real scenarios?] |
+| Timely | Y/N | [Is trigger condition clear?] |
+
+### Result
+- [ ] All criteria pass: Accept skill
+- [ ] Some criteria fail: Refine skill
+- [ ] Multiple criteria fail: Reject skill
+````
+
+## Dependency Ordering
+
+Order actions based on dependencies.
+
+**Template:**
+
+````markdown
+## Action Sequence
+
+| Order | Action | Depends On | Blocks |
+|-------|--------|------------|--------|
+| 1 | [First action] | None | [Actions 2, 3] |
+| 2 | [Second action] | [Action 1] | [Action 4] |
+| 3 | [Third action] | [Action 1] | None |
+````
+
+---
+
+## Atomicity Scoring
+
+All learnings scored 0-100%.
+
+| Factor | Adjustment |
+|--------|------------|
+| Compound statements ("and", "also") | -15% each |
+| Vague terms ("generally", "sometimes") | -20% each |
+| Length > 15 words | -5% per extra word |
+| Missing metrics/evidence | -25% |
+| No actionable guidance | -30% |
+
+### Quality Thresholds
+
+| Score | Quality | Action |
+|-------|---------|--------|
+| 95-100% | Excellent | Add to skillbook |
+| 70-94% | Good | Add with refinement |
+| 40-69% | Needs Work | Refine before adding |
+| <40% | Rejected | Too vague |
+
+### Examples
+
+**Bad (35%)**: "The caching strategy was effective"
+
+- Vague "effective" (-20%)
+- No specifics (-25%)
+- Not actionable (-30%)
+
+**Good (92%)**: "Redis cache with 5-min TTL reduced API calls by 73% for user profiles"
+
+- Specific tool (Redis)
+- Exact config (5-min TTL)
+- Measurable outcome (73%)
+- Clear context (user profiles)
+
+### Evidence-Based Tagging
+
+| Tag | Meaning | Evidence Required |
+|-----|---------|-------------------|
+| **helpful** | Contributed to success | Specific positive execution |
+| **harmful** | Caused failure | Specific negative execution |
+| **neutral** | No measurable impact | Use without effect |
+
+---
+
+## Root Cause Pattern Management
+
+After Five Whys analysis identifies root causes, systematically store patterns for future prevention.
+
+### Root Cause Categories
+
+Standard categories based on common failure modes:
+
+| Category | Description | Examples |
+|----------|-------------|----------|
+| **Cross-Cutting Concerns** | Issues affecting multiple components | Missing input validation, inconsistent error handling |
+| **Fail-Safe Design** | Missing defensive patterns | No fallbacks, unhandled edge cases |
+| **Test-Implementation Drift** | Tests don't match actual behavior | Mocks diverge from reality, stale fixtures |
+| **Premature Validation** | Validating before data is complete | Checking state too early, race conditions |
+| **Context Loss** | Information not preserved | Missing handoff data, dropped session state |
+| **Skill Gap** | Missing capability | No existing pattern for scenario |
+
+### Memory Storage Pattern
+
+Store root cause entities for future pattern matching:
+
+**Create root cause memory:**
+
+```text
+mcp__serena__write_memory
+memory_file_name: "rootcause-{category}-{nnn}"
+content: "# Root Cause: {Category} #{NNN}\n\n**Description**: [What failed and why]\n**Frequency**: [How often this occurs]\n**Impact**: [Severity when it occurs]\n**Detection**: [How to identify this pattern]\n**Prevention**: [How to avoid it]\n**Source**: [PR/Issue/Session reference]\n\n## Related\n- Prevention skill: [skill-file-name]\n- Incident: [incident-ref]\n- Category: [category-name]"
+```
+
+### Failure Prevention Matrix
+
+Maintain cumulative statistics across sessions:
+
+````markdown
+## Failure Prevention Matrix
+
+| Root Cause Category | Incidents | Prevention Skills | Last Occurrence | Trend |
+|---------------------|-----------|-------------------|-----------------|-------|
+| Cross-Cutting Concerns | [N] | Skill-Val-001, Skill-Val-002 | [PR/Session ref] | [Up/Down/Stable] |
+| Fail-Safe Design | [N] | Skill-Safe-001 | [PR/Session ref] | [Up/Down/Stable] |
+| Test-Implementation Drift | [N] | Skill-Test-001 | [PR/Session ref] | [Up/Down/Stable] |
+| Premature Validation | [N] | Skill-Val-003 | [PR/Session ref] | [Up/Down/Stable] |
+| Context Loss | [N] | Skill-Ctx-001 | [PR/Session ref] | [Up/Down/Stable] |
+| Skill Gap | [N] | [New skills added] | [PR/Session ref] | [Up/Down/Stable] |
+````
+
+### Root Cause Pattern Template
+
+Add to retrospective artifact when Five Whys identifies root cause:
+
+````markdown
+## Root Cause Pattern
+
+**Pattern ID**: RootCause-{Category}-{NNN}
+**Category**: [Cross-Cutting | Fail-Safe | Test-Implementation Drift | Premature | Context | Skill-Gap]
+
+### Description
+[What failed and why - from Five Whys analysis]
+
+### Detection Signals
+- [Signal 1]: How to recognize this pattern early
+- [Signal 2]: Warning signs before failure
+
+### Prevention Skill
+**Skill ID**: Skill-{Category}-{NNN}
+**Statement**: [Atomic prevention strategy]
+**Application**: [When and how to apply]
+
+### Evidence
+- **Incident**: [PR/Issue/Session reference]
+- **Root Cause Path**: [Five Whys chain summary]
+- **Resolution**: [What fixed it]
+
+### Relations
+- **Prevents by**: [Prevention skill ID]
+- **Similar to**: [Related root cause patterns]
+- **Supersedes**: [Older patterns this replaces]
+````
+
+---
+
+## Memory Protocol
+
+Use Memory Router for search and Serena tools for persistence (ADR-037):
+
+**Search for existing patterns (before creating new):**
+
+```bash
+uv run python .claude/skills/memory/scripts/search_memory.py --query "{domain} {description} skill patterns"
+```
+
+**Create new skills:**
+
+```text
+mcp__serena__write_memory
+memory_file_name: "{domain}-{description}"
+content: "# Skill: {Description}\n\n**Statement**: [Skill statement with context and evidence]\n\n**Evidence**: [Source reference]\n\n## Details\n\n..."
+```
+
+**Update existing skills (add observations):**
+
+```text
+mcp__serena__edit_memory
+memory_file_name: "[skill-file-name]"
+content: "[Updated content with new observation appended]"
+```
+
+> **Fallback**: If Memory Router unavailable, read `.serena/memories/` directly with Read tool.
+
+**Deduplication Query:**
+
+```bash
+uv run python .claude/skills/memory/scripts/search_memory.py --query "rootcause {Category} {Keywords from description}"
+```
+
+If similar pattern exists (>70% similarity), UPDATE existing entity instead of creating new one.

--- a/src/copilot-cli/skills/retrospective/references/frameworks.md
+++ b/src/copilot-cli/skills/retrospective/references/frameworks.md
@@ -1,0 +1,484 @@
+# Retrospective Frameworks
+
+Phase 0 (Data Gathering), Phase 1 (Generate Insights), and the closing activities. The
+rubrics below are lifted verbatim from the canonical source agent body at
+`.claude/agents/retrospective.md` (the original Phase 0, Phase 1, and Phase 6 sections).
+Keep them byte-for-byte; the SKILL.md orchestration links to the activity headings here.
+
+---
+
+## Phase 0: Data Gathering
+
+Gather facts before interpretation. Observation precedes diagnosis.
+
+### Activity: 4-Step Debrief
+
+Separate observation from interpretation.
+
+| Step | Human Version | Agent Version | Output |
+|------|---------------|---------------|--------|
+| 1. Observe | "What did you see and hear?" | What tools called, outputs produced, errors occurred | Facts only |
+| 2. Respond | "What surprised you? Where were you challenged?" | Where did agents pivot, retry, escalate, or block? | Reactions |
+| 3. Analyze | "What insight do you have?" | What patterns emerge about agent behavior? | Interpretations |
+| 4. Apply | "What would you do differently?" | What skill updates or process changes follow? | Actions |
+
+**Template:**
+
+````markdown
+## 4-Step Debrief
+
+### Step 1: Observe (Facts Only)
+- Tool calls: [List with timestamps]
+- Outputs: [What was produced]
+- Errors: [What failed]
+- Duration: [Time spent]
+
+### Step 2: Respond (Reactions)
+- Pivots: [Where did flow change?]
+- Retries: [What was attempted multiple times?]
+- Escalations: [What required human input?]
+- Blocks: [What stopped progress?]
+
+### Step 3: Analyze (Interpretations)
+- Patterns: [What recurring behaviors?]
+- Anomalies: [What was unexpected?]
+- Correlations: [What happened together?]
+
+### Step 4: Apply (Actions)
+- Skills to update: [List]
+- Process changes: [List]
+- Context to preserve: [List]
+````
+
+### Activity: Execution Trace Analysis
+
+Adapted from Timeline activity. Create a chronological picture of agent execution.
+
+**Purpose:** See the full sequence. Identify where things stalled, accelerated, or went wrong.
+
+**Steps:**
+
+1. Extract execution sequence from logs, tool calls, and outputs
+2. Arrange events chronologically
+3. Mark significant events: starts, completions, failures, pivots
+4. Annotate with energy indicators (high activity, stalled, blocked)
+5. Look for patterns across the timeline
+
+**Template:**
+
+````markdown
+## Execution Trace
+
+| Time | Agent | Action | Outcome | Energy |
+|------|-------|--------|---------|--------|
+| T+0 | orchestrator | Route to analyst | Success | High |
+| T+1 | analyst | Research API | Success | High |
+| T+2 | analyst | Search memory | Empty result | Medium |
+| T+3 | analyst | Retry with broader query | Success | Medium |
+| ... | ... | ... | ... | ... |
+
+### Timeline Patterns
+- [Pattern 1]: [Description]
+- [Pattern 2]: [Description]
+
+### Energy Shifts
+- High to Low at: [Point] - Reason: [Why]
+- Stall points: [List]
+````
+
+### Activity: Outcome Classification
+
+Adapted from Mad Sad Glad. Classify execution outcomes by emotional valence.
+
+| Category | Agent Meaning | Examples |
+|----------|---------------|----------|
+| **Mad (Blocked)** | Failures that stopped progress | Errors, timeouts, missing dependencies |
+| **Sad (Suboptimal)** | Worked but poorly | Slow, inefficient, required retries |
+| **Glad (Success)** | Worked as intended | Clean execution, good outcomes |
+
+**Template:**
+
+````markdown
+## Outcome Classification
+
+### Mad (Blocked/Failed)
+- [Event]: [Why it blocked progress]
+
+### Sad (Suboptimal)
+- [Event]: [Why it was inefficient]
+
+### Glad (Success)
+- [Event]: [What made it work well]
+
+### Distribution
+- Mad: [N] events
+- Sad: [N] events
+- Glad: [N] events
+- Success Rate: [%]
+````
+
+---
+
+## Phase 1: Generate Insights
+
+Make meaning from data. Look past symptoms to find causes.
+
+### Activity: Five Whys
+
+Mandatory for all failures. Ask "Why?" until you reach root cause.
+
+**Purpose:** Discover underlying conditions that contribute to an issue.
+
+**Process:**
+
+1. State the problem
+2. Ask "Why did this happen?"
+3. For each answer, ask "Why?" again
+4. Repeat until you reach something outside agent control or a fixable root cause
+5. Stop at 5 levels or when cause is actionable
+
+**Template:**
+
+````markdown
+## Five Whys Analysis
+
+**Problem:** [Statement of what went wrong]
+
+**Q1:** Why did [problem] occur?
+**A1:** [Answer]
+
+**Q2:** Why did [A1] happen?
+**A2:** [Answer]
+
+**Q3:** Why did [A2] happen?
+**A3:** [Answer]
+
+**Q4:** Why did [A3] happen?
+**A4:** [Answer]
+
+**Q5:** Why did [A4] happen?
+**A5:** [Answer]
+
+**Root Cause:** [The actual underlying issue]
+**Actionable Fix:** [What can be changed]
+````
+
+**Example:**
+
+````markdown
+**Problem:** Implementer produced code that failed tests
+
+**Q1:** Why did the code fail tests?
+**A1:** The method signature didn't match the interface
+
+**Q2:** Why didn't the signature match?
+**A2:** Implementer didn't read the interface definition
+
+**Q3:** Why didn't implementer read the interface?
+**A3:** The plan didn't specify which interface to implement
+
+**Q4:** Why didn't the plan specify?
+**A4:** Analyst didn't identify the interface in research
+
+**Q5:** Why didn't analyst identify it?
+**A5:** Search query was too narrow
+
+**Root Cause:** Insufficient research scope
+**Actionable Fix:** Add interface discovery to analyst checklist
+````
+
+### Activity: Fishbone Analysis
+
+Use for complex failures with multiple contributing factors.
+
+**Purpose:** Look past symptoms to identify root causes across categories.
+
+**Agent-Specific Categories:**
+
+| Category | What It Covers |
+|----------|----------------|
+| **Prompt** | Instructions, context, framing, ambiguity |
+| **Tools** | Tool selection, tool usage, tool failures |
+| **Context** | Missing information, stale context, memory gaps |
+| **Dependencies** | External services, APIs, file system state |
+| **Sequence** | Agent routing, handoff issues, ordering problems |
+| **State** | Accumulated errors, drift, context pollution |
+
+**Template:**
+
+````markdown
+## Fishbone Analysis
+
+**Problem:** [Head of fish - the issue being analyzed]
+
+### Category: Prompt
+- [Contributing factor]
+- [Contributing factor]
+
+### Category: Tools
+- [Contributing factor]
+
+### Category: Context
+- [Contributing factor]
+
+### Category: Dependencies
+- [Contributing factor]
+
+### Category: Sequence
+- [Contributing factor]
+
+### Category: State
+- [Contributing factor]
+
+### Cross-Category Patterns
+Items appearing in multiple categories (likely root causes):
+- [Pattern]: Appears in [Category A] and [Category B]
+
+### Controllable vs Uncontrollable
+| Factor | Controllable? | Action |
+|--------|---------------|--------|
+| [Factor] | Yes | [Fix] |
+| [Factor] | No | [Mitigate] |
+````
+
+### Activity: Force Field Analysis
+
+Use when a pattern keeps recurring despite "knowing better."
+
+**Purpose:** Identify what drives change and what restrains it.
+
+**Template:**
+
+````markdown
+## Force Field Analysis
+
+**Desired State:** [What we want to achieve]
+**Current State:** [What happens now]
+
+### Driving Forces (Supporting Change)
+| Factor | Strength (1-5) | How to Strengthen |
+|--------|----------------|-------------------|
+| [Factor] | [N] | [Action] |
+
+### Restraining Forces (Blocking Change)
+| Factor | Strength (1-5) | How to Reduce |
+|--------|----------------|---------------|
+| [Factor] | [N] | [Action] |
+
+### Force Balance
+- Total Driving: [Sum]
+- Total Restraining: [Sum]
+- Net: [Driving - Restraining]
+
+### Recommended Strategy
+- [ ] Strengthen: [Driving factor]
+- [ ] Reduce: [Restraining factor]
+- [ ] Accept: [Factor outside control]
+````
+
+### Activity: Patterns and Shifts
+
+Use for multi-session or multi-execution analysis. Look for trends.
+
+**Purpose:** Find connections between facts and feelings across executions.
+
+**Template:**
+
+````markdown
+## Patterns and Shifts
+
+### Recurring Patterns
+| Pattern | Frequency | Impact | Category |
+|---------|-----------|--------|----------|
+| [Pattern] | [N times] | [H/M/L] | [Success/Failure/Efficiency] |
+
+### Shifts Detected
+| Shift | When | Before | After | Cause |
+|-------|------|--------|-------|-------|
+| [Shift name] | [Session/Time] | [Previous state] | [New state] | [Why] |
+
+### Pattern Questions
+- How do these patterns contribute to current issues?
+- What do these shifts tell us about trajectory?
+- Which patterns should we reinforce?
+- Which patterns should we break?
+````
+
+### Activity: Learning Matrix
+
+Quick categorization of insights. Use when short on time.
+
+**Categories:**
+
+| Quadrant | Icon | Question |
+|----------|------|----------|
+| Top-Left | :) | What did we do well that we want to continue? |
+| Top-Right | :( | What would we like to change? |
+| Bottom-Left | Idea | What new ideas have come up? |
+| Bottom-Right | Invest | What improvements should we invest in? |
+
+**Template:**
+
+````markdown
+## Learning Matrix
+
+### :) Continue (What worked)
+- [Item]
+
+### :( Change (What didn't work)
+- [Item]
+
+### Idea (New approaches)
+- [Item]
+
+### Invest (Long-term improvements)
+- [Item]
+
+### Priority Items
+Top items from each quadrant:
+1. [Item from Continue to reinforce]
+2. [Item from Change to fix]
+3. [Item from Ideas to try]
+````
+
+---
+
+## Closing Activities
+
+Evaluate the retrospective itself. Continuous improvement.
+
+### Activity: +/Delta
+
+Quick self-assessment of the retrospective process.
+
+| Category | Questions |
+|----------|-----------|
+| **+ (Keep)** | What worked in this analysis? What activities produced useful insights? |
+| **Delta (Change)** | What took too long? What activities yielded nothing? What should be skipped? |
+
+**Template:**
+
+````markdown
+## +/Delta
+
+### + Keep
+- [What worked well in this retrospective]
+
+### Delta Change
+- [What should be different next time]
+
+### Backlog Candidates
+| Delta Item | Priority | Action |
+|------------|----------|--------|
+| [Item] | P0/P1/P2/P3 | Issue/Memory/Skip |
+````
+
+### Activity: Delta Triage
+
+Process Delta items to capture actionable improvements. Delta items represent change requests that should not be forgotten.
+
+**Actionable Delta Categories:**
+
+| Category | Description | Examples |
+|----------|-------------|----------|
+| **Missing Documentation** | Gaps in guides, READMEs, or inline comments | "Agent didn't know about X script" |
+| **Tool/Script Awareness** | Existing tools that agents fail to discover | "Should have used Y instead of Z" |
+| **Process Improvements** | Workflow or protocol changes | "Need earlier validation step" |
+| **Feature Requests** | New capabilities needed | "Add automated X detection" |
+
+**Triage Protocol:**
+
+1. **Review each Delta item** from the +/Delta output
+2. **Classify as actionable** if it matches a category above
+3. **Assign priority** based on impact and frequency:
+   - **P0**: Blocks core functionality, recurring failures
+   - **P1**: Significant impact, affects multiple sessions
+   - **P2**: Normal improvement, would help efficiency
+   - **P3**: Nice-to-have, low frequency
+4. **Route to destination**:
+   - **P0/P1**: Create GitHub issue immediately (use the `github` skill)
+   - **P2/P3**: Store in backlog memory for future triage
+   - **Skip**: Not actionable or duplicate of existing item
+
+**Delta Triage Template:**
+
+````markdown
+## Delta Triage
+
+### Actionable Items Identified
+
+| Delta Item | Category | Priority | Destination | Reference |
+|------------|----------|----------|-------------|-----------|
+| [Item from Delta] | [Missing Docs/Tool Gap/Process/Feature] | P0/P1/P2/P3 | Issue #N / Memory / Skip | [Link] |
+
+### Issues Created
+
+| Issue | Title | Priority | Labels |
+|-------|-------|----------|--------|
+| #[N] | [Title] | P0/P1 | enhancement, source:retrospective |
+
+### Backlog Items Stored
+
+| Item | Priority | Memory File |
+|------|----------|-------------|
+| [Item] | P2/P3 | backlog/retro-YYYY-MM-DD-items.md |
+
+### Skipped Items
+
+| Item | Reason |
+|------|--------|
+| [Item] | [Duplicate of #X / Not actionable / Already addressed] |
+````
+
+### Activity: ROTI (Return on Time Invested)
+
+Measure if retrospective was worth the effort.
+
+| Score | Meaning | Action |
+|-------|---------|--------|
+| 0 | No benefit, wasted cycles | Stop this retrospective pattern |
+| 1 | Break-even | Continue with modifications |
+| 2 | Benefit > effort | Keep pattern |
+| 3 | High return | Document as best practice |
+| 4 | Exceptional | Extract into reusable template |
+
+**Template:**
+
+````markdown
+## ROTI Assessment
+
+**Score**: [0-4]
+
+**Benefits Received**:
+- [Benefit 1]
+- [Benefit 2]
+
+**Time Invested**: [Duration]
+
+**Verdict**: [Continue | Modify | Stop]
+````
+
+### Activity: Helped, Hindered, Hypothesis
+
+Meta-learning about the retrospective process.
+
+| Category | Questions |
+|----------|-----------|
+| **Helped** | What data, tools, or context made analysis easier? |
+| **Hindered** | What was missing, broken, or unclear? |
+| **Hypothesis** | What should be tried next time to improve? |
+
+**Template:**
+
+````markdown
+## Helped, Hindered, Hypothesis
+
+### Helped
+- [What made this retrospective effective]
+
+### Hindered
+- [What got in the way]
+
+### Hypothesis
+- [Experiment to try next retrospective]
+````

--- a/src/copilot-cli/skills/retrospective/references/learning-template.md
+++ b/src/copilot-cli/skills/retrospective/references/learning-template.md
@@ -1,0 +1,100 @@
+# Learning Extraction Template
+
+The byte-exact retrospective artifact structure. Lifted verbatim from the canonical source
+agent body at `.claude/agents/retrospective.md` (Phase 4, "Learning Extraction Template",
+original lines 696-789). The output artifact MUST match this template, modulo filled
+placeholders. Do not reword the headings or table columns; downstream readers and the
+auto-retro skeleton-fill path depend on the exact shape.
+
+Save to: `.agents/retrospective/YYYY-MM-DD-[scope].md`
+
+````markdown
+# Retrospective: [Scope]
+
+## Session Info
+- **Date**: YYYY-MM-DD
+- **Agents**: [List]
+- **Task Type**: [Feature | Bug | Research]
+- **Outcome**: [Success | Partial | Failure]
+
+## Phase 0: Data Gathering
+[4-Step Debrief output]
+[Execution Trace output]
+[Outcome Classification output]
+
+## Phase 1: Insights Generated
+[Five Whys output if failure]
+[Fishbone output if complex]
+[Patterns and Shifts output]
+[Learning Matrix output]
+
+## Phase 2: Diagnosis
+
+### Successes (Tag: helpful)
+| Strategy | Evidence | Impact | Atomicity |
+|----------|----------|--------|-----------|
+| [Strategy] | [Outcome] | [1-10] | [%] |
+
+### Failures (Tag: harmful)
+| Strategy | Error Type | Root Cause | Prevention | Atomicity |
+|----------|------------|------------|------------|-----------|
+| [Strategy] | [Type] | [Cause] | [Fix] | [%] |
+
+### Near Misses
+| What Almost Failed | Recovery | Learning |
+|--------------------|----------|----------|
+| [Situation] | [Save] | [Takeaway] |
+
+## Phase 3: Decisions
+
+### Action Classification
+[Keep/Drop/Add/Modify table]
+
+### SMART Validation
+[Validation for each new skill]
+
+### Action Sequence
+[Ordered actions with dependencies]
+
+## Phase 4: Extracted Learnings
+
+### Learning 1
+- **Statement**: [Atomic - max 15 words]
+- **Atomicity Score**: [%]
+- **Evidence**: [Execution detail]
+- **Skill Operation**: ADD | UPDATE | TAG | REMOVE
+- **Target Skill ID**: [If UPDATE/TAG/REMOVE]
+
+## Skillbook Updates
+
+### ADD
+```json
+{
+  "skill_id": "{domain}-{description}",
+  "statement": "[Atomic]",
+  "context": "[When to apply]",
+  "evidence": "[Source]",
+  "atomicity": [%]
+}
+```
+
+### UPDATE
+
+| Skill ID | Current | Proposed | Why |
+|----------|---------|----------|-----|
+
+### TAG
+
+| Skill ID | Tag | Evidence | Impact |
+|----------|-----|----------|--------|
+
+### REMOVE
+
+| Skill ID | Reason | Evidence |
+|----------|--------|----------|
+
+## Deduplication Check
+
+| New Skill | Most Similar | Similarity | Decision |
+|-----------|--------------|------------|----------|
+````

--- a/tests/test_retrospective_skill_decomposition.py
+++ b/tests/test_retrospective_skill_decomposition.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Structural tests for the retrospective skill decomposition (issue #2080, PR 1 of N).
+
+This PR creates the skill contract only: `.claude/skills/retrospective/SKILL.md`
+plus three `references/` files lifted verbatim from the source agent body. Scripts,
+agent deletion, and template removal are out of scope for this slice.
+
+These tests pin the structural contract that the SkillForge validator, the skill-size
+gate, and the canonical-source-mirror rule depend on:
+
+- The SKILL.md exists at the canonical path with valid frontmatter (name, version,
+  description) per `.agents/steering/claude-skills.md`.
+- The Triggers section has 1 to 5 backtick-wrapped trigger phrases (SkillForge
+  `validate_triggers` contract).
+- The Process section orchestrates the fixed Phase 0 through Phase 5 workflow.
+- A Success Criteria (Verification) section with checkboxes exists (SkillForge
+  `validate_verification` contract).
+- The three reference files exist and are linked from SKILL.md.
+- The rubrics in the references are byte-faithful to the source agent body
+  (`.claude/agents/retrospective.md`), per the canonical-source-mirror rule.
+- No file carries an em-dash (U+2014) or en-dash (U+2013) per universal.md.
+- This slice ships no `scripts/` directory (scope boundary; scripts are PR 2).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SKILL_DIR = PROJECT_ROOT / ".claude" / "skills" / "retrospective"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+REFERENCES_DIR = SKILL_DIR / "references"
+FRAMEWORKS = REFERENCES_DIR / "frameworks.md"
+LEARNING_TEMPLATE = REFERENCES_DIR / "learning-template.md"
+DIAGNOSIS_ACTIONS = REFERENCES_DIR / "diagnosis-and-actions.md"
+SOURCE_AGENT = PROJECT_ROOT / ".claude" / "agents" / "retrospective.md"
+
+# U+2014 em-dash, U+2013 en-dash. Banned by .claude/rules/universal.md.
+_DASH_PATTERN = re.compile("[\\u2013\\u2014]")
+# Mirrors SkillForge validate-skill.py:validate_triggers backtick extraction.
+_BACKTICK = re.compile(r"`([^`]+)`")
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    assert SKILL_MD.is_file(), f"SKILL.md not found at canonical path: {SKILL_MD}"
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def _triggers_section(content: str) -> str:
+    """Extract the Triggers section, mirroring the SkillForge validator regex."""
+    match = re.search(
+        r"##\s*Triggers\s*\n(.*?)(?=\n##|\Z)",
+        content,
+        re.DOTALL | re.IGNORECASE,
+    )
+    assert match is not None, "Missing Triggers section"
+    return match.group(1)
+
+
+class TestExistenceAndLayout:
+    def test_skill_md_exists(self) -> None:
+        assert SKILL_MD.is_file()
+
+    def test_references_directory_exists(self) -> None:
+        assert REFERENCES_DIR.is_dir()
+
+    @pytest.mark.parametrize(
+        "ref_path",
+        [FRAMEWORKS, LEARNING_TEMPLATE, DIAGNOSIS_ACTIONS],
+    )
+    def test_reference_file_exists(self, ref_path: Path) -> None:
+        assert ref_path.is_file(), f"missing reference file: {ref_path.name}"
+
+    def test_slice_ships_no_scripts_directory(self) -> None:
+        # Scope boundary: PR 1 sets up the contract; scripts arrive in PR 2.
+        assert not (SKILL_DIR / "scripts").exists(), (
+            "scripts/ is out of scope for this slice (PR 2 adds scripts)"
+        )
+
+
+class TestFrontmatter:
+    def test_frontmatter_starts_on_line_one(self, skill_text: str) -> None:
+        assert skill_text.startswith("---\n")
+
+    @pytest.mark.parametrize("field", ["name", "version", "description"])
+    def test_required_frontmatter_field_present(self, skill_text: str, field: str) -> None:
+        front = skill_text.split("---", 2)[1]
+        assert re.search(rf"(?m)^{field}:\s*\S", front), f"missing frontmatter field: {field}"
+
+    def test_name_matches_directory(self, skill_text: str) -> None:
+        front = skill_text.split("---", 2)[1]
+        match = re.search(r"(?m)^name:\s*(\S+)", front)
+        assert match is not None
+        assert match.group(1) == "retrospective"
+
+    def test_version_is_semver(self, skill_text: str) -> None:
+        front = skill_text.split("---", 2)[1]
+        match = re.search(r"(?m)^version:\s*(\S+)", front)
+        assert match is not None
+        assert re.fullmatch(r"\d+\.\d+\.\d+", match.group(1)), match.group(1)
+
+
+class TestTriggers:
+    def test_trigger_count_in_range(self, skill_text: str) -> None:
+        # SkillForge contract: 1 to 5 backtick-wrapped phrases in the section.
+        phrases = _BACKTICK.findall(_triggers_section(skill_text))
+        assert 1 <= len(phrases) <= 5, f"found {len(phrases)} trigger phrases"
+
+    def test_retro_fill_trigger_present(self, skill_text: str) -> None:
+        # #2079 invokes the skill from `/retro fill <date>`; the trigger must exist.
+        phrases = _BACKTICK.findall(_triggers_section(skill_text))
+        assert any("retro fill" in p for p in phrases)
+
+    def test_triggers_have_no_shell_metacharacters(self, skill_text: str) -> None:
+        # Negative: CWE-94 mitigation in the validator rejects shell metacharacters.
+        phrases = _BACKTICK.findall(_triggers_section(skill_text))
+        safe = re.compile(r"^[a-zA-Z0-9 \-:,./\'\"(){}#!_=+@*?]+$")
+        unsafe = [p for p in phrases if not safe.match(p)]
+        assert unsafe == [], f"unsafe trigger phrases: {unsafe}"
+
+
+class TestProcessOrchestration:
+    @pytest.mark.parametrize("phase", range(6))
+    def test_phase_heading_present(self, skill_text: str, phase: int) -> None:
+        # The binding decision: orchestrate Phase 0 through Phase 5.
+        assert re.search(rf"(?m)^###\s*Phase\s*{phase}\b", skill_text), (
+            f"missing Phase {phase} heading"
+        )
+
+    def test_has_process_section(self, skill_text: str) -> None:
+        assert re.search(r"(?m)^##\s*Process\b", skill_text)
+
+    def test_has_success_criteria_section_with_checkboxes(self, skill_text: str) -> None:
+        # SkillForge validate_verification: needs a Verification/Success Criteria/
+        # Checklist heading and at least 2 checkboxes.
+        assert re.search(r"(?m)^##\s*(Verification|Success Criteria|Checklist)\b", skill_text)
+        assert len(re.findall(r"\[\s*\]", skill_text)) >= 2
+
+
+class TestReferenceLinks:
+    @pytest.mark.parametrize(
+        "ref_name",
+        ["frameworks.md", "learning-template.md", "diagnosis-and-actions.md"],
+    )
+    def test_skill_links_each_reference(self, skill_text: str, ref_name: str) -> None:
+        assert f"references/{ref_name}" in skill_text, f"SKILL.md does not link references/{ref_name}"
+
+
+class TestCanonicalSourceFidelity:
+    """The references claim to lift rubrics verbatim from the source agent body.
+
+    Each anchor below is a load-bearing string that must appear identically in the
+    source agent and in the reference that claims to mirror it. A drift here is the
+    confident-incorrectness failure the canonical-source-mirror rule guards against.
+    """
+
+    def test_source_agent_exists(self) -> None:
+        assert SOURCE_AGENT.is_file()
+
+    @pytest.mark.parametrize(
+        "anchor",
+        [
+            "What did you see and hear?",
+            "Insufficient research scope",
+            "Mad (Blocked)",
+            "Redis cache with 5-min TTL reduced API calls by 73% for user profiles",
+        ],
+    )
+    def test_anchor_present_in_source(self, anchor: str) -> None:
+        assert anchor in SOURCE_AGENT.read_text(encoding="utf-8")
+
+    def test_frameworks_mirror_anchors_verbatim(self) -> None:
+        text = FRAMEWORKS.read_text(encoding="utf-8")
+        assert "What did you see and hear?" in text
+        assert "Insufficient research scope" in text
+
+    def test_diagnosis_mirrors_anchors_verbatim(self) -> None:
+        text = DIAGNOSIS_ACTIONS.read_text(encoding="utf-8")
+        assert "Redis cache with 5-min TTL reduced API calls by 73% for user profiles" in text
+        assert 'Compound statements ("and", "also")' in text
+
+    def test_learning_template_mirrors_artifact_skeleton_verbatim(self) -> None:
+        text = LEARNING_TEMPLATE.read_text(encoding="utf-8")
+        assert "# Retrospective: [Scope]" in text
+        assert "## Phase 4: Extracted Learnings" in text
+        assert "## Deduplication Check" in text
+
+    @pytest.mark.parametrize(
+        "ref_path",
+        [FRAMEWORKS, LEARNING_TEMPLATE, DIAGNOSIS_ACTIONS],
+    )
+    def test_reference_cites_canonical_source_path(self, ref_path: Path) -> None:
+        # canonical-source-mirror: the first commit must cite the source path verbatim.
+        assert ".claude/agents/retrospective.md" in ref_path.read_text(encoding="utf-8")
+
+
+class TestNoDashes:
+    @pytest.mark.parametrize(
+        "path",
+        [SKILL_MD, FRAMEWORKS, LEARNING_TEMPLATE, DIAGNOSIS_ACTIONS],
+    )
+    def test_contains_no_em_or_en_dash(self, path: Path) -> None:
+        match = _DASH_PATTERN.search(path.read_text(encoding="utf-8"))
+        assert match is None, (
+            f"prohibited dash in {path.name} at offset {match.start()}" if match else ""
+        )


### PR DESCRIPTION
## Summary

First bounded slice of converting the `retrospective` agent (1454 lines) to a decomposed skill, per the repo-owner binding decision on #2080. This PR creates only the skill contract so a later PR can add scripts and a third can delete the agent. Scripts, agent deletion, and template removal are out of scope here.

Verified against current `main`: `.claude/skills/retrospective/` did not exist, so no part of this slice was already resolved.

## Per-file change

- `.claude/skills/retrospective/SKILL.md` (new): frontmatter (`name`, `version` 0.1.0, `description`), 5 backtick triggers including `retro fill` for #2079, a `## Process` section that orchestrates Phase 0 through Phase 5, a `## Success Criteria` section with checkboxes, and links to each reference. 198 lines, under the 500-line cap.
- `.claude/skills/retrospective/references/frameworks.md` (new): Phase 0, Phase 1, and closing activity rubrics (4-Step Debrief, Execution Trace, Outcome Classification, Five Whys, Fishbone, Force Field, Patterns and Shifts, Learning Matrix, +/Delta, ROTI, Helped/Hindered/Hypothesis), lifted verbatim from the retrospective agent source.
- `.claude/skills/retrospective/references/learning-template.md` (new): the byte-exact Learning Extraction Template the output artifact must match.
- `.claude/skills/retrospective/references/diagnosis-and-actions.md` (new): Phase 2 through Phase 5 rubrics (diagnosis priority, traceability, root-cause patterns, action classification, SMART validation, atomicity scoring, evidence-based tagging, memory protocol), lifted verbatim.
- `tests/test_retrospective_skill_decomposition.py` (new): 41 structural tests.
- `.claude/.claude-plugin/plugin.json`, `src/copilot-cli/.claude-plugin/plugin.json`: version 0.5.14 to 0.5.15 for the new skill source.
- `src/copilot-cli/skills/retrospective/**` (4 generated files): copilot-cli mirror produced by the generated-skill build.

The references follow the canonical-source-mirror rule: each cites the retrospective agent source as the source and quotes the rubrics character-for-character.

Refs #2080

## Testing

- `uv run pytest tests/test_retrospective_skill_decomposition.py -q`: 41 passed. Covers frontmatter fields, trigger count and shell-metacharacter safety, Phase 0..5 orchestration, Success Criteria checkboxes, reference linkage, byte-faithful canonical-source mirroring (positive anchors verified in both source and references), the no-scripts scope boundary, and the em/en dash prohibition (with a negative control proving the dash detector catches an injected U+2014).
- SkillForge skill validator: exit 0, 16/19 checks pass. Three warnings only (6 phases vs recommended 1-3, no Anti-Patterns section, no Extension Points section); the 6 phases reflect the genuine Phase 0..5 workflow.
- skill size validator: pass, 198/500 lines.
- generated mirror check: exit 0, no drift; only the new skill mirror was generated.
- plugin version-bump validator: `plugin-version-bump: OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)