### PR TITLE
fix(hooks): warn not block third LSP read with one nav (#2200)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
@@ -153,11 +153,12 @@ def build_warmup_block(file_path: str, providers: list[str]) -> str:
 def build_warn_message(file_path: str, next_read_num: int, nav_count: int) -> str:
     """Build the Soft-warn guidance (kit ``Gate 3`` warning, adapted)."""
     remaining = NAV_REQUIRED - nav_count
-    plural = "call" if remaining == 1 else "calls"
+    current_plural = "call" if nav_count == 1 else "calls"
+    remaining_plural = "call" if remaining == 1 else "calls"
     return (
         f"LSP-FIRST WARNING (Read {next_read_num}): consider symbol navigation.\n"
         "Use find_symbol / find_referencing_symbols before more Reads.\n"
-        f"You have {nav_count} nav calls; make {remaining} more {plural} "
+        f"You have {nav_count} nav {current_plural}; make {remaining} more {remaining_plural} "
         f"before Read {next_read_num + 1}."
     )
 

--- a/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
@@ -50,8 +50,8 @@ Stricter/looser/different than canonical
   The Soft-warn tier therefore covers read 3 with ``nav_count < NAV_REQUIRED``
   (nav 0 or 1), not only ``nav_count == 0``: hard-block starts at read 4
   (``next_read_num > WARN_AT``), so read 3 always warns and allows (issue #2200).
-  This is LOOSER on read 3 than the kit, which blocks read 3 once nav>=1 leaves
-  its warn branch.
+  This warns more aggressively on read 3 than the kit: the kit silently allows
+  read 3 after one nav, while this port emits an advisory and still allows.
 - DIFFERENT conditioning: the kit gates by hard-coded code-extension regex and
   unconditionally blocks Warmup on any code file. This port gates ONLY when an
   overview-capable provider exists for the file type (``detect_providers`` non

--- a/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
@@ -47,6 +47,11 @@ Stricter/looser/different than canonical
   read 4+ with ``nav_count < 2`` is a HARD BLOCK (the kit's "1 nav unlocks 4-5"
   middle step is dropped). Surgical (``nav_count >= 2``) allows all. This is
   STRICTER on reads 4-5 (the kit allowed them after 1 nav; this requires 2).
+  The Soft-warn tier therefore covers read 3 with ``nav_count < NAV_REQUIRED``
+  (nav 0 or 1), not only ``nav_count == 0``: hard-block starts at read 4
+  (``next_read_num > WARN_AT``), so read 3 always warns and allows (issue #2200).
+  This is LOOSER on read 3 than the kit, which blocks read 3 once nav>=1 leaves
+  its warn branch.
 - DIFFERENT conditioning: the kit gates by hard-coded code-extension regex and
   unconditionally blocks Warmup on any code file. This port gates ONLY when an
   overview-capable provider exists for the file type (``detect_providers`` non
@@ -229,8 +234,11 @@ def evaluate(file_path: str, project_dir: str) -> tuple[int, str | None]:
         _note(f"free-read {next_read_num}/{FREE_READS}, allow: {file_path}")
         return 0, None
 
-    # Soft-warn tier: read WARN_AT with no nav yet -> advisory, still allow.
-    if next_read_num == WARN_AT and nav_count == 0:
+    # Soft-warn tier: read WARN_AT with nav below NAV_REQUIRED -> advisory, still
+    # allow. ADR-062 Section 3 hard-blocks from read 4 (next_read_num > WARN_AT);
+    # read 3 with one nav must warn, not block (issue #2200). nav_count >=
+    # NAV_REQUIRED is already short-circuited by the surgical tier above.
+    if next_read_num == WARN_AT and nav_count < NAV_REQUIRED:
         _emit_warn(build_warn_message(file_path, next_read_num))
         _note(f"soft-warn read {next_read_num}, allow: {file_path}")
         return 0, None

--- a/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
@@ -150,14 +150,16 @@ def build_warmup_block(file_path: str, providers: list[str]) -> str:
     return "\n".join(lines)
 
 
-def build_warn_message(file_path: str, next_read_num: int) -> str:
+def build_warn_message(file_path: str, next_read_num: int, nav_count: int) -> str:
     """Build the Soft-warn guidance (kit ``Gate 3`` warning, adapted)."""
+    remaining = NAV_REQUIRED - nav_count
+    plural = "call" if remaining == 1 else "calls"
     return (
         f"LSP-FIRST WARNING (Read {next_read_num}): consider symbol navigation.\n"
         "Use find_symbol / find_referencing_symbols before more Reads.\n"
-        f"The next Read is BLOCKED until you make {NAV_REQUIRED} nav calls (surgical mode)."
+        f"You have {nav_count} nav calls; make {remaining} more {plural} "
+        f"before Read {next_read_num + 1}."
     )
-
 
 def build_hard_block(
     file_path: str, next_read_num: int, nav_count: int, providers: list[str]
@@ -243,7 +245,7 @@ def evaluate(file_path: str, project_dir: str) -> tuple[int, str | None]:
     # read 3 with one nav must warn, not block (issue #2200). nav_count >=
     # NAV_REQUIRED is already short-circuited by the surgical tier above.
     if next_read_num == WARN_AT and nav_count < NAV_REQUIRED:
-        _emit_warn(build_warn_message(file_path, next_read_num))
+        _emit_warn(build_warn_message(file_path, next_read_num, nav_count))
         _note(f"soft-warn read {next_read_num}, allow: {file_path}")
         return 0, None
 

--- a/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
@@ -96,7 +96,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     # Fail-open: a navigation guard must never wedge a turn on bootstrap failure.
     sys.exit(0)
 if _lib_dir not in sys.path:

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "25 agent definitions, 81 reusable skills, 52 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "25 agent definitions, 81 reusable skills, 52 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/preToolUse/invoke_lsp_read_guard__Read_852b43.py
+++ b/src/copilot-cli/hooks/preToolUse/invoke_lsp_read_guard__Read_852b43.py
@@ -296,11 +296,12 @@ def _original_main(stdin_bytes):
     def build_warn_message(file_path: str, next_read_num: int, nav_count: int) -> str:
         """Build the Soft-warn guidance (kit ``Gate 3`` warning, adapted)."""
         remaining = NAV_REQUIRED - nav_count
-        plural = "call" if remaining == 1 else "calls"
+        current_plural = "call" if nav_count == 1 else "calls"
+        remaining_plural = "call" if remaining == 1 else "calls"
         return (
             f"LSP-FIRST WARNING (Read {next_read_num}): consider symbol navigation.\n"
             "Use find_symbol / find_referencing_symbols before more Reads.\n"
-            f"You have {nav_count} nav calls; make {remaining} more {plural} "
+            f"You have {nav_count} nav {current_plural}; make {remaining} more {remaining_plural} "
             f"before Read {next_read_num + 1}."
         )
 

--- a/src/copilot-cli/hooks/preToolUse/invoke_lsp_read_guard__Read_852b43.py
+++ b/src/copilot-cli/hooks/preToolUse/invoke_lsp_read_guard__Read_852b43.py
@@ -293,14 +293,16 @@ def _original_main(stdin_bytes):
         return "\n".join(lines)
 
 
-    def build_warn_message(file_path: str, next_read_num: int) -> str:
+    def build_warn_message(file_path: str, next_read_num: int, nav_count: int) -> str:
         """Build the Soft-warn guidance (kit ``Gate 3`` warning, adapted)."""
+        remaining = NAV_REQUIRED - nav_count
+        plural = "call" if remaining == 1 else "calls"
         return (
             f"LSP-FIRST WARNING (Read {next_read_num}): consider symbol navigation.\n"
             "Use find_symbol / find_referencing_symbols before more Reads.\n"
-            f"The next Read is BLOCKED until you make {NAV_REQUIRED} nav calls (surgical mode)."
+            f"You have {nav_count} nav calls; make {remaining} more {plural} "
+            f"before Read {next_read_num + 1}."
         )
-
 
     def build_hard_block(
         file_path: str, next_read_num: int, nav_count: int, providers: list[str]
@@ -386,7 +388,7 @@ def _original_main(stdin_bytes):
         # read 3 with one nav must warn, not block (issue #2200). nav_count >=
         # NAV_REQUIRED is already short-circuited by the surgical tier above.
         if next_read_num == WARN_AT and nav_count < NAV_REQUIRED:
-            _emit_warn(build_warn_message(file_path, next_read_num))
+            _emit_warn(build_warn_message(file_path, next_read_num, nav_count))
             _note(f"soft-warn read {next_read_num}, allow: {file_path}")
             return 0, None
 

--- a/src/copilot-cli/hooks/preToolUse/invoke_lsp_read_guard__Read_852b43.py
+++ b/src/copilot-cli/hooks/preToolUse/invoke_lsp_read_guard__Read_852b43.py
@@ -194,8 +194,8 @@ def _original_main(stdin_bytes):
       The Soft-warn tier therefore covers read 3 with ``nav_count < NAV_REQUIRED``
       (nav 0 or 1), not only ``nav_count == 0``: hard-block starts at read 4
       (``next_read_num > WARN_AT``), so read 3 always warns and allows (issue #2200).
-      This is LOOSER on read 3 than the kit, which blocks read 3 once nav>=1 leaves
-      its warn branch.
+      This warns more aggressively on read 3 than the kit: the kit silently allows
+      read 3 after one nav, while this port emits an advisory and still allows.
     - DIFFERENT conditioning: the kit gates by hard-coded code-extension regex and
       unconditionally blocks Warmup on any code file. This port gates ONLY when an
       overview-capable provider exists for the file type (``detect_providers`` non

--- a/src/copilot-cli/hooks/preToolUse/invoke_lsp_read_guard__Read_852b43.py
+++ b/src/copilot-cli/hooks/preToolUse/invoke_lsp_read_guard__Read_852b43.py
@@ -1,3 +1,4 @@
+# ruff: noqa
 from __future__ import annotations
 
 # AUTO-GENERATED MATCHER SHIM (REQ-003-007)
@@ -239,7 +240,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         # Fail-open: a navigation guard must never wedge a turn on bootstrap failure.
         sys.exit(0)
     if _lib_dir not in sys.path:

--- a/src/copilot-cli/hooks/preToolUse/invoke_lsp_read_guard__Read_852b43.py
+++ b/src/copilot-cli/hooks/preToolUse/invoke_lsp_read_guard__Read_852b43.py
@@ -191,6 +191,11 @@ def _original_main(stdin_bytes):
       read 4+ with ``nav_count < 2`` is a HARD BLOCK (the kit's "1 nav unlocks 4-5"
       middle step is dropped). Surgical (``nav_count >= 2``) allows all. This is
       STRICTER on reads 4-5 (the kit allowed them after 1 nav; this requires 2).
+      The Soft-warn tier therefore covers read 3 with ``nav_count < NAV_REQUIRED``
+      (nav 0 or 1), not only ``nav_count == 0``: hard-block starts at read 4
+      (``next_read_num > WARN_AT``), so read 3 always warns and allows (issue #2200).
+      This is LOOSER on read 3 than the kit, which blocks read 3 once nav>=1 leaves
+      its warn branch.
     - DIFFERENT conditioning: the kit gates by hard-coded code-extension regex and
       unconditionally blocks Warmup on any code file. This port gates ONLY when an
       overview-capable provider exists for the file type (``detect_providers`` non
@@ -372,8 +377,11 @@ def _original_main(stdin_bytes):
             _note(f"free-read {next_read_num}/{FREE_READS}, allow: {file_path}")
             return 0, None
 
-        # Soft-warn tier: read WARN_AT with no nav yet -> advisory, still allow.
-        if next_read_num == WARN_AT and nav_count == 0:
+        # Soft-warn tier: read WARN_AT with nav below NAV_REQUIRED -> advisory, still
+        # allow. ADR-062 Section 3 hard-blocks from read 4 (next_read_num > WARN_AT);
+        # read 3 with one nav must warn, not block (issue #2200). nav_count >=
+        # NAV_REQUIRED is already short-circuited by the surgical tier above.
+        if next_read_num == WARN_AT and nav_count < NAV_REQUIRED:
             _emit_warn(build_warn_message(file_path, next_read_num))
             _note(f"soft-warn read {next_read_num}, allow: {file_path}")
             return 0, None

--- a/src/copilot-cli/hooks/preToolUse/invoke_lsp_read_guard__Read_852b43.py
+++ b/src/copilot-cli/hooks/preToolUse/invoke_lsp_read_guard__Read_852b43.py
@@ -1,4 +1,3 @@
-# ruff: noqa
 from __future__ import annotations
 
 # AUTO-GENERATED MATCHER SHIM (REQ-003-007)

--- a/tests/hooks/test_invoke_lsp_read_guard.py
+++ b/tests/hooks/test_invoke_lsp_read_guard.py
@@ -162,7 +162,7 @@ class TestMessageBuilders:
         msg = guard.build_warn_message(PY_TARGET, 3, 1)
         assert "WARNING (Read 3)" in msg
         assert "find_symbol" in msg
-        assert "You have 1 nav calls; make 1 more call" in msg
+        assert "You have 1 nav call; make 1 more call" in msg
 
     def test_hard_block_names_providers(self):
         msg = guard.build_hard_block(PY_TARGET, 4, 1, ["serena", "native_lsp"])

--- a/tests/hooks/test_invoke_lsp_read_guard.py
+++ b/tests/hooks/test_invoke_lsp_read_guard.py
@@ -16,19 +16,12 @@ isolation and no test depends on a real state file.
 
 from __future__ import annotations
 
-import io
 import json
-import os
-import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_DIR = REPO_ROOT / ".claude" / "hooks" / "PreToolUse"
@@ -144,7 +137,7 @@ class TestIsGatedTarget:
         monkeypatch.setattr(guard.Path, "relative_to", fake_relative_to)
         # Path is in-repo (so it passes the parents check) but relative_to raises.
         assert guard.is_gated_target(PY_TARGET, str(REPO_ROOT)) is False
-        setattr(guard.Path, "relative_to", real_relative_to)
+        guard.Path.relative_to = real_relative_to
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/test_invoke_lsp_read_guard.py
+++ b/tests/hooks/test_invoke_lsp_read_guard.py
@@ -159,9 +159,10 @@ class TestMessageBuilders:
         assert "native LSP overview" not in msg
 
     def test_warn_message(self):
-        msg = guard.build_warn_message(PY_TARGET, 3)
+        msg = guard.build_warn_message(PY_TARGET, 3, 1)
         assert "WARNING (Read 3)" in msg
         assert "find_symbol" in msg
+        assert "You have 1 nav calls; make 1 more call" in msg
 
     def test_hard_block_names_providers(self):
         msg = guard.build_hard_block(PY_TARGET, 4, 1, ["serena", "native_lsp"])

--- a/tests/hooks/test_invoke_lsp_read_guard.py
+++ b/tests/hooks/test_invoke_lsp_read_guard.py
@@ -239,6 +239,21 @@ class TestEvaluateTiers:
 
     @patch.object(guard, "detect_providers", return_value=["serena"])
     @patch.object(guard, "read_state")
+    def test_third_read_one_nav_warns_but_allows(self, mock_state, _mock_providers, capsys):
+        # Issue #2200: read 3 with a single nav must warn and allow, not block.
+        # Hard-block starts at read 4 (next_read_num > WARN_AT). The earlier bug
+        # gated soft-warn on nav_count == 0, so nav 1 fell through to hard-block.
+        mock_state.return_value = _state(
+            warmup_done=True, nav_count=1, read_files=["a.py", "b.py"]
+        )
+        code, msg = guard.evaluate(PY_TARGET, str(REPO_ROOT))
+        assert code == 0
+        assert msg is None
+        payload = json.loads(capsys.readouterr().out.strip().splitlines()[0])
+        assert "WARNING (Read 3)" in payload["systemMessage"]
+
+    @patch.object(guard, "detect_providers", return_value=["serena"])
+    @patch.object(guard, "read_state")
     def test_fourth_read_hard_blocks(self, mock_state, _mock_providers):
         mock_state.return_value = _state(
             warmup_done=True, nav_count=0, read_files=["a.py", "b.py", "c.py"]


### PR DESCRIPTION
## Summary

The graduated LSP-first Read gate (ADR-062, `invoke_lsp_read_guard.py`) hard-blocked the third unique read once `nav_count` reached 1. Per ADR-062 Section 3, hard-block should start at the fourth read (`next_read_num > WARN_AT`) when `nav_count` is below `NAV_REQUIRED` (2). A single navigation call between reads 2 and 3 incorrectly triggered surgical blocking. Found by Cursor Bugbot during review of PR #2168.

Root cause at `invoke_lsp_read_guard.py:233`: the soft-warn tier matched only `next_read_num == WARN_AT and nav_count == 0`. Read 3 with `nav_count == 1` failed that condition and fell through to the hard-block tier; the surgical tier above (`nav_count >= NAV_REQUIRED`, i.e. 2) did not catch `nav_count == 1` either, so the read blocked.

## Per-file change

- `.claude/hooks/PreToolUse/invoke_lsp_read_guard.py`: broadened the soft-warn condition from `nav_count == 0` to `nav_count < NAV_REQUIRED`, so read 3 with nav 0 or 1 warns and allows. `nav_count >= NAV_REQUIRED` is already short-circuited by the surgical tier. Hard-block now starts at read 4 only. Extended the "Stricter/looser/different than canonical" docstring section to record the read-3 divergence (canonical-source-mirror rule).
- `tests/hooks/test_invoke_lsp_read_guard.py`: added `test_third_read_one_nav_warns_but_allows` pinning read=3, nav=1 -> allow + warn (the issue's suggested test). The existing `test_fourth_read_one_nav_still_blocks` (read 4, nav 1 -> block) remains green, proving the read-4 hard-block is unchanged.
- `src/copilot-cli/hooks/preToolUse/invoke_lsp_read_guard__Read_852b43.py`: regenerated Copilot mirror with generated-file validation (matches the source edit character-for-character).
- `.claude/.claude-plugin/plugin.json`, `src/copilot-cli/.claude-plugin/plugin.json`: patch bump 0.5.12 -> 0.5.14 (plugin source changed; both project-toolkit plugins flagged by the plugin version bump validator).

Fixes #2200

## Testing

- `uv run python -m pytest tests/hooks/test_invoke_lsp_read_guard.py -q` -> 29 passed
- `uv run python -m pytest tests/hooks/ -q` -> 1363 passed (no regressions)
- `uv run python build/scripts/build_all.py` then `git status` -> NO DRIFT (mirror regeneration idempotent)
- `uv run python build/scripts/validate_plugin_version_bump.py --base origin/main` -> OK
- `uv run python .claude/skills/security-scan/scripts/scan_vulnerabilities.py .claude/hooks/PreToolUse/invoke_lsp_read_guard.py` -> No vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

