### PR TITLE
fix(github): deduplicate superseded check runs in get_pr_checks

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.13",
+  "version": "0.5.15",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/github/scripts/pr/get_pr_checks.py
+++ b/.claude/skills/github/scripts/pr/get_pr_checks.py
@@ -96,7 +96,10 @@ _PENDING_STATUSES = {"QUEUED", "IN_PROGRESS", "WAITING", "PENDING", "REQUESTED"}
 # Passing conclusions for CheckRun
 _PASSING_CONCLUSIONS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
 # Failing conclusions for CheckRun
-_FAILING_CONCLUSIONS = {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"}
+_FAILING_CONCLUSIONS = {
+    "FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED",
+    "STALE", "STARTUP_FAILURE",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -171,6 +174,7 @@ def normalize_check(ctx: dict) -> dict | None:
 _PASSING_RANK = 0
 _FAILING_RANK = 1
 _PENDING_RANK = 2
+_UNKNOWN_RANK = 3
 
 
 def _check_rank(check: dict) -> int:
@@ -181,7 +185,7 @@ def _check_rank(check: dict) -> int:
         return _FAILING_RANK
     if check.get("IsPending"):
         return _PENDING_RANK
-    return _FAILING_RANK
+    return _UNKNOWN_RANK
 
 
 def dedupe_checks(checks: list[dict]) -> list[dict]:

--- a/.claude/skills/github/scripts/pr/get_pr_checks.py
+++ b/.claude/skills/github/scripts/pr/get_pr_checks.py
@@ -156,7 +156,7 @@ def normalize_check(ctx: dict) -> dict | None:
 # PENDING. A passing entry from a re-run supersedes a prior failure ("OK if any
 # SUCCESS exists" per the PR #1887 retrospective). A failure still wins over a
 # pending retry when no passing run exists, so pending work does not hide the
-# last concrete failure.
+# last concrete failure. The pending signal is still retained for wait polling.
 #
 # Stricter/looser/different than canonical: test_pr_merge_ready.py treats a
 # CANCELLED-only group as no-opinion (SKIP) so it neither blocks nor counts as
@@ -194,12 +194,16 @@ def dedupe_checks(checks: list[dict]) -> list[dict]:
     """
     best_by_name: dict[str, dict] = {}
     required_by_name: dict[str, bool] = {}
+    pending_by_name: dict[str, bool] = {}
     order: list[str] = []
     for check in checks:
         name_value = check.get("Name")
         name = "" if name_value is None else name_value
         required_by_name[name] = required_by_name.get(name, False) or bool(
             check.get("IsRequired")
+        )
+        pending_by_name[name] = pending_by_name.get(name, False) or bool(
+            check.get("IsPending")
         )
         current = best_by_name.get(name)
         if current is None:
@@ -208,10 +212,13 @@ def dedupe_checks(checks: list[dict]) -> list[dict]:
         elif _check_rank(check) < _check_rank(current):
             best_by_name[name] = check
 
-    return [
-        {**best_by_name[name], "IsRequired": required_by_name[name]}
-        for name in order
-    ]
+    deduped = []
+    for name in order:
+        winner = {**best_by_name[name], "IsRequired": required_by_name[name]}
+        if not winner.get("IsPassing") and pending_by_name[name]:
+            winner["IsPending"] = True
+        deduped.append(winner)
+    return deduped
 
 
 # ---------------------------------------------------------------------------

--- a/.claude/skills/github/scripts/pr/get_pr_checks.py
+++ b/.claude/skills/github/scripts/pr/get_pr_checks.py
@@ -175,6 +175,7 @@ _PASSING_RANK = 0
 _FAILING_RANK = 1
 _PENDING_RANK = 2
 _UNKNOWN_RANK = 3
+_TYPE_RANK = {"CheckRun": 0, "StatusContext": 1}
 
 
 def _check_rank(check: dict) -> int:
@@ -188,14 +189,20 @@ def _check_rank(check: dict) -> int:
     return _UNKNOWN_RANK
 
 
+def _dedupe_rank(check: dict) -> tuple[int, int]:
+    """Rank by source type first, then verdict precedence."""
+    return (_TYPE_RANK.get(check.get("Type"), 2), _check_rank(check))
+
+
 def dedupe_checks(checks: list[dict]) -> list[dict]:
     """Collapse multiple runs of one check name to the winning entry.
 
     Groups by ``Name`` and keeps the entry with the best precedence
     (passing over failing over pending), so a re-run SUCCESS supersedes a
     stale FAILURE on the same commit. The first-seen order of surviving
-    names is preserved. Required-check status is retained when any duplicate
-    row for a name is required.
+    names is preserved. CheckRun rows win over StatusContext rows with the
+    same name. Required-check status is retained when any duplicate row for a
+    name is required.
     """
     best_by_name: dict[str, dict] = {}
     required_by_name: dict[str, bool] = {}
@@ -214,7 +221,7 @@ def dedupe_checks(checks: list[dict]) -> list[dict]:
         if current is None:
             best_by_name[name] = check
             order.append(name)
-        elif _check_rank(check) < _check_rank(current):
+        elif _dedupe_rank(check) < _dedupe_rank(current):
             best_by_name[name] = check
 
     deduped = []

--- a/.claude/skills/github/scripts/pr/get_pr_checks.py
+++ b/.claude/skills/github/scripts/pr/get_pr_checks.py
@@ -147,36 +147,37 @@ def normalize_check(ctx: dict) -> dict | None:
 # GitHub keeps every check run for a check name on one commit, including older
 # runs that a newer run superseded (a re-run, or a debounce that cancels the
 # stale run). A stale FAILURE left alongside a fresh SUCCESS inflated
-# FailedCount and produced a false OverallState=FAILURE for PR #2201 even
-# though test_pr_merge_ready.py reported the PR ready. Refs Issue #2208.
+# FailedCount for PR #2201 even though test_pr_merge_ready.py reported the PR
+# ready. Refs Issue #2208.
 #
-# This mirrors the dedupe behavior in
-# .claude/skills/github/scripts/pr/test_pr_merge_ready.py: group by name and
-# keep the winning entry per group with precedence OK > PENDING > FAIL.
-# A passing entry from a re-run supersedes a prior failure ("OK if any SUCCESS
-# exists" per the PR #1887 retrospective). That script ranks by verdict, not by
-# a completedAt/startedAt timestamp, and the statusCheckRollup query here does
-# not fetch those timestamps; ranking by passing-state matches its contract
-# without a query change.
+# This script leaves OverallState as GitHub's rollup value. Deduplication only
+# affects the per-check rows and derived counts, such as FailedCount. The
+# precedence follows test_pr_merge_ready.py verdict ordering: OK > FAIL >
+# PENDING. A passing entry from a re-run supersedes a prior failure ("OK if any
+# SUCCESS exists" per the PR #1887 retrospective). A failure still wins over a
+# pending retry when no passing run exists, so pending work does not hide the
+# last concrete failure.
 #
 # Stricter/looser/different than canonical: test_pr_merge_ready.py treats a
 # CANCELLED-only group as no-opinion (SKIP) so it neither blocks nor counts as
 # passed. Here, normalize_check already maps CANCELLED into IsFailing (it is in
 # _FAILING_CONCLUSIONS), so a CANCELLED-only group surfaces as a failing check.
 # That preserves this script's long-standing CANCELLED semantics; the dedupe
-# only collapses duplicate names and prefers a passing or pending run when one
-# exists for the same name.
+# only collapses duplicate names and prefers a passing run when one exists for
+# the same name.
 
 # Precedence key: lower sorts first, so the winning entry is the minimum.
 _PASSING_RANK = 0
-_PENDING_RANK = 1
-_FAILING_RANK = 2
+_FAILING_RANK = 1
+_PENDING_RANK = 2
 
 
 def _check_rank(check: dict) -> int:
-    """Rank a normalized check by precedence: passing < pending < failing."""
+    """Rank a normalized check by precedence: passing < failing < pending."""
     if check.get("IsPassing"):
         return _PASSING_RANK
+    if check.get("IsFailing"):
+        return _FAILING_RANK
     if check.get("IsPending"):
         return _PENDING_RANK
     return _FAILING_RANK
@@ -186,21 +187,31 @@ def dedupe_checks(checks: list[dict]) -> list[dict]:
     """Collapse multiple runs of one check name to the winning entry.
 
     Groups by ``Name`` and keeps the entry with the best precedence
-    (passing over pending over failing), so a re-run SUCCESS supersedes a
+    (passing over failing over pending), so a re-run SUCCESS supersedes a
     stale FAILURE on the same commit. The first-seen order of surviving
-    names is preserved. Names that appear once pass through unchanged.
+    names is preserved. Required-check status is retained when any duplicate
+    row for a name is required.
     """
     best_by_name: dict[str, dict] = {}
+    required_by_name: dict[str, bool] = {}
     order: list[str] = []
     for check in checks:
-        name = check.get("Name", "")
+        name_value = check.get("Name")
+        name = "" if name_value is None else name_value
+        required_by_name[name] = required_by_name.get(name, False) or bool(
+            check.get("IsRequired")
+        )
         current = best_by_name.get(name)
         if current is None:
             best_by_name[name] = check
             order.append(name)
         elif _check_rank(check) < _check_rank(current):
             best_by_name[name] = check
-    return [best_by_name[name] for name in order]
+
+    return [
+        {**best_by_name[name], "IsRequired": required_by_name[name]}
+        for name in order
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/.claude/skills/github/scripts/pr/get_pr_checks.py
+++ b/.claude/skills/github/scripts/pr/get_pr_checks.py
@@ -156,7 +156,8 @@ def normalize_check(ctx: dict) -> dict | None:
 # PENDING. A passing entry from a re-run supersedes a prior failure ("OK if any
 # SUCCESS exists" per the PR #1887 retrospective). A failure still wins over a
 # pending retry when no passing run exists, so pending work does not hide the
-# last concrete failure. The pending signal is still retained for wait polling.
+# last concrete failure. Any pending signal is still retained for wait polling,
+# including when a same-name passing run is present.
 #
 # Stricter/looser/different than canonical: test_pr_merge_ready.py treats a
 # CANCELLED-only group as no-opinion (SKIP) so it neither blocks nor counts as
@@ -215,8 +216,7 @@ def dedupe_checks(checks: list[dict]) -> list[dict]:
     deduped = []
     for name in order:
         winner = {**best_by_name[name], "IsRequired": required_by_name[name]}
-        if not winner.get("IsPassing") and pending_by_name[name]:
-            winner["IsPending"] = True
+        winner["IsPending"] = pending_by_name[name]
         deduped.append(winner)
     return deduped
 

--- a/.claude/skills/github/scripts/pr/get_pr_checks.py
+++ b/.claude/skills/github/scripts/pr/get_pr_checks.py
@@ -141,6 +141,69 @@ def normalize_check(ctx: dict) -> dict | None:
 
 
 # ---------------------------------------------------------------------------
+# Deduplication of superseded check runs
+# ---------------------------------------------------------------------------
+#
+# GitHub keeps every check run for a check name on one commit, including older
+# runs that a newer run superseded (a re-run, or a debounce that cancels the
+# stale run). A stale FAILURE left alongside a fresh SUCCESS inflated
+# FailedCount and produced a false OverallState=FAILURE for PR #2201 even
+# though test_pr_merge_ready.py reported the PR ready. Refs Issue #2208.
+#
+# This mirrors the dedupe behavior in
+# .claude/skills/github/scripts/pr/test_pr_merge_ready.py: group by name and
+# keep the winning entry per group with precedence OK > PENDING > FAIL.
+# A passing entry from a re-run supersedes a prior failure ("OK if any SUCCESS
+# exists" per the PR #1887 retrospective). That script ranks by verdict, not by
+# a completedAt/startedAt timestamp, and the statusCheckRollup query here does
+# not fetch those timestamps; ranking by passing-state matches its contract
+# without a query change.
+#
+# Stricter/looser/different than canonical: test_pr_merge_ready.py treats a
+# CANCELLED-only group as no-opinion (SKIP) so it neither blocks nor counts as
+# passed. Here, normalize_check already maps CANCELLED into IsFailing (it is in
+# _FAILING_CONCLUSIONS), so a CANCELLED-only group surfaces as a failing check.
+# That preserves this script's long-standing CANCELLED semantics; the dedupe
+# only collapses duplicate names and prefers a passing or pending run when one
+# exists for the same name.
+
+# Precedence key: lower sorts first, so the winning entry is the minimum.
+_PASSING_RANK = 0
+_PENDING_RANK = 1
+_FAILING_RANK = 2
+
+
+def _check_rank(check: dict) -> int:
+    """Rank a normalized check by precedence: passing < pending < failing."""
+    if check.get("IsPassing"):
+        return _PASSING_RANK
+    if check.get("IsPending"):
+        return _PENDING_RANK
+    return _FAILING_RANK
+
+
+def dedupe_checks(checks: list[dict]) -> list[dict]:
+    """Collapse multiple runs of one check name to the winning entry.
+
+    Groups by ``Name`` and keeps the entry with the best precedence
+    (passing over pending over failing), so a re-run SUCCESS supersedes a
+    stale FAILURE on the same commit. The first-seen order of surviving
+    names is preserved. Names that appear once pass through unchanged.
+    """
+    best_by_name: dict[str, dict] = {}
+    order: list[str] = []
+    for check in checks:
+        name = check.get("Name", "")
+        current = best_by_name.get(name)
+        if current is None:
+            best_by_name[name] = check
+            order.append(name)
+        elif _check_rank(check) < _check_rank(current):
+            best_by_name[name] = check
+    return [best_by_name[name] for name in order]
+
+
+# ---------------------------------------------------------------------------
 # Query and parse
 # ---------------------------------------------------------------------------
 
@@ -191,6 +254,8 @@ def fetch_checks(
         check = normalize_check(ctx)
         if check:
             checks.append(check)
+
+    checks = dedupe_checks(checks)
 
     return {
         "Number": pr.get("number"),

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "25 agent definitions, 81 reusable skills, 52 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "25 agent definitions, 81 reusable skills, 52 lifecycle hooks for GitHub Copilot CLI workflows",
-  "version": "0.5.13",
+  "version": "0.5.15",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
@@ -96,7 +96,10 @@ _PENDING_STATUSES = {"QUEUED", "IN_PROGRESS", "WAITING", "PENDING", "REQUESTED"}
 # Passing conclusions for CheckRun
 _PASSING_CONCLUSIONS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
 # Failing conclusions for CheckRun
-_FAILING_CONCLUSIONS = {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"}
+_FAILING_CONCLUSIONS = {
+    "FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED",
+    "STALE", "STARTUP_FAILURE",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -171,6 +174,7 @@ def normalize_check(ctx: dict) -> dict | None:
 _PASSING_RANK = 0
 _FAILING_RANK = 1
 _PENDING_RANK = 2
+_UNKNOWN_RANK = 3
 
 
 def _check_rank(check: dict) -> int:
@@ -181,7 +185,7 @@ def _check_rank(check: dict) -> int:
         return _FAILING_RANK
     if check.get("IsPending"):
         return _PENDING_RANK
-    return _FAILING_RANK
+    return _UNKNOWN_RANK
 
 
 def dedupe_checks(checks: list[dict]) -> list[dict]:

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
@@ -156,7 +156,7 @@ def normalize_check(ctx: dict) -> dict | None:
 # PENDING. A passing entry from a re-run supersedes a prior failure ("OK if any
 # SUCCESS exists" per the PR #1887 retrospective). A failure still wins over a
 # pending retry when no passing run exists, so pending work does not hide the
-# last concrete failure.
+# last concrete failure. The pending signal is still retained for wait polling.
 #
 # Stricter/looser/different than canonical: test_pr_merge_ready.py treats a
 # CANCELLED-only group as no-opinion (SKIP) so it neither blocks nor counts as
@@ -194,12 +194,16 @@ def dedupe_checks(checks: list[dict]) -> list[dict]:
     """
     best_by_name: dict[str, dict] = {}
     required_by_name: dict[str, bool] = {}
+    pending_by_name: dict[str, bool] = {}
     order: list[str] = []
     for check in checks:
         name_value = check.get("Name")
         name = "" if name_value is None else name_value
         required_by_name[name] = required_by_name.get(name, False) or bool(
             check.get("IsRequired")
+        )
+        pending_by_name[name] = pending_by_name.get(name, False) or bool(
+            check.get("IsPending")
         )
         current = best_by_name.get(name)
         if current is None:
@@ -208,10 +212,13 @@ def dedupe_checks(checks: list[dict]) -> list[dict]:
         elif _check_rank(check) < _check_rank(current):
             best_by_name[name] = check
 
-    return [
-        {**best_by_name[name], "IsRequired": required_by_name[name]}
-        for name in order
-    ]
+    deduped = []
+    for name in order:
+        winner = {**best_by_name[name], "IsRequired": required_by_name[name]}
+        if not winner.get("IsPassing") and pending_by_name[name]:
+            winner["IsPending"] = True
+        deduped.append(winner)
+    return deduped
 
 
 # ---------------------------------------------------------------------------

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
@@ -175,6 +175,7 @@ _PASSING_RANK = 0
 _FAILING_RANK = 1
 _PENDING_RANK = 2
 _UNKNOWN_RANK = 3
+_TYPE_RANK = {"CheckRun": 0, "StatusContext": 1}
 
 
 def _check_rank(check: dict) -> int:
@@ -188,14 +189,20 @@ def _check_rank(check: dict) -> int:
     return _UNKNOWN_RANK
 
 
+def _dedupe_rank(check: dict) -> tuple[int, int]:
+    """Rank by source type first, then verdict precedence."""
+    return (_TYPE_RANK.get(check.get("Type"), 2), _check_rank(check))
+
+
 def dedupe_checks(checks: list[dict]) -> list[dict]:
     """Collapse multiple runs of one check name to the winning entry.
 
     Groups by ``Name`` and keeps the entry with the best precedence
     (passing over failing over pending), so a re-run SUCCESS supersedes a
     stale FAILURE on the same commit. The first-seen order of surviving
-    names is preserved. Required-check status is retained when any duplicate
-    row for a name is required.
+    names is preserved. CheckRun rows win over StatusContext rows with the
+    same name. Required-check status is retained when any duplicate row for a
+    name is required.
     """
     best_by_name: dict[str, dict] = {}
     required_by_name: dict[str, bool] = {}
@@ -214,7 +221,7 @@ def dedupe_checks(checks: list[dict]) -> list[dict]:
         if current is None:
             best_by_name[name] = check
             order.append(name)
-        elif _check_rank(check) < _check_rank(current):
+        elif _dedupe_rank(check) < _dedupe_rank(current):
             best_by_name[name] = check
 
     deduped = []

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
@@ -147,36 +147,37 @@ def normalize_check(ctx: dict) -> dict | None:
 # GitHub keeps every check run for a check name on one commit, including older
 # runs that a newer run superseded (a re-run, or a debounce that cancels the
 # stale run). A stale FAILURE left alongside a fresh SUCCESS inflated
-# FailedCount and produced a false OverallState=FAILURE for PR #2201 even
-# though test_pr_merge_ready.py reported the PR ready. Refs Issue #2208.
+# FailedCount for PR #2201 even though test_pr_merge_ready.py reported the PR
+# ready. Refs Issue #2208.
 #
-# This mirrors the dedupe behavior in
-# .claude/skills/github/scripts/pr/test_pr_merge_ready.py: group by name and
-# keep the winning entry per group with precedence OK > PENDING > FAIL.
-# A passing entry from a re-run supersedes a prior failure ("OK if any SUCCESS
-# exists" per the PR #1887 retrospective). That script ranks by verdict, not by
-# a completedAt/startedAt timestamp, and the statusCheckRollup query here does
-# not fetch those timestamps; ranking by passing-state matches its contract
-# without a query change.
+# This script leaves OverallState as GitHub's rollup value. Deduplication only
+# affects the per-check rows and derived counts, such as FailedCount. The
+# precedence follows test_pr_merge_ready.py verdict ordering: OK > FAIL >
+# PENDING. A passing entry from a re-run supersedes a prior failure ("OK if any
+# SUCCESS exists" per the PR #1887 retrospective). A failure still wins over a
+# pending retry when no passing run exists, so pending work does not hide the
+# last concrete failure.
 #
 # Stricter/looser/different than canonical: test_pr_merge_ready.py treats a
 # CANCELLED-only group as no-opinion (SKIP) so it neither blocks nor counts as
 # passed. Here, normalize_check already maps CANCELLED into IsFailing (it is in
 # _FAILING_CONCLUSIONS), so a CANCELLED-only group surfaces as a failing check.
 # That preserves this script's long-standing CANCELLED semantics; the dedupe
-# only collapses duplicate names and prefers a passing or pending run when one
-# exists for the same name.
+# only collapses duplicate names and prefers a passing run when one exists for
+# the same name.
 
 # Precedence key: lower sorts first, so the winning entry is the minimum.
 _PASSING_RANK = 0
-_PENDING_RANK = 1
-_FAILING_RANK = 2
+_FAILING_RANK = 1
+_PENDING_RANK = 2
 
 
 def _check_rank(check: dict) -> int:
-    """Rank a normalized check by precedence: passing < pending < failing."""
+    """Rank a normalized check by precedence: passing < failing < pending."""
     if check.get("IsPassing"):
         return _PASSING_RANK
+    if check.get("IsFailing"):
+        return _FAILING_RANK
     if check.get("IsPending"):
         return _PENDING_RANK
     return _FAILING_RANK
@@ -186,21 +187,31 @@ def dedupe_checks(checks: list[dict]) -> list[dict]:
     """Collapse multiple runs of one check name to the winning entry.
 
     Groups by ``Name`` and keeps the entry with the best precedence
-    (passing over pending over failing), so a re-run SUCCESS supersedes a
+    (passing over failing over pending), so a re-run SUCCESS supersedes a
     stale FAILURE on the same commit. The first-seen order of surviving
-    names is preserved. Names that appear once pass through unchanged.
+    names is preserved. Required-check status is retained when any duplicate
+    row for a name is required.
     """
     best_by_name: dict[str, dict] = {}
+    required_by_name: dict[str, bool] = {}
     order: list[str] = []
     for check in checks:
-        name = check.get("Name", "")
+        name_value = check.get("Name")
+        name = "" if name_value is None else name_value
+        required_by_name[name] = required_by_name.get(name, False) or bool(
+            check.get("IsRequired")
+        )
         current = best_by_name.get(name)
         if current is None:
             best_by_name[name] = check
             order.append(name)
         elif _check_rank(check) < _check_rank(current):
             best_by_name[name] = check
-    return [best_by_name[name] for name in order]
+
+    return [
+        {**best_by_name[name], "IsRequired": required_by_name[name]}
+        for name in order
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
@@ -156,7 +156,8 @@ def normalize_check(ctx: dict) -> dict | None:
 # PENDING. A passing entry from a re-run supersedes a prior failure ("OK if any
 # SUCCESS exists" per the PR #1887 retrospective). A failure still wins over a
 # pending retry when no passing run exists, so pending work does not hide the
-# last concrete failure. The pending signal is still retained for wait polling.
+# last concrete failure. Any pending signal is still retained for wait polling,
+# including when a same-name passing run is present.
 #
 # Stricter/looser/different than canonical: test_pr_merge_ready.py treats a
 # CANCELLED-only group as no-opinion (SKIP) so it neither blocks nor counts as
@@ -215,8 +216,7 @@ def dedupe_checks(checks: list[dict]) -> list[dict]:
     deduped = []
     for name in order:
         winner = {**best_by_name[name], "IsRequired": required_by_name[name]}
-        if not winner.get("IsPassing") and pending_by_name[name]:
-            winner["IsPending"] = True
+        winner["IsPending"] = pending_by_name[name]
         deduped.append(winner)
     return deduped
 

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py
@@ -141,6 +141,69 @@ def normalize_check(ctx: dict) -> dict | None:
 
 
 # ---------------------------------------------------------------------------
+# Deduplication of superseded check runs
+# ---------------------------------------------------------------------------
+#
+# GitHub keeps every check run for a check name on one commit, including older
+# runs that a newer run superseded (a re-run, or a debounce that cancels the
+# stale run). A stale FAILURE left alongside a fresh SUCCESS inflated
+# FailedCount and produced a false OverallState=FAILURE for PR #2201 even
+# though test_pr_merge_ready.py reported the PR ready. Refs Issue #2208.
+#
+# This mirrors the dedupe behavior in
+# .claude/skills/github/scripts/pr/test_pr_merge_ready.py: group by name and
+# keep the winning entry per group with precedence OK > PENDING > FAIL.
+# A passing entry from a re-run supersedes a prior failure ("OK if any SUCCESS
+# exists" per the PR #1887 retrospective). That script ranks by verdict, not by
+# a completedAt/startedAt timestamp, and the statusCheckRollup query here does
+# not fetch those timestamps; ranking by passing-state matches its contract
+# without a query change.
+#
+# Stricter/looser/different than canonical: test_pr_merge_ready.py treats a
+# CANCELLED-only group as no-opinion (SKIP) so it neither blocks nor counts as
+# passed. Here, normalize_check already maps CANCELLED into IsFailing (it is in
+# _FAILING_CONCLUSIONS), so a CANCELLED-only group surfaces as a failing check.
+# That preserves this script's long-standing CANCELLED semantics; the dedupe
+# only collapses duplicate names and prefers a passing or pending run when one
+# exists for the same name.
+
+# Precedence key: lower sorts first, so the winning entry is the minimum.
+_PASSING_RANK = 0
+_PENDING_RANK = 1
+_FAILING_RANK = 2
+
+
+def _check_rank(check: dict) -> int:
+    """Rank a normalized check by precedence: passing < pending < failing."""
+    if check.get("IsPassing"):
+        return _PASSING_RANK
+    if check.get("IsPending"):
+        return _PENDING_RANK
+    return _FAILING_RANK
+
+
+def dedupe_checks(checks: list[dict]) -> list[dict]:
+    """Collapse multiple runs of one check name to the winning entry.
+
+    Groups by ``Name`` and keeps the entry with the best precedence
+    (passing over pending over failing), so a re-run SUCCESS supersedes a
+    stale FAILURE on the same commit. The first-seen order of surviving
+    names is preserved. Names that appear once pass through unchanged.
+    """
+    best_by_name: dict[str, dict] = {}
+    order: list[str] = []
+    for check in checks:
+        name = check.get("Name", "")
+        current = best_by_name.get(name)
+        if current is None:
+            best_by_name[name] = check
+            order.append(name)
+        elif _check_rank(check) < _check_rank(current):
+            best_by_name[name] = check
+    return [best_by_name[name] for name in order]
+
+
+# ---------------------------------------------------------------------------
 # Query and parse
 # ---------------------------------------------------------------------------
 
@@ -191,6 +254,8 @@ def fetch_checks(
         check = normalize_check(ctx)
         if check:
             checks.append(check)
+
+    checks = dedupe_checks(checks)
 
     return {
         "Number": pr.get("number"),

--- a/tests/test_get_pr_checks.py
+++ b/tests/test_get_pr_checks.py
@@ -973,6 +973,22 @@ class TestBuildOutputAdditional:
         assert output["PendingCount"] == 1
         assert output["AllPassing"] is False
 
+    def test_passing_pending_duplicate_counts_as_pending_not_all_passing(self):
+        checks = dedupe_checks([
+            _check("build", passing=True, conclusion="SUCCESS"),
+            _check("build", pending=True, state="IN_PROGRESS"),
+        ])
+        check_data = {
+            "Number": 42,
+            "HasChecks": True,
+            "OverallState": "PENDING",
+            "Checks": checks,
+        }
+        output = build_output(check_data, "o", "r")
+        assert output["FailedCount"] == 0
+        assert output["PendingCount"] == 1
+        assert output["AllPassing"] is False
+
     def test_has_checks_false(self):
         check_data = {
             "Number": 42,
@@ -1070,8 +1086,8 @@ class TestDedupeChecks:
         assert result[0]["IsFailing"] is True
         assert result[0]["IsPending"] is True
 
-    def test_passing_supersedes_pending(self):
-        """A passing run wins over a pending run for the same name."""
+    def test_passing_supersedes_pending_but_keeps_pending_signal(self):
+        """A same-name pending run keeps wait polling active."""
         checks = [
             _check("build", pending=True, state="IN_PROGRESS"),
             _check("build", passing=True, conclusion="SUCCESS"),
@@ -1079,6 +1095,7 @@ class TestDedupeChecks:
         result = dedupe_checks(checks)
         assert len(result) == 1
         assert result[0]["IsPassing"] is True
+        assert result[0]["IsPending"] is True
 
     def test_status_context_dedupes_by_name(self):
         """StatusContext entries dedupe by Name like CheckRun entries."""

--- a/tests/test_get_pr_checks.py
+++ b/tests/test_get_pr_checks.py
@@ -37,6 +37,57 @@ build_parser = _mod.build_parser
 normalize_check = _mod.normalize_check
 fetch_checks = _mod.fetch_checks
 build_output = _mod.build_output
+dedupe_checks = _mod.dedupe_checks
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _check(name: str, *, passing=False, failing=False, pending=False,
+           required=True, state="COMPLETED", conclusion="", details=""):
+    """Build a normalized check dict for dedupe tests."""
+    return {
+        "Name": name,
+        "Type": "CheckRun",
+        "State": state,
+        "Conclusion": conclusion,
+        "DetailsUrl": details,
+        "IsRequired": required,
+        "IsPending": pending,
+        "IsPassing": passing,
+        "IsFailing": failing,
+    }
+
+
+def _check_run_node(name, status, conclusion, *, required=True):
+    return {
+        "__typename": "CheckRun",
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "detailsUrl": "",
+        "isRequired": required,
+    }
+
+
+def _rollup_response(nodes, state="FAILURE", number=2201):
+    return {
+        "repository": {
+            "pullRequest": {
+                "number": number,
+                "commits": {
+                    "nodes": [
+                        {"commit": {"statusCheckRollup": {
+                            "state": state,
+                            "contexts": {"nodes": nodes},
+                        }}},
+                    ],
+                },
+            },
+        },
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -915,3 +966,166 @@ class TestBuildOutputAdditional:
         }
         output = build_output(check_data, "o", "r")
         assert output["AllPassing"] is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: dedupe_checks (superseded check runs, Issue #2208)
+# ---------------------------------------------------------------------------
+
+
+class TestDedupeChecks:
+    def test_empty_list_returns_empty(self):
+        assert dedupe_checks([]) == []
+
+    def test_single_check_passes_through(self):
+        checks = [_check("build", passing=True)]
+        assert dedupe_checks(checks) == checks
+
+    def test_distinct_names_preserved_in_order(self):
+        checks = [
+            _check("build", passing=True),
+            _check("test", failing=True),
+            _check("lint", pending=True),
+        ]
+        result = dedupe_checks(checks)
+        assert [c["Name"] for c in result] == ["build", "test", "lint"]
+
+    def test_passing_supersedes_earlier_failure(self):
+        """A re-run SUCCESS wins over a stale FAILURE for the same name."""
+        checks = [
+            _check("Validate PR", failing=True, conclusion="FAILURE"),
+            _check("Validate PR", passing=True, conclusion="SUCCESS"),
+        ]
+        result = dedupe_checks(checks)
+        assert len(result) == 1
+        assert result[0]["IsPassing"] is True
+        assert result[0]["IsFailing"] is False
+
+    def test_passing_supersedes_later_failure(self):
+        """Order does not matter: a passing run wins even when seen first."""
+        checks = [
+            _check("Validate PR", passing=True, conclusion="SUCCESS"),
+            _check("Validate PR", failing=True, conclusion="FAILURE"),
+        ]
+        result = dedupe_checks(checks)
+        assert len(result) == 1
+        assert result[0]["IsPassing"] is True
+
+    def test_real_failure_with_no_passing_run_survives(self):
+        """No passing run means the failing entry is kept (true failure)."""
+        checks = [
+            _check("test", failing=True, conclusion="FAILURE"),
+            _check("test", failing=True, conclusion="TIMED_OUT"),
+        ]
+        result = dedupe_checks(checks)
+        assert len(result) == 1
+        assert result[0]["IsFailing"] is True
+
+    def test_pending_supersedes_failure(self):
+        """A pending re-run wins over a stale failure (not yet conclusive)."""
+        checks = [
+            _check("build", failing=True, conclusion="FAILURE"),
+            _check("build", pending=True, state="IN_PROGRESS"),
+        ]
+        result = dedupe_checks(checks)
+        assert len(result) == 1
+        assert result[0]["IsPending"] is True
+        assert result[0]["IsFailing"] is False
+
+    def test_passing_supersedes_pending(self):
+        """A passing run wins over a pending run for the same name."""
+        checks = [
+            _check("build", pending=True, state="IN_PROGRESS"),
+            _check("build", passing=True, conclusion="SUCCESS"),
+        ]
+        result = dedupe_checks(checks)
+        assert len(result) == 1
+        assert result[0]["IsPassing"] is True
+
+    def test_status_context_dedupes_by_name(self):
+        """StatusContext entries dedupe by Name like CheckRun entries."""
+        checks = [
+            {
+                "Name": "ci/travis", "Type": "StatusContext",
+                "State": "FAILURE", "Conclusion": "FAILURE", "DetailsUrl": "",
+                "IsRequired": True, "IsPending": False,
+                "IsPassing": False, "IsFailing": True,
+            },
+            {
+                "Name": "ci/travis", "Type": "StatusContext",
+                "State": "SUCCESS", "Conclusion": "SUCCESS", "DetailsUrl": "",
+                "IsRequired": True, "IsPending": False,
+                "IsPassing": True, "IsFailing": False,
+            },
+        ]
+        result = dedupe_checks(checks)
+        assert len(result) == 1
+        assert result[0]["IsPassing"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: fetch_checks + main with superseded runs (Issue #2208 scenario)
+# ---------------------------------------------------------------------------
+
+
+class TestSupersededCheckRuns:
+    def test_fetch_checks_collapses_superseded_failure(self):
+        """fetch_checks dedupes a stale FAILURE against a fresh SUCCESS."""
+        nodes = [
+            _check_run_node("Validate PR", "COMPLETED", "FAILURE"),
+            _check_run_node("Validate PR", "COMPLETED", "SUCCESS"),
+        ]
+        with patch(
+            "get_pr_checks.gh_graphql",
+            return_value=_rollup_response(nodes),
+        ):
+            result = fetch_checks("o", "r", 2201)
+        assert len(result["Checks"]) == 1
+        assert result["Checks"][0]["IsPassing"] is True
+
+    def test_main_superseded_failure_returns_0(self, capsys):
+        """End-to-end: PR #2201 shape (stale FAILURE + fresh SUCCESS) is ready.
+
+        Reproduces Issue #2208: an older Validate PR run failed while a newer
+        run succeeded on the same commit. Before the fix, FailedCount was 1
+        and the exit code was 1; after dedupe it is 0.
+        """
+        nodes = [
+            _check_run_node("Validate PR", "COMPLETED", "FAILURE"),
+            _check_run_node("Validate PR", "COMPLETED", "SUCCESS"),
+        ]
+        with patch(
+            "get_pr_checks.assert_gh_authenticated",
+        ), patch(
+            "get_pr_checks.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "get_pr_checks.gh_graphql",
+            return_value=_rollup_response(nodes),
+        ):
+            rc = main(["--pull-request", "2201"])
+        assert rc == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output["Data"]["FailedCount"] == 0
+        assert output["Data"]["PassedCount"] == 1
+        assert output["Data"]["AllPassing"] is True
+
+    def test_main_genuine_failure_still_returns_1(self, capsys):
+        """A name with only failing runs still blocks (no false PASS)."""
+        nodes = [
+            _check_run_node("test", "COMPLETED", "FAILURE"),
+            _check_run_node("test", "COMPLETED", "FAILURE"),
+        ]
+        with patch(
+            "get_pr_checks.assert_gh_authenticated",
+        ), patch(
+            "get_pr_checks.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "get_pr_checks.gh_graphql",
+            return_value=_rollup_response(nodes),
+        ):
+            rc = main(["--pull-request", "42"])
+        assert rc == 1
+        output = json.loads(capsys.readouterr().out)
+        assert output["Data"]["FailedCount"] == 1

--- a/tests/test_get_pr_checks.py
+++ b/tests/test_get_pr_checks.py
@@ -174,6 +174,20 @@ class TestNormalizeCheck:
         result = normalize_check(ctx)
         assert result["IsPending"] is True
 
+    @pytest.mark.parametrize("conclusion", ["STALE", "STARTUP_FAILURE"])
+    def test_check_run_stale_and_startup_failure_are_failing(self, conclusion):
+        ctx = {
+            "__typename": "CheckRun",
+            "name": "build",
+            "status": "COMPLETED",
+            "conclusion": conclusion,
+            "detailsUrl": "",
+            "isRequired": True,
+        }
+        result = normalize_check(ctx)
+        assert result["IsFailing"] is True
+        assert result["IsPassing"] is False
+
     def test_status_context(self):
         ctx = {
             "__typename": "StatusContext",
@@ -1073,6 +1087,17 @@ class TestDedupeChecks:
         ]
         result = dedupe_checks(checks)
         assert len(result) == 1
+        assert result[0]["IsFailing"] is True
+
+    def test_failure_supersedes_unknown_conclusion(self):
+        """Unknown conclusions do not hide real failures."""
+        checks = [
+            _check("test", conclusion="UNKNOWN"),
+            _check("test", failing=True, conclusion="FAILURE"),
+        ]
+        result = dedupe_checks(checks)
+        assert len(result) == 1
+        assert result[0]["Conclusion"] == "FAILURE"
         assert result[0]["IsFailing"] is True
 
     def test_failure_supersedes_pending_but_keeps_pending_signal(self):

--- a/tests/test_get_pr_checks.py
+++ b/tests/test_get_pr_checks.py
@@ -1142,6 +1142,22 @@ class TestDedupeChecks:
         assert len(result) == 1
         assert result[0]["IsPassing"] is True
 
+    def test_check_run_preferred_over_same_name_status_context(self):
+        """A StatusContext duplicate cannot mask a failing CheckRun."""
+        checks = [
+            {
+                "Name": "build", "Type": "StatusContext",
+                "State": "SUCCESS", "Conclusion": "SUCCESS", "DetailsUrl": "",
+                "IsRequired": True, "IsPending": False,
+                "IsPassing": True, "IsFailing": False,
+            },
+            _check("build", failing=True, conclusion="FAILURE"),
+        ]
+        result = dedupe_checks(checks)
+        assert len(result) == 1
+        assert result[0]["Type"] == "CheckRun"
+        assert result[0]["IsFailing"] is True
+
 
 # ---------------------------------------------------------------------------
 # Tests: fetch_checks + main with superseded runs (Issue #2208 scenario)

--- a/tests/test_get_pr_checks.py
+++ b/tests/test_get_pr_checks.py
@@ -957,6 +957,22 @@ class TestBuildOutputAdditional:
         assert output["PendingCount"] == 1
         assert output["AllPassing"] is False
 
+    def test_failed_pending_duplicate_counts_as_failed_and_pending(self):
+        checks = dedupe_checks([
+            _check("build", failing=True, conclusion="FAILURE"),
+            _check("build", pending=True, state="IN_PROGRESS"),
+        ])
+        check_data = {
+            "Number": 42,
+            "HasChecks": True,
+            "OverallState": "FAILURE",
+            "Checks": checks,
+        }
+        output = build_output(check_data, "o", "r")
+        assert output["FailedCount"] == 1
+        assert output["PendingCount"] == 1
+        assert output["AllPassing"] is False
+
     def test_has_checks_false(self):
         check_data = {
             "Number": 42,
@@ -1043,8 +1059,8 @@ class TestDedupeChecks:
         assert len(result) == 1
         assert result[0]["IsFailing"] is True
 
-    def test_failure_supersedes_pending(self):
-        """A pending re-run does not hide the last concrete failure."""
+    def test_failure_supersedes_pending_but_keeps_pending_signal(self):
+        """A pending re-run keeps wait polling active after a failure."""
         checks = [
             _check("build", failing=True, conclusion="FAILURE"),
             _check("build", pending=True, state="IN_PROGRESS"),
@@ -1052,7 +1068,7 @@ class TestDedupeChecks:
         result = dedupe_checks(checks)
         assert len(result) == 1
         assert result[0]["IsFailing"] is True
-        assert result[0]["IsPending"] is False
+        assert result[0]["IsPending"] is True
 
     def test_passing_supersedes_pending(self):
         """A passing run wins over a pending run for the same name."""

--- a/tests/test_get_pr_checks.py
+++ b/tests/test_get_pr_checks.py
@@ -1011,6 +1011,28 @@ class TestDedupeChecks:
         assert len(result) == 1
         assert result[0]["IsPassing"] is True
 
+    def test_required_status_survives_when_any_duplicate_is_required(self):
+        """A required duplicate keeps the deduped row required."""
+        checks = [
+            _check("security", passing=True, conclusion="SUCCESS", required=False),
+            _check("security", failing=True, conclusion="FAILURE", required=True),
+        ]
+        result = dedupe_checks(checks)
+        assert len(result) == 1
+        assert result[0]["IsPassing"] is True
+        assert result[0]["IsRequired"] is True
+
+    def test_null_name_collapses_to_empty_name(self):
+        """Explicit null names dedupe through the empty-name bucket."""
+        checks = [
+            {**_check("ignored", failing=True, conclusion="FAILURE"), "Name": None},
+            {**_check("", passing=True, conclusion="SUCCESS"), "Name": ""},
+        ]
+        result = dedupe_checks(checks)
+        assert len(result) == 1
+        assert result[0]["Name"] == ""
+        assert result[0]["IsPassing"] is True
+
     def test_real_failure_with_no_passing_run_survives(self):
         """No passing run means the failing entry is kept (true failure)."""
         checks = [
@@ -1021,16 +1043,16 @@ class TestDedupeChecks:
         assert len(result) == 1
         assert result[0]["IsFailing"] is True
 
-    def test_pending_supersedes_failure(self):
-        """A pending re-run wins over a stale failure (not yet conclusive)."""
+    def test_failure_supersedes_pending(self):
+        """A pending re-run does not hide the last concrete failure."""
         checks = [
             _check("build", failing=True, conclusion="FAILURE"),
             _check("build", pending=True, state="IN_PROGRESS"),
         ]
         result = dedupe_checks(checks)
         assert len(result) == 1
-        assert result[0]["IsPending"] is True
-        assert result[0]["IsFailing"] is False
+        assert result[0]["IsFailing"] is True
+        assert result[0]["IsPending"] is False
 
     def test_passing_supersedes_pending(self):
         """A passing run wins over a pending run for the same name."""


### PR DESCRIPTION
## Summary

`get_pr_checks.py` reported `OverallState=FAILURE` and a non-zero `FailedCount` when GitHub kept a superseded check run with the same name on one commit. During pr-autofix for PR #2201, an older `Validate PR` run failed while a newer run succeeded on the same commit. `fetch_checks` listed both, so the stale FAILURE counted as a failed required check. The readiness validator reported the PR ready, so the two scripts disagreed and automation treated a ready PR as blocked.

This adds name-based deduplication so a re-run SUCCESS supersedes a prior failure, while a pending retry no longer hides the last concrete failure.

## Per-file change

- `.claude/skills/github/scripts/pr/get_pr_checks.py`: add `dedupe_checks`, called in `fetch_checks` right after the normalized checks list is built. It groups checks by `Name`, collapses explicit null names to the empty-name bucket, keeps the winning entry per group with precedence passing > failing > pending, prefers CheckRun rows over same-name StatusContext rows, ORs `IsRequired` across duplicates, and retains a pending signal for active same-name re-runs so `--wait` keeps polling.
- `src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py`: keep the Copilot CLI copy byte-identical to the source script.
- `tests/test_get_pr_checks.py`: add focused coverage for superseded failures, failure versus pending precedence, required-flag retention, null names, stale/startup-failure conclusions, StatusContext dedupe, distinct names, and the Issue #2208 end-to-end path.
- `.claude/.claude-plugin/plugin.json` and `src/copilot-cli/.claude-plugin/plugin.json`: bump project-toolkit to 0.5.15 because plugin source under both source dirs changed.

## Design note

The issue text suggested ranking by latest timestamps. The `statusCheckRollup` GraphQL query in this script does not fetch those timestamps, and the canonical readiness validator uses verdict precedence, not timestamps. This change follows that verdict precedence without changing the query. `OverallState` remains a pass-through of GitHub's raw rollup state; the automation-blocking signals (`FailedCount`, `AllPassing`, exit code) are derived from the deduped checks and now report correctly.

Fixes #2208

## Testing

- `python -m pytest tests/test_get_pr_checks.py -q` => 65 passed
- `ruff check .claude/skills/github/scripts/pr/get_pr_checks.py src/copilot-cli/skills/github/scripts/pr/get_pr_checks.py tests/test_get_pr_checks.py` => passed
- Plugin library sync check => passed
- Plugin manifest validation => passed
- Dash check against `origin/main...HEAD` => no prohibited dash characters





