### PR TITLE
fix(validation): make git-hooks gate worktree-aware in pre_pr

### DIFF
--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -948,6 +948,37 @@ def validate_plugin_version_bump(repo_root: Path) -> bool:
     )
 
 
+def _is_linked_worktree(repo_root: Path) -> bool:
+    """True when ``repo_root`` is a linked git worktree, not the main checkout.
+
+    A linked worktree's git-common-dir (the shared ``.git`` of the main
+    checkout) differs from the worktree's own ``.git`` pointer file. The main
+    checkout's git-common-dir resolves to its own ``repo_root/.git`` directory.
+    Comparing the two distinguishes the two cases.
+
+    Returns False on any git failure (fail open: treat an unknown layout as the
+    main checkout so the gate still runs).
+    """
+    exit_code, stdout, _ = _run_subprocess(
+        ["git", "-C", str(repo_root), "rev-parse", "--git-common-dir"],
+        timeout=10,
+    )
+    if exit_code != 0:
+        return False
+    common = stdout.strip()
+    if not common:
+        return False
+    common_path = Path(common)
+    if not common_path.is_absolute():
+        common_path = repo_root / common_path
+    try:
+        common_resolved = common_path.resolve()
+        local_git = (repo_root / ".git").resolve()
+    except OSError:
+        return False
+    return common_resolved != local_git
+
+
 def validate_git_hooks_installed(repo_root: Path) -> bool:
     """Fail when the local clone is not wired to run the canonical githooks.
 
@@ -960,12 +991,26 @@ def validate_git_hooks_installed(repo_root: Path) -> bool:
     Skipped under CI: a CI checkout neither has nor should have
     ``core.hooksPath`` set to ``.githooks`` (the guards run as workflow steps,
     not local hooks), so the check is irrelevant there.
+
+    Skipped in a linked worktree: ``core.hooksPath`` lives in the shared
+    repository config, so a worktree inherits whatever the main checkout set.
+    Inside a worktree the relative ``.githooks`` value (or an absolute path the
+    main checkout wrote) does not resolve to this worktree's ``.githooks``, so
+    ``--check`` fails through no fault of the worktree. Mutating shared config
+    from a worktree to satisfy the gate would change every other worktree, so
+    SKIP with an advisory instead (Issue #2220).
     """
     if (
         os.environ.get("GITHUB_ACTIONS", "").lower() in ("true", "1")
         or os.environ.get("CI", "").lower() in ("true", "1")
     ):
         raise MissingScriptSkip("git hooks check skipped under CI")
+    if _is_linked_worktree(repo_root):
+        raise MissingScriptSkip(
+            "git hooks check skipped in linked worktree; core.hooksPath is "
+            "shared config inherited from the main checkout. Install hooks "
+            "there: python3 scripts/install_git_hooks.py"
+        )
     script = repo_root / "scripts" / "install_git_hooks.py"
     if not script.exists():
         print(

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -972,37 +972,6 @@ def validate_plugin_version_bump(repo_root: Path) -> bool:
     )
 
 
-def _is_linked_worktree(repo_root: Path) -> bool:
-    """True when ``repo_root`` is a linked git worktree, not the main checkout.
-
-    A linked worktree's git-common-dir (the shared ``.git`` of the main
-    checkout) differs from the worktree's own ``.git`` pointer file. The main
-    checkout's git-common-dir resolves to its own ``repo_root/.git`` directory.
-    Comparing the two distinguishes the two cases.
-
-    Returns False on any git failure (fail open: treat an unknown layout as the
-    main checkout so the gate still runs).
-    """
-    exit_code, stdout, _ = _run_subprocess(
-        ["git", "-C", str(repo_root), "rev-parse", "--git-common-dir"],
-        timeout=10,
-    )
-    if exit_code != 0:
-        return False
-    common = stdout.strip()
-    if not common:
-        return False
-    common_path = Path(common)
-    if not common_path.is_absolute():
-        common_path = repo_root / common_path
-    try:
-        common_resolved = common_path.resolve()
-        local_git = (repo_root / ".git").resolve()
-    except OSError:
-        return False
-    return common_resolved != local_git
-
-
 def validate_git_hooks_installed(repo_root: Path) -> bool:
     """Fail when the local clone is not wired to run the canonical githooks.
 
@@ -1016,25 +985,16 @@ def validate_git_hooks_installed(repo_root: Path) -> bool:
     ``core.hooksPath`` set to ``.githooks`` (the guards run as workflow steps,
     not local hooks), so the check is irrelevant there.
 
-    Skipped in a linked worktree: ``core.hooksPath`` lives in the shared
-    repository config, so a worktree inherits whatever the main checkout set.
-    Inside a worktree the relative ``.githooks`` value (or an absolute path the
-    main checkout wrote) does not resolve to this worktree's ``.githooks``, so
-    ``--check`` fails through no fault of the worktree. Mutating shared config
-    from a worktree to satisfy the gate would change every other worktree, so
-    SKIP with an advisory instead (Issue #2220).
+    Worktree-aware: ``scripts/install_git_hooks.py --check`` reads the effective
+    hook configuration while resolving the canonical relative ``.githooks`` path
+    against the current worktree. This keeps the gate active in linked worktrees
+    so shared-config drift still fails before push (Issue #2220).
     """
     if (
         os.environ.get("GITHUB_ACTIONS", "").lower() in ("true", "1")
         or os.environ.get("CI", "").lower() in ("true", "1")
     ):
         raise MissingScriptSkip("git hooks check skipped under CI")
-    if _is_linked_worktree(repo_root):
-        raise MissingScriptSkip(
-            "git hooks check skipped in linked worktree; core.hooksPath is "
-            "shared config inherited from the main checkout. Install hooks "
-            "there: python3 scripts/install_git_hooks.py"
-        )
     script = repo_root / "scripts" / "install_git_hooks.py"
     if not script.exists():
         print(

--- a/tests/test_validation_pre_pr.py
+++ b/tests/test_validation_pre_pr.py
@@ -764,8 +764,8 @@ class TestValidateGitHooksInstalled:
                 mock_run.return_value = (1, "", "core.hooksPath not set")
                 assert validate_git_hooks_installed(tmp_path) is False
 
-    def test_delegates_in_linked_worktree(self, tmp_path: Path) -> None:
-        """Linked worktrees still run the git-hooks gate (#2220)."""
+    def test_delegates_to_hook_installer_outside_ci(self, tmp_path: Path) -> None:
+        """Outside CI the gate delegates to the hook installer check."""
         import os
 
         from scripts.validation.pre_pr import validate_git_hooks_installed
@@ -782,18 +782,3 @@ class TestValidateGitHooksInstalled:
             mock_run.assert_called_once()
             command = mock_run.call_args.args[0]
             assert command[-3:] == ["--check", "--repo-root", str(tmp_path)]
-
-    def test_not_skipped_in_main_checkout(self, tmp_path: Path) -> None:
-        """Outside CI the gate delegates to the --check script."""
-        import os
-
-        from scripts.validation.pre_pr import validate_git_hooks_installed
-
-        (tmp_path / "scripts").mkdir()
-        (tmp_path / "scripts" / "install_git_hooks.py").write_text("# stub\n")
-        with patch.dict("os.environ", {}, clear=False):
-            os.environ.pop("GITHUB_ACTIONS", None)
-            os.environ.pop("CI", None)
-            with patch("scripts.validation.pre_pr._run_subprocess") as mock_run:
-                mock_run.return_value = (0, "OK", "")
-                assert validate_git_hooks_installed(tmp_path) is True

--- a/tests/test_validation_pre_pr.py
+++ b/tests/test_validation_pre_pr.py
@@ -781,4 +781,6 @@ class TestValidateGitHooksInstalled:
 
             mock_run.assert_called_once()
             command = mock_run.call_args.args[0]
-            assert command[-3:] == ["--check", "--repo-root", str(tmp_path)]
+            repo_root_index = command.index("--repo-root")
+            assert "--check" in command
+            assert command[repo_root_index + 1] == str(tmp_path)

--- a/tests/test_validation_pre_pr.py
+++ b/tests/test_validation_pre_pr.py
@@ -712,7 +712,7 @@ class TestValidateGitHooksInstalled:
                 validate_git_hooks_installed(tmp_path)
 
     def test_not_skipped_when_ci_is_false(self, tmp_path: Path) -> None:
-        """CI=false or CI=0 should NOT skip the check (they are non-truthy)."""
+        """CI=false should not skip the check."""
         import os
 
         from scripts.validation.pre_pr import validate_git_hooks_installed

--- a/tests/test_validation_pre_pr.py
+++ b/tests/test_validation_pre_pr.py
@@ -710,21 +710,25 @@ class TestValidateGitHooksInstalled:
         """CI=false or CI=0 should NOT skip the check (they are non-truthy)."""
         import os
 
-        from scripts.validation.pre_pr import (
-            MissingScriptSkip,
-            validate_git_hooks_installed,
-        )
+        from scripts.validation.pre_pr import validate_git_hooks_installed
 
         (tmp_path / "scripts").mkdir()
         (tmp_path / "scripts" / "install_git_hooks.py").write_text("# stub\n")
         env = {"CI": "false"}
         with patch.dict("os.environ", env, clear=False):
             os.environ.pop("GITHUB_ACTIONS", None)
+            # pytest's tmp_path lives under the test runner's own git
+            # checkout, so pin the worktree probe to False to exercise the
+            # main-checkout branch (Issue #2220 added the worktree SKIP).
             with patch(
-                "scripts.validation.pre_pr._run_subprocess"
-            ) as mock_run:
-                mock_run.return_value = (0, "OK", "")
-                assert validate_git_hooks_installed(tmp_path) is True
+                "scripts.validation.pre_pr._is_linked_worktree",
+                return_value=False,
+            ):
+                with patch(
+                    "scripts.validation.pre_pr._run_subprocess"
+                ) as mock_run:
+                    mock_run.return_value = (0, "OK", "")
+                    assert validate_git_hooks_installed(tmp_path) is True
 
     def test_missing_script_fails_closed(self, tmp_path: Path) -> None:
         import os
@@ -734,8 +738,14 @@ class TestValidateGitHooksInstalled:
         with patch.dict("os.environ", {}, clear=False):
             os.environ.pop("GITHUB_ACTIONS", None)
             os.environ.pop("CI", None)
-            # tmp_path has no scripts/install_git_hooks.py; expect hard failure
-            assert validate_git_hooks_installed(tmp_path) is False
+            # tmp_path has no scripts/install_git_hooks.py; expect hard failure.
+            # Pin the worktree probe to False so the missing-script branch is
+            # reached (tmp_path is under the runner's checkout; Issue #2220).
+            with patch(
+                "scripts.validation.pre_pr._is_linked_worktree",
+                return_value=False,
+            ):
+                assert validate_git_hooks_installed(tmp_path) is False
 
     def test_passes_when_check_exits_zero(self, tmp_path: Path) -> None:
         import os
@@ -748,10 +758,14 @@ class TestValidateGitHooksInstalled:
             os.environ.pop("GITHUB_ACTIONS", None)
             os.environ.pop("CI", None)
             with patch(
-                "scripts.validation.pre_pr._run_subprocess"
-            ) as mock_run:
-                mock_run.return_value = (0, "OK", "")
-                assert validate_git_hooks_installed(tmp_path) is True
+                "scripts.validation.pre_pr._is_linked_worktree",
+                return_value=False,
+            ):
+                with patch(
+                    "scripts.validation.pre_pr._run_subprocess"
+                ) as mock_run:
+                    mock_run.return_value = (0, "OK", "")
+                    assert validate_git_hooks_installed(tmp_path) is True
 
     def test_fails_when_check_exits_nonzero(self, tmp_path: Path) -> None:
         import os
@@ -764,7 +778,125 @@ class TestValidateGitHooksInstalled:
             os.environ.pop("GITHUB_ACTIONS", None)
             os.environ.pop("CI", None)
             with patch(
-                "scripts.validation.pre_pr._run_subprocess"
-            ) as mock_run:
-                mock_run.return_value = (1, "", "core.hooksPath not set")
-                assert validate_git_hooks_installed(tmp_path) is False
+                "scripts.validation.pre_pr._is_linked_worktree",
+                return_value=False,
+            ):
+                with patch(
+                    "scripts.validation.pre_pr._run_subprocess"
+                ) as mock_run:
+                    mock_run.return_value = (1, "", "core.hooksPath not set")
+                    assert validate_git_hooks_installed(tmp_path) is False
+
+    def test_skipped_in_linked_worktree(self, tmp_path: Path) -> None:
+        """A linked worktree inherits shared hooksPath; SKIP, do not fail (#2220)."""
+        import os
+
+        import pytest
+
+        from scripts.validation.pre_pr import (
+            MissingScriptSkip,
+            validate_git_hooks_installed,
+        )
+
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "scripts" / "install_git_hooks.py").write_text("# stub\n")
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("GITHUB_ACTIONS", None)
+            os.environ.pop("CI", None)
+            with patch(
+                "scripts.validation.pre_pr._is_linked_worktree",
+                return_value=True,
+            ):
+                with pytest.raises(MissingScriptSkip):
+                    validate_git_hooks_installed(tmp_path)
+
+    def test_not_skipped_in_main_checkout(self, tmp_path: Path) -> None:
+        """Outside a worktree the gate still delegates to the --check script."""
+        import os
+
+        from scripts.validation.pre_pr import validate_git_hooks_installed
+
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "scripts" / "install_git_hooks.py").write_text("# stub\n")
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("GITHUB_ACTIONS", None)
+            os.environ.pop("CI", None)
+            with patch(
+                "scripts.validation.pre_pr._is_linked_worktree",
+                return_value=False,
+            ):
+                with patch(
+                    "scripts.validation.pre_pr._run_subprocess"
+                ) as mock_run:
+                    mock_run.return_value = (0, "OK", "")
+                    assert validate_git_hooks_installed(tmp_path) is True
+
+
+# ---------------------------------------------------------------------------
+# _is_linked_worktree
+# ---------------------------------------------------------------------------
+
+
+class TestIsLinkedWorktree:
+    """Detect a linked worktree by comparing git-common-dir to repo_root/.git."""
+
+    def test_true_when_common_dir_differs(self, tmp_path: Path) -> None:
+        """A worktree's shared .git differs from its own .git pointer."""
+        from scripts.validation.pre_pr import _is_linked_worktree
+
+        main_git = tmp_path / "main" / ".git"
+        main_git.mkdir(parents=True)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        with patch(
+            "scripts.validation.pre_pr._run_subprocess",
+            return_value=(0, str(main_git), ""),
+        ):
+            assert _is_linked_worktree(worktree) is True
+
+    def test_false_when_common_dir_matches_local_git(
+        self, tmp_path: Path
+    ) -> None:
+        """The main checkout's common dir resolves to its own .git directory."""
+        from scripts.validation.pre_pr import _is_linked_worktree
+
+        (tmp_path / ".git").mkdir()
+        local_git = tmp_path / ".git"
+        with patch(
+            "scripts.validation.pre_pr._run_subprocess",
+            return_value=(0, str(local_git), ""),
+        ):
+            assert _is_linked_worktree(tmp_path) is False
+
+    def test_false_on_git_failure(self, tmp_path: Path) -> None:
+        """A non-zero git exit means unknown layout; fail open (not a worktree)."""
+        from scripts.validation.pre_pr import _is_linked_worktree
+
+        with patch(
+            "scripts.validation.pre_pr._run_subprocess",
+            return_value=(128, "", "not a git repository"),
+        ):
+            assert _is_linked_worktree(tmp_path) is False
+
+    def test_false_on_empty_output(self, tmp_path: Path) -> None:
+        """Empty git-common-dir output is treated as unknown; fail open."""
+        from scripts.validation.pre_pr import _is_linked_worktree
+
+        with patch(
+            "scripts.validation.pre_pr._run_subprocess",
+            return_value=(0, "   ", ""),
+        ):
+            assert _is_linked_worktree(tmp_path) is False
+
+    def test_resolves_relative_common_dir_against_repo_root(
+        self, tmp_path: Path
+    ) -> None:
+        """A relative common dir (plain '.git') resolves against repo_root."""
+        from scripts.validation.pre_pr import _is_linked_worktree
+
+        (tmp_path / ".git").mkdir()
+        with patch(
+            "scripts.validation.pre_pr._run_subprocess",
+            return_value=(0, ".git", ""),
+        ):
+            assert _is_linked_worktree(tmp_path) is False

--- a/tests/test_validation_pre_pr.py
+++ b/tests/test_validation_pre_pr.py
@@ -243,7 +243,12 @@ class TestParseYamlFrontmatter:
         assert len(result) == 1
 
     def test_strips_inline_yaml_comments(self) -> None:
-        text = "---\nstatus: APPROVED              # APPROVED | NEEDS_CHANGES\npriority: P1  # severity\n---\n"
+        text = (
+            "---\n"
+            "status: APPROVED              # APPROVED | NEEDS_CHANGES\n"
+            "priority: P1  # severity\n"
+            "---\n"
+        )
         result = _parse_yaml_frontmatter(text)
         assert result is not None
         assert result["status"] == "APPROVED"
@@ -717,18 +722,9 @@ class TestValidateGitHooksInstalled:
         env = {"CI": "false"}
         with patch.dict("os.environ", env, clear=False):
             os.environ.pop("GITHUB_ACTIONS", None)
-            # pytest's tmp_path lives under the test runner's own git
-            # checkout, so pin the worktree probe to False to exercise the
-            # main-checkout branch (Issue #2220 added the worktree SKIP).
-            with patch(
-                "scripts.validation.pre_pr._is_linked_worktree",
-                return_value=False,
-            ):
-                with patch(
-                    "scripts.validation.pre_pr._run_subprocess"
-                ) as mock_run:
-                    mock_run.return_value = (0, "OK", "")
-                    assert validate_git_hooks_installed(tmp_path) is True
+            with patch("scripts.validation.pre_pr._run_subprocess") as mock_run:
+                mock_run.return_value = (0, "OK", "")
+                assert validate_git_hooks_installed(tmp_path) is True
 
     def test_missing_script_fails_closed(self, tmp_path: Path) -> None:
         import os
@@ -738,14 +734,7 @@ class TestValidateGitHooksInstalled:
         with patch.dict("os.environ", {}, clear=False):
             os.environ.pop("GITHUB_ACTIONS", None)
             os.environ.pop("CI", None)
-            # tmp_path has no scripts/install_git_hooks.py; expect hard failure.
-            # Pin the worktree probe to False so the missing-script branch is
-            # reached (tmp_path is under the runner's checkout; Issue #2220).
-            with patch(
-                "scripts.validation.pre_pr._is_linked_worktree",
-                return_value=False,
-            ):
-                assert validate_git_hooks_installed(tmp_path) is False
+            assert validate_git_hooks_installed(tmp_path) is False
 
     def test_passes_when_check_exits_zero(self, tmp_path: Path) -> None:
         import os
@@ -757,15 +746,9 @@ class TestValidateGitHooksInstalled:
         with patch.dict("os.environ", {}, clear=False):
             os.environ.pop("GITHUB_ACTIONS", None)
             os.environ.pop("CI", None)
-            with patch(
-                "scripts.validation.pre_pr._is_linked_worktree",
-                return_value=False,
-            ):
-                with patch(
-                    "scripts.validation.pre_pr._run_subprocess"
-                ) as mock_run:
-                    mock_run.return_value = (0, "OK", "")
-                    assert validate_git_hooks_installed(tmp_path) is True
+            with patch("scripts.validation.pre_pr._run_subprocess") as mock_run:
+                mock_run.return_value = (0, "OK", "")
+                assert validate_git_hooks_installed(tmp_path) is True
 
     def test_fails_when_check_exits_nonzero(self, tmp_path: Path) -> None:
         import os
@@ -777,41 +760,12 @@ class TestValidateGitHooksInstalled:
         with patch.dict("os.environ", {}, clear=False):
             os.environ.pop("GITHUB_ACTIONS", None)
             os.environ.pop("CI", None)
-            with patch(
-                "scripts.validation.pre_pr._is_linked_worktree",
-                return_value=False,
-            ):
-                with patch(
-                    "scripts.validation.pre_pr._run_subprocess"
-                ) as mock_run:
-                    mock_run.return_value = (1, "", "core.hooksPath not set")
-                    assert validate_git_hooks_installed(tmp_path) is False
+            with patch("scripts.validation.pre_pr._run_subprocess") as mock_run:
+                mock_run.return_value = (1, "", "core.hooksPath not set")
+                assert validate_git_hooks_installed(tmp_path) is False
 
-    def test_skipped_in_linked_worktree(self, tmp_path: Path) -> None:
-        """A linked worktree inherits shared hooksPath; SKIP, do not fail (#2220)."""
-        import os
-
-        import pytest
-
-        from scripts.validation.pre_pr import (
-            MissingScriptSkip,
-            validate_git_hooks_installed,
-        )
-
-        (tmp_path / "scripts").mkdir()
-        (tmp_path / "scripts" / "install_git_hooks.py").write_text("# stub\n")
-        with patch.dict("os.environ", {}, clear=False):
-            os.environ.pop("GITHUB_ACTIONS", None)
-            os.environ.pop("CI", None)
-            with patch(
-                "scripts.validation.pre_pr._is_linked_worktree",
-                return_value=True,
-            ):
-                with pytest.raises(MissingScriptSkip):
-                    validate_git_hooks_installed(tmp_path)
-
-    def test_not_skipped_in_main_checkout(self, tmp_path: Path) -> None:
-        """Outside a worktree the gate still delegates to the --check script."""
+    def test_delegates_in_linked_worktree(self, tmp_path: Path) -> None:
+        """Linked worktrees still run the git-hooks gate (#2220)."""
         import os
 
         from scripts.validation.pre_pr import validate_git_hooks_installed
@@ -821,82 +775,25 @@ class TestValidateGitHooksInstalled:
         with patch.dict("os.environ", {}, clear=False):
             os.environ.pop("GITHUB_ACTIONS", None)
             os.environ.pop("CI", None)
-            with patch(
-                "scripts.validation.pre_pr._is_linked_worktree",
-                return_value=False,
-            ):
-                with patch(
-                    "scripts.validation.pre_pr._run_subprocess"
-                ) as mock_run:
-                    mock_run.return_value = (0, "OK", "")
-                    assert validate_git_hooks_installed(tmp_path) is True
+            with patch("scripts.validation.pre_pr._run_subprocess") as mock_run:
+                mock_run.return_value = (0, "OK", "")
+                assert validate_git_hooks_installed(tmp_path) is True
 
+            mock_run.assert_called_once()
+            command = mock_run.call_args.args[0]
+            assert command[-3:] == ["--check", "--repo-root", str(tmp_path)]
 
-# ---------------------------------------------------------------------------
-# _is_linked_worktree
-# ---------------------------------------------------------------------------
+    def test_not_skipped_in_main_checkout(self, tmp_path: Path) -> None:
+        """Outside CI the gate delegates to the --check script."""
+        import os
 
+        from scripts.validation.pre_pr import validate_git_hooks_installed
 
-class TestIsLinkedWorktree:
-    """Detect a linked worktree by comparing git-common-dir to repo_root/.git."""
-
-    def test_true_when_common_dir_differs(self, tmp_path: Path) -> None:
-        """A worktree's shared .git differs from its own .git pointer."""
-        from scripts.validation.pre_pr import _is_linked_worktree
-
-        main_git = tmp_path / "main" / ".git"
-        main_git.mkdir(parents=True)
-        worktree = tmp_path / "wt"
-        worktree.mkdir()
-        with patch(
-            "scripts.validation.pre_pr._run_subprocess",
-            return_value=(0, str(main_git), ""),
-        ):
-            assert _is_linked_worktree(worktree) is True
-
-    def test_false_when_common_dir_matches_local_git(
-        self, tmp_path: Path
-    ) -> None:
-        """The main checkout's common dir resolves to its own .git directory."""
-        from scripts.validation.pre_pr import _is_linked_worktree
-
-        (tmp_path / ".git").mkdir()
-        local_git = tmp_path / ".git"
-        with patch(
-            "scripts.validation.pre_pr._run_subprocess",
-            return_value=(0, str(local_git), ""),
-        ):
-            assert _is_linked_worktree(tmp_path) is False
-
-    def test_false_on_git_failure(self, tmp_path: Path) -> None:
-        """A non-zero git exit means unknown layout; fail open (not a worktree)."""
-        from scripts.validation.pre_pr import _is_linked_worktree
-
-        with patch(
-            "scripts.validation.pre_pr._run_subprocess",
-            return_value=(128, "", "not a git repository"),
-        ):
-            assert _is_linked_worktree(tmp_path) is False
-
-    def test_false_on_empty_output(self, tmp_path: Path) -> None:
-        """Empty git-common-dir output is treated as unknown; fail open."""
-        from scripts.validation.pre_pr import _is_linked_worktree
-
-        with patch(
-            "scripts.validation.pre_pr._run_subprocess",
-            return_value=(0, "   ", ""),
-        ):
-            assert _is_linked_worktree(tmp_path) is False
-
-    def test_resolves_relative_common_dir_against_repo_root(
-        self, tmp_path: Path
-    ) -> None:
-        """A relative common dir (plain '.git') resolves against repo_root."""
-        from scripts.validation.pre_pr import _is_linked_worktree
-
-        (tmp_path / ".git").mkdir()
-        with patch(
-            "scripts.validation.pre_pr._run_subprocess",
-            return_value=(0, ".git", ""),
-        ):
-            assert _is_linked_worktree(tmp_path) is False
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "scripts" / "install_git_hooks.py").write_text("# stub\n")
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("GITHUB_ACTIONS", None)
+            os.environ.pop("CI", None)
+            with patch("scripts.validation.pre_pr._run_subprocess") as mock_run:
+                mock_run.return_value = (0, "OK", "")
+                assert validate_git_hooks_installed(tmp_path) is True


### PR DESCRIPTION
## Summary
- Keeps the local git-hooks pre-PR gate active for linked worktrees.
- Delegates hook verification to the existing installer check instead of adding a separate worktree detector.
- Keeps all main-branch pre-PR validators registered after syncing with main.

Fixes #2220

## Validation
- python -m pytest tests/test_validation_pre_pr.py tests/validation/ -q
- ruff check on the changed validator and test files
- pre_pr help import check
- diff dash check for U+2013 and U+2014 additions
