### PR TITLE
fix(scripts): detect_scope_explosion prefers origin/<base> over stale local main

### DIFF
--- a/scripts/detect_scope_explosion.py
+++ b/scripts/detect_scope_explosion.py
@@ -64,8 +64,55 @@ def get_current_branch() -> str | None:
     return branch if branch else None
 
 
+def _ref_exists(ref: str) -> bool:
+    """Return True if a git ref resolves locally.
+
+    Args:
+        ref: The ref name to check (e.g. "origin/main", "main").
+    """
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def resolve_base_ref(base_branch: str) -> str | None:
+    """Resolve the most accurate base ref for diff comparison.
+
+    In a worktree (or any checkout where the local trunk branch lags the
+    remote), the local ``main`` ref can be stale and produce a diff full of
+    files the PR never touched. Prefer ``origin/<base>`` when it exists so the
+    scope check reflects the real PR diff (Issue #2207).
+
+    Resolution order:
+      1. ``origin/<base_branch>`` if the ref exists locally.
+      2. ``<base_branch>`` as a local fallback.
+      3. None if neither resolves.
+
+    Args:
+        base_branch: The plain branch name (e.g. "main").
+
+    Returns:
+        The resolved ref string, or None if no candidate exists.
+    """
+    remote_ref = f"origin/{base_branch}"
+    if _ref_exists(remote_ref):
+        return remote_ref
+    if _ref_exists(base_branch):
+        return base_branch
+    return None
+
+
 def get_merge_base(base_branch: str) -> str | None:
     """Find the merge base between HEAD and the base branch.
+
+    Prefers ``origin/<base_branch>`` over the local branch ref to avoid stale
+    merge bases in worktrees where local ``main`` lags the remote
+    (Issue #2207).
 
     Args:
         base_branch: The branch to compare against (e.g. "main").
@@ -73,8 +120,11 @@ def get_merge_base(base_branch: str) -> str | None:
     Returns:
         Merge base commit SHA, or None if not found.
     """
+    base_ref = resolve_base_ref(base_branch)
+    if base_ref is None:
+        return None
     result = subprocess.run(
-        ["git", "merge-base", "HEAD", base_branch],
+        ["git", "merge-base", "HEAD", base_ref],
         capture_output=True,
         text=True,
         timeout=10,

--- a/tests/test_detect_scope_explosion.py
+++ b/tests/test_detect_scope_explosion.py
@@ -27,6 +27,7 @@ from scripts.detect_scope_explosion import (
     get_staged_new_files,
     main,
     report,
+    resolve_base_ref,
 )
 
 if TYPE_CHECKING:
@@ -101,16 +102,72 @@ class TestGetCurrentBranch:
             assert result is None
 
 
+class TestResolveBaseRef:
+    """Tests for resolve_base_ref function (Issue #2207)."""
+
+    def test_prefers_origin_when_available(self) -> None:
+        # origin/main resolves -> use it (worktrees may have stale local main).
+        with patch("scripts.detect_scope_explosion.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="abc123\n", stderr=""
+            )
+            assert resolve_base_ref("main") == "origin/main"
+            # First (and only) probe should target origin/<base>.
+            first_call_args = mock_run.call_args_list[0].args[0]
+            assert "origin/main^{commit}" in first_call_args
+
+    def test_falls_back_to_local_when_origin_missing(self) -> None:
+        # origin/main missing, local main present.
+        with patch("scripts.detect_scope_explosion.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.CompletedProcess(args=[], returncode=128, stdout="", stderr=""),
+                subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n", stderr=""),
+            ]
+            assert resolve_base_ref("main") == "main"
+
+    def test_returns_none_when_neither_exists(self) -> None:
+        with patch("scripts.detect_scope_explosion.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=128, stdout="", stderr=""
+            )
+            assert resolve_base_ref("main") is None
+
+
 class TestGetMergeBase:
     """Tests for get_merge_base function."""
 
+    def test_returns_none_when_base_ref_unresolvable(self) -> None:
+        with patch(
+            "scripts.detect_scope_explosion.resolve_base_ref", return_value=None
+        ):
+            result = get_merge_base("main")
+            assert result is None
+
     def test_returns_none_on_failure(self) -> None:
-        with patch("scripts.detect_scope_explosion.subprocess.run") as mock_run:
+        # resolve_base_ref succeeds, but merge-base itself fails.
+        with patch(
+            "scripts.detect_scope_explosion.resolve_base_ref", return_value="origin/main"
+        ), patch("scripts.detect_scope_explosion.subprocess.run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=[], returncode=1, stdout="", stderr=""
             )
             result = get_merge_base("main")
             assert result is None
+
+    def test_uses_resolved_ref_for_merge_base(self) -> None:
+        # Regression for Issue #2207: must hand origin/main (not bare main) to git merge-base
+        # so stale local main in worktrees doesn't poison the diff.
+        with patch(
+            "scripts.detect_scope_explosion.resolve_base_ref", return_value="origin/main"
+        ), patch("scripts.detect_scope_explosion.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="deadbeef1234\n", stderr=""
+            )
+            result = get_merge_base("main")
+            assert result == "deadbeef1234"
+            cmd = mock_run.call_args.args[0]
+            assert cmd[:3] == ["git", "merge-base", "HEAD"]
+            assert cmd[3] == "origin/main"
 
 
 class TestGetChangedFiles:


### PR DESCRIPTION
## Summary

In a worktree, or any checkout where the local trunk lags the remote, `git merge-base HEAD main` resolves against a stale local `main` ref. That produces a diff full of files the PR never touched. Issue #2207 hit this on PR #2202, reporting 329 files against a 50-file limit even though the PR diff was small.

## Fix

- `scripts/detect_scope_explosion.py` now resolves the configured base branch through the remote-tracking ref first, then falls back to the local branch.
- The new base-ref helper returns no ref when neither candidate resolves, preserving the existing unresolvable-base behavior.
- Scope checks now align with the real PR diff when a worktree has stale local trunk state.

## Tests

- `tests/test_detect_scope_explosion.py` covers remote preference, local fallback, missing-base handling, and the merge-base regression path from Issue #2207.
- Existing scope-explosion behavior remains covered by the prior tests in the same file.

## Test Plan

- [x] `python3 -m pytest tests/test_detect_scope_explosion.py`
- [x] `python3 scripts/validation/pr_description.py --pr-number 2279 --ci`

Fixes #2207
