### PR TITLE
fix(cache-guard): anchor default cache_root to repo root, not CWD (#2224)

### DIFF
--- a/.claude/lib/ai_review_common/cache_guard.py
+++ b/.claude/lib/ai_review_common/cache_guard.py
@@ -10,9 +10,29 @@ from pathlib import Path
 _AGENT_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 NON_CACHEABLE_VERDICTS = frozenset({"NEEDS_REVIEW"})
 
+_REPO_MARKERS = (".git", ".claude")
+
 
 class CacheGuardConfigError(ValueError):
     """Raised when the cache guard receives invalid configuration."""
+
+
+def get_repo_root() -> Path:
+    """Return the repo root by walking up from this file to a `.git` or `.claude` marker.
+
+    Anchoring defaults to the repo root (rather than CWD) keeps script
+    behavior stable regardless of where the process is launched from and
+    avoids CWE-22 path-traversal surface introduced by CWD-relative defaults.
+    """
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if any((parent / marker).exists() for marker in _REPO_MARKERS):
+            return parent
+    # Fallback: two levels up (scripts/ai_review_common/ -> repo root).
+    return here.parents[2]
+
+
+_DEFAULT_CACHE_ROOT = get_repo_root() / "ai-review-cache"
 
 
 def validate_agent_name(agent: str) -> str:
@@ -48,7 +68,7 @@ def populate_cache(
     findings: str,
     infra_failure: str,
     github_output: Path,
-    cache_root: Path = Path("ai-review-cache"),
+    cache_root: Path = _DEFAULT_CACHE_ROOT,
 ) -> bool:
     """Populate the review cache only when the verdict is structurally valid."""
     safe_agent = validate_agent_name(agent)

--- a/scripts/ai_review_common/cache_guard.py
+++ b/scripts/ai_review_common/cache_guard.py
@@ -10,9 +10,29 @@ from pathlib import Path
 _AGENT_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 NON_CACHEABLE_VERDICTS = frozenset({"NEEDS_REVIEW"})
 
+_REPO_MARKERS = (".git", ".claude")
+
 
 class CacheGuardConfigError(ValueError):
     """Raised when the cache guard receives invalid configuration."""
+
+
+def get_repo_root() -> Path:
+    """Return the repo root by walking up from this file to a `.git` or `.claude` marker.
+
+    Anchoring defaults to the repo root (rather than CWD) keeps script
+    behavior stable regardless of where the process is launched from and
+    avoids CWE-22 path-traversal surface introduced by CWD-relative defaults.
+    """
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if any((parent / marker).exists() for marker in _REPO_MARKERS):
+            return parent
+    # Fallback: two levels up (scripts/ai_review_common/ -> repo root).
+    return here.parents[2]
+
+
+_DEFAULT_CACHE_ROOT = get_repo_root() / "ai-review-cache"
 
 
 def validate_agent_name(agent: str) -> str:
@@ -48,7 +68,7 @@ def populate_cache(
     findings: str,
     infra_failure: str,
     github_output: Path,
-    cache_root: Path = Path("ai-review-cache"),
+    cache_root: Path = _DEFAULT_CACHE_ROOT,
 ) -> bool:
     """Populate the review cache only when the verdict is structurally valid."""
     safe_agent = validate_agent_name(agent)

--- a/src/copilot-cli/lib/ai_review_common/cache_guard.py
+++ b/src/copilot-cli/lib/ai_review_common/cache_guard.py
@@ -10,9 +10,29 @@ from pathlib import Path
 _AGENT_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 NON_CACHEABLE_VERDICTS = frozenset({"NEEDS_REVIEW"})
 
+_REPO_MARKERS = (".git", ".claude")
+
 
 class CacheGuardConfigError(ValueError):
     """Raised when the cache guard receives invalid configuration."""
+
+
+def get_repo_root() -> Path:
+    """Return the repo root by walking up from this file to a `.git` or `.claude` marker.
+
+    Anchoring defaults to the repo root (rather than CWD) keeps script
+    behavior stable regardless of where the process is launched from and
+    avoids CWE-22 path-traversal surface introduced by CWD-relative defaults.
+    """
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if any((parent / marker).exists() for marker in _REPO_MARKERS):
+            return parent
+    # Fallback: two levels up (scripts/ai_review_common/ -> repo root).
+    return here.parents[2]
+
+
+_DEFAULT_CACHE_ROOT = get_repo_root() / "ai-review-cache"
 
 
 def validate_agent_name(agent: str) -> str:
@@ -48,7 +68,7 @@ def populate_cache(
     findings: str,
     infra_failure: str,
     github_output: Path,
-    cache_root: Path = Path("ai-review-cache"),
+    cache_root: Path = _DEFAULT_CACHE_ROOT,
 ) -> bool:
     """Populate the review cache only when the verdict is structurally valid."""
     safe_agent = validate_agent_name(agent)

--- a/tests/workflows/test_agent_review_cache_guards.py
+++ b/tests/workflows/test_agent_review_cache_guards.py
@@ -17,7 +17,11 @@ from pathlib import Path
 import pytest
 import yaml
 
-from scripts.ai_review_common.cache_guard import populate_cache, skip_cache_reason
+from scripts.ai_review_common.cache_guard import (
+    get_repo_root,
+    populate_cache,
+    skip_cache_reason,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ACTION_PATH = REPO_ROOT / ".github" / "actions" / "agent-review" / "action.yml"
@@ -117,3 +121,56 @@ def test_no_save_cache_when_populate_skipped(action_yaml: dict) -> None:
     assert len(save) == 1
     cond = save[0].get("if", "")
     assert "steps.populate-cache.outputs.cache_populated == 'true'" in cond
+
+
+def test_get_repo_root_walks_up_to_repo_marker() -> None:
+    """`get_repo_root()` resolves to a real repo dir containing `.git` or `.claude`."""
+    root = get_repo_root()
+    assert root.is_dir()
+    assert (root / ".git").exists() or (root / ".claude").exists()
+
+
+def test_populate_cache_default_cache_root_anchored_to_repo(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default `cache_root` must resolve under the repo root, not CWD (#2224, CWE-22)."""
+    # Run from an unrelated CWD to prove the default does NOT use it.
+    monkeypatch.chdir(tmp_path)
+
+    repo_root = get_repo_root()
+    expected_cache = repo_root / "ai-review-cache"
+    # Snapshot whether the dir existed before so we don't pollute the repo.
+    pre_existed = expected_cache.exists()
+    pre_existing_agents = (
+        {p.name for p in expected_cache.iterdir()} if pre_existed else set()
+    )
+
+    github_output = tmp_path / "github-output.txt"
+    # Use a recognizable, unique agent name that won't collide with a real one.
+    test_agent = "_test_2224_agent"
+
+    try:
+        populated = populate_cache(
+            agent=test_agent,
+            verdict="PASS",
+            findings="anchored-default",
+            infra_failure="false",
+            github_output=github_output,
+        )
+        assert populated is True
+        # The agent dir MUST land under the repo-anchored default, not under CWD.
+        assert (expected_cache / test_agent / "verdict.txt").read_text(
+            encoding="utf-8"
+        ) == "PASS"
+        # And it MUST NOT have leaked into the CWD.
+        assert not (tmp_path / "ai-review-cache").exists()
+    finally:
+        # Clean only what we created; never disturb pre-existing cache contents.
+        agent_dir = expected_cache / test_agent
+        if agent_dir.exists():
+            shutil.rmtree(agent_dir, ignore_errors=True)
+        if not pre_existed and expected_cache.exists():
+            remaining = {p.name for p in expected_cache.iterdir()}
+            if not remaining - pre_existing_agents:
+                expected_cache.rmdir()


### PR DESCRIPTION
## Summary

Fixes #2224 (CWE-22). `populate_cache(...)` in `scripts/ai_review_common/cache_guard.py` previously defaulted `cache_root` to `Path("ai-review-cache")`, a relative path resolved against the current working directory. Per repo path-safety rules, relative paths in scripts must anchor to a defined base (repo root via `__file__` walk-up), not CWD.

## Changes

- Add `get_repo_root()` helper that walks up from `__file__` to the first parent containing `.git` or `.claude`.
- Default `cache_root` to `get_repo_root() / "ai-review-cache"` (computed at import time, frozen as `_DEFAULT_CACHE_ROOT`).
- Regenerated mirrors in `.claude/lib/ai_review_common/cache_guard.py` and `src/copilot-cli/lib/ai_review_common/cache_guard.py` via `scripts/sync_plugin_lib.py` and `build/scripts/build_all.py`. Drift checks pass.

## Tests

TDD: failing test written first, then implementation.

Added 2 regression tests to `tests/workflows/test_agent_review_cache_guards.py`:

| Test | Purpose |
|---|---|
| `test_get_repo_root_walks_up_to_repo_marker` | Verifies helper finds a real repo dir containing `.git` or `.claude`. |
| `test_populate_cache_default_cache_root_anchored_to_repo` | CWE-22 regression: `chdir` to `tmp_path`, then assert cache lands under repo root and **not** under CWD. |

```
tests/workflows/test_agent_review_cache_guards.py ......... [100%]
============================== 9 passed in 0.09s ===============================
```

Full `tests/workflows/` suite: 28/28 pass.

## Acceptance checklist

- [x] Reproduces failing behavior first (RED test, then fix to GREEN)
- [x] All existing cache_guard tests still pass
- [x] New test covers the CWE-22 fix specifically
- [x] Canonical source edited; mirrors regenerated via documented pipeline
- [x] `python3 build/scripts/build_all.py --check` clean
- [x] `python3 scripts/sync_plugin_lib.py --check` clean
- [x] PR opened against `main`, references "Fixes #2224"

## Refs

Refs #2195, #2221. Flagged by gemini-code-assist on PR #2221.

Fixes #2224