### PR TITLE
fix(ci): add ADR number uniqueness gate to catch concurrent-PR races (#2253)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.34",
+  "version": "0.5.35",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.32",
+  "version": "0.5.33",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.33",
+  "version": "0.5.34",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/adr-generator/SKILL.md
+++ b/.claude/skills/adr-generator/SKILL.md
@@ -110,6 +110,21 @@ If no ADRs or template files exist anywhere in the codebase:
 - Determine the next sequential number (zero-padded to match existing convention)
 - Verify no collision with existing files in that directory
 
+For this repo's canonical `.agents/architecture/` location, use the
+deterministic helper instead of eyeballing the directory (it also accounts
+for the #2228 allowlist of pre-existing duplicates):
+
+```bash
+python3 scripts/validation/check_adr_uniqueness.py --print-next
+```
+
+The same script is enforced as a merge-time CI gate
+(`.github/workflows/validate-adr-number-uniqueness.yml`, issue #2253), so a
+PR that picked a number which has since been merged by another branch will
+fail with a remediation message naming the next free value. Re-run
+`--print-next` and rename the file, the `# ADR-NNN:` heading, and any
+references before pushing.
+
 ### Phase G3: Generate
 
 Populate the detected template with gathered content:

--- a/.claude/skills/adr-generator/SKILL.md
+++ b/.claude/skills/adr-generator/SKILL.md
@@ -208,8 +208,8 @@ Before delivering, confirm all items in the [quality checklist](references/quali
 
 ## References
 
-- [ADR Template](references/adr-template.md) — This project's canonical ADR document structure
-- [ADR Templates Catalog](references/adr-templates-catalog.md) — Comparison of Nygard, MADR, Alexandrian, Tyree & Akerman, and other formats
-- [AD Quality Frameworks](references/ad-quality-frameworks.md) — ASR Test, START (DoR), ecADR (DoD), anti-patterns, review checklist (Zimmermann)
-- [ADR Best Practices](references/adr-best-practices.md) — Writing guidance, lifecycle, naming conventions, teamwork advice
-- [Quality Checklist](references/quality-checklist.md) — Validation checklist for Phase G4
+- [ADR Template](references/adr-template.md): This project's canonical ADR document structure
+- [ADR Templates Catalog](references/adr-templates-catalog.md): Comparison of Nygard, MADR, Alexandrian, Tyree & Akerman, and other formats
+- [AD Quality Frameworks](references/ad-quality-frameworks.md): ASR Test, START (DoR), ecADR (DoD), anti-patterns, review checklist (Zimmermann)
+- [ADR Best Practices](references/adr-best-practices.md): Writing guidance, lifecycle, naming conventions, teamwork advice
+- [Quality Checklist](references/quality-checklist.md): Validation checklist for Phase G4

--- a/.github/workflows/validate-adr-number-uniqueness.yml
+++ b/.github/workflows/validate-adr-number-uniqueness.yml
@@ -1,0 +1,104 @@
+# Validate ADR Number Uniqueness (Issue #2253)
+#
+# Catches the concurrent-ADR-PR race where two branches each pick the same
+# "next" ADR number off main. As later PRs merge, earlier branches collide;
+# this gate fails them deterministically at PR time and tells the author
+# the exact next free number to use (via --print-next).
+#
+# Uses dorny/paths-filter (Issue #103): fires on all PRs to satisfy the
+# required-check contract, skips with a passing status when no ADR files
+# changed.
+
+name: Validate ADR Number Uniqueness
+
+on:
+  push:
+    branches:
+      - main
+      - 'feat/**'
+      - 'fix/**'
+      - 'copilot/**'
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  check-changes:
+    name: Check for ADR Changes
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should-run: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.adrs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Check path filters
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          filters: |
+            adrs:
+              - '.agents/architecture/ADR-*.md'
+              - 'scripts/validation/check_adr_uniqueness.py'
+              - '.github/workflows/validate-adr-number-uniqueness.yml'
+
+  validate-adr-numbers:
+    name: Validate ADR Number Uniqueness
+    needs: check-changes
+    if: needs.check-changes.outputs.should-run == 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 3
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Verify unique ADR numbers
+        run: python3 scripts/validation/check_adr_uniqueness.py
+
+      - name: Show remediation on failure
+        if: failure()
+        run: |
+          echo ""
+          echo "=== ADR Number Uniqueness Validation Failed ==="
+          echo ""
+          echo "Two ADR files under .agents/architecture/ share the same"
+          echo "number. This is the concurrent-PR race described in #2253:"
+          echo "your branch picked an ADR number that another PR has since"
+          echo "merged to main."
+          echo ""
+          echo "To fix:"
+          echo "  1. Get the next free number:"
+          echo "       python3 scripts/validation/check_adr_uniqueness.py --print-next"
+          echo "  2. Rename your ADR file to ADR-<new>-<slug>.md"
+          echo "  3. Update the '# ADR-NNN:' heading inside the file"
+          echo "  4. Sweep references:"
+          echo "       git grep -nE 'ADR-<old>\\b' .agents/ .claude/ src/ docs/"
+          echo "  5. Re-run the gate locally:"
+          echo "       python3 scripts/validation/check_adr_uniqueness.py"
+          echo ""
+          echo "See issue #2253 for context. Pre-existing duplicates from"
+          echo "#2228 (ADR-058, ADR-062, ADR-063) are intentionally"
+          echo "allowlisted and do not trigger this gate."
+
+  skip-validation:
+    name: Skip Validation (No ADR Changes)
+    needs: check-changes
+    if: needs.check-changes.outputs.should-run != 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 1
+    permissions:
+      contents: read
+    steps:
+      - name: Skip message
+        run: |
+          echo "ADR number uniqueness validation skipped - no ADR files changed"

--- a/scripts/validation/check_adr_uniqueness.py
+++ b/scripts/validation/check_adr_uniqueness.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Verify ADR numbers under `.agents/architecture/` are unique.
+
+Per Issue #2253: concurrent ADR PRs each pick the same "next" number from
+main at branch time. When the later PR merges, the earlier branches now
+collide and must be manually renumbered. This script is the merge-time
+gate that catches collisions deterministically and tells the author the
+exact next free number to use.
+
+Files are scanned by filename: `ADR-NNN-<slug>.md` in
+`.agents/architecture/`. README and DESIGN-REVIEW prefixes are ignored.
+
+A small allowlist exists for known pre-existing duplicates tracked by
+Issue #2228 (ADR-058, ADR-062, ADR-063). Those collisions exist on main
+today and the cleanup is owned by #2228; this gate must not block merges
+on a problem it did not introduce. Once #2228 lands, the allowlist below
+should be emptied.
+
+Exit codes (per ADR-035):
+    0 - all ADR numbers unique (or only allowlisted dupes remain)
+    1 - one or more new duplicates detected
+    2 - config error (e.g. architecture directory missing)
+
+Operator helpers:
+    --print-next            print the next free ADR number and exit 0
+    --print-next-padded N   same, zero-padded to N digits (default 3)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# ADR-NNN-<slug>.md. We accept 2+ digits to be forgiving but normalise to int.
+ADR_FILENAME_RE = re.compile(r"^ADR-(\d{2,})-[^/]+\.md$")
+
+# Pre-existing duplicate ADR numbers on main, tracked by Issue #2228.
+# This gate intentionally does NOT fail on these; #2228 owns the cleanup.
+# Remove a number from this set the moment #2228 deduplicates it.
+KNOWN_DUPLICATES_ISSUE_2228 = frozenset({58, 62, 63})
+
+
+def collect_adr_numbers(adr_dir: Path) -> dict[int, list[Path]]:
+    """Return {adr_number: [paths]} for every ADR file under adr_dir."""
+    by_number: dict[int, list[Path]] = defaultdict(list)
+    for md in sorted(adr_dir.glob("ADR-*.md")):
+        m = ADR_FILENAME_RE.match(md.name)
+        if not m:
+            # e.g. ADR-EXAMPLE.md or other non-numeric variants — skip.
+            continue
+        by_number[int(m.group(1))].append(md)
+    return by_number
+
+
+def find_new_duplicates(
+    by_number: dict[int, list[Path]],
+    allowlist: frozenset[int] = KNOWN_DUPLICATES_ISSUE_2228,
+) -> list[tuple[int, list[Path]]]:
+    """Return duplicates not covered by the #2228 allowlist."""
+    return [
+        (num, sorted(paths))
+        for num, paths in sorted(by_number.items())
+        if len(paths) > 1 and num not in allowlist
+    ]
+
+
+def next_free_number(by_number: dict[int, list[Path]]) -> int:
+    """Return max(existing) + 1. Empty repo yields 1."""
+    return (max(by_number) + 1) if by_number else 1
+
+
+def _format_dupes(dupes: list[tuple[int, list[Path]]], repo_root: Path) -> list[str]:
+    lines = []
+    for num, paths in dupes:
+        rels = ", ".join(str(p.relative_to(repo_root)) for p in paths)
+        lines.append(f"ADR-{num:03d}: {rels}")
+    return lines
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root (defaults to two levels above this script).",
+    )
+    parser.add_argument(
+        "--print-next",
+        action="store_true",
+        help="Print the next free ADR number and exit 0. Use as a "
+        "one-shot helper before authoring a new ADR.",
+    )
+    parser.add_argument(
+        "--print-next-padded",
+        type=int,
+        metavar="N",
+        default=3,
+        help="Zero-pad width for --print-next (default 3).",
+    )
+    args = parser.parse_args()
+
+    adr_dir = args.repo_root / ".agents" / "architecture"
+    if not adr_dir.is_dir():
+        print(f"[CONFIG] ADR directory not found: {adr_dir}", file=sys.stderr)
+        return 2
+
+    by_number = collect_adr_numbers(adr_dir)
+
+    if args.print_next:
+        width = max(args.print_next_padded, 1)
+        print(f"{next_free_number(by_number):0{width}d}")
+        return 0
+
+    new_dupes = find_new_duplicates(by_number)
+
+    if new_dupes:
+        print("[FAIL] Duplicate ADR numbers detected (see issue #2253):")
+        for line in _format_dupes(new_dupes, args.repo_root):
+            print(f"  - {line}")
+        print(
+            "\nTwo ADR PRs picked the same number off main. To fix the "
+            "incoming PR, renumber its ADR to the next free value:"
+        )
+        print(f"\n  next free ADR number: {next_free_number(by_number):03d}")
+        print(
+            "\nRename the file, update the `# ADR-NNN:` heading, and sweep "
+            "references with:\n"
+            "  git grep -nE 'ADR-OLD\\b' .agents/ .claude/ src/ docs/\n\n"
+            "Pre-existing duplicates from issue #2228 are intentionally "
+            "allowlisted; do not extend the allowlist for new collisions."
+        )
+        return 1
+
+    print(
+        "[PASS] All ADR numbers in .agents/architecture/ unique "
+        f"(next free: {next_free_number(by_number):03d})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validation/check_adr_uniqueness.py
+++ b/scripts/validation/check_adr_uniqueness.py
@@ -49,7 +49,7 @@ def collect_adr_numbers(adr_dir: Path) -> dict[int, list[Path]]:
     for md in sorted(adr_dir.glob("ADR-*.md")):
         m = ADR_FILENAME_RE.match(md.name)
         if not m:
-            # e.g. ADR-EXAMPLE.md or other non-numeric variants — skip.
+            # e.g. ADR-EXAMPLE.md or other non-numeric variants, skip.
             continue
         by_number[int(m.group(1))].append(md)
     return by_number
@@ -63,7 +63,7 @@ def find_new_duplicates(
     return [
         (num, sorted(paths))
         for num, paths in sorted(by_number.items())
-        if len(paths) > 1 and num not in allowlist
+        if len(paths) > 1 and (num not in allowlist or len(paths) > 2)
     ]
 
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.34",
+  "version": "0.5.35",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.32",
+  "version": "0.5.33",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.33",
+  "version": "0.5.34",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/adr-generator/SKILL.md
+++ b/src/copilot-cli/skills/adr-generator/SKILL.md
@@ -110,6 +110,21 @@ If no ADRs or template files exist anywhere in the codebase:
 - Determine the next sequential number (zero-padded to match existing convention)
 - Verify no collision with existing files in that directory
 
+For this repo's canonical `.agents/architecture/` location, use the
+deterministic helper instead of eyeballing the directory (it also accounts
+for the #2228 allowlist of pre-existing duplicates):
+
+```bash
+python3 scripts/validation/check_adr_uniqueness.py --print-next
+```
+
+The same script is enforced as a merge-time CI gate
+(`.github/workflows/validate-adr-number-uniqueness.yml`, issue #2253), so a
+PR that picked a number which has since been merged by another branch will
+fail with a remediation message naming the next free value. Re-run
+`--print-next` and rename the file, the `# ADR-NNN:` heading, and any
+references before pushing.
+
 ### Phase G3: Generate
 
 Populate the detected template with gathered content:
@@ -193,8 +208,8 @@ Before delivering, confirm all items in the [quality checklist](references/quali
 
 ## References
 
-- [ADR Template](references/adr-template.md) — This project's canonical ADR document structure
-- [ADR Templates Catalog](references/adr-templates-catalog.md) — Comparison of Nygard, MADR, Alexandrian, Tyree & Akerman, and other formats
-- [AD Quality Frameworks](references/ad-quality-frameworks.md) — ASR Test, START (DoR), ecADR (DoD), anti-patterns, review checklist (Zimmermann)
-- [ADR Best Practices](references/adr-best-practices.md) — Writing guidance, lifecycle, naming conventions, teamwork advice
-- [Quality Checklist](references/quality-checklist.md) — Validation checklist for Phase G4
+- [ADR Template](references/adr-template.md): This project's canonical ADR document structure
+- [ADR Templates Catalog](references/adr-templates-catalog.md): Comparison of Nygard, MADR, Alexandrian, Tyree & Akerman, and other formats
+- [AD Quality Frameworks](references/ad-quality-frameworks.md): ASR Test, START (DoR), ecADR (DoD), anti-patterns, review checklist (Zimmermann)
+- [ADR Best Practices](references/adr-best-practices.md): Writing guidance, lifecycle, naming conventions, teamwork advice
+- [Quality Checklist](references/quality-checklist.md): Validation checklist for Phase G4

--- a/tests/validation/test_check_adr_uniqueness.py
+++ b/tests/validation/test_check_adr_uniqueness.py
@@ -96,7 +96,7 @@ def test_duplicate_outside_allowlist_fails_even_when_allowlisted_present(
     # Pre-existing dupe (allowlisted)
     _make_adr(adr_dir, 58, "agent-eval")
     _make_adr(adr_dir, 58, "context-corpus")
-    # New, post-merge dupe — must fail.
+    # New, post-merge dupe must fail.
     _make_adr(adr_dir, 80, "first")
     _make_adr(adr_dir, 80, "second")
 
@@ -119,6 +119,18 @@ def test_allowlist_suppresses_known_2228_duplicates(tmp_path: Path) -> None:
     result = _run(tmp_path)
     assert result.returncode == 0, result.stdout + result.stderr
     assert "[PASS]" in result.stdout
+
+
+def test_new_duplicate_of_allowlisted_number_fails(tmp_path: Path) -> None:
+    adr_dir = _scaffold(tmp_path)
+    _make_adr(adr_dir, 58, "agent-eval")
+    _make_adr(adr_dir, 58, "context-corpus")
+    _make_adr(adr_dir, 58, "third-one")
+
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    assert "ADR-058" in result.stdout
+    assert "next free ADR number: 059" in result.stdout
 
 
 def test_readme_and_non_adr_files_are_ignored(tmp_path: Path) -> None:

--- a/tests/validation/test_check_adr_uniqueness.py
+++ b/tests/validation/test_check_adr_uniqueness.py
@@ -1,0 +1,182 @@
+"""Tests for scripts/validation/check_adr_uniqueness.py (Issue #2253).
+
+Pins behaviour of the ADR-number-collision gate:
+
+- pos: a unique-number tree returns exit 0
+- neg: a tree with a colliding ADR number returns exit 1
+- edge: README and non-ADR files are ignored; missing directory is a
+  config error (exit 2 per ADR-035); the #2228 allowlist suppresses
+  pre-existing duplicates (58/62/63) but not new ones
+- branch: --print-next returns max(existing)+1, exit 0; empty tree
+  yields 001; padding width is respected
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "validation" / "check_adr_uniqueness.py"
+
+
+def _make_adr(adr_dir: Path, number: int, slug: str = "thing") -> Path:
+    adr_dir.mkdir(parents=True, exist_ok=True)
+    path = adr_dir / f"ADR-{number:03d}-{slug}.md"
+    path.write_text(
+        textwrap.dedent(
+            f"""\
+            # ADR-{number:03d}: {slug}
+
+            ## Status
+
+            Proposed
+            """
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _scaffold(tmp_path: Path) -> Path:
+    adr_dir = tmp_path / ".agents" / "architecture"
+    adr_dir.mkdir(parents=True)
+    return adr_dir
+
+
+def _run(
+    repo_root: Path, *extra: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo-root", str(repo_root), *extra],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# --- pos --------------------------------------------------------------------
+
+
+def test_unique_numbers_pass(tmp_path: Path) -> None:
+    adr_dir = _scaffold(tmp_path)
+    _make_adr(adr_dir, 1, "alpha")
+    _make_adr(adr_dir, 2, "beta")
+    _make_adr(adr_dir, 3, "gamma")
+
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "[PASS]" in result.stdout
+    assert "next free: 004" in result.stdout
+
+
+# --- neg --------------------------------------------------------------------
+
+
+def test_new_duplicate_fails(tmp_path: Path) -> None:
+    adr_dir = _scaffold(tmp_path)
+    _make_adr(adr_dir, 70, "first")
+    _make_adr(adr_dir, 70, "second")
+
+    result = _run(tmp_path)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "[FAIL]" in result.stdout
+    assert "ADR-070" in result.stdout
+    # Remediation must point the author at the next free number.
+    assert "next free ADR number: 071" in result.stdout
+
+
+def test_duplicate_outside_allowlist_fails_even_when_allowlisted_present(
+    tmp_path: Path,
+) -> None:
+    """Allowlist suppresses #2228 dupes but never new ones in the same tree."""
+    adr_dir = _scaffold(tmp_path)
+    # Pre-existing dupe (allowlisted)
+    _make_adr(adr_dir, 58, "agent-eval")
+    _make_adr(adr_dir, 58, "context-corpus")
+    # New, post-merge dupe — must fail.
+    _make_adr(adr_dir, 80, "first")
+    _make_adr(adr_dir, 80, "second")
+
+    result = _run(tmp_path)
+    assert result.returncode == 1
+    assert "ADR-080" in result.stdout
+    # The allowlisted number must not be listed as a failure.
+    assert "ADR-058" not in result.stdout
+
+
+# --- edge -------------------------------------------------------------------
+
+
+def test_allowlist_suppresses_known_2228_duplicates(tmp_path: Path) -> None:
+    adr_dir = _scaffold(tmp_path)
+    for num in (58, 62, 63):
+        _make_adr(adr_dir, num, "first")
+        _make_adr(adr_dir, num, "second")
+
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "[PASS]" in result.stdout
+
+
+def test_readme_and_non_adr_files_are_ignored(tmp_path: Path) -> None:
+    adr_dir = _scaffold(tmp_path)
+    _make_adr(adr_dir, 1, "alpha")
+    (adr_dir / "README.md").write_text("# index\n", encoding="utf-8")
+    (adr_dir / "DESIGN-REVIEW-something.md").write_text("# review\n", encoding="utf-8")
+    (adr_dir / "ADR-EXAMPLE.md").write_text("# example\n", encoding="utf-8")
+
+    result = _run(tmp_path)
+    assert result.returncode == 0
+    assert "[PASS]" in result.stdout
+
+
+def test_missing_architecture_dir_is_config_error(tmp_path: Path) -> None:
+    # No .agents/architecture created.
+    result = _run(tmp_path)
+    assert result.returncode == 2
+    assert "[CONFIG]" in result.stderr
+
+
+def test_empty_architecture_dir_pass_next_is_one(tmp_path: Path) -> None:
+    _scaffold(tmp_path)
+    result = _run(tmp_path, "--print-next")
+    assert result.returncode == 0
+    assert result.stdout.strip() == "001"
+
+
+# --- branch (--print-next) --------------------------------------------------
+
+
+def test_print_next_returns_max_plus_one(tmp_path: Path) -> None:
+    adr_dir = _scaffold(tmp_path)
+    _make_adr(adr_dir, 1)
+    _make_adr(adr_dir, 5)
+    _make_adr(adr_dir, 42)
+
+    result = _run(tmp_path, "--print-next")
+    assert result.returncode == 0
+    assert result.stdout.strip() == "043"
+
+
+def test_print_next_respects_padding(tmp_path: Path) -> None:
+    adr_dir = _scaffold(tmp_path)
+    _make_adr(adr_dir, 3)
+
+    result = _run(tmp_path, "--print-next", "--print-next-padded", "5")
+    assert result.returncode == 0
+    assert result.stdout.strip() == "00004"
+
+
+def test_print_next_ignores_existing_duplicates(tmp_path: Path) -> None:
+    """--print-next must work even when the tree is currently broken."""
+    adr_dir = _scaffold(tmp_path)
+    _make_adr(adr_dir, 10, "first")
+    _make_adr(adr_dir, 10, "second")
+    _make_adr(adr_dir, 20)
+
+    result = _run(tmp_path, "--print-next")
+    assert result.returncode == 0
+    assert result.stdout.strip() == "021"


### PR DESCRIPTION
## Summary
Adds a deterministic merge-time gate for duplicate ADR numbers. This catches the concurrent ADR PR race from #2253 and fails CI with the next free ADR number when a collision appears.

## Changes
- Adds a validation script with ADR-035 exit codes and a `--print-next` helper.
- Adds a GitHub Actions workflow that runs the gate when ADR files or the gate itself change.
- Adds pytest coverage for unique numbers, new duplicates, allowlisted legacy duplicates, third-file allowlist regressions, ignored files, missing directories, and `--print-next`.
- Updates the ADR generator skill to use the helper for the canonical ADR directory.
- Regenerates the Copilot CLI skill copy and bumps project-toolkit plugin manifests to 0.5.35.

## Verification
- `uv run pytest tests/validation/test_check_adr_uniqueness.py`
- `python3 scripts/validation/check_adr_uniqueness.py`
- Duplicate fixture check confirms the gate exits 1 and prints `next free ADR number`.
- `python3 build/scripts/generate_skills.py`
- `python3 build/scripts/validate_plugin_version_bump.py --base origin/main`
- `python3 scripts/validation/pr_description.py --pr-number 2283 --ci`

Fixes #2253
