### PR TITLE
fix(github-skill): test_pr_merge_ready reports BLOCKED as not mergeable (#2326)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.105",
+  "version": "0.5.106",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -502,9 +502,12 @@ def _fetch_pr_data(owner: str, repo: str, pr_number: int, op_start: float) -> di
     return pr
 
 
-def _evaluate_pr_state(
-    pr: dict, reasons: list[str], allow_blocked: bool = False
-) -> str:
+def _merge_state_status(pr: dict) -> str:
+    value = pr.get("mergeStateStatus")
+    return "" if value is None else str(value)
+
+
+def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
     """Append draft/state/merge-conflict reasons; return mergeable string.
 
     Also gates on ``mergeStateStatus == BEHIND`` (issue #2157): a branch
@@ -513,23 +516,16 @@ def _evaluate_pr_state(
     ``DIRTY``, and ``UNKNOWN`` are already covered by the ``isDraft`` and
     ``mergeable`` checks.
 
-    ``mergeStateStatus == BLOCKED`` blocks by default (issue #2326). A
-    BLOCKED state means GitHub's branch protection still refuses the merge:
-    a missing required review decision, an unmet branch-protection rule, or
-    another protection gate. The previous behavior treated BLOCKED as a
-    pass on the theory that "awaiting required review" is when enabling
-    auto-merge is correct; that produced a false ready signal for PRs that
-    branch protection actually refused (observed on PR #2323) and conflicted
-    with this repo's own four-condition merge gate
-    (``.claude/commands/pr-autofix.md``, ``.claude/commands/pr-review-config.yaml``),
-    which both require ``mergeStateStatus in ('CLEAN', 'UNSTABLE')``.
-
-    The auto-merge-eligible case (a clean PR that is only BLOCKED because a
-    required review is still pending) stays available behind an explicit
-    opt-in: pass ``allow_blocked=True`` (CLI ``--allow-blocked``) to classify
-    BLOCKED as allowed. When allowed, no reason is appended, but the state is
-    still surfaced via the ``MergeStateStatus`` output field so callers can
-    see it.
+    ``mergeStateStatus == BLOCKED`` blocks (issue #2326). A BLOCKED state
+    means GitHub's branch protection still refuses the merge: a missing
+    required review decision, an unmet branch-protection rule, or another
+    protection gate. The previous behavior treated BLOCKED as a pass on the
+    theory that "awaiting required review" is when enabling auto-merge is
+    correct; that produced a false ready signal for PRs that branch protection
+    actually refused (observed on PR #2323) and conflicted with this repo's
+    own four-condition merge gate (``.claude/commands/pr-autofix.md``,
+    ``.claude/commands/pr-review-config.yaml``), which both require
+    ``mergeStateStatus in ('CLEAN', 'UNSTABLE')``.
     """
     if pr["state"] != "OPEN":
         reasons.append(f"PR is {pr['state'].lower()}, not open")
@@ -540,14 +536,13 @@ def _evaluate_pr_state(
         reasons.append("PR has merge conflicts")
     elif mergeable == "UNKNOWN":
         reasons.append("Merge status is being calculated")
-    merge_state = pr.get("mergeStateStatus")
+    merge_state = _merge_state_status(pr)
     if merge_state == "BEHIND":
         reasons.append("Branch is behind base; update against the base branch before merging")
-    elif merge_state == "BLOCKED" and not allow_blocked:
+    elif merge_state == "BLOCKED":
         reasons.append(
             "Merge blocked by branch protection (missing review decision or "
-            "unmet protection rule); pass --allow-blocked only when a pending "
-            "required review is the sole blocker and auto-merge will land it"
+            "unmet protection rule)"
         )
     return mergeable
 
@@ -812,14 +807,14 @@ def check_merge_readiness(
     ignore_ci: bool = False,
     ignore_threads: bool = False,
     include_non_required: bool = False,
-    allow_blocked: bool = False,
 ) -> dict:
     """Check if a PR is ready to merge. Sergeant orchestrator."""
     op_start = time.monotonic()
     pr = _fetch_pr_data(owner, repo, pr_number, op_start)
 
     reasons: list[str] = []
-    mergeable = _evaluate_pr_state(pr, reasons, allow_blocked)
+    merge_state = _merge_state_status(pr)
+    mergeable = _evaluate_pr_state(pr, reasons)
     unresolved_count, total_threads, threads_pages_complete = _evaluate_review_threads(
         pr, ignore_threads, reasons, owner, repo, pr_number,
     )
@@ -846,7 +841,7 @@ def check_merge_readiness(
         "State": pr["state"],
         "IsDraft": pr.get("isDraft", False),
         "Mergeable": mergeable,
-        "MergeStateStatus": pr.get("mergeStateStatus", ""),
+        "MergeStateStatus": merge_state,
         "UnresolvedThreads": unresolved_count,
         "TotalThreads": total_threads,
         "FailedRequiredChecks": failed_required,
@@ -888,15 +883,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--include-non-required", action="store_true",
         help="Non-required check failures also block merge",
     )
-    parser.add_argument(
-        "--allow-blocked", action="store_true",
-        help=(
-            "Classify mergeStateStatus=BLOCKED as allowed (does not block "
-            "CanMerge). Use only when a pending required review is the sole "
-            "blocker and auto-merge will land it; BLOCKED blocks by default "
-            "(issue #2326)."
-        ),
-    )
     return parser
 
 
@@ -915,7 +901,6 @@ def main(argv: list[str] | None = None) -> int:
         ignore_ci=args.ignore_ci,
         ignore_threads=args.ignore_threads,
         include_non_required=args.include_non_required,
-        allow_blocked=args.allow_blocked,
     )
 
     print(json.dumps(result, indent=2))

--- a/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/.claude/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -502,17 +502,34 @@ def _fetch_pr_data(owner: str, repo: str, pr_number: int, op_start: float) -> di
     return pr
 
 
-def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
+def _evaluate_pr_state(
+    pr: dict, reasons: list[str], allow_blocked: bool = False
+) -> str:
     """Append draft/state/merge-conflict reasons; return mergeable string.
 
     Also gates on ``mergeStateStatus == BEHIND`` (issue #2157): a branch
     behind its base cannot land, and this repo does not auto-update it on
     auto-merge (issue #2048 concrete failure), so it must block. ``DRAFT``,
     ``DIRTY``, and ``UNKNOWN`` are already covered by the ``isDraft`` and
-    ``mergeable`` checks. ``BLOCKED`` is intentionally NOT blocked: it
-    usually means "awaiting required review", which is exactly when enabling
-    auto-merge is the correct action; it stays surfaced via the
-    ``MergeStateStatus`` output field.
+    ``mergeable`` checks.
+
+    ``mergeStateStatus == BLOCKED`` blocks by default (issue #2326). A
+    BLOCKED state means GitHub's branch protection still refuses the merge:
+    a missing required review decision, an unmet branch-protection rule, or
+    another protection gate. The previous behavior treated BLOCKED as a
+    pass on the theory that "awaiting required review" is when enabling
+    auto-merge is correct; that produced a false ready signal for PRs that
+    branch protection actually refused (observed on PR #2323) and conflicted
+    with this repo's own four-condition merge gate
+    (``.claude/commands/pr-autofix.md``, ``.claude/commands/pr-review-config.yaml``),
+    which both require ``mergeStateStatus in ('CLEAN', 'UNSTABLE')``.
+
+    The auto-merge-eligible case (a clean PR that is only BLOCKED because a
+    required review is still pending) stays available behind an explicit
+    opt-in: pass ``allow_blocked=True`` (CLI ``--allow-blocked``) to classify
+    BLOCKED as allowed. When allowed, no reason is appended, but the state is
+    still surfaced via the ``MergeStateStatus`` output field so callers can
+    see it.
     """
     if pr["state"] != "OPEN":
         reasons.append(f"PR is {pr['state'].lower()}, not open")
@@ -523,8 +540,15 @@ def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
         reasons.append("PR has merge conflicts")
     elif mergeable == "UNKNOWN":
         reasons.append("Merge status is being calculated")
-    if pr.get("mergeStateStatus") == "BEHIND":
+    merge_state = pr.get("mergeStateStatus")
+    if merge_state == "BEHIND":
         reasons.append("Branch is behind base; update against the base branch before merging")
+    elif merge_state == "BLOCKED" and not allow_blocked:
+        reasons.append(
+            "Merge blocked by branch protection (missing review decision or "
+            "unmet protection rule); pass --allow-blocked only when a pending "
+            "required review is the sole blocker and auto-merge will land it"
+        )
     return mergeable
 
 
@@ -788,13 +812,14 @@ def check_merge_readiness(
     ignore_ci: bool = False,
     ignore_threads: bool = False,
     include_non_required: bool = False,
+    allow_blocked: bool = False,
 ) -> dict:
     """Check if a PR is ready to merge. Sergeant orchestrator."""
     op_start = time.monotonic()
     pr = _fetch_pr_data(owner, repo, pr_number, op_start)
 
     reasons: list[str] = []
-    mergeable = _evaluate_pr_state(pr, reasons)
+    mergeable = _evaluate_pr_state(pr, reasons, allow_blocked)
     unresolved_count, total_threads, threads_pages_complete = _evaluate_review_threads(
         pr, ignore_threads, reasons, owner, repo, pr_number,
     )
@@ -863,6 +888,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--include-non-required", action="store_true",
         help="Non-required check failures also block merge",
     )
+    parser.add_argument(
+        "--allow-blocked", action="store_true",
+        help=(
+            "Classify mergeStateStatus=BLOCKED as allowed (does not block "
+            "CanMerge). Use only when a pending required review is the sole "
+            "blocker and auto-merge will land it; BLOCKED blocks by default "
+            "(issue #2326)."
+        ),
+    )
     return parser
 
 
@@ -881,6 +915,7 @@ def main(argv: list[str] | None = None) -> int:
         ignore_ci=args.ignore_ci,
         ignore_threads=args.ignore_threads,
         include_non_required=args.include_non_required,
+        allow_blocked=args.allow_blocked,
     )
 
     print(json.dumps(result, indent=2))

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.105",
+  "version": "0.5.106",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -502,9 +502,12 @@ def _fetch_pr_data(owner: str, repo: str, pr_number: int, op_start: float) -> di
     return pr
 
 
-def _evaluate_pr_state(
-    pr: dict, reasons: list[str], allow_blocked: bool = False
-) -> str:
+def _merge_state_status(pr: dict) -> str:
+    value = pr.get("mergeStateStatus")
+    return "" if value is None else str(value)
+
+
+def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
     """Append draft/state/merge-conflict reasons; return mergeable string.
 
     Also gates on ``mergeStateStatus == BEHIND`` (issue #2157): a branch
@@ -513,23 +516,16 @@ def _evaluate_pr_state(
     ``DIRTY``, and ``UNKNOWN`` are already covered by the ``isDraft`` and
     ``mergeable`` checks.
 
-    ``mergeStateStatus == BLOCKED`` blocks by default (issue #2326). A
-    BLOCKED state means GitHub's branch protection still refuses the merge:
-    a missing required review decision, an unmet branch-protection rule, or
-    another protection gate. The previous behavior treated BLOCKED as a
-    pass on the theory that "awaiting required review" is when enabling
-    auto-merge is correct; that produced a false ready signal for PRs that
-    branch protection actually refused (observed on PR #2323) and conflicted
-    with this repo's own four-condition merge gate
-    (``.claude/commands/pr-autofix.md``, ``.claude/commands/pr-review-config.yaml``),
-    which both require ``mergeStateStatus in ('CLEAN', 'UNSTABLE')``.
-
-    The auto-merge-eligible case (a clean PR that is only BLOCKED because a
-    required review is still pending) stays available behind an explicit
-    opt-in: pass ``allow_blocked=True`` (CLI ``--allow-blocked``) to classify
-    BLOCKED as allowed. When allowed, no reason is appended, but the state is
-    still surfaced via the ``MergeStateStatus`` output field so callers can
-    see it.
+    ``mergeStateStatus == BLOCKED`` blocks (issue #2326). A BLOCKED state
+    means GitHub's branch protection still refuses the merge: a missing
+    required review decision, an unmet branch-protection rule, or another
+    protection gate. The previous behavior treated BLOCKED as a pass on the
+    theory that "awaiting required review" is when enabling auto-merge is
+    correct; that produced a false ready signal for PRs that branch protection
+    actually refused (observed on PR #2323) and conflicted with this repo's
+    own four-condition merge gate (``.claude/commands/pr-autofix.md``,
+    ``.claude/commands/pr-review-config.yaml``), which both require
+    ``mergeStateStatus in ('CLEAN', 'UNSTABLE')``.
     """
     if pr["state"] != "OPEN":
         reasons.append(f"PR is {pr['state'].lower()}, not open")
@@ -540,14 +536,13 @@ def _evaluate_pr_state(
         reasons.append("PR has merge conflicts")
     elif mergeable == "UNKNOWN":
         reasons.append("Merge status is being calculated")
-    merge_state = pr.get("mergeStateStatus")
+    merge_state = _merge_state_status(pr)
     if merge_state == "BEHIND":
         reasons.append("Branch is behind base; update against the base branch before merging")
-    elif merge_state == "BLOCKED" and not allow_blocked:
+    elif merge_state == "BLOCKED":
         reasons.append(
             "Merge blocked by branch protection (missing review decision or "
-            "unmet protection rule); pass --allow-blocked only when a pending "
-            "required review is the sole blocker and auto-merge will land it"
+            "unmet protection rule)"
         )
     return mergeable
 
@@ -812,14 +807,14 @@ def check_merge_readiness(
     ignore_ci: bool = False,
     ignore_threads: bool = False,
     include_non_required: bool = False,
-    allow_blocked: bool = False,
 ) -> dict:
     """Check if a PR is ready to merge. Sergeant orchestrator."""
     op_start = time.monotonic()
     pr = _fetch_pr_data(owner, repo, pr_number, op_start)
 
     reasons: list[str] = []
-    mergeable = _evaluate_pr_state(pr, reasons, allow_blocked)
+    merge_state = _merge_state_status(pr)
+    mergeable = _evaluate_pr_state(pr, reasons)
     unresolved_count, total_threads, threads_pages_complete = _evaluate_review_threads(
         pr, ignore_threads, reasons, owner, repo, pr_number,
     )
@@ -846,7 +841,7 @@ def check_merge_readiness(
         "State": pr["state"],
         "IsDraft": pr.get("isDraft", False),
         "Mergeable": mergeable,
-        "MergeStateStatus": pr.get("mergeStateStatus", ""),
+        "MergeStateStatus": merge_state,
         "UnresolvedThreads": unresolved_count,
         "TotalThreads": total_threads,
         "FailedRequiredChecks": failed_required,
@@ -888,15 +883,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--include-non-required", action="store_true",
         help="Non-required check failures also block merge",
     )
-    parser.add_argument(
-        "--allow-blocked", action="store_true",
-        help=(
-            "Classify mergeStateStatus=BLOCKED as allowed (does not block "
-            "CanMerge). Use only when a pending required review is the sole "
-            "blocker and auto-merge will land it; BLOCKED blocks by default "
-            "(issue #2326)."
-        ),
-    )
     return parser
 
 
@@ -915,7 +901,6 @@ def main(argv: list[str] | None = None) -> int:
         ignore_ci=args.ignore_ci,
         ignore_threads=args.ignore_threads,
         include_non_required=args.include_non_required,
-        allow_blocked=args.allow_blocked,
     )
 
     print(json.dumps(result, indent=2))

--- a/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
+++ b/src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
@@ -502,17 +502,34 @@ def _fetch_pr_data(owner: str, repo: str, pr_number: int, op_start: float) -> di
     return pr
 
 
-def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
+def _evaluate_pr_state(
+    pr: dict, reasons: list[str], allow_blocked: bool = False
+) -> str:
     """Append draft/state/merge-conflict reasons; return mergeable string.
 
     Also gates on ``mergeStateStatus == BEHIND`` (issue #2157): a branch
     behind its base cannot land, and this repo does not auto-update it on
     auto-merge (issue #2048 concrete failure), so it must block. ``DRAFT``,
     ``DIRTY``, and ``UNKNOWN`` are already covered by the ``isDraft`` and
-    ``mergeable`` checks. ``BLOCKED`` is intentionally NOT blocked: it
-    usually means "awaiting required review", which is exactly when enabling
-    auto-merge is the correct action; it stays surfaced via the
-    ``MergeStateStatus`` output field.
+    ``mergeable`` checks.
+
+    ``mergeStateStatus == BLOCKED`` blocks by default (issue #2326). A
+    BLOCKED state means GitHub's branch protection still refuses the merge:
+    a missing required review decision, an unmet branch-protection rule, or
+    another protection gate. The previous behavior treated BLOCKED as a
+    pass on the theory that "awaiting required review" is when enabling
+    auto-merge is correct; that produced a false ready signal for PRs that
+    branch protection actually refused (observed on PR #2323) and conflicted
+    with this repo's own four-condition merge gate
+    (``.claude/commands/pr-autofix.md``, ``.claude/commands/pr-review-config.yaml``),
+    which both require ``mergeStateStatus in ('CLEAN', 'UNSTABLE')``.
+
+    The auto-merge-eligible case (a clean PR that is only BLOCKED because a
+    required review is still pending) stays available behind an explicit
+    opt-in: pass ``allow_blocked=True`` (CLI ``--allow-blocked``) to classify
+    BLOCKED as allowed. When allowed, no reason is appended, but the state is
+    still surfaced via the ``MergeStateStatus`` output field so callers can
+    see it.
     """
     if pr["state"] != "OPEN":
         reasons.append(f"PR is {pr['state'].lower()}, not open")
@@ -523,8 +540,15 @@ def _evaluate_pr_state(pr: dict, reasons: list[str]) -> str:
         reasons.append("PR has merge conflicts")
     elif mergeable == "UNKNOWN":
         reasons.append("Merge status is being calculated")
-    if pr.get("mergeStateStatus") == "BEHIND":
+    merge_state = pr.get("mergeStateStatus")
+    if merge_state == "BEHIND":
         reasons.append("Branch is behind base; update against the base branch before merging")
+    elif merge_state == "BLOCKED" and not allow_blocked:
+        reasons.append(
+            "Merge blocked by branch protection (missing review decision or "
+            "unmet protection rule); pass --allow-blocked only when a pending "
+            "required review is the sole blocker and auto-merge will land it"
+        )
     return mergeable
 
 
@@ -788,13 +812,14 @@ def check_merge_readiness(
     ignore_ci: bool = False,
     ignore_threads: bool = False,
     include_non_required: bool = False,
+    allow_blocked: bool = False,
 ) -> dict:
     """Check if a PR is ready to merge. Sergeant orchestrator."""
     op_start = time.monotonic()
     pr = _fetch_pr_data(owner, repo, pr_number, op_start)
 
     reasons: list[str] = []
-    mergeable = _evaluate_pr_state(pr, reasons)
+    mergeable = _evaluate_pr_state(pr, reasons, allow_blocked)
     unresolved_count, total_threads, threads_pages_complete = _evaluate_review_threads(
         pr, ignore_threads, reasons, owner, repo, pr_number,
     )
@@ -863,6 +888,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--include-non-required", action="store_true",
         help="Non-required check failures also block merge",
     )
+    parser.add_argument(
+        "--allow-blocked", action="store_true",
+        help=(
+            "Classify mergeStateStatus=BLOCKED as allowed (does not block "
+            "CanMerge). Use only when a pending required review is the sole "
+            "blocker and auto-merge will land it; BLOCKED blocks by default "
+            "(issue #2326)."
+        ),
+    )
     return parser
 
 
@@ -881,6 +915,7 @@ def main(argv: list[str] | None = None) -> int:
         ignore_ci=args.ignore_ci,
         ignore_threads=args.ignore_threads,
         include_non_required=args.include_non_required,
+        allow_blocked=args.allow_blocked,
     )
 
     print(json.dumps(result, indent=2))

--- a/tests/test_test_pr_merge_ready.py
+++ b/tests/test_test_pr_merge_ready.py
@@ -98,6 +98,18 @@ class TestBuildParser:
         assert args.ignore_ci is True
         assert args.ignore_threads is True
 
+    def test_allow_blocked_defaults_false(self):
+        # issue #2326: BLOCKED blocks by default, so --allow-blocked must be
+        # opt-in (default False) rather than the prior implicit allow.
+        args = build_parser().parse_args(["--pull-request", "1"])
+        assert args.allow_blocked is False
+
+    def test_allow_blocked_flag(self):
+        args = build_parser().parse_args([
+            "--pull-request", "1", "--allow-blocked",
+        ])
+        assert args.allow_blocked is True
+
 
 # ---------------------------------------------------------------------------
 # Tests: check_merge_readiness
@@ -139,14 +151,62 @@ class TestCheckMergeReadiness:
         assert result["MergeStateStatus"] == "BEHIND"
         assert any("behind" in r.lower() for r in result["Reasons"])
 
-    def test_blocked_state_still_ready(self):
-        # issue #2157: BLOCKED usually means "awaiting required review", which
-        # is exactly when enabling auto-merge is correct. It must NOT block
-        # CanMerge; it is surfaced via MergeStateStatus for the agent.
+    def test_blocked_state_blocks_by_default(self):
+        # issue #2326 (supersedes the prior #2157 BLOCKED-is-ready behavior):
+        # BLOCKED means GitHub's branch protection still refuses the merge
+        # (missing review decision / unmet protection rule). Treating it as
+        # ready produced a false ready signal observed on PR #2323 and
+        # contradicted the repo's own four-condition merge gate. BLOCKED must
+        # make CanMerge False by default, with the blocker named in Reasons,
+        # while MergeStateStatus still surfaces the state for the agent.
         pr_data = json.loads(json.dumps(_OPEN_PR))
         pr_data["repository"]["pullRequest"]["mergeStateStatus"] = "BLOCKED"
         with patch("test_pr_merge_ready.gh_graphql", return_value=pr_data):
             result = check_merge_readiness("o", "r", 42)
+        assert result["CanMerge"] is False
+        assert result["MergeStateStatus"] == "BLOCKED"
+        assert any("blocked" in r.lower() for r in result["Reasons"]), (
+            f"a BLOCKED merge state must name the blocker; reasons: "
+            f"{result['Reasons']}"
+        )
+        assert any(
+            "branch protection" in r.lower() or "review" in r.lower()
+            for r in result["Reasons"]
+        ), (
+            "blocker reason should name branch protection / missing review "
+            f"decision; reasons: {result['Reasons']}"
+        )
+
+    def test_blocked_state_no_other_blockers_still_blocks(self):
+        # The exact PR #2323 shape: OPEN, not draft, 0 unresolved threads,
+        # 0 failing checks, 0 pending checks, but mergeStateStatus=BLOCKED.
+        # Every other gate is clean, so without this fix CanMerge would be
+        # True (the false ready signal #2326 reports). With the fix, the
+        # only reason is the BLOCKED merge state.
+        pr_data = json.loads(json.dumps(_OPEN_PR))
+        pr_data["repository"]["pullRequest"]["mergeStateStatus"] = "BLOCKED"
+        with patch("test_pr_merge_ready.gh_graphql", return_value=pr_data):
+            result = check_merge_readiness("o", "r", 42)
+        assert result["CanMerge"] is False
+        assert result["UnresolvedThreads"] == 0
+        assert result["FailedRequiredChecks"] == []
+        assert result["PendingRequiredChecks"] == []
+        assert result["CIPassing"] is True
+        assert len(result["Reasons"]) == 1, (
+            "BLOCKED should be the sole blocker on an otherwise-clean PR; "
+            f"reasons: {result['Reasons']}"
+        )
+
+    def test_blocked_state_ready_with_allow_blocked(self):
+        # Auto-merge-eligible path preserved behind an explicit opt-in
+        # (the fd62812b5 / #2303 intent): when a pending required review is
+        # the sole blocker, --allow-blocked (allow_blocked=True) classifies
+        # BLOCKED as allowed so CanMerge is True. The state is still surfaced
+        # via MergeStateStatus.
+        pr_data = json.loads(json.dumps(_OPEN_PR))
+        pr_data["repository"]["pullRequest"]["mergeStateStatus"] = "BLOCKED"
+        with patch("test_pr_merge_ready.gh_graphql", return_value=pr_data):
+            result = check_merge_readiness("o", "r", 42, allow_blocked=True)
         assert result["CanMerge"] is True
         assert result["MergeStateStatus"] == "BLOCKED"
         assert result["Reasons"] == []

--- a/tests/test_test_pr_merge_ready.py
+++ b/tests/test_test_pr_merge_ready.py
@@ -98,18 +98,6 @@ class TestBuildParser:
         assert args.ignore_ci is True
         assert args.ignore_threads is True
 
-    def test_allow_blocked_defaults_false(self):
-        # issue #2326: BLOCKED blocks by default, so --allow-blocked must be
-        # opt-in (default False) rather than the prior implicit allow.
-        args = build_parser().parse_args(["--pull-request", "1"])
-        assert args.allow_blocked is False
-
-    def test_allow_blocked_flag(self):
-        args = build_parser().parse_args([
-            "--pull-request", "1", "--allow-blocked",
-        ])
-        assert args.allow_blocked is True
-
 
 # ---------------------------------------------------------------------------
 # Tests: check_merge_readiness
@@ -197,18 +185,13 @@ class TestCheckMergeReadiness:
             f"reasons: {result['Reasons']}"
         )
 
-    def test_blocked_state_ready_with_allow_blocked(self):
-        # Auto-merge-eligible path preserved behind an explicit opt-in
-        # (the fd62812b5 / #2303 intent): when a pending required review is
-        # the sole blocker, --allow-blocked (allow_blocked=True) classifies
-        # BLOCKED as allowed so CanMerge is True. The state is still surfaced
-        # via MergeStateStatus.
+    def test_null_merge_state_status_normalizes_to_empty_string(self):
         pr_data = json.loads(json.dumps(_OPEN_PR))
-        pr_data["repository"]["pullRequest"]["mergeStateStatus"] = "BLOCKED"
+        pr_data["repository"]["pullRequest"]["mergeStateStatus"] = None
         with patch("test_pr_merge_ready.gh_graphql", return_value=pr_data):
-            result = check_merge_readiness("o", "r", 42, allow_blocked=True)
+            result = check_merge_readiness("o", "r", 42)
         assert result["CanMerge"] is True
-        assert result["MergeStateStatus"] == "BLOCKED"
+        assert result["MergeStateStatus"] == ""
         assert result["Reasons"] == []
 
     def test_unresolved_threads(self):


### PR DESCRIPTION
## Summary

### What

The merge-readiness check now reports `CanMerge=false` when `mergeStateStatus` is `BLOCKED`, names the branch-protection blocker, and normalizes JSON `null` merge states to an empty output string.

### Why

`CanMerge=true` with `mergeStateStatus=BLOCKED` created a false ready signal. Fixes #2326.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| Issue | Fixes #2326 | P2 merge-readiness fix |

## Changes

```text
.claude/.claude-plugin/plugin.json
.claude/skills/github/scripts/pr/test_pr_merge_ready.py
src/copilot-cli/.claude-plugin/plugin.json
src/copilot-cli/skills/github/scripts/pr/test_pr_merge_ready.py
tests/test_test_pr_merge_ready.py
```

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Testing

- [x] `uv run pytest tests/test_test_pr_merge_ready.py -q`
- [x] `python3 scripts/validation/run_plugin_version_bump_ci.py`
- [x] `python3 build/scripts/build_all.py --platform copilot-cli --check`
- [x] Pre-push hook passed on push to `fix/p2-2326-merge-ready-blocked`

## Policy

No `BLOCKED` opt-in remains. Ready-to-merge remains the 4-condition gate: branch up to date, required checks pass, conversations resolved, and `mergeStateStatus` is `CLEAN` or `UNSTABLE` with documented non-required failures.
