### PR TITLE
chore(adr): resolve duplicate ADR numbers 058/062/063 (#2228)

### DIFF
--- a/.agents/architecture/ADR-063-memory-skill-decomposition.md
+++ b/.agents/architecture/ADR-063-memory-skill-decomposition.md
@@ -97,9 +97,8 @@ moves to Accepted.
    the router (cheapest to reach, but couples the router to gate prose) or in a
    dedicated `memory-gate` sibling (cleaner boundary, one more hop). Either way
    the gate keeps its current BLOCKING semantics from
-   `ADR-062-memory-first-gate-spec-pipeline.md`. The repository currently also
-   contains `ADR-062-conditional-lsp-first-enforcement.md`; full filenames are
-   used here to avoid the existing numbering collision.
+   `ADR-070-memory-first-gate-spec-pipeline.md` (renumbered from the former
+   ADR-062 collision per #2228).
 
 4. **Boundaries from ADR-007, ADR-037, ADR-038, and ADR-056 are preserved.**
    The decomposition is a SKILL-surface change only. Serena remains the
@@ -274,10 +273,9 @@ the adr-review debate gate.
   decomposed siblings inherit unchanged)
 - ADR-056: Skill Output Format Standardization (the output envelope every
   sub-skill must emit)
-- `ADR-062-memory-first-gate-spec-pipeline.md`: Memory-First Gate Is a
+- `ADR-070-memory-first-gate-spec-pipeline.md`: Memory-First Gate Is a
   BLOCKING Step in the Spec Pipeline (the gate semantics the decomposition must
-  keep). This repository also has `ADR-062-conditional-lsp-first-enforcement.md`,
-  so this ADR cites the full filename when it relies on gate semantics.
+  keep). Renumbered from the former ADR-062 collision per #2228.
 
 ## References
 
@@ -286,8 +284,8 @@ the adr-review debate gate.
 - Issue #1948: M3 implementation (the decomposition this ADR authorizes but
   does not perform)
 - Epic #1944: parent epic
-- Issue #2228: follow-up to resolve the pre-existing ADR-058 and ADR-062
-  numbering collisions surfaced during adr-review
+- Issue #2228: resolved the pre-existing ADR-058 and ADR-062 numbering
+  collisions surfaced during adr-review (the gate ADR is now ADR-070)
 - `.agents/analysis/skill-triage-2026-05-09.md`: finding F2 (143.6 KB size,
   +2.83 eval delta) and F4 (memory cluster table), the measurement driver
 - `.agents/plans/active/PLAN-skill-catalog-triage-action-slate.md`: Tier 2

--- a/.agents/architecture/ADR-066-hook-fail-open-reconciliation.md
+++ b/.agents/architecture/ADR-066-hook-fail-open-reconciliation.md
@@ -105,7 +105,7 @@ The implementer follow-up PR for #2271 MUST update prior governance surfaces to 
 | ADR-033 | Remove recommendations that downgrade blocking hook failures to advisory success. |
 | ADR-035 | Update hook exit-code guidance to D2 and remove fail-open semantics. |
 | ADR-062 LSP-first ADR | Reframe LSP handling per D3. |
-| ADR-062 memory-first gate ADR | Reframe fallback language as prevention and loud failure, not success-shaped degradation. |
+| ADR-070 memory-first gate ADR | Reframe fallback language as prevention and loud failure, not success-shaped degradation. |
 | Release It guidance | Scope graceful degradation away from hook invariants per D4. |
 | Memory cross-reference hooks | Remove launcher-level fail-open behavior and add fail-closed runtime-contract coverage. |
 

--- a/.agents/architecture/ADR-068-consolidated-hook-dispatcher.md
+++ b/.agents/architecture/ADR-068-consolidated-hook-dispatcher.md
@@ -32,13 +32,13 @@ The root cause is a per-tool-call process-spawn storm:
    threshold is 2-3 s, which `timeoutSec: 5` in `hooks.json` does not raise:
    the budget is host-controlled, not generator-controlled.
 4. When the budget is exceeded, Copilot reports `hook errored` and fails
-   closed per ADR-063 Decision item 5. The fail-closed policy is correct.
+   closed per ADR-071 Decision item 5. The fail-closed policy is correct.
    The defect is that a HEALTHY hook is killed by our own dispatch overhead,
    manufacturing a false `errored` signal.
 
-This is distinct from #2290 (payload casing, fixed) and from #2205 / ADR-063
+This is distinct from #2290 (payload casing, fixed) and from #2205 / ADR-071
 (launcher cwd, fixed). Both prior fixes corrected correctness defects. This
-ADR addresses a performance defect that turns ADR-063's fail-closed policy
+ADR addresses a performance defect that turns ADR-071's fail-closed policy
 into a denial-of-service against benign tool calls.
 
 ## Decision
@@ -63,13 +63,13 @@ dispatchers execute each matched guard in `__main__` context using
    the dispatcher with the same exit code, surfacing through Copilot's
    existing `hook errored` path. The dispatcher itself fails closed (exit
    2) on malformed stdin, missing `tool_name`, or guard import failure.
-   ADR-063 Decision item 5 (prevention plus loud failure) is unchanged.
+   ADR-071 Decision item 5 (prevention plus loud failure) is unchanged.
 4. **Bounded shared budget.** The dispatcher enforces a per-event
    wall-clock cap (default 1500 ms, configurable via
    `COPILOT_HOOK_DISPATCH_BUDGET_MS`). On budget exhaustion it fails
    closed with a structured `budget_exceeded` reason so the failure is
    distinguishable from a guard rejection.
-5. **No daemon.** The dispatcher is short-lived. ADR-063's host-launcher
+5. **No daemon.** The dispatcher is short-lived. ADR-071's host-launcher
    contract (cwd, exit code semantics) is unchanged. No persistent IPC.
 6. **Regenerated artifacts are authoritative.** Per
    `.claude/rules/generated-artifacts.md` and ADR-061's CI drift gate, the
@@ -119,7 +119,7 @@ dispatchers execute each matched guard in `__main__` context using
   in-process without re-introducing the drift class ADR-061 worried about,
   because there is now ONE dispatcher per event (not N delegates).
 - **What are the risks of change?** A dispatcher bug affects every guard
-  for that event. Mitigation: the runtime-contract test from ADR-063
+  for that event. Mitigation: the runtime-contract test from ADR-071
   already exists; extend it to cover the dispatcher's classify-and-route
   path with the full installed guard set.
 
@@ -131,8 +131,8 @@ dispatchers execute each matched guard in `__main__` context using
 |-------------|------|------|----------------|
 | Raise `timeoutSec` in `hooks.json` | Zero generator change | Copilot ignores it (killed at 2-3s when set to 5s); host-controlled budget | Rejected: ineffective |
 | Speed up each shim body | Minimal architectural change | Python cold start (~200 ms) is a floor; 40 x floor still blows budget | Rejected: insufficient |
-| Persistent hook daemon | Lowest steady-state latency | Process lifecycle, IPC, stale-state, security surface; violates ADR-063 launcher contract | Rejected: disproportionate; revisit only if single-dispatcher is insufficient |
-| Consolidated per-event dispatcher | Collapses N spawns to 1; preserves ADR-063 fail-closed; preserves ADR-061 grammar; no new IPC | One dispatcher bug affects all guards for that event | **Chosen**: smallest change that fits within the host-imposed budget |
+| Persistent hook daemon | Lowest steady-state latency | Process lifecycle, IPC, stale-state, security surface; violates ADR-071 launcher contract | Rejected: disproportionate; revisit only if single-dispatcher is insufficient |
+| Consolidated per-event dispatcher | Collapses N spawns to 1; preserves ADR-071 fail-closed; preserves ADR-061 grammar; no new IPC | One dispatcher bug affects all guards for that event | **Chosen**: smallest change that fits within the host-imposed budget |
 
 ### Trade-offs
 
@@ -143,7 +143,7 @@ unchanged in Claude Code (which DOES honor `matcher` and dispatches one
 guard per entry natively). The dispatcher is a Copilot-side adapter, not
 a replacement for the canonical guard layout.
 
-A dispatcher failure cascades to every guard for that event. ADR-063's
+A dispatcher failure cascades to every guard for that event. ADR-071's
 runtime-contract gate caught the launcher cwd defect that motivated it;
 the same gate must be extended to cover dispatcher classification and
 route correctness against the full installed guard set, not a sample.
@@ -168,7 +168,7 @@ route correctness against the full installed guard set, not a sample.
 ### Negative
 
 - A dispatcher defect (classifier mismatch, import failure) takes down
-  every guard for that event. Mitigation: extend ADR-063's runtime-contract
+  every guard for that event. Mitigation: extend ADR-071's runtime-contract
   test to assert that, for every installed `(event, matcher, payload)`
   triple, the dispatcher routes to the same guard the per-shim layout would
   have invoked.
@@ -196,7 +196,7 @@ route correctness against the full installed guard set, not a sample.
 | `tests/build_scripts/test_generate_hooks.py` | Direct | New parametrized tests covering dispatcher routing, fail-closed on malformed input, budget enforcement, and guard isolation | High (must cover full installed guard set, not samples) |
 | `.agents/governance/GENERATOR-FILES.md` | Indirect | Document dispatcher pattern alongside per-matcher-shim history | Low |
 | Claude Code `.claude/hooks/**` | None | Unchanged | None |
-| ADR-063 runtime-contract test | Direct | Extend to assert dispatcher classification matches per-matcher reference for every installed payload | High |
+| ADR-071 runtime-contract test | Direct | Extend to assert dispatcher classification matches per-matcher reference for every installed payload | High |
 | `.claude/rules/generated-artifacts.md` | Indirect | Add dispatcher runtime-test requirement to the runtime-contract test family | Low |
 
 ## Implementation Notes
@@ -226,12 +226,12 @@ test-first reproduction:
    step in CI catches non-deterministic dispatcher emission. The generator
    must sort guards by `(matcher_kind, matcher_pattern, source_path)`
    before emission.
-6. **Runtime-contract extension.** Extend the ADR-063 runtime-contract test
+6. **Runtime-contract extension.** Extend the ADR-071 runtime-contract test
    to enumerate every installed guard and assert that the dispatcher routes
    each registered matcher to the same guard the per-shim layout would
    have invoked. Use the matcher classification table as the oracle.
 
-The implementer should NOT add a launcher-level fail-open; ADR-063 closed
+The implementer should NOT add a launcher-level fail-open; ADR-071 closed
 that path explicitly. The dispatcher fails closed on all internal errors.
 
 ## Related Decisions
@@ -239,7 +239,7 @@ that path explicitly. The dispatcher fails closed on all internal errors.
 - ADR-061 (withdrawn): Hook matcher shims delegate pattern. Establishes the
   matcher grammar this ADR preserves and the drift-gate discipline this
   ADR inherits.
-- ADR-063: Plugin hook runtime-contract verification. Establishes
+- ADR-071: Plugin hook runtime-contract verification. Establishes
   fail-closed semantics and the runtime-contract test family this ADR
   extends.
 - ADR-035: Exit-code standardization. Governs the dispatcher's exit codes.
@@ -250,7 +250,7 @@ that path explicitly. The dispatcher fails closed on all internal errors.
 - Issue #2295: source defect (this ADR).
 - Issue #2290 / PR #2293: payload casing fix. Distinct defect, verified
   working in the same session that surfaced #2295.
-- Issue #2205: launcher cwd fix (ADR-063).
+- Issue #2205: launcher cwd fix (ADR-071).
 - Issue #2230: launcher-level fail-open proposal, closed
   addressed-by-prevention. Reaffirmed by this ADR's Decision item 3.
 - Issue #2112: ADR-061 follow-up tracking when to revisit shared-body

--- a/.agents/architecture/ADR-069-context-corpus-is-the-product.md
+++ b/.agents/architecture/ADR-069-context-corpus-is-the-product.md
@@ -6,7 +6,7 @@ consulted: ["analyst", "critic", "qa"]
 informed: ["implementer", "devops", "security", "roadmap"]
 ---
 
-# ADR-058: The Curated Context Corpus IS the Product — Orchestration Is Plumbing
+# ADR-069: The Curated Context Corpus IS the Product, Orchestration Is Plumbing
 
 ## Context and Problem Statement
 
@@ -63,7 +63,7 @@ Concretely, this ADR:
 ### What This ADR Is NOT
 
 - **Not** a reorganization of `.serena/memories/`, `.agents/`, `.claude/skills/`, or any other context source.
-- **Not** a new schema. ADR-058 does not define field requirements, frontmatter standards, or validation rules.
+- **Not** a new schema. ADR-069 does not define field requirements, frontmatter standards, or validation rules.
 - **Not** a deprecation of any existing agent, orchestration command, lifecycle hook, or workflow.
 - **Not** a commitment to build telemetry, an assembly layer, or a unified catalog as part of this ADR. Those are downstream issues.
 
@@ -128,7 +128,7 @@ Concretely, this ADR:
 | Component | Dependency Type | Required Update | Risk |
 |-----------|----------------|-----------------|------|
 | `.serena/memories/` | Indirect | None in this ADR; future ADRs may reference this principle when proposing memory-corpus changes | Low |
-| `.agents/architecture/` (other ADRs) | Indirect | None now; ADRs that touch context sources should cite ADR-058 | Low |
+| `.agents/architecture/` (other ADRs) | Indirect | None now; ADRs that touch context sources should cite ADR-069 | Low |
 | `.claude/skills/` | Indirect | None now; skill authors may cite the principle when justifying corpus-shaping skills | Low |
 | Lifecycle commands (`/spec`, `/plan`, `/build`, `/test`, `/review`, `/ship`) | None | No change | None |
 | CI workflows | None | No change | None |
@@ -149,7 +149,7 @@ None of the above are part of this ADR's acceptance criteria.
 
 ## Related Decisions
 
-- **ADR-007** (Memory-First Architecture) — establishes that retrieval precedes reasoning; ADR-058 generalizes the principle from "memory" to "the entire curated corpus."
+- **ADR-007** (Memory-First Architecture): establishes that retrieval precedes reasoning; ADR-069 generalizes the principle from "memory" to "the entire curated corpus."
 - **ADR-017** (Tiered Memory Index Architecture) — provides one concrete realization of corpus organization within `.serena/memories/`.
 - **ADR-030** (Skills Pattern Superiority) — skills are one corpus surface among several.
 - **ADR-050** (ADR Protocol Sync) — governs how this ADR is propagated and discovered.

--- a/.agents/architecture/ADR-069-context-corpus-is-the-product.md
+++ b/.agents/architecture/ADR-069-context-corpus-is-the-product.md
@@ -14,19 +14,19 @@ The competitive value of this repository over a generic Copilot or Claude prompt
 
 Today these artifacts live across many locations with no unified theory of why they exist together or what role each plays at inference time:
 
-- `.serena/memories/` — learned patterns, skills (Zettelkasten atomic notes, tiered)
-- `.agents/architecture/` — ADRs and architectural decisions
-- `.agents/governance/` — constraints and policies
-- `.agents/HANDOFF.md`, `.agents/SESSION-PROTOCOL.md` — session bridge / protocol
-- `templates/agents/` — agent definitions (YAML frontmatter + Markdown)
-- `.claude/skills/*/SKILL.md` — skill definitions
-- `.github/instructions/` — platform-specific rules with `applyTo` globs
-- `.github/prompts/` — quality gate prompts
-- `.baseline/` — coverage thresholds (JSON with schema)
+- `.serena/memories/`: learned patterns, skills (Zettelkasten atomic notes, tiered)
+- `.agents/architecture/`: ADRs and architectural decisions
+- `.agents/governance/`: constraints and policies
+- `.agents/HANDOFF.md`, `.agents/SESSION-PROTOCOL.md`: session bridge / protocol
+- `templates/agents/`: agent definitions (YAML frontmatter + Markdown)
+- `.claude/skills/*/SKILL.md`: skill definitions
+- `.github/instructions/`: platform-specific rules with `applyTo` globs
+- `.github/prompts/`: quality gate prompts
+- `.baseline/`: coverage thresholds (JSON with schema)
 - `CLAUDE.md`, `AGENTS.md`, root entry-point context
-- `scripts/memory/`, `scripts/memory_sync/` — index maintenance
+- `scripts/memory/`, `scripts/memory_sync/`: index maintenance
 
-This catalog is descriptive, not prescriptive — it names the territory as it currently exists. **This ADR does not propose reorganizing any of it.**
+This catalog is descriptive, not prescriptive. It names the territory as it currently exists. **This ADR does not propose reorganizing any of it.**
 
 ## Frame: LLMs as Ghosts, Not Animals
 
@@ -52,10 +52,10 @@ Concretely, this ADR:
 
 1. **Establishes the principle** as a first-class architectural commitment, on equal footing with ADR-007 (memory-first architecture) and ADR-017 (tiered memory index).
 2. **Catalogs the existing context sources** (see Context section above) as a snapshot of the territory, without reorganizing them.
-3. **Names — but explicitly does not answer — the open questions** that downstream work will address:
+3. **Names, but explicitly does not answer, the open questions** that downstream work will address:
    - **Corpus catalog**: What is the authoritative, machine-readable inventory of all context artifacts the system can assemble?
    - **Schema spike**: Should there be a canonical schema for context artifacts, or a family of per-type schemas, or none at all? (Schema-first risks killing the corpus this principle is trying to protect.)
-   - **Assembly-layer prototype**: What does a context-assembly layer look like in practice — RAG, rule-based, agent-mediated, hybrid? Likely needs prototyping before deciding.
+   - **Assembly-layer prototype**: What does a context-assembly layer look like in practice (RAG, rule-based, agent-mediated, hybrid)? Likely needs prototyping before deciding.
    - **Telemetry-of-influence**: What signal would prove a given artifact actually influenced output, beyond "it was in the prompt window"?
    - **Curation cadence**: What is the cadence and ownership for pruning stale artifacts, refreshing summaries, and retiring obsolete patterns?
 4. **Does not prescribe** answers to any of the above. Each becomes a separate, appropriately-sized issue **after** this ADR merges.
@@ -72,7 +72,7 @@ Concretely, this ADR:
 ### What Currently Exists
 
 - **Structure/pattern being changed**: Implicit, distributed treatment of context artifacts across multiple directories with no unified architectural narrative.
-- **When introduced**: Incrementally over the project's history — `.serena/memories/` (ADR-007 era), `.agents/` (ADR-008 era), `.claude/skills/` (ADR-030), governance and instructions added piecemeal.
+- **When introduced**: Incrementally over the project's history: `.serena/memories/` (ADR-007 era), `.agents/` (ADR-008 era), `.claude/skills/` (ADR-030), governance and instructions added piecemeal.
 - **Original author and context**: Multiple authors; each subsystem solved a local problem (memory retrieval, session handoff, agent definitions, skill discovery) without a unifying principle for *why context lives where it lives*.
 
 ### Historical Rationale
@@ -96,7 +96,7 @@ Concretely, this ADR:
 | Status quo (no ADR) | Zero cost; nothing breaks | Contributors continue investing in the wrong layer; no shared vocabulary for "context is the product" | Status quo is the problem this ADR addresses |
 | ADR + immediate canonical schema | Forces consistency; enables tooling | Schema-first kills the corpus before the principle lands; existing artifacts revolt against retrofit | Premature; better to prototype assembly before locking schema |
 | ADR + immediate catalog + schema + assembly + telemetry + cadence (the original issue scope) | Comprehensive | A 12-month roadmap dressed as one decision; high blast radius; mixes principle with implementation | Per the issue's edit log, this scope was explicitly stripped |
-| Principle-only ADR with named open questions (this ADR) | Establishes vocabulary; preserves optionality; downstream issues can be sized appropriately | Doesn't deliver any tooling itself | Chosen — matches the issue's deliverable scope and protects the corpus from premature schema |
+| Principle-only ADR with named open questions (this ADR) | Establishes vocabulary; preserves optionality; downstream issues can be sized appropriately | Doesn't deliver any tooling itself | Chosen: matches the issue's deliverable scope and protects the corpus from premature schema |
 
 ### Trade-offs
 
@@ -115,7 +115,7 @@ Concretely, this ADR:
 
 ### Negative
 
-- Risk of misuse as a rhetorical cudgel against legitimate orchestration improvements. Mitigation: the principle says orchestration is plumbing, not that plumbing is worthless — plumbing failures still ship broken software.
+- Risk of misuse as a rhetorical cudgel against legitimate orchestration improvements. Mitigation: the principle says orchestration is plumbing, not that plumbing is worthless; plumbing failures still ship broken software.
 - Risk that "principle without implementation" reads as procedural overhead. Mitigation: the downstream issues are real work, not paperwork; they are deferred precisely so they can be sized properly.
 
 ### Neutral
@@ -139,25 +139,25 @@ This ADR is documentation-only. There is no code change, no schema change, no mi
 
 **Post-merge follow-ups** (to be filed as separate issues, per the originating issue's Deliverable section):
 
-1. Corpus catalog — authoritative inventory of context artifacts.
-2. Schema spike — investigate whether a canonical or per-type schema is desirable, with explicit attention to the schema-first risk.
-3. Assembly-layer prototype — explore RAG / rule-based / hybrid context assembly.
-4. Telemetry-of-influence — define signal that an artifact actually influenced output.
-5. Curation cadence — define ownership and cadence for pruning, refreshing, retiring.
+1. Corpus catalog: authoritative inventory of context artifacts.
+2. Schema spike: investigate whether a canonical or per-type schema is desirable, with explicit attention to the schema-first risk.
+3. Assembly-layer prototype: explore RAG / rule-based / hybrid context assembly.
+4. Telemetry-of-influence: define signal that an artifact actually influenced output.
+5. Curation cadence: define ownership and cadence for pruning, refreshing, retiring.
 
 None of the above are part of this ADR's acceptance criteria.
 
 ## Related Decisions
 
 - **ADR-007** (Memory-First Architecture): establishes that retrieval precedes reasoning; ADR-069 generalizes the principle from "memory" to "the entire curated corpus."
-- **ADR-017** (Tiered Memory Index Architecture) — provides one concrete realization of corpus organization within `.serena/memories/`.
-- **ADR-030** (Skills Pattern Superiority) — skills are one corpus surface among several.
-- **ADR-050** (ADR Protocol Sync) — governs how this ADR is propagated and discovered.
-- **ADR-053** (ADR Exception Criteria) — clarifies when ADRs are required; this ADR is in-scope.
+- **ADR-017** (Tiered Memory Index Architecture): provides one concrete realization of corpus organization within `.serena/memories/`.
+- **ADR-030** (Skills Pattern Superiority): skills are one corpus surface among several.
+- **ADR-050** (ADR Protocol Sync): governs how this ADR is propagated and discovered.
+- **ADR-053** (ADR Exception Criteria): clarifies when ADRs are required; this ADR is in-scope.
 
 ## References
 
-- Issue [#1859](https://github.com/rjmurillo/ai-agents/issues/1859) — originating issue and edit log.
-- Related issues: [#1769](https://github.com/rjmurillo/ai-agents/issues/1769) (refactor: extract monolith `.agents/*.md` — this ADR reframes the *why*), [#1728](https://github.com/rjmurillo/ai-agents/issues/1728) (context pressure detection — measurement complement), [#1854](https://github.com/rjmurillo/ai-agents/issues/1854), [#1855](https://github.com/rjmurillo/ai-agents/issues/1855), [#1857](https://github.com/rjmurillo/ai-agents/issues/1857) (eval/gate/router companions).
-- Frame: *LLMs as Ghosts not Animals* (`wiki/concepts/AI Strategy/LLMs as Ghosts not Animals.md`, as cited in the originating issue) — no learning between runs; the corpus is what persists.
-- ADR-TEMPLATE.md — `.agents/architecture/ADR-TEMPLATE.md`.
+- Issue [#1859](https://github.com/rjmurillo/ai-agents/issues/1859): originating issue and edit log.
+- Related issues: [#1769](https://github.com/rjmurillo/ai-agents/issues/1769) (refactor: extract monolith `.agents/*.md`; this ADR reframes the *why*), [#1728](https://github.com/rjmurillo/ai-agents/issues/1728) (context pressure detection, the measurement complement), [#1854](https://github.com/rjmurillo/ai-agents/issues/1854), [#1855](https://github.com/rjmurillo/ai-agents/issues/1855), [#1857](https://github.com/rjmurillo/ai-agents/issues/1857) (eval/gate/router companions).
+- Frame: *LLMs as Ghosts not Animals* (`wiki/concepts/AI Strategy/LLMs as Ghosts not Animals.md`, as cited in the originating issue): no learning between runs; the corpus is what persists.
+- ADR-TEMPLATE.md: `.agents/architecture/ADR-TEMPLATE.md`.

--- a/.agents/architecture/ADR-070-memory-first-gate-spec-pipeline.md
+++ b/.agents/architecture/ADR-070-memory-first-gate-spec-pipeline.md
@@ -1,4 +1,4 @@
-# ADR-062: Memory-First Gate Is a BLOCKING Step in the Spec Pipeline
+# ADR-070: Memory-First Gate Is a BLOCKING Step in the Spec Pipeline
 
 ## Status
 

--- a/.agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md
+++ b/.agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md
@@ -1,4 +1,4 @@
-# ADR-063: Plugin Hook Runtime-Contract Verification
+# ADR-071: Plugin Hook Runtime-Contract Verification
 
 ## Status
 

--- a/.agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md
+++ b/.agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md
@@ -6,7 +6,7 @@ Accepted (2026-06-02, six-agent adr-review: 2 Accept, 4 Disagree-and-Commit, 0
 Block). The P0 dissent proposed a committed launcher-level fail-open follow-up;
 that was subsequently rejected in favor of prevention plus loud failure (issue
 #2230 closed addressed-by-prevention), and Decision item 5 records the
-fail-closed position. Debate log: `.agents/critique/ADR-063-debate-log.md`.
+fail-closed position. Debate log: `.agents/critique/ADR-071-debate-log.md`.
 
 ## Date
 
@@ -219,7 +219,7 @@ item 5.)
 - `tests/e2e/test_cli_hook_e2e.py`. Real-CLI smoke (forced in pre-push).
 - Serena memory `decision-copilot-cli-hook-plugin-root-contract`. Verified contract.
 - `.github/workflows/validate-plugin-manifests.yml`. Server-side anchoring gate.
-- `.agents/critique/ADR-063-debate-log.md`. Six-agent review debate.
+- `.agents/critique/ADR-071-debate-log.md`. Six-agent review debate.
 - Issues #2205 (fix), #2223 (module-size/complexity debt), #2230 (launcher
   fail-open, closed: rejected, addressed-by-prevention), #2231 (Windows
   contract sim, glob artifact discovery, authenticated nightly smoke).

--- a/.agents/critique/ADR-063-debate-log.md
+++ b/.agents/critique/ADR-063-debate-log.md
@@ -1,4 +1,4 @@
-# ADR-063 Review Debate Log
+# ADR-071 Review Debate Log (renumbered from ADR-063)
 
 **ADR**: `.agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md` (renumbered from ADR-063 per #2228)
 **Date**: 2026-06-02

--- a/.agents/critique/ADR-063-debate-log.md
+++ b/.agents/critique/ADR-063-debate-log.md
@@ -1,6 +1,6 @@
 # ADR-063 Review Debate Log
 
-**ADR**: `.agents/architecture/ADR-063-plugin-hook-runtime-contract-verification.md`
+**ADR**: `.agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md` (renumbered from ADR-063 per #2228)
 **Date**: 2026-06-02
 **Protocol**: 6-agent adr-review (architect, critic, independent-thinker, security, analyst, high-level-advisor)
 **Outcome**: Consensus reached. 2 Accept, 4 Disagree-and-Commit, 0 Block. P0/P1 dissents resolved in revision.

--- a/.agents/critique/ADR-071-debate-log.md
+++ b/.agents/critique/ADR-071-debate-log.md
@@ -34,4 +34,4 @@ No Pass-Through (all agents produced substantive, cited findings). No Groundhog 
 
 ## Disposition
 
-ADR-063 status set to Accepted. All P0 issues resolved in code/ADR; all P1 issues resolved or tracked with an issue (#2230, #2231). Dissent preserved here.
+ADR-071 status set to Accepted. All P0 issues resolved in code/ADR; all P1 issues resolved or tracked with an issue (#2230, #2231). Dissent preserved here.

--- a/.agents/governance/FAILURE-MODES.md
+++ b/.agents/governance/FAILURE-MODES.md
@@ -25,7 +25,7 @@ Trust-based compliance fails at scale. Instructions asking agents to "remember",
 | 8 | Security drift | Critical | `2026-01-04-pr760-security-suppression-failure.md` |
 | 9 | Confident-incorrectness recurrence | High | `2026-05-08-pr-1897-confident-incorrectness-recurrence.md` |
 | 10 | Silent defaults and guard-clause suppression | High | PR #1965 round-9/round-11 fixes; daniel.haxx.se 2026-05-11 |
-| 11 | Customer-facing generated artifact shipped without runtime verification | Critical | `2026-06-02-pr-2205-customer-wedge-incident.md`; ADR-063 |
+| 11 | Customer-facing generated artifact shipped without runtime verification | Critical | `2026-06-02-pr-2205-customer-wedge-incident.md`; ADR-071 |
 
 ---
 
@@ -472,7 +472,7 @@ smoke MUST be loud.
 ### References
 
 - `.agents/retrospective/2026-06-02-pr-2205-customer-wedge-incident.md`
-- ADR-063 (plugin hook runtime-contract verification)
+- ADR-071 (plugin hook runtime-contract verification)
 - `.claude/rules/generated-artifacts.md`
 - `.claude/rules/canonical-source-mirror.md` (self-referential test anti-pattern)
 - Issues #2205 (fix), #2223 (follow-up debt)

--- a/.agents/memory/episodes/episode-2026-06-04-session-1875.json
+++ b/.agents/memory/episodes/episode-2026-06-04-session-1875.json
@@ -1,0 +1,59 @@
+{
+  "id": "episode-2026-06-04-session-1875",
+  "session": "2026-06-04-session-1875",
+  "timestamp": "2026-06-04T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Autofix PR #2332 review feedback, validate ADR numbering, resolve threads, and merge if governance gates allow",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-06-04T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read PR #2332 state and unresolved review threads",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-06-04T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Updated validate-adr-number-uniqueness remediation text",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-06-04T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Updated debate-log H1",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-06-04T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran scoped validation",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-06-04T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran full pre_pr validation",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 0
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-06-04-session-1875.json
+++ b/.agents/memory/episodes/episode-2026-06-04-session-1875.json
@@ -45,6 +45,22 @@
       "content": "Ran full pre_pr validation",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-06-04T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Aligned Post-PR Retrospective action pin contract",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-06-04T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Resolved follow-up ADR reference comments",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/sessions/2026-06-04-session-1875-pr-2332-autofix.json
+++ b/.agents/sessions/2026-06-04-session-1875-pr-2332-autofix.json
@@ -68,7 +68,7 @@
       "validationPassed": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "ADR uniqueness passed, actionlint passed on changed workflow, and targeted pytest passed 37 tests"
+        "Evidence": "ADR uniqueness passed, actionlint passed on changed workflows, and targeted pytest passed 47 tests"
       }
     }
   },
@@ -92,11 +92,19 @@
     {
       "action": "Ran full pre_pr validation",
       "outcome": "Changed workflow local run passed; remaining full-suite failures are unrelated repository-wide markdown lint, ai-spec-validation shellcheck findings, and merge-resolver drift"
+    },
+    {
+      "action": "Aligned Post-PR Retrospective action pin contract",
+      "outcome": "Updated workflow and test constant to main-canonical Claude Code action SHA; tests/workflows/test_post_pr_retrospective.py passed 10 tests"
+    },
+    {
+      "action": "Resolved follow-up ADR reference comments",
+      "outcome": "Updated check_adr_uniqueness.py remediation, renamed ADR-071 debate log, updated ADR-071 inbound references, and reran adr-review change detection"
     }
   ],
   "nextSteps": [
-    "Commit and push PR #2332 autofix changes",
-    "Resolve both review threads with evidence",
-    "Wait for required checks and merge only if four-condition gate and governance gates allow it"
+    "Push follow-up review-thread fixes",
+    "Resolve new review threads with evidence",
+    "Merge only if four-condition gate and governance gates allow it"
   ]
 }

--- a/.agents/sessions/2026-06-04-session-1875-pr-2332-autofix.json
+++ b/.agents/sessions/2026-06-04-session-1875-pr-2332-autofix.json
@@ -1,0 +1,102 @@
+{
+  "session": {
+    "number": 1875,
+    "date": "2026-06-04",
+    "branch": "fix/p2-2228-adr-number-dedup",
+    "startingCommit": "bedf8f48e6d0af866fbebb5a1820fac02aac10b2",
+    "objective": "Autofix PR #2332 review feedback, validate ADR numbering, resolve threads, and merge if governance gates allow"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena initial instructions loaded before edits"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena instructions manual read in this session"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read as read-only dashboard"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This JSON session log created under .agents/sessions"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Branch fix/p2-2228-adr-number-dedup verified in isolated worktree"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Work ran on fix/p2-2228-adr-number-dedup, not main"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Autofix checklist executed through local validation and commit gate"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md remained untouched"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory sessions/pr-2332-autofix written"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 with project config pointer linted .agents/critique/ADR-063-debate-log.md with 0 errors"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Commit gate staged this session log with the PR #2332 autofix changes"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ADR uniqueness passed, actionlint passed on changed workflow, and targeted pytest passed 37 tests"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Read PR #2332 state and unresolved review threads",
+      "outcome": "Found two open Copilot threads: misleading ADR renumbering remediation text and stale ADR-063 debate-log title"
+    },
+    {
+      "action": "Updated validate-adr-number-uniqueness remediation text",
+      "outcome": "Message now says incoming files that collided with canonical ADR-058, ADR-062, and ADR-063 were renumbered to ADR-069, ADR-070, and ADR-071"
+    },
+    {
+      "action": "Updated debate-log H1",
+      "outcome": "H1 now reads ADR-071 Review Debate Log with renumbered-from ADR-063 note"
+    },
+    {
+      "action": "Ran scoped validation",
+      "outcome": "check_adr_uniqueness passed, targeted markdownlint passed, actionlint passed for changed workflow, and targeted pytest passed 37 tests"
+    },
+    {
+      "action": "Ran full pre_pr validation",
+      "outcome": "Changed workflow local run passed; remaining full-suite failures are unrelated repository-wide markdown lint, ai-spec-validation shellcheck findings, and merge-resolver drift"
+    }
+  ],
+  "nextSteps": [
+    "Commit and push PR #2332 autofix changes",
+    "Resolve both review threads with evidence",
+    "Wait for required checks and merge only if four-condition gate and governance gates allow it"
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.105",
+  "version": "0.5.106",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
+++ b/.claude/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
@@ -11,7 +11,7 @@ Exit Codes (Claude Hook Semantics, exempt from ADR-035):
     0 = Always for the educational injection logic (not blocking).
     2 = Bootstrap failure only (plugin lib directory not found). A hook that
         cannot locate its lib is a hard misconfiguration; it fails closed and
-        loud per ADR-066 D2 and ADR-063 Decision item 5, NOT fail-open. A
+        loud per ADR-066 D2 and ADR-071 Decision item 5, NOT fail-open. A
         silent exit 0 would disable the hook and hide the misconfiguration
         (launcher/hook fail-open rejected: issues #2230, #2271).
 """

--- a/.claude/hooks/invoke_user_prompt_memory_check.py
+++ b/.claude/hooks/invoke_user_prompt_memory_check.py
@@ -12,7 +12,7 @@ Exit Codes (Claude Hook Semantics, exempt from ADR-035):
         logic never blocks a prompt.
     2 = Bootstrap failure only (plugin lib directory not found). A hook that
         cannot locate its lib is a hard misconfiguration; it fails closed and
-        loud per ADR-066 D2 and ADR-063 Decision item 5, NOT fail-open. A
+        loud per ADR-066 D2 and ADR-071 Decision item 5, NOT fail-open. A
         silent exit 0 would disable the hook and hide the misconfiguration
         (launcher/hook fail-open rejected: issues #2230, #2271).
 """

--- a/.github/workflows/post-pr-retrospective.yml
+++ b/.github/workflows/post-pr-retrospective.yml
@@ -240,7 +240,7 @@ jobs:
       #   maintainer acts on (for example, to rotate the OAuth token).
       - name: Run retrospective via Claude Code
         continue-on-error: true
-        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1.0.134
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1.0.135
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.PROMPT }}

--- a/.github/workflows/validate-adr-number-uniqueness.yml
+++ b/.github/workflows/validate-adr-number-uniqueness.yml
@@ -68,27 +68,29 @@ jobs:
       - name: Show remediation on failure
         if: failure()
         run: |
-          echo ""
-          echo "=== ADR Number Uniqueness Validation Failed ==="
-          echo ""
-          echo "Two ADR files under .agents/architecture/ share the same"
-          echo "number. This is the concurrent-PR race described in #2253:"
-          echo "your branch picked an ADR number that another PR has since"
-          echo "merged to main."
-          echo ""
-          echo "To fix:"
-          echo "  1. Get the next free number:"
-          echo "       python3 scripts/validation/check_adr_uniqueness.py --print-next"
-          echo "  2. Rename your ADR file to ADR-<new>-<slug>.md"
-          echo "  3. Update the '# ADR-NNN:' heading inside the file"
-          echo "  4. Sweep references:"
-          echo "       git grep -nE 'ADR-<old>\\b' .agents/ .claude/ src/ docs/"
-          echo "  5. Re-run the gate locally:"
-          echo "       python3 scripts/validation/check_adr_uniqueness.py"
-          echo ""
-          echo "See issue #2253 for context. The former #2228 duplicates"
-          echo "(ADR-058, ADR-062, ADR-063) were renumbered to 069/070/071;"
-          echo "the allowlist is now empty and the gate has zero exceptions."
+          printf '%s\n' \
+            "" \
+            "=== ADR Number Uniqueness Validation Failed ===" \
+            "" \
+            "Two ADR files under .agents/architecture/ share the same" \
+            "number. This is the concurrent-PR race described in #2253:" \
+            "your branch picked an ADR number that another PR has since" \
+            "merged to main." \
+            "" \
+            "To fix:" \
+            "  1. Get the next free number:" \
+            "       python3 scripts/validation/check_adr_uniqueness.py --print-next" \
+            "  2. Rename your ADR file to ADR-<new>-<slug>.md" \
+            "  3. Update the '# ADR-NNN:' heading inside the file" \
+            "  4. Sweep references:" \
+            "       git grep -nE 'ADR-<old>\\b' .agents/ .claude/ src/ docs/" \
+            "  5. Re-run the gate locally:" \
+            "       python3 scripts/validation/check_adr_uniqueness.py" \
+            "" \
+            "See issue #2253 for context. In #2228, the incoming ADR" \
+            "files that collided with canonical ADR-058, ADR-062, and" \
+            "ADR-063 were renumbered to ADR-069, ADR-070, and ADR-071;" \
+            "the allowlist is empty and the gate has zero exceptions."
 
   skip-validation:
     name: Skip Validation (No ADR Changes)

--- a/.github/workflows/validate-adr-number-uniqueness.yml
+++ b/.github/workflows/validate-adr-number-uniqueness.yml
@@ -86,9 +86,9 @@ jobs:
           echo "  5. Re-run the gate locally:"
           echo "       python3 scripts/validation/check_adr_uniqueness.py"
           echo ""
-          echo "See issue #2253 for context. Pre-existing duplicates from"
-          echo "#2228 (ADR-058, ADR-062, ADR-063) are intentionally"
-          echo "allowlisted and do not trigger this gate."
+          echo "See issue #2253 for context. The former #2228 duplicates"
+          echo "(ADR-058, ADR-062, ADR-063) were renumbered to 069/070/071;"
+          echo "the allowlist is now empty and the gate has zero exceptions."
 
   skip-validation:
     name: Skip Validation (No ADR Changes)

--- a/.github/workflows/validate-plugin-manifests.yml
+++ b/.github/workflows/validate-plugin-manifests.yml
@@ -74,7 +74,7 @@ jobs:
         run: python3 -m pip install 'PyYAML==6.0.3'
 
       # Server-side enforcement of the hook-anchoring contract (issue #2205,
-      # FM #11, ADR-063). The pre-push hook also runs this, but pre-push is
+      # FM #11, ADR-071). The pre-push hook also runs this, but pre-push is
       # local and bypassable; this gate runs in CI on any plugin hooks.json or
       # manifest change so a hand-edit or merge cannot ship an unanchored path.
       - name: Run hook anchoring gate

--- a/.serena/memories/copilot-hooks-observations.md
+++ b/.serena/memories/copilot-hooks-observations.md
@@ -6,7 +6,7 @@
 ## Constraints (HIGH confidence)
 
 - Copilot CLI event name casing is load-bearing for payload field names. camelCase events send `toolName`/`toolArgs`, PascalCase events send `tool_name`/`tool_input`. Always use PascalCase in `eventRemap` to get snake_case payloads matching what hook scripts expect. (Session fix/2290, 2026-06-02)
-- Verify stdin payload format empirically (probe plugin) before implementing shim dispatch logic. ADR-063 verified env vars and cwd but NOT stdin field names. The cost of a probe is 15 minutes; the cost of assumption is a P0. (Session fix/2290, 2026-06-02)
+- Verify stdin payload format empirically (probe plugin) before implementing shim dispatch logic. ADR-071 (formerly ADR-063, renumbered per #2228) verified env vars and cwd but NOT stdin field names. The cost of a probe is 15 minutes; the cost of assumption is a P0. (Session fix/2290, 2026-06-02)
 - Never use raw `gh` commands in Claude Code sessions. Use `.claude/skills/github/scripts/` instead. `invoke_skill_first_guard` blocks raw `gh` calls. (Session fix/2290, 2026-06-02)
 
 ## Edge Cases (MED confidence)

--- a/scripts/validation/check_adr_uniqueness.py
+++ b/scripts/validation/check_adr_uniqueness.py
@@ -130,8 +130,10 @@ def main() -> int:
             "\nRename the file, update the `# ADR-NNN:` heading, and sweep "
             "references with:\n"
             "  git grep -nE 'ADR-OLD\\b' .agents/ .claude/ src/ docs/\n\n"
-            "Pre-existing duplicates from issue #2228 are intentionally "
-            "allowlisted; do not extend the allowlist for new collisions."
+            "Issue #2228 is already resolved: the incoming files that "
+            "collided with canonical ADR-058, ADR-062, and ADR-063 were "
+            "renumbered to ADR-069, ADR-070, and ADR-071. The allowlist is "
+            "empty; do not add exceptions for new collisions."
         )
         return 1
 

--- a/scripts/validation/check_adr_uniqueness.py
+++ b/scripts/validation/check_adr_uniqueness.py
@@ -10,15 +10,15 @@ exact next free number to use.
 Files are scanned by filename: `ADR-NNN-<slug>.md` in
 `.agents/architecture/`. README and DESIGN-REVIEW prefixes are ignored.
 
-A small allowlist exists for known pre-existing duplicates tracked by
-Issue #2228 (ADR-058, ADR-062, ADR-063). Those collisions exist on main
-today and the cleanup is owned by #2228; this gate must not block merges
-on a problem it did not introduce. Once #2228 lands, the allowlist below
-should be emptied.
+The pre-existing duplicates tracked by Issue #2228 (ADR-058, ADR-062,
+ADR-063) were resolved by renaming the non-canonical file in each pair to
+the next free number (069, 070, 071). The allowlist is therefore empty: the
+gate now enforces uniqueness with zero exceptions. Do NOT re-add numbers to
+the allowlist for new collisions; renumber the incoming ADR instead.
 
 Exit codes (per ADR-035):
-    0 - all ADR numbers unique (or only allowlisted dupes remain)
-    1 - one or more new duplicates detected
+    0 - all ADR numbers unique
+    1 - one or more duplicates detected
     2 - config error (e.g. architecture directory missing)
 
 Operator helpers:
@@ -37,10 +37,10 @@ from pathlib import Path
 # ADR-NNN-<slug>.md. We accept 2+ digits to be forgiving but normalise to int.
 ADR_FILENAME_RE = re.compile(r"^ADR-(\d{2,})-[^/]+\.md$")
 
-# Pre-existing duplicate ADR numbers on main, tracked by Issue #2228.
-# This gate intentionally does NOT fail on these; #2228 owns the cleanup.
-# Remove a number from this set the moment #2228 deduplicates it.
-KNOWN_DUPLICATES_ISSUE_2228 = frozenset({58, 62, 63})
+# Issue #2228 deduplicated the formerly-colliding numbers (58/62/63), so the
+# allowlist is now empty: the gate enforces uniqueness with zero exceptions.
+# Do NOT re-add numbers here for new collisions; renumber the incoming ADR.
+KNOWN_DUPLICATES_ISSUE_2228: frozenset[int] = frozenset()
 
 
 def collect_adr_numbers(adr_dir: Path) -> dict[int, list[Path]]:

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.105",
+  "version": "0.5.106",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
+++ b/src/copilot-cli/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
@@ -11,7 +11,7 @@ Exit Codes (Claude Hook Semantics, exempt from ADR-035):
     0 = Always for the educational injection logic (not blocking).
     2 = Bootstrap failure only (plugin lib directory not found). A hook that
         cannot locate its lib is a hard misconfiguration; it fails closed and
-        loud per ADR-066 D2 and ADR-063 Decision item 5, NOT fail-open. A
+        loud per ADR-066 D2 and ADR-071 Decision item 5, NOT fail-open. A
         silent exit 0 would disable the hook and hide the misconfiguration
         (launcher/hook fail-open rejected: issues #2230, #2271).
 """

--- a/src/copilot-cli/hooks/UserPromptSubmit/invoke_user_prompt_memory_check.py
+++ b/src/copilot-cli/hooks/UserPromptSubmit/invoke_user_prompt_memory_check.py
@@ -12,7 +12,7 @@ Exit Codes (Claude Hook Semantics, exempt from ADR-035):
         logic never blocks a prompt.
     2 = Bootstrap failure only (plugin lib directory not found). A hook that
         cannot locate its lib is a hard misconfiguration; it fails closed and
-        loud per ADR-066 D2 and ADR-063 Decision item 5, NOT fail-open. A
+        loud per ADR-066 D2 and ADR-071 Decision item 5, NOT fail-open. A
         silent exit 0 would disable the hook and hide the misconfiguration
         (launcher/hook fail-open rejected: issues #2230, #2271).
 """

--- a/tests/test_adr_063_memory_skill_decomposition.py
+++ b/tests/test_adr_063_memory_skill_decomposition.py
@@ -12,7 +12,8 @@ depend on:
 - Its status resolves to "proposed" via the adr-review detector contract
   (`status: proposed`), so the BLOCKING adr-review debate gate fires.
 - It cross-references the boundary ADRs the issue requires (ADR-007, ADR-056)
-  and the gate ADR (ADR-062).
+  and the gate ADR (ADR-070, renumbered from the former ADR-062 collision per
+  #2228).
 - It contains no em-dash (U+2014) or en-dash (U+2013) per universal.md.
 
 The status-detection assertion mirrors the canonical detector contract at
@@ -117,14 +118,16 @@ class TestDraftStatusTriggersReview:
 
 
 class TestRequiredCrossReferences:
-    @pytest.mark.parametrize("adr_ref", ["ADR-007", "ADR-056", "ADR-062"])
+    @pytest.mark.parametrize("adr_ref", ["ADR-007", "ADR-056", "ADR-070"])
     def test_boundary_and_gate_adrs_cross_referenced(self, adr_text: str, adr_ref: str) -> None:
         # ADR-007 (memory-first) and ADR-056 (output envelope) are the boundary
-        # constraints the issue requires; ADR-062 is the gate semantics to keep.
+        # constraints the issue requires; ADR-070 is the gate semantics to keep
+        # (renumbered from the former ADR-062 collision per #2228).
         assert adr_ref in adr_text, f"missing required cross-reference: {adr_ref}"
 
-    def test_gate_semantics_reference_uses_full_adr_062_filename(self, adr_text: str) -> None:
-        assert "ADR-062-memory-first-gate-spec-pipeline.md" in adr_text
+    def test_gate_semantics_reference_uses_full_adr_070_filename(self, adr_text: str) -> None:
+        # Gate ADR renumbered 062 -> 070 per #2228 dedup.
+        assert "ADR-070-memory-first-gate-spec-pipeline.md" in adr_text
 
     def test_links_to_implementation_issue_1948(self, adr_text: str) -> None:
         # The ADR records the decision; #1948 implements it. The boundary must

--- a/tests/validation/test_check_adr_uniqueness.py
+++ b/tests/validation/test_check_adr_uniqueness.py
@@ -5,8 +5,8 @@ Pins behaviour of the ADR-number-collision gate:
 - pos: a unique-number tree returns exit 0
 - neg: a tree with a colliding ADR number returns exit 1
 - edge: README and non-ADR files are ignored; missing directory is a
-  config error (exit 2 per ADR-035); the #2228 allowlist suppresses
-  pre-existing duplicates (58/62/63) but not new ones
+  config error (exit 2 per ADR-035); the #2228 allowlist is now empty, so
+  the formerly-exempt 58/62/63 fail when duplicated and pass when unique
 - branch: --print-next returns max(existing)+1, exit 0; empty tree
   yields 001; padding width is respected
 """
@@ -88,49 +88,50 @@ def test_new_duplicate_fails(tmp_path: Path) -> None:
     assert "next free ADR number: 071" in result.stdout
 
 
-def test_duplicate_outside_allowlist_fails_even_when_allowlisted_present(
-    tmp_path: Path,
-) -> None:
-    """Allowlist suppresses #2228 dupes but never new ones in the same tree."""
+def test_multiple_duplicate_numbers_all_reported(tmp_path: Path) -> None:
+    """With the empty allowlist (#2228 resolved), every duplicate fails."""
     adr_dir = _scaffold(tmp_path)
-    # Pre-existing dupe (allowlisted)
     _make_adr(adr_dir, 58, "agent-eval")
     _make_adr(adr_dir, 58, "context-corpus")
-    # New, post-merge dupe must fail.
     _make_adr(adr_dir, 80, "first")
     _make_adr(adr_dir, 80, "second")
 
     result = _run(tmp_path)
     assert result.returncode == 1
+    # No exceptions remain: both the formerly-allowlisted 58 and the new 80 fail.
+    assert "ADR-058" in result.stdout
     assert "ADR-080" in result.stdout
-    # The allowlisted number must not be listed as a failure.
-    assert "ADR-058" not in result.stdout
 
 
 # --- edge -------------------------------------------------------------------
 
 
-def test_allowlist_suppresses_known_2228_duplicates(tmp_path: Path) -> None:
+def test_formerly_allowlisted_numbers_now_fail_when_duplicated(
+    tmp_path: Path,
+) -> None:
+    """#2228 emptied the allowlist; 58/62/63 duplicates are no longer exempt."""
     adr_dir = _scaffold(tmp_path)
     for num in (58, 62, 63):
         _make_adr(adr_dir, num, "first")
         _make_adr(adr_dir, num, "second")
 
     result = _run(tmp_path)
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert "[PASS]" in result.stdout
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "[FAIL]" in result.stdout
+    assert "ADR-058" in result.stdout
+    assert "ADR-062" in result.stdout
+    assert "ADR-063" in result.stdout
 
 
-def test_new_duplicate_of_allowlisted_number_fails(tmp_path: Path) -> None:
+def test_single_files_at_formerly_duplicated_numbers_pass(tmp_path: Path) -> None:
+    """After dedup, one file per number (incl. 58/62/63) is unique and passes."""
     adr_dir = _scaffold(tmp_path)
-    _make_adr(adr_dir, 58, "agent-eval")
-    _make_adr(adr_dir, 58, "context-corpus")
-    _make_adr(adr_dir, 58, "third-one")
+    for num in (58, 62, 63):
+        _make_adr(adr_dir, num, "only-one")
 
     result = _run(tmp_path)
-    assert result.returncode == 1
-    assert "ADR-058" in result.stdout
-    assert "next free ADR number: 059" in result.stdout
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "[PASS]" in result.stdout
 
 
 def test_readme_and_non_adr_files_are_ignored(tmp_path: Path) -> None:

--- a/tests/workflows/test_post_pr_retrospective.py
+++ b/tests/workflows/test_post_pr_retrospective.py
@@ -23,7 +23,7 @@ _WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "post-pr-retrospective.y
 
 _AGENT_STEP_NAME = "Run retrospective via Claude Code"
 _ACTION_REF = (
-    "anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98"
+    "anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f"
 )
 _OAUTH_TOKEN_EXPR = "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
 


### PR DESCRIPTION
## Summary

### What

Resolves three duplicate ADR-number collisions (058, 062, 063) by renaming the non-canonical file in each pair to the next free numbers and retargeting inbound references.

### Why

Duplicate ADR numbers break the uniqueness validator and confuse cross-references. Fixes #2228.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2228 | P2 triage fix |

## Changes

```text
.agents/architecture/ADR-063-memory-skill-decomposition.md
.agents/architecture/ADR-066-hook-fail-open-reconciliation.md
.agents/architecture/ADR-068-consolidated-hook-dispatcher.md
.agents/architecture/ADR-069-context-corpus-is-the-product.md
.agents/architecture/ADR-070-memory-first-gate-spec-pipeline.md
.agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md
.agents/critique/ADR-063-debate-log.md
.agents/governance/FAILURE-MODES.md
.claude/.claude-plugin/plugin.json
.claude/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
.claude/hooks/invoke_user_prompt_memory_check.py
.github/workflows/validate-adr-number-uniqueness.yml
.github/workflows/validate-plugin-manifests.yml
.serena/memories/copilot-hooks-observations.md
scripts/validation/check_adr_uniqueness.py
src/copilot-cli/.claude-plugin/plugin.json
src/copilot-cli/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
src/copilot-cli/hooks/UserPromptSubmit/invoke_user_prompt_memory_check.py
tests/test_adr_063_memory_skill_decomposition.py
tests/validation/test_check_adr_uniqueness.py
```

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Positive, negative, and edge tests added for the changed behavior; the relevant pytest suite passes locally and the pre-PR validation gate introduces no new blocking findings.

_PR body normalized during P2 batch triage to satisfy the description-matches-diff gate; file paths are listed in the fenced block above._
