### PR TITLE
ci(smoke): nightly real-CLI hook smoke plus smoke-ran gate (ADR-063 items 3-4)

### DIFF
--- a/.github/workflows/nightly-cli-smoke.yml
+++ b/.github/workflows/nightly-cli-smoke.yml
@@ -11,7 +11,7 @@
 #   - Triggers only on schedule and workflow_dispatch. GitHub never fires these
 #     from a fork, so a fork PR can never reach the secret-bearing job.
 #   - A trusted-context gate (scripts/validation/assert_trusted_smoke_context.py,
-#     ADR-006: decision in Python, not YAML) re-checks event + repository and
+#     ADR-006: decision in Python, not YAML) re-checks event, repository, and ref
 #     fails closed, so a fork running this workflow on its own schedule is denied.
 #   - Least-privilege: top-level permissions are contents: read.
 #   - Every action is pinned to a commit SHA (no floating tags).
@@ -65,10 +65,12 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           REPOSITORY: ${{ github.repository }}
+          REF: ${{ github.ref }}
         run: |
           trusted=$(python3 scripts/validation/assert_trusted_smoke_context.py \
             --event-name "$EVENT_NAME" \
-            --repository "$REPOSITORY")
+            --repository "$REPOSITORY" \
+            --ref "$REF")
           echo "trusted=$trusted" >> "$GITHUB_OUTPUT"
 
   smoke:
@@ -131,7 +133,7 @@ jobs:
         # (which pytest exits 0 for) is still caught and reported as a red job.
         if: always()
         shell: bash
-        run: python3 scripts/validation/assert_smoke_ran.py smoke-report.xml
+        run: uv run python scripts/validation/assert_smoke_ran.py smoke-report.xml
 
   smoke-result:
     name: Smoke Result

--- a/.github/workflows/nightly-cli-smoke.yml
+++ b/.github/workflows/nightly-cli-smoke.yml
@@ -90,7 +90,7 @@ jobs:
       # skips loudly when a CLI is unauthenticated; the smoke gate then fails the
       # job, so a missing secret is a red run, never a silent green one.
       ANTHROPIC_API_KEY: ${{ secrets.SMOKE_ANTHROPIC_API_KEY }}
-      COPILOT_CLI_TOKEN: ${{ secrets.SMOKE_COPILOT_CLI_TOKEN }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.SMOKE_COPILOT_CLI_TOKEN }}
     steps:
       - name: Harden Runner
         # Windows and macOS runners do not support harden-runner; gate it.

--- a/.github/workflows/nightly-cli-smoke.yml
+++ b/.github/workflows/nightly-cli-smoke.yml
@@ -1,0 +1,164 @@
+# Nightly Real-CLI Hook Smoke (issue #2231 items 3-4, ADR-071)
+#
+# Installs the real Copilot and Claude CLIs and runs the plugin hook end to end
+# on ubuntu/macos/windows. This is the authenticated cross-platform smoke that
+# ADR-071 deferred: the no-auth gates (validate_hook_anchoring,
+# test_generate_hooks_runtime_contract) verify path resolution in PR CI; this
+# job verifies the real CLI launcher contract that bare CI cannot, on the
+# platforms (Windows PowerShell) where #2205 was reported.
+#
+# Security (.claude/rules/security.md, issue #2231 item 3):
+#   - Triggers only on schedule and workflow_dispatch. GitHub never fires these
+#     from a fork, so a fork PR can never reach the secret-bearing job.
+#   - A trusted-context gate (scripts/validation/assert_trusted_smoke_context.py,
+#     ADR-006: decision in Python, not YAML) re-checks event + repository and
+#     fails closed, so a fork running this workflow on its own schedule is denied.
+#   - Least-privilege: top-level permissions are contents: read.
+#   - Every action is pinned to a commit SHA (no floating tags).
+#   - Auth tokens come from the secrets manager (secrets.*), scoped to the smoke
+#     job's env only, never written to the repo.
+#
+# Loud, not silent (.claude/rules/generated-artifacts.md, issue #2231 item 4):
+#   The smoke tests skip without RUN_CLI_E2E=1 and the CLIs, and a skip reads as
+#   a pass in a green summary. scripts/validation/assert_smoke_ran.py parses the
+#   JUnit report and fails the job if the smoke was skipped or not collected, so
+#   a missing auth secret surfaces as a red run, not a silent green one.
+#
+# Local equivalent:
+#   RUN_CLI_E2E=1 uv run pytest tests/e2e/test_cli_hook_e2e.py -m smoke -v
+
+name: Nightly CLI Smoke
+
+on:
+  schedule:
+    # 06:00 UTC daily. Off the top of the hour to avoid the cron thundering herd.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  authorize:
+    name: Trusted-context gate
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    outputs:
+      trusted: ${{ steps.gate.outputs.trusted }}
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Check trusted context
+        id: gate
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          trusted=$(python3 scripts/validation/assert_trusted_smoke_context.py \
+            --event-name "$EVENT_NAME" \
+            --repository "$REPOSITORY")
+          echo "trusted=$trusted" >> "$GITHUB_OUTPUT"
+
+  smoke:
+    name: Smoke (${{ matrix.os }})
+    needs: authorize
+    if: needs.authorize.outputs.trusted == 'true'
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      RUN_CLI_E2E: '1'
+      # Scoped, least-privilege tokens from the secrets manager. The e2e harness
+      # skips loudly when a CLI is unauthenticated; the smoke gate then fails the
+      # job, so a missing secret is a red run, never a silent green one.
+      ANTHROPIC_API_KEY: ${{ secrets.SMOKE_ANTHROPIC_API_KEY }}
+      COPILOT_CLI_TOKEN: ${{ secrets.SMOKE_COPILOT_CLI_TOKEN }}
+    steps:
+      - name: Harden Runner
+        # Windows and macOS runners do not support harden-runner; gate it.
+        if: runner.os == 'Linux'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Setup Python
+        # yamllint disable-line rule:line-length
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        # yamllint disable-line rule:line-length
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: true
+
+      - name: Setup Node
+        # yamllint disable-line rule:line-length
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 'lts/*'
+
+      - name: Install Claude and Copilot CLIs
+        shell: bash
+        run: npm install -g @anthropic-ai/claude-code @github/copilot
+
+      - name: Run real-CLI hook smoke
+        shell: bash
+        run: uv run pytest tests/e2e/test_cli_hook_e2e.py -m smoke --junitxml=smoke-report.xml
+
+      - name: Assert the smoke actually ran
+        # always(): the gate must run even if the smoke step failed, so a skip
+        # (which pytest exits 0 for) is still caught and reported as a red job.
+        if: always()
+        shell: bash
+        run: python3 scripts/validation/assert_smoke_ran.py smoke-report.xml
+
+  smoke-result:
+    name: Smoke Result
+    needs: [authorize, smoke]
+    # Pass-through summary so the run has one terminal status to alert on.
+    if: always()
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    steps:
+      - name: Report
+        shell: bash
+        env:
+          AUTHORIZE_RESULT: ${{ needs.authorize.result }}
+          TRUSTED: ${{ needs.authorize.outputs.trusted }}
+          SMOKE_RESULT: ${{ needs.smoke.result }}
+        run: |
+          if [ "$AUTHORIZE_RESULT" != "success" ]; then
+            echo "::error::Trusted-context gate result: $AUTHORIZE_RESULT"
+            exit 1
+          fi
+          if [ "$TRUSTED" != "true" ]; then
+            echo "::error::Untrusted context; smoke skipped. Run on trusted repo via schedule/workflow_dispatch."
+            exit 1
+          fi
+          if [ "$SMOKE_RESULT" != "success" ]; then
+            echo "::error::Nightly smoke result: $SMOKE_RESULT"
+            exit 1
+          fi
+          echo "Nightly CLI smoke passed on all platforms."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ markers = [
     "unit: Unit tests",
     "integration: Integration tests",
     "security: Security-focused tests",
+    "smoke: Real-CLI smoke tests (need auth/credits; nightly only). The smoke gate asserts these were not skipped (issue #2231 item 4).",
 ]
 
 [tool.coverage.run]

--- a/scripts/validation/assert_smoke_ran.py
+++ b/scripts/validation/assert_smoke_ran.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Fail loud when the real-CLI smoke did not actually run (issue #2231 item 4).
+
+The smoke tests in ``tests/e2e/test_cli_hook_e2e.py`` carry
+``@pytest.mark.skipif`` guards: without ``RUN_CLI_E2E=1`` and the CLIs on PATH
+they SKIP. A skipped test reads as a pass in a green pytest summary, so "skipped
+smoke must be loud" otherwise depends on a human reading skip reasons. This gate
+removes that human step: it parses the JUnit XML pytest emits and exits non-zero
+when a smoke test was skipped or when no smoke test was collected at all.
+
+The nightly workflow (``.github/workflows/nightly-cli-smoke.yml``) runs the smoke
+under ``RUN_CLI_E2E=1`` with ``--junitxml``, then calls this gate. A skip there
+means the runtime contract was never exercised, which is exactly the silent pass
+this gate is built to reject (see ``.claude/rules/generated-artifacts.md``: "a
+skipped smoke MUST be loud, never silent").
+
+Contract (JUnit XML, the format pytest's ``--junitxml`` writes):
+- Each ``<testcase>`` is one test. A skipped case has a child ``<skipped>`` tag.
+- A case with a child ``<failure>`` or ``<error>`` tag failed.
+- This gate selects smoke cases by name substring (``--smoke-substr``, default
+  ``test_cli_hook_e2e``) because JUnit XML does not record pytest markers. The
+  default targets the file that holds the ``@pytest.mark.smoke`` tests, so the
+  selection tracks the marked set without parsing pytest internals.
+
+Exit codes (per AGENTS.md / ADR-035):
+- 0: at least one smoke test ran and none were skipped, failed, or errored.
+- 1: a smoke test was skipped, failed, errored, or none were collected (logic).
+- 2: usage or a malformed/missing report (config).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from xml.etree import ElementTree
+
+EXIT_OK = 0
+EXIT_NOT_RUN = 1
+EXIT_CONFIG = 2
+
+_DEFAULT_SMOKE_SUBSTR = "test_cli_hook_e2e"
+
+
+class SmokeReportError(Exception):
+    """The JUnit report could not be read or parsed."""
+
+
+def _reject_doctype(text: str, report_path: Path) -> None:
+    """Reject a report that declares a DTD or an entity.
+
+    ``defusedxml`` is not a project dependency, so this is the dependency-free
+    XXE / billion-laughs defense: pytest's JUnit writer never emits a DOCTYPE or
+    an internal entity, so any report that contains one is either corrupt or
+    tampered. Reject it before the stdlib parser can expand it (CWE-611,
+    CWE-776). This is a fail-closed check: a malformed report is a config error,
+    not a silent pass.
+    """
+    lowered = text.lower()
+    if "<!doctype" in lowered or "<!entity" in lowered:
+        raise SmokeReportError(
+            f"report declares a DTD or entity, which a pytest JUnit report never "
+            f"does; refusing to parse {report_path} (possible XXE/entity attack)."
+        )
+
+
+def _iter_testcases(report_path: Path) -> list[ElementTree.Element]:
+    """Return every ``<testcase>`` element in a JUnit XML report.
+
+    JUnit XML nests testcases under either a single ``<testsuite>`` root or a
+    ``<testsuites>`` wrapper. ``iter`` walks both shapes without branching on the
+    root tag.
+    """
+    try:
+        text = report_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise SmokeReportError(f"report not found: {report_path}") from exc
+    except OSError as exc:
+        raise SmokeReportError(f"report could not be read: {report_path}: {exc}") from exc
+
+    _reject_doctype(text, report_path)
+
+    try:
+        root = ElementTree.fromstring(text)  # noqa: S314 (DTD/entity rejected above)
+    except ElementTree.ParseError as exc:
+        raise SmokeReportError(f"report is not valid XML: {report_path}: {exc}") from exc
+    return list(root.iter("testcase"))
+
+
+def _case_id(case: ElementTree.Element) -> str:
+    classname = case.get("classname", "")
+    name = case.get("name", "")
+    return f"{classname}::{name}" if classname else name
+
+
+def _is_smoke(case: ElementTree.Element, smoke_substr: str) -> bool:
+    return smoke_substr in _case_id(case)
+
+
+def _is_skipped(case: ElementTree.Element) -> bool:
+    return case.find("skipped") is not None
+
+
+def _is_failed(case: ElementTree.Element) -> bool:
+    return case.find("failure") is not None or case.find("error") is not None
+
+
+def evaluate(report_path: Path, smoke_substr: str) -> tuple[int, str]:
+    """Decide whether the smoke ran. Returns ``(exit_code, message)``.
+
+    Raises ``SmokeReportError`` on a missing or malformed report.
+    """
+    cases = _iter_testcases(report_path)
+    smoke_cases = [c for c in cases if _is_smoke(c, smoke_substr)]
+
+    if not smoke_cases:
+        return (
+            EXIT_NOT_RUN,
+            f"no smoke test matched '{smoke_substr}' in {report_path}. "
+            "The smoke was not collected, so the runtime contract never ran.",
+        )
+
+    skipped = [_case_id(c) for c in smoke_cases if _is_skipped(c)]
+    failed = [_case_id(c) for c in smoke_cases if _is_failed(c)]
+
+    if skipped:
+        names = ", ".join(skipped)
+        return (
+            EXIT_NOT_RUN,
+            f"{len(skipped)} smoke test(s) SKIPPED: {names}. "
+            "A skipped smoke is not a passed smoke. Set RUN_CLI_E2E=1 and "
+            "ensure the CLIs are installed and authenticated.",
+        )
+
+    if failed:
+        names = ", ".join(failed)
+        return (EXIT_NOT_RUN, f"{len(failed)} smoke test(s) FAILED: {names}.")
+
+    ran = ", ".join(_case_id(c) for c in smoke_cases)
+    return (EXIT_OK, f"{len(smoke_cases)} smoke test(s) ran and passed: {ran}.")
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fail loud when the real-CLI smoke did not run (issue #2231 item 4).",
+    )
+    parser.add_argument(
+        "report",
+        type=Path,
+        help="Path to the JUnit XML report from the smoke pytest run.",
+    )
+    parser.add_argument(
+        "--smoke-substr",
+        default=_DEFAULT_SMOKE_SUBSTR,
+        help=(
+            "Substring that identifies smoke testcases in the JUnit report "
+            f"(default: {_DEFAULT_SMOKE_SUBSTR!r})."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        exit_code, message = evaluate(args.report, args.smoke_substr)
+    except SmokeReportError as exc:
+        print(f"::error::smoke gate: {exc}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    if exit_code == EXIT_OK:
+        print(f"smoke gate OK: {message}")
+    else:
+        print(f"::error::smoke gate: {message}", file=sys.stderr)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/assert_smoke_ran.py
+++ b/scripts/validation/assert_smoke_ran.py
@@ -21,6 +21,9 @@ Contract (JUnit XML, the format pytest's ``--junitxml`` writes):
   ``test_cli_hook_e2e``) because JUnit XML does not record pytest markers. The
   default targets the file that holds the ``@pytest.mark.smoke`` tests, so the
   selection tracks the marked set without parsing pytest internals.
+- The gate expects both real-CLI hook smoke cases by default
+  (``--expected-count 2``), so losing either the Copilot or Claude case fails
+  closed instead of passing on the remaining case.
 
 Exit codes (per AGENTS.md / ADR-035):
 - 0: at least one smoke test ran and none were skipped, failed, or errored.
@@ -40,6 +43,7 @@ EXIT_NOT_RUN = 1
 EXIT_CONFIG = 2
 
 _DEFAULT_SMOKE_SUBSTR = "test_cli_hook_e2e"
+_DEFAULT_EXPECTED_COUNT = 2
 
 
 class SmokeReportError(Exception):
@@ -81,7 +85,7 @@ def _iter_testcases(report_path: Path) -> list[ElementTree.Element]:
     _reject_doctype(text, report_path)
 
     try:
-        root = ElementTree.fromstring(text)  # noqa: S314 (DTD/entity rejected above)
+        root = ElementTree.fromstring(text)
     except ElementTree.ParseError as exc:
         raise SmokeReportError(f"report is not valid XML: {report_path}: {exc}") from exc
     return list(root.iter("testcase"))
@@ -105,7 +109,11 @@ def _is_failed(case: ElementTree.Element) -> bool:
     return case.find("failure") is not None or case.find("error") is not None
 
 
-def evaluate(report_path: Path, smoke_substr: str) -> tuple[int, str]:
+def evaluate(
+    report_path: Path,
+    smoke_substr: str,
+    expected_count: int = _DEFAULT_EXPECTED_COUNT,
+) -> tuple[int, str]:
     """Decide whether the smoke ran. Returns ``(exit_code, message)``.
 
     Raises ``SmokeReportError`` on a missing or malformed report.
@@ -113,11 +121,21 @@ def evaluate(report_path: Path, smoke_substr: str) -> tuple[int, str]:
     cases = _iter_testcases(report_path)
     smoke_cases = [c for c in cases if _is_smoke(c, smoke_substr)]
 
+    if expected_count < 1:
+        raise SmokeReportError(f"expected smoke count must be positive: {expected_count}")
+
     if not smoke_cases:
         return (
             EXIT_NOT_RUN,
             f"no smoke test matched '{smoke_substr}' in {report_path}. "
             "The smoke was not collected, so the runtime contract never ran.",
+        )
+
+    if len(smoke_cases) < expected_count:
+        return (
+            EXIT_NOT_RUN,
+            f"only {len(smoke_cases)} of {expected_count} expected smoke test(s) "
+            "were collected. The smoke set is incomplete.",
         )
 
     skipped = [_case_id(c) for c in smoke_cases if _is_skipped(c)]
@@ -157,13 +175,19 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
             f"(default: {_DEFAULT_SMOKE_SUBSTR!r})."
         ),
     )
+    parser.add_argument(
+        "--expected-count",
+        type=int,
+        default=_DEFAULT_EXPECTED_COUNT,
+        help=f"Minimum expected smoke testcase count (default: {_DEFAULT_EXPECTED_COUNT}).",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(sys.argv[1:] if argv is None else argv)
     try:
-        exit_code, message = evaluate(args.report, args.smoke_substr)
+        exit_code, message = evaluate(args.report, args.smoke_substr, args.expected_count)
     except SmokeReportError as exc:
         print(f"::error::smoke gate: {exc}", file=sys.stderr)
         return EXIT_CONFIG

--- a/scripts/validation/assert_trusted_smoke_context.py
+++ b/scripts/validation/assert_trusted_smoke_context.py
@@ -20,6 +20,8 @@ Authorized when ALL hold:
 - ``--repository`` equals the expected trusted repo (default
   ``rjmurillo/ai-agents``), so a fork running this workflow on its own schedule
   does not match and is denied.
+- ``--ref`` equals the expected trusted ref (default ``refs/heads/main``), so a
+  manual dispatch from another branch cannot run code with smoke secrets.
 
 Prints ``true`` or ``false`` to stdout for the workflow to branch on.
 
@@ -38,9 +40,16 @@ EXIT_USAGE = 2
 
 _TRUSTED_EVENTS = frozenset({"schedule", "workflow_dispatch"})
 _DEFAULT_TRUSTED_REPO = "rjmurillo/ai-agents"
+_DEFAULT_TRUSTED_REF = "refs/heads/main"
 
 
-def is_trusted(event_name: str, repository: str, expected_repo: str) -> tuple[bool, str]:
+def is_trusted(
+    event_name: str,
+    repository: str,
+    expected_repo: str,
+    ref: str = _DEFAULT_TRUSTED_REF,
+    expected_ref: str = _DEFAULT_TRUSTED_REF,
+) -> tuple[bool, str]:
     """Return ``(trusted, reason)`` for the given execution context.
 
     Fail-closed: an unrecognized event or a non-matching repository is untrusted.
@@ -48,9 +57,11 @@ def is_trusted(event_name: str, repository: str, expected_repo: str) -> tuple[bo
     if event_name not in _TRUSTED_EVENTS:
         allowed = ", ".join(sorted(_TRUSTED_EVENTS))
         return (False, f"event is not a trusted trigger (allowed: {allowed})")
-    if repository != expected_repo:
+    if repository.casefold() != expected_repo.casefold():
         return (False, "repository is not the trusted repo")
-    return (True, "trusted context: approved event on the trusted repo")
+    if ref != expected_ref:
+        return (False, "ref is not the trusted ref")
+    return (True, "trusted context: approved event, repo, and ref")
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -68,16 +79,32 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         help="The github.repository the workflow is running in (owner/name).",
     )
     parser.add_argument(
+        "--ref",
+        required=True,
+        help="The github.ref the workflow is running from.",
+    )
+    parser.add_argument(
         "--expected-repo",
         default=_DEFAULT_TRUSTED_REPO,
         help=f"The trusted repository (default: {_DEFAULT_TRUSTED_REPO}).",
+    )
+    parser.add_argument(
+        "--expected-ref",
+        default=_DEFAULT_TRUSTED_REF,
+        help=f"The trusted ref (default: {_DEFAULT_TRUSTED_REF}).",
     )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(sys.argv[1:] if argv is None else argv)
-    trusted, _ = is_trusted(args.event_name, args.repository, args.expected_repo)
+    trusted, _ = is_trusted(
+        args.event_name,
+        args.repository,
+        args.expected_repo,
+        args.ref,
+        args.expected_ref,
+    )
     # stdout: the machine-readable decision the workflow branches on.
     print("true" if trusted else "false")
     # stderr: static audit trail only. CodeQL treats repository input as sensitive.

--- a/scripts/validation/assert_trusted_smoke_context.py
+++ b/scripts/validation/assert_trusted_smoke_context.py
@@ -47,10 +47,10 @@ def is_trusted(event_name: str, repository: str, expected_repo: str) -> tuple[bo
     """
     if event_name not in _TRUSTED_EVENTS:
         allowed = ", ".join(sorted(_TRUSTED_EVENTS))
-        return (False, f"event '{event_name}' is not a trusted trigger (allowed: {allowed})")
+        return (False, f"event is not a trusted trigger (allowed: {allowed})")
     if repository != expected_repo:
-        return (False, f"repository '{repository}' is not the trusted repo '{expected_repo}'")
-    return (True, f"trusted context: event '{event_name}' on '{repository}'")
+        return (False, "repository is not the trusted repo")
+    return (True, "trusted context: approved event on the trusted repo")
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:

--- a/scripts/validation/assert_trusted_smoke_context.py
+++ b/scripts/validation/assert_trusted_smoke_context.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Gate the authenticated CLI smoke to a trusted execution context (issue #2231 item 3).
+
+The nightly smoke installs the real Copilot/Claude CLIs and runs a hook end to
+end. That needs auth secrets, so the run MUST NOT execute attacker-controlled
+code with those secrets in scope. Per ``.claude/rules/security.md`` and the
+issue-3 requirement ("run from a trusted ref only, do not auto-run the probe on
+fork PRs"), this script is the trusted-context gate. Per ADR-006 the decision
+lives here, not in workflow YAML.
+
+The smoke workflow triggers only on ``schedule`` and ``workflow_dispatch``,
+which GitHub never fires from a fork. This gate is defense in depth: it
+re-checks the event and the repository so that adding a new trigger later (or a
+misconfigured fork of this repo) cannot silently start running the probe with
+secrets. It fails closed: anything it cannot positively confirm is untrusted.
+
+Authorized when ALL hold:
+- ``--event-name`` is ``schedule`` or ``workflow_dispatch`` (never a PR, so a
+  fork PR can never reach the secret-bearing job).
+- ``--repository`` equals the expected trusted repo (default
+  ``rjmurillo/ai-agents``), so a fork running this workflow on its own schedule
+  does not match and is denied.
+
+Prints ``true`` or ``false`` to stdout for the workflow to branch on.
+
+Exit codes (per AGENTS.md / ADR-035):
+- 0: decision made (stdout is ``true`` or ``false``).
+- 2: usage error (missing or malformed arguments).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+
+_TRUSTED_EVENTS = frozenset({"schedule", "workflow_dispatch"})
+_DEFAULT_TRUSTED_REPO = "rjmurillo/ai-agents"
+
+
+def is_trusted(event_name: str, repository: str, expected_repo: str) -> tuple[bool, str]:
+    """Return ``(trusted, reason)`` for the given execution context.
+
+    Fail-closed: an unrecognized event or a non-matching repository is untrusted.
+    """
+    if event_name not in _TRUSTED_EVENTS:
+        allowed = ", ".join(sorted(_TRUSTED_EVENTS))
+        return (False, f"event '{event_name}' is not a trusted trigger (allowed: {allowed})")
+    if repository != expected_repo:
+        return (False, f"repository '{repository}' is not the trusted repo '{expected_repo}'")
+    return (True, f"trusted context: event '{event_name}' on '{repository}'")
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Gate the authenticated CLI smoke to a trusted context (issue #2231 item 3).",
+    )
+    parser.add_argument(
+        "--event-name",
+        required=True,
+        help="The github.event_name of the triggering event.",
+    )
+    parser.add_argument(
+        "--repository",
+        required=True,
+        help="The github.repository the workflow is running in (owner/name).",
+    )
+    parser.add_argument(
+        "--expected-repo",
+        default=_DEFAULT_TRUSTED_REPO,
+        help=f"The trusted repository (default: {_DEFAULT_TRUSTED_REPO}).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    trusted, reason = is_trusted(args.event_name, args.repository, args.expected_repo)
+    # stdout: the machine-readable decision the workflow branches on.
+    print("true" if trusted else "false")
+    # stderr: the human-readable reason for the audit trail.
+    print(f"smoke trusted-context gate: {reason}", file=sys.stderr)
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/assert_trusted_smoke_context.py
+++ b/scripts/validation/assert_trusted_smoke_context.py
@@ -77,11 +77,16 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(sys.argv[1:] if argv is None else argv)
-    trusted, reason = is_trusted(args.event_name, args.repository, args.expected_repo)
+    trusted, _ = is_trusted(args.event_name, args.repository, args.expected_repo)
     # stdout: the machine-readable decision the workflow branches on.
     print("true" if trusted else "false")
-    # stderr: the human-readable reason for the audit trail.
-    print(f"smoke trusted-context gate: {reason}", file=sys.stderr)
+    # stderr: static audit trail only. CodeQL treats repository input as sensitive.
+    print(
+        "smoke trusted-context gate: trusted"
+        if trusted
+        else "smoke trusted-context gate: untrusted",
+        file=sys.stderr,
+    )
     return EXIT_OK
 
 

--- a/tests/e2e/test_cli_hook_e2e.py
+++ b/tests/e2e/test_cli_hook_e2e.py
@@ -97,12 +97,12 @@ def test_copilot_vendor_install_hook_resolves(tmp_path: Path) -> None:
     userland = tmp_path / "userland"
     marker = tmp_path / "copilot_marker.txt"
     userland.mkdir()
-    _write_probe_script(plugin / "hooks" / "sessionStart" / "probe.py", marker)
+    _write_probe_script(plugin / "hooks" / "SessionStart" / "probe.py", marker)
     (plugin / "plugin.json").write_text(_manifest(_PROBE_NAME), encoding="utf-8")
     # Use the exact command shape the generator emits.
-    entry = generate_hooks._build_copilot_entry("sessionStart", "probe.py")
+    entry = generate_hooks._build_copilot_entry("SessionStart", "probe.py")
     (plugin / "hooks" / "hooks.json").write_text(
-        json.dumps({"hooks": {"sessionStart": [entry]}, "version": 1}), encoding="utf-8"
+        json.dumps({"hooks": {"SessionStart": [entry]}, "version": 1}), encoding="utf-8"
     )
 
     try:
@@ -167,6 +167,7 @@ def test_claude_plugin_dir_hook_resolves(tmp_path: Path) -> None:
     _write_probe_script(plugin / "hooks" / "probe.py", marker)
     (plugin / ".claude-plugin").mkdir(parents=True)
     (plugin / ".claude-plugin" / "plugin.json").write_text(_manifest(_PROBE_NAME), encoding="utf-8")
+    hook_command = f'"{sys.executable}" -u "${{CLAUDE_PLUGIN_ROOT}}/hooks/probe.py"'
     (plugin / "hooks" / "hooks.json").write_text(
         json.dumps(
             {
@@ -176,7 +177,7 @@ def test_claude_plugin_dir_hook_resolves(tmp_path: Path) -> None:
                             "hooks": [
                                 {
                                     "type": "command",
-                                    "command": 'python3 -u "${CLAUDE_PLUGIN_ROOT}/hooks/probe.py"',
+                                    "command": hook_command,
                                 }
                             ]
                         }

--- a/tests/e2e/test_cli_hook_e2e.py
+++ b/tests/e2e/test_cli_hook_e2e.py
@@ -89,6 +89,7 @@ def _clean_env() -> dict[str, str]:
     return env
 
 
+@pytest.mark.smoke
 @requires_copilot
 def test_copilot_vendor_install_hook_resolves(tmp_path: Path) -> None:
     """copilot plugin install -> hook resolves from install tree, not cwd."""
@@ -155,6 +156,7 @@ def test_copilot_vendor_install_hook_resolves(tmp_path: Path) -> None:
             pass
 
 
+@pytest.mark.smoke
 @requires_claude
 def test_claude_plugin_dir_hook_resolves(tmp_path: Path) -> None:
     """claude --plugin-dir -> hook resolves via ${CLAUDE_PLUGIN_ROOT}, not cwd."""

--- a/tests/validation/test_assert_smoke_ran.py
+++ b/tests/validation/test_assert_smoke_ran.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Tests for the smoke-ran gate (issue #2231 item 4).
+
+The gate proves the real-CLI smoke actually ran instead of skipping silently.
+Each test builds a JUnit XML report (the format pytest's ``--junitxml`` writes)
+and asserts the gate's exit code and message, covering positive, negative, and
+edge cases plus the CLI argv path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "validation" / "assert_smoke_ran.py"
+)
+_spec = importlib.util.spec_from_file_location("assert_smoke_ran", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+assert_smoke_ran = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(assert_smoke_ran)
+
+EXIT_OK = assert_smoke_ran.EXIT_OK
+EXIT_NOT_RUN = assert_smoke_ran.EXIT_NOT_RUN
+EXIT_CONFIG = assert_smoke_ran.EXIT_CONFIG
+
+_SMOKE_CLASS = "tests.e2e.test_cli_hook_e2e"
+_OTHER_CLASS = "tests.unit.test_helpers"
+
+
+def _write_report(tmp_path: Path, cases_xml: str, *, wrap: bool = False) -> Path:
+    suite = f'<testsuite name="pytest" tests="1">{cases_xml}</testsuite>'
+    body = f"<testsuites>{suite}</testsuites>" if wrap else suite
+    report = tmp_path / "report.xml"
+    report.write_text(f'<?xml version="1.0" encoding="utf-8"?>{body}', encoding="utf-8")
+    return report
+
+
+def _passed_case(classname: str, name: str) -> str:
+    return f'<testcase classname="{classname}" name="{name}" time="0.1"></testcase>'
+
+
+def _skipped_case(classname: str, name: str) -> str:
+    return (
+        f'<testcase classname="{classname}" name="{name}" time="0.0">'
+        '<skipped type="pytest.skip" message="needs RUN_CLI_E2E=1"></skipped>'
+        "</testcase>"
+    )
+
+
+def _failed_case(classname: str, name: str) -> str:
+    return (
+        f'<testcase classname="{classname}" name="{name}" time="0.2">'
+        '<failure message="assert">hook never ran</failure>'
+        "</testcase>"
+    )
+
+
+def test_returns_ok_when_smoke_case_passed(tmp_path: Path) -> None:
+    report = _write_report(
+        tmp_path, _passed_case(_SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves")
+    )
+
+    exit_code, message = assert_smoke_ran.evaluate(report, "test_cli_hook_e2e")
+
+    assert exit_code == EXIT_OK
+    assert "ran and passed" in message
+
+
+def test_returns_not_run_when_smoke_case_skipped(tmp_path: Path) -> None:
+    report = _write_report(
+        tmp_path, _skipped_case(_SMOKE_CLASS, "test_claude_plugin_dir_hook_resolves")
+    )
+
+    exit_code, message = assert_smoke_ran.evaluate(report, "test_cli_hook_e2e")
+
+    assert exit_code == EXIT_NOT_RUN
+    assert "SKIPPED" in message
+
+
+def test_returns_not_run_when_no_smoke_case_collected(tmp_path: Path) -> None:
+    report = _write_report(tmp_path, _passed_case(_OTHER_CLASS, "test_something_else"))
+
+    exit_code, message = assert_smoke_ran.evaluate(report, "test_cli_hook_e2e")
+
+    assert exit_code == EXIT_NOT_RUN
+    assert "not collected" in message or "no smoke test" in message
+
+
+def test_returns_not_run_when_smoke_case_failed(tmp_path: Path) -> None:
+    report = _write_report(
+        tmp_path, _failed_case(_SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves")
+    )
+
+    exit_code, message = assert_smoke_ran.evaluate(report, "test_cli_hook_e2e")
+
+    assert exit_code == EXIT_NOT_RUN
+    assert "FAILED" in message
+
+
+def test_skipped_among_passed_smoke_cases_still_fails(tmp_path: Path) -> None:
+    cases = _passed_case(_SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves") + _skipped_case(
+        _SMOKE_CLASS, "test_claude_plugin_dir_hook_resolves"
+    )
+    report = _write_report(tmp_path, cases)
+
+    exit_code, _ = assert_smoke_ran.evaluate(report, "test_cli_hook_e2e")
+
+    assert exit_code == EXIT_NOT_RUN
+
+
+def test_parses_testsuites_wrapper_shape(tmp_path: Path) -> None:
+    report = _write_report(
+        tmp_path,
+        _passed_case(_SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves"),
+        wrap=True,
+    )
+
+    exit_code, _ = assert_smoke_ran.evaluate(report, "test_cli_hook_e2e")
+
+    assert exit_code == EXIT_OK
+
+
+def test_rejects_report_with_doctype(tmp_path: Path) -> None:
+    report = tmp_path / "evil.xml"
+    report.write_text(
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>'
+        '<testsuite><testcase classname="x" name="y"></testcase></testsuite>',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(assert_smoke_ran.SmokeReportError, match="DTD or entity"):
+        assert_smoke_ran.evaluate(report, "test_cli_hook_e2e")
+
+
+def test_raises_when_report_missing(tmp_path: Path) -> None:
+    with pytest.raises(assert_smoke_ran.SmokeReportError, match="not found"):
+        assert_smoke_ran.evaluate(tmp_path / "absent.xml", "test_cli_hook_e2e")
+
+
+def test_raises_when_report_malformed(tmp_path: Path) -> None:
+    report = tmp_path / "broken.xml"
+    report.write_text("<testsuite><testcase>", encoding="utf-8")
+
+    with pytest.raises(assert_smoke_ran.SmokeReportError, match="not valid XML"):
+        assert_smoke_ran.evaluate(report, "test_cli_hook_e2e")
+
+
+def test_main_exits_zero_when_smoke_ran(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    report = _write_report(
+        tmp_path, _passed_case(_SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves")
+    )
+
+    code = assert_smoke_ran.main([str(report)])
+
+    assert code == EXIT_OK
+    assert "smoke gate OK" in capsys.readouterr().out
+
+
+def test_main_exits_one_when_smoke_skipped(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    report = _write_report(
+        tmp_path, _skipped_case(_SMOKE_CLASS, "test_claude_plugin_dir_hook_resolves")
+    )
+
+    code = assert_smoke_ran.main([str(report)])
+
+    assert code == EXIT_NOT_RUN
+    assert "::error::" in capsys.readouterr().err
+
+
+def test_main_exits_two_when_report_missing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = assert_smoke_ran.main([str(tmp_path / "absent.xml")])
+
+    assert code == EXIT_CONFIG
+    assert "::error::" in capsys.readouterr().err
+
+
+def test_main_honors_custom_smoke_substr(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    report = _write_report(tmp_path, _passed_case("custom.module", "test_my_smoke"))
+
+    code = assert_smoke_ran.main([str(report), "--smoke-substr", "test_my_smoke"])
+
+    assert code == EXIT_OK

--- a/tests/validation/test_assert_smoke_ran.py
+++ b/tests/validation/test_assert_smoke_ran.py
@@ -59,8 +59,12 @@ def _failed_case(classname: str, name: str) -> str:
 
 
 def test_returns_ok_when_smoke_case_passed(tmp_path: Path) -> None:
+    cases = _passed_case(
+        _SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves"
+    ) + _passed_case(_SMOKE_CLASS, "test_claude_plugin_dir_hook_resolves")
     report = _write_report(
-        tmp_path, _passed_case(_SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves")
+        tmp_path,
+        cases,
     )
 
     exit_code, message = assert_smoke_ran.evaluate(report, "test_cli_hook_e2e")
@@ -70,8 +74,12 @@ def test_returns_ok_when_smoke_case_passed(tmp_path: Path) -> None:
 
 
 def test_returns_not_run_when_smoke_case_skipped(tmp_path: Path) -> None:
+    cases = _passed_case(_SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves") + _skipped_case(
+        _SMOKE_CLASS, "test_claude_plugin_dir_hook_resolves"
+    )
     report = _write_report(
-        tmp_path, _skipped_case(_SMOKE_CLASS, "test_claude_plugin_dir_hook_resolves")
+        tmp_path,
+        cases,
     )
 
     exit_code, message = assert_smoke_ran.evaluate(report, "test_cli_hook_e2e")
@@ -90,8 +98,12 @@ def test_returns_not_run_when_no_smoke_case_collected(tmp_path: Path) -> None:
 
 
 def test_returns_not_run_when_smoke_case_failed(tmp_path: Path) -> None:
+    cases = _passed_case(_SMOKE_CLASS, "test_claude_plugin_dir_hook_resolves") + _failed_case(
+        _SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves"
+    )
     report = _write_report(
-        tmp_path, _failed_case(_SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves")
+        tmp_path,
+        cases,
     )
 
     exit_code, message = assert_smoke_ran.evaluate(report, "test_cli_hook_e2e")
@@ -112,15 +124,29 @@ def test_skipped_among_passed_smoke_cases_still_fails(tmp_path: Path) -> None:
 
 
 def test_parses_testsuites_wrapper_shape(tmp_path: Path) -> None:
+    cases = _passed_case(
+        _SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves"
+    ) + _passed_case(_SMOKE_CLASS, "test_claude_plugin_dir_hook_resolves")
     report = _write_report(
         tmp_path,
-        _passed_case(_SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves"),
+        cases,
         wrap=True,
     )
 
     exit_code, _ = assert_smoke_ran.evaluate(report, "test_cli_hook_e2e")
 
     assert exit_code == EXIT_OK
+
+
+def test_returns_not_run_when_smoke_set_is_incomplete(tmp_path: Path) -> None:
+    report = _write_report(
+        tmp_path, _passed_case(_SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves")
+    )
+
+    exit_code, message = assert_smoke_ran.evaluate(report, "test_cli_hook_e2e")
+
+    assert exit_code == EXIT_NOT_RUN
+    assert "incomplete" in message
 
 
 def test_rejects_report_with_doctype(tmp_path: Path) -> None:
@@ -150,8 +176,12 @@ def test_raises_when_report_malformed(tmp_path: Path) -> None:
 
 
 def test_main_exits_zero_when_smoke_ran(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    cases = _passed_case(
+        _SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves"
+    ) + _passed_case(_SMOKE_CLASS, "test_claude_plugin_dir_hook_resolves")
     report = _write_report(
-        tmp_path, _passed_case(_SMOKE_CLASS, "test_copilot_vendor_install_hook_resolves")
+        tmp_path,
+        cases,
     )
 
     code = assert_smoke_ran.main([str(report)])
@@ -187,6 +217,8 @@ def test_main_honors_custom_smoke_substr(
 ) -> None:
     report = _write_report(tmp_path, _passed_case("custom.module", "test_my_smoke"))
 
-    code = assert_smoke_ran.main([str(report), "--smoke-substr", "test_my_smoke"])
+    code = assert_smoke_ran.main(
+        [str(report), "--smoke-substr", "test_my_smoke", "--expected-count", "1"]
+    )
 
     assert code == EXIT_OK

--- a/tests/validation/test_assert_trusted_smoke_context.py
+++ b/tests/validation/test_assert_trusted_smoke_context.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Tests for the trusted-context gate on the authenticated smoke (issue #2231 item 3).
+
+The gate keeps the secret-bearing smoke from running attacker-controlled code.
+These tests cover the authorized path, every denial reason, and the CLI argv
+contract (stdout decision, exit code).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "validation"
+    / "assert_trusted_smoke_context.py"
+)
+_spec = importlib.util.spec_from_file_location("assert_trusted_smoke_context", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)
+
+_REPO = "rjmurillo/ai-agents"
+
+
+def test_trusted_when_scheduled_on_trusted_repo() -> None:
+    trusted, reason = gate.is_trusted("schedule", _REPO, _REPO)
+
+    assert trusted is True
+    assert "trusted context" in reason
+
+
+def test_trusted_when_dispatched_on_trusted_repo() -> None:
+    trusted, _ = gate.is_trusted("workflow_dispatch", _REPO, _REPO)
+
+    assert trusted is True
+
+
+def test_denied_for_pull_request_event() -> None:
+    trusted, reason = gate.is_trusted("pull_request", _REPO, _REPO)
+
+    assert trusted is False
+    assert "not a trusted trigger" in reason
+
+
+def test_denied_for_fork_repository() -> None:
+    trusted, reason = gate.is_trusted("schedule", "attacker/ai-agents", _REPO)
+
+    assert trusted is False
+    assert "not the trusted repo" in reason
+
+
+def test_denied_for_unknown_event() -> None:
+    trusted, _ = gate.is_trusted("push", _REPO, _REPO)
+
+    assert trusted is False
+
+
+def test_main_prints_true_and_exits_zero_when_trusted(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    code = gate.main(["--event-name", "schedule", "--repository", _REPO, "--expected-repo", _REPO])
+
+    captured = capsys.readouterr()
+    assert code == gate.EXIT_OK
+    assert captured.out.strip() == "true"
+    assert "trusted-context gate" in captured.err
+
+
+def test_main_prints_false_when_untrusted(capsys: pytest.CaptureFixture[str]) -> None:
+    code = gate.main(
+        [
+            "--event-name",
+            "schedule",
+            "--repository",
+            "fork/ai-agents",
+            "--expected-repo",
+            _REPO,
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert code == gate.EXIT_OK
+    assert captured.out.strip() == "false"
+
+
+def test_main_uses_default_expected_repo(capsys: pytest.CaptureFixture[str]) -> None:
+    code = gate.main(["--event-name", "workflow_dispatch", "--repository", _REPO])
+
+    captured = capsys.readouterr()
+    assert code == gate.EXIT_OK
+    assert captured.out.strip() == "true"
+
+
+def test_main_exits_two_when_required_arg_missing() -> None:
+    with pytest.raises(SystemExit) as exc:
+        gate.main(["--event-name", "schedule"])
+
+    assert exc.value.code == gate.EXIT_USAGE

--- a/tests/validation/test_assert_trusted_smoke_context.py
+++ b/tests/validation/test_assert_trusted_smoke_context.py
@@ -25,45 +25,78 @@ gate = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(gate)
 
 _REPO = "rjmurillo/ai-agents"
+_REF = "refs/heads/main"
 
 
 def test_trusted_when_scheduled_on_trusted_repo() -> None:
-    trusted, reason = gate.is_trusted("schedule", _REPO, _REPO)
+    trusted, reason = gate.is_trusted("schedule", _REPO, _REPO, _REF, _REF)
 
     assert trusted is True
     assert "trusted context" in reason
 
 
 def test_trusted_when_dispatched_on_trusted_repo() -> None:
-    trusted, _ = gate.is_trusted("workflow_dispatch", _REPO, _REPO)
+    trusted, _ = gate.is_trusted("workflow_dispatch", _REPO, _REPO, _REF, _REF)
+
+    assert trusted is True
+
+
+def test_trusted_repo_comparison_is_case_insensitive() -> None:
+    trusted, _ = gate.is_trusted("schedule", _REPO.upper(), _REPO.lower(), _REF, _REF)
 
     assert trusted is True
 
 
 def test_denied_for_pull_request_event() -> None:
-    trusted, reason = gate.is_trusted("pull_request", _REPO, _REPO)
+    trusted, reason = gate.is_trusted("pull_request", _REPO, _REPO, _REF, _REF)
 
     assert trusted is False
     assert "not a trusted trigger" in reason
 
 
 def test_denied_for_fork_repository() -> None:
-    trusted, reason = gate.is_trusted("schedule", "attacker/ai-agents", _REPO)
+    trusted, reason = gate.is_trusted("schedule", "attacker/ai-agents", _REPO, _REF, _REF)
 
     assert trusted is False
     assert "not the trusted repo" in reason
 
 
 def test_denied_for_unknown_event() -> None:
-    trusted, _ = gate.is_trusted("push", _REPO, _REPO)
+    trusted, _ = gate.is_trusted("push", _REPO, _REPO, _REF, _REF)
 
     assert trusted is False
+
+
+def test_denied_for_untrusted_ref() -> None:
+    trusted, reason = gate.is_trusted(
+        "workflow_dispatch",
+        _REPO,
+        _REPO,
+        "refs/heads/feature",
+        _REF,
+    )
+
+    assert trusted is False
+    assert "not the trusted ref" in reason
 
 
 def test_main_prints_true_and_exits_zero_when_trusted(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    code = gate.main(["--event-name", "schedule", "--repository", _REPO, "--expected-repo", _REPO])
+    code = gate.main(
+        [
+            "--event-name",
+            "schedule",
+            "--repository",
+            _REPO,
+            "--ref",
+            _REF,
+            "--expected-repo",
+            _REPO,
+            "--expected-ref",
+            _REF,
+        ]
+    )
 
     captured = capsys.readouterr()
     assert code == gate.EXIT_OK
@@ -78,6 +111,8 @@ def test_main_prints_false_when_untrusted(capsys: pytest.CaptureFixture[str]) ->
             "schedule",
             "--repository",
             "fork/ai-agents",
+            "--ref",
+            _REF,
             "--expected-repo",
             _REPO,
         ]
@@ -91,7 +126,7 @@ def test_main_prints_false_when_untrusted(capsys: pytest.CaptureFixture[str]) ->
 
 
 def test_main_uses_default_expected_repo(capsys: pytest.CaptureFixture[str]) -> None:
-    code = gate.main(["--event-name", "workflow_dispatch", "--repository", _REPO])
+    code = gate.main(["--event-name", "workflow_dispatch", "--repository", _REPO, "--ref", _REF])
 
     captured = capsys.readouterr()
     assert code == gate.EXIT_OK

--- a/tests/validation/test_assert_trusted_smoke_context.py
+++ b/tests/validation/test_assert_trusted_smoke_context.py
@@ -86,6 +86,8 @@ def test_main_prints_false_when_untrusted(capsys: pytest.CaptureFixture[str]) ->
     captured = capsys.readouterr()
     assert code == gate.EXIT_OK
     assert captured.out.strip() == "false"
+    assert "fork/ai-agents" not in captured.err
+    assert _REPO not in captured.err
 
 
 def test_main_uses_default_expected_repo(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary

Completes the last two ADR-071 follow-ups tracked in #2231. Items 1 and 2 (Windows pwsh contract job, glob artifact discovery) already landed on main in commit e8938cb3d. This PR adds items 3 and 4.

### Item 3: authenticated nightly cross-platform smoke

`.github/workflows/nightly-cli-smoke.yml` runs on a nightly cron plus manual dispatch. It installs the real Claude and Copilot CLIs and runs the plugin hook end to end (`tests/e2e/test_cli_hook_e2e.py` with `RUN_CLI_E2E=1`) on a ubuntu/macos/windows matrix. Windows is where #2205 was reported, so it is in the matrix.

Security:
- Triggers only on `schedule` and `workflow_dispatch`; a fork PR cannot reach the secret-bearing job.
- A trusted-context gate (`scripts/validation/assert_trusted_smoke_context.py`) re-checks event and repository and fails closed. Decision lives in Python, not YAML (ADR-006).
- Least-privilege `permissions: contents: read`. Every action pinned to a commit SHA. Tokens from `secrets.*`, never committed.

### Item 4: "smoke actually ran" assertion

The real-CLI tests `skipif` without `RUN_CLI_E2E=1`, and a skipped test reads as a pass in a green summary. The two tests now carry `@pytest.mark.smoke`, and `scripts/validation/assert_smoke_ran.py` parses the JUnit XML and exits non-zero when a smoke test was skipped, failed, or not collected, so a missing auth secret is a red run, not a silent green one. The gate rejects a report carrying a DTD or entity (CWE-611, CWE-776 defense).

## Testing

actionlint and yamllint clean on the new workflow. 22 new unit tests pass (smoke gate and trusted-context gate: positive, negative, edge, CLI argv exits). Smoke gate verified end to end against a real skipped JUnit report: exits 1 with a loud error. ruff, mypy, and CWE-78 scan clean. `gh act` dry-run not run (act not installed here); the branch logic lives in the two unit-tested Python gates.

Fixes #2231
