### PR TITLE
fix(github-skill): add close_issue, wrap review-threads, fix pre-push and security-scan

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.106",
+  "version": "0.5.107",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github
-version: 4.0.0
+version: 4.1.0
 model: claude-opus-4-6
 description: Execute GitHub operations (PRs, issues, milestones, labels, comments, merges)
   using Python scripts with structured output and error handling. Use when working
@@ -37,7 +37,7 @@ Use these scripts instead of raw `gh` commands for consistent error handling and
 | `create a PR` | new_pr.py |
 | `respond to review comments` | post_pr_comment_reply.py |
 | `check CI status` | get_pr_checks.py / get_pr_check_logs.py |
-| `close issue, add label to issue` | close_pr.py / set_issue_labels.py |
+| `close issue, add label to issue` | close_issue.py / set_issue_labels.py |
 | `list actionable items, check notifications` | get_actionable_items.py |
 
 ---
@@ -72,6 +72,7 @@ Need GitHub data?
    ├─ Set issue milestone → set_issue_milestone.py
    ├─ Set PR/issue milestone (auto-detect) → set_item_milestone.py
    ├─ Assign issue → set_issue_assignee.py
+   ├─ Close issue → close_issue.py
    ├─ Resolve threads → resolve_pr_review_thread.py
    ├─ Unresolve threads → unresolve_pr_review_thread.py
    ├─ Process AI triage → invoke_pr_comment_processing.py
@@ -124,6 +125,7 @@ Need GitHub data?
 | `set_issue_labels.py` | Apply labels (auto-create) | `--issue`, `--labels`, `--priority` |
 | `set_issue_milestone.py` | Assign milestone | `--issue`, `--milestone` |
 | `post_issue_comment.py` | Comments with idempotency | `--issue`, `--body`, `--marker` |
+| `close_issue.py` | Close issue with optional comment | `--issue`, `--reason {completed,not planned}`, `--comment`/`--comment-file` |
 | `invoke_copilot_assignment.py` | Synthesize context for Copilot | `--issue-number`, `--what-if` |
 | `set_issue_assignee.py` | Assign users to issues | `--issue`, `--assignees` |
 

--- a/.claude/skills/github/scripts/issue/close_issue.py
+++ b/.claude/skills/github/scripts/issue/close_issue.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Close a GitHub Issue with an optional closing comment.
+
+Posts an optional comment (from ``--comment`` or ``--comment-file``) and then
+closes the issue via ``gh issue close --reason``. Emits the standard ADR-056
+skill output envelope ({Success, Data, Error, Metadata}).
+
+Exit codes follow ADR-035:
+    0 - Success (issue closed, or already closed)
+    1 - Invalid parameters / logic error
+    2 - File not found / config error
+    3 - External error (API failure)
+    4 - Auth error (not authenticated)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_workspace = os.environ.get("GITHUB_WORKSPACE")
+if _plugin_root:
+    _lib_dir = os.path.join(_plugin_root, "lib")
+elif _workspace:
+    _lib_dir = os.path.join(_workspace, ".claude", "lib")
+else:
+    _lib_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "lib")
+    )
+if not os.path.isdir(_lib_dir):
+    print(f"Plugin lib directory not found: {_lib_dir}", file=sys.stderr)
+    sys.exit(2)  # Config error per ADR-035
+if _lib_dir not in sys.path:
+    sys.path.insert(0, _lib_dir)
+
+from github_core.api import (  # noqa: E402
+    assert_gh_authenticated,
+    error_and_exit,
+    resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
+)
+
+# gh issue close --reason accepts exactly these two values. "not planned" is the
+# spelling gh expects (with a space), so we pass the value through verbatim.
+_VALID_REASONS = ("completed", "not planned")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Close a GitHub Issue with an optional closing comment.",
+    )
+    parser.add_argument("--owner", default="", help="Repository owner")
+    parser.add_argument("--repo", default="", help="Repository name")
+    parser.add_argument("--issue", type=int, required=True, help="Issue number")
+    parser.add_argument(
+        "--reason",
+        choices=list(_VALID_REASONS),
+        default="completed",
+        help="Close reason: 'completed' (default) or 'not planned'.",
+    )
+
+    comment_group = parser.add_mutually_exclusive_group()
+    comment_group.add_argument(
+        "--comment", default="", help="Closing comment body text",
+    )
+    comment_group.add_argument(
+        "--comment-file", default="", help="Path to a file containing the comment body",
+    )
+
+    add_output_format_arg(parser)
+    return parser
+
+
+def _resolve_comment(comment: str, comment_file: str, fmt: str) -> str:
+    """Return the closing comment body, reading the file when one is given.
+
+    Exits with code 2 (config error) when the comment file is missing. Returns
+    an empty string when no comment was requested.
+    """
+    if comment_file:
+        path = Path(comment_file)
+        if not path.exists():
+            write_skill_error(
+                f"Comment file not found: {comment_file}",
+                2,
+                error_type="NotFound",
+                output_format=fmt,
+                script_name="close_issue.py",
+                extra={"issue": None},
+            )
+            raise SystemExit(2)
+        return path.read_text(encoding="utf-8")
+    return comment
+
+
+def _post_comment(owner: str, repo: str, issue: int, body: str, fmt: str) -> None:
+    """Post a closing comment via gh api. Exits with code 3 on failure."""
+    payload = json.dumps({"body": body})
+    result = subprocess.run(
+        [
+            "gh", "api",
+            f"repos/{owner}/{repo}/issues/{issue}/comments",
+            "-X", "POST",
+            "--input", "-",
+        ],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        error_str = result.stderr.strip() or result.stdout.strip()
+        write_skill_error(
+            f"Failed to post closing comment: {error_str}",
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="close_issue.py",
+            extra={"issue": issue},
+        )
+        raise SystemExit(3)
+
+
+def _close_issue(owner: str, repo: str, issue: int, reason: str) -> subprocess.CompletedProcess[str]:
+    """Run gh issue close with the given reason. Returns the completed process."""
+    return subprocess.run(
+        [
+            "gh", "issue", "close", str(issue),
+            "--repo", f"{owner}/{repo}",
+            "--reason", reason,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
+
+    assert_gh_authenticated()
+    resolved = resolve_repo_params(args.owner, args.repo)
+    owner, repo = resolved.owner, resolved.repo
+    issue: int = args.issue
+
+    body = _resolve_comment(args.comment, args.comment_file, fmt)
+    commented = bool(body and body.strip())
+    if commented:
+        _post_comment(owner, repo, issue, body, fmt)
+
+    result = _close_issue(owner, repo, issue, args.reason)
+    if result.returncode != 0:
+        error_str = result.stderr.strip() or result.stdout.strip()
+        write_skill_error(
+            f"Failed to close issue #{issue}: {error_str}",
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="close_issue.py",
+            extra={"issue": issue},
+        )
+        return 3
+
+    data = {
+        "issue": issue,
+        "owner": owner,
+        "repo": repo,
+        "state": "closed",
+        "reason": args.reason,
+        "commented": commented,
+    }
+    write_skill_output(
+        data,
+        output_format=fmt,
+        human_summary=f"Closed issue #{issue} as '{args.reason}'",
+        status="PASS",
+        script_name="close_issue.py",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/github/scripts/pr/get_pr_review_threads.py
+++ b/.claude/skills/github/scripts/pr/get_pr_review_threads.py
@@ -18,7 +18,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 import os
 import sys
@@ -51,6 +50,11 @@ from github_core.api import (  # noqa: E402
     gh_graphql,
     resolve_repo_params,
     transform_review_thread,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
 )
 
 # Page size for the reviewThreads connection. GitHub GraphQL caps connection
@@ -124,6 +128,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--include-comments", action="store_true",
         help="Include all comments in each thread (not just first)",
     )
+    add_output_format_arg(parser)
     return parser
 
 
@@ -332,8 +337,11 @@ def main(argv: list[str] | None = None) -> int:
     total = len(threads)
     unresolved = count_unresolved_threads(threads)
 
-    output = {
-        "success": True,
+    # ADR-056 standard envelope: callers read the documented {Success, Data,
+    # Error, Metadata} shape and parse `.Data` for the result (Issue #2372). The
+    # operation-specific fields below live under Data; write_skill_output adds
+    # Success, Error, and Metadata (Script/Version/Timestamp).
+    data = {
         "pull_request": pr,
         "owner": owner,
         "repo": repo,
@@ -344,7 +352,7 @@ def main(argv: list[str] | None = None) -> int:
         "threads": transformed,
     }
     # Truncation is signaled to consumers via two channels:
-    # - `pagination_truncated: bool` field in JSON output (machine-readable)
+    # - `pagination_truncated: bool` field in Data (machine-readable)
     # - `warnings.warn` emitted by `_collect_all_threads` (human-readable on
     #   stderr). Python's default warnings filter prints UserWarning to
     #   stderr at most once per call site; CI pipelines reading stderr for
@@ -352,7 +360,19 @@ def main(argv: list[str] | None = None) -> int:
     # No second `print(WARNING ...)` here: duplicate stderr output would
     # confuse callers parsing for a single signal.
 
-    print(json.dumps(output, indent=2))
+    fmt = get_output_format(args.output_format)
+    truncation_note = " (truncated)" if truncated else ""
+    summary = (
+        f"PR #{pr}: {total} review thread(s), {unresolved} unresolved"
+        f"{truncation_note}"
+    )
+    write_skill_output(
+        data,
+        output_format=fmt,
+        human_summary=summary,
+        status="PASS",
+        script_name="get_pr_review_threads.py",
+    )
     return 0
 
 

--- a/.claude/skills/security-scan/SKILL.md
+++ b/.claude/skills/security-scan/SKILL.md
@@ -3,7 +3,7 @@ name: security-scan
 description: Detect CWE-78 (command injection) regex patterns in Python, PowerShell, Bash, and C# files before PR submission. CWE-22 is delegated to CodeQL; see Scope. Use when you ask "scan for command injection", "CWE-78 check before PR". Do NOT use to decide whether security review is warranted (use security-detection).
 license: MIT
 metadata:
-  version: 2.0.0
+  version: 2.0.1
   model: claude-sonnet-4-6
 ---
 

--- a/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -231,8 +231,54 @@ CWE78_PATTERNS = {
 }
 
 
+# Shebang interpreters mapped to the scanner's language keys. Covers the common
+# forms a Bash hook uses: "#!/usr/bin/env bash", "#!/bin/bash", "#!/bin/sh", and
+# "#!/usr/bin/env sh". POSIX "sh" scripts share the CWE-78 surface (command
+# substitution, eval) the bash patterns target, so they map to "bash" too.
+_SHEBANG_INTERPRETERS = {
+    "bash": "bash",
+    "sh": "bash",
+}
+
+
+def detect_shebang_language(file_path: str) -> str | None:
+    """Detect language from a script's shebang line for extensionless files.
+
+    Reads only the first line. Returns a language key when the shebang names a
+    known interpreter (bash or sh), else None. Files that cannot be read (binary,
+    missing, permission denied) return None rather than raising, so the caller's
+    extensionless fallback degrades to "unsupported" instead of crashing.
+    """
+    try:
+        with open(file_path, encoding="utf-8", errors="ignore") as f:
+            first_line = f.readline()
+    except OSError:
+        return None
+
+    if not first_line.startswith("#!"):
+        return None
+
+    # The interpreter is the basename of the path, or the argument after
+    # "env". Examples: "#!/bin/bash" -> "bash"; "#!/usr/bin/env bash" -> "bash".
+    tokens = first_line[2:].strip().split()
+    if not tokens:
+        return None
+
+    interpreter = os.path.basename(tokens[0])
+    if interpreter == "env" and len(tokens) > 1:
+        interpreter = os.path.basename(tokens[1])
+
+    return _SHEBANG_INTERPRETERS.get(interpreter)
+
+
 def get_language(file_path: str) -> str | None:
-    """Detect language from file extension."""
+    """Detect language from file extension, falling back to shebang detection.
+
+    Files with a recognized extension resolve by extension. Files with no
+    recognized extension (for example, the executable Bash hook
+    ``.githooks/pre-push``) fall back to reading the shebang line so they are
+    not silently skipped as unsupported. Refs issue #2367.
+    """
     ext = Path(file_path).suffix.lower()
     language_map = {
         ".py": "python",
@@ -242,7 +288,11 @@ def get_language(file_path: str) -> str | None:
         ".bash": "bash",
         ".cs": "csharp",
     }
-    return language_map.get(ext)
+    language = language_map.get(ext)
+    if language is not None:
+        return language
+
+    return detect_shebang_language(file_path)
 
 
 def get_staged_files() -> list[str]:
@@ -264,13 +314,21 @@ def get_staged_files() -> list[str]:
 
 
 def get_directory_files(directory: str) -> list[str]:
-    """Get all scannable files from a directory."""
+    """Get all scannable files from a directory.
+
+    Includes files with a recognized extension plus extensionless files whose
+    shebang names a supported interpreter (for example, ``.githooks/pre-push``).
+    Refs issue #2367.
+    """
     supported_extensions = {".py", ".ps1", ".psm1", ".sh", ".bash", ".cs"}
     files = []
     for root, _, filenames in os.walk(directory):
         for filename in filenames:
+            path = os.path.join(root, filename)
             if Path(filename).suffix.lower() in supported_extensions:
-                files.append(os.path.join(root, filename))
+                files.append(path)
+            elif detect_shebang_language(path) is not None:
+                files.append(path)
     return files
 
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -678,60 +678,73 @@ fi
 echo_phase "Phase 3: Build Validation"
 
 # 10. Agent generation drift
-GENERATE_AGENTS_SCRIPT="$REPO_ROOT/build/Generate-Agents.ps1"
+#
+# The PowerShell generator (build/Generate-Agents.ps1) was replaced by the
+# Python generator build/generate_agents.py per ADR-042. The old ps1 path no
+# longer exists, so the prior check recorded a confusing "script not found"
+# SKIP that agents misread as a validation gap even though build_all.py --check
+# (11b) passes cleanly (Issue #2343). Repoint to the Python equivalent and use
+# set_python_cmd (uv-aware) for the same reason as 11b: the generator imports
+# third-party packages typically only present in the project's venv.
+GENERATE_AGENTS_SCRIPT="$REPO_ROOT/build/generate_agents.py"
 
 if [ -n "$CHANGED_TEMPLATES" ] || [ -n "$(echo "$CHANGED_FILES" | grep -E '^src/(copilot-cli|vs-code-agents)/' || true)" ]; then
     if [ -L "$GENERATE_AGENTS_SCRIPT" ]; then
         record_warn "Agent generation script is a symlink (skipping)"
     elif [ -f "$GENERATE_AGENTS_SCRIPT" ]; then
-        if command -v pwsh &> /dev/null; then
+        if set_python_cmd; then
             GEN_OUTPUT=$(mktemp)
             TEMP_FILES+=("$GEN_OUTPUT")
-            if pwsh -NoProfile -ExecutionPolicy Bypass -File "$GENERATE_AGENTS_SCRIPT" -Validate > "$GEN_OUTPUT" 2>&1; then
+            if "${PYTHON_CMD[@]}" "$GENERATE_AGENTS_SCRIPT" --validate > "$GEN_OUTPUT" 2>&1; then
                 record_pass "Agent generation (templates match generated)"
             else
                 echo_info "  Agent generation output:"
                 head -20 "$GEN_OUTPUT"
                 record_fail "Agent generation drift detected"
-                echo_info "  Fix: pwsh build/Generate-Agents.ps1"
+                echo_info "  Fix: ${PYTHON_CMD[*]} build/generate_agents.py"
                 echo_info "  Then commit the regenerated files."
             fi
             rm -f "$GEN_OUTPUT"
         else
-            record_skip "Agent generation (pwsh not available)"
+            record_skip "Agent generation (no Python available)"
         fi
     else
-        record_skip "Agent generation (script not found)"
+        record_skip "Agent generation (script not found: build/generate_agents.py)"
     fi
 else
     record_skip "Agent generation (no template/agent files changed)"
 fi
 
 # 11. Agent drift detection
-AGENT_DRIFT_SCRIPT="$REPO_ROOT/build/scripts/Detect-AgentDrift.ps1"
+#
+# The PowerShell drift detector (build/scripts/Detect-AgentDrift.ps1) was
+# replaced by the Python detector build/scripts/detect_agent_drift.py per
+# ADR-042. Repoint to the Python equivalent and use set_python_cmd, matching
+# check 10 and 11b (Issue #2343).
+AGENT_DRIFT_SCRIPT="$REPO_ROOT/build/scripts/detect_agent_drift.py"
 
 if [ -n "$(echo "$CHANGED_FILES" | grep -E '^(src/|templates/)' || true)" ]; then
     if [ -L "$AGENT_DRIFT_SCRIPT" ]; then
         record_warn "Agent drift script is a symlink (skipping)"
     elif [ -f "$AGENT_DRIFT_SCRIPT" ]; then
-        if command -v pwsh &> /dev/null; then
+        if set_python_cmd; then
             DRIFT_OUTPUT=$(mktemp)
             TEMP_FILES+=("$DRIFT_OUTPUT")
-            if pwsh -NoProfile -ExecutionPolicy Bypass -File "$AGENT_DRIFT_SCRIPT" > "$DRIFT_OUTPUT" 2>&1; then
+            if "${PYTHON_CMD[@]}" "$AGENT_DRIFT_SCRIPT" > "$DRIFT_OUTPUT" 2>&1; then
                 record_pass "Agent drift detection"
             else
                 echo_info "  Agent drift output:"
                 head -20 "$DRIFT_OUTPUT"
                 record_fail "Agent drift detected"
                 echo_info "  Fix: Sync agent content across platforms."
-                echo_info "  Run: pwsh build/scripts/Detect-AgentDrift.ps1 -Verbose"
+                echo_info "  Run: ${PYTHON_CMD[*]} build/scripts/detect_agent_drift.py"
             fi
             rm -f "$DRIFT_OUTPUT"
         else
-            record_skip "Agent drift detection (pwsh not available)"
+            record_skip "Agent drift detection (no Python available)"
         fi
     else
-        record_skip "Agent drift detection (script not found)"
+        record_skip "Agent drift detection (script not found: build/scripts/detect_agent_drift.py)"
     fi
 else
     record_skip "Agent drift detection (no src/template files changed)"

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.106",
+  "version": "0.5.107",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/github/SKILL.md
+++ b/src/copilot-cli/skills/github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github
-version: 4.0.0
+version: 4.1.0
 model: claude-opus-4-6
 description: Execute GitHub operations (PRs, issues, milestones, labels, comments, merges)
   using Python scripts with structured output and error handling. Use when working
@@ -37,7 +37,7 @@ Use these scripts instead of raw `gh` commands for consistent error handling and
 | `create a PR` | new_pr.py |
 | `respond to review comments` | post_pr_comment_reply.py |
 | `check CI status` | get_pr_checks.py / get_pr_check_logs.py |
-| `close issue, add label to issue` | close_pr.py / set_issue_labels.py |
+| `close issue, add label to issue` | close_issue.py / set_issue_labels.py |
 | `list actionable items, check notifications` | get_actionable_items.py |
 
 ---
@@ -72,6 +72,7 @@ Need GitHub data?
    ├─ Set issue milestone → set_issue_milestone.py
    ├─ Set PR/issue milestone (auto-detect) → set_item_milestone.py
    ├─ Assign issue → set_issue_assignee.py
+   ├─ Close issue → close_issue.py
    ├─ Resolve threads → resolve_pr_review_thread.py
    ├─ Unresolve threads → unresolve_pr_review_thread.py
    ├─ Process AI triage → invoke_pr_comment_processing.py
@@ -124,6 +125,7 @@ Need GitHub data?
 | `set_issue_labels.py` | Apply labels (auto-create) | `--issue`, `--labels`, `--priority` |
 | `set_issue_milestone.py` | Assign milestone | `--issue`, `--milestone` |
 | `post_issue_comment.py` | Comments with idempotency | `--issue`, `--body`, `--marker` |
+| `close_issue.py` | Close issue with optional comment | `--issue`, `--reason {completed,not planned}`, `--comment`/`--comment-file` |
 | `invoke_copilot_assignment.py` | Synthesize context for Copilot | `--issue-number`, `--what-if` |
 | `set_issue_assignee.py` | Assign users to issues | `--issue`, `--assignees` |
 

--- a/src/copilot-cli/skills/github/scripts/issue/close_issue.py
+++ b/src/copilot-cli/skills/github/scripts/issue/close_issue.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Close a GitHub Issue with an optional closing comment.
+
+Posts an optional comment (from ``--comment`` or ``--comment-file``) and then
+closes the issue via ``gh issue close --reason``. Emits the standard ADR-056
+skill output envelope ({Success, Data, Error, Metadata}).
+
+Exit codes follow ADR-035:
+    0 - Success (issue closed, or already closed)
+    1 - Invalid parameters / logic error
+    2 - File not found / config error
+    3 - External error (API failure)
+    4 - Auth error (not authenticated)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_workspace = os.environ.get("GITHUB_WORKSPACE")
+if _plugin_root:
+    _lib_dir = os.path.join(_plugin_root, "lib")
+elif _workspace:
+    _lib_dir = os.path.join(_workspace, ".claude", "lib")
+else:
+    _lib_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "lib")
+    )
+if not os.path.isdir(_lib_dir):
+    print(f"Plugin lib directory not found: {_lib_dir}", file=sys.stderr)
+    sys.exit(2)  # Config error per ADR-035
+if _lib_dir not in sys.path:
+    sys.path.insert(0, _lib_dir)
+
+from github_core.api import (  # noqa: E402
+    assert_gh_authenticated,
+    error_and_exit,
+    resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
+)
+
+# gh issue close --reason accepts exactly these two values. "not planned" is the
+# spelling gh expects (with a space), so we pass the value through verbatim.
+_VALID_REASONS = ("completed", "not planned")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Close a GitHub Issue with an optional closing comment.",
+    )
+    parser.add_argument("--owner", default="", help="Repository owner")
+    parser.add_argument("--repo", default="", help="Repository name")
+    parser.add_argument("--issue", type=int, required=True, help="Issue number")
+    parser.add_argument(
+        "--reason",
+        choices=list(_VALID_REASONS),
+        default="completed",
+        help="Close reason: 'completed' (default) or 'not planned'.",
+    )
+
+    comment_group = parser.add_mutually_exclusive_group()
+    comment_group.add_argument(
+        "--comment", default="", help="Closing comment body text",
+    )
+    comment_group.add_argument(
+        "--comment-file", default="", help="Path to a file containing the comment body",
+    )
+
+    add_output_format_arg(parser)
+    return parser
+
+
+def _resolve_comment(comment: str, comment_file: str, fmt: str) -> str:
+    """Return the closing comment body, reading the file when one is given.
+
+    Exits with code 2 (config error) when the comment file is missing. Returns
+    an empty string when no comment was requested.
+    """
+    if comment_file:
+        path = Path(comment_file)
+        if not path.exists():
+            write_skill_error(
+                f"Comment file not found: {comment_file}",
+                2,
+                error_type="NotFound",
+                output_format=fmt,
+                script_name="close_issue.py",
+                extra={"issue": None},
+            )
+            raise SystemExit(2)
+        return path.read_text(encoding="utf-8")
+    return comment
+
+
+def _post_comment(owner: str, repo: str, issue: int, body: str, fmt: str) -> None:
+    """Post a closing comment via gh api. Exits with code 3 on failure."""
+    payload = json.dumps({"body": body})
+    result = subprocess.run(
+        [
+            "gh", "api",
+            f"repos/{owner}/{repo}/issues/{issue}/comments",
+            "-X", "POST",
+            "--input", "-",
+        ],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        error_str = result.stderr.strip() or result.stdout.strip()
+        write_skill_error(
+            f"Failed to post closing comment: {error_str}",
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="close_issue.py",
+            extra={"issue": issue},
+        )
+        raise SystemExit(3)
+
+
+def _close_issue(owner: str, repo: str, issue: int, reason: str) -> subprocess.CompletedProcess[str]:
+    """Run gh issue close with the given reason. Returns the completed process."""
+    return subprocess.run(
+        [
+            "gh", "issue", "close", str(issue),
+            "--repo", f"{owner}/{repo}",
+            "--reason", reason,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
+
+    assert_gh_authenticated()
+    resolved = resolve_repo_params(args.owner, args.repo)
+    owner, repo = resolved.owner, resolved.repo
+    issue: int = args.issue
+
+    body = _resolve_comment(args.comment, args.comment_file, fmt)
+    commented = bool(body and body.strip())
+    if commented:
+        _post_comment(owner, repo, issue, body, fmt)
+
+    result = _close_issue(owner, repo, issue, args.reason)
+    if result.returncode != 0:
+        error_str = result.stderr.strip() or result.stdout.strip()
+        write_skill_error(
+            f"Failed to close issue #{issue}: {error_str}",
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="close_issue.py",
+            extra={"issue": issue},
+        )
+        return 3
+
+    data = {
+        "issue": issue,
+        "owner": owner,
+        "repo": repo,
+        "state": "closed",
+        "reason": args.reason,
+        "commented": commented,
+    }
+    write_skill_output(
+        data,
+        output_format=fmt,
+        human_summary=f"Closed issue #{issue} as '{args.reason}'",
+        status="PASS",
+        script_name="close_issue.py",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_review_threads.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_review_threads.py
@@ -18,7 +18,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 import os
 import sys
@@ -51,6 +50,11 @@ from github_core.api import (  # noqa: E402
     gh_graphql,
     resolve_repo_params,
     transform_review_thread,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
 )
 
 # Page size for the reviewThreads connection. GitHub GraphQL caps connection
@@ -124,6 +128,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--include-comments", action="store_true",
         help="Include all comments in each thread (not just first)",
     )
+    add_output_format_arg(parser)
     return parser
 
 
@@ -332,8 +337,11 @@ def main(argv: list[str] | None = None) -> int:
     total = len(threads)
     unresolved = count_unresolved_threads(threads)
 
-    output = {
-        "success": True,
+    # ADR-056 standard envelope: callers read the documented {Success, Data,
+    # Error, Metadata} shape and parse `.Data` for the result (Issue #2372). The
+    # operation-specific fields below live under Data; write_skill_output adds
+    # Success, Error, and Metadata (Script/Version/Timestamp).
+    data = {
         "pull_request": pr,
         "owner": owner,
         "repo": repo,
@@ -344,7 +352,7 @@ def main(argv: list[str] | None = None) -> int:
         "threads": transformed,
     }
     # Truncation is signaled to consumers via two channels:
-    # - `pagination_truncated: bool` field in JSON output (machine-readable)
+    # - `pagination_truncated: bool` field in Data (machine-readable)
     # - `warnings.warn` emitted by `_collect_all_threads` (human-readable on
     #   stderr). Python's default warnings filter prints UserWarning to
     #   stderr at most once per call site; CI pipelines reading stderr for
@@ -352,7 +360,19 @@ def main(argv: list[str] | None = None) -> int:
     # No second `print(WARNING ...)` here: duplicate stderr output would
     # confuse callers parsing for a single signal.
 
-    print(json.dumps(output, indent=2))
+    fmt = get_output_format(args.output_format)
+    truncation_note = " (truncated)" if truncated else ""
+    summary = (
+        f"PR #{pr}: {total} review thread(s), {unresolved} unresolved"
+        f"{truncation_note}"
+    )
+    write_skill_output(
+        data,
+        output_format=fmt,
+        human_summary=summary,
+        status="PASS",
+        script_name="get_pr_review_threads.py",
+    )
     return 0
 
 

--- a/src/copilot-cli/skills/security-scan/SKILL.md
+++ b/src/copilot-cli/skills/security-scan/SKILL.md
@@ -3,7 +3,7 @@ name: security-scan
 description: Detect CWE-78 (command injection) regex patterns in Python, PowerShell, Bash, and C# files before PR submission. CWE-22 is delegated to CodeQL; see Scope. Use when you ask "scan for command injection", "CWE-78 check before PR". Do NOT use to decide whether security review is warranted (use security-detection).
 license: MIT
 metadata:
-  version: 2.0.0
+  version: 2.0.1
   model: claude-sonnet-4-6
 ---
 

--- a/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -231,8 +231,54 @@ CWE78_PATTERNS = {
 }
 
 
+# Shebang interpreters mapped to the scanner's language keys. Covers the common
+# forms a Bash hook uses: "#!/usr/bin/env bash", "#!/bin/bash", "#!/bin/sh", and
+# "#!/usr/bin/env sh". POSIX "sh" scripts share the CWE-78 surface (command
+# substitution, eval) the bash patterns target, so they map to "bash" too.
+_SHEBANG_INTERPRETERS = {
+    "bash": "bash",
+    "sh": "bash",
+}
+
+
+def detect_shebang_language(file_path: str) -> str | None:
+    """Detect language from a script's shebang line for extensionless files.
+
+    Reads only the first line. Returns a language key when the shebang names a
+    known interpreter (bash or sh), else None. Files that cannot be read (binary,
+    missing, permission denied) return None rather than raising, so the caller's
+    extensionless fallback degrades to "unsupported" instead of crashing.
+    """
+    try:
+        with open(file_path, encoding="utf-8", errors="ignore") as f:
+            first_line = f.readline()
+    except OSError:
+        return None
+
+    if not first_line.startswith("#!"):
+        return None
+
+    # The interpreter is the basename of the path, or the argument after
+    # "env". Examples: "#!/bin/bash" -> "bash"; "#!/usr/bin/env bash" -> "bash".
+    tokens = first_line[2:].strip().split()
+    if not tokens:
+        return None
+
+    interpreter = os.path.basename(tokens[0])
+    if interpreter == "env" and len(tokens) > 1:
+        interpreter = os.path.basename(tokens[1])
+
+    return _SHEBANG_INTERPRETERS.get(interpreter)
+
+
 def get_language(file_path: str) -> str | None:
-    """Detect language from file extension."""
+    """Detect language from file extension, falling back to shebang detection.
+
+    Files with a recognized extension resolve by extension. Files with no
+    recognized extension (for example, the executable Bash hook
+    ``.githooks/pre-push``) fall back to reading the shebang line so they are
+    not silently skipped as unsupported. Refs issue #2367.
+    """
     ext = Path(file_path).suffix.lower()
     language_map = {
         ".py": "python",
@@ -242,7 +288,11 @@ def get_language(file_path: str) -> str | None:
         ".bash": "bash",
         ".cs": "csharp",
     }
-    return language_map.get(ext)
+    language = language_map.get(ext)
+    if language is not None:
+        return language
+
+    return detect_shebang_language(file_path)
 
 
 def get_staged_files() -> list[str]:
@@ -264,13 +314,21 @@ def get_staged_files() -> list[str]:
 
 
 def get_directory_files(directory: str) -> list[str]:
-    """Get all scannable files from a directory."""
+    """Get all scannable files from a directory.
+
+    Includes files with a recognized extension plus extensionless files whose
+    shebang names a supported interpreter (for example, ``.githooks/pre-push``).
+    Refs issue #2367.
+    """
     supported_extensions = {".py", ".ps1", ".psm1", ".sh", ".bash", ".cs"}
     files = []
     for root, _, filenames in os.walk(directory):
         for filename in filenames:
+            path = os.path.join(root, filename)
             if Path(filename).suffix.lower() in supported_extensions:
-                files.append(os.path.join(root, filename))
+                files.append(path)
+            elif detect_shebang_language(path) is not None:
+                files.append(path)
     return files
 
 

--- a/tests/test_close_issue.py
+++ b/tests/test_close_issue.py
@@ -1,0 +1,253 @@
+"""Tests for close_issue.py skill script (issue #2380)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.github_core.api import RepoInfo
+
+# ---------------------------------------------------------------------------
+# Import the script via importlib (not a package)
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / ".claude" / "skills" / "github" / "scripts" / "issue"
+)
+
+
+def _import_script(name: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS_DIR / f"{name}.py")
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _import_script("close_issue")
+main = _mod.main
+build_parser = _mod.build_parser
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _completed(stdout: str = "", stderr: str = "", rc: int = 0):
+    return subprocess.CompletedProcess(args=[], returncode=rc, stdout=stdout, stderr=stderr)
+
+
+def _envelope(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+# ---------------------------------------------------------------------------
+# build_parser
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    def test_issue_required(self):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args([])
+
+    def test_default_reason_is_completed(self):
+        args = build_parser().parse_args(["--issue", "5"])
+        assert args.reason == "completed"
+
+    def test_reason_not_planned_accepted(self):
+        args = build_parser().parse_args(["--issue", "5", "--reason", "not planned"])
+        assert args.reason == "not planned"
+
+    def test_invalid_reason_rejected(self):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["--issue", "5", "--reason", "wontfix"])
+
+    def test_comment_and_comment_file_mutually_exclusive(self):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(
+                ["--issue", "5", "--comment", "x", "--comment-file", "f.txt"]
+            )
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_not_authenticated_exits_4(self):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+            side_effect=SystemExit(4),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main(["--issue", "1"])
+            assert exc.value.code == 4
+
+    def test_close_success_no_comment(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout="closed", rc=0),
+        ) as mock_run:
+            rc = main(["--issue", "50"])
+        assert rc == 0
+
+        env = _envelope(capsys)
+        assert env["Success"] is True
+        assert env["Error"] is None
+        assert env["Metadata"]["Script"] == "close_issue.py"
+        data = env["Data"]
+        assert data["issue"] == 50
+        assert data["state"] == "closed"
+        assert data["reason"] == "completed"
+        assert data["commented"] is False
+
+        # Only the close call ran (no comment POST).
+        assert mock_run.call_count == 1
+        close_args = mock_run.call_args_list[0].args[0]
+        assert close_args[:3] == ["gh", "issue", "close"]
+        assert "--reason" in close_args
+        assert close_args[close_args.index("--reason") + 1] == "completed"
+
+    def test_close_with_reason_not_planned(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(rc=0),
+        ) as mock_run:
+            rc = main(["--issue", "7", "--reason", "not planned"])
+        assert rc == 0
+        data = _envelope(capsys)["Data"]
+        assert data["reason"] == "not planned"
+        close_args = mock_run.call_args_list[0].args[0]
+        assert close_args[close_args.index("--reason") + 1] == "not planned"
+
+    def test_close_with_comment_posts_then_closes(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout="{}", rc=0),
+        ) as mock_run:
+            rc = main(["--issue", "9", "--comment", "Fixed in PR #10"])
+        assert rc == 0
+        data = _envelope(capsys)["Data"]
+        assert data["commented"] is True
+
+        # First call posts the comment, second closes.
+        assert mock_run.call_count == 2
+        post_args = mock_run.call_args_list[0].args[0]
+        assert post_args[:2] == ["gh", "api"]
+        assert "comments" in post_args[2]
+        # The comment body is passed as JSON on stdin.
+        post_input = mock_run.call_args_list[0].kwargs["input"]
+        assert json.loads(post_input)["body"] == "Fixed in PR #10"
+        close_args = mock_run.call_args_list[1].args[0]
+        assert close_args[:3] == ["gh", "issue", "close"]
+
+    def test_comment_from_file(self, tmp_path, capsys):
+        comment_path = tmp_path / "body.md"
+        comment_path.write_text("Closing per triage.", encoding="utf-8")
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout="{}", rc=0),
+        ) as mock_run:
+            rc = main(["--issue", "11", "--comment-file", str(comment_path)])
+        assert rc == 0
+        assert _envelope(capsys)["Data"]["commented"] is True
+        post_input = mock_run.call_args_list[0].kwargs["input"]
+        assert json.loads(post_input)["body"] == "Closing per triage."
+
+    def test_missing_comment_file_exits_2(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main(["--issue", "12", "--comment-file", "/nonexistent/body.md"])
+            assert exc.value.code == 2
+        env = _envelope(capsys)
+        assert env["Success"] is False
+        assert env["Error"]["Code"] == 2
+
+    def test_close_api_failure_exits_3(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stderr="HTTP 404", rc=1),
+        ):
+            rc = main(["--issue", "13"])
+        assert rc == 3
+        env = _envelope(capsys)
+        assert env["Success"] is False
+        assert env["Error"]["Code"] == 3
+        assert env["Error"]["Type"] == "ApiError"
+
+    def test_comment_post_failure_exits_3_before_close(self, capsys):
+        """A failed comment POST aborts with code 3; the issue is not closed."""
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stderr="HTTP 403", rc=1),
+        ) as mock_run:
+            with pytest.raises(SystemExit) as exc:
+                main(["--issue", "14", "--comment", "note"])
+            assert exc.value.code == 3
+        # Only the comment POST ran; the close call was never reached.
+        assert mock_run.call_count == 1
+        env = _envelope(capsys)
+        assert env["Success"] is False
+        assert env["Error"]["Code"] == 3
+
+    def test_whitespace_only_comment_is_not_posted(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(rc=0),
+        ) as mock_run:
+            rc = main(["--issue", "15", "--comment", "   "])
+        assert rc == 0
+        # No comment POST; only the close call.
+        assert mock_run.call_count == 1
+        assert _envelope(capsys)["Data"]["commented"] is False

--- a/tests/test_get_pr_review_threads.py
+++ b/tests/test_get_pr_review_threads.py
@@ -47,6 +47,21 @@ def _completed(stdout: str = "", stderr: str = "", rc: int = 0):
     return subprocess.CompletedProcess(args=[], returncode=rc, stdout=stdout, stderr=stderr)
 
 
+def _envelope(capsys) -> dict:
+    """Parse the captured stdout into the ADR-056 envelope dict.
+
+    The script emits the {Success, Data, Error, Metadata} envelope as JSON when
+    stdout is not a TTY (pytest's capsys redirect satisfies that). Tests assert
+    on the envelope and on its Data payload.
+    """
+    return json.loads(capsys.readouterr().out)
+
+
+def _data(capsys) -> dict:
+    """Return just the Data payload of the captured envelope."""
+    return _envelope(capsys)["Data"]
+
+
 def _graphql_response(threads=None, total_count=None):
     if threads is None:
         threads = []
@@ -159,7 +174,7 @@ class TestMain:
         ):
             rc = main(["--pull-request", "50"])
         assert rc == 0
-        output = json.loads(capsys.readouterr().out)
+        output = _data(capsys)
         assert isinstance(output, dict)
         assert isinstance(output["total_threads"], int)
         assert output["total_threads"] == 2
@@ -183,7 +198,7 @@ class TestMain:
         ):
             rc = main(["--pull-request", "50", "--unresolved-only"])
         assert rc == 0
-        output = json.loads(capsys.readouterr().out)
+        output = _data(capsys)
         assert len(output["threads"]) == 1
         assert output["threads"][0]["is_resolved"] is False
 
@@ -201,7 +216,7 @@ class TestMain:
         ):
             rc = main(["--pull-request", "50", "--include-comments"])
         assert rc == 0
-        output = json.loads(capsys.readouterr().out)
+        output = _data(capsys)
         assert output["threads"][0]["comments"] is not None
         assert len(output["threads"][0]["comments"]) == 1
 
@@ -218,8 +233,56 @@ class TestMain:
         ):
             rc = main(["--pull-request", "50"])
         assert rc == 0
-        output = json.loads(capsys.readouterr().out)
+        output = _data(capsys)
         assert output["total_threads"] == 0
+
+    def test_output_uses_standard_envelope(self, capsys):
+        """Contract: output is the ADR-056 envelope, not a flat lowercase dict.
+
+        Issue #2372: consumers reading `.Data` per the GitHub skill docs got
+        null because the script printed flat keys (success, threads, ...) at the
+        top level. This pins the {Success, Data, Error, Metadata} shape and that
+        the documented Data payload fields are all present and reachable.
+        """
+        threads = [_thread("PRRT_1", resolved=False), _thread("PRRT_2", resolved=True)]
+        response = _graphql_response(threads)
+        with patch(
+            "get_pr_review_threads.assert_gh_authenticated",
+        ), patch(
+            "get_pr_review_threads.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stdout=response, rc=0),
+        ):
+            rc = main(["--pull-request", "50"])
+        assert rc == 0
+
+        envelope = _envelope(capsys)
+        assert set(envelope) == {"Success", "Data", "Error", "Metadata"}
+        assert envelope["Success"] is True
+        assert envelope["Error"] is None
+        assert envelope["Metadata"]["Script"] == "get_pr_review_threads.py"
+        assert "Version" in envelope["Metadata"]
+        assert "Timestamp" in envelope["Metadata"]
+
+        # No flat lowercase keys leak at the top level (the #2372 regression).
+        assert "success" not in envelope
+        assert "threads" not in envelope
+
+        data = envelope["Data"]
+        for key in (
+            "pull_request",
+            "owner",
+            "repo",
+            "total_threads",
+            "resolved_count",
+            "unresolved_count",
+            "pagination_truncated",
+            "threads",
+        ):
+            assert key in data, f"Data missing documented field: {key}"
+        assert data["threads"] is not None
 
     def test_api_error_exits_3(self):
         """Generic RuntimeError (not 'Could not resolve') exits with code 3."""
@@ -320,7 +383,7 @@ class TestMain:
         assert mock_query.call_count == 2, (
             "Pagination loop did not call the query twice; page 2 was missed"
         )
-        output = json.loads(capsys.readouterr().out)
+        output = _data(capsys)
         assert output["total_threads"] == 107
         assert output["unresolved_count"] == 100  # only page 1 unresolved
         assert output["resolved_count"] == 7
@@ -379,8 +442,7 @@ class TestMain:
         assert mock_query.call_count == cap, (
             f"Loop did not stop at cap; got {mock_query.call_count}, expected {cap}"
         )
-        captured = capsys.readouterr()
-        output = json.loads(captured.out)
+        output = _data(capsys)
         assert output["pagination_truncated"] is True, (
             "JSON output must surface pagination_truncated=True at cap"
         )

--- a/tests/test_pre_push_generation_checks.py
+++ b/tests/test_pre_push_generation_checks.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Regression coverage for Issue #2343: pre-push generation checks agree with
+build_all.py --check.
+
+Pre-push checks 10 (agent generation) and 11 (agent drift) previously pointed at
+PowerShell scripts (``build/Generate-Agents.ps1`` and
+``build/scripts/Detect-AgentDrift.ps1``) that were replaced by Python equivalents
+per ADR-042. In an isolated pr-autofix worktree (a clean checkout of main) the
+ps1 paths do not exist, so the checks recorded a confusing "script not found"
+SKIP that agents misread as a validation gap, even though ``build_all.py --check``
+(check 11b) passed cleanly.
+
+These tests pin the producer side at the script-content level (the same approach
+as ``tests/test_pre_push_tree_neutral.py``): the hook references the Python
+generators, the deleted ps1 paths are gone, and the referenced Python scripts
+actually exist in the worktree so the checks can run rather than skip.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PRE_PUSH = REPO_ROOT / ".githooks" / "pre-push"
+
+
+def _pre_push_text() -> str:
+    return PRE_PUSH.read_text(encoding="utf-8")
+
+
+def test_generation_check_uses_python_generator() -> None:
+    # Arrange
+    text = _pre_push_text()
+
+    # Assert: check 10 invokes the Python generator with --validate.
+    assert "build/generate_agents.py" in text
+    assert '"$GENERATE_AGENTS_SCRIPT" --validate' in text
+
+
+def test_drift_check_uses_python_detector() -> None:
+    # Arrange
+    text = _pre_push_text()
+
+    # Assert: check 11 invokes the Python drift detector.
+    assert "build/scripts/detect_agent_drift.py" in text
+
+
+def test_no_deleted_powershell_generator_script_assignments_remain() -> None:
+    # Arrange
+    text = _pre_push_text()
+
+    # Assert: the script-path variables no longer point at the deleted ps1 files.
+    # A prose mention of the old path in an explanatory comment is allowed; what
+    # must be gone is the assignment that the check actually executes against, so
+    # an isolated worktree no longer records a "script not found" SKIP for a path
+    # that cannot exist.
+    assert 'GENERATE_AGENTS_SCRIPT="$REPO_ROOT/build/Generate-Agents.ps1"' not in text
+    assert 'AGENT_DRIFT_SCRIPT="$REPO_ROOT/build/scripts/Detect-AgentDrift.ps1"' not in text
+    assert 'GENERATE_AGENTS_SCRIPT="$REPO_ROOT/build/generate_agents.py"' in text
+    assert 'AGENT_DRIFT_SCRIPT="$REPO_ROOT/build/scripts/detect_agent_drift.py"' in text
+
+
+def test_generation_checks_use_set_python_cmd() -> None:
+    # Arrange
+    text = _pre_push_text()
+
+    # Assert: both repointed checks resolve Python via set_python_cmd (uv-aware),
+    # matching check 11b (build_all.py --check). No bare pwsh invocation drives
+    # generation any longer.
+    assert "pwsh -NoProfile -ExecutionPolicy Bypass -File \"$GENERATE_AGENTS_SCRIPT\"" not in text
+    assert "pwsh -NoProfile -ExecutionPolicy Bypass -File \"$AGENT_DRIFT_SCRIPT\"" not in text
+
+
+def test_referenced_python_generators_exist_in_worktree() -> None:
+    # Assert: the scripts the repointed checks invoke exist in this checkout, so
+    # an isolated pr-autofix worktree runs the check instead of skipping it.
+    assert (REPO_ROOT / "build" / "generate_agents.py").is_file()
+    assert (REPO_ROOT / "build" / "scripts" / "detect_agent_drift.py").is_file()

--- a/tests/test_security_scan_vulnerabilities.py
+++ b/tests/test_security_scan_vulnerabilities.py
@@ -112,6 +112,67 @@ def test_get_language_maps_extension(filename: str, expected: str | None) -> Non
 
 
 # ---------------------------------------------------------------------------
+# Shebang detection for extensionless scripts (issue #2367)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("shebang", "expected"),
+    [
+        ("#!/usr/bin/env bash\n", "bash"),
+        ("#!/bin/bash\n", "bash"),
+        ("#!/bin/sh\n", "bash"),
+        ("#!/usr/bin/env sh\n", "bash"),
+        ("#!/usr/bin/env python3\n", None),
+        ("#!/usr/bin/perl\n", None),
+        ("not a shebang\n", None),
+        ("", None),
+    ],
+)
+def test_detect_shebang_language(
+    tmp_path: Path, shebang: str, expected: str | None
+) -> None:
+    target = tmp_path / "hook"
+    target.write_text(shebang, encoding="utf-8")
+    assert scanner.detect_shebang_language(str(target)) == expected
+
+
+def test_detect_shebang_language_missing_file_returns_none(tmp_path: Path) -> None:
+    assert scanner.detect_shebang_language(str(tmp_path / "absent")) is None
+
+
+def test_get_language_falls_back_to_shebang_for_extensionless(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "pre-push"
+    target.write_text("#!/usr/bin/env bash\necho hi\n", encoding="utf-8")
+    assert scanner.get_language(str(target)) == "bash"
+
+
+def test_get_language_extensionless_without_shebang_is_none(tmp_path: Path) -> None:
+    target = tmp_path / "data"
+    target.write_text("plain text, no shebang\n", encoding="utf-8")
+    assert scanner.get_language(str(target)) is None
+
+
+def test_get_directory_files_includes_extensionless_shebang_scripts(
+    tmp_path: Path,
+) -> None:
+    hook = tmp_path / "pre-push"
+    hook.write_text("#!/usr/bin/env bash\necho hi\n", encoding="utf-8")
+    plain = tmp_path / "notes"
+    plain.write_text("no shebang here\n", encoding="utf-8")
+    py = tmp_path / "module.py"
+    py.write_text("x = 1\n", encoding="utf-8")
+
+    found = scanner.get_directory_files(str(tmp_path))
+
+    assert str(hook) in found
+    assert str(py) in found
+    assert str(plain) not in found
+
+
+# ---------------------------------------------------------------------------
 # CWE-78 positive detections, one parametrize per language
 # ---------------------------------------------------------------------------
 
@@ -487,6 +548,24 @@ def test_cli_exit_success_when_only_unsupported_files(tmp_path: Path) -> None:
     result = _run_cli(name, cwd=tmp_path)
     assert result.returncode == scanner.EXIT_SUCCESS
     assert "No supported files found" in result.stdout
+
+
+def test_cli_scans_extensionless_bash_hook(tmp_path: Path) -> None:
+    """An extensionless Bash hook (the .githooks/pre-push shape) must be scanned,
+    not skipped as unsupported. Refs issue #2367."""
+    name = _write(tmp_path, "pre-push", "#!/usr/bin/env bash\necho clean\n")
+    result = _run_cli(name, cwd=tmp_path)
+    assert result.returncode == scanner.EXIT_SUCCESS
+    assert "No supported files found" not in result.stdout
+
+
+def test_cli_detects_injection_in_extensionless_bash_hook(tmp_path: Path) -> None:
+    """The extensionless hook is scanned for real CWE-78 findings, not merely
+    recognized. Negative control for the shebang fallback. Refs issue #2367."""
+    name = _write(tmp_path, "pre-push", '#!/usr/bin/env bash\neval "$cmd"\n')
+    result = _run_cli(name, cwd=tmp_path)
+    assert result.returncode == scanner.EXIT_VULNERABILITIES
+    assert "CWE-78" in result.stdout
 
 
 def test_cli_json_output_reports_findings(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Resolves four P2 bugs across the github skill, pre-push hook, and security-scan skill.

- **#2380**: add `close_issue.py` to the github skill. The skill could list, create, edit, comment, label, and assign issues but not close one, forcing a raw `gh issue close` fallback. New script takes `--issue`, `--reason {completed,not planned}`, optional `--comment`/`--comment-file`, `--output-format`; posts the optional comment then closes, emitting the standard envelope. Documented in SKILL.md.
- **#2372**: `get_pr_review_threads.py` printed a flat dict, so consumers reading `.Data` per the docs got null. Output now uses the `{Success, Data, Error, Metadata}` envelope plus a `--output-format` flag.
- **#2343**: pre-push checks 10 and 11 referenced `Generate-Agents.ps1` and `Detect-AgentDrift.ps1` (gone since the Python migration), producing "script not found" SKIPs. Repointed to `build/generate_agents.py --validate` and `build/scripts/detect_agent_drift.py`.
- **#2367**: security-scan advertised Bash support but skipped the extensionless `.githooks/pre-push`. `get_language()` now falls back to shebang detection and directory walks include extensionless `bash`/`sh` scripts.

## Tests

122 tests pass. Mirrors synced; plugin versions bumped to 0.5.107.

Fixes #2380
Fixes #2372
Fixes #2343
Fixes #2367
