### PR TITLE
chore(build): track build/scripts sources in git by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,12 +46,19 @@ ENV/
 .pytest_cache/
 .pytest_tmp/
 .ruff_cache/
-# Anchored to repo root: the legacy python build/dist outputs live at /build
-# and /dist. An unanchored `build/` rule silently shadowed
+# Legacy python build/dist outputs live at /build and /dist, anchored to repo
+# root. An unanchored `build/` rule silently shadowed
 # `src/copilot-cli/skills/build/` (the M4 generated `/build` slash-command
 # skill), which made local file-counts diverge from CI.
 /dist/
-/build/
+# The generator SOURCE tree (build/scripts, build/*.py, build/*.md) also lives
+# under build/. A blanket `/build/` would re-hide a NEW source file (git does not
+# descend into an excluded directory, so `!build/scripts/` cannot rescue it),
+# forcing `git add -f`. So do NOT exclude the build/ tree; ignore only the real
+# OUTPUT subdirs. New files under build/ track by default.
+/build/dist/
+/build/build/
+**/__pycache__/
 
 # Agent PR scratch files
 .agents/pr-comments/

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,10 @@ ENV/
 # OUTPUT subdirs. New files under build/ track by default.
 /build/dist/
 /build/build/
+/build/lib/
+/build/temp/
+/build/bdist.*/
+/build/audit/
 **/__pycache__/
 
 # Agent PR scratch files


### PR DESCRIPTION
## Summary

`.gitignore` excluded the entire `/build/` directory. Git does not descend into an excluded directory, so a new file under `build/scripts/` was silently ignored and required `git add -f`. Negations cannot rescue files once the parent is excluded.

## Fix

Remove the blanket `/build/` exclusion. The `build/` tree holds generator sources, not output. Ignore only the genuine output subdirs instead: `/build/dist/`, `/build/build/`, and `**/__pycache__/`. Reconciled the stale comment.

## References

Generator source examples: `build/scripts/*.py`, `build/generate_agents*.py`.

## Verification

A new `build/scripts/_probe.py` shows in `git status` without `-f` (`check-ignore` exit 1). Output dirs remain ignored. `src/copilot-cli/skills/build/` stays tracked.

Fixes #2383

