### PR TITLE
fix(ci): quality gate ignores superseded concurrency-cancelled runs

### DIFF
--- a/.github/workflows/ai-pr-quality-gate.yml
+++ b/.github/workflows/ai-pr-quality-gate.yml
@@ -48,8 +48,18 @@ permissions:
 
 # Mitigation: Path filtering, timeouts, and PR-specific temp files reduce impact
 
+# Issue #2347: the group key includes github.event_name so a manual
+
+# workflow_dispatch rerun does NOT share a group with the pull_request run and
+
+# therefore cannot cancel it. A cancelled pull_request run used to leave the
+
+# SHA-keyed Aggregate Results check stuck in a blocking state with no successor
+
+# run to replace it, forcing a no-op commit to unblock the PR.
+
 concurrency:
-  group: ai-quality-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: ai-quality-${{ github.event.pull_request.number || inputs.pr_number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 env:
@@ -567,8 +577,28 @@ jobs:
         if: steps.should-run.outputs.skip != 'true'
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
-      - name: Check for failed agents
+      # Issue #2347: a run cancelled by a newer run (cancel-in-progress) leaves
+      # review jobs in 'cancelled'. Detect that here and treat it like skip so
+      # the blocking gate does not fire and the SHA-keyed Aggregate Results
+      # check stays SUCCESS (neutral) instead of a stale failure.
+      - name: Detect superseded run
         if: steps.should-run.outputs.skip != 'true'
+        id: superseded
+        env:
+          SECURITY_RESULT: ${{ needs.security-review.result }}
+          QA_RESULT: ${{ needs.qa-review.result }}
+          ANALYST_RESULT: ${{ needs.analyst-review.result }}
+          ARCHITECT_RESULT: ${{ needs.architect-review.result }}
+          DEVOPS_RESULT: ${{ needs.devops-review.result }}
+          ROADMAP_RESULT: ${{ needs.roadmap-review.result }}
+          RELIABILITY_RESULT: ${{ needs.reliability-review.result }}
+          OBSERVABILITY_RESULT: ${{ needs.observability-review.result }}
+          AGENT_SAFETY_RESULT: ${{ needs.agent-safety-review.result }}
+          DECISION_RIGOR_RESULT: ${{ needs.decision-rigor-review.result }}
+        run: python3 scripts/quality_gate/check_superseded.py
+
+      - name: Check for failed agents
+        if: steps.should-run.outputs.skip != 'true' && steps.superseded.outputs.superseded != 'true'
         id: failed-agents
         env:
           SECURITY_RESULT: ${{ needs.security-review.result }}
@@ -584,7 +614,7 @@ jobs:
         run: python3 scripts/quality_gate/check_failed_agents.py
 
       - name: Download all review artifacts
-        if: steps.should-run.outputs.skip != 'true'
+        if: steps.should-run.outputs.skip != 'true' && steps.superseded.outputs.superseded != 'true'
         uses: actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317
         with:
           pattern: review-*
@@ -592,16 +622,16 @@ jobs:
           merge-multiple: true
 
       - name: Validate artifact download
-        if: steps.should-run.outputs.skip != 'true'
+        if: steps.should-run.outputs.skip != 'true' && steps.superseded.outputs.superseded != 'true'
         run: python3 scripts/quality_gate/validate_artifact_download.py
 
       - name: Load review results
-        if: steps.should-run.outputs.skip != 'true'
+        if: steps.should-run.outputs.skip != 'true' && steps.superseded.outputs.superseded != 'true'
         id: load-results
         run: python3 scripts/quality_gate/load_review_results.py
 
       - name: Aggregate Verdicts
-        if: steps.should-run.outputs.skip != 'true'
+        if: steps.should-run.outputs.skip != 'true' && steps.superseded.outputs.superseded != 'true'
         id: aggregate
         env:
           SECURITY_VERDICT: ${{ steps.load-results.outputs.security_verdict }}
@@ -633,7 +663,7 @@ jobs:
       # replace the authoritative gate in check_critical_failures.py. Swapping
       # the final gate is tracked as a follow-up (see PR description).
       - name: External-signal gate (observe)
-        if: steps.should-run.outputs.skip != 'true'
+        if: steps.should-run.outputs.skip != 'true' && steps.superseded.outputs.superseded != 'true'
         id: external-gate
         continue-on-error: true
         env:
@@ -651,7 +681,7 @@ jobs:
         run: python3 scripts/quality_gate/external_signal_gate.py
 
       - name: Generate Report
-        if: steps.should-run.outputs.skip != 'true'
+        if: steps.should-run.outputs.skip != 'true' && steps.superseded.outputs.superseded != 'true'
         id: report
         env:
           RUN_ID: ${{ github.run_id }}
@@ -686,7 +716,7 @@ jobs:
         run: python3 .github/scripts/generate_quality_report.py
 
       - name: Check for infrastructure failures and add label
-        if: steps.should-run.outputs.skip != 'true'
+        if: steps.should-run.outputs.skip != 'true' && steps.superseded.outputs.superseded != 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -694,7 +724,7 @@ jobs:
         run: python3 scripts/quality_gate/check_infrastructure_failures.py
 
       - name: Post PR Comment
-        if: steps.should-run.outputs.skip != 'true'
+        if: steps.should-run.outputs.skip != 'true' && steps.superseded.outputs.superseded != 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -703,7 +733,7 @@ jobs:
         run: python3 scripts/quality_gate/post_pr_comment.py
 
       - name: Set Job Summary
-        if: steps.should-run.outputs.skip != 'true'
+        if: steps.should-run.outputs.skip != 'true' && steps.superseded.outputs.superseded != 'true'
         shell: pwsh -NoProfile -Command "& '{0}'"
         env:
           REPORT_FILE: ${{ steps.report.outputs.report_file }}
@@ -712,7 +742,7 @@ jobs:
           Get-Content $env:REPORT_FILE | Add-Content $env:GITHUB_STEP_SUMMARY
 
       - name: Check for Critical Failures
-        if: steps.should-run.outputs.skip != 'true'
+        if: steps.should-run.outputs.skip != 'true' && steps.superseded.outputs.superseded != 'true'
         env:
           FINAL_VERDICT: ${{ steps.aggregate.outputs.final_verdict }}
           SECURITY_VERDICT: ${{ steps.aggregate.outputs.security_verdict }}

--- a/scripts/quality_gate/check_superseded.py
+++ b/scripts/quality_gate/check_superseded.py
@@ -130,7 +130,11 @@ def main(argv: list[str] | None = None) -> int:
         print("error: GITHUB_OUTPUT is not set", file=sys.stderr)
         return 2
 
-    write_superseded(Path(github_output), superseded)
+    output_path = Path(github_output).expanduser()
+    if not output_path.is_absolute():
+        output_path = REPOSITORY_ROOT / output_path
+    output_path = output_path.resolve()
+    write_superseded(output_path, superseded)
     return 0
 
 

--- a/scripts/quality_gate/check_superseded.py
+++ b/scripts/quality_gate/check_superseded.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Detect a superseded AI PR quality-gate run so it does not leave a stale block.
+
+Issue #2347. When a newer run cancels an in-progress ``AI PR Quality Gate`` run
+(``cancel-in-progress: true``), GitHub marks the in-flight review jobs as
+``cancelled``. The ``aggregate`` job still runs (``if: always()``) and, with empty
+verdicts, the downstream ``Check for Critical Failures`` step blocks the merge.
+The cancelled run's ``Aggregate Results`` check is keyed by the head SHA, so the
+PR stays ``BLOCKED`` until a successor run re-emits the check on that SHA. When
+the cancelling run has no jobs (a bare ``workflow_dispatch`` on the same head),
+no successor ever replaces it, so the PR is wedged until a no-op commit creates a
+new head.
+
+This module decides whether the current ``aggregate`` invocation is a superseded
+run that should emit a neutral, non-blocking status instead of a stale failure.
+
+Signal source: the per-agent review job results that the ``aggregate`` job reads
+from its ``needs.<agent>-review.result`` context. GitHub sets these to:
+
+    - ``cancelled`` for a job interrupted by concurrency cancellation,
+    - ``failure`` for a genuine job failure,
+    - ``success`` / ``skipped`` for a job that ran or was gated off.
+
+Decision rule (superseded => neutral, do not block):
+
+    A run is SUPERSEDED when at least one review job is ``cancelled`` AND no
+    review job is ``failure``. A cancellation with no genuine failure means the
+    run was interrupted, not that review found a blocking problem.
+
+    A run is NOT superseded when any review job is ``failure`` (a genuine failure
+    must still block) or when no review job is ``cancelled`` (a normal run).
+
+This is intentionally conservative: a single genuine ``failure`` keeps the gate
+blocking, so a real problem is never masked by a coincident cancellation.
+
+Input env vars (one ``<AGENT>_RESULT`` per quality-gate agent, mirroring
+``check_failed_agents.py``):
+    SECURITY_RESULT, QA_RESULT, ANALYST_RESULT, ARCHITECT_RESULT,
+    DEVOPS_RESULT, ROADMAP_RESULT, RELIABILITY_RESULT, OBSERVABILITY_RESULT,
+    AGENT_SAFETY_RESULT, DECISION_RIGOR_RESULT
+    GITHUB_OUTPUT - path to the GitHub Actions output file.
+
+Output:
+    ``superseded=true|false`` appended to ``GITHUB_OUTPUT``.
+
+Exit codes (ADR-035):
+    0 - results inspected and ``superseded`` written (a superseded run is not an
+        error; this step never fails the build).
+    2 - GITHUB_OUTPUT is not set (config error).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+try:
+    from .path_utils import REPOSITORY_ROOT
+except ImportError:  # pragma: no cover - script execution path
+    from path_utils import REPOSITORY_ROOT
+
+_GITHUB_SCRIPTS = REPOSITORY_ROOT / ".github" / "scripts"
+sys.path.insert(0, str(_GITHUB_SCRIPTS))
+
+from quality_gate_agents import (  # noqa: E402
+    QUALITY_GATE_AGENTS,
+    agent_env_name,
+)
+
+_CANCELLED = "cancelled"
+_FAILURE = "failure"
+
+
+def collect_results(env: dict[str, str]) -> list[str]:
+    """Return each review job's result in the canonical agent order."""
+
+    return [
+        env.get(f"{agent_env_name(agent)}_RESULT", "")
+        for agent in QUALITY_GATE_AGENTS
+    ]
+
+
+def is_superseded(results: list[str]) -> bool:
+    """Return True when the run was cancelled (superseded) without a real failure.
+
+    Superseded => at least one ``cancelled`` AND no ``failure``. A genuine
+    ``failure`` always wins so a real blocking problem is never neutralized.
+    """
+
+    has_cancelled = any(result == _CANCELLED for result in results)
+    has_failure = any(result == _FAILURE for result in results)
+    return has_cancelled and not has_failure
+
+
+def write_superseded(output_path: Path, superseded: bool) -> None:
+    """Append ``superseded=true|false`` to the GitHub output file."""
+
+    value = "true" if superseded else "false"
+    with output_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"superseded={value}\n")
+
+
+def report(results: list[str], superseded: bool) -> None:
+    """Print the per-agent results and the supersession decision."""
+
+    print("Review job results:")
+    for agent, result in zip(QUALITY_GATE_AGENTS, results):
+        print(f"  {agent}: {result}")
+    if superseded:
+        print(
+            "::notice::Run superseded by a newer AI PR Quality Gate run "
+            "(review jobs cancelled, no genuine failure). Emitting a neutral, "
+            "non-blocking status instead of a stale failure (Issue #2347)."
+        )
+    else:
+        print("Run not superseded; normal gate evaluation applies.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0]).parse_args(argv)
+
+    results = collect_results(dict(os.environ))
+    superseded = is_superseded(results)
+    report(results, superseded)
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if not github_output:
+        print("error: GITHUB_OUTPUT is not set", file=sys.stderr)
+        return 2
+
+    write_superseded(Path(github_output), superseded)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/quality_gate/test_check_superseded.py
+++ b/tests/quality_gate/test_check_superseded.py
@@ -1,0 +1,176 @@
+"""Tests for scripts/quality_gate/check_superseded.py.
+
+Pins the supersession-detection behavior that keeps a concurrency-cancelled
+``AI PR Quality Gate`` run from leaving a stale blocking status on the PR head
+(Issue #2347).
+
+Decision rule under test: a run is SUPERSEDED when at least one review job is
+``cancelled`` AND no review job is ``failure``. A genuine ``failure`` always
+keeps the gate blocking so a real problem is never masked by a coincident
+cancellation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.quality_gate.check_superseded import (
+    collect_results,
+    is_superseded,
+    main,
+    write_superseded,
+)
+
+_ALL_ENV_KEYS = [
+    "SECURITY_RESULT",
+    "QA_RESULT",
+    "ANALYST_RESULT",
+    "ARCHITECT_RESULT",
+    "DEVOPS_RESULT",
+    "ROADMAP_RESULT",
+    "RELIABILITY_RESULT",
+    "OBSERVABILITY_RESULT",
+    "AGENT_SAFETY_RESULT",
+    "DECISION_RIGOR_RESULT",
+]
+
+
+def _all_env(value: str) -> dict[str, str]:
+    return {key: value for key in _ALL_ENV_KEYS}
+
+
+# ---------------------------------------------------------------------------
+# collect_results
+# ---------------------------------------------------------------------------
+
+
+class TestCollectResults:
+    def test_returns_ten_results_in_canonical_order(self) -> None:
+        env = _all_env("success")
+        env["SECURITY_RESULT"] = "cancelled"
+        env["DECISION_RIGOR_RESULT"] = "failure"
+        results = collect_results(env)
+        assert len(results) == 10
+        assert results[0] == "cancelled"
+        assert results[-1] == "failure"
+
+    def test_missing_env_yields_empty_string(self) -> None:
+        results = collect_results({})
+        assert results == [""] * 10
+
+
+# ---------------------------------------------------------------------------
+# is_superseded
+# ---------------------------------------------------------------------------
+
+
+class TestIsSuperseded:
+    def test_cancelled_with_success_is_superseded(self) -> None:
+        # Run interrupted mid-flight: some reviews finished, no genuine failure.
+        results = ["cancelled"] + ["success"] * 9
+        assert is_superseded(results) is True
+
+    def test_all_cancelled_is_superseded(self) -> None:
+        assert is_superseded(["cancelled"] * 10) is True
+
+    def test_cancelled_with_skipped_is_superseded(self) -> None:
+        results = ["cancelled"] + ["skipped"] * 9
+        assert is_superseded(results) is True
+
+    def test_cancelled_with_failure_is_not_superseded(self) -> None:
+        # A genuine failure must still block, even alongside a cancellation.
+        results = ["cancelled", "failure"] + ["success"] * 8
+        assert is_superseded(results) is False
+
+    def test_all_success_is_not_superseded(self) -> None:
+        assert is_superseded(["success"] * 10) is False
+
+    def test_all_skipped_is_not_superseded(self) -> None:
+        assert is_superseded(["skipped"] * 10) is False
+
+    def test_only_failure_is_not_superseded(self) -> None:
+        results = ["failure"] + ["success"] * 9
+        assert is_superseded(results) is False
+
+    def test_all_empty_is_not_superseded(self) -> None:
+        # Empty strings (no result reported) are neither cancelled nor failure.
+        assert is_superseded([""] * 10) is False
+
+
+# ---------------------------------------------------------------------------
+# write_superseded
+# ---------------------------------------------------------------------------
+
+
+class TestWriteSuperseded:
+    def test_writes_true(self, tmp_path: Path) -> None:
+        output = tmp_path / "out"
+        output.touch()
+        write_superseded(output, True)
+        assert output.read_text(encoding="utf-8") == "superseded=true\n"
+
+    def test_writes_false(self, tmp_path: Path) -> None:
+        output = tmp_path / "out"
+        output.touch()
+        write_superseded(output, False)
+        assert output.read_text(encoding="utf-8") == "superseded=false\n"
+
+
+# ---------------------------------------------------------------------------
+# main (CLI / exit codes)
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_superseded_run_writes_true_and_notices(
+        self, tmp_path, monkeypatch, capsys
+    ) -> None:
+        output = tmp_path / "gh_output"
+        output.touch()
+        for key in _ALL_ENV_KEYS:
+            monkeypatch.setenv(key, "success")
+        monkeypatch.setenv("QA_RESULT", "cancelled")
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+        rc = main([])
+        assert rc == 0
+        assert "superseded=true" in output.read_text(encoding="utf-8")
+        captured = capsys.readouterr()
+        assert "::notice::Run superseded" in captured.out
+
+    def test_genuine_failure_writes_false(self, tmp_path, monkeypatch) -> None:
+        output = tmp_path / "gh_output"
+        output.touch()
+        for key in _ALL_ENV_KEYS:
+            monkeypatch.setenv(key, "success")
+        monkeypatch.setenv("ANALYST_RESULT", "cancelled")
+        monkeypatch.setenv("DEVOPS_RESULT", "failure")
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+        rc = main([])
+        assert rc == 0
+        assert "superseded=false" in output.read_text(encoding="utf-8")
+
+    def test_normal_run_writes_false(self, tmp_path, monkeypatch) -> None:
+        output = tmp_path / "gh_output"
+        output.touch()
+        for key in _ALL_ENV_KEYS:
+            monkeypatch.setenv(key, "success")
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+        rc = main([])
+        assert rc == 0
+        assert "superseded=false" in output.read_text(encoding="utf-8")
+
+    def test_superseded_run_does_not_fail_step(self, tmp_path, monkeypatch) -> None:
+        output = tmp_path / "gh_output"
+        output.touch()
+        for key in _ALL_ENV_KEYS:
+            monkeypatch.setenv(key, "cancelled")
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+        rc = main([])
+        assert rc == 0
+
+    def test_missing_github_output_returns_two(self, monkeypatch) -> None:
+        for key in _ALL_ENV_KEYS:
+            monkeypatch.setenv(key, "cancelled")
+        monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+        rc = main([])
+        assert rc == 2


### PR DESCRIPTION
## Summary

`AI PR Quality Gate` could leave a PR BLOCKED after a concurrency-cancelled run, forcing a no-op commit to unblock. Two compounding causes, both fixed.

## Root cause

1. The concurrency group was keyed only on PR number, so a manual `workflow_dispatch` rerun shared one group with the `pull_request` run and either cancelled the other. A bare dispatch run with 0 jobs cancelled the PR run and never re-emitted the SHA-keyed `Aggregate Results` check.
2. The `aggregate` job runs `if: always()`; on cancellation the verdicts are empty and the aggregate critical-failure check blocked on missing verdicts, treating a supersession as a real failure.

## Fix

- Updated `.github/workflows/ai-pr-quality-gate.yml` so the concurrency group is now `ai-quality-${PR_NUMBER}-${github.event_name}`, separating the two event types (the event name is a fixed enum, no injection surface).
- New `scripts/quality_gate/check_superseded.py`: a run is superseded when at least one job is `cancelled` AND none is `failure`. The aggregate job gates its work and block steps on the result, so a superseded run ends GREEN (neutral), like the existing no-relevant-changes skip. A genuine failure still blocks.

ADR-006: the decision logic lives in a tested Python script, not YAML.

## Tests

`tests/quality_gate/test_check_superseded.py`: 17 cases. actionlint clean; `gh act -n` dry-run parses with the new step. Full quality_gate suite: 189 passed.

Fixes #2347

