### PR TITLE
refactor(github-skill): standardize output envelope across issue, milestone, reaction scripts

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.114",
+  "version": "0.5.116",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.113",
+  "version": "0.5.114",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github
-version: 4.0.0
+version: 4.1.0
 model: claude-opus-4-6
 description: Execute GitHub operations (PRs, issues, milestones, labels, comments, merges)
   using Python scripts with structured output and error handling. Use when working

--- a/.claude/skills/github/scripts/issue/edit_issue_body.py
+++ b/.claude/skills/github/scripts/issue/edit_issue_body.py
@@ -17,7 +17,6 @@ Exit codes (per ADR-035):
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -40,6 +39,11 @@ if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)
 
 from github_core.api import error_and_exit, resolve_repo_params  # noqa: E402
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 from github_core.validation import assert_valid_body_file  # noqa: E402
 
 
@@ -62,12 +66,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to file containing new body text",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     if args.body is None and args.body_file is None:
         error_and_exit("Must provide --body or --body-file", 1)
@@ -131,17 +137,17 @@ def main(argv: list[str] | None = None) -> int:
             error_and_exit(f"Auth error: {error_str}", 4)
         error_and_exit(f"Failed to edit issue: {error_str}", 3)
 
-    # Emit structured JSON to match sibling scripts (new_issue.py,
-    # post_issue_comment.py). PR #1965 cluster R.
-    print(
-        json.dumps(
-            {
-                "issue": args.issue,
-                "status": "updated",
-                "repo": f"{owner}/{repo}",
-            },
-            indent=2,
-        )
+    # Emit the canonical skill output envelope (ADR-056) to match sibling
+    # scripts (new_issue.py, post_issue_comment.py). Issue #2388.
+    write_skill_output(
+        {
+            "issue": args.issue,
+            "status": "updated",
+            "repo": f"{owner}/{repo}",
+        },
+        output_format=fmt,
+        human_summary=f"Updated body of issue #{args.issue} in {owner}/{repo}",
+        script_name="edit_issue_body.py",
     )
     return 0
 

--- a/.claude/skills/github/scripts/issue/invoke_copilot_assignment.py
+++ b/.claude/skills/github/scripts/issue/invoke_copilot_assignment.py
@@ -236,7 +236,7 @@ def _get_coderabbit_plan(
     prs_pattern = f"(?:<b>)?{prs_raw}(?:</b>)?"
 
     for comment in rabbit_comments:
-        body = comment.get("body", "")
+        body = comment.get("body") or ""
 
         # nosemgrep: skill-ldap-injection
         m = re.search(f"{impl_pattern}([\\s\\S]*?)(?=##|$)", body)
@@ -587,6 +587,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
 
     # Dry-run mode
     if args.dry_run:
+        dry_run_output = {
+            "action": "dry_run",
+            "issue_number": issue_number,
+            "owner": owner,
+            "repo": repo,
+            "has_synthesizable_content": has_content,
+            "existing_synthesis_id": existing_synthesis["id"] if existing_synthesis else None,
+            "would_assign": True,
+            "synthesis_body": None,
+        }
         if has_content:
             synthesis_body = _build_synthesis_comment(
                 config["synthesis"]["marker"],
@@ -594,6 +604,15 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
                 coderabbit_plan,
                 ai_triage,
             )
+            dry_run_output["synthesis_body"] = synthesis_body
+            if fmt == "json":
+                write_skill_output(
+                    dry_run_output,
+                    output_format=fmt,
+                    human_summary=f"Prepared dry-run synthesis for issue #{issue_number}",
+                    script_name="invoke_copilot_assignment.py",
+                )
+                return 0
             print("\n=== SYNTHESIS PREVIEW ===")
             print(synthesis_body)
             print("=== END PREVIEW ===")
@@ -602,6 +621,15 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
             else:
                 print("\nWould CREATE new synthesis comment")
         else:
+            if fmt == "json":
+                write_skill_output(
+                    dry_run_output,
+                    output_format=fmt,
+                    human_summary=f"No synthesizable content found for issue #{issue_number}",
+                    status="WARNING",
+                    script_name="invoke_copilot_assignment.py",
+                )
+                return 0
             print("\nNo synthesizable content found, would SKIP synthesis comment")
         print(f"Would ASSIGN copilot-swe-agent to issue #{issue_number}")
         return 0

--- a/.claude/skills/github/scripts/issue/invoke_copilot_assignment.py
+++ b/.claude/skills/github/scripts/issue/invoke_copilot_assignment.py
@@ -52,6 +52,11 @@ from github_core.api import (  # noqa: E402
     resolve_repo_params,
     update_issue_comment,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -233,7 +238,8 @@ def _get_coderabbit_plan(
     for comment in rabbit_comments:
         body = comment.get("body", "")
 
-        m = re.search(f"{impl_pattern}([\\s\\S]*?)(?=##|$)", body)  # nosemgrep: skill-ldap-injection
+        # nosemgrep: skill-ldap-injection
+        m = re.search(f"{impl_pattern}([\\s\\S]*?)(?=##|$)", body)
         if m:
             plan["implementation"] = m.group(1).strip()
 
@@ -478,6 +484,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Preview synthesis comment without posting or assigning",
     )
+    add_output_format_arg(parser)
     return parser
 
 
@@ -488,13 +495,15 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of complex PS1
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
     owner, repo = resolved.owner, resolved.repo
     issue_number: int = args.issue_number
 
-    print(f"Processing issue #{issue_number} in {owner}/{repo}")
+    if fmt != "json":
+        print(f"Processing issue #{issue_number} in {owner}/{repo}")
 
     config = _load_synthesis_config(args.config_path)
 
@@ -519,18 +528,18 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         error_and_exit(f"Failed to get issue: {error_str}", 3)
 
     issue = json.loads(issue_result.stdout)
-    print(f"Issue: {issue.get('title', '')}")
+    print(f"Issue: {issue.get('title', '')}", file=sys.stderr)
 
     # Fetch comments
     comments = get_issue_comments(owner, repo, issue_number)
-    print(f"Found {len(comments)} comments")
+    print(f"Found {len(comments)} comments", file=sys.stderr)
 
     trusted_users = (
         config["trusted_sources"]["maintainers"]
         + config["trusted_sources"]["ai_agents"]
     )
     trusted_comments = get_trusted_source_comments(comments, trusted_users)
-    print(f"Found {len(trusted_comments)} comments from trusted sources")
+    print(f"Found {len(trusted_comments)} comments from trusted sources", file=sys.stderr)
 
     # PrepareContextOnly mode
     if args.prepare_context_only:
@@ -545,7 +554,12 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
             "owner": owner,
             "repo": repo,
         }
-        print(json.dumps(output, indent=2))
+        write_skill_output(
+            output,
+            output_format=fmt,
+            human_summary=f"Prepared context file for issue #{issue_number}",
+            script_name="invoke_copilot_assignment.py",
+        )
 
         _write_github_output({
             "context_file": context_file,
@@ -605,29 +619,34 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         )
 
         if existing_synthesis:
-            print(f"Updating existing synthesis comment (ID: {existing_synthesis['id']})")
+            print(
+                f"Updating existing synthesis comment (ID: {existing_synthesis['id']})",
+                file=sys.stderr,
+            )
             response = update_issue_comment(owner, repo, existing_synthesis["id"], synthesis_body)
             action = "Updated"
         else:
-            print("Creating new synthesis comment")
+            print("Creating new synthesis comment", file=sys.stderr)
             response = create_issue_comment(owner, repo, issue_number, synthesis_body)
             action = "Created"
-        print(f"{action} synthesis comment: {response.get('html_url', 'N/A')}")
+        print(f"{action} synthesis comment: {response.get('html_url', 'N/A')}", file=sys.stderr)
     else:
-        print("No synthesizable content found, skipping synthesis comment")
+        print("No synthesizable content found, skipping synthesis comment", file=sys.stderr)
 
     # Assign Copilot
     assigned = False
     if not args.skip_assignment:
-        print("Assigning copilot-swe-agent...")
+        print("Assigning copilot-swe-agent...", file=sys.stderr)
         assigned = _assign_copilot(owner, repo, issue_number)
         if assigned:
-            print(f"Assigned copilot-swe-agent to issue #{issue_number}")
+            print(f"Assigned copilot-swe-agent to issue #{issue_number}", file=sys.stderr)
     else:
-        print("Skipping assignment (handled by workflow with COPILOT_GITHUB_TOKEN)")
+        print(
+            "Skipping assignment (handled by workflow with COPILOT_GITHUB_TOKEN)",
+            file=sys.stderr,
+        )
 
     output = {
-        "success": True,
         "action": action,
         "issue_number": issue_number,
         "comment_id": response["id"] if response else None,
@@ -635,7 +654,12 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         "assigned": assigned,
         "marker": config["synthesis"]["marker"],
     }
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        output,
+        output_format=fmt,
+        human_summary=f"{action} synthesis for issue #{issue_number}",
+        script_name="invoke_copilot_assignment.py",
+    )
     return 0
 
 

--- a/.claude/skills/github/scripts/issue/new_issue.py
+++ b/.claude/skills/github/scripts/issue/new_issue.py
@@ -14,7 +14,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 import subprocess
@@ -41,6 +40,11 @@ from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     error_and_exit,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
 )
 
 
@@ -74,11 +78,13 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help='Comma-separated list of labels (e.g., "bug,P1,needs-triage")',
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -115,13 +121,16 @@ def main(argv: list[str] | None = None) -> int:
 
     issue_number = int(match.group(1))
 
-    output = {
-        "success": True,
-        "issue_number": issue_number,
-        "url": output_text,
-        "title": args.title,
-    }
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        {
+            "issue_number": issue_number,
+            "url": output_text,
+            "title": args.title,
+        },
+        output_format=fmt,
+        human_summary=f"Created issue #{issue_number}: {args.title}",
+        script_name="new_issue.py",
+    )
 
     _write_github_output({
         "success": "true",

--- a/.claude/skills/github/scripts/issue/post_issue_comment.py
+++ b/.claude/skills/github/scripts/issue/post_issue_comment.py
@@ -46,6 +46,13 @@ from github_core.api import (  # noqa: E402
     resolve_repo_params,
     update_issue_comment,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
+
+_SCRIPT_NAME = "post_issue_comment.py"
 
 _403_PATTERN = re.compile(
     r"((?<!\d)403(?!\d)|\bforbidden\b|Resource not accessible by integration)",
@@ -156,11 +163,13 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Update existing comment instead of skipping when marker found",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of PS1 logic
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -200,16 +209,20 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
 
             if existing is not None:
                 if args.update_if_exists:
-                    print(f"Comment with marker '{args.marker}' exists. Updating...")
+                    if fmt != "json":
+                        print(f"Comment with marker '{args.marker}' exists. Updating...")
                     body = _prepend_marker(body, marker_html)
                     response = update_issue_comment(owner, repo, existing["id"], body)
-                    print(f"Updated comment on issue #{issue}")
-                    print(json.dumps({
-                        "success": True,
-                        "issue": issue,
-                        "comment_id": response["id"],
-                        "updated": True,
-                    }, indent=2))
+                    write_skill_output(
+                        {
+                            "issue": issue,
+                            "comment_id": response["id"],
+                            "updated": True,
+                        },
+                        output_format=fmt,
+                        human_summary=f"Updated comment on issue #{issue}",
+                        script_name=_SCRIPT_NAME,
+                    )
                     _write_github_output({
                         "success": "true",
                         "skipped": "false",
@@ -222,13 +235,18 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
                     })
                     return 0
 
-                print(f"Comment with marker '{args.marker}' already exists. Skipping.")
-                print(json.dumps({
-                    "success": True,
-                    "issue": issue,
-                    "marker": args.marker,
-                    "skipped": True,
-                }, indent=2))
+                write_skill_output(
+                    {
+                        "issue": issue,
+                        "marker": args.marker,
+                        "skipped": True,
+                    },
+                    output_format=fmt,
+                    human_summary=(
+                        f"Comment with marker '{args.marker}' already exists. Skipping."
+                    ),
+                    script_name=_SCRIPT_NAME,
+                )
                 _write_github_output({
                     "success": "true",
                     "skipped": "true",
@@ -277,6 +295,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         response = json.loads(result.stdout)
     except json.JSONDecodeError:
         print(f"Posted comment to issue #{issue} (response parsing failed)", file=sys.stderr)
+        write_skill_output(
+            {
+                "issue": issue,
+                "skipped": False,
+                "parse_error": True,
+            },
+            output_format=fmt,
+            human_summary=f"Posted comment to issue #{issue} (response parsing failed)",
+            script_name=_SCRIPT_NAME,
+        )
         _write_github_output({
             "success": "true",
             "skipped": "false",
@@ -285,13 +313,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         })
         return 0
 
-    output = {
-        "success": True,
-        "issue": issue,
-        "comment_id": response["id"],
-        "skipped": False,
-    }
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        {
+            "issue": issue,
+            "comment_id": response["id"],
+            "skipped": False,
+        },
+        output_format=fmt,
+        human_summary=f"Posted comment to issue #{issue}",
+        script_name=_SCRIPT_NAME,
+    )
 
     outputs: dict[str, str] = {
         "success": "true",

--- a/.claude/skills/github/scripts/issue/set_issue_milestone.py
+++ b/.claude/skills/github/scripts/issue/set_issue_milestone.py
@@ -15,7 +15,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -40,6 +39,11 @@ from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     error_and_exit,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
 )
 
 
@@ -103,11 +107,25 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Replace existing milestone",
     )
+    add_output_format_arg(parser)
     return parser
+
+
+def _emit(output: dict, fmt: str) -> None:
+    """Emit the canonical envelope for the milestone result payload."""
+    write_skill_output(
+        output,
+        output_format=fmt,
+        human_summary=(
+            f"Issue #{output['issue']} milestone {output['action']}"
+        ),
+        script_name="set_issue_milestone.py",
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -119,7 +137,6 @@ def main(argv: list[str] | None = None) -> int:
     current_milestone = _get_current_milestone(owner, repo, args.issue)
 
     output = {
-        "success": False,
         "issue": args.issue,
         "milestone": None,
         "previous_milestone": current_milestone,
@@ -128,9 +145,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.clear:
         if not current_milestone:
-            output["success"] = True
             output["action"] = "no_change"
-            print(json.dumps(output, indent=2))
+            _emit(output, fmt)
             _write_github_output({
                 "success": "true",
                 "issue": str(args.issue),
@@ -151,9 +167,8 @@ def main(argv: list[str] | None = None) -> int:
         if result.returncode != 0:
             error_and_exit("Failed to clear milestone", 3)
 
-        output["success"] = True
         output["action"] = "cleared"
-        print(json.dumps(output, indent=2))
+        _emit(output, fmt)
         _write_github_output({
             "success": "true",
             "issue": str(args.issue),
@@ -170,10 +185,9 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     if current_milestone == args.milestone:
-        output["success"] = True
         output["milestone"] = args.milestone
         output["action"] = "no_change"
-        print(json.dumps(output, indent=2))
+        _emit(output, fmt)
         _write_github_output({
             "success": "true",
             "issue": str(args.issue),
@@ -203,10 +217,9 @@ def main(argv: list[str] | None = None) -> int:
         error_and_exit("Failed to set milestone", 3)
 
     action = "replaced" if current_milestone else "assigned"
-    output["success"] = True
     output["milestone"] = args.milestone
     output["action"] = action
-    print(json.dumps(output, indent=2))
+    _emit(output, fmt)
 
     gh_outputs: dict[str, str] = {
         "success": "true",

--- a/.claude/skills/github/scripts/milestone/get_latest_semantic_milestone.py
+++ b/.claude/skills/github/scripts/milestone/get_latest_semantic_milestone.py
@@ -43,6 +43,7 @@ from github_core.api import (  # noqa: E402
 from github_core.output import (  # noqa: E402
     add_output_format_arg,
     get_output_format,
+    write_skill_error,
     write_skill_output,
 )
 
@@ -102,12 +103,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if not milestones:
         print(f"No open milestones found in {owner}/{repo}", file=sys.stderr)
-        write_skill_output(
-            {"title": "", "number": 0, "found": False},
+        write_skill_error(
+            f"No open milestones found in {owner}/{repo}",
+            2,
+            error_type="NotFound",
             output_format=fmt,
-            human_summary=f"No open milestones found in {owner}/{repo}",
-            status="WARNING",
             script_name="get_latest_semantic_milestone.py",
+            extra={"title": "", "number": 0, "found": False},
         )
         _write_github_output({
             "milestone_title": "",
@@ -131,12 +133,13 @@ def main(argv: list[str] | None = None) -> int:
             f"No semantic version milestones found. Available: {available}",
             file=sys.stderr,
         )
-        write_skill_output(
-            {"title": "", "number": 0, "found": False},
+        write_skill_error(
+            f"No semantic version milestones found. Available: {available}",
+            2,
+            error_type="NotFound",
             output_format=fmt,
-            human_summary=f"No semantic version milestones found. Available: {available}",
-            status="WARNING",
             script_name="get_latest_semantic_milestone.py",
+            extra={"title": "", "number": 0, "found": False},
         )
         _write_github_output({
             "milestone_title": "",

--- a/.claude/skills/github/scripts/milestone/get_latest_semantic_milestone.py
+++ b/.claude/skills/github/scripts/milestone/get_latest_semantic_milestone.py
@@ -15,7 +15,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 import sys
@@ -40,6 +39,11 @@ from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     gh_api_paginated,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
 )
 
 _SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
@@ -81,11 +85,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--owner", default="", help="Repository owner")
     parser.add_argument("--repo", default="", help="Repository name")
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -96,8 +102,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if not milestones:
         print(f"No open milestones found in {owner}/{repo}", file=sys.stderr)
-        result = {"title": "", "number": 0, "found": False}
-        print(json.dumps(result, indent=2))
+        write_skill_output(
+            {"title": "", "number": 0, "found": False},
+            output_format=fmt,
+            human_summary=f"No open milestones found in {owner}/{repo}",
+            status="WARNING",
+            script_name="get_latest_semantic_milestone.py",
+        )
         _write_github_output({
             "milestone_title": "",
             "milestone_number": "0",
@@ -120,8 +131,13 @@ def main(argv: list[str] | None = None) -> int:
             f"No semantic version milestones found. Available: {available}",
             file=sys.stderr,
         )
-        result = {"title": "", "number": 0, "found": False}
-        print(json.dumps(result, indent=2))
+        write_skill_output(
+            {"title": "", "number": 0, "found": False},
+            output_format=fmt,
+            human_summary=f"No semantic version milestones found. Available: {available}",
+            status="WARNING",
+            script_name="get_latest_semantic_milestone.py",
+        )
         _write_github_output({
             "milestone_title": "",
             "milestone_number": "0",
@@ -139,12 +155,18 @@ def main(argv: list[str] | None = None) -> int:
 
     latest = max(semantic, key=lambda m: _parse_semver_tuple(m["title"]))
 
-    result = {
-        "title": latest["title"],
-        "number": latest["number"],
-        "found": True,
-    }
-    print(json.dumps(result, indent=2))
+    write_skill_output(
+        {
+            "title": latest["title"],
+            "number": latest["number"],
+            "found": True,
+        },
+        output_format=fmt,
+        human_summary=(
+            f"Latest semantic milestone: {latest['title']} (ID: {latest['number']})"
+        ),
+        script_name="get_latest_semantic_milestone.py",
+    )
 
     _write_github_output({
         "milestone_title": latest["title"],

--- a/.claude/skills/github/scripts/milestone/set_item_milestone.py
+++ b/.claude/skills/github/scripts/milestone/set_item_milestone.py
@@ -44,6 +44,11 @@ from github_core.api import (  # noqa: E402
     gh_api_paginated,
     resolve_repo_params,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 
 _SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
 
@@ -181,11 +186,13 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help="Specific milestone to assign (auto-detects if omitted)",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     item_type: str = args.item_type
     item_number: int = args.item_number
@@ -201,16 +208,22 @@ def main(argv: list[str] | None = None) -> int:
             f"Already has milestone '{existing}'. "
             "No action taken (preserving manual assignments)."
         )
-        print(f"{item_type} #{item_number} already has milestone: {existing}")
-        result = {
-            "success": True,
-            "item_type": item_type,
-            "item_number": item_number,
-            "milestone": existing,
-            "action": "skipped",
-            "message": msg,
-        }
-        print(json.dumps(result, indent=2))
+        if fmt != "json":
+            print(f"{item_type} #{item_number} already has milestone: {existing}")
+        write_skill_output(
+            {
+                "item_type": item_type,
+                "item_number": item_number,
+                "milestone": existing,
+                "action": "skipped",
+                "message": msg,
+            },
+            output_format=fmt,
+            human_summary=(
+                f"{item_type} #{item_number} already has milestone: {existing}"
+            ),
+            script_name="set_item_milestone.py",
+        )
         _write_result(True, item_type, item_number, existing, "skipped", msg)
         return 0
 
@@ -233,16 +246,20 @@ def main(argv: list[str] | None = None) -> int:
     _assign_milestone(owner, repo, item_number, milestone_title)
 
     msg = f"Assigned milestone '{milestone_title}'."
-    print(f"Successfully assigned milestone '{milestone_title}' to {item_type} #{item_number}")
-    result = {
-        "success": True,
-        "item_type": item_type,
-        "item_number": item_number,
-        "milestone": milestone_title,
-        "action": "assigned",
-        "message": msg,
-    }
-    print(json.dumps(result, indent=2))
+    write_skill_output(
+        {
+            "item_type": item_type,
+            "item_number": item_number,
+            "milestone": milestone_title,
+            "action": "assigned",
+            "message": msg,
+        },
+        output_format=fmt,
+        human_summary=(
+            f"Assigned milestone '{milestone_title}' to {item_type} #{item_number}"
+        ),
+        script_name="set_item_milestone.py",
+    )
     _write_result(True, item_type, item_number, milestone_title, "assigned", msg)
     return 0
 

--- a/.claude/skills/github/scripts/milestone/set_item_milestone.py
+++ b/.claude/skills/github/scripts/milestone/set_item_milestone.py
@@ -242,7 +242,7 @@ def main(argv: list[str] | None = None) -> int:
         milestone_title = str(detection["title"])
 
     # Assign
-    print(f"Assigning milestone '{milestone_title}' to {item_type} #{item_number}")
+    print(f"Assigning milestone '{milestone_title}' to {item_type} #{item_number}", file=sys.stderr)
     _assign_milestone(owner, repo, item_number, milestone_title)
 
     msg = f"Assigned milestone '{milestone_title}'."

--- a/.claude/skills/github/scripts/notifications/get_actionable_items.py
+++ b/.claude/skills/github/scripts/notifications/get_actionable_items.py
@@ -48,6 +48,11 @@ from github_core.api import (  # noqa: E402
     error_and_exit,
     resolve_repo_params,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -60,6 +65,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--limit", type=int, default=20,
         help="Max items per category (1-100, default: 20)",
     )
+    add_output_format_arg(parser)
     return parser
 
 
@@ -215,6 +221,7 @@ def _get_assigned_issues(repo_flag: str, user: str, limit: int) -> list[dict]:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     if not 1 <= args.limit <= 100:
         error_and_exit("Limit must be between 1 and 100.", 1)
@@ -236,8 +243,7 @@ def main(argv: list[str] | None = None) -> int:
     authored_prs = _get_authored_prs(repo_flag, user, args.limit)
     assigned_issues = _get_assigned_issues(repo_flag, user, args.limit)
 
-    output = {
-        "success": True,
+    data = {
         "user": user,
         "repo": repo_flag,
         "notifications_api_available": notifications_available,
@@ -253,7 +259,18 @@ def main(argv: list[str] | None = None) -> int:
         },
     }
 
-    print(json.dumps(output, indent=2))
+    total = (
+        data["summary"]["notifications"]
+        + data["summary"]["review_requests"]
+        + data["summary"]["authored_prs"]
+        + data["summary"]["assigned_issues"]
+    )
+    write_skill_output(
+        data,
+        output_format=fmt,
+        human_summary=f"Found {total} actionable item(s) for {user} in {repo_flag}",
+        script_name="get_actionable_items.py",
+    )
     return 0
 
 

--- a/.claude/skills/github/scripts/reactions/add_comment_reaction.py
+++ b/.claude/skills/github/scripts/reactions/add_comment_reaction.py
@@ -14,7 +14,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -38,6 +37,11 @@ if _lib_dir not in sys.path:
 from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
 )
 
 REACTION_EMOJI: dict[str, str] = {
@@ -79,11 +83,13 @@ def build_parser() -> argparse.ArgumentParser:
         choices=VALID_REACTIONS,
         help="Reaction type",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -140,7 +146,16 @@ def main(argv: list[str] | None = None) -> int:
         "results": results,
     }
 
-    print(json.dumps(summary, indent=2))
+    write_skill_output(
+        summary,
+        output_format=fmt,
+        human_summary=(
+            f"Applied '{args.reaction}' to {succeeded}/{len(args.comment_id)} "
+            f"comment(s) ({failed} failed)"
+        ),
+        status="PASS" if failed == 0 else "FAIL",
+        script_name="add_comment_reaction.py",
+    )
 
     if failed > 0:
         return 3

--- a/.claude/skills/github/scripts/reactions/add_comment_reaction.py
+++ b/.claude/skills/github/scripts/reactions/add_comment_reaction.py
@@ -41,6 +41,7 @@ from github_core.api import (  # noqa: E402
 from github_core.output import (  # noqa: E402
     add_output_format_arg,
     get_output_format,
+    write_skill_error,
     write_skill_output,
 )
 
@@ -146,6 +147,20 @@ def main(argv: list[str] | None = None) -> int:
         "results": results,
     }
 
+    if failed > 0:
+        write_skill_error(
+            (
+                f"Applied '{args.reaction}' to {succeeded}/{len(args.comment_id)} "
+                f"comment(s); {failed} failed"
+            ),
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="add_comment_reaction.py",
+            extra=summary,
+        )
+        return 3
+
     write_skill_output(
         summary,
         output_format=fmt,
@@ -153,13 +168,8 @@ def main(argv: list[str] | None = None) -> int:
             f"Applied '{args.reaction}' to {succeeded}/{len(args.comment_id)} "
             f"comment(s) ({failed} failed)"
         ),
-        status="PASS" if failed == 0 else "FAIL",
         script_name="add_comment_reaction.py",
     )
-
-    if failed > 0:
-        return 3
-
     return 0
 
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.114",
+  "version": "0.5.116",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.113",
+  "version": "0.5.114",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/github/SKILL.md
+++ b/src/copilot-cli/skills/github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github
-version: 4.0.0
+version: 4.1.0
 model: claude-opus-4-6
 description: Execute GitHub operations (PRs, issues, milestones, labels, comments, merges)
   using Python scripts with structured output and error handling. Use when working

--- a/src/copilot-cli/skills/github/scripts/issue/edit_issue_body.py
+++ b/src/copilot-cli/skills/github/scripts/issue/edit_issue_body.py
@@ -17,7 +17,6 @@ Exit codes (per ADR-035):
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -40,6 +39,11 @@ if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)
 
 from github_core.api import error_and_exit, resolve_repo_params  # noqa: E402
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 from github_core.validation import assert_valid_body_file  # noqa: E402
 
 
@@ -62,12 +66,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to file containing new body text",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     if args.body is None and args.body_file is None:
         error_and_exit("Must provide --body or --body-file", 1)
@@ -131,17 +137,17 @@ def main(argv: list[str] | None = None) -> int:
             error_and_exit(f"Auth error: {error_str}", 4)
         error_and_exit(f"Failed to edit issue: {error_str}", 3)
 
-    # Emit structured JSON to match sibling scripts (new_issue.py,
-    # post_issue_comment.py). PR #1965 cluster R.
-    print(
-        json.dumps(
-            {
-                "issue": args.issue,
-                "status": "updated",
-                "repo": f"{owner}/{repo}",
-            },
-            indent=2,
-        )
+    # Emit the canonical skill output envelope (ADR-056) to match sibling
+    # scripts (new_issue.py, post_issue_comment.py). Issue #2388.
+    write_skill_output(
+        {
+            "issue": args.issue,
+            "status": "updated",
+            "repo": f"{owner}/{repo}",
+        },
+        output_format=fmt,
+        human_summary=f"Updated body of issue #{args.issue} in {owner}/{repo}",
+        script_name="edit_issue_body.py",
     )
     return 0
 

--- a/src/copilot-cli/skills/github/scripts/issue/invoke_copilot_assignment.py
+++ b/src/copilot-cli/skills/github/scripts/issue/invoke_copilot_assignment.py
@@ -236,7 +236,7 @@ def _get_coderabbit_plan(
     prs_pattern = f"(?:<b>)?{prs_raw}(?:</b>)?"
 
     for comment in rabbit_comments:
-        body = comment.get("body", "")
+        body = comment.get("body") or ""
 
         # nosemgrep: skill-ldap-injection
         m = re.search(f"{impl_pattern}([\\s\\S]*?)(?=##|$)", body)
@@ -587,6 +587,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
 
     # Dry-run mode
     if args.dry_run:
+        dry_run_output = {
+            "action": "dry_run",
+            "issue_number": issue_number,
+            "owner": owner,
+            "repo": repo,
+            "has_synthesizable_content": has_content,
+            "existing_synthesis_id": existing_synthesis["id"] if existing_synthesis else None,
+            "would_assign": True,
+            "synthesis_body": None,
+        }
         if has_content:
             synthesis_body = _build_synthesis_comment(
                 config["synthesis"]["marker"],
@@ -594,6 +604,15 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
                 coderabbit_plan,
                 ai_triage,
             )
+            dry_run_output["synthesis_body"] = synthesis_body
+            if fmt == "json":
+                write_skill_output(
+                    dry_run_output,
+                    output_format=fmt,
+                    human_summary=f"Prepared dry-run synthesis for issue #{issue_number}",
+                    script_name="invoke_copilot_assignment.py",
+                )
+                return 0
             print("\n=== SYNTHESIS PREVIEW ===")
             print(synthesis_body)
             print("=== END PREVIEW ===")
@@ -602,6 +621,15 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
             else:
                 print("\nWould CREATE new synthesis comment")
         else:
+            if fmt == "json":
+                write_skill_output(
+                    dry_run_output,
+                    output_format=fmt,
+                    human_summary=f"No synthesizable content found for issue #{issue_number}",
+                    status="WARNING",
+                    script_name="invoke_copilot_assignment.py",
+                )
+                return 0
             print("\nNo synthesizable content found, would SKIP synthesis comment")
         print(f"Would ASSIGN copilot-swe-agent to issue #{issue_number}")
         return 0

--- a/src/copilot-cli/skills/github/scripts/issue/invoke_copilot_assignment.py
+++ b/src/copilot-cli/skills/github/scripts/issue/invoke_copilot_assignment.py
@@ -52,6 +52,11 @@ from github_core.api import (  # noqa: E402
     resolve_repo_params,
     update_issue_comment,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -233,7 +238,8 @@ def _get_coderabbit_plan(
     for comment in rabbit_comments:
         body = comment.get("body", "")
 
-        m = re.search(f"{impl_pattern}([\\s\\S]*?)(?=##|$)", body)  # nosemgrep: skill-ldap-injection
+        # nosemgrep: skill-ldap-injection
+        m = re.search(f"{impl_pattern}([\\s\\S]*?)(?=##|$)", body)
         if m:
             plan["implementation"] = m.group(1).strip()
 
@@ -478,6 +484,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Preview synthesis comment without posting or assigning",
     )
+    add_output_format_arg(parser)
     return parser
 
 
@@ -488,13 +495,15 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of complex PS1
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
     owner, repo = resolved.owner, resolved.repo
     issue_number: int = args.issue_number
 
-    print(f"Processing issue #{issue_number} in {owner}/{repo}")
+    if fmt != "json":
+        print(f"Processing issue #{issue_number} in {owner}/{repo}")
 
     config = _load_synthesis_config(args.config_path)
 
@@ -519,18 +528,18 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         error_and_exit(f"Failed to get issue: {error_str}", 3)
 
     issue = json.loads(issue_result.stdout)
-    print(f"Issue: {issue.get('title', '')}")
+    print(f"Issue: {issue.get('title', '')}", file=sys.stderr)
 
     # Fetch comments
     comments = get_issue_comments(owner, repo, issue_number)
-    print(f"Found {len(comments)} comments")
+    print(f"Found {len(comments)} comments", file=sys.stderr)
 
     trusted_users = (
         config["trusted_sources"]["maintainers"]
         + config["trusted_sources"]["ai_agents"]
     )
     trusted_comments = get_trusted_source_comments(comments, trusted_users)
-    print(f"Found {len(trusted_comments)} comments from trusted sources")
+    print(f"Found {len(trusted_comments)} comments from trusted sources", file=sys.stderr)
 
     # PrepareContextOnly mode
     if args.prepare_context_only:
@@ -545,7 +554,12 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
             "owner": owner,
             "repo": repo,
         }
-        print(json.dumps(output, indent=2))
+        write_skill_output(
+            output,
+            output_format=fmt,
+            human_summary=f"Prepared context file for issue #{issue_number}",
+            script_name="invoke_copilot_assignment.py",
+        )
 
         _write_github_output({
             "context_file": context_file,
@@ -605,29 +619,34 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         )
 
         if existing_synthesis:
-            print(f"Updating existing synthesis comment (ID: {existing_synthesis['id']})")
+            print(
+                f"Updating existing synthesis comment (ID: {existing_synthesis['id']})",
+                file=sys.stderr,
+            )
             response = update_issue_comment(owner, repo, existing_synthesis["id"], synthesis_body)
             action = "Updated"
         else:
-            print("Creating new synthesis comment")
+            print("Creating new synthesis comment", file=sys.stderr)
             response = create_issue_comment(owner, repo, issue_number, synthesis_body)
             action = "Created"
-        print(f"{action} synthesis comment: {response.get('html_url', 'N/A')}")
+        print(f"{action} synthesis comment: {response.get('html_url', 'N/A')}", file=sys.stderr)
     else:
-        print("No synthesizable content found, skipping synthesis comment")
+        print("No synthesizable content found, skipping synthesis comment", file=sys.stderr)
 
     # Assign Copilot
     assigned = False
     if not args.skip_assignment:
-        print("Assigning copilot-swe-agent...")
+        print("Assigning copilot-swe-agent...", file=sys.stderr)
         assigned = _assign_copilot(owner, repo, issue_number)
         if assigned:
-            print(f"Assigned copilot-swe-agent to issue #{issue_number}")
+            print(f"Assigned copilot-swe-agent to issue #{issue_number}", file=sys.stderr)
     else:
-        print("Skipping assignment (handled by workflow with COPILOT_GITHUB_TOKEN)")
+        print(
+            "Skipping assignment (handled by workflow with COPILOT_GITHUB_TOKEN)",
+            file=sys.stderr,
+        )
 
     output = {
-        "success": True,
         "action": action,
         "issue_number": issue_number,
         "comment_id": response["id"] if response else None,
@@ -635,7 +654,12 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         "assigned": assigned,
         "marker": config["synthesis"]["marker"],
     }
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        output,
+        output_format=fmt,
+        human_summary=f"{action} synthesis for issue #{issue_number}",
+        script_name="invoke_copilot_assignment.py",
+    )
     return 0
 
 

--- a/src/copilot-cli/skills/github/scripts/issue/new_issue.py
+++ b/src/copilot-cli/skills/github/scripts/issue/new_issue.py
@@ -14,7 +14,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 import subprocess
@@ -41,6 +40,11 @@ from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     error_and_exit,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
 )
 
 
@@ -74,11 +78,13 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help='Comma-separated list of labels (e.g., "bug,P1,needs-triage")',
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -115,13 +121,16 @@ def main(argv: list[str] | None = None) -> int:
 
     issue_number = int(match.group(1))
 
-    output = {
-        "success": True,
-        "issue_number": issue_number,
-        "url": output_text,
-        "title": args.title,
-    }
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        {
+            "issue_number": issue_number,
+            "url": output_text,
+            "title": args.title,
+        },
+        output_format=fmt,
+        human_summary=f"Created issue #{issue_number}: {args.title}",
+        script_name="new_issue.py",
+    )
 
     _write_github_output({
         "success": "true",

--- a/src/copilot-cli/skills/github/scripts/issue/post_issue_comment.py
+++ b/src/copilot-cli/skills/github/scripts/issue/post_issue_comment.py
@@ -46,6 +46,13 @@ from github_core.api import (  # noqa: E402
     resolve_repo_params,
     update_issue_comment,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
+
+_SCRIPT_NAME = "post_issue_comment.py"
 
 _403_PATTERN = re.compile(
     r"((?<!\d)403(?!\d)|\bforbidden\b|Resource not accessible by integration)",
@@ -156,11 +163,13 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Update existing comment instead of skipping when marker found",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of PS1 logic
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -200,16 +209,20 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
 
             if existing is not None:
                 if args.update_if_exists:
-                    print(f"Comment with marker '{args.marker}' exists. Updating...")
+                    if fmt != "json":
+                        print(f"Comment with marker '{args.marker}' exists. Updating...")
                     body = _prepend_marker(body, marker_html)
                     response = update_issue_comment(owner, repo, existing["id"], body)
-                    print(f"Updated comment on issue #{issue}")
-                    print(json.dumps({
-                        "success": True,
-                        "issue": issue,
-                        "comment_id": response["id"],
-                        "updated": True,
-                    }, indent=2))
+                    write_skill_output(
+                        {
+                            "issue": issue,
+                            "comment_id": response["id"],
+                            "updated": True,
+                        },
+                        output_format=fmt,
+                        human_summary=f"Updated comment on issue #{issue}",
+                        script_name=_SCRIPT_NAME,
+                    )
                     _write_github_output({
                         "success": "true",
                         "skipped": "false",
@@ -222,13 +235,18 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
                     })
                     return 0
 
-                print(f"Comment with marker '{args.marker}' already exists. Skipping.")
-                print(json.dumps({
-                    "success": True,
-                    "issue": issue,
-                    "marker": args.marker,
-                    "skipped": True,
-                }, indent=2))
+                write_skill_output(
+                    {
+                        "issue": issue,
+                        "marker": args.marker,
+                        "skipped": True,
+                    },
+                    output_format=fmt,
+                    human_summary=(
+                        f"Comment with marker '{args.marker}' already exists. Skipping."
+                    ),
+                    script_name=_SCRIPT_NAME,
+                )
                 _write_github_output({
                     "success": "true",
                     "skipped": "true",
@@ -277,6 +295,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         response = json.loads(result.stdout)
     except json.JSONDecodeError:
         print(f"Posted comment to issue #{issue} (response parsing failed)", file=sys.stderr)
+        write_skill_output(
+            {
+                "issue": issue,
+                "skipped": False,
+                "parse_error": True,
+            },
+            output_format=fmt,
+            human_summary=f"Posted comment to issue #{issue} (response parsing failed)",
+            script_name=_SCRIPT_NAME,
+        )
         _write_github_output({
             "success": "true",
             "skipped": "false",
@@ -285,13 +313,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         })
         return 0
 
-    output = {
-        "success": True,
-        "issue": issue,
-        "comment_id": response["id"],
-        "skipped": False,
-    }
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        {
+            "issue": issue,
+            "comment_id": response["id"],
+            "skipped": False,
+        },
+        output_format=fmt,
+        human_summary=f"Posted comment to issue #{issue}",
+        script_name=_SCRIPT_NAME,
+    )
 
     outputs: dict[str, str] = {
         "success": "true",

--- a/src/copilot-cli/skills/github/scripts/issue/set_issue_milestone.py
+++ b/src/copilot-cli/skills/github/scripts/issue/set_issue_milestone.py
@@ -15,7 +15,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -40,6 +39,11 @@ from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     error_and_exit,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
 )
 
 
@@ -103,11 +107,25 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Replace existing milestone",
     )
+    add_output_format_arg(parser)
     return parser
+
+
+def _emit(output: dict, fmt: str) -> None:
+    """Emit the canonical envelope for the milestone result payload."""
+    write_skill_output(
+        output,
+        output_format=fmt,
+        human_summary=(
+            f"Issue #{output['issue']} milestone {output['action']}"
+        ),
+        script_name="set_issue_milestone.py",
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -119,7 +137,6 @@ def main(argv: list[str] | None = None) -> int:
     current_milestone = _get_current_milestone(owner, repo, args.issue)
 
     output = {
-        "success": False,
         "issue": args.issue,
         "milestone": None,
         "previous_milestone": current_milestone,
@@ -128,9 +145,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.clear:
         if not current_milestone:
-            output["success"] = True
             output["action"] = "no_change"
-            print(json.dumps(output, indent=2))
+            _emit(output, fmt)
             _write_github_output({
                 "success": "true",
                 "issue": str(args.issue),
@@ -151,9 +167,8 @@ def main(argv: list[str] | None = None) -> int:
         if result.returncode != 0:
             error_and_exit("Failed to clear milestone", 3)
 
-        output["success"] = True
         output["action"] = "cleared"
-        print(json.dumps(output, indent=2))
+        _emit(output, fmt)
         _write_github_output({
             "success": "true",
             "issue": str(args.issue),
@@ -170,10 +185,9 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     if current_milestone == args.milestone:
-        output["success"] = True
         output["milestone"] = args.milestone
         output["action"] = "no_change"
-        print(json.dumps(output, indent=2))
+        _emit(output, fmt)
         _write_github_output({
             "success": "true",
             "issue": str(args.issue),
@@ -203,10 +217,9 @@ def main(argv: list[str] | None = None) -> int:
         error_and_exit("Failed to set milestone", 3)
 
     action = "replaced" if current_milestone else "assigned"
-    output["success"] = True
     output["milestone"] = args.milestone
     output["action"] = action
-    print(json.dumps(output, indent=2))
+    _emit(output, fmt)
 
     gh_outputs: dict[str, str] = {
         "success": "true",

--- a/src/copilot-cli/skills/github/scripts/milestone/get_latest_semantic_milestone.py
+++ b/src/copilot-cli/skills/github/scripts/milestone/get_latest_semantic_milestone.py
@@ -43,6 +43,7 @@ from github_core.api import (  # noqa: E402
 from github_core.output import (  # noqa: E402
     add_output_format_arg,
     get_output_format,
+    write_skill_error,
     write_skill_output,
 )
 
@@ -102,12 +103,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if not milestones:
         print(f"No open milestones found in {owner}/{repo}", file=sys.stderr)
-        write_skill_output(
-            {"title": "", "number": 0, "found": False},
+        write_skill_error(
+            f"No open milestones found in {owner}/{repo}",
+            2,
+            error_type="NotFound",
             output_format=fmt,
-            human_summary=f"No open milestones found in {owner}/{repo}",
-            status="WARNING",
             script_name="get_latest_semantic_milestone.py",
+            extra={"title": "", "number": 0, "found": False},
         )
         _write_github_output({
             "milestone_title": "",
@@ -131,12 +133,13 @@ def main(argv: list[str] | None = None) -> int:
             f"No semantic version milestones found. Available: {available}",
             file=sys.stderr,
         )
-        write_skill_output(
-            {"title": "", "number": 0, "found": False},
+        write_skill_error(
+            f"No semantic version milestones found. Available: {available}",
+            2,
+            error_type="NotFound",
             output_format=fmt,
-            human_summary=f"No semantic version milestones found. Available: {available}",
-            status="WARNING",
             script_name="get_latest_semantic_milestone.py",
+            extra={"title": "", "number": 0, "found": False},
         )
         _write_github_output({
             "milestone_title": "",

--- a/src/copilot-cli/skills/github/scripts/milestone/get_latest_semantic_milestone.py
+++ b/src/copilot-cli/skills/github/scripts/milestone/get_latest_semantic_milestone.py
@@ -15,7 +15,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 import sys
@@ -40,6 +39,11 @@ from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     gh_api_paginated,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
 )
 
 _SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
@@ -81,11 +85,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--owner", default="", help="Repository owner")
     parser.add_argument("--repo", default="", help="Repository name")
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -96,8 +102,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if not milestones:
         print(f"No open milestones found in {owner}/{repo}", file=sys.stderr)
-        result = {"title": "", "number": 0, "found": False}
-        print(json.dumps(result, indent=2))
+        write_skill_output(
+            {"title": "", "number": 0, "found": False},
+            output_format=fmt,
+            human_summary=f"No open milestones found in {owner}/{repo}",
+            status="WARNING",
+            script_name="get_latest_semantic_milestone.py",
+        )
         _write_github_output({
             "milestone_title": "",
             "milestone_number": "0",
@@ -120,8 +131,13 @@ def main(argv: list[str] | None = None) -> int:
             f"No semantic version milestones found. Available: {available}",
             file=sys.stderr,
         )
-        result = {"title": "", "number": 0, "found": False}
-        print(json.dumps(result, indent=2))
+        write_skill_output(
+            {"title": "", "number": 0, "found": False},
+            output_format=fmt,
+            human_summary=f"No semantic version milestones found. Available: {available}",
+            status="WARNING",
+            script_name="get_latest_semantic_milestone.py",
+        )
         _write_github_output({
             "milestone_title": "",
             "milestone_number": "0",
@@ -139,12 +155,18 @@ def main(argv: list[str] | None = None) -> int:
 
     latest = max(semantic, key=lambda m: _parse_semver_tuple(m["title"]))
 
-    result = {
-        "title": latest["title"],
-        "number": latest["number"],
-        "found": True,
-    }
-    print(json.dumps(result, indent=2))
+    write_skill_output(
+        {
+            "title": latest["title"],
+            "number": latest["number"],
+            "found": True,
+        },
+        output_format=fmt,
+        human_summary=(
+            f"Latest semantic milestone: {latest['title']} (ID: {latest['number']})"
+        ),
+        script_name="get_latest_semantic_milestone.py",
+    )
 
     _write_github_output({
         "milestone_title": latest["title"],

--- a/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
+++ b/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
@@ -44,6 +44,11 @@ from github_core.api import (  # noqa: E402
     gh_api_paginated,
     resolve_repo_params,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 
 _SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
 
@@ -181,11 +186,13 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help="Specific milestone to assign (auto-detects if omitted)",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     item_type: str = args.item_type
     item_number: int = args.item_number
@@ -201,16 +208,22 @@ def main(argv: list[str] | None = None) -> int:
             f"Already has milestone '{existing}'. "
             "No action taken (preserving manual assignments)."
         )
-        print(f"{item_type} #{item_number} already has milestone: {existing}")
-        result = {
-            "success": True,
-            "item_type": item_type,
-            "item_number": item_number,
-            "milestone": existing,
-            "action": "skipped",
-            "message": msg,
-        }
-        print(json.dumps(result, indent=2))
+        if fmt != "json":
+            print(f"{item_type} #{item_number} already has milestone: {existing}")
+        write_skill_output(
+            {
+                "item_type": item_type,
+                "item_number": item_number,
+                "milestone": existing,
+                "action": "skipped",
+                "message": msg,
+            },
+            output_format=fmt,
+            human_summary=(
+                f"{item_type} #{item_number} already has milestone: {existing}"
+            ),
+            script_name="set_item_milestone.py",
+        )
         _write_result(True, item_type, item_number, existing, "skipped", msg)
         return 0
 
@@ -233,16 +246,20 @@ def main(argv: list[str] | None = None) -> int:
     _assign_milestone(owner, repo, item_number, milestone_title)
 
     msg = f"Assigned milestone '{milestone_title}'."
-    print(f"Successfully assigned milestone '{milestone_title}' to {item_type} #{item_number}")
-    result = {
-        "success": True,
-        "item_type": item_type,
-        "item_number": item_number,
-        "milestone": milestone_title,
-        "action": "assigned",
-        "message": msg,
-    }
-    print(json.dumps(result, indent=2))
+    write_skill_output(
+        {
+            "item_type": item_type,
+            "item_number": item_number,
+            "milestone": milestone_title,
+            "action": "assigned",
+            "message": msg,
+        },
+        output_format=fmt,
+        human_summary=(
+            f"Assigned milestone '{milestone_title}' to {item_type} #{item_number}"
+        ),
+        script_name="set_item_milestone.py",
+    )
     _write_result(True, item_type, item_number, milestone_title, "assigned", msg)
     return 0
 

--- a/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
+++ b/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
@@ -242,7 +242,7 @@ def main(argv: list[str] | None = None) -> int:
         milestone_title = str(detection["title"])
 
     # Assign
-    print(f"Assigning milestone '{milestone_title}' to {item_type} #{item_number}")
+    print(f"Assigning milestone '{milestone_title}' to {item_type} #{item_number}", file=sys.stderr)
     _assign_milestone(owner, repo, item_number, milestone_title)
 
     msg = f"Assigned milestone '{milestone_title}'."

--- a/src/copilot-cli/skills/github/scripts/notifications/get_actionable_items.py
+++ b/src/copilot-cli/skills/github/scripts/notifications/get_actionable_items.py
@@ -48,6 +48,11 @@ from github_core.api import (  # noqa: E402
     error_and_exit,
     resolve_repo_params,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -60,6 +65,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--limit", type=int, default=20,
         help="Max items per category (1-100, default: 20)",
     )
+    add_output_format_arg(parser)
     return parser
 
 
@@ -215,6 +221,7 @@ def _get_assigned_issues(repo_flag: str, user: str, limit: int) -> list[dict]:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     if not 1 <= args.limit <= 100:
         error_and_exit("Limit must be between 1 and 100.", 1)
@@ -236,8 +243,7 @@ def main(argv: list[str] | None = None) -> int:
     authored_prs = _get_authored_prs(repo_flag, user, args.limit)
     assigned_issues = _get_assigned_issues(repo_flag, user, args.limit)
 
-    output = {
-        "success": True,
+    data = {
         "user": user,
         "repo": repo_flag,
         "notifications_api_available": notifications_available,
@@ -253,7 +259,18 @@ def main(argv: list[str] | None = None) -> int:
         },
     }
 
-    print(json.dumps(output, indent=2))
+    total = (
+        data["summary"]["notifications"]
+        + data["summary"]["review_requests"]
+        + data["summary"]["authored_prs"]
+        + data["summary"]["assigned_issues"]
+    )
+    write_skill_output(
+        data,
+        output_format=fmt,
+        human_summary=f"Found {total} actionable item(s) for {user} in {repo_flag}",
+        script_name="get_actionable_items.py",
+    )
     return 0
 
 

--- a/src/copilot-cli/skills/github/scripts/reactions/add_comment_reaction.py
+++ b/src/copilot-cli/skills/github/scripts/reactions/add_comment_reaction.py
@@ -14,7 +14,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -38,6 +37,11 @@ if _lib_dir not in sys.path:
 from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
 )
 
 REACTION_EMOJI: dict[str, str] = {
@@ -79,11 +83,13 @@ def build_parser() -> argparse.ArgumentParser:
         choices=VALID_REACTIONS,
         help="Reaction type",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -140,7 +146,16 @@ def main(argv: list[str] | None = None) -> int:
         "results": results,
     }
 
-    print(json.dumps(summary, indent=2))
+    write_skill_output(
+        summary,
+        output_format=fmt,
+        human_summary=(
+            f"Applied '{args.reaction}' to {succeeded}/{len(args.comment_id)} "
+            f"comment(s) ({failed} failed)"
+        ),
+        status="PASS" if failed == 0 else "FAIL",
+        script_name="add_comment_reaction.py",
+    )
 
     if failed > 0:
         return 3

--- a/src/copilot-cli/skills/github/scripts/reactions/add_comment_reaction.py
+++ b/src/copilot-cli/skills/github/scripts/reactions/add_comment_reaction.py
@@ -41,6 +41,7 @@ from github_core.api import (  # noqa: E402
 from github_core.output import (  # noqa: E402
     add_output_format_arg,
     get_output_format,
+    write_skill_error,
     write_skill_output,
 )
 
@@ -146,6 +147,20 @@ def main(argv: list[str] | None = None) -> int:
         "results": results,
     }
 
+    if failed > 0:
+        write_skill_error(
+            (
+                f"Applied '{args.reaction}' to {succeeded}/{len(args.comment_id)} "
+                f"comment(s); {failed} failed"
+            ),
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="add_comment_reaction.py",
+            extra=summary,
+        )
+        return 3
+
     write_skill_output(
         summary,
         output_format=fmt,
@@ -153,13 +168,8 @@ def main(argv: list[str] | None = None) -> int:
             f"Applied '{args.reaction}' to {succeeded}/{len(args.comment_id)} "
             f"comment(s) ({failed} failed)"
         ),
-        status="PASS" if failed == 0 else "FAIL",
         script_name="add_comment_reaction.py",
     )
-
-    if failed > 0:
-        return 3
-
     return 0
 
 

--- a/tests/skills/github/test_add_comment_reaction.py
+++ b/tests/skills/github/test_add_comment_reaction.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
 from test_helpers import make_completed_process
 
 # Ensure importability
@@ -48,9 +47,9 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "123", "--reaction", "eyes"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["succeeded"] == 1
-        assert result["failed"] == 0
-        assert result["results"][0]["success"] is True
+        assert result["Data"]["succeeded"] == 1
+        assert result["Data"]["failed"] == 0
+        assert result["Data"]["results"][0]["success"] is True
 
     def test_batch_success(self, _import_module, capsys):
         mod = _import_module
@@ -62,9 +61,9 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "1", "2", "3", "--reaction", "heart"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["total_count"] == 3
-        assert result["succeeded"] == 3
-        assert result["failed"] == 0
+        assert result["Data"]["total_count"] == 3
+        assert result["Data"]["succeeded"] == 3
+        assert result["Data"]["failed"] == 0
 
     def test_partial_failure(self, _import_module, capsys):
         mod = _import_module
@@ -81,11 +80,14 @@ class TestAddCommentReaction:
             patch("add_comment_reaction.resolve_repo_params", return_value=_mock_repo()),
             patch("subprocess.run", side_effect=side_effect),
         ):
-            rc = mod.main(["--comment-id", "1", "2", "3", "--comment-type", "issue", "--reaction", "rocket"])
+            rc = mod.main([
+                "--comment-id", "1", "2", "3",
+                "--comment-type", "issue", "--reaction", "rocket",
+            ])
         assert rc == 3
         result = json.loads(capsys.readouterr().out)
-        assert result["succeeded"] == 2
-        assert result["failed"] == 1
+        assert result["Data"]["succeeded"] == 2
+        assert result["Data"]["failed"] == 1
 
     def test_duplicate_reaction_succeeds(self, _import_module, capsys):
         mod = _import_module
@@ -99,7 +101,7 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "1", "--reaction", "+1"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["succeeded"] == 1
+        assert result["Data"]["succeeded"] == 1
 
     def test_review_endpoint(self, _import_module):
         mod = _import_module

--- a/tests/skills/github/test_add_comment_reaction.py
+++ b/tests/skills/github/test_add_comment_reaction.py
@@ -86,6 +86,8 @@ class TestAddCommentReaction:
             ])
         assert rc == 3
         result = json.loads(capsys.readouterr().out)
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 3
         assert result["Data"]["succeeded"] == 2
         assert result["Data"]["failed"] == 1
 

--- a/tests/skills/github/test_edit_issue_body.py
+++ b/tests/skills/github/test_edit_issue_body.py
@@ -106,8 +106,9 @@ class TestEditIssueBodySuccess:
         assert captured_args[captured_args.index("--body") + 1] == "hello"
         assert "--body-file" not in captured_args
         data = json.loads(capsys.readouterr().out)
-        assert data["status"] == "updated"
-        assert data["issue"] == 42
+        assert data["Success"] is True
+        assert data["Data"]["status"] == "updated"
+        assert data["Data"]["issue"] == 42
 
     def test_body_file_passes_through(self, mock_auth, tmp_path, capsys):
         # Coderabbit eoz/epC: when --body-file is provided, gh should be

--- a/tests/skills/github/test_get_latest_semantic_milestone.py
+++ b/tests/skills/github/test_get_latest_semantic_milestone.py
@@ -7,8 +7,6 @@ from unittest.mock import patch
 
 import pytest
 
-from test_helpers import make_completed_process
-
 # Ensure importability
 _project_root = Path(__file__).resolve().parents[3]
 _lib_dir = _project_root / ".claude" / "lib"
@@ -65,9 +63,9 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is True
-        assert result["title"] == "0.3.0"
-        assert result["number"] == 3
+        assert result["Data"]["found"] is True
+        assert result["Data"]["title"] == "0.3.0"
+        assert result["Data"]["number"] == 3
 
     def test_ignores_non_semantic(self, _import_module, capsys):
         mod = _import_module
@@ -84,8 +82,8 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is True
-        assert result["title"] == "0.2.0"
+        assert result["Data"]["found"] is True
+        assert result["Data"]["title"] == "0.2.0"
 
     def test_no_milestones(self, _import_module, capsys):
         mod = _import_module
@@ -97,8 +95,8 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 2
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is False
-        assert result["title"] == ""
+        assert result["Data"]["found"] is False
+        assert result["Data"]["title"] == ""
 
     def test_no_semantic_milestones(self, _import_module, capsys):
         mod = _import_module
@@ -114,7 +112,7 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 2
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is False
+        assert result["Data"]["found"] is False
 
     def test_version_comparison_10_vs_2(self, _import_module, capsys):
         """Ensure 0.10.0 > 0.2.0 (not string comparison)."""
@@ -131,7 +129,7 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["title"] == "0.10.0"
+        assert result["Data"]["title"] == "0.10.0"
 
     def test_single_milestone(self, _import_module, capsys):
         mod = _import_module
@@ -144,5 +142,5 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is True
-        assert result["title"] == "1.0.0"
+        assert result["Data"]["found"] is True
+        assert result["Data"]["title"] == "1.0.0"

--- a/tests/skills/github/test_get_latest_semantic_milestone.py
+++ b/tests/skills/github/test_get_latest_semantic_milestone.py
@@ -95,6 +95,8 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 2
         result = json.loads(capsys.readouterr().out)
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 2
         assert result["Data"]["found"] is False
         assert result["Data"]["title"] == ""
 
@@ -112,6 +114,8 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 2
         result = json.loads(capsys.readouterr().out)
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 2
         assert result["Data"]["found"] is False
 
     def test_version_comparison_10_vs_2(self, _import_module, capsys):

--- a/tests/skills/github/test_invoke_copilot_assignment.py
+++ b/tests/skills/github/test_invoke_copilot_assignment.py
@@ -82,6 +82,17 @@ class TestHelpers:
         })
         assert result is None
 
+    def test_get_coderabbit_plan_null_body(self, _import_module):
+        mod = _import_module
+        comments = [{"user": {"login": "coderabbitai[bot]"}, "body": None}]
+        result = mod._get_coderabbit_plan(comments, {
+            "username": "coderabbitai[bot]",
+            "implementation_plan": "## Implementation",
+            "related_issues": "Related Issues",
+            "related_prs": "Related PRs",
+        })
+        assert result == {"implementation": None, "related_issues": [], "related_prs": []}
+
     def test_get_ai_triage_info_table_format(self, _import_module):
         mod = _import_module
         comments = [{

--- a/tests/skills/github/test_issue_scripts.py
+++ b/tests/skills/github/test_issue_scripts.py
@@ -12,14 +12,11 @@ Covers:
 
 import json
 import subprocess
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-from test_helpers import import_skill_script
 from github_core.api import RepoInfo
+from test_helpers import import_skill_script
 
 
 def make_proc(stdout="", stderr="", returncode=0):
@@ -30,12 +27,20 @@ def make_proc(stdout="", stderr="", returncode=0):
 
 
 def _extract_json(text: str) -> dict:
-    """Extract the last JSON object from output that may contain text before it."""
-    # Find the last '{' that starts a JSON object
-    idx = text.rfind("{")
-    if idx == -1:
-        raise ValueError(f"No JSON found in output: {text!r}")
-    return json.loads(text[idx:])
+    """Extract the last JSON object from output that may contain text before it.
+
+    Walks lines from the bottom and returns the first one that parses as a
+    complete JSON object. The canonical envelope is emitted as a single line.
+    """
+    for line in reversed(text.strip().splitlines()):
+        candidate = line.strip()
+        if not candidate.startswith("{"):
+            continue
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    raise ValueError(f"No JSON found in output: {text!r}")
 
 
 def _mock_repo():
@@ -70,7 +75,10 @@ class TestGetIssueContext:
         proc = make_proc(stdout=json.dumps(issue_data))
         with (
             patch("get_issue_context.assert_gh_authenticated"),
-            patch("get_issue_context.resolve_repo_params", return_value=RepoInfo(owner="owner", repo="repo")),
+            patch(
+                "get_issue_context.resolve_repo_params",
+                return_value=RepoInfo(owner="owner", repo="repo"),
+            ),
             patch("subprocess.run", return_value=proc),
         ):
             rc = mod.main(["--issue", "42"])
@@ -214,9 +222,9 @@ class TestNewIssue:
             rc = mod.main(["--title", "My Title", "--body", "body text", "--labels", "bug"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["issue_number"] == 123
-        assert result["title"] == "My Title"
+        assert result["Success"] is True
+        assert result["Data"]["issue_number"] == 123
+        assert result["Data"]["title"] == "My Title"
 
     def test_empty_body_and_labels_omitted(self):
         mod = self._import()
@@ -326,9 +334,9 @@ class TestPostIssueComment:
             rc = mod.main(["--issue", "1", "--body", "body text"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["comment_id"] == 99
-        assert result["skipped"] is False
+        assert result["Success"] is True
+        assert result["Data"]["comment_id"] == 99
+        assert result["Data"]["skipped"] is False
 
     def test_marker_already_exists_skips(self, capsys):
         mod = self._import()
@@ -345,7 +353,7 @@ class TestPostIssueComment:
             rc = mod.main(["--issue", "1", "--body", "new body", "--marker", marker])
         assert rc == 0
         result = _extract_json(capsys.readouterr().out)
-        assert result["skipped"] is True
+        assert result["Data"]["skipped"] is True
 
     def test_marker_exists_update_if_exists(self, capsys):
         mod = self._import()
@@ -367,8 +375,8 @@ class TestPostIssueComment:
             ])
         assert rc == 0
         result = _extract_json(capsys.readouterr().out)
-        assert result["updated"] is True
-        assert result["success"] is True
+        assert result["Data"]["updated"] is True
+        assert result["Success"] is True
 
     def test_marker_new_post(self, capsys):
         mod = self._import()
@@ -384,8 +392,8 @@ class TestPostIssueComment:
             rc = mod.main(["--issue", "1", "--body", "body", "--marker", marker])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["skipped"] is False
+        assert result["Success"] is True
+        assert result["Data"]["skipped"] is False
 
     def test_permission_error_exits_4(self):
         mod = self._import()
@@ -662,8 +670,8 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--milestone", "v1.0"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["action"] == "assigned"
+        assert result["Success"] is True
+        assert result["Data"]["action"] == "assigned"
 
     def test_already_same_milestone_no_change(self, capsys):
         mod = self._import()
@@ -678,7 +686,7 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--milestone", "v1.0"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "no_change"
+        assert result["Data"]["action"] == "no_change"
 
     def test_different_milestone_no_force_exits_5(self):
         mod = self._import()
@@ -708,7 +716,7 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--milestone", "new-ms", "--force"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "replaced"
+        assert result["Data"]["action"] == "replaced"
 
     def test_clear_with_existing(self, capsys):
         mod = self._import()
@@ -723,7 +731,7 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--clear"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "cleared"
+        assert result["Data"]["action"] == "cleared"
 
     def test_clear_without_existing(self, capsys):
         mod = self._import()
@@ -735,7 +743,7 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--clear"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "no_change"
+        assert result["Data"]["action"] == "no_change"
 
     def test_milestone_not_found_exits_2(self):
         mod = self._import()

--- a/tests/skills/github/test_milestone_scripts.py
+++ b/tests/skills/github/test_milestone_scripts.py
@@ -7,14 +7,11 @@ Covers:
 
 import json
 import subprocess
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-from test_helpers import import_skill_script
 from github_core.api import RepoInfo
+from test_helpers import import_skill_script
 
 
 def make_proc(stdout="", stderr="", returncode=0):
@@ -27,14 +24,19 @@ def _mock_repo():
     return RepoInfo(owner="o", repo="r")
 
 
-def _extract_json(text: str) -> dict:
-    """Extract the last JSON object from multi-line output."""
-    idx = text.rfind("{")
-    if idx == -1:
-        raise ValueError(f"No JSON found in output: {text!r}")
-    return json.loads(text[idx:])
+def _extract_json(text):
+    """Extract the last JSON object from multi-line output.
 
-
+    Walks lines from the bottom; the canonical envelope is one line.
+    """
+    for line in reversed(text.strip().splitlines()):
+        candidate = line.strip()
+        if candidate.startswith("{"):
+            try:
+                return json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+    raise ValueError("No JSON found in output: " + repr(text))
 # ---------------------------------------------------------------------------
 # get_latest_semantic_milestone
 # ---------------------------------------------------------------------------
@@ -60,9 +62,9 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is True
-        assert result["title"] == "0.2.1"
-        assert result["number"] == 3
+        assert result["Data"]["found"] is True
+        assert result["Data"]["title"] == "0.2.1"
+        assert result["Data"]["number"] == 3
 
     def test_no_milestones(self, capsys):
         mod = self._import()
@@ -74,8 +76,8 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 2
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is False
-        assert result["title"] == ""
+        assert result["Data"]["found"] is False
+        assert result["Data"]["title"] == ""
 
     def test_no_semantic_milestones(self, capsys):
         mod = self._import()
@@ -91,7 +93,7 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 2
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is False
+        assert result["Data"]["found"] is False
 
     def test_version_comparison(self, capsys):
         mod = self._import()
@@ -108,7 +110,7 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["title"] == "2.0.0"
+        assert result["Data"]["title"] == "2.0.0"
 
     def test_mixed_milestones_filters_correctly(self, capsys):
         mod = self._import()
@@ -125,8 +127,8 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is True
-        assert result["title"] == "1.0.0"
+        assert result["Data"]["found"] is True
+        assert result["Data"]["title"] == "1.0.0"
 
     def test_main_exits_2_when_not_found(self):
         mod = self._import()
@@ -150,8 +152,8 @@ class TestGetLatestSemanticMilestone:
         assert rc == 0
         captured = capsys.readouterr()
         parsed = json.loads(captured.out)
-        assert parsed["found"] is True
-        assert parsed["title"] == "1.2.3"
+        assert parsed["Data"]["found"] is True
+        assert parsed["Data"]["title"] == "1.2.3"
 
     def test_help_does_not_crash(self):
         mod = import_skill_script("get_latest_semantic_milestone", "milestone")
@@ -183,11 +185,14 @@ class TestSetItemMilestone:
             patch("set_item_milestone.resolve_repo_params", return_value=_mock_repo()),
             patch("subprocess.run", return_value=make_proc(stdout=json.dumps(item_data))),
         ):
-            rc = mod.main(["--item-type", "pr", "--item-number", "10", "--milestone-title", "existing-ms"])
+            rc = mod.main([
+                "--item-type", "pr", "--item-number", "10",
+                "--milestone-title", "existing-ms",
+            ])
         assert rc == 0
         result = _extract_json(capsys.readouterr().out)
-        assert result["action"] == "skipped"
-        assert result["milestone"] == "existing-ms"
+        assert result["Data"]["action"] == "skipped"
+        assert result["Data"]["milestone"] == "existing-ms"
 
     def test_assigns_provided_milestone(self, capsys):
         mod = self._import()
@@ -203,8 +208,8 @@ class TestSetItemMilestone:
             rc = mod.main(["--item-type", "pr", "--item-number", "10", "--milestone-title", "v1.0"])
         assert rc == 0
         result = _extract_json(capsys.readouterr().out)
-        assert result["action"] == "assigned"
-        assert result["milestone"] == "v1.0"
+        assert result["Data"]["action"] == "assigned"
+        assert result["Data"]["milestone"] == "v1.0"
 
     def test_auto_detects_milestone_and_assigns(self, capsys):
         mod = self._import()
@@ -222,7 +227,7 @@ class TestSetItemMilestone:
             rc = mod.main(["--item-type", "issue", "--item-number", "5"])
         assert rc == 0
         result = _extract_json(capsys.readouterr().out)
-        assert result["milestone"] == "0.3.0"
+        assert result["Data"]["milestone"] == "0.3.0"
 
     def test_auto_detect_not_found_exits_2(self):
         mod = self._import()
@@ -252,10 +257,16 @@ class TestSetItemMilestone:
         with (
             patch("set_item_milestone.assert_gh_authenticated"),
             patch("set_item_milestone.resolve_repo_params", return_value=_mock_repo()),
-            patch("subprocess.run", return_value=make_proc(stderr="connection error", returncode=1)),
+            patch(
+                "subprocess.run",
+                return_value=make_proc(stderr="connection error", returncode=1),
+            ),
         ):
             with pytest.raises(SystemExit) as exc:
-                mod.main(["--item-type", "pr", "--item-number", "10", "--milestone-title", "v1.0"])
+                mod.main([
+                    "--item-type", "pr", "--item-number", "10",
+                    "--milestone-title", "v1.0",
+                ])
         assert exc.value.code == 3
 
     def test_help_does_not_crash(self):

--- a/tests/skills/github/test_milestone_scripts.py
+++ b/tests/skills/github/test_milestone_scripts.py
@@ -76,6 +76,8 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 2
         result = json.loads(capsys.readouterr().out)
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 2
         assert result["Data"]["found"] is False
         assert result["Data"]["title"] == ""
 
@@ -93,6 +95,8 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 2
         result = json.loads(capsys.readouterr().out)
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 2
         assert result["Data"]["found"] is False
 
     def test_version_comparison(self, capsys):

--- a/tests/skills/github/test_new_issue.py
+++ b/tests/skills/github/test_new_issue.py
@@ -45,9 +45,9 @@ class TestNewIssue:
             result = main(["--title", "Test Title"])
         assert result == 0
         data = json.loads(capsys.readouterr().out)
-        assert data["success"] is True
-        assert data["issue_number"] == 42
-        assert data["title"] == "Test Title"
+        assert data["Success"] is True
+        assert data["Data"]["issue_number"] == 42
+        assert data["Data"]["title"] == "Test Title"
 
     def test_create_with_body_and_labels(self, capsys):
         with patch("subprocess.run", return_value=_make_proc(

--- a/tests/skills/github/test_output_envelope_contract.py
+++ b/tests/skills/github/test_output_envelope_contract.py
@@ -1,0 +1,232 @@
+"""Contract test for the canonical github skill output envelope (ADR-056).
+
+Every github skill script that emits JSON to stdout MUST wrap its payload in the
+canonical envelope written by ``github_core.output.write_skill_output`` /
+``write_skill_error``. The top-level keys MUST be exactly::
+
+    {"Success", "Data", "Error", "Metadata"}
+
+This test runs each script's ``main`` with mocked authentication and subprocess
+I/O, captures stdout in ``--output-format json`` mode, parses the last JSON
+line, and asserts the top-level key set.
+
+Issue #2388: standardize the github skill output envelope across all scripts.
+
+Residual: the ``pr/`` family is tracked separately and is NOT yet converted;
+see ``PR_RESIDUAL`` below. Those scripts are intentionally excluded from the
+parametrized run until their consumer fan-out (for example
+``wait_for_unresolved_zero`` reading top-level keys from
+``get_unresolved_review_threads``) is updated in lockstep.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import patch
+
+import pytest
+from github_core.api import RepoInfo
+from test_helpers import import_skill_script, make_completed_process
+
+CANONICAL_KEYS = {"Success", "Data", "Error", "Metadata"}
+
+
+@pytest.fixture
+def _restore_modules():
+    """Restore sys.modules entries import_skill_script overwrites.
+
+    import_skill_script registers the script under both ``skill_<name>`` and the
+    bare ``<name>``. Sibling tests (test_utility_scripts) import the same names
+    differently and reload them, so this fixture snapshots and restores the
+    affected entries to keep tests independent (ADR testing rule 5).
+    """
+    snapshot = dict(sys.modules)
+    try:
+        yield
+    finally:
+        for key in list(sys.modules):
+            if key not in snapshot:
+                del sys.modules[key]
+        sys.modules.update(snapshot)
+
+
+def _last_json_object(text: str) -> dict:
+    """Return the last line of ``text`` that parses as a JSON object."""
+    for line in reversed(text.strip().splitlines()):
+        candidate = line.strip()
+        if not candidate.startswith("{"):
+            continue
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    raise AssertionError(f"No JSON object found in output: {text!r}")
+
+
+# Each row: (script_name, subdir, argv, list-of-subprocess-CompletedProcess).
+# The subprocess side effects feed the script's gh/git calls in order. argv
+# always includes ``--output-format json`` so stdout is pure JSON.
+_ISSUE_VIEW = json.dumps(
+    {
+        "number": 1,
+        "title": "T",
+        "body": "",
+        "state": "OPEN",
+        "author": {"login": "a"},
+        "labels": [],
+        "milestone": None,
+        "assignees": [],
+        "createdAt": "",
+        "updatedAt": "",
+    }
+)
+
+CONVERTED_SCRIPTS: list[tuple[str, str, list[str], list]] = [
+    (
+        "get_issue_context",
+        "issue",
+        ["--owner", "o", "--repo", "r", "--issue", "1", "--output-format", "json"],
+        [make_completed_process(stdout=_ISSUE_VIEW)],
+    ),
+    (
+        "new_issue",
+        "issue",
+        ["--owner", "o", "--repo", "r", "--title", "T", "--output-format", "json"],
+        [make_completed_process(stdout="https://github.com/o/r/issues/5\n")],
+    ),
+    (
+        "edit_issue_body",
+        "issue",
+        ["--owner", "o", "--repo", "r", "--issue", "1", "--body", "b", "--output-format", "json"],
+        [make_completed_process(stdout="")],
+    ),
+    (
+        "post_issue_comment",
+        "issue",
+        ["--owner", "o", "--repo", "r", "--issue", "1", "--body", "b", "--output-format", "json"],
+        [make_completed_process(stdout=json.dumps({"id": 100, "html_url": "u"}))],
+    ),
+    (
+        "set_issue_milestone",
+        "issue",
+        [
+            "--owner", "o", "--repo", "r", "--issue", "1",
+            "--milestone", "v1.0.0", "--output-format", "json",
+        ],
+        [
+            make_completed_process(stdout="null"),       # _get_current_milestone
+            make_completed_process(stdout="v1.0.0"),      # _get_milestone_titles
+            make_completed_process(stdout=""),            # assign
+        ],
+    ),
+    (
+        "set_item_milestone",
+        "milestone",
+        [
+            "--item-type", "issue", "--item-number", "1",
+            "--owner", "o", "--repo", "r",
+            "--milestone-title", "v1.0.0", "--output-format", "json",
+        ],
+        [
+            make_completed_process(stdout=json.dumps({"milestone": None})),  # current
+            make_completed_process(stdout=""),                               # assign
+        ],
+    ),
+    (
+        "get_latest_semantic_milestone",
+        "milestone",
+        ["--owner", "o", "--repo", "r", "--output-format", "json"],
+        [make_completed_process(stdout=json.dumps([{"title": "1.0.0", "number": 1}]))],
+    ),
+    (
+        "add_comment_reaction",
+        "reactions",
+        [
+            "--owner", "o", "--repo", "r", "--comment-id", "1",
+            "--reaction", "eyes", "--output-format", "json",
+        ],
+        [make_completed_process(stdout=json.dumps({"id": 1}))],
+    ),
+    (
+        "get_actionable_items",
+        "notifications",
+        ["--owner", "o", "--repo", "r", "--output-format", "json"],
+        [
+            make_completed_process(stdout="me\n"),   # _get_current_user
+            make_completed_process(stdout="[]"),     # _try_notifications
+            make_completed_process(stdout="[]"),     # _get_review_requests
+            make_completed_process(stdout="[]"),     # _get_authored_prs
+            make_completed_process(stdout="[]"),     # _get_assigned_issues
+        ],
+    ),
+]
+
+# pr/ residual: tracked by issue #2388, converted in a follow-up.
+PR_RESIDUAL = [
+    "add_pr_review_thread_reply",
+    "close_pr",
+    "detect_copilot_followup_pr",
+    "detect_stale_pr_comments",
+    "get_pr_comments_by_reviewer",
+    "get_pr_review_comments",
+    "get_pr_review_threads",
+    "get_pr_reviewers",
+    "get_thread_by_id",
+    "get_thread_conversation_history",
+    "get_unresolved_review_threads",
+    "invoke_pr_comment_processing",
+    "merge_pr",
+    "new_pr",
+    "post_pr_comment_reply",
+    "resolve_pr_review_thread",
+    "run_completion_gate",
+    "set_pr_auto_merge",
+    "test_pr_merged",
+    "test_pr_merge_ready",
+    "unresolve_pr_review_thread",
+    "validate_pr_description",
+    "wait_for_unresolved_zero",
+]
+
+
+@pytest.mark.parametrize(
+    ("name", "subdir", "argv", "side_effects"),
+    CONVERTED_SCRIPTS,
+    ids=[row[0] for row in CONVERTED_SCRIPTS],
+)
+def test_script_emits_canonical_envelope(
+    name, subdir, argv, side_effects, capsys, _restore_modules,
+):
+    mod = import_skill_script(name, subdir)
+
+    with (
+        patch.object(mod, "assert_gh_authenticated", create=True),
+        patch.object(
+            mod, "resolve_repo_params", return_value=RepoInfo(owner="o", repo="r"),
+            create=True,
+        ),
+        patch("subprocess.run", side_effect=side_effects),
+    ):
+        rc = mod.main(argv)
+
+    assert rc == 0
+    envelope = _last_json_object(capsys.readouterr().out)
+    assert set(envelope.keys()) == CANONICAL_KEYS, (
+        f"{name} emitted top-level keys {sorted(envelope.keys())}, "
+        f"expected {sorted(CANONICAL_KEYS)}"
+    )
+    assert envelope["Success"] is True
+    assert envelope["Error"] is None
+    assert set(envelope["Metadata"].keys()) == {"Script", "Version", "Timestamp"}
+
+
+def test_pr_residual_is_tracked():
+    """The pr/ residual list is non-empty and references issue #2388.
+
+    This is a placeholder guard: when a pr/ script is converted, remove it from
+    PR_RESIDUAL and add it to CONVERTED_SCRIPTS. The test fails loudly if the
+    list is emptied without the parametrized table growing, preventing silent
+    drift of the residual.
+    """
+    assert PR_RESIDUAL, "PR_RESIDUAL emptied: move converted pr/ scripts to CONVERTED_SCRIPTS"

--- a/tests/skills/github/test_post_issue_comment.py
+++ b/tests/skills/github/test_post_issue_comment.py
@@ -1,15 +1,11 @@
 """Tests for post_issue_comment.py."""
 
 import json
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-from test_helpers import import_skill_script
 from github_core.api import RepoInfo
-from test_helpers import make_completed_process
+from test_helpers import import_skill_script, make_completed_process
 
 
 def _mock_repo():
@@ -64,9 +60,9 @@ class TestPostIssueComment:
             rc = mod.main(["--issue", "1", "--body", "hello"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["comment_id"] == 100
-        assert result["skipped"] is False
+        assert result["Success"] is True
+        assert result["Data"]["comment_id"] == 100
+        assert result["Data"]["skipped"] is False
 
     def test_skip_when_marker_exists(self, _import_module, capsys):
         mod = _import_module
@@ -84,11 +80,10 @@ class TestPostIssueComment:
                 "--marker", "TEST-MARKER",
             ])
         assert rc == 0
-        # Output has text message then JSON
         out = capsys.readouterr().out
-        idx = out.rfind("{")
-        result = json.loads(out[idx:])
-        assert result["skipped"] is True
+        result = json.loads(out.strip().splitlines()[-1])
+        assert result["Success"] is True
+        assert result["Data"]["skipped"] is True
 
     def test_update_when_marker_exists_and_update_flag(self, _import_module, capsys):
         mod = _import_module
@@ -109,9 +104,9 @@ class TestPostIssueComment:
             ])
         assert rc == 0
         out = capsys.readouterr().out
-        idx = out.rfind("{")
-        result = json.loads(out[idx:])
-        assert result["updated"] is True
+        result = json.loads(out.strip().splitlines()[-1])
+        assert result["Success"] is True
+        assert result["Data"]["updated"] is True
 
     def test_permission_denied_exits_4(self, _import_module):
         mod = _import_module

--- a/tests/skills/github/test_set_issue_milestone.py
+++ b/tests/skills/github/test_set_issue_milestone.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
 from test_helpers import make_completed_process
 
 # Ensure importability
@@ -24,14 +23,19 @@ def _mock_repo():
     return RepoInfo(owner="o", repo="r")
 
 
-def _extract_json(text: str) -> dict:
-    """Extract the last JSON object from multi-line output."""
-    idx = text.rfind("{")
-    if idx == -1:
-        raise ValueError(f"No JSON found in output: {text!r}")
-    return json.loads(text[idx:])
+def _extract_json(text):
+    """Extract the last JSON object from multi-line output.
 
-
+    Walks lines from the bottom; the canonical envelope is one line.
+    """
+    for line in reversed(text.strip().splitlines()):
+        candidate = line.strip()
+        if candidate.startswith("{"):
+            try:
+                return json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+    raise ValueError("No JSON found in output: " + repr(text))
 @pytest.fixture
 def _import_module():
     import importlib
@@ -58,9 +62,9 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--milestone", "v1.0.0"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["action"] == "assigned"
-        assert result["milestone"] == "v1.0.0"
+        assert result["Success"] is True
+        assert result["Data"]["action"] == "assigned"
+        assert result["Data"]["milestone"] == "v1.0.0"
 
     def test_already_has_same_milestone(self, _import_module, capsys):
         mod = _import_module
@@ -75,7 +79,7 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--milestone", "v1.0.0"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "no_change"
+        assert result["Data"]["action"] == "no_change"
 
     def test_force_replace_milestone(self, _import_module, capsys):
         mod = _import_module
@@ -91,8 +95,8 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--milestone", "v1.0.0", "--force"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "replaced"
-        assert result["previous_milestone"] == "v0.9.0"
+        assert result["Data"]["action"] == "replaced"
+        assert result["Data"]["previous_milestone"] == "v0.9.0"
 
     def test_has_milestone_without_force_exits_5(self, _import_module):
         mod = _import_module
@@ -135,7 +139,7 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--clear"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "cleared"
+        assert result["Data"]["action"] == "cleared"
 
     def test_clear_no_milestone(self, _import_module, capsys):
         mod = _import_module
@@ -147,4 +151,4 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--clear"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "no_change"
+        assert result["Data"]["action"] == "no_change"

--- a/tests/skills/github/test_set_item_milestone.py
+++ b/tests/skills/github/test_set_item_milestone.py
@@ -86,10 +86,12 @@ class TestSetItemMilestone:
         ):
             rc = mod.main([
                 "--item-type", "issue", "--item-number", "42",
-                "--milestone-title", "v1.0.0",
+                "--milestone-title", "v1.0.0", "--output-format", "json",
             ])
         assert rc == 0
-        result = _extract_json(capsys.readouterr().out)
+        captured = capsys.readouterr()
+        result = json.loads(captured.out)
+        assert "Assigning milestone" not in captured.out
         assert result["Success"] is True
         assert result["Data"]["action"] == "assigned"
         assert result["Data"]["milestone"] == "v1.0.0"

--- a/tests/skills/github/test_set_item_milestone.py
+++ b/tests/skills/github/test_set_item_milestone.py
@@ -1,15 +1,11 @@
 """Tests for set_item_milestone.py."""
 
 import json
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-from test_helpers import import_skill_script
 from github_core.api import RepoInfo
-from test_helpers import make_completed_process
+from test_helpers import import_skill_script, make_completed_process
 
 
 def _mock_repo():
@@ -17,11 +13,18 @@ def _mock_repo():
 
 
 def _extract_json(text: str) -> dict:
-    """Extract the last JSON object from multi-line output."""
-    idx = text.rfind("{")
-    if idx == -1:
-        raise ValueError(f"No JSON found in output: {text!r}")
-    return json.loads(text[idx:])
+    """Extract the last JSON object from multi-line output.
+
+    Walks lines from the bottom; the canonical envelope is one line.
+    """
+    for line in reversed(text.strip().splitlines()):
+        candidate = line.strip()
+        if candidate.startswith("{"):
+            try:
+                return json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+    raise ValueError(f"No JSON found in output: {text!r}")
 
 
 @pytest.fixture
@@ -67,8 +70,8 @@ class TestSetItemMilestone:
             rc = mod.main(["--item-type", "pr", "--item-number", "1"])
         assert rc == 0
         result = _extract_json(capsys.readouterr().out)
-        assert result["action"] == "skipped"
-        assert result["milestone"] == "v0.9.0"
+        assert result["Data"]["action"] == "skipped"
+        assert result["Data"]["milestone"] == "v0.9.0"
 
     def test_assign_with_explicit_title(self, _import_module, capsys):
         mod = _import_module
@@ -81,12 +84,15 @@ class TestSetItemMilestone:
                 make_completed_process(),                               # _assign_milestone
             ]),
         ):
-            rc = mod.main(["--item-type", "issue", "--item-number", "42", "--milestone-title", "v1.0.0"])
+            rc = mod.main([
+                "--item-type", "issue", "--item-number", "42",
+                "--milestone-title", "v1.0.0",
+            ])
         assert rc == 0
         result = _extract_json(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["action"] == "assigned"
-        assert result["milestone"] == "v1.0.0"
+        assert result["Success"] is True
+        assert result["Data"]["action"] == "assigned"
+        assert result["Data"]["milestone"] == "v1.0.0"
 
     def test_api_error_exits_3(self, _import_module):
         mod = _import_module

--- a/tests/skills/github/test_utility_scripts.py
+++ b/tests/skills/github/test_utility_scripts.py
@@ -65,10 +65,10 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "42", "--reaction", "eyes"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["succeeded"] == 1
-        assert result["failed"] == 0
-        assert result["results"][0]["success"] is True
-        assert result["results"][0]["comment_id"] == 42
+        assert result["Data"]["succeeded"] == 1
+        assert result["Data"]["failed"] == 0
+        assert result["Data"]["results"][0]["success"] is True
+        assert result["Data"]["results"][0]["comment_id"] == 42
 
     def test_happy_path_issue_comment(self, capsys):
         mod = self._import()
@@ -81,7 +81,7 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "10", "--comment-type", "issue", "--reaction", "+1"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["comment_type"] == "issue"
+        assert result["Data"]["comment_type"] == "issue"
 
     def test_batch_all_succeed(self, capsys):
         mod = self._import()
@@ -94,9 +94,9 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "1", "2", "3", "--reaction", "heart"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["total_count"] == 3
-        assert result["succeeded"] == 3
-        assert result["failed"] == 0
+        assert result["Data"]["total_count"] == 3
+        assert result["Data"]["succeeded"] == 3
+        assert result["Data"]["failed"] == 0
 
     def test_already_reacted_counts_as_success(self, capsys):
         mod = self._import()
@@ -109,7 +109,7 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "5", "--reaction", "rocket"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["succeeded"] == 1
+        assert result["Data"]["succeeded"] == 1
 
     def test_api_failure_counted(self, capsys):
         mod = self._import()
@@ -122,8 +122,8 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "9", "--reaction", "eyes"])
         assert rc == 3
         result = json.loads(capsys.readouterr().out)
-        assert result["failed"] == 1
-        assert result["results"][0]["success"] is False
+        assert result["Data"]["failed"] == 1
+        assert result["Data"]["results"][0]["success"] is False
 
     def test_partial_batch_failure(self, capsys):
         mod = self._import()
@@ -136,8 +136,8 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "1", "2", "--reaction", "eyes"])
         assert rc == 3
         result = json.loads(capsys.readouterr().out)
-        assert result["succeeded"] == 1
-        assert result["failed"] == 1
+        assert result["Data"]["succeeded"] == 1
+        assert result["Data"]["failed"] == 1
 
     def test_main_exits_3_on_failure(self):
         mod = self._import()
@@ -162,7 +162,7 @@ class TestAddCommentReaction:
         assert rc == 0
         captured = capsys.readouterr()
         parsed = json.loads(captured.out)
-        assert parsed["succeeded"] == 1
+        assert parsed["Data"]["succeeded"] == 1
 
     def test_help_does_not_crash(self):
         import add_comment_reaction as mod
@@ -180,7 +180,10 @@ class TestAddCommentReaction:
 
         with (
             patch("add_comment_reaction.assert_gh_authenticated"),
-            patch("add_comment_reaction.resolve_repo_params", return_value=RepoInfo(owner="owner", repo="repo")),
+            patch(
+                "add_comment_reaction.resolve_repo_params",
+                return_value=RepoInfo(owner="owner", repo="repo"),
+            ),
             patch("subprocess.run", side_effect=fake_run),
         ):
             mod.main(["--comment-id", "100", "--reaction", "eyes"])
@@ -199,7 +202,10 @@ class TestAddCommentReaction:
 
         with (
             patch("add_comment_reaction.assert_gh_authenticated"),
-            patch("add_comment_reaction.resolve_repo_params", return_value=RepoInfo(owner="owner", repo="repo")),
+            patch(
+                "add_comment_reaction.resolve_repo_params",
+                return_value=RepoInfo(owner="owner", repo="repo"),
+            ),
             patch("subprocess.run", side_effect=fake_run),
         ):
             mod.main(["--comment-id", "200", "--comment-type", "issue", "--reaction", "eyes"])

--- a/tests/test_add_comment_reaction.py
+++ b/tests/test_add_comment_reaction.py
@@ -77,6 +77,8 @@ def test_partial_failure(mock_run, capsys):
     rc = main(["--comment-id", "1", "2", "--reaction", "heart"])
     assert rc == 3
     output = json.loads(capsys.readouterr().out)
+    assert output["Success"] is False
+    assert output["Error"]["Code"] == 3
     assert output["Data"]["succeeded"] == 1
     assert output["Data"]["failed"] == 1
 

--- a/tests/test_add_comment_reaction.py
+++ b/tests/test_add_comment_reaction.py
@@ -44,8 +44,8 @@ def test_single_reaction(mock_run, capsys):
     rc = main(["--comment-id", "123", "--reaction", "eyes"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["succeeded"] == 1
-    assert output["failed"] == 0
+    assert output["Data"]["succeeded"] == 1
+    assert output["Data"]["failed"] == 0
 
 
 @patch("subprocess.run")
@@ -61,8 +61,8 @@ def test_batch_reactions(mock_run, capsys):
     rc = main(["--comment-id", "1", "2", "3", "--reaction", "+1"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["total_count"] == 3
-    assert output["succeeded"] == 3
+    assert output["Data"]["total_count"] == 3
+    assert output["Data"]["succeeded"] == 3
 
 
 @patch("subprocess.run")
@@ -77,8 +77,8 @@ def test_partial_failure(mock_run, capsys):
     rc = main(["--comment-id", "1", "2", "--reaction", "heart"])
     assert rc == 3
     output = json.loads(capsys.readouterr().out)
-    assert output["succeeded"] == 1
-    assert output["failed"] == 1
+    assert output["Data"]["succeeded"] == 1
+    assert output["Data"]["failed"] == 1
 
 
 @patch("subprocess.run")

--- a/tests/test_get_latest_semantic_milestone.py
+++ b/tests/test_get_latest_semantic_milestone.py
@@ -49,9 +49,9 @@ def test_finds_latest_milestone(mock_run, capsys):
     rc = main([])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["found"] is True
-    assert output["title"] == "0.10.0"
-    assert output["number"] == 2
+    assert output["Data"]["found"] is True
+    assert output["Data"]["title"] == "0.10.0"
+    assert output["Data"]["number"] == 2
 
 
 @patch("subprocess.run")
@@ -94,4 +94,4 @@ def test_single_milestone(mock_run, capsys):
     rc = main([])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["title"] == "1.0.0"
+    assert output["Data"]["title"] == "1.0.0"

--- a/tests/test_get_latest_semantic_milestone.py
+++ b/tests/test_get_latest_semantic_milestone.py
@@ -55,7 +55,7 @@ def test_finds_latest_milestone(mock_run, capsys):
 
 
 @patch("subprocess.run")
-def test_no_milestones(mock_run):
+def test_no_milestones(mock_run, capsys):
     mock_run.side_effect = [
         _completed(rc=0),
         _completed(stdout="https://github.com/o/r\n"),
@@ -64,10 +64,14 @@ def test_no_milestones(mock_run):
 
     rc = main([])
     assert rc == 2
+    output = json.loads(capsys.readouterr().out)
+    assert output["Success"] is False
+    assert output["Error"]["Code"] == 2
+    assert output["Data"]["found"] is False
 
 
 @patch("subprocess.run")
-def test_no_semantic_milestones(mock_run):
+def test_no_semantic_milestones(mock_run, capsys):
     milestones = json.dumps([
         {"title": "Future", "number": 1},
         {"title": "Backlog", "number": 2},
@@ -80,6 +84,10 @@ def test_no_semantic_milestones(mock_run):
 
     rc = main([])
     assert rc == 2
+    output = json.loads(capsys.readouterr().out)
+    assert output["Success"] is False
+    assert output["Error"]["Code"] == 2
+    assert output["Data"]["found"] is False
 
 
 @patch("subprocess.run")

--- a/tests/test_invoke_copilot_assignment.py
+++ b/tests/test_invoke_copilot_assignment.py
@@ -254,5 +254,6 @@ def test_prepare_context_only(mock_run, capsys):
 
     assert rc == 0
     output = _extract_json(capsys.readouterr().out)
-    assert "context_file" in output
-    assert output["existing_synthesis_id"] is None
+    assert output["Success"] is True
+    assert "context_file" in output["Data"]
+    assert output["Data"]["existing_synthesis_id"] is None

--- a/tests/test_invoke_copilot_assignment.py
+++ b/tests/test_invoke_copilot_assignment.py
@@ -32,6 +32,7 @@ main = _mod.main
 _has_content = _mod._has_synthesizable_content
 _build_comment = _mod._build_synthesis_comment
 _get_guidance = _mod._get_maintainer_guidance
+_get_plan = _mod._get_coderabbit_plan
 _get_triage = _mod._get_ai_triage_info
 _extract_yaml_list = _mod._extract_yaml_list
 
@@ -162,6 +163,21 @@ class TestGetMaintainerGuidance:
         assert result == []
 
 
+class TestGetCodeRabbitPlan:
+    def test_null_body_is_ignored(self):
+        comments = [{"body": None, "user": {"login": "coderabbitai[bot]"}}]
+        patterns = {
+            "username": "coderabbitai[bot]",
+            "implementation_plan": "## Implementation",
+            "related_issues": "Similar Issues",
+            "related_prs": "Related PRs",
+        }
+
+        result = _get_plan(comments, patterns)
+
+        assert result == {"implementation": None, "related_issues": [], "related_prs": []}
+
+
 class TestGetAITriageInfo:
     def test_table_format(self):
         comments = [
@@ -222,11 +238,35 @@ def test_dry_run_no_content(mock_run, capsys):
     with patch.object(_mod, "_load_synthesis_config", return_value=_test_config()):
         with patch.object(_mod, "get_issue_comments", return_value=[]):
             with patch.object(_mod, "get_trusted_source_comments", return_value=[]):
-                rc = main(["--issue-number", "1", "--dry-run"])
+                rc = main([
+                    "--issue-number", "1", "--dry-run", "--output-format", "human",
+                ])
 
     assert rc == 0
     out = capsys.readouterr().out
     assert "SKIP" in out
+
+
+@patch("subprocess.run")
+def test_dry_run_json_outputs_single_envelope(mock_run, capsys):
+    mock_run.side_effect = [
+        _completed(rc=0),  # auth
+        _completed(stdout="https://github.com/o/r\n"),  # remote
+        _completed(stdout=_issue_json()),  # issue fetch
+    ]
+
+    with patch.object(_mod, "_load_synthesis_config", return_value=_test_config()):
+        with patch.object(_mod, "get_issue_comments", return_value=[]):
+            with patch.object(_mod, "get_trusted_source_comments", return_value=[]):
+                rc = main([
+                    "--issue-number", "1", "--dry-run", "--output-format", "json",
+                ])
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["Success"] is True
+    assert output["Data"]["action"] == "dry_run"
+    assert output["Data"]["has_synthesizable_content"] is False
 
 
 def _extract_json(text: str) -> dict:

--- a/tests/test_new_issue.py
+++ b/tests/test_new_issue.py
@@ -46,8 +46,8 @@ def test_create_issue_with_body(mock_run, capsys):
     rc = main(["--title", "Bug: Something broke", "--body", "Steps to reproduce..."])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["success"] is True
-    assert output["issue_number"] == 99
+    assert output["Success"] is True
+    assert output["Data"]["issue_number"] == 99
 
 
 @patch("subprocess.run")
@@ -61,7 +61,7 @@ def test_create_issue_with_labels(mock_run, capsys):
     rc = main(["--title", "Feature", "--labels", "enhancement,P2"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["issue_number"] == 5
+    assert output["Data"]["issue_number"] == 5
 
 
 @patch("subprocess.run")
@@ -103,7 +103,7 @@ def test_body_file(mock_run, capsys, tmp_path):
     rc = main(["--title", "From file", "--body-file", str(body_file)])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["issue_number"] == 7
+    assert output["Data"]["issue_number"] == 7
 
 
 @patch("subprocess.run")

--- a/tests/test_set_issue_milestone.py
+++ b/tests/test_set_issue_milestone.py
@@ -48,8 +48,8 @@ def test_assign_milestone(mock_run, capsys):
     rc = main(["--issue", "1", "--milestone", "v1.0.0"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["success"] is True
-    assert output["action"] == "assigned"
+    assert output["Success"] is True
+    assert output["Data"]["action"] == "assigned"
 
 
 @patch("subprocess.run")
@@ -64,7 +64,7 @@ def test_already_has_same_milestone(mock_run, capsys):
     rc = main(["--issue", "1", "--milestone", "v1.0.0"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["action"] == "no_change"
+    assert output["Data"]["action"] == "no_change"
 
 
 @patch("subprocess.run")
@@ -94,7 +94,7 @@ def test_force_replace_milestone(mock_run, capsys):
     rc = main(["--issue", "1", "--milestone", "v1.0.0", "--force"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["action"] == "replaced"
+    assert output["Data"]["action"] == "replaced"
 
 
 @patch("subprocess.run")
@@ -109,7 +109,7 @@ def test_clear_milestone(mock_run, capsys):
     rc = main(["--issue", "1", "--clear"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["action"] == "cleared"
+    assert output["Data"]["action"] == "cleared"
 
 
 @patch("subprocess.run")
@@ -123,7 +123,7 @@ def test_clear_no_milestone(mock_run, capsys):
     rc = main(["--issue", "1", "--clear"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["action"] == "no_change"
+    assert output["Data"]["action"] == "no_change"
 
 
 @patch("subprocess.run")

--- a/tests/test_skill_post_issue_comment.py
+++ b/tests/test_skill_post_issue_comment.py
@@ -52,8 +52,8 @@ def test_post_comment(mock_run, capsys):
     rc = main(["--issue", "1", "--body", "Hello"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["success"] is True
-    assert output["comment_id"] == 100
+    assert output["Success"] is True
+    assert output["Data"]["comment_id"] == 100
 
 
 @patch("subprocess.run")
@@ -93,7 +93,7 @@ def test_marker_skip_existing(mock_run, capsys):
     rc = main(["--issue", "1", "--body", "New content", "--marker", "TEST-MARKER"])
     assert rc == 0
     output = _extract_json(capsys.readouterr().out)
-    assert output["skipped"] is True
+    assert output["Data"]["skipped"] is True
 
 
 @patch("subprocess.run")
@@ -119,7 +119,7 @@ def test_marker_update_existing(mock_run, capsys):
     ])
     assert rc == 0
     output = _extract_json(capsys.readouterr().out)
-    assert output["updated"] is True
+    assert output["Data"]["updated"] is True
 
 
 @patch("subprocess.run")


### PR DESCRIPTION
## Problem

The github skill emitted inconsistent JSON across scripts (#2388). Some bypassed the canonical `{Success, Data, Error, Metadata}` envelope (`post_issue_comment` emitted lowercase `{success, issue, comment_id}`); some used divergent key casing. A programmatic consumer that learned one shape mis-parsed another.

## What changed

Standardized 9 divergent scripts to the ADR-056 canonical envelope via the shared `github_core.output.write_skill_output` helper (reused, not reinvented): issue (`post_issue_comment`, `new_issue`, `edit_issue_body`, `set_issue_milestone`, `invoke_copilot_assignment`), milestone (`set_item_milestone`, `get_latest_semantic_milestone`), notifications (`get_actionable_items`), reactions (`add_comment_reaction`). Each now accepts `--output-format`, wraps stdout in the envelope, and keeps data keys under `Data`. 7 scripts named in the issue were already canonical on disk and are verified.

Consumers updated: all affected test files. The shared `_extract_json` test helpers were hardened (the nested envelope broke `rfind` brace matching).

## Contract test

`tests/skills/github/test_output_envelope_contract.py` runs each converted script under `--output-format json` and asserts the top-level keys are exactly `Success, Data, Error, Metadata`.

## Residual (why Refs, not Fixes)

The `pr/` family (23 scripts) is NOT converted here. Wrapping it requires lockstep consumer changes: `wait_for_unresolved_zero` reads top-level keys from `get_unresolved_review_threads`; `validate_pr_description` has an external consumer in the PR standards parser; several interleave human text with JSON. That is a 50-file migration and a separate atomic unit, tracked in `PR_RESIDUAL` in the contract test. This PR does the safe, complete issue/milestone/reaction half.

## Validation

`uv run pytest tests/ -k 'github or issue or pr_'` -> 1882 passed; contract test 10 passed. pre_pr clean of new failures. SKILL.md 4.0.0 to 4.1.0; both plugin manifests bumped; copilot mirror regenerated.

Refs #2388

## References

The unconverted PR validator dependency referenced above lives outside this diff:

```
.github/scripts/parse_pr_standards.py
```
