### PR TITLE
fix(build): exclude .pytest_tmp from plugin manifest discovery

### DIFF
--- a/build/scripts/validate_plugin_manifests.py
+++ b/build/scripts/validate_plugin_manifests.py
@@ -290,7 +290,7 @@ def find_manifests(root: Path) -> list[Path]:
     """
     import os
 
-    excluded_dirs = {"worktrees", "node_modules", ".git", "cache"}
+    excluded_dirs = {"worktrees", "node_modules", ".git", "cache", ".pytest_tmp"}
     results: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(root):
         # Prune excluded directories in-place so os.walk does not descend.

--- a/tests/build_scripts/test_validate_plugin_manifests.py
+++ b/tests/build_scripts/test_validate_plugin_manifests.py
@@ -385,6 +385,33 @@ def test_find_manifests_skips_worktrees(tmp_path: Path) -> None:
     assert "worktrees" not in str(found[0])
 
 
+def test_find_manifests_skips_pytest_tmp(tmp_path: Path) -> None:
+    """Regression for #2366: fixture manifests under .pytest_tmp must be ignored.
+
+    Tests that write fixtures under repo-root `.pytest_tmp` (for CWE-22
+    compliance with extract_and_index.py) would otherwise pollute later
+    plugin-manifest validation runs.
+    """
+    repo_manifest = tmp_path / "a" / ".claude-plugin" / "plugin.json"
+    repo_manifest.parent.mkdir(parents=True)
+    repo_manifest.write_text("{}", encoding="utf-8")
+    # Simulate the nested pytest temp tree shape from the issue.
+    fixture_manifest = (
+        tmp_path
+        / ".pytest_tmp"
+        / "pytest-of-user"
+        / "pytest-0"
+        / "fixture"
+        / ".claude-plugin"
+        / "plugin.json"
+    )
+    fixture_manifest.parent.mkdir(parents=True)
+    fixture_manifest.write_text("{}", encoding="utf-8")
+    found = vpm.find_manifests(tmp_path)
+    assert len(found) == 1
+    assert ".pytest_tmp" not in str(found[0])
+
+
 def test_main_returns_zero_when_all_valid(tmp_path: Path, capsys) -> None:
     target = _write(tmp_path, {"name": "p"})
     assert vpm.main(["--manifest", str(target), "--root", str(tmp_path)]) == 0


### PR DESCRIPTION
Fixes #2366

## Problem
Tests write fixture plugin manifests under repo-root `.pytest_tmp` (required for CWE-22 compliance in `extract_and_index` tests; see `tests/test_extract_and_index.py:78` and `tests/context-optimizer/test_compress_markdown_content.py:54`). The plugin manifest validator's `os.walk` did not prune that directory, so leftover/in-flight fixture manifests were scanned as if they were real repo plugin data:

```
33 of 67 manifest(s) invalid
assert 1 == 0
```

## Fix
Add `.pytest_tmp` to `excluded_dirs` in `build/scripts/validate_plugin_manifests.py::find_manifests`. Same approach as the existing `worktrees` exclusion.

## Tests
New regression test `test_find_manifests_skips_pytest_tmp` reproduces pytest-managed temporary plugin manifests from the issue. Verified failing on `main` without the fix, passing with it. All 39 `test_validate_plugin_manifests.py` tests pass.

## Acceptance
- [x] Plugin manifest validation ignores `.pytest_tmp` if it exists
- [x] Regression coverage proves invalid manifests under `.pytest_tmp` are ignored
- [x] Failing test first, then fix (TDD)
