### PR TITLE
fix(gitignore): track build/ generator sources by default (#2383)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,12 +46,16 @@ ENV/
 .pytest_cache/
 .pytest_tmp/
 .ruff_cache/
-# Anchored to repo root: the legacy python build/dist outputs live at /build
-# and /dist. An unanchored `build/` rule silently shadowed
-# `src/copilot-cli/skills/build/` (the M4 generated `/build` slash-command
-# skill), which made local file-counts diverge from CI.
+# Anchored to repo root: legacy python build/dist outputs live at /build
+# and /dist. Issue #2383: an unconditional `/build/` rule silently swallowed
+# tracked generator sources under build/scripts/, requiring `git add -f` for
+# new modules (which silently broke imports). We now ignore everything one
+# level under /build/ by default and re-include the known source paths.
 /dist/
-/build/
+/build/*
+!/build/*.py
+!/build/*.md
+!/build/scripts/
 
 # Agent PR scratch files
 .agents/pr-comments/

--- a/tests/test_gitignore_build_scripts.py
+++ b/tests/test_gitignore_build_scripts.py
@@ -1,0 +1,75 @@
+"""Regression tests for issue #2383.
+
+`.gitignore` must permit new generator sources under `build/` and
+`build/scripts/` to be tracked without `git add -f`, while still ignoring
+real build outputs under `build/` (e.g. `build/lib/`, `build/dist/`).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _check_ignore(repo: Path, relpath: str) -> bool:
+    """Return True iff git considers `relpath` ignored inside `repo`."""
+    # check-ignore exits 0 when the path IS ignored, 1 when NOT ignored.
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", "--no-index", relpath],
+        cwd=repo,
+        check=False,
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    raise RuntimeError(
+        f"git check-ignore failed (exit {result.returncode}) on {relpath}"
+    )
+
+
+def test_new_build_script_is_not_ignored():
+    """A brand-new build/scripts/*.py must be trackable without `git add -f`."""
+    new_path = "build/scripts/__regression_2383_new_module.py"
+    assert not _check_ignore(REPO_ROOT, new_path), (
+        f"{new_path} is gitignored; new generators silently won't be tracked. "
+        "See issue #2383."
+    )
+
+
+def test_nested_build_script_is_not_ignored():
+    """Nested subdirectories under build/scripts/ stay trackable."""
+    nested = "build/scripts/sub/__regression_2383_module.py"
+    assert not _check_ignore(REPO_ROOT, nested)
+
+
+def test_top_level_build_python_files_are_not_ignored():
+    """build/*.py (e.g. generate_agents.py) must be trackable."""
+    assert not _check_ignore(REPO_ROOT, "build/generate_agents.py")
+    assert not _check_ignore(REPO_ROOT, "build/__regression_2383_top.py")
+
+
+def test_top_level_build_markdown_is_not_ignored():
+    """build/AGENTS.md and other top-level .md files must be trackable."""
+    assert not _check_ignore(REPO_ROOT, "build/AGENTS.md")
+
+
+def test_build_output_directories_remain_ignored():
+    """Real build outputs (build/lib/, build/dist/) must still be ignored."""
+    for output in (
+        "build/lib/foo.txt",
+        "build/dist/wheel.whl",
+        "build/temp.linux/obj.o",
+    ):
+        assert _check_ignore(REPO_ROOT, output), (
+            f"{output} should remain gitignored — it's a real build output."
+        )
+
+
+def test_dist_root_remains_ignored():
+    """/dist/ must remain ignored."""
+    assert _check_ignore(REPO_ROOT, "dist/anything.whl")


### PR DESCRIPTION
## Summary

Fixes #2383. The repo-anchored `/build/` rule silently swallowed everything under `build/`, including the **tracked** generator sources in `build/scripts/`. A newly added `build/scripts/*.py` module required `git add -f` and would otherwise cause an `ImportError` when whatever facade landed first referenced the still-untracked sibling.

## Fix

Switch `.gitignore` from `/build/` to `/build/*` plus explicit re-includes:

```
/build/*
!/build/*.py
!/build/*.md
!/build/scripts/
```

Result:
- `build/*.py` (generate_agents.py, generate_agent_catalog.py, ...) — trackable
- `build/*.md` (AGENTS.md) — trackable
- `build/scripts/` and everything beneath it — trackable (including nested dirs)
- real build outputs (`build/lib/`, `build/dist/`, `build/temp.*`) — still ignored
- `/dist/` — still ignored

## Tests

New `tests/test_gitignore_build_scripts.py` (6 cases) covers both the regression and the negative side (build outputs must stay ignored). All pass locally.

## Acceptance
- [x] Reproduced the failure (`git check-ignore -v build/scripts/new_module.py` matched `/build/` before the fix)
- [x] Failing test written first, passes after the .gitignore change
- [x] Existing tests unaffected (only adds a new test file)
- [x] PR references "Fixes #2383"

Fixes #2383