### PR TITLE
fix(workflow-local-test): detect linked git worktree and exit 3 with precise error (#2344)

### DIFF
--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -24,6 +24,24 @@ block with an actionable message. A documented bypass exists for workflows that
 genuinely cannot run under act (secrets, ARM-only runners): set
 ``SKIP_WORKFLOW_LOCAL_TEST=true``; the bypass is logged, not hidden.
 
+When ``SKIP_WORKFLOW_LOCAL_TEST=true`` is allowed
+-------------------------------------------------
+
+The bypass is intended for environment limitations, NOT to mask workflow
+defects. Allowed cases:
+
+- The workflow requires secrets that cannot be provided to ``gh act``
+  (e.g. ``BOT_PAT``, OIDC-only credentials).
+- The workflow targets an ARM-only or self-hosted runner that ``act`` cannot
+  emulate (composite actions pinned to ``runs-on: [self-hosted, arm64]``).
+- The runner reports exit 3 because of an environment incompatibility it
+  could detect precisely (e.g. ``linked git worktree`` per Issue #2344) and
+  re-running from the main worktree is not feasible.
+- Docker is unavailable on the host and ``--no-full`` is not an option.
+
+Not allowed: silencing a workflow that genuinely fails the dry-run or full
+execution stages. Those are workflow defects and must be fixed.
+
 CLI
 ---
 
@@ -113,6 +131,35 @@ def _gh_act_available() -> bool:
     """True when the ``gh act`` extension is installed."""
     rc, _, _ = _run(["gh", "act", "--help"], timeout=20)
     return rc == 0
+
+
+def _linked_worktree_gitdir(repo_root: Path) -> str | None:
+    """Return the absolute gitdir path if ``repo_root`` is a linked worktree.
+
+    Per ``git-worktree(1)``, a linked worktree's ``.git`` is a regular file
+    whose contents are ``gitdir: <absolute path>`` pointing into the main
+    repo's ``.git/worktrees/<name>/`` directory. The main worktree has a
+    ``.git`` *directory* instead. Returns ``None`` for the main worktree,
+    a non-git checkout, or any unreadable ``.git`` marker.
+
+    ``act`` / ``gh act`` resolves git metadata via go-git and trips on this
+    layout under pr-autofix's bare-clone cache
+    (``$HOME/.cache/pr-autofix/<repo>.git/worktrees/<id>/``) — full execution
+    produces what looks like a workflow failure. The caller uses this to
+    emit a precise exit-3 environment error before that misdirection occurs.
+    See Issue #2344.
+    """
+    dot_git = repo_root / ".git"
+    if not dot_git.is_file():
+        return None
+    try:
+        marker = dot_git.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return None
+    prefix = "gitdir:"
+    if not marker.startswith(prefix):
+        return None
+    return marker[len(prefix):].strip() or None
 
 
 def _run(cmd: list[str], *, timeout: int, cwd: Path | None = None) -> tuple[int, str, str]:
@@ -259,6 +306,25 @@ def run_local_test(
         report.note = (
             "gh act extension not installed. Install it via "
             f"'gh extension install nektos/gh-act' or set {_BYPASS_ENV}=true."
+        )
+        return report
+
+    # Linked-worktree gate. ``act`` / ``gh act`` resolves git metadata via
+    # go-git and fails opaquely from a linked worktree (the ``.git`` file +
+    # ``.git/worktrees/<name>/`` layout); pr-autofix runs under exactly that
+    # shape at ``$HOME/.cache/pr-autofix/<repo>.git/worktrees/<id>/``. Without
+    # this gate the failure surfaces as a workflow validation error and the
+    # agent reaches for ``SKIP_WORKFLOW_LOCAL_TEST=true`` for a valid workflow.
+    # Surface it as exit 3 (tool/env), not exit 1 (workflow), with bypass
+    # guidance. See Issue #2344.
+    linked_gitdir = _linked_worktree_gitdir(repo_root)
+    if linked_gitdir is not None:
+        report.exit_code = 3
+        report.note = (
+            "gh act does not support running from a linked git worktree "
+            f"({repo_root} -> {linked_gitdir}). Re-run from the main worktree, "
+            f"or set {_BYPASS_ENV}=true to bypass (logged). "
+            "Tracked in Issue #2344."
         )
         return report
 

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -144,7 +144,7 @@ def _linked_worktree_gitdir(repo_root: Path) -> str | None:
 
     ``act`` / ``gh act`` resolves git metadata via go-git and trips on this
     layout under pr-autofix's bare-clone cache
-    (``$HOME/.cache/pr-autofix/<repo>.git/worktrees/<id>/``) — full execution
+    (``$HOME/.cache/pr-autofix/<repo>.git/worktrees/<id>/``); full execution
     produces what looks like a workflow failure. The caller uses this to
     emit a precise exit-3 environment error before that misdirection occurs.
     See Issue #2344.
@@ -153,13 +153,26 @@ def _linked_worktree_gitdir(repo_root: Path) -> str | None:
     if not dot_git.is_file():
         return None
     try:
-        marker = dot_git.read_text(encoding="utf-8", errors="replace").strip()
+        content = dot_git.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return None
-    prefix = "gitdir:"
-    if not marker.startswith(prefix):
+    lines = content.splitlines()
+    if not lines:
         return None
-    return marker[len(prefix):].strip() or None
+    prefix = "gitdir:"
+    first_line = lines[0].strip()
+    if not first_line.startswith(prefix):
+        return None
+    path_str = first_line[len(prefix):].strip()
+    if not path_str:
+        return None
+    # git records an absolute path by default; return it verbatim so the
+    # value is not re-mangled by the host platform's path semantics. Only a
+    # relative marker (git >= 2.48 --relative-paths) needs anchoring to
+    # repo_root to honor the documented absolute-path contract (CWE-22).
+    if path_str.startswith("/") or Path(path_str).is_absolute():
+        return path_str
+    return str((repo_root / path_str).resolve())
 
 
 def _run(cmd: list[str], *, timeout: int, cwd: Path | None = None) -> tuple[int, str, str]:

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -179,6 +179,75 @@ def test_no_full_does_not_require_docker(all_tools, monkeypatch, tmp_path):
     assert r.exit_code == 0
 
 
+# --- linked-worktree detection (Issue #2344) -----------------------------
+
+
+def _make_linked_worktree(tmp_path, gitdir_target: str = "/some/main/.git/worktrees/wt"):
+    """Stage a fake linked worktree: ``.git`` is a file with ``gitdir: <path>``."""
+    (tmp_path / ".git").write_text(f"gitdir: {gitdir_target}\n", encoding="utf-8")
+    (tmp_path / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def test_linked_worktree_detected_returns_path(tmp_path):
+    _make_linked_worktree(tmp_path, gitdir_target="/main/.git/worktrees/abc")
+    assert w._linked_worktree_gitdir(tmp_path) == "/main/.git/worktrees/abc"
+
+
+def test_main_worktree_with_dotgit_dir_returns_none(tmp_path):
+    (tmp_path / ".git").mkdir()
+    assert w._linked_worktree_gitdir(tmp_path) is None
+
+
+def test_no_dotgit_at_all_returns_none(tmp_path):
+    assert w._linked_worktree_gitdir(tmp_path) is None
+
+
+def test_dotgit_file_without_gitdir_prefix_returns_none(tmp_path):
+    (tmp_path / ".git").write_text("not a gitdir marker\n", encoding="utf-8")
+    assert w._linked_worktree_gitdir(tmp_path) is None
+
+
+def test_linked_worktree_is_exit_3_not_exit_1(all_tools, monkeypatch, tmp_path):
+    # The whole point: a linked worktree must surface as a tool/env failure
+    # (exit 3) BEFORE the act stages run, not as a workflow failure (exit 1).
+    _make_linked_worktree(tmp_path)
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    called = {"act": False}
+
+    def _act(f, r):
+        called["act"] = True
+        return _ok("gh act -n")
+
+    monkeypatch.setattr(w, "_act_dryrun_stage", _act)
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 3
+    assert called["act"] is False  # never reach act
+    assert "linked git worktree" in r.note
+    assert "SKIP_WORKFLOW_LOCAL_TEST" in r.note
+    assert "#2344" in r.note
+
+
+def test_linked_worktree_bypass_still_works(monkeypatch, tmp_path):
+    # Bypass short-circuits BEFORE the linked-worktree check; the env flag is
+    # the documented escape hatch and must continue to work from a worktree.
+    _make_linked_worktree(tmp_path)
+    monkeypatch.setenv(w._BYPASS_ENV, "true")
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 0
+    assert r.bypassed is True
+
+
+def test_main_worktree_unaffected(all_tools, monkeypatch, tmp_path):
+    # A regular checkout (.git is a directory) must not trigger the gate.
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
+    monkeypatch.setattr(w, "_act_full_stage", lambda f, r: _ok("gh act (full)"))
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 0
+
+
 # --- stage ordering + short-circuit --------------------------------------
 
 

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -194,6 +194,14 @@ def test_linked_worktree_detected_returns_path(tmp_path):
     assert w._linked_worktree_gitdir(tmp_path) == "/main/.git/worktrees/abc"
 
 
+def test_relative_gitdir_marker_is_resolved_absolute(tmp_path):
+    # git >= 2.48 (--relative-paths) can record a relative gitdir; the helper
+    # must anchor it to repo_root and return an absolute path per its contract.
+    _make_linked_worktree(tmp_path, gitdir_target="../abc/.git/worktrees/x")
+    expected = str((tmp_path / "../abc/.git/worktrees/x").resolve())
+    assert w._linked_worktree_gitdir(tmp_path) == expected
+
+
 def test_main_worktree_with_dotgit_dir_returns_none(tmp_path):
     (tmp_path / ".git").mkdir()
     assert w._linked_worktree_gitdir(tmp_path) is None


### PR DESCRIPTION
Fixes #2344

## Problem

`gh act` resolves git metadata via go-git and fails opaquely when invoked from a linked git worktree (the layout pr-autofix uses under `$HOME/.cache/pr-autofix/<repo>.git/worktrees/<id>/`). The failure surfaced as a workflow validation error (exit 1), tempting agents to set `SKIP_WORKFLOW_LOCAL_TEST=true` on valid workflows  -  exactly what happened on PR #2332.

## Fix

`scripts/validation/run_workflow_local_test.py`:

1. New `_linked_worktree_gitdir(repo_root)` helper: returns the absolute gitdir path when `.git` is a *file* containing `gitdir: <path>` (linked-worktree marker per `git-worktree(1)`), `None` otherwise.
2. After the gh / gh-act presence checks and before the act stages, check for the linked-worktree shape. If detected, exit 3 (tool/env) with a message naming the worktree path, the gitdir target, and bypass guidance referencing #2344.
3. Updated module docstring to document the four allowed cases for `SKIP_WORKFLOW_LOCAL_TEST=true` (env limitations only, never to mask workflow defects).

The bypass env check still runs first, so operators who knowingly accept the worktree limitation can opt out as before.

## Acceptance

- [x] Local workflow testing fails with a specific non-workflow error explaining the unsupported layout (exit 3, not exit 1).
- [x] The failure no longer looks like a workflow validation failure.
- [x] Tests cover linked-worktree git metadata detection (8 new cases).

## Tests

`tests/validation/test_run_workflow_local_test.py`  -  8 new tests:

- `_linked_worktree_gitdir` returns the path / None for all four shapes (linked file, main dir, no .git, malformed marker)
- linked worktree is exit 3, NOT exit 1, and the act stages never run
- bypass env still short-circuits from a linked worktree
- main worktree (`.git` is a directory) is unaffected

All 305 tests in `tests/validation/` + `tests/skills/github/` suites pass.

## Reviewer notes

The fix is narrow on purpose: making `gh act` actually work from a linked worktree would require shipping a copy of the repo metadata into the worktree (or relinking the gitdir), and the upstream go-git issue is unresolved. Surfacing a precise environment error preserves the validation guarantee for the main-worktree case while telling agents what to do (re-run from main, or bypass with logged justification).

Co-Authored-By: Richard Murillo <rjmurillo@users.noreply.github.com>
