### PR TITLE
fix(ci): align retrospective action SHA assertion with v1.0.136 bump

### DIFF
--- a/.github/workflows/post-pr-retrospective.yml
+++ b/.github/workflows/post-pr-retrospective.yml
@@ -222,7 +222,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # Pin to SHA matches rjmurillo-bot.yml.
-      # https://github.com/anthropics/claude-code-action/releases/tag/v1.0.135
+      # https://github.com/anthropics/claude-code-action/releases/tag/v1.0.136
       #
       # Failure isolation (Issue #2015):
       #   This workflow is async, best-effort, and never blocks merge (see the

--- a/tests/workflows/test_post_pr_retrospective.py
+++ b/tests/workflows/test_post_pr_retrospective.py
@@ -23,7 +23,7 @@ _WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "post-pr-retrospective.y
 
 _AGENT_STEP_NAME = "Run retrospective via Claude Code"
 _ACTION_REF = (
-    "anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f"
+    "anthropics/claude-code-action@0b1b62002952733671bde978d429b50b51c51c85"
 )
 _OAUTH_TOKEN_EXPR = "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
 


### PR DESCRIPTION
## Summary

Renovate #2420 bumped `anthropics/claude-code-action` to **v1.0.136** (`0b1b6200`) in `post-pr-retrospective.yml`, but left two references pinned at **v1.0.135** (`70a6e525`):

1. `tests/workflows/test_post_pr_retrospective.py` `_ACTION_REF` constant. `test_agent_step_keeps_sha_pinned_action` reads the workflow's pinned SHA and asserts it equals `_ACTION_REF`. The mismatch makes **"Run Python Tests"** fail on `main` and on **every PR merge ref**, blocking the merge queue fleet-wide.
2. The release-link comment above the pinned step (cosmetic, but kept consistent).

This PR updates both to v1.0.136 to match the actual pinned SHA.

## Verification

- `pytest tests/workflows/test_post_pr_retrospective.py` -> 10/10 pass (was 1 failing).
- Confirmed against `origin/main` HEAD that the test fails before this change.

## Impact

Unblocks `Run Python Tests` across all open PRs once merged and branches rebase.

Refs #2015
