### PR TITLE
feat(ci): wire external-signal aggregator into ai-spec-validation (observe)

### DIFF
--- a/.github/workflows/ai-spec-validation.yml
+++ b/.github/workflows/ai-spec-validation.yml
@@ -106,7 +106,7 @@ jobs:
           HAS_CODE_CHANGES: ${{ needs.check-paths.outputs.has-code-changes }}
         run: |
           if [ "$HAS_CODE_CHANGES" != "true" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Skipped - no code changes detected"
           fi
 
@@ -166,17 +166,19 @@ jobs:
           # Parsing lives in a tested script per ADR-006.
           INCREMENTAL_SCOPE=$(python3 .github/scripts/extract_incremental_scope.py "$PR_TITLE")
 
-          echo "spec_refs=$SPEC_REFS" >> $GITHUB_OUTPUT
-          echo "issue_refs=$ISSUE_REFS" >> $GITHUB_OUTPUT
-          echo "incremental_scope=$INCREMENTAL_SCOPE" >> $GITHUB_OUTPUT
+          {
+            echo "spec_refs=$SPEC_REFS"
+            echo "issue_refs=$ISSUE_REFS"
+            echo "incremental_scope=$INCREMENTAL_SCOPE"
+          } >> "$GITHUB_OUTPUT"
 
           if [ -z "$SPEC_REFS" ] && [ -z "$ISSUE_REFS" ]; then
             echo "No spec references found in PR"
-            echo "has_specs=false" >> $GITHUB_OUTPUT
+            echo "has_specs=false" >> "$GITHUB_OUTPUT"
           else
             echo "Found spec references: $SPEC_REFS"
             echo "Found issue references: $ISSUE_REFS"
-            echo "has_specs=true" >> $GITHUB_OUTPUT
+            echo "has_specs=true" >> "$GITHUB_OUTPUT"
           fi
 
           # Cleanup temp files
@@ -192,6 +194,7 @@ jobs:
           SPEC_CONTENT=""
 
           # Load from spec files
+          # shellcheck disable=SC2086 # SPEC_REFS is a space-delimited ref list.
           for ref in $SPEC_REFS; do
             # If it's a path, load directly
             if [[ "$ref" == *.md ]]; then
@@ -208,6 +211,7 @@ jobs:
           done
 
           # Load from linked issues
+          # shellcheck disable=SC2086 # ISSUE_REFS is a space-delimited ref list.
           for issue in $ISSUE_REFS; do
             # Parse cross-repo format (owner/repo#123) vs simple format (123)
             if [[ "$issue" == *"/"* ]]; then
@@ -234,7 +238,7 @@ jobs:
 
           # Save to file for later steps
           echo "$SPEC_CONTENT" > /tmp/spec-content.md
-          echo "spec_file=/tmp/spec-content.md" >> $GITHUB_OUTPUT
+          echo "spec_file=/tmp/spec-content.md" >> "$GITHUB_OUTPUT"
 
       - name: Prepare Spec Context
         if: steps.should-run.outputs.skip != 'true' && steps.spec-ref.outputs.has_specs == 'true'
@@ -264,9 +268,9 @@ jobs:
                 echo "and must be treated as N/A for this evaluation."
               fi
               echo "EOF_SPEC"
-            } >> $GITHUB_OUTPUT
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "spec_context=No spec content loaded" >> $GITHUB_OUTPUT
+            echo "spec_context=No spec content loaded" >> "$GITHUB_OUTPUT"
           fi
 
       - name: 🔗 Requirements Traceability Check (Analyst Agent)
@@ -324,20 +328,26 @@ jobs:
           if [ -z "$PR_BODY" ] && [ -n "$PR_NUMBER" ]; then
             PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json body -q .body 2>/dev/null || true)
           fi
-          printf '%s' "$PR_BODY" > /tmp/pr-body-signal.md
+          body_file="${RUNNER_TEMP:-.}/pr-body-signal-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.md"
+          summary_file="${RUNNER_TEMP:-.}/external-gate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
+          printf '%s' "$PR_BODY" > "$body_file"
           # Capture the observe verdict and surface it in the job summary, so a
           # run records the externally-grounded signal whether or not it blocks.
-          PR_BODY_FILE=/tmp/pr-body-signal.md \
+          set +e
+          PR_BODY_FILE="$body_file" \
             python3 scripts/quality_gate/spec_external_signal_gate.py \
-            | tee /tmp/external-gate.json || true
+            | tee "$summary_file"
+          gate_rc=${PIPESTATUS[0]}
+          set -e
           {
             echo "### External-signal gate (observe)"
             echo ""
             echo '```json'
-            cat /tmp/external-gate.json 2>/dev/null || echo "(no output)"
+            cat "$summary_file" 2>/dev/null || echo "(no output)"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          rm -f /tmp/pr-body-signal.md /tmp/external-gate.json
+          rm -f "$body_file" "$summary_file"
+          exit "$gate_rc"
 
       - name: Generate Validation Report
         if: steps.should-run.outputs.skip != 'true'

--- a/.github/workflows/ai-spec-validation.yml
+++ b/.github/workflows/ai-spec-validation.yml
@@ -319,9 +319,25 @@ jobs:
         run: |
           # PR body passed via env and written to a file to avoid shell
           # injection from special characters; the adapter reads PR_BODY_FILE.
+          # On workflow_dispatch the event body is empty, so fall back to the
+          # body fetched via gh (mirrors the Extract Spec References step).
+          if [ -z "$PR_BODY" ] && [ -n "$PR_NUMBER" ]; then
+            PR_BODY=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json body -q .body 2>/dev/null || true)
+          fi
           printf '%s' "$PR_BODY" > /tmp/pr-body-signal.md
+          # Capture the observe verdict and surface it in the job summary, so a
+          # run records the externally-grounded signal whether or not it blocks.
           PR_BODY_FILE=/tmp/pr-body-signal.md \
-            python3 scripts/quality_gate/spec_external_signal_gate.py
+            python3 scripts/quality_gate/spec_external_signal_gate.py \
+            | tee /tmp/external-gate.json || true
+          {
+            echo "### External-signal gate (observe)"
+            echo ""
+            echo '```json'
+            cat /tmp/external-gate.json 2>/dev/null || echo "(no output)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          rm -f /tmp/pr-body-signal.md /tmp/external-gate.json
 
       - name: Generate Validation Report
         if: steps.should-run.outputs.skip != 'true'

--- a/.github/workflows/ai-spec-validation.yml
+++ b/.github/workflows/ai-spec-validation.yml
@@ -299,6 +299,30 @@ jobs:
           bot-pat: ${{ secrets.BOT_PAT }}
           copilot-token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 
+      # Issue #2108 / #1855: enforce the closed-loop rule (no PASS on LLM
+      # verdicts alone) by adding the deterministic acceptance-criteria
+      # extractor as an external signal alongside the analyst (trace) and
+      # critic (completeness) verdicts, fed to
+      # scripts/external_signals/gate_aggregator.py. This is observable
+      # (continue-on-error) and reported in the job summary; it does not yet
+      # replace the authoritative gate in check_spec_failures.py. Swapping the
+      # final gate is deferred to a canary (see PR #2361 and the PR
+      # description).
+      - name: External-signal gate (observe)
+        if: steps.should-run.outputs.skip != 'true' && steps.spec-ref.outputs.has_specs == 'true'
+        id: external-gate
+        continue-on-error: true
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          TRACE_VERDICT: ${{ steps.trace.outputs.verdict }}
+          COMPLETENESS_VERDICT: ${{ steps.completeness.outputs.verdict }}
+        run: |
+          # PR body passed via env and written to a file to avoid shell
+          # injection from special characters; the adapter reads PR_BODY_FILE.
+          printf '%s' "$PR_BODY" > /tmp/pr-body-signal.md
+          PR_BODY_FILE=/tmp/pr-body-signal.md \
+            python3 scripts/quality_gate/spec_external_signal_gate.py
+
       - name: Generate Validation Report
         if: steps.should-run.outputs.skip != 'true'
         id: report

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -181,6 +181,11 @@ jobs:
 
       - name: Run pip-audit
         run: |
+          # Keep the audited environment on the first fixed pip release for
+          # PYSEC-2026-196. CI hit pip 26.1.1 after setup-code-env installed
+          # dependencies, and pip-audit reports the fixed version as 26.1.2.
+          python -m pip install --upgrade pip==26.1.2
+
           # Ignored CVEs (re-evaluate when upstream releases a fix):
           #   CVE-2026-4539: pygments 2.19.2, no fix available.
           #   CVE-2026-3219: pip 26.0/26.0.1 mishandles concatenated tar/ZIP

--- a/scripts/quality_gate/spec_external_signal_gate.py
+++ b/scripts/quality_gate/spec_external_signal_gate.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Build gate-aggregator signals for the spec-validation workflow.
+
+Issue #2108 / #1855: no quality gate may pass on LLM verdicts alone. The
+spec-validation workflow (``ai-spec-validation.yml``) decides requirements
+coverage from two LLM agents (analyst traceability, critic completeness). This
+adapter adds the deterministic acceptance-criteria extractor
+(``scripts/external_signals/acceptance_criteria.py``) as an externally-grounded
+signal, then feeds all three to
+``scripts/external_signals/gate_aggregator.py``, which refuses ``PASS`` when no
+external signal is present (the closed-loop rule).
+
+This job is ADDITIVE and OBSERVABLE. It does NOT replace the authoritative gate
+in ``.github/scripts/check_spec_failures.py``; it surfaces the
+externally-grounded verdict alongside it so the closed-loop guarantee from
+#1855 is enforced and visible. Swapping the final spec gate to this aggregator
+is a separate, higher-risk change deferred to a canary (see PR #2361 and the
+PR description).
+
+Signals built:
+
+* ``external:acceptance-criteria=VERDICT`` from the PR body. The extractor is
+  deterministic (no model calls, no network):
+    - criteria declared and all checked -> PASS
+    - criteria declared with one or more unchecked -> FAIL
+    - no acceptance section / no criteria found -> UNKNOWN (inconclusive;
+      forces NEEDS_REVIEW under the closed-loop rule rather than blocking a PR
+      that legitimately declares no checkbox section).
+* ``llm:trace=VERDICT`` and ``llm:completeness=VERDICT`` from the two agents.
+  Tokens are normalized to the gate_aggregator vocabulary:
+    - COMPLIANT -> PASS, NON_COMPLIANT -> FAIL, PARTIAL -> WARN,
+      NEEDS_REVIEW -> FAIL (matches scripts/ai_review_common/verdict.py
+      FAIL_VERDICTS, which include NEEDS_REVIEW), empty/missing -> UNKNOWN.
+    - any other verdict is passed through and validated by gate_aggregator.
+
+Input env vars:
+    PR_BODY_FILE         - path to a file holding the PR body markdown. When
+                           unset or unreadable, the acceptance-criteria signal
+                           is UNKNOWN (no deterministic result available).
+    TRACE_VERDICT        - analyst traceability agent verdict.
+    COMPLETENESS_VERDICT - critic completeness agent verdict.
+
+Exit codes: delegated to gate_aggregator.main (ADR-035):
+    0 - final verdict PASS or WARN
+    1 - blocking verdict, or closed-loop refusal (no external signal)
+    2 - bad invocation
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+try:
+    from .path_utils import REPOSITORY_ROOT
+except ImportError:  # pragma: no cover - script execution path
+    from path_utils import REPOSITORY_ROOT
+
+_WORKSPACE = REPOSITORY_ROOT
+sys.path.insert(0, str(_WORKSPACE))
+
+from scripts.external_signals import acceptance_criteria, gate_aggregator  # noqa: E402
+
+# Agent verdict tokens normalized to preserve the authoritative gate semantics.
+# Mirrors scripts/quality_gate/external_signal_gate.py:_AGENT_VERDICT_ALIAS.
+_AGENT_VERDICT_ALIAS = {
+    "COMPLIANT": "PASS",
+    "NEEDS_REVIEW": "FAIL",
+    "NON_COMPLIANT": "FAIL",
+    "PARTIAL": "WARN",
+    "": "UNKNOWN",
+}
+
+
+def acceptance_verdict(body: str) -> str:
+    """Return the deterministic acceptance-criteria verdict token.
+
+    * criteria declared and all checked -> PASS
+    * criteria declared with unchecked items -> FAIL
+    * no criteria declared -> UNKNOWN (inconclusive, not a hard block)
+    """
+
+    report = acceptance_criteria.evaluate(body)
+    if not report.criteria:
+        return "UNKNOWN"
+    return "PASS" if report.passed else "FAIL"
+
+
+def acceptance_signal(body: str) -> str:
+    """Return an ``external:acceptance-criteria=VERDICT`` spec."""
+
+    return f"external:acceptance-criteria={acceptance_verdict(body)}"
+
+
+def agent_signal(agent: str, verdict: str) -> str:
+    """Return an ``llm:<agent>=VERDICT`` spec, aliasing known tokens."""
+
+    normalized = verdict.strip().upper()
+    normalized = _AGENT_VERDICT_ALIAS.get(normalized, normalized)
+    return f"llm:{agent}={normalized}"
+
+
+def _read_body(path_str: str) -> str:
+    """Read the PR body from ``path_str``; return '' on any miss.
+
+    A missing or unreadable body file yields an empty string, which maps to an
+    UNKNOWN acceptance-criteria signal (no deterministic result available)
+    rather than crashing the observe step.
+    """
+
+    if not path_str:
+        return ""
+    path = Path(path_str)
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def build_signals(env: dict[str, str]) -> list[str]:
+    """Return the full ``--signal`` argument list for gate_aggregator."""
+
+    body = _read_body(env.get("PR_BODY_FILE", ""))
+    return [
+        acceptance_signal(body),
+        agent_signal("trace", env.get("TRACE_VERDICT", "")),
+        agent_signal("completeness", env.get("COMPLETENESS_VERDICT", "")),
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0]).parse_args(argv)
+
+    signals = build_signals(dict(os.environ))
+    aggregator_argv: list[str] = ["--json"]
+    for signal in signals:
+        aggregator_argv.extend(["--signal", signal])
+
+    return gate_aggregator.main(aggregator_argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quality_gate/spec_external_signal_gate.py
+++ b/scripts/quality_gate/spec_external_signal_gate.py
@@ -105,9 +105,13 @@ def agent_signal(agent: str, verdict: str) -> str:
 def _read_body(path_str: str) -> str:
     """Read the PR body from ``path_str``; return '' on any miss.
 
-    A missing or unreadable body file yields an empty string, which maps to an
-    UNKNOWN acceptance-criteria signal (no deterministic result available)
-    rather than crashing the observe step.
+    A missing, unreadable, or non-UTF-8 body file yields an empty string, which
+    maps to an UNKNOWN acceptance-criteria signal (no deterministic result
+    available) rather than crashing the observe step. ``UnicodeDecodeError`` is
+    treated as a miss alongside ``OSError`` because a body that is not valid
+    UTF-8 carries no parseable acceptance criteria; the empty result forces
+    NEEDS_REVIEW under the closed-loop rule, so the degradation is visible, not
+    silent.
     """
 
     if not path_str:
@@ -115,7 +119,7 @@ def _read_body(path_str: str) -> str:
     path = Path(path_str)
     try:
         return path.read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return ""
 
 

--- a/tests/quality_gate/test_spec_external_signal_gate.py
+++ b/tests/quality_gate/test_spec_external_signal_gate.py
@@ -150,6 +150,19 @@ class TestBuildSignals:
         signals = build_signals({"TRACE_VERDICT": "PASS"})
         assert signals[0] == "external:acceptance-criteria=UNKNOWN"
 
+    def test_non_utf8_body_file_is_unknown(self, tmp_path) -> None:
+        # A body file that is not valid UTF-8 must degrade to UNKNOWN, not crash
+        # the observe step with UnicodeDecodeError.
+        body_file = tmp_path / "body.md"
+        body_file.write_bytes(b"\xff\xfe acceptance criteria \x80\x81")
+        env = {
+            "PR_BODY_FILE": str(body_file),
+            "TRACE_VERDICT": "PASS",
+            "COMPLETENESS_VERDICT": "PASS",
+        }
+        signals = build_signals(env)
+        assert signals[0] == "external:acceptance-criteria=UNKNOWN"
+
 
 # ---------------------------------------------------------------------------
 # main: end-to-end through gate_aggregator

--- a/tests/quality_gate/test_spec_external_signal_gate.py
+++ b/tests/quality_gate/test_spec_external_signal_gate.py
@@ -1,0 +1,227 @@
+"""Tests for scripts/quality_gate/spec_external_signal_gate.py (Issue #2108).
+
+Pins the signal-building adapter that feeds the gate aggregator for the
+spec-validation workflow: deterministic acceptance-criteria mapping, agent
+verdict aliasing, and the closed-loop guarantee (#1855) that PASS is refused
+without a usable external signal.
+"""
+
+from __future__ import annotations
+
+from scripts.quality_gate.spec_external_signal_gate import (
+    acceptance_signal,
+    acceptance_verdict,
+    agent_signal,
+    build_signals,
+    main,
+)
+
+_BODY_ALL_CHECKED = """
+## Acceptance Criteria
+
+- [x] wire the aggregator into the spec workflow
+- [x] add tests for the adapter
+"""
+
+_BODY_UNCHECKED = """
+## Acceptance Criteria
+
+- [x] wire the aggregator into the spec workflow
+- [ ] add tests for the adapter
+"""
+
+_BODY_NO_CRITERIA = """
+## Summary
+
+This PR has no acceptance section.
+"""
+
+
+# ---------------------------------------------------------------------------
+# acceptance_verdict
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptanceVerdict:
+    def test_all_checked_is_pass(self) -> None:
+        assert acceptance_verdict(_BODY_ALL_CHECKED) == "PASS"
+
+    def test_unchecked_is_fail(self) -> None:
+        assert acceptance_verdict(_BODY_UNCHECKED) == "FAIL"
+
+    def test_no_criteria_is_unknown(self) -> None:
+        assert acceptance_verdict(_BODY_NO_CRITERIA) == "UNKNOWN"
+
+    def test_empty_body_is_unknown(self) -> None:
+        assert acceptance_verdict("") == "UNKNOWN"
+
+
+class TestAcceptanceSignal:
+    def test_prefixes_external_acceptance_criteria(self) -> None:
+        assert (
+            acceptance_signal(_BODY_ALL_CHECKED)
+            == "external:acceptance-criteria=PASS"
+        )
+
+    def test_unchecked_signal_is_fail(self) -> None:
+        assert (
+            acceptance_signal(_BODY_UNCHECKED) == "external:acceptance-criteria=FAIL"
+        )
+
+    def test_no_criteria_signal_is_unknown(self) -> None:
+        assert (
+            acceptance_signal(_BODY_NO_CRITERIA)
+            == "external:acceptance-criteria=UNKNOWN"
+        )
+
+
+# ---------------------------------------------------------------------------
+# agent_signal
+# ---------------------------------------------------------------------------
+
+
+class TestAgentSignal:
+    def test_pass_through_known_verdict(self) -> None:
+        assert agent_signal("trace", "PASS") == "llm:trace=PASS"
+
+    def test_compliant_aliases_to_pass(self) -> None:
+        assert agent_signal("trace", "COMPLIANT") == "llm:trace=PASS"
+
+    def test_non_compliant_aliases_to_fail(self) -> None:
+        assert agent_signal("completeness", "NON_COMPLIANT") == "llm:completeness=FAIL"
+
+    def test_needs_review_aliases_to_fail(self) -> None:
+        assert agent_signal("trace", "NEEDS_REVIEW") == "llm:trace=FAIL"
+
+    def test_partial_aliases_to_warn(self) -> None:
+        assert agent_signal("completeness", "PARTIAL") == "llm:completeness=WARN"
+
+    def test_empty_verdict_is_unknown(self) -> None:
+        assert agent_signal("trace", "") == "llm:trace=UNKNOWN"
+
+    def test_critical_fail_passes_through(self) -> None:
+        assert agent_signal("trace", "CRITICAL_FAIL") == "llm:trace=CRITICAL_FAIL"
+
+    def test_case_insensitive(self) -> None:
+        assert agent_signal("trace", "compliant") == "llm:trace=PASS"
+
+
+# ---------------------------------------------------------------------------
+# build_signals
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSignals:
+    def test_first_signal_is_external_acceptance(self, tmp_path) -> None:
+        body_file = tmp_path / "body.md"
+        body_file.write_text(_BODY_ALL_CHECKED, encoding="utf-8")
+        env = {
+            "PR_BODY_FILE": str(body_file),
+            "TRACE_VERDICT": "PASS",
+            "COMPLETENESS_VERDICT": "PASS",
+        }
+        signals = build_signals(env)
+        assert signals[0] == "external:acceptance-criteria=PASS"
+
+    def test_includes_two_agent_signals(self, tmp_path) -> None:
+        body_file = tmp_path / "body.md"
+        body_file.write_text(_BODY_ALL_CHECKED, encoding="utf-8")
+        env = {
+            "PR_BODY_FILE": str(body_file),
+            "TRACE_VERDICT": "COMPLIANT",
+            "COMPLETENESS_VERDICT": "COMPLIANT",
+        }
+        signals = build_signals(env)
+        # 1 acceptance + 2 agents.
+        assert len(signals) == 3
+        assert any(s.startswith("llm:trace=") for s in signals)
+        assert any(s.startswith("llm:completeness=") for s in signals)
+
+    def test_missing_body_file_is_unknown(self) -> None:
+        env = {
+            "PR_BODY_FILE": "/nonexistent/path/body.md",
+            "TRACE_VERDICT": "PASS",
+            "COMPLETENESS_VERDICT": "PASS",
+        }
+        signals = build_signals(env)
+        assert signals[0] == "external:acceptance-criteria=UNKNOWN"
+
+    def test_unset_body_file_is_unknown(self) -> None:
+        signals = build_signals({"TRACE_VERDICT": "PASS"})
+        assert signals[0] == "external:acceptance-criteria=UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# main: end-to-end through gate_aggregator
+# ---------------------------------------------------------------------------
+
+
+def _write_body(tmp_path, body: str) -> str:
+    body_file = tmp_path / "body.md"
+    body_file.write_text(body, encoding="utf-8")
+    return str(body_file)
+
+
+class TestMain:
+    def test_pass_with_external_acceptance_pass(
+        self, monkeypatch, capsys, tmp_path
+    ) -> None:
+        monkeypatch.setenv("PR_BODY_FILE", _write_body(tmp_path, _BODY_ALL_CHECKED))
+        monkeypatch.setenv("TRACE_VERDICT", "COMPLIANT")
+        monkeypatch.setenv("COMPLETENESS_VERDICT", "COMPLIANT")
+        rc = main([])
+        assert rc == 0
+        assert "PASS" in capsys.readouterr().out
+
+    def test_acceptance_fail_blocks(self, monkeypatch, capsys, tmp_path) -> None:
+        monkeypatch.setenv("PR_BODY_FILE", _write_body(tmp_path, _BODY_UNCHECKED))
+        monkeypatch.setenv("TRACE_VERDICT", "COMPLIANT")
+        monkeypatch.setenv("COMPLETENESS_VERDICT", "COMPLIANT")
+        rc = main([])
+        assert rc == 1
+        assert "FAIL" in capsys.readouterr().out
+
+    def test_non_compliant_agent_blocks(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setenv("PR_BODY_FILE", _write_body(tmp_path, _BODY_ALL_CHECKED))
+        monkeypatch.setenv("TRACE_VERDICT", "NON_COMPLIANT")
+        monkeypatch.setenv("COMPLETENESS_VERDICT", "COMPLIANT")
+        rc = main([])
+        assert rc == 1
+
+    def test_needs_review_agent_blocks(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setenv("PR_BODY_FILE", _write_body(tmp_path, _BODY_ALL_CHECKED))
+        monkeypatch.setenv("TRACE_VERDICT", "COMPLIANT")
+        monkeypatch.setenv("COMPLETENESS_VERDICT", "NEEDS_REVIEW")
+        rc = main([])
+        assert rc == 1
+
+    def test_partial_agent_warns(self, monkeypatch, capsys, tmp_path) -> None:
+        monkeypatch.setenv("PR_BODY_FILE", _write_body(tmp_path, _BODY_ALL_CHECKED))
+        monkeypatch.setenv("TRACE_VERDICT", "COMPLIANT")
+        monkeypatch.setenv("COMPLETENESS_VERDICT", "PARTIAL")
+        rc = main([])
+        # WARN still exits 0 (gate_aggregator treats PASS/WARN as success).
+        assert rc == 0
+        assert "WARN" in capsys.readouterr().out
+
+    def test_closed_loop_refused_when_no_criteria(
+        self, monkeypatch, capsys, tmp_path
+    ) -> None:
+        # No acceptance criteria -> external:acceptance-criteria=UNKNOWN, so no
+        # usable external signal; the aggregator must refuse PASS (#1855).
+        monkeypatch.setenv("PR_BODY_FILE", _write_body(tmp_path, _BODY_NO_CRITERIA))
+        monkeypatch.setenv("TRACE_VERDICT", "COMPLIANT")
+        monkeypatch.setenv("COMPLETENESS_VERDICT", "COMPLIANT")
+        rc = main([])
+        assert rc == 1
+        assert "NEEDS_REVIEW" in capsys.readouterr().out
+
+    def test_closed_loop_refused_when_body_missing(
+        self, monkeypatch, capsys
+    ) -> None:
+        monkeypatch.delenv("PR_BODY_FILE", raising=False)
+        monkeypatch.setenv("TRACE_VERDICT", "COMPLIANT")
+        monkeypatch.setenv("COMPLETENESS_VERDICT", "COMPLIANT")
+        rc = main([])
+        assert rc == 1
+        assert "NEEDS_REVIEW" in capsys.readouterr().out

--- a/tests/workflows/test_post_pr_retrospective.py
+++ b/tests/workflows/test_post_pr_retrospective.py
@@ -23,7 +23,7 @@ _WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "post-pr-retrospective.y
 
 _AGENT_STEP_NAME = "Run retrospective via Claude Code"
 _ACTION_REF = (
-    "anthropics/claude-code-action@0b1b62002952733671bde978d429b50b51c51c85"
+    "anthropics/claude-code-action@41ea7642c1436fa0ee57aae58347904b71a5af27"
 )
 _OAUTH_TOKEN_EXPR = "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
 


### PR DESCRIPTION
## Summary

Wires the deterministic external-signal aggregator into `ai-spec-validation.yml` as an observe step, closing the #1855 gap (no quality gate may PASS on LLM verdicts alone) for the spec workflow.

New adapter `scripts/quality_gate/spec_external_signal_gate.py` builds three signals and feeds the external-signal aggregator: an `external:acceptance-criteria` verdict from the PR body via the deterministic acceptance-criteria extractor, `llm:trace` from the analyst, and `llm:completeness` from the critic. The aggregator refuses PASS when no usable external signal is present.

## Specification References

| Type | Reference |
|:-----|:----------|
| Issue | Refs #2108 |
| Issue | Refs #1855 |

## Type of Change

- [x] CI / workflow gate change
- [x] Test coverage

## Changes

- `.github/workflows/ai-spec-validation.yml`: adds the external-signal gate observe step after the analyst and critic checks while preserving the existing blocking gate.
- `scripts/quality_gate/spec_external_signal_gate.py`: adapts acceptance criteria and agent verdicts into external-signal aggregator inputs.
- `tests/quality_gate/test_spec_external_signal_gate.py`: covers verdict mapping, signal building, missing body handling, non-UTF-8 degradation, and closed-loop refusal.
- `.github/workflows/pytest.yml`: upgrades the audited pip runtime to 26.1.2 before `pip-audit`, fixing PYSEC-2026-196 in CI.
- `tests/workflows/test_post_pr_retrospective.py`: aligns the pinned Claude action assertion with the workflow SHA already present on the branch, unblocking full Python validation.

## Scope and what is deferred

This wiring is additive and observable (`continue-on-error: true`); it does NOT replace the authoritative spec gate. The final merge-decision swap was explicitly deferred to a canary (#2361), and README badges remain. So this lands the spec-validation observe slice, not the full closure of #2108.

## Safety

The untrusted PR body is passed via an env var and written to a temp file with `printf '%s'`, never interpolated into a `run:` command (matches the existing safe pattern).

## Tests

- `uv run --extra dev pytest tests/quality_gate/test_spec_external_signal_gate.py tests/workflows/test_post_pr_retrospective.py -q`
- `uv run --extra dev ruff check scripts/quality_gate/spec_external_signal_gate.py tests/quality_gate/test_spec_external_signal_gate.py`
- `SHELLCHECK_OPTS='--severity=warning' actionlint .github/workflows/ai-spec-validation.yml .github/workflows/pytest.yml`
- `uv run --extra dev python scripts/validation/run_workflow_local_test.py --no-full --files .github/workflows/pytest.yml --format text`
- `uv run --extra dev sh -c 'python -m pip install --upgrade pip==26.1.2 >/dev/null && python -m pip --version && pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-6357'`

## References

Files this PR builds on but does not modify (context, not change claims):

- `scripts/external_signals/gate_aggregator.py` is the aggregator the adapter feeds.
- `scripts/external_signals/acceptance_criteria.py` is the deterministic acceptance-criteria extractor.
- `.github/scripts/check_spec_failures.py` is the authoritative gate this observe step does not replace.

Refs #2108
Refs #1855

