### PR TITLE
fix(github-skill): standardize output contracts

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.117",
+  "version": "0.5.119",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/github/scripts/issue/close_issue.py
+++ b/.claude/skills/github/scripts/issue/close_issue.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Close a GitHub Issue with an optional closing comment.
+
+Posts an optional comment (from ``--comment`` or ``--comment-file``) and then
+closes the issue via ``gh issue close --reason``. Emits the standard ADR-056
+skill output envelope ({Success, Data, Error, Metadata}).
+
+Exit codes follow ADR-035:
+    0 - Success (issue closed, or already closed)
+    1 - Invalid parameters / logic error
+    2 - File not found / config error
+    3 - External error (API failure)
+    4 - Auth error (not authenticated)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_workspace = os.environ.get("GITHUB_WORKSPACE")
+if _plugin_root:
+    _lib_dir = os.path.join(_plugin_root, "lib")
+elif _workspace:
+    _lib_dir = os.path.join(_workspace, ".claude", "lib")
+else:
+    _lib_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "lib")
+    )
+if not os.path.isdir(_lib_dir):
+    print(f"Plugin lib directory not found: {_lib_dir}", file=sys.stderr)
+    sys.exit(2)  # Config error per ADR-035
+if _lib_dir not in sys.path:
+    sys.path.insert(0, _lib_dir)
+
+from github_core.api import (  # noqa: E402
+    assert_gh_authenticated,
+    resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
+)
+
+# gh issue close --reason accepts exactly these two values. "not planned" is the
+# spelling gh expects (with a space), so we pass the value through verbatim.
+_VALID_REASONS = ("completed", "not planned")
+_AUTH_ERROR_MARKERS = (
+    "credential",
+    "not logged in",
+    "bad credentials",
+    "could not authenticate",
+    "authentication",
+    "requires authentication",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Close a GitHub Issue with an optional closing comment.",
+    )
+    parser.add_argument("--owner", default="", help="Repository owner")
+    parser.add_argument("--repo", default="", help="Repository name")
+    parser.add_argument("--issue", type=int, required=True, help="Issue number")
+    parser.add_argument(
+        "--reason",
+        choices=list(_VALID_REASONS),
+        default="completed",
+        help="Close reason: 'completed' (default) or 'not planned'.",
+    )
+
+    comment_group = parser.add_mutually_exclusive_group()
+    comment_group.add_argument(
+        "--comment", default="", help="Closing comment body text",
+    )
+    comment_group.add_argument(
+        "--comment-file", default="", help="Path to a file containing the comment body",
+    )
+
+    add_output_format_arg(parser)
+    return parser
+
+
+def _comment_base_dir() -> Path:
+    """Return the directory that comment files must stay under."""
+    workspace = os.environ.get("GITHUB_WORKSPACE", "").strip()
+    if workspace:
+        return Path(workspace).expanduser().resolve()
+    for parent in Path(__file__).resolve().parents:
+        if (parent / ".git").exists() or (parent / ".claude").is_dir():
+            return parent
+    return Path(os.getcwd()).resolve()
+
+
+def _resolve_comment_file(comment_file: str, fmt: str) -> Path:
+    base_dir = _comment_base_dir()
+    raw_path = Path(comment_file)
+    path = raw_path if raw_path.is_absolute() else base_dir / raw_path
+    resolved = path.resolve()
+    if not resolved.is_relative_to(base_dir):
+        write_skill_error(
+            f"Comment file must stay under {base_dir}: {comment_file}",
+            2,
+            error_type="InvalidParams",
+            output_format=fmt,
+            script_name="close_issue.py",
+            extra={"issue": None},
+        )
+        raise SystemExit(2)
+    if not resolved.is_file():
+        write_skill_error(
+            f"Comment file not found: {comment_file}",
+            2,
+            error_type="NotFound",
+            output_format=fmt,
+            script_name="close_issue.py",
+            extra={"issue": None},
+        )
+        raise SystemExit(2)
+    return resolved
+
+
+def _resolve_comment(comment: str, comment_file: str, fmt: str) -> str:
+    """Return the closing comment body, reading the file when one is given.
+
+    Exits with code 2 (config error) when the comment file is missing. Returns
+    an empty string when no comment was requested.
+    """
+    if comment_file:
+        path = _resolve_comment_file(comment_file, fmt)
+        try:
+            return path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            write_skill_error(
+                f"Failed to read comment file {comment_file}: {exc}",
+                2,
+                error_type="InvalidParams",
+                output_format=fmt,
+                script_name="close_issue.py",
+                extra={"issue": None},
+            )
+            raise SystemExit(2) from exc
+    return comment
+
+
+def _is_auth_error(message: str) -> bool:
+    lowered = message.lower()
+    return any(marker in lowered for marker in _AUTH_ERROR_MARKERS)
+
+
+def _write_subprocess_error(
+    message: str, issue: int, fmt: str, *, not_found: bool = False
+) -> int:
+    if not_found:
+        code = 2
+        error_type = "NotFound"
+    elif _is_auth_error(message):
+        code = 4
+        error_type = "AuthError"
+    else:
+        code = 3
+        error_type = "ApiError"
+    write_skill_error(
+        message,
+        code,
+        error_type=error_type,
+        output_format=fmt,
+        script_name="close_issue.py",
+        extra={"issue": issue},
+    )
+    return code
+
+
+def _get_issue_state(owner: str, repo: str, issue: int, fmt: str) -> str:
+    """Return the issue state from GitHub, lowercased."""
+    result = subprocess.run(
+        [
+            "gh", "issue", "view", str(issue),
+            "--repo", f"{owner}/{repo}",
+            "--json", "state",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        error_str = result.stderr.strip() or result.stdout.strip()
+        code = _write_subprocess_error(
+            f"Failed to get issue #{issue}: {error_str}",
+            issue,
+            fmt,
+            not_found=(
+                "Could not resolve" in error_str
+                or "not found" in error_str.lower()
+            ),
+        )
+        raise SystemExit(code)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        write_skill_error(
+            f"Failed to parse issue #{issue} state: {exc}",
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="close_issue.py",
+            extra={"issue": issue},
+        )
+        raise SystemExit(3) from exc
+    if not isinstance(payload, dict):
+        return ""
+    state = payload.get("state")
+    return "" if state is None else str(state).lower()
+
+
+def _post_comment(owner: str, repo: str, issue: int, body: str, fmt: str) -> None:
+    """Post a closing comment via gh api. Exits with code 3 on failure."""
+    payload = json.dumps({"body": body})
+    result = subprocess.run(
+        [
+            "gh", "api",
+            f"repos/{owner}/{repo}/issues/{issue}/comments",
+            "-X", "POST",
+            "--input", "-",
+        ],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        error_str = result.stderr.strip() or result.stdout.strip()
+        code = _write_subprocess_error(
+            f"Failed to post closing comment: {error_str}",
+            issue,
+            fmt,
+        )
+        raise SystemExit(code)
+
+
+def _close_issue(owner: str, repo: str, issue: int, reason: str) -> subprocess.CompletedProcess[str]:
+    """Run gh issue close with the given reason. Returns the completed process."""
+    return subprocess.run(
+        [
+            "gh", "issue", "close", str(issue),
+            "--repo", f"{owner}/{repo}",
+            "--reason", reason,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
+    body = _resolve_comment(args.comment, args.comment_file, fmt)
+
+    assert_gh_authenticated()
+    resolved = resolve_repo_params(args.owner, args.repo)
+    owner, repo = resolved.owner, resolved.repo
+    issue: int = args.issue
+
+    state = _get_issue_state(owner, repo, issue, fmt)
+    if state == "closed":
+        data = {
+            "issue": issue,
+            "owner": owner,
+            "repo": repo,
+            "state": "closed",
+            "reason": args.reason,
+            "commented": False,
+            "action": "already_closed",
+        }
+        write_skill_output(
+            data,
+            output_format=fmt,
+            human_summary=f"Issue #{issue} is already closed",
+            status="PASS",
+            script_name="close_issue.py",
+        )
+        return 0
+
+    result = _close_issue(owner, repo, issue, args.reason)
+    if result.returncode != 0:
+        error_str = result.stderr.strip() or result.stdout.strip()
+        code = _write_subprocess_error(
+            f"Failed to close issue #{issue}: {error_str}",
+            issue,
+            fmt,
+        )
+        return code
+
+    commented = bool(body and body.strip())
+    if commented:
+        _post_comment(owner, repo, issue, body, fmt)
+
+    data = {
+        "issue": issue,
+        "owner": owner,
+        "repo": repo,
+        "state": "closed",
+        "reason": args.reason,
+        "commented": commented,
+        "action": "closed",
+    }
+    write_skill_output(
+        data,
+        output_format=fmt,
+        human_summary=f"Closed issue #{issue} as '{args.reason}'",
+        status="PASS",
+        script_name="close_issue.py",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/github/scripts/issue/close_issue.py
+++ b/.claude/skills/github/scripts/issue/close_issue.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Close a GitHub Issue with an optional closing comment.
 
-Posts an optional comment (from ``--comment`` or ``--comment-file``) and then
-closes the issue via ``gh issue close --reason``. Emits the standard ADR-056
-skill output envelope ({Success, Data, Error, Metadata}).
+Closes the issue via ``gh issue close --reason`` and posts an optional comment
+from ``--comment`` or ``--comment-file``. On retry, an already-closed issue can
+still receive a missing closing comment without duplicating an existing one.
+Emits the standard ADR-056 skill output envelope ({Success, Data, Error,
+Metadata}).
 
 Exit codes follow ADR-035:
     0 - Success (issue closed, or already closed)
@@ -96,7 +98,7 @@ def _comment_base_dir() -> Path:
     for parent in Path(__file__).resolve().parents:
         if (parent / ".git").exists() or (parent / ".claude").is_dir():
             return parent
-    return Path(os.getcwd()).resolve()
+    return Path(__file__).resolve().parent
 
 
 def _resolve_comment_file(comment_file: str, fmt: str) -> Path:
@@ -247,6 +249,47 @@ def _post_comment(owner: str, repo: str, issue: int, body: str, fmt: str) -> Non
         raise SystemExit(code)
 
 
+def _comment_exists(owner: str, repo: str, issue: int, body: str, fmt: str) -> bool:
+    result = subprocess.run(
+        [
+            "gh", "issue", "view", str(issue),
+            "--repo", f"{owner}/{repo}",
+            "--json", "comments",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        error_str = result.stderr.strip() or result.stdout.strip()
+        code = _write_subprocess_error(
+            f"Failed to inspect issue #{issue} comments: {error_str}",
+            issue,
+            fmt,
+        )
+        raise SystemExit(code)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        write_skill_error(
+            f"Failed to parse issue #{issue} comments: {exc}",
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="close_issue.py",
+            extra={"issue": issue},
+        )
+        raise SystemExit(3) from exc
+    comments = payload.get("comments") if isinstance(payload, dict) else None
+    if not isinstance(comments, list):
+        return False
+    for comment in comments:
+        if isinstance(comment, dict) and comment.get("body") == body:
+            return True
+    return False
+
+
 def _close_issue(owner: str, repo: str, issue: int, reason: str) -> subprocess.CompletedProcess[str]:
     """Run gh issue close with the given reason. Returns the completed process."""
     return subprocess.run(
@@ -274,13 +317,21 @@ def main(argv: list[str] | None = None) -> int:
 
     state = _get_issue_state(owner, repo, issue, fmt)
     if state == "closed":
+        commented = False
+        comment_already_present = False
+        if body and body.strip():
+            comment_already_present = _comment_exists(owner, repo, issue, body, fmt)
+            if not comment_already_present:
+                _post_comment(owner, repo, issue, body, fmt)
+                commented = True
         data = {
             "issue": issue,
             "owner": owner,
             "repo": repo,
             "state": "closed",
             "reason": args.reason,
-            "commented": False,
+            "commented": commented,
+            "commentAlreadyPresent": comment_already_present,
             "action": "already_closed",
         }
         write_skill_output(

--- a/.claude/skills/github/scripts/issue/close_issue.py
+++ b/.claude/skills/github/scripts/issue/close_issue.py
@@ -249,12 +249,27 @@ def _post_comment(owner: str, repo: str, issue: int, body: str, fmt: str) -> Non
         raise SystemExit(code)
 
 
+def _comment_bodies(payload: object) -> list[str]:
+    if isinstance(payload, dict):
+        return _comment_bodies(payload.get("comments"))
+    if not isinstance(payload, list):
+        return []
+    bodies: list[str] = []
+    for item in payload:
+        if isinstance(item, list):
+            bodies.extend(_comment_bodies(item))
+        elif isinstance(item, dict) and isinstance(item.get("body"), str):
+            bodies.append(item["body"])
+    return bodies
+
+
 def _comment_exists(owner: str, repo: str, issue: int, body: str, fmt: str) -> bool:
     result = subprocess.run(
         [
-            "gh", "issue", "view", str(issue),
-            "--repo", f"{owner}/{repo}",
-            "--json", "comments",
+            "gh", "api",
+            f"repos/{owner}/{repo}/issues/{issue}/comments?per_page=100",
+            "--paginate",
+            "--slurp",
         ],
         capture_output=True,
         text=True,
@@ -281,13 +296,7 @@ def _comment_exists(owner: str, repo: str, issue: int, body: str, fmt: str) -> b
             extra={"issue": issue},
         )
         raise SystemExit(3) from exc
-    comments = payload.get("comments") if isinstance(payload, dict) else None
-    if not isinstance(comments, list):
-        return False
-    for comment in comments:
-        if isinstance(comment, dict) and comment.get("body") == body:
-            return True
-    return False
+    return body in _comment_bodies(payload)
 
 
 def _close_issue(owner: str, repo: str, issue: int, reason: str) -> subprocess.CompletedProcess[str]:

--- a/.claude/skills/github/scripts/issue/edit_issue_body.py
+++ b/.claude/skills/github/scripts/issue/edit_issue_body.py
@@ -17,7 +17,6 @@ Exit codes (per ADR-035):
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -40,6 +39,11 @@ if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)
 
 from github_core.api import error_and_exit, resolve_repo_params  # noqa: E402
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 from github_core.validation import assert_valid_body_file  # noqa: E402
 
 
@@ -62,12 +66,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to file containing new body text",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     if args.body is None and args.body_file is None:
         error_and_exit("Must provide --body or --body-file", 1)
@@ -131,17 +137,17 @@ def main(argv: list[str] | None = None) -> int:
             error_and_exit(f"Auth error: {error_str}", 4)
         error_and_exit(f"Failed to edit issue: {error_str}", 3)
 
-    # Emit structured JSON to match sibling scripts (new_issue.py,
-    # post_issue_comment.py). PR #1965 cluster R.
-    print(
-        json.dumps(
-            {
-                "issue": args.issue,
-                "status": "updated",
-                "repo": f"{owner}/{repo}",
-            },
-            indent=2,
-        )
+    # Emit the canonical skill output envelope (ADR-056) to match sibling
+    # scripts (new_issue.py, post_issue_comment.py). Issue #2388.
+    write_skill_output(
+        {
+            "issue": args.issue,
+            "status": "updated",
+            "repo": f"{owner}/{repo}",
+        },
+        output_format=fmt,
+        human_summary=f"Updated body of issue #{args.issue} in {owner}/{repo}",
+        script_name="edit_issue_body.py",
     )
     return 0
 

--- a/.claude/skills/github/scripts/issue/invoke_copilot_assignment.py
+++ b/.claude/skills/github/scripts/issue/invoke_copilot_assignment.py
@@ -52,6 +52,11 @@ from github_core.api import (  # noqa: E402
     resolve_repo_params,
     update_issue_comment,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -231,9 +236,10 @@ def _get_coderabbit_plan(
     prs_pattern = f"(?:<b>)?{prs_raw}(?:</b>)?"
 
     for comment in rabbit_comments:
-        body = comment.get("body", "")
+        body = comment.get("body") or ""
 
-        m = re.search(f"{impl_pattern}([\\s\\S]*?)(?=##|$)", body)  # nosemgrep: skill-ldap-injection
+        # nosemgrep: skill-ldap-injection
+        m = re.search(f"{impl_pattern}([\\s\\S]*?)(?=##|$)", body)
         if m:
             plan["implementation"] = m.group(1).strip()
 
@@ -478,6 +484,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Preview synthesis comment without posting or assigning",
     )
+    add_output_format_arg(parser)
     return parser
 
 
@@ -488,13 +495,15 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of complex PS1
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
     owner, repo = resolved.owner, resolved.repo
     issue_number: int = args.issue_number
 
-    print(f"Processing issue #{issue_number} in {owner}/{repo}")
+    if fmt != "json":
+        print(f"Processing issue #{issue_number} in {owner}/{repo}")
 
     config = _load_synthesis_config(args.config_path)
 
@@ -518,19 +527,21 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
             error_and_exit(f"Issue #{issue_number} not found in {owner}/{repo}", 2)
         error_and_exit(f"Failed to get issue: {error_str}", 3)
 
-    issue = json.loads(issue_result.stdout)
-    print(f"Issue: {issue.get('title', '')}")
+    issue_payload = json.loads(issue_result.stdout)
+    issue = issue_payload if isinstance(issue_payload, dict) else {}
+    title = "" if issue.get("title") is None else str(issue.get("title"))
+    print(f"Issue: {title}", file=sys.stderr)
 
     # Fetch comments
     comments = get_issue_comments(owner, repo, issue_number)
-    print(f"Found {len(comments)} comments")
+    print(f"Found {len(comments)} comments", file=sys.stderr)
 
     trusted_users = (
         config["trusted_sources"]["maintainers"]
         + config["trusted_sources"]["ai_agents"]
     )
     trusted_comments = get_trusted_source_comments(comments, trusted_users)
-    print(f"Found {len(trusted_comments)} comments from trusted sources")
+    print(f"Found {len(trusted_comments)} comments from trusted sources", file=sys.stderr)
 
     # PrepareContextOnly mode
     if args.prepare_context_only:
@@ -545,7 +556,12 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
             "owner": owner,
             "repo": repo,
         }
-        print(json.dumps(output, indent=2))
+        write_skill_output(
+            output,
+            output_format=fmt,
+            human_summary=f"Prepared context file for issue #{issue_number}",
+            script_name="invoke_copilot_assignment.py",
+        )
 
         _write_github_output({
             "context_file": context_file,
@@ -573,6 +589,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
 
     # Dry-run mode
     if args.dry_run:
+        dry_run_output = {
+            "action": "dry_run",
+            "issue_number": issue_number,
+            "owner": owner,
+            "repo": repo,
+            "has_synthesizable_content": has_content,
+            "existing_synthesis_id": existing_synthesis["id"] if existing_synthesis else None,
+            "would_assign": not args.skip_assignment,
+            "synthesis_body": None,
+        }
         if has_content:
             synthesis_body = _build_synthesis_comment(
                 config["synthesis"]["marker"],
@@ -580,6 +606,15 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
                 coderabbit_plan,
                 ai_triage,
             )
+            dry_run_output["synthesis_body"] = synthesis_body
+            if fmt == "json":
+                write_skill_output(
+                    dry_run_output,
+                    output_format=fmt,
+                    human_summary=f"Prepared dry-run synthesis for issue #{issue_number}",
+                    script_name="invoke_copilot_assignment.py",
+                )
+                return 0
             print("\n=== SYNTHESIS PREVIEW ===")
             print(synthesis_body)
             print("=== END PREVIEW ===")
@@ -588,8 +623,20 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
             else:
                 print("\nWould CREATE new synthesis comment")
         else:
+            if fmt == "json":
+                write_skill_output(
+                    dry_run_output,
+                    output_format=fmt,
+                    human_summary=f"No synthesizable content found for issue #{issue_number}",
+                    status="WARNING",
+                    script_name="invoke_copilot_assignment.py",
+                )
+                return 0
             print("\nNo synthesizable content found, would SKIP synthesis comment")
-        print(f"Would ASSIGN copilot-swe-agent to issue #{issue_number}")
+        if args.skip_assignment:
+            print(f"Would SKIP assignment for issue #{issue_number}")
+        else:
+            print(f"Would ASSIGN copilot-swe-agent to issue #{issue_number}")
         return 0
 
     # Post or update synthesis
@@ -605,29 +652,34 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         )
 
         if existing_synthesis:
-            print(f"Updating existing synthesis comment (ID: {existing_synthesis['id']})")
+            print(
+                f"Updating existing synthesis comment (ID: {existing_synthesis['id']})",
+                file=sys.stderr,
+            )
             response = update_issue_comment(owner, repo, existing_synthesis["id"], synthesis_body)
             action = "Updated"
         else:
-            print("Creating new synthesis comment")
+            print("Creating new synthesis comment", file=sys.stderr)
             response = create_issue_comment(owner, repo, issue_number, synthesis_body)
             action = "Created"
-        print(f"{action} synthesis comment: {response.get('html_url', 'N/A')}")
+        print(f"{action} synthesis comment: {response.get('html_url', 'N/A')}", file=sys.stderr)
     else:
-        print("No synthesizable content found, skipping synthesis comment")
+        print("No synthesizable content found, skipping synthesis comment", file=sys.stderr)
 
     # Assign Copilot
     assigned = False
     if not args.skip_assignment:
-        print("Assigning copilot-swe-agent...")
+        print("Assigning copilot-swe-agent...", file=sys.stderr)
         assigned = _assign_copilot(owner, repo, issue_number)
         if assigned:
-            print(f"Assigned copilot-swe-agent to issue #{issue_number}")
+            print(f"Assigned copilot-swe-agent to issue #{issue_number}", file=sys.stderr)
     else:
-        print("Skipping assignment (handled by workflow with COPILOT_GITHUB_TOKEN)")
+        print(
+            "Skipping assignment (handled by workflow with COPILOT_GITHUB_TOKEN)",
+            file=sys.stderr,
+        )
 
     output = {
-        "success": True,
         "action": action,
         "issue_number": issue_number,
         "comment_id": response["id"] if response else None,
@@ -635,7 +687,12 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         "assigned": assigned,
         "marker": config["synthesis"]["marker"],
     }
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        output,
+        output_format=fmt,
+        human_summary=f"{action} synthesis for issue #{issue_number}",
+        script_name="invoke_copilot_assignment.py",
+    )
     return 0
 
 

--- a/.claude/skills/github/scripts/issue/new_issue.py
+++ b/.claude/skills/github/scripts/issue/new_issue.py
@@ -14,7 +14,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 import subprocess
@@ -41,6 +40,11 @@ from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     error_and_exit,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
 )
 
 
@@ -74,11 +78,13 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help='Comma-separated list of labels (e.g., "bug,P1,needs-triage")',
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -115,13 +121,16 @@ def main(argv: list[str] | None = None) -> int:
 
     issue_number = int(match.group(1))
 
-    output = {
-        "success": True,
-        "issue_number": issue_number,
-        "url": output_text,
-        "title": args.title,
-    }
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        {
+            "issue_number": issue_number,
+            "url": output_text,
+            "title": args.title,
+        },
+        output_format=fmt,
+        human_summary=f"Created issue #{issue_number}: {args.title}",
+        script_name="new_issue.py",
+    )
 
     _write_github_output({
         "success": "true",

--- a/.claude/skills/github/scripts/issue/post_issue_comment.py
+++ b/.claude/skills/github/scripts/issue/post_issue_comment.py
@@ -46,6 +46,13 @@ from github_core.api import (  # noqa: E402
     resolve_repo_params,
     update_issue_comment,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
+
+_SCRIPT_NAME = "post_issue_comment.py"
 
 _403_PATTERN = re.compile(
     r"((?<!\d)403(?!\d)|\bforbidden\b|Resource not accessible by integration)",
@@ -156,11 +163,13 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Update existing comment instead of skipping when marker found",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of PS1 logic
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -200,16 +209,20 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
 
             if existing is not None:
                 if args.update_if_exists:
-                    print(f"Comment with marker '{args.marker}' exists. Updating...")
+                    if fmt != "json":
+                        print(f"Comment with marker '{args.marker}' exists. Updating...")
                     body = _prepend_marker(body, marker_html)
                     response = update_issue_comment(owner, repo, existing["id"], body)
-                    print(f"Updated comment on issue #{issue}")
-                    print(json.dumps({
-                        "success": True,
-                        "issue": issue,
-                        "comment_id": response["id"],
-                        "updated": True,
-                    }, indent=2))
+                    write_skill_output(
+                        {
+                            "issue": issue,
+                            "comment_id": response["id"],
+                            "updated": True,
+                        },
+                        output_format=fmt,
+                        human_summary=f"Updated comment on issue #{issue}",
+                        script_name=_SCRIPT_NAME,
+                    )
                     _write_github_output({
                         "success": "true",
                         "skipped": "false",
@@ -222,13 +235,18 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
                     })
                     return 0
 
-                print(f"Comment with marker '{args.marker}' already exists. Skipping.")
-                print(json.dumps({
-                    "success": True,
-                    "issue": issue,
-                    "marker": args.marker,
-                    "skipped": True,
-                }, indent=2))
+                write_skill_output(
+                    {
+                        "issue": issue,
+                        "marker": args.marker,
+                        "skipped": True,
+                    },
+                    output_format=fmt,
+                    human_summary=(
+                        f"Comment with marker '{args.marker}' already exists. Skipping."
+                    ),
+                    script_name=_SCRIPT_NAME,
+                )
                 _write_github_output({
                     "success": "true",
                     "skipped": "true",
@@ -277,6 +295,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         response = json.loads(result.stdout)
     except json.JSONDecodeError:
         print(f"Posted comment to issue #{issue} (response parsing failed)", file=sys.stderr)
+        write_skill_output(
+            {
+                "issue": issue,
+                "skipped": False,
+                "parse_error": True,
+            },
+            output_format=fmt,
+            human_summary=f"Posted comment to issue #{issue} (response parsing failed)",
+            script_name=_SCRIPT_NAME,
+        )
         _write_github_output({
             "success": "true",
             "skipped": "false",
@@ -285,13 +313,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         })
         return 0
 
-    output = {
-        "success": True,
-        "issue": issue,
-        "comment_id": response["id"],
-        "skipped": False,
-    }
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        {
+            "issue": issue,
+            "comment_id": response["id"],
+            "skipped": False,
+        },
+        output_format=fmt,
+        human_summary=f"Posted comment to issue #{issue}",
+        script_name=_SCRIPT_NAME,
+    )
 
     outputs: dict[str, str] = {
         "success": "true",

--- a/.claude/skills/github/scripts/issue/set_issue_milestone.py
+++ b/.claude/skills/github/scripts/issue/set_issue_milestone.py
@@ -15,7 +15,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -38,8 +37,13 @@ if _lib_dir not in sys.path:
 
 from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
-    error_and_exit,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
 )
 
 
@@ -103,23 +107,54 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Replace existing milestone",
     )
+    add_output_format_arg(parser)
     return parser
+
+
+def _emit(output: dict, fmt: str) -> None:
+    """Emit the canonical envelope for the milestone result payload."""
+    write_skill_output(
+        output,
+        output_format=fmt,
+        human_summary=(
+            f"Issue #{output['issue']} milestone {output['action']}"
+        ),
+        script_name="set_issue_milestone.py",
+    )
+
+
+def _emit_error(message: str, code: int, fmt: str, error_type: str, output: dict) -> None:
+    write_skill_error(
+        message,
+        code,
+        error_type=error_type,
+        output_format=fmt,
+        script_name="set_issue_milestone.py",
+        extra=output,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
     owner, repo = resolved.owner, resolved.repo
 
     if not args.clear and not args.milestone:
-        error_and_exit("Must specify --milestone or --clear.", 2)
+        _emit_error(
+            "Must specify --milestone or --clear.",
+            2,
+            fmt,
+            "InvalidParams",
+            {"issue": args.issue, "milestone": None, "action": "failed"},
+        )
+        raise SystemExit(2)
 
     current_milestone = _get_current_milestone(owner, repo, args.issue)
 
     output = {
-        "success": False,
         "issue": args.issue,
         "milestone": None,
         "previous_milestone": current_milestone,
@@ -128,9 +163,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.clear:
         if not current_milestone:
-            output["success"] = True
             output["action"] = "no_change"
-            print(json.dumps(output, indent=2))
+            _emit(output, fmt)
             _write_github_output({
                 "success": "true",
                 "issue": str(args.issue),
@@ -149,11 +183,17 @@ def main(argv: list[str] | None = None) -> int:
             check=False,
         )
         if result.returncode != 0:
-            error_and_exit("Failed to clear milestone", 3)
+            _emit_error(
+                "Failed to clear milestone",
+                3,
+                fmt,
+                "ApiError",
+                output | {"action": "failed"},
+            )
+            raise SystemExit(3)
 
-        output["success"] = True
         output["action"] = "cleared"
-        print(json.dumps(output, indent=2))
+        _emit(output, fmt)
         _write_github_output({
             "success": "true",
             "issue": str(args.issue),
@@ -164,16 +204,19 @@ def main(argv: list[str] | None = None) -> int:
 
     milestone_titles = _get_milestone_titles(owner, repo)
     if args.milestone not in milestone_titles:
-        error_and_exit(
+        _emit_error(
             f"Milestone '{args.milestone}' does not exist in {owner}/{repo}.",
             2,
+            fmt,
+            "NotFound",
+            output | {"milestone": args.milestone, "action": "failed"},
         )
+        raise SystemExit(2)
 
     if current_milestone == args.milestone:
-        output["success"] = True
         output["milestone"] = args.milestone
         output["action"] = "no_change"
-        print(json.dumps(output, indent=2))
+        _emit(output, fmt)
         _write_github_output({
             "success": "true",
             "issue": str(args.issue),
@@ -183,11 +226,15 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if current_milestone and not args.force:
-        error_and_exit(
+        _emit_error(
             f"Issue #{args.issue} already has milestone "
             f"'{current_milestone}'. Use --force to override.",
             5,
+            fmt,
+            "General",
+            output | {"milestone": args.milestone, "action": "has_milestone"},
         )
+        raise SystemExit(5)
 
     result = subprocess.run(
         [
@@ -200,13 +247,19 @@ def main(argv: list[str] | None = None) -> int:
         check=False,
     )
     if result.returncode != 0:
-        error_and_exit("Failed to set milestone", 3)
+        _emit_error(
+            "Failed to set milestone",
+            3,
+            fmt,
+            "ApiError",
+            output | {"milestone": args.milestone, "action": "failed"},
+        )
+        raise SystemExit(3)
 
     action = "replaced" if current_milestone else "assigned"
-    output["success"] = True
     output["milestone"] = args.milestone
     output["action"] = action
-    print(json.dumps(output, indent=2))
+    _emit(output, fmt)
 
     gh_outputs: dict[str, str] = {
         "success": "true",

--- a/.claude/skills/github/scripts/milestone/get_latest_semantic_milestone.py
+++ b/.claude/skills/github/scripts/milestone/get_latest_semantic_milestone.py
@@ -15,7 +15,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 import sys
@@ -40,6 +39,12 @@ from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     gh_api_paginated,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
 )
 
 _SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
@@ -81,11 +86,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--owner", default="", help="Repository owner")
     parser.add_argument("--repo", default="", help="Repository name")
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -96,8 +103,14 @@ def main(argv: list[str] | None = None) -> int:
 
     if not milestones:
         print(f"No open milestones found in {owner}/{repo}", file=sys.stderr)
-        result = {"title": "", "number": 0, "found": False}
-        print(json.dumps(result, indent=2))
+        write_skill_error(
+            f"No open milestones found in {owner}/{repo}",
+            2,
+            error_type="NotFound",
+            output_format=fmt,
+            script_name="get_latest_semantic_milestone.py",
+            extra={"title": "", "number": 0, "found": False},
+        )
         _write_github_output({
             "milestone_title": "",
             "milestone_number": "0",
@@ -120,8 +133,14 @@ def main(argv: list[str] | None = None) -> int:
             f"No semantic version milestones found. Available: {available}",
             file=sys.stderr,
         )
-        result = {"title": "", "number": 0, "found": False}
-        print(json.dumps(result, indent=2))
+        write_skill_error(
+            f"No semantic version milestones found. Available: {available}",
+            2,
+            error_type="NotFound",
+            output_format=fmt,
+            script_name="get_latest_semantic_milestone.py",
+            extra={"title": "", "number": 0, "found": False},
+        )
         _write_github_output({
             "milestone_title": "",
             "milestone_number": "0",
@@ -139,12 +158,18 @@ def main(argv: list[str] | None = None) -> int:
 
     latest = max(semantic, key=lambda m: _parse_semver_tuple(m["title"]))
 
-    result = {
-        "title": latest["title"],
-        "number": latest["number"],
-        "found": True,
-    }
-    print(json.dumps(result, indent=2))
+    write_skill_output(
+        {
+            "title": latest["title"],
+            "number": latest["number"],
+            "found": True,
+        },
+        output_format=fmt,
+        human_summary=(
+            f"Latest semantic milestone: {latest['title']} (ID: {latest['number']})"
+        ),
+        script_name="get_latest_semantic_milestone.py",
+    )
 
     _write_github_output({
         "milestone_title": latest["title"],

--- a/.claude/skills/github/scripts/milestone/set_item_milestone.py
+++ b/.claude/skills/github/scripts/milestone/set_item_milestone.py
@@ -208,8 +208,6 @@ def main(argv: list[str] | None = None) -> int:
             f"Already has milestone '{existing}'. "
             "No action taken (preserving manual assignments)."
         )
-        if fmt != "json":
-            print(f"{item_type} #{item_number} already has milestone: {existing}")
         write_skill_output(
             {
                 "item_type": item_type,

--- a/.claude/skills/github/scripts/milestone/set_item_milestone.py
+++ b/.claude/skills/github/scripts/milestone/set_item_milestone.py
@@ -44,6 +44,11 @@ from github_core.api import (  # noqa: E402
     gh_api_paginated,
     resolve_repo_params,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 
 _SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
 
@@ -181,11 +186,13 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help="Specific milestone to assign (auto-detects if omitted)",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     item_type: str = args.item_type
     item_number: int = args.item_number
@@ -201,16 +208,22 @@ def main(argv: list[str] | None = None) -> int:
             f"Already has milestone '{existing}'. "
             "No action taken (preserving manual assignments)."
         )
-        print(f"{item_type} #{item_number} already has milestone: {existing}")
-        result = {
-            "success": True,
-            "item_type": item_type,
-            "item_number": item_number,
-            "milestone": existing,
-            "action": "skipped",
-            "message": msg,
-        }
-        print(json.dumps(result, indent=2))
+        if fmt != "json":
+            print(f"{item_type} #{item_number} already has milestone: {existing}")
+        write_skill_output(
+            {
+                "item_type": item_type,
+                "item_number": item_number,
+                "milestone": existing,
+                "action": "skipped",
+                "message": msg,
+            },
+            output_format=fmt,
+            human_summary=(
+                f"{item_type} #{item_number} already has milestone: {existing}"
+            ),
+            script_name="set_item_milestone.py",
+        )
         _write_result(True, item_type, item_number, existing, "skipped", msg)
         return 0
 
@@ -229,20 +242,24 @@ def main(argv: list[str] | None = None) -> int:
         milestone_title = str(detection["title"])
 
     # Assign
-    print(f"Assigning milestone '{milestone_title}' to {item_type} #{item_number}")
+    print(f"Assigning milestone '{milestone_title}' to {item_type} #{item_number}", file=sys.stderr)
     _assign_milestone(owner, repo, item_number, milestone_title)
 
     msg = f"Assigned milestone '{milestone_title}'."
-    print(f"Successfully assigned milestone '{milestone_title}' to {item_type} #{item_number}")
-    result = {
-        "success": True,
-        "item_type": item_type,
-        "item_number": item_number,
-        "milestone": milestone_title,
-        "action": "assigned",
-        "message": msg,
-    }
-    print(json.dumps(result, indent=2))
+    write_skill_output(
+        {
+            "item_type": item_type,
+            "item_number": item_number,
+            "milestone": milestone_title,
+            "action": "assigned",
+            "message": msg,
+        },
+        output_format=fmt,
+        human_summary=(
+            f"Assigned milestone '{milestone_title}' to {item_type} #{item_number}"
+        ),
+        script_name="set_item_milestone.py",
+    )
     _write_result(True, item_type, item_number, milestone_title, "assigned", msg)
     return 0
 

--- a/.claude/skills/github/scripts/notifications/get_actionable_items.py
+++ b/.claude/skills/github/scripts/notifications/get_actionable_items.py
@@ -48,6 +48,12 @@ from github_core.api import (  # noqa: E402
     error_and_exit,
     resolve_repo_params,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -60,6 +66,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--limit", type=int, default=20,
         help="Max items per category (1-100, default: 20)",
     )
+    add_output_format_arg(parser)
     return parser
 
 
@@ -215,9 +222,18 @@ def _get_assigned_issues(repo_flag: str, user: str, limit: int) -> list[dict]:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     if not 1 <= args.limit <= 100:
-        error_and_exit("Limit must be between 1 and 100.", 1)
+        write_skill_error(
+            "Limit must be between 1 and 100.",
+            1,
+            error_type="InvalidParams",
+            output_format=fmt,
+            script_name="get_actionable_items.py",
+            extra={"limit": args.limit},
+        )
+        return 1
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -236,8 +252,7 @@ def main(argv: list[str] | None = None) -> int:
     authored_prs = _get_authored_prs(repo_flag, user, args.limit)
     assigned_issues = _get_assigned_issues(repo_flag, user, args.limit)
 
-    output = {
-        "success": True,
+    data = {
         "user": user,
         "repo": repo_flag,
         "notifications_api_available": notifications_available,
@@ -253,7 +268,18 @@ def main(argv: list[str] | None = None) -> int:
         },
     }
 
-    print(json.dumps(output, indent=2))
+    total = (
+        data["summary"]["notifications"]
+        + data["summary"]["review_requests"]
+        + data["summary"]["authored_prs"]
+        + data["summary"]["assigned_issues"]
+    )
+    write_skill_output(
+        data,
+        output_format=fmt,
+        human_summary=f"Found {total} actionable item(s) for {user} in {repo_flag}",
+        script_name="get_actionable_items.py",
+    )
     return 0
 
 

--- a/.claude/skills/github/scripts/pr/get_pr_review_threads.py
+++ b/.claude/skills/github/scripts/pr/get_pr_review_threads.py
@@ -46,11 +46,16 @@ if _lib_dir not in sys.path:
 from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     count_unresolved_threads,
-    error_and_exit,
     filter_unresolved_threads,
     gh_graphql,
     resolve_repo_params,
     transform_review_thread,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
 )
 
 # Page size for the reviewThreads connection. GitHub GraphQL caps connection
@@ -124,6 +129,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--include-comments", action="store_true",
         help="Include all comments in each thread (not just first)",
     )
+    add_output_format_arg(parser)
     return parser
 
 
@@ -303,6 +309,7 @@ def _transform_thread(thread: dict, include_comments: bool) -> dict:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -318,11 +325,32 @@ def main(argv: list[str] | None = None) -> int:
     except RuntimeError as exc:
         msg = str(exc)
         if "Could not resolve" in msg:
-            error_and_exit(f"PR #{pr} not found in {owner}/{repo}", 2)
-        error_and_exit(f"Failed to query review threads: {msg}", 3)
+            write_skill_error(
+                f"PR #{pr} not found in {owner}/{repo}",
+                2,
+                error_type="NotFound",
+                output_format=fmt,
+                script_name="get_pr_review_threads.py",
+            )
+            return 2
+        write_skill_error(
+            f"Failed to query review threads: {msg}",
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="get_pr_review_threads.py",
+        )
+        return 3
 
     if threads is None:
-        error_and_exit(f"PR #{pr} not found or has no review threads", 2)
+        write_skill_error(
+            f"PR #{pr} not found or has no review threads",
+            2,
+            error_type="NotFound",
+            output_format=fmt,
+            script_name="get_pr_review_threads.py",
+        )
+        return 2
 
     if args.unresolved_only:
         threads = filter_unresolved_threads(threads)
@@ -332,19 +360,18 @@ def main(argv: list[str] | None = None) -> int:
     total = len(threads)
     unresolved = count_unresolved_threads(threads)
 
-    output = {
-        "success": True,
-        "pull_request": pr,
-        "owner": owner,
-        "repo": repo,
-        "total_threads": total,
-        "resolved_count": total - unresolved,
-        "unresolved_count": unresolved,
-        "pagination_truncated": truncated,
-        "threads": transformed,
+    data = {
+        "PullRequest": pr,
+        "Owner": owner,
+        "Repo": repo,
+        "TotalThreads": total,
+        "ResolvedCount": total - unresolved,
+        "UnresolvedCount": unresolved,
+        "PaginationTruncated": truncated,
+        "Threads": transformed,
     }
     # Truncation is signaled to consumers via two channels:
-    # - `pagination_truncated: bool` field in JSON output (machine-readable)
+    # - `Data.PaginationTruncated: bool` field in JSON output (machine-readable)
     # - `warnings.warn` emitted by `_collect_all_threads` (human-readable on
     #   stderr). Python's default warnings filter prints UserWarning to
     #   stderr at most once per call site; CI pipelines reading stderr for
@@ -352,7 +379,15 @@ def main(argv: list[str] | None = None) -> int:
     # No second `print(WARNING ...)` here: duplicate stderr output would
     # confuse callers parsing for a single signal.
 
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        data,
+        output_format=fmt,
+        human_summary=(
+            f"PR #{pr}: {total} thread(s), {unresolved} unresolved"
+        ),
+        status="PASS",
+        script_name="get_pr_review_threads.py",
+    )
     return 0
 
 

--- a/.claude/skills/github/scripts/pr/validate_pr_description.py
+++ b/.claude/skills/github/scripts/pr/validate_pr_description.py
@@ -161,9 +161,20 @@ def main(argv: list[str] | None = None) -> int:
             warnings.append(f"Incomplete template sections: {', '.join(warn_sections)}")
 
     success = len(errors) == 0
+    # Under --fail-on-violation, warnings are treated as fatal: a run with
+    # warnings will exit nonzero even when no errors were detected. The output
+    # must reflect this so humans and automation see a coherent pass/fail signal
+    # (fix for #2369).
+    warnings_are_fatal = bool(args.fail_on_violation) and len(warnings) > 0
+    effective_success = success and not warnings_are_fatal
 
     result = {
         "Success": success,
+        "EffectiveSuccess": effective_success,
+        "FailOnViolation": bool(args.fail_on_violation),
+        "WarningsAreFatal": warnings_are_fatal,
+        "WarningCount": len(warnings),
+        "ErrorCount": len(errors),
         "Validations": {
             "ConventionalCommit": conv,
             "IssueKeywords": keywords,
@@ -182,6 +193,12 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Conventional Commit: {conv['Status']} - {conv['Message']}", file=sys.stderr)
     print(f"Issue Keywords:      {keywords['Status']} - {keywords['Message']}", file=sys.stderr)
     print(f"Template Compliance: {template['Status']} - {template['Message']}", file=sys.stderr)
+    fatality_policy = (
+        "warnings are fatal (--fail-on-violation)"
+        if args.fail_on_violation
+        else "warnings are advisory (default mode)"
+    )
+    print(f"Policy:              {fatality_policy}", file=sys.stderr)
 
     if warnings:
         print("\nWarnings:", file=sys.stderr)
@@ -193,22 +210,24 @@ def main(argv: list[str] | None = None) -> int:
         for e in errors:
             print(f"  ✗ {e}", file=sys.stderr)
 
-    has_issues = not success or (args.fail_on_violation and warnings)
-    fail = has_issues and args.fail_on_violation
-
-    if fail:
-        if success and warnings:
-            print(
-                f"\n✗ Validation failed: {len(warnings)} warning(s) treated as "
-                "violations (--fail-on-violation)",
-                file=sys.stderr,
-            )
-        else:
-            print("\n✗ Validation failed", file=sys.stderr)
-        return 1
-
-    if not has_issues:
+    if effective_success:
         print("\n✓ Validation passed", file=sys.stderr)
+    elif warnings_are_fatal and success:
+        # No hard errors, but warnings are fatal under --fail-on-violation.
+        # Do NOT print "Validation passed" because exit will be nonzero (#2369).
+        print(
+            f"\n✗ Validation failed: {len(warnings)} warning(s) treated as "
+            "violations (--fail-on-violation)",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"\n✗ Validation failed: {len(errors)} error(s), {len(warnings)} warning(s)",
+            file=sys.stderr,
+        )
+
+    if args.fail_on_violation and not effective_success:
+        return 1
 
     return 0
 

--- a/.claude/skills/github/scripts/reactions/add_comment_reaction.py
+++ b/.claude/skills/github/scripts/reactions/add_comment_reaction.py
@@ -14,7 +14,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -38,6 +37,12 @@ if _lib_dir not in sys.path:
 from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
 )
 
 REACTION_EMOJI: dict[str, str] = {
@@ -79,11 +84,13 @@ def build_parser() -> argparse.ArgumentParser:
         choices=VALID_REACTIONS,
         help="Reaction type",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -140,11 +147,29 @@ def main(argv: list[str] | None = None) -> int:
         "results": results,
     }
 
-    print(json.dumps(summary, indent=2))
-
     if failed > 0:
+        write_skill_error(
+            (
+                f"Applied '{args.reaction}' to {succeeded}/{len(args.comment_id)} "
+                f"comment(s); {failed} failed"
+            ),
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="add_comment_reaction.py",
+            extra=summary,
+        )
         return 3
 
+    write_skill_output(
+        summary,
+        output_format=fmt,
+        human_summary=(
+            f"Applied '{args.reaction}' to {succeeded}/{len(args.comment_id)} "
+            f"comment(s) ({failed} failed)"
+        ),
+        script_name="add_comment_reaction.py",
+    )
     return 0
 
 

--- a/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -140,8 +140,11 @@ def _get_shebang_language(file_path: str) -> str | None:
     if not command:
         return None
     executable = Path(command[0]).name
-    if executable == "env" and len(command) > 1:
-        executable = Path(command[1]).name
+    if executable == "env":
+        for arg in command[1:]:
+            if not arg.startswith("-"):
+                executable = Path(arg).name
+                break
     if executable in shell_names:
         return "bash"
     return None

--- a/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -129,11 +129,20 @@ def get_language(file_path: str) -> str | None:
 def _get_shebang_language(file_path: str) -> str | None:
     """Detect supported extensionless scripts from their shebang."""
     try:
-        with open(file_path, encoding="utf-8", errors="ignore") as f:
+        with open(file_path, encoding="utf-8") as f:
             first_line = f.readline().strip().lower()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None
-    if first_line.startswith("#!") and "bash" in first_line:
+    if not first_line.startswith("#!"):
+        return None
+    shell_names = {"bash", "dash", "ksh", "sh"}
+    command = first_line[2:].strip().split()
+    if not command:
+        return None
+    executable = Path(command[0]).name
+    if executable == "env" and len(command) > 1:
+        executable = Path(command[1]).name
+    if executable in shell_names:
         return "bash"
     return None
 
@@ -159,8 +168,22 @@ def get_staged_files() -> list[str]:
 def get_directory_files(directory: str) -> list[str]:
     """Get all scannable files from a directory."""
     supported_extensions = {".py", ".ps1", ".psm1", ".sh", ".bash", ".cs"}
+    pruned_directories = {
+        ".git",
+        ".hg",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "__pycache__",
+        "node_modules",
+    }
     files = []
-    for root, _, filenames in os.walk(directory):
+    for root, dirnames, filenames in os.walk(directory):
+        dirnames[:] = [
+            name for name in dirnames if name.lower() not in pruned_directories
+        ]
         for filename in filenames:
             file_path = os.path.join(root, filename)
             suffix = Path(filename).suffix.lower()

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.117",
+  "version": "0.5.119",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/github/scripts/issue/close_issue.py
+++ b/src/copilot-cli/skills/github/scripts/issue/close_issue.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Close a GitHub Issue with an optional closing comment.
+
+Posts an optional comment (from ``--comment`` or ``--comment-file``) and then
+closes the issue via ``gh issue close --reason``. Emits the standard ADR-056
+skill output envelope ({Success, Data, Error, Metadata}).
+
+Exit codes follow ADR-035:
+    0 - Success (issue closed, or already closed)
+    1 - Invalid parameters / logic error
+    2 - File not found / config error
+    3 - External error (API failure)
+    4 - Auth error (not authenticated)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_workspace = os.environ.get("GITHUB_WORKSPACE")
+if _plugin_root:
+    _lib_dir = os.path.join(_plugin_root, "lib")
+elif _workspace:
+    _lib_dir = os.path.join(_workspace, ".claude", "lib")
+else:
+    _lib_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "lib")
+    )
+if not os.path.isdir(_lib_dir):
+    print(f"Plugin lib directory not found: {_lib_dir}", file=sys.stderr)
+    sys.exit(2)  # Config error per ADR-035
+if _lib_dir not in sys.path:
+    sys.path.insert(0, _lib_dir)
+
+from github_core.api import (  # noqa: E402
+    assert_gh_authenticated,
+    resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
+)
+
+# gh issue close --reason accepts exactly these two values. "not planned" is the
+# spelling gh expects (with a space), so we pass the value through verbatim.
+_VALID_REASONS = ("completed", "not planned")
+_AUTH_ERROR_MARKERS = (
+    "credential",
+    "not logged in",
+    "bad credentials",
+    "could not authenticate",
+    "authentication",
+    "requires authentication",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Close a GitHub Issue with an optional closing comment.",
+    )
+    parser.add_argument("--owner", default="", help="Repository owner")
+    parser.add_argument("--repo", default="", help="Repository name")
+    parser.add_argument("--issue", type=int, required=True, help="Issue number")
+    parser.add_argument(
+        "--reason",
+        choices=list(_VALID_REASONS),
+        default="completed",
+        help="Close reason: 'completed' (default) or 'not planned'.",
+    )
+
+    comment_group = parser.add_mutually_exclusive_group()
+    comment_group.add_argument(
+        "--comment", default="", help="Closing comment body text",
+    )
+    comment_group.add_argument(
+        "--comment-file", default="", help="Path to a file containing the comment body",
+    )
+
+    add_output_format_arg(parser)
+    return parser
+
+
+def _comment_base_dir() -> Path:
+    """Return the directory that comment files must stay under."""
+    workspace = os.environ.get("GITHUB_WORKSPACE", "").strip()
+    if workspace:
+        return Path(workspace).expanduser().resolve()
+    for parent in Path(__file__).resolve().parents:
+        if (parent / ".git").exists() or (parent / ".claude").is_dir():
+            return parent
+    return Path(os.getcwd()).resolve()
+
+
+def _resolve_comment_file(comment_file: str, fmt: str) -> Path:
+    base_dir = _comment_base_dir()
+    raw_path = Path(comment_file)
+    path = raw_path if raw_path.is_absolute() else base_dir / raw_path
+    resolved = path.resolve()
+    if not resolved.is_relative_to(base_dir):
+        write_skill_error(
+            f"Comment file must stay under {base_dir}: {comment_file}",
+            2,
+            error_type="InvalidParams",
+            output_format=fmt,
+            script_name="close_issue.py",
+            extra={"issue": None},
+        )
+        raise SystemExit(2)
+    if not resolved.is_file():
+        write_skill_error(
+            f"Comment file not found: {comment_file}",
+            2,
+            error_type="NotFound",
+            output_format=fmt,
+            script_name="close_issue.py",
+            extra={"issue": None},
+        )
+        raise SystemExit(2)
+    return resolved
+
+
+def _resolve_comment(comment: str, comment_file: str, fmt: str) -> str:
+    """Return the closing comment body, reading the file when one is given.
+
+    Exits with code 2 (config error) when the comment file is missing. Returns
+    an empty string when no comment was requested.
+    """
+    if comment_file:
+        path = _resolve_comment_file(comment_file, fmt)
+        try:
+            return path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            write_skill_error(
+                f"Failed to read comment file {comment_file}: {exc}",
+                2,
+                error_type="InvalidParams",
+                output_format=fmt,
+                script_name="close_issue.py",
+                extra={"issue": None},
+            )
+            raise SystemExit(2) from exc
+    return comment
+
+
+def _is_auth_error(message: str) -> bool:
+    lowered = message.lower()
+    return any(marker in lowered for marker in _AUTH_ERROR_MARKERS)
+
+
+def _write_subprocess_error(
+    message: str, issue: int, fmt: str, *, not_found: bool = False
+) -> int:
+    if not_found:
+        code = 2
+        error_type = "NotFound"
+    elif _is_auth_error(message):
+        code = 4
+        error_type = "AuthError"
+    else:
+        code = 3
+        error_type = "ApiError"
+    write_skill_error(
+        message,
+        code,
+        error_type=error_type,
+        output_format=fmt,
+        script_name="close_issue.py",
+        extra={"issue": issue},
+    )
+    return code
+
+
+def _get_issue_state(owner: str, repo: str, issue: int, fmt: str) -> str:
+    """Return the issue state from GitHub, lowercased."""
+    result = subprocess.run(
+        [
+            "gh", "issue", "view", str(issue),
+            "--repo", f"{owner}/{repo}",
+            "--json", "state",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        error_str = result.stderr.strip() or result.stdout.strip()
+        code = _write_subprocess_error(
+            f"Failed to get issue #{issue}: {error_str}",
+            issue,
+            fmt,
+            not_found=(
+                "Could not resolve" in error_str
+                or "not found" in error_str.lower()
+            ),
+        )
+        raise SystemExit(code)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        write_skill_error(
+            f"Failed to parse issue #{issue} state: {exc}",
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="close_issue.py",
+            extra={"issue": issue},
+        )
+        raise SystemExit(3) from exc
+    if not isinstance(payload, dict):
+        return ""
+    state = payload.get("state")
+    return "" if state is None else str(state).lower()
+
+
+def _post_comment(owner: str, repo: str, issue: int, body: str, fmt: str) -> None:
+    """Post a closing comment via gh api. Exits with code 3 on failure."""
+    payload = json.dumps({"body": body})
+    result = subprocess.run(
+        [
+            "gh", "api",
+            f"repos/{owner}/{repo}/issues/{issue}/comments",
+            "-X", "POST",
+            "--input", "-",
+        ],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        error_str = result.stderr.strip() or result.stdout.strip()
+        code = _write_subprocess_error(
+            f"Failed to post closing comment: {error_str}",
+            issue,
+            fmt,
+        )
+        raise SystemExit(code)
+
+
+def _close_issue(owner: str, repo: str, issue: int, reason: str) -> subprocess.CompletedProcess[str]:
+    """Run gh issue close with the given reason. Returns the completed process."""
+    return subprocess.run(
+        [
+            "gh", "issue", "close", str(issue),
+            "--repo", f"{owner}/{repo}",
+            "--reason", reason,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
+    body = _resolve_comment(args.comment, args.comment_file, fmt)
+
+    assert_gh_authenticated()
+    resolved = resolve_repo_params(args.owner, args.repo)
+    owner, repo = resolved.owner, resolved.repo
+    issue: int = args.issue
+
+    state = _get_issue_state(owner, repo, issue, fmt)
+    if state == "closed":
+        data = {
+            "issue": issue,
+            "owner": owner,
+            "repo": repo,
+            "state": "closed",
+            "reason": args.reason,
+            "commented": False,
+            "action": "already_closed",
+        }
+        write_skill_output(
+            data,
+            output_format=fmt,
+            human_summary=f"Issue #{issue} is already closed",
+            status="PASS",
+            script_name="close_issue.py",
+        )
+        return 0
+
+    result = _close_issue(owner, repo, issue, args.reason)
+    if result.returncode != 0:
+        error_str = result.stderr.strip() or result.stdout.strip()
+        code = _write_subprocess_error(
+            f"Failed to close issue #{issue}: {error_str}",
+            issue,
+            fmt,
+        )
+        return code
+
+    commented = bool(body and body.strip())
+    if commented:
+        _post_comment(owner, repo, issue, body, fmt)
+
+    data = {
+        "issue": issue,
+        "owner": owner,
+        "repo": repo,
+        "state": "closed",
+        "reason": args.reason,
+        "commented": commented,
+        "action": "closed",
+    }
+    write_skill_output(
+        data,
+        output_format=fmt,
+        human_summary=f"Closed issue #{issue} as '{args.reason}'",
+        status="PASS",
+        script_name="close_issue.py",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/copilot-cli/skills/github/scripts/issue/close_issue.py
+++ b/src/copilot-cli/skills/github/scripts/issue/close_issue.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Close a GitHub Issue with an optional closing comment.
 
-Posts an optional comment (from ``--comment`` or ``--comment-file``) and then
-closes the issue via ``gh issue close --reason``. Emits the standard ADR-056
-skill output envelope ({Success, Data, Error, Metadata}).
+Closes the issue via ``gh issue close --reason`` and posts an optional comment
+from ``--comment`` or ``--comment-file``. On retry, an already-closed issue can
+still receive a missing closing comment without duplicating an existing one.
+Emits the standard ADR-056 skill output envelope ({Success, Data, Error,
+Metadata}).
 
 Exit codes follow ADR-035:
     0 - Success (issue closed, or already closed)
@@ -96,7 +98,7 @@ def _comment_base_dir() -> Path:
     for parent in Path(__file__).resolve().parents:
         if (parent / ".git").exists() or (parent / ".claude").is_dir():
             return parent
-    return Path(os.getcwd()).resolve()
+    return Path(__file__).resolve().parent
 
 
 def _resolve_comment_file(comment_file: str, fmt: str) -> Path:
@@ -247,6 +249,47 @@ def _post_comment(owner: str, repo: str, issue: int, body: str, fmt: str) -> Non
         raise SystemExit(code)
 
 
+def _comment_exists(owner: str, repo: str, issue: int, body: str, fmt: str) -> bool:
+    result = subprocess.run(
+        [
+            "gh", "issue", "view", str(issue),
+            "--repo", f"{owner}/{repo}",
+            "--json", "comments",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        error_str = result.stderr.strip() or result.stdout.strip()
+        code = _write_subprocess_error(
+            f"Failed to inspect issue #{issue} comments: {error_str}",
+            issue,
+            fmt,
+        )
+        raise SystemExit(code)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        write_skill_error(
+            f"Failed to parse issue #{issue} comments: {exc}",
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="close_issue.py",
+            extra={"issue": issue},
+        )
+        raise SystemExit(3) from exc
+    comments = payload.get("comments") if isinstance(payload, dict) else None
+    if not isinstance(comments, list):
+        return False
+    for comment in comments:
+        if isinstance(comment, dict) and comment.get("body") == body:
+            return True
+    return False
+
+
 def _close_issue(owner: str, repo: str, issue: int, reason: str) -> subprocess.CompletedProcess[str]:
     """Run gh issue close with the given reason. Returns the completed process."""
     return subprocess.run(
@@ -274,13 +317,21 @@ def main(argv: list[str] | None = None) -> int:
 
     state = _get_issue_state(owner, repo, issue, fmt)
     if state == "closed":
+        commented = False
+        comment_already_present = False
+        if body and body.strip():
+            comment_already_present = _comment_exists(owner, repo, issue, body, fmt)
+            if not comment_already_present:
+                _post_comment(owner, repo, issue, body, fmt)
+                commented = True
         data = {
             "issue": issue,
             "owner": owner,
             "repo": repo,
             "state": "closed",
             "reason": args.reason,
-            "commented": False,
+            "commented": commented,
+            "commentAlreadyPresent": comment_already_present,
             "action": "already_closed",
         }
         write_skill_output(

--- a/src/copilot-cli/skills/github/scripts/issue/close_issue.py
+++ b/src/copilot-cli/skills/github/scripts/issue/close_issue.py
@@ -249,12 +249,27 @@ def _post_comment(owner: str, repo: str, issue: int, body: str, fmt: str) -> Non
         raise SystemExit(code)
 
 
+def _comment_bodies(payload: object) -> list[str]:
+    if isinstance(payload, dict):
+        return _comment_bodies(payload.get("comments"))
+    if not isinstance(payload, list):
+        return []
+    bodies: list[str] = []
+    for item in payload:
+        if isinstance(item, list):
+            bodies.extend(_comment_bodies(item))
+        elif isinstance(item, dict) and isinstance(item.get("body"), str):
+            bodies.append(item["body"])
+    return bodies
+
+
 def _comment_exists(owner: str, repo: str, issue: int, body: str, fmt: str) -> bool:
     result = subprocess.run(
         [
-            "gh", "issue", "view", str(issue),
-            "--repo", f"{owner}/{repo}",
-            "--json", "comments",
+            "gh", "api",
+            f"repos/{owner}/{repo}/issues/{issue}/comments?per_page=100",
+            "--paginate",
+            "--slurp",
         ],
         capture_output=True,
         text=True,
@@ -281,13 +296,7 @@ def _comment_exists(owner: str, repo: str, issue: int, body: str, fmt: str) -> b
             extra={"issue": issue},
         )
         raise SystemExit(3) from exc
-    comments = payload.get("comments") if isinstance(payload, dict) else None
-    if not isinstance(comments, list):
-        return False
-    for comment in comments:
-        if isinstance(comment, dict) and comment.get("body") == body:
-            return True
-    return False
+    return body in _comment_bodies(payload)
 
 
 def _close_issue(owner: str, repo: str, issue: int, reason: str) -> subprocess.CompletedProcess[str]:

--- a/src/copilot-cli/skills/github/scripts/issue/edit_issue_body.py
+++ b/src/copilot-cli/skills/github/scripts/issue/edit_issue_body.py
@@ -17,7 +17,6 @@ Exit codes (per ADR-035):
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -40,6 +39,11 @@ if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)
 
 from github_core.api import error_and_exit, resolve_repo_params  # noqa: E402
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 from github_core.validation import assert_valid_body_file  # noqa: E402
 
 
@@ -62,12 +66,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to file containing new body text",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     if args.body is None and args.body_file is None:
         error_and_exit("Must provide --body or --body-file", 1)
@@ -131,17 +137,17 @@ def main(argv: list[str] | None = None) -> int:
             error_and_exit(f"Auth error: {error_str}", 4)
         error_and_exit(f"Failed to edit issue: {error_str}", 3)
 
-    # Emit structured JSON to match sibling scripts (new_issue.py,
-    # post_issue_comment.py). PR #1965 cluster R.
-    print(
-        json.dumps(
-            {
-                "issue": args.issue,
-                "status": "updated",
-                "repo": f"{owner}/{repo}",
-            },
-            indent=2,
-        )
+    # Emit the canonical skill output envelope (ADR-056) to match sibling
+    # scripts (new_issue.py, post_issue_comment.py). Issue #2388.
+    write_skill_output(
+        {
+            "issue": args.issue,
+            "status": "updated",
+            "repo": f"{owner}/{repo}",
+        },
+        output_format=fmt,
+        human_summary=f"Updated body of issue #{args.issue} in {owner}/{repo}",
+        script_name="edit_issue_body.py",
     )
     return 0
 

--- a/src/copilot-cli/skills/github/scripts/issue/invoke_copilot_assignment.py
+++ b/src/copilot-cli/skills/github/scripts/issue/invoke_copilot_assignment.py
@@ -52,6 +52,11 @@ from github_core.api import (  # noqa: E402
     resolve_repo_params,
     update_issue_comment,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -231,9 +236,10 @@ def _get_coderabbit_plan(
     prs_pattern = f"(?:<b>)?{prs_raw}(?:</b>)?"
 
     for comment in rabbit_comments:
-        body = comment.get("body", "")
+        body = comment.get("body") or ""
 
-        m = re.search(f"{impl_pattern}([\\s\\S]*?)(?=##|$)", body)  # nosemgrep: skill-ldap-injection
+        # nosemgrep: skill-ldap-injection
+        m = re.search(f"{impl_pattern}([\\s\\S]*?)(?=##|$)", body)
         if m:
             plan["implementation"] = m.group(1).strip()
 
@@ -478,6 +484,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Preview synthesis comment without posting or assigning",
     )
+    add_output_format_arg(parser)
     return parser
 
 
@@ -488,13 +495,15 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of complex PS1
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
     owner, repo = resolved.owner, resolved.repo
     issue_number: int = args.issue_number
 
-    print(f"Processing issue #{issue_number} in {owner}/{repo}")
+    if fmt != "json":
+        print(f"Processing issue #{issue_number} in {owner}/{repo}")
 
     config = _load_synthesis_config(args.config_path)
 
@@ -518,19 +527,21 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
             error_and_exit(f"Issue #{issue_number} not found in {owner}/{repo}", 2)
         error_and_exit(f"Failed to get issue: {error_str}", 3)
 
-    issue = json.loads(issue_result.stdout)
-    print(f"Issue: {issue.get('title', '')}")
+    issue_payload = json.loads(issue_result.stdout)
+    issue = issue_payload if isinstance(issue_payload, dict) else {}
+    title = "" if issue.get("title") is None else str(issue.get("title"))
+    print(f"Issue: {title}", file=sys.stderr)
 
     # Fetch comments
     comments = get_issue_comments(owner, repo, issue_number)
-    print(f"Found {len(comments)} comments")
+    print(f"Found {len(comments)} comments", file=sys.stderr)
 
     trusted_users = (
         config["trusted_sources"]["maintainers"]
         + config["trusted_sources"]["ai_agents"]
     )
     trusted_comments = get_trusted_source_comments(comments, trusted_users)
-    print(f"Found {len(trusted_comments)} comments from trusted sources")
+    print(f"Found {len(trusted_comments)} comments from trusted sources", file=sys.stderr)
 
     # PrepareContextOnly mode
     if args.prepare_context_only:
@@ -545,7 +556,12 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
             "owner": owner,
             "repo": repo,
         }
-        print(json.dumps(output, indent=2))
+        write_skill_output(
+            output,
+            output_format=fmt,
+            human_summary=f"Prepared context file for issue #{issue_number}",
+            script_name="invoke_copilot_assignment.py",
+        )
 
         _write_github_output({
             "context_file": context_file,
@@ -573,6 +589,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
 
     # Dry-run mode
     if args.dry_run:
+        dry_run_output = {
+            "action": "dry_run",
+            "issue_number": issue_number,
+            "owner": owner,
+            "repo": repo,
+            "has_synthesizable_content": has_content,
+            "existing_synthesis_id": existing_synthesis["id"] if existing_synthesis else None,
+            "would_assign": not args.skip_assignment,
+            "synthesis_body": None,
+        }
         if has_content:
             synthesis_body = _build_synthesis_comment(
                 config["synthesis"]["marker"],
@@ -580,6 +606,15 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
                 coderabbit_plan,
                 ai_triage,
             )
+            dry_run_output["synthesis_body"] = synthesis_body
+            if fmt == "json":
+                write_skill_output(
+                    dry_run_output,
+                    output_format=fmt,
+                    human_summary=f"Prepared dry-run synthesis for issue #{issue_number}",
+                    script_name="invoke_copilot_assignment.py",
+                )
+                return 0
             print("\n=== SYNTHESIS PREVIEW ===")
             print(synthesis_body)
             print("=== END PREVIEW ===")
@@ -588,8 +623,20 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
             else:
                 print("\nWould CREATE new synthesis comment")
         else:
+            if fmt == "json":
+                write_skill_output(
+                    dry_run_output,
+                    output_format=fmt,
+                    human_summary=f"No synthesizable content found for issue #{issue_number}",
+                    status="WARNING",
+                    script_name="invoke_copilot_assignment.py",
+                )
+                return 0
             print("\nNo synthesizable content found, would SKIP synthesis comment")
-        print(f"Would ASSIGN copilot-swe-agent to issue #{issue_number}")
+        if args.skip_assignment:
+            print(f"Would SKIP assignment for issue #{issue_number}")
+        else:
+            print(f"Would ASSIGN copilot-swe-agent to issue #{issue_number}")
         return 0
 
     # Post or update synthesis
@@ -605,29 +652,34 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         )
 
         if existing_synthesis:
-            print(f"Updating existing synthesis comment (ID: {existing_synthesis['id']})")
+            print(
+                f"Updating existing synthesis comment (ID: {existing_synthesis['id']})",
+                file=sys.stderr,
+            )
             response = update_issue_comment(owner, repo, existing_synthesis["id"], synthesis_body)
             action = "Updated"
         else:
-            print("Creating new synthesis comment")
+            print("Creating new synthesis comment", file=sys.stderr)
             response = create_issue_comment(owner, repo, issue_number, synthesis_body)
             action = "Created"
-        print(f"{action} synthesis comment: {response.get('html_url', 'N/A')}")
+        print(f"{action} synthesis comment: {response.get('html_url', 'N/A')}", file=sys.stderr)
     else:
-        print("No synthesizable content found, skipping synthesis comment")
+        print("No synthesizable content found, skipping synthesis comment", file=sys.stderr)
 
     # Assign Copilot
     assigned = False
     if not args.skip_assignment:
-        print("Assigning copilot-swe-agent...")
+        print("Assigning copilot-swe-agent...", file=sys.stderr)
         assigned = _assign_copilot(owner, repo, issue_number)
         if assigned:
-            print(f"Assigned copilot-swe-agent to issue #{issue_number}")
+            print(f"Assigned copilot-swe-agent to issue #{issue_number}", file=sys.stderr)
     else:
-        print("Skipping assignment (handled by workflow with COPILOT_GITHUB_TOKEN)")
+        print(
+            "Skipping assignment (handled by workflow with COPILOT_GITHUB_TOKEN)",
+            file=sys.stderr,
+        )
 
     output = {
-        "success": True,
         "action": action,
         "issue_number": issue_number,
         "comment_id": response["id"] if response else None,
@@ -635,7 +687,12 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         "assigned": assigned,
         "marker": config["synthesis"]["marker"],
     }
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        output,
+        output_format=fmt,
+        human_summary=f"{action} synthesis for issue #{issue_number}",
+        script_name="invoke_copilot_assignment.py",
+    )
     return 0
 
 

--- a/src/copilot-cli/skills/github/scripts/issue/new_issue.py
+++ b/src/copilot-cli/skills/github/scripts/issue/new_issue.py
@@ -14,7 +14,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 import subprocess
@@ -41,6 +40,11 @@ from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     error_and_exit,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
 )
 
 
@@ -74,11 +78,13 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help='Comma-separated list of labels (e.g., "bug,P1,needs-triage")',
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -115,13 +121,16 @@ def main(argv: list[str] | None = None) -> int:
 
     issue_number = int(match.group(1))
 
-    output = {
-        "success": True,
-        "issue_number": issue_number,
-        "url": output_text,
-        "title": args.title,
-    }
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        {
+            "issue_number": issue_number,
+            "url": output_text,
+            "title": args.title,
+        },
+        output_format=fmt,
+        human_summary=f"Created issue #{issue_number}: {args.title}",
+        script_name="new_issue.py",
+    )
 
     _write_github_output({
         "success": "true",

--- a/src/copilot-cli/skills/github/scripts/issue/post_issue_comment.py
+++ b/src/copilot-cli/skills/github/scripts/issue/post_issue_comment.py
@@ -46,6 +46,13 @@ from github_core.api import (  # noqa: E402
     resolve_repo_params,
     update_issue_comment,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
+
+_SCRIPT_NAME = "post_issue_comment.py"
 
 _403_PATTERN = re.compile(
     r"((?<!\d)403(?!\d)|\bforbidden\b|Resource not accessible by integration)",
@@ -156,11 +163,13 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Update existing comment instead of skipping when marker found",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of PS1 logic
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -200,16 +209,20 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
 
             if existing is not None:
                 if args.update_if_exists:
-                    print(f"Comment with marker '{args.marker}' exists. Updating...")
+                    if fmt != "json":
+                        print(f"Comment with marker '{args.marker}' exists. Updating...")
                     body = _prepend_marker(body, marker_html)
                     response = update_issue_comment(owner, repo, existing["id"], body)
-                    print(f"Updated comment on issue #{issue}")
-                    print(json.dumps({
-                        "success": True,
-                        "issue": issue,
-                        "comment_id": response["id"],
-                        "updated": True,
-                    }, indent=2))
+                    write_skill_output(
+                        {
+                            "issue": issue,
+                            "comment_id": response["id"],
+                            "updated": True,
+                        },
+                        output_format=fmt,
+                        human_summary=f"Updated comment on issue #{issue}",
+                        script_name=_SCRIPT_NAME,
+                    )
                     _write_github_output({
                         "success": "true",
                         "skipped": "false",
@@ -222,13 +235,18 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
                     })
                     return 0
 
-                print(f"Comment with marker '{args.marker}' already exists. Skipping.")
-                print(json.dumps({
-                    "success": True,
-                    "issue": issue,
-                    "marker": args.marker,
-                    "skipped": True,
-                }, indent=2))
+                write_skill_output(
+                    {
+                        "issue": issue,
+                        "marker": args.marker,
+                        "skipped": True,
+                    },
+                    output_format=fmt,
+                    human_summary=(
+                        f"Comment with marker '{args.marker}' already exists. Skipping."
+                    ),
+                    script_name=_SCRIPT_NAME,
+                )
                 _write_github_output({
                     "success": "true",
                     "skipped": "true",
@@ -277,6 +295,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         response = json.loads(result.stdout)
     except json.JSONDecodeError:
         print(f"Posted comment to issue #{issue} (response parsing failed)", file=sys.stderr)
+        write_skill_output(
+            {
+                "issue": issue,
+                "skipped": False,
+                "parse_error": True,
+            },
+            output_format=fmt,
+            human_summary=f"Posted comment to issue #{issue} (response parsing failed)",
+            script_name=_SCRIPT_NAME,
+        )
         _write_github_output({
             "success": "true",
             "skipped": "false",
@@ -285,13 +313,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         })
         return 0
 
-    output = {
-        "success": True,
-        "issue": issue,
-        "comment_id": response["id"],
-        "skipped": False,
-    }
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        {
+            "issue": issue,
+            "comment_id": response["id"],
+            "skipped": False,
+        },
+        output_format=fmt,
+        human_summary=f"Posted comment to issue #{issue}",
+        script_name=_SCRIPT_NAME,
+    )
 
     outputs: dict[str, str] = {
         "success": "true",

--- a/src/copilot-cli/skills/github/scripts/issue/set_issue_milestone.py
+++ b/src/copilot-cli/skills/github/scripts/issue/set_issue_milestone.py
@@ -15,7 +15,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -38,8 +37,13 @@ if _lib_dir not in sys.path:
 
 from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
-    error_and_exit,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
 )
 
 
@@ -103,23 +107,54 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Replace existing milestone",
     )
+    add_output_format_arg(parser)
     return parser
+
+
+def _emit(output: dict, fmt: str) -> None:
+    """Emit the canonical envelope for the milestone result payload."""
+    write_skill_output(
+        output,
+        output_format=fmt,
+        human_summary=(
+            f"Issue #{output['issue']} milestone {output['action']}"
+        ),
+        script_name="set_issue_milestone.py",
+    )
+
+
+def _emit_error(message: str, code: int, fmt: str, error_type: str, output: dict) -> None:
+    write_skill_error(
+        message,
+        code,
+        error_type=error_type,
+        output_format=fmt,
+        script_name="set_issue_milestone.py",
+        extra=output,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
     owner, repo = resolved.owner, resolved.repo
 
     if not args.clear and not args.milestone:
-        error_and_exit("Must specify --milestone or --clear.", 2)
+        _emit_error(
+            "Must specify --milestone or --clear.",
+            2,
+            fmt,
+            "InvalidParams",
+            {"issue": args.issue, "milestone": None, "action": "failed"},
+        )
+        raise SystemExit(2)
 
     current_milestone = _get_current_milestone(owner, repo, args.issue)
 
     output = {
-        "success": False,
         "issue": args.issue,
         "milestone": None,
         "previous_milestone": current_milestone,
@@ -128,9 +163,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.clear:
         if not current_milestone:
-            output["success"] = True
             output["action"] = "no_change"
-            print(json.dumps(output, indent=2))
+            _emit(output, fmt)
             _write_github_output({
                 "success": "true",
                 "issue": str(args.issue),
@@ -149,11 +183,17 @@ def main(argv: list[str] | None = None) -> int:
             check=False,
         )
         if result.returncode != 0:
-            error_and_exit("Failed to clear milestone", 3)
+            _emit_error(
+                "Failed to clear milestone",
+                3,
+                fmt,
+                "ApiError",
+                output | {"action": "failed"},
+            )
+            raise SystemExit(3)
 
-        output["success"] = True
         output["action"] = "cleared"
-        print(json.dumps(output, indent=2))
+        _emit(output, fmt)
         _write_github_output({
             "success": "true",
             "issue": str(args.issue),
@@ -164,16 +204,19 @@ def main(argv: list[str] | None = None) -> int:
 
     milestone_titles = _get_milestone_titles(owner, repo)
     if args.milestone not in milestone_titles:
-        error_and_exit(
+        _emit_error(
             f"Milestone '{args.milestone}' does not exist in {owner}/{repo}.",
             2,
+            fmt,
+            "NotFound",
+            output | {"milestone": args.milestone, "action": "failed"},
         )
+        raise SystemExit(2)
 
     if current_milestone == args.milestone:
-        output["success"] = True
         output["milestone"] = args.milestone
         output["action"] = "no_change"
-        print(json.dumps(output, indent=2))
+        _emit(output, fmt)
         _write_github_output({
             "success": "true",
             "issue": str(args.issue),
@@ -183,11 +226,15 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if current_milestone and not args.force:
-        error_and_exit(
+        _emit_error(
             f"Issue #{args.issue} already has milestone "
             f"'{current_milestone}'. Use --force to override.",
             5,
+            fmt,
+            "General",
+            output | {"milestone": args.milestone, "action": "has_milestone"},
         )
+        raise SystemExit(5)
 
     result = subprocess.run(
         [
@@ -200,13 +247,19 @@ def main(argv: list[str] | None = None) -> int:
         check=False,
     )
     if result.returncode != 0:
-        error_and_exit("Failed to set milestone", 3)
+        _emit_error(
+            "Failed to set milestone",
+            3,
+            fmt,
+            "ApiError",
+            output | {"milestone": args.milestone, "action": "failed"},
+        )
+        raise SystemExit(3)
 
     action = "replaced" if current_milestone else "assigned"
-    output["success"] = True
     output["milestone"] = args.milestone
     output["action"] = action
-    print(json.dumps(output, indent=2))
+    _emit(output, fmt)
 
     gh_outputs: dict[str, str] = {
         "success": "true",

--- a/src/copilot-cli/skills/github/scripts/milestone/get_latest_semantic_milestone.py
+++ b/src/copilot-cli/skills/github/scripts/milestone/get_latest_semantic_milestone.py
@@ -15,7 +15,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 import sys
@@ -40,6 +39,12 @@ from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     gh_api_paginated,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
 )
 
 _SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
@@ -81,11 +86,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--owner", default="", help="Repository owner")
     parser.add_argument("--repo", default="", help="Repository name")
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -96,8 +103,14 @@ def main(argv: list[str] | None = None) -> int:
 
     if not milestones:
         print(f"No open milestones found in {owner}/{repo}", file=sys.stderr)
-        result = {"title": "", "number": 0, "found": False}
-        print(json.dumps(result, indent=2))
+        write_skill_error(
+            f"No open milestones found in {owner}/{repo}",
+            2,
+            error_type="NotFound",
+            output_format=fmt,
+            script_name="get_latest_semantic_milestone.py",
+            extra={"title": "", "number": 0, "found": False},
+        )
         _write_github_output({
             "milestone_title": "",
             "milestone_number": "0",
@@ -120,8 +133,14 @@ def main(argv: list[str] | None = None) -> int:
             f"No semantic version milestones found. Available: {available}",
             file=sys.stderr,
         )
-        result = {"title": "", "number": 0, "found": False}
-        print(json.dumps(result, indent=2))
+        write_skill_error(
+            f"No semantic version milestones found. Available: {available}",
+            2,
+            error_type="NotFound",
+            output_format=fmt,
+            script_name="get_latest_semantic_milestone.py",
+            extra={"title": "", "number": 0, "found": False},
+        )
         _write_github_output({
             "milestone_title": "",
             "milestone_number": "0",
@@ -139,12 +158,18 @@ def main(argv: list[str] | None = None) -> int:
 
     latest = max(semantic, key=lambda m: _parse_semver_tuple(m["title"]))
 
-    result = {
-        "title": latest["title"],
-        "number": latest["number"],
-        "found": True,
-    }
-    print(json.dumps(result, indent=2))
+    write_skill_output(
+        {
+            "title": latest["title"],
+            "number": latest["number"],
+            "found": True,
+        },
+        output_format=fmt,
+        human_summary=(
+            f"Latest semantic milestone: {latest['title']} (ID: {latest['number']})"
+        ),
+        script_name="get_latest_semantic_milestone.py",
+    )
 
     _write_github_output({
         "milestone_title": latest["title"],

--- a/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
+++ b/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
@@ -208,8 +208,6 @@ def main(argv: list[str] | None = None) -> int:
             f"Already has milestone '{existing}'. "
             "No action taken (preserving manual assignments)."
         )
-        if fmt != "json":
-            print(f"{item_type} #{item_number} already has milestone: {existing}")
         write_skill_output(
             {
                 "item_type": item_type,

--- a/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
+++ b/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
@@ -44,6 +44,11 @@ from github_core.api import (  # noqa: E402
     gh_api_paginated,
     resolve_repo_params,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_output,
+)
 
 _SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
 
@@ -181,11 +186,13 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help="Specific milestone to assign (auto-detects if omitted)",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     item_type: str = args.item_type
     item_number: int = args.item_number
@@ -201,16 +208,22 @@ def main(argv: list[str] | None = None) -> int:
             f"Already has milestone '{existing}'. "
             "No action taken (preserving manual assignments)."
         )
-        print(f"{item_type} #{item_number} already has milestone: {existing}")
-        result = {
-            "success": True,
-            "item_type": item_type,
-            "item_number": item_number,
-            "milestone": existing,
-            "action": "skipped",
-            "message": msg,
-        }
-        print(json.dumps(result, indent=2))
+        if fmt != "json":
+            print(f"{item_type} #{item_number} already has milestone: {existing}")
+        write_skill_output(
+            {
+                "item_type": item_type,
+                "item_number": item_number,
+                "milestone": existing,
+                "action": "skipped",
+                "message": msg,
+            },
+            output_format=fmt,
+            human_summary=(
+                f"{item_type} #{item_number} already has milestone: {existing}"
+            ),
+            script_name="set_item_milestone.py",
+        )
         _write_result(True, item_type, item_number, existing, "skipped", msg)
         return 0
 
@@ -229,20 +242,24 @@ def main(argv: list[str] | None = None) -> int:
         milestone_title = str(detection["title"])
 
     # Assign
-    print(f"Assigning milestone '{milestone_title}' to {item_type} #{item_number}")
+    print(f"Assigning milestone '{milestone_title}' to {item_type} #{item_number}", file=sys.stderr)
     _assign_milestone(owner, repo, item_number, milestone_title)
 
     msg = f"Assigned milestone '{milestone_title}'."
-    print(f"Successfully assigned milestone '{milestone_title}' to {item_type} #{item_number}")
-    result = {
-        "success": True,
-        "item_type": item_type,
-        "item_number": item_number,
-        "milestone": milestone_title,
-        "action": "assigned",
-        "message": msg,
-    }
-    print(json.dumps(result, indent=2))
+    write_skill_output(
+        {
+            "item_type": item_type,
+            "item_number": item_number,
+            "milestone": milestone_title,
+            "action": "assigned",
+            "message": msg,
+        },
+        output_format=fmt,
+        human_summary=(
+            f"Assigned milestone '{milestone_title}' to {item_type} #{item_number}"
+        ),
+        script_name="set_item_milestone.py",
+    )
     _write_result(True, item_type, item_number, milestone_title, "assigned", msg)
     return 0
 

--- a/src/copilot-cli/skills/github/scripts/notifications/get_actionable_items.py
+++ b/src/copilot-cli/skills/github/scripts/notifications/get_actionable_items.py
@@ -48,6 +48,12 @@ from github_core.api import (  # noqa: E402
     error_and_exit,
     resolve_repo_params,
 )
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -60,6 +66,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--limit", type=int, default=20,
         help="Max items per category (1-100, default: 20)",
     )
+    add_output_format_arg(parser)
     return parser
 
 
@@ -215,9 +222,18 @@ def _get_assigned_issues(repo_flag: str, user: str, limit: int) -> list[dict]:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     if not 1 <= args.limit <= 100:
-        error_and_exit("Limit must be between 1 and 100.", 1)
+        write_skill_error(
+            "Limit must be between 1 and 100.",
+            1,
+            error_type="InvalidParams",
+            output_format=fmt,
+            script_name="get_actionable_items.py",
+            extra={"limit": args.limit},
+        )
+        return 1
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -236,8 +252,7 @@ def main(argv: list[str] | None = None) -> int:
     authored_prs = _get_authored_prs(repo_flag, user, args.limit)
     assigned_issues = _get_assigned_issues(repo_flag, user, args.limit)
 
-    output = {
-        "success": True,
+    data = {
         "user": user,
         "repo": repo_flag,
         "notifications_api_available": notifications_available,
@@ -253,7 +268,18 @@ def main(argv: list[str] | None = None) -> int:
         },
     }
 
-    print(json.dumps(output, indent=2))
+    total = (
+        data["summary"]["notifications"]
+        + data["summary"]["review_requests"]
+        + data["summary"]["authored_prs"]
+        + data["summary"]["assigned_issues"]
+    )
+    write_skill_output(
+        data,
+        output_format=fmt,
+        human_summary=f"Found {total} actionable item(s) for {user} in {repo_flag}",
+        script_name="get_actionable_items.py",
+    )
     return 0
 
 

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_review_threads.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_review_threads.py
@@ -46,11 +46,16 @@ if _lib_dir not in sys.path:
 from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     count_unresolved_threads,
-    error_and_exit,
     filter_unresolved_threads,
     gh_graphql,
     resolve_repo_params,
     transform_review_thread,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
 )
 
 # Page size for the reviewThreads connection. GitHub GraphQL caps connection
@@ -124,6 +129,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--include-comments", action="store_true",
         help="Include all comments in each thread (not just first)",
     )
+    add_output_format_arg(parser)
     return parser
 
 
@@ -303,6 +309,7 @@ def _transform_thread(thread: dict, include_comments: bool) -> dict:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -318,11 +325,32 @@ def main(argv: list[str] | None = None) -> int:
     except RuntimeError as exc:
         msg = str(exc)
         if "Could not resolve" in msg:
-            error_and_exit(f"PR #{pr} not found in {owner}/{repo}", 2)
-        error_and_exit(f"Failed to query review threads: {msg}", 3)
+            write_skill_error(
+                f"PR #{pr} not found in {owner}/{repo}",
+                2,
+                error_type="NotFound",
+                output_format=fmt,
+                script_name="get_pr_review_threads.py",
+            )
+            return 2
+        write_skill_error(
+            f"Failed to query review threads: {msg}",
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="get_pr_review_threads.py",
+        )
+        return 3
 
     if threads is None:
-        error_and_exit(f"PR #{pr} not found or has no review threads", 2)
+        write_skill_error(
+            f"PR #{pr} not found or has no review threads",
+            2,
+            error_type="NotFound",
+            output_format=fmt,
+            script_name="get_pr_review_threads.py",
+        )
+        return 2
 
     if args.unresolved_only:
         threads = filter_unresolved_threads(threads)
@@ -332,19 +360,18 @@ def main(argv: list[str] | None = None) -> int:
     total = len(threads)
     unresolved = count_unresolved_threads(threads)
 
-    output = {
-        "success": True,
-        "pull_request": pr,
-        "owner": owner,
-        "repo": repo,
-        "total_threads": total,
-        "resolved_count": total - unresolved,
-        "unresolved_count": unresolved,
-        "pagination_truncated": truncated,
-        "threads": transformed,
+    data = {
+        "PullRequest": pr,
+        "Owner": owner,
+        "Repo": repo,
+        "TotalThreads": total,
+        "ResolvedCount": total - unresolved,
+        "UnresolvedCount": unresolved,
+        "PaginationTruncated": truncated,
+        "Threads": transformed,
     }
     # Truncation is signaled to consumers via two channels:
-    # - `pagination_truncated: bool` field in JSON output (machine-readable)
+    # - `Data.PaginationTruncated: bool` field in JSON output (machine-readable)
     # - `warnings.warn` emitted by `_collect_all_threads` (human-readable on
     #   stderr). Python's default warnings filter prints UserWarning to
     #   stderr at most once per call site; CI pipelines reading stderr for
@@ -352,7 +379,15 @@ def main(argv: list[str] | None = None) -> int:
     # No second `print(WARNING ...)` here: duplicate stderr output would
     # confuse callers parsing for a single signal.
 
-    print(json.dumps(output, indent=2))
+    write_skill_output(
+        data,
+        output_format=fmt,
+        human_summary=(
+            f"PR #{pr}: {total} thread(s), {unresolved} unresolved"
+        ),
+        status="PASS",
+        script_name="get_pr_review_threads.py",
+    )
     return 0
 
 

--- a/src/copilot-cli/skills/github/scripts/pr/validate_pr_description.py
+++ b/src/copilot-cli/skills/github/scripts/pr/validate_pr_description.py
@@ -161,9 +161,20 @@ def main(argv: list[str] | None = None) -> int:
             warnings.append(f"Incomplete template sections: {', '.join(warn_sections)}")
 
     success = len(errors) == 0
+    # Under --fail-on-violation, warnings are treated as fatal: a run with
+    # warnings will exit nonzero even when no errors were detected. The output
+    # must reflect this so humans and automation see a coherent pass/fail signal
+    # (fix for #2369).
+    warnings_are_fatal = bool(args.fail_on_violation) and len(warnings) > 0
+    effective_success = success and not warnings_are_fatal
 
     result = {
         "Success": success,
+        "EffectiveSuccess": effective_success,
+        "FailOnViolation": bool(args.fail_on_violation),
+        "WarningsAreFatal": warnings_are_fatal,
+        "WarningCount": len(warnings),
+        "ErrorCount": len(errors),
         "Validations": {
             "ConventionalCommit": conv,
             "IssueKeywords": keywords,
@@ -182,6 +193,12 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Conventional Commit: {conv['Status']} - {conv['Message']}", file=sys.stderr)
     print(f"Issue Keywords:      {keywords['Status']} - {keywords['Message']}", file=sys.stderr)
     print(f"Template Compliance: {template['Status']} - {template['Message']}", file=sys.stderr)
+    fatality_policy = (
+        "warnings are fatal (--fail-on-violation)"
+        if args.fail_on_violation
+        else "warnings are advisory (default mode)"
+    )
+    print(f"Policy:              {fatality_policy}", file=sys.stderr)
 
     if warnings:
         print("\nWarnings:", file=sys.stderr)
@@ -193,22 +210,24 @@ def main(argv: list[str] | None = None) -> int:
         for e in errors:
             print(f"  ✗ {e}", file=sys.stderr)
 
-    has_issues = not success or (args.fail_on_violation and warnings)
-    fail = has_issues and args.fail_on_violation
-
-    if fail:
-        if success and warnings:
-            print(
-                f"\n✗ Validation failed: {len(warnings)} warning(s) treated as "
-                "violations (--fail-on-violation)",
-                file=sys.stderr,
-            )
-        else:
-            print("\n✗ Validation failed", file=sys.stderr)
-        return 1
-
-    if not has_issues:
+    if effective_success:
         print("\n✓ Validation passed", file=sys.stderr)
+    elif warnings_are_fatal and success:
+        # No hard errors, but warnings are fatal under --fail-on-violation.
+        # Do NOT print "Validation passed" because exit will be nonzero (#2369).
+        print(
+            f"\n✗ Validation failed: {len(warnings)} warning(s) treated as "
+            "violations (--fail-on-violation)",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"\n✗ Validation failed: {len(errors)} error(s), {len(warnings)} warning(s)",
+            file=sys.stderr,
+        )
+
+    if args.fail_on_violation and not effective_success:
+        return 1
 
     return 0
 

--- a/src/copilot-cli/skills/github/scripts/reactions/add_comment_reaction.py
+++ b/src/copilot-cli/skills/github/scripts/reactions/add_comment_reaction.py
@@ -14,7 +14,6 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -38,6 +37,12 @@ if _lib_dir not in sys.path:
 from github_core.api import (  # noqa: E402
     assert_gh_authenticated,
     resolve_repo_params,
+)
+from github_core.output import (  # noqa: E402
+    add_output_format_arg,
+    get_output_format,
+    write_skill_error,
+    write_skill_output,
 )
 
 REACTION_EMOJI: dict[str, str] = {
@@ -79,11 +84,13 @@ def build_parser() -> argparse.ArgumentParser:
         choices=VALID_REACTIONS,
         help="Reaction type",
     )
+    add_output_format_arg(parser)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    fmt = get_output_format(args.output_format)
 
     assert_gh_authenticated()
     resolved = resolve_repo_params(args.owner, args.repo)
@@ -140,11 +147,29 @@ def main(argv: list[str] | None = None) -> int:
         "results": results,
     }
 
-    print(json.dumps(summary, indent=2))
-
     if failed > 0:
+        write_skill_error(
+            (
+                f"Applied '{args.reaction}' to {succeeded}/{len(args.comment_id)} "
+                f"comment(s); {failed} failed"
+            ),
+            3,
+            error_type="ApiError",
+            output_format=fmt,
+            script_name="add_comment_reaction.py",
+            extra=summary,
+        )
         return 3
 
+    write_skill_output(
+        summary,
+        output_format=fmt,
+        human_summary=(
+            f"Applied '{args.reaction}' to {succeeded}/{len(args.comment_id)} "
+            f"comment(s) ({failed} failed)"
+        ),
+        script_name="add_comment_reaction.py",
+    )
     return 0
 
 

--- a/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -140,8 +140,11 @@ def _get_shebang_language(file_path: str) -> str | None:
     if not command:
         return None
     executable = Path(command[0]).name
-    if executable == "env" and len(command) > 1:
-        executable = Path(command[1]).name
+    if executable == "env":
+        for arg in command[1:]:
+            if not arg.startswith("-"):
+                executable = Path(arg).name
+                break
     if executable in shell_names:
         return "bash"
     return None

--- a/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -129,11 +129,20 @@ def get_language(file_path: str) -> str | None:
 def _get_shebang_language(file_path: str) -> str | None:
     """Detect supported extensionless scripts from their shebang."""
     try:
-        with open(file_path, encoding="utf-8", errors="ignore") as f:
+        with open(file_path, encoding="utf-8") as f:
             first_line = f.readline().strip().lower()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None
-    if first_line.startswith("#!") and "bash" in first_line:
+    if not first_line.startswith("#!"):
+        return None
+    shell_names = {"bash", "dash", "ksh", "sh"}
+    command = first_line[2:].strip().split()
+    if not command:
+        return None
+    executable = Path(command[0]).name
+    if executable == "env" and len(command) > 1:
+        executable = Path(command[1]).name
+    if executable in shell_names:
         return "bash"
     return None
 
@@ -159,8 +168,22 @@ def get_staged_files() -> list[str]:
 def get_directory_files(directory: str) -> list[str]:
     """Get all scannable files from a directory."""
     supported_extensions = {".py", ".ps1", ".psm1", ".sh", ".bash", ".cs"}
+    pruned_directories = {
+        ".git",
+        ".hg",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "__pycache__",
+        "node_modules",
+    }
     files = []
-    for root, _, filenames in os.walk(directory):
+    for root, dirnames, filenames in os.walk(directory):
+        dirnames[:] = [
+            name for name in dirnames if name.lower() not in pruned_directories
+        ]
         for filename in filenames:
             file_path = os.path.join(root, filename)
             suffix = Path(filename).suffix.lower()

--- a/tests/skills/github/test_add_comment_reaction.py
+++ b/tests/skills/github/test_add_comment_reaction.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
 from test_helpers import make_completed_process
 
 # Ensure importability
@@ -48,9 +47,9 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "123", "--reaction", "eyes"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["succeeded"] == 1
-        assert result["failed"] == 0
-        assert result["results"][0]["success"] is True
+        assert result["Data"]["succeeded"] == 1
+        assert result["Data"]["failed"] == 0
+        assert result["Data"]["results"][0]["success"] is True
 
     def test_batch_success(self, _import_module, capsys):
         mod = _import_module
@@ -62,9 +61,9 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "1", "2", "3", "--reaction", "heart"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["total_count"] == 3
-        assert result["succeeded"] == 3
-        assert result["failed"] == 0
+        assert result["Data"]["total_count"] == 3
+        assert result["Data"]["succeeded"] == 3
+        assert result["Data"]["failed"] == 0
 
     def test_partial_failure(self, _import_module, capsys):
         mod = _import_module
@@ -81,11 +80,16 @@ class TestAddCommentReaction:
             patch("add_comment_reaction.resolve_repo_params", return_value=_mock_repo()),
             patch("subprocess.run", side_effect=side_effect),
         ):
-            rc = mod.main(["--comment-id", "1", "2", "3", "--comment-type", "issue", "--reaction", "rocket"])
+            rc = mod.main([
+                "--comment-id", "1", "2", "3",
+                "--comment-type", "issue", "--reaction", "rocket",
+            ])
         assert rc == 3
         result = json.loads(capsys.readouterr().out)
-        assert result["succeeded"] == 2
-        assert result["failed"] == 1
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 3
+        assert result["Data"]["succeeded"] == 2
+        assert result["Data"]["failed"] == 1
 
     def test_duplicate_reaction_succeeds(self, _import_module, capsys):
         mod = _import_module
@@ -99,7 +103,7 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "1", "--reaction", "+1"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["succeeded"] == 1
+        assert result["Data"]["succeeded"] == 1
 
     def test_review_endpoint(self, _import_module):
         mod = _import_module

--- a/tests/skills/github/test_edit_issue_body.py
+++ b/tests/skills/github/test_edit_issue_body.py
@@ -106,8 +106,9 @@ class TestEditIssueBodySuccess:
         assert captured_args[captured_args.index("--body") + 1] == "hello"
         assert "--body-file" not in captured_args
         data = json.loads(capsys.readouterr().out)
-        assert data["status"] == "updated"
-        assert data["issue"] == 42
+        assert data["Success"] is True
+        assert data["Data"]["status"] == "updated"
+        assert data["Data"]["issue"] == 42
 
     def test_body_file_passes_through(self, mock_auth, tmp_path, capsys):
         # Coderabbit eoz/epC: when --body-file is provided, gh should be

--- a/tests/skills/github/test_get_latest_semantic_milestone.py
+++ b/tests/skills/github/test_get_latest_semantic_milestone.py
@@ -7,8 +7,6 @@ from unittest.mock import patch
 
 import pytest
 
-from test_helpers import make_completed_process
-
 # Ensure importability
 _project_root = Path(__file__).resolve().parents[3]
 _lib_dir = _project_root / ".claude" / "lib"
@@ -65,9 +63,9 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is True
-        assert result["title"] == "0.3.0"
-        assert result["number"] == 3
+        assert result["Data"]["found"] is True
+        assert result["Data"]["title"] == "0.3.0"
+        assert result["Data"]["number"] == 3
 
     def test_ignores_non_semantic(self, _import_module, capsys):
         mod = _import_module
@@ -84,8 +82,8 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is True
-        assert result["title"] == "0.2.0"
+        assert result["Data"]["found"] is True
+        assert result["Data"]["title"] == "0.2.0"
 
     def test_no_milestones(self, _import_module, capsys):
         mod = _import_module
@@ -97,8 +95,10 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 2
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is False
-        assert result["title"] == ""
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 2
+        assert result["Data"]["found"] is False
+        assert result["Data"]["title"] == ""
 
     def test_no_semantic_milestones(self, _import_module, capsys):
         mod = _import_module
@@ -114,7 +114,9 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 2
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is False
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 2
+        assert result["Data"]["found"] is False
 
     def test_version_comparison_10_vs_2(self, _import_module, capsys):
         """Ensure 0.10.0 > 0.2.0 (not string comparison)."""
@@ -131,7 +133,7 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["title"] == "0.10.0"
+        assert result["Data"]["title"] == "0.10.0"
 
     def test_single_milestone(self, _import_module, capsys):
         mod = _import_module
@@ -144,5 +146,5 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is True
-        assert result["title"] == "1.0.0"
+        assert result["Data"]["found"] is True
+        assert result["Data"]["title"] == "1.0.0"

--- a/tests/skills/github/test_issue_scripts.py
+++ b/tests/skills/github/test_issue_scripts.py
@@ -12,14 +12,11 @@ Covers:
 
 import json
 import subprocess
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-from test_helpers import import_skill_script
 from github_core.api import RepoInfo
+from test_helpers import import_skill_script
 
 
 def make_proc(stdout="", stderr="", returncode=0):
@@ -30,12 +27,20 @@ def make_proc(stdout="", stderr="", returncode=0):
 
 
 def _extract_json(text: str) -> dict:
-    """Extract the last JSON object from output that may contain text before it."""
-    # Find the last '{' that starts a JSON object
-    idx = text.rfind("{")
-    if idx == -1:
-        raise ValueError(f"No JSON found in output: {text!r}")
-    return json.loads(text[idx:])
+    """Extract the last JSON object from output that may contain text before it.
+
+    Walks lines from the bottom and returns the first one that parses as a
+    complete JSON object. The canonical envelope is emitted as a single line.
+    """
+    for line in reversed(text.strip().splitlines()):
+        candidate = line.strip()
+        if not candidate.startswith("{"):
+            continue
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    raise ValueError(f"No JSON found in output: {text!r}")
 
 
 def _mock_repo():
@@ -70,7 +75,10 @@ class TestGetIssueContext:
         proc = make_proc(stdout=json.dumps(issue_data))
         with (
             patch("get_issue_context.assert_gh_authenticated"),
-            patch("get_issue_context.resolve_repo_params", return_value=RepoInfo(owner="owner", repo="repo")),
+            patch(
+                "get_issue_context.resolve_repo_params",
+                return_value=RepoInfo(owner="owner", repo="repo"),
+            ),
             patch("subprocess.run", return_value=proc),
         ):
             rc = mod.main(["--issue", "42"])
@@ -214,9 +222,9 @@ class TestNewIssue:
             rc = mod.main(["--title", "My Title", "--body", "body text", "--labels", "bug"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["issue_number"] == 123
-        assert result["title"] == "My Title"
+        assert result["Success"] is True
+        assert result["Data"]["issue_number"] == 123
+        assert result["Data"]["title"] == "My Title"
 
     def test_empty_body_and_labels_omitted(self):
         mod = self._import()
@@ -326,9 +334,9 @@ class TestPostIssueComment:
             rc = mod.main(["--issue", "1", "--body", "body text"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["comment_id"] == 99
-        assert result["skipped"] is False
+        assert result["Success"] is True
+        assert result["Data"]["comment_id"] == 99
+        assert result["Data"]["skipped"] is False
 
     def test_marker_already_exists_skips(self, capsys):
         mod = self._import()
@@ -345,7 +353,7 @@ class TestPostIssueComment:
             rc = mod.main(["--issue", "1", "--body", "new body", "--marker", marker])
         assert rc == 0
         result = _extract_json(capsys.readouterr().out)
-        assert result["skipped"] is True
+        assert result["Data"]["skipped"] is True
 
     def test_marker_exists_update_if_exists(self, capsys):
         mod = self._import()
@@ -367,8 +375,8 @@ class TestPostIssueComment:
             ])
         assert rc == 0
         result = _extract_json(capsys.readouterr().out)
-        assert result["updated"] is True
-        assert result["success"] is True
+        assert result["Data"]["updated"] is True
+        assert result["Success"] is True
 
     def test_marker_new_post(self, capsys):
         mod = self._import()
@@ -384,8 +392,8 @@ class TestPostIssueComment:
             rc = mod.main(["--issue", "1", "--body", "body", "--marker", marker])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["skipped"] is False
+        assert result["Success"] is True
+        assert result["Data"]["skipped"] is False
 
     def test_permission_error_exits_4(self):
         mod = self._import()
@@ -662,8 +670,8 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--milestone", "v1.0"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["action"] == "assigned"
+        assert result["Success"] is True
+        assert result["Data"]["action"] == "assigned"
 
     def test_already_same_milestone_no_change(self, capsys):
         mod = self._import()
@@ -678,7 +686,7 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--milestone", "v1.0"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "no_change"
+        assert result["Data"]["action"] == "no_change"
 
     def test_different_milestone_no_force_exits_5(self):
         mod = self._import()
@@ -708,7 +716,7 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--milestone", "new-ms", "--force"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "replaced"
+        assert result["Data"]["action"] == "replaced"
 
     def test_clear_with_existing(self, capsys):
         mod = self._import()
@@ -723,7 +731,7 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--clear"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "cleared"
+        assert result["Data"]["action"] == "cleared"
 
     def test_clear_without_existing(self, capsys):
         mod = self._import()
@@ -735,7 +743,7 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--clear"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "no_change"
+        assert result["Data"]["action"] == "no_change"
 
     def test_milestone_not_found_exits_2(self):
         mod = self._import()

--- a/tests/skills/github/test_milestone_scripts.py
+++ b/tests/skills/github/test_milestone_scripts.py
@@ -7,14 +7,11 @@ Covers:
 
 import json
 import subprocess
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-from test_helpers import import_skill_script
 from github_core.api import RepoInfo
+from test_helpers import import_skill_script
 
 
 def make_proc(stdout="", stderr="", returncode=0):
@@ -27,14 +24,19 @@ def _mock_repo():
     return RepoInfo(owner="o", repo="r")
 
 
-def _extract_json(text: str) -> dict:
-    """Extract the last JSON object from multi-line output."""
-    idx = text.rfind("{")
-    if idx == -1:
-        raise ValueError(f"No JSON found in output: {text!r}")
-    return json.loads(text[idx:])
+def _extract_json(text):
+    """Extract the last JSON object from multi-line output.
 
-
+    Walks lines from the bottom; the canonical envelope is one line.
+    """
+    for line in reversed(text.strip().splitlines()):
+        candidate = line.strip()
+        if candidate.startswith("{"):
+            try:
+                return json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+    raise ValueError("No JSON found in output: " + repr(text))
 # ---------------------------------------------------------------------------
 # get_latest_semantic_milestone
 # ---------------------------------------------------------------------------
@@ -60,9 +62,9 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is True
-        assert result["title"] == "0.2.1"
-        assert result["number"] == 3
+        assert result["Data"]["found"] is True
+        assert result["Data"]["title"] == "0.2.1"
+        assert result["Data"]["number"] == 3
 
     def test_no_milestones(self, capsys):
         mod = self._import()
@@ -74,8 +76,10 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 2
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is False
-        assert result["title"] == ""
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 2
+        assert result["Data"]["found"] is False
+        assert result["Data"]["title"] == ""
 
     def test_no_semantic_milestones(self, capsys):
         mod = self._import()
@@ -91,7 +95,9 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 2
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is False
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 2
+        assert result["Data"]["found"] is False
 
     def test_version_comparison(self, capsys):
         mod = self._import()
@@ -108,7 +114,7 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["title"] == "2.0.0"
+        assert result["Data"]["title"] == "2.0.0"
 
     def test_mixed_milestones_filters_correctly(self, capsys):
         mod = self._import()
@@ -125,8 +131,8 @@ class TestGetLatestSemanticMilestone:
             rc = mod.main([])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["found"] is True
-        assert result["title"] == "1.0.0"
+        assert result["Data"]["found"] is True
+        assert result["Data"]["title"] == "1.0.0"
 
     def test_main_exits_2_when_not_found(self):
         mod = self._import()
@@ -150,8 +156,8 @@ class TestGetLatestSemanticMilestone:
         assert rc == 0
         captured = capsys.readouterr()
         parsed = json.loads(captured.out)
-        assert parsed["found"] is True
-        assert parsed["title"] == "1.2.3"
+        assert parsed["Data"]["found"] is True
+        assert parsed["Data"]["title"] == "1.2.3"
 
     def test_help_does_not_crash(self):
         mod = import_skill_script("get_latest_semantic_milestone", "milestone")
@@ -183,11 +189,14 @@ class TestSetItemMilestone:
             patch("set_item_milestone.resolve_repo_params", return_value=_mock_repo()),
             patch("subprocess.run", return_value=make_proc(stdout=json.dumps(item_data))),
         ):
-            rc = mod.main(["--item-type", "pr", "--item-number", "10", "--milestone-title", "existing-ms"])
+            rc = mod.main([
+                "--item-type", "pr", "--item-number", "10",
+                "--milestone-title", "existing-ms",
+            ])
         assert rc == 0
         result = _extract_json(capsys.readouterr().out)
-        assert result["action"] == "skipped"
-        assert result["milestone"] == "existing-ms"
+        assert result["Data"]["action"] == "skipped"
+        assert result["Data"]["milestone"] == "existing-ms"
 
     def test_assigns_provided_milestone(self, capsys):
         mod = self._import()
@@ -203,8 +212,8 @@ class TestSetItemMilestone:
             rc = mod.main(["--item-type", "pr", "--item-number", "10", "--milestone-title", "v1.0"])
         assert rc == 0
         result = _extract_json(capsys.readouterr().out)
-        assert result["action"] == "assigned"
-        assert result["milestone"] == "v1.0"
+        assert result["Data"]["action"] == "assigned"
+        assert result["Data"]["milestone"] == "v1.0"
 
     def test_auto_detects_milestone_and_assigns(self, capsys):
         mod = self._import()
@@ -222,7 +231,7 @@ class TestSetItemMilestone:
             rc = mod.main(["--item-type", "issue", "--item-number", "5"])
         assert rc == 0
         result = _extract_json(capsys.readouterr().out)
-        assert result["milestone"] == "0.3.0"
+        assert result["Data"]["milestone"] == "0.3.0"
 
     def test_auto_detect_not_found_exits_2(self):
         mod = self._import()
@@ -252,10 +261,16 @@ class TestSetItemMilestone:
         with (
             patch("set_item_milestone.assert_gh_authenticated"),
             patch("set_item_milestone.resolve_repo_params", return_value=_mock_repo()),
-            patch("subprocess.run", return_value=make_proc(stderr="connection error", returncode=1)),
+            patch(
+                "subprocess.run",
+                return_value=make_proc(stderr="connection error", returncode=1),
+            ),
         ):
             with pytest.raises(SystemExit) as exc:
-                mod.main(["--item-type", "pr", "--item-number", "10", "--milestone-title", "v1.0"])
+                mod.main([
+                    "--item-type", "pr", "--item-number", "10",
+                    "--milestone-title", "v1.0",
+                ])
         assert exc.value.code == 3
 
     def test_help_does_not_crash(self):

--- a/tests/skills/github/test_new_issue.py
+++ b/tests/skills/github/test_new_issue.py
@@ -45,9 +45,9 @@ class TestNewIssue:
             result = main(["--title", "Test Title"])
         assert result == 0
         data = json.loads(capsys.readouterr().out)
-        assert data["success"] is True
-        assert data["issue_number"] == 42
-        assert data["title"] == "Test Title"
+        assert data["Success"] is True
+        assert data["Data"]["issue_number"] == 42
+        assert data["Data"]["title"] == "Test Title"
 
     def test_create_with_body_and_labels(self, capsys):
         with patch("subprocess.run", return_value=_make_proc(

--- a/tests/skills/github/test_post_issue_comment.py
+++ b/tests/skills/github/test_post_issue_comment.py
@@ -1,15 +1,11 @@
 """Tests for post_issue_comment.py."""
 
 import json
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-from test_helpers import import_skill_script
 from github_core.api import RepoInfo
-from test_helpers import make_completed_process
+from test_helpers import import_skill_script, make_completed_process
 
 
 def _mock_repo():
@@ -64,9 +60,9 @@ class TestPostIssueComment:
             rc = mod.main(["--issue", "1", "--body", "hello"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["comment_id"] == 100
-        assert result["skipped"] is False
+        assert result["Success"] is True
+        assert result["Data"]["comment_id"] == 100
+        assert result["Data"]["skipped"] is False
 
     def test_skip_when_marker_exists(self, _import_module, capsys):
         mod = _import_module
@@ -84,11 +80,10 @@ class TestPostIssueComment:
                 "--marker", "TEST-MARKER",
             ])
         assert rc == 0
-        # Output has text message then JSON
         out = capsys.readouterr().out
-        idx = out.rfind("{")
-        result = json.loads(out[idx:])
-        assert result["skipped"] is True
+        result = json.loads(out.strip().splitlines()[-1])
+        assert result["Success"] is True
+        assert result["Data"]["skipped"] is True
 
     def test_update_when_marker_exists_and_update_flag(self, _import_module, capsys):
         mod = _import_module
@@ -109,9 +104,9 @@ class TestPostIssueComment:
             ])
         assert rc == 0
         out = capsys.readouterr().out
-        idx = out.rfind("{")
-        result = json.loads(out[idx:])
-        assert result["updated"] is True
+        result = json.loads(out.strip().splitlines()[-1])
+        assert result["Success"] is True
+        assert result["Data"]["updated"] is True
 
     def test_permission_denied_exits_4(self, _import_module):
         mod = _import_module

--- a/tests/skills/github/test_set_issue_milestone.py
+++ b/tests/skills/github/test_set_issue_milestone.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
 from test_helpers import make_completed_process
 
 # Ensure importability
@@ -24,14 +23,19 @@ def _mock_repo():
     return RepoInfo(owner="o", repo="r")
 
 
-def _extract_json(text: str) -> dict:
-    """Extract the last JSON object from multi-line output."""
-    idx = text.rfind("{")
-    if idx == -1:
-        raise ValueError(f"No JSON found in output: {text!r}")
-    return json.loads(text[idx:])
+def _extract_json(text):
+    """Extract the last JSON object from multi-line output.
 
-
+    Walks lines from the bottom; the canonical envelope is one line.
+    """
+    for line in reversed(text.strip().splitlines()):
+        candidate = line.strip()
+        if candidate.startswith("{"):
+            try:
+                return json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+    raise ValueError("No JSON found in output: " + repr(text))
 @pytest.fixture
 def _import_module():
     import importlib
@@ -58,9 +62,9 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--milestone", "v1.0.0"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["action"] == "assigned"
-        assert result["milestone"] == "v1.0.0"
+        assert result["Success"] is True
+        assert result["Data"]["action"] == "assigned"
+        assert result["Data"]["milestone"] == "v1.0.0"
 
     def test_already_has_same_milestone(self, _import_module, capsys):
         mod = _import_module
@@ -75,7 +79,7 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--milestone", "v1.0.0"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "no_change"
+        assert result["Data"]["action"] == "no_change"
 
     def test_force_replace_milestone(self, _import_module, capsys):
         mod = _import_module
@@ -91,8 +95,8 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--milestone", "v1.0.0", "--force"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "replaced"
-        assert result["previous_milestone"] == "v0.9.0"
+        assert result["Data"]["action"] == "replaced"
+        assert result["Data"]["previous_milestone"] == "v0.9.0"
 
     def test_has_milestone_without_force_exits_5(self, _import_module):
         mod = _import_module
@@ -108,7 +112,7 @@ class TestSetIssueMilestone:
                 mod.main(["--issue", "1", "--milestone", "v1.0.0"])
         assert exc.value.code == 5
 
-    def test_milestone_not_found_exits_2(self, _import_module):
+    def test_milestone_not_found_exits_2(self, _import_module, capsys):
         mod = _import_module
         with (
             patch("set_issue_milestone.assert_gh_authenticated"),
@@ -119,8 +123,51 @@ class TestSetIssueMilestone:
             ]),
         ):
             with pytest.raises(SystemExit) as exc:
-                mod.main(["--issue", "1", "--milestone", "v1.0.0"])
+                mod.main([
+                    "--issue", "1", "--milestone", "v1.0.0",
+                    "--output-format", "json",
+                ])
         assert exc.value.code == 2
+        result = json.loads(capsys.readouterr().out)
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 2
+        assert result["Error"]["Type"] == "NotFound"
+
+    def test_missing_milestone_argument_emits_json_error(self, _import_module, capsys):
+        mod = _import_module
+        with (
+            patch("set_issue_milestone.assert_gh_authenticated"),
+            patch("set_issue_milestone.resolve_repo_params", return_value=_mock_repo()),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                mod.main(["--issue", "1", "--output-format", "json"])
+        assert exc.value.code == 2
+        result = json.loads(capsys.readouterr().out)
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 2
+        assert result["Error"]["Type"] == "InvalidParams"
+
+    def test_set_milestone_failure_emits_json_error(self, _import_module, capsys):
+        mod = _import_module
+        with (
+            patch("set_issue_milestone.assert_gh_authenticated"),
+            patch("set_issue_milestone.resolve_repo_params", return_value=_mock_repo()),
+            patch("subprocess.run", side_effect=[
+                make_completed_process(stdout="null"),
+                make_completed_process(stdout="v1.0.0"),
+                make_completed_process(returncode=1, stderr="api failed"),
+            ]),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                mod.main([
+                    "--issue", "1", "--milestone", "v1.0.0",
+                    "--output-format", "json",
+                ])
+        assert exc.value.code == 3
+        result = json.loads(capsys.readouterr().out)
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 3
+        assert result["Error"]["Type"] == "ApiError"
 
     def test_clear_milestone(self, _import_module, capsys):
         mod = _import_module
@@ -135,7 +182,7 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--clear"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "cleared"
+        assert result["Data"]["action"] == "cleared"
 
     def test_clear_no_milestone(self, _import_module, capsys):
         mod = _import_module
@@ -147,4 +194,4 @@ class TestSetIssueMilestone:
             rc = mod.main(["--issue", "1", "--clear"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["action"] == "no_change"
+        assert result["Data"]["action"] == "no_change"

--- a/tests/skills/github/test_set_item_milestone.py
+++ b/tests/skills/github/test_set_item_milestone.py
@@ -73,6 +73,25 @@ class TestSetItemMilestone:
         assert result["Data"]["action"] == "skipped"
         assert result["Data"]["milestone"] == "v0.9.0"
 
+    def test_human_skip_outputs_single_summary_line(self, _import_module, capsys):
+        mod = _import_module
+        item_data = {"milestone": {"title": "v0.9.0"}}
+        with (
+            patch("set_item_milestone.assert_gh_authenticated"),
+            patch("set_item_milestone.resolve_repo_params", return_value=_mock_repo()),
+            patch("subprocess.run", return_value=make_completed_process(
+                stdout=json.dumps(item_data)
+            )),
+        ):
+            rc = mod.main([
+                "--item-type", "pr", "--item-number", "1",
+                "--output-format", "human",
+            ])
+        assert rc == 0
+        lines = [line for line in capsys.readouterr().out.splitlines() if line.strip()]
+        assert len(lines) == 1
+        assert "already has milestone: v0.9.0" in lines[0]
+
     def test_assign_with_explicit_title(self, _import_module, capsys):
         mod = _import_module
         item_data = {"milestone": None}

--- a/tests/skills/github/test_set_item_milestone.py
+++ b/tests/skills/github/test_set_item_milestone.py
@@ -1,15 +1,11 @@
 """Tests for set_item_milestone.py."""
 
 import json
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
-from test_helpers import import_skill_script
 from github_core.api import RepoInfo
-from test_helpers import make_completed_process
+from test_helpers import import_skill_script, make_completed_process
 
 
 def _mock_repo():
@@ -17,11 +13,18 @@ def _mock_repo():
 
 
 def _extract_json(text: str) -> dict:
-    """Extract the last JSON object from multi-line output."""
-    idx = text.rfind("{")
-    if idx == -1:
-        raise ValueError(f"No JSON found in output: {text!r}")
-    return json.loads(text[idx:])
+    """Extract the last JSON object from multi-line output.
+
+    Walks lines from the bottom; the canonical envelope is one line.
+    """
+    for line in reversed(text.strip().splitlines()):
+        candidate = line.strip()
+        if candidate.startswith("{"):
+            try:
+                return json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+    raise ValueError(f"No JSON found in output: {text!r}")
 
 
 @pytest.fixture
@@ -67,8 +70,8 @@ class TestSetItemMilestone:
             rc = mod.main(["--item-type", "pr", "--item-number", "1"])
         assert rc == 0
         result = _extract_json(capsys.readouterr().out)
-        assert result["action"] == "skipped"
-        assert result["milestone"] == "v0.9.0"
+        assert result["Data"]["action"] == "skipped"
+        assert result["Data"]["milestone"] == "v0.9.0"
 
     def test_assign_with_explicit_title(self, _import_module, capsys):
         mod = _import_module
@@ -81,12 +84,17 @@ class TestSetItemMilestone:
                 make_completed_process(),                               # _assign_milestone
             ]),
         ):
-            rc = mod.main(["--item-type", "issue", "--item-number", "42", "--milestone-title", "v1.0.0"])
+            rc = mod.main([
+                "--item-type", "issue", "--item-number", "42",
+                "--milestone-title", "v1.0.0", "--output-format", "json",
+            ])
         assert rc == 0
-        result = _extract_json(capsys.readouterr().out)
-        assert result["success"] is True
-        assert result["action"] == "assigned"
-        assert result["milestone"] == "v1.0.0"
+        captured = capsys.readouterr()
+        result = json.loads(captured.out)
+        assert "Assigning milestone" not in captured.out
+        assert result["Success"] is True
+        assert result["Data"]["action"] == "assigned"
+        assert result["Data"]["milestone"] == "v1.0.0"
 
     def test_api_error_exits_3(self, _import_module):
         mod = _import_module

--- a/tests/skills/github/test_utility_scripts.py
+++ b/tests/skills/github/test_utility_scripts.py
@@ -21,6 +21,7 @@ _scripts_dir = _project_root / ".claude" / "skills" / "github" / "scripts"
 for _p in (
     str(_lib_dir),
     str(_scripts_dir / "reactions"),
+    str(_scripts_dir / "notifications"),
     str(_scripts_dir / "utils"),
     str(_scripts_dir),
 ):
@@ -38,6 +39,32 @@ def make_proc(stdout="", stderr="", returncode=0):
 
 def _mock_repo():
     return RepoInfo(owner="o", repo="r")
+
+
+# ---------------------------------------------------------------------------
+# get_actionable_items
+# ---------------------------------------------------------------------------
+
+class TestGetActionableItems:
+    """Tests for get_actionable_items.main."""
+
+    def _import(self):
+        import importlib
+
+        import get_actionable_items as mod
+        importlib.reload(mod)
+        return mod
+
+    def test_invalid_limit_emits_error_envelope(self, capsys):
+        mod = self._import()
+
+        rc = mod.main(["--limit", "0", "--output-format", "json"])
+
+        assert rc == 1
+        result = json.loads(capsys.readouterr().out)
+        assert result["Success"] is False
+        assert result["Error"]["Code"] == 1
+        assert result["Error"]["Type"] == "InvalidParams"
 
 
 # ---------------------------------------------------------------------------
@@ -65,10 +92,10 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "42", "--reaction", "eyes"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["succeeded"] == 1
-        assert result["failed"] == 0
-        assert result["results"][0]["success"] is True
-        assert result["results"][0]["comment_id"] == 42
+        assert result["Data"]["succeeded"] == 1
+        assert result["Data"]["failed"] == 0
+        assert result["Data"]["results"][0]["success"] is True
+        assert result["Data"]["results"][0]["comment_id"] == 42
 
     def test_happy_path_issue_comment(self, capsys):
         mod = self._import()
@@ -81,7 +108,7 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "10", "--comment-type", "issue", "--reaction", "+1"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["comment_type"] == "issue"
+        assert result["Data"]["comment_type"] == "issue"
 
     def test_batch_all_succeed(self, capsys):
         mod = self._import()
@@ -94,9 +121,9 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "1", "2", "3", "--reaction", "heart"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["total_count"] == 3
-        assert result["succeeded"] == 3
-        assert result["failed"] == 0
+        assert result["Data"]["total_count"] == 3
+        assert result["Data"]["succeeded"] == 3
+        assert result["Data"]["failed"] == 0
 
     def test_already_reacted_counts_as_success(self, capsys):
         mod = self._import()
@@ -109,7 +136,7 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "5", "--reaction", "rocket"])
         assert rc == 0
         result = json.loads(capsys.readouterr().out)
-        assert result["succeeded"] == 1
+        assert result["Data"]["succeeded"] == 1
 
     def test_api_failure_counted(self, capsys):
         mod = self._import()
@@ -122,8 +149,8 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "9", "--reaction", "eyes"])
         assert rc == 3
         result = json.loads(capsys.readouterr().out)
-        assert result["failed"] == 1
-        assert result["results"][0]["success"] is False
+        assert result["Data"]["failed"] == 1
+        assert result["Data"]["results"][0]["success"] is False
 
     def test_partial_batch_failure(self, capsys):
         mod = self._import()
@@ -136,8 +163,8 @@ class TestAddCommentReaction:
             rc = mod.main(["--comment-id", "1", "2", "--reaction", "eyes"])
         assert rc == 3
         result = json.loads(capsys.readouterr().out)
-        assert result["succeeded"] == 1
-        assert result["failed"] == 1
+        assert result["Data"]["succeeded"] == 1
+        assert result["Data"]["failed"] == 1
 
     def test_main_exits_3_on_failure(self):
         mod = self._import()
@@ -162,7 +189,7 @@ class TestAddCommentReaction:
         assert rc == 0
         captured = capsys.readouterr()
         parsed = json.loads(captured.out)
-        assert parsed["succeeded"] == 1
+        assert parsed["Data"]["succeeded"] == 1
 
     def test_help_does_not_crash(self):
         import add_comment_reaction as mod
@@ -180,7 +207,10 @@ class TestAddCommentReaction:
 
         with (
             patch("add_comment_reaction.assert_gh_authenticated"),
-            patch("add_comment_reaction.resolve_repo_params", return_value=RepoInfo(owner="owner", repo="repo")),
+            patch(
+                "add_comment_reaction.resolve_repo_params",
+                return_value=RepoInfo(owner="owner", repo="repo"),
+            ),
             patch("subprocess.run", side_effect=fake_run),
         ):
             mod.main(["--comment-id", "100", "--reaction", "eyes"])
@@ -199,7 +229,10 @@ class TestAddCommentReaction:
 
         with (
             patch("add_comment_reaction.assert_gh_authenticated"),
-            patch("add_comment_reaction.resolve_repo_params", return_value=RepoInfo(owner="owner", repo="repo")),
+            patch(
+                "add_comment_reaction.resolve_repo_params",
+                return_value=RepoInfo(owner="owner", repo="repo"),
+            ),
             patch("subprocess.run", side_effect=fake_run),
         ):
             mod.main(["--comment-id", "200", "--comment-type", "issue", "--reaction", "eyes"])

--- a/tests/test_add_comment_reaction.py
+++ b/tests/test_add_comment_reaction.py
@@ -44,8 +44,8 @@ def test_single_reaction(mock_run, capsys):
     rc = main(["--comment-id", "123", "--reaction", "eyes"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["succeeded"] == 1
-    assert output["failed"] == 0
+    assert output["Data"]["succeeded"] == 1
+    assert output["Data"]["failed"] == 0
 
 
 @patch("subprocess.run")
@@ -61,8 +61,8 @@ def test_batch_reactions(mock_run, capsys):
     rc = main(["--comment-id", "1", "2", "3", "--reaction", "+1"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["total_count"] == 3
-    assert output["succeeded"] == 3
+    assert output["Data"]["total_count"] == 3
+    assert output["Data"]["succeeded"] == 3
 
 
 @patch("subprocess.run")
@@ -77,8 +77,10 @@ def test_partial_failure(mock_run, capsys):
     rc = main(["--comment-id", "1", "2", "--reaction", "heart"])
     assert rc == 3
     output = json.loads(capsys.readouterr().out)
-    assert output["succeeded"] == 1
-    assert output["failed"] == 1
+    assert output["Success"] is False
+    assert output["Error"]["Code"] == 3
+    assert output["Data"]["succeeded"] == 1
+    assert output["Data"]["failed"] == 1
 
 
 @patch("subprocess.run")

--- a/tests/test_close_issue.py
+++ b/tests/test_close_issue.py
@@ -58,6 +58,13 @@ def _comments(*bodies: str):
     return _completed(stdout=json.dumps({"comments": [{"body": b} for b in bodies]}), rc=0)
 
 
+def _paginated_comments(*pages: list[str]):
+    return _completed(
+        stdout=json.dumps([[{"body": body} for body in page] for page in pages]),
+        rc=0,
+    )
+
+
 def _envelope(capsys) -> dict:
     return json.loads(capsys.readouterr().out)
 
@@ -386,6 +393,30 @@ class TestMain:
             rc = main(["--issue", "18", "--comment", "Closing note"])
         assert rc == 0
         assert mock_run.call_count == 2
+        env = _envelope(capsys)
+        assert env["Data"]["commented"] is False
+        assert env["Data"]["commentAlreadyPresent"] is True
+
+    def test_already_closed_dedup_checks_all_comment_pages(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=[
+                _state_closed(),
+                _paginated_comments(["older note"], ["Closing note"]),
+            ],
+        ) as mock_run:
+            rc = main(["--issue", "18", "--comment", "Closing note"])
+        assert rc == 0
+        assert mock_run.call_count == 2
+        comment_lookup_args = mock_run.call_args_list[1].args[0]
+        assert comment_lookup_args[:2] == ["gh", "api"]
+        assert "--paginate" in comment_lookup_args
+        assert "--slurp" in comment_lookup_args
         env = _envelope(capsys)
         assert env["Data"]["commented"] is False
         assert env["Data"]["commentAlreadyPresent"] is True

--- a/tests/test_close_issue.py
+++ b/tests/test_close_issue.py
@@ -1,0 +1,471 @@
+"""Tests for close_issue.py skill script (issue #2380)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.github_core.api import RepoInfo
+
+# ---------------------------------------------------------------------------
+# Import the script via importlib (not a package)
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / ".claude" / "skills" / "github" / "scripts" / "issue"
+)
+
+
+def _import_script(name: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS_DIR / f"{name}.py")
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _import_script("close_issue")
+main = _mod.main
+build_parser = _mod.build_parser
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _completed(stdout: str = "", stderr: str = "", rc: int = 0):
+    return subprocess.CompletedProcess(args=[], returncode=rc, stdout=stdout, stderr=stderr)
+
+
+def _state_open():
+    return _completed(stdout=json.dumps({"state": "OPEN"}), rc=0)
+
+
+def _state_closed():
+    return _completed(stdout=json.dumps({"state": "CLOSED"}), rc=0)
+
+
+def _envelope(capsys) -> dict:
+    return json.loads(capsys.readouterr().out)
+
+
+# ---------------------------------------------------------------------------
+# build_parser
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    def test_issue_required(self):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args([])
+
+    def test_default_reason_is_completed(self):
+        args = build_parser().parse_args(["--issue", "5"])
+        assert args.reason == "completed"
+
+    def test_reason_not_planned_accepted(self):
+        args = build_parser().parse_args(["--issue", "5", "--reason", "not planned"])
+        assert args.reason == "not planned"
+
+    def test_invalid_reason_rejected(self):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["--issue", "5", "--reason", "wontfix"])
+
+    def test_comment_and_comment_file_mutually_exclusive(self):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(
+                ["--issue", "5", "--comment", "x", "--comment-file", "f.txt"]
+            )
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_not_authenticated_exits_4(self):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+            side_effect=SystemExit(4),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main(["--issue", "1"])
+            assert exc.value.code == 4
+
+    def test_close_success_no_comment(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=[_state_open(), _completed(stdout="closed", rc=0)],
+        ) as mock_run:
+            rc = main(["--issue", "50"])
+        assert rc == 0
+
+        env = _envelope(capsys)
+        assert env["Success"] is True
+        assert env["Error"] is None
+        assert env["Metadata"]["Script"] == "close_issue.py"
+        data = env["Data"]
+        assert data["issue"] == 50
+        assert data["state"] == "closed"
+        assert data["reason"] == "completed"
+        assert data["commented"] is False
+
+        # State check and close call ran (no comment POST).
+        assert mock_run.call_count == 2
+        close_args = mock_run.call_args_list[1].args[0]
+        assert close_args[:3] == ["gh", "issue", "close"]
+        assert "--reason" in close_args
+        assert close_args[close_args.index("--reason") + 1] == "completed"
+
+    def test_close_with_reason_not_planned(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=[_state_open(), _completed(rc=0)],
+        ) as mock_run:
+            rc = main(["--issue", "7", "--reason", "not planned"])
+        assert rc == 0
+        data = _envelope(capsys)["Data"]
+        assert data["reason"] == "not planned"
+        close_args = mock_run.call_args_list[1].args[0]
+        assert close_args[close_args.index("--reason") + 1] == "not planned"
+
+    def test_close_with_comment_posts_then_closes(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=[
+                _state_open(),
+                _completed(stdout="{}", rc=0),
+                _completed(stdout="closed", rc=0),
+            ],
+        ) as mock_run:
+            rc = main(["--issue", "9", "--comment", "Fixed in PR #10"])
+        assert rc == 0
+        data = _envelope(capsys)["Data"]
+        assert data["commented"] is True
+
+        # State check, close, then comment. Closing first avoids duplicate
+        # comments if the close operation fails and callers retry.
+        assert mock_run.call_count == 3
+        close_args = mock_run.call_args_list[1].args[0]
+        assert close_args[:3] == ["gh", "issue", "close"]
+        post_args = mock_run.call_args_list[2].args[0]
+        assert post_args[:2] == ["gh", "api"]
+        assert "comments" in post_args[2]
+        # The comment body is passed as JSON on stdin.
+        post_input = mock_run.call_args_list[2].kwargs["input"]
+        assert json.loads(post_input)["body"] == "Fixed in PR #10"
+
+    def test_comment_from_file(self, tmp_path, capsys, monkeypatch):
+        comment_path = tmp_path / "body.md"
+        comment_path.write_text("Closing per triage.", encoding="utf-8")
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=[
+                _state_open(),
+                _completed(stdout="{}", rc=0),
+                _completed(stdout="closed", rc=0),
+            ],
+        ) as mock_run:
+            rc = main(["--issue", "11", "--comment-file", comment_path.name])
+        assert rc == 0
+        assert _envelope(capsys)["Data"]["commented"] is True
+        post_input = mock_run.call_args_list[2].kwargs["input"]
+        assert json.loads(post_input)["body"] == "Closing per triage."
+
+    def test_missing_comment_file_exits_2(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_state_open(),
+        ) as mock_run:
+            with pytest.raises(SystemExit) as exc:
+                main(["--issue", "12", "--comment-file", "missing.md"])
+            assert exc.value.code == 2
+        mock_run.assert_not_called()
+        env = _envelope(capsys)
+        assert env["Success"] is False
+        assert env["Error"]["Code"] == 2
+
+    def test_comment_file_path_traversal_exits_2(self, tmp_path, capsys, monkeypatch):
+        work = tmp_path / "work"
+        work.mkdir()
+        outside = tmp_path / "outside.md"
+        outside.write_text("secret", encoding="utf-8")
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(work))
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_state_open(),
+        ) as mock_run:
+            with pytest.raises(SystemExit) as exc:
+                main(["--issue", "12", "--comment-file", "../outside.md"])
+            assert exc.value.code == 2
+        mock_run.assert_not_called()
+        env = _envelope(capsys)
+        assert env["Success"] is False
+        assert env["Error"]["Type"] == "InvalidParams"
+
+    def test_comment_base_uses_repo_root_when_workspace_missing(self, tmp_path, monkeypatch):
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        monkeypatch.chdir(nested)
+        monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+
+        assert _mod._comment_base_dir() == Path(__file__).resolve().parents[1]
+
+    def test_comment_base_expands_workspace(self, tmp_path, monkeypatch):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(workspace))
+
+        assert _mod._comment_base_dir() == workspace.resolve()
+
+    def test_issue_not_found_exits_2(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stderr="Could not resolve to an Issue", rc=1),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main(["--issue", "404"])
+            assert exc.value.code == 2
+        env = _envelope(capsys)
+        assert env["Success"] is False
+        assert env["Error"]["Code"] == 2
+        assert env["Error"]["Type"] == "NotFound"
+
+    def test_issue_state_auth_failure_exits_4(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stderr="not logged in", rc=1),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main(["--issue", "401"])
+            assert exc.value.code == 4
+        env = _envelope(capsys)
+        assert env["Success"] is False
+        assert env["Error"]["Code"] == 4
+        assert env["Error"]["Type"] == "AuthError"
+
+    def test_issue_state_author_error_is_api_error(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_completed(stderr="author is invalid", rc=1),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main(["--issue", "401"])
+            assert exc.value.code == 3
+        env = _envelope(capsys)
+        assert env["Success"] is False
+        assert env["Error"]["Code"] == 3
+        assert env["Error"]["Type"] == "ApiError"
+
+    def test_issue_state_non_dict_json_treated_as_open(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=[
+                _completed(stdout="null", rc=0),
+                _completed(stdout="closed", rc=0),
+            ],
+        ) as mock_run:
+            rc = main(["--issue", "18"])
+        assert rc == 0
+        assert mock_run.call_count == 2
+        assert _envelope(capsys)["Data"]["action"] == "closed"
+
+    def test_invalid_utf8_comment_file_exits_2(self, tmp_path, capsys, monkeypatch):
+        comment_path = tmp_path / "body.md"
+        comment_path.write_bytes(b"\xff\xfe")
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_state_open(),
+        ) as mock_run:
+            with pytest.raises(SystemExit) as exc:
+                main(["--issue", "12", "--comment-file", comment_path.name])
+            assert exc.value.code == 2
+        mock_run.assert_not_called()
+        env = _envelope(capsys)
+        assert env["Success"] is False
+        assert env["Error"]["Code"] == 2
+        assert env["Error"]["Type"] == "InvalidParams"
+
+    def test_close_api_failure_exits_3(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=[_state_open(), _completed(stderr="HTTP 404", rc=1)],
+        ):
+            rc = main(["--issue", "13"])
+        assert rc == 3
+        env = _envelope(capsys)
+        assert env["Success"] is False
+        assert env["Error"]["Code"] == 3
+        assert env["Error"]["Type"] == "ApiError"
+
+    def test_comment_post_failure_exits_3_after_close(self, capsys):
+        """A failed comment POST returns code 3 after a successful close."""
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=[
+                _state_open(),
+                _completed(rc=0),
+                _completed(stderr="HTTP 403", rc=1),
+            ],
+        ) as mock_run:
+            with pytest.raises(SystemExit) as exc:
+                main(["--issue", "14", "--comment", "note"])
+            assert exc.value.code == 3
+        # State check, close, and comment POST ran.
+        assert mock_run.call_count == 3
+        env = _envelope(capsys)
+        assert env["Success"] is False
+        assert env["Error"]["Code"] == 3
+
+    def test_comment_post_auth_failure_exits_4(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=[
+                _state_open(),
+                _completed(rc=0),
+                _completed(stderr="HTTP 401: requires authentication", rc=1),
+            ],
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main(["--issue", "14", "--comment", "note"])
+            assert exc.value.code == 4
+        env = _envelope(capsys)
+        assert env["Success"] is False
+        assert env["Error"]["Code"] == 4
+        assert env["Error"]["Type"] == "AuthError"
+
+    def test_whitespace_only_comment_is_not_posted(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=[_state_open(), _completed(rc=0)],
+        ) as mock_run:
+            rc = main(["--issue", "15", "--comment", "   "])
+        assert rc == 0
+        # No comment POST; only state check and close call.
+        assert mock_run.call_count == 2
+        assert _envelope(capsys)["Data"]["commented"] is False
+
+    def test_close_auth_failure_returns_4(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=[
+                _state_open(),
+                _completed(stderr="Bad credentials", rc=1),
+            ],
+        ):
+            rc = main(["--issue", "17"])
+        assert rc == 4
+        env = _envelope(capsys)
+        assert env["Success"] is False
+        assert env["Error"]["Code"] == 4
+        assert env["Error"]["Type"] == "AuthError"
+
+    def test_already_closed_skips_comment_and_close(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            return_value=_state_closed(),
+        ) as mock_run:
+            rc = main(["--issue", "16", "--comment", "do not duplicate"])
+        assert rc == 0
+        data = _envelope(capsys)["Data"]
+        assert data["state"] == "closed"
+        assert data["action"] == "already_closed"
+        assert data["commented"] is False
+        assert mock_run.call_count == 1

--- a/tests/test_close_issue.py
+++ b/tests/test_close_issue.py
@@ -54,6 +54,10 @@ def _state_closed():
     return _completed(stdout=json.dumps({"state": "CLOSED"}), rc=0)
 
 
+def _comments(*bodies: str):
+    return _completed(stdout=json.dumps({"comments": [{"body": b} for b in bodies]}), rc=0)
+
+
 def _envelope(capsys) -> dict:
     return json.loads(capsys.readouterr().out)
 
@@ -252,6 +256,17 @@ class TestMain:
 
         assert _mod._comment_base_dir() == Path(__file__).resolve().parents[1]
 
+    def test_comment_base_falls_back_to_script_parent(self, tmp_path, monkeypatch):
+        script_dir = tmp_path / "installed" / "scripts"
+        script_dir.mkdir(parents=True)
+        nested = tmp_path / "cwd"
+        nested.mkdir()
+        monkeypatch.chdir(nested)
+        monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+        monkeypatch.setattr(_mod, "__file__", str(script_dir / "close_issue.py"))
+
+        assert _mod._comment_base_dir() == script_dir.resolve()
+
     def test_comment_base_expands_workspace(self, tmp_path, monkeypatch):
         workspace = tmp_path / "workspace"
         workspace.mkdir()
@@ -330,6 +345,50 @@ class TestMain:
         assert rc == 0
         assert mock_run.call_count == 2
         assert _envelope(capsys)["Data"]["action"] == "closed"
+
+    def test_already_closed_with_missing_comment_posts_once(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=[
+                _state_closed(),
+                _comments(),
+                _completed(stdout="{}", rc=0),
+            ],
+        ) as mock_run:
+            rc = main(["--issue", "18", "--comment", "Closing note"])
+        assert rc == 0
+        assert mock_run.call_count == 3
+        post_args = mock_run.call_args_list[2].args[0]
+        assert post_args[:2] == ["gh", "api"]
+        env = _envelope(capsys)
+        assert env["Data"]["action"] == "already_closed"
+        assert env["Data"]["commented"] is True
+        assert env["Data"]["commentAlreadyPresent"] is False
+
+    def test_already_closed_with_existing_comment_skips_duplicate(self, capsys):
+        with patch(
+            "close_issue.assert_gh_authenticated",
+        ), patch(
+            "close_issue.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "subprocess.run",
+            side_effect=[
+                _state_closed(),
+                _comments("Closing note"),
+            ],
+        ) as mock_run:
+            rc = main(["--issue", "18", "--comment", "Closing note"])
+        assert rc == 0
+        assert mock_run.call_count == 2
+        env = _envelope(capsys)
+        assert env["Data"]["commented"] is False
+        assert env["Data"]["commentAlreadyPresent"] is True
 
     def test_invalid_utf8_comment_file_exits_2(self, tmp_path, capsys, monkeypatch):
         comment_path = tmp_path / "body.md"
@@ -452,7 +511,7 @@ class TestMain:
         assert env["Error"]["Code"] == 4
         assert env["Error"]["Type"] == "AuthError"
 
-    def test_already_closed_skips_comment_and_close(self, capsys):
+    def test_already_closed_posts_missing_comment_without_close(self, capsys):
         with patch(
             "close_issue.assert_gh_authenticated",
         ), patch(
@@ -460,12 +519,18 @@ class TestMain:
             return_value=RepoInfo(owner="o", repo="r"),
         ), patch(
             "subprocess.run",
-            return_value=_state_closed(),
+            side_effect=[
+                _state_closed(),
+                _comments(),
+                _completed(stdout="{}", rc=0),
+            ],
         ) as mock_run:
-            rc = main(["--issue", "16", "--comment", "do not duplicate"])
+            rc = main(["--issue", "16", "--comment", "retry note"])
         assert rc == 0
         data = _envelope(capsys)["Data"]
         assert data["state"] == "closed"
         assert data["action"] == "already_closed"
-        assert data["commented"] is False
-        assert mock_run.call_count == 1
+        assert data["commented"] is True
+        assert data["commentAlreadyPresent"] is False
+        assert mock_run.call_count == 3
+        assert mock_run.call_args_list[2].args[0][:2] == ["gh", "api"]

--- a/tests/test_get_latest_semantic_milestone.py
+++ b/tests/test_get_latest_semantic_milestone.py
@@ -49,13 +49,13 @@ def test_finds_latest_milestone(mock_run, capsys):
     rc = main([])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["found"] is True
-    assert output["title"] == "0.10.0"
-    assert output["number"] == 2
+    assert output["Data"]["found"] is True
+    assert output["Data"]["title"] == "0.10.0"
+    assert output["Data"]["number"] == 2
 
 
 @patch("subprocess.run")
-def test_no_milestones(mock_run):
+def test_no_milestones(mock_run, capsys):
     mock_run.side_effect = [
         _completed(rc=0),
         _completed(stdout="https://github.com/o/r\n"),
@@ -64,10 +64,14 @@ def test_no_milestones(mock_run):
 
     rc = main([])
     assert rc == 2
+    output = json.loads(capsys.readouterr().out)
+    assert output["Success"] is False
+    assert output["Error"]["Code"] == 2
+    assert output["Data"]["found"] is False
 
 
 @patch("subprocess.run")
-def test_no_semantic_milestones(mock_run):
+def test_no_semantic_milestones(mock_run, capsys):
     milestones = json.dumps([
         {"title": "Future", "number": 1},
         {"title": "Backlog", "number": 2},
@@ -80,6 +84,10 @@ def test_no_semantic_milestones(mock_run):
 
     rc = main([])
     assert rc == 2
+    output = json.loads(capsys.readouterr().out)
+    assert output["Success"] is False
+    assert output["Error"]["Code"] == 2
+    assert output["Data"]["found"] is False
 
 
 @patch("subprocess.run")
@@ -94,4 +102,4 @@ def test_single_milestone(mock_run, capsys):
     rc = main([])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["title"] == "1.0.0"
+    assert output["Data"]["title"] == "1.0.0"

--- a/tests/test_get_pr_review_threads.py
+++ b/tests/test_get_pr_review_threads.py
@@ -15,6 +15,41 @@ from scripts.github_core.api import RepoInfo
 from tests.mock_fidelity import assert_mock_keys_match
 
 # ---------------------------------------------------------------------------
+# Envelope helpers (ADR-056)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def force_json_output(monkeypatch):
+    """Force JSON output regardless of how pytest is invoked.
+
+    get_output_format("auto") returns "human" when sys.stdout.isatty() is
+    True (e.g. `pytest -s` in a real terminal), which would make the envelope
+    parsers below fail with json.JSONDecodeError. Setting CI=1 takes the
+    CI branch that always emits JSON.
+    """
+    monkeypatch.setenv("CI", "1")
+
+
+def _parse_envelope(captured_out: str) -> dict:
+    """Parse the JSON envelope from captured stdout."""
+    out = captured_out.strip()
+    assert out, "expected JSON envelope on stdout; got empty output"
+    return json.loads(out)
+
+
+def _assert_envelope_shape(envelope: dict, *, success: bool) -> None:
+    """Assert the ADR-056 envelope shape."""
+    assert set(envelope.keys()) == {"Success", "Data", "Error", "Metadata"}, (
+        f"envelope keys mismatch: {sorted(envelope.keys())}"
+    )
+    assert envelope["Success"] is success
+    assert isinstance(envelope["Metadata"], dict)
+    assert envelope["Metadata"].get("Script") == "get_pr_review_threads.py"
+    assert "Version" in envelope["Metadata"]
+    assert "Timestamp" in envelope["Metadata"]
+
+# ---------------------------------------------------------------------------
 # Import the script via importlib (not a package)
 # ---------------------------------------------------------------------------
 _SCRIPTS_DIR = (
@@ -131,7 +166,7 @@ class TestMain:
                 main(["--pull-request", "1"])
             assert exc.value.code == 4
 
-    def test_pr_not_found_exits_2(self):
+    def test_pr_not_found_returns_2(self, capsys):
         with patch(
             "get_pr_review_threads.assert_gh_authenticated",
         ), patch(
@@ -141,9 +176,12 @@ class TestMain:
             "subprocess.run",
             return_value=_completed(rc=1, stderr="Could not resolve"),
         ):
-            with pytest.raises(SystemExit) as exc:
-                main(["--pull-request", "999"])
-            assert exc.value.code == 2
+            rc = main(["--pull-request", "999"])
+        assert rc == 2
+        envelope = _parse_envelope(capsys.readouterr().out)
+        _assert_envelope_shape(envelope, success=False)
+        assert envelope["Error"]["Code"] == 2
+        assert envelope["Error"]["Type"] == "NotFound"
 
     def test_success_all_threads(self, capsys):
         threads = [_thread("PRRT_1", resolved=False), _thread("PRRT_2", resolved=True)]
@@ -159,15 +197,16 @@ class TestMain:
         ):
             rc = main(["--pull-request", "50"])
         assert rc == 0
-        output = json.loads(capsys.readouterr().out)
-        assert isinstance(output, dict)
-        assert isinstance(output["total_threads"], int)
-        assert output["total_threads"] == 2
-        assert isinstance(output["unresolved_count"], int)
-        assert output["unresolved_count"] == 1
-        assert isinstance(output["resolved_count"], int)
-        assert output["resolved_count"] == 1
-        assert isinstance(output["threads"], list)
+        envelope = _parse_envelope(capsys.readouterr().out)
+        _assert_envelope_shape(envelope, success=True)
+        data = envelope["Data"]
+        assert data["TotalThreads"] == 2
+        assert data["UnresolvedCount"] == 1
+        assert data["ResolvedCount"] == 1
+        assert isinstance(data["Threads"], list)
+        assert data["PullRequest"] == 50
+        assert data["Owner"] == "o"
+        assert data["Repo"] == "r"
 
     def test_unresolved_only_filter(self, capsys):
         threads = [_thread("PRRT_1", resolved=False), _thread("PRRT_2", resolved=True)]
@@ -183,9 +222,9 @@ class TestMain:
         ):
             rc = main(["--pull-request", "50", "--unresolved-only"])
         assert rc == 0
-        output = json.loads(capsys.readouterr().out)
-        assert len(output["threads"]) == 1
-        assert output["threads"][0]["is_resolved"] is False
+        data = _parse_envelope(capsys.readouterr().out)["Data"]
+        assert len(data["Threads"]) == 1
+        assert data["Threads"][0]["is_resolved"] is False
 
     def test_include_comments(self, capsys):
         threads = [_thread("PRRT_1")]
@@ -201,9 +240,9 @@ class TestMain:
         ):
             rc = main(["--pull-request", "50", "--include-comments"])
         assert rc == 0
-        output = json.loads(capsys.readouterr().out)
-        assert output["threads"][0]["comments"] is not None
-        assert len(output["threads"][0]["comments"]) == 1
+        data = _parse_envelope(capsys.readouterr().out)["Data"]
+        assert data["Threads"][0]["comments"] is not None
+        assert len(data["Threads"][0]["comments"]) == 1
 
     def test_empty_threads(self, capsys):
         response = _graphql_response([])
@@ -218,11 +257,12 @@ class TestMain:
         ):
             rc = main(["--pull-request", "50"])
         assert rc == 0
-        output = json.loads(capsys.readouterr().out)
-        assert output["total_threads"] == 0
+        envelope = _parse_envelope(capsys.readouterr().out)
+        _assert_envelope_shape(envelope, success=True)
+        assert envelope["Data"]["TotalThreads"] == 0
 
-    def test_api_error_exits_3(self):
-        """Generic RuntimeError (not 'Could not resolve') exits with code 3."""
+    def test_api_error_returns_3(self, capsys):
+        """Generic RuntimeError (not 'Could not resolve') returns code 3 with ApiError envelope."""
         with patch(
             "get_pr_review_threads.assert_gh_authenticated",
         ), patch(
@@ -232,12 +272,15 @@ class TestMain:
             "get_pr_review_threads._run_threads_query",
             side_effect=RuntimeError("rate limit exceeded"),
         ):
-            with pytest.raises(SystemExit) as exc:
-                main(["--pull-request", "50"])
-            assert exc.value.code == 3
+            rc = main(["--pull-request", "50"])
+        assert rc == 3
+        envelope = _parse_envelope(capsys.readouterr().out)
+        _assert_envelope_shape(envelope, success=False)
+        assert envelope["Error"]["Code"] == 3
+        assert envelope["Error"]["Type"] == "ApiError"
 
-    def test_threads_none_exits_2(self):
-        """PR found but reviewThreads nodes is None exits with code 2."""
+    def test_threads_none_returns_2(self, capsys):
+        """PR found but reviewThreads nodes is None returns code 2."""
         data = {
             "repository": {
                 "pullRequest": {
@@ -254,12 +297,14 @@ class TestMain:
             "get_pr_review_threads._run_threads_query",
             return_value=data,
         ):
-            with pytest.raises(SystemExit) as exc:
-                main(["--pull-request", "50"])
-            assert exc.value.code == 2
+            rc = main(["--pull-request", "50"])
+        assert rc == 2
+        envelope = _parse_envelope(capsys.readouterr().out)
+        _assert_envelope_shape(envelope, success=False)
+        assert envelope["Error"]["Type"] == "NotFound"
 
-    def test_missing_pull_request_exits_2(self):
-        """Missing pullRequest in response exits with code 2."""
+    def test_missing_pull_request_returns_2(self, capsys):
+        """Missing pullRequest in response returns code 2."""
         data = {"repository": {}}
         with patch(
             "get_pr_review_threads.assert_gh_authenticated",
@@ -270,9 +315,11 @@ class TestMain:
             "get_pr_review_threads._run_threads_query",
             return_value=data,
         ):
-            with pytest.raises(SystemExit) as exc:
-                main(["--pull-request", "50"])
-            assert exc.value.code == 2
+            rc = main(["--pull-request", "50"])
+        assert rc == 2
+        envelope = _parse_envelope(capsys.readouterr().out)
+        _assert_envelope_shape(envelope, success=False)
+        assert envelope["Error"]["Type"] == "NotFound"
 
     def test_paginates_across_multiple_pages(self, capsys):
         """The PR #1887 cliff: a >100-thread PR must report all threads, not page 1.
@@ -320,12 +367,12 @@ class TestMain:
         assert mock_query.call_count == 2, (
             "Pagination loop did not call the query twice; page 2 was missed"
         )
-        output = json.loads(capsys.readouterr().out)
-        assert output["total_threads"] == 107
-        assert output["unresolved_count"] == 100  # only page 1 unresolved
-        assert output["resolved_count"] == 7
+        output = _parse_envelope(capsys.readouterr().out)["Data"]
+        assert output["TotalThreads"] == 107
+        assert output["UnresolvedCount"] == 100  # only page 1 unresolved
+        assert output["ResolvedCount"] == 7
 
-        ids = {t["thread_id"] for t in output["threads"]}
+        ids = {t["thread_id"] for t in output["Threads"]}
         assert any(i.startswith("p1-") for i in ids), "page 1 IDs missing"
         assert any(i.startswith("p2-") for i in ids), "page 2 IDs missing (cliff returned)"
 
@@ -380,15 +427,15 @@ class TestMain:
             f"Loop did not stop at cap; got {mock_query.call_count}, expected {cap}"
         )
         captured = capsys.readouterr()
-        output = json.loads(captured.out)
-        assert output["pagination_truncated"] is True, (
-            "JSON output must surface pagination_truncated=True at cap"
+        output = _parse_envelope(captured.out)["Data"]
+        assert output["PaginationTruncated"] is True, (
+            "JSON output must surface PaginationTruncated=True at cap"
         )
         # Partial threads still returned, not discarded. The warnings.warn
         # at cap is captured by pytest.warns above; consumers also see
-        # `pagination_truncated=True` in JSON. No second stderr print line
-        # is emitted (duplicate signaling would confuse parsers).
-        assert len(output["threads"]) == cap
+        # `Data.PaginationTruncated=True` in JSON. No second stderr print
+        # line is emitted (duplicate signaling would confuse parsers).
+        assert len(output["Threads"]) == cap
 
     def test_collect_all_threads_return_contract(self, caplog):
         """Document the (None, 0, False) vs ([], 0, False) distinction.

--- a/tests/test_invoke_copilot_assignment.py
+++ b/tests/test_invoke_copilot_assignment.py
@@ -32,6 +32,7 @@ main = _mod.main
 _has_content = _mod._has_synthesizable_content
 _build_comment = _mod._build_synthesis_comment
 _get_guidance = _mod._get_maintainer_guidance
+_get_plan = _mod._get_coderabbit_plan
 _get_triage = _mod._get_ai_triage_info
 _extract_yaml_list = _mod._extract_yaml_list
 
@@ -162,6 +163,21 @@ class TestGetMaintainerGuidance:
         assert result == []
 
 
+class TestGetCodeRabbitPlan:
+    def test_null_body_is_ignored(self):
+        comments = [{"body": None, "user": {"login": "coderabbitai[bot]"}}]
+        patterns = {
+            "username": "coderabbitai[bot]",
+            "implementation_plan": "## Implementation",
+            "related_issues": "Similar Issues",
+            "related_prs": "Related PRs",
+        }
+
+        result = _get_plan(comments, patterns)
+
+        assert result == {"implementation": None, "related_issues": [], "related_prs": []}
+
+
 class TestGetAITriageInfo:
     def test_table_format(self):
         comments = [
@@ -222,11 +238,80 @@ def test_dry_run_no_content(mock_run, capsys):
     with patch.object(_mod, "_load_synthesis_config", return_value=_test_config()):
         with patch.object(_mod, "get_issue_comments", return_value=[]):
             with patch.object(_mod, "get_trusted_source_comments", return_value=[]):
-                rc = main(["--issue-number", "1", "--dry-run"])
+                rc = main([
+                    "--issue-number", "1", "--dry-run", "--output-format", "human",
+                ])
 
     assert rc == 0
     out = capsys.readouterr().out
     assert "SKIP" in out
+
+
+@patch("subprocess.run")
+def test_dry_run_json_outputs_single_envelope(mock_run, capsys):
+    mock_run.side_effect = [
+        _completed(rc=0),  # auth
+        _completed(stdout="https://github.com/o/r\n"),  # remote
+        _completed(stdout=_issue_json()),  # issue fetch
+    ]
+
+    with patch.object(_mod, "_load_synthesis_config", return_value=_test_config()):
+        with patch.object(_mod, "get_issue_comments", return_value=[]):
+            with patch.object(_mod, "get_trusted_source_comments", return_value=[]):
+                rc = main([
+                    "--issue-number", "1", "--dry-run", "--output-format", "json",
+                ])
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["Success"] is True
+    assert output["Data"]["action"] == "dry_run"
+    assert output["Data"]["has_synthesizable_content"] is False
+    assert output["Data"]["would_assign"] is True
+
+
+@patch("subprocess.run")
+def test_dry_run_json_honors_skip_assignment(mock_run, capsys):
+    mock_run.side_effect = [
+        _completed(rc=0),  # auth
+        _completed(stdout="https://github.com/o/r\n"),  # remote
+        _completed(stdout=_issue_json()),  # issue fetch
+    ]
+
+    with patch.object(_mod, "_load_synthesis_config", return_value=_test_config()):
+        with patch.object(_mod, "get_issue_comments", return_value=[]):
+            with patch.object(_mod, "get_trusted_source_comments", return_value=[]):
+                rc = main([
+                    "--issue-number", "1", "--dry-run", "--skip-assignment",
+                    "--output-format", "json",
+                ])
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["Success"] is True
+    assert output["Data"]["action"] == "dry_run"
+    assert output["Data"]["would_assign"] is False
+
+
+@patch("subprocess.run")
+def test_issue_json_null_payload_does_not_crash(mock_run, capsys):
+    mock_run.side_effect = [
+        _completed(rc=0),  # auth
+        _completed(stdout="https://github.com/o/r\n"),  # remote
+        _completed(stdout="null"),  # issue fetch
+    ]
+
+    with patch.object(_mod, "_load_synthesis_config", return_value=_test_config()):
+        with patch.object(_mod, "get_issue_comments", return_value=[]):
+            with patch.object(_mod, "get_trusted_source_comments", return_value=[]):
+                rc = main([
+                    "--issue-number", "1", "--dry-run", "--output-format", "json",
+                ])
+
+    assert rc == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["Success"] is True
+    assert output["Data"]["action"] == "dry_run"
 
 
 def _extract_json(text: str) -> dict:
@@ -254,5 +339,6 @@ def test_prepare_context_only(mock_run, capsys):
 
     assert rc == 0
     output = _extract_json(capsys.readouterr().out)
-    assert "context_file" in output
-    assert output["existing_synthesis_id"] is None
+    assert output["Success"] is True
+    assert "context_file" in output["Data"]
+    assert output["Data"]["existing_synthesis_id"] is None

--- a/tests/test_new_issue.py
+++ b/tests/test_new_issue.py
@@ -46,8 +46,8 @@ def test_create_issue_with_body(mock_run, capsys):
     rc = main(["--title", "Bug: Something broke", "--body", "Steps to reproduce..."])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["success"] is True
-    assert output["issue_number"] == 99
+    assert output["Success"] is True
+    assert output["Data"]["issue_number"] == 99
 
 
 @patch("subprocess.run")
@@ -61,7 +61,7 @@ def test_create_issue_with_labels(mock_run, capsys):
     rc = main(["--title", "Feature", "--labels", "enhancement,P2"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["issue_number"] == 5
+    assert output["Data"]["issue_number"] == 5
 
 
 @patch("subprocess.run")
@@ -103,7 +103,7 @@ def test_body_file(mock_run, capsys, tmp_path):
     rc = main(["--title", "From file", "--body-file", str(body_file)])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["issue_number"] == 7
+    assert output["Data"]["issue_number"] == 7
 
 
 @patch("subprocess.run")

--- a/tests/test_pr_description.py
+++ b/tests/test_pr_description.py
@@ -123,6 +123,72 @@ class TestOverall:
         # --fail-on-violation should cause non-zero exit even for warnings
         assert result.returncode == 1
 
+    def test_fail_on_violation_warnings_no_unconditional_pass_message(self):
+        """Regression for #2369: must not print 'Validation passed' while exiting 1.
+
+        Under --fail-on-violation with warnings (and no errors), the validator
+        previously printed '✓ Validation passed' on stderr while exiting 1,
+        producing a contradictory signal. The fix:
+          - Suppresses the success message when warnings are fatal.
+          - Surfaces an explicit failure summary.
+          - Exposes EffectiveSuccess/WarningsAreFatal/FailOnViolation in JSON.
+        """
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--title", "feat: Feature", "--body", "Minimal body",
+             "--fail-on-violation"],
+            capture_output=True, text=True, timeout=30,
+        )
+        r = json.loads(result.stdout)
+        assert result.returncode == 1
+        assert len(r["Warnings"]) > 0
+        # Hard-fail invariant: never print the unconditional pass banner when
+        # the process exits nonzero.
+        assert "Validation passed" not in result.stderr, (
+            "Validator must not claim 'Validation passed' while exiting nonzero "
+            f"(stderr was:\n{result.stderr})"
+        )
+        # New JSON fields make fatality policy visible to automation.
+        assert r["FailOnViolation"] is True
+        assert r["WarningsAreFatal"] is True
+        assert r["EffectiveSuccess"] is False
+        assert r["Success"] is True  # no hard errors
+        assert r["WarningCount"] == len(r["Warnings"])
+        # Human output must explain WHY this failed.
+        assert "warnings are fatal" in result.stderr.lower()
+
+    def test_default_mode_warnings_still_pass(self):
+        """Without --fail-on-violation, warnings remain advisory and exit is 0."""
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--title", "feat: Feature", "--body", "Minimal body"],
+            capture_output=True, text=True, timeout=30,
+        )
+        r = json.loads(result.stdout)
+        assert result.returncode == 0
+        assert r["FailOnViolation"] is False
+        assert r["WarningsAreFatal"] is False
+        assert r["EffectiveSuccess"] is True
+        assert "Validation passed" in result.stderr
+        assert "warnings are advisory" in result.stderr.lower()
+
+    def test_fail_on_violation_no_warnings_passes(self):
+        """--fail-on-violation with a fully clean body still exits 0 and reports pass."""
+        body = (
+            "## Summary\n\nAdded auth.\n\n"
+            "| Type | Reference |\n|------|--------|\n| **Issue** | Closes #1 |\n\n"
+            "## Type of Change\n\n- [x] New feature\n\n"
+            "## Changes\n\n- Added OAuth2\n"
+        )
+        result = subprocess.run(
+            [sys.executable, SCRIPT, "--title", "feat: Auth", "--body", body,
+             "--fail-on-violation"],
+            capture_output=True, text=True, timeout=30,
+        )
+        r = json.loads(result.stdout)
+        assert result.returncode == 0
+        assert r["EffectiveSuccess"] is True
+        assert r["WarningsAreFatal"] is False
+        assert "Validation passed" in result.stderr
+
     def test_fail_on_violation_with_errors(self):
         """--fail-on-violation returns exit code 1 when errors exist."""
         result = subprocess.run(

--- a/tests/test_security_scan_vulnerabilities.py
+++ b/tests/test_security_scan_vulnerabilities.py
@@ -776,3 +776,122 @@ def test_main_directory_scan_in_process(
     # reported the CWE-78 finding.
     assert code == scanner.EXIT_VULNERABILITIES
     assert "CWE-78" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Extensionless shebang detection (issue #2367)
+# ---------------------------------------------------------------------------
+# .githooks/pre-push and other extensionless executables advertise their
+# interpreter only via a shebang. The detector must read the first line and
+# treat bash/sh-family shebangs as bash, otherwise high-risk shell entry
+# points are silently skipped under `.githooks/**` per
+# `.github/instructions/security.instructions.md`.
+
+
+@pytest.mark.parametrize(
+    ("shebang", "expected"),
+    [
+        ("#!/usr/bin/env bash\n", "bash"),
+        ("#!/bin/bash\n", "bash"),
+        ("#!/bin/sh\n", "bash"),
+        ("#!/usr/bin/env sh\n", "bash"),
+        ("#! /usr/bin/env bash\n", "bash"),
+        ("#!/usr/bin/env dash\n", "bash"),
+        ("#!/usr/bin/env ksh\n", "bash"),
+        ("#!/usr/bin/env python3\n", None),
+        ("#!/usr/bin/env node\n", None),
+        ("#!/usr/bin/env pwsh\n", None),
+        ("plain text, no shebang\n", None),
+        ("", None),
+    ],
+)
+def test_get_language_shebang_fallback(
+    tmp_path: Path, shebang: str, expected: str | None
+) -> None:
+    """Extensionless files classify by shebang interpreter; non-shell shebangs reject."""
+    f = tmp_path / "pre-push"
+    f.write_text(shebang + "echo hi\n", encoding="utf-8")
+    assert scanner.get_language(str(f)) == expected
+
+
+def test_get_language_extension_wins_over_shebang(tmp_path: Path) -> None:
+    """A known suffix never triggers the shebang path; suffix is authoritative."""
+    f = tmp_path / "thing.txt"
+    f.write_text("#!/usr/bin/env bash\necho hi\n", encoding="utf-8")
+    assert scanner.get_language(str(f)) is None
+
+
+def test_get_language_missing_file_returns_none(tmp_path: Path) -> None:
+    """Unreadable extensionless paths don't raise; they classify as unsupported."""
+    assert scanner.get_language(str(tmp_path / "does-not-exist")) is None
+
+
+def test_get_language_invalid_utf8_shebang_returns_none(tmp_path: Path) -> None:
+    """Invalid UTF-8 in a shebang is treated as unsupported, not replaced."""
+    hook = tmp_path / "pre-push"
+    hook.write_bytes(b"#!\xff\xfe\n")
+    assert scanner.get_language(str(hook)) is None
+
+
+def test_get_directory_files_includes_extensionless_bash(tmp_path: Path) -> None:
+    """Directory walk surfaces extensionless bash scripts under `.githooks/`-style layouts."""
+    hooks = tmp_path / ".githooks"
+    hooks.mkdir()
+    bash_hook = hooks / "pre-push"
+    bash_hook.write_text("#!/usr/bin/env bash\necho hi\n", encoding="utf-8")
+    (hooks / "README").write_text("just docs\n", encoding="utf-8")
+    py_hook = hooks / "py-hook"
+    py_hook.write_text("#!/usr/bin/env python3\nprint('x')\n", encoding="utf-8")
+
+    found = scanner.get_directory_files(str(tmp_path))
+    assert str(bash_hook) in found
+    assert str(hooks / "README") not in found
+    assert str(py_hook) not in found
+
+
+def test_get_directory_files_prunes_noisy_directories(tmp_path: Path) -> None:
+    """Directory walk skips dependency and metadata trees before shebang reads."""
+    git_objects = tmp_path / ".git" / "objects"
+    git_objects.mkdir(parents=True)
+    git_object = git_objects / "abcdef"
+    git_object.write_text("#!/usr/bin/env bash\neval $payload\n", encoding="utf-8")
+
+    node_bin = tmp_path / "node_modules" / ".bin"
+    node_bin.mkdir(parents=True)
+    node_script = node_bin / "tool"
+    node_script.write_text("#!/usr/bin/env bash\neval $payload\n", encoding="utf-8")
+
+    mixed_case = tmp_path / "Node_Modules" / ".bin"
+    mixed_case.mkdir(parents=True)
+    mixed_case_script = mixed_case / "tool"
+    mixed_case_script.write_text(
+        "#!/usr/bin/env bash\neval $payload\n", encoding="utf-8"
+    )
+
+    hooks = tmp_path / ".githooks"
+    hooks.mkdir()
+    hook = hooks / "pre-push"
+    hook.write_text("#!/usr/bin/env bash\neval $payload\n", encoding="utf-8")
+
+    found = scanner.get_directory_files(str(tmp_path))
+
+    assert str(hook) in found
+    assert str(git_object) not in found
+    assert str(node_script) not in found
+    assert str(mixed_case_script) not in found
+
+
+def test_scan_extensionless_bash_hook_emits_cwe78(tmp_path: Path) -> None:
+    """End-to-end: an extensionless bash hook with a CWE-78 pattern is detected."""
+    hook = tmp_path / "pre-push"
+    hook.write_text(
+        "#!/usr/bin/env bash\n"
+        "FILE=$1\n"
+        'echo "running $FILE"\n'
+        "eval $FILE\n",
+        encoding="utf-8",
+    )
+    vulns, _suppressed = scanner.scan_file(str(hook))
+    assert any(v.cwe == "CWE-78" for v in vulns), (
+        f"expected at least one CWE-78 finding, got {[v.cwe for v in vulns]}"
+    )

--- a/tests/test_security_scan_vulnerabilities.py
+++ b/tests/test_security_scan_vulnerabilities.py
@@ -792,6 +792,8 @@ def test_main_directory_scan_in_process(
     ("shebang", "expected"),
     [
         ("#!/usr/bin/env bash\n", "bash"),
+        ("#!/usr/bin/env -S bash\n", "bash"),
+        ("#!/usr/bin/env -i sh\n", "bash"),
         ("#!/bin/bash\n", "bash"),
         ("#!/bin/sh\n", "bash"),
         ("#!/usr/bin/env sh\n", "bash"),
@@ -799,6 +801,7 @@ def test_main_directory_scan_in_process(
         ("#!/usr/bin/env dash\n", "bash"),
         ("#!/usr/bin/env ksh\n", "bash"),
         ("#!/usr/bin/env python3\n", None),
+        ("#!/usr/bin/env -S python3\n", None),
         ("#!/usr/bin/env node\n", None),
         ("#!/usr/bin/env pwsh\n", None),
         ("plain text, no shebang\n", None),

--- a/tests/test_set_issue_milestone.py
+++ b/tests/test_set_issue_milestone.py
@@ -48,8 +48,8 @@ def test_assign_milestone(mock_run, capsys):
     rc = main(["--issue", "1", "--milestone", "v1.0.0"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["success"] is True
-    assert output["action"] == "assigned"
+    assert output["Success"] is True
+    assert output["Data"]["action"] == "assigned"
 
 
 @patch("subprocess.run")
@@ -64,7 +64,7 @@ def test_already_has_same_milestone(mock_run, capsys):
     rc = main(["--issue", "1", "--milestone", "v1.0.0"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["action"] == "no_change"
+    assert output["Data"]["action"] == "no_change"
 
 
 @patch("subprocess.run")
@@ -94,7 +94,7 @@ def test_force_replace_milestone(mock_run, capsys):
     rc = main(["--issue", "1", "--milestone", "v1.0.0", "--force"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["action"] == "replaced"
+    assert output["Data"]["action"] == "replaced"
 
 
 @patch("subprocess.run")
@@ -109,7 +109,7 @@ def test_clear_milestone(mock_run, capsys):
     rc = main(["--issue", "1", "--clear"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["action"] == "cleared"
+    assert output["Data"]["action"] == "cleared"
 
 
 @patch("subprocess.run")
@@ -123,7 +123,7 @@ def test_clear_no_milestone(mock_run, capsys):
     rc = main(["--issue", "1", "--clear"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["action"] == "no_change"
+    assert output["Data"]["action"] == "no_change"
 
 
 @patch("subprocess.run")

--- a/tests/test_skill_post_issue_comment.py
+++ b/tests/test_skill_post_issue_comment.py
@@ -52,8 +52,8 @@ def test_post_comment(mock_run, capsys):
     rc = main(["--issue", "1", "--body", "Hello"])
     assert rc == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["success"] is True
-    assert output["comment_id"] == 100
+    assert output["Success"] is True
+    assert output["Data"]["comment_id"] == 100
 
 
 @patch("subprocess.run")
@@ -93,7 +93,7 @@ def test_marker_skip_existing(mock_run, capsys):
     rc = main(["--issue", "1", "--body", "New content", "--marker", "TEST-MARKER"])
     assert rc == 0
     output = _extract_json(capsys.readouterr().out)
-    assert output["skipped"] is True
+    assert output["Data"]["skipped"] is True
 
 
 @patch("subprocess.run")
@@ -119,7 +119,7 @@ def test_marker_update_existing(mock_run, capsys):
     ])
     assert rc == 0
     output = _extract_json(capsys.readouterr().out)
-    assert output["updated"] is True
+    assert output["Data"]["updated"] is True
 
 
 @patch("subprocess.run")


### PR DESCRIPTION
## Summary
Standardizes GitHub skill output contracts and ports the security-scan hook detection fix onto current main.

Fixes #2406
Refs #2391
Refs #2402
Refs #2418
Refs #2407
Supersedes #2435

| Issue | Link |
| --- | --- |
| Fixes | #2406 |
| Refs | #2391, #2402, #2418, #2407 |
| Supersedes | #2435 |

## Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor

## Changes
- Add `close_issue.py` with idempotent close behavior and safe optional comments.
- Normalize GitHub skill success and error envelopes across issue, milestone, reaction, notification, and PR scripts.
- Preserve security-scan coverage for extensionless shell hooks after the scanner refactor.

## Validation
- `uv run pytest tests/skills/github tests/test_close_issue.py tests/test_pr_description.py tests/test_security_scan_vulnerabilities.py tests/test_get_pr_review_threads.py tests/test_add_comment_reaction.py tests/test_get_latest_semantic_milestone.py tests/test_invoke_copilot_assignment.py tests/test_new_issue.py tests/test_set_issue_milestone.py tests/test_skill_post_issue_comment.py -q` (563 passed)
- `uv run python build/scripts/build_all.py --check`
- `uv run python scripts/validation/pre_pr.py`
- `git push -u origin fix/github-skill-contract-final3` pre-push gate (48-file range)