### PR TITLE
fix(hooks): emit valid PreToolUse advisory envelope so advisories are not dropped (#2468)

### DIFF
--- a/.agents/memory/episodes/episode-2026-06-06-session-2369-fix-2468-pretooluse-advisory-hooks.json
+++ b/.agents/memory/episodes/episode-2026-06-06-session-2369-fix-2468-pretooluse-advisory-hooks.json
@@ -1,0 +1,27 @@
+{
+  "id": "episode-2026-06-06-session-2369-fix-2468-pretooluse-advisory-hooks",
+  "session": "2026-06-06-session-2369-fix-2468-pretooluse-advisory-hooks",
+  "timestamp": "2026-06-06T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Fix #2468: PreToolUse advisory hooks emit invalid decision:allow JSON, dropping correction and topical-memory advisories",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-06-06T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: e6031e99c3f984cd6872256ea7dee5f85040f00c",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 0
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-06-06-session-2369-fix-2468-pretooluse-advisory-hooks.json
+++ b/.agents/sessions/2026-06-06-session-2369-fix-2468-pretooluse-advisory-hooks.json
@@ -1,0 +1,123 @@
+{
+  "session": {
+    "number": 2369,
+    "date": "2026-06-06",
+    "branch": "fix/2468-hook-advisory-envelope",
+    "startingCommit": "e6031e99c",
+    "objective": "Fix #2468: PreToolUse advisory hooks emit invalid decision:allow JSON, dropping correction and topical-memory advisories"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena active this session (initial_instructions, project ai-agents)"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read Serena Instructions Manual"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-loaded read-only at session start"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "github, security-scan, session-init skills invoked"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read usage-mandatory memory; using github skill scripts"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".claude/rules/* in context; ADR-042/006/035, Claude Code hook contract consulted"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read triage-001, usage-mandatory; topical-memory advisories surfaced"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2468-hook-advisory-envelope"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/2468-hook-advisory-envelope"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status checked; branched from origin/main"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "e6031e99c"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Start gates complete; checkpoint push for #2468 fix"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified (ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "session/2026-06-06-issue-triage-31-batch memory written"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "pre_pr.py Markdown Linting PASS"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "hook fixes + tests + shims + plugin bump committed"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "python3 scripts/validation/pre_pr.py: All validations passed"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "timestamp": "2026-06-06",
+      "entry": "Fixed #2468 (P0): invoke_correction_applier.py and invoke_topical_memory_injection.py emitted invalid {\"decision\":\"allow\"} which Claude Code rejected, silently dropping advisories. Changed both to {\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":...}}. Verified live (advisories now surface). Added stdout-JSON regression guards to both tests (54 pass). Regenerated copilot-cli shims. Bumped plugin.json .claude + copilot to 0.5.135. pre_pr all pass."
+    }
+  ],
+  "endingCommit": "e6031e99c3f984cd6872256ea7dee5f85040f00c",
+  "nextSteps": []
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.134",
+  "version": "0.5.135",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PreToolUse/invoke_correction_applier.py
+++ b/.claude/hooks/PreToolUse/invoke_correction_applier.py
@@ -215,13 +215,21 @@ def main() -> int:
         for source, text in shown:
             lines.append(f"- [{source}] {text}")
 
-        # Match the {decision, reason} envelope used by every other
-        # PreToolUse hook in this repo (invoke_branch_protection_guard,
-        # invoke_branch_context_guard, invoke_false_completion_gate,
-        # invoke_security_commit_gate, invoke_prompt_eval_gate). Claude
-        # Code surfaces the `reason` field; `message` was silently dropped.
+        # PreToolUse ADVISORY output: inject context through
+        # hookSpecificOutput.additionalContext. The top-level `decision` field
+        # accepts only "approve"/"block" (the blocking guards correctly use
+        # "block"); "allow" is invalid there, so Claude Code rejected the whole
+        # envelope and silently dropped the advisory (Issue #2468). The
+        # allow/deny/ask values belong under
+        # hookSpecificOutput.permissionDecision, which is a permission verdict,
+        # not the context-injection an advisory needs.
         advisory = "\n".join(lines)
-        output = {"decision": "allow", "reason": advisory}
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": advisory,
+            }
+        }
         print(json.dumps(output))
         # Mirror advisory text to stderr for human visibility in logs
         # (stdout must remain valid JSON for the hook protocol).

--- a/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
+++ b/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
@@ -265,7 +265,20 @@ def main() -> int:
             return 0
 
         advisory = render_advisory(topic, memories)
-        print(json.dumps({"decision": "allow", "reason": advisory}))
+        # PreToolUse advisory: inject context via
+        # hookSpecificOutput.additionalContext. Top-level `decision` accepts
+        # only "approve"/"block"; "allow" is invalid and made Claude Code reject
+        # the envelope, silently dropping the advisory (Issue #2468).
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "additionalContext": advisory,
+                    }
+                }
+            )
+        )
         print(advisory, file=sys.stderr)
     except Exception as exc:  # noqa: BLE001 - advisory hook fails open
         print(f"[{hook_name}] Error (fail-open): {exc}", file=sys.stderr)

--- a/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
+++ b/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
@@ -24,6 +24,7 @@ import os
 import re
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 # Bootstrap: find lib directory via env var or manifest walk-up (mirrors
@@ -77,7 +78,7 @@ SCAN_DEADLINE_SECONDS = 0.08
 # Table-driven topic keying: first match wins. Each rule maps a path prefix to
 # a topic; a callable receives the regex match so per-skill names can be
 # extracted. Order matters (most specific first).
-_TOPIC_RULES: list[tuple[re.Pattern[str], object]] = [
+_TOPIC_RULES: list[tuple[re.Pattern[str], Callable[[re.Match[str]], str]]] = [
     (re.compile(r"^\.claude/skills/([^/]+)/"), lambda m: m.group(1)),
     (re.compile(r"^\.claude/hooks/"), lambda m: "hooks"),
     (re.compile(r"^\.claude/commands/"), lambda m: "commands"),
@@ -142,7 +143,7 @@ def derive_topic(rel_path: str) -> str | None:
     for pattern, resolver in _TOPIC_RULES:
         match = pattern.match(rel_path)
         if match:
-            topic = resolver(match)  # type: ignore[operator]
+            topic = resolver(match)
             return _SAFE_TOPIC_RE.sub("", topic.lower()) or None
     # Fallback: first non-dot path segment.
     for segment in rel_path.split("/"):

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.134",
+  "version": "0.5.135",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
@@ -405,13 +405,21 @@ def _original_main(stdin_bytes):
             for source, text in shown:
                 lines.append(f"- [{source}] {text}")
 
-            # Match the {decision, reason} envelope used by every other
-            # PreToolUse hook in this repo (invoke_branch_protection_guard,
-            # invoke_branch_context_guard, invoke_false_completion_gate,
-            # invoke_security_commit_gate, invoke_prompt_eval_gate). Claude
-            # Code surfaces the `reason` field; `message` was silently dropped.
+            # PreToolUse ADVISORY output: inject context through
+            # hookSpecificOutput.additionalContext. The top-level `decision` field
+            # accepts only "approve"/"block" (the blocking guards correctly use
+            # "block"); "allow" is invalid there, so Claude Code rejected the whole
+            # envelope and silently dropped the advisory (Issue #2468). The
+            # allow/deny/ask values belong under
+            # hookSpecificOutput.permissionDecision, which is a permission verdict,
+            # not the context-injection an advisory needs.
             advisory = "\n".join(lines)
-            output = {"decision": "allow", "reason": advisory}
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "additionalContext": advisory,
+                }
+            }
             print(json.dumps(output))
             # Mirror advisory text to stderr for human visibility in logs
             # (stdout must remain valid JSON for the hook protocol).

--- a/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
@@ -455,7 +455,20 @@ def _original_main(stdin_bytes):
                 return 0
 
             advisory = render_advisory(topic, memories)
-            print(json.dumps({"decision": "allow", "reason": advisory}))
+            # PreToolUse advisory: inject context via
+            # hookSpecificOutput.additionalContext. Top-level `decision` accepts
+            # only "approve"/"block"; "allow" is invalid and made Claude Code reject
+            # the envelope, silently dropping the advisory (Issue #2468).
+            print(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "additionalContext": advisory,
+                        }
+                    }
+                )
+            )
             print(advisory, file=sys.stderr)
         except Exception as exc:  # noqa: BLE001 - advisory hook fails open
             print(f"[{hook_name}] Error (fail-open): {exc}", file=sys.stderr)

--- a/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
@@ -214,6 +214,7 @@ def _original_main(stdin_bytes):
     import re
     import sys
     import time
+    from collections.abc import Callable
     from pathlib import Path
 
     # Bootstrap: find lib directory via env var or manifest walk-up (mirrors
@@ -267,7 +268,7 @@ def _original_main(stdin_bytes):
     # Table-driven topic keying: first match wins. Each rule maps a path prefix to
     # a topic; a callable receives the regex match so per-skill names can be
     # extracted. Order matters (most specific first).
-    _TOPIC_RULES: list[tuple[re.Pattern[str], object]] = [
+    _TOPIC_RULES: list[tuple[re.Pattern[str], Callable[[re.Match[str]], str]]] = [
         (re.compile(r"^\.claude/skills/([^/]+)/"), lambda m: m.group(1)),
         (re.compile(r"^\.claude/hooks/"), lambda m: "hooks"),
         (re.compile(r"^\.claude/commands/"), lambda m: "commands"),
@@ -332,7 +333,7 @@ def _original_main(stdin_bytes):
         for pattern, resolver in _TOPIC_RULES:
             match = pattern.match(rel_path)
             if match:
-                topic = resolver(match)  # type: ignore[operator]
+                topic = resolver(match)
                 return _SAFE_TOPIC_RE.sub("", topic.lower()) or None
         # Fallback: first non-dot path segment.
         for segment in rel_path.split("/"):

--- a/tests/hooks/test_topical_memory_injection.py
+++ b/tests/hooks/test_topical_memory_injection.py
@@ -175,6 +175,16 @@ class TestMain:
         rc, cap = self._run(tmp_path, stdin, monkeypatch, capsys)
         assert rc == 0
         assert "Topical memory (github)" in cap.out
+        # Regression #2468: stdout MUST be the valid PreToolUse advisory
+        # envelope (hookSpecificOutput.additionalContext), not a top-level
+        # decision:"allow", which Claude Code rejects and silently drops.
+        payload = json.loads(cap.out)
+        assert "decision" not in payload
+        assert payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        assert (
+            "Topical memory (github)"
+            in payload["hookSpecificOutput"]["additionalContext"]
+        )
 
     def test_silent_when_no_match(self, tmp_path, monkeypatch, capsys):
         _seed_memories(tmp_path, {"powershell/x.md": "# x\n"})

--- a/tests/test_invoke_correction_applier.py
+++ b/tests/test_invoke_correction_applier.py
@@ -255,6 +255,18 @@ class TestMainOutputPath:
             # must be valid JSON or empty for hook payloads).
             assert "Self-Improving Agent" in captured.err
             assert "pnpm" in captured.err
+            # Regression #2468: stdout MUST be the valid PreToolUse advisory
+            # envelope. The top-level `decision` field accepts only
+            # approve/block; "allow" there is rejected by Claude Code, which
+            # silently drops the advisory. Advisories inject context via
+            # hookSpecificOutput.additionalContext.
+            payload = json.loads(captured.out)
+            assert "decision" not in payload
+            assert payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+            assert (
+                "Self-Improving Agent"
+                in payload["hookSpecificOutput"]["additionalContext"]
+            )
 
     @patch("invoke_correction_applier.skip_if_consumer_repo", return_value=False)
     @patch(


### PR DESCRIPTION
## Summary

Two PreToolUse advisory hooks emitted `{"decision": "allow", "reason": ...}`. The top-level `decision` field accepts only `approve`/`block` (the blocking guards correctly use `block`), so Claude Code rejected the whole envelope with `Hook JSON output validation failed: (root): Invalid input` and **silently dropped the advisory**. Correction memories (Self-Improving Agent, #1763) and topical memories (#2005) never reached the model. This is the silent-API/runtime-contract failure mode from `.claude/rules/generated-artifacts.md`.

## Fix

- `.claude/hooks/PreToolUse/invoke_correction_applier.py` and `invoke_topical_memory_injection.py` now emit the valid advisory envelope:
  ```json
  {"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": "<advisory>"}}
  ```
  (`allow`/`deny`/`ask` belong under `hookSpecificOutput.permissionDecision`, a permission verdict, not the context injection an advisory needs.)
- Added **stdout-JSON regression guards** to both tests. The prior tests only checked stderr or substring-matched stdout, so the bad envelope passed green (runtime-contract-not-tested). The guards now parse stdout and assert no top-level `decision` plus a `PreToolUse` `additionalContext` payload.
- Typed `_TOPIC_RULES` resolvers as `Callable[[re.Match[str]], str]` to drop a `# type: ignore[operator]` (also satisfies the pre-push security-suppression gate).
- Regenerated the `src/copilot-cli/hooks/` shims; bumped both `plugin.json` manifests 0.5.134 -> 0.5.135.

## Verification

- Behavioral: with the fix live in this working tree, both advisories now surface (the `Self-Improving Agent` and `Topical memory` blocks appear in PreToolUse context instead of being dropped).
- 54 hook tests pass; `pre_pr.py` all green (hook anchoring, plugin version bump, drift, security-suppression).

## Acceptance criteria

- [x] Both hooks emit a valid PreToolUse advisory envelope; advisories reach the model.
- [x] The terminal `Hook JSON output validation failed` error is gone.
- [x] Regression tests assert the stdout envelope shape, not just stderr/substring.

Fixes #2468

🤖 Generated with [Claude Code](https://claude.com/claude-code)