### PR TITLE
fix(hooks): PreToolUse advisory hooks emit valid additionalContext envelope

### DIFF
--- a/.agents/memory/episodes/episode-2026-06-06-session-2368-fix-pretooluse-advisory-hooks-emitting.json
+++ b/.agents/memory/episodes/episode-2026-06-06-session-2368-fix-pretooluse-advisory-hooks-emitting.json
@@ -1,0 +1,91 @@
+{
+  "id": "episode-2026-06-06-session-2368-fix-pretooluse-advisory-hooks-emitting",
+  "session": "2026-06-06-session-2368-fix-pretooluse-advisory-hooks-emitting",
+  "timestamp": "2026-06-06T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Fix PreToolUse advisory hooks emitting invalid decision:allow JSON; switch to hookSpecificOutput.additionalContext envelope, regenerate copilot shims, add stdout-JSON regression tests, bump plugin.json to 0.5.135",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-06-06T00:00:00+00:00",
+      "type": "milestone",
+      "content": "diagnose",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-06-06T00:00:00+00:00",
+      "type": "milestone",
+      "content": "confirm-schema",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-06-06T00:00:00+00:00",
+      "type": "milestone",
+      "content": "fix-hooks",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-06-06T00:00:00+00:00",
+      "type": "milestone",
+      "content": "tests",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-06-06T00:00:00+00:00",
+      "type": "test",
+      "content": "Ran: uv run python -m pytest tests/test_invoke_correction_applier.py tests/hooks/test_topical_memory_injection.py -> 54 passed (exit code 0). Added stdout-JSON regression guards; the prior tests only checked stderr or substring-matched stdout, so the bad envelope passed green",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-06-06T00:00:00+00:00",
+      "type": "milestone",
+      "content": "regenerate-mirror",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-06-06T00:00:00+00:00",
+      "type": "milestone",
+      "content": "plugin-bump",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-06-06T00:00:00+00:00",
+      "type": "milestone",
+      "content": "stopgap",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-06-06T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: ee35428b3",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 0
+  },
+  "lessons": []
+}

--- a/.agents/retrospective/2026-06-06-pretooluse-advisory-envelope.md
+++ b/.agents/retrospective/2026-06-06-pretooluse-advisory-envelope.md
@@ -1,0 +1,63 @@
+# Retrospective: PreToolUse advisory hooks emitted invalid decision:allow JSON
+
+> **Date**: 2026-06-06
+> **Severity**: Medium (developer-facing; advisory dropped, terminal error surfaced)
+> **Issue**: #2468
+> **No blame**: This retro critiques artifacts and process, not individuals.
+
+## Summary
+
+Two advisory `PreToolUse` hooks emitted `{"decision": "allow", "reason": ...}`.
+`"allow"` is not a valid value for a PreToolUse hook's top-level `decision`
+field (it accepts only `approve`/`block`). The values `allow`/`deny`/`ask`
+belong under `hookSpecificOutput.permissionDecision`. The harness schema check
+rejected the output, so the advisory was dropped before reaching the model and
+a `Hook JSON output validation failed: (root): Invalid input` error surfaced on
+every Bash command.
+
+## Impact
+
+| Area | Severity | Description |
+|------|----------|-------------|
+| Self-Improving Agent | Medium | Correction memories never surfaced; the Apply step was a silent no-op |
+| Topical memory injection | Medium | Topical memories never surfaced on Write/Edit |
+| Developer experience | Medium | A hook error printed on every Bash command for ~8 days |
+
+## Failure modes
+
+- **Silent failure at an integration point** (`.claude/rules/release-it.md`,
+  "Silent API Migration Failures"). The hook loaded and ran without raising; the
+  only signal was the harness validation error. The advisory side effect never
+  fired and nothing asserted that it did.
+- **Runtime contract not tested** (`.claude/rules/generated-artifacts.md`;
+  `.claude/rules/canonical-source-mirror.md`, self-referential test anti-pattern).
+  Both hook tests asserted the wrong surface: `test_invoke_correction_applier`
+  checked `stderr`, `test_topical_memory_injection` substring-matched `stdout`.
+  Neither parsed stdout as JSON or asserted the hook protocol envelope, so the
+  invalid `{"decision": "allow"}` output passed green.
+
+## Evidence
+
+- Root cause code: `.claude/hooks/PreToolUse/invoke_correction_applier.py` (was line 224),
+  `.claude/hooks/PreToolUse/invoke_topical_memory_injection.py` (was line 268).
+- Introduced: #1763 (2026-05-29), #2005 (2026-05-31).
+- Sibling blocking guards use the valid `{"decision": "block"}` form, which is
+  why only the two advisory hooks were affected.
+- Fix commits: `6d9b96be8` (hooks + shims + plugin bump), `ee35428b3` (tests).
+
+## Remediation
+
+- Both hooks now emit `{"hookSpecificOutput": {"hookEventName": "PreToolUse",
+  "additionalContext": "<advisory>"}}`. Verified live: the running harness
+  injected the advisory as `additionalContext` with no error.
+- Added stdout-JSON regression guards to both tests: parse stdout, assert the
+  `additionalContext` envelope, assert no top-level `decision` key.
+- Regenerated the `src/copilot-cli/hooks/` shims; the hook-drift guard exits 0.
+- Bumped `plugin.json` 0.5.134 to 0.5.135.
+
+## Follow-up
+
+- Republish the `project-toolkit` plugin from this fix so consumer cache copies
+  are durably fixed (the active local cache was patched as a stopgap only).
+- Consider a guard or lint that flags `decision: allow|deny|ask` in any
+  PreToolUse hook, since those values are only valid under `permissionDecision`.

--- a/.agents/sessions/2026-06-06-session-2368-fix-pretooluse-advisory-hooks-emitting.json
+++ b/.agents/sessions/2026-06-06-session-2368-fix-pretooluse-advisory-hooks-emitting.json
@@ -1,0 +1,150 @@
+{
+  "session": {
+    "number": 2368,
+    "date": "2026-06-06",
+    "branch": "fix/pretooluse-advisory-hook-json-schema",
+    "startingCommit": "e6031e99c",
+    "objective": "Fix PreToolUse advisory hooks emitting invalid decision:allow JSON; switch to hookSpecificOutput.additionalContext envelope, regenerate copilot shims, add stdout-JSON regression tests, bump plugin.json to 0.5.135"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena active; project 'ai-agents' activated; get_symbols_overview used on test files; initial_instructions invoked"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "mcp__serena__initial_instructions invoked this session"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-loaded by context-loader hook at SessionStart and reviewed"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Skill catalog injected at SessionStart; session-init skill invoked"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md + .claude/CLAUDE.md mandatory usage instructions auto-loaded at session start"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read this session"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "MEMORY.md auto-loaded; Serena memory index loaded via initial_instructions; topical correction memories surfaced via PreToolUse hooks"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/pretooluse-advisory-hook-json-schema"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/pretooluse-advisory-hook-json-schema"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status checked at session start and throughout"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "e6031e99c"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All session-end MUSTs complete; fix landed in two atomic commits"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md unchanged this session"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory claude/claude-code-pretooluse-advisory-envelope written"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "npx markdownlint-cli2 --fix run; 0 errors (.agents/ paths excluded by repo config)"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Commits 6d9b96be8 (hooks + shims + plugin bump) and ee35428b3 (tests)"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run python -m pytest -> 54 passed; validate_session_json.py exit 0"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Work tracked in this session log and retro 2026-06-06-pretooluse-advisory-envelope.md"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": ".agents/retrospective/2026-06-06-pretooluse-advisory-envelope.md"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": "diagnose",
+      "evidence": "Reproduced PreToolUse:Bash hook error by feeding the tool payload to each Bash-matcher hook; isolated invoke_correction_applier.py emitting {decision: allow}, which is invalid because the top-level decision field accepts only approve/block"
+    },
+    {
+      "step": "confirm-schema",
+      "evidence": "claude-code-guide plus the context-mode kimi/hooks.ts adapter note confirmed PreToolUse advisory context uses hookSpecificOutput.additionalContext; sibling blocking guards (branch_protection, branch_context, false_completion) use decision:block"
+    },
+    {
+      "step": "fix-hooks",
+      "evidence": "invoke_correction_applier.py and invoke_topical_memory_injection.py switched to the hookSpecificOutput.additionalContext envelope; verified live (harness injected additionalContext with no error)"
+    },
+    {
+      "step": "tests",
+      "evidence": "Ran: uv run python -m pytest tests/test_invoke_correction_applier.py tests/hooks/test_topical_memory_injection.py -> 54 passed (exit code 0). Added stdout-JSON regression guards; the prior tests only checked stderr or substring-matched stdout, so the bad envelope passed green"
+    },
+    {
+      "step": "regenerate-mirror",
+      "evidence": "Ran generate_hooks with an absolute repo_root to regenerate the src/copilot-cli/hooks shims; hook_drift_guard exits 0; the regenerated Bash shim emits valid additionalContext end to end"
+    },
+    {
+      "step": "plugin-bump",
+      "evidence": ".claude/.claude-plugin/plugin.json bumped 0.5.134 to 0.5.135 for the plugin source change"
+    },
+    {
+      "step": "stopgap",
+      "evidence": "Patched the active plugin cache v0.5.134 copies to clear the live terminal error; non-durable, overwritten on the next plugin update which carries the published fix"
+    }
+  ],
+  "endingCommit": "ee35428b3",
+  "nextSteps": [
+    "Open PR linking the tracking issue",
+    "Republish project-toolkit plugin from this fix so consumer cache copies are durably fixed"
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.134",
+  "version": "0.5.135",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PreToolUse/invoke_correction_applier.py
+++ b/.claude/hooks/PreToolUse/invoke_correction_applier.py
@@ -215,13 +215,22 @@ def main() -> int:
         for source, text in shown:
             lines.append(f"- [{source}] {text}")
 
-        # Match the {decision, reason} envelope used by every other
-        # PreToolUse hook in this repo (invoke_branch_protection_guard,
-        # invoke_branch_context_guard, invoke_false_completion_gate,
-        # invoke_security_commit_gate, invoke_prompt_eval_gate). Claude
-        # Code surfaces the `reason` field; `message` was silently dropped.
+        # Advisory hook: surface corrections to the model WITHOUT making a
+        # permission decision. PreToolUse model-visible context goes in
+        # hookSpecificOutput.additionalContext. {"decision": "allow"} is INVALID:
+        # the top-level `decision` field accepts only "approve"/"block" (the
+        # blocking guards use "block"); "allow"/"deny"/"ask" belong to
+        # hookSpecificOutput.permissionDecision, and setting permissionDecision
+        # would auto-approve the tool. additionalContext advises and leaves the
+        # normal permission flow intact. The old envelope failed schema
+        # validation ("(root): Invalid input"), so the advisory was dropped.
         advisory = "\n".join(lines)
-        output = {"decision": "allow", "reason": advisory}
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": advisory,
+            }
+        }
         print(json.dumps(output))
         # Mirror advisory text to stderr for human visibility in logs
         # (stdout must remain valid JSON for the hook protocol).

--- a/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
+++ b/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
@@ -265,7 +265,20 @@ def main() -> int:
             return 0
 
         advisory = render_advisory(topic, memories)
-        print(json.dumps({"decision": "allow", "reason": advisory}))
+        # Advisory only: inject as model-visible context via
+        # hookSpecificOutput.additionalContext. {"decision": "allow"} is invalid
+        # (top-level `decision` accepts only "approve"/"block"); see
+        # invoke_correction_applier.py for the full rationale.
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "additionalContext": advisory,
+                    }
+                }
+            )
+        )
         print(advisory, file=sys.stderr)
     except Exception as exc:  # noqa: BLE001 - advisory hook fails open
         print(f"[{hook_name}] Error (fail-open): {exc}", file=sys.stderr)

--- a/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
+++ b/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
@@ -28,7 +28,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 # Bootstrap: find lib directory via env var or manifest walk-up (mirrors
-# invoke_correction_applier.py so the hook works in both the source tree and
+# .claude/hooks/PreToolUse/invoke_correction_applier.py so the hook works in both
 # the deeper src/<provider>/hooks/<event>/ copy).
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
 if _plugin_root:
@@ -269,7 +269,7 @@ def main() -> int:
         # Advisory only: inject as model-visible context via
         # hookSpecificOutput.additionalContext. {"decision": "allow"} is invalid
         # (top-level `decision` accepts only "approve"/"block"); see
-        # invoke_correction_applier.py for the full rationale.
+        # .claude/hooks/PreToolUse/invoke_correction_applier.py for the full rationale.
         print(
             json.dumps(
                 {

--- a/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
+++ b/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
@@ -24,6 +24,7 @@ import os
 import re
 import sys
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 # Bootstrap: find lib directory via env var or manifest walk-up (mirrors
@@ -77,7 +78,7 @@ SCAN_DEADLINE_SECONDS = 0.08
 # Table-driven topic keying: first match wins. Each rule maps a path prefix to
 # a topic; a callable receives the regex match so per-skill names can be
 # extracted. Order matters (most specific first).
-_TOPIC_RULES: list[tuple[re.Pattern[str], object]] = [
+_TOPIC_RULES: list[tuple[re.Pattern[str], Callable[[re.Match[str]], str]]] = [
     (re.compile(r"^\.claude/skills/([^/]+)/"), lambda m: m.group(1)),
     (re.compile(r"^\.claude/hooks/"), lambda m: "hooks"),
     (re.compile(r"^\.claude/commands/"), lambda m: "commands"),
@@ -142,7 +143,7 @@ def derive_topic(rel_path: str) -> str | None:
     for pattern, resolver in _TOPIC_RULES:
         match = pattern.match(rel_path)
         if match:
-            topic = resolver(match)  # type: ignore[operator]
+            topic = resolver(match)
             return _SAFE_TOPIC_RE.sub("", topic.lower()) or None
     # Fallback: first non-dot path segment.
     for segment in rel_path.split("/"):

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.134",
+  "version": "0.5.135",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
@@ -405,13 +405,22 @@ def _original_main(stdin_bytes):
             for source, text in shown:
                 lines.append(f"- [{source}] {text}")
 
-            # Match the {decision, reason} envelope used by every other
-            # PreToolUse hook in this repo (invoke_branch_protection_guard,
-            # invoke_branch_context_guard, invoke_false_completion_gate,
-            # invoke_security_commit_gate, invoke_prompt_eval_gate). Claude
-            # Code surfaces the `reason` field; `message` was silently dropped.
+            # Advisory hook: surface corrections to the model WITHOUT making a
+            # permission decision. PreToolUse model-visible context goes in
+            # hookSpecificOutput.additionalContext. {"decision": "allow"} is INVALID:
+            # the top-level `decision` field accepts only "approve"/"block" (the
+            # blocking guards use "block"); "allow"/"deny"/"ask" belong to
+            # hookSpecificOutput.permissionDecision, and setting permissionDecision
+            # would auto-approve the tool. additionalContext advises and leaves the
+            # normal permission flow intact. The old envelope failed schema
+            # validation ("(root): Invalid input"), so the advisory was dropped.
             advisory = "\n".join(lines)
-            output = {"decision": "allow", "reason": advisory}
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "additionalContext": advisory,
+                }
+            }
             print(json.dumps(output))
             # Mirror advisory text to stderr for human visibility in logs
             # (stdout must remain valid JSON for the hook protocol).

--- a/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
@@ -218,7 +218,7 @@ def _original_main(stdin_bytes):
     from pathlib import Path
 
     # Bootstrap: find lib directory via env var or manifest walk-up (mirrors
-    # invoke_correction_applier.py so the hook works in both the source tree and
+    # .claude/hooks/PreToolUse/invoke_correction_applier.py so the hook works in both
     # the deeper src/<provider>/hooks/<event>/ copy).
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
     if _plugin_root:
@@ -459,7 +459,7 @@ def _original_main(stdin_bytes):
             # Advisory only: inject as model-visible context via
             # hookSpecificOutput.additionalContext. {"decision": "allow"} is invalid
             # (top-level `decision` accepts only "approve"/"block"); see
-            # invoke_correction_applier.py for the full rationale.
+            # .claude/hooks/PreToolUse/invoke_correction_applier.py for the full rationale.
             print(
                 json.dumps(
                     {

--- a/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
@@ -455,7 +455,20 @@ def _original_main(stdin_bytes):
                 return 0
 
             advisory = render_advisory(topic, memories)
-            print(json.dumps({"decision": "allow", "reason": advisory}))
+            # Advisory only: inject as model-visible context via
+            # hookSpecificOutput.additionalContext. {"decision": "allow"} is invalid
+            # (top-level `decision` accepts only "approve"/"block"); see
+            # invoke_correction_applier.py for the full rationale.
+            print(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "additionalContext": advisory,
+                        }
+                    }
+                )
+            )
             print(advisory, file=sys.stderr)
         except Exception as exc:  # noqa: BLE001 - advisory hook fails open
             print(f"[{hook_name}] Error (fail-open): {exc}", file=sys.stderr)

--- a/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
@@ -214,6 +214,7 @@ def _original_main(stdin_bytes):
     import re
     import sys
     import time
+    from collections.abc import Callable
     from pathlib import Path
 
     # Bootstrap: find lib directory via env var or manifest walk-up (mirrors
@@ -267,7 +268,7 @@ def _original_main(stdin_bytes):
     # Table-driven topic keying: first match wins. Each rule maps a path prefix to
     # a topic; a callable receives the regex match so per-skill names can be
     # extracted. Order matters (most specific first).
-    _TOPIC_RULES: list[tuple[re.Pattern[str], object]] = [
+    _TOPIC_RULES: list[tuple[re.Pattern[str], Callable[[re.Match[str]], str]]] = [
         (re.compile(r"^\.claude/skills/([^/]+)/"), lambda m: m.group(1)),
         (re.compile(r"^\.claude/hooks/"), lambda m: "hooks"),
         (re.compile(r"^\.claude/commands/"), lambda m: "commands"),
@@ -332,7 +333,7 @@ def _original_main(stdin_bytes):
         for pattern, resolver in _TOPIC_RULES:
             match = pattern.match(rel_path)
             if match:
-                topic = resolver(match)  # type: ignore[operator]
+                topic = resolver(match)
                 return _SAFE_TOPIC_RE.sub("", topic.lower()) or None
         # Fallback: first non-dot path segment.
         for segment in rel_path.split("/"):

--- a/tests/hooks/test_topical_memory_injection.py
+++ b/tests/hooks/test_topical_memory_injection.py
@@ -174,7 +174,15 @@ class TestMain:
         stdin = _stdin_for(tmp_path)
         rc, cap = self._run(tmp_path, stdin, monkeypatch, capsys)
         assert rc == 0
-        assert "Topical memory (github)" in cap.out
+        # stdout MUST be the valid PreToolUse advisory envelope. Regression
+        # guard for the {"decision": "allow"} schema bug, which failed
+        # "(root): Invalid input" validation and dropped the advisory (the prior
+        # assertion substring-matched stdout, so the bad envelope passed green).
+        payload = json.loads(cap.out)
+        assert "decision" not in payload
+        hso = payload["hookSpecificOutput"]
+        assert hso["hookEventName"] == "PreToolUse"
+        assert "Topical memory (github)" in hso["additionalContext"]
 
     def test_silent_when_no_match(self, tmp_path, monkeypatch, capsys):
         _seed_memories(tmp_path, {"powershell/x.md": "# x\n"})

--- a/tests/test_invoke_correction_applier.py
+++ b/tests/test_invoke_correction_applier.py
@@ -251,10 +251,19 @@ class TestMainOutputPath:
             result = main()
             assert result == 0
             captured = capsys.readouterr()
-            # Advisory text now goes to stderr (commit 92df3875: stdout
-            # must be valid JSON or empty for hook payloads).
+            # Advisory text is mirrored to stderr for human visibility in logs.
             assert "Self-Improving Agent" in captured.err
             assert "pnpm" in captured.err
+            # stdout MUST be the valid PreToolUse advisory envelope. Regression
+            # guard for the {"decision": "allow"} schema bug, which failed
+            # "(root): Invalid input" validation and silently dropped the
+            # advisory (the prior test only checked stderr, so it passed green).
+            payload = json.loads(captured.out)
+            assert "decision" not in payload
+            hso = payload["hookSpecificOutput"]
+            assert hso["hookEventName"] == "PreToolUse"
+            assert "Self-Improving Agent" in hso["additionalContext"]
+            assert "pnpm" in hso["additionalContext"]
 
     @patch("invoke_correction_applier.skip_if_consumer_repo", return_value=False)
     @patch(


### PR DESCRIPTION
## Summary

### What

Two advisory `PreToolUse` hooks emitted `{"decision": "allow", ...}`, an invalid
envelope the harness rejected, so the advisory was dropped before reaching the
model. Both now emit `hookSpecificOutput.additionalContext`.

### Why

`"allow"` is not a valid value for a PreToolUse hook's top-level `decision`
field (only `approve`/`block`; the blocking guards use `block`).
`allow`/`deny`/`ask` belong under `hookSpecificOutput.permissionDecision`.
Schema validation failed with `(root): Invalid input` on every Bash command,
and the Self-Improving-Agent corrections plus topical memories never surfaced.
Introduced #1763 (2026-05-29) and #2005 (2026-05-31).

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Closes #2468 | PreToolUse advisory hooks emit invalid decision:allow JSON |

## Changes

- `invoke_correction_applier.py` and `invoke_topical_memory_injection.py` emit
  `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": ...}}`.
- Regenerated the `src/copilot-cli/hooks/` shims; the hook-drift guard is clean.
- Added stdout-JSON regression guards to both hook tests. The prior tests only
  checked stderr or substring-matched stdout, so the bad envelope passed green.
- Typed the `_TOPIC_RULES` resolver as `Callable[[re.Match[str]], str]`, removing
  a `# type: ignore[operator]`.
- Bumped both project-toolkit manifests (`.claude/` and `src/copilot-cli/`)
  0.5.134 to 0.5.135.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard, soft target

**Focus areas**: the hook output envelope against the Claude Code PreToolUse
schema, and the regression-test approach (assert stdout JSON, not the side channel).

## Testing

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Verified live: the running harness injected the advisory as `additionalContext`
with no error. `uv run python -m pytest` on both hook tests reports 54 passed.
The regenerated shim runs end to end and emits valid `additionalContext`. The
pre-push hook passed 14 checks.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

The change is the hook output envelope plus a type annotation; no auth, secrets,
or CI surface is touched.

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (pre-push hook: 14 checks passed)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed
- [x] Comments added only where the why is non-obvious
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced

## Related Issues

Closes #2468
