### PR TITLE
docs(agents): restore AGENTS.md under workspace budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,10 @@ Read first, reason second. Pre-training last resort.
 
 ## Boundaries
 
-**Always**: Python new scripts (ADR-042)|Verify branch|Update Serena|Check skills|Assign issues|PR template|Atomic commits (≤5 files)|Scoped lint|Pin Actions to SHA|Run changed workflows pre-push|Bump `plugin.json` (semver) on plugin source change
+**Always**: Python new scripts (ADR-042)|Verify branch|Update Serena|Check skills|Assign issues|PR template|Atomic commits ≤5 files|Scoped lint|Pin Actions to SHA|Run changed workflows pre-push|Bump `plugin.json` semver on plugin-source change
 **Ask First**: Architecture changes|New ADRs|Breaking changes|Security-sensitive
-**Autonomy Guardrail**: Internal+reversible (read,edit,memory): act|External/Irreversible: confirm|Ambiguous: act minimal, flag rest
-**Never**: Commit secrets|Update HANDOFF.md|Use bash|Skip validation|Logic in YAML (ADR-006)|Raw gh when skills exist|Force push|Skip hooks|Internal refs in src/|Scratch in working tree (`$TMPDIR`/`mktemp`)|Resolve security threads without fixing the vulnerability (CWE/OWASP/CVE) in code|Ship gen'd artifact unrun in target runtime
+**Autonomy**: Internal+reversible (read,edit,memory): act|External/Irreversible: confirm|Ambiguous: act minimal, flag rest
+**Never**: Commit secrets|Update HANDOFF.md|Use bash|Skip validation|Logic in YAML (ADR-006)|Raw gh when skills exist|Force push|Skip hooks|Internal refs in src/|Scratch in working tree (`$TMPDIR`/`mktemp`)|Resolve security threads w/o fixing the vuln (CWE/OWASP/CVE) in code|Ship gen'd artifact unrun in target runtime
 
 ## Context Type Decision
 
@@ -43,8 +43,8 @@ Knowledge → passive context (@imports). Actions → skills.
 |Session: session-init, session-end|CI fix: session-log-fixer|Push: /push-pr
 |Security: security-detection|Quality: analyze|Learn: reflect
 |Lifecycle: /spec, /plan, /build, /test, /review, /ship
-|CI-feedback sub-loop (findings on a pushed branch): cluster, then ladder build->test->review->ship per cluster. Commit `fix(subloop): <axis> cluster <id>`. See `.agents/governance/CI-FEEDBACK-SUBLOOP.md`
-|New capability (Context/module/scanner/validator/pipeline): run buy-vs-build-framework Quick tier BEFORE spec-generator|Skip: bug fixes, doc-only, refactors w/o new capability, approved extensions
+|CI-feedback sub-loop: see `.agents/governance/CI-FEEDBACK-SUBLOOP.md`
+|New capability: run buy-vs-build-framework Quick tier BEFORE spec-generator|Skip: bug fixes, doc-only, refactors w/o new capability, approved exts
 
 ### ADR Review (BLOCKING)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Read first, reason second. Pre-training last resort.
 **Always**: Python new scripts (ADR-042)|Verify branch|Update Serena|Check skills|Assign issues|PR template|Atomic commits ≤5 files|Scoped lint|Pin Actions to SHA|Run changed workflows pre-push|Bump `plugin.json` semver on plugin-source change
 **Ask First**: Architecture changes|New ADRs|Breaking changes|Security-sensitive
 **Autonomy**: Internal+reversible (read,edit,memory): act|External/Irreversible: confirm|Ambiguous: act minimal, flag rest
-**Never**: Commit secrets|Update HANDOFF.md|Use bash|Skip validation|Logic in YAML (ADR-006)|Raw gh when skills exist|Force push|Skip hooks|Internal refs in src/|Scratch in working tree (`$TMPDIR`/`mktemp`)|Resolve security threads w/o fixing the vuln (CWE/OWASP/CVE) in code|Ship gen'd artifact unrun in target runtime
+**Never**: Commit secrets|Update HANDOFF.md|Use bash|Skip validation|Logic in YAML (ADR-006)|Raw gh when skills exist|Force push|Skip hooks|Internal refs in src/|Scratch in working tree (`$TMPDIR`/`mktemp`)|Resolve security threads without vuln fix (CWE/OWASP/CVE) in code|Ship gen'd artifact unrun in target runtime
 
 ## Context Type Decision
 
@@ -44,7 +44,7 @@ Knowledge → passive context (@imports). Actions → skills.
 |Security: security-detection|Quality: analyze|Learn: reflect
 |Lifecycle: /spec, /plan, /build, /test, /review, /ship
 |CI-feedback sub-loop: see `.agents/governance/CI-FEEDBACK-SUBLOOP.md`
-|New capability: run buy-vs-build-framework Quick tier BEFORE spec-generator|Skip: bug fixes, doc-only, refactors w/o new capability, approved exts
+|New capability: run buy-vs-build-framework Quick tier BEFORE spec-generator|Skip: bug fixes, doc-only, refactors w/o new capability, approved extensions
 
 ### ADR Review (BLOCKING)
 


### PR DESCRIPTION
## Summary

### What

Restore `AGENTS.md` under the 3000-byte per-file workspace budget by collapsing the CI-feedback sub-loop entry to a pointer and tightening a few verbose Boundaries lines by phrasing only.

### Why

PR #2425 added a CI-feedback sub-loop line to `AGENTS.md`, growing it from 2995 to 3200 bytes, over the 3000-byte per-file budget enforced by the workspace-budget validator and its tests. That made the required "Run Python Tests" check fail on main and blocked other open PRs whose merge ref inherits the oversized file. The full sub-loop detail already lives in the governance reference, so the index only needs a pointer.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #2014 | CI-feedback sub-loop primitive, the AGENTS.md entry this adjusts |

## Changes

- Collapse the AGENTS.md `CI-feedback sub-loop` entry to a pointer to the governance reference. Detail is preserved there.
- Tighten phrasing on the `Always`, `Autonomy`, `Never`, and `New capability` lines. Abbreviations and one illustrative parenthetical were removed. No directive dropped.
- Result: `AGENTS.md` is 2989 bytes, under budget. Workspace-budget validation passes.

## Type of Change

- [x] Documentation update

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard governance-file review, unblocks open PRs.

**Focus areas**: confirm no distinct Boundaries directive was lost in the phrasing trims.

## Testing

- [x] Workspace-budget validation passes locally. AGENTS.md is 2989 bytes.

## References

These files provide context and validation coverage. They are not changed by this PR.

- `.agents/governance/CI-FEEDBACK-SUBLOOP.md`
- `scripts/validate_workspace_budget.py`
- `tests/test_workspace_limits.py`

## Related Issues

Refs #2014
