### PR TITLE
fix(bootstrap): provision pinned Python via uv instead of pyenv source compile

### DIFF
--- a/.agents/memory/episodes/episode-2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
+++ b/.agents/memory/episodes/episode-2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
@@ -1,0 +1,59 @@
+{
+  "id": "episode-2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python",
+  "session": "2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python",
+  "timestamp": "2026-06-10T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Make bootstrap-vm.sh provision the pinned Python via uv and a current uv so the pre-push gate runs on fresh Claude web containers without manual intervention",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-06-10T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Diagnose",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-06-10T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Implement",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-06-10T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verify",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-06-10T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Curate",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-06-10T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: be4099b",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 0
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
+++ b/.agents/memory/episodes/episode-2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
@@ -45,6 +45,22 @@
       "content": "Commit: be4099b",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-06-10T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Review response",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-06-10T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 2bfa8d7",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/retrospective/2026-06-10-auto-retro.md
+++ b/.agents/retrospective/2026-06-10-auto-retro.md
@@ -1,0 +1,32 @@
+<!-- RETRO-STATE: skeleton-pending-fill -->
+# Retrospective: 2026-06-10
+
+> UNFILLED SKELETON written by invoke_auto_retrospective.py (Stop hook).
+> The sections below are empty placeholders, not a completed retrospective.
+> Run /retro fill 2026-06-10 (or the retrospective skill) to populate them, then
+> delete this banner and the RETRO-STATE marker above.
+
+## Session Context
+
+### Work Items
+- Diagnose
+- Implement
+- Verify
+- Curate
+
+
+## What Went Well
+
+- _UNFILLED. Run the retrospective agent to populate this section._
+
+## What Could Improve
+
+- _UNFILLED. Run the retrospective agent to populate this section._
+
+## Key Learnings
+
+- _UNFILLED. Run the retrospective agent to populate this section._
+
+## Failure Patterns
+
+- _UNFILLED. Run the retrospective agent to populate this section (check .agents/failure-modes/)._

--- a/.agents/sessions/2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
+++ b/.agents/sessions/2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
@@ -1,0 +1,138 @@
+{
+  "session": {
+    "number": 2381,
+    "date": "2026-06-10",
+    "branch": "claude/pre-push-gate-python-uv-7x757l",
+    "startingCommit": "42068c0",
+    "objective": "Make bootstrap-vm.sh provision the pinned Python via uv and a current uv so the pre-push gate runs on fresh Claude web containers without manual intervention"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP active: mcp__serena__get_symbols_overview on scripts/bootstrap-vm.sh returned symbol list; edit_memory calls succeeded"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena re-assertion injected by UserPromptSubmit hook; symbolic tools used for code navigation per LSP-first rule"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-loaded by SessionStart context loader hook (read-only dashboard, protocol v1.4)"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file, created via .claude/skills/session-init/scripts/new_session_log.py"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Available skills enumerated by harness at session start; session-init skill invoked via Skill tool"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md and .claude/rules/*.md loaded in session context (project instructions)"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md boundaries applied: Python-first exception (edited grandfathered bash bootstrap, no new bash script), atomic commits <=5 files, pinned-version single source of truth"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Hook-surfaced corrections consumed (github-pr1873, bash-integration, environment-observations); read ci/environment-observations.md and python/python-version-compatibility.md before editing"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "claude/pre-push-gate-python-uv-7x757l"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On claude/pre-push-gate-python-uv-7x757l"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status at start: working tree clean at 42068c0"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "42068c0"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart and sessionEnd MUST items completed with evidence in this log"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md untouched (read-only per ADR-014); git status shows no HANDOFF.md modification"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Marked ci/environment-observations.md and python/python-version-compatibility.md SUPERSEDED (pyenv 3.12.8 path replaced by uv-managed 3.14.5)"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "npx markdownlint-cli2 --fix on the two edited .serena/memories files: 0 errors"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "be4099b fix(bootstrap): provision pinned Python via uv instead of pyenv source compile; session artifacts committed separately"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run --frozen python scripts/validation/pre_pr.py --quick: RESULT All validations passed; bootstrap-vm.sh executed end to end in target container, exit 0; gate probe uv run --frozen python OK on 3.14.5"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Single-task session; no open task list to update"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Skipped: small focused fix, learnings captured directly in superseded-memory updates"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Diagnose",
+      "details": "Fresh Claude web container shows the failure state: uv 0.8.17 (predates CPython 3.14.x downloads), python3 -> 3.11.15, pyenv section of bootstrap-vm.sh compiles 3.12.8 from source and blows the SessionStart hook budget so uv/deps steps never run; pyenv local 3.12.8 would clobber the committed .python-version (3.14.5). Pre-push gate probes 'uv run --frozen python' (.githooks/pre-push:153)."
+    },
+    {
+      "action": "Implement",
+      "details": "scripts/bootstrap-vm.sh: replaced pyenv source-compile section with uv-managed provisioning. Reads .python-version as single source of truth; reinstalls uv via astral.sh standalone installer when 'uv python list <pin>' resolves nothing (capability check, never 'uv self update' whose GitHub API path is rate-limited); 'uv python install --default <pin>' (prebuilt, seconds); 'uv sync --frozen --extra dev' for the .venv the pre-push gate uses; venv-first PATH persisted to bashrc; yamllint via 'uv tool install' so the shim lands on PATH. .claude/hooks/session-start.sh: persist repo .venv/bin first in CLAUDE_ENV_FILE PATH; updated stale pyenv comments."
+    },
+    {
+      "action": "Verify",
+      "details": "Ran ./scripts/bootstrap-vm.sh twice in the target container: exit 0 both runs (idempotent). uv 0.11.19 installed; python3 -> .venv/bin/python3 = 3.14.5; import yaml OK; python3 scripts/validation/pre_pr.py --help OK under bare python3; 'uv run --frozen python' gate probe OK; .bashrc venv PATH line appended exactly once. Discovered and fixed mid-session: uv-managed interpreters are PEP 668 externally-managed, so 'uv pip install --system --python <pin>' fails by design; switched to venv-first PATH instead. Dash byte-check: 0 em/en dashes in edited files. pre_pr.py --quick: all validations passed."
+    },
+    {
+      "action": "Curate",
+      "details": "Marked .serena/memories/ci/environment-observations.md and .serena/memories/python/python-version-compatibility.md SUPERSEDED so future agents are not steered back to pyenv 3.12.8."
+    }
+  ],
+  "endingCommit": "be4099b",
+  "nextSteps": [
+    "Flagged, not fixed: CONTRIBUTING.md Prerequisites still documents the pyenv 3.12.8 flow; needs a doc-only follow-up to describe the uv-based setup",
+    "Optional: Pester Install-Module step in bootstrap-vm.sh runs unconditionally every session start (1-2 min); could be guarded on an installed-version check"
+  ]
+}

--- a/.agents/sessions/2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
+++ b/.agents/sessions/2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
@@ -128,9 +128,13 @@
     {
       "action": "Curate",
       "details": "Marked .serena/memories/ci/environment-observations.md and .serena/memories/python/python-version-compatibility.md SUPERSEDED so future agents are not steered back to pyenv 3.12.8."
+    },
+    {
+      "action": "Review response",
+      "details": "PR #2529 CI + bot review round: bumped src/copilot-cli plugin.json mirror to 0.5.168 (manifest parity CI failure); re-keyed the session-start env-file PATH guard on the venv bin marker instead of PYENV_ROOT so upgraded containers get the venv-first PATH (Cursor bugbot + Gemini high); anchored bootstrap-vm.sh to repo root via BASH_SOURCE (Gemini high, CWE-22). Verified: bash -n clean, bootstrap run from /tmp exits 0 and syncs .venv."
     }
   ],
-  "endingCommit": "be4099b",
+  "endingCommit": "2bfa8d7",
   "nextSteps": [
     "Flagged, not fixed: CONTRIBUTING.md Prerequisites still documents the pyenv 3.12.8 flow; needs a doc-only follow-up to describe the uv-based setup",
     "Optional: Pester Install-Module step in bootstrap-vm.sh runs unconditionally every session start (1-2 min); could be guarded on an installed-version check"

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.167",
+  "version": "0.5.168",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -32,31 +32,34 @@ fi
 cd "$repo_root"
 # Run bootstrap-vm.sh as best-effort: capture its exit code and continue so a
 # partial failure (e.g. a single tool install step erroring out) does not abort
-# session start. Anything that did install successfully (uv, pyenv, project
-# Python deps) remains available; failures are logged for the maintainer to
-# diagnose later.
+# session start. Anything that did install successfully (uv, the pinned
+# Python, project deps) remains available; failures are logged for the
+# maintainer to diagnose later.
 bootstrap_status=0
 ./scripts/bootstrap-vm.sh || bootstrap_status=$?
 if [ "$bootstrap_status" -ne 0 ]; then
   echo "[session-start] bootstrap-vm.sh exited $bootstrap_status; continuing in degraded mode" >&2
 fi
 
-# Persist PATH for the agent loop so newly-installed tools (uv, pyenv, etc.)
-# are reachable from subsequent Bash tool calls in the session.
+# Persist PATH for the agent loop so newly-installed tools (uv, the
+# uv-managed python3, etc.) are reachable from subsequent Bash tool calls in
+# the session.
 #
-# Order matters: $HOME/.pyenv/shims must come before /usr/local/bin (where the
-# system python3 lives) so `python3` resolves to pyenv's shim, which redirects
-# to the version pyenv installed (currently 3.12.8). bootstrap-vm.sh runs
-# `eval "$(pyenv init -)"` to set this up for its own subshell, but those PATH
-# changes are lost when the script exits — we reproduce the shim entry here so
-# `python3` keeps resolving to the pyenv version where uv pip installed deps.
+# Order matters: the project venv's bin must come first so bare `python3`
+# resolves to the synced .venv (the interpreter pinned in .python-version,
+# with project deps installed by `uv sync`). $HOME/.local/bin follows so
+# `uv` and the uv-managed default python3 (the no-venv fallback) resolve to
+# the bootstrap-installed copies rather than older image-provided ones. The
+# pyenv entries are kept for container images that still carry
+# pyenv-provisioned interpreters; they sit last so they never shadow the
+# uv-managed toolchain.
 #
 # Idempotent: SessionStart fires every session, so guard on PYENV_ROOT being
 # already exported in $CLAUDE_ENV_FILE to avoid appending duplicate lines.
 if [ -n "${CLAUDE_ENV_FILE:-}" ] \
    && ! grep -q '^export PYENV_ROOT=' "$CLAUDE_ENV_FILE" 2>/dev/null; then
   {
-    echo 'export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.pyenv/shims:$HOME/.pyenv/bin:$PATH"'
+    echo "export PATH=\"$repo_root/.venv/bin:\$HOME/.local/bin:\$HOME/.cargo/bin:\$HOME/.pyenv/shims:\$HOME/.pyenv/bin:\$PATH\""
     echo 'export PYENV_ROOT="$HOME/.pyenv"'
   } >> "$CLAUDE_ENV_FILE"
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -54,12 +54,16 @@ fi
 # pyenv-provisioned interpreters; they sit last so they never shadow the
 # uv-managed toolchain.
 #
-# Idempotent: SessionStart fires every session, so guard on PYENV_ROOT being
-# already exported in $CLAUDE_ENV_FILE to avoid appending duplicate lines.
-if [ -n "${CLAUDE_ENV_FILE:-}" ] \
-   && ! grep -q '^export PYENV_ROOT=' "$CLAUDE_ENV_FILE" 2>/dev/null; then
-  {
-    echo "export PATH=\"$repo_root/.venv/bin:\$HOME/.local/bin:\$HOME/.cargo/bin:\$HOME/.pyenv/shims:\$HOME/.pyenv/bin:\$PATH\""
-    echo 'export PYENV_ROOT="$HOME/.pyenv"'
-  } >> "$CLAUDE_ENV_FILE"
+# Idempotent: SessionStart fires every session, so each line is guarded by
+# its own marker. The PATH line is keyed on the venv bin dir (not on
+# PYENV_ROOT): containers that ran an older version of this hook already
+# have a PYENV_ROOT line in $CLAUDE_ENV_FILE, and keying the PATH append on
+# it would skip the venv-first PATH on upgraded sessions.
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  if ! grep -qF "$repo_root/.venv/bin" "$CLAUDE_ENV_FILE" 2>/dev/null; then
+    echo "export PATH=\"$repo_root/.venv/bin:\$HOME/.local/bin:\$HOME/.cargo/bin:\$HOME/.pyenv/shims:\$HOME/.pyenv/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+  fi
+  if ! grep -q '^export PYENV_ROOT=' "$CLAUDE_ENV_FILE" 2>/dev/null; then
+    echo 'export PYENV_ROOT="$HOME/.pyenv"' >> "$CLAUDE_ENV_FILE"
+  fi
 fi

--- a/.serena/memories/ci/environment-observations.md
+++ b/.serena/memories/ci/environment-observations.md
@@ -11,7 +11,8 @@ This memory captures learnings from environment setup, platform compatibility, a
 
 These are corrections that MUST be followed:
 
-- Python 3.13.x SystemError breaks CodeQL and skill validation - use Python 3.12.8 via pyenv for compatibility (Session 05, 2026-01-15)
+- SUPERSEDED (2026-06-10, Session 2381): the repo now pins Python 3.14.5 in `.python-version` and `scripts/bootstrap-vm.sh` provisions it via `uv python install --default` plus `uv sync --frozen --extra dev` (prebuilt, seconds). Do NOT reintroduce pyenv or 3.12.8; the pyenv source compile blew the SessionStart hook budget on Claude web containers. If the image uv is too old to know the pin (0.8.17 was), bootstrap reinstalls uv via the astral.sh standalone installer; never `uv self update` (GitHub-API path, rate-limited).
+- OBSOLETE: Python 3.13.x SystemError breaks CodeQL and skill validation - use Python 3.12.8 via pyenv for compatibility (Session 05, 2026-01-15)
   - Evidence: Batch 37 - Python 3.13.7 SystemError during CodeQL database creation and skill validation on Ubuntu 25.10
   - Root cause: Python 3.13.7 SystemError: failed to join paths during CodeQL Python database creation
   - Solution: `pyenv install 3.12.8` + create `.python-version` file with `3.12.8` to pin version for CodeQL

--- a/.serena/memories/python/python-version-compatibility.md
+++ b/.serena/memories/python/python-version-compatibility.md
@@ -1,6 +1,15 @@
 # Python Version Compatibility
 
-## Known Issues
+> **SUPERSEDED (2026-06-10, Session 2381)**: the project pin is now Python 3.14.5
+> (`.python-version`), provisioned by `scripts/bootstrap-vm.sh` via
+> `uv python install --default` + `uv sync --frozen --extra dev`. The pyenv
+> instructions below are historical: the pyenv source compile took minutes and
+> blew the SessionStart hook budget on Claude web containers, and
+> `pyenv local 3.12.8` clobbered the committed `.python-version`. Bare `python3`
+> now resolves to `.venv/bin/python3` (venv-first PATH); uv-managed interpreters
+> are PEP 668 externally-managed, so deps live only in `.venv`.
+
+## Known Issues (historical, pre-3.14.5 pin)
 
 ### Python 3.13.7 - Skill Validator Failure
 

--- a/docs/retros/INDEX.md
+++ b/docs/retros/INDEX.md
@@ -7,3 +7,4 @@
 |------|------|---------|
 | 2026-06-02 | 2026-06-02-pr-2205-customer-wedge-incident.md | Auto-generated session retro |
 | 2026-06-02 | 2026-06-02-issue-2290-copilot-hook-payload-format.md | P0: Copilot CLI preToolUse hooks crashed (FM-CONTRACT: eventRemap camelCase sent toolName, shim read tool_name) |
+| 2026-06-10 | [2026-06-10-auto-retro.md](../../.agents/retrospective/2026-06-10-auto-retro.md) | Auto-generated session retro |

--- a/scripts/bootstrap-vm.sh
+++ b/scripts/bootstrap-vm.sh
@@ -4,6 +4,12 @@
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
+# Anchor to the repository root so relative paths (.python-version, uv.lock,
+# pyproject.toml, .githooks) resolve correctly regardless of the caller's CWD
+# (CWE-22 defense: never resolve repo paths against an attacker-influenced CWD).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
 echo "=== System Prerequisites ==="
 sudo apt-get update -qq
 sudo apt-get install -y -qq curl wget git jq unzip zstd apt-transport-https \

--- a/scripts/bootstrap-vm.sh
+++ b/scripts/bootstrap-vm.sh
@@ -10,6 +10,22 @@ export DEBIAN_FRONTEND=noninteractive
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Bound every outbound download: a hung mirror must fail the step, not hang
+# the SessionStart hook. Retries are only safe on curls that write to a file
+# (-o); a --retry on a piped transfer can re-send bytes mid-stream.
+CURL_OPTS=(--connect-timeout 10 --max-time 300)
+CURL_RETRY_OPTS=("${CURL_OPTS[@]}" --retry 3 --retry-delay 5)
+
+install_uv() {
+    # Download then execute (not curl|sh) so a partial transfer never
+    # reaches the shell and retries are safe.
+    local installer
+    installer="$(mktemp)"
+    curl "${CURL_RETRY_OPTS[@]}" -LsSf https://astral.sh/uv/install.sh -o "$installer"
+    sh "$installer"
+    rm -f "$installer"
+}
+
 echo "=== System Prerequisites ==="
 sudo apt-get update -qq
 sudo apt-get install -y -qq curl wget git jq unzip zstd apt-transport-https \
@@ -17,7 +33,7 @@ sudo apt-get install -y -qq curl wget git jq unzip zstd apt-transport-https \
 
 echo "=== Node.js LTS ==="
 if ! command -v node &>/dev/null; then
-    curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+    curl "${CURL_OPTS[@]}" -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
     sudo apt-get install -y -qq nodejs
 fi
 node --version && npm --version
@@ -33,7 +49,7 @@ pwsh --version
 
 echo "=== GitHub CLI ==="
 if ! command -v gh &>/dev/null; then
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+    curl "${CURL_OPTS[@]}" -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
         sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | \
         sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
@@ -60,10 +76,10 @@ fi
 # `uv self update` here: that path queries the GitHub API and gets
 # rate-limited on shared container egress IPs.
 if ! command -v uv &>/dev/null; then
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    install_uv
 elif [[ -n "$PYTHON_PIN" ]] && ! uv python list "$PYTHON_PIN" 2>/dev/null | grep -q .; then
     echo "uv $(uv --version) cannot resolve Python ${PYTHON_PIN}; reinstalling latest uv"
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    install_uv
 fi
 grep -q 'local/bin' "$HOME/.bashrc" 2>/dev/null || echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
 uv --version
@@ -108,8 +124,15 @@ if [[ -f "uv.lock" ]]; then
     fi
 elif [[ -f "pyproject.toml" ]]; then
     echo "Installing Python dependencies from pyproject.toml..."
-    uv pip install --system -e ".[dev]"
-    echo "✓ Python dependencies installed"
+    # Non-fatal: when python3 resolves to a uv-managed interpreter this
+    # fails under PEP 668 (externally managed), and `set -e` would abort
+    # the rest of bootstrap. This repo always has uv.lock, so this branch
+    # only serves forks or derivatives without a lockfile.
+    if uv pip install --system -e ".[dev]"; then
+        echo "✓ Python dependencies installed"
+    else
+        echo "⚠ uv pip install --system failed (PEP 668 externally-managed interpreter?); run 'uv venv && uv pip install -e .[dev]' instead"
+    fi
 else
     echo "⚠ No pyproject.toml found, skipping Python dependency installation"
 fi
@@ -169,7 +192,7 @@ if ! command -v actionlint &>/dev/null; then
     mkdir -p "$HOME/.local/bin"
     TMP_DIR=$(mktemp -d)
     trap 'rm -rf -- "$TMP_DIR"' EXIT
-    curl -fsSL "$AL_URL" -o "$TMP_DIR/$AL_TARBALL"
+    curl "${CURL_RETRY_OPTS[@]}" -fsSL "$AL_URL" -o "$TMP_DIR/$AL_TARBALL"
     echo "${AL_SHA256}  $TMP_DIR/$AL_TARBALL" | sha256sum --check --strict
     tar -xzf "$TMP_DIR/$AL_TARBALL" -C "$TMP_DIR" actionlint
     install -m 755 "$TMP_DIR/actionlint" "$HOME/.local/bin/actionlint"

--- a/scripts/bootstrap-vm.sh
+++ b/scripts/bootstrap-vm.sh
@@ -37,97 +37,73 @@ gh --version
 
 [[ -n "${GITHUB_TOKEN:-}" ]] && export GH_TOKEN="$GITHUB_TOKEN"
 
-echo "=== pyenv (Python 3.12.8) ==="
-# Python 3.13.7 has a critical bug affecting CodeQL extractor and skill validation
-# See: https://github.com/python/cpython/issues/128974 (frozen modules issue)
-# Ubuntu 25.10 has no packages for 3.12.x, so we use pyenv
-if ! command -v pyenv &>/dev/null; then
-    # Install build dependencies for Python compilation
-    sudo apt-get install -y -qq build-essential libssl-dev zlib1g-dev \
-        libbz2-dev libreadline-dev libsqlite3-dev curl git \
-        libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-
-    # Install pyenv: Download installer, verify, and execute locally
-    # This avoids piping curl directly to bash (security best practice)
-    curl -fsSL https://pyenv.run -o /tmp/pyenv-installer.sh
-    bash /tmp/pyenv-installer.sh
-    rm -f /tmp/pyenv-installer.sh
-
-    # Add pyenv to PATH for this session
-    export PYENV_ROOT="$HOME/.pyenv"
-    export PATH="$PYENV_ROOT/bin:$PATH"
-    eval "$(pyenv init -)"
-
-    # Add pyenv to shell config for future sessions
-    # Detect shell and update appropriate config file
-    SHELL_CONFIG=""
-    # Guard with default-empty expansions because the script runs under
-    # `set -u`. ZSH_VERSION/BASH_VERSION are unset when the script is invoked
-    # by a non-interactive shell (e.g. SessionStart hook on a fresh
-    # container), and `set -u` would otherwise abort here on first run.
-    if [[ -n "${ZSH_VERSION:-}" ]] || [[ "${SHELL:-}" == *"zsh"* ]]; then
-        SHELL_CONFIG="$HOME/.zshrc"
-    elif [[ -n "${BASH_VERSION:-}" ]] || [[ "${SHELL:-}" == *"bash"* ]]; then
-        SHELL_CONFIG="$HOME/.bashrc"
-    else
-        # Default to bashrc if shell cannot be detected
-        SHELL_CONFIG="$HOME/.bashrc"
-    fi
-
-    # Only add if not already present
-    if ! grep -q "PYENV_ROOT" "$SHELL_CONFIG" 2>/dev/null; then
-        {
-            echo ''
-            echo '# pyenv'
-            echo 'export PYENV_ROOT="$HOME/.pyenv"'
-            echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
-            echo 'eval "$(pyenv init -)"'
-        } >> "$SHELL_CONFIG"
-        echo "Added pyenv configuration to $SHELL_CONFIG"
-    fi
-fi
-
-# Ensure pyenv is available
-export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:$PATH"
-if command -v pyenv &>/dev/null; then
-    eval "$(pyenv init -)"
-fi
-
-# Install Python 3.12.8
-if ! pyenv versions --bare | grep -q "^3.12.8$"; then
-    echo "Installing Python 3.12.8 via pyenv (this may take a few minutes)..."
-    pyenv install 3.12.8
-fi
-
-# Set Python 3.12.8 as the local version for this project
-if [[ -d ".git" ]]; then
-    pyenv local 3.12.8
-    echo "Python 3.12.8 set as local version (.python-version file created)"
-fi
-
-python3 --version
-
 echo "=== Python uv ==="
-if ! command -v uv &>/dev/null && [[ ! -f "$HOME/.local/bin/uv" ]]; then
+export PATH="$HOME/.local/bin:$PATH"
+# Single source of truth for the interpreter version is the committed
+# .python-version pin. Do not hardcode interpreter versions in this script;
+# bump the pin instead.
+PYTHON_PIN=""
+if [[ -f ".python-version" ]]; then
+    PYTHON_PIN="$(tr -d '[:space:]' < .python-version)"
+fi
+
+# Container images can ship a uv too old to know the pinned interpreter
+# (uv 0.8.17 predates the CPython 3.14.x downloads). Detect by capability,
+# not version compare: ask uv to resolve the pin against its download list,
+# and re-run the standalone installer when it cannot. Never use
+# `uv self update` here: that path queries the GitHub API and gets
+# rate-limited on shared container egress IPs.
+if ! command -v uv &>/dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+elif [[ -n "$PYTHON_PIN" ]] && ! uv python list "$PYTHON_PIN" 2>/dev/null | grep -q .; then
+    echo "uv $(uv --version) cannot resolve Python ${PYTHON_PIN}; reinstalling latest uv"
     curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
-export PATH="$HOME/.local/bin:$PATH"
 grep -q 'local/bin' "$HOME/.bashrc" 2>/dev/null || echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+uv --version
+
+echo "=== Python ${PYTHON_PIN:-(no .python-version pin)} ==="
+if [[ -n "$PYTHON_PIN" ]]; then
+    # Prebuilt interpreter download (seconds). The previous pyenv source
+    # compile took minutes and blew the SessionStart hook budget on Claude
+    # web containers, so the steps after it never ran. --default links
+    # python3/python into ~/.local/bin so bare python3 resolves to the
+    # pinned interpreter.
+    uv python install --default "$PYTHON_PIN"
+fi
+python3 --version
 
 echo "=== Python Dependencies ==="
-if [[ -f "pyproject.toml" ]]; then
+if [[ -f "uv.lock" ]]; then
+    # Sync the project venv from the lockfile, dev extras included. The
+    # pre-push gate (.githooks/pre-push) runs validation through
+    # `uv run --frozen`, so .venv is the environment that must exist for a
+    # push to validate without on-the-fly downloads.
+    uv sync --frozen --extra dev
+    echo "✓ Python dependencies synced into .venv (uv sync --frozen --extra dev)"
+
+    # Put the project venv first on PATH for this run and future shells so
+    # bare `python3 scripts/...` invocations (AGENTS.md, CI docs) resolve to
+    # the synced environment. Installing project deps into the interpreter
+    # itself is not an option: uv-managed interpreters are PEP 668
+    # externally-managed and uv refuses to modify them. The venv is the one
+    # environment that has the project deps.
+    VENV_BIN="$(pwd)/.venv/bin"
+    export PATH="$VENV_BIN:$PATH"
+    grep -qF "$VENV_BIN" "$HOME/.bashrc" 2>/dev/null \
+        || echo "export PATH=\"$VENV_BIN:\$PATH\"" >> "$HOME/.bashrc"
+
+    # Verify key tools are available through the project environment
+    if uv run --frozen ruff --version &>/dev/null; then
+        echo "✓ ruff $(uv run --frozen ruff --version) available for Python linting"
+    fi
+    if uv run --frozen pytest --version &>/dev/null; then
+        echo "✓ pytest $(uv run --frozen pytest --version 2>&1 | head -1) available for Python testing"
+    fi
+elif [[ -f "pyproject.toml" ]]; then
     echo "Installing Python dependencies from pyproject.toml..."
     uv pip install --system -e ".[dev]"
     echo "✓ Python dependencies installed"
-
-    # Verify key tools are available
-    if command -v ruff &>/dev/null; then
-        echo "✓ ruff $(ruff --version) available for Python linting"
-    fi
-    if command -v pytest &>/dev/null; then
-        echo "✓ pytest $(pytest --version 2>&1 | head -1) available for Python testing"
-    fi
 else
     echo "⚠ No pyproject.toml found, skipping Python dependency installation"
 fi
@@ -198,7 +174,10 @@ if ! command -v actionlint &>/dev/null; then
     fi
 fi
 if ! command -v yamllint &>/dev/null; then
-    uv pip install --system yamllint --quiet
+    # `uv tool install` puts the yamllint shim into ~/.local/bin (on PATH);
+    # a `uv pip install` into the uv-managed interpreter would land the
+    # entry point in the interpreter's own bin dir, off PATH.
+    uv tool install --quiet yamllint
 
     if ! command -v yamllint &>/dev/null; then
         echo "yamllint installation failed: binary not found on PATH" >&2

--- a/scripts/bootstrap-vm.sh
+++ b/scripts/bootstrap-vm.sh
@@ -33,7 +33,17 @@ sudo apt-get install -y -qq curl wget git jq unzip zstd apt-transport-https \
 
 echo "=== Node.js LTS ==="
 if ! command -v node &>/dev/null; then
-    curl "${CURL_OPTS[@]}" -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+    # Signed keyring + explicit apt repo instead of piping the NodeSource
+    # setup script into root bash (semgrep curl-pipe-bash: a MITM'd response
+    # would execute as root). NODE_MAJOR pins the current LTS line because
+    # NodeSource publishes no rolling LTS path (node_lts.x returns 404).
+    NODE_MAJOR=22
+    curl "${CURL_RETRY_OPTS[@]}" -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key -o /tmp/nodesource.gpg
+    sudo gpg --yes --dearmor -o /usr/share/keyrings/nodesource.gpg /tmp/nodesource.gpg
+    rm -f /tmp/nodesource.gpg
+    echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | \
+        sudo tee /etc/apt/sources.list.d/nodesource.list >/dev/null
+    sudo apt-get update -qq
     sudo apt-get install -y -qq nodejs
 fi
 node --version && npm --version

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.167",
+  "version": "0.5.168",
   "author": {
     "name": "rjmurillo"
   }


### PR DESCRIPTION
# Pull Request

## Summary

### What

`scripts/bootstrap-vm.sh` now provisions the pinned Python (`.python-version`, currently 3.14.5) via uv prebuilt downloads and syncs the project `.venv`, replacing the pyenv source-compile of a hardcoded 3.12.8. `.claude/hooks/session-start.sh` persists a venv-first PATH so bare `python3` resolves to the synced interpreter.

### Why

On fresh Claude Code web containers the pre-push gate could not run without manual setup every session: the pyenv source compile (minutes) blew the SessionStart hook budget so uv was never upgraded and deps never installed; the image's uv 0.8.17 predates CPython 3.14.x downloads and the gate's `uv run --frozen python` probe (`.githooks/pre-push:153`) failed; `uv self update` is GitHub-API rate-limited. The hardcoded 3.12.8 also contradicted the committed pin (moved to 3.14.5 by #2394), and `pyenv local 3.12.8` would clobber it.

Alternatives: pyenv is the incumbent that failed. uv was chosen over conda (a second toolchain to install and operate) and direct CPython downloads (no pin resolution or dependency management) because the repo already uses uv for deps and the gate already runs through `uv run --frozen`, so one tool owns the whole chain. Reversible: the pyenv block can be restored from git history if the uv path fails on some platform.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #2394 | PR that moved `.python-version` to 3.14.5, creating the image mismatch |

### Spec Requirement Guidelines

Bug fix / infrastructure PR: spec optional per the template's guidance table; root cause explained above.

## Changes

- `scripts/bootstrap-vm.sh`: anchor to repo root via `BASH_SOURCE` (CWE-22 defense); read `.python-version` as single source of truth; reinstall uv via the astral.sh standalone installer (download-then-execute, never `curl | sh`, never `uv self update`) when `uv python list <pin>` cannot resolve the pin; `uv python install --default <pin>` (prebuilt, seconds); `uv sync --frozen --extra dev` to build the `.venv` the pre-push gate uses; venv-first PATH in bashrc; `--connect-timeout/--max-time` on all curls, retry+backoff on file downloads; Node.js via signed keyring + explicit apt repo (`node_22.x`) instead of piping the NodeSource setup script to root bash; non-fatal PEP 668 fallback for lockfile-less forks; yamllint via `uv tool install`
- `.claude/hooks/session-start.sh`: persist `<repo>/.venv/bin` first in `CLAUDE_ENV_FILE` PATH, with the append keyed on the venv marker (not `PYENV_ROOT`) so containers that ran the older hook still upgrade; rewrote stale pyenv comments
- `.claude/.claude-plugin/plugin.json`, `src/copilot-cli/.claude-plugin/plugin.json`: bump to 0.5.168 (session-start.sh is plugin source; manifest parity)
- `.serena/memories/ci/environment-observations.md`, `.serena/memories/python/python-version-compatibility.md`: mark the pyenv-3.12.8 guidance SUPERSEDED
- `.agents/sessions/2026-06-10-session-2381-*.json`, `.agents/memory/episodes/episode-2026-06-10-*.json`, `.agents/retrospective/2026-06-10-auto-retro.md`, `docs/retros/INDEX.md`: session protocol artifacts

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted review, standard scrutiny (developer-environment scripts, no production code), no rush

**Focus areas**: PATH ordering in `session-start.sh` (venv-first), the uv capability check in `bootstrap-vm.sh`, and the NodeSource keyring block

## Testing

Deliverables in this PR:

- [ ] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Verified in a Claude web container that had the exact failure state (uv 0.8.17, system Python 3.11): bootstrap exits 0 three times including once from a foreign CWD (idempotent + anchored); uv 0.11.19; `python3` -> `.venv/bin/python3` = 3.14.5 with `import yaml` OK; gate probe `uv run --frozen python` OK; `pre_pr.py --quick` all green; the NodeSource keyring + `node_22.x` repo resolves nodejs 22.22.3 (`node_lts.x` 404s, which is why Semgrep's literal suggestion was adjusted); every push of this branch ran the full `.githooks/pre-push` gate in this environment and passed. The QA gate's "pre-executed pytest failure" is container fixture noise: the managed environment forces commit signing through a session-scoped signing server that rejects commits in throwaway fixture repos (exit 128); the PR's CI test jobs report no failed jobs.

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [ ] No security-critical changes in this PR
- [x] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [x] Security patterns applied (see `.agents/security/`)

**Files requiring security review:**

- `scripts/bootstrap-vm.sh` (AI quality gate security agent: PASS; Semgrep curl-pipe-bash finding fixed via signed keyring + apt repo)
- `.claude/hooks/session-start.sh` (CWE-22 anchored path resolution)

### Other Agent Reviews

- [x] Architect reviewed design changes (AI quality gate)
- [ ] Critic validated implementation plan
- [x] QA verified test coverage (AI quality gate QA: PASS)

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`python3 scripts/validation/pre_pr.py --quick`)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if you did not write it)
- [x] Comments added only where the *why* is non-obvious
- [ ] Documentation updated (if applicable) - CONTRIBUTING.md pyenv section flagged as doc-only follow-up
- [x] No new warnings introduced

## Notes for Reviewers

Noticed, not fixed (follow-ups): `CONTRIBUTING.md` Prerequisites still documents the pyenv 3.12.8 flow (doc-only follow-up); the Pester `Install-Module` step runs unconditionally every session start (~1-2 min) and could be guarded by an installed-version check.

## Related Issues

Refs #2394

https://claude.ai/code/session_01PXZEcFFAMANwT7hUTuNTA9