### PR TITLE
test(workflows): assert action pin shape, not exact SHA, in retrospective test (Fixes #2348)

### DIFF
--- a/.agents/memory/episodes/episode-2026-06-10-session-2381-fix-issue-2348-derive-action.json
+++ b/.agents/memory/episodes/episode-2026-06-10-session-2381-fix-issue-2348-derive-action.json
@@ -1,0 +1,18 @@
+{
+  "id": "episode-2026-06-10-session-2381-fix-issue-2348-derive-action",
+  "session": "2026-06-10-session-2381-fix-issue-2348-derive-action",
+  "timestamp": "2026-06-10T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Fix issue 2348: derive action pin shape from workflow in post-pr-retrospective test",
+  "decisions": [],
+  "events": [],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 0
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-06-10-session-2381-fix-issue-2348-derive-action.json
+++ b/.agents/sessions/2026-06-10-session-2381-fix-issue-2348-derive-action.json
@@ -1,0 +1,129 @@
+{
+  "session": {
+    "number": 2381,
+    "date": "2026-06-10",
+    "branch": "fix/2348-derive-action-pin",
+    "startingCommit": "42068c0",
+    "objective": "Fix issue 2348: derive action pin shape from workflow in post-pr-retrospective test"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP active; get_symbols_overview used on test file this session"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena server instructions present in session context"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-loaded via SessionStart context loader"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Skill catalog auto-injected; session-init script used"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md, CLAUDE.md, .claude/rules/*.md loaded in session context"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read this session"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory observations injected via hooks; session memory written earlier"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2348-derive-action-pin"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/2348-derive-action-pin"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git fetch origin main + branch created from origin/main 42068c0"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "42068c0"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart/sessionEnd MUST items complete"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified this session (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Wrote .serena memory session-2026-06-10-latent-issues-review earlier this session"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown files changed in this commit (py/json only)"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Committed in this commit (test fix + session log)"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "validate_session_json.py run after field completion, exit code: 0"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "2026-06-10",
+      "entry": "Issue #2348: replaced exact-SHA _ACTION_REF with pin-shape regex (_SHA_PINNED_ACTION_RE) in tests/workflows/test_post_pr_retrospective.py; added 6 negative controls (floating tag, short SHA, wrong owner, subpath, uppercase hex, valid-shape acceptance)"
+    },
+    {
+      "time": "2026-06-10",
+      "entry": "Verification: uv run pytest tests/workflows/test_post_pr_retrospective.py -q: 16 passed in 0.14s; ruff check on the file: All checks passed"
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Open PR Fixes #2348; CI Python Tests should go green on next Renovate action bump without test edits"
+  ]
+}

--- a/tests/workflows/test_post_pr_retrospective.py
+++ b/tests/workflows/test_post_pr_retrospective.py
@@ -13,6 +13,7 @@ to a step annotation, not a red check.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -22,9 +23,14 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "post-pr-retrospective.yml"
 
 _AGENT_STEP_NAME = "Run retrospective via Claude Code"
-_ACTION_REF = (
-    "anthropics/claude-code-action@593d7a5c4e0073569f74772c2b7b64c30ec14707"
-)
+_ACTION_PATH = "anthropics/claude-code-action"
+# Assert the pin's SHAPE (exact action path + 40-hex SHA), not an exact SHA.
+# Renovate owns the SHA and bumps it in the workflow; duplicating the literal
+# here re-broke main on every bump (Issue #2348, recurrence 2026-06-09 after
+# the v1.0.140/141/142 bumps in #2486/#2506/#2516).
+_SHA_PINNED_ACTION_RE = re.compile(rf"^{re.escape(_ACTION_PATH)}@[0-9a-f]{{40}}$")
+# Synthetic, valid-shape ref for in-memory negative-control workflows.
+_FAKE_ACTION_REF = f"{_ACTION_PATH}@{'0' * 40}"
 _OAUTH_TOKEN_EXPR = "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
 
 
@@ -96,9 +102,13 @@ class TestAgentStepFailureIsolation:
         assert step is not None
         # Act
         uses = step.get("uses", "")
-        # Assert: exact pin so a path change (owner/repo/path@ref) is caught,
-        # not just the prefix
-        assert uses == _ACTION_REF
+        # Assert: the action path is exact (a repo/owner/path change is caught)
+        # and the ref is a full 40-hex commit SHA (a floating tag is caught).
+        # The specific SHA is owned by the workflow + Renovate, not this test.
+        assert _SHA_PINNED_ACTION_RE.fullmatch(uses), (
+            f"agent step 'uses' is {uses!r}; expected "
+            f"'{_ACTION_PATH}@<40-hex-sha>'"
+        )
 
     def test_agent_step_still_wires_oauth_token(self) -> None:
         # Arrange
@@ -127,7 +137,7 @@ class TestFailureIsolationDetectionNegative:
             "jobs": {
                 "retrospective": {
                     "steps": [
-                        {"name": _AGENT_STEP_NAME, "uses": _ACTION_REF},
+                        {"name": _AGENT_STEP_NAME, "uses": _FAKE_ACTION_REF},
                     ]
                 }
             }
@@ -147,7 +157,7 @@ class TestFailureIsolationDetectionNegative:
                     "steps": [
                         {
                             "name": _AGENT_STEP_NAME,
-                            "uses": _ACTION_REF,
+                            "uses": _FAKE_ACTION_REF,
                             "continue-on-error": False,
                         },
                     ]
@@ -160,6 +170,45 @@ class TestFailureIsolationDetectionNegative:
         continue_on_error = step.get("continue-on-error")
         # Assert
         assert continue_on_error is not True
+
+
+class TestShaPinPredicateNegative:
+    """Negative coverage: the pin-shape predicate rejects bad refs.
+
+    The positive test asserts shape, not an exact SHA. These controls prove
+    the relaxation did not open the door to floating tags, short SHAs, or a
+    hijacked action path.
+    """
+
+    def test_floating_tag_is_rejected(self) -> None:
+        # Arrange / Act / Assert
+        assert _SHA_PINNED_ACTION_RE.fullmatch(f"{_ACTION_PATH}@v1") is None
+
+    def test_short_sha_is_rejected(self) -> None:
+        # Arrange / Act / Assert
+        assert _SHA_PINNED_ACTION_RE.fullmatch(f"{_ACTION_PATH}@{'a' * 12}") is None
+
+    def test_wrong_owner_is_rejected(self) -> None:
+        # Arrange
+        hijacked = f"evil/claude-code-action@{'0' * 40}"
+        # Act / Assert
+        assert _SHA_PINNED_ACTION_RE.fullmatch(hijacked) is None
+
+    def test_subpath_suffix_is_rejected(self) -> None:
+        # Arrange: a path change after the action name must be caught
+        suffixed = f"{_ACTION_PATH}/subdir@{'0' * 40}"
+        # Act / Assert
+        assert _SHA_PINNED_ACTION_RE.fullmatch(suffixed) is None
+
+    def test_uppercase_hex_is_rejected(self) -> None:
+        # Arrange: GitHub SHAs are lowercase; uppercase signals a hand edit
+        # Act / Assert
+        assert _SHA_PINNED_ACTION_RE.fullmatch(f"{_ACTION_PATH}@{'A' * 40}") is None
+
+    def test_valid_shape_is_accepted(self) -> None:
+        # Arrange / Act / Assert: the synthetic ref used by negative-control
+        # workflows passes, proving those fixtures stay representative
+        assert _SHA_PINNED_ACTION_RE.fullmatch(_FAKE_ACTION_REF) is not None
 
 
 class TestStepLookupEdgeCases:


### PR DESCRIPTION
## Summary

### What

Replaces the exact-SHA equality assertion in `tests/workflows/test_post_pr_retrospective.py` with a pin-SHAPE assertion: the agent step's `uses` ref must be exactly `anthropics/claude-code-action@<40-hex-sha>`. The specific SHA is no longer duplicated in the test.

### Why

Renovate owns the action SHA and bumps it in the workflow (`post-pr-retrospective.yml:243`). The test hardcoded the same SHA, so every bump (#2486 v1.0.140, #2506 v1.0.141, #2516 v1.0.142) re-broke `Python Tests` on `main` until someone hand-edited the test. The 2026-06-09 recurrence left main red on every push (run 27232682871). Acceptance criterion 3 of #2348 ("future action pin updates require one source-of-truth change") was never delivered on the first close; this delivers it.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2348 | post-pr-retrospective workflow pin test drifts from workflow |

## Changes

- `tests/workflows/test_post_pr_retrospective.py`:
  - `_ACTION_REF` (exact SHA) replaced with `_SHA_PINNED_ACTION_RE` (`^anthropics/claude-code-action@[0-9a-f]{40}$`).
  - `test_agent_step_keeps_sha_pinned_action` now asserts shape, not the literal SHA.
  - Added `_FAKE_ACTION_REF` (valid-shape synthetic) for the in-memory negative-control workflows.
  - Added `TestShaPinPredicateNegative` with 6 controls: floating tag, short SHA, wrong owner, subpath suffix, uppercase hex (all rejected), and valid-shape acceptance.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard, unblocks main

**Focus areas**: the regex still catches the things the old exact assertion caught (action-path hijack, floating tag, non-SHA ref) while tolerating Renovate's SHA bumps. The negative controls prove that.

## Testing

Deliverables in this PR:

- [x] Tests added/updated

`uv run pytest tests/workflows/test_post_pr_retrospective.py -q` gives **16 passed** against the current v1.0.142 pin. `ruff` and `mypy` clean on the file.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR (test-only; the assertion still enforces full-SHA pinning, so it does not weaken supply-chain posture)

## Author Pre-flight

- [x] Pre-PR validation passed (full pre-push suite green)
- [x] Lint and formatting clean (ruff, mypy)
- [x] Self-review completed
- [x] No new warnings introduced

## Related Issues

Fixes #2348.

---

https://claude.ai/code/session_01JPLKQWSjsSh2XHfh7mZvkr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPLKQWSjsSh2XHfh7mZvkr)_