### PR TITLE
docs: remove drift-prone component counts from README and skill-reference (Fixes #2525)

### DIFF
--- a/.agents/memory/episodes/episode-2026-06-10-session-2381-fix-issue-2525-remove-hardcoded.json
+++ b/.agents/memory/episodes/episode-2026-06-10-session-2381-fix-issue-2525-remove-hardcoded.json
@@ -1,0 +1,18 @@
+{
+  "id": "episode-2026-06-10-session-2381-fix-issue-2525-remove-hardcoded",
+  "session": "2026-06-10-session-2381-fix-issue-2525-remove-hardcoded",
+  "timestamp": "2026-06-10T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Fix issue 2525: remove hardcoded component counts from README and skill-reference, replace with non-drifting prose; mark incoherence deprecated",
+  "decisions": [],
+  "events": [],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 0
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-06-10-session-2381-fix-issue-2525-remove-hardcoded.json
+++ b/.agents/sessions/2026-06-10-session-2381-fix-issue-2525-remove-hardcoded.json
@@ -1,0 +1,133 @@
+{
+  "session": {
+    "number": 2381,
+    "date": "2026-06-10",
+    "branch": "fix/2525-remove-readme-counts",
+    "startingCommit": "42068c0",
+    "objective": "Fix issue 2525: remove hardcoded component counts from README and skill-reference, replace with non-drifting prose; mark incoherence deprecated"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP active; get_symbols_overview used on README/skill-reference this session"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena server instructions in session context"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-loaded via SessionStart context loader"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Skill catalog auto-injected; session-init used"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md, CLAUDE.md, .claude/rules/*.md in session context"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read this session"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory observations injected via hooks"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2525-remove-readme-counts"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/2525-remove-readme-counts"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git branch from origin/main; grep count sweep run"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "42068c0"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart/sessionEnd MUST items complete"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Session memory written earlier this session"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 README.md docs/skill-reference.md: 0 errors"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Committed in this commit (README + skill-reference + session log)"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "validate_session_json.py exit code: 0"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "2026-06-10",
+      "entry": "Issue #2525: removed all hardcoded component counts from README.md (lines 38,115,163,164,174,176,386) and the per-category Skills count column from docs/skill-reference.md; replaced with non-drifting prose per maintainer directive. Verify Installation section reports exact per-install counts instead."
+    },
+    {
+      "time": "2026-06-10",
+      "entry": "Marked the incoherence skill entry deprecated in docs/skill-reference.md with a pointer to doc-accuracy (anchor verified)."
+    },
+    {
+      "time": "2026-06-10",
+      "entry": "Verification: grep sweep confirms NO hardcoded counts remain in README.md or docs/skill-reference.md; markdownlint-cli2 on both files = 0 errors."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Open PR Fixes #2525"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Specialized agent roles include analyst, architect, implementer, QA, security, d
 
 AI Agents is a coordinated multi-agent system for software development. It provides specialized AI agents that handle different phases of the development lifecycle, from research and planning through implementation and quality assurance.
 
-The orchestrator is the hub of operations. Within it has logic from taking everything from a "vibe" or a "shower thought" and building out a fully functional spec with acceptance criteria and user stories, to taking a well defined idea as input and executing on it. Both bundles ship a roster of agents that cover the roles of software development, from vision and strategy, to architecture, implementation, and verification. Each role looks at something specific, like the critic that just looks to poke holes in other agents' (or your own) work, or DevOps that's concerned about how you deploy and operate the thing you just built.
+The orchestrator is the hub of operations. Its logic spans the full range, from taking a "vibe" or a "shower thought" and building out a functional spec with acceptance criteria and user stories, to taking a well-defined idea as input and executing on it. Both bundles ship a roster of agents that cover the roles of software development, from vision and strategy, to architecture, implementation, and verification. Each role looks at something specific, like the critic that just looks to poke holes in other agents' (or your own) work, or DevOps that's concerned about how you deploy and operate the thing you just built.
 
 The agents themselves use the platform specific handoffs to invoke subagents, keeping the orchestrator context clean. A great example of this is orchestrator facilitating creating and debating an [Architectural Decision Record](https://adr.github.io/) from research and drafting, to discussion, iterating on the issues, tie breaking when agents don't agree. And then  extracting persistent knowledge to steer future agents to adhere. Artifacts are stored in your memory system if you have one enabled, and Markdown files for easy reference to both agents and humans.
 
@@ -383,7 +383,7 @@ flowchart LR
 
 ### Agent Catalog
 
-The Copilot CLI bundle adds `backlog-generator`; both bundles include the rest. `spec-generator` is now a skill (issue #2001), available in both bundles. Both bundles share the same templates.
+The Copilot CLI bundle adds the `backlog-generator` agent; both bundles include all the other agents. `spec-generator` is now a skill (issue #2001), available in both bundles. Both bundles share the same templates.
 
 | Agent | Purpose | Output | Bundle |
 |-------|---------|--------|--------|

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Each AI tool has its own native marketplace flow. This repo ships a Claude Code 
 /plugin install project-toolkit@ai-agents
 ```
 
-A Claude install lands 23 agents, 23 commands, 29 hooks, and 69 skills. A Copilot install lands 24 agents, 28 hooks, and 81 skills generated from the same canonical sources. See [Verify Installation](#verify-installation) for the per-tool sanity check, or [More Installation Options](#alternative-full-installation) for component-level installs (agents only, etc.).
+A Claude install lands the full set of agents, commands, hooks, and skills. A Copilot install lands the same capabilities generated from the same canonical sources. See [Verify Installation](#verify-installation) for the per-tool sanity check that reports the exact counts for your install, or [More Installation Options](#alternative-full-installation) for component-level installs (agents only, etc.).
 
 ### What You Get
 
@@ -112,7 +112,7 @@ Specialized agent roles include analyst, architect, implementer, QA, security, d
 
 AI Agents is a coordinated multi-agent system for software development. It provides specialized AI agents that handle different phases of the development lifecycle, from research and planning through implementation and quality assurance.
 
-The orchestrator is the hub of operations. Within it has logic from taking everything from a "vibe" or a "shower thought" and building out a fully functional spec with acceptance criteria and user stories, to taking a well defined idea as input and executing on it. The Claude bundle ships 23 agents and the Copilot bundle ships 24 agents that cover the roles of software development, from vision and strategy, to architecture, implementation, and verification. Each role looks at something specific, like the critic that just looks to poke holes in other agents' (or your own) work, or DevOps that's concerned about how you deploy and operate the thing you just built.
+The orchestrator is the hub of operations. Within it has logic from taking everything from a "vibe" or a "shower thought" and building out a fully functional spec with acceptance criteria and user stories, to taking a well defined idea as input and executing on it. Both bundles ship a roster of agents that cover the roles of software development, from vision and strategy, to architecture, implementation, and verification. Each role looks at something specific, like the critic that just looks to poke holes in other agents' (or your own) work, or DevOps that's concerned about how you deploy and operate the thing you just built.
 
 The agents themselves use the platform specific handoffs to invoke subagents, keeping the orchestrator context clean. A great example of this is orchestrator facilitating creating and debating an [Architectural Decision Record](https://adr.github.io/) from research and drafting, to discussion, iterating on the issues, tie breaking when agents don't agree. And then  extracting persistent knowledge to steer future agents to adhere. Artifacts are stored in your memory system if you have one enabled, and Markdown files for easy reference to both agents and humans.
 
@@ -160,8 +160,8 @@ The [Fastest Start](#fastest-start) commands install the full toolkit. For compo
 
 | Component | Install Command | What You Get |
 |-----------|----------------|--------------|
-| Claude agents only | `/plugin install claude-agents@ai-agents` | 24 agent definitions from `src/claude/` (no skills, commands, or hooks) |
-| Project toolkit | `/plugin install project-toolkit@ai-agents` | 23 agents, 23 slash commands, 29 hooks, and 69 reusable skills from `.claude/` |
+| Claude agents only | `/plugin install claude-agents@ai-agents` | Agent definitions from `src/claude/` (no skills, commands, or hooks) |
+| Project toolkit | `/plugin install project-toolkit@ai-agents` | Agents, slash commands, hooks, and reusable skills from `.claude/` |
 
 **GitHub Copilot CLI:**
 
@@ -171,9 +171,9 @@ The [Fastest Start](#fastest-start) commands install the full toolkit. For compo
 
 | Component | Install Command | What You Get |
 |-----------|----------------|--------------|
-| Copilot full toolkit | `/plugin install project-toolkit@ai-agents` | 24 agents, 28 hooks, 81 skills from `src/copilot-cli/` (Copilot CLI) |
+| Copilot full toolkit | `/plugin install project-toolkit@ai-agents` | Agents, hooks, and skills from `src/copilot-cli/` (Copilot CLI) |
 
-Claude exposes both an agents-only bundle (`claude-agents`, from `src/claude/`) and the full toolkit (`project-toolkit`, from `./.claude`); the latter ships 23 agents because `src/claude/` and `.claude/agents/` are two different curated sets, kept in sync where they overlap. Copilot CLI installs ship a single `project-toolkit` plugin from `src/copilot-cli/` because that directory's `plugin.json` declares one identity; an agents-only Copilot install would silently register as `project-toolkit` and is therefore not advertised (issue #1840).
+Claude exposes both an agents-only bundle (`claude-agents`, from `src/claude/`) and the full toolkit (`project-toolkit`, from `./.claude`); the two draw from different curated sets (`src/claude/` versus `.claude/agents/`), kept in sync where they overlap. Copilot CLI installs ship a single `project-toolkit` plugin from `src/copilot-cli/` because that directory's `plugin.json` declares one identity; an agents-only Copilot install would silently register as `project-toolkit` and is therefore not advertised (issue #1840).
 
 ### Verify Installation
 
@@ -383,7 +383,7 @@ flowchart LR
 
 ### Agent Catalog
 
-The Claude Code bundle ships 23 agents and the Copilot CLI bundle ships 24 (Copilot adds `backlog-generator`; both bundles include the rest). `spec-generator` is now a skill (issue #2001), available in both bundles. Both bundles share the same templates.
+The Copilot CLI bundle adds `backlog-generator`; both bundles include the rest. `spec-generator` is now a skill (issue #2001), available in both bundles. Both bundles share the same templates.
 
 | Agent | Purpose | Output | Bundle |
 |-------|---------|--------|--------|

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ A Claude install lands the full set of agents, commands, hooks, and skills. A Co
 
 | Component | Claude Code | Copilot CLI |
 |-----------|-------------|-------------|
-| Agents | 23 | 24 |
-| Skills | 69 | 81 |
-| Slash commands | 23 | n/a (interactive only) |
-| Lifecycle hooks | 29 | 28 |
-| Session protocol | 1 | 1 |
-| Review gates | 5 | 5 |
+| Agents | Included | Included |
+| Skills | Included | Included |
+| Slash commands | Included | n/a (interactive only) |
+| Lifecycle hooks | Included | Included |
+| Session protocol | Included | Included |
+| Review gates | Included | Included |
 
 Specialized agent roles include analyst, architect, implementer, QA, security, devops, and more. See the [Agent Catalog](#agent-catalog) for the full list.
 
@@ -118,13 +118,13 @@ The agents themselves use the platform specific handoffs to invoke subagents, ke
 
 ### Core Capabilities
 
-- **23+ specialized agents** for different development phases (analysis, architecture, implementation, QA, etc.)
+- **Specialized agents** for different development phases (analysis, architecture, implementation, QA, etc.)
 - **Explicit handoff protocols** between agents with clear accountability
 - **Multi-Agent Impact Analysis Framework** for comprehensive planning
 - **Cross-session memory** with citation verification, graph traversal, and health reporting via Serena + Forgetful
 - **Self-improvement system** with skill tracking and retrospectives
 - **Quality gates** with pre-PR validation, session protocol enforcement, and automated CI checks
-- **69+ reusable skills** for common development workflows (git, PR management, testing, linting)
+- **Reusable skills** for common development workflows (git, PR management, testing, linting)
 - **One-step plugin install** through Claude Code's `/install-plugin` or Copilot CLI's `/plugin marketplace add` flow
 - **AI-powered CI/CD** with issue triage, PR quality gates, and spec validation
 
@@ -135,7 +135,7 @@ The agents themselves use the platform specific handoffs to invoke subagents, ke
 | **Agent** | A specialized AI persona with a defined role (analyst, implementer, security, etc.) |
 | **Orchestrator** | The coordinating agent that routes tasks to specialists and synthesizes results |
 | **Handoff** | Explicit transfer of context and control between agents with clear accountability |
-| **Skill** | A reusable workflow component for common tasks (69+ included: git, PR, testing, linting) |
+| **Skill** | A reusable workflow component for common tasks (git, PR, testing, linting, and more) |
 | **Memory** | Cross-session context persistence via Serena + Forgetful for knowledge retention |
 | **ADR** | Architectural Decision Record, structured documents capturing design decisions |
 | **Quality Gate** | Validation checkpoint (critic review, QA pass, security scan) before proceeding |
@@ -524,8 +524,8 @@ This project uses a **template-based generation system**. To modify agents:
 | Document | Description |
 |----------|-------------|
 | [docs/getting-started.md](docs/getting-started.md) | Step-by-step setup guide |
-| [docs/agent-catalog.md](docs/agent-catalog.md) | All agents with capabilities and examples (23 in Claude bundle, 24 in Copilot bundle) |
-| [docs/skill-reference.md](docs/skill-reference.md) | All skills with usage descriptions (69 in Claude bundle, 81 in Copilot bundle) |
+| [docs/agent-catalog.md](docs/agent-catalog.md) | All agents with capabilities and examples |
+| [docs/skill-reference.md](docs/skill-reference.md) | All skills with usage descriptions |
 | [docs/architecture.md](docs/architecture.md) | Plugin structure, template system, design decisions |
 | [docs/customization.md](docs/customization.md) | How to extend and customize agents, skills, and hooks |
 | [docs/installation.md](docs/installation.md) | Complete installation guide |

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -1,6 +1,6 @@
 # Skill Reference
 
-Skills are reusable workflow components that agents and users invoke for common tasks. Skills are organized by category; counts in the table below reflect the categories documented in this reference.
+Skills are reusable workflow components that agents and users invoke for common tasks. Skills are organized by category in the table below.
 
 ## How to Use Skills
 

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -128,7 +128,7 @@ Assesses code maintainability through 5 foundational qualities: cohesion, coupli
 
 ### incoherence
 
-> **Deprecated.** Use [doc-accuracy](#doc-accuracy) instead, which absorbed incoherence detection and is the canonical doc-vs-code audit entrypoint. Retained only for the legacy `scripts/incoherence.py` reconciliation workflow.
+> **Deprecated.** Use [doc-accuracy](#doc-accuracy) instead, which absorbed incoherence detection and is the canonical doc-vs-code audit entrypoint. Retained only for the legacy `.claude/skills/incoherence/scripts/incoherence.py` reconciliation workflow.
 
 Detects contradictions between documentation and code, ambiguous definitions, and inconsistent patterns across the codebase.
 

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -20,19 +20,19 @@ Agents invoke skills internally. You do not call skills directly.
 
 ## Skill Categories
 
-| Category | Skills | Purpose |
-|----------|--------|---------|
-| [GitHub Operations](#github-operations) | 3 | PR management, issue operations, URL handling |
-| [Session Management](#session-management) | 6 | Session lifecycle, validation, migration |
-| [Memory and Knowledge](#memory-and-knowledge) | 6 | Memory search, curation, exploration, enhancement |
-| [Security](#security) | 4 | Scanning, detection, threat modeling, CodeQL |
-| [Code Quality](#code-quality) | 6 | Style enforcement, taste lints, golden principles, code-qualities assessment, incoherence detection, codebase analysis |
-| [Architecture and Design](#architecture-and-design) | 7 | ADR review, CVA, decisions, architecture analysis |
-| [Planning and Strategy](#planning-and-strategy) | 4 | Planning, pre-mortem, buy-vs-build, Cynefin |
-| [Documentation](#documentation) | 3 | Doc accuracy verification, markdown fixes, context optimization |
-| [Development Workflows](#development-workflows) | 5 | Git workflows, merge resolution, metrics, encoding |
-| [Agent and Skill Management](#agent-and-skill-management) | 3 | Skill creation, Serena symbols, reflection |
-| [Research](#research) | 3 | Research, programming advice, prompt engineering |
+| Category | Purpose |
+|----------|---------|
+| [GitHub Operations](#github-operations) | PR management, issue operations, URL handling |
+| [Session Management](#session-management) | Session lifecycle, validation, migration |
+| [Memory and Knowledge](#memory-and-knowledge) | Memory search, curation, exploration, enhancement |
+| [Security](#security) | Scanning, detection, threat modeling, CodeQL |
+| [Code Quality](#code-quality) | Style enforcement, taste lints, golden principles, code-qualities assessment, incoherence detection, codebase analysis |
+| [Architecture and Design](#architecture-and-design) | ADR review, CVA, decisions, architecture analysis |
+| [Planning and Strategy](#planning-and-strategy) | Planning, pre-mortem, buy-vs-build, Cynefin |
+| [Documentation](#documentation) | Doc accuracy verification, markdown fixes, context optimization |
+| [Development Workflows](#development-workflows) | Git workflows, merge resolution, metrics, encoding |
+| [Agent and Skill Management](#agent-and-skill-management) | Skill creation, Serena symbols, reflection |
+| [Research](#research) | Research, programming advice, prompt engineering |
 
 ## GitHub Operations
 
@@ -127,6 +127,8 @@ Analyzes codebase architecture, security posture, or code quality. Produces stru
 Assesses code maintainability through 5 foundational qualities: cohesion, coupling, DRY, encapsulation, and testability.
 
 ### incoherence
+
+> **Deprecated.** Use [doc-accuracy](#doc-accuracy) instead, which absorbed incoherence detection and is the canonical doc-vs-code audit entrypoint. Retained only for the legacy `scripts/incoherence.py` reconciliation workflow.
 
 Detects contradictions between documentation and code, ambiguous definitions, and inconsistent patterns across the codebase.
 


### PR DESCRIPTION
## Summary

### What

Removes every hardcoded component count from `README.md` (seven places) and the per-category skill-count column from `docs/skill-reference.md`, replacing them with non-drifting prose. Also marks the deprecated `incoherence` skill entry with a pointer to `doc-accuracy`.

### Why

The counts (23 agents / 23 commands / 29 hooks / 69 skills, etc.) drifted from the tree and matched no single counting method, so every skill/agent/hook addition silently invalidated them, producing recurring bot-flagged drift and merge churn with no validator to catch it. Per maintainer direction, the durable fix is to stop hardcoding counts in prose rather than add a validator: the numbers were marketing copy that cost more in churn than they delivered. Readers who want exact numbers are pointed to the Verify Installation section, which reports the counts for their actual install.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2525 | README component counts drifted from tree; skill-reference lists deprecated incoherence as active |

## Changes

- `README.md`: lines 38, 115, 163, 164, 174, 176, 386 reworded to drop hardcoded counts (e.g. "23 agents, 23 commands, 29 hooks, and 69 skills" -> "the full set of agents, commands, hooks, and skills"). The intro now points to Verify Installation for per-install exact counts.
- `docs/skill-reference.md`: dropped the "Skills" count column from the category table; marked the `incoherence` entry deprecated with a link to `doc-accuracy` (anchor verified present).

## Type of Change

- [x] Documentation update

## Reviewer Expectations

**Review kind / scrutiny / urgency**: rubber stamp, low, no rush

**Focus areas**: prose only; no behavioral claims. A `grep` sweep confirms no hardcoded counts remain in either file.

## Testing

- [x] No testing required (documentation only)

`markdownlint-cli2 README.md docs/skill-reference.md` reports 0 errors. Full pre-push suite green.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

## Author Pre-flight

- [x] Pre-PR validation passed (full pre-push suite green)
- [x] Lint clean (markdownlint 0 errors)
- [x] Self-review completed

## Related Issues

Fixes #2525.

---

https://claude.ai/code/session_01JPLKQWSjsSh2XHfh7mZvkr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPLKQWSjsSh2XHfh7mZvkr)_