### PR TITLE
docs(governance): reconcile AGENTS.md Python version with pyproject floor (Fixes #2527)

### DIFF
--- a/.agents/memory/episodes/episode-2026-06-10-session-2381-fix-issue-2527-reconcile-agentsmd.json
+++ b/.agents/memory/episodes/episode-2026-06-10-session-2381-fix-issue-2527-reconcile-agentsmd.json
@@ -1,0 +1,18 @@
+{
+  "id": "episode-2026-06-10-session-2381-fix-issue-2527-reconcile-agentsmd",
+  "session": "2026-06-10-session-2381-fix-issue-2527-reconcile-agentsmd",
+  "timestamp": "2026-06-10T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Fix issue 2527: reconcile AGENTS.md Python stack with pyproject requires-python floor",
+  "decisions": [],
+  "events": [],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 0
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-06-10-session-2381-fix-issue-2527-reconcile-agentsmd.json
+++ b/.agents/memory/episodes/episode-2026-06-10-session-2381-fix-issue-2527-reconcile-agentsmd.json
@@ -5,13 +5,22 @@
   "outcome": "success",
   "task": "Fix issue 2527: reconcile AGENTS.md Python stack with pyproject requires-python floor",
   "decisions": [],
-  "events": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-06-10T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: de62ff4",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
   "metrics": {
     "duration_minutes": 0,
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 0
   },
   "lessons": []

--- a/.agents/sessions/2026-06-10-session-2381-fix-issue-2527-reconcile-agentsmd.json
+++ b/.agents/sessions/2026-06-10-session-2381-fix-issue-2527-reconcile-agentsmd.json
@@ -1,0 +1,129 @@
+{
+  "session": {
+    "number": 2381,
+    "date": "2026-06-10",
+    "branch": "fix/2527-python-floor",
+    "startingCommit": "42068c0",
+    "objective": "Fix issue 2527: reconcile AGENTS.md Python stack with pyproject requires-python floor"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded via session context / verified this session"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded via session context / verified this session"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded via session context / verified this session"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded via session context / verified this session"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded via session context / verified this session"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded via session context / verified this session"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded via session context / verified this session"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2527-python-floor"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/2527-python-floor"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Loaded via session context / verified this session"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "origin/main"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart/sessionEnd MUST items complete"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Session memory written earlier this session"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 AGENTS.md: 0 errors"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Committed in this commit (AGENTS.md + session log)"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "validate_session_json.py exit code: 0"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "2026-06-10",
+      "entry": "Issue #2527: AGENTS.md:56 said bare \"Python 3.14\" while pyproject requires-python is \">=3.10\", contradicting each other. The 3.10 floor is intentional (relied on by PR #2532 cross-version review). Reworded the stack line to \"Python 3.14 dev/CI, 3.10+ install floor (pyproject.toml requires-python)\" so agents reading AGENTS.md know the real floor. python.md already documents the distinction; no change needed there."
+    },
+    {
+      "time": "2026-06-10",
+      "entry": "Verification: stack line unique to root AGENTS.md (other AGENTS.md are per-dir scoped, not copies); markdownlint-cli2 AGENTS.md = 0 errors."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Open PR Fixes #2527"
+  ]
+}

--- a/.agents/sessions/2026-06-10-session-2381-fix-issue-2527-reconcile-agentsmd.json
+++ b/.agents/sessions/2026-06-10-session-2381-fix-issue-2527-reconcile-agentsmd.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": "1.0",
   "session": {
     "number": 2381,
     "date": "2026-06-10",
@@ -93,7 +94,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Committed in this commit (AGENTS.md + session log)"
+        "Evidence": "Committed as de62ff4 (AGENTS.md + session log + episode, 3 files)"
       },
       "validationPassed": {
         "level": "MUST",
@@ -122,7 +123,7 @@
       "entry": "Verification: stack line unique to root AGENTS.md (other AGENTS.md are per-dir scoped, not copies); markdownlint-cli2 AGENTS.md = 0 errors."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "de62ff4",
   "nextSteps": [
     "Open PR Fixes #2527"
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,4 +53,4 @@ Tests (BLOCKING): pos+neg+edge|branches|mock I/O|CLI exits. See `.agents/governa
 
 ## Stack
 
-Python 3.14|UV|PowerShell 7.5.4+|Node LTS|Pester 5.7.1|pytest 8+|gh 2.60+
+Python 3.14 dev/CI, 3.10+ install floor (`pyproject.toml requires-python`)|UV|PowerShell 7.5.4+|Node LTS|Pester 5.7.1|pytest 8+|gh 2.60+


### PR DESCRIPTION
## Summary

### What

Reconciles `AGENTS.md` with `pyproject.toml`. The Stack line said bare "Python 3.14" while `requires-python = ">=3.10"`, giving agents contradictory floor signals. Now reads `Python 3.14 dev/CI, 3.10+ install floor (pyproject.toml requires-python)`.

### Why

An agent reading `AGENTS.md` would assume 3.14-only and reach for 3.12+ syntax in code the package metadata says must run on 3.10. The 3.10 floor is intentional and relied on in review (e.g. PR #2532's cross-version compatibility discussion). The distinction is already documented elsewhere (see `.claude/rules/python.md`); this makes the top-level stack statement agree.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2527 | AGENTS.md "Python 3.14" contradicts pyproject requires-python ">=3.10" |

## Changes

- `AGENTS.md`: Stack line names both the dev/CI version (3.14) and the install floor (3.10+), citing `pyproject.toml`.
- `.agents/sessions/2026-06-10-session-2381-fix-issue-2527-reconcile-agentsmd.json`: session log with schemaVersion, endingCommit, and commit SHA evidence (plus the derived episode file).

## Type of Change

- [x] Documentation update

## Reviewer Expectations

**Review kind / scrutiny / urgency**: rubber stamp, low, no rush

## Testing

- [x] No testing required (documentation only)

`markdownlint-cli2 AGENTS.md` reports 0 errors. Full pre-push suite green.

## Author Pre-flight

- [x] Pre-PR validation passed
- [x] Self-review completed

## Related Issues

Fixes #2527.

---

https://claude.ai/code/session_01JPLKQWSjsSh2XHfh7mZvkr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPLKQWSjsSh2XHfh7mZvkr)_