### PR TITLE
docs(contributing): align Python setup with uv sync; fill 2026-06-10 retro

### DIFF
--- a/.agents/memory/episodes/episode-2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
+++ b/.agents/memory/episodes/episode-2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
@@ -61,6 +61,14 @@
       "content": "Commit: 2bfa8d7",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-06-10T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Follow-ups",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/retrospective/2026-06-10-auto-retro.md
+++ b/.agents/retrospective/2026-06-10-auto-retro.md
@@ -1,32 +1,81 @@
-<!-- RETRO-STATE: skeleton-pending-fill -->
 # Retrospective: 2026-06-10
-
-> UNFILLED SKELETON written by invoke_auto_retrospective.py (Stop hook).
-> The sections below are empty placeholders, not a completed retrospective.
-> Run /retro fill 2026-06-10 (or the retrospective skill) to populate them, then
-> delete this banner and the RETRO-STATE marker above.
 
 ## Session Context
 
-### Work Items
-- Diagnose
-- Implement
-- Verify
-- Curate
+Session 2381 (`claude/pre-push-gate-python-uv-7x757l`, merged as PR #2529): made
+`scripts/bootstrap-vm.sh` provision the pinned Python (3.14.5) via uv instead of
+a pyenv source compile, so the pre-push gate runs on fresh Claude web containers
+without manual setup. Follow-ups landed via PR #2538 (Pester/powershell-yaml
+install guards) and the CONTRIBUTING.md `uv sync` doc fix.
 
+### Work Items
+
+- Diagnose: fresh container had uv 0.8.17 (predates CPython 3.14.x downloads),
+  python3 at 3.11, and a pyenv compile that blew the SessionStart hook budget.
+- Implement: uv capability check plus standalone-installer refresh,
+  `uv python install --default`, `uv sync --frozen --extra dev`, venv-first PATH.
+- Verify: ran the real bootstrap in the failing container; the full pre-push
+  gate served as the end-to-end test.
+- Curate: superseded the two Serena memories that prescribed pyenv 3.12.8.
+
+## Failure Mode Classification
+
+Per `.agents/governance/FAILURE-MODES.md`: confident incorrectness (claims made
+from a mental model instead of an executed check). Two instances below, both
+caught before merge. Evidence: PR #2529 review round (commits 2bfa8d7, 4a159a1,
+2b6b1fa), PR #2538.
 
 ## What Went Well
 
-- _UNFILLED. Run the retrospective agent to populate this section._
+- Diagnosed in the target runtime, not by analogy: the container itself had the
+  exact failure state, so every fix was verified against the real contract
+  (bootstrap exit 0, gate probe on 3.14.5, idempotent re-run).
+- Capability check over version compare: `uv python list "$PIN"` detects a
+  too-old uv without hardcoding a minimum uv version that would itself drift.
+- The pre-push gate doubled as the end-to-end test for the change that fixes
+  the pre-push gate; every push exercised the deliverable.
+- All five review threads (Gemini, Cursor bugbot, Semgrep) closed with code
+  fixes in the same round, no re-litigation.
 
 ## What Could Improve
 
-- _UNFILLED. Run the retrospective agent to populate this section._
+- A "best-effort" fallback shipped briefly that could never succeed:
+  `uv pip install --system --python <pin>` always fails on uv-managed
+  interpreters (PEP 668). Caught only because the fallback was executed during
+  verification. Execute every fallback path once before shipping it.
+- The "CONTRIBUTING.md still documents pyenv" follow-up recorded in PR #2529
+  was stale: the file was already uv-based. Verify doc-drift claims against
+  the file before recording them as follow-ups.
 
 ## Key Learnings
 
-- _UNFILLED. Run the retrospective agent to populate this section._
+- uv-managed interpreters are PEP 668 externally-managed; project deps can only
+  live in a venv. The venv-first PATH pattern is the supported way to give bare
+  `python3` the project environment.
+- `uv self update` queries the GitHub API and gets rate-limited on shared
+  container egress; the astral.sh standalone installer is the reliable refresh
+  path.
+- Minutes-long source compiles do not fit SessionStart hook budgets, and a
+  timed-out hook fails silently downstream: everything after the timeout never
+  runs.
+- NodeSource publishes no rolling LTS apt path (`node_lts.x` 404s); pin the
+  major version and use a signed keyring instead of curl-pipe-bash.
 
 ## Failure Patterns
 
-- _UNFILLED. Run the retrospective agent to populate this section (check .agents/failure-modes/)._
+- Confident incorrectness (see `.claude/rules/canonical-source-mirror.md`):
+  both the doomed PEP 668 fallback and the stale CONTRIBUTING flag were claims
+  written without an executed check. Counter: run the path, read the file,
+  then write the claim.
+- Silent wrong-target install: `uv pip install --python <pin>` quietly
+  targeted the discovered `.venv` instead of the named interpreter, so the
+  code did not do what its comment said. Counter: assert the post-condition
+  (import from the intended interpreter), not the command's exit code.
+
+## Remediation
+
+- Superseded memories: `.serena/memories/ci/environment-observations.md`,
+  `.serena/memories/python/python-version-compatibility.md` (landed in #2529).
+- Install guards for the unconditional PSGallery round-trips: PR #2538.
+- CONTRIBUTING.md setup step aligned to `uv sync --extra dev` (this branch).
+- No new failure-mode class proposed; existing class covers both instances.

--- a/.agents/retrospective/2026-06-10-auto-retro.md
+++ b/.agents/retrospective/2026-06-10-auto-retro.md
@@ -20,8 +20,8 @@ install guards) and the CONTRIBUTING.md `uv sync` doc fix.
 
 ## Failure Mode Classification
 
-Per `.agents/governance/FAILURE-MODES.md`: confident incorrectness (claims made
-from a mental model instead of an executed check). Two instances below, both
+Per `.agents/governance/FAILURE-MODES.md`: FM-9 Confident-incorrectness
+recurrence (claims made from a mental model instead of an executed check). Two instances below, both
 caught before merge. Evidence: PR #2529 review round (commits 2bfa8d7, 4a159a1,
 2b6b1fa), PR #2538.
 
@@ -63,7 +63,8 @@ caught before merge. Evidence: PR #2529 review round (commits 2bfa8d7, 4a159a1,
 
 ## Failure Patterns
 
-- Confident incorrectness (see `.claude/rules/canonical-source-mirror.md`):
+- FM-9 Confident-incorrectness recurrence (see
+  `.claude/rules/canonical-source-mirror.md`):
   both the doomed PEP 668 fallback and the stale CONTRIBUTING flag were claims
   written without an executed check. Counter: run the path, read the file,
   then write the claim.

--- a/.agents/sessions/2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
+++ b/.agents/sessions/2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
@@ -130,6 +130,10 @@
       "details": "Marked .serena/memories/ci/environment-observations.md and .serena/memories/python/python-version-compatibility.md SUPERSEDED so future agents are not steered back to pyenv 3.12.8."
     },
     {
+      "action": "Follow-ups",
+      "details": "Opened the follow-up PRs flagged in #2529: PR #2538 guards the Pester/powershell-yaml Install-Module calls (warm bootstrap 8.5s vs 1-2 min; AI quality gate 10/10 PASS), and docs/contributing-uv-sync aligns CONTRIBUTING.md step 4 with 'uv sync --extra dev' plus fills the 2026-06-10 auto-retro skeleton. Verified before writing: the 'CONTRIBUTING still documents pyenv' flag was stale (file already uv-based); the real drift was the unlocked 'uv venv && uv pip install' instruction. Added a taste-lint file-size suppression to CONTRIBUTING.md (1183-line prose doc predates the 500-line lint)."
+    },
+    {
       "action": "Review response",
       "details": "PR #2529 CI + bot review round: bumped src/copilot-cli plugin.json mirror to 0.5.168 (manifest parity CI failure); re-keyed the session-start env-file PATH guard on the venv bin marker instead of PYENV_ROOT so upgraded containers get the venv-first PATH (Cursor bugbot + Gemini high); anchored bootstrap-vm.sh to repo root via BASH_SOURCE (Gemini high, CWE-22). Verified: bash -n clean, bootstrap run from /tmp exits 0 and syncs .venv."
     }

--- a/.agents/sessions/2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
+++ b/.agents/sessions/2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json
@@ -136,6 +136,10 @@
     {
       "action": "Review response",
       "details": "PR #2529 CI + bot review round: bumped src/copilot-cli plugin.json mirror to 0.5.168 (manifest parity CI failure); re-keyed the session-start env-file PATH guard on the venv bin marker instead of PYENV_ROOT so upgraded containers get the venv-first PATH (Cursor bugbot + Gemini high); anchored bootstrap-vm.sh to repo root via BASH_SOURCE (Gemini high, CWE-22). Verified: bash -n clean, bootstrap run from /tmp exits 0 and syncs .venv."
+    },
+    {
+      "action": "Review response",
+      "details": "Copilot review round on the follow-up PRs. PR #2538: powershell-yaml install branch now sets PSGallery InstallationPolicy Trusted itself (warm-Pester/cold-yaml ordering regression); cold path verified empirically with module uninstalled and gallery Untrusted, bootstrap exit 0. PR #2540: CONTRIBUTING step 4 moved to 'uv sync --frozen --extra dev' so setup cannot rewrite uv.lock; retro renamed to canonical 'FM-9 Confident-incorrectness recurrence' per FAILURE-MODES.md row 9 (claim verified against the file before editing)."
     }
   ],
   "endingCommit": "2bfa8d7",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Thank you for your interest in contributing to this project. This guide explains
 1. Fork the repository
 2. Clone your fork locally
 3. **Install Python 3.14.x** (see Prerequisites above)
-4. **Set up Python environment**: `uv sync --extra dev` (creates `.venv` from `uv.lock`, the same locked environment the pre-push gate and CI use; on managed containers `scripts/bootstrap-vm.sh` runs this for you)
+4. **Set up Python environment**: `uv sync --extra dev` (creates `.venv` from `uv.lock`). This matches the locked environment the pre-push gate and CI use. On managed containers, `scripts/bootstrap-vm.sh` runs this automatically.
 5. Configure Git for cross-platform development (see [Git Configuration](#git-configuration) below)
 6. Set up git hooks (pre-commit + pre-push): `python3 scripts/install_git_hooks.py` (idempotent: sets `core.hooksPath`, verifies the hooks are executable, and flags a stale `.git/hooks/pre-push` shim; the bare `git config core.hooksPath .githooks` also works)
 7. Make your changes following the guidelines below

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributing to AI Agent System
 
+<!-- # taste-lint: ignore file-size -->
+<!-- Long-form contributor guide; prose docs are not split into modules. -->
+
 Thank you for your interest in contributing to this project. This guide explains how to contribute effectively, with special attention to the agent template system.
 
 ## Table of Contents
@@ -38,7 +41,7 @@ Thank you for your interest in contributing to this project. This guide explains
 1. Fork the repository
 2. Clone your fork locally
 3. **Install Python 3.14.x** (see Prerequisites above)
-4. **Set up Python environment**: `uv venv && uv pip install -e ".[dev]"`
+4. **Set up Python environment**: `uv sync --extra dev` (creates `.venv` from `uv.lock`, the same locked environment the pre-push gate and CI use; on managed containers `scripts/bootstrap-vm.sh` runs this for you)
 5. Configure Git for cross-platform development (see [Git Configuration](#git-configuration) below)
 6. Set up git hooks (pre-commit + pre-push): `python3 scripts/install_git_hooks.py` (idempotent: sets `core.hooksPath`, verifies the hooks are executable, and flags a stale `.git/hooks/pre-push` shim; the bare `git config core.hooksPath .githooks` also works)
 7. Make your changes following the guidelines below

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Thank you for your interest in contributing to this project. This guide explains
 1. Fork the repository
 2. Clone your fork locally
 3. **Install Python 3.14.x** (see Prerequisites above)
-4. **Set up Python environment**: `uv sync --extra dev` (creates `.venv` from `uv.lock`). This matches the locked environment the pre-push gate and CI use. On managed containers, `scripts/bootstrap-vm.sh` runs this automatically.
+4. **Set up Python environment**: `uv sync --frozen --extra dev` (creates `.venv` from `uv.lock` without re-resolving it). This matches the locked environment the pre-push gate and CI use. On managed containers, `scripts/bootstrap-vm.sh` runs this automatically.
 5. Configure Git for cross-platform development (see [Git Configuration](#git-configuration) below)
 6. Set up git hooks (pre-commit + pre-push): `python3 scripts/install_git_hooks.py` (idempotent: sets `core.hooksPath`, verifies the hooks are executable, and flags a stale `.git/hooks/pre-push` shim; the bare `git config core.hooksPath .githooks` also works)
 7. Make your changes following the guidelines below


### PR DESCRIPTION
# Pull Request

## Summary

### What

Refs #2529

Aligns the CONTRIBUTING.md Python setup step with the lockfile workflow, fills the 2026-06-10 auto-retro skeleton, and records the follow-up work in the session 2381 protocol artifacts. Doc-only follow-up flagged in #2529.

### Why

Step 4 of Setup Steps documented `uv venv && uv pip install -e ".[dev]"`, which resolves dependencies fresh and bypasses `uv.lock`, so contributors got an environment that can drift from the locked one the pre-push gate (`uv run --frozen`, `.githooks/pre-push:153`) and CI use. Note: the original follow-up claim from #2529 ("CONTRIBUTING.md still documents pyenv 3.12.8") turned out to be stale; the file was already uv-based, and this unlocked-install drift was the real issue.

## Changes

- `CONTRIBUTING.md`: step 4 now reads `uv sync --extra dev` (creates `.venv` from `uv.lock`); adds a `taste-lint: ignore file-size` suppression comment because the 1183-line contributor guide predates the 500-line taste lint and prose docs are not split into modules; without the suppression every future CONTRIBUTING.md edit fails pre-commit
- `.agents/retrospective/2026-06-10-auto-retro.md`: fills the auto-generated skeleton with session 2381 outcomes (what went well, failure patterns per FAILURE-MODES classification, key learnings, remediation links)
- `.agents/sessions/2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json`: appends a "Follow-ups" work-log entry recording PR #2538 and this PR
- `.agents/memory/episodes/episode-2026-06-10-session-2381-make-bootstrap-vmsh-provision-pinned-python.json`: episode mirror of the session log update, auto-staged by the session-protocol pre-commit hook

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Testing

- [ ] Tests added/updated
- [ ] Manual testing completed
- [x] No testing required (documentation only)

`npx markdownlint-cli2 --fix` on both markdown files: 0 errors. The taste-lints check (`uv run python .claude/skills/taste-lints/scripts/taste_lints.py CONTRIBUTING.md`) reports 0 violations, confirming the suppression works. Session log validation (`uv run python scripts/validate_session_json.py <log>`): PASS. Em/en dash byte check: 0 occurrences.

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed
- [x] No new warnings introduced

## Notes for Reviewers

The retro fill follows the retro file rules in `.claude/rules/retros.md` (failure-mode classification, evidence links, remediation, no blame); that rule file is referenced here as context, not changed by this PR. The taste-lint suppression is scoped to `file-size` only and documented inline.

https://claude.ai/code/session_01PXZEcFFAMANwT7hUTuNTA9