### PR TITLE
fix(ci): pr-maintenance auto-resolve calls resolve_pr_conflicts.py, not removed PS1 (Fixes #2519)

### DIFF
--- a/.agents/memory/episodes/episode-2026-06-10-session-2381-fix-issue-2348-derive-action.json
+++ b/.agents/memory/episodes/episode-2026-06-10-session-2381-fix-issue-2348-derive-action.json
@@ -1,0 +1,18 @@
+{
+  "id": "episode-2026-06-10-session-2381-fix-issue-2348-derive-action",
+  "session": "2026-06-10-session-2381-fix-issue-2348-derive-action",
+  "timestamp": "2026-06-10T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Fix issue 2348: derive action pin shape from workflow in post-pr-retrospective test",
+  "decisions": [],
+  "events": [],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 0
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-06-10-session-2381-fix-issue-2519-pr-maintenance-auto-resolve.json
+++ b/.agents/memory/episodes/episode-2026-06-10-session-2381-fix-issue-2519-pr-maintenance-auto-resolve.json
@@ -1,0 +1,18 @@
+{
+  "id": "episode-2026-06-10-session-2381-fix-issue-2519-pr-maintenance-auto-resolve",
+  "session": "2026-06-10-session-2381-fix-issue-2519-pr-maintenance-auto-resolve",
+  "timestamp": "2026-06-10T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Fix issue 2519: pr-maintenance auto-resolve calls existing resolve_pr_conflicts.py instead of removed Resolve-PRConflicts.ps1",
+  "decisions": [],
+  "events": [],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 0
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-06-10-session-2381-fix-issue-2348-derive-action.json
+++ b/.agents/sessions/2026-06-10-session-2381-fix-issue-2348-derive-action.json
@@ -1,0 +1,129 @@
+{
+  "session": {
+    "number": 2381,
+    "date": "2026-06-10",
+    "branch": "fix/2348-derive-action-pin",
+    "startingCommit": "42068c0",
+    "objective": "Fix issue 2348: derive action pin shape from workflow in post-pr-retrospective test"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP active; get_symbols_overview used on test file this session"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena server instructions present in session context"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-loaded via SessionStart context loader"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Skill catalog auto-injected; session-init script used"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md, CLAUDE.md, .claude/rules/*.md loaded in session context"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read this session"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory observations injected via hooks; session memory written earlier"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2348-derive-action-pin"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/2348-derive-action-pin"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git fetch origin main + branch created from origin/main 42068c0"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "42068c0"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart/sessionEnd MUST items complete"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified this session (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Wrote .serena memory session-2026-06-10-latent-issues-review earlier this session"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown files changed in this commit (py/json only)"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Committed in this commit (test fix + session log)"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "validate_session_json.py run after field completion, exit code: 0"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "2026-06-10",
+      "entry": "Issue #2348: replaced exact-SHA _ACTION_REF with pin-shape regex (_SHA_PINNED_ACTION_RE) in tests/workflows/test_post_pr_retrospective.py; added 6 negative controls (floating tag, short SHA, wrong owner, subpath, uppercase hex, valid-shape acceptance)"
+    },
+    {
+      "time": "2026-06-10",
+      "entry": "Verification: uv run pytest tests/workflows/test_post_pr_retrospective.py -q: 16 passed in 0.14s; ruff check on the file: All checks passed"
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Open PR Fixes #2348; CI Python Tests should go green on next Renovate action bump without test edits"
+  ]
+}

--- a/.agents/sessions/2026-06-10-session-2381-fix-issue-2519-pr-maintenance-auto-resolve.json
+++ b/.agents/sessions/2026-06-10-session-2381-fix-issue-2519-pr-maintenance-auto-resolve.json
@@ -1,0 +1,134 @@
+{
+  "session": {
+    "number": 2381,
+    "date": "2026-06-10",
+    "branch": "fix/2519-missing-ps1",
+    "startingCommit": "42068c0",
+    "objective": "Fix issue 2519: pr-maintenance auto-resolve calls existing resolve_pr_conflicts.py instead of removed Resolve-PRConflicts.ps1"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded/verified this session"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded/verified this session"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded/verified this session"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded/verified this session"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded/verified this session"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded/verified this session"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded/verified this session"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2519-missing-ps1"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/2519-missing-ps1"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Loaded/verified this session"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Loaded/verified this session"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Done this session"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Done this session"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Done this session"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown changed (workflow yaml only)"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Done this session"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "validate_session_json.py exit code: 0; workflow YAML parses"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "2026-06-10",
+      "entry": "Issue #2519: .github/workflows/pr-maintenance.yml auto-resolve step called ./.claude/skills/merge-resolver/scripts/Resolve-PRConflicts.ps1, removed in the ADR-042 Python migration (dir has only resolve_pr_conflicts.py). Every PR with conflicts hit a hard PowerShell error and the conflict path was dead. Rewired the step to call python3 resolve_pr_conflicts.py with --owner/--repo/--pr-number/--branch-name/--target-branch and parse the snake_case JSON (success/files_resolved/files_blocked)."
+    },
+    {
+      "time": "2026-06-10",
+      "entry": "Also routed PR number + branch names through env (PR_NUMBER/HEAD_REF/BASE_REF/REPO_OWNER/REPO_NAME) instead of run-block ${{ }} interpolation, hardening this step against CWE-78 injection via crafted PR branch names (partial #2520)."
+    },
+    {
+      "time": "2026-06-10",
+      "entry": "Verification: target script resolve_pr_conflicts.py exists; workflow YAML parses via yaml.safe_load. AC2 (a CI validator that fails when a workflow references a nonexistent script path) deferred: a naive scan false-positives across 57 workflows and risks an #1711-style all-PR block; needs careful allowlist design. Noted as follow-up."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Open PR Fixes #2519",
+    "Follow-up: design a low-false-positive workflow-script-path validator (AC2)"
+  ]
+}

--- a/.agents/sessions/2026-06-10-session-2381-fix-issue-2519-pr-maintenance-auto-resolve.json
+++ b/.agents/sessions/2026-06-10-session-2381-fix-issue-2519-pr-maintenance-auto-resolve.json
@@ -124,6 +124,10 @@
     {
       "time": "2026-06-10",
       "entry": "Verification: target script resolve_pr_conflicts.py exists; workflow YAML parses via yaml.safe_load. AC2 (a CI validator that fails when a workflow references a nonexistent script path) deferred: a naive scan false-positives across 57 workflows and risks an #1711-style all-PR block; needs careful allowlist design. Noted as follow-up."
+    },
+    {
+      "time": "2026-06-10",
+      "entry": "PR #2545 Cursor high-severity finding: resolve_pr_conflicts.py exits 1 for the expected blocked-resolution outcome (return 0 if success else 1, line 493), and the step never inspected $LASTEXITCODE, so a blocked resolution could fail the step and skip the needs_ai AI-analysis steps; a real error (exit 2/3/4, non-JSON stdout) would crash ConvertFrom-Json opaquely. Fix: capture $resolverExit after the python3 call, fail loudly with ::error for exit >1, and exit 0 explicitly after writing needs_ai outputs. Verified: workflow YAML parses via yaml.safe_load."
     }
   ],
   "endingCommit": "",

--- a/.github/workflows/pr-maintenance.yml
+++ b/.github/workflows/pr-maintenance.yml
@@ -131,24 +131,35 @@ jobs:
         if: matrix.hasConflicts == true && (inputs.process_conflicts != false)
         env:
           GH_TOKEN: ${{ secrets.BOT_PAT }}
+          PR_NUMBER: ${{ matrix.number }}
+          HEAD_REF: ${{ matrix.headRefName }}
+          BASE_REF: ${{ matrix.baseRefName }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
         shell: pwsh -NoProfile -Command "& '{0}'"
         run: |
-          Write-Host "Attempting auto-resolution for PR #${{ matrix.number }}"
-          Write-Host "Branch: ${{ matrix.headRefName }} -> ${{ matrix.baseRefName }}"
+          Write-Host "Attempting auto-resolution for PR #$env:PR_NUMBER"
+          Write-Host "Branch: $env:HEAD_REF -> $env:BASE_REF"
 
-          $result = ./.claude/skills/merge-resolver/scripts/Resolve-PRConflicts.ps1 `
-            -PRNumber ${{ matrix.number }} `
-            -BranchName '${{ matrix.headRefName }}' `
-            -TargetBranch '${{ matrix.baseRefName }}'
+          # Issue #2519: the PowerShell Resolve-PRConflicts.ps1 was removed in the
+          # ADR-042 Python migration; call the existing Python resolver instead.
+          # Branch names flow through env (not run-block interpolation) to avoid
+          # CWE-78 injection via crafted PR branch names.
+          $result = python3 ./.claude/skills/merge-resolver/scripts/resolve_pr_conflicts.py `
+            --owner $env:REPO_OWNER `
+            --repo $env:REPO_NAME `
+            --pr-number $env:PR_NUMBER `
+            --branch-name $env:HEAD_REF `
+            --target-branch $env:BASE_REF
 
           $parsed = $result | ConvertFrom-Json
-          if ($parsed.Success) {
-            Write-Host "::notice::PR #${{ matrix.number }}: Auto-resolved - $($parsed.FilesResolved.Count) file(s)"
+          if ($parsed.success) {
+            Write-Host "::notice::PR #$($env:PR_NUMBER): Auto-resolved - $($parsed.files_resolved.Count) file(s)"
             "needs_ai=false" | Out-File $env:GITHUB_OUTPUT -Append
           } else {
-            Write-Host "::warning::PR #${{ matrix.number }}: Auto-resolution blocked on: $($parsed.FilesBlocked -join ', ')"
+            Write-Host "::warning::PR #$($env:PR_NUMBER): Auto-resolution blocked on: $($parsed.files_blocked -join ', ')"
             "needs_ai=true" | Out-File $env:GITHUB_OUTPUT -Append
-            "blocked_files=$($parsed.FilesBlocked | ConvertTo-Json -Compress)" | Out-File $env:GITHUB_OUTPUT -Append
+            "blocked_files=$($parsed.files_blocked | ConvertTo-Json -Compress)" | Out-File $env:GITHUB_OUTPUT -Append
           }
 
       - name: Prepare conflict context for AI analysis

--- a/.github/workflows/pr-maintenance.yml
+++ b/.github/workflows/pr-maintenance.yml
@@ -151,6 +151,16 @@ jobs:
             --pr-number $env:PR_NUMBER `
             --branch-name $env:HEAD_REF `
             --target-branch $env:BASE_REF
+          $resolverExit = $LASTEXITCODE
+
+          # Resolver exit contract (resolve_pr_conflicts.py, ADR-035): 0 = all
+          # conflicts auto-resolved, 1 = some files blocked. Both are expected
+          # outcomes with JSON on stdout. Exit 2/3/4 = config/external/auth
+          # error where stdout may not be JSON: fail the step loudly.
+          if ($resolverExit -gt 1) {
+            Write-Host "::error::PR #$($env:PR_NUMBER): resolver failed (exit $resolverExit): $result"
+            exit $resolverExit
+          }
 
           $parsed = $result | ConvertFrom-Json
           if ($parsed.success) {
@@ -161,6 +171,11 @@ jobs:
             "needs_ai=true" | Out-File $env:GITHUB_OUTPUT -Append
             "blocked_files=$($parsed.files_blocked | ConvertTo-Json -Compress)" | Out-File $env:GITHUB_OUTPUT -Append
           }
+
+          # Blocked resolution (resolver exit 1) is an expected outcome routed
+          # to the AI steps via needs_ai, not a step failure: clear the lingering
+          # $LASTEXITCODE so the step exits 0 (Cursor finding, PR #2545).
+          exit 0
 
       - name: Prepare conflict context for AI analysis
         id: conflict-context

--- a/tests/workflows/test_post_pr_retrospective.py
+++ b/tests/workflows/test_post_pr_retrospective.py
@@ -13,6 +13,7 @@ to a step annotation, not a red check.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -22,9 +23,14 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "post-pr-retrospective.yml"
 
 _AGENT_STEP_NAME = "Run retrospective via Claude Code"
-_ACTION_REF = (
-    "anthropics/claude-code-action@593d7a5c4e0073569f74772c2b7b64c30ec14707"
-)
+_ACTION_PATH = "anthropics/claude-code-action"
+# Assert the pin's SHAPE (exact action path + 40-hex SHA), not an exact SHA.
+# Renovate owns the SHA and bumps it in the workflow; duplicating the literal
+# here re-broke main on every bump (Issue #2348, recurrence 2026-06-09 after
+# the v1.0.140/141/142 bumps in #2486/#2506/#2516).
+_SHA_PINNED_ACTION_RE = re.compile(rf"^{re.escape(_ACTION_PATH)}@[0-9a-f]{{40}}$")
+# Synthetic, valid-shape ref for in-memory negative-control workflows.
+_FAKE_ACTION_REF = f"{_ACTION_PATH}@{'0' * 40}"
 _OAUTH_TOKEN_EXPR = "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
 
 
@@ -96,9 +102,13 @@ class TestAgentStepFailureIsolation:
         assert step is not None
         # Act
         uses = step.get("uses", "")
-        # Assert: exact pin so a path change (owner/repo/path@ref) is caught,
-        # not just the prefix
-        assert uses == _ACTION_REF
+        # Assert: the action path is exact (a repo/owner/path change is caught)
+        # and the ref is a full 40-hex commit SHA (a floating tag is caught).
+        # The specific SHA is owned by the workflow + Renovate, not this test.
+        assert _SHA_PINNED_ACTION_RE.fullmatch(uses), (
+            f"agent step 'uses' is {uses!r}; expected "
+            f"'{_ACTION_PATH}@<40-hex-sha>'"
+        )
 
     def test_agent_step_still_wires_oauth_token(self) -> None:
         # Arrange
@@ -127,7 +137,7 @@ class TestFailureIsolationDetectionNegative:
             "jobs": {
                 "retrospective": {
                     "steps": [
-                        {"name": _AGENT_STEP_NAME, "uses": _ACTION_REF},
+                        {"name": _AGENT_STEP_NAME, "uses": _FAKE_ACTION_REF},
                     ]
                 }
             }
@@ -147,7 +157,7 @@ class TestFailureIsolationDetectionNegative:
                     "steps": [
                         {
                             "name": _AGENT_STEP_NAME,
-                            "uses": _ACTION_REF,
+                            "uses": _FAKE_ACTION_REF,
                             "continue-on-error": False,
                         },
                     ]
@@ -160,6 +170,45 @@ class TestFailureIsolationDetectionNegative:
         continue_on_error = step.get("continue-on-error")
         # Assert
         assert continue_on_error is not True
+
+
+class TestShaPinPredicateNegative:
+    """Negative coverage: the pin-shape predicate rejects bad refs.
+
+    The positive test asserts shape, not an exact SHA. These controls prove
+    the relaxation did not open the door to floating tags, short SHAs, or a
+    hijacked action path.
+    """
+
+    def test_floating_tag_is_rejected(self) -> None:
+        # Arrange / Act / Assert
+        assert _SHA_PINNED_ACTION_RE.fullmatch(f"{_ACTION_PATH}@v1") is None
+
+    def test_short_sha_is_rejected(self) -> None:
+        # Arrange / Act / Assert
+        assert _SHA_PINNED_ACTION_RE.fullmatch(f"{_ACTION_PATH}@{'a' * 12}") is None
+
+    def test_wrong_owner_is_rejected(self) -> None:
+        # Arrange
+        hijacked = f"evil/claude-code-action@{'0' * 40}"
+        # Act / Assert
+        assert _SHA_PINNED_ACTION_RE.fullmatch(hijacked) is None
+
+    def test_subpath_suffix_is_rejected(self) -> None:
+        # Arrange: a path change after the action name must be caught
+        suffixed = f"{_ACTION_PATH}/subdir@{'0' * 40}"
+        # Act / Assert
+        assert _SHA_PINNED_ACTION_RE.fullmatch(suffixed) is None
+
+    def test_uppercase_hex_is_rejected(self) -> None:
+        # Arrange: GitHub SHAs are lowercase; uppercase signals a hand edit
+        # Act / Assert
+        assert _SHA_PINNED_ACTION_RE.fullmatch(f"{_ACTION_PATH}@{'A' * 40}") is None
+
+    def test_valid_shape_is_accepted(self) -> None:
+        # Arrange / Act / Assert: the synthetic ref used by negative-control
+        # workflows passes, proving those fixtures stay representative
+        assert _SHA_PINNED_ACTION_RE.fullmatch(_FAKE_ACTION_REF) is not None
 
 
 class TestStepLookupEdgeCases:


### PR DESCRIPTION
## Summary

### What

The PR Maintenance workflow's auto-resolve step called Resolve-PRConflicts.ps1, a script that no longer exists in the tree (it was removed when conflict resolution moved to Python). Every scheduled auto-resolve run therefore failed at the missing-script call. This rewires the step to the real script (see `.claude/skills/merge-resolver/scripts/resolve_pr_conflicts.py`) and parses its `snake_case` JSON contract (`success`, `files_resolved`, `files_blocked`).

### Why

The auto-resolve step was dead on arrival: a Resolve-PRConflicts.ps1 invocation that resolves to nothing, so the maintenance workflow could never auto-resolve a conflicted PR (Issue #2519). The Python script that replaced it is present and tested (see `tests/skills/merge-resolver/test_resolve_pr_conflicts.py`).

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2519 | pr-maintenance auto-resolve calls a removed PowerShell script |

## Changes

- `.github/workflows/pr-maintenance.yml`: the auto-resolve step now calls `python3 ./.claude/skills/merge-resolver/scripts/resolve_pr_conflicts.py --owner ... --repo ... --pr-number ... --branch-name ... --target-branch ...`, parsing the `snake_case` result fields. Branch and PR identifiers are passed through the step `env:` block (`PR_NUMBER`, `HEAD_REF`, `BASE_REF`, `REPO_OWNER`, `REPO_NAME`) rather than interpolated into the run script, which closes a `${{ }}`-in-`run` injection seam (CWE-78 hardening; partial overlap with #2520).
- Follow-up commit (Cursor high-severity finding on this PR): the step now captures `$LASTEXITCODE` after the resolver call. Resolver exit 0 (all resolved) and exit 1 (some files blocked, JSON on stdout, routed to the AI steps via `needs_ai`) are both expected outcomes and the step exits 0 explicitly; exit 2/3/4 (config/external/auth, stdout may not be JSON) fail the step loudly with `::error` and the raw output instead of an opaque `ConvertFrom-Json` crash.
- Session-protocol artifacts for the work (session log + extracted episode).

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] Infrastructure/CI change

## Base note

The stacked base `fix/2348-derive-action-pin` (PR #2530) has merged; this PR now targets `main` directly and its diff contains only its own changes.

## Testing

- [x] Workflow YAML parses (`yaml.safe_load`).
- [x] The called script (see `resolve_pr_conflicts.py`) exists and its unit suite passes.
- Full pre-push suite green **except** the `act`/`actionlint`/Docker workflow-local-run, which is **not available in this environment**. That check was bypassed with the hook's sanctioned `SKIP_WORKFLOW_LOCAL_TEST=true` escape hatch (audible warning, not `--no-verify`). CI runs the real workflow validation; a maintainer with `act` available locally can exercise the full local run.

## Deferred follow-up

- AC2 of #2519 (a validator that fails when a workflow references a non-existent script path) is **not** in this PR. A naive "grep workflows for script paths" validator risks false positives across the 57 workflows and could block all PRs (the #1711 failure mode), so it needs its own design pass. Tracked as a follow-up on #2519.

## Author Pre-flight

- [x] Self-review completed
- [x] Workflow YAML validated locally (parse + called-script existence)

## Related Issues

Fixes #2519. Refs #2520 (injection hardening overlap), #2348 (former stacked base, merged as #2530).

---

https://claude.ai/code/session_01JPLKQWSjsSh2XHfh7mZvkr