### PR TITLE
fix(governance): trim AGENTS.md Stack line back under workspace budget (Fixes #2553)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,4 +53,4 @@ Tests (BLOCKING): pos+neg+edge|branches|mock I/O|CLI exits. See `.agents/governa
 
 ## Stack
 
-Python 3.14 (floor per pyproject)|UV|PowerShell 7.5.4+|Node LTS|Pester 5.7.1|pytest 8+|gh 2.60+
+Python 3.14 dev; floor: pyproject|UV|PowerShell 7.5.4+|Node LTS|Pester 5.7.1|pytest 8+|gh 2.60+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,4 +53,4 @@ Tests (BLOCKING): pos+neg+edge|branches|mock I/O|CLI exits. See `.agents/governa
 
 ## Stack
 
-Python 3.14 dev/CI, 3.10+ install floor (`pyproject.toml requires-python`)|UV|PowerShell 7.5.4+|Node LTS|Pester 5.7.1|pytest 8+|gh 2.60+
+Python 3.14 (floor per pyproject)|UV|PowerShell 7.5.4+|Node LTS|Pester 5.7.1|pytest 8+|gh 2.60+


### PR DESCRIPTION
# Pull Request

## Summary

### What

Fixes #2553

Trims the AGENTS.md Stack line from 3,039 back to 2,998 bytes, under the 3,000-byte per-file workspace budget. The Python floor statement now points at pyproject (the single source of truth) instead of restating the version number.

### Why

PR #2536 (merge `0faa74f`) grew the Stack line and pushed AGENTS.md over budget, which broke the workspace-budget test on every Linux "Run Python Tests" job since (first observed on PR #2532, job 80489766047). The regression slipped through because #2536 was docs-only and the path filter skipped the Python test leg; that bypass gap is recorded in #2553 as a follow-up.

The reconciliation intent of #2527 is preserved: the line no longer claims "Python 3.14" as the only supported version, and the install floor lives where it is defined instead of being duplicated.

## Changes

- `AGENTS.md`: Stack line shortened to `Python 3.14 (floor per pyproject)`. File size 3,039 to 2,998 bytes.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] Documentation update

## Testing

- [x] Tests added/updated (existing test now passes)

```text
uv run python scripts/validate_workspace_budget.py
  -> passed (AGENTS.md 2,998 bytes, total 5,968 / 6,600)
uv run pytest tests/test_validate_workspace_budget.py
  -> 19 passed
```

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Lint and formatting clean (scoped to changed file)
- [x] Self-review completed
- [x] No new warnings introduced

## References

- `scripts/validate_workspace_budget.py`: the budget validator (per-file limit at line 29). Not changed by this PR.
- `tests/test_validate_workspace_budget.py`: the failing test this PR turns green. Not changed by this PR.

## Related Issues

Fixes #2553. Refs #2527, #2536.

https://claude.ai/code/session_01MJJt4Nj8TovWc6JmnR8WWf