### PR TITLE
fix(ci): make needs-split labeling non-fatal and route it through the REST API

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -391,8 +391,9 @@ jobs:
           # the real limit), so labeling failures warn instead of failing the job.
           # Mutations go through the REST issues API: gh pr edit mutates via
           # GraphQL, which rejects this workflow's token with HTTP 401 (issue #2557).
-          # 2>$null is safe - PR exists when workflow runs
-          $existingLabels = gh api "repos/$env:GITHUB_REPOSITORY/issues/$env:PR_NUMBER/labels" --jq '.[].name' 2>$null
+          # Stderr stays visible so a failure's HTTP status/message lands in
+          # the step log next to the warning.
+          $existingLabels = gh api "repos/$env:GITHUB_REPOSITORY/issues/$env:PR_NUMBER/labels" --jq '.[].name'
           if ($LASTEXITCODE -ne 0) {
             Write-Host "::warning::Could not fetch PR labels (exit code: $LASTEXITCODE); skipping needs-split labeling"
             exit 0
@@ -418,8 +419,9 @@ jobs:
           # Remove label if it exists and commit count is back below threshold.
           # Advisory label: failures warn instead of failing the job; REST API
           # instead of gh pr edit (GraphQL 401, issue #2557).
-          # 2>$null is safe - PR exists when workflow runs
-          $existingLabels = gh api "repos/$env:GITHUB_REPOSITORY/issues/$env:PR_NUMBER/labels" --jq '.[].name' 2>$null
+          # Stderr stays visible so a failure's HTTP status/message lands in
+          # the step log next to the warning.
+          $existingLabels = gh api "repos/$env:GITHUB_REPOSITORY/issues/$env:PR_NUMBER/labels" --jq '.[].name'
           if ($LASTEXITCODE -ne 0) {
             Write-Host "::warning::Could not fetch PR labels (exit code: $LASTEXITCODE); skipping needs-split removal"
             exit 0

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -387,13 +387,23 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Check if label already exists on PR (2>$null is safe - PR exists when workflow runs)
-          $existingLabels = gh pr view $env:PR_NUMBER --repo $env:GITHUB_REPOSITORY --json labels --jq '.labels[].name' 2>$null
-          if ($LASTEXITCODE -ne 0) { throw "Failed to fetch PR labels (exit code: $LASTEXITCODE)" }
+          # The needs-split label is advisory (the 20-commit BLOCK tier enforces
+          # the real limit), so labeling failures warn instead of failing the job.
+          # Mutations go through the REST issues API: gh pr edit mutates via
+          # GraphQL, which rejects this workflow's token with HTTP 401 (issue #2557).
+          # 2>$null is safe - PR exists when workflow runs
+          $existingLabels = gh api "repos/$env:GITHUB_REPOSITORY/issues/$env:PR_NUMBER/labels" --jq '.[].name' 2>$null
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::warning::Could not fetch PR labels (exit code: $LASTEXITCODE); skipping needs-split labeling"
+            exit 0
+          }
 
           if ($existingLabels -notcontains 'needs-split') {
-            gh pr edit $env:PR_NUMBER --repo $env:GITHUB_REPOSITORY --add-label "needs-split"
-            if ($LASTEXITCODE -ne 0) { throw "Failed to add needs-split label (exit code: $LASTEXITCODE)" }
+            gh api --method POST "repos/$env:GITHUB_REPOSITORY/issues/$env:PR_NUMBER/labels" -f "labels[]=needs-split" | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "::warning::Could not add needs-split label (exit code: $LASTEXITCODE); label is advisory, continuing"
+              exit 0
+            }
             Write-Host "Added 'needs-split' label to PR #$env:PR_NUMBER"
           } else {
             Write-Host "PR #$env:PR_NUMBER already has 'needs-split' label"
@@ -405,14 +415,22 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Remove label if it exists and commit count is back below threshold
+          # Remove label if it exists and commit count is back below threshold.
+          # Advisory label: failures warn instead of failing the job; REST API
+          # instead of gh pr edit (GraphQL 401, issue #2557).
           # 2>$null is safe - PR exists when workflow runs
-          $existingLabels = gh pr view $env:PR_NUMBER --repo $env:GITHUB_REPOSITORY --json labels --jq '.labels[].name' 2>$null
-          if ($LASTEXITCODE -ne 0) { throw "Failed to fetch PR labels (exit code: $LASTEXITCODE)" }
+          $existingLabels = gh api "repos/$env:GITHUB_REPOSITORY/issues/$env:PR_NUMBER/labels" --jq '.[].name' 2>$null
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::warning::Could not fetch PR labels (exit code: $LASTEXITCODE); skipping needs-split removal"
+            exit 0
+          }
 
           if ($existingLabels -contains 'needs-split') {
-            gh pr edit $env:PR_NUMBER --repo $env:GITHUB_REPOSITORY --remove-label "needs-split"
-            if ($LASTEXITCODE -ne 0) { throw "Failed to remove needs-split label (exit code: $LASTEXITCODE)" }
+            gh api --method DELETE "repos/$env:GITHUB_REPOSITORY/issues/$env:PR_NUMBER/labels/needs-split" | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "::warning::Could not remove needs-split label (exit code: $LASTEXITCODE); label is advisory, continuing"
+              exit 0
+            }
             Write-Host "Removed 'needs-split' label from PR #$env:PR_NUMBER"
           }
 


### PR DESCRIPTION
# Pull Request

## Summary

### What

The two needs-split label steps in the Validate PR workflow no longer fail the job when labeling fails, and they mutate labels through the REST issues API (`gh api`) instead of `gh pr edit`.

### Why

`gh pr edit` mutates labels via the GraphQL API, which rejects the workflow's token with HTTP 401, and the step's `throw` turned the advisory 10-commit notice into a hard job failure for every PR with 10-19 commits. Observed on PR #2556 where all validations passed (`DESCRIPTION_RESULT: PASS`) yet the check went red on `Failed to add needs-split label (exit code: 1)`. The label is cosmetic; the 20-commit BLOCK tier enforces the real limit separately and is unchanged.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2557 | Validate PR hard-fails on advisory needs-split labeling (GraphQL 401) |

## Changes

- `.github/workflows/pr-validation.yml` "Apply needs-split label" step: label reads and the add-mutation go through `gh api repos/{repo}/issues/{n}/labels` (REST, which the workflow token accepts); any failure emits a `::warning` and exits 0 instead of `throw`.
- Same treatment for the "Remove needs-split label when below threshold" step (REST DELETE, warn-and-continue on failure).
- The `Enforce Blocking Issues` step and the 20-commit BLOCK threshold are untouched: a genuinely oversized PR still fails.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted review, standard scrutiny, soft target (PR #2556 is currently red on this bug)

**Focus areas**: the severity decision: labeling failures now warn instead of fail. The rationale: the label annotates an advisory notice tier; failing the whole validation job for a cosmetic label inverts severity and masks real validation results.

## Testing

Deliverables in this PR:

- [ ] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

YAML parses; workflow validation and yamllint passed in the pre-push gate. The local workflow run was bypassed via the sanctioned `SKIP_WORKFLOW_LOCAL_TEST` (no act/Docker in this environment), flagged loudly here per policy. The behavior change is exercised by this PR's own Validate PR run (the rewritten label-removal step already executed cleanly on this PR's first run) and by re-running it on PR #2556 (10 commits) once merged, which is the real-runtime verification.

## Agent Review

### Security Review

> Required for: Authentication, authorization, CI/CD, git hooks, secrets, infrastructure

- [ ] No security-critical changes in this PR
- [x] Security agent reviewed infrastructure changes
- [ ] Security agent reviewed authentication/authorization changes
- [x] Security patterns applied (see `.agents/security/`)

**Files requiring security review:**

- `.github/workflows/pr-validation.yml` (no permission changes, no new Actions, no secrets; failure handling softened only for the advisory label mutation, evidence: run 27280632030 / CWE-636 severity-inversion shape)

---

https://claude.ai/code/session_01JPLKQWSjsSh2XHfh7mZvkr