### PR TITLE
ci(deps): preflight guard for empty GH_ACTIONS_PR_WRITE secret (Refs #2551)

### DIFF
--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           PAT: ${{ secrets.GH_ACTIONS_PR_WRITE }}
         run: |
-          if [ -z "$PAT" ]; then
+          if [ -z "${PAT:-}" ]; then
             echo "::error::secrets.GH_ACTIONS_PR_WRITE is empty at run time. A repo admin must rotate the PAT in Settings > Secrets and variables > Actions (needs 'repo' scope; approvals must come from a real user identity to satisfy branch rulesets). See #2551."
             exit 1
           fi
@@ -96,7 +96,7 @@ jobs:
         env:
           PAT: ${{ secrets.GH_ACTIONS_PR_WRITE }}
         run: |
-          if [ -z "$PAT" ]; then
+          if [ -z "${PAT:-}" ]; then
             echo "::error::secrets.GH_ACTIONS_PR_WRITE is empty at run time. A repo admin must rotate the PAT in Settings > Secrets and variables > Actions (needs 'repo' scope; approvals must come from a real user identity to satisfy branch rulesets). See #2551."
             exit 1
           fi

--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -29,6 +29,21 @@ jobs:
     runs-on: ubuntu-24.04-arm
     if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     steps:
+      # Preflight: fail fast with a self-diagnosing annotation when the PAT
+      # secret is empty (expired, rotated, renamed in repo settings). Without
+      # this guard, the next `gh` call dies with the cryptic message
+      # "gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN
+      # environment variable" and an operator has to read raw logs to discover
+      # the real root cause is a missing repository secret. Guards #2551.
+      - name: Verify GH_ACTIONS_PR_WRITE secret is set
+        env:
+          PAT: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "::error::secrets.GH_ACTIONS_PR_WRITE is empty at run time. A repo admin must rotate the PAT in Settings > Secrets and variables > Actions (needs 'repo' scope; approvals must come from a real user identity to satisfy branch rulesets). See #2551."
+            exit 1
+          fi
+
       - name: Fetch metadata
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
@@ -71,6 +86,21 @@ jobs:
     # 'major.addLabels' applies on major PRs. Label-based detection is
     # reliable; PR title regex was not (no marker configured upstream).
     steps:
+      # Preflight: fail fast with a self-diagnosing annotation when the PAT
+      # secret is empty (expired, rotated, renamed in repo settings). Without
+      # this guard, the next `gh pr view` call dies with the cryptic message
+      # "gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN
+      # environment variable" and an operator has to read raw logs to discover
+      # the real root cause is a missing repository secret. Guards #2551.
+      - name: Verify GH_ACTIONS_PR_WRITE secret is set
+        env:
+          PAT: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "::error::secrets.GH_ACTIONS_PR_WRITE is empty at run time. A repo admin must rotate the PAT in Settings > Secrets and variables > Actions (needs 'repo' scope; approvals must come from a real user identity to satisfy branch rulesets). See #2551."
+            exit 1
+          fi
+
       - name: Detect major update
         id: detect-major
         env:

--- a/tests/test_renovate_workflow_secret_guard.py
+++ b/tests/test_renovate_workflow_secret_guard.py
@@ -56,7 +56,8 @@ def _step_mapping(step: dict, key: str) -> dict:
 
 def _job_uses_pat(job: dict) -> bool:
     """Return True if any step in this job references the PAT secret in env."""
-    for step in job.get("steps", []):
+    steps = job.get("steps") or []
+    for step in steps:
         env = _step_mapping(step, "env")
         for value in env.values():
             if isinstance(value, str) and PAT_SECRET in value:
@@ -66,7 +67,7 @@ def _job_uses_pat(job: dict) -> bool:
 
 def _jobs_requiring_pat(workflow: dict) -> dict[str, dict]:
     """Return jobs whose steps depend on the GH_ACTIONS_PR_WRITE PAT."""
-    jobs = workflow.get("jobs", {})
+    jobs = workflow.get("jobs") or {}
     return {name: job for name, job in jobs.items() if _job_uses_pat(job)}
 
 
@@ -80,7 +81,8 @@ def _preflight_step(job: dict) -> dict | None:
       * emit a `::error::` annotation so the failure surfaces in the UI,
       * exit non-zero.
     """
-    for step in job.get("steps", []):
+    steps = job.get("steps") or []
+    for step in steps:
         run_block = _step_string(step, "run")
         env = _step_mapping(step, "env")
         pat_in_env = any(
@@ -148,7 +150,7 @@ def test_preflight_runs_before_any_gh_call(workflow: dict, job_name: str) -> Non
     happens first and the operator never sees the helpful error.
     """
     job = workflow["jobs"][job_name]
-    steps = job.get("steps", [])
+    steps = job.get("steps") or []
     guard_index = next(
         (i for i, step in enumerate(steps) if step is _preflight_step(job)),
         -1,
@@ -184,7 +186,7 @@ def test_preflight_annotation_names_the_secret_and_admin_action(
         f"Preflight annotation must name {PAT_SECRET!r} so operators know "
         f"which secret to rotate. See #2551."
     )
-    # Either 'admin' or 'rotate' is fine — both signal "this isn't a code fix".
+    # Either 'admin' or 'rotate' is fine, both signal "this isn't a code fix".
     assert any(
         marker in run_block.lower() for marker in ("admin", "rotate", "settings")
     ), (

--- a/tests/test_renovate_workflow_secret_guard.py
+++ b/tests/test_renovate_workflow_secret_guard.py
@@ -1,0 +1,221 @@
+"""Regression test for #2551.
+
+The "Renovate" job in `.github/workflows/dependabot-approve-and-auto-merge.yml`
+silently fails when `secrets.GH_ACTIONS_PR_WRITE` resolves to an empty string
+at run time (PAT expired, rotated, or renamed). The visible failure is
+`gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN
+environment variable.` which does not tell an operator that the actual root
+cause is a missing repository secret.
+
+Evidence:
+https://github.com/rjmurillo/ai-agents/actions/runs/27254832120/job/79190113142
+
+This test asserts every job that depends on `GH_ACTIONS_PR_WRITE` runs a
+preflight guard that:
+
+  1. Fails fast (exit 1) when the secret is empty.
+  2. Emits a `::error::` annotation naming the secret and the admin remediation
+     so the failure is self-diagnosing in the Actions UI.
+
+Without this guard, an empty secret produces a cryptic `gh` error in a later
+step and operators have to read raw logs to discover the root cause.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "workflows"
+    / "dependabot-approve-and-auto-merge.yml"
+)
+
+PAT_SECRET = "GH_ACTIONS_PR_WRITE"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def _step_string(step: dict, key: str) -> str:
+    value = step.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _step_mapping(step: dict, key: str) -> dict:
+    value = step.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def _job_uses_pat(job: dict) -> bool:
+    """Return True if any step in this job references the PAT secret in env."""
+    for step in job.get("steps", []):
+        env = _step_mapping(step, "env")
+        for value in env.values():
+            if isinstance(value, str) and PAT_SECRET in value:
+                return True
+    return False
+
+
+def _jobs_requiring_pat(workflow: dict) -> dict[str, dict]:
+    """Return jobs whose steps depend on the GH_ACTIONS_PR_WRITE PAT."""
+    jobs = workflow.get("jobs", {})
+    return {name: job for name, job in jobs.items() if _job_uses_pat(job)}
+
+
+def _preflight_step(job: dict) -> dict | None:
+    """Return the first step whose `run` block guards against an empty PAT.
+
+    A guard step MUST:
+
+      * reference `GH_ACTIONS_PR_WRITE` in `env`,
+      * test the variable for emptiness in `run` (e.g. `[ -z "$..." ]`),
+      * emit a `::error::` annotation so the failure surfaces in the UI,
+      * exit non-zero.
+    """
+    for step in job.get("steps", []):
+        run_block = _step_string(step, "run")
+        env = _step_mapping(step, "env")
+        pat_in_env = any(
+            isinstance(value, str) and PAT_SECRET in value for value in env.values()
+        )
+        if not pat_in_env:
+            continue
+        if "-z" not in run_block:
+            continue
+        if "::error::" not in run_block:
+            continue
+        if "exit 1" not in run_block:
+            continue
+        return step
+    return None
+
+
+def test_renovate_job_uses_pat(workflow: dict) -> None:
+    """Sanity: the Renovate job still depends on GH_ACTIONS_PR_WRITE.
+
+    If this fails, the workflow no longer needs the PAT and the rest of the
+    suite should be deleted or rewritten. Without this assertion the guard
+    tests below would pass vacuously on an unrelated workflow refactor.
+    """
+    job = workflow["jobs"]["renovate"]
+    assert _job_uses_pat(job), (
+        "Renovate job no longer references GH_ACTIONS_PR_WRITE; either the "
+        "PAT is no longer needed (delete this test) or the secret was renamed "
+        "(update PAT_SECRET in this file). See #2551."
+    )
+
+
+def test_dependabot_job_uses_pat(workflow: dict) -> None:
+    """Sanity: the Dependabot job still depends on GH_ACTIONS_PR_WRITE."""
+    job = workflow["jobs"]["dependabot"]
+    assert _job_uses_pat(job), (
+        "Dependabot job no longer references GH_ACTIONS_PR_WRITE. Update "
+        "PAT_SECRET or delete this test. See #2551."
+    )
+
+
+@pytest.mark.parametrize("job_name", ["renovate", "dependabot"])
+def test_job_has_preflight_secret_guard(workflow: dict, job_name: str) -> None:
+    """Positive: every PAT-using job runs a preflight guard.
+
+    The guard checks that GH_ACTIONS_PR_WRITE is non-empty, emits a
+    `::error::` annotation, and exits 1. This prevents the cryptic
+    `gh: To use GitHub CLI ... set the GH_TOKEN environment variable.`
+    failure mode documented in #2551.
+    """
+    job = workflow["jobs"][job_name]
+    guard = _preflight_step(job)
+    assert guard is not None, (
+        f"Job {job_name!r} must declare a preflight step that fails fast "
+        f"with `::error::` when secrets.{PAT_SECRET} is empty. See #2551 for "
+        f"the failure mode this guards against."
+    )
+
+
+@pytest.mark.parametrize("job_name", ["renovate", "dependabot"])
+def test_preflight_runs_before_any_gh_call(workflow: dict, job_name: str) -> None:
+    """Negative: the guard must run BEFORE any gh CLI invocation.
+
+    A guard that runs after `gh pr view` is useless; the cryptic failure
+    happens first and the operator never sees the helpful error.
+    """
+    job = workflow["jobs"][job_name]
+    steps = job.get("steps", [])
+    guard_index = next(
+        (i for i, step in enumerate(steps) if step is _preflight_step(job)),
+        -1,
+    )
+    assert guard_index >= 0, (
+        f"Job {job_name!r} missing preflight guard (see other test for "
+        f"details)."
+    )
+    for i, step in enumerate(steps[:guard_index]):
+        run_block = _step_string(step, "run")
+        assert "gh " not in run_block, (
+            f"Job {job_name!r} step {i} ({step.get('name')!r}) invokes `gh` "
+            f"before the preflight secret guard at index {guard_index}. The "
+            f"guard must run first or the cryptic GH_TOKEN error happens "
+            f"before the helpful annotation. See #2551."
+        )
+
+
+@pytest.mark.parametrize("job_name", ["renovate", "dependabot"])
+def test_preflight_annotation_names_the_secret_and_admin_action(
+    workflow: dict, job_name: str
+) -> None:
+    """Edge: the `::error::` annotation must be self-diagnosing.
+
+    An operator landing on a failed run needs to see, without reading raw
+    logs, that the secret is missing and a repo admin must rotate the PAT.
+    """
+    job = workflow["jobs"][job_name]
+    guard = _preflight_step(job)
+    assert guard is not None
+    run_block = _step_string(guard, "run")
+    assert PAT_SECRET in run_block, (
+        f"Preflight annotation must name {PAT_SECRET!r} so operators know "
+        f"which secret to rotate. See #2551."
+    )
+    # Either 'admin' or 'rotate' is fine — both signal "this isn't a code fix".
+    assert any(
+        marker in run_block.lower() for marker in ("admin", "rotate", "settings")
+    ), (
+        "Preflight annotation must mention admin/rotate/settings so the "
+        "operator knows this is a repo-settings fix, not a code fix. "
+        "See #2551."
+    )
+
+
+def test_yaml_null_env_does_not_crash_guard_detection() -> None:
+    """Edge: YAML `env:` blocks that are explicit null are handled safely."""
+    workflow = {
+        "jobs": {
+            "renovate": {
+                "steps": [
+                    {"name": "noop", "uses": "actions/checkout@v5", "env": None},
+                    {
+                        "name": "guard",
+                        "env": {"PAT": "${{ secrets.GH_ACTIONS_PR_WRITE }}"},
+                        "run": (
+                            'if [ -z "$PAT" ]; then\n'
+                            '  echo "::error::secrets.GH_ACTIONS_PR_WRITE is '
+                            'empty; admin must rotate the PAT"\n'
+                            "  exit 1\n"
+                            "fi\n"
+                        ),
+                    },
+                ]
+            }
+        }
+    }
+    guard = _preflight_step(workflow["jobs"]["renovate"])
+    assert guard is not None
+    assert guard["name"] == "guard"


### PR DESCRIPTION
## Summary

Issue #2551 reports the `Renovate` job in
`dependabot-approve-and-auto-merge.yml` fails on every renovate PR because
`secrets.GH_ACTIONS_PR_WRITE` resolves to an empty string at run time. The
real fix is admin-only (rotate the PAT in repo settings), but the
**failure mode itself is silently cryptic**: the visible error in the job
log is

> gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN
> environment variable.

which does not tell an operator that the root cause is a missing
repository secret. PR #2518 sat blocked under exactly this failure and
had to be approved manually.

This PR adds the resilience half of #2551: a **preflight guard step** at
the top of each PAT-dependent job that fails fast with a self-diagnosing
`::error::` annotation when the secret is empty.

## Behavior change

Both the `dependabot` and `renovate` jobs now start with:

```yaml
- name: Verify GH_ACTIONS_PR_WRITE secret is set
  env:
    PAT: ${{ secrets.GH_ACTIONS_PR_WRITE }}
  run: |
    if [ -z "$PAT" ]; then
      echo "::error::secrets.GH_ACTIONS_PR_WRITE is empty at run time. A repo admin must rotate the PAT in Settings > Secrets and variables > Actions (needs 'repo' scope; approvals must come from a real user identity to satisfy branch rulesets). See #2551."
      exit 1
    fi
```

- When the PAT is set (normal case): step prints nothing, exits 0, job
  continues unchanged.
- When the PAT is empty (the #2551 failure): step emits a one-line
  `::error::` annotation that surfaces in the Actions UI summary, names
  the secret, names the admin remediation, and exits 1 before any `gh`
  call runs.

The annotation makes the failure self-diagnosing the next time the PAT
rotates out: the operator lands on the failed run and immediately sees
"secret empty, admin rotate" instead of having to grep raw logs for a
generic `gh` error.

## What this does NOT fix

The actual #2551 root cause, `GH_ACTIONS_PR_WRITE` being empty in repo
settings, requires repo-admin action (rotate the PAT). That is out of
scope for a PR; only Richard can do it. This change just makes sure the
NEXT operator who hits an empty-secret state sees a useful error
instead of a confusing one.

## Tests

`tests/test_renovate_workflow_secret_guard.py` adds 9 assertions:

- **Sanity (2)**: Both jobs still depend on `GH_ACTIONS_PR_WRITE` (so
  the guard tests don't pass vacuously after an unrelated refactor).
- **Positive (2, parametrized)**: Each job declares a preflight step
  that tests `-z` against the PAT, emits `::error::`, and exits 1.
- **Negative (2, parametrized)**: The guard runs BEFORE any `gh`
  invocation in the same job. A guard after `gh pr view` is useless.
- **Edge (2, parametrized)**: The annotation names the secret AND
  signals admin/rotate/settings remediation, so an operator knows
  this is not a code fix.
- **Edge (1)**: Explicit YAML null `env:` blocks don't crash the
  detector.

Local results (worktree at `e02408d8` base):

```
============================== 13 passed in 0.21s ==============================
9 new + 4 existing (test_dependabot_workflow_token.py from #2307) all green
```

Broader sweep (166 workflow-related tests): all pass. actionlint clean:

```bash
actionlint .github/workflows/dependabot-approve-and-auto-merge.yml
```

Guard shell semantics validated locally for PAT-set, PAT-empty, and PAT-unset
cases.

## RED-then-GREEN evidence

The 9 new assertions were written first and confirmed to fail against
unmodified `main` (6 of the 9 failed; 3 sanity tests passed); only then
were the two `Verify GH_ACTIONS_PR_WRITE secret is set` steps added.
After the workflow change, all 9 pass.

Refs #2551

