### PR TITLE
fix(hooks): hardening sweep (#2523)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.171",
+  "version": "0.5.172",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PostToolUse/invoke_markdown_auto_lint.py
+++ b/.claude/hooks/PostToolUse/invoke_markdown_auto_lint.py
@@ -99,6 +99,7 @@ def main() -> int:
             capture_output=True,
             text=True,
             cwd=project_dir,
+            timeout=30,
         )
 
         if result.returncode != 0:
@@ -128,6 +129,11 @@ def main() -> int:
                 )
         else:
             print(f"\n**Markdown Auto-Lint**: Fixed formatting in `{file_path}`\n")
+    except subprocess.TimeoutExpired:
+        print(
+            f"WARNING: Markdown auto-lint: markdownlint-cli2 timed out for {file_path}",
+            file=sys.stderr,
+        )
     except FileNotFoundError:
         print(
             f"WARNING: npx not found. Cannot lint {file_path}",

--- a/.claude/hooks/PostToolUse/invoke_plan_state_sync.py
+++ b/.claude/hooks/PostToolUse/invoke_plan_state_sync.py
@@ -158,7 +158,10 @@ def _acquire_lock(handle) -> None:
     if os.name == "nt":  # pragma: no cover - platform branch
         import msvcrt
 
-        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        try:
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 0x7FFFFFFF)
+        except OSError:
+            pass
         return
     import fcntl
 
@@ -171,7 +174,7 @@ def _release_lock(handle) -> None:
         import msvcrt
 
         try:
-            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 0x7FFFFFFF)
         except OSError:
             pass
         return

--- a/.claude/hooks/PreToolUse/invoke_security_commit_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_security_commit_gate.py
@@ -137,10 +137,12 @@ def find_security_evidence(project_dir: str) -> bool:
                 reverse=True,
             )
             for log_path in session_logs:
-                content = log_path.read_text(encoding="utf-8")
-                for pattern in _SECURITY_REVIEW_PATTERNS:
-                    if pattern.search(content):
-                        return True
+                # Stream line-by-line: avoids loading multi-MB logs into memory.
+                with log_path.open(encoding="utf-8", errors="replace") as handle:
+                    for line in handle:
+                        for pattern in _SECURITY_REVIEW_PATTERNS:
+                            if pattern.search(line):
+                                return True
         except OSError:
             pass
 

--- a/.claude/hooks/PreToolUse/invoke_security_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_security_gate.py
@@ -144,10 +144,12 @@ def find_security_evidence(project_dir: str) -> bool:
                 reverse=True,
             )
             for log_path in session_logs:
-                content = log_path.read_text(encoding="utf-8")
-                for pattern in _SECURITY_REVIEW_PATTERNS:
-                    if pattern.search(content):
-                        return True
+                # Stream line-by-line: avoids loading multi-MB logs into memory.
+                with log_path.open(encoding="utf-8", errors="replace") as handle:
+                    for line in handle:
+                        for pattern in _SECURITY_REVIEW_PATTERNS:
+                            if pattern.search(line):
+                                return True
         except OSError:
             pass
 

--- a/.claude/hooks/Stop/invoke_session_validator.py
+++ b/.claude/hooks/Stop/invoke_session_validator.py
@@ -41,7 +41,7 @@ else:
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
     print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
-    sys.exit(2)
+    sys.exit(0)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)
 

--- a/.claude/hooks/invoke_adr_change_detection.py
+++ b/.claude/hooks/invoke_adr_change_detection.py
@@ -50,7 +50,9 @@ def get_project_root() -> str | None:
 
     Uses CLAUDE_PROJECT_DIR if set and validates that this script lives
     within the specified project root (CWE-22 protection).
-    Falls back to deriving from script location.
+    Falls back to walking up from __file__ looking for a .git directory,
+    which is layout-independent (works in .claude/hooks/ and in the deeper
+    src/<provider>/hooks/<event>/ plugin install layout).
     """
     script_dir = str(Path(__file__).resolve().parent)
     env_dir = os.environ.get("CLAUDE_PROJECT_DIR", "").strip()
@@ -68,7 +70,18 @@ def get_project_root() -> str | None:
             return None
         return env_dir
 
-    # parents[2] walks up: hooks -> .claude -> project root
+    # Walk up from __file__ looking for a .git marker. This is layout-independent:
+    # it works in .claude/hooks/ (3 levels) and in src/<provider>/hooks/<event>/
+    # (4+ levels). parents[2] is kept only as a last-resort fallback.
+    cur = Path(__file__).resolve().parent
+    while True:
+        if (cur / ".git").exists():
+            return str(cur)
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+
+    # Last-resort fallback: original parents[2] derivation for .claude/hooks/ layout.
     return str(Path(__file__).resolve().parents[2])
 
 

--- a/tests/hooks/test_adr_change_detection.py
+++ b/tests/hooks/test_adr_change_detection.py
@@ -237,3 +237,50 @@ class TestModuleAsScript:
         with pytest.raises(SystemExit) as exc_info:
             runpy.run_path(hook_path, run_name="__main__")
         assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Regression test: plugin install layout (src/<provider>/hooks/<event>/)
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjectRootPluginLayout:
+    """Ensure get_project_root finds .git root regardless of install depth."""
+
+    def test_vendored_layout_resolves_to_git_root(self, monkeypatch, tmp_path):
+        """Simulate src/<provider>/hooks/SessionStart/ layout.
+
+        In this layout parents[2] would land inside src/, NOT at the repo
+        root. The fixed implementation should walk up from __file__ looking
+        for .git and return the directory that contains it.
+        """
+        # Build: tmp_path/.git  (repo root)
+        #        tmp_path/src/myprovider/hooks/SessionStart/invoke_adr_change_detection.py
+        git_root = tmp_path
+        (git_root / ".git").mkdir()
+
+        fake_script = (
+            git_root / "src" / "myprovider" / "hooks" / "SessionStart"
+            / "invoke_adr_change_detection.py"
+        )
+        fake_script.parent.mkdir(parents=True)
+        fake_script.write_text("# stub")
+
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.delenv("BUILD_REPOSITORY_LOCALPATH", raising=False)
+
+        with patch.object(
+            invoke_adr_change_detection,
+            "__file__",
+            str(fake_script),
+        ):
+            result = invoke_adr_change_detection.get_project_root()
+
+        assert result is not None
+        resolved = str(Path(result).resolve())
+        expected = str(git_root.resolve())
+        assert resolved == expected, (
+            f"Expected git root {expected!r}, got {resolved!r}. "
+            "parents[2] from src/myprovider/hooks/SessionStart/ points inside "
+            "src/, not at the repo root."
+        )

--- a/tests/hooks/test_markdown_auto_lint.py
+++ b/tests/hooks/test_markdown_auto_lint.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import io
 import json
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -201,3 +202,15 @@ class TestSubprocessErrorPaths:
             assert main() == 0
         captured = capsys.readouterr()
         assert "no output" in captured.err.lower() or "not installed" in captured.err.lower()
+
+    def test_timeout_returns_zero_with_warning(
+        self, _lint_input, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """TimeoutExpired from subprocess.run returns 0 (fail-open) with stderr warning."""
+        with patch(
+            "invoke_markdown_auto_lint.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["npx", "markdownlint-cli2"], timeout=30),
+        ):
+            assert main() == 0
+        captured = capsys.readouterr()
+        assert "warning" in captured.err.lower() or "timeout" in captured.err.lower()

--- a/tests/hooks/test_security_commit_gate.py
+++ b/tests/hooks/test_security_commit_gate.py
@@ -268,3 +268,45 @@ class TestMain:
         data = json.loads(captured.out.strip())
         assert data["decision"] == "block"
         assert "enumerate staged files" in data["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Streaming read tests for find_security_evidence
+# ---------------------------------------------------------------------------
+
+
+class TestFindSecurityEvidenceStreaming:
+    """Verify find_security_evidence streams line-by-line (no full read_text)."""
+
+    def _make_large_log(self, sessions_dir: Path, today: str, *, pattern_at_start: bool) -> Path:
+        """Create a large fake session log (~50000 lines)."""
+        log = sessions_dir / f"{today}-session-001.json"
+        trigger_line = '  "notes": "security review completed"\n'
+        filler_line = '  "data": "x" * 1000,\n'
+        lines = []
+        if pattern_at_start:
+            lines.append(trigger_line)
+        for _ in range(50000):
+            lines.append(filler_line)
+        log.write_text("".join(lines))
+        return log
+
+    def test_large_log_with_pattern_at_line1_returns_true(self, tmp_path):
+        """Pattern at first line of a large file is found without reading whole file."""
+        from datetime import UTC, datetime
+
+        sessions_dir = tmp_path / ".agents" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        self._make_large_log(sessions_dir, today, pattern_at_start=True)
+        assert invoke_security_commit_gate.find_security_evidence(str(tmp_path))
+
+    def test_large_log_without_pattern_returns_false(self, tmp_path):
+        """Large file with no pattern returns False."""
+        from datetime import UTC, datetime
+
+        sessions_dir = tmp_path / ".agents" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        self._make_large_log(sessions_dir, today, pattern_at_start=False)
+        assert not invoke_security_commit_gate.find_security_evidence(str(tmp_path))

--- a/tests/hooks/test_security_gate.py
+++ b/tests/hooks/test_security_gate.py
@@ -176,3 +176,45 @@ class TestMain:
         mock_stdin(json.dumps({"tool_name": "Edit", "tool_input": None}))
         result = invoke_security_gate.main()
         assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# Streaming read tests for find_security_evidence
+# ---------------------------------------------------------------------------
+
+
+class TestFindSecurityEvidenceStreaming:
+    """Verify find_security_evidence streams line-by-line (no full read_text)."""
+
+    def _make_large_log(self, sessions_dir: Path, today: str, *, pattern_at_start: bool) -> Path:
+        """Create a large fake session log (~50000 lines)."""
+        log = sessions_dir / f"{today}-session-001.json"
+        trigger_line = '  "notes": "security review completed"\n'
+        filler_line = '  "data": "x" * 1000,\n'
+        lines = []
+        if pattern_at_start:
+            lines.append(trigger_line)
+        for _ in range(50000):
+            lines.append(filler_line)
+        log.write_text("".join(lines))
+        return log
+
+    def test_large_log_with_pattern_at_line1_returns_true(self, tmp_path):
+        """Pattern at first line of a large file is found without reading whole file."""
+        from datetime import UTC, datetime
+
+        sessions_dir = tmp_path / ".agents" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        self._make_large_log(sessions_dir, today, pattern_at_start=True)
+        assert invoke_security_gate.find_security_evidence(str(tmp_path))
+
+    def test_large_log_without_pattern_returns_false(self, tmp_path):
+        """Large file with no pattern returns False."""
+        from datetime import UTC, datetime
+
+        sessions_dir = tmp_path / ".agents" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        self._make_large_log(sessions_dir, today, pattern_at_start=False)
+        assert not invoke_security_gate.find_security_evidence(str(tmp_path))

--- a/tests/hooks/test_session_validator.py
+++ b/tests/hooks/test_session_validator.py
@@ -325,6 +325,26 @@ class TestModuleAsScript:
             runpy.run_path(hook_path, run_name="__main__")
         assert exc_info.value.code == 0
 
+    def test_lib_missing_exits_zero(self) -> None:
+        """When lib/ bootstrap fails (plugin not found), hook exits 0 not 2."""
+        import subprocess
+
+        hook_path = str(HOOK_DIR / "invoke_session_validator.py")
+        env = os.environ.copy()
+        env["CLAUDE_PLUGIN_ROOT"] = "/nonexistent/path/that/does/not/exist"
+        result = subprocess.run(
+            ["python3", hook_path],
+            input="",
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"Expected exit 0 on lib-missing path, got {result.returncode}. "
+            f"stderr: {result.stderr!r}"
+        )
+        assert result.stderr.strip(), "Expected a warning on stderr when lib dir is missing"
+
 
 class TestSessionEndCompliance:
     """Tests for session-end checklist enforcement in the Stop hook."""

--- a/tests/test_plan_state_sync.py
+++ b/tests/test_plan_state_sync.py
@@ -213,3 +213,57 @@ class TestFailOpen:
         )
         assert code == 0
         assert "boom" in stderr
+
+
+# ---------------------------------------------------------------------------
+# Windows lock range tests
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsLockRange:
+    """Verify the Windows msvcrt.locking call covers the full file, not 1 byte."""
+
+    def test_acquire_lock_uses_large_range(self) -> None:
+        """_acquire_lock must call msvcrt.locking with 0x7FFFFFFF, not 1."""
+        import os
+        import sys
+        from unittest.mock import MagicMock, call, patch
+
+        mock_handle = MagicMock()
+        mock_handle.fileno.return_value = 3
+
+        mock_msvcrt = MagicMock()
+        mock_msvcrt.LK_LOCK = 2
+
+        with patch.object(invoke_plan_state_sync, "_acquire_lock", wraps=invoke_plan_state_sync._acquire_lock):
+            with patch.dict("sys.modules", {"msvcrt": mock_msvcrt}):
+                with patch("os.name", "nt"):
+                    invoke_plan_state_sync._acquire_lock(mock_handle)
+
+        mock_msvcrt.locking.assert_called_once()
+        _fd, _mode, nbytes = mock_msvcrt.locking.call_args[0]
+        assert nbytes == 0x7FFFFFFF, (
+            f"Expected lock range 0x7FFFFFFF (full-file sentinel), got {nbytes!r}. "
+            "A value of 1 only locks a single byte and allows concurrent interleaved writes."
+        )
+
+    def test_release_lock_uses_large_range(self) -> None:
+        """_release_lock must call msvcrt.locking with 0x7FFFFFFF, not 1."""
+        import os
+        from unittest.mock import MagicMock, patch
+
+        mock_handle = MagicMock()
+        mock_handle.fileno.return_value = 3
+
+        mock_msvcrt = MagicMock()
+        mock_msvcrt.LK_UNLCK = 0
+
+        with patch.dict("sys.modules", {"msvcrt": mock_msvcrt}):
+            with patch("os.name", "nt"):
+                invoke_plan_state_sync._release_lock(mock_handle)
+
+        mock_msvcrt.locking.assert_called_once()
+        _fd, _mode, nbytes = mock_msvcrt.locking.call_args[0]
+        assert nbytes == 0x7FFFFFFF, (
+            f"Expected unlock range 0x7FFFFFFF, got {nbytes!r}."
+        )


### PR DESCRIPTION
Fixes #2523

Five latent defects found in `.claude/hooks/` -- each fixed in its own atomic commit with a RED-GREEN test cycle.

## Changes

- [ ] **Fix 1** - `.claude/hooks/PostToolUse/invoke_markdown_auto_lint.py`: Add `timeout=30` to `subprocess.run` and handle `subprocess.TimeoutExpired` (fail-open, warn to stderr).
- [ ] **Fix 2** - `.claude/hooks/Stop/invoke_session_validator.py`: Change `sys.exit(2)` to `sys.exit(0)` on lib-missing bootstrap path (docstring said exit 0 always, code said exit 2).
- [ ] **Fix 3** - `.claude/hooks/PreToolUse/invoke_security_gate.py` and `invoke_security_commit_gate.py`: Replace `read_text()` full-file load with line-by-line streaming iterator; break on first pattern match (O(match_line) memory instead of O(file_size)).
- [ ] **Fix 4** - `.claude/hooks/PostToolUse/invoke_plan_state_sync.py`: Expand Windows `msvcrt.locking` byte count from `1` to `0x7FFFFFFF` in both `_acquire_lock` and `_release_lock`; wrap acquire in `try/except OSError` for graceful degradation.
- [ ] **Fix 5** - `.claude/hooks/invoke_adr_change_detection.py`: Replace `parents[2]` with a `.git`-walk-up in `get_project_root()` so it works in both `.claude/hooks/` (3 levels) and `src/\<provider\>/hooks/\<event\>/` (4+ levels) plugin install layouts.
- [ ] **Chore** - `.claude/.claude-plugin/plugin.json`: Bump plugin version to 0.5.172 (required by Plugin Version Bump gate).

## Tests Added

| Fix | Test |
|-----|------|
| 1 | `tests/hooks/test_markdown_auto_lint.py::TestSubprocessErrorPaths::test_timeout_returns_zero_with_warning` |
| 2 | `tests/hooks/test_session_validator.py::TestModuleAsScript::test_lib_missing_exits_zero` |
| 3 | `tests/hooks/test_security_gate.py::TestFindSecurityEvidenceStreaming` (2 tests), `tests/hooks/test_security_commit_gate.py::TestFindSecurityEvidenceStreaming` (2 tests) |
| 4 | `tests/test_plan_state_sync.py::TestWindowsLockRange` (2 tests, mocks msvcrt so runs on all platforms) |
| 5 | `tests/hooks/test_adr_change_detection.py::TestGetProjectRootPluginLayout::test_vendored_layout_resolves_to_git_root` |

All 1514 hook tests pass. Pre-PR gate clean.