### PR TITLE
fix(adr-generator): correct catalog statuses, pin MADR 4.0.0, decidable immutability rule

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.175",
+  "version": "0.5.176",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.176",
+  "version": "0.5.177",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.174",
+  "version": "0.5.175",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/adr-generator/references/adr-best-practices.md
+++ b/.claude/skills/adr-generator/references/adr-best-practices.md
@@ -39,7 +39,7 @@ This project adopts the **GDS Way bounded rule**, because it is the only publish
 3. **Decision change before any implementation**: replace in place with stakeholder agreement, update `date`.
 4. **Decision change after any implementation**: create a new superseding ADR. Never delete the old one.
 
-An `implemented` boolean that flips at the first merged change gives this rule an objective, git-checkable gate between cases 3 and 4.
+If a project wants a machine-checkable gate between cases 3 and 4, it may add optional `implemented` metadata that flips at the first merged change. Do not emit that field unless the project's ADR template or existing ADRs already use it.
 
 When a new ADR supersedes another:
 

--- a/.claude/skills/adr-generator/references/adr-best-practices.md
+++ b/.claude/skills/adr-generator/references/adr-best-practices.md
@@ -7,7 +7,7 @@ Writing guidance adapted from [Joel Parker Henderson's ADR collection](https://g
 - **Rationale**: Explain the reasons for the decision. Include context, pros and cons, feature comparisons, cost/benefit discussions.
 - **Specific**: Each ADR addresses one decision, not multiple.
 - **Timestamped**: Identify when each item is written. Important for aspects that change over time (costs, schedules, scaling).
-- **Immutable**: Do not alter existing information in a finalized ADR. Instead, amend with dated additions or supersede by creating a new ADR. In practice, teams often treat ADRs as living documents with dated amendments — this is acceptable provided each change includes a date stamp and preserves the original reasoning.
+- **Mutable by a decidable rule**: Whether you may edit an accepted ADR depends on whether it has been implemented. See [ADR Mutability and Superseding](#adr-mutability-and-superseding) for the exact rule. Short version: clarifications and consequences are editable in place (update `date`); a decision change after any implementation requires a new superseding ADR.
 
 ## Writing Good Context Sections
 
@@ -22,13 +22,32 @@ Writing guidance adapted from [Joel Parker Henderson's ADR collection](https://g
 - Include information about subsequent ADRs triggered by this decision
 - Include after-action review processes (teams typically review each ADR one month later)
 
-## Superseding ADRs
+## ADR Mutability and Superseding
 
-When an AD replaces or invalidates a previous ADR:
+The field splits three ways on whether an accepted ADR may be edited:
 
-- Create a new ADR (do not modify the old one)
-- Mark the old ADR as `Superseded by ADR-NNN`
-- Reference the old ADR in the new one
+| School | Rule | Source |
+|--------|------|--------|
+| Strict append-only | Accepted (and rejected) ADRs are immutable; any change is a new superseding ADR; only the old ADR's status field changes. | AWS Prescriptive Guidance; Azure Well-Architected ("append-only log; don't edit accepted records") |
+| No rule | Nygard never says "immutable"; MADR's `date` means "when the decision was last updated" and all fields are optional. | Nygard 2011; MADR 4.0.0 |
+| Bounded in-place edits | Clarifications editable any time; Consequences updatable during implementation; replace in place only if never implemented and stakeholders agree; once any implementation occurred, supersede. | GDS Way |
+
+This project adopts the **GDS Way bounded rule**, because it is the only published rule with an objective boundary (implementation status):
+
+1. **Clarifications**: edit in place, update `date`.
+2. **Consequences**: update in place as implementation teaches, update `date`.
+3. **Decision change before any implementation**: replace in place with stakeholder agreement, update `date`.
+4. **Decision change after any implementation**: create a new superseding ADR. Never delete the old one.
+
+An `implemented` boolean that flips at the first merged change gives this rule an objective, git-checkable gate between cases 3 and 4.
+
+When a new ADR supersedes another:
+
+- Create the new ADR (do not rewrite the old one's decision).
+- Set the old ADR's status to `superseded` and reference the replacement (`Superseded by ADR-NNN`).
+- Reference the old ADR from the new one.
+
+Keep superseded ADRs; never delete them. This retention rule is unanimous across all sources.
 
 ## File Naming Approaches
 
@@ -74,13 +93,13 @@ Skip an ADR when:
 
 - Talk about the "why", do not mandate the "what"
 - Some teams prefer the directory name "decisions" over the abbreviation "ADRs"
-- In practice, teams treat ADRs as living documents with dated amendments rather than strict immutability — this works well when each change includes a date stamp
+- Treat ADRs as living documents only within the bounded rule above: clarifications and pre-implementation changes edit in place; post-implementation decision changes supersede. Always date each change
 - Typical updates: new teammates, new offerings, real-world results, vendor changes
 
 ## References
 
 - [Joel Parker Henderson ADR Collection](https://github.com/joelparkerhenderson/architecture-decision-record)
-- [Michael Nygard, "Documenting Architecture Decisions" (2011)](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
+- [Michael Nygard, "Documenting Architecture Decisions" (2011)](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
 - [ADR Templates Catalog](https://adr.github.io/adr-templates/)
-- [Arc42](https://arc42.org/) — Architecture documentation framework
-- [C4 Model](https://c4model.com/) — Architecture diagramming approach
+- [Arc42](https://arc42.org/): architecture documentation framework
+- [C4 Model](https://c4model.com/): architecture diagramming approach

--- a/.claude/skills/adr-generator/references/adr-best-practices.md
+++ b/.claude/skills/adr-generator/references/adr-best-practices.md
@@ -28,9 +28,9 @@ The field splits three ways on whether an accepted ADR may be edited:
 
 | School | Rule | Source |
 |--------|------|--------|
-| Strict append-only | Accepted (and rejected) ADRs are immutable; any change is a new superseding ADR; only the old ADR's status field changes. | AWS Prescriptive Guidance; Azure Well-Architected ("append-only log; don't edit accepted records") |
-| No rule | Nygard never says "immutable"; MADR's `date` means "when the decision was last updated" and all fields are optional. | Nygard 2011; MADR 4.0.0 |
-| Bounded in-place edits | Clarifications editable any time; Consequences updatable during implementation; replace in place only if never implemented and stakeholders agree; once any implementation occurred, supersede. | GDS Way |
+| Strict append-only | Accepted (and rejected) ADRs are immutable; any change is a new superseding ADR; only the old ADR's status field changes. | [AWS ADR process](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html), [AWS ADR best practices](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/best-practices.html), [Azure Well-Architected Framework](https://learn.microsoft.com/en-us/azure/well-architected/architect-role/architecture-decision-record) ("append-only log; don't edit accepted records") |
+| No rule | Nygard never says "immutable"; MADR's `date` means "when the decision was last updated" and all fields are optional. | [Nygard 2011](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions), [MADR 4.0.0](https://adr.github.io/madr/) |
+| Bounded in-place edits | Clarifications editable any time; Consequences updatable during implementation; replace in place only if never implemented and stakeholders agree; once any implementation occurred, supersede. | [GDS Way](https://gds-way.digital.cabinet-office.gov.uk/standards/architecture-decisions.html) |
 
 This project adopts the **GDS Way bounded rule**, because it is the only published rule with an objective boundary (implementation status):
 
@@ -101,5 +101,10 @@ Skip an ADR when:
 - [Joel Parker Henderson ADR Collection](https://github.com/joelparkerhenderson/architecture-decision-record)
 - [Michael Nygard, "Documenting Architecture Decisions" (2011)](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
 - [ADR Templates Catalog](https://adr.github.io/adr-templates/)
+- [MADR 4.0.0](https://adr.github.io/madr/)
+- [GDS Way: Architecture decisions](https://gds-way.digital.cabinet-office.gov.uk/standards/architecture-decisions.html)
+- [AWS Prescriptive Guidance: ADR process](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html)
+- [AWS Prescriptive Guidance: ADR best practices](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/best-practices.html)
+- [Azure Well-Architected Framework: ADRs](https://learn.microsoft.com/en-us/azure/well-architected/architect-role/architecture-decision-record)
 - [Arc42](https://arc42.org/): architecture documentation framework
 - [C4 Model](https://c4model.com/): architecture diagramming approach

--- a/.claude/skills/adr-generator/references/adr-templates-catalog.md
+++ b/.claude/skills/adr-generator/references/adr-templates-catalog.md
@@ -127,7 +127,7 @@ What is the change that we're proposing and/or doing?
 What becomes easier or more difficult to do because of this change?
 ```
 
-Nygard's original defines exactly four statuses: `proposed`, `accepted`, `deprecated`, `superseded`. `rejected` is **not** in the primary source; it is a common extension popularized by MADR and the broader ADR community. Add it only when your project explicitly tracks rejected proposals (this project does, see the lifecycle table in [adr-best-practices.md](adr-best-practices.md)).
+Nygard's original defines exactly four statuses: `proposed`, `accepted`, `deprecated`, `superseded`. `rejected` is **not** in the primary source; it is a common extension popularized by MADR and the broader ADR community. Add it only when the target project's ADR template or existing ADRs explicitly track rejected proposals.
 
 ---
 

--- a/.claude/skills/adr-generator/references/adr-templates-catalog.md
+++ b/.claude/skills/adr-generator/references/adr-templates-catalog.md
@@ -32,13 +32,16 @@ See [adr-template.md](adr-template.md) for the full template.
 
 ## MADR (Markdown Architectural Decision Records)
 
-Source: [github.com/adr/madr](https://github.com/adr/madr) (CC0-1.0 license)
+Source: [MADR 4.0.0 template](https://raw.githubusercontent.com/adr/madr/4.0.0/template/adr-template.md) (CC0-1.0 license). Pinned to version 4.0.0 (released 2024-09-17); an unpinned copy silently drifts as upstream evolves.
 
 ```markdown
 ---
+# These are optional metadata elements. Feel free to remove any of them.
 status: "{proposed | rejected | accepted | deprecated | superseded by ADR-0123}"
 date: {YYYY-MM-DD when the decision was last updated}
 decision-makers: {list everyone involved in the decision}
+consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
+informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
 ---
 
 # {short title, representative of solved problem and found solution}
@@ -90,11 +93,17 @@ Chosen option: "{title of option 1}", because {justification}.
 {Additional evidence, team agreement, links to other decisions.}
 ```
 
+**MADR 4.0.0 facts**:
+
+- All frontmatter fields are optional ("These are optional metadata elements. Feel free to remove any of them.").
+- 4.0.0 also ships `bare` and `minimal` template variants for low-ceremony decisions; offer them when the full template is too heavy.
+- Naming history: 3.0.0-beta (2022-05-17) renamed the project "Markdown Any Decision Records"; 4.0.0 reverted to "Markdown **Architectural** Decision Records". Cite the architectural form.
+
 ---
 
 ## Nygard Template
 
-Source: [Michael Nygard, "Documenting Architecture Decisions" (2011)](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
+Source: [Michael Nygard, "Documenting Architecture Decisions" (2011)](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
 
 The original and most widely adopted ADR format. Minimal by design.
 
@@ -103,7 +112,7 @@ The original and most widely adopted ADR format. Minimal by design.
 
 ## Status
 
-{proposed | accepted | rejected | deprecated | superseded}
+{proposed | accepted | deprecated | superseded}
 
 ## Context
 
@@ -117,6 +126,8 @@ What is the change that we're proposing and/or doing?
 
 What becomes easier or more difficult to do because of this change?
 ```
+
+Nygard's original defines exactly four statuses: `proposed`, `accepted`, `deprecated`, `superseded`. `rejected` is **not** in the primary source; it is a common extension popularized by MADR and the broader ADR community. Add it only when your project explicitly tracks rejected proposals (this project does, see the lifecycle table in [adr-best-practices.md](adr-best-practices.md)).
 
 ---
 
@@ -193,4 +204,4 @@ Source: [Planguage specification by Tom Gilb](https://www.iaria.org/conferences2
 - [ADR Templates Catalog](https://adr.github.io/adr-templates/)
 - [MADR Repository](https://github.com/adr/madr)
 - [Joel Parker Henderson ADR Collection](https://github.com/joelparkerhenderson/architecture-decision-record)
-- [ISO/IEC/IEEE 42010:2011](https://en.wikipedia.org/wiki/ISO/IEC_42010) — International standard for architecture descriptions
+- [ISO/IEC/IEEE 42010:2011](https://en.wikipedia.org/wiki/ISO/IEC_42010): international standard for architecture descriptions

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.176",
+  "version": "0.5.177",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.175",
+  "version": "0.5.176",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.174",
+  "version": "0.5.175",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/adr-generator/references/adr-best-practices.md
+++ b/src/copilot-cli/skills/adr-generator/references/adr-best-practices.md
@@ -39,7 +39,7 @@ This project adopts the **GDS Way bounded rule**, because it is the only publish
 3. **Decision change before any implementation**: replace in place with stakeholder agreement, update `date`.
 4. **Decision change after any implementation**: create a new superseding ADR. Never delete the old one.
 
-An `implemented` boolean that flips at the first merged change gives this rule an objective, git-checkable gate between cases 3 and 4.
+If a project wants a machine-checkable gate between cases 3 and 4, it may add optional `implemented` metadata that flips at the first merged change. Do not emit that field unless the project's ADR template or existing ADRs already use it.
 
 When a new ADR supersedes another:
 

--- a/src/copilot-cli/skills/adr-generator/references/adr-best-practices.md
+++ b/src/copilot-cli/skills/adr-generator/references/adr-best-practices.md
@@ -7,7 +7,7 @@ Writing guidance adapted from [Joel Parker Henderson's ADR collection](https://g
 - **Rationale**: Explain the reasons for the decision. Include context, pros and cons, feature comparisons, cost/benefit discussions.
 - **Specific**: Each ADR addresses one decision, not multiple.
 - **Timestamped**: Identify when each item is written. Important for aspects that change over time (costs, schedules, scaling).
-- **Immutable**: Do not alter existing information in a finalized ADR. Instead, amend with dated additions or supersede by creating a new ADR. In practice, teams often treat ADRs as living documents with dated amendments — this is acceptable provided each change includes a date stamp and preserves the original reasoning.
+- **Mutable by a decidable rule**: Whether you may edit an accepted ADR depends on whether it has been implemented. See [ADR Mutability and Superseding](#adr-mutability-and-superseding) for the exact rule. Short version: clarifications and consequences are editable in place (update `date`); a decision change after any implementation requires a new superseding ADR.
 
 ## Writing Good Context Sections
 
@@ -22,13 +22,32 @@ Writing guidance adapted from [Joel Parker Henderson's ADR collection](https://g
 - Include information about subsequent ADRs triggered by this decision
 - Include after-action review processes (teams typically review each ADR one month later)
 
-## Superseding ADRs
+## ADR Mutability and Superseding
 
-When an AD replaces or invalidates a previous ADR:
+The field splits three ways on whether an accepted ADR may be edited:
 
-- Create a new ADR (do not modify the old one)
-- Mark the old ADR as `Superseded by ADR-NNN`
-- Reference the old ADR in the new one
+| School | Rule | Source |
+|--------|------|--------|
+| Strict append-only | Accepted (and rejected) ADRs are immutable; any change is a new superseding ADR; only the old ADR's status field changes. | AWS Prescriptive Guidance; Azure Well-Architected ("append-only log; don't edit accepted records") |
+| No rule | Nygard never says "immutable"; MADR's `date` means "when the decision was last updated" and all fields are optional. | Nygard 2011; MADR 4.0.0 |
+| Bounded in-place edits | Clarifications editable any time; Consequences updatable during implementation; replace in place only if never implemented and stakeholders agree; once any implementation occurred, supersede. | GDS Way |
+
+This project adopts the **GDS Way bounded rule**, because it is the only published rule with an objective boundary (implementation status):
+
+1. **Clarifications**: edit in place, update `date`.
+2. **Consequences**: update in place as implementation teaches, update `date`.
+3. **Decision change before any implementation**: replace in place with stakeholder agreement, update `date`.
+4. **Decision change after any implementation**: create a new superseding ADR. Never delete the old one.
+
+An `implemented` boolean that flips at the first merged change gives this rule an objective, git-checkable gate between cases 3 and 4.
+
+When a new ADR supersedes another:
+
+- Create the new ADR (do not rewrite the old one's decision).
+- Set the old ADR's status to `superseded` and reference the replacement (`Superseded by ADR-NNN`).
+- Reference the old ADR from the new one.
+
+Keep superseded ADRs; never delete them. This retention rule is unanimous across all sources.
 
 ## File Naming Approaches
 
@@ -74,13 +93,13 @@ Skip an ADR when:
 
 - Talk about the "why", do not mandate the "what"
 - Some teams prefer the directory name "decisions" over the abbreviation "ADRs"
-- In practice, teams treat ADRs as living documents with dated amendments rather than strict immutability — this works well when each change includes a date stamp
+- Treat ADRs as living documents only within the bounded rule above: clarifications and pre-implementation changes edit in place; post-implementation decision changes supersede. Always date each change
 - Typical updates: new teammates, new offerings, real-world results, vendor changes
 
 ## References
 
 - [Joel Parker Henderson ADR Collection](https://github.com/joelparkerhenderson/architecture-decision-record)
-- [Michael Nygard, "Documenting Architecture Decisions" (2011)](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
+- [Michael Nygard, "Documenting Architecture Decisions" (2011)](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
 - [ADR Templates Catalog](https://adr.github.io/adr-templates/)
-- [Arc42](https://arc42.org/) — Architecture documentation framework
-- [C4 Model](https://c4model.com/) — Architecture diagramming approach
+- [Arc42](https://arc42.org/): architecture documentation framework
+- [C4 Model](https://c4model.com/): architecture diagramming approach

--- a/src/copilot-cli/skills/adr-generator/references/adr-best-practices.md
+++ b/src/copilot-cli/skills/adr-generator/references/adr-best-practices.md
@@ -28,9 +28,9 @@ The field splits three ways on whether an accepted ADR may be edited:
 
 | School | Rule | Source |
 |--------|------|--------|
-| Strict append-only | Accepted (and rejected) ADRs are immutable; any change is a new superseding ADR; only the old ADR's status field changes. | AWS Prescriptive Guidance; Azure Well-Architected ("append-only log; don't edit accepted records") |
-| No rule | Nygard never says "immutable"; MADR's `date` means "when the decision was last updated" and all fields are optional. | Nygard 2011; MADR 4.0.0 |
-| Bounded in-place edits | Clarifications editable any time; Consequences updatable during implementation; replace in place only if never implemented and stakeholders agree; once any implementation occurred, supersede. | GDS Way |
+| Strict append-only | Accepted (and rejected) ADRs are immutable; any change is a new superseding ADR; only the old ADR's status field changes. | [AWS ADR process](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html), [AWS ADR best practices](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/best-practices.html), [Azure Well-Architected Framework](https://learn.microsoft.com/en-us/azure/well-architected/architect-role/architecture-decision-record) ("append-only log; don't edit accepted records") |
+| No rule | Nygard never says "immutable"; MADR's `date` means "when the decision was last updated" and all fields are optional. | [Nygard 2011](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions), [MADR 4.0.0](https://adr.github.io/madr/) |
+| Bounded in-place edits | Clarifications editable any time; Consequences updatable during implementation; replace in place only if never implemented and stakeholders agree; once any implementation occurred, supersede. | [GDS Way](https://gds-way.digital.cabinet-office.gov.uk/standards/architecture-decisions.html) |
 
 This project adopts the **GDS Way bounded rule**, because it is the only published rule with an objective boundary (implementation status):
 
@@ -101,5 +101,10 @@ Skip an ADR when:
 - [Joel Parker Henderson ADR Collection](https://github.com/joelparkerhenderson/architecture-decision-record)
 - [Michael Nygard, "Documenting Architecture Decisions" (2011)](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
 - [ADR Templates Catalog](https://adr.github.io/adr-templates/)
+- [MADR 4.0.0](https://adr.github.io/madr/)
+- [GDS Way: Architecture decisions](https://gds-way.digital.cabinet-office.gov.uk/standards/architecture-decisions.html)
+- [AWS Prescriptive Guidance: ADR process](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html)
+- [AWS Prescriptive Guidance: ADR best practices](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/best-practices.html)
+- [Azure Well-Architected Framework: ADRs](https://learn.microsoft.com/en-us/azure/well-architected/architect-role/architecture-decision-record)
 - [Arc42](https://arc42.org/): architecture documentation framework
 - [C4 Model](https://c4model.com/): architecture diagramming approach

--- a/src/copilot-cli/skills/adr-generator/references/adr-templates-catalog.md
+++ b/src/copilot-cli/skills/adr-generator/references/adr-templates-catalog.md
@@ -127,7 +127,7 @@ What is the change that we're proposing and/or doing?
 What becomes easier or more difficult to do because of this change?
 ```
 
-Nygard's original defines exactly four statuses: `proposed`, `accepted`, `deprecated`, `superseded`. `rejected` is **not** in the primary source; it is a common extension popularized by MADR and the broader ADR community. Add it only when your project explicitly tracks rejected proposals (this project does, see the lifecycle table in [adr-best-practices.md](adr-best-practices.md)).
+Nygard's original defines exactly four statuses: `proposed`, `accepted`, `deprecated`, `superseded`. `rejected` is **not** in the primary source; it is a common extension popularized by MADR and the broader ADR community. Add it only when the target project's ADR template or existing ADRs explicitly track rejected proposals.
 
 ---
 

--- a/src/copilot-cli/skills/adr-generator/references/adr-templates-catalog.md
+++ b/src/copilot-cli/skills/adr-generator/references/adr-templates-catalog.md
@@ -32,13 +32,16 @@ See [adr-template.md](adr-template.md) for the full template.
 
 ## MADR (Markdown Architectural Decision Records)
 
-Source: [github.com/adr/madr](https://github.com/adr/madr) (CC0-1.0 license)
+Source: [MADR 4.0.0 template](https://raw.githubusercontent.com/adr/madr/4.0.0/template/adr-template.md) (CC0-1.0 license). Pinned to version 4.0.0 (released 2024-09-17); an unpinned copy silently drifts as upstream evolves.
 
 ```markdown
 ---
+# These are optional metadata elements. Feel free to remove any of them.
 status: "{proposed | rejected | accepted | deprecated | superseded by ADR-0123}"
 date: {YYYY-MM-DD when the decision was last updated}
 decision-makers: {list everyone involved in the decision}
+consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
+informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
 ---
 
 # {short title, representative of solved problem and found solution}
@@ -90,11 +93,17 @@ Chosen option: "{title of option 1}", because {justification}.
 {Additional evidence, team agreement, links to other decisions.}
 ```
 
+**MADR 4.0.0 facts**:
+
+- All frontmatter fields are optional ("These are optional metadata elements. Feel free to remove any of them.").
+- 4.0.0 also ships `bare` and `minimal` template variants for low-ceremony decisions; offer them when the full template is too heavy.
+- Naming history: 3.0.0-beta (2022-05-17) renamed the project "Markdown Any Decision Records"; 4.0.0 reverted to "Markdown **Architectural** Decision Records". Cite the architectural form.
+
 ---
 
 ## Nygard Template
 
-Source: [Michael Nygard, "Documenting Architecture Decisions" (2011)](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
+Source: [Michael Nygard, "Documenting Architecture Decisions" (2011)](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
 
 The original and most widely adopted ADR format. Minimal by design.
 
@@ -103,7 +112,7 @@ The original and most widely adopted ADR format. Minimal by design.
 
 ## Status
 
-{proposed | accepted | rejected | deprecated | superseded}
+{proposed | accepted | deprecated | superseded}
 
 ## Context
 
@@ -117,6 +126,8 @@ What is the change that we're proposing and/or doing?
 
 What becomes easier or more difficult to do because of this change?
 ```
+
+Nygard's original defines exactly four statuses: `proposed`, `accepted`, `deprecated`, `superseded`. `rejected` is **not** in the primary source; it is a common extension popularized by MADR and the broader ADR community. Add it only when your project explicitly tracks rejected proposals (this project does, see the lifecycle table in [adr-best-practices.md](adr-best-practices.md)).
 
 ---
 
@@ -193,4 +204,4 @@ Source: [Planguage specification by Tom Gilb](https://www.iaria.org/conferences2
 - [ADR Templates Catalog](https://adr.github.io/adr-templates/)
 - [MADR Repository](https://github.com/adr/madr)
 - [Joel Parker Henderson ADR Collection](https://github.com/joelparkerhenderson/architecture-decision-record)
-- [ISO/IEC/IEEE 42010:2011](https://en.wikipedia.org/wiki/ISO/IEC_42010) — International standard for architecture descriptions
+- [ISO/IEC/IEEE 42010:2011](https://en.wikipedia.org/wiki/ISO/IEC_42010): international standard for architecture descriptions


### PR DESCRIPTION
## Summary

### What
Corrects three documentation defects in the `adr-generator` skill reference files (and regenerates the `src/copilot-cli` mirror).

### Why
The ADR template catalog and best-practices guidance contained primary-source errors and a self-contradiction that left agents without a decidable rule.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2580 | Nygard catalog wrongly lists `rejected`; dead source link |
| **Issue** | Fixes #2581 | Pin MADR catalog entry to 4.0.0 |
| **Issue** | Fixes #2582 | adr-best-practices immutability guidance contradicts itself |

## Changes

- **#2580**: Dropped non-canonical `rejected` from the Nygard status line; annotated it as a MADR/community extension. Fixed the dead thinkrelevance.com link to the live cognitect.com URL.
- **#2581**: Pinned the MADR entry to template 4.0.0: added optional consulted/informed fields, the optional-fields note, the bare/minimal variants, and the name-revert history note.
- **#2582**: Replaced the self-contradicting "Immutable" bullet with the GDS Way bounded rule, citing the three documented schools. Aligned the Teamwork bullet and superseding section.
- Fixed pre-existing em-dash violations in the References sections.
- Regenerated copilot-cli mirror; bumped both plugin manifests to 0.5.177 after branch updates (parity gate).

## Type of Change

- [x] Documentation update

## Testing

- [x] No testing required (documentation only)
- Ran build_scripts parity + skills-generation tests (47 passed) to confirm mirror parity.

## Related Issues

Fixes #2580
Fixes #2581
Fixes #2582