### PR TITLE
fix(hooks): stop adr-architect gate blocking its own evidence artifact

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.174",
+  "version": "0.5.176",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PreToolUse/invoke_adr_architect_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_adr_architect_gate.py
@@ -24,10 +24,11 @@ from __future__ import annotations
 
 import json
 import os
+import posixpath
 import re
 import sys
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 # Bootstrap: find lib directory via env var or manifest walk-up.
 # CLAUDE_PLUGIN_ROOT honored when set; otherwise walk up from __file__
@@ -48,7 +49,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)
@@ -130,13 +135,25 @@ def write_audit_log(message: str) -> None:
         )
 
 
-def _is_evidence_artifact(file_path: str) -> bool:
+def _normalize_hook_path(file_path: str) -> str:
+    """Normalize a hook path for lexical gate matching.
+
+    Hook inputs are project-relative strings, not necessarily existing files.
+    ``posixpath.normpath`` collapses ``..`` without requiring the target to
+    exist; replacing backslashes first keeps Windows paths on the same path
+    separator contract as POSIX paths.
+    """
+    normalized = file_path.replace("\\", "/")
+    return posixpath.normpath(normalized)
+
+
+def _is_evidence_artifact(normalized_path: str) -> bool:
     """True if file_path lives under a gate evidence directory.
 
-    Matches ``.agents/analysis/`` and ``.agents/critique/`` as consecutive
-    path segments, for both relative and absolute paths.
+    Matches ``.agents/analysis/`` and ``.agents/critique/`` after lexical
+    normalization has collapsed traversal segments.
     """
-    parts = Path(file_path).parts
+    parts = PurePosixPath(normalized_path).parts
     for needle in _EVIDENCE_DIRS:
         span = len(needle)
         for start in range(len(parts) - span + 1):
@@ -155,9 +172,10 @@ def is_adr_file(file_path: str) -> bool:
     whose name starts with ``ADR-<digits>`` match, not any path containing the
     substring.
     """
-    if _is_evidence_artifact(file_path):
+    normalized_path = _normalize_hook_path(file_path)
+    if _is_evidence_artifact(normalized_path):
         return False
-    return _ADR_PATTERN.search(file_path) is not None
+    return _ADR_PATTERN.search(normalized_path) is not None
 
 
 def check_architect_evidence(project_dir: str) -> dict[str, object]:

--- a/.claude/hooks/PreToolUse/invoke_adr_architect_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_adr_architect_gate.py
@@ -58,7 +58,17 @@ from hook_utilities import (  # noqa: E402
     get_today_session_log,
 )
 
-_ADR_PATTERN = re.compile(r"ADR-\d+.*\.md$", re.IGNORECASE)
+_ADR_PATTERN = re.compile(r"(?:^|/)ADR-\d+[^/]*\.md$", re.IGNORECASE)
+
+# Directories that hold the gate's OWN evidence artifacts (debate logs,
+# critiques). Writing a debate log here is the act the gate asks for, so the
+# gate must never block writes under these directories, even when the filename
+# starts with an "ADR-<n>" substring (issue #2579: the natural evidence name
+# ADR-0002-architect-review-debate.md otherwise self-blocks, chicken-and-egg).
+_EVIDENCE_DIRS = (
+    (".agents", "analysis"),
+    (".agents", "critique"),
+)
 
 _ARCHITECT_EVIDENCE_PATTERNS = [
     re.compile(r"/adr-review"),
@@ -120,8 +130,33 @@ def write_audit_log(message: str) -> None:
         )
 
 
+def _is_evidence_artifact(file_path: str) -> bool:
+    """True if file_path lives under a gate evidence directory.
+
+    Matches ``.agents/analysis/`` and ``.agents/critique/`` as consecutive
+    path segments, for both relative and absolute paths.
+    """
+    parts = Path(file_path).parts
+    for needle in _EVIDENCE_DIRS:
+        span = len(needle)
+        for start in range(len(parts) - span + 1):
+            if parts[start : start + span] == needle:
+                return True
+    return False
+
+
 def is_adr_file(file_path: str) -> bool:
-    """Check if file path matches ADR naming pattern."""
+    """Check if file path matches ADR naming pattern.
+
+    Files under the gate's own evidence directories (``.agents/analysis/``,
+    ``.agents/critique/``) are excluded: writing the architect-review debate
+    log is the act the gate asks for, so blocking it is a chicken-and-egg
+    deadlock (issue #2579). The pattern is basename-anchored so only files
+    whose name starts with ``ADR-<digits>`` match, not any path containing the
+    substring.
+    """
+    if _is_evidence_artifact(file_path):
+        return False
     return _ADR_PATTERN.search(file_path) is not None
 
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.174",
+  "version": "0.5.176",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
@@ -214,10 +214,10 @@ def _original_main(stdin_bytes):
 
     import json
     import os
+    import posixpath
     import re
     import sys
     from datetime import UTC, datetime
-    import posixpath
     from pathlib import Path, PurePosixPath
 
     # Bootstrap: find lib directory via env var or manifest walk-up.

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
@@ -217,7 +217,8 @@ def _original_main(stdin_bytes):
     import re
     import sys
     from datetime import UTC, datetime
-    from pathlib import Path
+    import posixpath
+    from pathlib import Path, PurePosixPath
 
     # Bootstrap: find lib directory via env var or manifest walk-up.
     # CLAUDE_PLUGIN_ROOT honored when set; otherwise walk up from __file__
@@ -238,7 +239,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         sys.exit(2)
     if _lib_dir not in sys.path:
         sys.path.insert(0, _lib_dir)
@@ -320,13 +325,25 @@ def _original_main(stdin_bytes):
             )
 
 
-    def _is_evidence_artifact(file_path: str) -> bool:
+    def _normalize_hook_path(file_path: str) -> str:
+        """Normalize a hook path for lexical gate matching.
+
+        Hook inputs are project-relative strings, not necessarily existing files.
+        ``posixpath.normpath`` collapses ``..`` without requiring the target to
+        exist; replacing backslashes first keeps Windows paths on the same path
+        separator contract as POSIX paths.
+        """
+        normalized = file_path.replace("\\", "/")
+        return posixpath.normpath(normalized)
+
+
+    def _is_evidence_artifact(normalized_path: str) -> bool:
         """True if file_path lives under a gate evidence directory.
 
-        Matches ``.agents/analysis/`` and ``.agents/critique/`` as consecutive
-        path segments, for both relative and absolute paths.
+        Matches ``.agents/analysis/`` and ``.agents/critique/`` after lexical
+        normalization has collapsed traversal segments.
         """
-        parts = Path(file_path).parts
+        parts = PurePosixPath(normalized_path).parts
         for needle in _EVIDENCE_DIRS:
             span = len(needle)
             for start in range(len(parts) - span + 1):
@@ -345,9 +362,10 @@ def _original_main(stdin_bytes):
         whose name starts with ``ADR-<digits>`` match, not any path containing the
         substring.
         """
-        if _is_evidence_artifact(file_path):
+        normalized_path = _normalize_hook_path(file_path)
+        if _is_evidence_artifact(normalized_path):
             return False
-        return _ADR_PATTERN.search(file_path) is not None
+        return _ADR_PATTERN.search(normalized_path) is not None
 
 
     def check_architect_evidence(project_dir: str) -> dict[str, object]:

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
@@ -248,7 +248,17 @@ def _original_main(stdin_bytes):
         get_today_session_log,
     )
 
-    _ADR_PATTERN = re.compile(r"ADR-\d+.*\.md$", re.IGNORECASE)
+    _ADR_PATTERN = re.compile(r"(?:^|/)ADR-\d+[^/]*\.md$", re.IGNORECASE)
+
+    # Directories that hold the gate's OWN evidence artifacts (debate logs,
+    # critiques). Writing a debate log here is the act the gate asks for, so the
+    # gate must never block writes under these directories, even when the filename
+    # starts with an "ADR-<n>" substring (issue #2579: the natural evidence name
+    # ADR-0002-architect-review-debate.md otherwise self-blocks, chicken-and-egg).
+    _EVIDENCE_DIRS = (
+        (".agents", "analysis"),
+        (".agents", "critique"),
+    )
 
     _ARCHITECT_EVIDENCE_PATTERNS = [
         re.compile(r"/adr-review"),
@@ -310,8 +320,33 @@ def _original_main(stdin_bytes):
             )
 
 
+    def _is_evidence_artifact(file_path: str) -> bool:
+        """True if file_path lives under a gate evidence directory.
+
+        Matches ``.agents/analysis/`` and ``.agents/critique/`` as consecutive
+        path segments, for both relative and absolute paths.
+        """
+        parts = Path(file_path).parts
+        for needle in _EVIDENCE_DIRS:
+            span = len(needle)
+            for start in range(len(parts) - span + 1):
+                if parts[start : start + span] == needle:
+                    return True
+        return False
+
+
     def is_adr_file(file_path: str) -> bool:
-        """Check if file path matches ADR naming pattern."""
+        """Check if file path matches ADR naming pattern.
+
+        Files under the gate's own evidence directories (``.agents/analysis/``,
+        ``.agents/critique/``) are excluded: writing the architect-review debate
+        log is the act the gate asks for, so blocking it is a chicken-and-egg
+        deadlock (issue #2579). The pattern is basename-anchored so only files
+        whose name starts with ``ADR-<digits>`` match, not any path containing the
+        substring.
+        """
+        if _is_evidence_artifact(file_path):
+            return False
         return _ADR_PATTERN.search(file_path) is not None
 
 

--- a/tests/test_invoke_adr_architect_gate.py
+++ b/tests/test_invoke_adr_architect_gate.py
@@ -72,6 +72,24 @@ class TestIsADRFile:
         # Basename-anchored: ADR-<n> embedded mid-name does not match.
         assert is_adr_file("notes/about-ADR-5-stuff.md") is False
 
+    def test_matches_windows_separator_adr_path(self) -> None:
+        assert is_adr_file(r".agents\architecture\ADR-0002-decision.md") is True
+
+    def test_excludes_windows_separator_evidence_artifact(self) -> None:
+        assert is_adr_file(r".agents\analysis\ADR-0002-debate.md") is False
+
+    def test_rejects_path_traversal_bypass(self) -> None:
+        assert (
+            is_adr_file(".agents/analysis/../architecture/ADR-0002-decision.md")
+            is True
+        )
+
+    def test_rejects_nested_path_traversal_bypass(self) -> None:
+        assert (
+            is_adr_file(".agents/analysis/../../docs/architecture/ADR-0002.md")
+            is True
+        )
+
 
 class TestCheckArchitectEvidence:
     def test_complete_when_debate_log_in_analysis(self, tmp_path: Path) -> None:

--- a/tests/test_invoke_adr_architect_gate.py
+++ b/tests/test_invoke_adr_architect_gate.py
@@ -47,6 +47,31 @@ class TestIsADRFile:
     def test_rejects_partial_match(self) -> None:
         assert is_adr_file("ADR-notes.txt") is False
 
+    def test_excludes_evidence_artifact_in_analysis(self) -> None:
+        # Issue #2579: the architect-review debate log is the evidence the gate
+        # asks for; writing it must not be blocked even though its name starts
+        # with ADR-<n>.
+        assert (
+            is_adr_file(".agents/analysis/ADR-0002-architect-review-debate.md")
+            is False
+        )
+
+    def test_excludes_evidence_artifact_in_critique(self) -> None:
+        assert is_adr_file(".agents/critique/ADR-0002-debate-log.md") is False
+
+    def test_excludes_evidence_artifact_absolute_path(self) -> None:
+        assert (
+            is_adr_file("/home/u/repo/.agents/analysis/ADR-7-debate.md") is False
+        )
+
+    def test_still_gates_real_adr_outside_evidence_dirs(self) -> None:
+        # The exclusion is scoped to evidence dirs; a real ADR is still gated.
+        assert is_adr_file(".agents/architecture/ADR-0002-decision.md") is True
+
+    def test_rejects_substring_not_at_basename_start(self) -> None:
+        # Basename-anchored: ADR-<n> embedded mid-name does not match.
+        assert is_adr_file("notes/about-ADR-5-stuff.md") is False
+
 
 class TestCheckArchitectEvidence:
     def test_complete_when_debate_log_in_analysis(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

### What

Stops the PreToolUse ADR architect gate from blocking the write of its own evidence artifact, while preserving the gate for real ADR edits across POSIX and Windows-style paths.

### Why

The gate matched any path containing `ADR-<digits>` anywhere, so natural ADR-named debate logs in the evidence directory were themselves blocked. A follow-up review also found two bypass shapes: Windows backslash paths were not matched, and lexical `..` traversal could make real ADR files look like evidence artifacts.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2579 | adr-architect gate blocks writing its own evidence artifact |

## Changes

- Excludes the gate evidence directories (`.agents/analysis/`, `.agents/critique/`) from `is_adr_file` after normalizing hook input paths.
- Normalizes backslashes to `/` and collapses lexical `..` segments before evidence-dir checks and ADR basename matching.
- Anchors `_ADR_PATTERN` to the basename so an embedded `ADR-<n>` substring mid-name no longer over-matches.
- Updates tests for evidence-dir exclusion, real ADR gating, mid-name substring rejection, Windows separators, and traversal-bypass attempts.
- Regenerates the Copilot CLI hook mirror and bumps both plugin manifests 0.5.174 -> 0.5.176.

## Changed files

| File | Change |
|---|---|
| `.claude/hooks/PreToolUse/invoke_adr_architect_gate.py` | Canonical hook fix for evidence artifacts, Windows separators, and lexical traversal. |
| `src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py` | Copilot CLI mirror of the canonical hook behavior. |
| `tests/test_invoke_adr_architect_gate.py` | Regression tests for evidence artifacts, Windows separators, and traversal bypasses. |
| `.claude/.claude-plugin/plugin.json` and `src/copilot-cli/.claude-plugin/plugin.json` | Plugin manifest version bump for hook-source changes. |

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Testing

- [x] Tests added/updated
- `uv run --frozen --extra dev pytest tests/test_invoke_adr_architect_gate.py`: 32 passed.
- `uv run --frozen --extra dev ruff check .claude/hooks/PreToolUse/invoke_adr_architect_gate.py src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py tests/test_invoke_adr_architect_gate.py`: passed.
- `python3 .claude/skills/security-scan/scripts/scan_vulnerabilities.py ...`: no CWE-78 findings.

## Agent Review

### Security Review
- [x] Security agent reviewed infrastructure changes (PreToolUse hook). The change narrows the evidence-artifact exemption and preserves the architect-review requirement for real ADR files.

## Related Issues

Fixes #2579
