### PR TITLE
test(conftest): disable commit.gpgsign for git subprocesses (Refs #2548)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -12,6 +14,38 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts.validation.models import ValidationResult  # noqa: E402
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _disable_commit_signing_for_test_git() -> Iterator[None]:
+    """Neutralize host ``commit.gpgsign`` for all git subprocesses in the suite.
+
+    Some environments (e.g. Claude web containers) set a global
+    ``commit.gpgsign`` backed by a signing server that rejects commits made in
+    ``tmp_path`` fixture repos with HTTP 400, breaking the ~57 tests that create
+    commits (adr-review, metrics, merge-resolver, worktree tests, ...). Injecting
+    ``commit.gpgsign=false`` via ``GIT_CONFIG_COUNT`` gives it command-line
+    precedence over host config, so fixtures commit cleanly without per-fixture
+    edits (issue #2548). The signing-sensitive tests still RUN (they are not
+    skipped); only the signing requirement is removed.
+
+    No test sets ``GIT_CONFIG_COUNT``, so index 0 is free; if some outer process
+    already uses the indexed mechanism, this fixture leaves it untouched.
+    """
+    keys = ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0")
+    prior = {k: os.environ.get(k) for k in keys}
+    if not os.environ.get("GIT_CONFIG_COUNT"):
+        os.environ["GIT_CONFIG_COUNT"] = "1"
+        os.environ["GIT_CONFIG_KEY_0"] = "commit.gpgsign"
+        os.environ["GIT_CONFIG_VALUE_0"] = "false"
+    try:
+        yield
+    finally:
+        for key, value in prior.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 def assert_validation_result(

--- a/tests/test_conftest_git_signing.py
+++ b/tests/test_conftest_git_signing.py
@@ -1,0 +1,21 @@
+"""Behavioral check for the commit-signing conftest fixture (issue #2548)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+
+def test_subprocess_git_sees_signing_disabled() -> None:
+    # The autouse session fixture injects commit.gpgsign=false via
+    # GIT_CONFIG_COUNT, so a git subprocess must report it as false.
+    if os.environ.get("GIT_CONFIG_KEY_0") != "commit.gpgsign":
+        # An outer process already owned the indexed config; fixture is a no-op.
+        return
+    result = subprocess.run(
+        ["git", "config", "--get", "commit.gpgsign"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.stdout.strip() == "false"

--- a/tests/test_conftest_git_signing.py
+++ b/tests/test_conftest_git_signing.py
@@ -5,17 +5,19 @@ from __future__ import annotations
 import os
 import subprocess
 
+import pytest
+
 
 def test_subprocess_git_sees_signing_disabled() -> None:
     # The autouse session fixture injects commit.gpgsign=false via
     # GIT_CONFIG_COUNT, so a git subprocess must report it as false.
     if os.environ.get("GIT_CONFIG_KEY_0") != "commit.gpgsign":
-        # An outer process already owned the indexed config; fixture is a no-op.
-        return
+        pytest.skip("commit.gpgsign fixture did not claim GIT_CONFIG_KEY_0")
     result = subprocess.run(
         ["git", "config", "--get", "commit.gpgsign"],
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        env={**os.environ, "LC_ALL": "C"},
         check=False,
     )
     assert result.stdout.strip() == "false"


### PR DESCRIPTION
## Summary

### What
Adds an autouse session fixture that disables `commit.gpgsign` for git subprocesses across the test suite.

### Why
Host `commit.gpgsign` backed by a signing server (Claude web containers) returns HTTP 400 for commits made in `tmp_path` fixture repos, breaking ~57 tests that create commits. Contributors had to prepend `GIT_CONFIG_*` workarounds on every push, pushing toward the forbidden `--no-verify`.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #2548 | item 1: conftest fixture to neutralize host signing in fixture commits |

## Changes

- `tests/conftest.py`: autouse session fixture injects `commit.gpgsign=false` via `GIT_CONFIG_COUNT` (command-line precedence over host config), with env restore on teardown. Owns index 0 only when nothing else uses the indexed mechanism (no test does). Signing-sensitive tests still RUN; only the signing requirement is removed.
- `tests/test_conftest_git_signing.py`: behavioral test proving a git subprocess sees `commit.gpgsign=false` (per the release-it behavioral-smoke-test rule the issue cites).

## Scope note on #2548

This closes item 1. Item 2 (root chmod skipif guards) is already done in #2547. Item 3 (provision `gh act` in containers, or downgrade the pre-push `workflow-local-test` to a warning when `gh act` is unavailable in a remote container) remains; #2548 stays open for it.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Testing

- [x] Tests added/updated. Verified 198+ commit-creating tests (merge-resolver, adr-review gate, episode extractor) still pass; behavioral test confirms the fixture takes effect.

## Related Issues

Refs #2548