### PR TITLE
feat(cli): add --pack flag for optional skill packs (Fixes #2509)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -129,6 +129,22 @@ python3 scripts/validate_skill_installation.py
 python3 scripts/validate_skill_installation.py --verbose
 ```
 
+### Optional skill packs
+
+Some skills ship as optional packs: excluded from a default `ai-agents init` and
+installed only on request with `--pack`.
+
+```bash
+npx ai-agents init --pack business
+```
+
+| Pack | Installs | Purpose |
+|------|----------|---------|
+| `business` | `business-strategy` | Customer discovery, positioning, pricing, sales, and growth frameworks |
+
+`--pack` is repeatable and accepts comma-separated values (`--pack business` or
+`--pack a,b`). An unknown pack name fails with the list of available packs.
+
 ## Uninstallation
 
 Use your tool's native uninstall support.

--- a/docs/skill-reference.md
+++ b/docs/skill-reference.md
@@ -188,6 +188,10 @@ Strategic framework for evaluating build, buy, partner, or defer decisions. Scor
 
 Classifies problems into Cynefin Framework domains (Clear, Complicated, Complex, Chaotic). Recommends appropriate response strategies per domain.
 
+### business-strategy (optional pack)
+
+Routes a founder or business problem to the right framework (customer discovery, positioning, pricing, sales, growth, persuasion), then loads it on demand. Ships as an **optional pack**: it is not installed by a default `ai-agents init`. Add it with `npx ai-agents init --pack business` (see [installation.md](installation.md#optional-skill-packs)).
+
 ## Documentation
 
 ### doc-accuracy

--- a/packages/ai-agents-cli/src/cli.ts
+++ b/packages/ai-agents-cli/src/cli.ts
@@ -11,6 +11,7 @@ import { mergeClaudeMd } from "./target/merge-claude-md.js";
 import { mergeCopilotInstructions } from "./target/merge-copilot-instructions.js";
 import { writeAgentsMd } from "./target/write-agents-md.js";
 import { writeVersionPin } from "./target/version-pin.js";
+import { makePackFilter, knownPacks, parsePacks } from "./packs.js";
 import { TARGETS, type BundleEntry, type Target, type TargetContext } from "./types.js";
 
 const VERSION = "0.1.0";
@@ -23,6 +24,7 @@ export interface RunInitOptions {
   assetsDir: string;
   version: string;
   target?: Target;
+  packs?: string[];
 }
 
 // Append the inline harness block to the instruction file(s) the target selects.
@@ -67,7 +69,12 @@ export async function runInit(opts: RunInitOptions): Promise<number> {
     return entry;
   };
 
-  const code = await init(source, emitter, target, [capture]);
+  // Optional skill packs are excluded by default; --pack opts them in. The
+  // filter runs before capture so a non-requested pack's files are neither
+  // vendored nor recorded in the version pin (issue #2509).
+  const packFilter = makePackFilter(new Set(opts.packs ?? []));
+
+  const code = await init(source, emitter, target, [packFilter, capture]);
   if (code !== 0) return code;
 
   if (!opts.dryRun) {
@@ -105,6 +112,7 @@ async function main(): Promise<number> {
       yes: { type: "boolean", short: "y", default: false },
       help: { type: "boolean", short: "h", default: false },
       version: { type: "boolean", default: false },
+      pack: { type: "string", multiple: true },
     },
     allowPositionals: true,
     strict: true,
@@ -128,6 +136,8 @@ async function main(): Promise<number> {
         "  --dry-run     Show what would be written without touching disk",
         "  --target T    Instruction file(s) to update: claude, copilot, or both",
         "                (default: claude)",
+        `  --pack NAME   Also install an optional skill pack (${knownPacks().join(", ")});`,
+        "                repeatable or comma-separated",
         "  -y, --yes     Skip confirmation prompts",
         "  -h, --help    Show this help message",
         "  --version     Print the CLI version and exit",
@@ -157,6 +167,15 @@ async function main(): Promise<number> {
     return 2;
   }
 
+  let packs: string[];
+  try {
+    packs = [...parsePacks(values.pack as string[] | undefined)];
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`${message}\n`);
+    return 2;
+  }
+
   process.stdout.write(
     `ai-agents init: dir=${targetDir} target=${target} force=${force} dryRun=${dryRun}\n`,
   );
@@ -168,6 +187,7 @@ async function main(): Promise<number> {
     assetsDir: resolveAssetsDir(),
     version: VERSION,
     target,
+    packs,
   });
 }
 

--- a/packages/ai-agents-cli/src/cli.ts
+++ b/packages/ai-agents-cli/src/cli.ts
@@ -136,7 +136,7 @@ async function main(): Promise<number> {
         "  --dry-run     Show what would be written without touching disk",
         "  --target T    Instruction file(s) to update: claude, copilot, or both",
         "                (default: claude)",
-        `  --pack NAME   Also install an optional skill pack (${knownPacks().join(", ")});`,
+        `  --pack NAME   Also install an optional skill pack (${knownPacks().join(", ")})`,
         "                repeatable or comma-separated",
         "  -y, --yes     Skip confirmation prompts",
         "  -h, --help    Show this help message",

--- a/packages/ai-agents-cli/src/packs.ts
+++ b/packages/ai-agents-cli/src/packs.ts
@@ -21,7 +21,7 @@ export function parsePacks(raw: string[] | undefined): Set<string> {
   const requested = new Set<string>();
   for (const item of raw ?? []) {
     for (const name of item.split(",").map((s) => s.trim()).filter(Boolean)) {
-      if (!(name in PACKS)) {
+      if (!Object.prototype.hasOwnProperty.call(PACKS, name)) {
         throw new Error(
           `Unknown pack "${name}". Available packs: ${knownPacks().join(", ")}.`,
         );
@@ -42,9 +42,9 @@ export function makePackFilter(requestedPacks: Set<string>): Transform {
   );
   return (entry: BundleEntry): BundleEntry | null => {
     const normalized = entry.relativePath.replace(/\\/g, "/");
-    const match = normalized.match(/^skills\/([^/]+)\//);
+    const match = normalized.match(/^skills\/([^/]+)\//i);
     if (match) {
-      const dir = match[1];
+      const dir = match[1].toLowerCase();
       if (PACK_SKILL_DIRS.has(dir) && !requestedDirs.has(dir)) {
         return null;
       }

--- a/packages/ai-agents-cli/src/packs.ts
+++ b/packages/ai-agents-cli/src/packs.ts
@@ -1,0 +1,54 @@
+import type { BundleEntry, Transform } from "./types.js";
+
+// Optional skill packs. A pack is excluded from `ai-agents init` by default and
+// installed only when requested via `--pack <id>` (issue #2509, follow-up to
+// #1784). Maps the pack id (the --pack value) to the skill directory it vendors.
+export const PACKS: Record<string, string> = {
+  business: "business-strategy",
+};
+
+const PACK_SKILL_DIRS = new Set<string>(Object.values(PACKS));
+
+// Sorted list of known pack ids, for help text and error messages.
+export function knownPacks(): string[] {
+  return Object.keys(PACKS).sort();
+}
+
+// Parse and validate --pack values. Each value may be comma-separated
+// (`--pack a,b`) or the flag may repeat (`--pack a --pack b`). Throws on an
+// unknown pack id so the CLI can surface a clear, actionable error.
+export function parsePacks(raw: string[] | undefined): Set<string> {
+  const requested = new Set<string>();
+  for (const item of raw ?? []) {
+    for (const name of item.split(",").map((s) => s.trim()).filter(Boolean)) {
+      if (!(name in PACKS)) {
+        throw new Error(
+          `Unknown pack "${name}". Available packs: ${knownPacks().join(", ")}.`,
+        );
+      }
+      requested.add(name);
+    }
+  }
+  return requested;
+}
+
+// Transform that drops optional-pack skill entries unless their pack is
+// requested. Pack skills live under `skills/<dir>/` in the bundle; a
+// non-requested pack's files are skipped so they are neither vendored nor
+// recorded in the version-pin manifest.
+export function makePackFilter(requestedPacks: Set<string>): Transform {
+  const requestedDirs = new Set<string>(
+    [...requestedPacks].map((id) => PACKS[id]).filter(Boolean),
+  );
+  return (entry: BundleEntry): BundleEntry | null => {
+    const normalized = entry.relativePath.replace(/\\/g, "/");
+    const match = normalized.match(/^skills\/([^/]+)\//);
+    if (match) {
+      const dir = match[1];
+      if (PACK_SKILL_DIRS.has(dir) && !requestedDirs.has(dir)) {
+        return null;
+      }
+    }
+    return entry;
+  };
+}

--- a/packages/ai-agents-cli/tests/cli.test.ts
+++ b/packages/ai-agents-cli/tests/cli.test.ts
@@ -33,6 +33,8 @@ describe("CLI init (integration)", () => {
     expect(output).toContain("--force");
     expect(output).toContain("--dry-run");
     expect(output).toContain("--target");
+    expect(output).toContain("--pack NAME");
+    expect(output).not.toContain("skill pack (business);");
   });
 
   test("unknown command exits with error", async () => {
@@ -73,5 +75,16 @@ describe("CLI init (integration)", () => {
     await proc.exited;
     expect(proc.exitCode).toBe(2);
     expect(stderr).toContain('Invalid --target "gemini"');
+  });
+
+  test("init --pack with an invalid value exits with config error", async () => {
+    const proc = Bun.spawn(
+      ["bun", "run", "src/cli.ts", "init", testDir, "--pack", "nope"],
+      { cwd: join(import.meta.dir, ".."), stderr: "pipe" },
+    );
+    const stderr = await new Response(proc.stderr).text();
+    await proc.exited;
+    expect(proc.exitCode).toBe(2);
+    expect(stderr).toContain('Unknown pack "nope"');
   });
 });

--- a/packages/ai-agents-cli/tests/packs.test.ts
+++ b/packages/ai-agents-cli/tests/packs.test.ts
@@ -28,6 +28,10 @@ describe("parsePacks", () => {
   test("throws on an unknown pack id", () => {
     expect(() => parsePacks(["nope"])).toThrow(/Unknown pack "nope"/);
   });
+
+  test("rejects inherited object properties", () => {
+    expect(() => parsePacks(["toString"])).toThrow(/Unknown pack "toString"/);
+  });
 });
 
 describe("makePackFilter", () => {
@@ -55,5 +59,10 @@ describe("makePackFilter", () => {
     expect(
       filter(entry("skills\\business-strategy\\references\\x.md"), null as never),
     ).toBeNull();
+  });
+
+  test("normalizes skill directory casing", () => {
+    const filter = makePackFilter(new Set());
+    expect(filter(entry("Skills/BUSINESS-STRATEGY/SKILL.md"), null as never)).toBeNull();
   });
 });

--- a/packages/ai-agents-cli/tests/packs.test.ts
+++ b/packages/ai-agents-cli/tests/packs.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from "bun:test";
+import { parsePacks, makePackFilter, knownPacks } from "../src/packs.js";
+import type { BundleEntry } from "../src/types.js";
+
+const entry = (relativePath: string): BundleEntry => ({ relativePath });
+
+describe("knownPacks", () => {
+  test("includes the business pack", () => {
+    expect(knownPacks()).toContain("business");
+  });
+});
+
+describe("parsePacks", () => {
+  test("empty input yields an empty set", () => {
+    expect(parsePacks(undefined).size).toBe(0);
+    expect(parsePacks([]).size).toBe(0);
+  });
+
+  test("accepts a single pack id", () => {
+    expect([...parsePacks(["business"])]).toEqual(["business"]);
+  });
+
+  test("accepts comma-separated and repeated values, de-duplicated", () => {
+    expect([...parsePacks(["business,business"])]).toEqual(["business"]);
+    expect([...parsePacks(["business", "business"])]).toEqual(["business"]);
+  });
+
+  test("throws on an unknown pack id", () => {
+    expect(() => parsePacks(["nope"])).toThrow(/Unknown pack "nope"/);
+  });
+});
+
+describe("makePackFilter", () => {
+  test("drops a pack skill when its pack is not requested", () => {
+    const filter = makePackFilter(new Set());
+    expect(filter(entry("skills/business-strategy/SKILL.md"), null as never)).toBeNull();
+  });
+
+  test("keeps a pack skill when its pack is requested", () => {
+    const filter = makePackFilter(new Set(["business"]));
+    const e = entry("skills/business-strategy/SKILL.md");
+    expect(filter(e, null as never)).toBe(e);
+  });
+
+  test("always keeps non-pack skills and non-skill entries", () => {
+    const filter = makePackFilter(new Set());
+    const core = entry("skills/review/SKILL.md");
+    const agent = entry("agents/implementer.md");
+    expect(filter(core, null as never)).toBe(core);
+    expect(filter(agent, null as never)).toBe(agent);
+  });
+
+  test("normalizes backslash paths", () => {
+    const filter = makePackFilter(new Set());
+    expect(
+      filter(entry("skills\\business-strategy\\references\\x.md"), null as never),
+    ).toBeNull();
+  });
+});

--- a/packages/ai-agents-cli/tests/run-init.test.ts
+++ b/packages/ai-agents-cli/tests/run-init.test.ts
@@ -65,4 +65,35 @@ describe("runInit (end-to-end pipeline)", () => {
     ).rejects.toThrow();
     await expect(access(join(targetDir, "CLAUDE.md"))).rejects.toThrow();
   });
+
+  test("excludes optional pack skills by default", async () => {
+    await mkdir(join(assetsDir, "skills", "business-strategy"), { recursive: true });
+    await writeFile(join(assetsDir, "skills", "business-strategy", "SKILL.md"), "# biz\n");
+    await mkdir(join(assetsDir, "skills", "review"), { recursive: true });
+    await writeFile(join(assetsDir, "skills", "review", "SKILL.md"), "# review\n");
+
+    const code = await runInit({ targetDir, force: false, dryRun: false, assetsDir, version: "0.1.0" });
+    expect(code).toBe(0);
+    // Core skill vendored; pack skill excluded.
+    await access(join(targetDir, ".claude", "skills", "review", "SKILL.md"));
+    await expect(
+      access(join(targetDir, ".claude", "skills", "business-strategy", "SKILL.md")),
+    ).rejects.toThrow();
+  });
+
+  test("installs an optional pack when requested via packs", async () => {
+    await mkdir(join(assetsDir, "skills", "business-strategy"), { recursive: true });
+    await writeFile(join(assetsDir, "skills", "business-strategy", "SKILL.md"), "# biz\n");
+
+    const code = await runInit({
+      targetDir,
+      force: false,
+      dryRun: false,
+      assetsDir,
+      version: "0.1.0",
+      packs: ["business"],
+    });
+    expect(code).toBe(0);
+    await access(join(targetDir, ".claude", "skills", "business-strategy", "SKILL.md"));
+  });
 });


### PR DESCRIPTION
## Summary

### What
Adds an opt-in `--pack` flag to `ai-agents init` so optional skill packs install on demand. Wires `--pack business` to the `business-strategy` pack.

### Why
Follow-up to #1784 (business-strategy pack merged via #2508). The pack shipped but was not installable on demand, and it was being vendored by default. #2509 asks for `npx ai-agents init --pack business`.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2509 | feat(cli): add --pack business flag to install the business-strategy pack |

## Changes

- `packages/ai-agents-cli/src/packs.ts` (new): pack registry (`business -> business-strategy`), `parsePacks` (repeatable + comma-separated, validates unknown ids), and a `makePackFilter` transform that drops a pack`s skill files unless requested.
- `cli.ts`: `--pack` parseArgs option (multiple), help text, validation in `main()`, and `runInit` runs the pack filter ahead of the manifest capture so unrequested packs are neither vendored nor version-pinned.
- **business-strategy is now opt-in** (`npx ai-agents init --pack business`) instead of installed by default.
- Docs: `docs/installation.md` "Optional skill packs" section; `docs/skill-reference.md` business-strategy (optional pack) entry.

## Type of Change

- [x] New feature (non-breaking change adding functionality)

## Testing

- [x] Tests added/updated: 71 bun tests pass, incl. new `packs.test.ts` (parse/validate/filter) and run-init integration tests proving the pack is excluded by default and installed with `packs: ["business"]`.
- markdownlint clean on the changed docs.

## Notes for reviewers

Behavior change: a default `init` no longer vendors `business-strategy` (it becomes opt-in). The bundle still contains it (`build-bundle.ts` unchanged), so `--pack business` installs it without a rebuild.

## Related Issues

Fixes #2509