### PR TITLE
fix(skills): make printed advisory hints vendored-install aware (Refs #2050)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.188",
+  "version": "0.5.191",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/github/scripts/pr/set_pr_auto_merge.py
+++ b/.claude/skills/github/scripts/pr/set_pr_auto_merge.py
@@ -21,6 +21,7 @@ import argparse
 import json
 import os
 import sys
+from pathlib import Path
 
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
 _workspace = os.environ.get("GITHUB_WORKSPACE")
@@ -211,7 +212,7 @@ def enable_auto_merge(
         if "unstable status" in msg.lower():
             strategy = merge_method.lower()
             fallback = (
-                f"python3 .claude/skills/github/scripts/pr/merge_pr.py "
+                f"python3 {Path(__file__).resolve().parent / 'merge_pr.py'} "
                 f"--pull-request {pr_number} --strategy {strategy}"
             )
             error_and_exit(
@@ -233,7 +234,7 @@ def enable_auto_merge(
         if "clean status" in msg.lower():
             strategy = merge_method.lower()
             fallback = (
-                f"python3 .claude/skills/github/scripts/pr/merge_pr.py "
+                f"python3 {Path(__file__).resolve().parent / 'merge_pr.py'} "
                 f"--pull-request {pr_number} --strategy {strategy}"
             )
             error_and_exit(

--- a/.claude/skills/github/scripts/pr/set_pr_auto_merge.py
+++ b/.claude/skills/github/scripts/pr/set_pr_auto_merge.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 import sys
 from pathlib import Path
 
@@ -211,8 +212,11 @@ def enable_auto_merge(
         # documented fallback for this state.
         if "unstable status" in msg.lower():
             strategy = merge_method.lower()
+            merge_script = shlex.quote(
+                str(Path(__file__).resolve().parent / "merge_pr.py")
+            )
             fallback = (
-                f"python3 {Path(__file__).resolve().parent / 'merge_pr.py'} "
+                f"python3 {merge_script} "
                 f"--pull-request {pr_number} --strategy {strategy}"
             )
             error_and_exit(
@@ -233,8 +237,11 @@ def enable_auto_merge(
         # instead of leaking the raw GraphQL prefix.
         if "clean status" in msg.lower():
             strategy = merge_method.lower()
+            merge_script = shlex.quote(
+                str(Path(__file__).resolve().parent / "merge_pr.py")
+            )
             fallback = (
-                f"python3 {Path(__file__).resolve().parent / 'merge_pr.py'} "
+                f"python3 {merge_script} "
                 f"--pull-request {pr_number} --strategy {strategy}"
             )
             error_and_exit(

--- a/.claude/skills/slashcommandcreator/scripts/new_slash_command.py
+++ b/.claude/skills/slashcommandcreator/scripts/new_slash_command.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -127,10 +128,14 @@ allowed-tools: []
     print("\nNext steps:")
     print("  1. Edit frontmatter (description, argument-hint, allowed-tools)")
     print("  2. Write prompt body")
+    validator = shlex.quote(
+        str(Path(__file__).resolve().parent / "validate_slash_command.py")
+    )
+    target = shlex.quote(str(file_path))
     print(
         f"  3. Run: python3 "
-        f"{Path(__file__).resolve().parent / 'validate_slash_command.py'} "
-        f"--path {file_path}"
+        f"{validator} "
+        f"--path {target}"
     )
     print(f"  4. Test: /{name} [arguments]")
     return 0

--- a/.claude/skills/slashcommandcreator/scripts/new_slash_command.py
+++ b/.claude/skills/slashcommandcreator/scripts/new_slash_command.py
@@ -128,8 +128,9 @@ allowed-tools: []
     print("  1. Edit frontmatter (description, argument-hint, allowed-tools)")
     print("  2. Write prompt body")
     print(
-        f"  3. Run: python3 .claude/skills/slashcommandcreator/scripts/"
-        f"validate_slash_command.py --path {file_path}"
+        f"  3. Run: python3 "
+        f"{Path(__file__).resolve().parent / 'validate_slash_command.py'} "
+        f"--path {file_path}"
     )
     print(f"  4. Test: /{name} [arguments]")
     return 0

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.188",
+  "version": "0.5.191",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/github/scripts/pr/set_pr_auto_merge.py
+++ b/src/copilot-cli/skills/github/scripts/pr/set_pr_auto_merge.py
@@ -21,6 +21,7 @@ import argparse
 import json
 import os
 import sys
+from pathlib import Path
 
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
 _workspace = os.environ.get("GITHUB_WORKSPACE")
@@ -211,7 +212,7 @@ def enable_auto_merge(
         if "unstable status" in msg.lower():
             strategy = merge_method.lower()
             fallback = (
-                f"python3 .claude/skills/github/scripts/pr/merge_pr.py "
+                f"python3 {Path(__file__).resolve().parent / 'merge_pr.py'} "
                 f"--pull-request {pr_number} --strategy {strategy}"
             )
             error_and_exit(
@@ -233,7 +234,7 @@ def enable_auto_merge(
         if "clean status" in msg.lower():
             strategy = merge_method.lower()
             fallback = (
-                f"python3 .claude/skills/github/scripts/pr/merge_pr.py "
+                f"python3 {Path(__file__).resolve().parent / 'merge_pr.py'} "
                 f"--pull-request {pr_number} --strategy {strategy}"
             )
             error_and_exit(

--- a/src/copilot-cli/skills/github/scripts/pr/set_pr_auto_merge.py
+++ b/src/copilot-cli/skills/github/scripts/pr/set_pr_auto_merge.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 import sys
 from pathlib import Path
 
@@ -211,8 +212,11 @@ def enable_auto_merge(
         # documented fallback for this state.
         if "unstable status" in msg.lower():
             strategy = merge_method.lower()
+            merge_script = shlex.quote(
+                str(Path(__file__).resolve().parent / "merge_pr.py")
+            )
             fallback = (
-                f"python3 {Path(__file__).resolve().parent / 'merge_pr.py'} "
+                f"python3 {merge_script} "
                 f"--pull-request {pr_number} --strategy {strategy}"
             )
             error_and_exit(
@@ -233,8 +237,11 @@ def enable_auto_merge(
         # instead of leaking the raw GraphQL prefix.
         if "clean status" in msg.lower():
             strategy = merge_method.lower()
+            merge_script = shlex.quote(
+                str(Path(__file__).resolve().parent / "merge_pr.py")
+            )
             fallback = (
-                f"python3 {Path(__file__).resolve().parent / 'merge_pr.py'} "
+                f"python3 {merge_script} "
                 f"--pull-request {pr_number} --strategy {strategy}"
             )
             error_and_exit(

--- a/src/copilot-cli/skills/slashcommandcreator/scripts/new_slash_command.py
+++ b/src/copilot-cli/skills/slashcommandcreator/scripts/new_slash_command.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -127,10 +128,14 @@ allowed-tools: []
     print("\nNext steps:")
     print("  1. Edit frontmatter (description, argument-hint, allowed-tools)")
     print("  2. Write prompt body")
+    validator = shlex.quote(
+        str(Path(__file__).resolve().parent / "validate_slash_command.py")
+    )
+    target = shlex.quote(str(file_path))
     print(
         f"  3. Run: python3 "
-        f"{Path(__file__).resolve().parent / 'validate_slash_command.py'} "
-        f"--path {file_path}"
+        f"{validator} "
+        f"--path {target}"
     )
     print(f"  4. Test: /{name} [arguments]")
     return 0

--- a/src/copilot-cli/skills/slashcommandcreator/scripts/new_slash_command.py
+++ b/src/copilot-cli/skills/slashcommandcreator/scripts/new_slash_command.py
@@ -128,8 +128,9 @@ allowed-tools: []
     print("  1. Edit frontmatter (description, argument-hint, allowed-tools)")
     print("  2. Write prompt body")
     print(
-        f"  3. Run: python3 .claude/skills/slashcommandcreator/scripts/"
-        f"validate_slash_command.py --path {file_path}"
+        f"  3. Run: python3 "
+        f"{Path(__file__).resolve().parent / 'validate_slash_command.py'} "
+        f"--path {file_path}"
     )
     print(f"  4. Test: /{name} [arguments]")
     return 0


### PR DESCRIPTION
## Summary

Two skill scripts printed hardcoded `.claude/skills/...` paths in their advisory "next step" hints. Those printed commands are wrong when the skill is vendored into a consuming repo or installed as a plugin (the dev-repo prefix only exists here). Both now derive the sibling-script path from `Path(__file__)` so the printed command works regardless of install location.

### Sites fixed
- `set_pr_auto_merge.py`: two fallback hints (the merge-fallback path) printed a hardcoded dev-repo path.
- `new_slash_command.py`: the validate hint printed a hardcoded dev-repo path.

Both now print `python3 {Path(__file__).resolve().parent / 'sibling.py'} ...`.

## Why this is the safe slice of #2050

This is the small, unambiguous-bug portion of skill vendor-portability: printed advisory hints are pure UX strings with no consumer-data semantics, so making them install-location-aware is strictly correct. The ~137 other `.claude/skills/` references catalogued on #2050 are legitimate by design (consumer-data reads at protocol paths, conflict patterns, scan targets, help text, docstrings) and are intentionally not changed here.

## Testing
- `ruff check` clean on both changed scripts.
- set_pr_auto_merge suite: 18 passed (the stderr fallback assertion still holds; the derived path contains the filename).
- slashcommandcreator suite: 25 passed.
- Pre-push full suite: 15 passed, 2 warnings (non-blocking).

## References

Files referenced above for context but not modified in this PR (sibling scripts and test files):

\`\`\`
.claude/skills/github/scripts/pr/merge_pr.py
.claude/skills/slashcommandcreator/scripts/validate_slash_command.py
tests/test_set_pr_auto_merge.py
\`\`\`

Refs #2050