### PR TITLE
fix(ci): dedupe velocity-accelerator concurrency across event types (Refs #2490)

### DIFF
--- a/.github/workflows/velocity-accelerator.yml
+++ b/.github/workflows/velocity-accelerator.yml
@@ -19,7 +19,13 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: velocity-accelerator-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.sha }}
+  # Dedupe across event types for the same subject (issue or PR), not per
+  # event_name. Keying on github.event_name let an issues:opened run and a
+  # later issues:labeled run for the same issue land in different groups and
+  # execute concurrently (issue #2490). Type-prefix the subject so an issue and
+  # a PR that happen to share a number do not collide; fall back to the SHA for
+  # push and manual runs.
+  group: velocity-accelerator-${{ github.event.issue.number && format('issue-{0}', github.event.issue.number) || github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || github.sha }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
## Summary

Fixes the confirmed concurrency race in #2490 (item 2). The velocity-accelerator concurrency group was keyed on `github.event_name`, so an `issues:opened` run and a later `issues:labeled` run for the **same issue** landed in different groups and could execute concurrently, a duplicate-work race independent of the interactive-vs-autonomous split.

The new group key drops `event_name` and keys on the subject (issue or PR number), type-prefixed so an issue and a PR that share a number do not collide, with a SHA fallback for `push` and manual runs. With `cancel-in-progress: false`, same-issue events now serialize instead of racing.

## Why item 1 does not apply

#2490 item 1 asks to wire the issue-coordination preflight before "branch or PR creation" in the velocity accelerator. Verified against current code: the velocity-accelerator workflow has exactly two jobs (`detect-opportunities`, `post-summary`) and the script is detection-only. There is no branch or PR creation path to guard, so item 1 is obsolete. This PR resolves the real, confirmed part; recommend closing #2490 on merge.

## Testing

- `actionlint` clean on the changed workflow.
- `gh act -n` (dry-run plan) clean.
- The full `gh act` run cannot complete in this environment (the `setup-python` action clone fails in Docker, the #2548 class of limitation); concurrency keys are evaluated server-side and are not exercised by act, so actionlint plus the dry-run are the authoritative validators here. Used the hook's documented `SKIP_WORKFLOW_LOCAL_TEST` escape for that one check; the other 26 pre-push checks passed.

## References

Files cited for context but not changed here:

\`\`\`
scripts/velocity_accelerator.py
.claude/skills/github/scripts/issue/check_existing_pr_for_issue.py
.claude/skills/github/scripts/issue/claim_issue.py
\`\`\`

Refs #2490

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>