### PR TITLE
fix(hooks): accept Copilot tool_input.path so create/edit stop failing closed (#2610)

### DIFF
--- a/.agents/sessions/2026-06-15-session-2584-fix-2610-copilot-path-key.json
+++ b/.agents/sessions/2026-06-15-session-2584-fix-2610-copilot-path-key.json
@@ -1,0 +1,107 @@
+{
+  "session": {
+    "number": 2584,
+    "date": "2026-06-15",
+    "branch": "fix/2610-copilot-tool-input-path-key",
+    "startingCommit": "a310ffb5",
+    "objective": "RCA and fix issue #2610: the project-toolkit plugin denied every create/edit in Copilot CLI sessions. Root cause found by capturing the live hook stdin: Copilot's native create/edit/view tools deliver the target path under tool_input.path, but invoke_security_gate.py reads tool_input.file_path and fails closed when absent, so it blocked every write. Secondary: is_project_repo() keyed on a bare .agents/ directory, so the internal guards mis-fired in any consumer repo that has its own .agents/. Fixed both: hooks resolve path from file_path then path, the security gate fails open when no path is resolvable, and is_project_repo() resolves identity from the git origin remote with an AI_AGENTS_PROJECT_REPO override instead of an incidental on-disk marker."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena unavailable in this Copilot CLI harness; AGENTS.md and rule files loaded as the instruction source instead (AGENTS.md fallback)."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena unavailable in this Copilot CLI harness; AGENTS.md fallback used."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Reviewed repo AGENTS.md, governance rules, and the prior copilot-hooks retrospectives (#2290, ADR-068) before acting."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This log created at .agents/sessions/2026-06-15-session-2584-fix-2610-copilot-path-key.json."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current confirmed fix/2610-copilot-tool-input-path-key before staging."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Work branch is fix/2610-copilot-tool-input-path-key, created off origin/main (a310ffb5)."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Session-end checklist walked: tests, lint, regen parity, commit, validation for the #2610 change set."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md left untouched (read-only per ADR-014)."
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena unavailable; durable RCA captured in this session log and the GitHub issue #2610 body per the AGENTS.md fallback."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Change set is Python hooks, guards, tests, and plugin manifests; no lintable markdown changed under tracked paths."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Committed in atomic groups of five files or fewer on fix/2610-copilot-tool-input-path-key."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "pytest green on the changed hooks and guards (pre-existing Windows-only relativize/CodeQL failures confirmed on origin/main); sync_plugin_lib --check and build_all regen parity verified."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "timestamp": "2026-06-15T22:10:00Z",
+      "entry": "RCA from primary sources: read the failing session events.jsonl and OTEL. Found the denied tool was create with cwd in a different repo (consumer). Captured the live preToolUse stdin by instrumenting the installed dispatcher (reverted after): Copilot maps create->Write/edit->Edit/view->Read but keeps native arg keys (path, file_text, old_str). invoke_security_gate.py read tool_input.file_path, found it empty, and failed closed (exit 2, block to stdout = empty-stderr 'hook errored'). Reproduced deterministically and live in this session."
+    },
+    {
+      "timestamp": "2026-06-15T22:20:00Z",
+      "entry": "Secondary finding: 7 of 10 denials in the failing session were lsp-grep/glob guards blocking code searches in the consumer repo. is_project_repo() returned True there because the consumer repo had its own .agents/ directory (just tools/). skip_if_consumer_repo therefore did not skip."
+    },
+    {
+      "timestamp": "2026-06-15T22:45:00Z",
+      "entry": "Filed issue #2610 with the RCA and fix plan (genericized; repo is public). Created branch fix/2610-copilot-tool-input-path-key."
+    },
+    {
+      "timestamp": "2026-06-15T23:05:00Z",
+      "entry": "Fix part 1 (path-key class): resolved the target path from file_path then path in invoke_security_gate, invoke_adr_architect_gate, invoke_topical_memory_injection, invoke_lsp_read_guard (PreToolUse) and invoke_markdown_auto_lint, invoke_adr_lifecycle_hook, invoke_codeql_quick_scan, invoke_lsp_read_tracker (PostToolUse), matching the existing invoke_plan_state_sync precedent. Security gate now fails OPEN when no path is resolvable instead of blocking every write."
+    },
+    {
+      "timestamp": "2026-06-15T23:30:00Z",
+      "entry": "Fix part 2 (consumer-repo detection): at the owner's direction, replaced the brittle on-disk marker approach with authoritative git-origin-remote detection in is_project_repo(), cached per root, with an AI_AGENTS_PROJECT_REPO env override that doubles as the test/CI hook. Added a tests/conftest.py autouse default (AI_AGENTS_PROJECT_REPO=1, since the suite runs in the project repo); consumer-simulation tests override to 0."
+    },
+    {
+      "timestamp": "2026-06-15T23:50:00Z",
+      "entry": "Tests: updated the two security-gate tests that encoded the old fail-closed contract to assert fail-open; added path-key positive/negative cases; rewrote the guards tests for the env+remote model and added _remote_repo_name URL-parsing coverage. Regenerated src/copilot-cli shims and lib via build_all, reverting the unrelated Windows CRLF churn so the diff stays scoped. Bumped both plugin.json manifests to 0.5.199 (parity)."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Open the PR (Fixes #2610) once the full suite confirms no new failures beyond the pre-existing Windows-only relativize/CodeQL cases.",
+    "After merge and plugin republish, the vendored install needs `copilot plugin update` to pick up 0.5.199.",
+    "Pre-existing Windows-only test failures (topical relativize POSIX-path, codeql WindowsApps python3 stub) are unrelated to #2610 and out of scope; they pass on Linux CI."
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.198",
+  "version": "0.5.199",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PostToolUse/invoke_adr_lifecycle_hook.py
+++ b/.claude/hooks/PostToolUse/invoke_adr_lifecycle_hook.py
@@ -108,7 +108,8 @@ def _detect_adr_in_bash(command: str) -> bool:
 
 def _detect_write_or_edit(tool_input: dict[str, object]) -> str | None:
     """Detect Write or Edit targeting an ADR file. Returns the file path or None."""
-    file_path = str(tool_input.get("file_path", ""))
+    # file_path (Claude) or path (Copilot CLI create/edit); see #2610.
+    file_path = str(tool_input.get("file_path") or tool_input.get("path") or "")
     if not file_path:
         return None
     if _is_adr_path(file_path):

--- a/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
+++ b/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
@@ -30,7 +30,8 @@ def _get_file_path_from_input(hook_input: dict) -> str | None:
     """Extract file_path from hook input."""
     tool_input = hook_input.get("tool_input", {})
     if isinstance(tool_input, dict):
-        return tool_input.get("file_path")
+        # file_path (Claude) or path (Copilot CLI create/edit); see #2610.
+        return tool_input.get("file_path") or tool_input.get("path")
     return None
 
 

--- a/.claude/hooks/PostToolUse/invoke_lsp_read_tracker.py
+++ b/.claude/hooks/PostToolUse/invoke_lsp_read_tracker.py
@@ -84,7 +84,8 @@ def main() -> int:
         if not isinstance(tool_input, dict):
             return 0
 
-        file_path = str(tool_input.get("file_path") or "").strip()
+        # file_path (Claude) or path (Copilot CLI view); see #2610.
+        file_path = str(tool_input.get("file_path") or tool_input.get("path") or "").strip()
         if not file_path:
             return 0
 

--- a/.claude/hooks/PostToolUse/invoke_markdown_auto_lint.py
+++ b/.claude/hooks/PostToolUse/invoke_markdown_auto_lint.py
@@ -28,7 +28,8 @@ def get_file_path_from_input(hook_input: dict[str, object]) -> str | None:
     """Extract file_path from hook input's tool_input."""
     tool_input = hook_input.get("tool_input")
     if isinstance(tool_input, dict):
-        file_path = tool_input.get("file_path")
+        # file_path (Claude) or path (Copilot CLI create/edit); see #2610.
+        file_path = tool_input.get("file_path") or tool_input.get("path")
         if isinstance(file_path, str) and file_path.strip():
             return file_path.strip()
     return None

--- a/.claude/hooks/PreToolUse/invoke_adr_architect_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_adr_architect_gate.py
@@ -239,7 +239,8 @@ def main() -> int:
         if not isinstance(tool_input, dict):
             return 0
 
-        file_path = tool_input.get("file_path", "")
+        # file_path (Claude) or path (Copilot CLI create/edit); see #2610.
+        file_path = tool_input.get("file_path") or tool_input.get("path") or ""
         if not file_path:
             return 0
 

--- a/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
@@ -287,7 +287,8 @@ def main() -> int:
         if not isinstance(tool_input, dict):
             return 0
 
-        file_path = str(tool_input.get("file_path") or "").strip()
+        # file_path (Claude) or path (Copilot CLI view); see #2610.
+        file_path = str(tool_input.get("file_path") or tool_input.get("path") or "").strip()
         if not file_path:
             return 0
 

--- a/.claude/hooks/PreToolUse/invoke_security_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_security_gate.py
@@ -199,11 +199,28 @@ def main() -> int:
             block_security_gate_error("tool_input is missing or not an object")
             return 2
 
-        file_path_value = tool_input.get("file_path", "")
-        if not isinstance(file_path_value, str) or not file_path_value.strip():
-            block_security_gate_error("file_path is missing or not a string")
-            return 2
-        file_path = file_path_value.strip()
+        # Resolve the target path across harness key spellings. Claude Code's
+        # Write/Edit tools use "file_path"; GitHub Copilot CLI's native
+        # create/edit tools use "path" (same mapping documented in
+        # invoke_plan_state_sync.py). Reading only "file_path" made this gate
+        # fail closed on every Copilot create/edit, denying all writes (#2610).
+        file_path = ""
+        for _path_key in ("file_path", "path"):
+            _path_value = tool_input.get(_path_key)
+            if isinstance(_path_value, str) and _path_value.strip():
+                file_path = _path_value.strip()
+                break
+        if not file_path:
+            # No resolvable target path. This gate classifies auth files by
+            # their path; with no path it cannot, and blocking every pathless
+            # Write/Edit is a denial of service far worse than the gate's narrow
+            # purpose. Allow (fail open); identified auth-file edits without a
+            # review are still blocked below.
+            print(
+                "security-gate: no file path in tool_input; allowing (fail open)",
+                file=sys.stderr,
+            )
+            return 0
 
         if not is_auth_path(file_path):
             return 0

--- a/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
+++ b/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
@@ -112,7 +112,8 @@ def parse_file_path(stdin_data: str) -> str | None:
             return None
     if not isinstance(tool_input, dict):
         return None
-    path = tool_input.get("file_path")
+    # file_path (Claude) or path (Copilot CLI create/edit); see #2610.
+    path = tool_input.get("file_path") or tool_input.get("path")
     return path if isinstance(path, str) and path else None
 
 

--- a/.claude/lib/hook_utilities/guards.py
+++ b/.claude/lib/hook_utilities/guards.py
@@ -72,9 +72,9 @@ def is_project_repo() -> bool:
     project_root = get_project_directory()
     if project_root not in _origin_repo_cache:
         name = _remote_repo_name(project_root)
-        _origin_repo_cache[project_root] = (
-            name is not None and name.lower() == _PROJECT_REPO_NAME
-        )
+        if name is None:
+            return False
+        _origin_repo_cache[project_root] = name.lower() == _PROJECT_REPO_NAME
     return _origin_repo_cache[project_root]
 
 

--- a/.claude/lib/hook_utilities/guards.py
+++ b/.claude/lib/hook_utilities/guards.py
@@ -1,31 +1,89 @@
 """Canonical: scripts/hook_utilities/guards.py. Sync via scripts/sync_plugin_lib.py."""
 
+import os
+import shutil
+import subprocess
 import sys
-from pathlib import Path
 
 from .utilities import get_project_directory
 
+# The internal guards (LSP-first, skill-first, session protocol) must run only
+# in the ai-agents project repository, never in a consumer repo that vendors the
+# plugin. Repository identity is authoritative from the git origin remote, not
+# from incidental on-disk files: a consumer repo may keep its own .agents/
+# directory for unrelated tooling, which the previous .agents/-presence check
+# mistook for the project repo and so denied ordinary tool calls (issue #2610).
+_PROJECT_REPO_NAME = "ai-agents"
+
+# Override and cache hook. "1" forces project-repo behavior, "0" forces
+# consumer-repo behavior; any other value falls through to the git lookup. Tests
+# and CI set it directly, and a one-time remote lookup can persist it here.
+_PROJECT_REPO_ENV = "AI_AGENTS_PROJECT_REPO"
+
+# Per-root, per-process memo so the Copilot in-process dispatcher (every shim in
+# one interpreter, ADR-068) pays the git lookup at most once per repository root.
+_origin_repo_cache: dict[str, bool] = {}
+
+
+def _remote_repo_name(project_root: str) -> str | None:
+    """Return the origin remote's repository name, or None when unavailable.
+
+    Parses both HTTPS (``https://host/owner/ai-agents.git``) and SSH
+    (``git@host:owner/ai-agents.git``) forms. Any failure (git missing, no
+    origin, timeout) yields None so the caller treats the repo as a consumer.
+    """
+    git = shutil.which("git")
+    if git is None:
+        return None
+    try:
+        result = subprocess.run(
+            [git, "-C", project_root, "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    if not url:
+        return None
+    # Repository name is the last path segment, minus an optional ".git".
+    tail = url.rstrip("/").replace("\\", "/").rsplit("/", 1)[-1]
+    tail = tail.rsplit(":", 1)[-1]  # bare SSH "host:repo" with no owner segment
+    if tail.endswith(".git"):
+        tail = tail[:-4]
+    return tail or None
+
 
 def is_project_repo() -> bool:
-    """Check if running in ai-agents project (has .agents/ directory).
+    """Return True when running inside the ai-agents project repository.
 
-    Uses get_project_directory() to find the repo root, so this works
-    correctly even when CWD is a subdirectory.
+    Identity comes from the git origin remote (authoritative), not from
+    incidental on-disk files. The AI_AGENTS_PROJECT_REPO environment variable
+    overrides the lookup ("1"/"0") and caches a one-time resolution; tests set
+    it directly. Uses get_project_directory() so it works from a subdirectory.
     """
+    override = os.environ.get(_PROJECT_REPO_ENV, "").strip()
+    if override in ("0", "1"):
+        return override == "1"
     project_root = get_project_directory()
-    agents_path = Path(project_root) / ".agents"
-    if agents_path.exists() and not agents_path.is_dir():
-        print(
-            "[WARNING] .agents exists but is not a directory. "
-            "Guards will treat this as a consumer repo.",
-            file=sys.stderr,
+    if project_root not in _origin_repo_cache:
+        name = _remote_repo_name(project_root)
+        _origin_repo_cache[project_root] = (
+            name is not None and name.lower() == _PROJECT_REPO_NAME
         )
-    return agents_path.is_dir()
+    return _origin_repo_cache[project_root]
 
 
 def skip_if_consumer_repo(hook_name: str) -> bool:
     """Print skip message and return True if this is a consumer repo."""
     if not is_project_repo():
-        print(f"[SKIP] {hook_name}: .agents/ not found (consumer repo)", file=sys.stderr)
+        print(
+            f"[SKIP] {hook_name}: not the ai-agents project repo (consumer repo)",
+            file=sys.stderr,
+        )
         return True
     return False

--- a/.claude/lib/hook_utilities/guards.py
+++ b/.claude/lib/hook_utilities/guards.py
@@ -32,7 +32,7 @@ def _remote_repo_name(project_root: str) -> str | None:
 
     Parses both HTTPS (``https://host/owner/ai-agents.git``) and SSH
     (``git@host:owner/ai-agents.git``) forms. Any failure (git missing, no
-    origin, timeout) yields None so the caller can block on unknown identity.
+    origin, timeout) yields None so the caller can fail open outside the project.
     """
     git = shutil.which("git")
     if git is None:
@@ -91,7 +91,7 @@ def is_project_repo() -> bool:
 
 
 def skip_if_consumer_repo(hook_name: str) -> bool:
-    """Print skip message and return True if this is a consumer repo."""
+    """Print skip message and return True unless this is confirmed project repo."""
     identity = _project_repo_identity()
     if identity == "consumer":
         print(
@@ -101,9 +101,9 @@ def skip_if_consumer_repo(hook_name: str) -> bool:
         return True
     if identity == "unknown":
         print(
-            f"[BLOCK] {hook_name}: cannot verify ai-agents project repo identity; "
-            f"set {_PROJECT_REPO_ENV}=0 for consumer repos or restore git origin",
+            f"[SKIP] {hook_name}: cannot verify ai-agents project repo identity; "
+            "treating as consumer repo",
             file=sys.stderr,
         )
-        raise SystemExit(2)
+        return True
     return False

--- a/.claude/lib/hook_utilities/guards.py
+++ b/.claude/lib/hook_utilities/guards.py
@@ -72,9 +72,9 @@ def is_project_repo() -> bool:
     project_root = get_project_directory()
     if project_root not in _origin_repo_cache:
         name = _remote_repo_name(project_root)
-        if name is None:
-            return False
-        _origin_repo_cache[project_root] = name.lower() == _PROJECT_REPO_NAME
+        _origin_repo_cache[project_root] = (
+            name is not None and name.lower() == _PROJECT_REPO_NAME
+        )
     return _origin_repo_cache[project_root]
 
 

--- a/.claude/lib/hook_utilities/guards.py
+++ b/.claude/lib/hook_utilities/guards.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import sys
+from typing import Literal
 
 from .utilities import get_project_directory
 
@@ -22,7 +23,8 @@ _PROJECT_REPO_ENV = "AI_AGENTS_PROJECT_REPO"
 
 # Per-root, per-process memo so the Copilot in-process dispatcher (every shim in
 # one interpreter, ADR-068) pays the git lookup at most once per repository root.
-_origin_repo_cache: dict[str, bool] = {}
+RepoIdentity = Literal["project", "consumer", "unknown"]
+_origin_repo_cache: dict[str, RepoIdentity] = {}
 
 
 def _remote_repo_name(project_root: str) -> str | None:
@@ -30,7 +32,7 @@ def _remote_repo_name(project_root: str) -> str | None:
 
     Parses both HTTPS (``https://host/owner/ai-agents.git``) and SSH
     (``git@host:owner/ai-agents.git``) forms. Any failure (git missing, no
-    origin, timeout) yields None so the caller treats the repo as a consumer.
+    origin, timeout) yields None so the caller can block on unknown identity.
     """
     git = shutil.which("git")
     if git is None:
@@ -39,9 +41,10 @@ def _remote_repo_name(project_root: str) -> str | None:
         result = subprocess.run(
             [git, "-C", project_root, "remote", "get-url", "origin"],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
-            check=False,
+            check=True,
         )
     except (OSError, subprocess.SubprocessError):
         return None
@@ -58,6 +61,26 @@ def _remote_repo_name(project_root: str) -> str | None:
     return tail or None
 
 
+def _project_repo_identity() -> RepoIdentity:
+    """Resolve whether the current checkout is project, consumer, or unknown."""
+    override = os.environ.get(_PROJECT_REPO_ENV, "").strip()
+    if override == "1":
+        return "project"
+    if override == "0":
+        return "consumer"
+
+    project_root = get_project_directory()
+    if project_root not in _origin_repo_cache:
+        name = _remote_repo_name(project_root)
+        if name is None:
+            _origin_repo_cache[project_root] = "unknown"
+        elif name.lower() == _PROJECT_REPO_NAME:
+            _origin_repo_cache[project_root] = "project"
+        else:
+            _origin_repo_cache[project_root] = "consumer"
+    return _origin_repo_cache[project_root]
+
+
 def is_project_repo() -> bool:
     """Return True when running inside the ai-agents project repository.
 
@@ -66,24 +89,23 @@ def is_project_repo() -> bool:
     overrides the lookup ("1"/"0") and caches a one-time resolution; tests set
     it directly. Uses get_project_directory() so it works from a subdirectory.
     """
-    override = os.environ.get(_PROJECT_REPO_ENV, "").strip()
-    if override in ("0", "1"):
-        return override == "1"
-    project_root = get_project_directory()
-    if project_root not in _origin_repo_cache:
-        name = _remote_repo_name(project_root)
-        _origin_repo_cache[project_root] = (
-            name is not None and name.lower() == _PROJECT_REPO_NAME
-        )
-    return _origin_repo_cache[project_root]
+    return _project_repo_identity() == "project"
 
 
 def skip_if_consumer_repo(hook_name: str) -> bool:
     """Print skip message and return True if this is a consumer repo."""
-    if not is_project_repo():
+    identity = _project_repo_identity()
+    if identity == "consumer":
         print(
             f"[SKIP] {hook_name}: not the ai-agents project repo (consumer repo)",
             file=sys.stderr,
         )
         return True
+    if identity == "unknown":
+        print(
+            f"[BLOCK] {hook_name}: cannot verify ai-agents project repo identity; "
+            f"set {_PROJECT_REPO_ENV}=0 for consumer repos or restore git origin",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
     return False

--- a/.claude/lib/hook_utilities/guards.py
+++ b/.claude/lib/hook_utilities/guards.py
@@ -48,8 +48,6 @@ def _remote_repo_name(project_root: str) -> str | None:
         )
     except (OSError, subprocess.SubprocessError):
         return None
-    if result.returncode != 0:
-        return None
     url = result.stdout.strip()
     if not url:
         return None

--- a/scripts/hook_utilities/guards.py
+++ b/scripts/hook_utilities/guards.py
@@ -72,9 +72,9 @@ def is_project_repo() -> bool:
     project_root = get_project_directory()
     if project_root not in _origin_repo_cache:
         name = _remote_repo_name(project_root)
-        _origin_repo_cache[project_root] = (
-            name is not None and name.lower() == _PROJECT_REPO_NAME
-        )
+        if name is None:
+            return False
+        _origin_repo_cache[project_root] = name.lower() == _PROJECT_REPO_NAME
     return _origin_repo_cache[project_root]
 
 

--- a/scripts/hook_utilities/guards.py
+++ b/scripts/hook_utilities/guards.py
@@ -1,31 +1,89 @@
 """Plugin-mode guards for hook scripts."""
 
+import os
+import shutil
+import subprocess
 import sys
-from pathlib import Path
 
 from scripts.hook_utilities.utilities import get_project_directory
 
+# The internal guards (LSP-first, skill-first, session protocol) must run only
+# in the ai-agents project repository, never in a consumer repo that vendors the
+# plugin. Repository identity is authoritative from the git origin remote, not
+# from incidental on-disk files: a consumer repo may keep its own .agents/
+# directory for unrelated tooling, which the previous .agents/-presence check
+# mistook for the project repo and so denied ordinary tool calls (issue #2610).
+_PROJECT_REPO_NAME = "ai-agents"
+
+# Override and cache hook. "1" forces project-repo behavior, "0" forces
+# consumer-repo behavior; any other value falls through to the git lookup. Tests
+# and CI set it directly, and a one-time remote lookup can persist it here.
+_PROJECT_REPO_ENV = "AI_AGENTS_PROJECT_REPO"
+
+# Per-root, per-process memo so the Copilot in-process dispatcher (every shim in
+# one interpreter, ADR-068) pays the git lookup at most once per repository root.
+_origin_repo_cache: dict[str, bool] = {}
+
+
+def _remote_repo_name(project_root: str) -> str | None:
+    """Return the origin remote's repository name, or None when unavailable.
+
+    Parses both HTTPS (``https://host/owner/ai-agents.git``) and SSH
+    (``git@host:owner/ai-agents.git``) forms. Any failure (git missing, no
+    origin, timeout) yields None so the caller treats the repo as a consumer.
+    """
+    git = shutil.which("git")
+    if git is None:
+        return None
+    try:
+        result = subprocess.run(
+            [git, "-C", project_root, "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    if not url:
+        return None
+    # Repository name is the last path segment, minus an optional ".git".
+    tail = url.rstrip("/").replace("\\", "/").rsplit("/", 1)[-1]
+    tail = tail.rsplit(":", 1)[-1]  # bare SSH "host:repo" with no owner segment
+    if tail.endswith(".git"):
+        tail = tail[:-4]
+    return tail or None
+
 
 def is_project_repo() -> bool:
-    """Check if running in ai-agents project (has .agents/ directory).
+    """Return True when running inside the ai-agents project repository.
 
-    Uses get_project_directory() to find the repo root, so this works
-    correctly even when CWD is a subdirectory.
+    Identity comes from the git origin remote (authoritative), not from
+    incidental on-disk files. The AI_AGENTS_PROJECT_REPO environment variable
+    overrides the lookup ("1"/"0") and caches a one-time resolution; tests set
+    it directly. Uses get_project_directory() so it works from a subdirectory.
     """
+    override = os.environ.get(_PROJECT_REPO_ENV, "").strip()
+    if override in ("0", "1"):
+        return override == "1"
     project_root = get_project_directory()
-    agents_path = Path(project_root) / ".agents"
-    if agents_path.exists() and not agents_path.is_dir():
-        print(
-            "[WARNING] .agents exists but is not a directory. "
-            "Guards will treat this as a consumer repo.",
-            file=sys.stderr,
+    if project_root not in _origin_repo_cache:
+        name = _remote_repo_name(project_root)
+        _origin_repo_cache[project_root] = (
+            name is not None and name.lower() == _PROJECT_REPO_NAME
         )
-    return agents_path.is_dir()
+    return _origin_repo_cache[project_root]
 
 
 def skip_if_consumer_repo(hook_name: str) -> bool:
     """Print skip message and return True if this is a consumer repo."""
     if not is_project_repo():
-        print(f"[SKIP] {hook_name}: .agents/ not found (consumer repo)", file=sys.stderr)
+        print(
+            f"[SKIP] {hook_name}: not the ai-agents project repo (consumer repo)",
+            file=sys.stderr,
+        )
         return True
     return False

--- a/scripts/hook_utilities/guards.py
+++ b/scripts/hook_utilities/guards.py
@@ -32,7 +32,7 @@ def _remote_repo_name(project_root: str) -> str | None:
 
     Parses both HTTPS (``https://host/owner/ai-agents.git``) and SSH
     (``git@host:owner/ai-agents.git``) forms. Any failure (git missing, no
-    origin, timeout) yields None so the caller can block on unknown identity.
+    origin, timeout) yields None so the caller can fail open outside the project.
     """
     git = shutil.which("git")
     if git is None:
@@ -91,7 +91,7 @@ def is_project_repo() -> bool:
 
 
 def skip_if_consumer_repo(hook_name: str) -> bool:
-    """Print skip message and return True if this is a consumer repo."""
+    """Print skip message and return True unless this is confirmed project repo."""
     identity = _project_repo_identity()
     if identity == "consumer":
         print(
@@ -101,9 +101,9 @@ def skip_if_consumer_repo(hook_name: str) -> bool:
         return True
     if identity == "unknown":
         print(
-            f"[BLOCK] {hook_name}: cannot verify ai-agents project repo identity; "
-            f"set {_PROJECT_REPO_ENV}=0 for consumer repos or restore git origin",
+            f"[SKIP] {hook_name}: cannot verify ai-agents project repo identity; "
+            "treating as consumer repo",
             file=sys.stderr,
         )
-        raise SystemExit(2)
+        return True
     return False

--- a/scripts/hook_utilities/guards.py
+++ b/scripts/hook_utilities/guards.py
@@ -72,9 +72,9 @@ def is_project_repo() -> bool:
     project_root = get_project_directory()
     if project_root not in _origin_repo_cache:
         name = _remote_repo_name(project_root)
-        if name is None:
-            return False
-        _origin_repo_cache[project_root] = name.lower() == _PROJECT_REPO_NAME
+        _origin_repo_cache[project_root] = (
+            name is not None and name.lower() == _PROJECT_REPO_NAME
+        )
     return _origin_repo_cache[project_root]
 
 

--- a/scripts/hook_utilities/guards.py
+++ b/scripts/hook_utilities/guards.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import sys
+from typing import Literal
 
 from scripts.hook_utilities.utilities import get_project_directory
 
@@ -22,7 +23,8 @@ _PROJECT_REPO_ENV = "AI_AGENTS_PROJECT_REPO"
 
 # Per-root, per-process memo so the Copilot in-process dispatcher (every shim in
 # one interpreter, ADR-068) pays the git lookup at most once per repository root.
-_origin_repo_cache: dict[str, bool] = {}
+RepoIdentity = Literal["project", "consumer", "unknown"]
+_origin_repo_cache: dict[str, RepoIdentity] = {}
 
 
 def _remote_repo_name(project_root: str) -> str | None:
@@ -30,7 +32,7 @@ def _remote_repo_name(project_root: str) -> str | None:
 
     Parses both HTTPS (``https://host/owner/ai-agents.git``) and SSH
     (``git@host:owner/ai-agents.git``) forms. Any failure (git missing, no
-    origin, timeout) yields None so the caller treats the repo as a consumer.
+    origin, timeout) yields None so the caller can block on unknown identity.
     """
     git = shutil.which("git")
     if git is None:
@@ -39,9 +41,10 @@ def _remote_repo_name(project_root: str) -> str | None:
         result = subprocess.run(
             [git, "-C", project_root, "remote", "get-url", "origin"],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
-            check=False,
+            check=True,
         )
     except (OSError, subprocess.SubprocessError):
         return None
@@ -58,6 +61,26 @@ def _remote_repo_name(project_root: str) -> str | None:
     return tail or None
 
 
+def _project_repo_identity() -> RepoIdentity:
+    """Resolve whether the current checkout is project, consumer, or unknown."""
+    override = os.environ.get(_PROJECT_REPO_ENV, "").strip()
+    if override == "1":
+        return "project"
+    if override == "0":
+        return "consumer"
+
+    project_root = get_project_directory()
+    if project_root not in _origin_repo_cache:
+        name = _remote_repo_name(project_root)
+        if name is None:
+            _origin_repo_cache[project_root] = "unknown"
+        elif name.lower() == _PROJECT_REPO_NAME:
+            _origin_repo_cache[project_root] = "project"
+        else:
+            _origin_repo_cache[project_root] = "consumer"
+    return _origin_repo_cache[project_root]
+
+
 def is_project_repo() -> bool:
     """Return True when running inside the ai-agents project repository.
 
@@ -66,24 +89,23 @@ def is_project_repo() -> bool:
     overrides the lookup ("1"/"0") and caches a one-time resolution; tests set
     it directly. Uses get_project_directory() so it works from a subdirectory.
     """
-    override = os.environ.get(_PROJECT_REPO_ENV, "").strip()
-    if override in ("0", "1"):
-        return override == "1"
-    project_root = get_project_directory()
-    if project_root not in _origin_repo_cache:
-        name = _remote_repo_name(project_root)
-        _origin_repo_cache[project_root] = (
-            name is not None and name.lower() == _PROJECT_REPO_NAME
-        )
-    return _origin_repo_cache[project_root]
+    return _project_repo_identity() == "project"
 
 
 def skip_if_consumer_repo(hook_name: str) -> bool:
     """Print skip message and return True if this is a consumer repo."""
-    if not is_project_repo():
+    identity = _project_repo_identity()
+    if identity == "consumer":
         print(
             f"[SKIP] {hook_name}: not the ai-agents project repo (consumer repo)",
             file=sys.stderr,
         )
         return True
+    if identity == "unknown":
+        print(
+            f"[BLOCK] {hook_name}: cannot verify ai-agents project repo identity; "
+            f"set {_PROJECT_REPO_ENV}=0 for consumer repos or restore git origin",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
     return False

--- a/scripts/hook_utilities/guards.py
+++ b/scripts/hook_utilities/guards.py
@@ -48,8 +48,6 @@ def _remote_repo_name(project_root: str) -> str | None:
         )
     except (OSError, subprocess.SubprocessError):
         return None
-    if result.returncode != 0:
-        return None
     url = result.stdout.strip()
     if not url:
         return None

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.198",
+  "version": "0.5.199",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Bash_f620ca.py
@@ -298,7 +298,8 @@ def _original_main(stdin_bytes):
 
     def _detect_write_or_edit(tool_input: dict[str, object]) -> str | None:
         """Detect Write or Edit targeting an ADR file. Returns the file path or None."""
-        file_path = str(tool_input.get("file_path", ""))
+        # file_path (Claude) or path (Copilot CLI create/edit); see #2610.
+        file_path = str(tool_input.get("file_path") or tool_input.get("path") or "")
         if not file_path:
             return None
         if _is_adr_path(file_path):

--- a/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
@@ -298,7 +298,8 @@ def _original_main(stdin_bytes):
 
     def _detect_write_or_edit(tool_input: dict[str, object]) -> str | None:
         """Detect Write or Edit targeting an ADR file. Returns the file path or None."""
-        file_path = str(tool_input.get("file_path", ""))
+        # file_path (Claude) or path (Copilot CLI create/edit); see #2610.
+        file_path = str(tool_input.get("file_path") or tool_input.get("path") or "")
         if not file_path:
             return None
         if _is_adr_path(file_path):

--- a/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
@@ -274,7 +274,8 @@ def _original_main(stdin_bytes):
             if not isinstance(tool_input, dict):
                 return 0
 
-            file_path = str(tool_input.get("file_path") or "").strip()
+            # file_path (Claude) or path (Copilot CLI view); see #2610.
+            file_path = str(tool_input.get("file_path") or tool_input.get("path") or "").strip()
             if not file_path:
                 return 0
 

--- a/src/copilot-cli/hooks/PostToolUse/invoke_markdown_auto_lint__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_markdown_auto_lint__Write_Edit_c39898.py
@@ -218,7 +218,8 @@ def _original_main(stdin_bytes):
         """Extract file_path from hook input's tool_input."""
         tool_input = hook_input.get("tool_input")
         if isinstance(tool_input, dict):
-            file_path = tool_input.get("file_path")
+            # file_path (Claude) or path (Copilot CLI create/edit); see #2610.
+            file_path = tool_input.get("file_path") or tool_input.get("path")
             if isinstance(file_path, str) and file_path.strip():
                 return file_path.strip()
         return None

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
@@ -429,7 +429,8 @@ def _original_main(stdin_bytes):
             if not isinstance(tool_input, dict):
                 return 0
 
-            file_path = tool_input.get("file_path", "")
+            # file_path (Claude) or path (Copilot CLI create/edit); see #2610.
+            file_path = tool_input.get("file_path") or tool_input.get("path") or ""
             if not file_path:
                 return 0
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
@@ -477,7 +477,8 @@ def _original_main(stdin_bytes):
             if not isinstance(tool_input, dict):
                 return 0
 
-            file_path = str(tool_input.get("file_path") or "").strip()
+            # file_path (Claude) or path (Copilot CLI view); see #2610.
+            file_path = str(tool_input.get("file_path") or tool_input.get("path") or "").strip()
             if not file_path:
                 return 0
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_security_gate__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_security_gate__Write_Edit_c39898.py
@@ -389,11 +389,28 @@ def _original_main(stdin_bytes):
                 block_security_gate_error("tool_input is missing or not an object")
                 return 2
 
-            file_path_value = tool_input.get("file_path", "")
-            if not isinstance(file_path_value, str) or not file_path_value.strip():
-                block_security_gate_error("file_path is missing or not a string")
-                return 2
-            file_path = file_path_value.strip()
+            # Resolve the target path across harness key spellings. Claude Code's
+            # Write/Edit tools use "file_path"; GitHub Copilot CLI's native
+            # create/edit tools use "path" (same mapping documented in
+            # invoke_plan_state_sync.py). Reading only "file_path" made this gate
+            # fail closed on every Copilot create/edit, denying all writes (#2610).
+            file_path = ""
+            for _path_key in ("file_path", "path"):
+                _path_value = tool_input.get(_path_key)
+                if isinstance(_path_value, str) and _path_value.strip():
+                    file_path = _path_value.strip()
+                    break
+            if not file_path:
+                # No resolvable target path. This gate classifies auth files by
+                # their path; with no path it cannot, and blocking every pathless
+                # Write/Edit is a denial of service far worse than the gate's narrow
+                # purpose. Allow (fail open); identified auth-file edits without a
+                # review are still blocked below.
+                print(
+                    "security-gate: no file path in tool_input; allowing (fail open)",
+                    file=sys.stderr,
+                )
+                return 0
 
             if not is_auth_path(file_path):
                 return 0

--- a/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
@@ -302,7 +302,8 @@ def _original_main(stdin_bytes):
                 return None
         if not isinstance(tool_input, dict):
             return None
-        path = tool_input.get("file_path")
+        # file_path (Claude) or path (Copilot CLI create/edit); see #2610.
+        path = tool_input.get("file_path") or tool_input.get("path")
         return path if isinstance(path, str) and path else None
 
 

--- a/src/copilot-cli/lib/hook_utilities/guards.py
+++ b/src/copilot-cli/lib/hook_utilities/guards.py
@@ -1,31 +1,89 @@
 """Canonical: scripts/hook_utilities/guards.py. Sync via scripts/sync_plugin_lib.py."""
 
+import os
+import shutil
+import subprocess
 import sys
-from pathlib import Path
 
 from .utilities import get_project_directory
 
+# The internal guards (LSP-first, skill-first, session protocol) must run only
+# in the ai-agents project repository, never in a consumer repo that vendors the
+# plugin. Repository identity is authoritative from the git origin remote, not
+# from incidental on-disk files: a consumer repo may keep its own .agents/
+# directory for unrelated tooling, which the previous .agents/-presence check
+# mistook for the project repo and so denied ordinary tool calls (issue #2610).
+_PROJECT_REPO_NAME = "ai-agents"
+
+# Override and cache hook. "1" forces project-repo behavior, "0" forces
+# consumer-repo behavior; any other value falls through to the git lookup. Tests
+# and CI set it directly, and a one-time remote lookup can persist it here.
+_PROJECT_REPO_ENV = "AI_AGENTS_PROJECT_REPO"
+
+# Per-root, per-process memo so the Copilot in-process dispatcher (every shim in
+# one interpreter, ADR-068) pays the git lookup at most once per repository root.
+_origin_repo_cache: dict[str, bool] = {}
+
+
+def _remote_repo_name(project_root: str) -> str | None:
+    """Return the origin remote's repository name, or None when unavailable.
+
+    Parses both HTTPS (``https://host/owner/ai-agents.git``) and SSH
+    (``git@host:owner/ai-agents.git``) forms. Any failure (git missing, no
+    origin, timeout) yields None so the caller treats the repo as a consumer.
+    """
+    git = shutil.which("git")
+    if git is None:
+        return None
+    try:
+        result = subprocess.run(
+            [git, "-C", project_root, "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    if not url:
+        return None
+    # Repository name is the last path segment, minus an optional ".git".
+    tail = url.rstrip("/").replace("\\", "/").rsplit("/", 1)[-1]
+    tail = tail.rsplit(":", 1)[-1]  # bare SSH "host:repo" with no owner segment
+    if tail.endswith(".git"):
+        tail = tail[:-4]
+    return tail or None
+
 
 def is_project_repo() -> bool:
-    """Check if running in ai-agents project (has .agents/ directory).
+    """Return True when running inside the ai-agents project repository.
 
-    Uses get_project_directory() to find the repo root, so this works
-    correctly even when CWD is a subdirectory.
+    Identity comes from the git origin remote (authoritative), not from
+    incidental on-disk files. The AI_AGENTS_PROJECT_REPO environment variable
+    overrides the lookup ("1"/"0") and caches a one-time resolution; tests set
+    it directly. Uses get_project_directory() so it works from a subdirectory.
     """
+    override = os.environ.get(_PROJECT_REPO_ENV, "").strip()
+    if override in ("0", "1"):
+        return override == "1"
     project_root = get_project_directory()
-    agents_path = Path(project_root) / ".agents"
-    if agents_path.exists() and not agents_path.is_dir():
-        print(
-            "[WARNING] .agents exists but is not a directory. "
-            "Guards will treat this as a consumer repo.",
-            file=sys.stderr,
+    if project_root not in _origin_repo_cache:
+        name = _remote_repo_name(project_root)
+        _origin_repo_cache[project_root] = (
+            name is not None and name.lower() == _PROJECT_REPO_NAME
         )
-    return agents_path.is_dir()
+    return _origin_repo_cache[project_root]
 
 
 def skip_if_consumer_repo(hook_name: str) -> bool:
     """Print skip message and return True if this is a consumer repo."""
     if not is_project_repo():
-        print(f"[SKIP] {hook_name}: .agents/ not found (consumer repo)", file=sys.stderr)
+        print(
+            f"[SKIP] {hook_name}: not the ai-agents project repo (consumer repo)",
+            file=sys.stderr,
+        )
         return True
     return False

--- a/src/copilot-cli/lib/hook_utilities/guards.py
+++ b/src/copilot-cli/lib/hook_utilities/guards.py
@@ -32,7 +32,7 @@ def _remote_repo_name(project_root: str) -> str | None:
 
     Parses both HTTPS (``https://host/owner/ai-agents.git``) and SSH
     (``git@host:owner/ai-agents.git``) forms. Any failure (git missing, no
-    origin, timeout) yields None so the caller can block on unknown identity.
+    origin, timeout) yields None so the caller can fail open outside the project.
     """
     git = shutil.which("git")
     if git is None:
@@ -91,7 +91,7 @@ def is_project_repo() -> bool:
 
 
 def skip_if_consumer_repo(hook_name: str) -> bool:
-    """Print skip message and return True if this is a consumer repo."""
+    """Print skip message and return True unless this is confirmed project repo."""
     identity = _project_repo_identity()
     if identity == "consumer":
         print(
@@ -101,9 +101,9 @@ def skip_if_consumer_repo(hook_name: str) -> bool:
         return True
     if identity == "unknown":
         print(
-            f"[BLOCK] {hook_name}: cannot verify ai-agents project repo identity; "
-            f"set {_PROJECT_REPO_ENV}=0 for consumer repos or restore git origin",
+            f"[SKIP] {hook_name}: cannot verify ai-agents project repo identity; "
+            "treating as consumer repo",
             file=sys.stderr,
         )
-        raise SystemExit(2)
+        return True
     return False

--- a/src/copilot-cli/lib/hook_utilities/guards.py
+++ b/src/copilot-cli/lib/hook_utilities/guards.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import sys
+from typing import Literal
 
 from .utilities import get_project_directory
 
@@ -22,7 +23,8 @@ _PROJECT_REPO_ENV = "AI_AGENTS_PROJECT_REPO"
 
 # Per-root, per-process memo so the Copilot in-process dispatcher (every shim in
 # one interpreter, ADR-068) pays the git lookup at most once per repository root.
-_origin_repo_cache: dict[str, bool] = {}
+RepoIdentity = Literal["project", "consumer", "unknown"]
+_origin_repo_cache: dict[str, RepoIdentity] = {}
 
 
 def _remote_repo_name(project_root: str) -> str | None:
@@ -30,7 +32,7 @@ def _remote_repo_name(project_root: str) -> str | None:
 
     Parses both HTTPS (``https://host/owner/ai-agents.git``) and SSH
     (``git@host:owner/ai-agents.git``) forms. Any failure (git missing, no
-    origin, timeout) yields None so the caller treats the repo as a consumer.
+    origin, timeout) yields None so the caller can block on unknown identity.
     """
     git = shutil.which("git")
     if git is None:
@@ -39,9 +41,10 @@ def _remote_repo_name(project_root: str) -> str | None:
         result = subprocess.run(
             [git, "-C", project_root, "remote", "get-url", "origin"],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
-            check=False,
+            check=True,
         )
     except (OSError, subprocess.SubprocessError):
         return None
@@ -58,6 +61,26 @@ def _remote_repo_name(project_root: str) -> str | None:
     return tail or None
 
 
+def _project_repo_identity() -> RepoIdentity:
+    """Resolve whether the current checkout is project, consumer, or unknown."""
+    override = os.environ.get(_PROJECT_REPO_ENV, "").strip()
+    if override == "1":
+        return "project"
+    if override == "0":
+        return "consumer"
+
+    project_root = get_project_directory()
+    if project_root not in _origin_repo_cache:
+        name = _remote_repo_name(project_root)
+        if name is None:
+            _origin_repo_cache[project_root] = "unknown"
+        elif name.lower() == _PROJECT_REPO_NAME:
+            _origin_repo_cache[project_root] = "project"
+        else:
+            _origin_repo_cache[project_root] = "consumer"
+    return _origin_repo_cache[project_root]
+
+
 def is_project_repo() -> bool:
     """Return True when running inside the ai-agents project repository.
 
@@ -66,24 +89,23 @@ def is_project_repo() -> bool:
     overrides the lookup ("1"/"0") and caches a one-time resolution; tests set
     it directly. Uses get_project_directory() so it works from a subdirectory.
     """
-    override = os.environ.get(_PROJECT_REPO_ENV, "").strip()
-    if override in ("0", "1"):
-        return override == "1"
-    project_root = get_project_directory()
-    if project_root not in _origin_repo_cache:
-        name = _remote_repo_name(project_root)
-        _origin_repo_cache[project_root] = (
-            name is not None and name.lower() == _PROJECT_REPO_NAME
-        )
-    return _origin_repo_cache[project_root]
+    return _project_repo_identity() == "project"
 
 
 def skip_if_consumer_repo(hook_name: str) -> bool:
     """Print skip message and return True if this is a consumer repo."""
-    if not is_project_repo():
+    identity = _project_repo_identity()
+    if identity == "consumer":
         print(
             f"[SKIP] {hook_name}: not the ai-agents project repo (consumer repo)",
             file=sys.stderr,
         )
         return True
+    if identity == "unknown":
+        print(
+            f"[BLOCK] {hook_name}: cannot verify ai-agents project repo identity; "
+            f"set {_PROJECT_REPO_ENV}=0 for consumer repos or restore git origin",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
     return False

--- a/src/copilot-cli/lib/hook_utilities/guards.py
+++ b/src/copilot-cli/lib/hook_utilities/guards.py
@@ -48,8 +48,6 @@ def _remote_repo_name(project_root: str) -> str | None:
         )
     except (OSError, subprocess.SubprocessError):
         return None
-    if result.returncode != 0:
-        return None
     url = result.stdout.strip()
     if not url:
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,21 @@ def _disable_commit_signing_for_test_git() -> Iterator[None]:
                 os.environ[key] = value
 
 
+@pytest.fixture(autouse=True)
+def _default_project_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default every test to the ai-agents project repo (issue #2610).
+
+    ``is_project_repo()`` now resolves repository identity from the git origin
+    remote, not from an incidental ``.agents/`` directory. A ``tmp_path`` fixture
+    has no such remote, so without this default each guard would treat the test
+    as a consumer repo and skip its real work. The suite genuinely runs inside
+    the project repo, so ``"1"`` is the correct default. Consumer-repo
+    simulation tests override ``AI_AGENTS_PROJECT_REPO`` to ``"0"`` (or unset it
+    and stub the git lookup) to exercise the skip path.
+    """
+    monkeypatch.setenv("AI_AGENTS_PROJECT_REPO", "1")
+
+
 def assert_validation_result(
     result: ValidationResult,
     *,

--- a/tests/hooks/test_security_gate.py
+++ b/tests/hooks/test_security_gate.py
@@ -117,17 +117,29 @@ class TestMain:
         result = invoke_security_gate.main()
         assert result == 0
 
-    def test_exits_2_for_empty_file_path(
+    def test_exits_0_for_empty_file_path_fail_open(
         self, mock_stdin: Callable[[str], None], capsys
     ):
+        # Empty/absent path: fail open (allow) rather than block every write (#2610).
         mock_stdin(
             json.dumps(
                 {"tool_name": "Edit", "tool_input": {"file_path": ""}}
             )
         )
         result = invoke_security_gate.main()
-        assert result == 2
-        assert "file_path" in capsys.readouterr().out
+        assert result == 0
+        assert "fail open" in capsys.readouterr().err
+
+    def test_allows_create_via_path_key(
+        self, mock_stdin: Callable[[str], None]
+    ):
+        # Copilot CLI create sends the non-auth target under ``path`` (#2610).
+        mock_stdin(
+            json.dumps(
+                {"tool_name": "Write", "tool_input": {"path": "/project/notes.md"}}
+            )
+        )
+        assert invoke_security_gate.main() == 0
 
     @patch("invoke_security_gate.find_security_evidence", return_value=True)
     @patch("invoke_security_gate.get_project_directory", return_value="/project")

--- a/tests/hooks/test_topical_memory_injection.py
+++ b/tests/hooks/test_topical_memory_injection.py
@@ -202,7 +202,8 @@ class TestMain:
         assert rc == 0
 
     def test_consumer_repo_skips(self, tmp_path, monkeypatch, capsys):
-        # No .agents/ -> skip_if_consumer_repo returns True -> silent exit 0.
+        # Consumer repo (AI_AGENTS_PROJECT_REPO=0) -> skip -> silent exit 0 (#2610).
+        monkeypatch.setenv("AI_AGENTS_PROJECT_REPO", "0")
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
         stdin = json.dumps({"tool_input": {"file_path": "/x/.claude/skills/github/x.py"}})
         with patch.object(sys, "stdin", io.StringIO(stdin)):

--- a/tests/test_hook_plugin_guards.py
+++ b/tests/test_hook_plugin_guards.py
@@ -128,20 +128,6 @@ class TestRemoteRepoName:
         assert captured_kwargs["errors"] == "replace"
         assert captured_kwargs["check"] is True
 
-    def test_origin_lookup_subprocess_error_returns_none(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(guards.shutil, "which", lambda _name: "git")
-        monkeypatch.setattr(
-            guards.subprocess,
-            "run",
-            lambda *a, **k: (_ for _ in ()).throw(
-                subprocess.CalledProcessError(2, a, stderr="no origin")
-            ),
-        )
-
-        assert guards._remote_repo_name("/repo") is None
-
     def test_git_missing_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(guards.shutil, "which", lambda _name: None)
         assert guards._remote_repo_name("/repo") is None
@@ -161,7 +147,7 @@ class TestSkipIfConsumerRepo:
         assert "[SKIP] test-hook" in captured.err
         assert "consumer repo" in captured.err
 
-    def test_blocks_when_repo_identity_unknown(
+    def test_skips_when_repo_identity_unknown(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         monkeypatch.delenv("AI_AGENTS_PROJECT_REPO", raising=False)
@@ -169,12 +155,9 @@ class TestSkipIfConsumerRepo:
         monkeypatch.setattr(guards, "get_project_directory", lambda: "/repo")
         monkeypatch.setattr(guards, "_remote_repo_name", lambda _root: None)
 
-        with pytest.raises(SystemExit) as exc_info:
-            skip_if_consumer_repo("test-hook")
-
-        assert exc_info.value.code == 2
+        assert skip_if_consumer_repo("test-hook") is True
         captured = capsys.readouterr()
-        assert "[BLOCK] test-hook" in captured.err
+        assert "[SKIP] test-hook" in captured.err
         assert "cannot verify ai-agents project repo identity" in captured.err
 
 

--- a/tests/test_hook_plugin_guards.py
+++ b/tests/test_hook_plugin_guards.py
@@ -99,11 +99,11 @@ class TestRemoteRepoName:
 
     def test_no_origin_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(guards.shutil, "which", lambda _name: "git")
-        monkeypatch.setattr(
-            guards.subprocess,
-            "run",
-            lambda *a, **k: subprocess.CompletedProcess(a, 2, stdout="", stderr="no origin"),
-        )
+
+        def raise_no_origin(*a, **k):
+            raise subprocess.CalledProcessError(2, a, stderr="no origin")
+
+        monkeypatch.setattr(guards.subprocess, "run", raise_no_origin)
         assert guards._remote_repo_name("/repo") is None
 
     def test_origin_lookup_uses_utf8_and_check_true(

--- a/tests/test_hook_plugin_guards.py
+++ b/tests/test_hook_plugin_guards.py
@@ -64,7 +64,7 @@ class TestIsProjectRepo:
         )
         assert is_project_repo() is False
 
-    def test_no_remote_is_consumer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_no_remote_is_not_project(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("AI_AGENTS_PROJECT_REPO", raising=False)
         guards._origin_repo_cache.clear()
         monkeypatch.setattr(guards, "_remote_repo_name", lambda _root: None)
@@ -106,6 +106,42 @@ class TestRemoteRepoName:
         )
         assert guards._remote_repo_name("/repo") is None
 
+    def test_origin_lookup_uses_utf8_and_check_true(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured_kwargs: dict[str, object] = {}
+
+        def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            captured_kwargs.update(kwargs)
+            return subprocess.CompletedProcess(
+                ["git", "-C", "/repo", "remote", "get-url", "origin"],
+                0,
+                stdout="ai-agents\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(guards.shutil, "which", lambda _name: "git")
+        monkeypatch.setattr(guards.subprocess, "run", fake_run)
+
+        assert guards._remote_repo_name("/repo") == "ai-agents"
+        assert captured_kwargs["encoding"] == "utf-8"
+        assert captured_kwargs["errors"] == "replace"
+        assert captured_kwargs["check"] is True
+
+    def test_origin_lookup_subprocess_error_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(guards.shutil, "which", lambda _name: "git")
+        monkeypatch.setattr(
+            guards.subprocess,
+            "run",
+            lambda *a, **k: (_ for _ in ()).throw(
+                subprocess.CalledProcessError(2, a, stderr="no origin")
+            ),
+        )
+
+        assert guards._remote_repo_name("/repo") is None
+
     def test_git_missing_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(guards.shutil, "which", lambda _name: None)
         assert guards._remote_repo_name("/repo") is None
@@ -124,6 +160,22 @@ class TestSkipIfConsumerRepo:
         captured = capsys.readouterr()
         assert "[SKIP] test-hook" in captured.err
         assert "consumer repo" in captured.err
+
+    def test_blocks_when_repo_identity_unknown(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.delenv("AI_AGENTS_PROJECT_REPO", raising=False)
+        guards._origin_repo_cache.clear()
+        monkeypatch.setattr(guards, "get_project_directory", lambda: "/repo")
+        monkeypatch.setattr(guards, "_remote_repo_name", lambda _root: None)
+
+        with pytest.raises(SystemExit) as exc_info:
+            skip_if_consumer_repo("test-hook")
+
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "[BLOCK] test-hook" in captured.err
+        assert "cannot verify ai-agents project repo identity" in captured.err
 
 
 class TestHookSkipsInConsumerRepo:

--- a/tests/test_hook_plugin_guards.py
+++ b/tests/test_hook_plugin_guards.py
@@ -6,12 +6,14 @@ Verifies that project-specific hooks skip gracefully in consumer repos
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
+from scripts.hook_utilities import guards
 from scripts.hook_utilities.guards import is_project_repo, skip_if_consumer_repo
 
 # Hook scripts that should skip in consumer repos (no .agents/ dir).
@@ -36,37 +38,88 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 class TestIsProjectRepo:
-    def test_returns_true_in_project(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.chdir(REPO_ROOT)
+    """is_project_repo resolves identity from the env override or git remote (#2610)."""
+
+    def test_env_override_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AI_AGENTS_PROJECT_REPO", "1")
         assert is_project_repo() is True
 
-    def test_returns_false_in_consumer(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.chdir(tmp_path)
+    def test_env_override_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AI_AGENTS_PROJECT_REPO", "0")
         assert is_project_repo() is False
 
-    def test_returns_false_when_agents_is_file(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """A .agents file (not directory) should be treated as consumer repo with warning."""
-        (tmp_path / ".agents").write_text("not a directory")
-        monkeypatch.chdir(tmp_path)
+    def test_remote_ai_agents_is_project(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AI_AGENTS_PROJECT_REPO", raising=False)
+        guards._origin_repo_cache.clear()
+        monkeypatch.setattr(guards, "_remote_repo_name", lambda _root: "ai-agents")
+        assert is_project_repo() is True
+
+    def test_remote_other_repo_is_consumer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A consumer repo with its own .agents/ (e.g. a vendored install) must
+        # not be mistaken for the project repo just because that dir exists.
+        monkeypatch.delenv("AI_AGENTS_PROJECT_REPO", raising=False)
+        guards._origin_repo_cache.clear()
+        monkeypatch.setattr(
+            guards, "_remote_repo_name", lambda _root: "Wcd.Infra.ConfigurationGeneration2"
+        )
         assert is_project_repo() is False
-        captured = capsys.readouterr()
-        assert "[WARNING]" in captured.err
-        assert "not a directory" in captured.err
+
+    def test_no_remote_is_consumer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AI_AGENTS_PROJECT_REPO", raising=False)
+        guards._origin_repo_cache.clear()
+        monkeypatch.setattr(guards, "_remote_repo_name", lambda _root: None)
+        assert is_project_repo() is False
+
+
+class TestRemoteRepoName:
+    """_remote_repo_name parses the origin URL across HTTPS and SSH forms."""
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://github.com/rjmurillo/ai-agents.git", "ai-agents"),
+            ("https://github.com/rjmurillo/ai-agents", "ai-agents"),
+            ("git@github.com:rjmurillo/ai-agents.git", "ai-agents"),
+            (
+                "git@github.com:org/Wcd.Infra.ConfigurationGeneration2.git",
+                "Wcd.Infra.ConfigurationGeneration2",
+            ),
+        ],
+    )
+    def test_parses_remote_url(
+        self, url: str, expected: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(guards.shutil, "which", lambda _name: "git")
+        monkeypatch.setattr(
+            guards.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(a, 0, stdout=url + "\n", stderr=""),
+        )
+        assert guards._remote_repo_name("/repo") == expected
+
+    def test_no_origin_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(guards.shutil, "which", lambda _name: "git")
+        monkeypatch.setattr(
+            guards.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(a, 2, stdout="", stderr="no origin"),
+        )
+        assert guards._remote_repo_name("/repo") is None
+
+    def test_git_missing_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(guards.shutil, "which", lambda _name: None)
+        assert guards._remote_repo_name("/repo") is None
 
 
 class TestSkipIfConsumerRepo:
     def test_returns_false_in_project(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.chdir(REPO_ROOT)
+        monkeypatch.setenv("AI_AGENTS_PROJECT_REPO", "1")
         assert skip_if_consumer_repo("test-hook") is False
 
     def test_returns_true_in_consumer(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("AI_AGENTS_PROJECT_REPO", "0")
         assert skip_if_consumer_repo("test-hook") is True
         captured = capsys.readouterr()
         assert "[SKIP] test-hook" in captured.err
@@ -94,6 +147,11 @@ class TestHookSkipsInConsumerRepo:
         # Some hooks read stdin for hook input JSON
         hook_input = '{"tool_name": "Bash", "tool_input": {"command": "echo hi"}}'
 
+        # Force consumer-repo identity for the spawned hook. The suite-wide
+        # autouse default sets AI_AGENTS_PROJECT_REPO=1; override to "0" so the
+        # subprocess takes the skip path (#2610).
+        env = {**os.environ, "AI_AGENTS_PROJECT_REPO": "0"}
+
         result = subprocess.run(
             [sys.executable, str(full_path)],
             capture_output=True,
@@ -101,6 +159,7 @@ class TestHookSkipsInConsumerRepo:
             cwd=str(consumer_dir),
             input=hook_input,
             timeout=10,
+            env=env,
         )
 
         assert result.returncode == 0, (

--- a/tests/test_invoke_security_gate.py
+++ b/tests/test_invoke_security_gate.py
@@ -129,8 +129,35 @@ class TestMainAllowPath:
             assert main() == 0
 
     @patch("invoke_security_gate.sys.stdin", new_callable=StringIO)
-    def test_blocks_missing_file_path(self, mock_stdin: StringIO) -> None:
+    def test_allows_missing_file_path_fail_open(self, mock_stdin: StringIO) -> None:
+        # No resolvable path: the gate cannot classify an auth file, so it fails
+        # open instead of blocking every pathless write (#2610).
         hook_input = {"tool_input": {"command": "echo hello"}}
+        mock_stdin.write(json.dumps(hook_input))
+        mock_stdin.seek(0)
+        with patch.object(mock_stdin, "isatty", return_value=False):
+            assert main() == 0
+
+    @patch("invoke_security_gate.sys.stdin", new_callable=StringIO)
+    def test_allows_non_auth_file_via_path_key(self, mock_stdin: StringIO) -> None:
+        # Copilot CLI create/edit deliver the target as ``path`` (#2610).
+        hook_input = {"tool_name": "Write", "tool_input": {"path": "src/utils/helpers.py"}}
+        mock_stdin.write(json.dumps(hook_input))
+        mock_stdin.seek(0)
+        with patch.object(mock_stdin, "isatty", return_value=False):
+            assert main() == 0
+
+    @patch("invoke_security_gate.find_security_evidence", return_value=False)
+    @patch("invoke_security_gate.get_project_directory", return_value="/project")
+    @patch("invoke_security_gate.sys.stdin", new_callable=StringIO)
+    def test_blocks_auth_file_via_path_key(
+        self,
+        mock_stdin: StringIO,
+        _mock_project: MagicMock,
+        _mock_evidence: MagicMock,
+    ) -> None:
+        # An auth file created via Copilot's ``path`` key is still gated (#2610).
+        hook_input = {"tool_name": "Write", "tool_input": {"path": "src/Auth/Login.cs"}}
         mock_stdin.write(json.dumps(hook_input))
         mock_stdin.seek(0)
         with patch.object(mock_stdin, "isatty", return_value=False):


### PR DESCRIPTION
## Summary

Fixes the `project-toolkit` plugin denying every `create`/`edit` in GitHub Copilot CLI sessions (`Denied by preToolUse hook from "project-toolkit@ai-agents" (hook errored)`), plus a related guard misfire in consumer repositories.

## Root cause

Copilot CLI maps its native tools to Claude tool names but keeps native argument keys. `create`/`edit`/`view` deliver the target path under `tool_input.path`, while `invoke_security_gate.py` read `tool_input.file_path` and **failed closed** when it was absent, denying every create/edit. Because the gate prints its block to stdout, the failure surfaced as `hook errored` with an empty stderr.

Captured payloads:

| Copilot tool | tool_name | tool_input keys |
|--------------|-----------|-----------------|
| `create` | `Write` | `path`, `file_text` |
| `edit` | `Edit` | `path`, `old_str`, `new_str` |
| `view` | `Read` | `path`, `view_range` |

Secondary: `is_project_repo()` treated any repository with a `.agents/` directory as the project repo, so the internal guards (LSP-first, skill-first, ...) fired in a consumer repo that vendors the plugin and keeps its own `.agents/`, blocking ordinary `grep`/`glob` searches.

## Changes

- Resolve the target path from `file_path` then `path` in the nine Pre/PostToolUse hooks that read it (matching the existing plan-state-sync hook, which already resolved both keys).
- `invoke_security_gate.py` fails **open** (allow) when no path is resolvable, instead of blocking every write. Identified auth files are still gated.
- `is_project_repo()` (in `guards.py`) resolves repository identity from the git origin remote (authoritative), cached per root, with an `AI_AGENTS_PROJECT_REPO` override that doubles as the test/CI hook. It no longer keys on an incidental on-disk `.agents/` directory.
- Regenerated `src/copilot-cli` shims and lib; bumped both `plugin.json` manifests to 0.5.199.

## Files changed

- Hook sources: `.claude/hooks/PreToolUse/invoke_security_gate.py`, `invoke_adr_architect_gate.py`, `invoke_lsp_read_guard.py`, `invoke_topical_memory_injection.py`; `.claude/hooks/PostToolUse/invoke_adr_lifecycle_hook.py`, `invoke_codeql_quick_scan.py`, `invoke_markdown_auto_lint.py`, `invoke_lsp_read_tracker.py`.
- Consumer-repo detection: `scripts/hook_utilities/guards.py`, synced to `.claude/lib/hook_utilities/guards.py` and `src/copilot-cli/lib/hook_utilities/guards.py`.
- Generated Copilot shims under `src/copilot-cli/hooks/` (regenerated from the hook sources above: `invoke_security_gate__Write_Edit_c39898.py`, `invoke_adr_architect_gate__Edit_Write_1da157.py`, `invoke_lsp_read_guard__Read_852b43.py`, `invoke_topical_memory_injection__Write_Edit_c39898.py`, `invoke_adr_lifecycle_hook__Bash_f620ca.py`, `invoke_adr_lifecycle_hook__Write_Edit_c39898.py`, `invoke_markdown_auto_lint__Write_Edit_c39898.py`, `invoke_lsp_read_tracker__Read_852b43.py`).
- Tests: `tests/conftest.py`, `tests/test_hook_plugin_guards.py`, `tests/test_invoke_security_gate.py`, `tests/hooks/test_security_gate.py`, `tests/hooks/test_topical_memory_injection.py`.
- Manifests + log: `.claude/.claude-plugin/plugin.json`, `src/copilot-cli/.claude-plugin/plugin.json`, session log under `.agents/sessions/`.

## Validation

- Reproduced the create/edit denial deterministically with the captured Copilot payload; after the fix the same payload allows (exit 0), and an auth-file edit without review still blocks (exit 2).
- The `tests/hooks/` failure set is identical to `origin/main` (49 pre-existing Windows-only failures: POSIX-path `relativize`, CodeQL/WindowsApps `python3`, pre-push bash hooks); this branch adds one net passing test and zero new failures.
- Updated the two security-gate tests that encoded the old fail-closed contract; added path-key and remote-detection regression tests.

Fixes #2610