### PR TITLE
chore(retro): add 2026-06-12 auto-retro skeleton and INDEX row

### DIFF
--- a/.agents/memory/episodes/episode-2026-06-12-session-2386-commit-hook-generated-2026-06-12-auto-retro-skeleton.json
+++ b/.agents/memory/episodes/episode-2026-06-12-session-2386-commit-hook-generated-2026-06-12-auto-retro-skeleton.json
@@ -1,0 +1,18 @@
+{
+  "id": "episode-2026-06-12-session-2386-commit-hook-generated-2026-06-12-auto-retro-skeleton",
+  "session": "2026-06-12-session-2386-commit-hook-generated-2026-06-12-auto-retro-skeleton",
+  "timestamp": "2026-06-12T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Commit hook-generated 2026-06-12 auto-retro skeleton and retro INDEX row left after PR #2575 merged",
+  "decisions": [],
+  "events": [],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 0
+  },
+  "lessons": []
+}

--- a/.agents/retrospective/2026-06-12-auto-retro.md
+++ b/.agents/retrospective/2026-06-12-auto-retro.md
@@ -1,0 +1,32 @@
+<!-- RETRO-STATE: skeleton-pending-fill -->
+# Retrospective: 2026-06-12
+
+> UNFILLED SKELETON written by invoke_auto_retrospective.py (Stop hook).
+> The sections below are empty placeholders, not a completed retrospective.
+> Run /retro fill 2026-06-12 (or the retrospective skill) to populate them, then
+> delete this banner and the RETRO-STATE marker above.
+
+## Session Context
+
+### Work Items
+- {'timestamp': '2026-06-11T15:05:00Z', 'entry': "Architect agent reviewed the proposed ADR-008 amendment: REQUEST CHANGES with two corrections (heading must read 'Amended 2026-06-11 per ADR-066' to avoid contradicting Accepted status; Stop-hook clause rewritten to match ADR-066 D2 prevention language instead of asserting a continuation-JSON contract). Applied both."}
+- {'timestamp': '2026-06-11T15:12:00Z', 'entry': "Amended ADR-008 failure-semantics bullets and the Design Principles 'Fail-open' bullet to defer to ADR-066 (commit 3080d86); zero em/en dashes verified at byte level; markdownlint clean; Serena memory architecture/adr-008-066-reconciliation.md written."}
+- {'timestamp': '2026-06-11T15:20:00Z', 'entry': "Reset .agents/memory/causality/causal-graph.json to main's version: the memory hook re-staged 234 lines of auto-generated counter churn unrelated to the governance amendment."}
+- {'timestamp': '2026-06-11T16:05:00Z', 'entry': 'Copilot review on PR #2575: ADR-008 (Accepted) deferring solely to ADR-066 (Proposed) left an accepted-defers-to-proposed ambiguity. Verified ADR-071 is Accepted (six-agent adr-review 2026-06-02) and its Decision item 5 records the binding fail-closed rule; the amendment bullet now cites ADR-071 item 5 as binding with ADR-066 as the detailed D1/D2 reconciliation. Serena memory updated to match.'}
+
+
+## What Went Well
+
+- _UNFILLED. Run the retrospective agent to populate this section._
+
+## What Could Improve
+
+- _UNFILLED. Run the retrospective agent to populate this section._
+
+## Key Learnings
+
+- _UNFILLED. Run the retrospective agent to populate this section._
+
+## Failure Patterns
+
+- _UNFILLED. Run the retrospective agent to populate this section (check .agents/governance/FAILURE-MODES.md)._

--- a/.agents/sessions/2026-06-12-session-2386-commit-hook-generated-2026-06-12-auto-retro-skeleton.json
+++ b/.agents/sessions/2026-06-12-session-2386-commit-hook-generated-2026-06-12-auto-retro-skeleton.json
@@ -1,0 +1,133 @@
+{
+  "session": {
+    "number": 2386,
+    "date": "2026-06-12",
+    "branch": "chore/auto-retro-2026-06-12",
+    "startingCommit": "85ee1a9",
+    "objective": "Commit hook-generated 2026-06-12 auto-retro skeleton and retro INDEX row left after PR #2575 merged"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena unavailable in this remote harness; per-turn UserPromptSubmit re-assertion hooks active (fallback per AGENTS.md)"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena re-assertion delivered via UserPromptSubmit hook every turn this session"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-injected by SessionStart context loader at session resume"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Skill inventory auto-injected at session resume; session-init skill script used this session"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md and CLAUDE.md loaded in system context at session start"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "universal.md and .claude/rules loaded in system context at session start"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Topical Serena memories auto-injected via PreToolUse hooks (error-recovery, session-protocol, github observations)"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "chore/auto-retro-2026-06-12"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On chore/auto-retro-2026-06-12"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status verified: only hook-generated 2026-06-12-auto-retro.md and docs/retros/INDEX.md row pending"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "85ee1a9"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST items in this checklist completed with evidence"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md untouched (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "SKIPPED with justification: artifact-only commit of a hook-generated retro skeleton; no new durable knowledge produced and Serena MCP unavailable in this remote harness"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "npx markdownlint-cli2 --fix on 2026-06-12-auto-retro.md and docs/retros/INDEX.md: 0 errors"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Auto-retro skeleton, retro INDEX row, and this session log in this commit on chore/auto-retro-2026-06-12"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "scripts/validate_session_json.py PASS on this log"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "SKIPPED: no task tracker items for this artifact-only commit"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "SKIPPED: the committed artifact IS the auto-retro skeleton; fill via /retro fill 2026-06-12"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "timestamp": "2026-06-12T00:10:00Z",
+      "entry": "PR #2575 (ADR-008/ADR-066 reconciliation) merged to main as 85ee1a9; watch concluded. Stop hook flagged leftover hook-generated artifacts: 2026-06-12 auto-retro skeleton and its docs/retros/INDEX.md row."
+    },
+    {
+      "timestamp": "2026-06-12T00:15:00Z",
+      "entry": "Moved the dirty artifacts to chore/auto-retro-2026-06-12 cut from origin/main (the prior branch is merged); created this session log via session-init script; markdownlint clean."
+    },
+    {
+      "timestamp": "2026-06-12T00:20:00Z",
+      "entry": "Verification: tests run via python3 scripts/validate_session_json.py on this log returned PASS (exit 0); npx markdownlint-cli2 --fix on 2026-06-12-auto-retro.md and docs/retros/INDEX.md returned Summary: 0 error(s). Docs-only change; no code paths touched, so no pytest suite applies."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Fill the 2026-06-12 auto-retro skeleton via /retro fill 2026-06-12"
+  ]
+}

--- a/docs/retros/INDEX.md
+++ b/docs/retros/INDEX.md
@@ -9,3 +9,4 @@
 | 2026-06-02 | 2026-06-02-issue-2290-copilot-hook-payload-format.md | P0: Copilot CLI preToolUse hooks crashed (FM-CONTRACT: eventRemap camelCase sent toolName, shim read tool_name) |
 | 2026-06-10 | [2026-06-10-auto-retro.md](../../.agents/retrospective/2026-06-10-auto-retro.md) | Auto-generated session retro |
 | 2026-06-11 | [2026-06-11-auto-retro.md](../../.agents/retrospective/2026-06-11-auto-retro.md) | Auto-generated session retro |
+| 2026-06-12 | [2026-06-12-auto-retro.md](../../.agents/retrospective/2026-06-12-auto-retro.md) | Auto-generated session retro |


### PR DESCRIPTION
Hook-generated artifacts left in the working tree after PR #2575
landed on main: the Stop-hook auto-retrospective skeleton for
2026-06-12 and its docs/retros/INDEX.md row, plus the session log
for this commit. Skeleton fill tracked via /retro fill 2026-06-12.

Refs #2271

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01JPLKQWSjsSh2XHfh7mZvkr