### PR TITLE
fix(ci): exclude .worktrees from manifest + skill-violation scans (#2621, #2047)

### DIFF
--- a/.agents/memory/episodes/episode-2026-06-17-session-2585-fix-2621-exclude-worktrees-plugin-manifest.json
+++ b/.agents/memory/episodes/episode-2026-06-17-session-2585-fix-2621-exclude-worktrees-plugin-manifest.json
@@ -1,0 +1,35 @@
+{
+  "id": "episode-2026-06-17-session-2585-fix-2621-exclude-worktrees-plugin-manifest",
+  "session": "2026-06-17-session-2585-fix-2621-exclude-worktrees-plugin-manifest",
+  "timestamp": "2026-06-17T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Fix #2621: exclude .worktrees from plugin-manifest validator discovery (keystone unblock for pushes)",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-06-17T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fix #2621: add '.worktrees' to excluded_dirs in build/scripts/validate_plugin_manifests.py find_manifests. Ran: uv run pytest tests/build_scripts/test_validate_plugin_manifests.py -> 40 passed. Mutation check: removing '.worktrees' makes new test fail (finds 2 manifests including the .worktrees one); restoring passes. Validator over repo -> exit 0, 3 manifests valid, 0 .worktrees paths.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-06-17T00:00:00+00:00",
+      "type": "test",
+      "content": "pytest: 40 passed in 0.24s; mutation-checked; validator exit 0",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 5
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-06-17-session-2585-fix-2621-exclude-worktrees-plugin-manifest.json
+++ b/.agents/memory/episodes/episode-2026-06-17-session-2585-fix-2621-exclude-worktrees-plugin-manifest.json
@@ -21,6 +21,22 @@
       "content": "pytest: 40 passed in 0.24s; mutation-checked; validator exit 0",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-06-17T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Same root cause as #2621 in scripts/detect_skill_violation.py SKIP_DIRS: pruned basename 'worktrees' but not dot-prefixed '.worktrees', so the scan walked 40+ sibling checkouts -> 33.9s, failing the 30s budget perf test (#2047) that hard-gates pre-push. Added '.worktrees' to SKIP_DIRS. Measured scan 33.9s -> 1.0s. Added regression tests test_skip_dirs_registers_dot_worktrees + test_prunes_top_level_dot_worktrees (mutation-checked: fail when '.worktrees' removed). uv run pytest -k worktree -> 5 passed.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-06-17T00:00:00+00:00",
+      "type": "test",
+      "content": "scan 33.9s->1.0s; pytest 5 passed; mutation-checked; fixes #2047 perf test",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/sessions/2026-06-17-session-2585-fix-2621-exclude-worktrees-plugin-manifest.json
+++ b/.agents/sessions/2026-06-17-session-2585-fix-2621-exclude-worktrees-plugin-manifest.json
@@ -122,6 +122,15 @@
       ],
       "status": "complete",
       "evidence": "pytest: 40 passed in 0.24s; mutation-checked; validator exit 0"
+    },
+    {
+      "action": "Same root cause as #2621 in scripts/detect_skill_violation.py SKIP_DIRS: pruned basename 'worktrees' but not dot-prefixed '.worktrees', so the scan walked 40+ sibling checkouts -> 33.9s, failing the 30s budget perf test (#2047) that hard-gates pre-push. Added '.worktrees' to SKIP_DIRS. Measured scan 33.9s -> 1.0s. Added regression tests test_skip_dirs_registers_dot_worktrees + test_prunes_top_level_dot_worktrees (mutation-checked: fail when '.worktrees' removed). uv run pytest -k worktree -> 5 passed.",
+      "files": [
+        "scripts/detect_skill_violation.py",
+        "tests/test_detect_skill_violation.py"
+      ],
+      "status": "complete",
+      "evidence": "scan 33.9s->1.0s; pytest 5 passed; mutation-checked; fixes #2047 perf test"
     }
   ],
   "endingCommit": "",

--- a/.agents/sessions/2026-06-17-session-2585-fix-2621-exclude-worktrees-plugin-manifest.json
+++ b/.agents/sessions/2026-06-17-session-2585-fix-2621-exclude-worktrees-plugin-manifest.json
@@ -1,0 +1,129 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2585,
+    "date": "2026-06-17",
+    "branch": "fix/2621-manifest-validator-worktrees-scope",
+    "startingCommit": "ccf2020857",
+    "objective": "Fix #2621: exclude .worktrees from plugin-manifest validator discovery (keystone unblock for pushes)"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "mcp__serena__initial_instructions invoked; project ai-agents activated this session"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena Instructions Manual read via initial_instructions"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-loaded at SessionStart (read-only dashboard)"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ls .claude/skills/github/scripts/issue/ and pr/ enumerated"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ADR-007 retrieval-led reasoning followed; usage-mandatory in memory-index"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md + .claude/rules/* loaded at SessionStart; PROJECT-CONSTRAINTS honored"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "memory-index reviewed; read adr-retroactive-amendment-criteria and others"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2621-manifest-validator-worktrees-scope"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/2621-manifest-validator-worktrees-scope"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "ccf2020857"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart + sessionEnd MUSTs populated with evidence"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Wrote serena memory tasks/issue-2621-worktrees-manifest-scope"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "npx markdownlint-cli2 --fix over staged md -> 0 files, 0 errors (no md changed)"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This commit (fix #2621)"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run pytest tests/build_scripts/test_validate_plugin_manifests.py -> 40 passed; validator exit 0"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Fix #2621: add '.worktrees' to excluded_dirs in build/scripts/validate_plugin_manifests.py find_manifests. Ran: uv run pytest tests/build_scripts/test_validate_plugin_manifests.py -> 40 passed. Mutation check: removing '.worktrees' makes new test fail (finds 2 manifests including the .worktrees one); restoring passes. Validator over repo -> exit 0, 3 manifests valid, 0 .worktrees paths.",
+      "files": [
+        "build/scripts/validate_plugin_manifests.py",
+        "tests/build_scripts/test_validate_plugin_manifests.py"
+      ],
+      "status": "complete",
+      "evidence": "pytest: 40 passed in 0.24s; mutation-checked; validator exit 0"
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": []
+}

--- a/build/scripts/validate_plugin_manifests.py
+++ b/build/scripts/validate_plugin_manifests.py
@@ -203,8 +203,10 @@ def _validate_hooks_string_ref(value: str, manifest_dir: Path | None) -> list[st
         return errors
     # The plugin root is the directory containing .claude-plugin/, i.e.
     # the parent of manifest_dir. Hook string refs are relative to root.
-    plugin_root = manifest_dir.parent
+    plugin_root = manifest_dir.parent.resolve()
     referenced = (plugin_root / value).resolve()
+    if not referenced.is_relative_to(plugin_root):
+        return [f"`hooks`: path '{value}' escapes the plugin root directory"]
     if not referenced.exists():
         return errors  # Don't fail if path is just unresolvable here.
     try:
@@ -214,7 +216,7 @@ def _validate_hooks_string_ref(value: str, manifest_dir: Path | None) -> list[st
     return _validate_referenced_hooks_doc(value, inner)
 
 
-def _validate_hooks_inline(value: dict) -> list[str]:
+def _validate_hooks_inline(value: dict[str, object]) -> list[str]:
     """Validate an inline `hooks` object mapping event names to matcher groups."""
     inline_errors: list[str] = []
     for event, entries in value.items():
@@ -251,7 +253,7 @@ def _validate_hooks(value: object, manifest_dir: Path | None = None) -> list[str
     return _validate_hooks_inline(value)
 
 
-def _validate_manifest_data(data: dict, path: Path) -> list[str]:
+def _validate_manifest_data(data: dict[str, object], path: Path) -> list[str]:
     """Validate the parsed manifest object. Returns list of error messages.
 
     Split out of validate_manifest so each stays within the cyclomatic-complexity
@@ -260,12 +262,13 @@ def _validate_manifest_data(data: dict, path: Path) -> list[str]:
     errors: list[str] = []
 
     missing = REQUIRED_KEYS - data.keys()
+    name = data.get("name")
     if missing:
         errors.append(f"Missing required keys: {sorted(missing)}")
-    elif not isinstance(data.get("name"), str) or not data["name"].strip():
+    elif not isinstance(name, str) or not name.strip():
         errors.append(
             "`name`: must be a non-empty string "
-            f"(got {type(data.get('name')).__name__})"
+            f"(got {type(name).__name__})"
         )
 
     unknown = set(data.keys()) - ALLOWED_KEYS

--- a/build/scripts/validate_plugin_manifests.py
+++ b/build/scripts/validate_plugin_manifests.py
@@ -123,6 +123,28 @@ def _check_marketplace_runtime_forbidden_keys(
     ]
 
 
+def _validate_hook_group(event: str, idx: int, group: object) -> list[str]:
+    """Validate one matcher group (an object with a `hooks` array)."""
+    if not isinstance(group, dict):
+        return [f"`hooks.{event}[{idx}]`: must be an object with `hooks` array"]
+    if "hooks" not in group or not isinstance(group["hooks"], list):
+        return [f"`hooks.{event}[{idx}].hooks`: required array of hook commands"]
+    errors: list[str] = []
+    for hidx, hook in enumerate(group["hooks"]):
+        if not isinstance(hook, dict):
+            errors.append(f"`hooks.{event}[{idx}].hooks[{hidx}]`: must be an object")
+            continue
+        if hook.get("type") != "command":
+            errors.append(
+                f"`hooks.{event}[{idx}].hooks[{hidx}].type`: must be 'command'"
+            )
+        if not isinstance(hook.get("command"), str):
+            errors.append(
+                f"`hooks.{event}[{idx}].hooks[{hidx}].command`: required string"
+            )
+    return errors
+
+
 def _validate_hook_event_entries(event: str, entries: object) -> list[str]:
     """Each event maps to a list of matcher groups."""
     if not isinstance(entries, list):
@@ -134,91 +156,66 @@ def _validate_hook_event_entries(event: str, entries: object) -> list[str]:
         ]
     errors: list[str] = []
     for idx, group in enumerate(entries):
-        if not isinstance(group, dict):
-            errors.append(
-                f"`hooks.{event}[{idx}]`: must be an object with `hooks` array"
-            )
-            continue
-        if "hooks" not in group or not isinstance(group["hooks"], list):
-            errors.append(
-                f"`hooks.{event}[{idx}].hooks`: required array of hook commands"
-            )
-            continue
-        for hidx, hook in enumerate(group["hooks"]):
-            if not isinstance(hook, dict):
-                errors.append(
-                    f"`hooks.{event}[{idx}].hooks[{hidx}]`: must be an object"
-                )
-                continue
-            if hook.get("type") != "command":
-                errors.append(
-                    f"`hooks.{event}[{idx}].hooks[{hidx}].type`: must be 'command'"
-                )
-            if not isinstance(hook.get("command"), str):
-                errors.append(
-                    f"`hooks.{event}[{idx}].hooks[{hidx}].command`: required string"
-                )
+        errors.extend(_validate_hook_group(event, idx, group))
     return errors
 
 
-def _validate_hooks(value: object, manifest_dir: Path | None = None) -> list[str]:
-    """Hooks must be either a string path to a JSON file or an inline object.
-
-    Rejects the dict-of-strings shape (`{event: "./hooks/Event"}`) that broke
-    plugin install in PR #1773. When `value` is a string ref and `manifest_dir`
-    is provided, the referenced file is also loaded and its contents validated.
-    """
-    if isinstance(value, str):
-        if not value.endswith(".json"):
-            return [
-                "`hooks`: string value must reference a `.json` file "
-                f"(got '{value}'). Pointing to a directory is invalid."
-            ]
-        errors = _validate_relative_path("hooks", value)
-        if errors or manifest_dir is None:
-            return errors
-        # The plugin root is the directory containing .claude-plugin/, i.e.
-        # the parent of manifest_dir. Hook string refs are relative to root.
-        plugin_root = manifest_dir.parent
-        referenced = (plugin_root / value).resolve()
-        if not referenced.exists():
-            return errors  # Don't fail if path is just unresolvable here.
-        try:
-            inner = json.loads(referenced.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-            return [f"`hooks`: referenced file '{value}' is unreadable: {exc}"]
-        if not isinstance(inner, dict):
-            return [f"`hooks`: referenced file '{value}' must be a JSON object"]
-        # The canonical hooks.json shape (per production plugins
-        # context-mode and security-guidance) wraps event names under
-        # a top-level "hooks" key. Without the wrapper, Claude Code
-        # does not load the events. Enforce strictly.
-        if "hooks" not in inner:
-            return [
-                f"`hooks`: referenced file '{value}' must contain a top-level "
-                f"`hooks` key wrapping the event names "
-                f"(e.g. {{\"hooks\": {{\"PreToolUse\": [...]}}}}). "
-                f"Without the wrapper, Claude Code does not load the events."
-            ]
-        events_obj = inner["hooks"]
-        if not isinstance(events_obj, dict):
-            return [
-                f"`hooks`: referenced file '{value}' top-level `hooks` value "
-                f"must be an object of event names"
-            ]
-        nested_errors: list[str] = []
-        for event, entries in events_obj.items():
-            if event not in VALID_HOOK_EVENTS:
-                nested_errors.append(
-                    f"`hooks` ref '{value}': unknown hook event '{event}'"
-                )
-                continue
-            nested_errors.extend(_validate_hook_event_entries(event, entries))
-        return nested_errors
-    if not isinstance(value, dict):
+def _validate_referenced_hooks_doc(value: str, inner: object) -> list[str]:
+    """Validate the parsed contents of a referenced hooks JSON file."""
+    if not isinstance(inner, dict):
+        return [f"`hooks`: referenced file '{value}' must be a JSON object"]
+    # The canonical hooks.json shape (per production plugins context-mode and
+    # security-guidance) wraps event names under a top-level "hooks" key.
+    # Without the wrapper, Claude Code does not load the events. Enforce strictly.
+    if "hooks" not in inner:
         return [
-            f"`hooks`: must be an object or string path (got {type(value).__name__})"
+            f"`hooks`: referenced file '{value}' must contain a top-level "
+            f"`hooks` key wrapping the event names "
+            f"(e.g. {{\"hooks\": {{\"PreToolUse\": [...]}}}}). "
+            f"Without the wrapper, Claude Code does not load the events."
         ]
+    events_obj = inner["hooks"]
+    if not isinstance(events_obj, dict):
+        return [
+            f"`hooks`: referenced file '{value}' top-level `hooks` value "
+            f"must be an object of event names"
+        ]
+    nested_errors: list[str] = []
+    for event, entries in events_obj.items():
+        if event not in VALID_HOOK_EVENTS:
+            nested_errors.append(
+                f"`hooks` ref '{value}': unknown hook event '{event}'"
+            )
+            continue
+        nested_errors.extend(_validate_hook_event_entries(event, entries))
+    return nested_errors
+
+
+def _validate_hooks_string_ref(value: str, manifest_dir: Path | None) -> list[str]:
+    """Validate a `hooks` string ref to a JSON file and its referenced contents."""
+    if not value.endswith(".json"):
+        return [
+            "`hooks`: string value must reference a `.json` file "
+            f"(got '{value}'). Pointing to a directory is invalid."
+        ]
+    errors = _validate_relative_path("hooks", value)
+    if errors or manifest_dir is None:
+        return errors
+    # The plugin root is the directory containing .claude-plugin/, i.e.
+    # the parent of manifest_dir. Hook string refs are relative to root.
+    plugin_root = manifest_dir.parent
+    referenced = (plugin_root / value).resolve()
+    if not referenced.exists():
+        return errors  # Don't fail if path is just unresolvable here.
+    try:
+        inner = json.loads(referenced.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return [f"`hooks`: referenced file '{value}' is unreadable: {exc}"]
+    return _validate_referenced_hooks_doc(value, inner)
+
+
+def _validate_hooks_inline(value: dict) -> list[str]:
+    """Validate an inline `hooks` object mapping event names to matcher groups."""
     inline_errors: list[str] = []
     for event, entries in value.items():
         if event not in VALID_HOOK_EVENTS:
@@ -238,22 +235,28 @@ def _validate_hooks(value: object, manifest_dir: Path | None = None) -> list[str
     return inline_errors
 
 
-def validate_manifest(path: Path) -> list[str]:
-    """Validate a single plugin.json file. Returns list of error messages."""
-    try:
-        raw = path.read_text(encoding="utf-8")
-    except OSError as exc:
-        return [f"Manifest read error for '{path}': {exc}"]
-    except UnicodeDecodeError as exc:
-        return [f"Manifest decode error for '{path}': {exc}"]
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        return [f"JSON parse error: {exc}"]
+def _validate_hooks(value: object, manifest_dir: Path | None = None) -> list[str]:
+    """Hooks must be either a string path to a JSON file or an inline object.
 
-    if not isinstance(data, dict):
-        return ["Top-level value must be an object"]
+    Rejects the dict-of-strings shape (`{event: "./hooks/Event"}`) that broke
+    plugin install in PR #1773. When `value` is a string ref and `manifest_dir`
+    is provided, the referenced file is also loaded and its contents validated.
+    """
+    if isinstance(value, str):
+        return _validate_hooks_string_ref(value, manifest_dir)
+    if not isinstance(value, dict):
+        return [
+            f"`hooks`: must be an object or string path (got {type(value).__name__})"
+        ]
+    return _validate_hooks_inline(value)
 
+
+def _validate_manifest_data(data: dict, path: Path) -> list[str]:
+    """Validate the parsed manifest object. Returns list of error messages.
+
+    Split out of validate_manifest so each stays within the cyclomatic-complexity
+    budget; validate_manifest handles read/parse, this handles field semantics.
+    """
     errors: list[str] = []
 
     missing = REQUIRED_KEYS - data.keys()
@@ -281,6 +284,25 @@ def validate_manifest(path: Path) -> list[str]:
     return errors
 
 
+def validate_manifest(path: Path) -> list[str]:
+    """Validate a single plugin.json file. Returns list of error messages."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"Manifest read error for '{path}': {exc}"]
+    except UnicodeDecodeError as exc:
+        return [f"Manifest decode error for '{path}': {exc}"]
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return [f"JSON parse error: {exc}"]
+
+    if not isinstance(data, dict):
+        return ["Top-level value must be an object"]
+
+    return _validate_manifest_data(data, path)
+
+
 def find_manifests(root: Path) -> list[Path]:
     """Find all plugin.json files under `.claude-plugin/` directories.
 
@@ -290,7 +312,7 @@ def find_manifests(root: Path) -> list[Path]:
     """
     import os
 
-    excluded_dirs = {"worktrees", "node_modules", ".git", "cache", ".pytest_tmp"}
+    excluded_dirs = {".worktrees", "worktrees", "node_modules", ".git", "cache", ".pytest_tmp"}
     results: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(root):
         # Prune excluded directories in-place so os.walk does not descend.

--- a/scripts/detect_skill_violation.py
+++ b/scripts/detect_skill_violation.py
@@ -62,11 +62,13 @@ VALID_EXTENSIONS = frozenset({".md", ".py", ".ps1", ".psm1"})
 #
 # These directories hold no source the scanner needs and dominate the cost
 # as the checkout grows. os.walk prunes by directory basename, so the bare
-# name "worktrees" prunes the whole .claude/worktrees subtree. When the repo
+# name "worktrees" prunes the .claude/worktrees subtree and ".worktrees"
+# prunes the top-level git-worktree root (a 40+ checkout tree; #2047/#2621). When the repo
 # grows, add hot directories here rather than widening the walk.
 SKIP_DIRS = frozenset(
     {
         ".git",
+        ".worktrees",
         "node_modules",
         ".venv",
         "venv",

--- a/tests/build_scripts/test_validate_plugin_manifests.py
+++ b/tests/build_scripts/test_validate_plugin_manifests.py
@@ -8,8 +8,11 @@ plus the Claude-specific manifest regression from issue #1833.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "build" / "scripts"))
@@ -109,6 +112,28 @@ def test_hooks_string_path_no_traversal(tmp_path: Path) -> None:
     target = _write(tmp_path, {"name": "p", "hooks": "./../hooks.json"})
     errors = vpm.validate_manifest(target)
     assert any("'..'" in e for e in errors)
+
+
+def test_hooks_string_ref_rejects_symlink_escape(tmp_path: Path) -> None:
+    """Resolved hooks path must stay inside the plugin root."""
+    plugin_root = tmp_path / "plugin-root"
+    plugin_dir = plugin_root / ".claude-plugin"
+    plugin_dir.mkdir(parents=True)
+    manifest = plugin_dir / "plugin.json"
+    manifest.write_text(json.dumps({"name": "p", "hooks": "./hooks.json"}), encoding="utf-8")
+    outside = tmp_path / "outside-hooks.json"
+    outside.write_text(
+        json.dumps({"hooks": {"PreToolUse": [{"hooks": [{"type": "command", "command": "x"}]}]}}),
+        encoding="utf-8",
+    )
+    try:
+        os.symlink(outside, plugin_root / "hooks.json")
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    errors = vpm.validate_manifest(manifest)
+
+    assert any("escapes the plugin root" in e for e in errors)
 
 
 def test_manifest_read_error_returns_clean_message(tmp_path: Path) -> None:

--- a/tests/build_scripts/test_validate_plugin_manifests.py
+++ b/tests/build_scripts/test_validate_plugin_manifests.py
@@ -385,6 +385,21 @@ def test_find_manifests_skips_worktrees(tmp_path: Path) -> None:
     assert "worktrees" not in str(found[0])
 
 
+def test_find_manifests_skips_dot_worktrees(tmp_path: Path) -> None:
+    """Top-level worktree dir is `.worktrees` (dot-prefixed); it must be pruned
+    too. Regression for #2621: a broken manifest in a sibling .worktrees/ checkout
+    blocked unrelated pushes because the exclusion set listed only "worktrees"."""
+    repo_manifest = tmp_path / "a" / ".claude-plugin" / "plugin.json"
+    repo_manifest.parent.mkdir(parents=True)
+    repo_manifest.write_text("{}", encoding="utf-8")
+    dot_worktree = tmp_path / ".worktrees" / "sibling" / ".claude-plugin" / "plugin.json"
+    dot_worktree.parent.mkdir(parents=True)
+    dot_worktree.write_text("{ broken json", encoding="utf-8")
+    found = vpm.find_manifests(tmp_path)
+    assert len(found) == 1
+    assert ".worktrees" not in str(found[0])
+
+
 def test_find_manifests_skips_pytest_tmp(tmp_path: Path) -> None:
     """Regression for #2366: fixture manifests under .pytest_tmp must be ignored.
 

--- a/tests/test_detect_skill_violation.py
+++ b/tests/test_detect_skill_violation.py
@@ -225,6 +225,28 @@ class TestGetAllFiles:
         assert "worktrees" in SKIP_DIRS
         assert ".venv" in SKIP_DIRS
 
+    def test_skip_dirs_registers_dot_worktrees(self) -> None:
+        """SKIP_DIRS contains the dot-prefixed top-level git-worktree root.
+
+        os.walk prunes by basename. The repo top-level worktree root is
+        ".worktrees" (dot-prefixed), distinct from .claude/worktrees. Without
+        ".worktrees" the scanner descended into 40+ sibling checkouts and the
+        full scan exceeded the 30s budget (#2047 / #2621).
+        """
+        assert ".worktrees" in SKIP_DIRS
+
+    def test_prunes_top_level_dot_worktrees(self, tmp_path: Path) -> None:
+        """A top-level .worktrees/ sibling checkout is pruned, not scanned."""
+        wt = tmp_path / ".worktrees" / "pr-x" / "scripts"
+        wt.mkdir(parents=True)
+        (wt / "copy.py").write_text("gh pr create")
+        real = tmp_path / "scripts"
+        real.mkdir()
+        (real / "real.py").write_text("# real")
+        result = get_all_files(tmp_path)
+        assert "scripts/real.py" in result
+        assert not any("copy.py" in f for f in result)
+
 
 class TestCheckFileForViolations:
     """Tests for check_file_for_violations function."""


### PR DESCRIPTION
## Summary

Fixes two instances of the same root-cause bug: directory-walk pruning matched `worktrees` but missed the repo's top-level `.worktrees` root. On a checkout with many sibling worktrees, that made unrelated pushes fail or run slowly.

Fixes #2621
Fixes #2047

## Plugin manifest validator

`build/scripts/validate_plugin_manifests.py` now prunes `.worktrees`, keeps the existing `worktrees` exclusion, and validates referenced hook files after resolving paths so symlinks cannot escape the plugin root. The new helper annotations use typed JSON object maps so mypy accepts the validator.

## Skill violation scan

`scripts/detect_skill_violation.py` now prunes `.worktrees` in addition to `worktrees`, so full-tree scans avoid sibling checkout trees.

## Tests

- `tests/build_scripts/test_validate_plugin_manifests.py` covers `.worktrees` pruning, `.pytest_tmp` pruning, typed helper behavior through the manifest validator, and symlink escape rejection for referenced hooks files.
- `tests/test_detect_skill_violation.py` covers `.worktrees` registration and top-level `.worktrees` pruning.

## Validation

- `uv run pytest tests/build_scripts/test_validate_plugin_manifests.py tests/test_detect_skill_violation.py -q`
- `uv run --extra dev ruff check build/scripts/validate_plugin_manifests.py tests/build_scripts/test_validate_plugin_manifests.py scripts/detect_skill_violation.py tests/test_detect_skill_violation.py`
- `uv run --extra dev mypy build/scripts/validate_plugin_manifests.py tests/build_scripts/test_validate_plugin_manifests.py --follow-imports=skip`
- `uv run python .claude/skills/security-scan/scripts/scan_vulnerabilities.py build/scripts/validate_plugin_manifests.py tests/build_scripts/test_validate_plugin_manifests.py scripts/detect_skill_violation.py tests/test_detect_skill_violation.py`
- `python3 scripts/validate_session_json.py .agents/sessions/2026-06-17-session-2585-fix-2621-exclude-worktrees-plugin-manifest.json`
- `git diff --check`

## Notes

This branch also includes the session and episode artifacts created by the session protocol hook for the original fix.
