### PR TITLE
fix(github-skill): exclude skipped required checks from pending list

### DIFF
--- a/.agents/memory/episodes/episode-2026-06-17-session-2585-fix-2614-get_pr_checks-marks-skipped.json
+++ b/.agents/memory/episodes/episode-2026-06-17-session-2585-fix-2614-get_pr_checks-marks-skipped.json
@@ -1,0 +1,43 @@
+{
+  "id": "episode-2026-06-17-session-2585-fix-2614-get_pr_checks-marks-skipped",
+  "session": "2026-06-17-session-2585-fix-2614-get_pr_checks-marks-skipped",
+  "timestamp": "2026-06-17T00:00:00+00:00",
+  "outcome": "success",
+  "task": "fix #2614 get_pr_checks marks skipped required checks as pending",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-06-17T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fix #2614: get_pr_checks marked a SKIPPED required check as pending. Root cause: dedupe_checks ORs IsPending onto the winner from a stale StatusContext-PENDING sibling, and extract_required_check_lists (scripts/github_core/checks_rollup.py) appended to PendingRequiredChecks on IsPending alone. Fix: guard the pending append with `and not check.get('IsPassing')` so a completed-passing (incl SKIPPED) required check is not listed as pending, matching test_pr_merge_ready.py. Synced 3 github_core copies (scripts/, .claude/lib/, src/copilot-cli/lib/) via scripts/sync_plugin_lib.py + build_all.py --platform copilot-cli. TDD: wrote failing test test_skipped_winner_with_pending_sibling_excluded_from_required (RED: pending_required=['Run Python Tests']), applied fix, GREEN. Mutation (revert guard) -> test failed as expected, restored. Considered the deeper dedupe-layer fix but it broke 4 existing wait-polling contract tests (test_passing_supersedes_pending_but_keeps_pending_signal etc.), so kept the sanctioned minimal extract-layer guard. Test command: uv run pytest tests/test_get_pr_checks.py -q -> 77 passed. Related: uv run pytest tests/ -k 'pr_checks or merge_ready or checks_rollup' -> 123 passed.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-06-17T00:00:00+00:00",
+      "type": "test",
+      "content": "Fix #2614: get_pr_checks marked a SKIPPED required check as pending. Root cause: dedupe_checks ORs IsPending onto the winner from a stale StatusContext-PENDING sibling, and extract_required_check_lists (scripts/github_core/checks_rollup.py) appended to PendingRequiredChecks on IsPending alone. Fix: guard the pending append with `and not check.get('IsPassing')` so a completed-passing (incl SKIPPED) required check is not listed as pending, matching test_pr_merge_ready.py. Synced 3 github_core copies (scripts/, .claude/lib/, src/copilot-cli/lib/) via scripts/sync_plugin_lib.py + build_all.py --platform copilot-cli. TDD: wrote failing test test_skipped_winner_with_pending_sibling_excluded_from_required (RED: pending_required=['Run Python Tests']), applied fix, GREEN. Mutation (revert guard) -> test failed as expected, restored. Considered the deeper dedupe-layer fix but it broke 4 existing wait-polling contract tests (test_passing_supersedes_pending_but_keeps_pending_signal etc.), so kept the sanctioned minimal extract-layer guard. Test command: uv run pytest tests/test_get_pr_checks.py -q -> 77 passed. Related: uv run pytest tests/ -k 'pr_checks or merge_ready or checks_rollup' -> 123 passed.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-06-17T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 423152fb9",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 2
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-06-17-session-2585-fix-2614-get_pr_checks-marks-skipped.json
+++ b/.agents/sessions/2026-06-17-session-2585-fix-2614-get_pr_checks-marks-skipped.json
@@ -119,6 +119,6 @@
       "entry": "Fix #2614: get_pr_checks marked a SKIPPED required check as pending. Root cause: dedupe_checks ORs IsPending onto the winner from a stale StatusContext-PENDING sibling, and extract_required_check_lists (scripts/github_core/checks_rollup.py) appended to PendingRequiredChecks on IsPending alone. Fix: guard the pending append with `and not check.get('IsPassing')` so a completed-passing (incl SKIPPED) required check is not listed as pending, matching test_pr_merge_ready.py. Synced 3 github_core copies (scripts/, .claude/lib/, src/copilot-cli/lib/) via scripts/sync_plugin_lib.py + build_all.py --platform copilot-cli. TDD: wrote failing test test_skipped_winner_with_pending_sibling_excluded_from_required (RED: pending_required=['Run Python Tests']), applied fix, GREEN. Mutation (revert guard) -> test failed as expected, restored. Considered the deeper dedupe-layer fix but it broke 4 existing wait-polling contract tests (test_passing_supersedes_pending_but_keeps_pending_signal etc.), so kept the sanctioned minimal extract-layer guard. Test command: uv run pytest tests/test_get_pr_checks.py -q -> 77 passed. Related: uv run pytest tests/ -k 'pr_checks or merge_ready or checks_rollup' -> 123 passed."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "423152fb9",
   "nextSteps": []
 }

--- a/.agents/sessions/2026-06-17-session-2585-fix-2614-get_pr_checks-marks-skipped.json
+++ b/.agents/sessions/2026-06-17-session-2585-fix-2614-get_pr_checks-marks-skipped.json
@@ -1,0 +1,124 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2585,
+    "date": "2026-06-17",
+    "branch": "fix/2614-get-pr-checks-skipped-pending",
+    "startingCommit": "ccf2020857",
+    "objective": "fix #2614 get_pr_checks marks skipped required checks as pending"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena project active; wrote memory tasks/issue-2614-skipped-required-not-pending"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Operated under AGENTS.md Serena init contract; LSP-first guards active this session"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read /tmp/fix_2614.json triage plan and issue #2614 context/comments via get_issue_context.py"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file (new_session_log.py session 2585)"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Used .claude/skills/github/scripts/issue/* and pr/* via uv run python"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read AGENTS.md, CLAUDE.md, and .claude/rules/* loaded in context"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .claude/rules code-quality, python, release-it, canonical-source-mirror"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Topical worktree + pr-review memories surfaced via hooks; reviewed before edits"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2614-get-pr-checks-skipped-pending off HEAD ccf2020857"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/2614-get-pr-checks-skipped-pending"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "ccf2020857"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart/sessionEnd MUSTs populated with evidence"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md not modified (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Wrote tasks/issue-2614-skipped-required-not-pending"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No .md files changed in this fix; markdownlint not applicable"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Committed on fix branch; see endingCommit"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run pytest tests/test_get_pr_checks.py -q -> 77 passed; -k pr_checks or merge_ready or checks_rollup -> 123 passed"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Single-issue fix; no multi-task tracker used"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Reflection captured inline in Serena memory; no separate retro for an S-size single-line fix"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "timestamp": "2026-06-17T13:45:00Z",
+      "entry": "Fix #2614: get_pr_checks marked a SKIPPED required check as pending. Root cause: dedupe_checks ORs IsPending onto the winner from a stale StatusContext-PENDING sibling, and extract_required_check_lists (scripts/github_core/checks_rollup.py) appended to PendingRequiredChecks on IsPending alone. Fix: guard the pending append with `and not check.get('IsPassing')` so a completed-passing (incl SKIPPED) required check is not listed as pending, matching test_pr_merge_ready.py. Synced 3 github_core copies (scripts/, .claude/lib/, src/copilot-cli/lib/) via scripts/sync_plugin_lib.py + build_all.py --platform copilot-cli. TDD: wrote failing test test_skipped_winner_with_pending_sibling_excluded_from_required (RED: pending_required=['Run Python Tests']), applied fix, GREEN. Mutation (revert guard) -> test failed as expected, restored. Considered the deeper dedupe-layer fix but it broke 4 existing wait-polling contract tests (test_passing_supersedes_pending_but_keeps_pending_signal etc.), so kept the sanctioned minimal extract-layer guard. Test command: uv run pytest tests/test_get_pr_checks.py -q -> 77 passed. Related: uv run pytest tests/ -k 'pr_checks or merge_ready or checks_rollup' -> 123 passed."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": []
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.199",
+  "version": "0.5.200",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/lib/github_core/checks_rollup.py
+++ b/.claude/lib/github_core/checks_rollup.py
@@ -80,9 +80,8 @@ def extract_required_check_lists(
         # IsPending=true onto the winner from a stale sibling row. The IsPending
         # OR is retained on the row for wait polling, but PendingRequiredChecks
         # must classify a completed-passing required check consistently with
-        # test_pr_merge_ready.py, which treats it as non-blocking. Refs issue
-        # #2614: a SKIPPED required check with a PENDING sibling was reported as
-        # pending while test_pr_merge_ready.py treated it as non-blocking.
+        # test_pr_merge_ready.py, which treats it as non-blocking. Refs issue #2614:
+        # a SKIPPED required check with a PENDING sibling was reported as pending.
         if check.get("IsPending") and not check.get("IsPassing"):
             pending_required.append(name)
 

--- a/.claude/lib/github_core/checks_rollup.py
+++ b/.claude/lib/github_core/checks_rollup.py
@@ -75,7 +75,15 @@ def extract_required_check_lists(
 
         if check.get("IsFailing"):
             failed_required.append(name)
-        if check.get("IsPending"):
+        # A check whose dedupe winner is passing (SUCCESS, NEUTRAL, or SKIPPED)
+        # is not a pending required check, even when dedupe_checks ORed
+        # IsPending=true onto the winner from a stale sibling row. The IsPending
+        # OR is retained on the row for wait polling, but PendingRequiredChecks
+        # must classify a completed-passing required check consistently with
+        # test_pr_merge_ready.py, which treats it as non-blocking. Refs issue
+        # #2614: a SKIPPED required check with a PENDING sibling was reported as
+        # pending while test_pr_merge_ready.py treated it as non-blocking.
+        if check.get("IsPending") and not check.get("IsPassing"):
             pending_required.append(name)
 
     return pending_required, failed_required

--- a/scripts/github_core/checks_rollup.py
+++ b/scripts/github_core/checks_rollup.py
@@ -80,9 +80,8 @@ def extract_required_check_lists(
         # IsPending=true onto the winner from a stale sibling row. The IsPending
         # OR is retained on the row for wait polling, but PendingRequiredChecks
         # must classify a completed-passing required check consistently with
-        # test_pr_merge_ready.py, which treats it as non-blocking. Refs issue
-        # #2614: a SKIPPED required check with a PENDING sibling was reported as
-        # pending while test_pr_merge_ready.py treated it as non-blocking.
+        # test_pr_merge_ready.py, which treats it as non-blocking. Refs issue #2614:
+        # a SKIPPED required check with a PENDING sibling was reported as pending.
         if check.get("IsPending") and not check.get("IsPassing"):
             pending_required.append(name)
 

--- a/scripts/github_core/checks_rollup.py
+++ b/scripts/github_core/checks_rollup.py
@@ -75,7 +75,15 @@ def extract_required_check_lists(
 
         if check.get("IsFailing"):
             failed_required.append(name)
-        if check.get("IsPending"):
+        # A check whose dedupe winner is passing (SUCCESS, NEUTRAL, or SKIPPED)
+        # is not a pending required check, even when dedupe_checks ORed
+        # IsPending=true onto the winner from a stale sibling row. The IsPending
+        # OR is retained on the row for wait polling, but PendingRequiredChecks
+        # must classify a completed-passing required check consistently with
+        # test_pr_merge_ready.py, which treats it as non-blocking. Refs issue
+        # #2614: a SKIPPED required check with a PENDING sibling was reported as
+        # pending while test_pr_merge_ready.py treated it as non-blocking.
+        if check.get("IsPending") and not check.get("IsPassing"):
             pending_required.append(name)
 
     return pending_required, failed_required

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.199",
+  "version": "0.5.200",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/lib/github_core/checks_rollup.py
+++ b/src/copilot-cli/lib/github_core/checks_rollup.py
@@ -80,9 +80,8 @@ def extract_required_check_lists(
         # IsPending=true onto the winner from a stale sibling row. The IsPending
         # OR is retained on the row for wait polling, but PendingRequiredChecks
         # must classify a completed-passing required check consistently with
-        # test_pr_merge_ready.py, which treats it as non-blocking. Refs issue
-        # #2614: a SKIPPED required check with a PENDING sibling was reported as
-        # pending while test_pr_merge_ready.py treated it as non-blocking.
+        # test_pr_merge_ready.py, which treats it as non-blocking. Refs issue #2614:
+        # a SKIPPED required check with a PENDING sibling was reported as pending.
         if check.get("IsPending") and not check.get("IsPassing"):
             pending_required.append(name)
 

--- a/src/copilot-cli/lib/github_core/checks_rollup.py
+++ b/src/copilot-cli/lib/github_core/checks_rollup.py
@@ -75,7 +75,15 @@ def extract_required_check_lists(
 
         if check.get("IsFailing"):
             failed_required.append(name)
-        if check.get("IsPending"):
+        # A check whose dedupe winner is passing (SUCCESS, NEUTRAL, or SKIPPED)
+        # is not a pending required check, even when dedupe_checks ORed
+        # IsPending=true onto the winner from a stale sibling row. The IsPending
+        # OR is retained on the row for wait polling, but PendingRequiredChecks
+        # must classify a completed-passing required check consistently with
+        # test_pr_merge_ready.py, which treats it as non-blocking. Refs issue
+        # #2614: a SKIPPED required check with a PENDING sibling was reported as
+        # pending while test_pr_merge_ready.py treated it as non-blocking.
+        if check.get("IsPending") and not check.get("IsPassing"):
             pending_required.append(name)
 
     return pending_required, failed_required

--- a/tests/test_get_pr_checks.py
+++ b/tests/test_get_pr_checks.py
@@ -1591,7 +1591,7 @@ class TestSupersededCheckRuns:
            "get_pr_checks.gh_graphql",
            return_value=_rollup_response(nodes),
         ):
-           rc = main(["--pull-request", "2325", "--required-only"])
+           main(["--pull-request", "2325", "--required-only"])
         output = json.loads(capsys.readouterr().out)
         data = output["Data"]
         assert data["PendingCount"] == 2
@@ -1623,7 +1623,7 @@ class TestSupersededCheckRuns:
            "get_pr_checks.gh_graphql",
            return_value=_rollup_response(nodes),
         ):
-           rc = main(["--pull-request", "2325", "--required-only"])
+           main(["--pull-request", "2325", "--required-only"])
         output = json.loads(capsys.readouterr().out)
         data = output["Data"]
         # Should have both failed and pending required checks visible.

--- a/tests/test_get_pr_checks.py
+++ b/tests/test_get_pr_checks.py
@@ -1495,6 +1495,52 @@ class TestSupersededCheckRuns:
         assert names.count("Validate PR") == 1
         assert names.count("Validate PR title") == 1
 
+    def test_skipped_winner_with_pending_sibling_excluded_from_required(
+        self, capsys
+    ):
+        """Issue #2614: a required check whose dedupe winner is COMPLETED with
+        Conclusion=SKIPPED must be excluded from PendingRequiredChecks, even
+        when a stale sibling row for the same name is PENDING.
+
+        Reproduces PR #2611: ``Run Python Tests`` published a CheckRun
+        (COMPLETED/SKIPPED) and a StatusContext (PENDING) on the same commit.
+        dedupe_checks ORs IsPending onto the winner, so the SKIPPED winner
+        carried IsPending=true; before the fix the name was listed in
+        PendingRequiredChecks while test_pr_merge_ready.py treated the same
+        skipped check as non-blocking, so the two helpers disagreed. After the
+        fix, extract_required_check_lists classifies a passing (including
+        SKIPPED) required check as non-pending. The IsPending OR on the row is
+        retained for wait polling, so the aggregate PendingCount still reflects
+        the stale sibling; the acceptance criterion is PendingRequiredChecks.
+        """
+        nodes = [
+            _check_run_node("Run Python Tests", "COMPLETED", "SKIPPED"),
+            {
+                "__typename": "StatusContext",
+                "context": "Run Python Tests",
+                "state": "PENDING",
+                "targetUrl": "",
+                "isRequired": True,
+            },
+        ]
+        with patch(
+            "get_pr_checks.assert_gh_authenticated",
+        ), patch(
+            "get_pr_checks.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "get_pr_checks.gh_graphql",
+            return_value=_rollup_response(nodes),
+        ):
+            rc = main(["--pull-request", "2611", "--required-only"])
+        output = json.loads(capsys.readouterr().out)
+        data = output["Data"]
+        # The skipped required check is no longer reported as pending-required.
+        assert data["PendingRequiredChecks"] == []
+        # Exit code does not block on the stale pending sibling: no required
+        # check is failing and none is pending-required.
+        assert rc == 0
+
     def test_dual_row_required_or_semantics(self, capsys):
         """Issue #2325: When a check name has both CheckRun (not required) and
         StatusContext (required), --required-only should include it because any


### PR DESCRIPTION
# Exclude skipped required checks from pending list

Fixes #2614.

`get_pr_checks.py --required-only` reported a required check as pending after its dedupe winner had already completed with `Conclusion=SKIPPED`. PR automation could wait on a check that had finished, while merge readiness treated the same check as non-blocking.

## Root cause

Two layers produced the symptom:

1. The check dedupe layer keeps `IsPending=true` when a stale pending sibling exists. That signal is still needed for wait polling.
2. `scripts/github_core/checks_rollup.py` appended a required check to `PendingRequiredChecks` based on `IsPending` alone, without checking whether the winner was already passing.

## Changes

- `scripts/github_core/checks_rollup.py` now excludes passing winners from `PendingRequiredChecks`.
- `.claude/lib/github_core/checks_rollup.py` is synced from the canonical source.
- `src/copilot-cli/lib/github_core/checks_rollup.py` is synced for the Copilot CLI plugin artifact.
- `tests/test_get_pr_checks.py` covers a required `SKIPPED` winner with a stale pending sibling.
- `.claude/.claude-plugin/plugin.json` and `src/copilot-cli/.claude-plugin/plugin.json` are bumped to `0.5.200` so installs re-sync.
- `.agents/sessions/2026-06-17-session-2585-fix-2614-get_pr_checks-marks-skipped.json` now records `endingCommit`.

## Validation

- `uv run pytest tests/test_get_pr_checks.py -q`
- `uv run --extra dev ruff check scripts/github_core/checks_rollup.py .claude/lib/github_core/checks_rollup.py src/copilot-cli/lib/github_core/checks_rollup.py tests/test_get_pr_checks.py`
- `uv run --extra dev mypy tests/test_get_pr_checks.py --follow-imports=skip`
- `uv run python .claude/skills/security-scan/scripts/scan_vulnerabilities.py scripts/github_core/checks_rollup.py .claude/lib/github_core/checks_rollup.py src/copilot-cli/lib/github_core/checks_rollup.py tests/test_get_pr_checks.py`
- `python3 scripts/validate_session_json.py .agents/sessions/2026-06-17-session-2585-fix-2614-get_pr_checks-marks-skipped.json`
- `uv run python scripts/sync_plugin_lib.py --check`
- `git diff --check`

## References

- `test_pr_merge_ready.py`: expected readiness behavior for skipped required checks.
- `get_pr_checks.py`: caller of the shared rollup helper.
- `scripts/sync_plugin_lib.py`: sync path for `.claude/lib` copies.
