### PR TITLE
fix(workflows): classify Unicorn HTML flake vs real PR-title failure (#2616)

### DIFF
--- a/.agents/sessions/2026-06-17-session-2585-fix-2616-retryclassify-github-unicorn.json
+++ b/.agents/sessions/2026-06-17-session-2585-fix-2616-retryclassify-github-unicorn.json
@@ -1,0 +1,125 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2585,
+    "date": "2026-06-17",
+    "branch": "fix/2616-validate-pr-title-retry-unicorn",
+    "startingCommit": "ccf2020857",
+    "objective": "fix #2616 retry/classify GitHub Unicorn HTML failures in semantic PR title check"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena available; symbol/memory tools used (write_memory, deepwiki)."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read AGENTS.md retrieval rules and .claude/rules/* via context injection."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No open issue handoff for #2616; HANDOFF.md not modified (read-only)."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Used .claude/skills/github and session-init scripts; listed scripts/ci."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read AGENTS.md, CLAUDE.md, .claude/rules/* (injected each turn)."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Applied ADR-006 (no logic in YAML), ADR-042 (Python), ADR-035 exit codes."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Reviewed topical worktree memories surfaced by hooks; wrote issue-2616 memory."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2616-validate-pr-title-retry-unicorn"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/2616-validate-pr-title-retry-unicorn"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status checked; HEAD ccf2020857."
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "ccf2020857"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Session log workLog + protocolCompliance complete."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md untouched (read-only per ADR-014)."
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Wrote tasks/issue-2616-semantic-pr-title-unicorn-classifier."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No .md files authored this session; nothing to lint."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Atomic commits on fix/2616-validate-pr-title-retry-unicorn."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run pytest tests/ci/: 27 passed; workflow YAML parses OK."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Single-module fix; tracked inline, no stale tasks."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Lightweight fix; learnings captured in serena memory."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "timestamp": "2026-06-17T13:50:59.299885+00:00",
+      "action": "Implemented classifier for semantic-pr-title-check (issue #2616) with TDD",
+      "evidence": "uv run pytest tests/ci/test_classify_semantic_title_result.py -q: 12 passed. Full tests/ci/: 27 passed. RED confirmed first (ModuleNotFoundError), GREEN after implementation, mutation (exit_code 1->0 on semantic failure) made 3 tests fail then restored to 27 passed."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": []
+}

--- a/.github/workflows/semantic-pr-title-check.yml
+++ b/.github/workflows/semantic-pr-title-check.yml
@@ -9,6 +9,7 @@ on:
       - synchronize
 
 permissions:
+  contents: read
   pull-requests: read
 
 concurrency:
@@ -27,8 +28,14 @@ jobs:
           GH_ACTOR: ${{ github.actor }}
         run: echo "Skipped - bot actor ($GH_ACTOR)"
 
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      - name: Check out classifier
         if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' && github.actor != 'renovate[bot]'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - id: semantic
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' && github.actor != 'renovate[bot]'
+        continue-on-error: true
         with:
           types: |
             feat
@@ -43,3 +50,15 @@ jobs:
             build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Classify outcome (retry Unicorn HTML, block real failures)
+        if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' && github.actor != 'renovate[bot]'
+        env:
+          OUTCOME: ${{ steps.semantic.outcome }}
+          ERROR_MESSAGE: ${{ steps.semantic.outputs.error_message }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          python3 scripts/ci/classify_semantic_title_result.py \
+            --outcome "$OUTCOME" \
+            --error-message "$ERROR_MESSAGE" \
+            --pr-title "$PR_TITLE"

--- a/.github/workflows/semantic-pr-title-check.yml
+++ b/.github/workflows/semantic-pr-title-check.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Classify outcome (retry Unicorn HTML, block real failures)
+      - name: Classify outcome (ignore Unicorn HTML flake, block real failures)
         if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' && github.actor != 'renovate[bot]'
         env:
           OUTCOME: ${{ steps.semantic.outcome }}

--- a/scripts/ci/classify_semantic_title_result.py
+++ b/scripts/ci/classify_semantic_title_result.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Classify the outcome of the semantic-PR-title-check action (issue #2616).
+
+This is the decision half of `.github/workflows/semantic-pr-title-check.yml`.
+The workflow runs `amannn/action-semantic-pull-request` with
+`continue-on-error: true`, then calls this script to decide whether the job
+should pass or fail. Keeping the decision here (ADR-006: no logic in YAML) lets
+it be tested.
+
+Why this exists: on PR #2611 the action failed because GitHub returned its
+"Unicorn!" HTML error page instead of an API response while the action was
+fetching PR data. The PR title was valid; rerunning recovered without changing
+it. The required "Validate PR title" job must not fail on that transient
+infrastructure flake, but it must still fail on a genuine bad title.
+
+Discriminator (Layer 1, the action's own contract):
+`amannn/action-semantic-pull-request` sets its `error_message` step output
+from `raiseError()` BEFORE the step fails, but only when a validation gate
+fails (missing type, unknown scope, subject pattern, etc.). A network crash
+inside the action throws before any gate runs, so `error_message` stays empty.
+Therefore:
+
+    outcome == success/skipped              -> pass (exit 0)
+    outcome == failure, error_message set   -> real bad title, block (exit 1)
+    outcome == failure, error_message empty -> transient flake, pass (exit 0)
+
+The Unicorn HTML marker in the captured log is a secondary positive signal used
+only to label the transient case in output; the decision keys on whether the
+action reported a semantic reason.
+
+Exit Codes (ADR-035):
+    0 = pass (valid title, success, or transient infra flake)
+    1 = block (genuine semantic-title validation failure)
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+# Marker GitHub serves on its HTML error page (the "Unicorn!" page). Used only
+# to label a transient failure in output, not to drive the pass/fail decision.
+_UNICORN_MARKER = "<title>Unicorn"
+
+# Outcomes (GitHub Actions `steps.<id>.outcome`) that mean the action did not
+# report a bad title and the job should pass.
+_PASSING_OUTCOMES = frozenset({"success", "skipped"})
+
+
+@dataclass(frozen=True)
+class Classification:
+    """The pass/fail decision plus the reason to surface in the job log."""
+
+    exit_code: int
+    is_semantic_failure: bool
+    is_transient: bool
+    message: str
+
+
+def classify(*, outcome: str, error_message: str, log: str) -> Classification:
+    """Decide whether the title-check job should pass or fail.
+
+    Args:
+        outcome: GitHub Actions step outcome of the action
+            ("success", "failure", "skipped", "cancelled").
+        error_message: The action's `error_message` output. Non-empty only when
+            a real semantic-title validation gate failed.
+        log: Captured stdout/stderr of the action step, used only to label a
+            transient failure.
+
+    Returns:
+        A Classification carrying the exit code and a human-readable message.
+    """
+    if outcome in _PASSING_OUTCOMES:
+        return Classification(
+            exit_code=0,
+            is_semantic_failure=False,
+            is_transient=False,
+            message=f"PR title check passed (outcome={outcome}).",
+        )
+
+    reason = error_message.strip()
+    if reason:
+        return Classification(
+            exit_code=1,
+            is_semantic_failure=True,
+            is_transient=False,
+            message=reason,
+        )
+
+    # Failure with no semantic reason: the action crashed before any validation
+    # gate ran. This is the Unicorn HTML flake or another transient infra error.
+    if _UNICORN_MARKER in log:
+        detail = "GitHub returned its Unicorn HTML error page"
+    else:
+        detail = "the action failed without a semantic-title reason"
+    return Classification(
+        exit_code=0,
+        is_semantic_failure=False,
+        is_transient=True,
+        message=(
+            f"Transient infrastructure failure ({detail}); "
+            "not a PR title defect. Rerun to recover."
+        ),
+    )
+
+
+def _read_log(log_file: str | None) -> str:
+    """Read the captured action log, tolerating a missing file."""
+    if not log_file:
+        return ""
+    path = Path(log_file)
+    if not path.is_file():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _render(result: Classification, pr_title: str) -> str:
+    """Build the operator-facing message echoing the PR title and verdict."""
+    lines = [f"PR title: {pr_title}"]
+    if result.is_semantic_failure:
+        lines.append("Result: FAIL (semantic title validation)")
+        lines.append(f"Reason: {result.message}")
+    elif result.is_transient:
+        lines.append("Result: PASS (transient infrastructure flake, not blocking)")
+        lines.append(f"Detail: {result.message}")
+    else:
+        lines.append("Result: PASS")
+        lines.append(f"Detail: {result.message}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns the exit code (0 pass, 1 block)."""
+    parser = argparse.ArgumentParser(
+        description="Classify semantic-PR-title-check action outcome (issue #2616)."
+    )
+    parser.add_argument("--outcome", required=True, help="Action step outcome.")
+    parser.add_argument(
+        "--error-message",
+        default="",
+        help="The action's error_message output (empty unless a real bad title).",
+    )
+    parser.add_argument("--pr-title", default="", help="The PR title under check.")
+    parser.add_argument(
+        "--log-file",
+        default=None,
+        help="Path to the captured action log (used to label transient flakes).",
+    )
+    args = parser.parse_args(argv)
+
+    log = _read_log(args.log_file)
+    result = classify(
+        outcome=args.outcome, error_message=args.error_message, log=log
+    )
+    print(_render(result, args.pr_title))
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/classify_semantic_title_result.py
+++ b/scripts/ci/classify_semantic_title_result.py
@@ -24,9 +24,10 @@ Therefore:
     outcome == failure, error_message set   -> real bad title, block (exit 1)
     outcome == failure, error_message empty -> transient flake, pass (exit 0)
 
-The Unicorn HTML marker in the captured log is a secondary positive signal used
-only to label the transient case in output; the decision keys on whether the
-action reported a semantic reason.
+The Unicorn HTML marker in an optional ``--log-file`` is a secondary positive
+signal used only to label the transient case in output; the workflow does not
+currently pass a log file. The decision keys on whether the action reported a
+semantic reason.
 
 Exit Codes (ADR-035):
     0 = pass (valid title, success, or transient infra flake)
@@ -110,7 +111,15 @@ def _read_log(log_file: str | None) -> str:
     """Read the captured action log, tolerating a missing file."""
     if not log_file:
         return ""
+    base_dir = Path(__file__).resolve().parents[2]
     path = Path(log_file)
+    if not path.is_absolute():
+        path = base_dir / path
+    try:
+        path = path.resolve()
+        path.relative_to(base_dir)
+    except (OSError, ValueError):
+        return ""
     if not path.is_file():
         return ""
     return path.read_text(encoding="utf-8", errors="replace")

--- a/tests/ci/test_classify_semantic_title_result.py
+++ b/tests/ci/test_classify_semantic_title_result.py
@@ -151,7 +151,6 @@ def test_main_unicorn_flake_exits_zero(capsys, tmp_path):
 
 def test_main_success_exits_zero(capsys):
     exit_code = main(["--outcome", "success", "--error-message", "", "--pr-title", "x"])
-    captured = capsys.readouterr()
     assert exit_code == 0
 
 
@@ -170,6 +169,28 @@ def test_main_missing_log_file_is_tolerated(capsys, tmp_path):
         ]
     )
     assert exit_code == 0
+
+
+def test_main_ignores_log_file_outside_repo(capsys, tmp_path):
+    outside_log = tmp_path / "outside.log"
+    outside_log.write_text(UNICORN_LOG, encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--outcome",
+            "failure",
+            "--error-message",
+            "",
+            "--pr-title",
+            "x",
+            "--log-file",
+            str(outside_log),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "without a semantic-title reason" in captured.out
 
 
 def test_classification_is_a_dataclass_instance():

--- a/tests/ci/test_classify_semantic_title_result.py
+++ b/tests/ci/test_classify_semantic_title_result.py
@@ -1,0 +1,181 @@
+"""Tests for scripts/ci/classify_semantic_title_result.py.
+
+Covers issue #2616: the "Validate PR title" job failed because
+amannn/action-semantic-pull-request received GitHub's Unicorn HTML error page
+instead of an API response, on PR #2611 whose title was valid. Rerunning
+recovered without changing the title.
+
+The classifier separates a real semantic-title failure (the action sets its
+`error_message` output before failing) from a transient GitHub infrastructure
+flake (the action crashes fetching PR data, so `error_message` is empty and the
+log carries the Unicorn HTML marker). A real failure must block (exit 1) and
+echo the PR title plus the reason; a transient flake must not block (exit 0).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts/ci to path for import.
+_SCRIPTS_CI = Path(__file__).resolve().parent.parent.parent / "scripts" / "ci"
+sys.path.insert(0, str(_SCRIPTS_CI))
+
+from classify_semantic_title_result import (  # noqa: E402
+    Classification,
+    classify,
+    main,
+)
+
+UNICORN_LOG = (
+    "<!DOCTYPE html>\n<title>Unicorn! · GitHub</title>\n"
+    "Something went wrong, but worry not."
+)
+SEMANTIC_REASON = (
+    'No release type found in pull request title "broken title". '
+    "Add a prefix to indicate what kind of release this pull request "
+    "corresponds to."
+)
+
+
+# --- Positive: a real semantic-title failure must block ---------------------
+
+
+def test_real_semantic_failure_blocks_with_reason():
+    result = classify(outcome="failure", error_message=SEMANTIC_REASON, log="")
+    assert result.exit_code == 1
+    assert result.is_semantic_failure is True
+    assert SEMANTIC_REASON in result.message
+
+
+def test_real_semantic_failure_blocks_even_when_log_has_unicorn():
+    # error_message present is authoritative: a real reason blocks regardless of
+    # incidental Unicorn text elsewhere in the log.
+    result = classify(
+        outcome="failure", error_message=SEMANTIC_REASON, log=UNICORN_LOG
+    )
+    assert result.exit_code == 1
+    assert result.is_semantic_failure is True
+
+
+# --- Negative: a transient Unicorn flake must not block ---------------------
+
+
+def test_unicorn_flake_does_not_block():
+    result = classify(outcome="failure", error_message="", log=UNICORN_LOG)
+    assert result.exit_code == 0
+    assert result.is_semantic_failure is False
+    assert result.is_transient is True
+
+
+def test_empty_error_without_unicorn_treated_as_transient():
+    # Action failed but set no semantic reason and no Unicorn marker: still an
+    # infra/unknown failure, not a title problem. Do not block the required job
+    # on something that is not a title defect.
+    result = classify(outcome="failure", error_message="", log="connection reset")
+    assert result.exit_code == 0
+    assert result.is_semantic_failure is False
+    assert result.is_transient is True
+
+
+# --- Success path -----------------------------------------------------------
+
+
+def test_success_passes():
+    result = classify(outcome="success", error_message="", log="")
+    assert result.exit_code == 0
+    assert result.is_semantic_failure is False
+
+
+def test_skipped_passes():
+    # Bot-actor skip path: the action step did not run.
+    result = classify(outcome="skipped", error_message="", log="")
+    assert result.exit_code == 0
+    assert result.is_semantic_failure is False
+
+
+# --- Edge: whitespace-only error_message is not a real reason ---------------
+
+
+def test_whitespace_only_error_message_is_transient():
+    result = classify(outcome="failure", error_message="   \n  ", log=UNICORN_LOG)
+    assert result.exit_code == 0
+    assert result.is_semantic_failure is False
+
+
+# --- CLI: main echoes title + reason on a real failure and exits 1 ----------
+
+
+def test_main_real_failure_echoes_title_and_reason(capsys, tmp_path):
+    log_file = tmp_path / "action.log"
+    log_file.write_text("", encoding="utf-8")
+    exit_code = main(
+        [
+            "--outcome",
+            "failure",
+            "--error-message",
+            SEMANTIC_REASON,
+            "--pr-title",
+            "broken title",
+            "--log-file",
+            str(log_file),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "broken title" in captured.out
+    assert SEMANTIC_REASON in captured.out
+
+
+def test_main_unicorn_flake_exits_zero(capsys, tmp_path):
+    log_file = tmp_path / "action.log"
+    log_file.write_text(UNICORN_LOG, encoding="utf-8")
+    exit_code = main(
+        [
+            "--outcome",
+            "failure",
+            "--error-message",
+            "",
+            "--pr-title",
+            "fix(x): valid title",
+            "--log-file",
+            str(log_file),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "transient" in captured.out.lower() or "unicorn" in captured.out.lower()
+
+
+def test_main_success_exits_zero(capsys):
+    exit_code = main(["--outcome", "success", "--error-message", "", "--pr-title", "x"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+
+
+def test_main_missing_log_file_is_tolerated(capsys, tmp_path):
+    # A missing log file should not crash; treat as no log content.
+    exit_code = main(
+        [
+            "--outcome",
+            "failure",
+            "--error-message",
+            "",
+            "--pr-title",
+            "x",
+            "--log-file",
+            str(tmp_path / "does-not-exist.log"),
+        ]
+    )
+    assert exit_code == 0
+
+
+def test_classification_is_a_dataclass_instance():
+    result = classify(outcome="success", error_message="", log="")
+    assert isinstance(result, Classification)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

The required `Validate PR title` job failed on PR #2611 because `amannn/action-semantic-pull-request` received GitHub's "Unicorn!" HTML error page instead of an API response. The PR title was valid, and rerunning the job recovered without changing the title.

Fixes #2616.

## Changes

- `.github/workflows/semantic-pr-title-check.yml` now runs the semantic title action with `continue-on-error: true`, then calls the classifier step to decide whether the job should block.
- `scripts/ci/classify_semantic_title_result.py` classifies real semantic title failures as blocking and action crashes without `error_message` as transient infrastructure failures. Optional log files are anchored to the repository before reading.
- `tests/ci/test_classify_semantic_title_result.py` covers real semantic failure, Unicorn flake, missing log files, and log paths outside the repository.
- `.agents/sessions/2026-06-17-session-2585-fix-2616-retryclassify-github-unicorn.json` records the session.

## Validation

- `uv run pytest tests/ci/test_classify_semantic_title_result.py tests/ci/ -q`
- `uv run --extra dev ruff check scripts/ci/classify_semantic_title_result.py tests/ci/test_classify_semantic_title_result.py`
- `uv run --extra dev mypy scripts/ci/classify_semantic_title_result.py tests/ci/test_classify_semantic_title_result.py --follow-imports=skip`
- `uv run python .claude/skills/security-scan/scripts/scan_vulnerabilities.py scripts/ci/classify_semantic_title_result.py tests/ci/test_classify_semantic_title_result.py`
- `python3 scripts/validate_session_json.py .agents/sessions/2026-06-17-session-2585-fix-2616-retryclassify-github-unicorn.json`
- `git diff --check`

## References

- `scripts/ci/parse_drift_results.py` was used as the existing thin-workflow module pattern.
