### PR TITLE
fix(build): scope REQ-003-010 .claude/ guard to generator writes

### DIFF
--- a/.agents/sessions/2026-06-17-session-2585-fix-2613-build_all-req-003-010-generator-scoped.json
+++ b/.agents/sessions/2026-06-17-session-2585-fix-2613-build_all-req-003-010-generator-scoped.json
@@ -1,0 +1,132 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2585,
+    "date": "2026-06-17",
+    "branch": "fix/2613-build-all-claude-write-scope",
+    "startingCommit": "ccf2020857",
+    "objective": "fix #2613 build_all REQ-003-010 generator-scoped claude-write guard (snapshot, not git-diff) so legitimate .claude/lib sync passes"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP available; write_memory used this session"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md + .claude/rules/*.md retrieval-led context loaded at start"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No open issue handoff for #2613; HANDOFF.md not modified (read-only ADR-014)"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file (session 2585)"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Used .claude/skills/github/scripts + taste-lints/scripts/taste_lints.py + session-init script"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read fix plan /tmp/fix_2613.json + issue #2613 context/comments before coding"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .claude/rules (universal, ci-scripts, generated-artifacts, canonical-source-mirror) + AGENTS.md"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Topical worktree memories surfaced by hooks; reviewed before edits"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2613-build-all-claude-write-scope (off HEAD ccf2020857, not origin/main)"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/2613-build-all-claude-write-scope"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status checked; only build_all.py + test + session log changed"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "ccf2020857"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart + sessionEnd MUSTs populated"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md untouched (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Wrote serena memory tasks/issue-2613-build-all-claude-write-snapshot-scope"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No .md files changed this session; markdownlint not applicable (git diff --name-only '*.md' empty)"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Committed on fix/2613-build-all-claude-write-scope; HEAD will be recorded as endingCommit"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run pytest tests/build_scripts/ -q -> 671 passed; uvx ruff check -> All checks passed; taste-lints: no NEW errors"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Single-task fix; tracked inline, no separate task board entry"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Learning captured to serena memory in lieu of full retro for a scoped single-file fix"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "timestamp": "2026-06-17T14:10:00Z",
+      "action": "TDD fix for #2613: REQ-003-010 .claude/ guard now snapshot-scoped (pre-build baseline) not git-diff-scoped, so a legitimate .claude/lib sync before build_all no longer trips a false generator-write violation.",
+      "evidence": "RED first: new tests failed (AttributeError: no CLAUDE_GUARD_PREFIX). After implementing assert_no_claude_writes(repo_root, baseline) + threading claude_baseline through run/_run_generators: `uv run pytest tests/build_scripts/test_build_all.py -q` -> 43 passed. Full dir `uv run pytest tests/build_scripts/ -q` -> 671 passed. Mutation (if False: never flag) made 3 detection tests FAIL, restored to GREEN. Real-repo e2e: dirtied .claude/lib/hook_utilities/guards.py, ran `build_all.py --platform copilot-cli` -> EXIT 0, no REQ-003-010 VIOLATION (old code emitted the violation). ruff via uvx: All checks passed.",
+      "files": [
+        "build/scripts/build_all.py",
+        "tests/build_scripts/test_build_all.py"
+      ]
+    }
+  ],
+  "endingCommit": "ccf20208578ef9125036b750f6c03bfcfd8f96fb",
+  "nextSteps": [
+    "Push branch, open PR linking #2613",
+    "PR diff temporarily includes keystone commits until #2621 merges"
+  ]
+}

--- a/build/scripts/build_all.py
+++ b/build/scripts/build_all.py
@@ -594,12 +594,38 @@ def _git_diff_paths(repo_root: Path) -> list[str]:
     return paths
 
 
-def assert_no_claude_writes(repo_root: Path) -> list[str]:
+# The .claude/ tree is off-limits to generators (REQ-003-010). It is
+# snapshotted before the generators run, then compared after, so the guard
+# attributes only writes the generators themselves made. Git-diff scoping
+# (the prior approach) flagged any pre-build drift, including a legitimate
+# `.claude/lib` sync from scripts/sync_plugin_lib.py (issue #2613).
+CLAUDE_GUARD_PREFIX: tuple[str, ...] = (".claude/",)
+
+
+def assert_no_claude_writes(
+    repo_root: Path, baseline: dict[Path, bytes]
+) -> list[str]:
     """REQ-003-010: generators MUST NOT write under .claude/.
 
-    Returns the list of offending paths (empty when compliant).
+    ``baseline`` is a snapshot of the .claude/ tree captured BEFORE any
+    generator ran (see :func:`_snapshot_owned_prefixes`). This function
+    re-reads the tree and returns the repo-relative paths the generators
+    created, modified, or deleted relative to that baseline.
+
+    Scoping to generator-attributable writes (not raw git diff) lets a
+    legitimate pre-build sync of .claude/lib pass while still tripping on
+    a generator that writes under .claude/ during the run (issue #2613).
+
+    Returns the sorted list of offending paths (empty when compliant).
     """
-    return [p for p in _git_diff_paths(repo_root) if p.startswith(".claude/")]
+    current = _snapshot_owned_prefixes(repo_root, CLAUDE_GUARD_PREFIX)
+    offending: set[Path] = set()
+    for path, content in current.items():
+        if baseline.get(path) != content:
+            offending.add(path)  # created or modified by a generator
+    for path in baseline.keys() - current.keys():
+        offending.add(path)  # deleted by a generator
+    return sorted(str(p.relative_to(repo_root)) for p in offending)
 
 
 # --- Clean ----------------------------------------------------------------
@@ -832,9 +858,18 @@ def run(
     if check:
         snapshot = _snapshot_owned_prefixes(repo_root, OWNED_PREFIXES)
 
+    # REQ-003-010 (issue #2613): snapshot the .claude/ tree before any
+    # generator runs so the no-write guard attributes only writes the
+    # generators made, not pre-build drift such as a .claude/lib sync.
+    claude_baseline = _snapshot_owned_prefixes(repo_root, CLAUDE_GUARD_PREFIX)
+
     try:
         return _run_generators(
-            repo_root, configs, check=check, audit_format=audit_format
+            repo_root,
+            configs,
+            check=check,
+            audit_format=audit_format,
+            claude_baseline=claude_baseline,
         )
     finally:
         # #2440: ALWAYS restore on --check, including on exception paths.
@@ -850,6 +885,7 @@ def _run_generators(
     *,
     check: bool,
     audit_format: str,
+    claude_baseline: dict[Path, bytes],
 ) -> int:
     """Execute the generator pipeline and emit the audit log.
 
@@ -879,7 +915,7 @@ def _run_generators(
     audit.duration_s = time.monotonic() - started
 
     # REQ-003-010: enforce .claude/ no-write invariant.
-    claude_writes = assert_no_claude_writes(repo_root)
+    claude_writes = assert_no_claude_writes(repo_root, claude_baseline)
     if claude_writes:
         for p in claude_writes:
             print(f"REQ-003-010 VIOLATION: generator wrote to {p}", file=sys.stderr)

--- a/tests/build_scripts/test_build_all.py
+++ b/tests/build_scripts/test_build_all.py
@@ -181,21 +181,61 @@ def test_write_audit_writes_when_clean(tmp_path: Path) -> None:
 # .claude/ guard (REQ-003-010) ----------------------------------------------
 
 
-def test_assert_no_claude_writes_returns_offending(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    monkeypatch.setattr(
-        build_all,
-        "_git_diff_paths",
-        lambda repo_root: [".claude/agents/x.md", "src/foo.txt"],
+def test_assert_no_claude_writes_flags_generator_created_path(tmp_path: Path) -> None:
+    """A .claude/ file created AFTER the snapshot is a generator write."""
+    claude = tmp_path / ".claude" / "agents"
+    claude.mkdir(parents=True)
+    baseline = build_all._snapshot_owned_prefixes(
+        tmp_path, build_all.CLAUDE_GUARD_PREFIX
     )
-    bad = build_all.assert_no_claude_writes(tmp_path)
-    assert bad == [".claude/agents/x.md"]
+    # Generator writes a new file after the snapshot.
+    (claude / "leak.md").write_text("generated", encoding="utf-8")
+    bad = build_all.assert_no_claude_writes(tmp_path, baseline)
+    assert bad == [".claude/agents/leak.md"]
 
 
-def test_assert_no_claude_writes_clean(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setattr(build_all, "_git_diff_paths", lambda repo_root: ["src/foo.txt"])
-    assert build_all.assert_no_claude_writes(tmp_path) == []
+def test_assert_no_claude_writes_flags_generator_modified_path(tmp_path: Path) -> None:
+    """A .claude/ file whose bytes change after the snapshot is a write."""
+    claude = tmp_path / ".claude" / "agents"
+    claude.mkdir(parents=True)
+    target = claude / "x.md"
+    target.write_text("original", encoding="utf-8")
+    baseline = build_all._snapshot_owned_prefixes(
+        tmp_path, build_all.CLAUDE_GUARD_PREFIX
+    )
+    target.write_text("mutated by generator", encoding="utf-8")
+    assert build_all.assert_no_claude_writes(tmp_path, baseline) == [
+        ".claude/agents/x.md"
+    ]
+
+
+def test_assert_no_claude_writes_ignores_presync_dirty_lib(tmp_path: Path) -> None:
+    """A legitimate .claude/lib sync that predates the snapshot must pass.
+
+    Reproduces issue #2613: sync_plugin_lib.py updates
+    .claude/lib/hook_utilities/guards.py BEFORE build_all runs. The
+    snapshot captures that already-dirty state, so no generator write is
+    attributed to it and the guard returns clean.
+    """
+    lib = tmp_path / ".claude" / "lib" / "hook_utilities"
+    lib.mkdir(parents=True)
+    # Pre-build sync already wrote the file before the snapshot is taken.
+    (lib / "guards.py").write_text("def synced(): ...\n", encoding="utf-8")
+    baseline = build_all._snapshot_owned_prefixes(
+        tmp_path, build_all.CLAUDE_GUARD_PREFIX
+    )
+    # Generators run and touch nothing under .claude/.
+    assert build_all.assert_no_claude_writes(tmp_path, baseline) == []
+
+
+def test_assert_no_claude_writes_clean_when_unchanged(tmp_path: Path) -> None:
+    claude = tmp_path / ".claude" / "skills"
+    claude.mkdir(parents=True)
+    (claude / "a.md").write_text("a", encoding="utf-8")
+    baseline = build_all._snapshot_owned_prefixes(
+        tmp_path, build_all.CLAUDE_GUARD_PREFIX
+    )
+    assert build_all.assert_no_claude_writes(tmp_path, baseline) == []
 
 
 # _build_skills missing-stanza handling --------------------------------------
@@ -380,17 +420,49 @@ def test_run_returns_2_when_check_finds_drift(
     assert rc == 2
 
 
-def test_run_returns_2_when_claude_write_detected(
+def test_run_returns_2_when_generator_writes_claude(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(
-        build_all,
-        "_git_diff_paths",
-        lambda repo_root: [".claude/agents/leak.md"],
-    )
+    """A generator that writes under .claude/ during the run trips REQ-003-010."""
+    monkeypatch.setattr(build_all, "_git_diff_paths", lambda repo_root: [])
     repo = tmp_path / "repo"
     (repo / ".claude" / "skills").mkdir(parents=True)
     _write_skill(repo / ".claude" / "skills", "alpha")
+    _write_platform_with_skills(repo, provider="copilot-cli")
+
+    def _leaky_agents(repo_root, cfg, platform):  # type: ignore[no-untyped-def]
+        # Misbehaving generator writes under .claude/ after the snapshot.
+        leak = Path(repo_root) / ".claude" / "agents" / "leak.md"
+        leak.parent.mkdir(parents=True, exist_ok=True)
+        leak.write_text("generated\n", encoding="utf-8")
+        return build_all.GeneratorResult(
+            artifact="agents", platform="*", exit_code=0
+        )
+
+    monkeypatch.setattr(build_all, "_build_agents", _leaky_agents)
+    rc = build_all.run(
+        repo, platform=None, check=False, clean=False, audit_format="md"
+    )
+    assert rc == 2
+
+
+def test_run_returns_0_when_claude_lib_synced_before_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #2613: a pre-build .claude/lib sync must NOT trip REQ-003-010.
+
+    The file under .claude/lib is already dirty before run() snapshots
+    .claude/. No generator touches it, so the guard returns clean and the
+    build exits 0.
+    """
+    monkeypatch.setattr(build_all, "_git_diff_paths", lambda repo_root: [])
+    repo = tmp_path / "repo"
+    (repo / ".claude" / "skills").mkdir(parents=True)
+    _write_skill(repo / ".claude" / "skills", "alpha")
+    # Simulate sync_plugin_lib.py having already updated .claude/lib.
+    lib = repo / ".claude" / "lib" / "hook_utilities"
+    lib.mkdir(parents=True)
+    (lib / "guards.py").write_text("def synced(): ...\n", encoding="utf-8")
     _write_platform_with_skills(repo, provider="copilot-cli")
     monkeypatch.setattr(
         build_all,
@@ -402,7 +474,7 @@ def test_run_returns_2_when_claude_write_detected(
     rc = build_all.run(
         repo, platform=None, check=False, clean=False, audit_format="md"
     )
-    assert rc == 2
+    assert rc == 0
 
 
 def test_run_clean_purges_only_skill_outputs(tmp_path: Path) -> None:


### PR DESCRIPTION
# fix(build): scope REQ-003-010 .claude guard to generator writes

## Summary

Fixes #2613. `build/scripts/build_all.py --platform copilot-cli` returned a false `REQ-003-010 VIOLATION` when `.claude/lib` had already been legitimately synced before the build ran. The guard blamed pre-existing `.claude/` drift on the generator.

## Changes

- `build/scripts/build_all.py` now snapshots `.claude/` before generator execution and checks only generator-created, generator-modified, or generator-deleted `.claude/` paths after the run.
- `tests/build_scripts/test_build_all.py` covers generator-created and generator-modified `.claude/` writes, plus the clean pre-sync scenario.
- `.agents/sessions/2026-06-17-session-2585-fix-2613-build_all-req-003-010-generator-scoped.json` records the session.

## Behavior

A pre-build sync captured in the baseline no longer fails the generator guard. A generator that writes `.claude/` during the run still fails with exit 2, so the REQ-003-010 protection remains intact.

## Validation

- `uv run pytest tests/build_scripts/ -q`
- `uvx ruff check`
- Real repo repro: dirty a `.claude/lib` file, run `build_all.py --platform copilot-cli`, and observe exit 0 with no REQ-003-010 violation.

## References

- `scripts/sync_plugin_lib.py`: sync path that can legitimately update `.claude/lib` before a build.
- `.claude/lib/hook_utilities/guards.py`: example synced file from the #2613 incident.
