### PR TITLE
fix(validation): degrade gh act gate to warning in remote containers (#2548)

### DIFF
--- a/.agents/sessions/2026-06-17-session-2585-fix-2548-item-downgrade-gh-act-unavailable.json
+++ b/.agents/sessions/2026-06-17-session-2585-fix-2548-item-downgrade-gh-act-unavailable.json
@@ -1,0 +1,125 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2585,
+    "date": "2026-06-17",
+    "branch": "fix/2548-gh-act-container-downgrade",
+    "startingCommit": "ccf2020857",
+    "objective": "fix #2548 item 3: downgrade gh-act-unavailable pre-push gate to warning in remote containers"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena active; wrote tasks/issue-2548-gh-act-container-downgrade memory"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena instructions in effect this session"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read issue #2548 body + 4 comments + /tmp/fix_2548.json triage plan"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Listed .claude/skills/github + session-init + taste-lints scripts"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read AGENTS.md skill-first + boundaries; followed uv run + skill-first for github ops"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read AGENTS.md, .claude/rules/*, ci-scripts.md, canonical-source-mirror.md"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Reviewed PreToolUse memory hints (worktrees, github, environment)"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2548-gh-act-container-downgrade"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/2548-gh-act-container-downgrade"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status clean at start; HEAD ccf2020857"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "ccf2020857"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Session-end checklist walked: tests, lint, memory, commit done"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md not modified (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Wrote serena memory tasks/issue-2548-gh-act-container-downgrade"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown files changed this session (git diff --name-only HEAD over '*.md' empty), so markdownlint had nothing to run"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Committed on fix/2548-gh-act-container-downgrade; ending commit ccf20208578ef9125036b750f6c03bfcfd8f96fb"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run pytest tests/validation/test_run_workflow_local_test.py -> 52 passed; ruff clean; taste-lints complexity clean"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Tracked inline; no external task tracker entry required"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Single-issue scoped fix; learnings captured in serena memory instead of full retro"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "timestamp": "2026-06-17T14:30:00Z",
+      "action": "TDD fix for issue #2548 item 3: gh act gate degrades in remote containers",
+      "evidence": "RED then GREEN via pytest. Ran: uv run pytest tests/validation/test_run_workflow_local_test.py -> 52 passed (4 new tests + 48 existing). Initial run of the 4 new tests failed (true RED). After implementing _is_remote_container/_gh_act_gap_report all 52 passed. Mutation check: forcing _is_remote_container to return False made the 2 downgrade tests fail, then restored to green. ruff check clean; taste-lints complexity clean."
+    }
+  ],
+  "endingCommit": "ccf20208578ef9125036b750f6c03bfcfd8f96fb",
+  "nextSteps": []
+}

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -24,6 +24,15 @@ block with an actionable message. A documented bypass exists for workflows that
 genuinely cannot run under act (secrets, ARM-only runners): set
 ``SKIP_WORKFLOW_LOCAL_TEST=true``; the bypass is logged, not hidden.
 
+One gap degrades instead of blocking: when ``gh`` or the ``gh act`` extension is
+unavailable inside a remote/managed container (Claude web containers, GitHub
+Codespaces, or any Docker container, detected by env markers and
+``/.dockerenv``), the gate returns exit 0 with ``degraded=True`` and a logged
+warning. Such a container cannot provision ``gh act`` (its ``gh`` is
+unauthenticated), so blocking every workflow-touching push there is friction,
+not safety. A truthy ``CI`` marker overrides the container signal, so CI, where
+``gh act`` is provisioned, keeps the hard exit 3 (Issue #2548, item 3).
+
 CLI
 ---
 
@@ -62,6 +71,18 @@ _BYPASS_ENV = "SKIP_WORKFLOW_LOCAL_TEST"
 # env flags (see BUNDLE_CHECK_ENFORCED in scripts/validation/pre_pr.py, which
 # accepts "1" and "true").
 _TRUTHY = {"1", "true"}
+
+# Env markers that identify a remote/managed container where the developer
+# cannot provision ``gh act`` (the container's ``gh`` is unauthenticated, so the
+# extension cannot install). Observed on Claude web containers, which always set
+# ``CLAUDECODE``, and GitHub Codespaces. In such an environment a missing
+# ``gh act`` is an environment gap, not a code defect, so the gate degrades to a
+# logged warning instead of blocking the push (Issue #2548, item 3). The same
+# gate keeps its hard failure in CI, where ``gh act`` is provisioned: the ``CI``
+# marker (set to a truthy value by GitHub Actions) overrides the container
+# signal in :func:`_is_remote_container`.
+_REMOTE_CONTAINER_ENV_MARKERS = ("CLAUDECODE", "CODESPACES")
+_CI_ENV = "CI"
 
 # Only GitHub Actions workflow files can run under ``gh act``. Custom actions
 # under ``.github/actions/`` and any other path are filtered out before the act
@@ -119,6 +140,7 @@ class Report:
     exit_code: int
     stages: list[StageResult] = field(default_factory=list)
     bypassed: bool = False
+    degraded: bool = False
     note: str = ""
 
 
@@ -139,6 +161,27 @@ def _gh_act_available() -> bool:
     """True when the ``gh act`` extension is installed."""
     rc, _, _ = _run(["gh", "act", "--help"], timeout=20)
     return rc == 0
+
+
+def _env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def _is_remote_container() -> bool:
+    """True in a remote/managed container that cannot provision ``gh act``.
+
+    A truthy ``CI`` marker overrides every container signal: CI provisions
+    ``gh act``, so a gap there is a real failure and must keep blocking. Outside
+    CI, any of the remote-container env markers (``CLAUDECODE``, ``CODESPACES``)
+    or a Docker container marker (``/.dockerenv``) identifies an environment
+    where the ``gh act`` gap is expected and the gate should degrade rather than
+    block (Issue #2548, item 3).
+    """
+    if _env_truthy(_CI_ENV):
+        return False
+    if any(_env_truthy(marker) for marker in _REMOTE_CONTAINER_ENV_MARKERS):
+        return True
+    return Path("/.dockerenv").exists()
 
 
 def _run(
@@ -380,6 +423,29 @@ def _act_full_stage(files: Sequence[str], repo_root: Path) -> StageResult:
 # --- Orchestration -------------------------------------------------------
 
 
+def _gh_act_gap_report(report: Report, tool_note: str) -> Report:
+    """Resolve a missing-``gh``/``gh act`` gap into a blocking or degraded Report.
+
+    In a remote container (see :func:`_is_remote_container`) the gap is an
+    environment limitation, not a code defect, so the gate degrades to a logged
+    warning (exit 0, ``degraded=True``) and the push proceeds. Everywhere else
+    the gap stays a blocking tool-unavailable failure (exit 3). The bypass hint
+    in ``tool_note`` is preserved either way (Issue #2548, item 3).
+    """
+    if _is_remote_container():
+        report.exit_code = 0
+        report.degraded = True
+        report.note = (
+            f"{tool_note} Remote container detected; gh act cannot be "
+            "provisioned here, so this gate is downgraded to a warning. CI "
+            "still runs the full workflow check."
+        )
+        return report
+    report.exit_code = 3
+    report.note = tool_note
+    return report
+
+
 def run_local_test(
     workflow_files: Sequence[str],
     repo_root: Path,
@@ -432,16 +498,16 @@ def run_local_test(
     # Stage 2 (dry-run) needs gh act but not a running Docker daemon: act -n
     # only plans the run.
     if not _have("gh"):
-        report.exit_code = 3
-        report.note = f"gh CLI not installed. Install it or set {_BYPASS_ENV}=true."
-        return report
-    if not _gh_act_available():
-        report.exit_code = 3
-        report.note = (
-            "gh act extension not installed. Install it via "
-            f"'gh extension install nektos/gh-act' or set {_BYPASS_ENV}=true."
+        return _gh_act_gap_report(
+            report,
+            f"gh CLI not installed. Install it or set {_BYPASS_ENV}=true.",
         )
-        return report
+    if not _gh_act_available():
+        return _gh_act_gap_report(
+            report,
+            "gh act extension not installed. Install it via "
+            f"'gh extension install nektos/gh-act' or set {_BYPASS_ENV}=true.",
+        )
 
     worktree_error = _unsupported_worktree_gitdir_error(repo_root)
     if worktree_error is not None:
@@ -484,6 +550,8 @@ def run_local_test(
 def _format_text(report: Report) -> str:
     if report.bypassed:
         return f"workflow-local-test: BYPASSED ({report.note})"
+    if report.degraded:
+        return f"workflow-local-test: DEGRADED\n  {report.note}"
     if report.exit_code == 2:
         return f"workflow-local-test: CONFIG ERROR\n  {report.note}"
     if report.exit_code == 3:
@@ -506,6 +574,7 @@ def _format_json(report: Report) -> str:
         {
             "exit_code": report.exit_code,
             "bypassed": report.bypassed,
+            "degraded": report.degraded,
             "note": report.note,
             "stages": [
                 {"stage": s.stage, "ok": s.ok, "detail": s.detail} for s in report.stages

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -25,13 +25,12 @@ genuinely cannot run under act (secrets, ARM-only runners): set
 ``SKIP_WORKFLOW_LOCAL_TEST=true``; the bypass is logged, not hidden.
 
 One gap degrades instead of blocking: when ``gh`` or the ``gh act`` extension is
-unavailable inside a remote/managed container (Claude web containers, GitHub
-Codespaces, or any Docker container, detected by env markers and
-``/.dockerenv``), the gate returns exit 0 with ``degraded=True`` and a logged
-warning. Such a container cannot provision ``gh act`` (its ``gh`` is
-unauthenticated), so blocking every workflow-touching push there is friction,
-not safety. A truthy ``CI`` marker overrides the container signal, so CI, where
-``gh act`` is provisioned, keeps the hard exit 3 (Issue #2548, item 3).
+unavailable inside a managed remote container (Claude web containers or GitHub
+Codespaces, detected by env markers), the gate returns exit 0 with
+``degraded=True`` and a logged warning. Such an environment may not be able to
+provision ``gh act``, so blocking every workflow-touching push there is friction,
+not safety. A truthy ``CI`` marker overrides the managed-container signal, so CI,
+where ``gh act`` is provisioned, keeps the hard exit 3 (Issue #2548, item 3).
 
 CLI
 ---
@@ -72,15 +71,14 @@ _BYPASS_ENV = "SKIP_WORKFLOW_LOCAL_TEST"
 # accepts "1" and "true").
 _TRUTHY = {"1", "true"}
 
-# Env markers that identify a remote/managed container where the developer
-# cannot provision ``gh act`` (the container's ``gh`` is unauthenticated, so the
-# extension cannot install). Observed on Claude web containers, which always set
-# ``CLAUDECODE``, and GitHub Codespaces. In such an environment a missing
+# Env markers that identify managed remote containers where the developer may
+# not be able to provision ``gh act``. Observed on Claude web containers, which
+# set ``CLAUDECODE``, and GitHub Codespaces. In such environments a missing
 # ``gh act`` is an environment gap, not a code defect, so the gate degrades to a
 # logged warning instead of blocking the push (Issue #2548, item 3). The same
 # gate keeps its hard failure in CI, where ``gh act`` is provisioned: the ``CI``
-# marker (set to a truthy value by GitHub Actions) overrides the container
-# signal in :func:`_is_remote_container`.
+# marker (set to a truthy value by GitHub Actions) overrides the managed
+# container signal in :func:`_is_remote_container`.
 _REMOTE_CONTAINER_ENV_MARKERS = ("CLAUDECODE", "CODESPACES")
 _CI_ENV = "CI"
 
@@ -172,16 +170,13 @@ def _is_remote_container() -> bool:
 
     A truthy ``CI`` marker overrides every container signal: CI provisions
     ``gh act``, so a gap there is a real failure and must keep blocking. Outside
-    CI, any of the remote-container env markers (``CLAUDECODE``, ``CODESPACES``)
-    or a Docker container marker (``/.dockerenv``) identifies an environment
-    where the ``gh act`` gap is expected and the gate should degrade rather than
-    block (Issue #2548, item 3).
+    CI, the managed remote-container env markers (``CLAUDECODE``, ``CODESPACES``)
+    identify environments where the ``gh act`` gap is expected and the gate
+    should degrade rather than block (Issue #2548, item 3).
     """
     if _env_truthy(_CI_ENV):
         return False
-    if any(_env_truthy(marker) for marker in _REMOTE_CONTAINER_ENV_MARKERS):
-        return True
-    return Path("/.dockerenv").exists()
+    return any(_env_truthy(marker) for marker in _REMOTE_CONTAINER_ENV_MARKERS)
 
 
 def _run(

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -214,6 +214,23 @@ def test_gh_act_missing_without_container_signal_still_exit_3(monkeypatch, tmp_p
     assert r.degraded is False
 
 
+def test_plain_docker_marker_does_not_downgrade(monkeypatch, tmp_path):
+    """A local Docker/devcontainer environment should still report a tool gap."""
+    monkeypatch.setattr(w, "_have", lambda tool: True)
+    monkeypatch.setattr(w, "_gh_act_available", lambda: False)
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w.Path, "exists", lambda self: str(self) == "/.dockerenv")
+    monkeypatch.delenv(w._BYPASS_ENV, raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.delenv("CODESPACES", raising=False)
+
+    r = w.run_local_test([WF], tmp_path)
+
+    assert r.exit_code == 3
+    assert r.degraded is False
+
+
 def test_docker_down_is_exit_3_for_full(all_tools, monkeypatch, tmp_path):
     # Dry-run passes (no daemon needed); the full stage needs Docker -> exit 3.
     # docker is installed but the daemon is down -> "not running" note.

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -128,8 +128,12 @@ def test_actionlint_missing_is_exit_3(monkeypatch, tmp_path):
 
 
 def test_gh_missing_is_exit_3(monkeypatch, tmp_path):
+    # On a normal (non-container) box, a missing gh CLI is a real tool gap and
+    # blocks at exit 3. The container-downgrade seam is pinned off so the test
+    # is deterministic regardless of the host env (Issue #2548, item 3).
     monkeypatch.setattr(w, "_have", lambda tool: tool == "actionlint")
     monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
     monkeypatch.delenv(w._BYPASS_ENV, raising=False)
     r = w.run_local_test([WF], tmp_path)
     assert r.exit_code == 3
@@ -137,14 +141,77 @@ def test_gh_missing_is_exit_3(monkeypatch, tmp_path):
 
 
 def test_gh_act_extension_missing_is_exit_3(monkeypatch, tmp_path):
-    # gh is present but the act extension is not -> exit 3 before dry-run.
+    # gh is present but the act extension is not -> exit 3 before dry-run on a
+    # normal box. The container-downgrade seam is pinned off (Issue #2548).
     monkeypatch.setattr(w, "_have", lambda tool: True)
     monkeypatch.setattr(w, "_gh_act_available", lambda: False)
     monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
     monkeypatch.delenv(w._BYPASS_ENV, raising=False)
     r = w.run_local_test([WF], tmp_path)
     assert r.exit_code == 3
     assert "gh act extension" in r.note
+
+
+def test_gh_act_missing_in_remote_container_downgrades_to_warning(
+    monkeypatch, tmp_path
+):
+    # gh act unavailable inside a remote container (CLAUDECODE set, no CI) must
+    # not block the push: it degrades to a logged warning (exit 0). Item 3 of
+    # issue #2548.
+    monkeypatch.setattr(w, "_have", lambda tool: True)
+    monkeypatch.setattr(w, "_gh_act_available", lambda: False)
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.delenv(w._BYPASS_ENV, raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 0
+    assert r.degraded is True
+    assert "gh act" in r.note
+
+
+def test_gh_act_missing_in_ci_still_blocks_even_with_container_signal(
+    monkeypatch, tmp_path
+):
+    # In CI, gh act is provisioned, so a missing extension is a real failure.
+    # The CI marker overrides the container signal: hard exit 3, never degraded.
+    monkeypatch.setattr(w, "_have", lambda tool: True)
+    monkeypatch.setattr(w, "_gh_act_available", lambda: False)
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.delenv(w._BYPASS_ENV, raising=False)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("CI", "true")
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 3
+    assert r.degraded is False
+
+
+def test_gh_missing_in_remote_container_downgrades_to_warning(monkeypatch, tmp_path):
+    # The downgrade also covers a missing gh CLI: the container cannot install
+    # the act extension without an authenticated gh, so a warning is correct.
+    monkeypatch.setattr(w, "_have", lambda tool: tool == "actionlint")
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.delenv(w._BYPASS_ENV, raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 0
+    assert r.degraded is True
+
+
+def test_gh_act_missing_without_container_signal_still_exit_3(monkeypatch, tmp_path):
+    # No container signal and no CI: a local dev box missing the extension is a
+    # real tool gap and must keep blocking at exit 3.
+    monkeypatch.setattr(w, "_have", lambda tool: True)
+    monkeypatch.setattr(w, "_gh_act_available", lambda: False)
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
+    monkeypatch.delenv(w._BYPASS_ENV, raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 3
+    assert r.degraded is False
 
 
 def test_docker_down_is_exit_3_for_full(all_tools, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fixes #2548 item 3. The pre-push `workflow-local-test` gate should not block a managed remote container when `gh act` cannot be provisioned there, but it should still block normal local Docker/devcontainer tool gaps.

## Changes

- `scripts/validation/run_workflow_local_test.py` now treats only explicit managed remote markers (`CLAUDECODE`, `CODESPACES`) as downgrade signals when `CI` is not truthy.
- Removed the broad `/.dockerenv` downgrade signal so local Docker/devcontainer setups still report a real `gh act` tool gap.
- Updated the module docstring and comments to say managed remote containers may not be able to provision `gh act`, not that every Docker container has unauthenticated `gh`.
- `tests/validation/test_run_workflow_local_test.py` adds coverage that a plain Docker marker does not downgrade.
- `.agents/sessions/2026-06-17-session-2585-fix-2548-item-downgrade-gh-act-unavailable.json` records the session.

## Validation

- `uv run pytest tests/validation/test_run_workflow_local_test.py -q`
- `uv run --extra dev ruff check scripts/validation/run_workflow_local_test.py tests/validation/test_run_workflow_local_test.py`
- `uv run --extra dev mypy scripts/validation/run_workflow_local_test.py tests/validation/test_run_workflow_local_test.py --follow-imports=skip`
- `uv run python .claude/skills/security-scan/scripts/scan_vulnerabilities.py scripts/validation/run_workflow_local_test.py tests/validation/test_run_workflow_local_test.py`
- `python3 scripts/validate_session_json.py .agents/sessions/2026-06-17-session-2585-fix-2548-item-downgrade-gh-act-unavailable.json`
- `git diff --check`
