### PR TITLE
fix(hooks): LSP guards fail open when language server is down (#2622)

### DIFF
--- a/.agents/sessions/2026-06-17-session-2586-fix-2622-lsp-first-guards-fail.json
+++ b/.agents/sessions/2026-06-17-session-2586-fix-2622-lsp-first-guards-fail.json
@@ -1,0 +1,133 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2586,
+    "date": "2026-06-17",
+    "branch": "fix/2622-lsp-guards-fail-open",
+    "startingCommit": "14bb688be5",
+    "objective": "fix #2622: LSP-first guards fail open (allow+warn) when language server is down/uninitialized instead of hard-blocking native Read/Edit/Grep"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Retrieval-led: read ADR-062, the three guards, lsp_provider.py, lsp_gate_state.py, lsp-first.md before coding; Serena symbol tools were not needed for this in-process change"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md retrieval rules followed; read .claude/rules/* (release-it, clean-architecture, data-intensive) and ADR-062 sections 5 and 8 before implementing"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No open HANDOFF for this isolated worktree task; issue #2622 context read via get_issue_context.py and get_issue_comments.py"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Used github skill scripts (get_issue_context.py, get_issue_comments.py); identified guards under .claude/hooks/PreToolUse and lib under .claude/lib/hook_utilities"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read ADR-062 conditional LSP-first enforcement (sections 5 fail-open, 8 config-only availability) as the governing contract"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .claude/rules/release-it.md (graceful degradation), clean-architecture.md (thin guards, deep lib module), data-intensive-applications.md (SoR for the signal and dedup marker)"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Topical worktree memories surfaced by hooks reviewed (qa-007 worktree isolation, git-hooks-005); no LSP-down memory existed (this is the first)"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2622-lsp-guards-fail-open"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/2622-lsp-guards-fail-open"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status checked; only the 8 task files plus session log modified/added"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "14bb688be5"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST items populated with evidence; TDD RED->GREEN->mutation completed for all three guards"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not edited (read-only per ADR-014)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Wrote decision memory .serena/memories/tasks/issue-2622-lsp-guards-fail-open.md documenting the LSP_DOWN signal, marker dedup, and the config-only availability gap"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "npx markdownlint-cli2 --fix .claude/rules/lsp-first.md: Summary 0 error(s)"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Atomic commits (<=5 files each): lib module + tests, guards, doc; conventional commit messages ending Fixes #2622"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "pytest tests/hooks/test_lsp_health.py and the four LSP guard suites: 261 passed. Full tests/hooks suite: 1518 passed. ruff clean on new files. sync_plugin_lib.py --check: all copies in sync"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Single-issue task; no task tracker entry required"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Deferred: routine bug fix with clear scope; learning captured in Serena decision memory instead"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "timestamp": "2026-06-17T08:10:00Z",
+      "action": "Read issue #2622 and triage; read ADR-062 (sections 5 fail-open, 8 config-only availability), the three LSP guards, lsp_provider.py and lsp_gate_state.py. Confirmed root cause: detect_providers is config-only, so a timed-out markdown LSP still reports 'available' and the read and grep guards (which only fail open on exceptions, missing providers, or the kill switch) hard-block native Read/Edit/Grep.",
+      "evidence": "Triage comment on #2622 pinpointed config-vs-runtime gap; ADR-062 Section 8 states 'configured != active ... handled at the tool-call boundary by fail-open'"
+    },
+    {
+      "timestamp": "2026-06-17T08:35:00Z",
+      "action": "TDD. Added scripts/hook_utilities/lsp_health.py (lsp_runtime_down reads explicit LSP_DOWN env signal, no live probe per ADR-062 Section 8; warn_once_lsp_down emits one-time stderr warning deduped via a per-cwd marker outside the git tree). Synced to .claude/lib via sync_plugin_lib.py. Wrote failing guard tests (LSP up -> blocks; LSP down -> allows+warns), confirmed RED, wired all three guards to consult lsp_health, confirmed GREEN, mutated the read-guard fail-open to confirm the tests bite, then restored.",
+      "evidence": "pytest tests/hooks/test_lsp_health.py tests/hooks/test_invoke_lsp_read_guard.py tests/hooks/test_invoke_lsp_bash_grep_guard.py tests/hooks/test_invoke_lsp_pre_delegation_guard_main.py tests/hooks/test_invoke_lsp_pre_delegation_guard.py tests/hooks/test_lsp_provider.py -> 261 passed. Mutation (if False) made the 3 read-guard fail-open tests fail, then restored. Full tests/hooks suite: 1518 passed."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Security agent / architect review the ADR-062 policy relaxation (LSP_DOWN fail-open path) before merge",
+    "Optional follow-up: a SessionStart probe that sets LSP_DOWN automatically when the language server manager reports uninitialized, and clears the marker on recovery"
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.200",
+  "version": "0.5.201",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PostToolUse/invoke_lsp_read_tracker.py
+++ b/.claude/hooks/PostToolUse/invoke_lsp_read_tracker.py
@@ -54,6 +54,7 @@ if _lib_dir not in sys.path:
 from hook_utilities import get_project_directory  # noqa: E402
 from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
 from hook_utilities.lsp_gate_state import is_gated_target, record_read  # noqa: E402
+from hook_utilities.lsp_health import lsp_runtime_down  # noqa: E402
 from hook_utilities.lsp_provider import SYMBOLS_OVERVIEW, detect_providers  # noqa: E402
 
 
@@ -64,6 +65,13 @@ def main() -> int:
 
     try:
         if os.environ.get("SKIP_LSP_GATE", "").strip().lower() == "true":
+            return 0
+
+        # Symmetric with the PreToolUse guard: when LSP_DOWN is set, reads are
+        # allowed without gating, so we must not track them either. Otherwise
+        # tier state advances during degraded mode and hard-blocks resume when
+        # the LSP recovers (issue #2622).
+        if lsp_runtime_down():
             return 0
 
         if sys.stdin.isatty():

--- a/.claude/hooks/PreToolUse/invoke_lsp_bash_grep_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_bash_grep_guard.py
@@ -93,6 +93,10 @@ if _lib_dir not in sys.path:
 
 from hook_utilities import get_project_directory  # noqa: E402
 from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
+from hook_utilities.lsp_health import (  # noqa: E402
+    lsp_runtime_down,
+    warn_once_lsp_down,
+)
 from hook_utilities.lsp_provider import (  # noqa: E402
     SYMBOL_NAVIGATION,
     detect_providers,
@@ -415,6 +419,16 @@ def main() -> int:
         decision = evaluate_command(command, project_dir)
         if decision is None:
             # Not a gated grep, or no navigable target with an available LSP.
+            return 0
+
+        # Runtime fail-open (issue #2622): evaluate_command's provider check is
+        # config-only, so it still gates when the language server timed out at
+        # startup (ADR-062 Section 8, "configured != active"). If the LSP runtime
+        # is down, degrade to ALLOW with a one-time warning rather than block a
+        # grep the agent cannot replace with a (dead) symbol query (ADR-062
+        # Section 5, release-it.md graceful degradation).
+        if lsp_runtime_down():
+            warn_once_lsp_down("lsp-bash-grep-guard", project_dir)
             return 0
 
         guidance = build_guidance(decision["symbols"], decision["target"])

--- a/.claude/hooks/PreToolUse/invoke_lsp_glob_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_glob_guard.py
@@ -89,6 +89,10 @@ if _lib_dir not in sys.path:
 
 from hook_utilities import get_project_directory  # noqa: E402
 from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
+from hook_utilities.lsp_health import (  # noqa: E402
+    lsp_runtime_down,
+    warn_once_lsp_down,
+)
 from hook_utilities.lsp_provider import (  # noqa: E402
     EXTENSION_TO_SERENA_LANGUAGE,
     PROGRAMMING_SERENA_LANGUAGES,
@@ -270,6 +274,11 @@ def main() -> int:
             return 0
 
         pattern, symbols, providers = decision
+
+        if lsp_runtime_down():
+            warn_once_lsp_down(_HOOK_NAME, get_project_directory())
+            return 0
+
         guidance = build_guidance(pattern, symbols, providers)
         if os.environ.get("LSP_GATE_MODE", "").lower() == _WARN_MODE:
             _emit_warn(guidance)

--- a/.claude/hooks/PreToolUse/invoke_lsp_grep_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_grep_guard.py
@@ -100,6 +100,10 @@ if _lib_dir not in sys.path:
 
 from hook_utilities import get_project_directory  # noqa: E402
 from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
+from hook_utilities.lsp_health import (  # noqa: E402
+    lsp_runtime_down,
+    warn_once_lsp_down,
+)
 from hook_utilities.lsp_provider import (  # noqa: E402
     PROVIDERS,
     SYMBOL_NAVIGATION,
@@ -308,6 +312,11 @@ def main() -> int:
             return 0
 
         symbols, providers = decision
+
+        if lsp_runtime_down():
+            warn_once_lsp_down(_HOOK_NAME, get_project_directory())
+            return 0
+
         guidance = build_guidance(symbols, providers)
         if os.environ.get("LSP_GATE_MODE", "").lower() == _WARN_MODE:
             _emit_warn(guidance)

--- a/.claude/hooks/PreToolUse/invoke_lsp_pre_delegation_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_pre_delegation_guard.py
@@ -121,6 +121,10 @@ if _lib_dir not in sys.path:
 
 from hook_utilities import get_project_directory  # noqa: E402
 from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
+from hook_utilities.lsp_health import (  # noqa: E402
+    lsp_runtime_down,
+    warn_once_lsp_down,
+)
 from hook_utilities.lsp_provider import (  # noqa: E402
     SYMBOLS_OVERVIEW,
     configured_languages,
@@ -304,6 +308,16 @@ def main() -> int:
                 "LSP pre-delegation guard: no provider available, allowing",
                 file=sys.stderr,
             )
+            return 0
+
+        # Runtime fail-open (issue #2622): provider_available is config-only, so
+        # it still reports a provider when the language server timed out at
+        # startup (ADR-062 Section 8, "configured != active"). With the LSP down,
+        # the orchestrator cannot pre-resolve symbol context, so blocking the
+        # delegation just wedges the turn. Allow it with a one-time warning
+        # (ADR-062 Section 5, release-it.md graceful degradation).
+        if lsp_runtime_down():
+            warn_once_lsp_down("lsp-pre-delegation-guard", project_dir)
             return 0
 
         # Mode (ADR-062 Section 6): warn never blocks.

--- a/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
@@ -118,6 +118,10 @@ from hook_utilities import (  # noqa: E402
     read_state,
 )
 from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
+from hook_utilities.lsp_health import (  # noqa: E402
+    lsp_runtime_down,
+    warn_once_lsp_down,
+)
 
 _SKIP_ENV = "SKIP_LSP_GATE"
 _MODE_ENV = "LSP_GATE_MODE"
@@ -216,6 +220,16 @@ def evaluate(file_path: str, project_dir: str) -> tuple[int, str | None]:
     providers = detect_providers(file_path, SYMBOLS_OVERVIEW, project_dir)
     if not providers:
         _note(f"no overview provider, allow: {file_path}")
+        return 0, None
+
+    # Runtime fail-open (issue #2622): detect_providers is config-only, so it
+    # still reports "available" when the language server timed out at startup
+    # (ADR-062 Section 8, "configured != active"). If the LSP runtime is down,
+    # degrade to ALLOW with a one-time warning rather than hard-block native
+    # Read/Edit/Grep (ADR-062 Section 5, release-it.md graceful degradation).
+    if lsp_runtime_down():
+        warn_once_lsp_down("lsp-read-guard", project_dir)
+        _note(f"lsp runtime down, allow: {file_path}")
         return 0, None
 
     state = read_state(project_dir)

--- a/.claude/hooks/SessionStart/invoke_lsp_session_reset.py
+++ b/.claude/hooks/SessionStart/invoke_lsp_session_reset.py
@@ -89,7 +89,10 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     # Fail-open: SessionStart must never block session startup.
     sys.exit(0)
 if _lib_dir not in sys.path:
@@ -114,7 +117,14 @@ def main() -> int:
         # would reset a different state file than the one guards actually use.
         project_dir = get_project_directory()
 
-        ok = reset_state(project_dir)
+        try:
+            ok = reset_state(project_dir)
+        except Exception as exc:  # noqa: BLE001 - marker reset still must run.
+            ok = False
+            print(
+                f"lsp-session-reset state error: {type(exc).__name__} - {exc}",
+                file=sys.stderr,
+            )
         marker_ok = clear_lsp_down_marker(project_dir)
         mode = os.environ.get("LSP_GATE_MODE", "block")
         print(

--- a/.claude/hooks/SessionStart/invoke_lsp_session_reset.py
+++ b/.claude/hooks/SessionStart/invoke_lsp_session_reset.py
@@ -97,6 +97,7 @@ if _lib_dir not in sys.path:
 
 from hook_utilities import get_project_directory  # noqa: E402
 from hook_utilities.lsp_gate_state import reset_state  # noqa: E402
+from hook_utilities.lsp_health import clear_lsp_down_marker  # noqa: E402
 
 
 def main() -> int:
@@ -114,9 +115,11 @@ def main() -> int:
         project_dir = get_project_directory()
 
         ok = reset_state(project_dir)
+        marker_ok = clear_lsp_down_marker(project_dir)
         mode = os.environ.get("LSP_GATE_MODE", "block")
         print(
-            f"lsp-session-reset: reset={ok} mode={mode} key=sha256(project_dir)[:16]",
+            f"lsp-session-reset: reset={ok} marker_cleared={marker_ok} "
+            f"mode={mode} key=sha256(project_dir)[:16]",
             file=sys.stderr,
         )
         return 0

--- a/.claude/lib/hook_utilities/lsp_gate_state.py
+++ b/.claude/lib/hook_utilities/lsp_gate_state.py
@@ -109,7 +109,7 @@ def _cwd_key(cwd: str) -> str:
     """
     try:
         normalized = str(Path(cwd).resolve())
-    except (OSError, ValueError):
+    except OSError, ValueError:
         normalized = cwd
     digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
     return digest[:16]
@@ -148,7 +148,7 @@ def read_state(cwd: str) -> dict:
     try:
         raw = path.read_text(encoding="utf-8")
         data = json.loads(raw)
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return default
     if not isinstance(data, dict):
         return default
@@ -178,7 +178,7 @@ def _coerce_int(value: object) -> int:
         return 0
     try:
         result = int(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return 0
     return result if result >= 0 else 0
 
@@ -258,7 +258,7 @@ def _resolve_git_dir(project_dir: str) -> Path | None:
         if not git_path.is_file():
             return None
         content = git_path.read_text(encoding="utf-8").strip()
-    except (OSError, UnicodeError, ValueError):
+    except OSError, UnicodeError, ValueError:
         return None
 
     if not content.startswith("gitdir:"):
@@ -272,7 +272,7 @@ def _resolve_git_dir(project_dir: str) -> Path | None:
         git_dir = git_path.parent / git_dir
     try:
         return git_dir.resolve()
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return None
 
 
@@ -300,7 +300,7 @@ def _merge_in_progress(project_dir: str) -> bool:
         for marker in ("MERGE_HEAD", "rebase-merge", "rebase-apply"):
             if (git_dir / marker).exists():
                 return True
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return False
     return False
 
@@ -324,7 +324,7 @@ def _has_conflict_markers(file_path: str) -> bool:
     try:
         with open(file_path, "rb") as fh:
             raw = fh.read(_CONFLICT_MARKER_SCAN_BYTES)
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return False
     try:
         text = raw.decode("utf-8", errors="strict")
@@ -359,7 +359,7 @@ def is_gated_target(file_path: str, project_dir: str) -> bool:
         if not candidate.is_absolute():
             candidate = root / candidate
         resolved = candidate.resolve()
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return False
 
     # Out-of-repo targets are never gated.
@@ -373,7 +373,7 @@ def is_gated_target(file_path: str, project_dir: str) -> bool:
             tmp_root = Path(tmpdir).resolve()
             if tmp_root == resolved or tmp_root in resolved.parents:
                 return False
-        except (OSError, ValueError):
+        except OSError, ValueError:
             return False
 
     # Dotfiles and dot-directory members (.serena/, .git/, .agents/, ...) are
@@ -412,7 +412,7 @@ def normalize_path(file_path: str, cwd: str) -> str:
         if not candidate.is_absolute():
             candidate = Path(cwd) / candidate
         return str(candidate.resolve())
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return file_path
 
 

--- a/.claude/lib/hook_utilities/lsp_gate_state.py
+++ b/.claude/lib/hook_utilities/lsp_gate_state.py
@@ -70,6 +70,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import tempfile
 from pathlib import Path
 
 # Gate thresholds (ADR-062 Section 3; canonical names the guards consume).
@@ -83,10 +84,19 @@ _STATE_SUBDIR = "ai-agents-lsp-gate"
 def _state_dir() -> Path:
     """Return the user-scoped state directory, outside the git working tree.
 
-    Honors ``$XDG_STATE_HOME`` when set, else ``~/.cache``. Never the repo tree.
+    Honors ``$XDG_STATE_HOME`` when set, else ``~/.cache``. Falls back to
+    ``tempfile.gettempdir()`` when both are unavailable (e.g. sandboxed or
+    CI environments where ``Path.home()`` raises ``RuntimeError`` because the
+    running user has no home directory). Never the repo tree.
     """
     xdg = os.environ.get("XDG_STATE_HOME", "").strip()
-    base = Path(xdg) if xdg else Path.home() / ".cache"
+    if xdg:
+        base = Path(xdg)
+    else:
+        try:
+            base = Path.home() / ".cache"
+        except RuntimeError:
+            base = Path(tempfile.gettempdir()) / ".cache"
     return base / _STATE_SUBDIR
 
 

--- a/.claude/lib/hook_utilities/lsp_health.py
+++ b/.claude/lib/hook_utilities/lsp_health.py
@@ -1,8 +1,10 @@
 """Canonical: scripts/hook_utilities/lsp_health.py. Sync via scripts/sync_plugin_lib.py.
 
-Canonical module. Plugin-distributed copy at
-``.claude/lib/hook_utilities/lsp_health.py``; run
-``python3 scripts/sync_plugin_lib.py`` to sync.
+Canonical source path: ``scripts/hook_utilities/lsp_health.py``.
+Synced distribution paths:
+``.claude/lib/hook_utilities/lsp_health.py`` and
+``src/copilot-cli/lib/hook_utilities/lsp_health.py``. Run
+``python3 scripts/sync_plugin_lib.py`` to sync the distribution copies.
 
 WHY THIS EXISTS (issue #2622)
 -----------------------------
@@ -108,22 +110,25 @@ def _marker_path(project_dir: str) -> Path:
 def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
     """Emit the LSP-down fail-open warning at most once per session. Never raises.
 
-    Writes a per-cwd marker the first time it warns; subsequent calls observe
-    the marker and stay silent (the issue's "one-time warning instead of
-    repeated hard blocks"). Returns True when this call emitted the warning
-    (regardless of whether the dedup marker was successfully persisted).
+    Claims a per-cwd marker with exclusive create before it warns; subsequent
+    calls observe the marker and stay silent (the issue's "one-time warning
+    instead of repeated hard blocks"). Returns True when this call emitted the
+    warning (regardless of whether the dedup marker was successfully persisted).
     Returns False when the warning was already emitted this session (marker
     exists).
 
     Any marker filesystem error degrades to emitting without persistence rather
     than raising; a navigation gate must never wedge a turn (release-it.md).
     """
-    marker = _marker_path(project_dir)
     try:
-        if marker.exists():
-            return False
+        marker = _marker_path(project_dir)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        with marker.open("x", encoding="utf-8") as fh:
+            fh.write("1")
+    except FileExistsError:
+        return False
     except OSError, ValueError:
-        pass
+        marker = None
 
     message = (
         f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing this "
@@ -131,14 +136,6 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
         "language server recovers."
     )
     print(message, file=sys.stderr)
-
-    try:
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text("1", encoding="utf-8")
-    except OSError, ValueError:
-        # Could not persist the marker: we already printed once, so degrade to
-        # "warned" semantics for this call but allow a future call to warn again.
-        return True
     return True
 
 

--- a/.claude/lib/hook_utilities/lsp_health.py
+++ b/.claude/lib/hook_utilities/lsp_health.py
@@ -126,8 +126,8 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
         pass
 
     message = (
-        f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing native "
-        "tools (Read/Edit/Grep). LSP-first enforcement is paused until the "
+        f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing this "
+        "operation to continue. LSP-first enforcement is paused until the "
         "language server recovers."
     )
     print(message, file=sys.stderr)

--- a/.claude/lib/hook_utilities/lsp_health.py
+++ b/.claude/lib/hook_utilities/lsp_health.py
@@ -1,0 +1,143 @@
+"""Canonical: scripts/hook_utilities/lsp_health.py. Sync via scripts/sync_plugin_lib.py.
+
+Canonical module. Plugin-distributed copy at
+``.claude/lib/hook_utilities/lsp_health.py``; run
+``python3 scripts/sync_plugin_lib.py`` to sync.
+
+WHY THIS EXISTS (issue #2622)
+-----------------------------
+``lsp_provider.detect_providers`` is a PURE configuration check: a language
+listed in ``.serena/project.yml`` with the serena MCP server registered counts
+as "available" even when the language server is not actually running this turn
+(ADR-062 Section 8, "configured != active"). ADR-062 Section 5 says that gap is
+handled at the tool-call boundary by fail-open. Before this module, the Read and
+grep guards only failed open on *exceptions*, a *missing provider*, or the
+*kill switch*: none of those fire when the markdown language server times out at
+startup while config still lists it. The guards then converted a degraded
+capability (no symbols) into a hard block on basic Read/Edit/Grep, and the only
+escape was a manual ``SKIP_LSP_GATE=true`` for the whole session.
+
+This module adds the missing runtime-health gate. It is NOT a live probe (no
+outbound call, no timeout, ADR-062 Section 8 preserved): it reads an EXPLICIT
+"LSP is down" signal, the same env-signal shape the guards already use for
+``SKIP_LSP_GATE`` and ``LSP_GATE_MODE``. When the signal is set, the guards
+ALLOW the tool and emit a one-time warning instead of repeatedly hard-blocking.
+
+The signal is set out-of-band by whatever observes the language-server failure
+(the session, a SessionStart probe, or the user reacting to a timeout). Keeping
+the producer separate keeps this module a thin, pure reader (clean-architecture):
+the guard depends on the signal, not on Serena internals.
+
+System of record
+----------------
+The env var ``LSP_DOWN`` is the signal's SoR. The one-time-warning marker is
+derived per-session dedup state, rebuildable by definition (deleting it only
+re-emits the warning once). The marker lives OUTSIDE the git working tree in the
+same user-scoped state dir the gate-state file uses, so it is never committed
+and never collides with repo state (mirrors ``lsp_gate_state._state_dir``).
+
+Security (CWE-22, Low): the marker path is derived from a sha256 of the resolved
+cwd plus a fixed prefix, never from tool input, so there is no path-traversal
+surface. Tampering with the marker only changes whether one advisory line is
+printed; it is not a security boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+# Env signal: the explicit "the LSP runtime is down/uninitialized" flag. Mirrors
+# the truthy parsing of SKIP_LSP_GATE (case-insensitive ``true``/``1``/``yes``).
+LSP_DOWN_ENV = "LSP_DOWN"
+
+_TRUTHY = frozenset({"true", "1", "yes", "on"})
+
+# State subdir for the one-time-warning marker. Same base dir scheme as
+# lsp_gate_state so plugin state and gate state share a parent but distinct files.
+_STATE_SUBDIR = "ai-agents-lsp-gate"
+
+
+def lsp_runtime_down() -> bool:
+    """Return True when an explicit LSP-down signal is set for this session.
+
+    Pure read of the ``LSP_DOWN`` env var (no live probe, ADR-062 Section 8).
+    Truthy values: ``true``/``1``/``yes``/``on`` (case-insensitive). Any other
+    value, or an unset var, returns False (the guards enforce as normal).
+    """
+    return os.environ.get(LSP_DOWN_ENV, "").strip().lower() in _TRUTHY
+
+
+def _state_dir() -> Path:
+    """Return the user-scoped state directory, outside the git working tree.
+
+    Honors ``$XDG_STATE_HOME`` when set, else ``~/.cache``. Mirrors
+    ``lsp_gate_state._state_dir`` so the marker never lands in the repo tree.
+    """
+    xdg = os.environ.get("XDG_STATE_HOME", "").strip()
+    base = Path(xdg) if xdg else Path.home() / ".cache"
+    return base / _STATE_SUBDIR
+
+
+def _cwd_key(project_dir: str) -> str:
+    """Return a stable per-cwd key: sha256(resolved cwd) truncated to 16 hex."""
+    try:
+        normalized = str(Path(project_dir).resolve())
+    except (OSError, ValueError):
+        normalized = project_dir
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def _marker_path(project_dir: str) -> Path:
+    """Return the absolute one-time-warning marker path for ``project_dir``."""
+    return _state_dir() / f"lsp-down-warned-{_cwd_key(project_dir)}"
+
+
+def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
+    """Emit the LSP-down fail-open warning at most once per session. Never raises.
+
+    Writes a per-cwd marker the first time it warns; subsequent calls observe
+    the marker and stay silent (the issue's "one-time warning instead of
+    repeated hard blocks"). Returns True when this call emitted the warning,
+    False when it was already emitted or the marker could not be written.
+
+    Any filesystem error degrades to NOT emitting on the failed call rather than
+    raising; a navigation gate must never wedge a turn (release-it.md).
+    """
+    marker = _marker_path(project_dir)
+    try:
+        if marker.exists():
+            return False
+    except OSError:
+        return False
+
+    message = (
+        f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing native "
+        "tools (Read/Edit/Grep). LSP-first enforcement is paused until the "
+        "language server recovers."
+    )
+    print(message, file=sys.stderr)
+
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("1", encoding="utf-8")
+    except OSError:
+        # Could not persist the marker: we already printed once, so degrade to
+        # "warned" semantics for this call but allow a future call to warn again.
+        return True
+    return True
+
+
+def clear_lsp_down_marker(project_dir: str) -> bool:
+    """Remove the one-time-warning marker for ``project_dir``. Idempotent.
+
+    Called by the SessionStart reset so a fresh session warns again if the LSP
+    is still down. Returns False only on a filesystem error other than missing.
+    """
+    try:
+        _marker_path(project_dir).unlink(missing_ok=True)
+    except OSError:
+        return False
+    return True

--- a/.claude/lib/hook_utilities/lsp_health.py
+++ b/.claude/lib/hook_utilities/lsp_health.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 import hashlib
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 # Env signal: the explicit "the LSP runtime is down/uninitialized" flag. Mirrors
@@ -73,11 +74,20 @@ def lsp_runtime_down() -> bool:
 def _state_dir() -> Path:
     """Return the user-scoped state directory, outside the git working tree.
 
-    Honors ``$XDG_STATE_HOME`` when set, else ``~/.cache``. Mirrors
-    ``lsp_gate_state._state_dir`` so the marker never lands in the repo tree.
+    Honors ``$XDG_STATE_HOME`` when set, else ``~/.cache``. Falls back to
+    ``tempfile.gettempdir()`` when both are unavailable (e.g. sandboxed or
+    CI environments where ``Path.home()`` raises ``RuntimeError`` because the
+    running user has no home directory). Mirrors ``lsp_gate_state._state_dir``
+    so the marker never lands in the repo tree.
     """
     xdg = os.environ.get("XDG_STATE_HOME", "").strip()
-    base = Path(xdg) if xdg else Path.home() / ".cache"
+    if xdg:
+        base = Path(xdg)
+    else:
+        try:
+            base = Path.home() / ".cache"
+        except RuntimeError:
+            base = Path(tempfile.gettempdir()) / ".cache"
     return base / _STATE_SUBDIR
 
 
@@ -100,8 +110,10 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
 
     Writes a per-cwd marker the first time it warns; subsequent calls observe
     the marker and stay silent (the issue's "one-time warning instead of
-    repeated hard blocks"). Returns True when this call emitted the warning,
-    False when it was already emitted or the marker could not be written.
+    repeated hard blocks"). Returns True when this call emitted the warning
+    (regardless of whether the dedup marker was successfully persisted).
+    Returns False when the warning was already emitted this session (marker
+    exists) or when the marker existence check itself fails (OSError).
 
     Any filesystem error degrades to NOT emitting on the failed call rather than
     raising; a navigation gate must never wedge a turn (release-it.md).

--- a/.claude/lib/hook_utilities/lsp_health.py
+++ b/.claude/lib/hook_utilities/lsp_health.py
@@ -95,7 +95,7 @@ def _cwd_key(project_dir: str) -> str:
     """Return a stable per-cwd key: sha256(resolved cwd) truncated to 16 hex."""
     try:
         normalized = str(Path(project_dir).resolve())
-    except (OSError, ValueError):
+    except OSError, ValueError:
         normalized = project_dir
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
 
@@ -113,17 +113,17 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
     repeated hard blocks"). Returns True when this call emitted the warning
     (regardless of whether the dedup marker was successfully persisted).
     Returns False when the warning was already emitted this session (marker
-    exists) or when the marker existence check itself fails (OSError).
+    exists).
 
-    Any filesystem error degrades to NOT emitting on the failed call rather than
-    raising; a navigation gate must never wedge a turn (release-it.md).
+    Any marker filesystem error degrades to emitting without persistence rather
+    than raising; a navigation gate must never wedge a turn (release-it.md).
     """
     marker = _marker_path(project_dir)
     try:
         if marker.exists():
             return False
-    except OSError:
-        return False
+    except OSError, ValueError:
+        pass
 
     message = (
         f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing native "
@@ -135,7 +135,7 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
     try:
         marker.parent.mkdir(parents=True, exist_ok=True)
         marker.write_text("1", encoding="utf-8")
-    except OSError:
+    except OSError, ValueError:
         # Could not persist the marker: we already printed once, so degrade to
         # "warned" semantics for this call but allow a future call to warn again.
         return True
@@ -150,6 +150,6 @@ def clear_lsp_down_marker(project_dir: str) -> bool:
     """
     try:
         _marker_path(project_dir).unlink(missing_ok=True)
-    except OSError:
+    except OSError, ValueError:
         return False
     return True

--- a/.claude/rules/lsp-first.md
+++ b/.claude/rules/lsp-first.md
@@ -59,6 +59,16 @@ re-activate it: `mcp__serena__activate_project` then
 an advisory. The guards fail open: when no LSP is reachable they allow the raw
 tool rather than block.
 
+When the language server is configured but down or uninitialized (for example a
+markdown LSP that times out at startup), `detect_providers` still reports the
+provider as available (it is a config-only check), so the read, grep, and
+pre-delegation guards would otherwise hard-block native Read/Edit/Grep. Set
+`LSP_DOWN=true` to signal the runtime is down: the guards then ALLOW native tools
+and emit a one-time warning instead of blocking, until the language server
+recovers (issue #2622). Unlike `SKIP_LSP_GATE` (which disables the gate
+entirely), `LSP_DOWN` only relaxes the gate while the LSP cannot serve symbol
+queries; it is the graceful-degradation path, not a kill switch.
+
 During a merge or rebase, the read gate bypasses automatically for issue #2454.
 Either of these conditions skips the gate for the in-flight file: (a)
 `MERGE_HEAD`, `rebase-merge`, or `rebase-apply` exists in the active git admin

--- a/.github/instructions/lsp-first.instructions.md
+++ b/.github/instructions/lsp-first.instructions.md
@@ -58,6 +58,16 @@ re-activate it: `mcp__serena__activate_project` then
 an advisory. The guards fail open: when no LSP is reachable they allow the raw
 tool rather than block.
 
+When the language server is configured but down or uninitialized (for example a
+markdown LSP that times out at startup), `detect_providers` still reports the
+provider as available (it is a config-only check), so the read, grep, and
+pre-delegation guards would otherwise hard-block native Read/Edit/Grep. Set
+`LSP_DOWN=true` to signal the runtime is down: the guards then ALLOW native tools
+and emit a one-time warning instead of blocking, until the language server
+recovers (issue #2622). Unlike `SKIP_LSP_GATE` (which disables the gate
+entirely), `LSP_DOWN` only relaxes the gate while the LSP cannot serve symbol
+queries; it is the graceful-degradation path, not a kill switch.
+
 During a merge or rebase, the read gate bypasses automatically for issue #2454.
 Either of these conditions skips the gate for the in-flight file: (a)
 `MERGE_HEAD`, `rebase-merge`, or `rebase-apply` exists in the active git admin

--- a/.serena/memories/tasks/issue-2622-lsp-guards-fail-open.md
+++ b/.serena/memories/tasks/issue-2622-lsp-guards-fail-open.md
@@ -1,0 +1,49 @@
+# Issue 2622: LSP-first guards fail open when the language server is down
+
+## Question
+
+When the LSP runtime is configured but down (markdown LSP timed out at startup),
+should the ADR-062 read/grep/pre-delegation guards keep hard-blocking native
+Read/Edit/Grep, or fail open?
+
+## Conventional answer
+
+ADR-062 Section 8 says availability is a PURE configuration check with no live
+probe, and the "configured != active" gap is "handled at the actual tool-call
+boundary by fail-open." But before this fix the read and grep guards only failed
+open on exceptions, a missing provider, or the SKIP_LSP_GATE kill switch. None of
+those fire when the server times out while config still lists the language, so
+the guards converted a degraded capability (no symbols) into a hard block on
+basic file ops. The only escape was a manual session-wide SKIP_LSP_GATE=true.
+
+## First-principles position
+
+The fail-open promised by ADR-062 Section 5 was never wired for the runtime-down
+case. Add an explicit runtime-health signal the guards consult, ALLOW + warn once
+when it is set. Keep it a no-live-probe signal (env var LSP_DOWN) to preserve
+Section 8 (sub-100ms, no probe timeout). Do NOT remove the block when the LSP can
+actually serve: LSP-first enforcement stays intact when the server is up.
+
+## Evidence
+
+- scripts/hook_utilities/lsp_health.py (canonical; synced to .claude/lib via
+  scripts/sync_plugin_lib.py): lsp_runtime_down() reads LSP_DOWN
+  (true/1/yes/on); warn_once_lsp_down() emits one stderr line and writes a
+  per-cwd marker (sha256(cwd) under XDG_STATE_HOME/ai-agents-lsp-gate, outside
+  the git tree) so the warning is once per session; clear_lsp_down_marker() for
+  SessionStart reset.
+- Guards consult it AFTER the provider check (so it only fires when the guard
+  would otherwise block): invoke_lsp_read_guard.evaluate, the grep guard main()
+  after evaluate_command, the pre-delegation guard after provider_available.
+- pytest tests/hooks (LSP suites): 261 passed; full tests/hooks: 1518 passed.
+  Mutation of the read-guard fail-open made 3 tests fail, then restored.
+
+## Decision
+
+Shipped lsp_health as a deep module; three thin guards each gained a 3-line
+fail-open consult. LSP_DOWN is the graceful-degradation signal (relaxes the gate
+while the LSP cannot serve), distinct from SKIP_LSP_GATE (full kill switch).
+Documented in .claude/rules/lsp-first.md. SECURITY/POLICY-SENSITIVE: this relaxes
+an ADR-062 enforcement mechanism; routed for security/architect review before
+merge. The signal producer (auto-set LSP_DOWN on observed server timeout) is a
+follow-up; this PR adds the consumer + manual signal.

--- a/scripts/hook_utilities/lsp_gate_state.py
+++ b/scripts/hook_utilities/lsp_gate_state.py
@@ -109,7 +109,7 @@ def _cwd_key(cwd: str) -> str:
     """
     try:
         normalized = str(Path(cwd).resolve())
-    except (OSError, ValueError):
+    except OSError, ValueError:
         normalized = cwd
     digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
     return digest[:16]
@@ -148,7 +148,7 @@ def read_state(cwd: str) -> dict:
     try:
         raw = path.read_text(encoding="utf-8")
         data = json.loads(raw)
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return default
     if not isinstance(data, dict):
         return default
@@ -178,7 +178,7 @@ def _coerce_int(value: object) -> int:
         return 0
     try:
         result = int(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return 0
     return result if result >= 0 else 0
 
@@ -258,7 +258,7 @@ def _resolve_git_dir(project_dir: str) -> Path | None:
         if not git_path.is_file():
             return None
         content = git_path.read_text(encoding="utf-8").strip()
-    except (OSError, UnicodeError, ValueError):
+    except OSError, UnicodeError, ValueError:
         return None
 
     if not content.startswith("gitdir:"):
@@ -272,7 +272,7 @@ def _resolve_git_dir(project_dir: str) -> Path | None:
         git_dir = git_path.parent / git_dir
     try:
         return git_dir.resolve()
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return None
 
 
@@ -300,7 +300,7 @@ def _merge_in_progress(project_dir: str) -> bool:
         for marker in ("MERGE_HEAD", "rebase-merge", "rebase-apply"):
             if (git_dir / marker).exists():
                 return True
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return False
     return False
 
@@ -324,7 +324,7 @@ def _has_conflict_markers(file_path: str) -> bool:
     try:
         with open(file_path, "rb") as fh:
             raw = fh.read(_CONFLICT_MARKER_SCAN_BYTES)
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return False
     try:
         text = raw.decode("utf-8", errors="strict")
@@ -359,7 +359,7 @@ def is_gated_target(file_path: str, project_dir: str) -> bool:
         if not candidate.is_absolute():
             candidate = root / candidate
         resolved = candidate.resolve()
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return False
 
     # Out-of-repo targets are never gated.
@@ -373,7 +373,7 @@ def is_gated_target(file_path: str, project_dir: str) -> bool:
             tmp_root = Path(tmpdir).resolve()
             if tmp_root == resolved or tmp_root in resolved.parents:
                 return False
-        except (OSError, ValueError):
+        except OSError, ValueError:
             return False
 
     # Dotfiles and dot-directory members (.serena/, .git/, .agents/, ...) are
@@ -412,7 +412,7 @@ def normalize_path(file_path: str, cwd: str) -> str:
         if not candidate.is_absolute():
             candidate = Path(cwd) / candidate
         return str(candidate.resolve())
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return file_path
 
 

--- a/scripts/hook_utilities/lsp_gate_state.py
+++ b/scripts/hook_utilities/lsp_gate_state.py
@@ -70,6 +70,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import tempfile
 from pathlib import Path
 
 # Gate thresholds (ADR-062 Section 3; canonical names the guards consume).
@@ -83,10 +84,19 @@ _STATE_SUBDIR = "ai-agents-lsp-gate"
 def _state_dir() -> Path:
     """Return the user-scoped state directory, outside the git working tree.
 
-    Honors ``$XDG_STATE_HOME`` when set, else ``~/.cache``. Never the repo tree.
+    Honors ``$XDG_STATE_HOME`` when set, else ``~/.cache``. Falls back to
+    ``tempfile.gettempdir()`` when both are unavailable (e.g. sandboxed or
+    CI environments where ``Path.home()`` raises ``RuntimeError`` because the
+    running user has no home directory). Never the repo tree.
     """
     xdg = os.environ.get("XDG_STATE_HOME", "").strip()
-    base = Path(xdg) if xdg else Path.home() / ".cache"
+    if xdg:
+        base = Path(xdg)
+    else:
+        try:
+            base = Path.home() / ".cache"
+        except RuntimeError:
+            base = Path(tempfile.gettempdir()) / ".cache"
     return base / _STATE_SUBDIR
 
 

--- a/scripts/hook_utilities/lsp_health.py
+++ b/scripts/hook_utilities/lsp_health.py
@@ -126,8 +126,8 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
         pass
 
     message = (
-        f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing native "
-        "tools (Read/Edit/Grep). LSP-first enforcement is paused until the "
+        f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing this "
+        "operation to continue. LSP-first enforcement is paused until the "
         "language server recovers."
     )
     print(message, file=sys.stderr)

--- a/scripts/hook_utilities/lsp_health.py
+++ b/scripts/hook_utilities/lsp_health.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 import hashlib
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 # Env signal: the explicit "the LSP runtime is down/uninitialized" flag. Mirrors
@@ -73,11 +74,20 @@ def lsp_runtime_down() -> bool:
 def _state_dir() -> Path:
     """Return the user-scoped state directory, outside the git working tree.
 
-    Honors ``$XDG_STATE_HOME`` when set, else ``~/.cache``. Mirrors
-    ``lsp_gate_state._state_dir`` so the marker never lands in the repo tree.
+    Honors ``$XDG_STATE_HOME`` when set, else ``~/.cache``. Falls back to
+    ``tempfile.gettempdir()`` when both are unavailable (e.g. sandboxed or
+    CI environments where ``Path.home()`` raises ``RuntimeError`` because the
+    running user has no home directory). Mirrors ``lsp_gate_state._state_dir``
+    so the marker never lands in the repo tree.
     """
     xdg = os.environ.get("XDG_STATE_HOME", "").strip()
-    base = Path(xdg) if xdg else Path.home() / ".cache"
+    if xdg:
+        base = Path(xdg)
+    else:
+        try:
+            base = Path.home() / ".cache"
+        except RuntimeError:
+            base = Path(tempfile.gettempdir()) / ".cache"
     return base / _STATE_SUBDIR
 
 
@@ -100,8 +110,10 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
 
     Writes a per-cwd marker the first time it warns; subsequent calls observe
     the marker and stay silent (the issue's "one-time warning instead of
-    repeated hard blocks"). Returns True when this call emitted the warning,
-    False when it was already emitted or the marker could not be written.
+    repeated hard blocks"). Returns True when this call emitted the warning
+    (regardless of whether the dedup marker was successfully persisted).
+    Returns False when the warning was already emitted this session (marker
+    exists) or when the marker existence check itself fails (OSError).
 
     Any filesystem error degrades to NOT emitting on the failed call rather than
     raising; a navigation gate must never wedge a turn (release-it.md).

--- a/scripts/hook_utilities/lsp_health.py
+++ b/scripts/hook_utilities/lsp_health.py
@@ -1,8 +1,10 @@
 """Runtime LSP-health signal for the ADR-062 LSP-first guards (fail-open).
 
-Canonical module. Plugin-distributed copy at
-``.claude/lib/hook_utilities/lsp_health.py``; run
-``python3 scripts/sync_plugin_lib.py`` to sync.
+Canonical source path: ``scripts/hook_utilities/lsp_health.py``.
+Synced distribution paths:
+``.claude/lib/hook_utilities/lsp_health.py`` and
+``src/copilot-cli/lib/hook_utilities/lsp_health.py``. Run
+``python3 scripts/sync_plugin_lib.py`` to sync the distribution copies.
 
 WHY THIS EXISTS (issue #2622)
 -----------------------------
@@ -108,22 +110,25 @@ def _marker_path(project_dir: str) -> Path:
 def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
     """Emit the LSP-down fail-open warning at most once per session. Never raises.
 
-    Writes a per-cwd marker the first time it warns; subsequent calls observe
-    the marker and stay silent (the issue's "one-time warning instead of
-    repeated hard blocks"). Returns True when this call emitted the warning
-    (regardless of whether the dedup marker was successfully persisted).
+    Claims a per-cwd marker with exclusive create before it warns; subsequent
+    calls observe the marker and stay silent (the issue's "one-time warning
+    instead of repeated hard blocks"). Returns True when this call emitted the
+    warning (regardless of whether the dedup marker was successfully persisted).
     Returns False when the warning was already emitted this session (marker
     exists).
 
     Any marker filesystem error degrades to emitting without persistence rather
     than raising; a navigation gate must never wedge a turn (release-it.md).
     """
-    marker = _marker_path(project_dir)
     try:
-        if marker.exists():
-            return False
+        marker = _marker_path(project_dir)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        with marker.open("x", encoding="utf-8") as fh:
+            fh.write("1")
+    except FileExistsError:
+        return False
     except OSError, ValueError:
-        pass
+        marker = None
 
     message = (
         f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing this "
@@ -131,14 +136,6 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
         "language server recovers."
     )
     print(message, file=sys.stderr)
-
-    try:
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text("1", encoding="utf-8")
-    except OSError, ValueError:
-        # Could not persist the marker: we already printed once, so degrade to
-        # "warned" semantics for this call but allow a future call to warn again.
-        return True
     return True
 
 

--- a/scripts/hook_utilities/lsp_health.py
+++ b/scripts/hook_utilities/lsp_health.py
@@ -95,7 +95,7 @@ def _cwd_key(project_dir: str) -> str:
     """Return a stable per-cwd key: sha256(resolved cwd) truncated to 16 hex."""
     try:
         normalized = str(Path(project_dir).resolve())
-    except (OSError, ValueError):
+    except OSError, ValueError:
         normalized = project_dir
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
 
@@ -113,17 +113,17 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
     repeated hard blocks"). Returns True when this call emitted the warning
     (regardless of whether the dedup marker was successfully persisted).
     Returns False when the warning was already emitted this session (marker
-    exists) or when the marker existence check itself fails (OSError).
+    exists).
 
-    Any filesystem error degrades to NOT emitting on the failed call rather than
-    raising; a navigation gate must never wedge a turn (release-it.md).
+    Any marker filesystem error degrades to emitting without persistence rather
+    than raising; a navigation gate must never wedge a turn (release-it.md).
     """
     marker = _marker_path(project_dir)
     try:
         if marker.exists():
             return False
-    except OSError:
-        return False
+    except OSError, ValueError:
+        pass
 
     message = (
         f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing native "
@@ -135,7 +135,7 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
     try:
         marker.parent.mkdir(parents=True, exist_ok=True)
         marker.write_text("1", encoding="utf-8")
-    except OSError:
+    except OSError, ValueError:
         # Could not persist the marker: we already printed once, so degrade to
         # "warned" semantics for this call but allow a future call to warn again.
         return True
@@ -150,6 +150,6 @@ def clear_lsp_down_marker(project_dir: str) -> bool:
     """
     try:
         _marker_path(project_dir).unlink(missing_ok=True)
-    except OSError:
+    except OSError, ValueError:
         return False
     return True

--- a/scripts/hook_utilities/lsp_health.py
+++ b/scripts/hook_utilities/lsp_health.py
@@ -1,0 +1,143 @@
+"""Runtime LSP-health signal for the ADR-062 LSP-first guards (fail-open).
+
+Canonical module. Plugin-distributed copy at
+``.claude/lib/hook_utilities/lsp_health.py``; run
+``python3 scripts/sync_plugin_lib.py`` to sync.
+
+WHY THIS EXISTS (issue #2622)
+-----------------------------
+``lsp_provider.detect_providers`` is a PURE configuration check: a language
+listed in ``.serena/project.yml`` with the serena MCP server registered counts
+as "available" even when the language server is not actually running this turn
+(ADR-062 Section 8, "configured != active"). ADR-062 Section 5 says that gap is
+handled at the tool-call boundary by fail-open. Before this module, the Read and
+grep guards only failed open on *exceptions*, a *missing provider*, or the
+*kill switch*: none of those fire when the markdown language server times out at
+startup while config still lists it. The guards then converted a degraded
+capability (no symbols) into a hard block on basic Read/Edit/Grep, and the only
+escape was a manual ``SKIP_LSP_GATE=true`` for the whole session.
+
+This module adds the missing runtime-health gate. It is NOT a live probe (no
+outbound call, no timeout, ADR-062 Section 8 preserved): it reads an EXPLICIT
+"LSP is down" signal, the same env-signal shape the guards already use for
+``SKIP_LSP_GATE`` and ``LSP_GATE_MODE``. When the signal is set, the guards
+ALLOW the tool and emit a one-time warning instead of repeatedly hard-blocking.
+
+The signal is set out-of-band by whatever observes the language-server failure
+(the session, a SessionStart probe, or the user reacting to a timeout). Keeping
+the producer separate keeps this module a thin, pure reader (clean-architecture):
+the guard depends on the signal, not on Serena internals.
+
+System of record
+----------------
+The env var ``LSP_DOWN`` is the signal's SoR. The one-time-warning marker is
+derived per-session dedup state, rebuildable by definition (deleting it only
+re-emits the warning once). The marker lives OUTSIDE the git working tree in the
+same user-scoped state dir the gate-state file uses, so it is never committed
+and never collides with repo state (mirrors ``lsp_gate_state._state_dir``).
+
+Security (CWE-22, Low): the marker path is derived from a sha256 of the resolved
+cwd plus a fixed prefix, never from tool input, so there is no path-traversal
+surface. Tampering with the marker only changes whether one advisory line is
+printed; it is not a security boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+# Env signal: the explicit "the LSP runtime is down/uninitialized" flag. Mirrors
+# the truthy parsing of SKIP_LSP_GATE (case-insensitive ``true``/``1``/``yes``).
+LSP_DOWN_ENV = "LSP_DOWN"
+
+_TRUTHY = frozenset({"true", "1", "yes", "on"})
+
+# State subdir for the one-time-warning marker. Same base dir scheme as
+# lsp_gate_state so plugin state and gate state share a parent but distinct files.
+_STATE_SUBDIR = "ai-agents-lsp-gate"
+
+
+def lsp_runtime_down() -> bool:
+    """Return True when an explicit LSP-down signal is set for this session.
+
+    Pure read of the ``LSP_DOWN`` env var (no live probe, ADR-062 Section 8).
+    Truthy values: ``true``/``1``/``yes``/``on`` (case-insensitive). Any other
+    value, or an unset var, returns False (the guards enforce as normal).
+    """
+    return os.environ.get(LSP_DOWN_ENV, "").strip().lower() in _TRUTHY
+
+
+def _state_dir() -> Path:
+    """Return the user-scoped state directory, outside the git working tree.
+
+    Honors ``$XDG_STATE_HOME`` when set, else ``~/.cache``. Mirrors
+    ``lsp_gate_state._state_dir`` so the marker never lands in the repo tree.
+    """
+    xdg = os.environ.get("XDG_STATE_HOME", "").strip()
+    base = Path(xdg) if xdg else Path.home() / ".cache"
+    return base / _STATE_SUBDIR
+
+
+def _cwd_key(project_dir: str) -> str:
+    """Return a stable per-cwd key: sha256(resolved cwd) truncated to 16 hex."""
+    try:
+        normalized = str(Path(project_dir).resolve())
+    except (OSError, ValueError):
+        normalized = project_dir
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def _marker_path(project_dir: str) -> Path:
+    """Return the absolute one-time-warning marker path for ``project_dir``."""
+    return _state_dir() / f"lsp-down-warned-{_cwd_key(project_dir)}"
+
+
+def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
+    """Emit the LSP-down fail-open warning at most once per session. Never raises.
+
+    Writes a per-cwd marker the first time it warns; subsequent calls observe
+    the marker and stay silent (the issue's "one-time warning instead of
+    repeated hard blocks"). Returns True when this call emitted the warning,
+    False when it was already emitted or the marker could not be written.
+
+    Any filesystem error degrades to NOT emitting on the failed call rather than
+    raising; a navigation gate must never wedge a turn (release-it.md).
+    """
+    marker = _marker_path(project_dir)
+    try:
+        if marker.exists():
+            return False
+    except OSError:
+        return False
+
+    message = (
+        f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing native "
+        "tools (Read/Edit/Grep). LSP-first enforcement is paused until the "
+        "language server recovers."
+    )
+    print(message, file=sys.stderr)
+
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("1", encoding="utf-8")
+    except OSError:
+        # Could not persist the marker: we already printed once, so degrade to
+        # "warned" semantics for this call but allow a future call to warn again.
+        return True
+    return True
+
+
+def clear_lsp_down_marker(project_dir: str) -> bool:
+    """Remove the one-time-warning marker for ``project_dir``. Idempotent.
+
+    Called by the SessionStart reset so a fresh session warns again if the LSP
+    is still down. Returns False only on a filesystem error other than missing.
+    """
+    try:
+        _marker_path(project_dir).unlink(missing_ok=True)
+    except OSError:
+        return False
+    return True

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.200",
+  "version": "0.5.201",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
@@ -244,6 +244,7 @@ def _original_main(stdin_bytes):
     from hook_utilities import get_project_directory  # noqa: E402
     from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
     from hook_utilities.lsp_gate_state import is_gated_target, record_read  # noqa: E402
+    from hook_utilities.lsp_health import lsp_runtime_down  # noqa: E402
     from hook_utilities.lsp_provider import SYMBOLS_OVERVIEW, detect_providers  # noqa: E402
 
 
@@ -254,6 +255,13 @@ def _original_main(stdin_bytes):
 
         try:
             if os.environ.get("SKIP_LSP_GATE", "").strip().lower() == "true":
+                return 0
+
+            # Symmetric with the PreToolUse guard: when LSP_DOWN is set, reads are
+            # allowed without gating, so we must not track them either. Otherwise
+            # tier state advances during degraded mode and hard-blocks resume when
+            # the LSP recovers (issue #2622).
+            if lsp_runtime_down():
                 return 0
 
             if sys.stdin.isatty():

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_bash_grep_guard__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_bash_grep_guard__Bash_f620ca.py
@@ -283,6 +283,10 @@ def _original_main(stdin_bytes):
 
     from hook_utilities import get_project_directory  # noqa: E402
     from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
+    from hook_utilities.lsp_health import (  # noqa: E402
+        lsp_runtime_down,
+        warn_once_lsp_down,
+    )
     from hook_utilities.lsp_provider import (  # noqa: E402
         SYMBOL_NAVIGATION,
         detect_providers,
@@ -605,6 +609,16 @@ def _original_main(stdin_bytes):
             decision = evaluate_command(command, project_dir)
             if decision is None:
                 # Not a gated grep, or no navigable target with an available LSP.
+                return 0
+
+            # Runtime fail-open (issue #2622): evaluate_command's provider check is
+            # config-only, so it still gates when the language server timed out at
+            # startup (ADR-062 Section 8, "configured != active"). If the LSP runtime
+            # is down, degrade to ALLOW with a one-time warning rather than block a
+            # grep the agent cannot replace with a (dead) symbol query (ADR-062
+            # Section 5, release-it.md graceful degradation).
+            if lsp_runtime_down():
+                warn_once_lsp_down("lsp-bash-grep-guard", project_dir)
                 return 0
 
             guidance = build_guidance(decision["symbols"], decision["target"])

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_glob_guard__Glob_181cd6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_glob_guard__Glob_181cd6.py
@@ -279,6 +279,10 @@ def _original_main(stdin_bytes):
 
     from hook_utilities import get_project_directory  # noqa: E402
     from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
+    from hook_utilities.lsp_health import (  # noqa: E402
+        lsp_runtime_down,
+        warn_once_lsp_down,
+    )
     from hook_utilities.lsp_provider import (  # noqa: E402
         EXTENSION_TO_SERENA_LANGUAGE,
         PROGRAMMING_SERENA_LANGUAGES,
@@ -460,6 +464,11 @@ def _original_main(stdin_bytes):
                 return 0
 
             pattern, symbols, providers = decision
+
+            if lsp_runtime_down():
+                warn_once_lsp_down(_HOOK_NAME, get_project_directory())
+                return 0
+
             guidance = build_guidance(pattern, symbols, providers)
             if os.environ.get("LSP_GATE_MODE", "").lower() == _WARN_MODE:
                 _emit_warn(guidance)

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_grep_guard__Grep_2589b1.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_grep_guard__Grep_2589b1.py
@@ -290,6 +290,10 @@ def _original_main(stdin_bytes):
 
     from hook_utilities import get_project_directory  # noqa: E402
     from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
+    from hook_utilities.lsp_health import (  # noqa: E402
+        lsp_runtime_down,
+        warn_once_lsp_down,
+    )
     from hook_utilities.lsp_provider import (  # noqa: E402
         PROVIDERS,
         SYMBOL_NAVIGATION,
@@ -498,6 +502,11 @@ def _original_main(stdin_bytes):
                 return 0
 
             symbols, providers = decision
+
+            if lsp_runtime_down():
+                warn_once_lsp_down(_HOOK_NAME, get_project_directory())
+                return 0
+
             guidance = build_guidance(symbols, providers)
             if os.environ.get("LSP_GATE_MODE", "").lower() == _WARN_MODE:
                 _emit_warn(guidance)

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
@@ -311,6 +311,10 @@ def _original_main(stdin_bytes):
 
     from hook_utilities import get_project_directory  # noqa: E402
     from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
+    from hook_utilities.lsp_health import (  # noqa: E402
+        lsp_runtime_down,
+        warn_once_lsp_down,
+    )
     from hook_utilities.lsp_provider import (  # noqa: E402
         SYMBOLS_OVERVIEW,
         configured_languages,
@@ -494,6 +498,16 @@ def _original_main(stdin_bytes):
                     "LSP pre-delegation guard: no provider available, allowing",
                     file=sys.stderr,
                 )
+                return 0
+
+            # Runtime fail-open (issue #2622): provider_available is config-only, so
+            # it still reports a provider when the language server timed out at
+            # startup (ADR-062 Section 8, "configured != active"). With the LSP down,
+            # the orchestrator cannot pre-resolve symbol context, so blocking the
+            # delegation just wedges the turn. Allow it with a one-time warning
+            # (ADR-062 Section 5, release-it.md graceful degradation).
+            if lsp_runtime_down():
+                warn_once_lsp_down("lsp-pre-delegation-guard", project_dir)
                 return 0
 
             # Mode (ADR-062 Section 6): warn never blocks.

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
@@ -311,6 +311,10 @@ def _original_main(stdin_bytes):
 
     from hook_utilities import get_project_directory  # noqa: E402
     from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
+    from hook_utilities.lsp_health import (  # noqa: E402
+        lsp_runtime_down,
+        warn_once_lsp_down,
+    )
     from hook_utilities.lsp_provider import (  # noqa: E402
         SYMBOLS_OVERVIEW,
         configured_languages,
@@ -494,6 +498,16 @@ def _original_main(stdin_bytes):
                     "LSP pre-delegation guard: no provider available, allowing",
                     file=sys.stderr,
                 )
+                return 0
+
+            # Runtime fail-open (issue #2622): provider_available is config-only, so
+            # it still reports a provider when the language server timed out at
+            # startup (ADR-062 Section 8, "configured != active"). With the LSP down,
+            # the orchestrator cannot pre-resolve symbol context, so blocking the
+            # delegation just wedges the turn. Allow it with a one-time warning
+            # (ADR-062 Section 5, release-it.md graceful degradation).
+            if lsp_runtime_down():
+                warn_once_lsp_down("lsp-pre-delegation-guard", project_dir)
                 return 0
 
             # Mode (ADR-062 Section 6): warn never blocks.

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
@@ -308,6 +308,10 @@ def _original_main(stdin_bytes):
         read_state,
     )
     from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
+    from hook_utilities.lsp_health import (  # noqa: E402
+        lsp_runtime_down,
+        warn_once_lsp_down,
+    )
 
     _SKIP_ENV = "SKIP_LSP_GATE"
     _MODE_ENV = "LSP_GATE_MODE"
@@ -406,6 +410,16 @@ def _original_main(stdin_bytes):
         providers = detect_providers(file_path, SYMBOLS_OVERVIEW, project_dir)
         if not providers:
             _note(f"no overview provider, allow: {file_path}")
+            return 0, None
+
+        # Runtime fail-open (issue #2622): detect_providers is config-only, so it
+        # still reports "available" when the language server timed out at startup
+        # (ADR-062 Section 8, "configured != active"). If the LSP runtime is down,
+        # degrade to ALLOW with a one-time warning rather than hard-block native
+        # Read/Edit/Grep (ADR-062 Section 5, release-it.md graceful degradation).
+        if lsp_runtime_down():
+            warn_once_lsp_down("lsp-read-guard", project_dir)
+            _note(f"lsp runtime down, allow: {file_path}")
             return 0, None
 
         state = read_state(project_dir)

--- a/src/copilot-cli/hooks/SessionStart/invoke_lsp_session_reset.py
+++ b/src/copilot-cli/hooks/SessionStart/invoke_lsp_session_reset.py
@@ -89,7 +89,10 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     # Fail-open: SessionStart must never block session startup.
     sys.exit(0)
 if _lib_dir not in sys.path:
@@ -114,7 +117,14 @@ def main() -> int:
         # would reset a different state file than the one guards actually use.
         project_dir = get_project_directory()
 
-        ok = reset_state(project_dir)
+        try:
+            ok = reset_state(project_dir)
+        except Exception as exc:  # noqa: BLE001 - marker reset still must run.
+            ok = False
+            print(
+                f"lsp-session-reset state error: {type(exc).__name__} - {exc}",
+                file=sys.stderr,
+            )
         marker_ok = clear_lsp_down_marker(project_dir)
         mode = os.environ.get("LSP_GATE_MODE", "block")
         print(

--- a/src/copilot-cli/hooks/SessionStart/invoke_lsp_session_reset.py
+++ b/src/copilot-cli/hooks/SessionStart/invoke_lsp_session_reset.py
@@ -97,6 +97,7 @@ if _lib_dir not in sys.path:
 
 from hook_utilities import get_project_directory  # noqa: E402
 from hook_utilities.lsp_gate_state import reset_state  # noqa: E402
+from hook_utilities.lsp_health import clear_lsp_down_marker  # noqa: E402
 
 
 def main() -> int:
@@ -114,9 +115,11 @@ def main() -> int:
         project_dir = get_project_directory()
 
         ok = reset_state(project_dir)
+        marker_ok = clear_lsp_down_marker(project_dir)
         mode = os.environ.get("LSP_GATE_MODE", "block")
         print(
-            f"lsp-session-reset: reset={ok} mode={mode} key=sha256(project_dir)[:16]",
+            f"lsp-session-reset: reset={ok} marker_cleared={marker_ok} "
+            f"mode={mode} key=sha256(project_dir)[:16]",
             file=sys.stderr,
         )
         return 0

--- a/src/copilot-cli/instructions/lsp-first.instructions.md
+++ b/src/copilot-cli/instructions/lsp-first.instructions.md
@@ -58,6 +58,16 @@ re-activate it: `mcp__serena__activate_project` then
 an advisory. The guards fail open: when no LSP is reachable they allow the raw
 tool rather than block.
 
+When the language server is configured but down or uninitialized (for example a
+markdown LSP that times out at startup), `detect_providers` still reports the
+provider as available (it is a config-only check), so the read, grep, and
+pre-delegation guards would otherwise hard-block native Read/Edit/Grep. Set
+`LSP_DOWN=true` to signal the runtime is down: the guards then ALLOW native tools
+and emit a one-time warning instead of blocking, until the language server
+recovers (issue #2622). Unlike `SKIP_LSP_GATE` (which disables the gate
+entirely), `LSP_DOWN` only relaxes the gate while the LSP cannot serve symbol
+queries; it is the graceful-degradation path, not a kill switch.
+
 During a merge or rebase, the read gate bypasses automatically for issue #2454.
 Either of these conditions skips the gate for the in-flight file: (a)
 `MERGE_HEAD`, `rebase-merge`, or `rebase-apply` exists in the active git admin

--- a/src/copilot-cli/lib/hook_utilities/lsp_gate_state.py
+++ b/src/copilot-cli/lib/hook_utilities/lsp_gate_state.py
@@ -109,7 +109,7 @@ def _cwd_key(cwd: str) -> str:
     """
     try:
         normalized = str(Path(cwd).resolve())
-    except (OSError, ValueError):
+    except OSError, ValueError:
         normalized = cwd
     digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
     return digest[:16]
@@ -148,7 +148,7 @@ def read_state(cwd: str) -> dict:
     try:
         raw = path.read_text(encoding="utf-8")
         data = json.loads(raw)
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return default
     if not isinstance(data, dict):
         return default
@@ -178,7 +178,7 @@ def _coerce_int(value: object) -> int:
         return 0
     try:
         result = int(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return 0
     return result if result >= 0 else 0
 
@@ -258,7 +258,7 @@ def _resolve_git_dir(project_dir: str) -> Path | None:
         if not git_path.is_file():
             return None
         content = git_path.read_text(encoding="utf-8").strip()
-    except (OSError, UnicodeError, ValueError):
+    except OSError, UnicodeError, ValueError:
         return None
 
     if not content.startswith("gitdir:"):
@@ -272,7 +272,7 @@ def _resolve_git_dir(project_dir: str) -> Path | None:
         git_dir = git_path.parent / git_dir
     try:
         return git_dir.resolve()
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return None
 
 
@@ -300,7 +300,7 @@ def _merge_in_progress(project_dir: str) -> bool:
         for marker in ("MERGE_HEAD", "rebase-merge", "rebase-apply"):
             if (git_dir / marker).exists():
                 return True
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return False
     return False
 
@@ -324,7 +324,7 @@ def _has_conflict_markers(file_path: str) -> bool:
     try:
         with open(file_path, "rb") as fh:
             raw = fh.read(_CONFLICT_MARKER_SCAN_BYTES)
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return False
     try:
         text = raw.decode("utf-8", errors="strict")
@@ -359,7 +359,7 @@ def is_gated_target(file_path: str, project_dir: str) -> bool:
         if not candidate.is_absolute():
             candidate = root / candidate
         resolved = candidate.resolve()
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return False
 
     # Out-of-repo targets are never gated.
@@ -373,7 +373,7 @@ def is_gated_target(file_path: str, project_dir: str) -> bool:
             tmp_root = Path(tmpdir).resolve()
             if tmp_root == resolved or tmp_root in resolved.parents:
                 return False
-        except (OSError, ValueError):
+        except OSError, ValueError:
             return False
 
     # Dotfiles and dot-directory members (.serena/, .git/, .agents/, ...) are
@@ -412,7 +412,7 @@ def normalize_path(file_path: str, cwd: str) -> str:
         if not candidate.is_absolute():
             candidate = Path(cwd) / candidate
         return str(candidate.resolve())
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return file_path
 
 

--- a/src/copilot-cli/lib/hook_utilities/lsp_gate_state.py
+++ b/src/copilot-cli/lib/hook_utilities/lsp_gate_state.py
@@ -70,6 +70,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import tempfile
 from pathlib import Path
 
 # Gate thresholds (ADR-062 Section 3; canonical names the guards consume).
@@ -83,10 +84,19 @@ _STATE_SUBDIR = "ai-agents-lsp-gate"
 def _state_dir() -> Path:
     """Return the user-scoped state directory, outside the git working tree.
 
-    Honors ``$XDG_STATE_HOME`` when set, else ``~/.cache``. Never the repo tree.
+    Honors ``$XDG_STATE_HOME`` when set, else ``~/.cache``. Falls back to
+    ``tempfile.gettempdir()`` when both are unavailable (e.g. sandboxed or
+    CI environments where ``Path.home()`` raises ``RuntimeError`` because the
+    running user has no home directory). Never the repo tree.
     """
     xdg = os.environ.get("XDG_STATE_HOME", "").strip()
-    base = Path(xdg) if xdg else Path.home() / ".cache"
+    if xdg:
+        base = Path(xdg)
+    else:
+        try:
+            base = Path.home() / ".cache"
+        except RuntimeError:
+            base = Path(tempfile.gettempdir()) / ".cache"
     return base / _STATE_SUBDIR
 
 

--- a/src/copilot-cli/lib/hook_utilities/lsp_health.py
+++ b/src/copilot-cli/lib/hook_utilities/lsp_health.py
@@ -126,8 +126,8 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
         pass
 
     message = (
-        f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing native "
-        "tools (Read/Edit/Grep). LSP-first enforcement is paused until the "
+        f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing this "
+        "operation to continue. LSP-first enforcement is paused until the "
         "language server recovers."
     )
     print(message, file=sys.stderr)

--- a/src/copilot-cli/lib/hook_utilities/lsp_health.py
+++ b/src/copilot-cli/lib/hook_utilities/lsp_health.py
@@ -1,0 +1,155 @@
+"""Canonical: scripts/hook_utilities/lsp_health.py. Sync via scripts/sync_plugin_lib.py.
+
+Canonical module. Plugin-distributed copy at
+``.claude/lib/hook_utilities/lsp_health.py``; run
+``python3 scripts/sync_plugin_lib.py`` to sync.
+
+WHY THIS EXISTS (issue #2622)
+-----------------------------
+``lsp_provider.detect_providers`` is a PURE configuration check: a language
+listed in ``.serena/project.yml`` with the serena MCP server registered counts
+as "available" even when the language server is not actually running this turn
+(ADR-062 Section 8, "configured != active"). ADR-062 Section 5 says that gap is
+handled at the tool-call boundary by fail-open. Before this module, the Read and
+grep guards only failed open on *exceptions*, a *missing provider*, or the
+*kill switch*: none of those fire when the markdown language server times out at
+startup while config still lists it. The guards then converted a degraded
+capability (no symbols) into a hard block on basic Read/Edit/Grep, and the only
+escape was a manual ``SKIP_LSP_GATE=true`` for the whole session.
+
+This module adds the missing runtime-health gate. It is NOT a live probe (no
+outbound call, no timeout, ADR-062 Section 8 preserved): it reads an EXPLICIT
+"LSP is down" signal, the same env-signal shape the guards already use for
+``SKIP_LSP_GATE`` and ``LSP_GATE_MODE``. When the signal is set, the guards
+ALLOW the tool and emit a one-time warning instead of repeatedly hard-blocking.
+
+The signal is set out-of-band by whatever observes the language-server failure
+(the session, a SessionStart probe, or the user reacting to a timeout). Keeping
+the producer separate keeps this module a thin, pure reader (clean-architecture):
+the guard depends on the signal, not on Serena internals.
+
+System of record
+----------------
+The env var ``LSP_DOWN`` is the signal's SoR. The one-time-warning marker is
+derived per-session dedup state, rebuildable by definition (deleting it only
+re-emits the warning once). The marker lives OUTSIDE the git working tree in the
+same user-scoped state dir the gate-state file uses, so it is never committed
+and never collides with repo state (mirrors ``lsp_gate_state._state_dir``).
+
+Security (CWE-22, Low): the marker path is derived from a sha256 of the resolved
+cwd plus a fixed prefix, never from tool input, so there is no path-traversal
+surface. Tampering with the marker only changes whether one advisory line is
+printed; it is not a security boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Env signal: the explicit "the LSP runtime is down/uninitialized" flag. Mirrors
+# the truthy parsing of SKIP_LSP_GATE (case-insensitive ``true``/``1``/``yes``).
+LSP_DOWN_ENV = "LSP_DOWN"
+
+_TRUTHY = frozenset({"true", "1", "yes", "on"})
+
+# State subdir for the one-time-warning marker. Same base dir scheme as
+# lsp_gate_state so plugin state and gate state share a parent but distinct files.
+_STATE_SUBDIR = "ai-agents-lsp-gate"
+
+
+def lsp_runtime_down() -> bool:
+    """Return True when an explicit LSP-down signal is set for this session.
+
+    Pure read of the ``LSP_DOWN`` env var (no live probe, ADR-062 Section 8).
+    Truthy values: ``true``/``1``/``yes``/``on`` (case-insensitive). Any other
+    value, or an unset var, returns False (the guards enforce as normal).
+    """
+    return os.environ.get(LSP_DOWN_ENV, "").strip().lower() in _TRUTHY
+
+
+def _state_dir() -> Path:
+    """Return the user-scoped state directory, outside the git working tree.
+
+    Honors ``$XDG_STATE_HOME`` when set, else ``~/.cache``. Falls back to
+    ``tempfile.gettempdir()`` when both are unavailable (e.g. sandboxed or
+    CI environments where ``Path.home()`` raises ``RuntimeError`` because the
+    running user has no home directory). Mirrors ``lsp_gate_state._state_dir``
+    so the marker never lands in the repo tree.
+    """
+    xdg = os.environ.get("XDG_STATE_HOME", "").strip()
+    if xdg:
+        base = Path(xdg)
+    else:
+        try:
+            base = Path.home() / ".cache"
+        except RuntimeError:
+            base = Path(tempfile.gettempdir()) / ".cache"
+    return base / _STATE_SUBDIR
+
+
+def _cwd_key(project_dir: str) -> str:
+    """Return a stable per-cwd key: sha256(resolved cwd) truncated to 16 hex."""
+    try:
+        normalized = str(Path(project_dir).resolve())
+    except (OSError, ValueError):
+        normalized = project_dir
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def _marker_path(project_dir: str) -> Path:
+    """Return the absolute one-time-warning marker path for ``project_dir``."""
+    return _state_dir() / f"lsp-down-warned-{_cwd_key(project_dir)}"
+
+
+def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
+    """Emit the LSP-down fail-open warning at most once per session. Never raises.
+
+    Writes a per-cwd marker the first time it warns; subsequent calls observe
+    the marker and stay silent (the issue's "one-time warning instead of
+    repeated hard blocks"). Returns True when this call emitted the warning
+    (regardless of whether the dedup marker was successfully persisted).
+    Returns False when the warning was already emitted this session (marker
+    exists) or when the marker existence check itself fails (OSError).
+
+    Any filesystem error degrades to NOT emitting on the failed call rather than
+    raising; a navigation gate must never wedge a turn (release-it.md).
+    """
+    marker = _marker_path(project_dir)
+    try:
+        if marker.exists():
+            return False
+    except OSError:
+        return False
+
+    message = (
+        f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing native "
+        "tools (Read/Edit/Grep). LSP-first enforcement is paused until the "
+        "language server recovers."
+    )
+    print(message, file=sys.stderr)
+
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("1", encoding="utf-8")
+    except OSError:
+        # Could not persist the marker: we already printed once, so degrade to
+        # "warned" semantics for this call but allow a future call to warn again.
+        return True
+    return True
+
+
+def clear_lsp_down_marker(project_dir: str) -> bool:
+    """Remove the one-time-warning marker for ``project_dir``. Idempotent.
+
+    Called by the SessionStart reset so a fresh session warns again if the LSP
+    is still down. Returns False only on a filesystem error other than missing.
+    """
+    try:
+        _marker_path(project_dir).unlink(missing_ok=True)
+    except OSError:
+        return False
+    return True

--- a/src/copilot-cli/lib/hook_utilities/lsp_health.py
+++ b/src/copilot-cli/lib/hook_utilities/lsp_health.py
@@ -1,7 +1,10 @@
 """Canonical: scripts/hook_utilities/lsp_health.py. Sync via scripts/sync_plugin_lib.py.
 
-Synced copy. Canonical source path: ``scripts/hook_utilities/lsp_health.py``.
-Run ``python3 scripts/sync_plugin_lib.py`` to update this distribution copy.
+Canonical source path: ``scripts/hook_utilities/lsp_health.py``.
+Synced distribution paths:
+``.claude/lib/hook_utilities/lsp_health.py`` and
+``src/copilot-cli/lib/hook_utilities/lsp_health.py``. Run
+``python3 scripts/sync_plugin_lib.py`` to sync the distribution copies.
 
 WHY THIS EXISTS (issue #2622)
 -----------------------------
@@ -107,22 +110,25 @@ def _marker_path(project_dir: str) -> Path:
 def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
     """Emit the LSP-down fail-open warning at most once per session. Never raises.
 
-    Writes a per-cwd marker the first time it warns; subsequent calls observe
-    the marker and stay silent (the issue's "one-time warning instead of
-    repeated hard blocks"). Returns True when this call emitted the warning
-    (regardless of whether the dedup marker was successfully persisted).
+    Claims a per-cwd marker with exclusive create before it warns; subsequent
+    calls observe the marker and stay silent (the issue's "one-time warning
+    instead of repeated hard blocks"). Returns True when this call emitted the
+    warning (regardless of whether the dedup marker was successfully persisted).
     Returns False when the warning was already emitted this session (marker
     exists).
 
     Any marker filesystem error degrades to emitting without persistence rather
     than raising; a navigation gate must never wedge a turn (release-it.md).
     """
-    marker = _marker_path(project_dir)
     try:
-        if marker.exists():
-            return False
+        marker = _marker_path(project_dir)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        with marker.open("x", encoding="utf-8") as fh:
+            fh.write("1")
+    except FileExistsError:
+        return False
     except OSError, ValueError:
-        pass
+        marker = None
 
     message = (
         f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing this "
@@ -130,14 +136,6 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
         "language server recovers."
     )
     print(message, file=sys.stderr)
-
-    try:
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text("1", encoding="utf-8")
-    except OSError, ValueError:
-        # Could not persist the marker: we already printed once, so degrade to
-        # "warned" semantics for this call but allow a future call to warn again.
-        return True
     return True
 
 

--- a/src/copilot-cli/lib/hook_utilities/lsp_health.py
+++ b/src/copilot-cli/lib/hook_utilities/lsp_health.py
@@ -1,8 +1,7 @@
 """Canonical: scripts/hook_utilities/lsp_health.py. Sync via scripts/sync_plugin_lib.py.
 
-Canonical module. Plugin-distributed copy at
-``.claude/lib/hook_utilities/lsp_health.py``; run
-``python3 scripts/sync_plugin_lib.py`` to sync.
+Synced copy. Canonical source path: ``scripts/hook_utilities/lsp_health.py``.
+Run ``python3 scripts/sync_plugin_lib.py`` to update this distribution copy.
 
 WHY THIS EXISTS (issue #2622)
 -----------------------------

--- a/src/copilot-cli/lib/hook_utilities/lsp_health.py
+++ b/src/copilot-cli/lib/hook_utilities/lsp_health.py
@@ -95,7 +95,7 @@ def _cwd_key(project_dir: str) -> str:
     """Return a stable per-cwd key: sha256(resolved cwd) truncated to 16 hex."""
     try:
         normalized = str(Path(project_dir).resolve())
-    except (OSError, ValueError):
+    except OSError, ValueError:
         normalized = project_dir
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
 
@@ -113,17 +113,17 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
     repeated hard blocks"). Returns True when this call emitted the warning
     (regardless of whether the dedup marker was successfully persisted).
     Returns False when the warning was already emitted this session (marker
-    exists) or when the marker existence check itself fails (OSError).
+    exists).
 
-    Any filesystem error degrades to NOT emitting on the failed call rather than
-    raising; a navigation gate must never wedge a turn (release-it.md).
+    Any marker filesystem error degrades to emitting without persistence rather
+    than raising; a navigation gate must never wedge a turn (release-it.md).
     """
     marker = _marker_path(project_dir)
     try:
         if marker.exists():
             return False
-    except OSError:
-        return False
+    except OSError, ValueError:
+        pass
 
     message = (
         f"{guard_name}: LSP runtime is down ({LSP_DOWN_ENV} set); allowing native "
@@ -135,7 +135,7 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
     try:
         marker.parent.mkdir(parents=True, exist_ok=True)
         marker.write_text("1", encoding="utf-8")
-    except OSError:
+    except OSError, ValueError:
         # Could not persist the marker: we already printed once, so degrade to
         # "warned" semantics for this call but allow a future call to warn again.
         return True
@@ -150,6 +150,6 @@ def clear_lsp_down_marker(project_dir: str) -> bool:
     """
     try:
         _marker_path(project_dir).unlink(missing_ok=True)
-    except OSError:
+    except OSError, ValueError:
         return False
     return True

--- a/tests/hooks/test_invoke_lsp_bash_grep_guard.py
+++ b/tests/hooks/test_invoke_lsp_bash_grep_guard.py
@@ -321,6 +321,53 @@ class TestMainBlockAndWarn:
         assert guard.main() == 2
 
 
+class TestMainLspRuntimeDownFailOpen:
+    """LSP_DOWN makes a would-be-blocked grep ALLOW with a one-time warning.
+
+    detect_providers is config-only, so a grep on a configured language still
+    gates when the language server has timed out. With the LSP-down signal set,
+    the grep gate degrades to ALLOW (issue #2622, ADR-062 Section 5).
+
+    The block decision is forced via a patched ``evaluate_command`` so the gate
+    outcome is deterministic regardless of the host MCP config (whether a serena
+    provider is "configured" varies by environment; the gate-vs-allow split is
+    not what this test exercises, the LSP-down fail-open is).
+    """
+
+    _DECISION = {"symbols": ["parseConfig"], "target": "src/app.py"}
+
+    @pytest.fixture(autouse=True)
+    def _isolated(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        monkeypatch.delenv("LSP_GATE_MODE", raising=False)
+        monkeypatch.delenv("LSP_DOWN", raising=False)
+        monkeypatch.delenv("SKIP_LSP_GATE", raising=False)
+
+    @patch.object(guard, "skip_if_consumer_repo", return_value=False)
+    @patch.object(guard, "get_project_directory", return_value=str(REPO_ROOT))
+    @patch.object(guard, "evaluate_command")
+    def test_blocking_grep_allows_when_lsp_down(
+        self, mock_eval, _mock_dir, _mock_skip, mock_stdin, monkeypatch, capsys
+    ):
+        mock_eval.return_value = self._DECISION
+        monkeypatch.setenv("LSP_DOWN", "true")
+        mock_stdin(_bash_payload(_BLOCKING_CMD))
+        assert guard.main() == 0
+        assert "LSP runtime is down" in capsys.readouterr().err
+
+    @patch.object(guard, "skip_if_consumer_repo", return_value=False)
+    @patch.object(guard, "get_project_directory", return_value=str(REPO_ROOT))
+    @patch.object(guard, "evaluate_command")
+    def test_lsp_up_still_blocks(
+        self, mock_eval, _mock_dir, _mock_skip, mock_stdin, monkeypatch
+    ):
+        # Negative control: LSP_DOWN unset, the gated grep still blocks.
+        mock_eval.return_value = self._DECISION
+        monkeypatch.delenv("LSP_DOWN", raising=False)
+        mock_stdin(_bash_payload(_BLOCKING_CMD))
+        assert guard.main() == 2
+
+
 class TestMainAllowPaths:
     @patch.object(guard, "get_project_directory", return_value=str(REPO_ROOT))
     def test_allows_git_grep(self, _mock_dir, mock_stdin: Callable[[str], None]):

--- a/tests/hooks/test_invoke_lsp_glob_guard.py
+++ b/tests/hooks/test_invoke_lsp_glob_guard.py
@@ -51,6 +51,7 @@ def _glob_input(pattern: str) -> str:
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure env toggles do not leak between tests."""
     monkeypatch.delenv("SKIP_LSP_GATE", raising=False)
+    monkeypatch.delenv("LSP_DOWN", raising=False)
     monkeypatch.delenv("LSP_GATE_MODE", raising=False)
 
 
@@ -201,9 +202,7 @@ class TestBuildGuidance:
         assert "find_symbol" in text
 
     def test_no_dashes(self):
-        text = guard.build_guidance(
-            "*UserService*", ["UserService"], ["serena", "native_lsp"]
-        )
+        text = guard.build_guidance("*UserService*", ["UserService"], ["serena", "native_lsp"])
         assert chr(0x2014) not in text  # em dash
         assert chr(0x2013) not in text  # en dash
 
@@ -260,6 +259,24 @@ class TestFailOpen:
         monkeypatch.setenv("SKIP_LSP_GATE", "true")
         mock_stdin(_glob_input("*UserService*"))
         assert guard.main() == 0
+
+    @patch("invoke_lsp_glob_guard.get_project_directory", return_value="/project")
+    @patch("invoke_lsp_glob_guard.detect_providers", return_value=["serena"])
+    def test_lsp_down_allows_and_warns(
+        self,
+        _mock_detect,
+        _mock_dir,
+        mock_stdin: Callable[[str], None],
+        monkeypatch: pytest.MonkeyPatch,
+        capsys,
+    ):
+        monkeypatch.setenv("LSP_DOWN", "true")
+        warn_once = MagicMock(return_value=True)
+        monkeypatch.setattr(guard, "warn_once_lsp_down", warn_once)
+        mock_stdin(_glob_input("*UserService*"))
+        assert guard.main() == 0
+        warn_once.assert_called_once_with("lsp-glob-guard", "/project")
+        assert capsys.readouterr().out == ""
 
     def test_consumer_repo_skips(
         self, mock_stdin: Callable[[str], None], monkeypatch: pytest.MonkeyPatch
@@ -371,9 +388,7 @@ class TestWarnMode:
 
 
 class TestRealLibWiring:
-    def test_real_detect_providers_blocks_bare_symbol(
-        self, mock_stdin: Callable[[str], None]
-    ):
+    def test_real_detect_providers_blocks_bare_symbol(self, mock_stdin: Callable[[str], None]):
         """Without mocking the lib, a bare symbol glob blocks in this repo.
 
         This repo configures python in .serena/project.yml and registers the

--- a/tests/hooks/test_invoke_lsp_grep_guard.py
+++ b/tests/hooks/test_invoke_lsp_grep_guard.py
@@ -54,6 +54,7 @@ def _grep_input(pattern: str, *, path: str = "", glob: str = "") -> str:
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure env toggles do not leak between tests."""
     monkeypatch.delenv("SKIP_LSP_GATE", raising=False)
+    monkeypatch.delenv("LSP_DOWN", raising=False)
     monkeypatch.delenv("LSP_GATE_MODE", raising=False)
 
 
@@ -128,9 +129,7 @@ class TestFindCodeSymbols:
         assert guard.find_code_symbols(" SessionManager | ") == ["SessionManager"]
 
     def test_snake_case_function_symbol(self):
-        assert guard.find_code_symbols("find_referencing_symbols") == [
-            "find_referencing_symbols"
-        ]
+        assert guard.find_code_symbols("find_referencing_symbols") == ["find_referencing_symbols"]
 
 
 # ---------------------------------------------------------------------------
@@ -205,9 +204,7 @@ class TestFailOpen:
         assert guard.main() == 0
 
     def test_wrong_tool_name_allows(self, mock_stdin: Callable[[str], None]):
-        mock_stdin(
-            json.dumps({"tool_name": "Bash", "tool_input": {"command": "ls"}})
-        )
+        mock_stdin(json.dumps({"tool_name": "Bash", "tool_input": {"command": "ls"}}))
         assert guard.main() == 0
 
     def test_non_dict_tool_input_allows(self, mock_stdin: Callable[[str], None]):
@@ -243,6 +240,24 @@ class TestFailOpen:
         monkeypatch.setenv("SKIP_LSP_GATE", "TRUE")
         mock_stdin(_grep_input("SessionManager", glob="*.py"))
         assert guard.main() == 0
+
+    @patch("invoke_lsp_grep_guard.get_project_directory", return_value="/project")
+    @patch("invoke_lsp_grep_guard.detect_providers", return_value=["serena"])
+    def test_lsp_down_allows_and_warns(
+        self,
+        _mock_detect,
+        _mock_dir,
+        mock_stdin: Callable[[str], None],
+        monkeypatch: pytest.MonkeyPatch,
+        capsys,
+    ):
+        monkeypatch.setenv("LSP_DOWN", "true")
+        warn_once = MagicMock(return_value=True)
+        monkeypatch.setattr(guard, "warn_once_lsp_down", warn_once)
+        mock_stdin(_grep_input("SessionManager", glob="*.py"))
+        assert guard.main() == 0
+        warn_once.assert_called_once_with("lsp-grep-guard", "/project")
+        assert capsys.readouterr().out == ""
 
     def test_consumer_repo_skips(
         self, mock_stdin: Callable[[str], None], monkeypatch: pytest.MonkeyPatch
@@ -375,9 +390,7 @@ class TestResolveInRepo:
         assert guard._resolve_in_repo("/tmp/elsewhere") is None
 
     def test_parent_escape_returns_none(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setattr(
-            guard, "get_project_directory", lambda: str(HOOK_DIR.parent)
-        )
+        monkeypatch.setattr(guard, "get_project_directory", lambda: str(HOOK_DIR.parent))
         assert guard._resolve_in_repo("../../../../etc") is None
 
 
@@ -418,9 +431,7 @@ class TestRepoWideGating:
         # get_project_directory is left real so `scripts/` resolves on disk and
         # passes the is_dir() directory-scope check.
         repo_root = Path(__file__).resolve().parents[2]
-        with patch(
-            "invoke_lsp_grep_guard.get_project_directory", return_value=str(repo_root)
-        ):
+        with patch("invoke_lsp_grep_guard.get_project_directory", return_value=str(repo_root)):
             mock_stdin(_grep_input("SessionManager", path="scripts"))
             assert guard.main() == 2
 
@@ -499,9 +510,7 @@ class TestWarnMode:
 
 
 class TestRealLibWiring:
-    def test_real_detect_providers_blocks_py_glob(
-        self, mock_stdin: Callable[[str], None]
-    ):
+    def test_real_detect_providers_blocks_py_glob(self, mock_stdin: Callable[[str], None]):
         """Without mocking the lib, a code symbol on *.py blocks in this repo.
 
         This repo configures python in .serena/project.yml and registers the

--- a/tests/hooks/test_invoke_lsp_pre_delegation_guard_main.py
+++ b/tests/hooks/test_invoke_lsp_pre_delegation_guard_main.py
@@ -255,6 +255,53 @@ class TestMainBlock:
         assert guard.main() == 2
 
 
+class TestMainLspRuntimeDownFailOpen:
+    """LSP_DOWN turns a would-be delegation block into ALLOW + one-time warning.
+
+    provider_available is config-only (autouse stub forces True here). When the
+    language server is actually down, the orchestrator cannot pre-resolve LSP
+    context, so blocking the delegation is pointless; allow it (issue #2622,
+    ADR-062 Section 5).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_marker(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+        monkeypatch.delenv("LSP_DOWN", raising=False)
+
+    def test_block_becomes_allow_when_lsp_down(
+        self, monkeypatch, mock_stdin: Callable[[str], None], capsys
+    ):
+        monkeypatch.setenv("LSP_DOWN", "true")
+        mock_stdin(
+            _stdin_json(
+                tool_name="Agent",
+                tool_input={
+                    "subagent_type": "implementer",
+                    "prompt": LONG_PROMPT_NO_CONTEXT,
+                },
+            )
+        )
+        assert guard.main() == 0
+        assert "LSP runtime is down" in capsys.readouterr().err
+
+    def test_lsp_up_still_blocks(
+        self, monkeypatch, mock_stdin: Callable[[str], None]
+    ):
+        # Negative control: LSP_DOWN unset, the delegation block still fires.
+        monkeypatch.delenv("LSP_DOWN", raising=False)
+        mock_stdin(
+            _stdin_json(
+                tool_name="Agent",
+                tool_input={
+                    "subagent_type": "implementer",
+                    "prompt": LONG_PROMPT_NO_CONTEXT,
+                },
+            )
+        )
+        assert guard.main() == 2
+
+
 # ---------------------------------------------------------------------------
 # main(): warn mode (never blocks)
 # ---------------------------------------------------------------------------

--- a/tests/hooks/test_invoke_lsp_read_guard.py
+++ b/tests/hooks/test_invoke_lsp_read_guard.py
@@ -490,6 +490,74 @@ class TestEvaluateTiers:
 
 
 # ---------------------------------------------------------------------------
+# LSP runtime down: fail-open (issue #2622)
+# ---------------------------------------------------------------------------
+
+
+class TestLspRuntimeDownFailOpen:
+    """When the LSP runtime is down (LSP_DOWN set), the guard allows + warns once.
+
+    The markdown language server can time out at startup while config still lists
+    it, so detect_providers reports "available" and the guard would hard-block
+    Read/Edit/Grep. With the explicit LSP-down signal set, every block tier must
+    degrade to ALLOW with a one-time warning instead (ADR-062 Section 5).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_marker(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+
+    @patch.object(guard, "detect_providers", return_value=["serena"])
+    @patch.object(guard, "read_state")
+    def test_warmup_block_allows_when_lsp_down(
+        self, mock_state, _mock_providers, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("LSP_DOWN", "true")
+        mock_state.return_value = _state(warmup_done=False)
+        code, msg = guard.evaluate(PY_TARGET, str(REPO_ROOT))
+        assert code == 0
+        assert msg is None
+        assert "LSP runtime is down" in capsys.readouterr().err
+
+    @patch.object(guard, "detect_providers", return_value=["serena"])
+    @patch.object(guard, "read_state")
+    def test_hard_block_allows_when_lsp_down(
+        self, mock_state, _mock_providers, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("LSP_DOWN", "true")
+        mock_state.return_value = _state(
+            warmup_done=True, nav_count=0, read_files=["a.py", "b.py", "c.py"]
+        )
+        code, msg = guard.evaluate(PY_TARGET, str(REPO_ROOT))
+        assert code == 0
+        assert msg is None
+
+    @patch.object(guard, "detect_providers", return_value=["serena"])
+    @patch.object(guard, "read_state")
+    def test_warning_emitted_once_across_calls(
+        self, mock_state, _mock_providers, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("LSP_DOWN", "true")
+        mock_state.return_value = _state(warmup_done=False)
+        guard.evaluate(PY_TARGET, str(REPO_ROOT))
+        first = capsys.readouterr().err
+        guard.evaluate(PY_TARGET, str(REPO_ROOT))
+        second = capsys.readouterr().err
+        assert "LSP runtime is down" in first
+        assert "LSP runtime is down" not in second
+
+    @patch.object(guard, "detect_providers", return_value=["serena"])
+    @patch.object(guard, "read_state")
+    def test_lsp_up_still_blocks(self, mock_state, _mock_providers, monkeypatch):
+        # Negative control: with LSP_DOWN unset, the warmup tier still blocks.
+        monkeypatch.delenv("LSP_DOWN", raising=False)
+        mock_state.return_value = _state(warmup_done=False)
+        code, msg = guard.evaluate(PY_TARGET, str(REPO_ROOT))
+        assert code == 2
+        assert msg is not None
+
+
+# ---------------------------------------------------------------------------
 # main: dispatch, kill switch, fail-open paths
 # ---------------------------------------------------------------------------
 

--- a/tests/hooks/test_invoke_lsp_session_reset.py
+++ b/tests/hooks/test_invoke_lsp_session_reset.py
@@ -32,13 +32,9 @@ import runpy
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 HOOK_DIR = Path(__file__).resolve().parents[2] / ".claude" / "hooks" / "SessionStart"
 sys.path.insert(0, str(HOOK_DIR))
@@ -65,18 +61,14 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch):
 
 
 class TestKillSwitch:
-    def test_skip_lsp_gate_bypasses_reset(
-        self, monkeypatch: pytest.MonkeyPatch, capsys
-    ):
+    def test_skip_lsp_gate_bypasses_reset(self, monkeypatch: pytest.MonkeyPatch, capsys):
         monkeypatch.setenv("SKIP_LSP_GATE", "true")
         with patch(f"{MOD}.reset_state") as mock_reset:
             assert invoke_lsp_session_reset.main() == 0
         mock_reset.assert_not_called()
         assert "SKIP_LSP_GATE=true" in capsys.readouterr().err
 
-    def test_skip_lsp_gate_non_true_does_not_bypass(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
+    def test_skip_lsp_gate_non_true_does_not_bypass(self, monkeypatch: pytest.MonkeyPatch):
         # Only the exact string "true" bypasses; anything else runs the reset.
         monkeypatch.setenv("SKIP_LSP_GATE", "1")
         with patch(f"{MOD}.get_project_directory", return_value="/workspace"):
@@ -125,9 +117,7 @@ class TestResetOutcomes:
                 assert invoke_lsp_session_reset.main() == 0
         assert "reset=False" in capsys.readouterr().err
 
-    def test_warn_mode_still_runs_reset(
-        self, monkeypatch: pytest.MonkeyPatch, capsys
-    ):
+    def test_warn_mode_still_runs_reset(self, monkeypatch: pytest.MonkeyPatch, capsys):
         # warn mode affects read/grep/glob guards, not the reset itself.
         monkeypatch.setenv("LSP_GATE_MODE", "warn")
         with patch(f"{MOD}.get_project_directory", return_value="/repo"):
@@ -153,7 +143,16 @@ class TestExceptionFailOpen:
         with patch(f"{MOD}.get_project_directory", return_value="/repo"):
             with patch(f"{MOD}.reset_state", side_effect=RuntimeError("boom")):
                 assert invoke_lsp_session_reset.main() == 0
-        assert "lsp-session-reset error: RuntimeError" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert "lsp-session-reset state error: RuntimeError" in err
+        assert "marker_cleared=" in err
+
+    def test_marker_clear_runs_when_reset_state_raises(self):
+        with patch(f"{MOD}.get_project_directory", return_value="/repo"):
+            with patch(f"{MOD}.reset_state", side_effect=RuntimeError("boom")):
+                with patch(f"{MOD}.clear_lsp_down_marker", return_value=True) as mock_clear:
+                    assert invoke_lsp_session_reset.main() == 0
+        mock_clear.assert_called_once_with("/repo")
 
     def test_get_project_directory_raising_fails_open(self, capsys):
         with patch(f"{MOD}.get_project_directory", side_effect=OSError("git failed")):
@@ -167,9 +166,7 @@ class TestExceptionFailOpen:
 
 
 class TestRealReset:
-    def test_clears_existing_state_file(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path
-    ):
+    def test_clears_existing_state_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
         from hook_utilities import lsp_gate_state
 
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
@@ -184,9 +181,7 @@ class TestRealReset:
         assert invoke_lsp_session_reset.main() == 0
         assert not lsp_gate_state.state_path(project_dir).exists()
 
-    def test_idempotent_when_no_state_file(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path
-    ):
+    def test_idempotent_when_no_state_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
         monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/never/seen")
         # No file exists; reset is a no-op that still exits 0.

--- a/tests/hooks/test_lsp_gate_state.py
+++ b/tests/hooks/test_lsp_gate_state.py
@@ -70,6 +70,17 @@ class TestStatePath:
         monkeypatch.setattr(lsp_gate_state.Path, "home", classmethod(lambda cls: fake_home))
         assert ".cache/ai-agents-lsp-gate" in str(state_path(_CWD))
 
+    def test_state_dir_falls_back_when_home_raises(self, monkeypatch, tmp_path):
+        def _raise():
+            raise RuntimeError("Cannot determine home directory")
+
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        monkeypatch.setattr(lsp_gate_state.Path, "home", staticmethod(_raise))
+        monkeypatch.setattr(lsp_gate_state.tempfile, "gettempdir", lambda: str(tmp_path))
+        path = state_path(_CWD)
+        key = lsp_gate_state._cwd_key(_CWD)
+        assert str(path) == f"{tmp_path}/.cache/ai-agents-lsp-gate/lsp-gate-{key}.json"
+
     def test_distinct_cwds_distinct_files(self):
         assert state_path("/a") != state_path("/b")
 
@@ -450,4 +461,3 @@ class TestHasConflictMarkersHelper:
         target = tmp_path / "f.py"
         target.write_text("<<<<<<< HEAD\n" + ("x = 1\n" * 100), encoding="utf-8")
         assert lsp_gate_state._has_conflict_markers(str(target)) is True
-

--- a/tests/hooks/test_lsp_health.py
+++ b/tests/hooks/test_lsp_health.py
@@ -9,6 +9,7 @@ every fail-open degrade path (filesystem error never raises).
 from __future__ import annotations
 
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -76,6 +77,32 @@ class TestFailOpen:
         monkeypatch.setattr(
             lsp_health, "_state_dir", lambda: Path("/proc/nonexistent/cannot")
         )
+        emitted = lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
+        assert emitted is True
+        assert "LSP runtime is down" in capsys.readouterr().err
+
+    def test_state_dir_falls_back_when_home_raises(self, monkeypatch):
+        """_state_dir() uses tempfile.gettempdir() when XDG_STATE_HOME is absent
+        and Path.home() raises RuntimeError (sandboxed/CI/no-homedir environments).
+        """
+        def _raise() -> Path:
+            raise RuntimeError("Cannot determine home directory")
+
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", staticmethod(_raise))
+        state = lsp_health._state_dir()
+        assert str(state).startswith(tempfile.gettempdir())
+        assert state.name == lsp_health._STATE_SUBDIR
+
+    def test_warn_once_never_raises_when_home_fails(self, monkeypatch, capsys):
+        """warn_once_lsp_down() falls back gracefully when Path.home() raises
+        RuntimeError; the warning is still emitted (fail-open, never raises).
+        """
+        def _raise() -> Path:
+            raise RuntimeError("Cannot determine home directory")
+
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", staticmethod(_raise))
         emitted = lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
         assert emitted is True
         assert "LSP runtime is down" in capsys.readouterr().err

--- a/tests/hooks/test_lsp_health.py
+++ b/tests/hooks/test_lsp_health.py
@@ -73,9 +73,7 @@ class TestFailOpen:
     def test_warn_once_never_raises_on_unwritable_dir(self, monkeypatch, capsys):
         # Force the marker dir to an unwritable location: warning still prints,
         # the call reports warned, and no exception escapes.
-        monkeypatch.setattr(
-            lsp_health, "_state_dir", lambda: Path("/proc/nonexistent/cannot")
-        )
+        monkeypatch.setattr(lsp_health, "_state_dir", lambda: Path("/proc/nonexistent/cannot"))
         emitted = lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
         assert emitted is True
         assert "LSP runtime is down" in capsys.readouterr().err
@@ -84,6 +82,7 @@ class TestFailOpen:
         """_state_dir() uses tempfile.gettempdir() when XDG_STATE_HOME is absent
         and Path.home() raises RuntimeError (sandboxed/CI/no-homedir environments).
         """
+
         def _raise() -> Path:
             raise RuntimeError("Cannot determine home directory")
 
@@ -99,6 +98,7 @@ class TestFailOpen:
         """warn_once_lsp_down() falls back gracefully when Path.home() raises
         RuntimeError; the warning is still emitted (fail-open, never raises).
         """
+
         def _raise() -> Path:
             raise RuntimeError("Cannot determine home directory")
 
@@ -109,3 +109,13 @@ class TestFailOpen:
         emitted = lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
         assert emitted is True
         assert "LSP runtime is down" in capsys.readouterr().err
+
+    def test_warn_once_emits_when_marker_path_is_invalid(self, monkeypatch, capsys):
+        monkeypatch.setattr(lsp_health, "_marker_path", lambda _project_dir: Path("bad\0marker"))
+        emitted = lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
+        assert emitted is True
+        assert "LSP runtime is down" in capsys.readouterr().err
+
+    def test_clear_marker_fails_open_when_marker_path_is_invalid(self, monkeypatch):
+        monkeypatch.setattr(lsp_health, "_marker_path", lambda _project_dir: Path("bad\0marker"))
+        assert lsp_health.clear_lsp_down_marker(str(REPO_ROOT)) is False

--- a/tests/hooks/test_lsp_health.py
+++ b/tests/hooks/test_lsp_health.py
@@ -56,6 +56,14 @@ class TestWarnOnce:
         assert emitted is False
         assert capsys.readouterr().err == ""
 
+    def test_existing_marker_is_silent(self, capsys):
+        marker = lsp_health._marker_path(str(REPO_ROOT))
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("1", encoding="utf-8")
+        emitted = lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
+        assert emitted is False
+        assert capsys.readouterr().err == ""
+
     def test_clear_marker_re_enables_warning(self, capsys):
         lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
         capsys.readouterr()

--- a/tests/hooks/test_lsp_health.py
+++ b/tests/hooks/test_lsp_health.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Tests for the lsp_health runtime-down signal (issue #2622, ADR-062 fail-open).
+
+Covers the explicit ``LSP_DOWN`` env signal parse, the one-time-warning dedup
+marker (warn once per session, silent after), the SessionStart marker clear, and
+every fail-open degrade path (filesystem error never raises).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.hook_utilities import lsp_health  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the marker dir at a tmp dir and clear the env signal per test."""
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.delenv("LSP_DOWN", raising=False)
+
+
+class TestLspRuntimeDown:
+    def test_unset_is_not_down(self):
+        assert lsp_health.lsp_runtime_down() is False
+
+    @pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "on", " True "])
+    def test_truthy_values_are_down(self, monkeypatch, value):
+        monkeypatch.setenv("LSP_DOWN", value)
+        assert lsp_health.lsp_runtime_down() is True
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "", "maybe"])
+    def test_non_truthy_values_are_not_down(self, monkeypatch, value):
+        monkeypatch.setenv("LSP_DOWN", value)
+        assert lsp_health.lsp_runtime_down() is False
+
+
+class TestWarnOnce:
+    def test_first_call_warns_and_writes_marker(self, capsys):
+        emitted = lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
+        assert emitted is True
+        err = capsys.readouterr().err
+        assert "LSP runtime is down" in err
+        assert lsp_health._marker_path(str(REPO_ROOT)).exists()
+
+    def test_second_call_is_silent(self, capsys):
+        lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
+        capsys.readouterr()  # drain first warning
+        emitted = lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
+        assert emitted is False
+        assert capsys.readouterr().err == ""
+
+    def test_clear_marker_re_enables_warning(self, capsys):
+        lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
+        capsys.readouterr()
+        assert lsp_health.clear_lsp_down_marker(str(REPO_ROOT)) is True
+        emitted = lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
+        assert emitted is True
+        assert "LSP runtime is down" in capsys.readouterr().err
+
+    def test_clear_marker_is_idempotent_when_absent(self):
+        # No marker written yet; clearing must not raise and returns True.
+        assert lsp_health.clear_lsp_down_marker(str(REPO_ROOT)) is True
+
+
+class TestFailOpen:
+    def test_warn_once_never_raises_on_unwritable_dir(self, monkeypatch, capsys):
+        # Force the marker dir to an unwritable location: warning still prints,
+        # the call reports warned, and no exception escapes.
+        monkeypatch.setattr(
+            lsp_health, "_state_dir", lambda: Path("/proc/nonexistent/cannot")
+        )
+        emitted = lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
+        assert emitted is True
+        assert "LSP runtime is down" in capsys.readouterr().err

--- a/tests/hooks/test_lsp_health.py
+++ b/tests/hooks/test_lsp_health.py
@@ -9,7 +9,6 @@ every fail-open degrade path (filesystem error never raises).
 from __future__ import annotations
 
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -81,7 +80,7 @@ class TestFailOpen:
         assert emitted is True
         assert "LSP runtime is down" in capsys.readouterr().err
 
-    def test_state_dir_falls_back_when_home_raises(self, monkeypatch):
+    def test_state_dir_falls_back_when_home_raises(self, monkeypatch, tmp_path):
         """_state_dir() uses tempfile.gettempdir() when XDG_STATE_HOME is absent
         and Path.home() raises RuntimeError (sandboxed/CI/no-homedir environments).
         """
@@ -90,11 +89,13 @@ class TestFailOpen:
 
         monkeypatch.delenv("XDG_STATE_HOME", raising=False)
         monkeypatch.setattr(Path, "home", staticmethod(_raise))
+        # Route tempfile fallback to tmp_path to keep tests hermetic
+        monkeypatch.setattr(lsp_health.tempfile, "gettempdir", lambda: str(tmp_path))
         state = lsp_health._state_dir()
-        assert str(state).startswith(tempfile.gettempdir())
+        assert str(state).startswith(str(tmp_path))
         assert state.name == lsp_health._STATE_SUBDIR
 
-    def test_warn_once_never_raises_when_home_fails(self, monkeypatch, capsys):
+    def test_warn_once_never_raises_when_home_fails(self, monkeypatch, tmp_path, capsys):
         """warn_once_lsp_down() falls back gracefully when Path.home() raises
         RuntimeError; the warning is still emitted (fail-open, never raises).
         """
@@ -103,6 +104,8 @@ class TestFailOpen:
 
         monkeypatch.delenv("XDG_STATE_HOME", raising=False)
         monkeypatch.setattr(Path, "home", staticmethod(_raise))
+        # Route tempfile fallback to tmp_path to avoid stale markers from prior runs
+        monkeypatch.setattr(lsp_health.tempfile, "gettempdir", lambda: str(tmp_path))
         emitted = lsp_health.warn_once_lsp_down("lsp-read-guard", str(REPO_ROOT))
         assert emitted is True
         assert "LSP runtime is down" in capsys.readouterr().err


### PR DESCRIPTION
# fix(hooks): LSP guards fail open when the language server is down (#2622)

## Summary

The ADR-062 LSP-first guards (`invoke_lsp_read_guard.py`, `invoke_lsp_bash_grep_guard.py`, `invoke_lsp_pre_delegation_guard.py`) gate native Read/Edit/Grep on an LSP that can be down. When Serena's markdown language server timed out at startup (issue #2622), `detect_providers` still reported the language as available (it is a config-only check, ADR-062 Section 8), so the guards hard-blocked basic file operations for the whole session. The only escape was a manual `SKIP_LSP_GATE=true`.

ADR-062 Section 5 already promises fail-open at the tool-call boundary for this "configured != active" gap, but it was never wired for the runtime-down case: the read and grep guards only failed open on exceptions, a missing provider, or the kill switch. This PR wires the missing path.

## What changed

- New deep module `scripts/hook_utilities/lsp_health.py` (synced to `.claude/lib`):
  - `lsp_runtime_down()`: reads the explicit `LSP_DOWN` env signal. No live probe, so the sub-100ms budget and ADR-062 Section 8 hold.
  - `warn_once_lsp_down()`: emits one stderr warning, deduped per session via a marker file outside the git tree (so it is "one-time warning instead of repeated hard blocks", the acceptance criterion).
  - `clear_lsp_down_marker()`: for SessionStart reset.
- The three guards consult `lsp_runtime_down()` AFTER their provider check, so the relaxation fires only on a path that would otherwise block. When `LSP_DOWN` is set they ALLOW and warn once.
- Enforcement is unchanged when the LSP can serve: LSP-first stays intact. `LSP_DOWN` is the graceful-degradation signal, distinct from the `SKIP_LSP_GATE` kill switch.
- `.claude/rules/lsp-first.md` documents `LSP_DOWN` and contrasts it with `SKIP_LSP_GATE`.
- Bumped `project-toolkit` plugin version 0.5.200 to 0.5.201 (plugin source changed, #2118).

## Design notes

Reused the existing env-signal mechanism (`SKIP_LSP_GATE`, `LSP_GATE_MODE`) rather than inventing a parallel one, and the existing per-cwd state-dir scheme from `lsp_gate_state`. The signal producer (auto-set `LSP_DOWN` when the language server manager reports uninitialized) is a follow-up; this PR adds the consumer plus the manual signal. The marker dedup follows data-intensive-applications.md: `LSP_DOWN` is the SoR, the marker is rebuildable per-session dedup state.

## Testing

```text
pytest tests/hooks/test_lsp_health.py \
  tests/hooks/test_invoke_lsp_read_guard.py \
  tests/hooks/test_invoke_lsp_bash_grep_guard.py \
  tests/hooks/test_invoke_lsp_pre_delegation_guard_main.py \
  tests/hooks/test_invoke_lsp_pre_delegation_guard.py \
  tests/hooks/test_lsp_provider.py
-> 261 passed
```

Full `tests/hooks` suite: 1518 passed. Each guard has positive and negative coverage (LSP up blocks; LSP down allows and warns). TDD: RED confirmed before each implementation, GREEN after, then a mutation of the read-guard fail-open made the 3 tests fail to prove they bite, then restored. Pre-PR validation passed.

## Review needed

SECURITY/POLICY-SENSITIVE: this relaxes an ADR-062 enforcement mechanism. The security agent / architect should review the policy change (the new `LSP_DOWN` fail-open path) before merge.

Fixes #2622

🤖 Generated with [Claude Code](https://claude.com/claude-code)

