### PR TITLE
fix(github-skill): reject UNKNOWN merge state before direct merge

### DIFF
--- a/.agents/sessions/2026-06-17-session-2586-fix-2637-merge_prpy-reject-unknown.json
+++ b/.agents/sessions/2026-06-17-session-2586-fix-2637-merge_prpy-reject-unknown.json
@@ -1,0 +1,130 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2586,
+    "date": "2026-06-17",
+    "branch": "fix/2637-merge-pr-reject-unknown-state",
+    "startingCommit": "14bb688be5",
+    "objective": "fix #2637: merge_pr.py reject UNKNOWN mergeable/mergeStateStatus before direct (non --auto) merge"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena LSP server unavailable this session (markdown language server timed out at init); fell back to .serena/memories markdown per AGENTS.md fallback."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP down; followed .claude/rules/* and AGENTS.md directly as fallback."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No issue handoff for #2637; read issue body and discourse via get_issue_context.py and get_issue_comments.py."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file (session 2586)."
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Reviewed .claude/skills/github/scripts/pr/ (merge_pr.py, test_pr_merge_ready.py, run_completion_gate.py, check_pr_live_state.py)."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .claude/rules/* (universal, python, canonical-source-mirror, release-it) injected into context."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ADR-035 exit codes (3=external) and ADR-056 envelope honored in the fix."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Topical worktree memories surfaced by hook; wrote task memory issue-2637-merge-pr-reject-unknown.md."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/2637-merge-pr-reject-unknown-state off 14bb688be5"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/2637-merge-pr-reject-unknown-state"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status checked before branch creation."
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "14bb688be5"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST items populated with evidence."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Did not edit .agents/HANDOFF.md (read-only per ADR-014)."
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".serena/memories/tasks/issue-2637-merge-pr-reject-unknown.md written (Serena MCP down, markdown fallback)."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "npx markdownlint-cli2 --fix on changed md: 0 error(s). The memory file is under .serena/** (lint-excluded); no other .md changed."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Committed merge_pr.py fix + test, plus copilot mirror, on fix/2637-merge-pr-reject-unknown-state."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "pytest: 45 passed; ruff: All checks passed. Pre-push suite run before push."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Task memory written for issue #2637."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Single-issue fix; no retro warranted."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "timestamp": "2026-06-17T15:23:00Z",
+      "action": "Confirmed root cause: merge_pr.py fetched mergeable/mergeStateStatus but only checked state (MERGED/CLOSED), so it merged on mergeable=UNKNOWN. Wrote failing test TestUnknownMergeStateRejection.",
+      "evidence": "RED: pytest reported 'DID NOT RAISE SystemExit'; envelope showed state MERGED on mergeable=UNKNOWN."
+    },
+    {
+      "timestamp": "2026-06-17T15:24:00Z",
+      "action": "Added _reject_unknown_merge_state() gated on not args.auto (exit 3, ApiError), mirrored test_pr_merge_ready.py 'Merge status is being calculated'. Applied identical change to copilot-cli mirror.",
+      "evidence": "GREEN: uv run pytest tests/test_merge_pr.py -> 45 passed in 0.22s. Mutation (UNKNOWN -> MUTANT) made the 2 reject tests fail (DID NOT RAISE SystemExit); restoring -> 45 passed. ruff: All checks passed."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": []
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.200",
+  "version": "0.5.201",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.202",
+  "version": "0.5.203",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/github/scripts/pr/merge_pr.py
+++ b/.claude/skills/github/scripts/pr/merge_pr.py
@@ -221,6 +221,35 @@ def _fetch_pr_state(pr: int, repo_flag: str, output_format: str) -> dict:
     return json.loads(pr_result.stdout)
 
 
+def _reject_unknown_merge_state(pr_data: dict, pr: int, output_format: str) -> None:
+    """Reject a direct merge while GitHub is still calculating mergeability.
+
+    Issue #2637: after a base update, GitHub reports mergeable=UNKNOWN and
+    mergeStateStatus=UNKNOWN while it recalculates. The completion gate
+    (.claude/skills/github/scripts/pr/test_pr_merge_ready.py) rejects this
+    state with the reason "Merge status is being calculated" (its
+    ``_evaluate_pr_state`` appends that reason for ``mergeable == "UNKNOWN"``),
+    so a direct merge must reject it too instead of merging a PR its own gate
+    just refused. Exit code 3 (ADR-035 external/transient): the caller can
+    retry once GitHub settles. Callers that want auto-merge pass --auto, which
+    skips this check and hands the decision to GitHub's own gate.
+    """
+    mergeable = pr_data.get("mergeable") or ""
+    merge_state = pr_data.get("mergeStateStatus") or ""
+    if mergeable != "UNKNOWN" and merge_state != "UNKNOWN":
+        return
+    _emit_error(
+        f"PR #{pr} merge status is being calculated by GitHub "
+        f"(mergeable={mergeable or 'UNKNOWN'}, "
+        f"mergeStateStatus={merge_state or 'UNKNOWN'}). "
+        "Retry once it settles, or use --auto to defer to GitHub's gate.",
+        3,
+        "ApiError",
+        output_format,
+        pr,
+    )
+
+
 def _build_merge_args(args: argparse.Namespace, pr: int, repo_flag: str) -> list[str]:
     """Assemble the gh pr merge argv from parsed args."""
     merge_args = [
@@ -321,6 +350,11 @@ def main(argv: list[str] | None = None) -> int:
             output_format,
             pr,
         )
+
+    # Issue #2637: reject UNKNOWN mergeability on a direct merge. --auto is
+    # exempt: it hands the merge decision to GitHub's own gate.
+    if not args.auto:
+        _reject_unknown_merge_state(pr_data, pr, output_format)
 
     merge_args = _build_merge_args(args, pr, repo_flag)
     merge_result = subprocess.run(

--- a/.serena/memories/tasks/issue-2637-merge-pr-reject-unknown.md
+++ b/.serena/memories/tasks/issue-2637-merge-pr-reject-unknown.md
@@ -1,0 +1,34 @@
+# Issue 2637: merge_pr rejects UNKNOWN merge state before direct merge
+
+## Problem
+`merge_pr.py` fetched PR state (state, mergeable, mergeStateStatus) but only
+checked `state` for MERGED/CLOSED. It merged even when GitHub reported
+mergeable=UNKNOWN / mergeStateStatus=UNKNOWN (mid-recalculation after a base
+update), bypassing the readiness state that `test_pr_merge_ready.py` and
+`run_completion_gate.py` enforce ("Merge status is being calculated"). Observed
+on PRs #2632 and #2628 during pr-autofix: the completion gate rejected, merge_pr
+merged anyway.
+
+## Fix
+Added `_reject_unknown_merge_state(pr_data, pr, output_format)` in
+`merge_pr.py`. Called after the CLOSED check, gated on `not args.auto`. When
+`mergeable == "UNKNOWN"` OR `mergeStateStatus == "UNKNOWN"`, it emits an error
+envelope and exits with ADR-035 code 3 (external/transient), type `ApiError`.
+`--auto` is exempt: auto-merge defers to GitHub's own gate.
+
+## Canonical contract mirrored
+`test_pr_merge_ready.py::_evaluate_pr_state` appends reason
+"Merge status is being calculated" for `mergeable == "UNKNOWN"`.
+
+## Files
+- `.claude/skills/github/scripts/pr/merge_pr.py` (fix)
+- `src/copilot-cli/skills/github/scripts/pr/merge_pr.py` (1:1 mirror, kept byte-identical)
+- `tests/test_merge_pr.py` (TestUnknownMergeStateRejection: UNKNOWN rejects pos/neg, --auto bypass, READY merges)
+
+## Tests
+`uv run pytest tests/test_merge_pr.py` -> 45 passed. Mutation (UNKNOWN -> MUTANT)
+made the two reject tests fail; restored to green.
+
+## Note for future
+`write_skill_error` valid error_type set does not include "Transient"; code 3
+uses "ApiError" by existing convention in this script.

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.202",
+  "version": "0.5.203",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.200",
+  "version": "0.5.201",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/github/scripts/pr/merge_pr.py
+++ b/src/copilot-cli/skills/github/scripts/pr/merge_pr.py
@@ -221,6 +221,35 @@ def _fetch_pr_state(pr: int, repo_flag: str, output_format: str) -> dict:
     return json.loads(pr_result.stdout)
 
 
+def _reject_unknown_merge_state(pr_data: dict, pr: int, output_format: str) -> None:
+    """Reject a direct merge while GitHub is still calculating mergeability.
+
+    Issue #2637: after a base update, GitHub reports mergeable=UNKNOWN and
+    mergeStateStatus=UNKNOWN while it recalculates. The completion gate
+    (.claude/skills/github/scripts/pr/test_pr_merge_ready.py) rejects this
+    state with the reason "Merge status is being calculated" (its
+    ``_evaluate_pr_state`` appends that reason for ``mergeable == "UNKNOWN"``),
+    so a direct merge must reject it too instead of merging a PR its own gate
+    just refused. Exit code 3 (ADR-035 external/transient): the caller can
+    retry once GitHub settles. Callers that want auto-merge pass --auto, which
+    skips this check and hands the decision to GitHub's own gate.
+    """
+    mergeable = pr_data.get("mergeable") or ""
+    merge_state = pr_data.get("mergeStateStatus") or ""
+    if mergeable != "UNKNOWN" and merge_state != "UNKNOWN":
+        return
+    _emit_error(
+        f"PR #{pr} merge status is being calculated by GitHub "
+        f"(mergeable={mergeable or 'UNKNOWN'}, "
+        f"mergeStateStatus={merge_state or 'UNKNOWN'}). "
+        "Retry once it settles, or use --auto to defer to GitHub's gate.",
+        3,
+        "ApiError",
+        output_format,
+        pr,
+    )
+
+
 def _build_merge_args(args: argparse.Namespace, pr: int, repo_flag: str) -> list[str]:
     """Assemble the gh pr merge argv from parsed args."""
     merge_args = [
@@ -321,6 +350,11 @@ def main(argv: list[str] | None = None) -> int:
             output_format,
             pr,
         )
+
+    # Issue #2637: reject UNKNOWN mergeability on a direct merge. --auto is
+    # exempt: it hands the merge decision to GitHub's own gate.
+    if not args.auto:
+        _reject_unknown_merge_state(pr_data, pr, output_format)
 
     merge_args = _build_merge_args(args, pr, repo_flag)
     merge_result = subprocess.run(

--- a/tests/test_merge_pr.py
+++ b/tests/test_merge_pr.py
@@ -311,6 +311,138 @@ class TestMain:
 
 
 # ---------------------------------------------------------------------------
+# Tests: UNKNOWN merge state rejection (issue #2637)
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownMergeStateRejection:
+    """Reject UNKNOWN mergeable / mergeStateStatus before a direct merge.
+
+    Issue #2637: GitHub reports mergeable=UNKNOWN / mergeStateStatus=UNKNOWN
+    while recalculating mergeability after a base update. The completion gate
+    (test_pr_merge_ready.py) rejects this state ("Merge status is being
+    calculated"), but merge_pr.py merged anyway. A direct (non --auto) merge
+    must reject the UNKNOWN state with ADR-035 exit code 3 (external/transient).
+    --auto defers to GitHub's own gate and is exempt.
+    """
+
+    def test_unknown_mergeable_without_auto_exits_3(self, capsys):
+        state_json = json.dumps({
+            "state": "OPEN", "mergeable": "UNKNOWN",
+            "mergeStateStatus": "CLEAN", "headRefName": "feature",
+        })
+        calls = []
+
+        def _side_effect(*args, **kwargs):
+            calls.append(args[0] if args else kwargs.get("args", []))
+            return _completed(stdout=state_json, rc=0)
+
+        with patch(
+            "merge_pr.assert_gh_authenticated",
+        ), patch(
+            "merge_pr.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "merge_pr.get_allowed_merge_methods", return_value=_ALL_METHODS_ALLOWED,
+        ), patch(
+            "subprocess.run", side_effect=_side_effect,
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main(["--pull-request", "50", "--output-format", "json"])
+            assert exc.value.code == 3
+        # Only the state fetch ran; no merge was attempted.
+        assert len(calls) == 1
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["Success"] is False
+        assert envelope["Error"]["Code"] == 3
+        assert envelope["Error"]["Type"] == "ApiError"
+        assert "calculated" in envelope["Error"]["Message"].lower()
+
+    def test_unknown_merge_state_status_without_auto_exits_3(self, capsys):
+        state_json = json.dumps({
+            "state": "OPEN", "mergeable": "MERGEABLE",
+            "mergeStateStatus": "UNKNOWN", "headRefName": "feature",
+        })
+
+        def _side_effect(*args, **kwargs):
+            return _completed(stdout=state_json, rc=0)
+
+        with patch(
+            "merge_pr.assert_gh_authenticated",
+        ), patch(
+            "merge_pr.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "merge_pr.get_allowed_merge_methods", return_value=_ALL_METHODS_ALLOWED,
+        ), patch(
+            "subprocess.run", side_effect=_side_effect,
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main(["--pull-request", "50"])
+            assert exc.value.code == 3
+
+    def test_unknown_mergeable_with_auto_succeeds(self, capsys):
+        """--auto defers to GitHub's gate; UNKNOWN must not block it."""
+        state_json = json.dumps({
+            "state": "OPEN", "mergeable": "UNKNOWN",
+            "mergeStateStatus": "UNKNOWN", "headRefName": "feature",
+        })
+        call_count = 0
+
+        def _side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _completed(stdout=state_json, rc=0)
+            return _completed(rc=0)
+
+        with patch(
+            "merge_pr.assert_gh_authenticated",
+        ), patch(
+            "merge_pr.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "merge_pr.get_allowed_merge_methods", return_value=_ALL_METHODS_ALLOWED,
+        ), patch(
+            "subprocess.run", side_effect=_side_effect,
+        ):
+            rc = main(["--pull-request", "50", "--auto"])
+        assert rc == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output["Data"]["action"] == "auto-merge-enabled"
+
+    def test_ready_state_without_auto_merges(self, capsys):
+        """READY (MERGEABLE/CLEAN) still merges directly; no false block."""
+        state_json = json.dumps({
+            "state": "OPEN", "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN", "headRefName": "feature",
+        })
+        call_count = 0
+
+        def _side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _completed(stdout=state_json, rc=0)
+            return _completed(rc=0)
+
+        with patch(
+            "merge_pr.assert_gh_authenticated",
+        ), patch(
+            "merge_pr.resolve_repo_params",
+            return_value=RepoInfo(owner="o", repo="r"),
+        ), patch(
+            "merge_pr.get_allowed_merge_methods", return_value=_ALL_METHODS_ALLOWED,
+        ), patch(
+            "subprocess.run", side_effect=_side_effect,
+        ):
+            rc = main(["--pull-request", "50", "--strategy", "squash"])
+        assert rc == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output["Data"]["action"] == "merged"
+
+
+# ---------------------------------------------------------------------------
 # Tests: get_allowed_merge_methods
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# fix(github-skill): reject UNKNOWN merge state before direct merge

## Summary

`merge_pr.py` fetched `mergeable` and `mergeStateStatus` but only checked `state` (MERGED/CLOSED). It merged a PR even when GitHub reported `mergeable=UNKNOWN` / `mergeStateStatus=UNKNOWN` while recalculating mergeability after a base update. That bypassed the readiness state enforced by the merge readiness and completion gates ("Merge status is being calculated"), letting pr-autofix merge a PR its own completion gate had just rejected (observed on PR #2632 and PR #2628).

## Fix

- Add `_reject_unknown_merge_state(pr_data, pr, output_format)` in `.claude/skills/github/scripts/pr/merge_pr.py`, called after the CLOSED check and gated on `not args.auto`.
- When `mergeable == "UNKNOWN"` OR `mergeStateStatus == "UNKNOWN"`, it emits the standard envelope and exits with ADR-035 code 3 (external/transient). The caller retries once GitHub settles.
- `--auto` is exempt: auto-merge defers to GitHub's own gate.
- Mirror the identical change into `src/copilot-cli/skills/github/scripts/pr/merge_pr.py` so both skill trees stay 1:1.

> [!NOTE]
> The reject reason mirrors the canonical merge-readiness contract, which reports "Merge status is being calculated" for `mergeable == "UNKNOWN"`.

## Tests

`tests/test_merge_pr.py::TestUnknownMergeStateRejection`:

- UNKNOWN `mergeable` (non --auto) rejects with code 3, no merge attempted.
- UNKNOWN `mergeStateStatus` (non --auto) rejects with code 3.
- `--auto` bypasses the check and enables auto-merge.
- READY (MERGEABLE/CLEAN) still merges directly (no false block).

Verification: `uv run pytest tests/test_merge_pr.py` -> 45 passed. Mutation (UNKNOWN -> MUTANT) made the two reject tests fail (DID NOT RAISE SystemExit); restoring -> 45 passed. `ruff check` clean. Pre-PR validation passed (plugin version bumped 0.5.200 -> 0.5.201 on both manifests).

Fixes #2637

🤖 Generated with [Claude Code](https://claude.com/claude-code)

