### PR TITLE
fix(hooks): parenthesize Python 2 except clauses wedging Copilot CLI hooks

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.205",
+  "version": "0.5.206",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/lib/hook_utilities/lsp_gate_state.py
+++ b/.claude/lib/hook_utilities/lsp_gate_state.py
@@ -72,6 +72,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
+from typing import Any
 
 # Gate thresholds (ADR-062 Section 3; canonical names the guards consume).
 NAV_REQUIRED = 2
@@ -124,7 +125,7 @@ def state_path(cwd: str) -> Path:
     return _state_dir() / f"lsp-gate-{_cwd_key(cwd)}.json"
 
 
-def _default_state(cwd: str) -> dict:
+def _default_state(cwd: str) -> dict[str, Any]:
     """Return the needs-warmup default state for ``cwd`` (kit default shape)."""
     return {
         "cwd": cwd,
@@ -136,7 +137,7 @@ def _default_state(cwd: str) -> dict:
     }
 
 
-def read_state(cwd: str) -> dict:
+def read_state(cwd: str) -> dict[str, Any]:
     """Read gate state for ``cwd``. Never raises.
 
     A missing or unreadable or malformed state file returns the needs-warmup
@@ -155,7 +156,7 @@ def read_state(cwd: str) -> dict:
     return _normalize_state(data, cwd)
 
 
-def _normalize_state(data: dict, cwd: str) -> dict:
+def _normalize_state(data: dict[str, Any], cwd: str) -> dict[str, Any]:
     """Coerce a loaded state dict to the canonical shape and types."""
     read_files = data.get("read_files")
     if not isinstance(read_files, list):
@@ -183,7 +184,7 @@ def _coerce_int(value: object) -> int:
     return result if result >= 0 else 0
 
 
-def write_state(cwd: str, state: dict) -> bool:
+def write_state(cwd: str, state: dict[str, Any]) -> bool:
     """Persist ``state`` for ``cwd``. Never raises. Returns success.
 
     Creates the state directory if needed. On any filesystem error returns
@@ -213,7 +214,7 @@ def reset_state(cwd: str) -> bool:
     return True
 
 
-def record_warmup(cwd: str) -> dict:
+def record_warmup(cwd: str) -> dict[str, Any]:
     """Record that the first warmup LSP call happened. Returns the new state.
 
     Mirrors the kit's ``if (!existing.warmup_done)`` branch: sets the flag and
@@ -226,7 +227,7 @@ def record_warmup(cwd: str) -> dict:
     return state
 
 
-def record_nav(cwd: str) -> dict:
+def record_nav(cwd: str) -> dict[str, Any]:
     """Record one LSP navigation call. Returns the new state.
 
     Mirrors the kit's tracker: the first qualifying LSP call performs warmup
@@ -416,7 +417,7 @@ def normalize_path(file_path: str, cwd: str) -> str:
         return file_path
 
 
-def record_read(cwd: str, file_path: str) -> dict:
+def record_read(cwd: str, file_path: str) -> dict[str, Any]:
     """Record a gated Read of ``file_path``. Returns the new state.
 
     Appends the file to ``read_files`` (deduplicated by normalized path) and

--- a/.claude/lib/hook_utilities/lsp_gate_state.py
+++ b/.claude/lib/hook_utilities/lsp_gate_state.py
@@ -109,7 +109,7 @@ def _cwd_key(cwd: str) -> str:
     """
     try:
         normalized = str(Path(cwd).resolve())
-    except OSError, ValueError:
+    except (OSError, ValueError):
         normalized = cwd
     digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
     return digest[:16]
@@ -148,7 +148,7 @@ def read_state(cwd: str) -> dict:
     try:
         raw = path.read_text(encoding="utf-8")
         data = json.loads(raw)
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return default
     if not isinstance(data, dict):
         return default
@@ -178,7 +178,7 @@ def _coerce_int(value: object) -> int:
         return 0
     try:
         result = int(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return 0
     return result if result >= 0 else 0
 
@@ -258,7 +258,7 @@ def _resolve_git_dir(project_dir: str) -> Path | None:
         if not git_path.is_file():
             return None
         content = git_path.read_text(encoding="utf-8").strip()
-    except OSError, UnicodeError, ValueError:
+    except (OSError, UnicodeError, ValueError):
         return None
 
     if not content.startswith("gitdir:"):
@@ -272,7 +272,7 @@ def _resolve_git_dir(project_dir: str) -> Path | None:
         git_dir = git_path.parent / git_dir
     try:
         return git_dir.resolve()
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return None
 
 
@@ -300,7 +300,7 @@ def _merge_in_progress(project_dir: str) -> bool:
         for marker in ("MERGE_HEAD", "rebase-merge", "rebase-apply"):
             if (git_dir / marker).exists():
                 return True
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return False
     return False
 
@@ -324,7 +324,7 @@ def _has_conflict_markers(file_path: str) -> bool:
     try:
         with open(file_path, "rb") as fh:
             raw = fh.read(_CONFLICT_MARKER_SCAN_BYTES)
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return False
     try:
         text = raw.decode("utf-8", errors="strict")
@@ -359,7 +359,7 @@ def is_gated_target(file_path: str, project_dir: str) -> bool:
         if not candidate.is_absolute():
             candidate = root / candidate
         resolved = candidate.resolve()
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return False
 
     # Out-of-repo targets are never gated.
@@ -373,7 +373,7 @@ def is_gated_target(file_path: str, project_dir: str) -> bool:
             tmp_root = Path(tmpdir).resolve()
             if tmp_root == resolved or tmp_root in resolved.parents:
                 return False
-        except OSError, ValueError:
+        except (OSError, ValueError):
             return False
 
     # Dotfiles and dot-directory members (.serena/, .git/, .agents/, ...) are
@@ -412,7 +412,7 @@ def normalize_path(file_path: str, cwd: str) -> str:
         if not candidate.is_absolute():
             candidate = Path(cwd) / candidate
         return str(candidate.resolve())
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return file_path
 
 

--- a/.claude/lib/hook_utilities/lsp_health.py
+++ b/.claude/lib/hook_utilities/lsp_health.py
@@ -97,7 +97,7 @@ def _cwd_key(project_dir: str) -> str:
     """Return a stable per-cwd key: sha256(resolved cwd) truncated to 16 hex."""
     try:
         normalized = str(Path(project_dir).resolve())
-    except OSError, ValueError:
+    except (OSError, ValueError):
         normalized = project_dir
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
 
@@ -127,7 +127,7 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
             fh.write("1")
     except FileExistsError:
         return False
-    except OSError, ValueError:
+    except (OSError, ValueError):
         marker = None
 
     message = (
@@ -147,6 +147,6 @@ def clear_lsp_down_marker(project_dir: str) -> bool:
     """
     try:
         _marker_path(project_dir).unlink(missing_ok=True)
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return False
     return True

--- a/.claude/lib/hook_utilities/lsp_provider.py
+++ b/.claude/lib/hook_utilities/lsp_provider.py
@@ -94,12 +94,13 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from typing import Any
 
 # --- Provider registry (adapted per the divergence section above) ----------
 # Each provider maps abstract navigation intents to concrete tool names, and
 # declares which capabilities it offers. ``None`` means the provider does not
 # offer that intent.
-PROVIDERS: dict[str, dict] = {
+PROVIDERS: dict[str, dict[str, Any]] = {
     "serena": {
         "label": "Serena",
         "prefix": "mcp__serena__",
@@ -195,7 +196,7 @@ NATIVE_LSP_CODE_EXTENSIONS: frozenset[str] = frozenset(
 )
 
 
-def _read_json_silent(file_path: Path) -> dict | None:
+def _read_json_silent(file_path: Path) -> dict[str, Any] | None:
     """Read and parse a JSON file, returning None on any failure.
 
     Mirrors the kit's ``readJsonSilent`` (``detect-lsp-provider.js:88-95``):
@@ -204,7 +205,8 @@ def _read_json_silent(file_path: Path) -> dict | None:
     try:
         if not file_path.is_file():
             return None
-        return json.loads(file_path.read_text(encoding="utf-8"))
+        data: dict[str, Any] = json.loads(file_path.read_text(encoding="utf-8"))
+        return data
     except (OSError, ValueError):
         return None
 

--- a/.claude/lib/hook_utilities/utilities.py
+++ b/.claude/lib/hook_utilities/utilities.py
@@ -15,6 +15,7 @@ import sys
 import warnings
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 _GIT_COMMIT_PATTERN = re.compile(r"(?:^|\s)git\s+(commit|ci)")
 _GIT_PUSH_PATTERN = re.compile(r"(?:^|\s)git\s+push(?:\s|$)")
@@ -265,7 +266,7 @@ def get_recent_session_log(sessions_dir: str) -> Path | None:
     return _newest_by_mtime(yesterday_candidates)
 
 
-def coerce_to_list(value) -> list:
+def coerce_to_list(value) -> list[Any]:
     """Normalize work/outcomes to a list, regardless of session schema shape.
 
     Session logs in this repo have used several shapes over time:
@@ -298,7 +299,7 @@ def coerce_to_list(value) -> list:
     return []
 
 
-def format_work_item(item: dict) -> str:
+def format_work_item(item: dict[str, Any]) -> str:
     """Format a work item dict into a human-readable string.
 
     Supports multiple session schemas:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -100,6 +100,21 @@ jobs:
           enable-pester: false
           enable-git-hooks: false
 
+      # Issue #2655: blocking parse gate. PR #2640 shipped PEP 758 syntax
+      # (unparenthesized except tuples) that Python 3.14 accepts but 3.13 and
+      # earlier reject; the CLI runs hooks under the host interpreter, so it
+      # wedged on older hosts. Nothing caught it because the dev/CI target is
+      # 3.14 (where it is valid), ruff E999 is report-only below and exempts the
+      # generated src/copilot-cli mirrors, and pytest only fails when a collected
+      # test imports the broken module. This step parses every tracked .py at the
+      # declared support floor (pyproject requires-python) via ast feature_version
+      # and blocks on any failure, even though this runner is 3.14. It is separate
+      # from the ruff style backlog: a parse failure is a zero-false-positive
+      # defect. Keep it BEFORE the ruff step and do NOT add continue-on-error.
+      - name: Validate Python syntax (blocking)
+        if: steps.should-run.outputs.skip != 'true'
+        run: python scripts/validation/validate_python_syntax.py
+
       # Issue #2194: ruff is configured in pyproject.toml ([tool.ruff]) but no CI
       # workflow ran it. The repository has a pre-existing backlog of 2026 ruff
       # findings (measured 2026-06-01 with ruff>=0.15.14), so this step is

--- a/scripts/hook_utilities/lsp_gate_state.py
+++ b/scripts/hook_utilities/lsp_gate_state.py
@@ -72,6 +72,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
+from typing import Any
 
 # Gate thresholds (ADR-062 Section 3; canonical names the guards consume).
 NAV_REQUIRED = 2
@@ -124,7 +125,7 @@ def state_path(cwd: str) -> Path:
     return _state_dir() / f"lsp-gate-{_cwd_key(cwd)}.json"
 
 
-def _default_state(cwd: str) -> dict:
+def _default_state(cwd: str) -> dict[str, Any]:
     """Return the needs-warmup default state for ``cwd`` (kit default shape)."""
     return {
         "cwd": cwd,
@@ -136,7 +137,7 @@ def _default_state(cwd: str) -> dict:
     }
 
 
-def read_state(cwd: str) -> dict:
+def read_state(cwd: str) -> dict[str, Any]:
     """Read gate state for ``cwd``. Never raises.
 
     A missing or unreadable or malformed state file returns the needs-warmup
@@ -155,7 +156,7 @@ def read_state(cwd: str) -> dict:
     return _normalize_state(data, cwd)
 
 
-def _normalize_state(data: dict, cwd: str) -> dict:
+def _normalize_state(data: dict[str, Any], cwd: str) -> dict[str, Any]:
     """Coerce a loaded state dict to the canonical shape and types."""
     read_files = data.get("read_files")
     if not isinstance(read_files, list):
@@ -183,7 +184,7 @@ def _coerce_int(value: object) -> int:
     return result if result >= 0 else 0
 
 
-def write_state(cwd: str, state: dict) -> bool:
+def write_state(cwd: str, state: dict[str, Any]) -> bool:
     """Persist ``state`` for ``cwd``. Never raises. Returns success.
 
     Creates the state directory if needed. On any filesystem error returns
@@ -213,7 +214,7 @@ def reset_state(cwd: str) -> bool:
     return True
 
 
-def record_warmup(cwd: str) -> dict:
+def record_warmup(cwd: str) -> dict[str, Any]:
     """Record that the first warmup LSP call happened. Returns the new state.
 
     Mirrors the kit's ``if (!existing.warmup_done)`` branch: sets the flag and
@@ -226,7 +227,7 @@ def record_warmup(cwd: str) -> dict:
     return state
 
 
-def record_nav(cwd: str) -> dict:
+def record_nav(cwd: str) -> dict[str, Any]:
     """Record one LSP navigation call. Returns the new state.
 
     Mirrors the kit's tracker: the first qualifying LSP call performs warmup
@@ -416,7 +417,7 @@ def normalize_path(file_path: str, cwd: str) -> str:
         return file_path
 
 
-def record_read(cwd: str, file_path: str) -> dict:
+def record_read(cwd: str, file_path: str) -> dict[str, Any]:
     """Record a gated Read of ``file_path``. Returns the new state.
 
     Appends the file to ``read_files`` (deduplicated by normalized path) and

--- a/scripts/hook_utilities/lsp_gate_state.py
+++ b/scripts/hook_utilities/lsp_gate_state.py
@@ -109,7 +109,7 @@ def _cwd_key(cwd: str) -> str:
     """
     try:
         normalized = str(Path(cwd).resolve())
-    except OSError, ValueError:
+    except (OSError, ValueError):
         normalized = cwd
     digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
     return digest[:16]
@@ -148,7 +148,7 @@ def read_state(cwd: str) -> dict:
     try:
         raw = path.read_text(encoding="utf-8")
         data = json.loads(raw)
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return default
     if not isinstance(data, dict):
         return default
@@ -178,7 +178,7 @@ def _coerce_int(value: object) -> int:
         return 0
     try:
         result = int(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return 0
     return result if result >= 0 else 0
 
@@ -258,7 +258,7 @@ def _resolve_git_dir(project_dir: str) -> Path | None:
         if not git_path.is_file():
             return None
         content = git_path.read_text(encoding="utf-8").strip()
-    except OSError, UnicodeError, ValueError:
+    except (OSError, UnicodeError, ValueError):
         return None
 
     if not content.startswith("gitdir:"):
@@ -272,7 +272,7 @@ def _resolve_git_dir(project_dir: str) -> Path | None:
         git_dir = git_path.parent / git_dir
     try:
         return git_dir.resolve()
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return None
 
 
@@ -300,7 +300,7 @@ def _merge_in_progress(project_dir: str) -> bool:
         for marker in ("MERGE_HEAD", "rebase-merge", "rebase-apply"):
             if (git_dir / marker).exists():
                 return True
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return False
     return False
 
@@ -324,7 +324,7 @@ def _has_conflict_markers(file_path: str) -> bool:
     try:
         with open(file_path, "rb") as fh:
             raw = fh.read(_CONFLICT_MARKER_SCAN_BYTES)
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return False
     try:
         text = raw.decode("utf-8", errors="strict")
@@ -359,7 +359,7 @@ def is_gated_target(file_path: str, project_dir: str) -> bool:
         if not candidate.is_absolute():
             candidate = root / candidate
         resolved = candidate.resolve()
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return False
 
     # Out-of-repo targets are never gated.
@@ -373,7 +373,7 @@ def is_gated_target(file_path: str, project_dir: str) -> bool:
             tmp_root = Path(tmpdir).resolve()
             if tmp_root == resolved or tmp_root in resolved.parents:
                 return False
-        except OSError, ValueError:
+        except (OSError, ValueError):
             return False
 
     # Dotfiles and dot-directory members (.serena/, .git/, .agents/, ...) are
@@ -412,7 +412,7 @@ def normalize_path(file_path: str, cwd: str) -> str:
         if not candidate.is_absolute():
             candidate = Path(cwd) / candidate
         return str(candidate.resolve())
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return file_path
 
 

--- a/scripts/hook_utilities/lsp_health.py
+++ b/scripts/hook_utilities/lsp_health.py
@@ -97,7 +97,7 @@ def _cwd_key(project_dir: str) -> str:
     """Return a stable per-cwd key: sha256(resolved cwd) truncated to 16 hex."""
     try:
         normalized = str(Path(project_dir).resolve())
-    except OSError, ValueError:
+    except (OSError, ValueError):
         normalized = project_dir
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
 
@@ -127,7 +127,7 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
             fh.write("1")
     except FileExistsError:
         return False
-    except OSError, ValueError:
+    except (OSError, ValueError):
         marker = None
 
     message = (
@@ -147,6 +147,6 @@ def clear_lsp_down_marker(project_dir: str) -> bool:
     """
     try:
         _marker_path(project_dir).unlink(missing_ok=True)
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return False
     return True

--- a/scripts/hook_utilities/lsp_provider.py
+++ b/scripts/hook_utilities/lsp_provider.py
@@ -94,12 +94,13 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from typing import Any
 
 # --- Provider registry (adapted per the divergence section above) ----------
 # Each provider maps abstract navigation intents to concrete tool names, and
 # declares which capabilities it offers. ``None`` means the provider does not
 # offer that intent.
-PROVIDERS: dict[str, dict] = {
+PROVIDERS: dict[str, dict[str, Any]] = {
     "serena": {
         "label": "Serena",
         "prefix": "mcp__serena__",
@@ -195,7 +196,7 @@ NATIVE_LSP_CODE_EXTENSIONS: frozenset[str] = frozenset(
 )
 
 
-def _read_json_silent(file_path: Path) -> dict | None:
+def _read_json_silent(file_path: Path) -> dict[str, Any] | None:
     """Read and parse a JSON file, returning None on any failure.
 
     Mirrors the kit's ``readJsonSilent`` (``detect-lsp-provider.js:88-95``):
@@ -204,7 +205,8 @@ def _read_json_silent(file_path: Path) -> dict | None:
     try:
         if not file_path.is_file():
             return None
-        return json.loads(file_path.read_text(encoding="utf-8"))
+        data: dict[str, Any] = json.loads(file_path.read_text(encoding="utf-8"))
+        return data
     except (OSError, ValueError):
         return None
 

--- a/scripts/hook_utilities/utilities.py
+++ b/scripts/hook_utilities/utilities.py
@@ -15,6 +15,7 @@ import sys
 import warnings
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 _GIT_COMMIT_PATTERN = re.compile(r"(?:^|\s)git\s+(commit|ci)")
 _GIT_PUSH_PATTERN = re.compile(r"(?:^|\s)git\s+push(?:\s|$)")
@@ -265,7 +266,7 @@ def get_recent_session_log(sessions_dir: str) -> Path | None:
     return _newest_by_mtime(yesterday_candidates)
 
 
-def coerce_to_list(value) -> list:
+def coerce_to_list(value) -> list[Any]:
     """Normalize work/outcomes to a list, regardless of session schema shape.
 
     Session logs in this repo have used several shapes over time:
@@ -298,7 +299,7 @@ def coerce_to_list(value) -> list:
     return []
 
 
-def format_work_item(item: dict) -> str:
+def format_work_item(item: dict[str, Any]) -> str:
     """Format a work item dict into a human-readable string.
 
     Supports multiple session schemas:

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -111,6 +111,7 @@ from validate_design_review import (  # noqa: E402, F401
     _VALID_STATUSES,
     validate_design_review_frontmatter,
 )
+from validate_python_syntax import validate_python_syntax  # noqa: E402, F401
 from yaml_utils import _parse_yaml_frontmatter  # noqa: E402, F401
 
 
@@ -255,6 +256,18 @@ def main(argv: list[str] | None = None) -> int:
 
     state = ValidationState()
     start_time = time.monotonic()
+
+    # 0. Python Syntax (issue #2655). Blocking parse gate over every tracked
+    # .py file. A SyntaxError in a hook module wedges the CLI (PreToolUse
+    # dispatcher fails closed on import), and ruff/pytest never caught PR #2640
+    # because ruff is advisory and nothing imports those modules. Runs first
+    # and fast so the cheapest, highest-impact defect is caught before anything
+    # slower.
+    run_validation(
+        "Python Syntax (compile gate)",
+        state,
+        lambda: validate_python_syntax(repo_root),
+    )
 
     # 1. Session End
     run_validation(

--- a/scripts/validation/validate_python_syntax.py
+++ b/scripts/validation/validate_python_syntax.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Blocking gate: every tracked Python file must parse at the support floor.
+
+Root cause this prevents (issue #2655, regressed by PR #2640): code shipped to
+``main`` using ``except OSError, ValueError:`` in ``lsp_gate_state.py`` and
+``lsp_health.py``. This is PEP 758 syntax (unparenthesized ``except`` tuples),
+which Python 3.14 accepts but 3.13 and earlier reject as a ``SyntaxError``. The
+Copilot CLI runs plugin hooks under the host's ambient interpreter (``py -3`` /
+``python3``); on a machine where that resolved to 3.13 the PreToolUse dispatcher
+hit the ``SyntaxError`` at import, failed closed, and denied every tool call.
+
+Why no existing gate caught it:
+
+  - The dev and CI target is Python 3.14 (``[tool.ruff] target-version=py314``,
+    the pytest workflow runs 3.14). On 3.14 the code is *valid*, so it compiles,
+    imports, and tests pass. The defect only appears under the floor declared in
+    ``pyproject.toml`` (``requires-python = ">=3.10"``), which is the range the
+    host interpreter may actually be.
+  - ``ruff`` E999 is report-only in CI (issue #2194) and advisory in the hooks
+    (issue #2592), and its per-file-ignores exempt the generated
+    ``src/copilot-cli`` mirror trees, so it would not block this regardless.
+  - ``pytest`` only fails on a ``SyntaxError`` when a collected test imports the
+    broken module; nothing imports these utility modules.
+
+The fix is to validate syntax against the *minimum supported* Python version,
+not the dev target. ``ast.parse(..., feature_version=floor)`` re-parses with the
+floor grammar from any host interpreter (CI's 3.14 included) and rejects syntax
+that is newer than the floor, catching PEP 758 misuse and classic syntax errors
+alike. This is deliberately separate from the ruff style backlog: a file that
+does not parse at the floor is a zero-false-positive defect, so it blocks now.
+
+See ``decision-python-floor-syntax-gate`` (Serena memory) for the reasoning.
+
+Exit codes (ADR-035):
+    0 - Success (every file parses at the floor)
+    1 - Logic error (one or more files failed to parse at the floor)
+    2 - Config error (invalid repository root)
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Fallback floor if pyproject.toml cannot be read. Matches the documented
+# `requires-python = ">=3.10"` contract at the time of writing (issue #2655).
+_DEFAULT_FLOOR = (3, 10)
+
+# Directories never worth parsing: virtualenvs, VCS metadata, caches, vendored
+# node deps. Only consulted by the filesystem-walk fallback; the primary path
+# uses `git ls-files`, which already excludes untracked trees.
+_SKIP_DIRS = frozenset(
+    {".venv", "venv", ".git", "__pycache__", "node_modules", ".mypy_cache", ".ruff_cache"}
+)
+
+_REQUIRES_PYTHON_RE = re.compile(r"""requires-python\s*=\s*["'][^"']*?>=\s*(\d+)\.(\d+)""")
+
+
+def support_floor(repo_root: Path) -> tuple[int, int]:
+    """Return the (major, minor) floor from pyproject's ``requires-python``.
+
+    Parsed with a regex rather than ``tomllib`` so the gate itself runs on the
+    floor interpreter (3.10), where ``tomllib`` is absent. Falls back to
+    ``_DEFAULT_FLOOR`` when the field is missing or unparseable.
+    """
+    pyproject = repo_root / "pyproject.toml"
+    try:
+        text = pyproject.read_text(encoding="utf-8")
+    except OSError:
+        return _DEFAULT_FLOOR
+    match = _REQUIRES_PYTHON_RE.search(text)
+    if not match:
+        return _DEFAULT_FLOOR
+    return (int(match.group(1)), int(match.group(2)))
+
+
+def _tracked_python_files(repo_root: Path) -> list[Path]:
+    """Return tracked ``*.py`` files via ``git ls-files``; walk on failure.
+
+    ``git ls-files`` lists committed and staged files, which is exactly the set
+    a PR ships. CI checks out the branch (PR files are tracked) and local
+    pre-PR runs see staged work, so the gate covers what is about to merge.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-files", "*.py"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        rels = [line for line in completed.stdout.splitlines() if line.strip()]
+        return [repo_root / rel for rel in rels]
+    except (OSError, subprocess.SubprocessError):
+        return _walk_python_files(repo_root)
+
+
+def _walk_python_files(repo_root: Path) -> list[Path]:
+    """Fallback discovery when git is unavailable: walk excluding ``_SKIP_DIRS``."""
+    found: list[Path] = []
+    for path in repo_root.rglob("*.py"):
+        if any(part in _SKIP_DIRS for part in path.relative_to(repo_root).parts):
+            continue
+        found.append(path)
+    return found
+
+
+def find_syntax_errors(repo_root: Path, floor: tuple[int, int] | None = None) -> list[tuple[Path, str]]:
+    """Parse every tracked file at ``floor``; return ``(path, message)`` failures."""
+    if floor is None:
+        floor = support_floor(repo_root)
+    failures: list[tuple[Path, str]] = []
+    for path in _tracked_python_files(repo_root):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            failures.append((path, f"read error: {exc}"))
+            continue
+        try:
+            ast.parse(source, filename=str(path), feature_version=floor)
+        except SyntaxError as exc:
+            failures.append((path, f"{exc.msg} (line {exc.lineno})"))
+    return failures
+
+
+def validate_python_syntax(repo_root: Path) -> bool:
+    """Return True when every tracked file parses at the support floor.
+
+    Runner-facing entry point matching the ``validate_*(repo_root) -> bool``
+    contract used by ``pre_pr.py``.
+    """
+    floor = support_floor(repo_root)
+    failures = find_syntax_errors(repo_root, floor)
+    if not failures:
+        return True
+    floor_str = f"{floor[0]}.{floor[1]}"
+    print(
+        f"[FAIL] {len(failures)} Python file(s) failed to parse at the support "
+        f"floor (Python {floor_str}):",
+        file=sys.stderr,
+    )
+    for path, message in failures:
+        rel = path.relative_to(repo_root) if path.is_relative_to(repo_root) else path
+        print(f"  {rel}: {message}", file=sys.stderr)
+    print(
+        f"\nFix: use only syntax valid in Python {floor_str}+. Plugin hooks run "
+        "under the host interpreter, which may be older than the 3.14 dev target; "
+        "PEP 758 unparenthesized except clauses and other 3.14-only syntax wedge "
+        "the CLI on older hosts (issue #2655).",
+        file=sys.stderr,
+    )
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns an ADR-035 exit code."""
+    args = argv if argv is not None else sys.argv[1:]
+    repo_root = Path(args[0]).resolve() if args else Path(__file__).resolve().parents[2]
+    if not repo_root.is_dir():
+        print(f"[FAIL] Invalid repository root: {repo_root}", file=sys.stderr)
+        return 2
+    return 0 if validate_python_syntax(repo_root) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.205",
+  "version": "0.5.206",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/lib/hook_utilities/lsp_gate_state.py
+++ b/src/copilot-cli/lib/hook_utilities/lsp_gate_state.py
@@ -72,6 +72,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
+from typing import Any
 
 # Gate thresholds (ADR-062 Section 3; canonical names the guards consume).
 NAV_REQUIRED = 2
@@ -124,7 +125,7 @@ def state_path(cwd: str) -> Path:
     return _state_dir() / f"lsp-gate-{_cwd_key(cwd)}.json"
 
 
-def _default_state(cwd: str) -> dict:
+def _default_state(cwd: str) -> dict[str, Any]:
     """Return the needs-warmup default state for ``cwd`` (kit default shape)."""
     return {
         "cwd": cwd,
@@ -136,7 +137,7 @@ def _default_state(cwd: str) -> dict:
     }
 
 
-def read_state(cwd: str) -> dict:
+def read_state(cwd: str) -> dict[str, Any]:
     """Read gate state for ``cwd``. Never raises.
 
     A missing or unreadable or malformed state file returns the needs-warmup
@@ -155,7 +156,7 @@ def read_state(cwd: str) -> dict:
     return _normalize_state(data, cwd)
 
 
-def _normalize_state(data: dict, cwd: str) -> dict:
+def _normalize_state(data: dict[str, Any], cwd: str) -> dict[str, Any]:
     """Coerce a loaded state dict to the canonical shape and types."""
     read_files = data.get("read_files")
     if not isinstance(read_files, list):
@@ -183,7 +184,7 @@ def _coerce_int(value: object) -> int:
     return result if result >= 0 else 0
 
 
-def write_state(cwd: str, state: dict) -> bool:
+def write_state(cwd: str, state: dict[str, Any]) -> bool:
     """Persist ``state`` for ``cwd``. Never raises. Returns success.
 
     Creates the state directory if needed. On any filesystem error returns
@@ -213,7 +214,7 @@ def reset_state(cwd: str) -> bool:
     return True
 
 
-def record_warmup(cwd: str) -> dict:
+def record_warmup(cwd: str) -> dict[str, Any]:
     """Record that the first warmup LSP call happened. Returns the new state.
 
     Mirrors the kit's ``if (!existing.warmup_done)`` branch: sets the flag and
@@ -226,7 +227,7 @@ def record_warmup(cwd: str) -> dict:
     return state
 
 
-def record_nav(cwd: str) -> dict:
+def record_nav(cwd: str) -> dict[str, Any]:
     """Record one LSP navigation call. Returns the new state.
 
     Mirrors the kit's tracker: the first qualifying LSP call performs warmup
@@ -416,7 +417,7 @@ def normalize_path(file_path: str, cwd: str) -> str:
         return file_path
 
 
-def record_read(cwd: str, file_path: str) -> dict:
+def record_read(cwd: str, file_path: str) -> dict[str, Any]:
     """Record a gated Read of ``file_path``. Returns the new state.
 
     Appends the file to ``read_files`` (deduplicated by normalized path) and

--- a/src/copilot-cli/lib/hook_utilities/lsp_gate_state.py
+++ b/src/copilot-cli/lib/hook_utilities/lsp_gate_state.py
@@ -109,7 +109,7 @@ def _cwd_key(cwd: str) -> str:
     """
     try:
         normalized = str(Path(cwd).resolve())
-    except OSError, ValueError:
+    except (OSError, ValueError):
         normalized = cwd
     digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
     return digest[:16]
@@ -148,7 +148,7 @@ def read_state(cwd: str) -> dict:
     try:
         raw = path.read_text(encoding="utf-8")
         data = json.loads(raw)
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return default
     if not isinstance(data, dict):
         return default
@@ -178,7 +178,7 @@ def _coerce_int(value: object) -> int:
         return 0
     try:
         result = int(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return 0
     return result if result >= 0 else 0
 
@@ -258,7 +258,7 @@ def _resolve_git_dir(project_dir: str) -> Path | None:
         if not git_path.is_file():
             return None
         content = git_path.read_text(encoding="utf-8").strip()
-    except OSError, UnicodeError, ValueError:
+    except (OSError, UnicodeError, ValueError):
         return None
 
     if not content.startswith("gitdir:"):
@@ -272,7 +272,7 @@ def _resolve_git_dir(project_dir: str) -> Path | None:
         git_dir = git_path.parent / git_dir
     try:
         return git_dir.resolve()
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return None
 
 
@@ -300,7 +300,7 @@ def _merge_in_progress(project_dir: str) -> bool:
         for marker in ("MERGE_HEAD", "rebase-merge", "rebase-apply"):
             if (git_dir / marker).exists():
                 return True
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return False
     return False
 
@@ -324,7 +324,7 @@ def _has_conflict_markers(file_path: str) -> bool:
     try:
         with open(file_path, "rb") as fh:
             raw = fh.read(_CONFLICT_MARKER_SCAN_BYTES)
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return False
     try:
         text = raw.decode("utf-8", errors="strict")
@@ -359,7 +359,7 @@ def is_gated_target(file_path: str, project_dir: str) -> bool:
         if not candidate.is_absolute():
             candidate = root / candidate
         resolved = candidate.resolve()
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return False
 
     # Out-of-repo targets are never gated.
@@ -373,7 +373,7 @@ def is_gated_target(file_path: str, project_dir: str) -> bool:
             tmp_root = Path(tmpdir).resolve()
             if tmp_root == resolved or tmp_root in resolved.parents:
                 return False
-        except OSError, ValueError:
+        except (OSError, ValueError):
             return False
 
     # Dotfiles and dot-directory members (.serena/, .git/, .agents/, ...) are
@@ -412,7 +412,7 @@ def normalize_path(file_path: str, cwd: str) -> str:
         if not candidate.is_absolute():
             candidate = Path(cwd) / candidate
         return str(candidate.resolve())
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return file_path
 
 

--- a/src/copilot-cli/lib/hook_utilities/lsp_health.py
+++ b/src/copilot-cli/lib/hook_utilities/lsp_health.py
@@ -97,7 +97,7 @@ def _cwd_key(project_dir: str) -> str:
     """Return a stable per-cwd key: sha256(resolved cwd) truncated to 16 hex."""
     try:
         normalized = str(Path(project_dir).resolve())
-    except OSError, ValueError:
+    except (OSError, ValueError):
         normalized = project_dir
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
 
@@ -127,7 +127,7 @@ def warn_once_lsp_down(guard_name: str, project_dir: str) -> bool:
             fh.write("1")
     except FileExistsError:
         return False
-    except OSError, ValueError:
+    except (OSError, ValueError):
         marker = None
 
     message = (
@@ -147,6 +147,6 @@ def clear_lsp_down_marker(project_dir: str) -> bool:
     """
     try:
         _marker_path(project_dir).unlink(missing_ok=True)
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return False
     return True

--- a/src/copilot-cli/lib/hook_utilities/lsp_provider.py
+++ b/src/copilot-cli/lib/hook_utilities/lsp_provider.py
@@ -94,12 +94,13 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from typing import Any
 
 # --- Provider registry (adapted per the divergence section above) ----------
 # Each provider maps abstract navigation intents to concrete tool names, and
 # declares which capabilities it offers. ``None`` means the provider does not
 # offer that intent.
-PROVIDERS: dict[str, dict] = {
+PROVIDERS: dict[str, dict[str, Any]] = {
     "serena": {
         "label": "Serena",
         "prefix": "mcp__serena__",
@@ -195,7 +196,7 @@ NATIVE_LSP_CODE_EXTENSIONS: frozenset[str] = frozenset(
 )
 
 
-def _read_json_silent(file_path: Path) -> dict | None:
+def _read_json_silent(file_path: Path) -> dict[str, Any] | None:
     """Read and parse a JSON file, returning None on any failure.
 
     Mirrors the kit's ``readJsonSilent`` (``detect-lsp-provider.js:88-95``):
@@ -204,7 +205,8 @@ def _read_json_silent(file_path: Path) -> dict | None:
     try:
         if not file_path.is_file():
             return None
-        return json.loads(file_path.read_text(encoding="utf-8"))
+        data: dict[str, Any] = json.loads(file_path.read_text(encoding="utf-8"))
+        return data
     except (OSError, ValueError):
         return None
 

--- a/src/copilot-cli/lib/hook_utilities/utilities.py
+++ b/src/copilot-cli/lib/hook_utilities/utilities.py
@@ -15,6 +15,7 @@ import sys
 import warnings
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 _GIT_COMMIT_PATTERN = re.compile(r"(?:^|\s)git\s+(commit|ci)")
 _GIT_PUSH_PATTERN = re.compile(r"(?:^|\s)git\s+push(?:\s|$)")
@@ -265,7 +266,7 @@ def get_recent_session_log(sessions_dir: str) -> Path | None:
     return _newest_by_mtime(yesterday_candidates)
 
 
-def coerce_to_list(value) -> list:
+def coerce_to_list(value) -> list[Any]:
     """Normalize work/outcomes to a list, regardless of session schema shape.
 
     Session logs in this repo have used several shapes over time:
@@ -298,7 +299,7 @@ def coerce_to_list(value) -> list:
     return []
 
 
-def format_work_item(item: dict) -> str:
+def format_work_item(item: dict[str, Any]) -> str:
     """Format a work item dict into a human-readable string.
 
     Supports multiple session schemas:

--- a/tests/validation/test_validate_python_syntax.py
+++ b/tests/validation/test_validate_python_syntax.py
@@ -1,0 +1,134 @@
+"""Tests for scripts/validation/validate_python_syntax.py (issue #2655).
+
+Pins behaviour of the floor-aware parse gate that prevents the PR #2640
+regression: PEP 758 ``except A, B:`` syntax is valid on the 3.14 dev target but
+a ``SyntaxError`` on the 3.10-3.13 hosts the CLI may run under, so the gate must
+parse against the declared support floor, not the host interpreter.
+
+- pos: a tree that parses at the floor returns exit 0
+- neg (floor): the exact regression shape (PEP 758 except) is rejected at the
+  floor even though the host interpreter (3.14) would accept it
+- neg (classic): an always-invalid syntax error is rejected
+- edge: an invalid repo root returns exit 2 (config error per ADR-035)
+- branch: the git-unavailable filesystem-walk fallback skips vendored dirs
+- floor: ``support_floor`` reads ``requires-python`` from pyproject
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "validation" / "validate_python_syntax.py"
+_VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(_VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION_DIR))
+
+from validate_python_syntax import (  # noqa: E402
+    _walk_python_files,
+    find_syntax_errors,
+    support_floor,
+    validate_python_syntax,
+)
+
+# PEP 758: valid on Python 3.14, SyntaxError on 3.13 and earlier.
+_PEP758 = "try:\n    x = 1\nexcept OSError, ValueError:\n    pass\n"
+# Always invalid on every Python 3.
+_CLASSIC = "def broken(:\n    pass\n"
+# Floor-clean equivalent.
+_CLEAN = "try:\n    x = 1\nexcept (OSError, ValueError):\n    pass\n"
+
+_FLOOR_310 = 'requires-python = ">=3.10"\n'
+
+
+def _git_repo(root: Path) -> None:
+    """Initialise a git repo and stage everything so git ls-files sees it."""
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+
+
+def _run_cli(repo_root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(repo_root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_floor_clean_tree_passes(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(_FLOOR_310, encoding="utf-8")
+    (tmp_path / "ok.py").write_text(_CLEAN, encoding="utf-8")
+    _git_repo(tmp_path)
+
+    result = _run_cli(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert find_syntax_errors(tmp_path) == []
+
+
+def test_pep758_rejected_at_floor(tmp_path: Path) -> None:
+    # Guards against the exact regression: valid on the 3.14 host running this
+    # test, but the gate must reject it because the floor is 3.10.
+    (tmp_path / "pyproject.toml").write_text(_FLOOR_310, encoding="utf-8")
+    (tmp_path / "broken.py").write_text(_PEP758, encoding="utf-8")
+    _git_repo(tmp_path)
+
+    result = _run_cli(tmp_path)
+
+    assert result.returncode == 1
+    assert "broken.py" in result.stderr
+    assert "except expressions without parentheses" in result.stderr
+
+
+def test_classic_syntax_error_rejected(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(_FLOOR_310, encoding="utf-8")
+    (tmp_path / "classic.py").write_text(_CLASSIC, encoding="utf-8")
+    _git_repo(tmp_path)
+
+    failures = find_syntax_errors(tmp_path)
+
+    assert any(p.name == "classic.py" for p, _ in failures)
+
+
+def test_invalid_repo_root_returns_config_error(tmp_path: Path) -> None:
+    result = _run_cli(tmp_path / "does-not-exist")
+
+    assert result.returncode == 2
+
+
+def test_walk_fallback_skips_vendored_and_finds_broken(tmp_path: Path) -> None:
+    (tmp_path / "broken.py").write_text(_PEP758, encoding="utf-8")
+    vendored = tmp_path / ".venv" / "lib"
+    vendored.mkdir(parents=True)
+    (vendored / "alsobroken.py").write_text(_PEP758, encoding="utf-8")
+
+    found = {p.name for p in _walk_python_files(tmp_path)}
+
+    assert "broken.py" in found
+    assert "alsobroken.py" not in found
+
+
+def test_support_floor_reads_pyproject(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text('requires-python = ">=3.11"\n', encoding="utf-8")
+
+    assert support_floor(tmp_path) == (3, 11)
+
+
+def test_support_floor_defaults_when_missing(tmp_path: Path) -> None:
+    assert support_floor(tmp_path) == (3, 10)
+
+
+def test_validate_function_returns_false_on_floor_violation(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(_FLOOR_310, encoding="utf-8")
+    (tmp_path / "broken.py").write_text(_PEP758, encoding="utf-8")
+    _git_repo(tmp_path)
+
+    assert validate_python_syntax(tmp_path) is False
+
+
+def test_repo_itself_parses_at_floor() -> None:
+    # The live repository must pass its own gate.
+    assert find_syntax_errors(REPO_ROOT) == []


### PR DESCRIPTION
## Summary

Six `hook_utilities` files used `except OSError, ValueError:` (PEP 758, unparenthesized except tuples). This parses on Python 3.14 but is a `SyntaxError` on 3.13 and earlier. The Copilot CLI runs plugin hooks under the host interpreter (`py -3` / `python3`); on a host where that resolves to 3.13 the PreToolUse dispatcher hits the `SyntaxError` at import, fails closed (exit 2, ADR-066), and denies every tool call, wedging the session. This PR parenthesizes all 39 clauses (works on 3.10-3.14) and adds a structural gate so the class cannot regress.

## Root cause (corrected)

Not "Python 2 leftover syntax". It is PEP 758, a Python 3.14 language feature. The package floor is `requires-python = ">=3.10"`, but the hooks execute under whatever interpreter the host resolves, which can be older than the 3.14 dev/CI target. 3.14-only syntax in host-executed code is a latent crash for 3.10-3.13 users.

Empirical: CPython 3.14.5 accepts `except A, B:`; 3.13.14 and 3.12.10 reject it. The reporting machine's `py -3` resolved to 3.13.14.

### Why every existing gate missed it

- **ruff** (the only tool that flags syntax errors, E999) is non-blocking everywhere: `continue-on-error` in CI (#2194), `record_warn` advisory in pre-push (#2592), `|| true` in pre-commit. Its per-file-ignores also exempt the whole rule set for `src/copilot-cli/hooks/**` and `skills/**` (generated mirrors).
- **pytest** only fails on an import-time `SyntaxError` when a *collected test imports* the broken module. Nothing imports `lsp_gate_state` / `lsp_health`, so pytest stayed green.
- The dev/CI target is 3.14, where the code is valid, so a naive compile/import check on CI would also pass it and still ship the wedge to older hosts.

## Changes

1. **Correctness fix.** Parenthesized every multi-type except clause (`OSError, ValueError` / `TypeError, ValueError` / `OSError, UnicodeError, ValueError`) in all three trees (`.claude/lib/hook_utilities/`, `scripts/hook_utilities/`, `src/copilot-cli/lib/hook_utilities/`) for `lsp_gate_state.py` and `lsp_health.py`. Trees stay byte-identical, so source-mirror drift checks pass.
2. **Structural gate.** New `scripts/validation/validate_python_syntax.py` parses every tracked `.py` at the declared support floor (pyproject `requires-python`) via `ast.parse(feature_version=floor)`, which rejects too-new syntax even when the gate itself runs on 3.14. Wired first in `scripts/validation/pre_pr.py` and as a blocking step (before the report-only ruff step) in `.github/workflows/pytest.yml`. Deliberately separate from the ~2000-finding ruff style backlog: a sub-floor parse failure is a zero-false-positive defect.
3. **Tests.** `tests/validation/test_validate_python_syntax.py`: positive, negative (PEP 758 rejected at floor while valid on the 3.14 test host), negative (classic syntax error), edge (invalid root -> exit 2), walk-fallback, floor detection, and a guard that the live repo parses at the floor.

## Verification

- `validate_python_syntax.py` on the repo: exit 0.
- New test file: 9 passed.
- PreToolUse dispatcher rerun: EXIT=0 (was EXIT=2 deny).

## Decision record

`decision-python-floor-syntax-gate` (Serena memory) logs the Layer-3 contradiction: the conventional "add a compile gate" is wrong on the 3.14 target; the gate must validate against the support floor.

Fixes #2655
