### PR TITLE
fix(github): decode gh subprocess output as UTF-8 (Windows cp1252 crash)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.206",
+  "version": "0.5.207",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.205",
+  "version": "0.5.206",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/lib/github_core/api.py
+++ b/.claude/lib/github_core/api.py
@@ -105,7 +105,8 @@ def get_repo_info() -> RepoInfo | None:
         result = subprocess.run(
             ["git", "remote", "get-url", "origin"],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
         if result.returncode != 0:
@@ -162,7 +163,8 @@ def is_gh_authenticated() -> bool:
         result = subprocess.run(
             ["gh", "auth", "status"],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
         return result.returncode == 0
@@ -208,7 +210,8 @@ def gh_api_paginated(endpoint: str, page_size: int = 100) -> list[dict]:
         result = subprocess.run(
             ["gh", "api", url],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
         )
 
@@ -572,7 +575,8 @@ def update_issue_comment(owner: str, repo: str, comment_id: int, body: str) -> d
         ],
         input=payload,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
 
@@ -623,7 +627,8 @@ def create_issue_comment(
         ["gh", "api", endpoint, "-X", "POST", "--input", "-"],
         input=payload,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
 

--- a/.claude/skills/github/scripts/issue/post_issue_comment.py
+++ b/.claude/skills/github/scripts/issue/post_issue_comment.py
@@ -190,10 +190,14 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
     if args.marker:
         marker_html = f"<!-- {args.marker} -->"
 
-        comments_result = subprocess.run(
-            ["gh", "api", f"repos/{owner}/{repo}/issues/{issue}/comments"],
-            capture_output=True, encoding="utf-8", errors="replace", check=False,
-        )
+        try:
+            comments_result = subprocess.run(
+                ["gh", "api", f"repos/{owner}/{repo}/issues/{issue}/comments"],
+                capture_output=True, encoding="utf-8", errors="replace",
+                check=False, timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            error_and_exit("Timed out (30s) listing issue comments via gh.", 3)
 
         # Guard stdout: under locale text mode on Windows, gh's UTF-8 JSON was
         # decoded with cp1252, the reader thread died on a non-cp1252 byte, and
@@ -264,19 +268,23 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
 
     # Post new comment
     payload = json.dumps({"body": body})
-    result = subprocess.run(
-        [
-            "gh", "api",
-            f"repos/{owner}/{repo}/issues/{issue}/comments",
-            "-X", "POST",
-            "--input", "-",
-        ],
-        input=payload,
-        capture_output=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "gh", "api",
+                f"repos/{owner}/{repo}/issues/{issue}/comments",
+                "-X", "POST",
+                "--input", "-",
+            ],
+            input=payload,
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        error_and_exit("Timed out (30s) posting comment via gh.", 3)
 
     if result.returncode != 0:
         error_str = result.stderr.strip() or result.stdout.strip()

--- a/.claude/skills/github/scripts/issue/post_issue_comment.py
+++ b/.claude/skills/github/scripts/issue/post_issue_comment.py
@@ -95,7 +95,7 @@ def _save_failed_comment_artifact(
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--git-common-dir"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, encoding="utf-8", errors="replace", timeout=10,
         )
         if result.returncode == 0:
             git_common = Path(result.stdout.strip())
@@ -192,10 +192,15 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
 
         comments_result = subprocess.run(
             ["gh", "api", f"repos/{owner}/{repo}/issues/{issue}/comments"],
-            capture_output=True, text=True, check=False,
+            capture_output=True, encoding="utf-8", errors="replace", check=False,
         )
 
-        if comments_result.returncode == 0:
+        # Guard stdout: under locale text mode on Windows, gh's UTF-8 JSON was
+        # decoded with cp1252, the reader thread died on a non-cp1252 byte, and
+        # stdout came back None with returncode 0, so json.loads(None) crashed
+        # (issue #2657). encoding="utf-8" above is the fix; this guard is defense
+        # in depth for an empty or missing body.
+        if comments_result.returncode == 0 and comments_result.stdout:
             try:
                 comments = json.loads(comments_result.stdout)
             except json.JSONDecodeError:
@@ -268,7 +273,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         ],
         input=payload,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
     )
 

--- a/scripts/github_core/api.py
+++ b/scripts/github_core/api.py
@@ -105,7 +105,8 @@ def get_repo_info() -> RepoInfo | None:
         result = subprocess.run(
             ["git", "remote", "get-url", "origin"],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
         if result.returncode != 0:
@@ -162,7 +163,8 @@ def is_gh_authenticated() -> bool:
         result = subprocess.run(
             ["gh", "auth", "status"],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
         return result.returncode == 0
@@ -208,7 +210,8 @@ def gh_api_paginated(endpoint: str, page_size: int = 100) -> list[dict]:
         result = subprocess.run(
             ["gh", "api", url],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
         )
 
@@ -572,7 +575,8 @@ def update_issue_comment(owner: str, repo: str, comment_id: int, body: str) -> d
         ],
         input=payload,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
 
@@ -623,7 +627,8 @@ def create_issue_comment(
         ["gh", "api", endpoint, "-X", "POST", "--input", "-"],
         input=payload,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.205",
+  "version": "0.5.206",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.206",
+  "version": "0.5.207",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/lib/github_core/api.py
+++ b/src/copilot-cli/lib/github_core/api.py
@@ -105,7 +105,8 @@ def get_repo_info() -> RepoInfo | None:
         result = subprocess.run(
             ["git", "remote", "get-url", "origin"],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
         if result.returncode != 0:
@@ -162,7 +163,8 @@ def is_gh_authenticated() -> bool:
         result = subprocess.run(
             ["gh", "auth", "status"],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
         return result.returncode == 0
@@ -208,7 +210,8 @@ def gh_api_paginated(endpoint: str, page_size: int = 100) -> list[dict]:
         result = subprocess.run(
             ["gh", "api", url],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=30,
         )
 
@@ -572,7 +575,8 @@ def update_issue_comment(owner: str, repo: str, comment_id: int, body: str) -> d
         ],
         input=payload,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
 
@@ -623,7 +627,8 @@ def create_issue_comment(
         ["gh", "api", endpoint, "-X", "POST", "--input", "-"],
         input=payload,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
 

--- a/src/copilot-cli/skills/github/scripts/issue/post_issue_comment.py
+++ b/src/copilot-cli/skills/github/scripts/issue/post_issue_comment.py
@@ -190,10 +190,14 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
     if args.marker:
         marker_html = f"<!-- {args.marker} -->"
 
-        comments_result = subprocess.run(
-            ["gh", "api", f"repos/{owner}/{repo}/issues/{issue}/comments"],
-            capture_output=True, encoding="utf-8", errors="replace", check=False,
-        )
+        try:
+            comments_result = subprocess.run(
+                ["gh", "api", f"repos/{owner}/{repo}/issues/{issue}/comments"],
+                capture_output=True, encoding="utf-8", errors="replace",
+                check=False, timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            error_and_exit("Timed out (30s) listing issue comments via gh.", 3)
 
         # Guard stdout: under locale text mode on Windows, gh's UTF-8 JSON was
         # decoded with cp1252, the reader thread died on a non-cp1252 byte, and
@@ -264,19 +268,23 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
 
     # Post new comment
     payload = json.dumps({"body": body})
-    result = subprocess.run(
-        [
-            "gh", "api",
-            f"repos/{owner}/{repo}/issues/{issue}/comments",
-            "-X", "POST",
-            "--input", "-",
-        ],
-        input=payload,
-        capture_output=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "gh", "api",
+                f"repos/{owner}/{repo}/issues/{issue}/comments",
+                "-X", "POST",
+                "--input", "-",
+            ],
+            input=payload,
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        error_and_exit("Timed out (30s) posting comment via gh.", 3)
 
     if result.returncode != 0:
         error_str = result.stderr.strip() or result.stdout.strip()

--- a/src/copilot-cli/skills/github/scripts/issue/post_issue_comment.py
+++ b/src/copilot-cli/skills/github/scripts/issue/post_issue_comment.py
@@ -95,7 +95,7 @@ def _save_failed_comment_artifact(
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--git-common-dir"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, encoding="utf-8", errors="replace", timeout=10,
         )
         if result.returncode == 0:
             git_common = Path(result.stdout.strip())
@@ -192,10 +192,15 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
 
         comments_result = subprocess.run(
             ["gh", "api", f"repos/{owner}/{repo}/issues/{issue}/comments"],
-            capture_output=True, text=True, check=False,
+            capture_output=True, encoding="utf-8", errors="replace", check=False,
         )
 
-        if comments_result.returncode == 0:
+        # Guard stdout: under locale text mode on Windows, gh's UTF-8 JSON was
+        # decoded with cp1252, the reader thread died on a non-cp1252 byte, and
+        # stdout came back None with returncode 0, so json.loads(None) crashed
+        # (issue #2657). encoding="utf-8" above is the fix; this guard is defense
+        # in depth for an empty or missing body.
+        if comments_result.returncode == 0 and comments_result.stdout:
             try:
                 comments = json.loads(comments_result.stdout)
             except json.JSONDecodeError:
@@ -268,7 +273,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         ],
         input=payload,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
     )
 

--- a/tests/skills/github/test_post_issue_comment.py
+++ b/tests/skills/github/test_post_issue_comment.py
@@ -147,12 +147,15 @@ class TestPostIssueComment:
             rc = mod.main(["--issue", "1", "--body", "body"])
         assert rc == 0
 
-    def test_marker_list_none_stdout_does_not_crash(self, _import_module):
+    def test_marker_list_none_stdout_does_not_crash(self, _import_module, capsys):
         # Regression for issue #2657: on Windows the comments-list call decoded
-        # gh's UTF-8 with cp1252, the stdout reader thread died, and stdout came
-        # back None with returncode 0. Feeding None to json.loads crashed with
-        # TypeError. The marker path must guard stdout and fall through to
-        # posting a new comment. (First mock call = list comments, second = POST.)
+        # gh's UTF-8 with cp1252, the stdout reader thread died on an undecodable
+        # byte, and stdout came back None with returncode 0 (observed in repro).
+        # Feeding None to json.loads crashed with TypeError. The marker path must
+        # guard stdout and fall through to posting a new comment.
+        # First mock call = list comments (None), second = POST (valid).
+        # Negative control: on the pre-fix code (`if returncode == 0:` with no
+        # stdout guard) the first call raises TypeError and rc is never returned.
         mod = _import_module
         response = {"id": 101, "html_url": "https://example.com/c"}
         with (
@@ -161,35 +164,81 @@ class TestPostIssueComment:
             patch("subprocess.run", side_effect=[
                 make_completed_process(stdout=None, returncode=0),
                 make_completed_process(stdout=json.dumps(response), returncode=0),
-            ]),
+            ]) as mock_run,
         ):
             rc = mod.main(["--issue", "1", "--body", "b", "--marker", "M"])
         assert rc == 0
+        # Prove it fell through to actually POST the comment, not just avoid a crash.
+        assert mock_run.call_count == 2
+        result = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+        assert result["Success"] is True
+        assert result["Data"]["comment_id"] == 101
+        assert result["Data"]["skipped"] is False
 
 
 class TestSubprocessEncoding:
-    """Lock the issue #2657 fix: gh subprocess calls must declare UTF-8.
+    """Lock the issue #2657 fix: every gh/git subprocess call decodes as UTF-8.
 
     Bare ``text=True`` decodes with the OS locale codec (cp1252 on Windows),
-    which corrupts or drops gh's UTF-8 output. Every gh/git subprocess call in
-    the comment path and the shared api helper must pass ``encoding="utf-8"``.
+    which kills the reader thread on an undecodable byte (stdout -> None) or
+    silently mojibakes gh's UTF-8 output. The contract is that every
+    ``subprocess.run`` call in these files passes ``encoding="utf-8"`` AND
+    ``errors="replace"`` (the pattern ``gh_graphql`` established).
+
+    This parses the AST and checks each call independently, rather than scanning
+    for a substring, per .claude/rules/canonical-source-mirror.md (a substring
+    scan false-passes when one call is correct and another is bare, and
+    false-fails on the literal appearing in a comment).
     """
 
-    def test_post_issue_comment_has_no_bare_text_true(self):
+    _FILES = [
+        ".claude/lib/github_core/api.py",
+        ".claude/skills/github/scripts/issue/post_issue_comment.py",
+    ]
+
+    @staticmethod
+    def _kw(call, name):
+        for kw in call.keywords:
+            if kw.arg == name:
+                return kw.value
+        return None
+
+    def _subprocess_run_calls(self, tree):
+        import ast
+
+        calls = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "run"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "subprocess"
+            ):
+                calls.append(node)
+        return calls
+
+    @pytest.mark.parametrize("rel", _FILES)
+    def test_every_subprocess_run_declares_utf8(self, rel):
+        import ast
         from pathlib import Path
 
         repo_root = Path(__file__).resolve().parents[3]
-        src = (
-            repo_root
-            / ".claude/skills/github/scripts/issue/post_issue_comment.py"
-        ).read_text(encoding="utf-8")
-        assert "text=True" not in src
-        assert 'encoding="utf-8"' in src
-
-    def test_github_core_api_has_no_bare_text_true(self):
-        from pathlib import Path
-
-        repo_root = Path(__file__).resolve().parents[3]
-        src = (repo_root / ".claude/lib/github_core/api.py").read_text(encoding="utf-8")
-        assert "text=True" not in src
-        assert 'encoding="utf-8"' in src
+        tree = ast.parse((repo_root / rel).read_text(encoding="utf-8"))
+        calls = self._subprocess_run_calls(tree)
+        assert calls, f"expected subprocess.run calls in {rel}"
+        for call in calls:
+            encoding = self._kw(call, "encoding")
+            errors = self._kw(call, "errors")
+            assert (
+                isinstance(encoding, ast.Constant) and encoding.value == "utf-8"
+            ), f"{rel}:{call.lineno} subprocess.run missing encoding=\"utf-8\""
+            assert (
+                isinstance(errors, ast.Constant) and errors.value == "replace"
+            ), f"{rel}:{call.lineno} subprocess.run missing errors=\"replace\""
+            assert self._kw(call, "text") is None, (
+                f"{rel}:{call.lineno} subprocess.run still passes text= "
+                "(use encoding/errors instead)"
+            )

--- a/tests/skills/github/test_post_issue_comment.py
+++ b/tests/skills/github/test_post_issue_comment.py
@@ -1,6 +1,7 @@
 """Tests for post_issue_comment.py."""
 
 import json
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -162,7 +163,10 @@ class TestPostIssueComment:
             patch("post_issue_comment.assert_gh_authenticated"),
             patch("post_issue_comment.resolve_repo_params", return_value=_mock_repo()),
             patch("subprocess.run", side_effect=[
-                make_completed_process(stdout=None, returncode=0),
+                # Construct CompletedProcess directly: make_completed_process is
+                # typed stdout: str, but this regression needs the genuine
+                # stdout=None the Windows decode failure produces.
+                subprocess.CompletedProcess(args=["gh"], returncode=0, stdout=None, stderr=""),
                 make_completed_process(stdout=json.dumps(response), returncode=0),
             ]) as mock_run,
         ):
@@ -192,6 +196,9 @@ class TestSubprocessEncoding:
     """
 
     _FILES = [
+        # Canonical source first: a bare text=True here is overwritten into the
+        # mirrors on the next sync, so the source of truth must be validated too.
+        "scripts/github_core/api.py",
         ".claude/lib/github_core/api.py",
         ".claude/skills/github/scripts/issue/post_issue_comment.py",
     ]

--- a/tests/skills/github/test_post_issue_comment.py
+++ b/tests/skills/github/test_post_issue_comment.py
@@ -146,3 +146,50 @@ class TestPostIssueComment:
         ):
             rc = mod.main(["--issue", "1", "--body", "body"])
         assert rc == 0
+
+    def test_marker_list_none_stdout_does_not_crash(self, _import_module):
+        # Regression for issue #2657: on Windows the comments-list call decoded
+        # gh's UTF-8 with cp1252, the stdout reader thread died, and stdout came
+        # back None with returncode 0. Feeding None to json.loads crashed with
+        # TypeError. The marker path must guard stdout and fall through to
+        # posting a new comment. (First mock call = list comments, second = POST.)
+        mod = _import_module
+        response = {"id": 101, "html_url": "https://example.com/c"}
+        with (
+            patch("post_issue_comment.assert_gh_authenticated"),
+            patch("post_issue_comment.resolve_repo_params", return_value=_mock_repo()),
+            patch("subprocess.run", side_effect=[
+                make_completed_process(stdout=None, returncode=0),
+                make_completed_process(stdout=json.dumps(response), returncode=0),
+            ]),
+        ):
+            rc = mod.main(["--issue", "1", "--body", "b", "--marker", "M"])
+        assert rc == 0
+
+
+class TestSubprocessEncoding:
+    """Lock the issue #2657 fix: gh subprocess calls must declare UTF-8.
+
+    Bare ``text=True`` decodes with the OS locale codec (cp1252 on Windows),
+    which corrupts or drops gh's UTF-8 output. Every gh/git subprocess call in
+    the comment path and the shared api helper must pass ``encoding="utf-8"``.
+    """
+
+    def test_post_issue_comment_has_no_bare_text_true(self):
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[3]
+        src = (
+            repo_root
+            / ".claude/skills/github/scripts/issue/post_issue_comment.py"
+        ).read_text(encoding="utf-8")
+        assert "text=True" not in src
+        assert 'encoding="utf-8"' in src
+
+    def test_github_core_api_has_no_bare_text_true(self):
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[3]
+        src = (repo_root / ".claude/lib/github_core/api.py").read_text(encoding="utf-8")
+        assert "text=True" not in src
+        assert 'encoding="utf-8"' in src

--- a/tests/skills/github/test_post_issue_comment.py
+++ b/tests/skills/github/test_post_issue_comment.py
@@ -136,6 +136,36 @@ class TestPostIssueComment:
                 mod.main(["--issue", "1", "--body", "body"])
         assert exc.value.code == 3
 
+    def test_post_timeout_exits_3(self, _import_module):
+        # A hung gh on the POST call must surface as an external-error exit (3),
+        # not block the script indefinitely (Copilot review on PR #2659).
+        mod = _import_module
+        with (
+            patch("post_issue_comment.assert_gh_authenticated"),
+            patch("post_issue_comment.resolve_repo_params", return_value=_mock_repo()),
+            patch("subprocess.run", side_effect=subprocess.TimeoutExpired(
+                cmd=["gh"], timeout=30,
+            )),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                mod.main(["--issue", "1", "--body", "body"])
+        assert exc.value.code == 3
+
+    def test_marker_list_timeout_exits_3(self, _import_module):
+        # A hung gh on the comments-list (marker) call must exit 3 rather than
+        # wedge a CI or hook run (Copilot review on PR #2659).
+        mod = _import_module
+        with (
+            patch("post_issue_comment.assert_gh_authenticated"),
+            patch("post_issue_comment.resolve_repo_params", return_value=_mock_repo()),
+            patch("subprocess.run", side_effect=subprocess.TimeoutExpired(
+                cmd=["gh"], timeout=30,
+            )),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                mod.main(["--issue", "1", "--body", "body", "--marker", "M"])
+        assert exc.value.code == 3
+
     def test_json_parse_error_returns_success(self, _import_module):
         mod = _import_module
         with (

--- a/tests/skills/github/test_post_issue_comment.py
+++ b/tests/skills/github/test_post_issue_comment.py
@@ -201,6 +201,10 @@ class TestSubprocessEncoding:
         "scripts/github_core/api.py",
         ".claude/lib/github_core/api.py",
         ".claude/skills/github/scripts/issue/post_issue_comment.py",
+        # Shipped Copilot CLI mirrors: enforce the contract on what ships, not
+        # just the canonical, so a desynced mirror is caught by the test itself.
+        "src/copilot-cli/lib/github_core/api.py",
+        "src/copilot-cli/skills/github/scripts/issue/post_issue_comment.py",
     ]
 
     @staticmethod


### PR DESCRIPTION
## Summary

On Windows, `subprocess.run([...gh...], capture_output=True, text=True)` decodes gh's UTF-8 JSON with the locale codec (cp1252). When the output contains a byte not representable in cp1252, the stdout reader thread dies with `UnicodeDecodeError`, `subprocess.run` returns `stdout=None` with `returncode=0`, and `json.loads(None)` raises `TypeError`. `post_issue_comment.py` crashed this way on the marker (idempotency) path.

## Verified reproduction (CPython 3.14.5, Windows)

```
Exception in thread Thread-1 (_readerthread):
  ...
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 4341
returncode: 0
stdout type: NoneType
```

The reader-thread exception is swallowed; the main call returns `None` stdout with success returncode. `text=True` selects the locale codec; gh always emits UTF-8.

## Fix

Convert gh/git subprocess calls to `encoding="utf-8", errors="replace"` (the pattern `gh_graphql` in `github_core/api.py` already uses). `errors="replace"` makes the decode total, so the reader thread cannot die and stdout is always a `str` (never `None`).

- `.claude/lib/github_core/api.py`: 5 calls converted (`get_repo_info`, `is_gh_authenticated`, `gh_api_paginated`, `update_issue_comment`, `create_issue_comment`). All 6 gh/git calls in the file now declare UTF-8.
- `.claude/skills/github/scripts/issue/post_issue_comment.py`: comments-list, POST, and git-rev-parse calls converted; plus a defensive `and comments_result.stdout` guard before `json.loads` (belt-and-suspenders; the encoding fix already prevents `None`).

## Tests

- `test_marker_list_none_stdout_does_not_crash`: feeds `stdout=None, returncode=0` then a valid POST; asserts the path falls through and actually posts (`call_count == 2`, `comment_id`, `skipped False`). Negative control: pre-fix code raises `TypeError` (the marker path only catches `JSONDecodeError`).
- `TestSubprocessEncoding`: AST check that every `subprocess.run` in both files declares `encoding="utf-8"` and `errors="replace"` and no `text=`, per `canonical-source-mirror.md` (independent-contract test, not a substring scan).

13 passed.

## Out of Scope

This PR fixes the `post_issue_comment` crash path: `api.py` and `post_issue_comment.py`. The same `text=True`-without-encoding pattern remains in other gh callers (`.claude/lib/github_core/gh_client.py`, `repo.py`, `rate_limit.py`, and several `scripts/issue/*.py` and `scripts/pr/*.py`). They carry the identical latent Windows bug and are deferred to a follow-up sweep tracked in #2657. The highest-traffic shared path (`api.py`) and the reported failure are fixed first.

## Review

Adversarial review (principal, skeptic, junior; then a second consolidating pass) ran before push. Root cause was confirmed by live repro; regression test and AST lock were independently verified. Verdict: SHIP.

Fixes #2657
