### PR TITLE
feat(agents): promote 5 review agents to shared-agent family (install to Copilot CLI + VS Code)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.213",
+  "version": "0.5.214",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/agents/code-simplifier.md
+++ b/.claude/agents/code-simplifier.md
@@ -9,7 +9,7 @@ argument-hint: Point to the recently modified code to simplify
 
 # Code Simplifier Agent
 
-> **Complementary Role**: Core code-writing standards (clarity over brevity, no nested ternaries, comment hygiene, ES module patterns, React props types) are now in CLAUDE.md and the implementer agent. Implementers apply these standards during initial writing. This agent complements that by handling post-hoc refinement: balance judgments, language-specific polish, and final quality assessment that requires seeing complete code.
+> **Complementary Role**: Core code-writing standards are embedded here: clarity over brevity, no nested ternaries, comment hygiene, language-appropriate module patterns, and explicit public-boundary types. Implementers apply these standards during initial writing. This agent complements that by handling post-hoc refinement: balance judgments, language-specific polish, and final quality assessment that requires seeing complete code.
 
 You simplify recently modified code without changing what it does. You produce either a rewrite diff or a list of refactors, never a vague suggestion.
 
@@ -73,7 +73,7 @@ Prefer the simpler equivalent in every choice:
 - Prefer one return per branch over a mutable accumulator.
 - Prefer a table lookup over a long if/elif chain when the cases differ only in data.
 - Prefer the explicit type annotation on every public boundary.
-- Prefer ES modules with explicit import extensions and the `function` keyword for top-level functions (per CLAUDE.md).
+- Prefer ES modules with explicit import extensions and the `function` keyword for top-level functions when the language uses JavaScript or TypeScript.
 
 ## Functionality Preservation
 
@@ -95,8 +95,8 @@ Skip a refactor if:
 
 Ask first if:
 
-- Project-specific conventions in CLAUDE.md conflict with a stylistic positive above.
-- A refactor crosses an architectural boundary defined in `.agents/architecture/ADR-*.md`.
+- Project-specific conventions in the current repository conflict with a stylistic positive above.
+- A refactor crosses a documented architectural boundary or another agent's ownership boundary.
 
 ## Agent Contract (delegation, gates, handoff)
 

--- a/.claude/agents/code-simplifier.md
+++ b/.claude/agents/code-simplifier.md
@@ -1,7 +1,10 @@
 ---
 name: code-simplifier
-tier: integration
 description: Use this agent when code has been written or modified and needs to be simplified for clarity, consistency, and maintainability while preserving all functionality. This agent should be triggered automatically after completing a coding task or writing a logical chunk of code. It simplifies code by following project best practices while retaining all functionality. The agent focuses only on recently modified code unless instructed otherwise.
+model: sonnet
+metadata:
+  tier: integration
+argument-hint: Point to the recently modified code to simplify
 ---
 
 # Code Simplifier Agent

--- a/.claude/agents/comment-analyzer.md
+++ b/.claude/agents/comment-analyzer.md
@@ -1,7 +1,10 @@
 ---
 name: comment-analyzer
-tier: integration
 description: Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.
+model: sonnet
+metadata:
+  tier: integration
+argument-hint: Point to the comments or PR to review for accuracy
 ---
 
 # Comment Analyzer Agent

--- a/.claude/agents/comment-analyzer.md
+++ b/.claude/agents/comment-analyzer.md
@@ -43,7 +43,7 @@ Classify every comment into one of three buckets. State the bucket in the findin
 
 Emit three sections in this exact order. No preamble.
 
-**Summary** (3 sentences max): Total comments analyzed, count per bucket, the single most significant finding.
+**Summary** (3 sentences max): Total comments analyzed, count per bucket, the highest-impact finding.
 
 **Findings** (10 items max, one per finding, format below):
 

--- a/.claude/agents/pr-test-analyzer.md
+++ b/.claude/agents/pr-test-analyzer.md
@@ -7,7 +7,7 @@ metadata:
 argument-hint: Point to the PR or changes whose test coverage to assess
 ---
 
-# Pr Test Analyzer Agent
+# PR Test Analyzer Agent
 
 You analyze pull-request test coverage. You produce a ranked list of gaps with file:line evidence and a single recommendation. You measure behavioral coverage, not line coverage.
 

--- a/.claude/agents/pr-test-analyzer.md
+++ b/.claude/agents/pr-test-analyzer.md
@@ -1,7 +1,10 @@
 ---
 name: pr-test-analyzer
-tier: builder
 description: Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases.
+model: opus
+metadata:
+  tier: builder
+argument-hint: Point to the PR or changes whose test coverage to assess
 ---
 
 # Pr Test Analyzer Agent

--- a/.claude/agents/pr-test-analyzer.md
+++ b/.claude/agents/pr-test-analyzer.md
@@ -27,7 +27,7 @@ Before asserting that a behavior is untested:
 
 - Use Grep for the function name in `tests/` and `test/` (both are pytest-discoverable in this repo), `*_test.py`, `*.spec.ts`, and any project-specific test path.
 - Read at least one matching test file end-to-end if a match exists.
-- Check the project test rigor floor (`.agents/governance/TESTING-RIGOR.md` and the project's testing rules) for the language at hand: positive, negative, edge, every branch, mocked I/O.
+- Check the testing floor embedded in this prompt for the language at hand: positive, negative, edge, every branch, mocked I/O.
 
 Do not assert missing coverage without searching. Do not assert "no test exists" without grepping both the test directory and adjacent integration test suites. If grep is too broad to be conclusive, say so and downgrade the finding to "needs author confirmation."
 
@@ -88,7 +88,7 @@ Skip:
 Ask first:
 
 - The PR adds a new test framework or runner; flag the change to the architect agent before judging coverage under the new tool.
-- Coverage targets in `AGENTS.md` conflict with the project-local rule; surface the conflict and request resolution.
+- This prompt conflicts with a local rule; surface the conflict and request resolution.
 
 ## Agent Contract (delegation, gates, handoff)
 

--- a/.claude/agents/silent-failure-hunter.md
+++ b/.claude/agents/silent-failure-hunter.md
@@ -1,7 +1,10 @@
 ---
 name: silent-failure-hunter
-tier: builder
 description: Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. This agent should be invoked proactively after completing a logical chunk of work that involves error handling, catch blocks, fallback logic, or any code that could potentially suppress errors.
+model: opus
+metadata:
+  tier: builder
+argument-hint: Point to the PR, diff, or files whose error handling to audit
 ---
 
 # Silent Failure Hunter Agent

--- a/.claude/agents/silent-failure-hunter.md
+++ b/.claude/agents/silent-failure-hunter.md
@@ -44,7 +44,7 @@ For every error handling location, ask:
 
 - Is the error logged with appropriate severity (logError for production issues)?
 - Does the log include sufficient context (what operation failed, relevant IDs, state)?
-- Is there an error ID from constants/errorIds.ts for Sentry tracking?
+- Is there a stable error identifier when the repository defines an error-id catalog?
 - Would this log help someone debug the issue 6 months from now?
 
 **User Feedback:**
@@ -134,12 +134,12 @@ You are thorough, skeptical, and uncompromising about error handling quality. Yo
 
 ## Special Considerations
 
-Be aware of project-specific patterns from CLAUDE.md:
+Apply these error-handling rules in the repository under review:
 
-- This project has specific logging functions: logForDebugging (user-facing), logError (Sentry), logEvent (Statsig)
-- Error IDs should come from constants/errorIds.ts
-- The project explicitly forbids silent failures in production code
-- Empty catch blocks are never acceptable
-- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them
+- Surface user-facing failures through the repository's established notification or logging path.
+- Preserve diagnostic context for operators without logging secrets or raw private data.
+- Use stable error identifiers only when the repository already defines an error-id catalog.
+- Silent failures and empty catch blocks are never acceptable.
+- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them.
 
 Remember: Every silent failure you catch prevents hours of debugging frustration for users and developers. Be thorough, be skeptical, and never let an error slip through unnoticed.

--- a/.claude/agents/type-design-analyzer.md
+++ b/.claude/agents/type-design-analyzer.md
@@ -112,4 +112,4 @@ Always consider:
 - Performance implications of additional validation
 - The balance between safety and usability
 
-Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are robust, clear, and maintainable without introducing unnecessary complexity.
+Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are safe, clear, and maintainable without introducing unnecessary complexity.

--- a/.claude/agents/type-design-analyzer.md
+++ b/.claude/agents/type-design-analyzer.md
@@ -1,7 +1,10 @@
 ---
 name: type-design-analyzer
-tier: builder
 description: Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.
+model: opus
+metadata:
+  tier: builder
+argument-hint: Point to the type(s) or PR to review for design quality
 ---
 
 # Type Design Analyzer Agent

--- a/.github/agents/code-simplifier.agent.md
+++ b/.github/agents/code-simplifier.agent.md
@@ -6,7 +6,7 @@ description: Use this agent when code has been written or modified and needs to 
 
 # Code Simplifier Agent
 
-> **Complementary Role**: Core code-writing standards (clarity over brevity, no nested ternaries, comment hygiene, ES module patterns, React props types) are now in CLAUDE.md and the implementer agent. Implementers apply these standards during initial writing. This agent complements that by handling post-hoc refinement: balance judgments, language-specific polish, and final quality assessment that requires seeing complete code.
+> **Complementary Role**: Core code-writing standards are embedded here: clarity over brevity, no nested ternaries, comment hygiene, language-appropriate module patterns, and explicit public-boundary types. Implementers apply these standards during initial writing. This agent complements that by handling post-hoc refinement: balance judgments, language-specific polish, and final quality assessment that requires seeing complete code.
 
 You simplify recently modified code without changing what it does. You produce either a rewrite diff or a list of refactors, never a vague suggestion.
 
@@ -70,7 +70,7 @@ Prefer the simpler equivalent in every choice:
 - Prefer one return per branch over a mutable accumulator.
 - Prefer a table lookup over a long if/elif chain when the cases differ only in data.
 - Prefer the explicit type annotation on every public boundary.
-- Prefer ES modules with explicit import extensions and the `function` keyword for top-level functions (per CLAUDE.md).
+- Prefer ES modules with explicit import extensions and the `function` keyword for top-level functions when the language uses JavaScript or TypeScript.
 
 ## Functionality Preservation
 
@@ -92,8 +92,8 @@ Skip a refactor if:
 
 Ask first if:
 
-- Project-specific conventions in CLAUDE.md conflict with a stylistic positive above.
-- A refactor crosses an architectural boundary defined in `.agents/architecture/ADR-*.md`.
+- Project-specific conventions in the current repository conflict with a stylistic positive above.
+- A refactor crosses a documented architectural boundary or another agent's ownership boundary.
 
 ## Agent Contract (delegation, gates, handoff)
 

--- a/.github/agents/comment-analyzer.agent.md
+++ b/.github/agents/comment-analyzer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: comment-analyzer
 tier: integration
-description: Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.
+description: 'Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.'
 ---
 
 # Comment Analyzer Agent

--- a/.github/agents/comment-analyzer.agent.md
+++ b/.github/agents/comment-analyzer.agent.md
@@ -40,7 +40,7 @@ Classify every comment into one of three buckets. State the bucket in the findin
 
 Emit three sections in this exact order. No preamble.
 
-**Summary** (3 sentences max): Total comments analyzed, count per bucket, the single most significant finding.
+**Summary** (3 sentences max): Total comments analyzed, count per bucket, the highest-impact finding.
 
 **Findings** (10 items max, one per finding, format below):
 

--- a/.github/agents/pr-test-analyzer.agent.md
+++ b/.github/agents/pr-test-analyzer.agent.md
@@ -4,7 +4,7 @@ tier: builder
 description: Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases.
 ---
 
-# Pr Test Analyzer Agent
+# PR Test Analyzer Agent
 
 You analyze pull-request test coverage. You produce a ranked list of gaps with file:line evidence and a single recommendation. You measure behavioral coverage, not line coverage.
 

--- a/.github/agents/pr-test-analyzer.agent.md
+++ b/.github/agents/pr-test-analyzer.agent.md
@@ -24,7 +24,7 @@ Before asserting that a behavior is untested:
 
 - Use Grep for the function name in `tests/` and `test/` (both are pytest-discoverable in this repo), `*_test.py`, `*.spec.ts`, and any project-specific test path.
 - Read at least one matching test file end-to-end if a match exists.
-- Check the project test rigor floor (`.agents/governance/TESTING-RIGOR.md` and the project's testing rules) for the language at hand: positive, negative, edge, every branch, mocked I/O.
+- Check the testing floor embedded in this prompt for the language at hand: positive, negative, edge, every branch, mocked I/O.
 
 Do not assert missing coverage without searching. Do not assert "no test exists" without grepping both the test directory and adjacent integration test suites. If grep is too broad to be conclusive, say so and downgrade the finding to "needs author confirmation."
 
@@ -85,7 +85,7 @@ Skip:
 Ask first:
 
 - The PR adds a new test framework or runner; flag the change to the architect agent before judging coverage under the new tool.
-- Coverage targets in `AGENTS.md` conflict with the project-local rule; surface the conflict and request resolution.
+- This prompt conflicts with a local rule; surface the conflict and request resolution.
 
 ## Agent Contract (delegation, gates, handoff)
 

--- a/.github/agents/silent-failure-hunter.agent.md
+++ b/.github/agents/silent-failure-hunter.agent.md
@@ -41,7 +41,7 @@ For every error handling location, ask:
 
 - Is the error logged with appropriate severity (logError for production issues)?
 - Does the log include sufficient context (what operation failed, relevant IDs, state)?
-- Is there an error ID from constants/errorIds.ts for Sentry tracking?
+- Is there a stable error identifier when the repository defines an error-id catalog?
 - Would this log help someone debug the issue 6 months from now?
 
 **User Feedback:**
@@ -131,12 +131,12 @@ You are thorough, skeptical, and uncompromising about error handling quality. Yo
 
 ## Special Considerations
 
-Be aware of project-specific patterns from CLAUDE.md:
+Apply these error-handling rules in the repository under review:
 
-- This project has specific logging functions: logForDebugging (user-facing), logError (Sentry), logEvent (Statsig)
-- Error IDs should come from constants/errorIds.ts
-- The project explicitly forbids silent failures in production code
-- Empty catch blocks are never acceptable
-- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them
+- Surface user-facing failures through the repository's established notification or logging path.
+- Preserve diagnostic context for operators without logging secrets or raw private data.
+- Use stable error identifiers only when the repository already defines an error-id catalog.
+- Silent failures and empty catch blocks are never acceptable.
+- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them.
 
 Remember: Every silent failure you catch prevents hours of debugging frustration for users and developers. Be thorough, be skeptical, and never let an error slip through unnoticed.

--- a/.github/agents/type-design-analyzer.agent.md
+++ b/.github/agents/type-design-analyzer.agent.md
@@ -109,4 +109,4 @@ Always consider:
 - Performance implications of additional validation
 - The balance between safety and usability
 
-Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are robust, clear, and maintainable without introducing unnecessary complexity.
+Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are safe, clear, and maintainable without introducing unnecessary complexity.

--- a/.github/agents/type-design-analyzer.agent.md
+++ b/.github/agents/type-design-analyzer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: type-design-analyzer
 tier: builder
-description: Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.
+description: 'Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.'
 ---
 
 # Type Design Analyzer Agent

--- a/src/claude/.claude-plugin/plugin.json
+++ b/src/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-agents",
   "description": "25 specialized agent definitions with templates and governance for Claude Code",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/claude/code-simplifier.md
+++ b/src/claude/code-simplifier.md
@@ -9,7 +9,7 @@ argument-hint: Point to the recently modified code to simplify
 
 # Code Simplifier Agent
 
-> **Complementary Role**: Core code-writing standards (clarity over brevity, no nested ternaries, comment hygiene, ES module patterns, React props types) are now in CLAUDE.md and the implementer agent. Implementers apply these standards during initial writing. This agent complements that by handling post-hoc refinement: balance judgments, language-specific polish, and final quality assessment that requires seeing complete code.
+> **Complementary Role**: Core code-writing standards are embedded here: clarity over brevity, no nested ternaries, comment hygiene, language-appropriate module patterns, and explicit public-boundary types. Implementers apply these standards during initial writing. This agent complements that by handling post-hoc refinement: balance judgments, language-specific polish, and final quality assessment that requires seeing complete code.
 
 You simplify recently modified code without changing what it does. You produce either a rewrite diff or a list of refactors, never a vague suggestion.
 
@@ -73,7 +73,7 @@ Prefer the simpler equivalent in every choice:
 - Prefer one return per branch over a mutable accumulator.
 - Prefer a table lookup over a long if/elif chain when the cases differ only in data.
 - Prefer the explicit type annotation on every public boundary.
-- Prefer ES modules with explicit import extensions and the `function` keyword for top-level functions (per CLAUDE.md).
+- Prefer ES modules with explicit import extensions and the `function` keyword for top-level functions when the language uses JavaScript or TypeScript.
 
 ## Functionality Preservation
 
@@ -95,8 +95,8 @@ Skip a refactor if:
 
 Ask first if:
 
-- Project-specific conventions in CLAUDE.md conflict with a stylistic positive above.
-- A refactor crosses an architectural boundary defined in `.agents/architecture/ADR-*.md`.
+- Project-specific conventions in the current repository conflict with a stylistic positive above.
+- A refactor crosses a documented architectural boundary or another agent's ownership boundary.
 
 ## Agent Contract (delegation, gates, handoff)
 

--- a/src/claude/code-simplifier.md
+++ b/src/claude/code-simplifier.md
@@ -1,7 +1,10 @@
 ---
 name: code-simplifier
-tier: integration
 description: Use this agent when code has been written or modified and needs to be simplified for clarity, consistency, and maintainability while preserving all functionality. This agent should be triggered automatically after completing a coding task or writing a logical chunk of code. It simplifies code by following project best practices while retaining all functionality. The agent focuses only on recently modified code unless instructed otherwise.
+model: sonnet
+metadata:
+  tier: integration
+argument-hint: Point to the recently modified code to simplify
 ---
 
 # Code Simplifier Agent

--- a/src/claude/comment-analyzer.md
+++ b/src/claude/comment-analyzer.md
@@ -1,7 +1,10 @@
 ---
 name: comment-analyzer
-tier: integration
 description: Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.
+model: sonnet
+metadata:
+  tier: integration
+argument-hint: Point to the comments or PR to review for accuracy
 ---
 
 # Comment Analyzer Agent

--- a/src/claude/comment-analyzer.md
+++ b/src/claude/comment-analyzer.md
@@ -43,7 +43,7 @@ Classify every comment into one of three buckets. State the bucket in the findin
 
 Emit three sections in this exact order. No preamble.
 
-**Summary** (3 sentences max): Total comments analyzed, count per bucket, the single most significant finding.
+**Summary** (3 sentences max): Total comments analyzed, count per bucket, the highest-impact finding.
 
 **Findings** (10 items max, one per finding, format below):
 

--- a/src/claude/pr-test-analyzer.md
+++ b/src/claude/pr-test-analyzer.md
@@ -7,7 +7,7 @@ metadata:
 argument-hint: Point to the PR or changes whose test coverage to assess
 ---
 
-# Pr Test Analyzer Agent
+# PR Test Analyzer Agent
 
 You analyze pull-request test coverage. You produce a ranked list of gaps with file:line evidence and a single recommendation. You measure behavioral coverage, not line coverage.
 

--- a/src/claude/pr-test-analyzer.md
+++ b/src/claude/pr-test-analyzer.md
@@ -1,7 +1,10 @@
 ---
 name: pr-test-analyzer
-tier: builder
 description: Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases.
+model: opus
+metadata:
+  tier: builder
+argument-hint: Point to the PR or changes whose test coverage to assess
 ---
 
 # Pr Test Analyzer Agent

--- a/src/claude/pr-test-analyzer.md
+++ b/src/claude/pr-test-analyzer.md
@@ -27,7 +27,7 @@ Before asserting that a behavior is untested:
 
 - Use Grep for the function name in `tests/` and `test/` (both are pytest-discoverable in this repo), `*_test.py`, `*.spec.ts`, and any project-specific test path.
 - Read at least one matching test file end-to-end if a match exists.
-- Check the project test rigor floor (`.agents/governance/TESTING-RIGOR.md` and the project's testing rules) for the language at hand: positive, negative, edge, every branch, mocked I/O.
+- Check the testing floor embedded in this prompt for the language at hand: positive, negative, edge, every branch, mocked I/O.
 
 Do not assert missing coverage without searching. Do not assert "no test exists" without grepping both the test directory and adjacent integration test suites. If grep is too broad to be conclusive, say so and downgrade the finding to "needs author confirmation."
 
@@ -88,7 +88,7 @@ Skip:
 Ask first:
 
 - The PR adds a new test framework or runner; flag the change to the architect agent before judging coverage under the new tool.
-- Coverage targets in `AGENTS.md` conflict with the project-local rule; surface the conflict and request resolution.
+- This prompt conflicts with a local rule; surface the conflict and request resolution.
 
 ## Agent Contract (delegation, gates, handoff)
 

--- a/src/claude/silent-failure-hunter.md
+++ b/src/claude/silent-failure-hunter.md
@@ -1,7 +1,10 @@
 ---
 name: silent-failure-hunter
-tier: builder
 description: Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. This agent should be invoked proactively after completing a logical chunk of work that involves error handling, catch blocks, fallback logic, or any code that could potentially suppress errors.
+model: opus
+metadata:
+  tier: builder
+argument-hint: Point to the PR, diff, or files whose error handling to audit
 ---
 
 # Silent Failure Hunter Agent

--- a/src/claude/silent-failure-hunter.md
+++ b/src/claude/silent-failure-hunter.md
@@ -44,7 +44,7 @@ For every error handling location, ask:
 
 - Is the error logged with appropriate severity (logError for production issues)?
 - Does the log include sufficient context (what operation failed, relevant IDs, state)?
-- Is there an error ID from constants/errorIds.ts for Sentry tracking?
+- Is there a stable error identifier when the repository defines an error-id catalog?
 - Would this log help someone debug the issue 6 months from now?
 
 **User Feedback:**
@@ -134,12 +134,12 @@ You are thorough, skeptical, and uncompromising about error handling quality. Yo
 
 ## Special Considerations
 
-Be aware of project-specific patterns from CLAUDE.md:
+Apply these error-handling rules in the repository under review:
 
-- This project has specific logging functions: logForDebugging (user-facing), logError (Sentry), logEvent (Statsig)
-- Error IDs should come from constants/errorIds.ts
-- The project explicitly forbids silent failures in production code
-- Empty catch blocks are never acceptable
-- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them
+- Surface user-facing failures through the repository's established notification or logging path.
+- Preserve diagnostic context for operators without logging secrets or raw private data.
+- Use stable error identifiers only when the repository already defines an error-id catalog.
+- Silent failures and empty catch blocks are never acceptable.
+- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them.
 
 Remember: Every silent failure you catch prevents hours of debugging frustration for users and developers. Be thorough, be skeptical, and never let an error slip through unnoticed.

--- a/src/claude/type-design-analyzer.md
+++ b/src/claude/type-design-analyzer.md
@@ -112,4 +112,4 @@ Always consider:
 - Performance implications of additional validation
 - The balance between safety and usability
 
-Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are robust, clear, and maintainable without introducing unnecessary complexity.
+Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are safe, clear, and maintainable without introducing unnecessary complexity.

--- a/src/claude/type-design-analyzer.md
+++ b/src/claude/type-design-analyzer.md
@@ -1,7 +1,10 @@
 ---
 name: type-design-analyzer
-tier: builder
 description: Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.
+model: opus
+metadata:
+  tier: builder
+argument-hint: Point to the type(s) or PR to review for design quality
 ---
 
 # Type Design Analyzer Agent

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.213",
+  "version": "0.5.214",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/agents/code-simplifier.agent.md
+++ b/src/copilot-cli/agents/code-simplifier.agent.md
@@ -1,7 +1,20 @@
 ---
 name: code-simplifier
-tier: integration
 description: Use this agent when code has been written or modified and needs to be simplified for clarity, consistency, and maintainability while preserving all functionality. This agent should be triggered automatically after completing a coding task or writing a logical chunk of code. It simplifies code by following project best practices while retaining all functionality. The agent focuses only on recently modified code unless instructed otherwise.
+argument-hint: Point to the recently modified code to simplify
+tools:
+  - read
+  - edit
+  - search
+  - shell
+  - web
+  - cognitionai/deepwiki/*
+  - context7/*
+  - perplexity/*
+  - cloudmcp-manager/*
+  - serena/*
+model: claude-opus-4.6
+tier: integration
 ---
 
 # Code Simplifier Agent

--- a/src/copilot-cli/agents/code-simplifier.agent.md
+++ b/src/copilot-cli/agents/code-simplifier.agent.md
@@ -7,19 +7,13 @@ tools:
   - edit
   - search
   - shell
-  - web
-  - cognitionai/deepwiki/*
-  - context7/*
-  - perplexity/*
-  - cloudmcp-manager/*
-  - serena/*
-model: claude-opus-4.6
+model: claude-sonnet-4.6
 tier: integration
 ---
 
 # Code Simplifier Agent
 
-> **Complementary Role**: Core code-writing standards (clarity over brevity, no nested ternaries, comment hygiene, ES module patterns, React props types) are now in CLAUDE.md and the implementer agent. Implementers apply these standards during initial writing. This agent complements that by handling post-hoc refinement: balance judgments, language-specific polish, and final quality assessment that requires seeing complete code.
+> **Complementary Role**: Core code-writing standards are embedded here: clarity over brevity, no nested ternaries, comment hygiene, language-appropriate module patterns, and explicit public-boundary types. Implementers apply these standards during initial writing. This agent complements that by handling post-hoc refinement: balance judgments, language-specific polish, and final quality assessment that requires seeing complete code.
 
 You simplify recently modified code without changing what it does. You produce either a rewrite diff or a list of refactors, never a vague suggestion.
 
@@ -83,7 +77,7 @@ Prefer the simpler equivalent in every choice:
 - Prefer one return per branch over a mutable accumulator.
 - Prefer a table lookup over a long if/elif chain when the cases differ only in data.
 - Prefer the explicit type annotation on every public boundary.
-- Prefer ES modules with explicit import extensions and the `function` keyword for top-level functions (per CLAUDE.md).
+- Prefer ES modules with explicit import extensions and the `function` keyword for top-level functions when the language uses JavaScript or TypeScript.
 
 ## Functionality Preservation
 
@@ -105,8 +99,8 @@ Skip a refactor if:
 
 Ask first if:
 
-- Project-specific conventions in CLAUDE.md conflict with a stylistic positive above.
-- A refactor crosses an architectural boundary defined in `.agents/architecture/ADR-*.md`.
+- Project-specific conventions in the current repository conflict with a stylistic positive above.
+- A refactor crosses a documented architectural boundary or another agent's ownership boundary.
 
 ## Agent Contract (delegation, gates, handoff)
 

--- a/src/copilot-cli/agents/comment-analyzer.agent.md
+++ b/src/copilot-cli/agents/comment-analyzer.agent.md
@@ -59,7 +59,7 @@ Classify every comment into one of three buckets. State the bucket in the findin
 
 Emit three sections in this exact order. No preamble.
 
-**Summary** (3 sentences max): Total comments analyzed, count per bucket, the single most significant finding.
+**Summary** (3 sentences max): Total comments analyzed, count per bucket, the highest-impact finding.
 
 **Findings** (10 items max, one per finding, format below):
 

--- a/src/copilot-cli/agents/comment-analyzer.agent.md
+++ b/src/copilot-cli/agents/comment-analyzer.agent.md
@@ -1,7 +1,26 @@
 ---
 name: comment-analyzer
+description: 'Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.'
+argument-hint: Point to the comments or PR to review for accuracy
+tools:
+  - read
+  - edit
+  - search
+  - github/search_code
+  - github/search_issues
+  - github/search_pull_requests
+  - github/issue_read
+  - github/pull_request_read
+  - github/get_file_contents
+  - github/list_commits
+  - web
+  - cognitionai/deepwiki/*
+  - context7/*
+  - perplexity/*
+  - cloudmcp-manager/*
+  - serena/*
+model: claude-opus-4.6
 tier: integration
-description: Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.
 ---
 
 # Comment Analyzer Agent

--- a/src/copilot-cli/agents/comment-analyzer.agent.md
+++ b/src/copilot-cli/agents/comment-analyzer.agent.md
@@ -4,7 +4,6 @@ description: 'Use this agent when you need to analyze code comments for accuracy
 argument-hint: Point to the comments or PR to review for accuracy
 tools:
   - read
-  - edit
   - search
   - github/search_code
   - github/search_issues
@@ -19,7 +18,7 @@ tools:
   - perplexity/*
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.6
+model: claude-sonnet-4.6
 tier: integration
 ---
 

--- a/src/copilot-cli/agents/pr-test-analyzer.agent.md
+++ b/src/copilot-cli/agents/pr-test-analyzer.agent.md
@@ -1,7 +1,26 @@
 ---
 name: pr-test-analyzer
-tier: builder
 description: Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases.
+argument-hint: Point to the PR or changes whose test coverage to assess
+tools:
+  - read
+  - edit
+  - search
+  - github/search_code
+  - github/search_issues
+  - github/search_pull_requests
+  - github/issue_read
+  - github/pull_request_read
+  - github/get_file_contents
+  - github/list_commits
+  - web
+  - cognitionai/deepwiki/*
+  - context7/*
+  - perplexity/*
+  - cloudmcp-manager/*
+  - serena/*
+model: claude-opus-4.6
+tier: builder
 ---
 
 # Pr Test Analyzer Agent

--- a/src/copilot-cli/agents/pr-test-analyzer.agent.md
+++ b/src/copilot-cli/agents/pr-test-analyzer.agent.md
@@ -4,7 +4,6 @@ description: Use this agent when you need to review a pull request for test cove
 argument-hint: Point to the PR or changes whose test coverage to assess
 tools:
   - read
-  - edit
   - search
   - github/search_code
   - github/search_issues
@@ -23,7 +22,7 @@ model: claude-opus-4.6
 tier: builder
 ---
 
-# Pr Test Analyzer Agent
+# PR Test Analyzer Agent
 
 You analyze pull-request test coverage. You produce a ranked list of gaps with file:line evidence and a single recommendation. You measure behavioral coverage, not line coverage.
 

--- a/src/copilot-cli/agents/pr-test-analyzer.agent.md
+++ b/src/copilot-cli/agents/pr-test-analyzer.agent.md
@@ -43,7 +43,7 @@ Before asserting that a behavior is untested:
 
 - Use Grep for the function name in `tests/` and `test/` (both are pytest-discoverable in this repo), `*_test.py`, `*.spec.ts`, and any project-specific test path.
 - Read at least one matching test file end-to-end if a match exists.
-- Check the project test rigor floor (`.agents/governance/TESTING-RIGOR.md` and the project's testing rules) for the language at hand: positive, negative, edge, every branch, mocked I/O.
+- Check the testing floor embedded in this prompt for the language at hand: positive, negative, edge, every branch, mocked I/O.
 
 Do not assert missing coverage without searching. Do not assert "no test exists" without grepping both the test directory and adjacent integration test suites. If grep is too broad to be conclusive, say so and downgrade the finding to "needs author confirmation."
 
@@ -104,7 +104,7 @@ Skip:
 Ask first:
 
 - The PR adds a new test framework or runner; flag the change to the architect agent before judging coverage under the new tool.
-- Coverage targets in `AGENTS.md` conflict with the project-local rule; surface the conflict and request resolution.
+- This prompt conflicts with a local rule; surface the conflict and request resolution.
 
 ## Agent Contract (delegation, gates, handoff)
 

--- a/src/copilot-cli/agents/silent-failure-hunter.agent.md
+++ b/src/copilot-cli/agents/silent-failure-hunter.agent.md
@@ -1,7 +1,26 @@
 ---
 name: silent-failure-hunter
-tier: builder
 description: Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. This agent should be invoked proactively after completing a logical chunk of work that involves error handling, catch blocks, fallback logic, or any code that could potentially suppress errors.
+argument-hint: Point to the PR, diff, or files whose error handling to audit
+tools:
+  - read
+  - edit
+  - search
+  - github/search_code
+  - github/search_issues
+  - github/search_pull_requests
+  - github/issue_read
+  - github/pull_request_read
+  - github/get_file_contents
+  - github/list_commits
+  - web
+  - cognitionai/deepwiki/*
+  - context7/*
+  - perplexity/*
+  - cloudmcp-manager/*
+  - serena/*
+model: claude-opus-4.6
+tier: builder
 ---
 
 # Silent Failure Hunter Agent

--- a/src/copilot-cli/agents/silent-failure-hunter.agent.md
+++ b/src/copilot-cli/agents/silent-failure-hunter.agent.md
@@ -60,7 +60,7 @@ For every error handling location, ask:
 
 - Is the error logged with appropriate severity (logError for production issues)?
 - Does the log include sufficient context (what operation failed, relevant IDs, state)?
-- Is there an error ID from constants/errorIds.ts for Sentry tracking?
+- Is there a stable error identifier when the repository defines an error-id catalog?
 - Would this log help someone debug the issue 6 months from now?
 
 **User Feedback:**
@@ -150,12 +150,12 @@ You are thorough, skeptical, and uncompromising about error handling quality. Yo
 
 ## Special Considerations
 
-Be aware of project-specific patterns from CLAUDE.md:
+Apply these error-handling rules in the repository under review:
 
-- This project has specific logging functions: logForDebugging (user-facing), logError (Sentry), logEvent (Statsig)
-- Error IDs should come from constants/errorIds.ts
-- The project explicitly forbids silent failures in production code
-- Empty catch blocks are never acceptable
-- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them
+- Surface user-facing failures through the repository's established notification or logging path.
+- Preserve diagnostic context for operators without logging secrets or raw private data.
+- Use stable error identifiers only when the repository already defines an error-id catalog.
+- Silent failures and empty catch blocks are never acceptable.
+- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them.
 
 Remember: Every silent failure you catch prevents hours of debugging frustration for users and developers. Be thorough, be skeptical, and never let an error slip through unnoticed.

--- a/src/copilot-cli/agents/silent-failure-hunter.agent.md
+++ b/src/copilot-cli/agents/silent-failure-hunter.agent.md
@@ -4,7 +4,6 @@ description: Use this agent when reviewing code changes in a pull request to ide
 argument-hint: Point to the PR, diff, or files whose error handling to audit
 tools:
   - read
-  - edit
   - search
   - github/search_code
   - github/search_issues

--- a/src/copilot-cli/agents/type-design-analyzer.agent.md
+++ b/src/copilot-cli/agents/type-design-analyzer.agent.md
@@ -1,7 +1,26 @@
 ---
 name: type-design-analyzer
+description: 'Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.'
+argument-hint: Point to the type(s) or PR to review for design quality
+tools:
+  - read
+  - edit
+  - search
+  - github/search_code
+  - github/search_issues
+  - github/search_pull_requests
+  - github/issue_read
+  - github/pull_request_read
+  - github/get_file_contents
+  - github/list_commits
+  - web
+  - cognitionai/deepwiki/*
+  - context7/*
+  - perplexity/*
+  - cloudmcp-manager/*
+  - serena/*
+model: claude-opus-4.6
 tier: builder
-description: Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.
 ---
 
 # Type Design Analyzer Agent

--- a/src/copilot-cli/agents/type-design-analyzer.agent.md
+++ b/src/copilot-cli/agents/type-design-analyzer.agent.md
@@ -4,7 +4,6 @@ description: 'Use this agent when you need expert analysis of type design in you
 argument-hint: Point to the type(s) or PR to review for design quality
 tools:
   - read
-  - edit
   - search
   - github/search_code
   - github/search_issues
@@ -128,4 +127,4 @@ Always consider:
 - Performance implications of additional validation
 - The balance between safety and usability
 
-Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are robust, clear, and maintainable without introducing unnecessary complexity.
+Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are safe, clear, and maintainable without introducing unnecessary complexity.

--- a/src/vs-code-agents/code-simplifier.agent.md
+++ b/src/vs-code-agents/code-simplifier.agent.md
@@ -7,20 +7,13 @@ tools:
   - edit
   - search
   - execute
-  - web
-  - cognitionai/deepwiki/*
-  - context7/*
-  - perplexity/*
-  - cloudmcp-manager/*
-  - serena/*
-  - memory
-model: Claude Opus 4.6 (copilot)
+model: Claude Sonnet 4.6 (copilot)
 tier: integration
 ---
 
 # Code Simplifier Agent
 
-> **Complementary Role**: Core code-writing standards (clarity over brevity, no nested ternaries, comment hygiene, ES module patterns, React props types) are now in CLAUDE.md and the implementer agent. Implementers apply these standards during initial writing. This agent complements that by handling post-hoc refinement: balance judgments, language-specific polish, and final quality assessment that requires seeing complete code.
+> **Complementary Role**: Core code-writing standards are embedded here: clarity over brevity, no nested ternaries, comment hygiene, language-appropriate module patterns, and explicit public-boundary types. Implementers apply these standards during initial writing. This agent complements that by handling post-hoc refinement: balance judgments, language-specific polish, and final quality assessment that requires seeing complete code.
 
 You simplify recently modified code without changing what it does. You produce either a rewrite diff or a list of refactors, never a vague suggestion.
 
@@ -84,7 +77,7 @@ Prefer the simpler equivalent in every choice:
 - Prefer one return per branch over a mutable accumulator.
 - Prefer a table lookup over a long if/elif chain when the cases differ only in data.
 - Prefer the explicit type annotation on every public boundary.
-- Prefer ES modules with explicit import extensions and the `function` keyword for top-level functions (per CLAUDE.md).
+- Prefer ES modules with explicit import extensions and the `function` keyword for top-level functions when the language uses JavaScript or TypeScript.
 
 ## Functionality Preservation
 
@@ -106,8 +99,8 @@ Skip a refactor if:
 
 Ask first if:
 
-- Project-specific conventions in CLAUDE.md conflict with a stylistic positive above.
-- A refactor crosses an architectural boundary defined in `.agents/architecture/ADR-*.md`.
+- Project-specific conventions in the current repository conflict with a stylistic positive above.
+- A refactor crosses a documented architectural boundary or another agent's ownership boundary.
 
 ## Agent Contract (delegation, gates, handoff)
 

--- a/src/vs-code-agents/code-simplifier.agent.md
+++ b/src/vs-code-agents/code-simplifier.agent.md
@@ -1,7 +1,21 @@
 ---
-name: code-simplifier
-tier: integration
 description: Use this agent when code has been written or modified and needs to be simplified for clarity, consistency, and maintainability while preserving all functionality. This agent should be triggered automatically after completing a coding task or writing a logical chunk of code. It simplifies code by following project best practices while retaining all functionality. The agent focuses only on recently modified code unless instructed otherwise.
+argument-hint: Point to the recently modified code to simplify
+tools:
+  - vscode
+  - read
+  - edit
+  - search
+  - execute
+  - web
+  - cognitionai/deepwiki/*
+  - context7/*
+  - perplexity/*
+  - cloudmcp-manager/*
+  - serena/*
+  - memory
+model: Claude Opus 4.6 (copilot)
+tier: integration
 ---
 
 # Code Simplifier Agent

--- a/src/vs-code-agents/comment-analyzer.agent.md
+++ b/src/vs-code-agents/comment-analyzer.agent.md
@@ -60,7 +60,7 @@ Classify every comment into one of three buckets. State the bucket in the findin
 
 Emit three sections in this exact order. No preamble.
 
-**Summary** (3 sentences max): Total comments analyzed, count per bucket, the single most significant finding.
+**Summary** (3 sentences max): Total comments analyzed, count per bucket, the highest-impact finding.
 
 **Findings** (10 items max, one per finding, format below):
 

--- a/src/vs-code-agents/comment-analyzer.agent.md
+++ b/src/vs-code-agents/comment-analyzer.agent.md
@@ -1,7 +1,27 @@
 ---
-name: comment-analyzer
+description: 'Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.'
+argument-hint: Point to the comments or PR to review for accuracy
+tools:
+  - vscode
+  - read
+  - edit
+  - search
+  - github/search_code
+  - github/search_issues
+  - github/search_pull_requests
+  - github/issue_read
+  - github/pull_request_read
+  - github/get_file_contents
+  - github/list_commits
+  - web
+  - cognitionai/deepwiki/*
+  - context7/*
+  - perplexity/*
+  - cloudmcp-manager/*
+  - serena/*
+  - memory
+model: Claude Opus 4.6 (copilot)
 tier: integration
-description: Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.
 ---
 
 # Comment Analyzer Agent

--- a/src/vs-code-agents/comment-analyzer.agent.md
+++ b/src/vs-code-agents/comment-analyzer.agent.md
@@ -4,7 +4,6 @@ argument-hint: Point to the comments or PR to review for accuracy
 tools:
   - vscode
   - read
-  - edit
   - search
   - github/search_code
   - github/search_issues
@@ -20,7 +19,7 @@ tools:
   - cloudmcp-manager/*
   - serena/*
   - memory
-model: Claude Opus 4.6 (copilot)
+model: Claude Sonnet 4.6 (copilot)
 tier: integration
 ---
 

--- a/src/vs-code-agents/pr-test-analyzer.agent.md
+++ b/src/vs-code-agents/pr-test-analyzer.agent.md
@@ -44,7 +44,7 @@ Before asserting that a behavior is untested:
 
 - Use Grep for the function name in `tests/` and `test/` (both are pytest-discoverable in this repo), `*_test.py`, `*.spec.ts`, and any project-specific test path.
 - Read at least one matching test file end-to-end if a match exists.
-- Check the project test rigor floor (`.agents/governance/TESTING-RIGOR.md` and the project's testing rules) for the language at hand: positive, negative, edge, every branch, mocked I/O.
+- Check the testing floor embedded in this prompt for the language at hand: positive, negative, edge, every branch, mocked I/O.
 
 Do not assert missing coverage without searching. Do not assert "no test exists" without grepping both the test directory and adjacent integration test suites. If grep is too broad to be conclusive, say so and downgrade the finding to "needs author confirmation."
 
@@ -105,7 +105,7 @@ Skip:
 Ask first:
 
 - The PR adds a new test framework or runner; flag the change to the architect agent before judging coverage under the new tool.
-- Coverage targets in `AGENTS.md` conflict with the project-local rule; surface the conflict and request resolution.
+- This prompt conflicts with a local rule; surface the conflict and request resolution.
 
 ## Agent Contract (delegation, gates, handoff)
 

--- a/src/vs-code-agents/pr-test-analyzer.agent.md
+++ b/src/vs-code-agents/pr-test-analyzer.agent.md
@@ -1,7 +1,27 @@
 ---
-name: pr-test-analyzer
-tier: builder
 description: Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases.
+argument-hint: Point to the PR or changes whose test coverage to assess
+tools:
+  - vscode
+  - read
+  - edit
+  - search
+  - github/search_code
+  - github/search_issues
+  - github/search_pull_requests
+  - github/issue_read
+  - github/pull_request_read
+  - github/get_file_contents
+  - github/list_commits
+  - web
+  - cognitionai/deepwiki/*
+  - context7/*
+  - perplexity/*
+  - cloudmcp-manager/*
+  - serena/*
+  - memory
+model: Claude Opus 4.6 (copilot)
+tier: builder
 ---
 
 # Pr Test Analyzer Agent

--- a/src/vs-code-agents/pr-test-analyzer.agent.md
+++ b/src/vs-code-agents/pr-test-analyzer.agent.md
@@ -4,7 +4,6 @@ argument-hint: Point to the PR or changes whose test coverage to assess
 tools:
   - vscode
   - read
-  - edit
   - search
   - github/search_code
   - github/search_issues
@@ -24,7 +23,7 @@ model: Claude Opus 4.6 (copilot)
 tier: builder
 ---
 
-# Pr Test Analyzer Agent
+# PR Test Analyzer Agent
 
 You analyze pull-request test coverage. You produce a ranked list of gaps with file:line evidence and a single recommendation. You measure behavioral coverage, not line coverage.
 

--- a/src/vs-code-agents/silent-failure-hunter.agent.md
+++ b/src/vs-code-agents/silent-failure-hunter.agent.md
@@ -4,7 +4,6 @@ argument-hint: Point to the PR, diff, or files whose error handling to audit
 tools:
   - vscode
   - read
-  - edit
   - search
   - github/search_code
   - github/search_issues

--- a/src/vs-code-agents/silent-failure-hunter.agent.md
+++ b/src/vs-code-agents/silent-failure-hunter.agent.md
@@ -1,7 +1,27 @@
 ---
-name: silent-failure-hunter
-tier: builder
 description: Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. This agent should be invoked proactively after completing a logical chunk of work that involves error handling, catch blocks, fallback logic, or any code that could potentially suppress errors.
+argument-hint: Point to the PR, diff, or files whose error handling to audit
+tools:
+  - vscode
+  - read
+  - edit
+  - search
+  - github/search_code
+  - github/search_issues
+  - github/search_pull_requests
+  - github/issue_read
+  - github/pull_request_read
+  - github/get_file_contents
+  - github/list_commits
+  - web
+  - cognitionai/deepwiki/*
+  - context7/*
+  - perplexity/*
+  - cloudmcp-manager/*
+  - serena/*
+  - memory
+model: Claude Opus 4.6 (copilot)
+tier: builder
 ---
 
 # Silent Failure Hunter Agent

--- a/src/vs-code-agents/silent-failure-hunter.agent.md
+++ b/src/vs-code-agents/silent-failure-hunter.agent.md
@@ -61,7 +61,7 @@ For every error handling location, ask:
 
 - Is the error logged with appropriate severity (logError for production issues)?
 - Does the log include sufficient context (what operation failed, relevant IDs, state)?
-- Is there an error ID from constants/errorIds.ts for Sentry tracking?
+- Is there a stable error identifier when the repository defines an error-id catalog?
 - Would this log help someone debug the issue 6 months from now?
 
 **User Feedback:**
@@ -151,12 +151,12 @@ You are thorough, skeptical, and uncompromising about error handling quality. Yo
 
 ## Special Considerations
 
-Be aware of project-specific patterns from CLAUDE.md:
+Apply these error-handling rules in the repository under review:
 
-- This project has specific logging functions: logForDebugging (user-facing), logError (Sentry), logEvent (Statsig)
-- Error IDs should come from constants/errorIds.ts
-- The project explicitly forbids silent failures in production code
-- Empty catch blocks are never acceptable
-- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them
+- Surface user-facing failures through the repository's established notification or logging path.
+- Preserve diagnostic context for operators without logging secrets or raw private data.
+- Use stable error identifiers only when the repository already defines an error-id catalog.
+- Silent failures and empty catch blocks are never acceptable.
+- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them.
 
 Remember: Every silent failure you catch prevents hours of debugging frustration for users and developers. Be thorough, be skeptical, and never let an error slip through unnoticed.

--- a/src/vs-code-agents/type-design-analyzer.agent.md
+++ b/src/vs-code-agents/type-design-analyzer.agent.md
@@ -4,7 +4,6 @@ argument-hint: Point to the type(s) or PR to review for design quality
 tools:
   - vscode
   - read
-  - edit
   - search
   - github/search_code
   - github/search_issues
@@ -129,4 +128,4 @@ Always consider:
 - Performance implications of additional validation
 - The balance between safety and usability
 
-Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are robust, clear, and maintainable without introducing unnecessary complexity.
+Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are safe, clear, and maintainable without introducing unnecessary complexity.

--- a/src/vs-code-agents/type-design-analyzer.agent.md
+++ b/src/vs-code-agents/type-design-analyzer.agent.md
@@ -1,7 +1,27 @@
 ---
-name: type-design-analyzer
+description: 'Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.'
+argument-hint: Point to the type(s) or PR to review for design quality
+tools:
+  - vscode
+  - read
+  - edit
+  - search
+  - github/search_code
+  - github/search_issues
+  - github/search_pull_requests
+  - github/issue_read
+  - github/pull_request_read
+  - github/get_file_contents
+  - github/list_commits
+  - web
+  - cognitionai/deepwiki/*
+  - context7/*
+  - perplexity/*
+  - cloudmcp-manager/*
+  - serena/*
+  - memory
+model: Claude Opus 4.6 (copilot)
 tier: builder
-description: Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.
 ---
 
 # Type Design Analyzer Agent

--- a/templates/agents/code-simplifier.shared.md
+++ b/templates/agents/code-simplifier.shared.md
@@ -1,7 +1,17 @@
 ---
-name: code-simplifier
 tier: integration
 description: Use this agent when code has been written or modified and needs to be simplified for clarity, consistency, and maintainability while preserving all functionality. This agent should be triggered automatically after completing a coding task or writing a logical chunk of code. It simplifies code by following project best practices while retaining all functionality. The agent focuses only on recently modified code unless instructed otherwise.
+argument-hint: Point to the recently modified code to simplify
+tools_vscode:
+  - $toolset:editor
+  - $toolset:executor
+  - $toolset:research
+  - $toolset:knowledge
+tools_copilot:
+  - $toolset:editor
+  - $toolset:executor
+  - $toolset:research
+  - $toolset:knowledge
 ---
 
 # Code Simplifier Agent

--- a/templates/agents/code-simplifier.shared.md
+++ b/templates/agents/code-simplifier.shared.md
@@ -1,22 +1,24 @@
 ---
 tier: integration
+model_tier: sonnet
 description: Use this agent when code has been written or modified and needs to be simplified for clarity, consistency, and maintainability while preserving all functionality. This agent should be triggered automatically after completing a coding task or writing a logical chunk of code. It simplifies code by following project best practices while retaining all functionality. The agent focuses only on recently modified code unless instructed otherwise.
 argument-hint: Point to the recently modified code to simplify
 tools_vscode:
-  - $toolset:editor
-  - $toolset:executor
-  - $toolset:research
-  - $toolset:knowledge
+  - vscode
+  - read
+  - edit
+  - search
+  - execute
 tools_copilot:
-  - $toolset:editor
-  - $toolset:executor
-  - $toolset:research
-  - $toolset:knowledge
+  - read
+  - edit
+  - search
+  - shell
 ---
 
 # Code Simplifier Agent
 
-> **Complementary Role**: Core code-writing standards (clarity over brevity, no nested ternaries, comment hygiene, ES module patterns, React props types) are now in CLAUDE.md and the implementer agent. Implementers apply these standards during initial writing. This agent complements that by handling post-hoc refinement: balance judgments, language-specific polish, and final quality assessment that requires seeing complete code.
+> **Complementary Role**: Core code-writing standards are embedded here: clarity over brevity, no nested ternaries, comment hygiene, language-appropriate module patterns, and explicit public-boundary types. Implementers apply these standards during initial writing. This agent complements that by handling post-hoc refinement: balance judgments, language-specific polish, and final quality assessment that requires seeing complete code.
 
 You simplify recently modified code without changing what it does. You produce either a rewrite diff or a list of refactors, never a vague suggestion.
 
@@ -80,7 +82,7 @@ Prefer the simpler equivalent in every choice:
 - Prefer one return per branch over a mutable accumulator.
 - Prefer a table lookup over a long if/elif chain when the cases differ only in data.
 - Prefer the explicit type annotation on every public boundary.
-- Prefer ES modules with explicit import extensions and the `function` keyword for top-level functions (per CLAUDE.md).
+- Prefer ES modules with explicit import extensions and the `function` keyword for top-level functions when the language uses JavaScript or TypeScript.
 
 ## Functionality Preservation
 
@@ -102,8 +104,8 @@ Skip a refactor if:
 
 Ask first if:
 
-- Project-specific conventions in CLAUDE.md conflict with a stylistic positive above.
-- A refactor crosses an architectural boundary defined in `.agents/architecture/ADR-*.md`.
+- Project-specific conventions in the current repository conflict with a stylistic positive above.
+- A refactor crosses a documented architectural boundary or another agent's ownership boundary.
 
 ## Agent Contract (delegation, gates, handoff)
 

--- a/templates/agents/comment-analyzer.shared.md
+++ b/templates/agents/comment-analyzer.shared.md
@@ -1,7 +1,17 @@
 ---
-name: comment-analyzer
 tier: integration
 description: Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.
+argument-hint: Point to the comments or PR to review for accuracy
+tools_vscode:
+  - $toolset:editor
+  - $toolset:github-research
+  - $toolset:research
+  - $toolset:knowledge
+tools_copilot:
+  - $toolset:editor
+  - $toolset:github-research
+  - $toolset:research
+  - $toolset:knowledge
 ---
 
 # Comment Analyzer Agent

--- a/templates/agents/comment-analyzer.shared.md
+++ b/templates/agents/comment-analyzer.shared.md
@@ -1,14 +1,18 @@
 ---
 tier: integration
+model_tier: sonnet
 description: Use this agent when you need to analyze code comments for accuracy, completeness, and long-term maintainability. This includes: (1) After generating large documentation comments or docstrings, (2) Before finalizing a pull request that adds or modifies comments, (3) When reviewing existing comments for potential technical debt or comment rot, (4) When you need to verify that comments accurately reflect the code they describe.
 argument-hint: Point to the comments or PR to review for accuracy
 tools_vscode:
-  - $toolset:editor
+  - vscode
+  - read
+  - search
   - $toolset:github-research
   - $toolset:research
   - $toolset:knowledge
 tools_copilot:
-  - $toolset:editor
+  - read
+  - search
   - $toolset:github-research
   - $toolset:research
   - $toolset:knowledge

--- a/templates/agents/comment-analyzer.shared.md
+++ b/templates/agents/comment-analyzer.shared.md
@@ -50,7 +50,7 @@ Classify every comment into one of three buckets. State the bucket in the findin
 
 Emit three sections in this exact order. No preamble.
 
-**Summary** (3 sentences max): Total comments analyzed, count per bucket, the single most significant finding.
+**Summary** (3 sentences max): Total comments analyzed, count per bucket, the highest-impact finding.
 
 **Findings** (10 items max, one per finding, format below):
 

--- a/templates/agents/pr-test-analyzer.shared.md
+++ b/templates/agents/pr-test-analyzer.shared.md
@@ -3,18 +3,21 @@ tier: builder
 description: Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases.
 argument-hint: Point to the PR or changes whose test coverage to assess
 tools_vscode:
-  - $toolset:editor
+  - vscode
+  - read
+  - search
   - $toolset:github-research
   - $toolset:research
   - $toolset:knowledge
 tools_copilot:
-  - $toolset:editor
+  - read
+  - search
   - $toolset:github-research
   - $toolset:research
   - $toolset:knowledge
 ---
 
-# Pr Test Analyzer Agent
+# PR Test Analyzer Agent
 
 You analyze pull-request test coverage. You produce a ranked list of gaps with file:line evidence and a single recommendation. You measure behavioral coverage, not line coverage.
 

--- a/templates/agents/pr-test-analyzer.shared.md
+++ b/templates/agents/pr-test-analyzer.shared.md
@@ -34,7 +34,7 @@ Before asserting that a behavior is untested:
 
 - Use Grep for the function name in `tests/` and `test/` (both are pytest-discoverable in this repo), `*_test.py`, `*.spec.ts`, and any project-specific test path.
 - Read at least one matching test file end-to-end if a match exists.
-- Check the project test rigor floor (`.agents/governance/TESTING-RIGOR.md` and the project's testing rules) for the language at hand: positive, negative, edge, every branch, mocked I/O.
+- Check the testing floor embedded in this prompt for the language at hand: positive, negative, edge, every branch, mocked I/O.
 
 Do not assert missing coverage without searching. Do not assert "no test exists" without grepping both the test directory and adjacent integration test suites. If grep is too broad to be conclusive, say so and downgrade the finding to "needs author confirmation."
 
@@ -95,7 +95,7 @@ Skip:
 Ask first:
 
 - The PR adds a new test framework or runner; flag the change to the architect agent before judging coverage under the new tool.
-- Coverage targets in `AGENTS.md` conflict with the project-local rule; surface the conflict and request resolution.
+- This prompt conflicts with a local rule; surface the conflict and request resolution.
 
 ## Agent Contract (delegation, gates, handoff)
 

--- a/templates/agents/pr-test-analyzer.shared.md
+++ b/templates/agents/pr-test-analyzer.shared.md
@@ -1,7 +1,17 @@
 ---
-name: pr-test-analyzer
 tier: builder
 description: Use this agent when you need to review a pull request for test coverage quality and completeness. This agent should be invoked after a PR is created or updated to ensure tests adequately cover new functionality and edge cases.
+argument-hint: Point to the PR or changes whose test coverage to assess
+tools_vscode:
+  - $toolset:editor
+  - $toolset:github-research
+  - $toolset:research
+  - $toolset:knowledge
+tools_copilot:
+  - $toolset:editor
+  - $toolset:github-research
+  - $toolset:research
+  - $toolset:knowledge
 ---
 
 # Pr Test Analyzer Agent

--- a/templates/agents/silent-failure-hunter.shared.md
+++ b/templates/agents/silent-failure-hunter.shared.md
@@ -3,12 +3,15 @@ tier: builder
 description: Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. This agent should be invoked proactively after completing a logical chunk of work that involves error handling, catch blocks, fallback logic, or any code that could potentially suppress errors.
 argument-hint: Point to the PR, diff, or files whose error handling to audit
 tools_vscode:
-  - $toolset:editor
+  - vscode
+  - read
+  - search
   - $toolset:github-research
   - $toolset:research
   - $toolset:knowledge
 tools_copilot:
-  - $toolset:editor
+  - read
+  - search
   - $toolset:github-research
   - $toolset:research
   - $toolset:knowledge

--- a/templates/agents/silent-failure-hunter.shared.md
+++ b/templates/agents/silent-failure-hunter.shared.md
@@ -51,7 +51,7 @@ For every error handling location, ask:
 
 - Is the error logged with appropriate severity (logError for production issues)?
 - Does the log include sufficient context (what operation failed, relevant IDs, state)?
-- Is there an error ID from constants/errorIds.ts for Sentry tracking?
+- Is there a stable error identifier when the repository defines an error-id catalog?
 - Would this log help someone debug the issue 6 months from now?
 
 **User Feedback:**
@@ -141,12 +141,12 @@ You are thorough, skeptical, and uncompromising about error handling quality. Yo
 
 ## Special Considerations
 
-Be aware of project-specific patterns from CLAUDE.md:
+Apply these error-handling rules in the repository under review:
 
-- This project has specific logging functions: logForDebugging (user-facing), logError (Sentry), logEvent (Statsig)
-- Error IDs should come from constants/errorIds.ts
-- The project explicitly forbids silent failures in production code
-- Empty catch blocks are never acceptable
-- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them
+- Surface user-facing failures through the repository's established notification or logging path.
+- Preserve diagnostic context for operators without logging secrets or raw private data.
+- Use stable error identifiers only when the repository already defines an error-id catalog.
+- Silent failures and empty catch blocks are never acceptable.
+- Tests should not be fixed by disabling them; errors should not be fixed by bypassing them.
 
 Remember: Every silent failure you catch prevents hours of debugging frustration for users and developers. Be thorough, be skeptical, and never let an error slip through unnoticed.

--- a/templates/agents/silent-failure-hunter.shared.md
+++ b/templates/agents/silent-failure-hunter.shared.md
@@ -1,7 +1,17 @@
 ---
-name: silent-failure-hunter
 tier: builder
 description: Use this agent when reviewing code changes in a pull request to identify silent failures, inadequate error handling, and inappropriate fallback behavior. This agent should be invoked proactively after completing a logical chunk of work that involves error handling, catch blocks, fallback logic, or any code that could potentially suppress errors.
+argument-hint: Point to the PR, diff, or files whose error handling to audit
+tools_vscode:
+  - $toolset:editor
+  - $toolset:github-research
+  - $toolset:research
+  - $toolset:knowledge
+tools_copilot:
+  - $toolset:editor
+  - $toolset:github-research
+  - $toolset:research
+  - $toolset:knowledge
 ---
 
 # Silent Failure Hunter Agent

--- a/templates/agents/type-design-analyzer.shared.md
+++ b/templates/agents/type-design-analyzer.shared.md
@@ -3,12 +3,15 @@ tier: builder
 description: Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.
 argument-hint: Point to the type(s) or PR to review for design quality
 tools_vscode:
-  - $toolset:editor
+  - vscode
+  - read
+  - search
   - $toolset:github-research
   - $toolset:research
   - $toolset:knowledge
 tools_copilot:
-  - $toolset:editor
+  - read
+  - search
   - $toolset:github-research
   - $toolset:research
   - $toolset:knowledge
@@ -119,4 +122,4 @@ Always consider:
 - Performance implications of additional validation
 - The balance between safety and usability
 
-Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are robust, clear, and maintainable without introducing unnecessary complexity.
+Think deeply about each type's role in the larger system. Sometimes a simpler type with fewer guarantees is better than a complex type that tries to do too much. Your goal is to help create types that are safe, clear, and maintainable without introducing unnecessary complexity.

--- a/templates/agents/type-design-analyzer.shared.md
+++ b/templates/agents/type-design-analyzer.shared.md
@@ -1,7 +1,17 @@
 ---
-name: type-design-analyzer
 tier: builder
 description: Use this agent when you need expert analysis of type design in your codebase. Specifically use it: (1) when introducing a new type to ensure it follows best practices for encapsulation and invariant expression, (2) during pull request creation to review all types being added, (3) when refactoring existing types to improve their design quality. The agent will provide both qualitative feedback and quantitative ratings on encapsulation, invariant expression, usefulness, and enforcement.
+argument-hint: Point to the type(s) or PR to review for design quality
+tools_vscode:
+  - $toolset:editor
+  - $toolset:github-research
+  - $toolset:research
+  - $toolset:knowledge
+tools_copilot:
+  - $toolset:editor
+  - $toolset:github-research
+  - $toolset:research
+  - $toolset:knowledge
 ---
 
 # Type Design Analyzer Agent


### PR DESCRIPTION
Closes #2687

## Problem

Five review agents existed only on the GitHub cloud surface. Local Copilot CLI and VS Code installs did not receive them.

## Change

Promotes these agents to the shared-agent family:

- `silent-failure-hunter`
- `code-simplifier`
- `comment-analyzer`
- `pr-test-analyzer`
- `type-design-analyzer`

Each agent now has the expected source, install, and generated outputs for local use. Follow-up commits also addressed review feedback: banned wording was removed, prompt references were made self-contained, read-only review agents lost write tools, and plugin manifests were bumped.

## References

The shared-agent family uses these path shapes:

```text
templates/agents/<name>.shared.md
.claude/agents/<name>.md
src/claude/<name>.md
src/copilot-cli/agents/<name>.agent.md
src/vs-code-agents/<name>.agent.md
.github/agents/<name>.agent.md
```

The validation commands used for this PR include:

```text
build/scripts/build_all.py --check
build/scripts/detect_agent_drift.py
build/scripts/validate_install_parity.py
```

## Validation

- `validate_install_parity.py --base origin/main`: install-parity OK
- `build_all.py --check`: clean, no generated-file drift
- `detect_agent_drift.py`: promoted agents are 100% similar across the checked install pairs
- `markdownlint-cli2`: 0 errors on the promoted agent files
- pre-commit hook passed

## Note

This was found while removing downstream vendored copies. After this lands, `project-toolkit@ai-agents` delivers these agents to Copilot CLI and VS Code, so downstream vendoring is no longer needed.
