### PR TITLE
fix(eval): reasoning models (gpt-5, o-series) in the OpenAI-compatible provider

### DIFF
--- a/scripts/eval/_providers.py
+++ b/scripts/eval/_providers.py
@@ -31,6 +31,7 @@ no SDK and existing baselines do not move.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
@@ -126,6 +127,19 @@ def _normalize_and_raise(provider_label: str, exc: Exception) -> None:
     ) from exc
 
 
+# OpenAI reasoning models (o1/o3/o4 series, gpt-5 family) reject `max_tokens`
+# and a non-default `temperature` with HTTP 400; they require
+# `max_completion_tokens` and the provider's default temperature. Match by id,
+# tolerating a vendor prefix like "openai/". A new reasoning family is one more
+# alternative in this pattern, no other change.
+_REASONING_MODEL_RE = re.compile(r"^(?:[a-z0-9-]+/)?(?:o\d|gpt-5)", re.IGNORECASE)
+
+
+def _is_reasoning_model(model: str) -> bool:
+    """True for OpenAI reasoning models that need max_completion_tokens."""
+    return bool(_REASONING_MODEL_RE.match(model or ""))
+
+
 class _OpenAICompatibleProvider:
     """OpenAI Chat Completions transport. Backs both the OpenAI provider and
     the GitHub Models provider (GitHub Models mirrors the OpenAI API, differing
@@ -179,13 +193,16 @@ class _OpenAICompatibleProvider:
         if system:
             full_messages.append({"role": "system", "content": system})
         full_messages.extend(messages)
+        # Reasoning models reject max_tokens + custom temperature; send
+        # max_completion_tokens and omit temperature so o-series / gpt-5 work.
+        create_kwargs: dict[str, object] = {"model": model, "messages": full_messages}
+        if _is_reasoning_model(model):
+            create_kwargs["max_completion_tokens"] = max_tokens
+        else:
+            create_kwargs["max_tokens"] = max_tokens
+            create_kwargs["temperature"] = temperature
         try:
-            resp = client.chat.completions.create(
-                model=model,
-                messages=full_messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-            )
+            resp = client.chat.completions.create(**create_kwargs)
         except Exception as exc:  # noqa: BLE001 - normalize then re-raise
             _normalize_and_raise(self._provider_label, exc)
             raise  # unreachable; _normalize_and_raise always raises

--- a/tests/eval/test_providers.py
+++ b/tests/eval/test_providers.py
@@ -323,3 +323,63 @@ def test_read_env_key_raises_naming_candidates_when_absent(
 
     with pytest.raises(RuntimeError, match="ZZ_NOPE_ONE, ZZ_NOPE_TWO"):
         _providers._read_env_key(["ZZ_NOPE_ONE", "ZZ_NOPE_TWO"])
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("openai/gpt-5", True),
+        ("openai/gpt-5-mini", True),
+        ("gpt-5", True),
+        ("openai/o1", True),
+        ("openai/o3", True),
+        ("openai/o4-mini", True),
+        ("o3-mini", True),
+        ("openai/gpt-4o", False),
+        ("openai/gpt-4.1", False),
+        ("meta/llama-3.3-70b-instruct", False),
+        ("", False),
+    ],
+)
+def test_is_reasoning_model(model: str, expected: bool) -> None:
+    assert _providers._is_reasoning_model(model) is expected
+
+
+def test_reasoning_model_uses_max_completion_tokens_no_temperature(
+    fake_openai: type[_FakeOpenAI], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[_FakeOpenAI] = []
+    original_init = _FakeOpenAI.__init__
+
+    def _record_init(self: _FakeOpenAI, **kwargs: object) -> None:
+        original_init(self, **kwargs)
+        captured.append(self)
+
+    monkeypatch.setattr(_FakeOpenAI, "__init__", _record_init)
+    provider = _providers.resolve_provider("openai")
+    provider.complete(messages=[{"role": "user", "content": "hi"}], model="openai/gpt-5", max_tokens=4000)
+
+    sent = captured[0].recorder[0]
+    assert sent["max_completion_tokens"] == 4000
+    assert "max_tokens" not in sent
+    assert "temperature" not in sent  # reasoning models reject a custom temperature
+
+
+def test_normal_model_keeps_max_tokens_and_temperature(
+    fake_openai: type[_FakeOpenAI], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[_FakeOpenAI] = []
+    original_init = _FakeOpenAI.__init__
+
+    def _record_init(self: _FakeOpenAI, **kwargs: object) -> None:
+        original_init(self, **kwargs)
+        captured.append(self)
+
+    monkeypatch.setattr(_FakeOpenAI, "__init__", _record_init)
+    provider = _providers.resolve_provider("openai")
+    provider.complete(messages=[{"role": "user", "content": "hi"}], model="gpt-4o", max_tokens=512, temperature=0.0)
+
+    sent = captured[0].recorder[0]
+    assert sent["max_tokens"] == 512
+    assert sent["temperature"] == 0.0
+    assert "max_completion_tokens" not in sent


### PR DESCRIPTION
Closes #2711. Base is the #2710 branch so it ships with the multi-provider transport.

## Problem
`_OpenAICompatibleProvider.complete` hardcodes `max_tokens` + `temperature`. OpenAI reasoning models reject both (require `max_completion_tokens`, no custom temperature), so every reasoning model 400s through the github/openai transport: `openai/gpt-5`, `gpt-5-mini`, `o1`, `o3`, `o3-mini`, `o4-mini`.

## Fix
- `_is_reasoning_model(model)` — id match (`o\d` / `gpt-5`), tolerates a vendor prefix like `openai/`.
- Build `create()` kwargs conditionally: reasoning → `max_completion_tokens`, omit `temperature`; normal → `max_tokens` + `temperature` (unchanged).

## Tests
`tests/eval/test_providers.py`: id matrix (11 cases) + reasoning path asserts `max_completion_tokens` and no `max_tokens`/`temperature` + normal path unchanged. 39 pass.

## Verified live
`resolve_provider("github").complete(model="openai/gpt-5", max_tokens=2000)` returns 200 with the patch (HTTP 400 before).

Found while comparing eval providers on the code-qualities-assessment skill against moq.analyzers: mid-tier models (gpt-4o/mistral/deepseek) worked; gpt-5 and o3 all 400'd until this fix.