### PR TITLE
chore(copilot): emit scalar skill argument hints

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.231",
+  "version": "0.5.232",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,7 +1,7 @@
 ---
 description: Build incrementally. Implement changes in thin vertical slices with TDD and atomic commits. Run after /plan.
 allowed-tools: Task, Skill, Read, Write, Edit, Glob, Grep, Bash(*)
-argument-hint: [plan-step-or-task-description]
+argument-hint: plan-step-or-task-description
 ---
 
 @CLAUDE.md

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,7 +1,7 @@
 ---
 description: Plan how to build it. Decompose specs into milestones with dependencies and risk mitigations. Run after /spec.
 allowed-tools: Task, Skill, Read, Write, Glob, Grep
-argument-hint: [spec-output-or-issue-number]
+argument-hint: spec-output-or-issue-number
 ---
 
 @CLAUDE.md

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,7 +1,7 @@
 ---
 description: Ship it. Pre-flight validation, CI check, and PR creation. Run after /review.
 allowed-tools: Task, Skill, Read, Glob, Grep, Bash(*)
-argument-hint: [target-branch]
+argument-hint: target-branch
 ---
 
 @CLAUDE.md

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -1,7 +1,7 @@
 ---
 description: Define what to build. Transform a problem into testable requirements with acceptance criteria.
 allowed-tools: Task, Skill, Read, Write, Glob, Grep
-argument-hint: [problem-statement-or-issue-number]
+argument-hint: problem-statement-or-issue-number
 ---
 
 @CLAUDE.md

--- a/.claude/commands/sync.md
+++ b/.claude/commands/sync.md
@@ -1,7 +1,7 @@
 ---
 description: Detect Spec to Code drift. Scan REQ/DESIGN/TASK specs for references to code that no longer exists, then report drift for review. Run after a hand-edit that moved or deleted code.
 allowed-tools: Task, Skill, Read, Glob, Grep, Bash(python3 scripts/sync/detect_spec_drift.py*)
-argument-hint: [spec-tier-or-empty]
+argument-hint: spec-tier-or-empty
 ---
 
 # Sync Command

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,7 +1,7 @@
 ---
 description: Prove it works. Multi-dimensional quality validation across functional, non-functional, security, DevOps, DX, and observability. Run after /build.
 allowed-tools: Task, Skill, Read, Glob, Grep, Bash(*)
-argument-hint: [component-or-failure-description]
+argument-hint: component-or-failure-description
 ---
 
 @CLAUDE.md

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -2,8 +2,7 @@
 name: review
 version: 1.0.0
 description: Review before merge. Stage-1 spec-compliance gate, then 11 Stage-2 canonical axes (analyst, architect, qa, security, devops, roadmap, reliability, observability, agent-safety, decision-rigor, code-quality) plus 3 chained skills (code-qualities-assessment, golden-principles, taste-lints). Run after /test. Run for a full pre-merge review. Do NOT invoke code-qualities-assessment, golden-principles, or taste-lints directly for a full review; review chains them.
-argument-hint:
-  - branch-or-pr-number
+argument-hint: branch-or-pr-number
 allowed-tools: Task, Skill, Read, Glob, Grep, Bash(*)
 user-invocable: true
 license: MIT

--- a/build/generate_agents_common.py
+++ b/build/generate_agents_common.py
@@ -288,6 +288,9 @@ def format_frontmatter_yaml(frontmatter: dict[str, str | None]) -> str:
             return []
         value_str = str(value)
 
+        if key == "argument-hint":
+            return [f"{key}: {_yaml_quote_if_needed(value_str)}"]
+
         # Check if value is an inline array
         array_match = re.match(r"^\[(.*)\]$", value_str)
         if array_match:

--- a/scripts/validation/skill_frontmatter.py
+++ b/scripts/validation/skill_frontmatter.py
@@ -108,7 +108,8 @@ VALID_TOOLS: frozenset[str] = frozenset(
 # XML tag detection pattern
 _XML_TAG_PATTERN: re.Pattern[str] = re.compile(r"<[^>]+>")
 _SKILL_FILE_PATTERN: re.Pattern[str] = re.compile(
-    r"(?:^|/)(?:\.claude|src/copilot-cli)/skills/[^/]+/SKILL\.md$"
+    r"(?:^|/)(?:\.claude|src/copilot-cli)/skills/[^/]+/SKILL\.md$",
+    re.IGNORECASE,
 )
 
 # Copilot CLI rejects non-string values for this skill field at load time.
@@ -341,10 +342,20 @@ def validate_allowed_tools(allowed_tools: str | None) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def _is_skill_file_path(path: str) -> bool:
+def _normalize_skill_path(path: str, root: Path | None = None) -> str:
+    """Return a repo-relative, slash-normalized path when possible."""
+    candidate = Path(path)
+    if root is not None:
+        try:
+            candidate = candidate.resolve().relative_to(root.resolve())
+        except (OSError, ValueError):
+            pass
+    return str(candidate).replace("\\", "/")
+
+
+def _is_skill_file_path(path: str, root: Path | None = None) -> bool:
     """Return true for Claude skill files and Copilot CLI skill mirrors."""
-    normalized = path.replace("\\", "/")
-    return _SKILL_FILE_PATTERN.search(normalized) is not None
+    return _SKILL_FILE_PATTERN.fullmatch(_normalize_skill_path(path, root)) is not None
 
 
 def get_staged_skill_files() -> list[Path]:
@@ -378,7 +389,8 @@ def get_skill_files(
 ) -> list[Path]:
     """Get list of SKILL.md files to validate based on parameters."""
     if changed_files:
-        skill_files = [f for f in changed_files if _is_skill_file_path(f)]
+        root = Path(path)
+        skill_files = [f for f in changed_files if _is_skill_file_path(f, root)]
         if not skill_files:
             print("No SKILL.md files in changed files list. "
                   "Skipping frontmatter validation.")

--- a/scripts/validation/skill_frontmatter.py
+++ b/scripts/validation/skill_frontmatter.py
@@ -29,6 +29,8 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
+
 from scripts.validation.models import ValidationResult
 
 # Valid model identifiers.
@@ -105,6 +107,12 @@ VALID_TOOLS: frozenset[str] = frozenset(
 
 # XML tag detection pattern
 _XML_TAG_PATTERN: re.Pattern[str] = re.compile(r"<[^>]+>")
+_SKILL_FILE_PATTERN: re.Pattern[str] = re.compile(
+    r"(?:^|/)(?:\.claude|src/copilot-cli)/skills/[^/]+/SKILL\.md$"
+)
+
+# Copilot CLI rejects non-string values for this skill field at load time.
+STRING_ONLY_FIELDS: frozenset[str] = frozenset({"argument-hint"})
 
 
 @dataclass
@@ -164,6 +172,22 @@ def parse_frontmatter(content: str) -> FrontmatterResult:
         result.errors.append(
             "Frontmatter must use spaces for indentation (tabs not allowed)"
         )
+
+    try:
+        typed_frontmatter = yaml.safe_load(frontmatter_content) or {}
+    except yaml.YAMLError as exc:
+        result.errors.append(f"Frontmatter YAML parse error: {exc}")
+        typed_frontmatter = {}
+
+    if not isinstance(typed_frontmatter, dict):
+        result.errors.append("Frontmatter must be a YAML mapping")
+        typed_frontmatter = {}
+
+    for field_name in STRING_ONLY_FIELDS:
+        if field_name in typed_frontmatter and not isinstance(
+            typed_frontmatter[field_name], str
+        ):
+            result.errors.append(f"{field_name} must be a string")
 
     # Parse YAML using simple key-value parsing
     frontmatter: dict[str, str] = {}
@@ -317,6 +341,12 @@ def validate_allowed_tools(allowed_tools: str | None) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
+def _is_skill_file_path(path: str) -> bool:
+    """Return true for Claude skill files and Copilot CLI skill mirrors."""
+    normalized = path.replace("\\", "/")
+    return _SKILL_FILE_PATTERN.search(normalized) is not None
+
+
 def get_staged_skill_files() -> list[Path]:
     """Get staged SKILL.md files from git."""
     try:
@@ -334,7 +364,7 @@ def get_staged_skill_files() -> list[Path]:
 
     files: list[Path] = []
     for line in result.stdout.strip().split("\n"):
-        if re.search(r"\.claude/skills/.*/SKILL\.md$", line):
+        if _is_skill_file_path(line):
             path = Path(line)
             if path.exists():
                 files.append(path)
@@ -348,10 +378,7 @@ def get_skill_files(
 ) -> list[Path]:
     """Get list of SKILL.md files to validate based on parameters."""
     if changed_files:
-        skill_files = [
-            f for f in changed_files
-            if re.search(r"\.claude/skills/.*/SKILL\.md$", f)
-        ]
+        skill_files = [f for f in changed_files if _is_skill_file_path(f)]
         if not skill_files:
             print("No SKILL.md files in changed files list. "
                   "Skipping frontmatter validation.")

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.231",
+  "version": "0.5.232",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/build/SKILL.md
+++ b/src/copilot-cli/skills/build/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: build
 description: Build incrementally. Implement changes in thin vertical slices with TDD and atomic commits. Run after /plan.
-argument-hint:
-  - plan-step-or-task-description
+argument-hint: plan-step-or-task-description
 allowed-tools: Task, Skill, Read, Write, Edit, Glob, Grep, Bash(*)
 user-invocable: true
 ---

--- a/src/copilot-cli/skills/plan/SKILL.md
+++ b/src/copilot-cli/skills/plan/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: plan
 description: Plan how to build it. Decompose specs into milestones with dependencies and risk mitigations. Run after /spec.
-argument-hint:
-  - spec-output-or-issue-number
+argument-hint: spec-output-or-issue-number
 allowed-tools: Task, Skill, Read, Write, Glob, Grep
 user-invocable: true
 ---

--- a/src/copilot-cli/skills/review/SKILL.md
+++ b/src/copilot-cli/skills/review/SKILL.md
@@ -2,8 +2,7 @@
 name: review
 version: 1.0.0
 description: Review before merge. Stage-1 spec-compliance gate, then 11 Stage-2 canonical axes (analyst, architect, qa, security, devops, roadmap, reliability, observability, agent-safety, decision-rigor, code-quality) plus 3 chained skills (code-qualities-assessment, golden-principles, taste-lints). Run after /test. Run for a full pre-merge review. Do NOT invoke code-qualities-assessment, golden-principles, or taste-lints directly for a full review; review chains them.
-argument-hint:
-  - branch-or-pr-number
+argument-hint: branch-or-pr-number
 allowed-tools: Task, Skill, Read, Glob, Grep, Bash(*)
 user-invocable: true
 license: MIT

--- a/src/copilot-cli/skills/ship/SKILL.md
+++ b/src/copilot-cli/skills/ship/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: ship
 description: Ship it. Pre-flight validation, CI check, and PR creation. Run after /review.
-argument-hint:
-  - target-branch
+argument-hint: target-branch
 allowed-tools: Task, Skill, Read, Glob, Grep, Bash(*)
 user-invocable: true
 ---

--- a/src/copilot-cli/skills/spec/SKILL.md
+++ b/src/copilot-cli/skills/spec/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: spec
 description: Define what to build. Transform a problem into testable requirements with acceptance criteria.
-argument-hint:
-  - problem-statement-or-issue-number
+argument-hint: problem-statement-or-issue-number
 allowed-tools: Task, Skill, Read, Write, Glob, Grep
 user-invocable: true
 ---

--- a/src/copilot-cli/skills/sync/SKILL.md
+++ b/src/copilot-cli/skills/sync/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: sync
 description: Detect Spec to Code drift. Scan REQ/DESIGN/TASK specs for references to code that no longer exists, then report drift for review. Run after a hand-edit that moved or deleted code.
-argument-hint:
-  - spec-tier-or-empty
+argument-hint: spec-tier-or-empty
 allowed-tools: Task, Skill, Read, Glob, Grep, Bash(python3 scripts/sync/detect_spec_drift.py*)
 user-invocable: true
 ---

--- a/src/copilot-cli/skills/test/SKILL.md
+++ b/src/copilot-cli/skills/test/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: test
 description: Prove it works. Multi-dimensional quality validation across functional, non-functional, security, DevOps, DX, and observability. Run after /build.
-argument-hint:
-  - component-or-failure-description
+argument-hint: component-or-failure-description
 allowed-tools: Task, Skill, Read, Glob, Grep, Bash(*)
 user-invocable: true
 ---

--- a/tests/build_scripts/test_generate_commands.py
+++ b/tests/build_scripts/test_generate_commands.py
@@ -98,6 +98,26 @@ def test_command_without_frontmatter_backfills_description(tmp_path: Path) -> No
     assert "user-invocable: true" in out
 
 
+def test_command_argument_hint_inline_array_emits_scalar_string(tmp_path: Path) -> None:
+    _write_command(
+        tmp_path / "cmds",
+        "ship",
+        frontmatter=(
+            'description: "Ship changes."\n'
+            "argument-hint: [target-branch]\n"
+        ),
+        body="# Ship\n\nShip changes.\n",
+    )
+    cfg = _write_config(tmp_path)
+
+    rc = generate_commands.generate_commands(cfg, tmp_path)
+    assert rc == 0
+
+    out = _read_output(tmp_path, "ship")
+    assert "argument-hint: '[target-branch]'" in out
+    assert "argument-hint:\n  - target-branch" not in out
+
+
 def test_claude_md_excluded(tmp_path: Path) -> None:
     """CLAUDE.md is a passive context import, not a slash command — must be skipped."""
     _write_command(tmp_path / "cmds", "real", body="real cmd\n")

--- a/tests/test_validation_skill_frontmatter.py
+++ b/tests/test_validation_skill_frontmatter.py
@@ -331,6 +331,30 @@ class TestGetSkillFiles:
         )
         assert result == [skill_file]
 
+    def test_changed_files_match_skill_paths_case_insensitively(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "SRC" / "Copilot-CLI" / "Skills" / "test"
+        skill_dir.mkdir(parents=True)
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text("---\nname: test\ndescription: Test\n---")
+
+        result = get_skill_files(
+            path=str(tmp_path),
+            changed_files=[str(skill_file)],
+        )
+        assert result == [skill_file]
+
+    def test_changed_files_reject_nested_skill_path_prefix(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "nested" / ".claude" / "skills" / "test"
+        skill_dir.mkdir(parents=True)
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text("---\nname: test\ndescription: Test\n---")
+
+        result = get_skill_files(
+            path=str(tmp_path),
+            changed_files=[str(skill_file)],
+        )
+        assert result == []
+
     def test_changed_files_no_match(self, capsys: pytest.CaptureFixture[str]) -> None:
         result = get_skill_files(
             path=".",

--- a/tests/test_validation_skill_frontmatter.py
+++ b/tests/test_validation_skill_frontmatter.py
@@ -2,6 +2,7 @@
 
 Validates YAML frontmatter for SKILL.md files per ADR-040.
 Covers YAML syntax, required fields, name/description/model/tools validation,
+argument-hint scalar validation,
 CI vs local mode behavior, and edge cases.
 """
 
@@ -318,6 +319,18 @@ class TestGetSkillFiles:
         assert len(result) == 1
         assert result[0] == skill_file
 
+    def test_changed_files_includes_copilot_skill_mirror(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "src" / "copilot-cli" / "skills" / "test"
+        skill_dir.mkdir(parents=True)
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text("---\nname: test\ndescription: Test\n---")
+
+        result = get_skill_files(
+            path=str(tmp_path),
+            changed_files=[str(skill_file)],
+        )
+        assert result == [skill_file]
+
     def test_changed_files_no_match(self, capsys: pytest.CaptureFixture[str]) -> None:
         result = get_skill_files(
             path=".",
@@ -425,6 +438,17 @@ class TestValidateSkillFile:
         )
         result = validate_skill_file(skill_file)
         assert result.passed is True
+
+    def test_argument_hint_array_reports_error(self, tmp_path: Path) -> None:
+        skill_file = tmp_path / "SKILL.md"
+        skill_file.write_text(
+            "---\nname: bad-hint\n"
+            "description: Skill with bad hint\n"
+            "argument-hint:\n  - branch-or-pr-number\n---"
+        )
+        result = validate_skill_file(skill_file)
+        assert result.passed is False
+        assert any("argument-hint must be a string" in e for e in result.errors)
 
     def test_frontmatter_only_no_body(self, tmp_path: Path) -> None:
         skill_file = tmp_path / "SKILL.md"


### PR DESCRIPTION
## Summary

- emit `argument-hint` as a scalar string for command-to-skill generated Copilot skills
- normalize existing lifecycle command and review skill hints
- validate non-string `argument-hint` values in skill frontmatter, including Copilot skill mirrors
- bump project-toolkit plugin manifests to `0.5.232` so installs re-sync
- address review feedback on skill path matching with case-insensitive validation and boundary tests

## Harness Proof

Copilot CLI 1.0.65 loaded the PR branch Copilot plugin from a neutral directory without the prior `argument-hint must be a string` load failure:

```powershell
$tmp = Join-Path $env:TEMP 'copilot-pr-2735-smoke'
New-Item -ItemType Directory -Force -Path $tmp | Out-Null
copilot -C $tmp --plugin-dir C:\src\ai-agents\src\copilot-cli skill list --json |
  ConvertFrom-Json |
  Where-Object { @('build','plan','ship','test','review','spec','sync') -contains $_.name } |
  Select-Object name,source,path,description
```

Observed all seven affected skills loaded from `source: plugin`: `build`, `plan`, `review`, `ship`, `spec`, `sync`, `test`.

Claude Code 2.1.191 loaded the PR branch Claude plugin and reported project-toolkit `0.5.232` with 90 skills, including the affected skill names:

```powershell
npx --yes @anthropic-ai/claude-code --plugin-dir .\.claude plugin list
npx --yes @anthropic-ai/claude-code --plugin-dir .\.claude plugin details project-toolkit
```

Observed:

```text
project-toolkit@inline
Version: 0.5.232
Status: loaded
Skills (90) ... build ... plan ... review ... ship ... spec ... sync ... test ...
```

## Validation

- `UV_PYTHON=3.13 uv run python -m pytest tests\test_validation_skill_frontmatter.py tests\build_scripts\test_generate_commands.py -q`
- `python build\scripts\check_plugin_manifest_parity.py`
- PR checks: 88 passed, 0 failed, 0 pending
- Review threads: 0 unresolved

Fixes #2734
