### PR TITLE
fix(security-review): ESCALATE only when a verdict is unreachable (SkillOpt-gated)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.234",
+  "version": "0.5.235",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.232",
+  "version": "0.5.234",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -194,11 +194,12 @@ End every review with one verdict:
   action such as disclosure or secret rotation).
 
 If a verdict cannot be reached because the diff is incomplete, ESCALATE with the
-specific missing artifact rather than guessing. A verdict is reachable when the
-shown diff answers the three threat-model questions, even if surface, actor, and
-impact are all absent; in that case apply IDENTIFY or OK and never ESCALATE.
-ESCALATE is gated on unreachability alone, never on the mere absence of
-coverage data when the diff is complete.
+specific missing artifact rather than guessing. Treat external or irreversible
+owner-only decisions as unreachable by the model: name the owner decision needed
+and ESCALATE. A verdict is reachable when the shown diff answers the three
+threat-model questions, even if surface, actor, and impact are all absent; in
+that case apply IDENTIFY or OK and never ESCALATE. ESCALATE is never triggered
+by the mere absence of coverage data when the diff is complete.
 
 ## Finding Format
 

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -76,10 +76,11 @@ impact before assigning severity or a risk score.
 ### Phase 3: Return a Verdict
 
 Return IDENTIFY when a vulnerability is present, OK when no unmitigated medium
-or higher risk remains, and ESCALATE only when a verdict cannot be reached
-because the diff or evidence is incomplete. Reachability is decided first: if
-the shown diff lets you complete the threat model, return IDENTIFY or OK and do
-not ESCALATE.
+or higher risk remains, and ESCALATE when a verdict cannot be reached because
+the diff or evidence is incomplete, or when an external or irreversible security
+decision needs an owner. Reachability is decided first: if the shown diff lets
+you complete the threat model and no owner-only decision remains, return
+IDENTIFY or OK and do not ESCALATE.
 
 ## Verification
 

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -189,8 +189,8 @@ End every review with one verdict:
   is the required verdict. Do not ESCALATE a change whose verdict you can
   already reach.
 - ESCALATE: the diff is incomplete or the decision needs an owner (missing
-  changed files, missing coverage data, an external or irreversible action such
-  as disclosure or secret rotation).
+  changed files needed to judge reachability, an external or irreversible
+  action such as disclosure or secret rotation).
 
 If a verdict cannot be reached because the diff is incomplete, ESCALATE with the
 specific missing artifact rather than guessing. A verdict is reachable when the

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -76,7 +76,10 @@ impact before assigning severity or a risk score.
 ### Phase 3: Return a Verdict
 
 Return IDENTIFY when a vulnerability is present, OK when no unmitigated medium
-or higher risk remains, and ESCALATE when the diff or evidence is incomplete.
+or higher risk remains, and ESCALATE only when a verdict cannot be reached
+because the diff or evidence is incomplete. Reachability is decided first: if
+the shown diff lets you complete the threat model, return IDENTIFY or OK and do
+not ESCALATE.
 
 ## Verification
 
@@ -181,12 +184,20 @@ End every review with one verdict:
 - IDENTIFY: a vulnerability is present. Name the CWE, the surface, and the
   impact, then recommend the mitigation.
 - OK: the change is safe to merge; no unmitigated finding at or above MEDIUM.
+  When the threat model shows no attack surface, no actor, and no impact (for
+  example a pure rename or comment edit), the OK definition is satisfied and OK
+  is the required verdict. Do not ESCALATE a change whose verdict you can
+  already reach.
 - ESCALATE: the diff is incomplete or the decision needs an owner (missing
   changed files, missing coverage data, an external or irreversible action such
   as disclosure or secret rotation).
 
 If a verdict cannot be reached because the diff is incomplete, ESCALATE with the
-specific missing artifact rather than guessing.
+specific missing artifact rather than guessing. A verdict is reachable when the
+shown diff answers the three threat-model questions, even if surface, actor, and
+impact are all absent; in that case apply IDENTIFY or OK and never ESCALATE.
+ESCALATE is gated on unreachability alone, never on the mere absence of
+coverage data when the diff is complete.
 
 ## Finding Format
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.234",
+  "version": "0.5.235",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.232",
+  "version": "0.5.234",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Bash_f620ca.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PostToolUse/invoke_lsp_usage_tracker__mcp_serena_find_symbol_find_referencing_symbols_34dc50.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_lsp_usage_tracker__mcp_serena_find_symbol_find_referencing_symbols_34dc50.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PostToolUse/invoke_markdown_auto_lint__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_markdown_auto_lint__Write_Edit_c39898.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PostToolUse/invoke_plan_state_sync__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_plan_state_sync__Write_Edit_c39898.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_git_commit_442774.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_git_commit_442774.py
@@ -137,7 +137,6 @@ def _shim_dispatch():
         rc = 0
     _sys.exit(int(rc))
 
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_commit_442774.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_commit_442774.py
@@ -137,7 +137,6 @@ def _shim_dispatch():
         rc = 0
     _sys.exit(int(rc))
 
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_push_0e93bf.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_commit_442774.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_commit_442774.py
@@ -137,7 +137,6 @@ def _shim_dispatch():
         rc = 0
     _sys.exit(int(rc))
 
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_push_0e93bf.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_f620ca.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gh_pr_create_be117f.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gh_pr_create_be117f.py
@@ -137,7 +137,6 @@ def _shim_dispatch():
         rc = 0
     _sys.exit(int(rc))
 
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gh_pr_merge_ac4348.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gh_pr_merge_ac4348.py
@@ -137,7 +137,6 @@ def _shim_dispatch():
         rc = 0
     _sys.exit(int(rc))
 
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_git_commit_git_ci_fb3f5a.py
@@ -137,7 +137,6 @@ def _shim_dispatch():
         rc = 0
     _sys.exit(int(rc))
 
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_hook_drift_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_hook_drift_guard__Bash_git_push_0e93bf.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_install_parity_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_install_parity_guard__Bash_git_push_0e93bf.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_bash_grep_guard__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_bash_grep_guard__Bash_f620ca.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_glob_guard__Glob_181cd6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_glob_guard__Glob_181cd6.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_grep_guard__Grep_2589b1.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_grep_guard__Grep_2589b1.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_markdownlint_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_markdownlint_guard__Bash_git_push_0e93bf.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_plugin_version_bump_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_plugin_version_bump_guard__Bash_git_push_0e93bf.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_pr_description_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_pr_description_guard__Bash_git_push_0e93bf.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_git_commit_442774.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_git_commit_442774.py
@@ -137,7 +137,6 @@ def _shim_dispatch():
         rc = 0
     _sys.exit(int(rc))
 
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_git_commit_git_ci_fb3f5a.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_retrospective_gate__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_retrospective_gate__Bash_git_push_0e93bf.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_routing_gates__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_routing_gates__Bash_f620ca.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_security_commit_gate__Bash_git_commit_442774.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_security_commit_gate__Bash_git_commit_442774.py
@@ -137,7 +137,6 @@ def _shim_dispatch():
         rc = 0
     _sys.exit(int(rc))
 
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_security_commit_gate__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_security_commit_gate__Bash_git_commit_git_ci_fb3f5a.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_security_gate__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_security_gate__Write_Edit_c39898.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_field_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_field_guard__Bash_git_push_0e93bf.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gh_pr_create_be117f.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gh_pr_create_be117f.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_git_commit_442774.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_git_commit_442774.py
@@ -137,7 +137,6 @@ def _shim_dispatch():
         rc = 0
     _sys.exit(int(rc))
 
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_skill_first_guard__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_skill_first_guard__Bash_f620ca.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
@@ -231,8 +231,6 @@ def _shim_dispatch():
     if rc is None:
         rc = 0
     _sys.exit(int(rc))
-
-
 # END MATCHER SHIM
 
 def _original_main(stdin_bytes):

--- a/src/copilot-cli/skills/security-review/SKILL.md
+++ b/src/copilot-cli/skills/security-review/SKILL.md
@@ -194,11 +194,12 @@ End every review with one verdict:
   action such as disclosure or secret rotation).
 
 If a verdict cannot be reached because the diff is incomplete, ESCALATE with the
-specific missing artifact rather than guessing. A verdict is reachable when the
-shown diff answers the three threat-model questions, even if surface, actor, and
-impact are all absent; in that case apply IDENTIFY or OK and never ESCALATE.
-ESCALATE is gated on unreachability alone, never on the mere absence of
-coverage data when the diff is complete.
+specific missing artifact rather than guessing. Treat external or irreversible
+owner-only decisions as unreachable by the model: name the owner decision needed
+and ESCALATE. A verdict is reachable when the shown diff answers the three
+threat-model questions, even if surface, actor, and impact are all absent; in
+that case apply IDENTIFY or OK and never ESCALATE. ESCALATE is never triggered
+by the mere absence of coverage data when the diff is complete.
 
 ## Finding Format
 

--- a/src/copilot-cli/skills/security-review/SKILL.md
+++ b/src/copilot-cli/skills/security-review/SKILL.md
@@ -76,10 +76,11 @@ impact before assigning severity or a risk score.
 ### Phase 3: Return a Verdict
 
 Return IDENTIFY when a vulnerability is present, OK when no unmitigated medium
-or higher risk remains, and ESCALATE only when a verdict cannot be reached
-because the diff or evidence is incomplete. Reachability is decided first: if
-the shown diff lets you complete the threat model, return IDENTIFY or OK and do
-not ESCALATE.
+or higher risk remains, and ESCALATE when a verdict cannot be reached because
+the diff or evidence is incomplete, or when an external or irreversible security
+decision needs an owner. Reachability is decided first: if the shown diff lets
+you complete the threat model and no owner-only decision remains, return
+IDENTIFY or OK and do not ESCALATE.
 
 ## Verification
 

--- a/src/copilot-cli/skills/security-review/SKILL.md
+++ b/src/copilot-cli/skills/security-review/SKILL.md
@@ -189,8 +189,8 @@ End every review with one verdict:
   is the required verdict. Do not ESCALATE a change whose verdict you can
   already reach.
 - ESCALATE: the diff is incomplete or the decision needs an owner (missing
-  changed files, missing coverage data, an external or irreversible action such
-  as disclosure or secret rotation).
+  changed files needed to judge reachability, an external or irreversible
+  action such as disclosure or secret rotation).
 
 If a verdict cannot be reached because the diff is incomplete, ESCALATE with the
 specific missing artifact rather than guessing. A verdict is reachable when the

--- a/src/copilot-cli/skills/security-review/SKILL.md
+++ b/src/copilot-cli/skills/security-review/SKILL.md
@@ -76,7 +76,10 @@ impact before assigning severity or a risk score.
 ### Phase 3: Return a Verdict
 
 Return IDENTIFY when a vulnerability is present, OK when no unmitigated medium
-or higher risk remains, and ESCALATE when the diff or evidence is incomplete.
+or higher risk remains, and ESCALATE only when a verdict cannot be reached
+because the diff or evidence is incomplete. Reachability is decided first: if
+the shown diff lets you complete the threat model, return IDENTIFY or OK and do
+not ESCALATE.
 
 ## Verification
 
@@ -181,12 +184,20 @@ End every review with one verdict:
 - IDENTIFY: a vulnerability is present. Name the CWE, the surface, and the
   impact, then recommend the mitigation.
 - OK: the change is safe to merge; no unmitigated finding at or above MEDIUM.
+  When the threat model shows no attack surface, no actor, and no impact (for
+  example a pure rename or comment edit), the OK definition is satisfied and OK
+  is the required verdict. Do not ESCALATE a change whose verdict you can
+  already reach.
 - ESCALATE: the diff is incomplete or the decision needs an owner (missing
   changed files, missing coverage data, an external or irreversible action such
   as disclosure or secret rotation).
 
 If a verdict cannot be reached because the diff is incomplete, ESCALATE with the
-specific missing artifact rather than guessing.
+specific missing artifact rather than guessing. A verdict is reachable when the
+shown diff answers the three threat-model questions, even if surface, actor, and
+impact are all absent; in that case apply IDENTIFY or OK and never ESCALATE.
+ESCALATE is gated on unreachability alone, never on the mere absence of
+coverage data when the diff is complete.
 
 ## Finding Format
 


### PR DESCRIPTION
## Summary

SkillOpt-gated optimization for `security-review`. The held-out eval samples the skill failure mode where missing coverage data caused ESCALATE even when the diff itself made the verdict reachable.

Refs #1875

## Specification References

| Issue | Scope |
|-------|-------|
| #1875 | Security-review form-factor evaluation follow-up |

## Type of Change

- [x] Documentation or prompt update
- [x] Generated artifact update

## Changes

- Update `.claude/skills/security-review/SKILL.md` so ESCALATE is limited to unreachable verdicts.
- Update `src/copilot-cli/skills/security-review/SKILL.md` with the same mirrored wording.
- Bump `.claude/.claude-plugin/plugin.json` and `src/copilot-cli/.claude-plugin/plugin.json` to keep plugin manifest parity with main.

## Failure mode

The prior wording said to ESCALATE when the diff or evidence is incomplete. That over-escalated two held-out cases where the shown diff already answered the threat model:

- `s1`: a pure rename refactor with no surface, actor, or impact. It escalated because a coverage report was absent.
- `s2`: a reversible hardening change that adds `X-Content-Type-Options: nosniff`. It hit the same spurious escalation.

Both verdicts were reachable from the shown diff. Missing coverage alone is not an escalation trigger.

## Held-out result

| Split | Baseline | Candidate |
|-------|----------|-----------|
| s1 rename | FAIL, escalated | PASS, OK |
| s2 nosniff | FAIL, escalated | PASS, OK |
| s3 guard, unshown `resolve_upload_path` blocks verdict | PASS, escalate | PASS, escalate |
| score | 1/3 | 3/3 |

Strict-greater gate: 1.000 > 0.333, accepted. The guard still correctly escalates, so the fix removes over-escalation without weakening real escalation.

## Validation

- [x] markdownlint clean
- [x] mirrored skill files updated together
- [x] plugin manifest parity restored
