### PR TITLE
fix(hooks): support batched Copilot tool calls

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.231",
+  "version": "0.5.233",
   "author": {
     "name": "rjmurillo"
   }

--- a/build/scripts/generate_hooks_shim.py
+++ b/build/scripts/generate_hooks_shim.py
@@ -246,8 +246,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{{[\\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{{}}]: {{}} is not valid JSON: {{}}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -267,43 +313,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{{}}]: toolArgs is not valid JSON: {{}}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 
@@ -360,3 +408,4 @@ def _shim_dispatch():
 
 {_SHIM_END}
 '''
+

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.231",
+  "version": "0.5.233",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Bash_f620ca.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PostToolUse/invoke_lsp_usage_tracker__mcp_serena_find_symbol_find_referencing_symbols_34dc50.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_lsp_usage_tracker__mcp_serena_find_symbol_find_referencing_symbols_34dc50.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PostToolUse/invoke_markdown_auto_lint__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_markdown_auto_lint__Write_Edit_c39898.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PostToolUse/invoke_plan_state_sync__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_plan_state_sync__Write_Edit_c39898.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_push_0e93bf.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_push_0e93bf.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_f620ca.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_hook_drift_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_hook_drift_guard__Bash_git_push_0e93bf.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_install_parity_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_install_parity_guard__Bash_git_push_0e93bf.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_bash_grep_guard__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_bash_grep_guard__Bash_f620ca.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_glob_guard__Glob_181cd6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_glob_guard__Glob_181cd6.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_grep_guard__Grep_2589b1.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_grep_guard__Grep_2589b1.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_markdownlint_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_markdownlint_guard__Bash_git_push_0e93bf.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_plugin_version_bump_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_plugin_version_bump_guard__Bash_git_push_0e93bf.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_pr_description_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_pr_description_guard__Bash_git_push_0e93bf.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_git_commit_git_ci_fb3f5a.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_retrospective_gate__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_retrospective_gate__Bash_git_push_0e93bf.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_routing_gates__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_routing_gates__Bash_f620ca.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_security_commit_gate__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_security_commit_gate__Bash_git_commit_git_ci_fb3f5a.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_security_gate__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_security_gate__Write_Edit_c39898.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_field_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_field_guard__Bash_git_push_0e93bf.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gh_pr_create_be117f.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gh_pr_create_be117f.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_skill_first_guard__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_skill_first_guard__Bash_f620ca.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
@@ -73,8 +73,54 @@ def _shim_glob_match(args_glob, tool_args_norm):
     return False
 
 
-def _shim_should_fire(payload):
-    kind, params = _shim_classify(_MATCHER)
+def _shim_parse_json_string(raw_value, field_name):
+    if isinstance(raw_value, str):
+        stripped = raw_value.lstrip()
+        if not stripped or stripped[0] not in "{[\"":
+            return raw_value
+        try:
+            return _json.loads(raw_value)
+        except ValueError as exc:
+            print(
+                "matcher-shim [{}]: {} is not valid JSON: {}".format(
+                    _MATCHER, field_name, exc
+                ),
+                file=_sys.stderr,
+            )
+            return raw_value
+    return raw_value
+
+
+def _shim_tool_input_from_call_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolCalls.args")
+
+
+def _shim_tool_input_from_tool_args(raw_args):
+    return _shim_parse_json_string(raw_args, "toolArgs")
+
+
+def _shim_candidate_payloads(payload):
+    tool_calls = payload.get("toolCalls")
+    if isinstance(tool_calls, list):
+        candidates = []
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            name = call.get("name")
+            if not isinstance(name, str):
+                continue
+            candidate = dict(payload)
+            candidate.pop("toolCalls", None)
+            candidate["tool_name"] = name
+            candidate["tool_input"] = _shim_tool_input_from_call_args(call.get("args"))
+            if "id" in call:
+                candidate["tool_call_id"] = call.get("id")
+            candidates.append(candidate)
+        return candidates
+    return [payload]
+
+
+def _shim_match_candidate(payload, kind, params):
     # Support both VS Code-compatible snake_case (PascalCase event names)
     # and native camelCase (camelCase event names) payloads.
     # Copilot CLI sends snake_case when the event key is PascalCase,
@@ -94,43 +140,45 @@ def _shim_should_fire(payload):
             tool_args = payload.get("toolArgs")
         # camelCase payloads send toolArgs as a JSON string, not a parsed
         # object. Parse it so _shim_normalize_args can extract "command".
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError as exc:
-                # Host sent a string that is not valid JSON. Log so
-                # the operator can diagnose; fall through to normalize
-                # which treats raw strings as-is (glob may not match).
-                print(
-                    "matcher-shim [{}]: toolArgs is not valid JSON: {}".format(
-                        _MATCHER, exc
-                    ),
-                    file=_sys.stderr,
-                )
+        tool_args = _shim_tool_input_from_tool_args(tool_args)
         norm_args = _shim_normalize_args(tool_args)
         return _shim_glob_match(params["argsGlob"], norm_args)
     # bare
     return tool_name == params["toolName"]
 
 
+def _shim_select_payload(payload):
+    kind, params = _shim_classify(_MATCHER)
+    candidates = _shim_candidate_payloads(payload)
+    if not candidates:
+        return None
+    for candidate in candidates:
+        if _shim_match_candidate(candidate, kind, params):
+            return candidate
+    return None
+
+
+def _shim_should_fire(payload):
+    return _shim_select_payload(payload) is not None
+
+
 def _shim_replay_bytes(payload, raw):
-    replay = dict(payload)
-    changed = False
+    selected = _shim_select_payload(payload)
+    if selected is None:
+        return raw
+    replay = dict(selected)
+    changed = replay is not payload
     tool_name = replay.get("tool_name")
     if tool_name is None and isinstance(replay.get("toolName"), str):
         replay["tool_name"] = replay["toolName"]
         changed = True
     tool_input = replay.get("tool_input")
     if tool_input is None and "toolArgs" in replay:
-        tool_args = replay.get("toolArgs")
-        if isinstance(tool_args, str):
-            try:
-                tool_args = _json.loads(tool_args)
-            except ValueError:
-                pass
-        replay["tool_input"] = tool_args
+        replay["tool_input"] = _shim_tool_input_from_tool_args(replay.get("toolArgs"))
         changed = True
     if not changed:
+        return raw
+    if payload.get("tool_name") is not None:
         return raw
     return _json.dumps(replay, separators=(",", ":")).encode("utf-8")
 

--- a/tests/build_scripts/test_generate_hooks.py
+++ b/tests/build_scripts/test_generate_hooks.py
@@ -356,6 +356,53 @@ def test_inject_shim_no_op_on_bare_miss():
     assert "FIRED" not in proc.stdout
 
 
+def test_inject_shim_no_op_on_batched_toolcalls_without_match():
+    transformed = inject_shim(_TRACE_SCRIPT, "Bash")
+    proc = _run_shim(
+        transformed,
+        {
+            "toolCalls": [
+                {
+                    "id": "custom_call_patch",
+                    "name": "apply_patch",
+                    "args": "*** Begin Patch\n*** Add File: example.txt\n+hi\n*** End Patch\n",
+                }
+            ]
+        },
+    )
+    assert proc.returncode == 0
+    assert "FIRED" not in proc.stdout
+    assert proc.stderr == ""
+
+
+def test_inject_shim_fires_on_batched_toolcalls_with_tool_glob_match():
+    script = (
+        "import sys, json\n"
+        "data = json.load(sys.stdin) if sys.stdin else {}\n"
+        'print("FIRED:" + data.get("tool_name", ""))\n'
+        'print("COMMAND:" + data.get("tool_input", {}).get("command", ""))\n'
+        "sys.exit(0)\n"
+    )
+    transformed = inject_shim(script, "Bash(git commit*)")
+    proc = _run_shim(
+        transformed,
+        {
+            "sessionId": "s1",
+            "toolCalls": [
+                {"id": "custom_call_patch", "name": "apply_patch", "args": "patch"},
+                {
+                    "id": "custom_call_bash",
+                    "name": "Bash",
+                    "args": {"command": "git commit -m example"},
+                },
+            ],
+        },
+    )
+    assert proc.returncode == 0
+    assert "FIRED:Bash" in proc.stdout
+    assert "COMMAND:git commit -m example" in proc.stdout
+
+
 def test_inject_shim_fires_on_mcp_namespaced_bare():
     transformed = inject_shim(_TRACE_SCRIPT, "mcp__serena__write_memory")
     proc = _run_shim(transformed, {"tool_name": "mcp__serena__write_memory"})


### PR DESCRIPTION
## Summary

- support Copilot `preToolUse` batched `toolCalls` payloads in generated matcher shims
- keep existing snake_case and camelCase single-tool payload behavior
- regenerate Copilot hook shims and bump project-toolkit to `0.5.233`

## Evidence

Observed failure from Copilot CLI 1.0.65 session `2548151e-8e8f-4262-ae94-b299c89ed042`:

```text
matcher-shim [Bash]: dispatch error: hook input missing string `tool_name`/`toolName` field
Denied by preToolUse hook from "project-toolkit@ai-agents" (hook errored)
```

Live payload replay now exits 0 against the regenerated dispatcher:

```powershell
$env:COPILOT_PLUGIN_ROOT=(Join-Path (Get-Location) 'src\copilot-cli')
Get-Content C:\Users\rimuri\AppData\Local\Temp\hook-payload-line-458.json |
  py -3 -u "$env:COPILOT_PLUGIN_ROOT\hooks\PreToolUse\_dispatch.py"
# rc=0
```

## Validation

- `UV_PYTHON=3.13 uv run python -m pytest tests\build_scripts\test_generate_hooks.py -q`
- `python build\scripts\check_plugin_manifest_parity.py`
- `python build\scripts\build_all.py --check`
- `copilot -C <temp> --plugin-dir C:\src\ai-agents-hook-batched-toolcalls\src\copilot-cli skill list --json`

Fixes #2738
