### PR TITLE
test(e2e): add Claude and Copilot plugin-load smoke gates

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -321,6 +321,10 @@ CHANGED_AGENT_DRIFT_INPUTS=$(echo "$CHANGED_FILES" | grep -E '^(src/claude/[^/]+
 # the project-mode settings source, the anchoring gate, and the e2e itself.
 # A change to any forces the real-CLI e2e (resolution under the live contract).
 CHANGED_HOOKS=$(echo "$CHANGED_FILES" | grep -E '^(build/scripts/generate_hooks\.py|src/copilot-cli/hooks/|\.claude/hooks/|\.claude/settings\.json|scripts/validation/validate_hook_anchoring\.py|tests/e2e/test_cli_hook_e2e\.py)' || true)
+# Plugin-load relevant paths (#2736): sources, generated skill mirrors, plugin
+# manifests, generators, and the smoke itself. A change to any forces the real
+# CLI plugin-load smoke when a CLI is available.
+CHANGED_PLUGIN_LOAD=$(echo "$CHANGED_FILES" | grep -E '^(\.claude/(\.claude-plugin/plugin\.json|commands/|skills/)|src/copilot-cli/(\.claude-plugin/plugin\.json|skills/)|build/scripts/generate_(commands|skills)\.py|templates/platforms/copilot-cli\.yaml|tests/e2e/test_plugin_load_smoke\.py|\.github/workflows/nightly-cli-smoke\.yml)' || true)
 
 # ============================================================================
 # Phase 1: Fast Guards (< 5s)
@@ -1223,6 +1227,36 @@ fi
             fi
         else
             record_skip "Hook anchoring e2e (no copilot/claude CLI on PATH)"
+        fi
+    fi
+
+    # 14c. Plugin-load e2e (real CLIs) - FORCED when plugin load surfaces change
+    # (#2736). Loads the shipped Claude and Copilot plugin trees in the real CLIs
+    # and asserts the lifecycle skills parse and appear. Bare CI cannot run this
+    # without auth and credits, so pre-push runs it when a CLI is installed.
+    if [ -n "$CHANGED_PLUGIN_LOAD" ]; then
+        if [ "${SKIP_CLI_E2E:-}" = "true" ]; then
+            record_skip "Plugin-load e2e (SKIP_CLI_E2E=true)"
+        elif command -v copilot >/dev/null 2>&1 || command -v claude >/dev/null 2>&1; then
+            if set_python_cmd; then
+                PLUGIN_LOAD_OUTPUT=$(mktemp)
+                if env -u CLAUDE_PROJECT_DIR -u CLAUDE_PLUGIN_ROOT -u COPILOT_PLUGIN_ROOT \
+                    RUN_CLI_E2E=1 "${PYTHON_CMD[@]}" -m pytest \
+                    "$REPO_ROOT/tests/e2e/test_plugin_load_smoke.py" -v > "$PLUGIN_LOAD_OUTPUT" 2>&1; then
+                    rm -f "$PLUGIN_LOAD_OUTPUT"
+                    record_pass "Plugin-load e2e (real CLIs)"
+                else
+                    echo_info "  Plugin-load output (last 40 lines):"
+                    tail -40 "$PLUGIN_LOAD_OUTPUT"
+                    rm -f "$PLUGIN_LOAD_OUTPUT"
+                    record_fail "Plugin-load e2e failed (Copilot/Claude)"
+                    echo_info "  A shipped plugin tree did not load expected lifecycle skills."
+                fi
+            else
+                record_skip "Plugin-load e2e (Python 3 not available)"
+            fi
+        else
+            record_skip "Plugin-load e2e (no copilot/claude CLI on PATH)"
         fi
     fi
 

--- a/.github/workflows/nightly-cli-smoke.yml
+++ b/.github/workflows/nightly-cli-smoke.yml
@@ -1,11 +1,16 @@
-# Nightly Real-CLI Hook Smoke (issue #2231 items 3-4, ADR-071)
+# Nightly Real-CLI Smoke (issue #2231 items 3-4, ADR-071; issue #2736)
 #
-# Installs the real Copilot and Claude CLIs and runs the plugin hook end to end
-# on ubuntu/macos/windows. This is the authenticated cross-platform smoke that
-# ADR-071 deferred: the no-auth gates (validate_hook_anchoring,
-# test_generate_hooks_runtime_contract) verify path resolution in PR CI; this
-# job verifies the real CLI launcher contract that bare CI cannot, on the
-# platforms (Windows PowerShell) where #2205 was reported.
+# Installs the real Copilot and Claude CLIs and runs two real-CLI smokes end to
+# end on ubuntu/macos/windows:
+#   - Hook smoke (test_cli_hook_e2e.py): a plugin hook resolves and runs from the
+#     install tree. The authenticated cross-platform smoke ADR-071 deferred; the
+#     no-auth gates (validate_hook_anchoring, test_generate_hooks_runtime_contract)
+#     verify path resolution in PR CI, this verifies the real launcher contract
+#     bare CI cannot, on the platforms (Windows PowerShell) where #2205 was filed.
+#   - Plugin-load smoke (test_plugin_load_smoke.py, issue #2736): the shipped
+#     plugin dir loads in each CLI and the lifecycle skills load with no
+#     argument-hint loader warning. PR #2735 was green on schema and unit checks
+#     yet still needed manual proof the plugin loaded; this automates that proof.
 #
 # Security (.claude/rules/security.md, issue #2231 item 3):
 #   - Triggers only on schedule and workflow_dispatch. GitHub never fires these
@@ -26,6 +31,7 @@
 #
 # Local equivalent:
 #   RUN_CLI_E2E=1 uv run pytest tests/e2e/test_cli_hook_e2e.py -m smoke -v
+#   RUN_CLI_E2E=1 uv run pytest tests/e2e/test_plugin_load_smoke.py -m smoke -v
 
 name: Nightly CLI Smoke
 
@@ -128,12 +134,28 @@ jobs:
         shell: bash
         run: uv run pytest tests/e2e/test_cli_hook_e2e.py -m smoke --junitxml=smoke-report.xml
 
-      - name: Assert the smoke actually ran
+      - name: Assert the hook smoke actually ran
         # always(): the gate must run even if the smoke step failed, so a skip
         # (which pytest exits 0 for) is still caught and reported as a red job.
         if: always()
         shell: bash
         run: uv run python scripts/validation/assert_smoke_ran.py smoke-report.xml
+
+      - name: Run real-CLI plugin-load smoke
+        # always(): run even if the hook smoke step failed so both smokes report.
+        if: always()
+        shell: bash
+        run: >-
+          uv run pytest tests/e2e/test_plugin_load_smoke.py -m smoke
+          --junitxml=plugin-load-report.xml
+
+      - name: Assert the plugin-load smoke actually ran
+        # always(): a silent skip of the plugin-load smoke must also fail the job.
+        if: always()
+        shell: bash
+        run: >-
+          uv run python scripts/validation/assert_smoke_ran.py plugin-load-report.xml
+          --smoke-substr test_plugin_load_smoke --expected-count 2
 
   smoke-result:
     name: Smoke Result

--- a/tests/e2e/test_plugin_load_smoke.py
+++ b/tests/e2e/test_plugin_load_smoke.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""End-to-end plugin-load smoke for the shipped CLI plugins (issue #2736).
+
+PR #2735 was green on unit tests, schema checks, and generated-file checks, yet a
+broken skill front-matter field (``argument-hint must be a string``) could still
+reach a customer because nothing loaded the plugin in the real CLI and asserted
+the skills loaded. These tests close that gap: they launch the REAL CLIs, load
+the shipped plugin directory, list the plugin's skills, and assert the lifecycle
+skills load.
+
+  - Copilot: ``copilot --plugin-dir <repo>/src/copilot-cli skill list --json``
+    from a neutral cwd. Assert returncode 0, no ``argument-hint`` loader warning
+    in stderr, and the expected lifecycle skills load from ``source: plugin``.
+  - Claude:  ``claude --plugin-dir <repo>/.claude plugin list`` and
+    ``plugin details project-toolkit``. Assert returncode 0 and the manifest
+    version from ``.claude/.claude-plugin/plugin.json`` appears in the output.
+
+This is the plugin-LOAD smoke. The plugin-HOOK smoke (a hook resolves and runs
+from the install tree) lives in ``tests/e2e/test_cli_hook_e2e.py``. Both run in
+the same nightly workflow under ``RUN_CLI_E2E=1``; each has its own JUnit report
+and its own ``assert_smoke_ran`` gate so a silent skip of either is a red run.
+
+Why opt-in: these spawn real CLIs that need authentication and spend model
+credits, which bare CI does not have. They run wherever the CLIs are installed
+and ``RUN_CLI_E2E=1`` is set (local dev, the nightly job with secrets); elsewhere
+they SKIP with a loud reason so a skipped run never reads as a passed run. The
+fast, always-on guards are the unit checks at the bottom of this file: they pin
+the expected-skills set against the shipped plugin trees with no CLI, so a
+renamed or deleted lifecycle skill fails in bare CI too.
+
+Run locally:
+    RUN_CLI_E2E=1 uv run pytest tests/e2e/test_plugin_load_smoke.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from cli_exec import resolve_executable  # noqa: E402
+
+_RUN = os.environ.get("RUN_CLI_E2E") == "1"
+
+# The lifecycle skills PR #2735 verified by hand. They ship in BOTH plugin trees
+# (src/copilot-cli/skills/<name>/ and .claude/commands/<name>.md), so the same
+# set is the load contract for both CLIs. The always-on unit checks below pin
+# this set against the on-disk trees so a rename fails without a real CLI.
+EXPECTED_SKILLS = frozenset({"build", "plan", "ship", "test", "review", "spec", "sync"})
+
+_COPILOT_PLUGIN_DIR = REPO_ROOT / "src" / "copilot-cli"
+_CLAUDE_PLUGIN_DIR = REPO_ROOT / ".claude"
+_CLAUDE_MANIFEST = _CLAUDE_PLUGIN_DIR / ".claude-plugin" / "plugin.json"
+
+# The skill-loader warning class issue #2736 must catch before merge. Copilot
+# CLI emits this on stderr when a skill's front matter has a non-string
+# argument-hint; the schema check passes but the real loader rejects it.
+_ARGUMENT_HINT_WARNING = "argument-hint"
+
+_CLI_TIMEOUT_SECONDS = 240
+
+requires_copilot = pytest.mark.skipif(
+    not (_RUN and shutil.which("copilot")),
+    reason="needs RUN_CLI_E2E=1 and the copilot CLI on PATH (real auth + credits)",
+)
+requires_claude = pytest.mark.skipif(
+    not (_RUN and shutil.which("claude")),
+    reason="needs RUN_CLI_E2E=1 and the claude CLI on PATH (real auth + credits)",
+)
+
+
+def _clean_env() -> dict[str, str]:
+    """Env for the CLI subprocess with inherited plugin-root vars stripped.
+
+    A parent Claude session or the pre-push hook may export these; strip them so
+    the CLI under test resolves the plugin from ``--plugin-dir``, not from an
+    inherited root that points at a different tree.
+    """
+    env = os.environ.copy()
+    for var in ("CLAUDE_PLUGIN_ROOT", "CLAUDE_PROJECT_DIR", "COPILOT_PLUGIN_ROOT"):
+        env.pop(var, None)
+    return env
+
+
+def _plugin_skill_names(payload: object) -> set[str]:
+    """Extract skill names loaded from a plugin source out of `skill list --json`.
+
+    The Copilot CLI prints a JSON array of skill records. Each record carries a
+    ``name`` and a ``source``; only ``source == "plugin"`` records prove the
+    skill loaded from the plugin dir under test rather than from a built-in or a
+    user-level install. A record without a recognized source is ignored, not
+    counted, so a built-in ``build`` cannot mask a missing plugin ``build``.
+    """
+    if not isinstance(payload, list):
+        return set()
+    names: set[str] = set()
+    for record in payload:
+        if not isinstance(record, dict):
+            continue
+        if record.get("source") != "plugin":
+            continue
+        name = record.get("name")
+        if isinstance(name, str):
+            names.add(name)
+    return names
+
+
+def _read_manifest_version(manifest_path: Path) -> str:
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    version = data.get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError(f"manifest {manifest_path} has no string version: {data!r}")
+    return version
+
+
+@pytest.mark.smoke
+@requires_copilot
+def test_copilot_plugin_loads_expected_skills(tmp_path: Path) -> None:
+    """copilot --plugin-dir loads the lifecycle skills with no loader warning.
+
+    Asserts returncode 0, that no ``argument-hint`` loader warning appears on
+    stderr (the issue #2736 failure class), and that EXPECTED_SKILLS is a subset
+    of the skills the CLI loaded from ``source: plugin``.
+    """
+    version = subprocess.run(
+        [resolve_executable("copilot"), "--version"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+        env=_clean_env(),
+    )
+    print(f"copilot --version: {version.stdout.strip() or version.stderr.strip()}")
+
+    try:
+        run = subprocess.run(
+            [
+                resolve_executable("copilot"),
+                "-C",
+                str(tmp_path),
+                "--plugin-dir",
+                str(_COPILOT_PLUGIN_DIR),
+                "skill",
+                "list",
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SECONDS,
+            check=False,
+            env=_clean_env(),
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip(f"copilot skill list exceeded {_CLI_TIMEOUT_SECONDS}s (CLI/infra latency)")
+
+    assert run.returncode == 0, (
+        f"copilot skill list failed (rc={run.returncode}). "
+        f"stdout={run.stdout[-600:]!r} stderr={run.stderr[-600:]!r}"
+    )
+    assert _ARGUMENT_HINT_WARNING not in run.stderr.lower(), (
+        "copilot reported an argument-hint loader warning (issue #2736 failure class). "
+        f"stderr={run.stderr[-600:]!r}"
+    )
+
+    try:
+        payload = json.loads(run.stdout)
+    except json.JSONDecodeError as exc:
+        pytest.fail(f"copilot skill list emitted non-JSON: {exc}. stdout={run.stdout[-600:]!r}")
+
+    loaded = _plugin_skill_names(payload)
+    missing = EXPECTED_SKILLS - loaded
+    assert not missing, (
+        f"copilot did not load expected plugin skills: missing={sorted(missing)} "
+        f"loaded={sorted(loaded)}"
+    )
+
+
+@pytest.mark.smoke
+@requires_claude
+def test_claude_plugin_loads_expected_skills(tmp_path: Path) -> None:
+    """claude --plugin-dir loads project-toolkit at the manifest version.
+
+    Asserts returncode 0 on ``plugin list`` and that the version from
+    ``.claude/.claude-plugin/plugin.json`` appears in ``plugin details``, proving
+    the CLI loaded the shipped plugin rather than failing silently.
+    """
+    version = subprocess.run(
+        [resolve_executable("claude"), "--version"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+        env=_clean_env(),
+    )
+    print(f"claude --version: {version.stdout.strip() or version.stderr.strip()}")
+
+    manifest_version = _read_manifest_version(_CLAUDE_MANIFEST)
+
+    try:
+        listing = subprocess.run(
+            [
+                resolve_executable("claude"),
+                "-C",
+                str(tmp_path),
+                "--plugin-dir",
+                str(_CLAUDE_PLUGIN_DIR),
+                "plugin",
+                "list",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SECONDS,
+            check=False,
+            env=_clean_env(),
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip(f"claude plugin list exceeded {_CLI_TIMEOUT_SECONDS}s (CLI/infra latency)")
+
+    assert listing.returncode == 0, (
+        f"claude plugin list failed (rc={listing.returncode}). "
+        f"stdout={listing.stdout[-600:]!r} stderr={listing.stderr[-600:]!r}"
+    )
+
+    try:
+        details = subprocess.run(
+            [
+                resolve_executable("claude"),
+                "-C",
+                str(tmp_path),
+                "--plugin-dir",
+                str(_CLAUDE_PLUGIN_DIR),
+                "plugin",
+                "details",
+                "project-toolkit",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SECONDS,
+            check=False,
+            env=_clean_env(),
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip(f"claude plugin details exceeded {_CLI_TIMEOUT_SECONDS}s (CLI/infra latency)")
+
+    assert details.returncode == 0, (
+        f"claude plugin details failed (rc={details.returncode}). "
+        f"stdout={details.stdout[-600:]!r} stderr={details.stderr[-600:]!r}"
+    )
+    combined = details.stdout + details.stderr
+    assert manifest_version in combined, (
+        f"claude did not report manifest version {manifest_version!r}. "
+        f"stdout={details.stdout[-600:]!r} stderr={details.stderr[-600:]!r}"
+    )
+
+
+# Always-on unit checks. They need no real CLI, so they run in bare CI and pin
+# the load contract the gated smoke depends on: every expected lifecycle skill
+# ships in BOTH plugin trees. A break here means the gated smoke is asserting a
+# skill set that cannot load, so the contract drifted and the smoke is stale.
+
+
+def test_expected_skills_ship_in_copilot_plugin_tree() -> None:
+    """Each EXPECTED_SKILLS entry has a skill dir in the Copilot plugin tree.
+
+    If a lifecycle skill is renamed or removed from src/copilot-cli/skills, the
+    gated Copilot smoke would assert a name that can never load. Pin the set to
+    the on-disk tree so that drift fails in bare CI, not only in the nightly job.
+    """
+    skills_dir = _COPILOT_PLUGIN_DIR / "skills"
+    missing = {name for name in EXPECTED_SKILLS if not (skills_dir / name).is_dir()}
+    assert not missing, f"expected skills missing from {skills_dir}: {sorted(missing)}"
+
+
+def test_expected_skills_ship_in_claude_tree() -> None:
+    """Each EXPECTED_SKILLS entry ships in the Claude tree as command or skill.
+
+    The Claude plugin surfaces a lifecycle capability either as a slash command
+    under .claude/commands/<name>.md or as a skill under .claude/skills/<name>/.
+    Most lifecycle names ship as commands; `review` ships as a skill dir. Accept
+    either so the contract tracks how the plugin actually exposes the capability,
+    and so a rename in both places fails in bare CI before the nightly Claude
+    smoke ever runs.
+    """
+    commands_dir = _CLAUDE_PLUGIN_DIR / "commands"
+    skills_dir = _CLAUDE_PLUGIN_DIR / "skills"
+    missing = {
+        name
+        for name in EXPECTED_SKILLS
+        if not (commands_dir / f"{name}.md").is_file() and not (skills_dir / name).is_dir()
+    }
+    assert not missing, (
+        f"expected skills missing from {commands_dir} and {skills_dir}: {sorted(missing)}"
+    )
+
+
+def test_claude_manifest_exposes_string_version() -> None:
+    """The Claude manifest carries a non-empty string version.
+
+    The gated Claude smoke asserts this version appears in `plugin details`. If
+    the manifest loses its version or makes it non-string, the smoke assertion
+    becomes meaningless; pin the precondition here so it fails in bare CI.
+    """
+    version = _read_manifest_version(_CLAUDE_MANIFEST)
+    assert version
+
+
+def test_plugin_skill_names_counts_only_plugin_source() -> None:
+    """Only `source: plugin` records count toward the loaded set.
+
+    A built-in or user-level skill with the same name must not mask a missing
+    plugin skill. This pins the filter the gated Copilot assertion relies on.
+    """
+    payload = [
+        {"name": "build", "source": "plugin"},
+        {"name": "review", "source": "builtin"},
+        {"name": "plan", "source": "plugin"},
+        {"name": "noname-source-plugin"},
+        "not-a-record",
+    ]
+
+    names = _plugin_skill_names(payload)
+
+    assert names == {"build", "plan"}
+
+
+def test_plugin_skill_names_handles_non_list_payload() -> None:
+    """A non-list payload yields an empty set, not a crash.
+
+    The Copilot CLI should print a JSON array, but a malformed run must surface
+    as "no plugin skills loaded" (a failed assertion with diagnostics), not an
+    unhandled exception that hides the real output.
+    """
+    assert _plugin_skill_names({"unexpected": "object"}) == set()
+    assert _plugin_skill_names(None) == set()

--- a/tests/e2e/test_plugin_load_smoke.py
+++ b/tests/e2e/test_plugin_load_smoke.py
@@ -9,11 +9,13 @@ the shipped plugin directory, list the plugin's skills, and assert the lifecycle
 skills load.
 
   - Copilot: ``copilot --plugin-dir <repo>/src/copilot-cli skill list --json``
-    from a neutral cwd. Assert returncode 0, no ``argument-hint`` loader warning
-    in stderr, and the expected lifecycle skills load from ``source: plugin``.
-  - Claude:  ``claude --plugin-dir <repo>/.claude plugin list`` and
-    ``plugin details project-toolkit``. Assert returncode 0 and the manifest
-    version from ``.claude/.claude-plugin/plugin.json`` appears in the output.
+    with ``cwd`` set to a neutral directory. Assert returncode 0, no
+    ``argument-hint`` loader warning in stderr, and the expected lifecycle skills
+    load from ``source: plugin``.
+  - Claude: ``claude --plugin-dir <repo>/.claude plugin list`` and
+    ``plugin details project-toolkit`` with ``cwd`` set to a neutral directory.
+    Assert returncode 0, the manifest version appears, and the expected lifecycle
+    skills are present in the details output.
 
 This is the plugin-LOAD smoke. The plugin-HOOK smoke (a hook resolves and runs
 from the install tree) lives in ``tests/e2e/test_cli_hook_e2e.py``. Both run in
@@ -44,9 +46,12 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
-
-from cli_exec import resolve_executable  # noqa: E402
+_original_sys_path = sys.path.copy()
+try:
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    from cli_exec import resolve_executable  # noqa: E402
+finally:
+    sys.path[:] = _original_sys_path
 
 _RUN = os.environ.get("RUN_CLI_E2E") == "1"
 
@@ -66,6 +71,7 @@ _CLAUDE_MANIFEST = _CLAUDE_PLUGIN_DIR / ".claude-plugin" / "plugin.json"
 _ARGUMENT_HINT_WARNING = "argument-hint"
 
 _CLI_TIMEOUT_SECONDS = 240
+_PLUGIN_ROOT_ENV_KEYS = {"CLAUDE_PLUGIN_ROOT", "CLAUDE_PROJECT_DIR", "COPILOT_PLUGIN_ROOT"}
 
 requires_copilot = pytest.mark.skipif(
     not (_RUN and shutil.which("copilot")),
@@ -85,9 +91,28 @@ def _clean_env() -> dict[str, str]:
     inherited root that points at a different tree.
     """
     env = os.environ.copy()
-    for var in ("CLAUDE_PLUGIN_ROOT", "CLAUDE_PROJECT_DIR", "COPILOT_PLUGIN_ROOT"):
-        env.pop(var, None)
+    for key in list(env):
+        if key.upper() in _PLUGIN_ROOT_ENV_KEYS:
+            env.pop(key, None)
     return env
+
+
+def _run_cli(
+    args: list[str],
+    *,
+    timeout: int,
+    cwd: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
+        check=False,
+        env=_clean_env(),
+    )
 
 
 def _plugin_skill_names(payload: object) -> set[str]:
@@ -130,33 +155,24 @@ def test_copilot_plugin_loads_expected_skills(tmp_path: Path) -> None:
     stderr (the issue #2736 failure class), and that EXPECTED_SKILLS is a subset
     of the skills the CLI loaded from ``source: plugin``.
     """
-    version = subprocess.run(
+    version = _run_cli(
         [resolve_executable("copilot"), "--version"],
-        capture_output=True,
-        text=True,
         timeout=60,
-        check=False,
-        env=_clean_env(),
     )
     print(f"copilot --version: {version.stdout.strip() or version.stderr.strip()}")
 
     try:
-        run = subprocess.run(
+        run = _run_cli(
             [
                 resolve_executable("copilot"),
-                "-C",
-                str(tmp_path),
                 "--plugin-dir",
                 str(_COPILOT_PLUGIN_DIR),
                 "skill",
                 "list",
                 "--json",
             ],
-            capture_output=True,
-            text=True,
+            cwd=tmp_path,
             timeout=_CLI_TIMEOUT_SECONDS,
-            check=False,
-            env=_clean_env(),
         )
     except subprocess.TimeoutExpired:
         pytest.skip(f"copilot skill list exceeded {_CLI_TIMEOUT_SECONDS}s (CLI/infra latency)")
@@ -192,34 +208,25 @@ def test_claude_plugin_loads_expected_skills(tmp_path: Path) -> None:
     ``.claude/.claude-plugin/plugin.json`` appears in ``plugin details``, proving
     the CLI loaded the shipped plugin rather than failing silently.
     """
-    version = subprocess.run(
+    version = _run_cli(
         [resolve_executable("claude"), "--version"],
-        capture_output=True,
-        text=True,
         timeout=60,
-        check=False,
-        env=_clean_env(),
     )
     print(f"claude --version: {version.stdout.strip() or version.stderr.strip()}")
 
     manifest_version = _read_manifest_version(_CLAUDE_MANIFEST)
 
     try:
-        listing = subprocess.run(
+        listing = _run_cli(
             [
                 resolve_executable("claude"),
-                "-C",
-                str(tmp_path),
                 "--plugin-dir",
                 str(_CLAUDE_PLUGIN_DIR),
                 "plugin",
                 "list",
             ],
-            capture_output=True,
-            text=True,
+            cwd=tmp_path,
             timeout=_CLI_TIMEOUT_SECONDS,
-            check=False,
-            env=_clean_env(),
         )
     except subprocess.TimeoutExpired:
         pytest.skip(f"claude plugin list exceeded {_CLI_TIMEOUT_SECONDS}s (CLI/infra latency)")
@@ -230,22 +237,17 @@ def test_claude_plugin_loads_expected_skills(tmp_path: Path) -> None:
     )
 
     try:
-        details = subprocess.run(
+        details = _run_cli(
             [
                 resolve_executable("claude"),
-                "-C",
-                str(tmp_path),
                 "--plugin-dir",
                 str(_CLAUDE_PLUGIN_DIR),
                 "plugin",
                 "details",
                 "project-toolkit",
             ],
-            capture_output=True,
-            text=True,
+            cwd=tmp_path,
             timeout=_CLI_TIMEOUT_SECONDS,
-            check=False,
-            env=_clean_env(),
         )
     except subprocess.TimeoutExpired:
         pytest.skip(f"claude plugin details exceeded {_CLI_TIMEOUT_SECONDS}s (CLI/infra latency)")
@@ -257,6 +259,11 @@ def test_claude_plugin_loads_expected_skills(tmp_path: Path) -> None:
     combined = details.stdout + details.stderr
     assert manifest_version in combined, (
         f"claude did not report manifest version {manifest_version!r}. "
+        f"stdout={details.stdout[-600:]!r} stderr={details.stderr[-600:]!r}"
+    )
+    missing = {name for name in EXPECTED_SKILLS if name not in combined}
+    assert not missing, (
+        f"claude did not report expected plugin skills: missing={sorted(missing)}. "
         f"stdout={details.stdout[-600:]!r} stderr={details.stderr[-600:]!r}"
     )
 
@@ -340,3 +347,35 @@ def test_plugin_skill_names_handles_non_list_payload() -> None:
     """
     assert _plugin_skill_names({"unexpected": "object"}) == set()
     assert _plugin_skill_names(None) == set()
+
+
+def test_clean_env_strips_plugin_root_keys_case_insensitively(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plugin-root env cleanup handles Windows-style case-insensitive names."""
+    monkeypatch.setenv("claude_plugin_root", "/wrong/claude")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", "/wrong/project")
+    monkeypatch.setenv("Copilot_Plugin_Root", "/wrong/copilot")
+    monkeypatch.setenv("KEEP_ME", "1")
+
+    env = _clean_env()
+
+    assert "KEEP_ME" in env
+    assert not any(key.upper() in _PLUGIN_ROOT_ENV_KEYS for key in env)
+
+
+def test_run_cli_uses_cwd_and_decodes_utf8(tmp_path: Path) -> None:
+    """The subprocess helper uses neutral cwd and UTF-8 decoding."""
+    run = _run_cli(
+        [
+            sys.executable,
+            "-c",
+            "import os; print(os.getcwd()); print(chr(0x2713))",
+        ],
+        cwd=tmp_path,
+        timeout=60,
+    )
+
+    assert run.returncode == 0
+    lines = run.stdout.splitlines()
+    assert lines == [str(tmp_path), chr(0x2713)]


### PR DESCRIPTION
## Summary

Adds Claude and Copilot plugin-load smoke gates for the shipped plugin trees. This closes the #2736 gap: schema and generated-file checks can pass while the real CLI rejects a malformed skill at load time.

The smoke tests stay opt-in behind `RUN_CLI_E2E=1` because they launch real CLIs that need auth and credits. Bare CI still runs always-on unit guards for the expected lifecycle skill set and helper behavior.

## Specification References

| Type | Reference |
|------|-----------|
| Issue | Fixes #2736 |
| Issue | Refs #2231 |

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Tests
- [ ] Documentation
- [x] CI / validation

## Changes

- Added `tests/e2e/test_plugin_load_smoke.py` with real-CLI smoke tests for Copilot and Claude plugin loading.
- Added always-on unit guards for expected lifecycle skills, plugin-source filtering, manifest version shape, case-insensitive plugin-root env cleanup, and UTF-8 subprocess decoding from a neutral working directory.
- Extended `.github/workflows/nightly-cli-smoke.yml` with a plugin-load smoke step and `assert_smoke_ran` gate.
- Wired `.githooks/pre-push` to run the plugin-load smoke when plugin-load surfaces change and a local CLI is available.

## Verification

- `uv run --frozen --extra dev ruff check tests/e2e/test_plugin_load_smoke.py`
- `uv run --frozen pytest tests/e2e/test_plugin_load_smoke.py -q`
- `SKIP_WORKFLOW_LOCAL_TEST=true .githooks/pre-push` with the PR push range, passed including `Plugin-load e2e (real CLIs)`.
