### PR TITLE
fix(pre-push): downgrade act pull_request-context-undefined error to WARN

### DIFF
--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -392,7 +392,8 @@ _GIT_REPO_MISSING_PATTERN = "fatal: not a git repository"
 
 _ACT_PR_CONTEXT_MISSING_PATTERN = re.compile(
     r"Cannot read properties of undefined \(reading "
-    r"'(?:number|head|base|title|body|labels|draft|merged)'\)"
+    r"'(?:number|head|base|title|body|labels|draft|merged|user|html_url|state|id"
+    r"|assignee|assignees|requested_reviewers|milestone)'\)"
 )
 
 # Known act-only limitation signatures. A nonzero act exit whose combined output

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -389,6 +389,48 @@ def _select_act_event(wf_path: Path) -> str | None:
 # this exact prefix. See issue #2719.
 _GIT_REPO_MISSING_PATTERN = "fatal: not a git repository"
 
+# Emitted by act when a workflow reads ``github.event.pull_request.number`` (or
+# other ``pull_request`` event context) on a local/workflow_dispatch run. act
+# does not populate the ``pull_request`` event payload off a real PR, so the
+# expression evaluates ``github.event.pull_request`` to undefined and the run
+# aborts with this exact JS TypeError. It is an act limitation, not a workflow
+# defect: actionlint and the act dry-run already validated the workflow shape.
+# See issue #2758.
+_ACT_PR_CONTEXT_MISSING_PATTERN = "Cannot read properties of undefined (reading 'number')"
+
+# Known act-only limitation signatures. A nonzero act exit whose combined output
+# carries one of these is a local environment gap, not a workflow defect, so the
+# stage downgrades to a passing [WARN] instead of a hard FAIL. Each entry pairs
+# the exact substring with a hint surfaced to the developer. Kept conservative:
+# only these exact signatures downgrade; every other nonzero exit still blocks.
+_ACT_LIMITATION_PATTERNS: tuple[tuple[str, str], ...] = (
+    (
+        _GIT_REPO_MISSING_PATTERN,
+        "act container lacks .git; git-calling actions (e.g. dorny/paths-filter) "
+        "fail only in local act, not in CI.",
+    ),
+    (
+        _ACT_PR_CONTEXT_MISSING_PATTERN,
+        "act does not populate the pull_request event context on a local run, so "
+        "workflows reading github.event.pull_request.number fail only in local "
+        "act, not in CI.",
+    ),
+)
+
+
+def _act_limitation_hint(combined: str) -> str | None:
+    """Return the WARN hint when ``combined`` matches a known act limitation.
+
+    Returns the hint for the first matching signature in
+    ``_ACT_LIMITATION_PATTERNS``, or None when no known act-only limitation is
+    present (the caller then keeps the hard FAIL so real job failures still
+    block).
+    """
+    for pattern, hint in _ACT_LIMITATION_PATTERNS:
+        if pattern in combined:
+            return hint
+    return None
+
 
 def _run_act_stage(
     stage: str,
@@ -397,13 +439,15 @@ def _run_act_stage(
     files: Sequence[str],
     repo_root: Path,
 ) -> StageResult:
-    """Run an ``act`` invocation per workflow file, with git-missing downgrade.
+    """Run an ``act`` invocation per workflow file, with act-limitation downgrade.
 
-    A nonzero exit whose output carries ``_GIT_REPO_MISSING_PATTERN`` is a local
-    environment limitation, not a workflow defect: actionlint and the act
-    dry-run already validated the workflow shape. Downgrade it to a passing
-    stage with a ``[WARN]`` detail instead of a hard FAIL so the missing .git in
-    the container does not block an otherwise valid push.
+    A nonzero exit whose output carries a known act-only limitation signature
+    (see ``_ACT_LIMITATION_PATTERNS``: a missing .git in the container, or an
+    unpopulated ``pull_request`` event context) is a local environment gap, not
+    a workflow defect: actionlint and the act dry-run already validated the
+    workflow shape. Downgrade it to a passing stage with a ``[WARN]`` detail
+    instead of a hard FAIL so the act limitation does not block an otherwise
+    valid push. Every other nonzero exit still blocks.
     """
     env = _act_env(repo_root)
     warnings: list[str] = []
@@ -416,11 +460,10 @@ def _run_act_stage(
         rc, out, err = _run(cmd, timeout=timeout, cwd=repo_root, env=env)
         if rc != 0:
             combined = (out + err).strip()
-            if _GIT_REPO_MISSING_PATTERN in combined:
+            hint = _act_limitation_hint(combined)
+            if hint is not None:
                 warnings.append(
-                    f"[WARN] {wf}: act container lacks .git; git-calling actions "
-                    f"(e.g. dorny/paths-filter) fail only in local act, not in "
-                    f"CI. Set {_BYPASS_ENV}=true to silence."
+                    f"[WARN] {wf}: {hint} Set {_BYPASS_ENV}=true to silence."
                 )
                 continue
             return StageResult(stage, False, f"{wf}:\n{combined[:4000]}")

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -389,46 +390,35 @@ def _select_act_event(wf_path: Path) -> str | None:
 # this exact prefix. See issue #2719.
 _GIT_REPO_MISSING_PATTERN = "fatal: not a git repository"
 
-# Emitted by act when a workflow reads ``github.event.pull_request.number`` (or
-# other ``pull_request`` event context) on a local/workflow_dispatch run. act
-# does not populate the ``pull_request`` event payload off a real PR, so the
-# expression evaluates ``github.event.pull_request`` to undefined and the run
-# aborts with this exact JS TypeError. It is an act limitation, not a workflow
-# defect: actionlint and the act dry-run already validated the workflow shape.
-# See issue #2758.
-_ACT_PR_CONTEXT_MISSING_PATTERN = "Cannot read properties of undefined (reading 'number')"
+_ACT_PR_CONTEXT_MISSING_PATTERN = re.compile(
+    r"Cannot read properties of undefined \(reading "
+    r"'(?:number|head|base|title|body|labels|draft|merged)'\)"
+)
 
 # Known act-only limitation signatures. A nonzero act exit whose combined output
 # carries one of these is a local environment gap, not a workflow defect, so the
 # stage downgrades to a passing [WARN] instead of a hard FAIL. Each entry pairs
 # the exact substring with a hint surfaced to the developer. Kept conservative:
 # only these exact signatures downgrade; every other nonzero exit still blocks.
-_ACT_LIMITATION_PATTERNS: tuple[tuple[str, str], ...] = (
-    (
-        _GIT_REPO_MISSING_PATTERN,
-        "act container lacks .git; git-calling actions (e.g. dorny/paths-filter) "
-        "fail only in local act, not in CI.",
-    ),
-    (
-        _ACT_PR_CONTEXT_MISSING_PATTERN,
-        "act does not populate the pull_request event context on a local run, so "
-        "workflows reading github.event.pull_request.number fail only in local "
-        "act, not in CI.",
-    ),
-)
-
-
-def _act_limitation_hint(combined: str) -> str | None:
+def _act_limitation_hint(combined: str, event: str | None = None) -> str | None:
     """Return the WARN hint when ``combined`` matches a known act limitation.
 
-    Returns the hint for the first matching signature in
-    ``_ACT_LIMITATION_PATTERNS``, or None when no known act-only limitation is
-    present (the caller then keeps the hard FAIL so real job failures still
-    block).
+    Returns a hint for a known act-only limitation, or None when no known
+    limitation is present. The pull_request context TypeError is downgraded only
+    for pull_request runs. Under workflow_dispatch, the same error can be a real
+    workflow defect and must remain blocking.
     """
-    for pattern, hint in _ACT_LIMITATION_PATTERNS:
-        if pattern in combined:
-            return hint
+    if _GIT_REPO_MISSING_PATTERN in combined:
+        return (
+            "act container lacks .git; git-calling actions (e.g. dorny/paths-filter) "
+            "fail only in local act, not in CI."
+        )
+    if event == "pull_request" and _ACT_PR_CONTEXT_MISSING_PATTERN.search(combined):
+        return (
+            "act does not populate the pull_request event context on a local run, so "
+            "workflows reading github.event.pull_request properties fail only in local "
+            "act, not in CI."
+        )
     return None
 
 
@@ -442,9 +432,9 @@ def _run_act_stage(
     """Run an ``act`` invocation per workflow file, with act-limitation downgrade.
 
     A nonzero exit whose output carries a known act-only limitation signature
-    (see ``_ACT_LIMITATION_PATTERNS``: a missing .git in the container, or an
-    unpopulated ``pull_request`` event context) is a local environment gap, not
-    a workflow defect: actionlint and the act dry-run already validated the
+    (a missing .git in the container, or an unpopulated ``pull_request`` event
+    context during a pull_request run) is a local environment gap, not a
+    workflow defect: actionlint and the act dry-run already validated the
     workflow shape. Downgrade it to a passing stage with a ``[WARN]`` detail
     instead of a hard FAIL so the act limitation does not block an otherwise
     valid push. Every other nonzero exit still blocks.
@@ -460,7 +450,7 @@ def _run_act_stage(
         rc, out, err = _run(cmd, timeout=timeout, cwd=repo_root, env=env)
         if rc != 0:
             combined = (out + err).strip()
-            hint = _act_limitation_hint(combined)
+            hint = _act_limitation_hint(combined, event)
             if hint is not None:
                 warnings.append(
                     f"[WARN] {wf}: {hint} Set {_BYPASS_ENV}=true to silence."

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -397,10 +397,9 @@ _ACT_PR_CONTEXT_MISSING_PATTERN = re.compile(
 )
 
 # Known act-only limitation signatures. A nonzero act exit whose combined output
-# carries one of these is a local environment gap, not a workflow defect, so the
-# stage downgrades to a passing [WARN] instead of a hard FAIL. Each entry pairs
-# the exact substring with a hint surfaced to the developer. Kept conservative:
-# only these exact signatures downgrade; every other nonzero exit still blocks.
+# matches one of these rules can be a local environment gap, not a workflow
+# defect. The pull_request context rule is event-scoped in _act_limitation_hint;
+# every other nonzero exit still blocks.
 def _act_limitation_hint(combined: str, event: str | None = None) -> str | None:
     """Return the WARN hint when ``combined`` matches a known act limitation.
 

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -713,6 +713,71 @@ def test_act_full_reports_all_git_missing_warnings(monkeypatch, tmp_path):
     assert second.name in res.detail
 
 
+# --- issue #2758: act pull_request-context-undefined downgrades to a warning ---
+
+
+def test_act_full_downgrades_pr_context_missing_to_warning(monkeypatch, tmp_path):
+    wf = _write_wf(tmp_path, "name: x\non: pull_request\njobs: {}\n")
+    monkeypatch.setattr(
+        w,
+        "_run",
+        lambda cmd, *, timeout, cwd=None, env=None: (
+            1,
+            "",
+            "Error: Cannot read properties of undefined (reading 'number')",
+        ),
+    )
+    res = w._act_full_stage([wf.name], tmp_path)
+    assert res.ok is True
+    assert "[WARN]" in res.detail
+    assert "pull_request event context" in res.detail
+
+
+def test_act_dryrun_downgrades_pr_context_missing_to_warning(monkeypatch, tmp_path):
+    wf = _write_wf(tmp_path, "name: x\non: pull_request\njobs: {}\n")
+    monkeypatch.setattr(
+        w,
+        "_run",
+        lambda cmd, *, timeout, cwd=None, env=None: (
+            1,
+            "Cannot read properties of undefined (reading 'number')",
+            "",
+        ),
+    )
+    res = w._act_dryrun_stage([wf.name], tmp_path)
+    assert res.ok is True
+    assert "[WARN]" in res.detail
+
+
+def test_act_full_pr_context_real_failure_still_blocks(monkeypatch, tmp_path):
+    # A nonzero exit with no known act-limitation signature still hard-FAILs:
+    # the PR-context downgrade must not mask a real job failure.
+    wf = _write_wf(tmp_path, "name: x\non: pull_request\njobs: {}\n")
+    monkeypatch.setattr(
+        w,
+        "_run",
+        lambda cmd, *, timeout, cwd=None, env=None: (
+            1,
+            "",
+            "Cannot read properties of undefined (reading 'sha')",
+        ),
+    )
+    res = w._act_full_stage([wf.name], tmp_path)
+    assert res.ok is False
+    assert "reading 'sha'" in res.detail
+
+
+def test_act_limitation_hint_matches_known_patterns() -> None:
+    assert w._act_limitation_hint("fatal: not a git repository") is not None
+    assert (
+        w._act_limitation_hint(
+            "Cannot read properties of undefined (reading 'number')"
+        )
+        is not None
+    )
+    assert w._act_limitation_hint("Error: job 'build' exited 2") is None
+
+
 def test_format_text_surfaces_warning_detail_on_ok() -> None:
     report = w.Report(
         exit_code=0,

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -819,6 +819,13 @@ def test_act_limitation_hint_matches_known_patterns() -> None:
     )
     assert (
         w._act_limitation_hint(
+            "Cannot read properties of undefined (reading 'requested_reviewers')",
+            "pull_request",
+        )
+        is not None
+    )
+    assert (
+        w._act_limitation_hint(
             "Cannot read properties of undefined (reading 'number')",
             "workflow_dispatch",
         )

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -733,6 +733,40 @@ def test_act_full_downgrades_pr_context_missing_to_warning(monkeypatch, tmp_path
     assert "pull_request event context" in res.detail
 
 
+def test_act_full_downgrades_other_pr_context_properties(monkeypatch, tmp_path):
+    wf = _write_wf(tmp_path, "name: x\non: pull_request\njobs: {}\n")
+    monkeypatch.setattr(
+        w,
+        "_run",
+        lambda cmd, *, timeout, cwd=None, env=None: (
+            1,
+            "",
+            "Error: Cannot read properties of undefined (reading 'head')",
+        ),
+    )
+    res = w._act_full_stage([wf.name], tmp_path)
+    assert res.ok is True
+    assert "[WARN]" in res.detail
+
+
+def test_act_full_workflow_dispatch_pr_context_error_still_blocks(
+    monkeypatch, tmp_path
+):
+    wf = _write_wf(tmp_path, "name: x\non: workflow_dispatch\njobs: {}\n")
+    monkeypatch.setattr(
+        w,
+        "_run",
+        lambda cmd, *, timeout, cwd=None, env=None: (
+            1,
+            "",
+            "Error: Cannot read properties of undefined (reading 'number')",
+        ),
+    )
+    res = w._act_full_stage([wf.name], tmp_path)
+    assert res.ok is False
+    assert "reading 'number'" in res.detail
+
+
 def test_act_dryrun_downgrades_pr_context_missing_to_warning(monkeypatch, tmp_path):
     wf = _write_wf(tmp_path, "name: x\non: pull_request\njobs: {}\n")
     monkeypatch.setattr(
@@ -771,9 +805,24 @@ def test_act_limitation_hint_matches_known_patterns() -> None:
     assert w._act_limitation_hint("fatal: not a git repository") is not None
     assert (
         w._act_limitation_hint(
-            "Cannot read properties of undefined (reading 'number')"
+            "Cannot read properties of undefined (reading 'number')",
+            "pull_request",
         )
         is not None
+    )
+    assert (
+        w._act_limitation_hint(
+            "Cannot read properties of undefined (reading 'head')",
+            "pull_request",
+        )
+        is not None
+    )
+    assert (
+        w._act_limitation_hint(
+            "Cannot read properties of undefined (reading 'number')",
+            "workflow_dispatch",
+        )
+        is None
     )
     assert w._act_limitation_hint("Error: job 'build' exited 2") is None
 


### PR DESCRIPTION
## Problem

`#2719` downgraded the local `act` missing-git limitation to a warning. A second local `act` limitation still failed the pre-push workflow test: workflows that read `github.event.pull_request` properties can abort under local `act` because the synthetic event payload is missing.

## Fix

`scripts/validation/run_workflow_local_test.py` now downgrades known `pull_request` context TypeErrors only when the selected `act` event is `pull_request`. The same TypeError still blocks under `workflow_dispatch`, where it can represent a real workflow bug.

The matcher now covers common `pull_request` properties such as `number`, `head`, `base`, `title`, `body`, `labels`, `draft`, and `merged`.

## Tests

`tests/validation/test_run_workflow_local_test.py` covers:

- Full `act` downgrade for a missing `pull_request.number` payload.
- Dry-run downgrade for the same signature.
- Downgrade for another common property, `head`.
- No downgrade for the same signature under `workflow_dispatch`.
- No downgrade for unrelated TypeErrors or real job failures.

## Validation

- `pytest tests/validation/test_run_workflow_local_test.py -x`: passed.
- `ruff check scripts/validation/run_workflow_local_test.py tests/validation/test_run_workflow_local_test.py`: passed.
- `python3 scripts/validation/pr_description.py --pr-number 2763 --ci`: passed.

## References

- `agent-skill-discriminator-check.yml`

Fixes #2758
Refs #2719
