### PR TITLE
fix(gitignore): ignore top-level .worktrees/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ worktree--/
 .memory_sync_state.json
 
 .claude/worktrees/
+.worktrees/
 
 # doc-accuracy gate output (skill produces large reports under .doc-accuracy/)
 .doc-accuracy/


### PR DESCRIPTION
# fix(gitignore): ignore top-level .worktrees/ dir

## Problem

`.gitignore` ignored `.claude/worktrees/` and `worktree-*/` but missed the bare top-level `.worktrees/` directory. That directory is where git worktrees get created at the repo root.

Because the path was not ignored, the markdown language server (Marksman) crawled it. Marksman honors `.gitignore`; an unignored tree is fair game. `.worktrees/` held 150,893 `.md` files (each worktree carries a full copy of the repo's markdown). The server tried to index all of them and timed out, taking markdown navigation down with it.

## Fix

Add one line to `.gitignore`, next to the existing worktree-ignore block:

```text
.worktrees/
```

Marksman now skips the tree. The index drops from 150,893 files to the tracked set.

## Verification

- `git check-ignore -v .worktrees/foo` resolves to `.gitignore:135:.worktrees/`, confirming the pattern matches paths under the directory.
- `git ls-files '*.md' | wc -l` is unchanged at 3717 (the rule only affects the untracked worktree tree, not tracked files).
- `git diff --stat`: one file changed, one insertion.

## Issue linkage

`Refs #2761` and `Refs #2759`.

Not `Fixes #2761`: that issue also asks for worktree garbage collection, which this one-line change does not deliver. `Refs` keeps the issue open for the GC work.
