### PR TITLE
fix(renovate): disable the dependency dashboard singleton

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "dependencyDashboard": false,
   "minor": {
     "automerge": true
   },


### PR DESCRIPTION
# fix(renovate): disable the dependency dashboard singleton

Refs #1351

## Summary

Disables the Renovate "Dependency Dashboard" singleton issue by setting `"dependencyDashboard": false` in `renovate.json`.

## Problem

Issue #1351 ("Dependency Dashboard") is auto-created and recreated by `app/renovate`. It is not a real bug or task; it is Renovate's standing dashboard. Closing it by hand does not stick: Renovate reopens it on the next run. The durable fix is to tell Renovate to stop creating the dashboard.

## Change

`renovate.json`: add `"dependencyDashboard": false`. All other config preserved (extends, minor/patch automerge, major label, platformAutomerge). JSON validated.

## Maintainer follow-up (manual, post-merge)

Once this merges, manually close #1351 one final time. With the dashboard disabled, Renovate will not recreate it. The issue is left open here on purpose: closing it before the config lands would just bounce (Renovate reopens until the config is on the default branch).
