### PR TITLE
feat(maintenance): guarded worktree garbage-collection script (dry-run default)

### DIFF
--- a/scripts/maintenance/gc_worktrees.py
+++ b/scripts/maintenance/gc_worktrees.py
@@ -130,12 +130,30 @@ def _run_git(args: list[str], cwd: str | None = None) -> str:
     return result.stdout.strip()
 
 
+def _apply_attribute(worktree: Worktree, line: str) -> None:
+    """Apply one porcelain attribute line to the current worktree record.
+
+    ``HEAD``, ``branch``, ``bare``, ``detached``, and ``locked`` are the lines
+    that may follow a ``worktree <path>`` line. Unknown lines are ignored.
+    """
+    if line.startswith("HEAD "):
+        worktree.head = line[len("HEAD ") :].strip()
+    elif line.startswith("branch "):
+        worktree.branch = line[len("branch ") :].strip().removeprefix("refs/heads/")
+    elif line == "bare":
+        worktree.bare = True
+    elif line == "detached":
+        worktree.detached = True
+    elif line == "locked" or line.startswith("locked "):
+        worktree.locked = True
+
+
 def list_worktrees() -> list[Worktree]:
     """Parse ``git worktree list --porcelain`` into Worktree records.
 
     The porcelain format groups attributes per worktree, separated by blank
-    lines. Each group starts with a ``worktree <path>`` line. ``branch``,
-    ``HEAD``, ``locked``, ``bare``, and ``detached`` lines may follow.
+    lines. Each group starts with a ``worktree <path>`` line; attribute lines
+    follow and are applied by ``_apply_attribute``.
     """
     raw = _run_git(["worktree", "list", "--porcelain"])
     worktrees: list[Worktree] = []
@@ -146,19 +164,8 @@ def list_worktrees() -> list[Worktree]:
             if current is not None:
                 worktrees.append(current)
             current = Worktree(path=line[len("worktree ") :].strip())
-        elif current is None:
-            continue
-        elif line.startswith("HEAD "):
-            current.head = line[len("HEAD ") :].strip()
-        elif line.startswith("branch "):
-            ref = line[len("branch ") :].strip()
-            current.branch = ref.removeprefix("refs/heads/")
-        elif line == "bare":
-            current.bare = True
-        elif line == "detached":
-            current.detached = True
-        elif line == "locked" or line.startswith("locked "):
-            current.locked = True
+        elif current is not None:
+            _apply_attribute(current, line)
 
     if current is not None:
         worktrees.append(current)

--- a/scripts/maintenance/gc_worktrees.py
+++ b/scripts/maintenance/gc_worktrees.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Garbage-collect stale git worktrees safely.
+
+Agent and PR workflows create git worktrees that accumulate without cleanup.
+Issue #2761 recorded 113 worktrees totalling 10.6G on one machine, which
+starved the markdown language server (333,979 .md files under the workspace).
+This tool reaps worktrees whose branch is fully pushed or merged, while
+refusing to touch anything that could lose work.
+
+A worktree is REMOVED only when EVERY safety condition holds:
+
+  1. It is not the current or main worktree.
+  2. It is not locked (``git worktree lock``).
+  3. Its working tree is clean (``git status --porcelain`` empty).
+  4. Its branch is fully pushed (no commits absent from every remote)
+     OR its branch is merged into ``origin/main``.
+
+A worktree that fails any condition is KEPT, and the reason is reported.
+
+DEFAULT IS DRY-RUN. Nothing is removed unless ``--apply`` is passed. Dry-run
+prints the removal candidates and the kept-with-reason list and exits without
+mutating anything.
+
+USAGE:
+  # Preview what would be removed (safe, default):
+  uv run python scripts/maintenance/gc_worktrees.py
+
+  # Actually remove the safe candidates:
+  uv run python scripts/maintenance/gc_worktrees.py --apply
+
+  # Compare merge status against a different base:
+  uv run python scripts/maintenance/gc_worktrees.py --base origin/main
+
+  # Machine-readable output:
+  uv run python scripts/maintenance/gc_worktrees.py --json
+
+EXIT CODES:
+  0 - Success (dry-run completed, or apply removed/kept as planned)
+  2 - Error: configuration or runtime error (git failure, bad base ref)
+
+See: ADR-035 Exit Code Standardization
+Related: Issue #2761 (worktree accumulation starves markdown LSP), #2759
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+
+_DEFAULT_BASE = "origin/main"
+
+# Reasons a worktree is kept (never removed). Stable strings for tests/automation.
+KEEP_MAIN = "main-or-current worktree"
+KEEP_BARE = "bare worktree"
+KEEP_LOCKED = "locked"
+KEEP_DIRTY = "uncommitted changes"
+KEEP_DETACHED = "detached HEAD (no branch to evaluate)"
+KEEP_UNPUSHED = "unpushed commits and not merged to base"
+KEEP_GIT_ERROR = "git inspection failed"
+
+
+@dataclass
+class Worktree:
+    """A single registered git worktree parsed from porcelain output."""
+
+    path: str
+    branch: str | None = None
+    head: str | None = None
+    locked: bool = False
+    bare: bool = False
+    detached: bool = False
+
+
+@dataclass
+class Decision:
+    """The GC decision for one worktree."""
+
+    path: str
+    branch: str | None
+    remove: bool
+    reason: str
+
+    @property
+    def kept(self) -> bool:
+        """True when this worktree is kept rather than removed."""
+        return not self.remove
+
+
+@dataclass
+class GcReport:
+    """Complete garbage-collection plan across all worktrees."""
+
+    timestamp: str
+    base_ref: str
+    apply: bool
+    main_worktree: str
+    total_worktrees: int = 0
+    decisions: list[Decision] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+    remove_errors: list[str] = field(default_factory=list)
+
+    @property
+    def candidates(self) -> list[Decision]:
+        """Decisions marked for removal."""
+        return [d for d in self.decisions if d.remove]
+
+    @property
+    def kept(self) -> list[Decision]:
+        """Decisions kept with a reason."""
+        return [d for d in self.decisions if d.kept]
+
+
+def _run_git(args: list[str], cwd: str | None = None) -> str:
+    """Run a git command and return stripped stdout. Raises on failure."""
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=cwd,
+    )
+    if result.returncode != 0:
+        location = f" in {cwd}" if cwd else ""
+        msg = f"git {' '.join(args)}{location} failed: {result.stderr.strip()}"
+        raise RuntimeError(msg)
+    return result.stdout.strip()
+
+
+def list_worktrees() -> list[Worktree]:
+    """Parse ``git worktree list --porcelain`` into Worktree records.
+
+    The porcelain format groups attributes per worktree, separated by blank
+    lines. Each group starts with a ``worktree <path>`` line. ``branch``,
+    ``HEAD``, ``locked``, ``bare``, and ``detached`` lines may follow.
+    """
+    raw = _run_git(["worktree", "list", "--porcelain"])
+    worktrees: list[Worktree] = []
+    current: Worktree | None = None
+
+    for line in raw.splitlines():
+        if line.startswith("worktree "):
+            if current is not None:
+                worktrees.append(current)
+            current = Worktree(path=line[len("worktree ") :].strip())
+        elif current is None:
+            continue
+        elif line.startswith("HEAD "):
+            current.head = line[len("HEAD ") :].strip()
+        elif line.startswith("branch "):
+            ref = line[len("branch ") :].strip()
+            current.branch = ref.removeprefix("refs/heads/")
+        elif line == "bare":
+            current.bare = True
+        elif line == "detached":
+            current.detached = True
+        elif line == "locked" or line.startswith("locked "):
+            current.locked = True
+
+    if current is not None:
+        worktrees.append(current)
+    return worktrees
+
+
+def has_uncommitted_changes(path: str) -> bool:
+    """Return True when the worktree has staged or unstaged changes."""
+    return bool(_run_git(["status", "--porcelain"], cwd=path))
+
+
+def has_unpushed_commits(path: str) -> bool:
+    """Return True when the branch has commits not present on any remote.
+
+    ``git log --branches --not --remotes`` lists commits reachable from local
+    branches but from no remote-tracking ref. We scope it to HEAD so the
+    result reflects this worktree's branch, not every local branch.
+    """
+    out = _run_git(
+        ["log", "--format=%H", "HEAD", "--not", "--remotes"],
+        cwd=path,
+    )
+    return bool(out)
+
+
+def is_merged_to_base(path: str, base_ref: str) -> bool:
+    """Return True when the worktree's HEAD is an ancestor of ``base_ref``.
+
+    Uses ``git merge-base --is-ancestor`` (exit 0 = ancestor/merged,
+    exit 1 = not). Any other exit is a real git error and propagates.
+    """
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", "HEAD", base_ref],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=path,
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    msg = f"git merge-base in {path} failed: {result.stderr.strip()}"
+    raise RuntimeError(msg)
+
+
+def decide(worktree: Worktree, main_path: str, base_ref: str) -> Decision:
+    """Decide whether a worktree is safe to remove. KEEP on any doubt.
+
+    Order matters: cheap structural checks first, git-state checks last. A git
+    inspection failure keeps the worktree (fail-safe), never removes it.
+    """
+    if worktree.path == main_path or worktree.bare:
+        reason = KEEP_BARE if worktree.bare else KEEP_MAIN
+        return Decision(worktree.path, worktree.branch, remove=False, reason=reason)
+
+    if worktree.locked:
+        return Decision(worktree.path, worktree.branch, remove=False, reason=KEEP_LOCKED)
+
+    if worktree.detached or worktree.branch is None:
+        return Decision(worktree.path, worktree.branch, remove=False, reason=KEEP_DETACHED)
+
+    try:
+        if has_uncommitted_changes(worktree.path):
+            return Decision(worktree.path, worktree.branch, remove=False, reason=KEEP_DIRTY)
+        merged = is_merged_to_base(worktree.path, base_ref)
+        if not merged and has_unpushed_commits(worktree.path):
+            return Decision(worktree.path, worktree.branch, remove=False, reason=KEEP_UNPUSHED)
+    except RuntimeError:
+        return Decision(worktree.path, worktree.branch, remove=False, reason=KEEP_GIT_ERROR)
+
+    pushed = "merged to base" if merged else "fully pushed"
+    return Decision(worktree.path, worktree.branch, remove=True, reason=pushed)
+
+
+def remove_worktree(path: str) -> None:
+    """Remove a worktree via ``git worktree remove``. Raises on failure."""
+    _run_git(["worktree", "remove", path])
+
+
+def prune_worktrees() -> str:
+    """Prune dead worktree admin entries. Returns git's stdout (may be empty)."""
+    return _run_git(["worktree", "prune", "-v"])
+
+
+def build_report(base_ref: str, apply: bool) -> GcReport:
+    """Inspect all worktrees and build the GC plan (no mutation here)."""
+    worktrees = list_worktrees()
+    main_path = worktrees[0].path if worktrees else ""
+    report = GcReport(
+        timestamp=datetime.now(UTC).isoformat(),
+        base_ref=base_ref,
+        apply=apply,
+        main_worktree=main_path,
+        total_worktrees=len(worktrees),
+    )
+    report.decisions = [decide(wt, main_path, base_ref) for wt in worktrees]
+    return report
+
+
+def apply_removals(report: GcReport) -> None:
+    """Remove the candidate worktrees, then prune admin entries.
+
+    Records each success in ``report.removed`` and each failure in
+    ``report.remove_errors`` without aborting the batch. Pruning runs once
+    after removals to clean up any orphaned admin entries.
+    """
+    for decision in report.candidates:
+        try:
+            remove_worktree(decision.path)
+            report.removed.append(decision.path)
+        except RuntimeError as exc:
+            report.remove_errors.append(f"{decision.path}: {exc}")
+    try:
+        prune_worktrees()
+    except RuntimeError as exc:
+        report.remove_errors.append(f"prune: {exc}")
+
+
+def format_report(report: GcReport) -> str:
+    """Human-readable summary of the GC plan or result."""
+    mode = "APPLY" if report.apply else "DRY-RUN"
+    lines = [
+        f"Worktree GC [{mode}] base={report.base_ref}",
+        f"  total worktrees: {report.total_worktrees}",
+        f"  removal candidates: {len(report.candidates)}",
+        f"  kept: {len(report.kept)}",
+    ]
+    if report.candidates:
+        lines.append("  Candidates:")
+        for d in report.candidates:
+            lines.append(f"    - {d.path} [{d.branch}] ({d.reason})")
+    if report.kept:
+        lines.append("  Kept:")
+        for d in report.kept:
+            lines.append(f"    - {d.path} [{d.branch}] KEEP: {d.reason}")
+    if report.apply:
+        lines.append(f"  removed: {len(report.removed)}")
+        for path in report.removed:
+            lines.append(f"    - removed {path}")
+        if report.remove_errors:
+            lines.append(f"  errors: {len(report.remove_errors)}")
+            for err in report.remove_errors:
+                lines.append(f"    - {err}")
+    else:
+        lines.append(
+            f"  DRY-RUN: removed nothing. Pass --apply to remove "
+            f"{len(report.candidates)} candidate(s)."
+        )
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Safely garbage-collect stale git worktrees (dry-run by default)."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually remove safe candidates. Default is dry-run (no mutation).",
+    )
+    parser.add_argument(
+        "--base",
+        default=_DEFAULT_BASE,
+        help=f"Base ref to test merge status against (default: {_DEFAULT_BASE}).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the report as JSON instead of human-readable text.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns an ADR-035 exit code."""
+    args = parse_args(argv)
+    try:
+        report = build_report(base_ref=args.base, apply=args.apply)
+        if args.apply:
+            apply_removals(report)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(asdict(report), indent=2))
+    else:
+        print(format_report(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/maintenance/gc_worktrees.py
+++ b/scripts/maintenance/gc_worktrees.py
@@ -52,6 +52,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 
 _DEFAULT_BASE = "origin/main"
+_GIT_TIMEOUT_SECONDS = 30
 
 # Reasons a worktree is kept (never removed). Stable strings for tests/automation.
 KEEP_MAIN = "main-or-current worktree"
@@ -116,13 +117,19 @@ class GcReport:
 
 def _run_git(args: list[str], cwd: str | None = None) -> str:
     """Run a git command and return stripped stdout. Raises on failure."""
-    result = subprocess.run(
-        ["git", *args],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=cwd,
-    )
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            cwd=cwd,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        location = f" in {cwd}" if cwd else ""
+        raise RuntimeError(f"git {' '.join(args)}{location} failed: {exc}") from exc
     if result.returncode != 0:
         location = f" in {cwd}" if cwd else ""
         msg = f"git {' '.join(args)}{location} failed: {result.stderr.strip()}"
@@ -180,9 +187,9 @@ def has_uncommitted_changes(path: str) -> bool:
 def has_unpushed_commits(path: str) -> bool:
     """Return True when the branch has commits not present on any remote.
 
-    ``git log --branches --not --remotes`` lists commits reachable from local
-    branches but from no remote-tracking ref. We scope it to HEAD so the
-    result reflects this worktree's branch, not every local branch.
+    ``git log HEAD --not --remotes`` lists commits reachable from this
+    worktree's HEAD but from no remote-tracking ref. That scopes the result to
+    this worktree's branch, not every local branch.
     """
     out = _run_git(
         ["log", "--format=%H", "HEAD", "--not", "--remotes"],
@@ -197,13 +204,18 @@ def is_merged_to_base(path: str, base_ref: str) -> bool:
     Uses ``git merge-base --is-ancestor`` (exit 0 = ancestor/merged,
     exit 1 = not). Any other exit is a real git error and propagates.
     """
-    result = subprocess.run(
-        ["git", "merge-base", "--is-ancestor", "HEAD", base_ref],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=path,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", "HEAD", base_ref],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            cwd=path,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"git merge-base in {path} failed: {exc}") from exc
     if result.returncode == 0:
         return True
     if result.returncode == 1:
@@ -212,13 +224,22 @@ def is_merged_to_base(path: str, base_ref: str) -> bool:
     raise RuntimeError(msg)
 
 
-def decide(worktree: Worktree, main_path: str, base_ref: str) -> Decision:
+def decide(
+    worktree: Worktree,
+    main_path: str,
+    base_ref: str,
+    *,
+    current_path: str | None = None,
+) -> Decision:
     """Decide whether a worktree is safe to remove. KEEP on any doubt.
 
     Order matters: cheap structural checks first, git-state checks last. A git
     inspection failure keeps the worktree (fail-safe), never removes it.
     """
-    if worktree.path == main_path or worktree.bare:
+    protected_paths = {main_path}
+    if current_path:
+        protected_paths.add(current_path)
+    if worktree.path in protected_paths or worktree.bare:
         reason = KEEP_BARE if worktree.bare else KEEP_MAIN
         return Decision(worktree.path, worktree.branch, remove=False, reason=reason)
 
@@ -255,6 +276,7 @@ def build_report(base_ref: str, apply: bool) -> GcReport:
     """Inspect all worktrees and build the GC plan (no mutation here)."""
     worktrees = list_worktrees()
     main_path = worktrees[0].path if worktrees else ""
+    current_path = _run_git(["rev-parse", "--show-toplevel"])
     report = GcReport(
         timestamp=datetime.now(UTC).isoformat(),
         base_ref=base_ref,
@@ -262,7 +284,9 @@ def build_report(base_ref: str, apply: bool) -> GcReport:
         main_worktree=main_path,
         total_worktrees=len(worktrees),
     )
-    report.decisions = [decide(wt, main_path, base_ref) for wt in worktrees]
+    report.decisions = [
+        decide(wt, main_path, base_ref, current_path=current_path) for wt in worktrees
+    ]
     return report
 
 
@@ -356,6 +380,8 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(asdict(report), indent=2))
     else:
         print(format_report(report))
+    if args.apply and report.remove_errors:
+        return 2
     return 0
 
 

--- a/tests/test_gc_worktrees.py
+++ b/tests/test_gc_worktrees.py
@@ -8,6 +8,7 @@ Related: Issue #2761 (worktree accumulation starves the markdown LSP).
 
 from __future__ import annotations
 
+import subprocess
 from unittest.mock import patch
 
 from scripts.maintenance.gc_worktrees import (
@@ -20,10 +21,12 @@ from scripts.maintenance.gc_worktrees import (
     Decision,
     GcReport,
     Worktree,
+    _run_git,
     apply_removals,
     build_report,
     decide,
     format_report,
+    is_merged_to_base,
     list_worktrees,
     main,
     parse_args,
@@ -86,6 +89,54 @@ class TestListWorktrees:
     def test_empty_output_yields_no_worktrees(self):
         with patch("scripts.maintenance.gc_worktrees._run_git", return_value=""):
             assert list_worktrees() == []
+
+
+class TestGitSubprocesses:
+    """Git subprocess wrapper behavior."""
+
+    def test_run_git_uses_utf8_timeout_and_replacement_errors(self):
+        completed = subprocess.CompletedProcess(
+            ["git", "status"], 0, stdout="ok\n", stderr=""
+        )
+        with patch(
+            "scripts.maintenance.gc_worktrees.subprocess.run",
+            return_value=completed,
+        ) as run:
+            assert _run_git(["status"], cwd="/repo") == "ok"
+
+        kwargs = run.call_args.kwargs
+        assert kwargs["encoding"] == "utf-8"
+        assert kwargs["errors"] == "replace"
+        assert kwargs["timeout"] > 0
+        assert kwargs["cwd"] == "/repo"
+
+    def test_run_git_wraps_timeout_as_runtime_error(self):
+        with patch(
+            "scripts.maintenance.gc_worktrees.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(["git", "status"], 30),
+        ):
+            try:
+                _run_git(["status"], cwd="/repo")
+            except RuntimeError as exc:
+                assert "git status in /repo failed" in str(exc)
+            else:  # pragma: no cover - assertion branch
+                raise AssertionError("expected RuntimeError")
+
+    def test_is_merged_to_base_uses_utf8_timeout_and_replacement_errors(self):
+        completed = subprocess.CompletedProcess(
+            ["git", "merge-base"], 0, stdout="", stderr=""
+        )
+        with patch(
+            "scripts.maintenance.gc_worktrees.subprocess.run",
+            return_value=completed,
+        ) as run:
+            assert is_merged_to_base("/repo/wt", _BASE) is True
+
+        kwargs = run.call_args.kwargs
+        assert kwargs["encoding"] == "utf-8"
+        assert kwargs["errors"] == "replace"
+        assert kwargs["timeout"] > 0
+        assert kwargs["cwd"] == "/repo/wt"
 
 
 class TestDecide:
@@ -198,6 +249,7 @@ class TestBuildReport:
                     Worktree(path="/repo/wt", branch="feat/x"),
                 ],
             ),
+            patch("scripts.maintenance.gc_worktrees._run_git", return_value=_MAIN),
             patch(
                 "scripts.maintenance.gc_worktrees.has_uncommitted_changes",
                 return_value=False,
@@ -218,10 +270,40 @@ class TestBuildReport:
         with patch(
             "scripts.maintenance.gc_worktrees.list_worktrees",
             return_value=[Worktree(path=_MAIN, branch="main")],
-        ):
+        ), patch("scripts.maintenance.gc_worktrees._run_git", return_value=_MAIN):
             report = build_report(base_ref=_BASE, apply=False)
         assert report.candidates == []
         assert len(report.kept) == 1
+
+    def test_current_linked_worktree_is_always_kept(self):
+        with (
+            patch(
+                "scripts.maintenance.gc_worktrees.list_worktrees",
+                return_value=[
+                    Worktree(path=_MAIN, branch="main"),
+                    Worktree(path="/repo/active", branch="feat/active"),
+                    Worktree(path="/repo/wt", branch="feat/done"),
+                ],
+            ),
+            patch(
+                "scripts.maintenance.gc_worktrees._run_git",
+                return_value="/repo/active",
+            ),
+            patch(
+                "scripts.maintenance.gc_worktrees.has_uncommitted_changes",
+                return_value=False,
+            ),
+            patch(
+                "scripts.maintenance.gc_worktrees.is_merged_to_base",
+                return_value=True,
+            ),
+        ):
+            report = build_report(base_ref=_BASE, apply=False)
+
+        candidate_paths = [d.path for d in report.candidates]
+        kept = {d.path: d.reason for d in report.kept}
+        assert candidate_paths == ["/repo/wt"]
+        assert kept["/repo/active"] == KEEP_MAIN
 
 
 class TestApplyRemovals:
@@ -362,6 +444,32 @@ class TestCli:
             code = main(["--apply"])
         apply_mock.assert_called_once_with(plan)
         assert code == 0
+
+    def test_main_apply_returns_2_when_removal_errors_recorded(self):
+        plan = GcReport(
+            timestamp="t",
+            base_ref=_BASE,
+            apply=True,
+            main_worktree=_MAIN,
+            total_worktrees=1,
+            decisions=[
+                Decision("/repo/wt", "feat/x", remove=True, reason="merged to base"),
+            ],
+        )
+
+        def record_error(report: GcReport) -> None:
+            report.remove_errors.append("/repo/wt: locked by index")
+
+        with (
+            patch("scripts.maintenance.gc_worktrees.build_report", return_value=plan),
+            patch(
+                "scripts.maintenance.gc_worktrees.apply_removals",
+                side_effect=record_error,
+            ),
+        ):
+            code = main(["--apply"])
+
+        assert code == 2
 
     def test_main_returns_2_on_git_error(self, capsys):
         with patch(

--- a/tests/test_gc_worktrees.py
+++ b/tests/test_gc_worktrees.py
@@ -1,0 +1,388 @@
+"""Tests for gc_worktrees module.
+
+Verifies the worktree garbage-collection safety contract: dry-run removes
+nothing, only clean+merged-or-pushed worktrees are candidates, and locked,
+dirty, or unpushed worktrees are kept. Mocks at the subprocess boundary.
+Related: Issue #2761 (worktree accumulation starves the markdown LSP).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from scripts.maintenance.gc_worktrees import (
+    KEEP_DETACHED,
+    KEEP_DIRTY,
+    KEEP_GIT_ERROR,
+    KEEP_LOCKED,
+    KEEP_MAIN,
+    KEEP_UNPUSHED,
+    Decision,
+    GcReport,
+    Worktree,
+    apply_removals,
+    build_report,
+    decide,
+    format_report,
+    list_worktrees,
+    main,
+    parse_args,
+)
+
+_MAIN = "/repo"
+_BASE = "origin/main"
+
+_PORCELAIN = """\
+worktree /repo
+HEAD aaaa
+branch refs/heads/main
+
+worktree /repo/wt-clean
+HEAD bbbb
+branch refs/heads/feat/done
+
+worktree /repo/wt-locked
+HEAD cccc
+branch refs/heads/feat/locked
+locked
+
+worktree /repo/wt-bare
+HEAD dddd
+bare
+
+worktree /repo/wt-detached
+HEAD eeee
+detached
+"""
+
+
+class TestListWorktrees:
+    """Parsing of git worktree list --porcelain."""
+
+    def test_parses_each_worktree_block(self):
+        with patch("scripts.maintenance.gc_worktrees._run_git", return_value=_PORCELAIN.strip()):
+            result = list_worktrees()
+        assert [w.path for w in result] == [
+            "/repo",
+            "/repo/wt-clean",
+            "/repo/wt-locked",
+            "/repo/wt-bare",
+            "/repo/wt-detached",
+        ]
+
+    def test_strips_refs_heads_prefix_from_branch(self):
+        with patch("scripts.maintenance.gc_worktrees._run_git", return_value=_PORCELAIN.strip()):
+            result = list_worktrees()
+        assert result[1].branch == "feat/done"
+
+    def test_flags_locked_bare_and_detached(self):
+        with patch("scripts.maintenance.gc_worktrees._run_git", return_value=_PORCELAIN.strip()):
+            result = list_worktrees()
+        by_path = {w.path: w for w in result}
+        assert by_path["/repo/wt-locked"].locked is True
+        assert by_path["/repo/wt-bare"].bare is True
+        assert by_path["/repo/wt-detached"].detached is True
+
+    def test_empty_output_yields_no_worktrees(self):
+        with patch("scripts.maintenance.gc_worktrees._run_git", return_value=""):
+            assert list_worktrees() == []
+
+
+class TestDecide:
+    """The per-worktree safety decision. KEEP on any doubt."""
+
+    def test_keeps_main_worktree(self):
+        wt = Worktree(path=_MAIN, branch="main")
+        decision = decide(wt, _MAIN, _BASE)
+        assert decision.remove is False
+        assert decision.reason == KEEP_MAIN
+
+    def test_keeps_locked_worktree(self):
+        wt = Worktree(path="/repo/wt", branch="feat/x", locked=True)
+        decision = decide(wt, _MAIN, _BASE)
+        assert decision.remove is False
+        assert decision.reason == KEEP_LOCKED
+
+    def test_keeps_detached_worktree(self):
+        wt = Worktree(path="/repo/wt", branch=None, detached=True)
+        decision = decide(wt, _MAIN, _BASE)
+        assert decision.remove is False
+        assert decision.reason == KEEP_DETACHED
+
+    def test_keeps_dirty_worktree(self):
+        wt = Worktree(path="/repo/wt", branch="feat/x")
+        with patch(
+            "scripts.maintenance.gc_worktrees.has_uncommitted_changes",
+            return_value=True,
+        ):
+            decision = decide(wt, _MAIN, _BASE)
+        assert decision.remove is False
+        assert decision.reason == KEEP_DIRTY
+
+    def test_keeps_unpushed_and_unmerged_worktree(self):
+        wt = Worktree(path="/repo/wt", branch="feat/x")
+        with (
+            patch(
+                "scripts.maintenance.gc_worktrees.has_uncommitted_changes",
+                return_value=False,
+            ),
+            patch(
+                "scripts.maintenance.gc_worktrees.is_merged_to_base",
+                return_value=False,
+            ),
+            patch(
+                "scripts.maintenance.gc_worktrees.has_unpushed_commits",
+                return_value=True,
+            ),
+        ):
+            decision = decide(wt, _MAIN, _BASE)
+        assert decision.remove is False
+        assert decision.reason == KEEP_UNPUSHED
+
+    def test_removes_clean_merged_worktree(self):
+        wt = Worktree(path="/repo/wt", branch="feat/x")
+        with (
+            patch(
+                "scripts.maintenance.gc_worktrees.has_uncommitted_changes",
+                return_value=False,
+            ),
+            patch(
+                "scripts.maintenance.gc_worktrees.is_merged_to_base",
+                return_value=True,
+            ),
+        ):
+            decision = decide(wt, _MAIN, _BASE)
+        assert decision.remove is True
+        assert decision.reason == "merged to base"
+
+    def test_removes_clean_fully_pushed_worktree(self):
+        wt = Worktree(path="/repo/wt", branch="feat/x")
+        with (
+            patch(
+                "scripts.maintenance.gc_worktrees.has_uncommitted_changes",
+                return_value=False,
+            ),
+            patch(
+                "scripts.maintenance.gc_worktrees.is_merged_to_base",
+                return_value=False,
+            ),
+            patch(
+                "scripts.maintenance.gc_worktrees.has_unpushed_commits",
+                return_value=False,
+            ),
+        ):
+            decision = decide(wt, _MAIN, _BASE)
+        assert decision.remove is True
+        assert decision.reason == "fully pushed"
+
+    def test_keeps_worktree_when_git_inspection_fails(self):
+        wt = Worktree(path="/repo/wt", branch="feat/x")
+        with patch(
+            "scripts.maintenance.gc_worktrees.has_uncommitted_changes",
+            side_effect=RuntimeError("git boom"),
+        ):
+            decision = decide(wt, _MAIN, _BASE)
+        assert decision.remove is False
+        assert decision.reason == KEEP_GIT_ERROR
+
+
+class TestBuildReport:
+    """End-to-end plan construction with mocked git state."""
+
+    def test_dry_run_marks_apply_false_and_keeps_main(self):
+        with (
+            patch(
+                "scripts.maintenance.gc_worktrees.list_worktrees",
+                return_value=[
+                    Worktree(path=_MAIN, branch="main"),
+                    Worktree(path="/repo/wt", branch="feat/x"),
+                ],
+            ),
+            patch(
+                "scripts.maintenance.gc_worktrees.has_uncommitted_changes",
+                return_value=False,
+            ),
+            patch(
+                "scripts.maintenance.gc_worktrees.is_merged_to_base",
+                return_value=True,
+            ),
+        ):
+            report = build_report(base_ref=_BASE, apply=False)
+        assert report.apply is False
+        assert report.main_worktree == _MAIN
+        assert report.total_worktrees == 2
+        candidate_paths = [d.path for d in report.candidates]
+        assert candidate_paths == ["/repo/wt"]
+
+    def test_main_worktree_is_always_kept(self):
+        with patch(
+            "scripts.maintenance.gc_worktrees.list_worktrees",
+            return_value=[Worktree(path=_MAIN, branch="main")],
+        ):
+            report = build_report(base_ref=_BASE, apply=False)
+        assert report.candidates == []
+        assert len(report.kept) == 1
+
+
+class TestApplyRemovals:
+    """Removal execution. Only runs on candidates; never in dry-run."""
+
+    def test_apply_removes_each_candidate_and_prunes(self):
+        report = GcReport(
+            timestamp="t",
+            base_ref=_BASE,
+            apply=True,
+            main_worktree=_MAIN,
+            decisions=[
+                Decision("/repo/a", "feat/a", remove=True, reason="merged to base"),
+                Decision("/repo/b", "feat/b", remove=True, reason="fully pushed"),
+                Decision("/repo/c", "feat/c", remove=False, reason=KEEP_LOCKED),
+            ],
+        )
+        with (
+            patch("scripts.maintenance.gc_worktrees.remove_worktree") as remove,
+            patch("scripts.maintenance.gc_worktrees.prune_worktrees") as prune,
+        ):
+            apply_removals(report)
+        assert [c.args[0] for c in remove.call_args_list] == ["/repo/a", "/repo/b"]
+        prune.assert_called_once()
+        assert report.removed == ["/repo/a", "/repo/b"]
+
+    def test_apply_records_removal_errors_without_aborting(self):
+        report = GcReport(
+            timestamp="t",
+            base_ref=_BASE,
+            apply=True,
+            main_worktree=_MAIN,
+            decisions=[
+                Decision("/repo/a", "feat/a", remove=True, reason="merged to base"),
+                Decision("/repo/b", "feat/b", remove=True, reason="fully pushed"),
+            ],
+        )
+
+        def fail_on_a(path: str) -> None:
+            if path == "/repo/a":
+                raise RuntimeError("locked by index")
+
+        with (
+            patch(
+                "scripts.maintenance.gc_worktrees.remove_worktree",
+                side_effect=fail_on_a,
+            ),
+            patch("scripts.maintenance.gc_worktrees.prune_worktrees"),
+        ):
+            apply_removals(report)
+        assert report.removed == ["/repo/b"]
+        assert len(report.remove_errors) == 1
+        assert "/repo/a" in report.remove_errors[0]
+
+
+class TestFormatReport:
+    """Human-readable summary content."""
+
+    def test_dry_run_summary_states_nothing_removed(self):
+        report = GcReport(
+            timestamp="t",
+            base_ref=_BASE,
+            apply=False,
+            main_worktree=_MAIN,
+            total_worktrees=2,
+            decisions=[
+                Decision("/repo/wt", "feat/x", remove=True, reason="merged to base"),
+                Decision(_MAIN, "main", remove=False, reason=KEEP_MAIN),
+            ],
+        )
+        text = format_report(report)
+        assert "DRY-RUN" in text
+        assert "removed nothing" in text
+        assert "/repo/wt" in text
+
+    def test_apply_summary_lists_removed(self):
+        report = GcReport(
+            timestamp="t",
+            base_ref=_BASE,
+            apply=True,
+            main_worktree=_MAIN,
+            total_worktrees=2,
+            decisions=[
+                Decision("/repo/wt", "feat/x", remove=True, reason="merged to base"),
+            ],
+            removed=["/repo/wt"],
+        )
+        text = format_report(report)
+        assert "APPLY" in text
+        assert "removed /repo/wt" in text
+
+
+class TestCli:
+    """Argument parsing and the main() exit-code contract."""
+
+    def test_apply_defaults_to_false(self):
+        args = parse_args([])
+        assert args.apply is False
+        assert args.base == _BASE
+
+    def test_apply_flag_sets_true(self):
+        args = parse_args(["--apply"])
+        assert args.apply is True
+
+    def test_main_dry_run_does_not_call_apply_removals(self, capsys):
+        plan = GcReport(
+            timestamp="t",
+            base_ref=_BASE,
+            apply=False,
+            main_worktree=_MAIN,
+            total_worktrees=2,
+            decisions=[
+                Decision("/repo/wt", "feat/x", remove=True, reason="merged to base"),
+            ],
+        )
+        with (
+            patch("scripts.maintenance.gc_worktrees.build_report", return_value=plan),
+            patch("scripts.maintenance.gc_worktrees.apply_removals") as apply_mock,
+        ):
+            code = main([])
+        apply_mock.assert_not_called()
+        assert code == 0
+        assert "DRY-RUN" in capsys.readouterr().out
+
+    def test_main_apply_calls_apply_removals(self):
+        plan = GcReport(
+            timestamp="t",
+            base_ref=_BASE,
+            apply=True,
+            main_worktree=_MAIN,
+            total_worktrees=1,
+            decisions=[],
+        )
+        with (
+            patch("scripts.maintenance.gc_worktrees.build_report", return_value=plan),
+            patch("scripts.maintenance.gc_worktrees.apply_removals") as apply_mock,
+        ):
+            code = main(["--apply"])
+        apply_mock.assert_called_once_with(plan)
+        assert code == 0
+
+    def test_main_returns_2_on_git_error(self, capsys):
+        with patch(
+            "scripts.maintenance.gc_worktrees.build_report",
+            side_effect=RuntimeError("git worktree list failed"),
+        ):
+            code = main([])
+        assert code == 2
+        assert "error:" in capsys.readouterr().err
+
+    def test_main_json_output(self, capsys):
+        plan = GcReport(
+            timestamp="t",
+            base_ref=_BASE,
+            apply=False,
+            main_worktree=_MAIN,
+            total_worktrees=1,
+            decisions=[],
+        )
+        with patch("scripts.maintenance.gc_worktrees.build_report", return_value=plan):
+            code = main(["--json"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert '"base_ref": "origin/main"' in out


### PR DESCRIPTION
## Summary

Adds a SAFE, guarded worktree garbage-collection tool. Issue #2761 recorded 113 accumulated worktrees (10.6G) on one machine, producing 333,979 markdown files under the workspace and starving the markdown language server (Marksman times out, forcing the `LSP_DOWN=true` escape hatch per #2759).

The gitignore half of the fix shipped in PR #2765. This is the durable hygiene half: a reaper that removes only worktrees that cannot lose work.

## What it does

`scripts/maintenance/gc_worktrees.py`:

- Lists registered worktrees via `git worktree list --porcelain`.
- For each, inspects: locked, working-tree dirty (`git status --porcelain`), unpushed commits (`git log HEAD --not --remotes`), merged to `origin/main` (`git merge-base --is-ancestor`).
- Removes a worktree ONLY when ALL hold: not the current/main worktree, not bare, not locked, not detached, clean working tree, and (fully pushed OR merged to base). Uses `git worktree remove` then `git worktree prune`.
- Keeps everything else and reports the reason (locked, uncommitted changes, unpushed commits, detached HEAD, git-inspection-failed).
- Defaults to DRY-RUN. Removes nothing without an explicit `--apply` flag.
- Prints a summary (candidates, kept-with-reason) or `--json`.
- Exit codes per ADR-035: 0 ok, 2 runtime error.

Fail-safe by design: any git inspection error keeps the worktree, never removes it.

## Verification

Live dry-run against this machine (read-only, no `--apply`): 122 worktrees, 9 safe candidates (merged or fully pushed), 113 kept. Worktrees with unpushed commits, detached HEAD, or locks were all correctly kept.

Tests (`tests/test_gc_worktrees.py`, 24 cases, mocked at the subprocess boundary):

- dry-run removes nothing and requires `--apply`
- a clean+merged worktree is a removal candidate
- a clean+fully-pushed worktree is a removal candidate
- locked, dirty, unpushed-and-unmerged, and detached worktrees are KEPT
- git-inspection failure keeps the worktree
- `--apply` records per-worktree removal errors without aborting the batch
- porcelain parsing, CLI exit codes, JSON output

`uv run pytest tests/test_gc_worktrees.py` -> 24 passed. ruff check and format clean. `scripts/validation/pre_pr.py` -> all validations passed.

## Scope

This is the tool only. The first manual GC run remains for the operator (do not run `--apply` blind on a shared machine). Hence `Refs`, not `Fixes`.

Refs #2761
