### PR TITLE
fix(build): guard against orphaned build_all --check deferrals

### DIFF
--- a/build/AGENTS.md
+++ b/build/AGENTS.md
@@ -102,6 +102,29 @@ Two automated checks enforce these rules:
 | `validate-generated-agents.yml` | Verify generated files match templates | Must regenerate |
 | `drift-detection.yml` | Check Claude/VS Code consistency | Review and sync |
 
+#### Staleness deferrals (issue #2770)
+
+`build_all.py --check` is a "commit all generator output" gate. SkillForge is a
+"block a broken skill" gate. When a generator mirrors an upstream-broken skill,
+the two deadlock: the clean mirror cannot be committed, so `--check` cannot pass.
+The historical fix was an ad-hoc `STALENESS_DEFERRALS` constant exempting the
+broken mirror. It got orphaned: after the skill was fixed nobody removed the
+exemption, and it hid stale mirrors until caught by hand (#2780).
+
+Sanctioned protocol for a NEW upstream-broken skill you genuinely cannot mirror:
+
+1. Open a tracking issue for the upstream breakage. Keep it OPEN until fixed.
+2. Add a deferral entry in `build_all.py` that cites that OPEN issue as
+   `#<number>` plus a one-line reason.
+3. When the skill is fixed, regenerate the mirror, commit it, remove the
+   deferral, and close the tracking issue.
+
+`scripts/validation/validate_no_orphaned_build_deferrals.py` auto-polices step 3:
+it scans `build_all.py` for any deferral-style exemption, reads each cited issue
+state, and FAILS the gate when a deferral references a CLOSED issue. A closed
+tracking issue is the orphan signature, so you cannot leave a dead exemption
+behind. There are zero deferrals today; the gate passes until someone adds one.
+
 ---
 
 ## Agent Catalog

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -112,6 +112,9 @@ from validate_design_review import (  # noqa: E402, F401
     _VALID_STATUSES,
     validate_design_review_frontmatter,
 )
+from validate_no_orphaned_build_deferrals import (  # noqa: E402, F401
+    validate_no_orphaned_build_deferrals,
+)
 from validate_python_syntax import validate_python_syntax  # noqa: E402, F401
 from yaml_utils import _parse_yaml_frontmatter  # noqa: E402, F401
 
@@ -323,6 +326,17 @@ def main(argv: list[str] | None = None) -> int:
         "Build Command Exit Gates",
         state,
         lambda: validate_build_gates(repo_root),
+    )
+
+    # 3.72 Orphaned build_all --check deferrals (Issue #2770). Fails when a
+    # staleness-deferral exemption in build_all.py cites a CLOSED tracking
+    # issue, the orphan signature that hid stale mirrors before #2780.
+    run_validation(
+        "Orphaned Build Deferrals",
+        state,
+        lambda: validate_no_orphaned_build_deferrals(
+            repo_root / "build" / "scripts" / "build_all.py"
+        ),
     )
 
     # 3.75 Spec ID Uniqueness (Issue #2068)

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -330,12 +330,16 @@ def main(argv: list[str] | None = None) -> int:
 
     # 3.72 Orphaned build_all --check deferrals (Issue #2770). Fails when a
     # staleness-deferral exemption in build_all.py cites a CLOSED tracking
-    # issue, the orphan signature that hid stale mirrors before #2780.
+    # issue, the orphan signature that hid stale mirrors before #2780. Honor
+    # GH_REPO so the gate can run against a different upstream without code edits;
+    # the validator keeps the canonical default when GH_REPO is unset.
+    deferral_repo = os.environ.get("GH_REPO")
     run_validation(
         "Orphaned Build Deferrals",
         state,
         lambda: validate_no_orphaned_build_deferrals(
-            repo_root / "build" / "scripts" / "build_all.py"
+            repo_root / "build" / "scripts" / "build_all.py",
+            *([deferral_repo] if deferral_repo else []),
         ),
     )
 

--- a/scripts/validation/validate_no_orphaned_build_deferrals.py
+++ b/scripts/validation/validate_no_orphaned_build_deferrals.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Police staleness deferrals in build/scripts/build_all.py against orphaning.
+
+Motivation (issue #2770)
+========================
+build_all.py --check is a "commit all generator output" gate: every file a
+generator owns must match what is committed, or --check fails. SkillForge is a
+"block a broken skill" gate. When a generator mirrors an upstream-broken skill,
+the two deadlock: the mirror cannot be committed clean, so --check cannot pass.
+
+The historical workaround was an ad-hoc ``STALENESS_DEFERRALS`` constant in
+build_all.py that exempted the broken mirror's path from the staleness diff.
+That workaround had two structural defects:
+
+1. No sanctioned path. The next person facing a new upstream-broken skill
+   re-invented the same ad-hoc exemption from scratch, with no rules.
+2. Orphaned-deferral failure. The exemption's only drop-trigger was a comment
+   on issue #2755. After the skills were fixed (#2762), nobody removed the dead
+   exemption. It sat hiding stale mirrors until #2780 caught it by hand.
+
+This validator makes defect 2 impossible to leave behind. It scans build_all.py
+for any deferral-style exemption, extracts the tracking issue each one cites,
+and FAILS the gate if that issue is CLOSED. A closed tracking issue is the exact
+signature of an orphan: the work that justified the deferral is done, so the
+deferral must go and the now-valid mirror must be committed.
+
+Sanctioned deferral protocol
+============================
+A staleness deferral is a narrow, temporary escape valve, not a config surface.
+If a generator change touches a NEW upstream-broken skill and you genuinely
+cannot commit the clean mirror:
+
+1. Open a tracking issue for the upstream breakage. It MUST stay open until the
+   skill is fixed and the mirror is regenerated clean.
+2. Add a deferral entry in build_all.py whose value or adjacent comment cites
+   that OPEN issue as ``#<number>`` and states the reason.
+3. When the upstream skill is fixed, regenerate the mirror, commit it, remove
+   the deferral, and close the tracking issue.
+
+This validator auto-polices step 3: once the tracking issue closes, the gate
+fails until the deferral is removed. You cannot orphan it.
+
+Scope
+=====
+This is a pure scanner over build_all.py source text plus a per-issue ``gh``
+state lookup. It does not import or run build_all.py, so it stays out of the
+build orchestrator's network-free, snapshot-pure path. build_all.py has zero
+deferrals today (the #2780 cleanup removed the last one), so this gate passes
+trivially until someone adds one.
+
+Exit codes (per ADR-035):
+    0 - no orphaned deferrals (no deferrals at all, or all cite OPEN issues,
+        or issue state could not be resolved and was kept with a warning)
+    1 - one or more deferrals cite a CLOSED tracking issue (orphan)
+    2 - config error (build_all.py missing)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+# Bounded timeout for every subprocess call (Release It! integration-point rule).
+_GH_TIMEOUT_S = 30
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_BUILD_ALL = _REPO_ROOT / "build" / "scripts" / "build_all.py"
+
+# A module-level constant whose name carries deferral / exemption intent. This
+# is the shape of the historical ``STALENESS_DEFERRALS`` workaround and any
+# re-invention of it. Anchored at column 0 (MULTILINE ^) so a local variable
+# inside a function does not trip the scan.
+_DEFERRAL_NAME_RE = re.compile(
+    r"^(?P<name>[A-Z][A-Z0-9_]*"
+    r"(?:DEFERRAL|DEFERRALS|EXEMPTION|EXEMPTIONS|"
+    r"STALENESS_SKIP|SKIP_STALENESS|STALENESS_ALLOWLIST))"
+    r"\s*[:=]",
+    re.MULTILINE,
+)
+
+# An issue reference inside a deferral block: ``#1234`` or ``issue 1234``.
+_ISSUE_REF_RE = re.compile(r"(?:#|issue\s+)(\d{1,7})", re.IGNORECASE)
+
+
+class DeferralBlock:
+    """One deferral-style constant and the issue numbers it cites."""
+
+    def __init__(self, name: str, start: int, end: int, text: str) -> None:
+        self.name = name
+        self.start_line = start
+        self.end_line = end
+        self.text = text
+        self.issues = sorted({int(m.group(1)) for m in _ISSUE_REF_RE.finditer(text)})
+
+
+def _block_extent(source_lines: list[str], name_line_idx: int) -> int:
+    """Return the exclusive end line index of a deferral block.
+
+    A block runs from its declaration line until the next column-0,
+    non-comment, non-blank line (the next top-level statement). This captures
+    multi-line list/dict literals and the comments interleaved with them.
+    """
+    idx = name_line_idx + 1
+    n = len(source_lines)
+    while idx < n:
+        line = source_lines[idx]
+        stripped = line.strip()
+        is_indented = line[:1] in (" ", "\t")
+        is_comment_or_blank = stripped == "" or stripped.startswith("#")
+        if not is_indented and not is_comment_or_blank:
+            break
+        idx += 1
+    return idx
+
+
+def find_deferral_blocks(source: str) -> list[DeferralBlock]:
+    """Return every deferral-style exemption block found in ``source``."""
+    lines = source.splitlines()
+    blocks: list[DeferralBlock] = []
+    for match in _DEFERRAL_NAME_RE.finditer(source):
+        name = match.group("name")
+        start_idx = source.count("\n", 0, match.start())
+        end_idx = _block_extent(lines, start_idx)
+        text = "\n".join(lines[start_idx:end_idx])
+        blocks.append(DeferralBlock(name, start_idx + 1, end_idx, text))
+    return blocks
+
+
+def lookup_issue_state(
+    issue: int,
+    repo: str,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> str | None:
+    """Return the GitHub state ("OPEN"/"CLOSED") for ``issue``, or None.
+
+    None signals an unresolved state: gh missing, not authenticated, network
+    down, or the issue not found. Callers treat None as "keep but warn", never
+    a hard fail, so an offline run does not block on a transient lookup.
+    """
+    try:
+        result = runner(
+            ["gh", "issue", "view", str(issue), "--repo", repo, "--json", "state"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_GH_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    state = data.get("state")
+    if not isinstance(state, str):
+        return None
+    return state.upper()
+
+
+def evaluate_deferrals(
+    blocks: list[DeferralBlock],
+    repo: str,
+    *,
+    lookup: Callable[[int, str], str | None] = lookup_issue_state,
+) -> tuple[list[str], list[str]]:
+    """Classify deferrals into orphan failures and keep-with-warning notices.
+
+    Returns ``(failures, warnings)``. ``failures`` are deferrals citing a
+    CLOSED issue (orphans). ``warnings`` are deferrals whose issue state could
+    not be resolved (offline / unknown) and deferrals citing no issue at all.
+    """
+    failures: list[str] = []
+    warnings: list[str] = []
+    for block in blocks:
+        if not block.issues:
+            warnings.append(
+                f"{block.name} (build_all.py:{block.start_line}) cites no "
+                f"tracking issue; a deferral must reference an OPEN issue and "
+                f"a reason"
+            )
+            continue
+        for issue in block.issues:
+            state = lookup(issue, repo)
+            if state == "CLOSED":
+                failures.append(
+                    f"deferral {block.name} (build_all.py:{block.start_line}) "
+                    f"references closed issue #{issue}; remove the deferral and "
+                    f"commit the now-valid mirror"
+                )
+            elif state is None:
+                warnings.append(
+                    f"deferral {block.name} (build_all.py:{block.start_line}) "
+                    f"references issue #{issue} but its state could not be "
+                    f"resolved (offline or not found); keeping it"
+                )
+    return failures, warnings
+
+
+def validate_no_orphaned_build_deferrals(
+    build_all_path: Path = _BUILD_ALL,
+    repo: str = "rjmurillo/ai-agents",
+    *,
+    lookup: Callable[[int, str], str | None] = lookup_issue_state,
+) -> bool:
+    """Return True when no deferral in build_all.py is orphaned.
+
+    Importable entry point for pre_pr.py. Prints failures and warnings to
+    stderr. Raises FileNotFoundError when build_all.py is missing so the
+    caller can map it to a config-error exit.
+    """
+    if not build_all_path.is_file():
+        raise FileNotFoundError(f"build_all.py not found: {build_all_path}")
+
+    source = build_all_path.read_text(encoding="utf-8")
+    blocks = find_deferral_blocks(source)
+    if not blocks:
+        return True
+
+    failures, warnings = evaluate_deferrals(blocks, repo, lookup=lookup)
+    for warning in warnings:
+        print(f"WARN: {warning}", file=sys.stderr)
+    for failure in failures:
+        print(f"ORPHANED-DEFERRAL: {failure}", file=sys.stderr)
+    return not failures
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--build-all",
+        type=Path,
+        default=_BUILD_ALL,
+        help="Path to build_all.py (default: repo build/scripts/build_all.py).",
+    )
+    parser.add_argument(
+        "--repo",
+        type=str,
+        default=os.environ.get("GH_REPO", "rjmurillo/ai-agents"),
+        help="owner/name for gh issue-state lookups.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        ok = validate_no_orphaned_build_deferrals(args.build_all, args.repo)
+    except FileNotFoundError as exc:
+        print(f"CONFIG-ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validation/validate_no_orphaned_build_deferrals.py
+++ b/scripts/validation/validate_no_orphaned_build_deferrals.py
@@ -76,10 +76,23 @@ _BUILD_ALL = _REPO_ROOT / "build" / "scripts" / "build_all.py"
 # is the shape of the historical ``STALENESS_DEFERRALS`` workaround and any
 # re-invention of it. Anchored at column 0 (MULTILINE ^) so a local variable
 # inside a function does not trip the scan.
+#
+# A name qualifies when it is an ALLCAPS constant that EITHER:
+#   * ends in DEFERRAL(S) or EXEMPTION(S) (the canonical exemption suffixes), OR
+#   * carries a STALENESS_* segment paired with an exemption marker
+#     (SKIP / ALLOWLIST / BLOCKLIST / DENYLIST / EXCLUDE / IGNORE / BYPASS), in
+#     either order.
+# A plain numeric threshold such as STALENESS_THRESHOLD_DAYS has no exemption
+# marker, so it does not match and is not mistaken for a deferral registry.
+_EXEMPTION_MARKER = r"SKIP|ALLOWLIST|BLOCKLIST|DENYLIST|EXCLUDE|IGNORE|BYPASS"
 _DEFERRAL_NAME_RE = re.compile(
-    r"^(?P<name>[A-Z][A-Z0-9_]*"
-    r"(?:DEFERRAL|DEFERRALS|EXEMPTION|EXEMPTIONS|"
-    r"STALENESS_SKIP|SKIP_STALENESS|STALENESS_ALLOWLIST))"
+    r"^(?P<name>"
+    # Exemption suffix: any prefix then DEFERRAL(S) / EXEMPTION(S) at the end.
+    r"(?:[A-Z][A-Z0-9_]*?(?:DEFERRALS?|EXEMPTIONS?)"
+    # STALENESS adjacent to an exemption marker, in either order, anywhere.
+    rf"|[A-Z0-9_]*STALENESS_(?:{_EXEMPTION_MARKER})[A-Z0-9_]*"
+    rf"|[A-Z0-9_]*(?:{_EXEMPTION_MARKER})_STALENESS[A-Z0-9_]*"
+    r")(?![A-Z0-9_]))"
     r"\s*[:=]",
     re.MULTILINE,
 )
@@ -148,6 +161,8 @@ def lookup_issue_state(
             ["gh", "issue", "view", str(issue), "--repo", repo, "--json", "state"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=False,
             timeout=_GH_TIMEOUT_S,
         )
@@ -159,6 +174,11 @@ def lookup_issue_state(
         data = json.loads(result.stdout)
     except (json.JSONDecodeError, ValueError):
         return None
+    if not isinstance(data, dict):
+        return None
+    # data.get("state") returns None both when the key is absent and when it is
+    # present with an explicit JSON null; the isinstance guard below collapses
+    # both to None, matching the "keep but warn" contract for unresolved state.
     state = data.get("state")
     if not isinstance(state, str):
         return None
@@ -204,6 +224,24 @@ def evaluate_deferrals(
     return failures, warnings
 
 
+def _resolve_within_repo(build_all_path: Path) -> Path:
+    """Resolve ``build_all_path``, anchoring relatives to the repo root (CWE-22).
+
+    A relative path is the traversal vector: without anchoring it resolves
+    against the current working directory, so ``../../etc/passwd`` could redirect
+    the scan outside the repository. Anchor relatives to ``_REPO_ROOT``, resolve,
+    and reject (ValueError) any that still escape the repo root. Absolute paths
+    are explicit caller intent (the default and the tests pass absolute paths) and
+    are resolved as-given, not containment-checked.
+    """
+    if build_all_path.is_absolute():
+        return build_all_path.resolve()
+    resolved = (_REPO_ROOT / build_all_path).resolve()
+    if not resolved.is_relative_to(_REPO_ROOT):
+        raise ValueError(f"build_all.py path escapes repo root: {build_all_path}")
+    return resolved
+
+
 def validate_no_orphaned_build_deferrals(
     build_all_path: Path = _BUILD_ALL,
     repo: str = "rjmurillo/ai-agents",
@@ -214,8 +252,10 @@ def validate_no_orphaned_build_deferrals(
 
     Importable entry point for pre_pr.py. Prints failures and warnings to
     stderr. Raises FileNotFoundError when build_all.py is missing so the
-    caller can map it to a config-error exit.
+    caller can map it to a config-error exit. Raises ValueError when a relative
+    ``build_all_path`` resolves outside the repo root (CWE-22 path traversal).
     """
+    build_all_path = _resolve_within_repo(build_all_path)
     if not build_all_path.is_file():
         raise FileNotFoundError(f"build_all.py not found: {build_all_path}")
 

--- a/tests/build_scripts/test_validate_no_orphaned_build_deferrals.py
+++ b/tests/build_scripts/test_validate_no_orphaned_build_deferrals.py
@@ -1,0 +1,248 @@
+"""Tests for scripts/validation/validate_no_orphaned_build_deferrals.py (#2770).
+
+The validator polices staleness-deferral exemptions in build_all.py so an
+orphaned deferral (one whose tracking issue has CLOSED) cannot be left behind.
+Every test mocks the GitHub issue-state lookup at the boundary; none hit the
+live API.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "validation"))
+
+import validate_no_orphaned_build_deferrals as mod  # noqa: E402
+
+# --- Block scanning --------------------------------------------------------
+
+
+def test_find_deferral_blocks_empty_source_has_none() -> None:
+    """A build_all.py with no deferral constant yields zero blocks."""
+    source = "X = 1\n\n\ndef run():\n    return 0\n"
+    assert mod.find_deferral_blocks(source) == []
+
+
+def test_find_deferral_blocks_matches_named_constant() -> None:
+    """A column-0 *_DEFERRALS constant is detected and its issues parsed."""
+    source = (
+        "OWNED = ('src/',)\n"
+        "STALENESS_DEFERRALS = {\n"
+        "    # cva-analysis broken upstream, see #1234\n"
+        '    "src/copilot-cli/skills/cva-analysis/SKILL.md": "broken",\n'
+        "}\n"
+        "\n"
+        "def run():\n"
+        "    return 0\n"
+    )
+    blocks = mod.find_deferral_blocks(source)
+    assert len(blocks) == 1
+    assert blocks[0].name == "STALENESS_DEFERRALS"
+    assert blocks[0].issues == [1234]
+
+
+def test_find_deferral_blocks_ignores_indented_local_variable() -> None:
+    """A deferral-shaped name indented inside a function is not a registry."""
+    source = "def run():\n    STALENESS_DEFERRALS = []\n    return STALENESS_DEFERRALS\n"
+    assert mod.find_deferral_blocks(source) == []
+
+
+def test_block_extent_stops_at_next_top_level_statement() -> None:
+    """A multi-line block ends at the next column-0 code line, not mid-literal."""
+    source = (
+        "STALENESS_EXEMPTIONS = [\n"
+        "    # issue 4321\n"
+        '    "a",\n'
+        "]\n"
+        "NEXT = 2\n"
+    )
+    blocks = mod.find_deferral_blocks(source)
+    assert len(blocks) == 1
+    assert blocks[0].issues == [4321]
+    assert "NEXT = 2" not in blocks[0].text
+
+
+# --- Issue-state lookup boundary -------------------------------------------
+
+
+def _fake_runner(stdout: str, returncode: int = 0):
+    def runner(argv, **kwargs):  # noqa: ANN001, ANN003
+        return subprocess.CompletedProcess(argv, returncode, stdout=stdout, stderr="")
+
+    return runner
+
+
+def test_lookup_issue_state_open() -> None:
+    state = mod.lookup_issue_state(
+        7, "owner/repo", runner=_fake_runner('{"state": "open"}')
+    )
+    assert state == "OPEN"
+
+
+def test_lookup_issue_state_closed() -> None:
+    state = mod.lookup_issue_state(
+        7, "owner/repo", runner=_fake_runner('{"state": "CLOSED"}')
+    )
+    assert state == "CLOSED"
+
+
+def test_lookup_issue_state_none_on_gh_failure() -> None:
+    """A non-zero gh return (not found, auth, offline) yields None."""
+    state = mod.lookup_issue_state(
+        7, "owner/repo", runner=_fake_runner("", returncode=1)
+    )
+    assert state is None
+
+
+def test_lookup_issue_state_none_on_subprocess_error() -> None:
+    """gh missing from PATH (OSError) yields None, never raises."""
+
+    def boom(argv, **kwargs):  # noqa: ANN001, ANN003
+        raise OSError("gh not found")
+
+    assert mod.lookup_issue_state(7, "owner/repo", runner=boom) is None
+
+
+def test_lookup_issue_state_none_on_bad_json() -> None:
+    state = mod.lookup_issue_state(
+        7, "owner/repo", runner=_fake_runner("not json")
+    )
+    assert state is None
+
+
+# --- End-to-end validation -------------------------------------------------
+
+
+def _write_build_all(tmp_path: Path, body: str) -> Path:
+    target = tmp_path / "build_all.py"
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def test_validate_empty_registry_passes(tmp_path: Path) -> None:
+    """(a) No deferral constant: gate passes, lookup never invoked."""
+    path = _write_build_all(tmp_path, "OWNED = ('src/',)\n\n\ndef run():\n    return 0\n")
+
+    def fail_if_called(issue: int, repo: str) -> str | None:
+        raise AssertionError("lookup must not run when there are no deferrals")
+
+    assert mod.validate_no_orphaned_build_deferrals(
+        path, "owner/repo", lookup=fail_if_called
+    )
+
+
+def test_validate_open_issue_deferral_passes(tmp_path: Path) -> None:
+    """(b) Deferral whose issue is OPEN: gate passes."""
+    path = _write_build_all(
+        tmp_path,
+        'STALENESS_DEFERRALS = {\n    "x": "broken, see #555",\n}\n',
+    )
+    assert mod.validate_no_orphaned_build_deferrals(
+        path, "owner/repo", lookup=lambda issue, repo: "OPEN"
+    )
+
+
+def test_validate_closed_issue_deferral_fails(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """(c) Deferral whose issue is CLOSED: gate fails with remove message."""
+    path = _write_build_all(
+        tmp_path,
+        'STALENESS_DEFERRALS = {\n    "x": "broken, see #555",\n}\n',
+    )
+    ok = mod.validate_no_orphaned_build_deferrals(
+        path, "owner/repo", lookup=lambda issue, repo: "CLOSED"
+    )
+    assert ok is False
+    err = capsys.readouterr().err
+    assert "references closed issue #555" in err
+    assert "remove the deferral and commit the now-valid mirror" in err
+
+
+def test_validate_unknown_state_keeps_with_warning(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """(d) Offline / unknown issue state: kept with a warning, not a hard fail."""
+    path = _write_build_all(
+        tmp_path,
+        'STALENESS_DEFERRALS = {\n    "x": "broken, see #555",\n}\n',
+    )
+    ok = mod.validate_no_orphaned_build_deferrals(
+        path, "owner/repo", lookup=lambda issue, repo: None
+    )
+    assert ok is True
+    err = capsys.readouterr().err
+    assert "state could not be resolved" in err
+    assert "keeping it" in err
+
+
+def test_validate_deferral_without_issue_warns(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A deferral that cites no issue is kept but warns it must reference one."""
+    path = _write_build_all(
+        tmp_path,
+        'STALENESS_DEFERRALS = {\n    "x": "broken, no tracker",\n}\n',
+    )
+    ok = mod.validate_no_orphaned_build_deferrals(
+        path, "owner/repo", lookup=lambda issue, repo: "OPEN"
+    )
+    assert ok is True
+    assert "cites no tracking issue" in capsys.readouterr().err
+
+
+def test_validate_mixed_open_and_closed_fails_on_closed(tmp_path: Path) -> None:
+    """One OPEN and one CLOSED deferral: the CLOSED one fails the gate."""
+    path = _write_build_all(
+        tmp_path,
+        "STALENESS_DEFERRALS = {\n"
+        '    "a": "see #100",\n'
+        "}\n"
+        "STALENESS_EXEMPTIONS = [\n"
+        "    # see #200\n"
+        '    "b",\n'
+        "]\n",
+    )
+    states = {100: "OPEN", 200: "CLOSED"}
+    ok = mod.validate_no_orphaned_build_deferrals(
+        path, "owner/repo", lookup=lambda issue, repo: states[issue]
+    )
+    assert ok is False
+
+
+def test_validate_missing_build_all_raises(tmp_path: Path) -> None:
+    """A missing build_all.py raises FileNotFoundError for a config-error exit."""
+    with pytest.raises(FileNotFoundError):
+        mod.validate_no_orphaned_build_deferrals(
+            tmp_path / "nope.py", "owner/repo", lookup=lambda issue, repo: "OPEN"
+        )
+
+
+# --- CLI -------------------------------------------------------------------
+
+
+def test_main_returns_zero_for_clean_build_all(tmp_path: Path) -> None:
+    path = _write_build_all(tmp_path, "OWNED = ('src/',)\n")
+    assert mod.main(["--build-all", str(path), "--repo", "owner/repo"]) == 0
+
+
+def test_main_returns_two_for_missing_build_all(tmp_path: Path) -> None:
+    rc = mod.main(["--build-all", str(tmp_path / "gone.py"), "--repo", "owner/repo"])
+    assert rc == 2
+
+
+def test_real_build_all_has_no_orphaned_deferrals() -> None:
+    """The shipped build_all.py has zero deferrals, so the gate passes offline.
+
+    Uses a lookup stub so the test never touches the network; with no deferral
+    blocks the lookup is never called anyway.
+    """
+    build_all = REPO_ROOT / "build" / "scripts" / "build_all.py"
+    assert mod.validate_no_orphaned_build_deferrals(
+        build_all, "rjmurillo/ai-agents", lookup=lambda issue, repo: "OPEN"
+    )

--- a/tests/build_scripts/test_validate_no_orphaned_build_deferrals.py
+++ b/tests/build_scripts/test_validate_no_orphaned_build_deferrals.py
@@ -52,6 +52,26 @@ def test_find_deferral_blocks_ignores_indented_local_variable() -> None:
     assert mod.find_deferral_blocks(source) == []
 
 
+def test_find_deferral_blocks_matches_staleness_blocklist() -> None:
+    """A STALENESS_* constant with an exemption marker is a deferral registry."""
+    source = (
+        "STALENESS_BLOCKLIST = {\n"
+        "    # broken upstream, see #1234\n"
+        '    "x": "broken",\n'
+        "}\n"
+    )
+    blocks = mod.find_deferral_blocks(source)
+    assert len(blocks) == 1
+    assert blocks[0].name == "STALENESS_BLOCKLIST"
+    assert blocks[0].issues == [1234]
+
+
+def test_find_deferral_blocks_ignores_plain_staleness_threshold() -> None:
+    """A numeric STALENESS threshold has no exemption marker, so it is not a registry."""
+    source = "STALENESS_THRESHOLD_DAYS = 30\n"
+    assert mod.find_deferral_blocks(source) == []
+
+
 def test_block_extent_stops_at_next_top_level_statement() -> None:
     """A multi-line block ends at the next column-0 code line, not mid-literal."""
     source = (
@@ -111,6 +131,22 @@ def test_lookup_issue_state_none_on_subprocess_error() -> None:
 def test_lookup_issue_state_none_on_bad_json() -> None:
     state = mod.lookup_issue_state(
         7, "owner/repo", runner=_fake_runner("not json")
+    )
+    assert state is None
+
+
+def test_lookup_issue_state_none_on_explicit_json_null() -> None:
+    """An explicit JSON null state resolves to None, not a crash."""
+    state = mod.lookup_issue_state(
+        7, "owner/repo", runner=_fake_runner('{"state": null}')
+    )
+    assert state is None
+
+
+def test_lookup_issue_state_none_on_non_dict_json() -> None:
+    """A non-object JSON payload (e.g. a bare number) yields None, never raises."""
+    state = mod.lookup_issue_state(
+        7, "owner/repo", runner=_fake_runner("123")
     )
     assert state is None
 
@@ -221,6 +257,28 @@ def test_validate_missing_build_all_raises(tmp_path: Path) -> None:
         mod.validate_no_orphaned_build_deferrals(
             tmp_path / "nope.py", "owner/repo", lookup=lambda issue, repo: "OPEN"
         )
+
+
+def test_validate_relative_traversal_path_rejected() -> None:
+    """A relative build_all path that escapes the repo root is rejected (CWE-22).
+
+    The lookup stub raises if reached, proving the traversal is refused before any
+    gh call: the path check fails closed at the boundary, not over the network.
+    """
+
+    def fail_if_called(issue: int, repo: str) -> str | None:
+        raise AssertionError("lookup must not run for a rejected traversal path")
+
+    with pytest.raises(ValueError, match="escapes repo root"):
+        mod.validate_no_orphaned_build_deferrals(
+            Path("../../etc/passwd"), "owner/repo", lookup=fail_if_called
+        )
+
+
+def test_resolve_within_repo_anchors_relative_to_repo_root() -> None:
+    """A safe relative path resolves under the repo root, not the cwd."""
+    resolved = mod._resolve_within_repo(Path("build/scripts/build_all.py"))
+    assert resolved == mod._REPO_ROOT / "build" / "scripts" / "build_all.py"
 
 
 # --- CLI -------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2770

## What

A guarded, self-expiring deferral mechanism for the build-all `--check` orchestrator, so an orphaned staleness exemption can never be left behind.

New gate: `scripts/validation/validate_no_orphaned_build_deferrals.py`, wired into `scripts/validation/pre_pr.py`. It scans the build orchestrator for any deferral-style exemption (a column-0 constant named `*_DEFERRAL(S)`, `*_EXEMPTION(S)`, `*_STALENESS_*`), reads each cited GitHub issue state via `gh`, and FAILS when a deferral references a CLOSED tracking issue with the message: `references closed issue #<n>; remove the deferral and commit the now-valid mirror`.

## Which option, and why it is the minimal correct fix

The issue offered two shapes: (A) a typed `STALENESS_DEFERRALS` registry inside the build orchestrator with an inline guard, or (B) a standalone validator wired into `pre_pr.py`. I implemented **option B**.

Reasons B is the smaller correct change:

1. **Option A re-introduces the exact anti-pattern a live regression test forbids.** The #2777 regression test (in the build_scripts suite) asserts `STALENESS_DEFERRALS` does not exist as an attribute AND does not appear in the orchestrator source text. A registry constant would force renaming around, or deleting, that guard. B leaves it intact.
2. **B keeps the build orchestrator network-free and snapshot-pure.** The `--check` path is read-only via the #2440 snapshot/restore guard and issues no network calls. Embedding a `gh` issue-state lookup inside it couples the build orchestrator to GitHub. B isolates the network call in a separate pre-PR gate.
3. **Zero entries today.** #2780 removed the last deferral. A registry with 0 entries is YAGNI; a scanner that finds any future ad-hoc exemption (whatever it is named) polices the orphan failure mode without standing infrastructure.

Motivation, concretely: the historical `STALENESS_DEFERRALS` exemption was orphaned. Its only drop-trigger was a comment on #2755; after #2762 fixed the skills, nobody removed the dead exemption, and it hid stale mirrors until #2780 caught it by hand. This gate makes that impossible: a closed tracking issue is the orphan signature, and the gate fails on it.

## Behavior

- Empty registry (today): gate passes, no `gh` call.
- Deferral citing an OPEN issue: passes (the path stays exempt from staleness, as intended).
- Deferral citing a CLOSED issue: fails with the remove-the-deferral message.
- Offline / unknown issue state: kept with a warning, never a hard fail (graceful degradation, `gh` timeout-bounded at 30s).

## Tests

`tests/build_scripts/test_validate_no_orphaned_build_deferrals.py`, 19 tests, all GitHub lookups mocked at the boundary (no live API):
- empty registry -> pass (lookup never called)
- OPEN-issue deferral -> pass
- CLOSED-issue deferral -> fail with exact message
- offline/unknown -> kept with warning, not a hard fail
- block scanning (named constant, multi-line literal, indented-local ignored), lookup boundary (open/closed/gh-failure/OSError/bad-JSON), mixed open+closed, missing orchestrator config error, CLI exit codes, and a check that the shipped orchestrator has zero deferrals.

`uv run pytest tests/build_scripts/ -q`: 73 passed (19 new + 54 existing, no regression). `uvx ruff check` clean. `pre_pr.py --quick` rc=0, the new "Orphaned Build Deferrals" gate PASSes in sequence.

## Sanctioned protocol (documented)

`build/AGENTS.md` Rule 4 now documents the protocol: a new deferral must cite an OPEN tracking issue plus a reason, and the gate auto-polices its removal once the issue closes.

## Flag (out of scope)

`scripts/validation/pre_pr.py` crossed the 500-line taste-lint threshold (549 lines) with the 14-line wiring. The lint is advisory (exit 0). Splitting `pre_pr.py` into modules is a separate multi-module refactor that many imports depend on; flagging rather than expanding scope.

## Related Files

Referenced by this PR but not changed by it (the new validator scans the first; the regression test lives beside it):

```text
build/scripts/build_all.py
tests/build_scripts/test_build_all.py
```
