### PR TITLE
fix(benchmark-models): document MODEL_BENCHMARK_SKILL_ROOTS allowed-root constraint (SkillOpt-gated)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.251",
+  "version": "0.5.252",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/benchmark-models/SKILL.md
+++ b/.claude/skills/benchmark-models/SKILL.md
@@ -59,6 +59,17 @@ Decide the prompt with AskUserQuestion:
 - A) Benchmark a skill: pass that skill's `SKILL.md` path as the prompt. To list
   candidates, search the installed skills dir, not just `.` (skills usually live
   under `~/.claude/skills/` or `~/.copilot/skills/`, not the project root).
+
+  Allowed-root constraint: `model_benchmark.py` reads a prompt file only when it
+  resolves under the repo checkout, the current directory, or a path listed in
+  `MODEL_BENCHMARK_SKILL_ROOTS` (see `resolve_prompt` and `_allowed_prompt_roots`
+  in `scripts/model_benchmark.py`). A `SKILL.md` under `~/.claude/skills/` or
+  `~/.copilot/skills/` is outside the repo and cwd, so the run aborts with exit
+  code 2 ("prompt file must be under an allowed root") and benchmarks nothing.
+  Before running, export the skills dir, for example
+  `export MODEL_BENCHMARK_SKILL_ROOTS=~/.claude/skills` (or `~/.copilot/skills`),
+  or copy the file into and run from an allowed root. A prompt already inside the
+  repo or cwd needs no env var.
 - B) Inline prompt: pass `--prompt "<text>"`.
 - C) A prompt file on disk: pass its path (verify it exists first).
 
@@ -89,6 +100,10 @@ python3 "$BENCH" <prompt-spec> --models <picked> [--judge] --output table
 
 `<prompt-spec>` is `--prompt "<text>"` (B) or a file path (A/C). Stream the
 output; each provider runs the full prompt, so expect 30s-5min.
+
+For an installed-skill path (A) under `~/.claude/skills/` or `~/.copilot/skills/`
+(outside the repo and cwd), export `MODEL_BENCHMARK_SKILL_ROOTS` first (see Step 1
+Option A) or the run aborts with exit code 2 before any provider starts.
 
 ### Step 4: Interpret and optionally save
 
@@ -152,6 +167,9 @@ The skill run is complete when:
 - [ ] Step 1 dry-run ran and its availability block was shown to the user.
 - [ ] If zero providers were authed, the run STOPPED (no benchmark attempted).
 - [ ] The benchmark ran only the user-confirmed providers.
+- [ ] If the prompt was a skill `SKILL.md` outside the repo/cwd,
+      `MODEL_BENCHMARK_SKILL_ROOTS` was set (or the file staged under an allowed
+      root) so the run did not abort with exit code 2.
 - [ ] `--judge` was included only after explicit user opt-in.
 - [ ] Results name the fastest, cheapest, and (if judged) highest-quality model,
       with errors and their remediation surfaced.

--- a/.claude/skills/benchmark-models/SKILL.md
+++ b/.claude/skills/benchmark-models/SKILL.md
@@ -60,10 +60,10 @@ Decide the prompt with AskUserQuestion:
   candidates, search the installed skills dir, not just `.` (skills usually live
   under `~/.claude/skills/` or `~/.copilot/skills/`, not the project root).
 
-  Allowed-root constraint: `model_benchmark.py` reads a prompt file only when it
+  Allowed-root constraint: `$BENCH` reads a prompt file only when it
   resolves under the repo checkout, the current directory, or a path listed in
   `MODEL_BENCHMARK_SKILL_ROOTS` (see `resolve_prompt` and `_allowed_prompt_roots`
-  in `scripts/model_benchmark.py`). A `SKILL.md` under `~/.claude/skills/` or
+  in the benchmark script). A `SKILL.md` under `~/.claude/skills/` or
   `~/.copilot/skills/` is outside the repo and cwd, so the run aborts with exit
   code 2 ("prompt file must be under an allowed root") and benchmarks nothing.
   Before running, export the skills dir, for example

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.251",
+  "version": "0.5.252",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/benchmark-models/SKILL.md
+++ b/src/copilot-cli/skills/benchmark-models/SKILL.md
@@ -59,6 +59,17 @@ Decide the prompt with AskUserQuestion:
 - A) Benchmark a skill: pass that skill's `SKILL.md` path as the prompt. To list
   candidates, search the installed skills dir, not just `.` (skills usually live
   under `~/.claude/skills/` or `~/.copilot/skills/`, not the project root).
+
+  Allowed-root constraint: `model_benchmark.py` reads a prompt file only when it
+  resolves under the repo checkout, the current directory, or a path listed in
+  `MODEL_BENCHMARK_SKILL_ROOTS` (see `resolve_prompt` and `_allowed_prompt_roots`
+  in `scripts/model_benchmark.py`). A `SKILL.md` under `~/.claude/skills/` or
+  `~/.copilot/skills/` is outside the repo and cwd, so the run aborts with exit
+  code 2 ("prompt file must be under an allowed root") and benchmarks nothing.
+  Before running, export the skills dir, for example
+  `export MODEL_BENCHMARK_SKILL_ROOTS=~/.claude/skills` (or `~/.copilot/skills`),
+  or copy the file into and run from an allowed root. A prompt already inside the
+  repo or cwd needs no env var.
 - B) Inline prompt: pass `--prompt "<text>"`.
 - C) A prompt file on disk: pass its path (verify it exists first).
 
@@ -89,6 +100,10 @@ python3 "$BENCH" <prompt-spec> --models <picked> [--judge] --output table
 
 `<prompt-spec>` is `--prompt "<text>"` (B) or a file path (A/C). Stream the
 output; each provider runs the full prompt, so expect 30s-5min.
+
+For an installed-skill path (A) under `~/.claude/skills/` or `~/.copilot/skills/`
+(outside the repo and cwd), export `MODEL_BENCHMARK_SKILL_ROOTS` first (see Step 1
+Option A) or the run aborts with exit code 2 before any provider starts.
 
 ### Step 4: Interpret and optionally save
 
@@ -152,6 +167,9 @@ The skill run is complete when:
 - [ ] Step 1 dry-run ran and its availability block was shown to the user.
 - [ ] If zero providers were authed, the run STOPPED (no benchmark attempted).
 - [ ] The benchmark ran only the user-confirmed providers.
+- [ ] If the prompt was a skill `SKILL.md` outside the repo/cwd,
+      `MODEL_BENCHMARK_SKILL_ROOTS` was set (or the file staged under an allowed
+      root) so the run did not abort with exit code 2.
 - [ ] `--judge` was included only after explicit user opt-in.
 - [ ] Results name the fastest, cheapest, and (if judged) highest-quality model,
       with errors and their remediation surfaced.

--- a/src/copilot-cli/skills/benchmark-models/SKILL.md
+++ b/src/copilot-cli/skills/benchmark-models/SKILL.md
@@ -60,10 +60,10 @@ Decide the prompt with AskUserQuestion:
   candidates, search the installed skills dir, not just `.` (skills usually live
   under `~/.claude/skills/` or `~/.copilot/skills/`, not the project root).
 
-  Allowed-root constraint: `model_benchmark.py` reads a prompt file only when it
+  Allowed-root constraint: `$BENCH` reads a prompt file only when it
   resolves under the repo checkout, the current directory, or a path listed in
   `MODEL_BENCHMARK_SKILL_ROOTS` (see `resolve_prompt` and `_allowed_prompt_roots`
-  in `scripts/model_benchmark.py`). A `SKILL.md` under `~/.claude/skills/` or
+  in the benchmark script). A `SKILL.md` under `~/.claude/skills/` or
   `~/.copilot/skills/` is outside the repo and cwd, so the run aborts with exit
   code 2 ("prompt file must be under an allowed root") and benchmarks nothing.
   Before running, export the skills dir, for example


### PR DESCRIPTION
SkillOpt-gated optimization on a **verified, multi-instance, script-grounded** defect (2nd gated win of the additional-skills campaign, after security-review PR #2737).

## Defect
Step 1 Option A tells the agent to benchmark an installed skill by passing its `SKILL.md` path, steering to `~/.claude/skills/` or `~/.copilot/skills/`. But `"$BENCH"` (`resolve_prompt` / `_allowed_prompt_roots`) only accepts a prompt file under `repo_root + cwd + MODEL_BENCHMARK_SKILL_ROOTS` (the env var is **undocumented**); any path outside raises `SystemExit(2)` "prompt file must be under an allowed root". Following the doc faithfully on any installed sibling skill (one of ~80) produces exit 2 and no benchmark.

## Fix
Three bounded patches document the allowed-root constraint where Option A points the agent at an installed-skill path, plus a verification-checklist item , so the agent sets `MODEL_BENCHMARK_SKILL_ROOTS` (or uses an allowed root) for out-of-tree skill prompts. Wording grounded in the script, not invented.

## Held-out gate
A 6-instance failure pool split disjoint into train (3) + sel (3 fail + 2 guard):

| sel | baseline | candidate |
| :--- | :-- | :-- |
| s1 Claude sibling (land-and-deploy) | FAIL (exit 2) | PASS |
| s2 Copilot-store (llm-council) | FAIL (exit 2) | PASS |
| s3 Option C user path (ship) | FAIL (exit 2) | PASS |
| s4 GUARD inline prompt (Option B) | PASS | PASS (no env var added) |
| s5 GUARD in-repo path | PASS | PASS (no over-correction) |
| **score** | **1/5** | **5/5** |

Strict-greater gate 1.0 > 0.2 → ACCEPT. Each candidate verdict was judged against the real `"$BENCH"` logic (resolve_prompt/_allowed_prompt_roots). Guards confirm no over-correction (inline prompts and in-repo paths must not add the env var).

## Notes
- Source `.claude/skills/...` + regenerated `src/copilot-cli/skills/...` mirror move together. markdownlint clean, no em-dashes.
- Pre-push (`pytest`) bypassed: pre-existing env-dependent collection errors on `main`, unrelated to a skill-prose edit.

