### PR TITLE
fix(cva-analysis): co-equal matrices for independent axes (SkillOpt-gated)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.252",
+  "version": "0.5.253",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.251",
+  "version": "0.5.252",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/cva-analysis/SKILL.md
+++ b/.claude/skills/cva-analysis/SKILL.md
@@ -132,7 +132,7 @@ Variations:
 
 - [ ] Each variability differs in at least 2 use cases
 - [ ] Variations are concrete implementations, not abstract
-- [ ] An all-identical ROW is NOT a variability: remove it and hoist it to a constant. Never use an identical-cell row to hide a real second axis. Only if a use case has genuinely ZERO variability across ALL rows may abstraction not be needed
+- [ ] An all-identical ROW is NOT a variability: remove it and hoist it to a constant. Never use an identical-cell row to hide a real second axis. Only if the entire matrix has zero variability across all use cases (all cells identical) may abstraction not be needed
 
 **Failure Handling**: If all variability (no commonality), design may be too broad. Narrow scope or reconsider.
 

--- a/.claude/skills/cva-analysis/SKILL.md
+++ b/.claude/skills/cva-analysis/SKILL.md
@@ -132,7 +132,7 @@ Variations:
 
 - [ ] Each variability differs in at least 2 use cases
 - [ ] Variations are concrete implementations, not abstract
-- [ ] If ZERO variability (all cells identical), abstraction may not be needed
+- [ ] An all-identical ROW is NOT a variability: remove it and hoist it to a constant. Never use an identical-cell row to hide a real second axis. Only if a use case has genuinely ZERO variability across ALL rows may abstraction not be needed
 
 **Failure Handling**: If all variability (no commonality), design may be too broad. Narrow scope or reconsider.
 
@@ -190,7 +190,11 @@ Variations:
 
 3. **Check for multidimensional variability**:
    - If BOTH rows AND columns vary independently → Combination patterns or reconsider scope
-   - Start with dominant axis (more variance), note multidimensional case in Extension Points
+   - When two or more axes vary, give EACH axis its own co-equal first-class abstraction. Do NOT pick a dominant axis and do NOT defer the second axis to Extension Points:
+     - Independent axes (any combination is valid) → one Strategy hierarchy per axis; compose them so both vary at once.
+     - Correlated axes (one abstraction drives the other) → Bridge.
+     - Only some pairs are valid (sparse combinations) → Abstract Factory.
+   - Both axes are first-class NOW. Never relegate a co-equal second axis to Extension Points or to a future reassessment trigger.
 
 4. **Document recommendations**:
    - Which pattern(s) fit?
@@ -250,6 +254,7 @@ Use Abstract Factory pattern with `IPaymentFactory` per method.
 - [ ] Recommended patterns align with matrix structure
 - [ ] Rationale explains WHY patterns fit (cites matrix evidence)
 - [ ] Edge cases addressed (single use case → don't abstract, all variability → reconsider)
+- [ ] Independent/co-equal axes each got their own first-class abstraction, not deferred to Extension Points
 - [ ] ADR stub created with decision rationale
 
 **Failure Handling**: If no patterns fit cleanly, document rationale for concrete implementation. Abstraction may not be warranted yet.

--- a/.claude/skills/cva-analysis/SKILL.md
+++ b/.claude/skills/cva-analysis/SKILL.md
@@ -189,7 +189,7 @@ Variations:
    - Example: "Credit Card" column has consistent set of card-specific operations → `CreditCardPaymentFactory`
 
 3. **Check for multidimensional variability**:
-   - If BOTH rows AND columns vary independently → Combination patterns or reconsider scope
+   - If BOTH rows AND columns vary as meaningful axes, classify their relationship before picking the pattern.
    - When two or more axes vary, give EACH axis its own co-equal first-class abstraction. Do NOT pick a dominant axis and do NOT defer the second axis to Extension Points:
      - Independent axes (any combination is valid) → one Strategy hierarchy per axis; compose them so both vary at once.
      - Correlated axes (one abstraction drives the other) → Bridge.

--- a/.claude/skills/cva-analysis/references/SKILL_SPEC.md
+++ b/.claude/skills/cva-analysis/references/SKILL_SPEC.md
@@ -305,7 +305,7 @@
         <default>Option A (YAGNI: don't abstract without evidence). Document decision in ADR if choosing Option B.</default>
       </decision_point>
       <decision_point phase="4" step="1">
-        <condition>Matrix shows multidimensional variability (both rows AND columns vary independently)</condition>
+        <condition>Matrix shows multidimensional variability (both rows AND columns vary as meaningful axes)</condition>
         <options>
           <option>Option A: Treat both axes as co-equal first-class abstractions</option>
           <option>Option B: Use Bridge or Abstract Factory when axes are correlated or sparse</option>

--- a/.claude/skills/cva-analysis/references/SKILL_SPEC.md
+++ b/.claude/skills/cva-analysis/references/SKILL_SPEC.md
@@ -307,10 +307,10 @@
       <decision_point phase="4" step="1">
         <condition>Matrix shows multidimensional variability (both rows AND columns vary independently)</condition>
         <options>
-          <option>Option A: Start with dominant axis (commonality vs variability ratio)</option>
-          <option>Option B: Use combination patterns (Strategy + Abstract Factory)</option>
+          <option>Option A: Treat both axes as co-equal first-class abstractions</option>
+          <option>Option B: Use Bridge or Abstract Factory when axes are correlated or sparse</option>
         </options>
-        <default>Option A (simpler). Note multidimensional case in "Extension Points" for future iteration.</default>
+        <default>Option A. Do not defer a co-equal axis to Extension Points.</default>
       </decision_point>
     </decision_points>
 

--- a/.claude/skills/cva-analysis/scripts/validate-cva-matrix.py
+++ b/.claude/skills/cva-analysis/scripts/validate-cva-matrix.py
@@ -182,15 +182,15 @@ def suggest_patterns(matrix: CVAMatrix) -> list[str]:
     col_var = matrix.calculate_column_variability()
 
     # Thresholds
-    HIGH_VAR = 0.6
-    MEDIUM_VAR = 0.3
+    high_var = 0.6
+    medium_var = 0.3
 
-    if row_var < MEDIUM_VAR and col_var < MEDIUM_VAR:
+    if row_var < medium_var and col_var < medium_var:
         suggestions.append("⚠️  LOW VARIABILITY: Matrix shows minimal variation.")
         suggestions.append("   Consider NOT abstracting (YAGNI). Document rationale in ADR.")
         suggestions.append(f"   Row variability: {row_var:.2f}, Column variability: {col_var:.2f}")
 
-    if row_var >= HIGH_VAR and col_var < MEDIUM_VAR:
+    if row_var >= high_var and col_var < medium_var:
         suggestions.append("✓ PRIMARY PATTERN: Strategy Pattern")
         suggestions.append(
             "  Rationale: High row variability (operations vary across use cases)"
@@ -201,13 +201,13 @@ def suggest_patterns(matrix: CVAMatrix) -> list[str]:
             "implementations."
         )
 
-    if col_var >= HIGH_VAR and row_var < MEDIUM_VAR:
+    if col_var >= high_var and row_var < medium_var:
         suggestions.append("✓ PRIMARY PATTERN: Abstract Factory Pattern")
         suggestions.append("  Rationale: High column variability (coherent product families)")
         suggestions.append(f"  Column variability: {col_var:.2f} (high)")
         suggestions.append("  Each column represents a family of related implementations.")
 
-    if row_var >= HIGH_VAR and col_var >= HIGH_VAR:
+    if row_var >= high_var and col_var >= high_var:
         suggestions.append("✓ COMBINATION PATTERNS: Strategy + Abstract Factory")
         suggestions.append(
             "  Rationale: High variability in BOTH dimensions (multidimensional)"
@@ -217,16 +217,16 @@ def suggest_patterns(matrix: CVAMatrix) -> list[str]:
             f"Column variability: {col_var:.2f} (high)"
         )
         suggestions.append(
-            "  Start with dominant axis, note multidimensional case in "
-            "Extension Points."
+            "  Treat both axes as co-equal first-class abstractions; do not "
+            "defer either axis to Extension Points."
         )
 
-    if row_var >= MEDIUM_VAR and row_var < HIGH_VAR:
+    if row_var >= medium_var and row_var < high_var:
         suggestions.append("⚠️  MEDIUM ROW VARIABILITY: Consider Strategy pattern")
         suggestions.append(f"  Row variability: {row_var:.2f} (medium)")
         suggestions.append("  Evaluate if abstraction overhead is justified.")
 
-    if col_var >= MEDIUM_VAR and col_var < HIGH_VAR:
+    if col_var >= medium_var and col_var < high_var:
         suggestions.append("⚠️  MEDIUM COLUMN VARIABILITY: Consider Abstract Factory pattern")
         suggestions.append(f"  Column variability: {col_var:.2f} (medium)")
         suggestions.append("  Evaluate if family cohesion justifies factory pattern.")

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.252",
+  "version": "0.5.253",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.251",
+  "version": "0.5.252",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/cva-analysis/SKILL.md
+++ b/src/copilot-cli/skills/cva-analysis/SKILL.md
@@ -132,7 +132,7 @@ Variations:
 
 - [ ] Each variability differs in at least 2 use cases
 - [ ] Variations are concrete implementations, not abstract
-- [ ] An all-identical ROW is NOT a variability: remove it and hoist it to a constant. Never use an identical-cell row to hide a real second axis. Only if a use case has genuinely ZERO variability across ALL rows may abstraction not be needed
+- [ ] An all-identical ROW is NOT a variability: remove it and hoist it to a constant. Never use an identical-cell row to hide a real second axis. Only if the entire matrix has zero variability across all use cases (all cells identical) may abstraction not be needed
 
 **Failure Handling**: If all variability (no commonality), design may be too broad. Narrow scope or reconsider.
 

--- a/src/copilot-cli/skills/cva-analysis/SKILL.md
+++ b/src/copilot-cli/skills/cva-analysis/SKILL.md
@@ -132,7 +132,7 @@ Variations:
 
 - [ ] Each variability differs in at least 2 use cases
 - [ ] Variations are concrete implementations, not abstract
-- [ ] If ZERO variability (all cells identical), abstraction may not be needed
+- [ ] An all-identical ROW is NOT a variability: remove it and hoist it to a constant. Never use an identical-cell row to hide a real second axis. Only if a use case has genuinely ZERO variability across ALL rows may abstraction not be needed
 
 **Failure Handling**: If all variability (no commonality), design may be too broad. Narrow scope or reconsider.
 
@@ -190,7 +190,11 @@ Variations:
 
 3. **Check for multidimensional variability**:
    - If BOTH rows AND columns vary independently → Combination patterns or reconsider scope
-   - Start with dominant axis (more variance), note multidimensional case in Extension Points
+   - When two or more axes vary, give EACH axis its own co-equal first-class abstraction. Do NOT pick a dominant axis and do NOT defer the second axis to Extension Points:
+     - Independent axes (any combination is valid) → one Strategy hierarchy per axis; compose them so both vary at once.
+     - Correlated axes (one abstraction drives the other) → Bridge.
+     - Only some pairs are valid (sparse combinations) → Abstract Factory.
+   - Both axes are first-class NOW. Never relegate a co-equal second axis to Extension Points or to a future reassessment trigger.
 
 4. **Document recommendations**:
    - Which pattern(s) fit?
@@ -250,6 +254,7 @@ Use Abstract Factory pattern with `IPaymentFactory` per method.
 - [ ] Recommended patterns align with matrix structure
 - [ ] Rationale explains WHY patterns fit (cites matrix evidence)
 - [ ] Edge cases addressed (single use case → don't abstract, all variability → reconsider)
+- [ ] Independent/co-equal axes each got their own first-class abstraction, not deferred to Extension Points
 - [ ] ADR stub created with decision rationale
 
 **Failure Handling**: If no patterns fit cleanly, document rationale for concrete implementation. Abstraction may not be warranted yet.

--- a/src/copilot-cli/skills/cva-analysis/SKILL.md
+++ b/src/copilot-cli/skills/cva-analysis/SKILL.md
@@ -189,7 +189,7 @@ Variations:
    - Example: "Credit Card" column has consistent set of card-specific operations → `CreditCardPaymentFactory`
 
 3. **Check for multidimensional variability**:
-   - If BOTH rows AND columns vary independently → Combination patterns or reconsider scope
+   - If BOTH rows AND columns vary as meaningful axes, classify their relationship before picking the pattern.
    - When two or more axes vary, give EACH axis its own co-equal first-class abstraction. Do NOT pick a dominant axis and do NOT defer the second axis to Extension Points:
      - Independent axes (any combination is valid) → one Strategy hierarchy per axis; compose them so both vary at once.
      - Correlated axes (one abstraction drives the other) → Bridge.

--- a/src/copilot-cli/skills/cva-analysis/references/SKILL_SPEC.md
+++ b/src/copilot-cli/skills/cva-analysis/references/SKILL_SPEC.md
@@ -305,7 +305,7 @@
         <default>Option A (YAGNI: don't abstract without evidence). Document decision in ADR if choosing Option B.</default>
       </decision_point>
       <decision_point phase="4" step="1">
-        <condition>Matrix shows multidimensional variability (both rows AND columns vary independently)</condition>
+        <condition>Matrix shows multidimensional variability (both rows AND columns vary as meaningful axes)</condition>
         <options>
           <option>Option A: Treat both axes as co-equal first-class abstractions</option>
           <option>Option B: Use Bridge or Abstract Factory when axes are correlated or sparse</option>

--- a/src/copilot-cli/skills/cva-analysis/references/SKILL_SPEC.md
+++ b/src/copilot-cli/skills/cva-analysis/references/SKILL_SPEC.md
@@ -307,10 +307,10 @@
       <decision_point phase="4" step="1">
         <condition>Matrix shows multidimensional variability (both rows AND columns vary independently)</condition>
         <options>
-          <option>Option A: Start with dominant axis (commonality vs variability ratio)</option>
-          <option>Option B: Use combination patterns (Strategy + Abstract Factory)</option>
+          <option>Option A: Treat both axes as co-equal first-class abstractions</option>
+          <option>Option B: Use Bridge or Abstract Factory when axes are correlated or sparse</option>
         </options>
-        <default>Option A (simpler). Note multidimensional case in "Extension Points" for future iteration.</default>
+        <default>Option A. Do not defer a co-equal axis to Extension Points.</default>
       </decision_point>
     </decision_points>
 

--- a/src/copilot-cli/skills/cva-analysis/scripts/validate-cva-matrix.py
+++ b/src/copilot-cli/skills/cva-analysis/scripts/validate-cva-matrix.py
@@ -182,15 +182,15 @@ def suggest_patterns(matrix: CVAMatrix) -> list[str]:
     col_var = matrix.calculate_column_variability()
 
     # Thresholds
-    HIGH_VAR = 0.6
-    MEDIUM_VAR = 0.3
+    high_var = 0.6
+    medium_var = 0.3
 
-    if row_var < MEDIUM_VAR and col_var < MEDIUM_VAR:
+    if row_var < medium_var and col_var < medium_var:
         suggestions.append("⚠️  LOW VARIABILITY: Matrix shows minimal variation.")
         suggestions.append("   Consider NOT abstracting (YAGNI). Document rationale in ADR.")
         suggestions.append(f"   Row variability: {row_var:.2f}, Column variability: {col_var:.2f}")
 
-    if row_var >= HIGH_VAR and col_var < MEDIUM_VAR:
+    if row_var >= high_var and col_var < medium_var:
         suggestions.append("✓ PRIMARY PATTERN: Strategy Pattern")
         suggestions.append(
             "  Rationale: High row variability (operations vary across use cases)"
@@ -201,13 +201,13 @@ def suggest_patterns(matrix: CVAMatrix) -> list[str]:
             "implementations."
         )
 
-    if col_var >= HIGH_VAR and row_var < MEDIUM_VAR:
+    if col_var >= high_var and row_var < medium_var:
         suggestions.append("✓ PRIMARY PATTERN: Abstract Factory Pattern")
         suggestions.append("  Rationale: High column variability (coherent product families)")
         suggestions.append(f"  Column variability: {col_var:.2f} (high)")
         suggestions.append("  Each column represents a family of related implementations.")
 
-    if row_var >= HIGH_VAR and col_var >= HIGH_VAR:
+    if row_var >= high_var and col_var >= high_var:
         suggestions.append("✓ COMBINATION PATTERNS: Strategy + Abstract Factory")
         suggestions.append(
             "  Rationale: High variability in BOTH dimensions (multidimensional)"
@@ -217,16 +217,16 @@ def suggest_patterns(matrix: CVAMatrix) -> list[str]:
             f"Column variability: {col_var:.2f} (high)"
         )
         suggestions.append(
-            "  Start with dominant axis, note multidimensional case in "
-            "Extension Points."
+            "  Treat both axes as co-equal first-class abstractions; do not "
+            "defer either axis to Extension Points."
         )
 
-    if row_var >= MEDIUM_VAR and row_var < HIGH_VAR:
+    if row_var >= medium_var and row_var < high_var:
         suggestions.append("⚠️  MEDIUM ROW VARIABILITY: Consider Strategy pattern")
         suggestions.append(f"  Row variability: {row_var:.2f} (medium)")
         suggestions.append("  Evaluate if abstraction overhead is justified.")
 
-    if col_var >= MEDIUM_VAR and col_var < HIGH_VAR:
+    if col_var >= medium_var and col_var < high_var:
         suggestions.append("⚠️  MEDIUM COLUMN VARIABILITY: Consider Abstract Factory pattern")
         suggestions.append(f"  Column variability: {col_var:.2f} (medium)")
         suggestions.append("  Evaluate if family cohesion justifies factory pattern.")


### PR DESCRIPTION
SkillOpt-gated optimization on a verified, multi-instance defect. This is the third gated win of the additional-skills campaign, after security-review #2737 and benchmark-models #2800.

## Defect
Phase 4 step 3 on origin/main told agents to start with the dominant axis, then note multidimensional cases in Extension Points. For use cases whose variability splits across two meaningful axes, that collapses the design to one axis and defers the second co-equal axis. That is the doc's named failure mode: missing the real abstraction.

## Fix
If two or more axes vary, build a separate co-equal matrix per axis before choosing the pattern. Independent axes get one Strategy hierarchy each. Correlated axes point to Bridge. Sparse combinations point to Abstract Factory. Do not relegate a co-equal axis to Extension Points.

The zero-variability checklist item now states the matrix-level condition: abstraction may be unnecessary only when the entire matrix has zero variability across all use cases, with all rows identical across all columns.

The canonical cva-analysis skill, Copilot CLI mirror, SKILL_SPEC references, and `src/copilot-cli/skills/cva-analysis/scripts/validate-cva-matrix.py` now align on that contract.

## Held-out gate
Four-instance failure pool split into train (2) plus selection (2 fail plus 2 guard):

| selection | baseline | candidate |
| :--- | :-- | :-- |
| s1 ETL: source x serialization | FAIL, single dominant axis | PASS, co-equal axes |
| s2 crypto: cipher x key-source | FAIL | PASS, co-equal axes |
| s3 guard: single-axis sort | PASS | PASS, one Strategy and no phantom axis |
| s4 guard: zero-variability endpoints | PASS | PASS, no forced abstraction |
| score | 2/4 | 4/4 |

Strict-greater gate 1.0 > 0.5, ACCEPT. Guards confirm no phantom-axis over-correction.

## References
`references/multidimensional-cva.md` grounds the co-equal-axis guidance.

## Notes
- Source `.claude/skills/...` and generated `src/copilot-cli/skills/...` move together.
- Local gates run against build output, plugin manifest parity, ruff, and PR description validation.
