### PR TITLE
fix: safety-audit remediation batch (7 issues) + AI-review neutral check + ADR triggers

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.254",
+  "version": "0.5.255",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
+++ b/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
@@ -26,7 +26,7 @@ import subprocess
 import sys
 
 
-def _get_file_path_from_input(hook_input: dict) -> str | None:
+def _get_file_path_from_input(hook_input: dict[str, object]) -> str | None:
     """Extract file_path from hook input."""
     tool_input = hook_input.get("tool_input", {})
     if isinstance(tool_input, dict):
@@ -35,7 +35,7 @@ def _get_file_path_from_input(hook_input: dict) -> str | None:
     return None
 
 
-def _get_project_directory(hook_input: dict) -> str:
+def _get_project_directory(hook_input: dict[str, object]) -> str:
     """Resolve project directory from env or hook input."""
     env_dir = os.environ.get("CLAUDE_PROJECT_DIR", "").strip()
     if env_dir:

--- a/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
+++ b/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
@@ -98,6 +98,14 @@ def main() -> int:
             return 0
 
         hook_input = json.loads(input_json)
+        if not isinstance(hook_input, dict):
+            # A bare JSON string/list would raise AttributeError on the .get()
+            # calls below and be swallowed by the catch-all; surface it instead.
+            print(
+                "CodeQL Quick Scan skipped (input JSON is not an object)",
+                file=sys.stderr,
+            )
+            return 0
         file_path = _get_file_path_from_input(hook_input)
 
         if file_path is None or not _should_scan_file(file_path):
@@ -181,8 +189,14 @@ def main() -> int:
         pass
     except (OSError, PermissionError):
         pass
-    except Exception:
-        pass
+    except Exception as exc:
+        # Non-blocking hook: still return 0, but do not silently swallow an
+        # unexpected error. Surface the type and message so a broken scan is
+        # observable instead of vanishing.
+        print(
+            f"CodeQL Quick Scan skipped (unexpected {type(exc).__name__}: {exc})",
+            file=sys.stderr,
+        )
 
     return 0
 

--- a/.claude/hooks/PreToolUse/invoke_branch_protection_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_branch_protection_guard.py
@@ -52,8 +52,17 @@ def main() -> int:
 
         hook_input = json.loads(input_json)
     except (json.JSONDecodeError, ValueError) as exc:
-        print(f"branch_protection_guard: Failed to parse input JSON: {exc}", file=sys.stderr)
-        return 0
+        # Fail closed to match this file's contract: the git-error and generic
+        # exception paths below both block (return 2 via write_block_response).
+        # Unparseable input means branch safety cannot be verified, so block
+        # rather than allow a possibly-protected-branch commit or push.
+        msg = (
+            f"branch_protection_guard: Failed to parse input JSON: {exc}. "
+            "Cannot verify branch safety; blocking."
+        )
+        print(msg, file=sys.stderr)
+        write_block_response(msg)
+        return 2
 
     cwd = get_working_directory(hook_input)
 

--- a/.claude/hooks/PreToolUse/push_guard_base.py
+++ b/.claude/hooks/PreToolUse/push_guard_base.py
@@ -381,25 +381,40 @@ def _detect_default_base_ref(cwd: str) -> str:
     return "origin/main"
 
 
-def _read_stdin_command() -> str | None:
+def _read_stdin_command(name: str) -> str | None:
+    """Parse the tool command from hook stdin, or return None.
+
+    Fail-open with telemetry: every anomalous stdin shape (oversize, unparseable
+    JSON, non-object payload, missing/mistyped tool_input, missing/mistyped
+    command) emits a structured ``EVENT=...`` fail-open line via _emit_fail_open
+    and still returns None, preserving the framework's documented allow-but-observe
+    contract (see the module docstring, "Operations and telemetry"). The isatty
+    and empty-stdin paths are legitimate no-ops (interactive terminal, nothing
+    piped) and do NOT emit an event.
+    """
     if sys.stdin.isatty():
         return None
     raw = sys.stdin.read(MAX_STDIN_BYTES + 1)
     if len(raw) > MAX_STDIN_BYTES:
+        _emit_fail_open(name, "bad_stdin", f"stdin exceeds {MAX_STDIN_BYTES} bytes")
         return None
     if not raw.strip():
         return None
     try:
         payload = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError) as exc:
+        _emit_fail_open(name, "bad_stdin", f"unparseable JSON: {type(exc).__name__}")
         return None
     if not isinstance(payload, dict):
+        _emit_fail_open(name, "bad_stdin", "payload not a JSON object")
         return None
     tool_input = payload.get("tool_input")
     if not isinstance(tool_input, dict):
+        _emit_fail_open(name, "bad_stdin", "tool_input missing/not object")
         return None
     command = tool_input.get("command")
     if not isinstance(command, str) or not command:
+        _emit_fail_open(name, "bad_stdin", "command missing/not non-empty string")
         return None
     return command
 
@@ -481,7 +496,7 @@ def run_guard(
     if skip_if_consumer_repo(name):
         return 0
     try:
-        command = _read_stdin_command()
+        command = _read_stdin_command(name)
         if command is None:
             return 0
         # Defense in depth: even when the harness matcher is `Bash(git push*)`,

--- a/.claude/lib/hook_utilities/guards.py
+++ b/.claude/lib/hook_utilities/guards.py
@@ -1,10 +1,16 @@
 """Canonical: scripts/hook_utilities/guards.py. Sync via scripts/sync_plugin_lib.py."""
 
+import json
 import os
 import shutil
 import subprocess
 import sys
 from typing import Literal
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback path
+    tomllib = None  # type: ignore[assignment]
 
 from .utilities import get_project_directory
 
@@ -90,6 +96,58 @@ def is_project_repo() -> bool:
     return _project_repo_identity() == "project"
 
 
+def _project_repo_corroborated(project_root: str) -> bool:
+    """Second cheap signal that ``project_root`` is the ai-agents project repo.
+
+    Used only when the git origin remote is unavailable (identity "unknown").
+    Reads ``pyproject.toml``'s ``[project].name``: the ai-agents project repo
+    declares ``name = "ai-agents"`` (verified in the repo-root pyproject.toml),
+    while a consumer repo that vendors the plugin declares its own name, so this
+    stays False there. A missing file, unavailable tomllib (Python 3.10), or a
+    parse error yields False so the caller still fails open outside the project.
+    """
+    if tomllib is None:
+        return False
+    pyproject = os.path.join(project_root, "pyproject.toml")
+    try:
+        with open(pyproject, "rb") as handle:
+            data = tomllib.load(handle)
+    except (OSError, ValueError):
+        return False
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return False
+    name = project.get("name")
+    return isinstance(name, str) and name.strip().lower() == _PROJECT_REPO_NAME
+
+
+def _emit_skip_event(hook_name: str, reason: str, detail: str) -> None:
+    """Emit a structured ``EVENT=...`` line when an unknown-identity checkout
+    skips every internal guard, so a silent whole-surface fail-open is
+    observable in telemetry.
+
+    Mirrors the fail-open EVENT shape emitted by
+    ``.claude/hooks/PreToolUse/push_guard_base.py::_emit_fail_open``:
+        event = {
+            "guard": name,
+            "code": f"E_{code}",
+            "outcome": "fail_open",
+            "reason": reason,
+            "detail": detail,
+        }
+        print(f"EVENT={json.dumps(event, separators=(',', ':'))}", file=sys.stderr)
+    """
+    code = hook_name.upper().replace("-", "_")
+    event = {
+        "guard": hook_name,
+        "code": f"E_{code}",
+        "outcome": "fail_open",
+        "reason": reason,
+        "detail": detail,
+    }
+    print(f"EVENT={json.dumps(event, separators=(',', ':'))}", file=sys.stderr)
+
+
 def skip_if_consumer_repo(hook_name: str) -> bool:
     """Print skip message and return True unless this is confirmed project repo."""
     identity = _project_repo_identity()
@@ -100,6 +158,18 @@ def skip_if_consumer_repo(hook_name: str) -> bool:
         )
         return True
     if identity == "unknown":
+        # Git origin is unavailable, so identity is indeterminate. Before
+        # skipping every internal guard (a silent whole-surface fail-open),
+        # corroborate with a second cheap signal: pyproject.toml's
+        # [project].name. Only the ai-agents project repo declares that name,
+        # so a consumer repo that vendors the plugin still skips here.
+        if _project_repo_corroborated(get_project_directory()):
+            return False
+        _emit_skip_event(
+            hook_name,
+            "identity_unknown",
+            "git origin unavailable and pyproject name corroboration absent",
+        )
         print(
             f"[SKIP] {hook_name}: cannot verify ai-agents project repo identity; "
             "treating as consumer repo",

--- a/.claude/lib/hook_utilities/guards.py
+++ b/.claude/lib/hook_utilities/guards.py
@@ -7,10 +7,10 @@ import subprocess
 import sys
 from typing import Literal
 
-try:
-    import tomllib  # Python 3.11+
-except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback path
-    tomllib = None  # type: ignore[assignment]
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - 3.10 fallback path
+    tomllib = None
 
 from .utilities import get_project_directory
 

--- a/.claude/skills/adr-generator/SKILL.md
+++ b/.claude/skills/adr-generator/SKILL.md
@@ -2,7 +2,7 @@
 name: adr-generator
 version: 1.1.0
 model: claude-opus-4-6
-description: Create comprehensive Architectural Decision Records (ADRs). Researches the destination directory to detect existing template conventions, gathers context, determines next ADR number, generates the ADR, validates completeness, and saves. Supports multiple ADR formats (MADR, Nygard, Alexandrian, project canonical). Use when documenting technical decisions or creating new ADR files. Use when you say "write an ADR", "document this decision". Do NOT use to debate or review an existing ADR (use adr-review).
+description: Create comprehensive Architectural Decision Records (ADRs). Researches the destination directory to detect existing template conventions, gathers context, determines next ADR number, generates the ADR, validates completeness, and saves. Supports multiple ADR formats (MADR, Nygard, Alexandrian, project canonical). Use when documenting technical decisions, creating new ADR files, or capturing rationale so future readers can revisit a choice. Use when you say "write an ADR", "document this decision", "document these design choices", "record why we chose this", "capture the rationale", or "for future maintainers", or when creating an ADR-like markdown file under docs/decisions/, docs/adr/, docs/architecture/, architecture/decisions/, or .agents/architecture/. Do NOT use to debate or review an existing ADR (use adr-review).
 license: MIT
 user-invocable: true
 metadata:
@@ -24,7 +24,7 @@ Create well-structured Architectural Decision Records that document technical de
 | `generate ADR` | Full ADR generation workflow |
 | `write an architecture decision record` | Full ADR generation workflow |
 | `new ADR for` | Targeted ADR for a specific decision |
-| `document this architecture decision` | Full ADR generation workflow |
+| `document these design choices` | Full ADR generation workflow (paraphrase) |
 
 ---
 
@@ -36,6 +36,7 @@ create an ADR for database selection
 new ADR for authentication strategy
 document this architecture decision about event sourcing
 generate ADR for switching from REST to gRPC
+document these design choices for future us to revisit as models change
 ```
 
 ---
@@ -84,7 +85,7 @@ Explore the codebase to find where ADRs live. Do not assume a fixed location.
 3. **Check for ADR tooling config**: Look for `.adr-dir` files (used by `adr-tools`) or ADR references in README, CONTRIBUTING, or project documentation
 4. **If user specifies a location**: Use that, regardless of what exists elsewhere
 
-Note: `.agents/architecture/` and `docs/architecture/` are monitored by `adr-review` for auto-triggered review. ADRs in other directories require manual `adr-review` invocation.
+Note: `.agents/architecture/` and `docs/architecture/` are monitored by `adr-review` for auto-triggered review. ADRs written to `docs/decisions/`, `docs/adr/`, or `architecture/decisions/` are NOT auto-monitored; after saving to any of these, explicitly recommend the user invoke `adr-review` manually. This keeps this skill's discovered path list aligned with `adr-review`'s real auto-trigger coverage.
 
 #### Step 2: Detect template from existing ADRs
 

--- a/.claude/skills/adr-review/SKILL.md
+++ b/.claude/skills/adr-review/SKILL.md
@@ -2,7 +2,7 @@
 name: adr-review
 version: 1.1.0
 model: claude-opus-4-6
-description: Multi-agent debate orchestration for Architecture Decision Records. Automatically triggers on ADR create/edit/delete. Coordinates architect, critic, independent-thinker, security, analyst, and high-level-advisor agents in structured debate rounds until consensus. Use when you say "review this ADR", or on ADR create/edit. Do NOT use to author a new ADR (use adr-generator).
+description: Multi-agent debate orchestration for Architecture Decision Records. Automatically triggers on ADR create/edit/delete. Coordinates architect, critic, independent-thinker, security, analyst, and high-level-advisor agents in structured debate rounds until consensus. Use when you say "review this ADR", when an ADR is created/edited/deleted, or when reviewing, accepting, or updating a decision file under .agents/architecture/, docs/architecture/, docs/decisions/, docs/adr/, or architecture/decisions/ (only .agents/architecture and docs/architecture auto-trigger; the rest need manual invocation). Do NOT use to author a new ADR (use adr-generator).
 license: MIT
 metadata:
   subagent_model: claude-opus-4-6

--- a/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -35,7 +35,7 @@ import sys
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 # Sibling helpers must import when this file is loaded by path in tests.
 # Keep any sys.path change scoped to this import block.
@@ -103,9 +103,9 @@ class ScanResult:
         default_factory=lambda: datetime.now(UTC).isoformat()
     )
     files_scanned: int = 0
-    vulnerabilities: list = field(default_factory=list)
-    suppressed: list = field(default_factory=list)
-    errors: list = field(default_factory=list)
+    vulnerabilities: list[Any] = field(default_factory=list)
+    suppressed: list[Any] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
 
 
 def get_language(file_path: str) -> str | None:

--- a/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -164,7 +164,23 @@ def get_staged_files() -> list[str]:
             check=True,
         )
         return [f for f in result.stdout.strip().split("\n") if f]
-    except subprocess.CalledProcessError:
+    except FileNotFoundError:
+        # git binary missing on PATH: distinct from a non-zero git exit. Emit a
+        # clear diagnostic and return [] so _collect_files_to_scan fails closed
+        # (prints "No files to scan" and exits EXIT_ERROR), never fail-open.
+        print(
+            "ERROR: git executable not found on PATH; cannot enumerate staged files.",
+            file=sys.stderr,
+        )
+        return []
+    except subprocess.CalledProcessError as exc:
+        # git ran but returned non-zero. Report the failure explicitly; return []
+        # so the caller reports no files and exits with error (fail-closed).
+        print(
+            f"ERROR: git staged-file enumeration failed ({exc}); "
+            "scan will report no files and exit with error.",
+            file=sys.stderr,
+        )
         return []
 
 

--- a/.github/actions/agent-review/action.yml
+++ b/.github/actions/agent-review/action.yml
@@ -121,6 +121,11 @@ runs:
     - name: ${{ inputs.emoji }} ${{ inputs.agent }} Review
       if: inputs.should-run == 'true' && steps.cache.outputs.cache-hit != 'true'
       id: review
+      # An internal ai-review infra failure (Copilot CLI unavailable) exits non-zero.
+      # continue-on-error lets the always() "Check verdict and fail if needed" step be
+      # the single authority on job pass/fail: infra failures exit 0 there (green,
+      # non-blocking), while a genuine code-quality FAIL still exits 1 there (red).
+      continue-on-error: true
       uses: ./.github/actions/ai-review
       with:
         agent: ${{ inputs.review-agent != '' && inputs.review-agent || inputs.agent }}

--- a/.github/scripts/generate_quality_report.py
+++ b/.github/scripts/generate_quality_report.py
@@ -113,10 +113,14 @@ def _build_action_required_section(
     pr_author: str,
     final_verdict: str,
     verdicts: dict[str, str],
+    categories: dict[str, str],
 ) -> str:
     """Build an action-required section that @mentions the PR author.
 
     Only emits content when actionable verdicts (CRITICAL_FAIL, FAIL, etc.) exist.
+    Agents whose failure category is INFRASTRUCTURE never ran (Copilot CLI
+    unavailable), so they are excluded: listing them as having flagged issues is
+    the alarm-fatigue symptom of issue #2818.
     """
     if not pr_author:
         return ""
@@ -125,6 +129,7 @@ def _build_action_required_section(
         _AGENT_DISPLAY_NAMES[agent]
         for agent in _AGENTS
         if verdicts.get(agent, "") in FAIL_VERDICTS
+        and categories.get(agent, "") != "INFRASTRUCTURE"
     ]
     if not actionable_agents:
         return ""
@@ -146,7 +151,19 @@ def _build_action_required_section(
     return "\n".join(lines)
 
 
-def _build_findings_sections() -> str:
+def _empty_findings_message(agent: str, categories: dict[str, str]) -> str:
+    """Message for an agent whose findings file exists but is empty.
+
+    An INFRASTRUCTURE category means the agent never ran (Copilot CLI
+    unavailable), so an empty file is expected and reported as such rather than
+    as a missing-findings warning (issue #2818).
+    """
+    if categories.get(agent, "") == "INFRASTRUCTURE":
+        return "\u2139\ufe0f Agent did not run: Copilot CLI unavailable"
+    return "\u26a0\ufe0f No findings available (empty file)"
+
+
+def _build_findings_sections(categories: dict[str, str]) -> str:
     """Read findings files for each agent and build collapsible sections."""
     sections = ""
     for agent in _AGENTS:
@@ -165,7 +182,7 @@ def _build_findings_sections() -> str:
                 else:
                     sections += (
                         f"\n<details>\n<summary>{title}</summary>"
-                        "\n\n\u26a0\ufe0f No findings available (empty file)\n\n</details>\n"
+                        f"\n\n{_empty_findings_message(agent, categories)}\n\n</details>\n"
                     )
             except OSError as exc:
                 print(f"::error::Failed to read findings file for {agent}: {exc}")
@@ -266,8 +283,10 @@ def main(argv: list[str] | None = None) -> int:
     lines.append("")
 
     report = "\n".join(lines)
-    report += _build_action_required_section(pr_author, final_verdict, verdicts)
-    report += _build_findings_sections()
+    report += _build_action_required_section(
+        pr_author, final_verdict, verdicts, categories
+    )
+    report += _build_findings_sections(categories)
 
     footer_lines = [
         "",

--- a/.github/workflows/audit-hook-bypass.yml
+++ b/.github/workflows/audit-hook-bypass.yml
@@ -46,10 +46,20 @@ jobs:
       - name: Run bypass detection
         id: detect
         run: |
+          # Issue #2808: `|| true` masked the crash path. detect_hook_bypass.py
+          # returns 0=no indicators, 1=indicators (intended non-blocking audit),
+          # 2=config/crash. Capture the code and hard-fail on >=2 instead of
+          # reporting a clean audit when the detector never ran.
+          rc=0
           python3 scripts/detect_hook_bypass.py \
             --base-ref origin/main \
             --output artifacts/hook-bypass-audit.json \
-            || true
+            || rc=$?
+
+          if [ "$rc" -ge 2 ]; then
+            echo "::error::hook-bypass detection failed (exit $rc)"
+            exit "$rc"
+          fi
 
           if [ -f artifacts/hook-bypass-audit.json ]; then
             count=$(python3 -c "
@@ -60,7 +70,10 @@ jobs:
           ")
             echo "indicator_count=$count" >> "$GITHUB_OUTPUT"
           else
-            echo "indicator_count=0" >> "$GITHUB_OUTPUT"
+            # No JSON means the detector produced no output: fail instead of
+            # masking it as a zero-indicator (clean) audit.
+            echo "::error::detection produced no JSON output"
+            exit 1
           fi
 
       - name: Report findings

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -93,8 +93,18 @@ jobs:
         id: details
         if: steps.drift.outputs.drift_detected == 'true'
         run: |
-          # Re-run to get JSON output for issue body
-          python3 build/scripts/detect_agent_drift.py --output-format json > "drift-results.json" 2>/dev/null || true
+          # Re-run to get JSON output for issue body. Issue #2808: the old
+          # `2>/dev/null || true` swallowed stderr and every exit code, so a
+          # crashed re-run fed empty JSON to parse_drift_results.py. This step
+          # only runs when drift was already detected, so exit 1 (blocking
+          # drift) is the EXPECTED path here; only exit >=2 (config/crash) is a
+          # real failure. Capture the code, keep stderr, and fail on >=2.
+          rc=0
+          python3 build/scripts/detect_agent_drift.py --output-format json > "drift-results.json" || rc=$?
+          if [ "$rc" -ge 2 ]; then
+            echo "::error::drift detection crashed on re-run (exit $rc)"
+            exit "$rc"
+          fi
 
           # Parse JSON into the issue body and agent count (ADR-006: no logic in YAML).
           python3 scripts/ci/parse_drift_results.py \

--- a/.github/workflows/memory-validation.yml
+++ b/.github/workflows/memory-validation.yml
@@ -91,8 +91,16 @@ jobs:
         id: verify
         continue-on-error: true
         run: |
-          python -m memory_enhancement verify-all --json > memory-validation-results.json
-          echo "exit_code=$?" >> $GITHUB_OUTPUT
+          # Issue #2808: GitHub runs steps with `bash -eo pipefail`, so a
+          # verify-all crash aborted the step before `$?` was captured, and the
+          # parse step below then defaulted to a green Pass. Capture the code
+          # explicitly so the parse step can distinguish crash from clean.
+          rc=0
+          python -m memory_enhancement verify-all --json > memory-validation-results.json || rc=$?
+          echo "exit_code=$rc" >> $GITHUB_OUTPUT
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning::verify-all exited $rc; results may be incomplete"
+          fi
 
       - name: Generate health report
         if: steps.should-run.outputs.skip != 'true'
@@ -113,7 +121,10 @@ jobs:
         if: steps.should-run.outputs.skip != 'true'
         id: parse
         run: |
-          if [ -f memory-validation-results.json ]; then
+          # Issue #2808: use -s (exists AND non-empty) so a truncated results
+          # file from a crashed verify-all falls into the error branch instead
+          # of a silent Pass.
+          if [ -s memory-validation-results.json ]; then
             total=$(jq 'length' memory-validation-results.json)
             stale=$(jq '[.[] | select(.valid == false)] | length' memory-validation-results.json)
             valid=$((total - stale))
@@ -128,7 +139,10 @@ jobs:
               echo "has_stale=false" >> $GITHUB_OUTPUT
             fi
           else
-            echo "has_stale=false" >> $GITHUB_OUTPUT
+            # Missing/empty results means verify-all crashed. Fail the job
+            # instead of posting the green Pass banner on a broken run.
+            echo "::error::memory-validation-results.json missing or empty (verify-all likely crashed)"
+            exit 1
           fi
 
       - name: Post PR comment

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -227,7 +227,7 @@ jobs:
       - name: Run Bandit
         run: |
           mkdir -p artifacts
-          bandit -r .claude/ scripts/ -f sarif -o artifacts/bandit-results.sarif --severity-level high --confidence-level high
+          bandit -r .claude/ scripts/ -x '*/tests/*,*/test/*' -f sarif -o artifacts/bandit-results.sarif --severity-level high --confidence-level high
 
       - name: Upload Bandit results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -243,7 +243,11 @@ jobs:
       # codeql-analysis.yml.
       - name: Upload Bandit SARIF to code scanning
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        # Best-effort surfacing: the Bandit step above is the hard gate. Code
+        # scanning may be unavailable (GHAS not enabled, fork PR), so do not let
+        # the upload fail the security job. Issue #2808.
         if: always()
+        continue-on-error: true
         with:
           sarif_file: artifacts/bandit-results.sarif
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -178,9 +178,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # Required so bandit findings reach GitHub code scanning via
-      # codeql-action/upload-sarif (Issue #2808).
-      security-events: write
 
     steps:
       - name: Harden Runner
@@ -219,37 +216,25 @@ jobs:
             --ignore-vuln CVE-2026-6357
 
       # Issue #2808: `|| true` masked both bandit crashes and genuine findings,
-      # turning this security step green regardless. Gate on high severity AND
-      # high confidence so real high-risk findings (and config/crash exits) fail
-      # CI while the pre-existing low/medium backlog stays non-blocking. The
-      # SARIF is still written before a non-zero exit, so the upload steps below
-      # (both if: always()) publish it either way.
+      # turning this step green regardless (bandit even errored on the missing
+      # SARIF formatter and nobody noticed). Gate on high severity AND high
+      # confidence so real high-risk findings fail CI, scoped off test-only
+      # false positives. JSON output keeps the artifact self-contained; the
+      # code-scanning SARIF surfacing needs the bandit-sarif-formatter dep and
+      # is deferred to a focused follow-up PR (lockfile change, over this PR's
+      # file budget).
       - name: Run Bandit
         run: |
           mkdir -p artifacts
-          bandit -r .claude/ scripts/ -x '*/tests/*,*/test/*' -f sarif -o artifacts/bandit-results.sarif --severity-level high --confidence-level high
+          bandit -r .claude/ scripts/ -x '*/tests/*,*/test/*' -f json -o artifacts/bandit-results.json --severity-level high --confidence-level high
 
       - name: Upload Bandit results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: bandit-results
-          path: artifacts/bandit-results.sarif
+          path: artifacts/bandit-results.json
           retention-days: 7
-
-      # Issue #2808: publish bandit findings to code scanning instead of leaving
-      # them in an artifact nobody reads. if: always() so findings surface even
-      # when the bandit step above exits non-zero. SHA matches the pin in
-      # codeql-analysis.yml.
-      - name: Upload Bandit SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
-        # Best-effort surfacing: the Bandit step above is the hard gate. Code
-        # scanning may be unavailable (GHAS not enabled, fork PR), so do not let
-        # the upload fail the security job. Issue #2808.
-        if: always()
-        continue-on-error: true
-        with:
-          sarif_file: artifacts/bandit-results.sarif
 
   # Pass-through job: satisfies required "Run Python Tests" check when no Python files changed.
   # GitHub branch protection requires SUCCESS (not SKIPPED) for required checks.

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -178,6 +178,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required so bandit findings reach GitHub code scanning via
+      # codeql-action/upload-sarif (Issue #2808).
+      security-events: write
 
     steps:
       - name: Harden Runner
@@ -215,10 +218,16 @@ jobs:
             --ignore-vuln CVE-2026-3219 \
             --ignore-vuln CVE-2026-6357
 
+      # Issue #2808: `|| true` masked both bandit crashes and genuine findings,
+      # turning this security step green regardless. Gate on high severity AND
+      # high confidence so real high-risk findings (and config/crash exits) fail
+      # CI while the pre-existing low/medium backlog stays non-blocking. The
+      # SARIF is still written before a non-zero exit, so the upload steps below
+      # (both if: always()) publish it either way.
       - name: Run Bandit
         run: |
           mkdir -p artifacts
-          bandit -r .claude/ scripts/ -f sarif -o artifacts/bandit-results.sarif || true
+          bandit -r .claude/ scripts/ -f sarif -o artifacts/bandit-results.sarif --severity-level high --confidence-level high
 
       - name: Upload Bandit results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -227,6 +236,16 @@ jobs:
           name: bandit-results
           path: artifacts/bandit-results.sarif
           retention-days: 7
+
+      # Issue #2808: publish bandit findings to code scanning instead of leaving
+      # them in an artifact nobody reads. if: always() so findings surface even
+      # when the bandit step above exits non-zero. SHA matches the pin in
+      # codeql-analysis.yml.
+      - name: Upload Bandit SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        if: always()
+        with:
+          sarif_file: artifacts/bandit-results.sarif
 
   # Pass-through job: satisfies required "Run Python Tests" check when no Python files changed.
   # GitHub branch protection requires SUCCESS (not SKIPPED) for required checks.

--- a/evals/skill-router-spike/fixtures.json
+++ b/evals/skill-router-spike/fixtures.json
@@ -102,6 +102,18 @@
     "correct": "adr-review"
   },
   {
+    "id": "adr-03-paraphrase",
+    "query": "We should document those design choices for future us to revisit when models and harnesses change.",
+    "candidates": ["adr-generator", "adr-review"],
+    "correct": "adr-generator"
+  },
+  {
+    "id": "adr-04-review-path",
+    "query": "I created a decision record under docs/decisions. Review it before we keep going.",
+    "candidates": ["adr-generator", "adr-review"],
+    "correct": "adr-review"
+  },
+  {
     "id": "bvb-01-library-exists",
     "query": "Is there an existing library for this? Should I build it or use something that already exists?",
     "candidates": ["buy-vs-build-framework", "programming-advisor"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,17 @@ disallow_any_generics = false
 module = "test_rework_warning"
 disable_error_code = ["misc"]
 
+
+[[tool.mypy.overrides]]
+# Pre-existing try/except ImportError fallback pattern (from .path_utils / from
+# path_utils) reads as a redefinition under standalone mypy; used across
+# scripts/quality_gate/*. Not a real redefinition.
+module = [
+    "scripts.quality_gate.load_review_results",
+    "scripts.quality_gate.check_infrastructure_failures",
+]
+disable_error_code = ["no-redef"]
+
 [dependency-groups]
 dev = [
     "pytest-cov>=7.1.0",

--- a/scripts/hook_utilities/guards.py
+++ b/scripts/hook_utilities/guards.py
@@ -1,10 +1,16 @@
 """Plugin-mode guards for hook scripts."""
 
+import json
 import os
 import shutil
 import subprocess
 import sys
 from typing import Literal
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback path
+    tomllib = None  # type: ignore[assignment]
 
 from scripts.hook_utilities.utilities import get_project_directory
 
@@ -90,6 +96,58 @@ def is_project_repo() -> bool:
     return _project_repo_identity() == "project"
 
 
+def _project_repo_corroborated(project_root: str) -> bool:
+    """Second cheap signal that ``project_root`` is the ai-agents project repo.
+
+    Used only when the git origin remote is unavailable (identity "unknown").
+    Reads ``pyproject.toml``'s ``[project].name``: the ai-agents project repo
+    declares ``name = "ai-agents"`` (verified in the repo-root pyproject.toml),
+    while a consumer repo that vendors the plugin declares its own name, so this
+    stays False there. A missing file, unavailable tomllib (Python 3.10), or a
+    parse error yields False so the caller still fails open outside the project.
+    """
+    if tomllib is None:
+        return False
+    pyproject = os.path.join(project_root, "pyproject.toml")
+    try:
+        with open(pyproject, "rb") as handle:
+            data = tomllib.load(handle)
+    except (OSError, ValueError):
+        return False
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return False
+    name = project.get("name")
+    return isinstance(name, str) and name.strip().lower() == _PROJECT_REPO_NAME
+
+
+def _emit_skip_event(hook_name: str, reason: str, detail: str) -> None:
+    """Emit a structured ``EVENT=...`` line when an unknown-identity checkout
+    skips every internal guard, so a silent whole-surface fail-open is
+    observable in telemetry.
+
+    Mirrors the fail-open EVENT shape emitted by
+    ``.claude/hooks/PreToolUse/push_guard_base.py::_emit_fail_open``:
+        event = {
+            "guard": name,
+            "code": f"E_{code}",
+            "outcome": "fail_open",
+            "reason": reason,
+            "detail": detail,
+        }
+        print(f"EVENT={json.dumps(event, separators=(',', ':'))}", file=sys.stderr)
+    """
+    code = hook_name.upper().replace("-", "_")
+    event = {
+        "guard": hook_name,
+        "code": f"E_{code}",
+        "outcome": "fail_open",
+        "reason": reason,
+        "detail": detail,
+    }
+    print(f"EVENT={json.dumps(event, separators=(',', ':'))}", file=sys.stderr)
+
+
 def skip_if_consumer_repo(hook_name: str) -> bool:
     """Print skip message and return True unless this is confirmed project repo."""
     identity = _project_repo_identity()
@@ -100,6 +158,18 @@ def skip_if_consumer_repo(hook_name: str) -> bool:
         )
         return True
     if identity == "unknown":
+        # Git origin is unavailable, so identity is indeterminate. Before
+        # skipping every internal guard (a silent whole-surface fail-open),
+        # corroborate with a second cheap signal: pyproject.toml's
+        # [project].name. Only the ai-agents project repo declares that name,
+        # so a consumer repo that vendors the plugin still skips here.
+        if _project_repo_corroborated(get_project_directory()):
+            return False
+        _emit_skip_event(
+            hook_name,
+            "identity_unknown",
+            "git origin unavailable and pyproject name corroboration absent",
+        )
         print(
             f"[SKIP] {hook_name}: cannot verify ai-agents project repo identity; "
             "treating as consumer repo",

--- a/scripts/hook_utilities/guards.py
+++ b/scripts/hook_utilities/guards.py
@@ -7,10 +7,10 @@ import subprocess
 import sys
 from typing import Literal
 
-try:
-    import tomllib  # Python 3.11+
-except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback path
-    tomllib = None  # type: ignore[assignment]
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - 3.10 fallback path
+    tomllib = None
 
 from scripts.hook_utilities.utilities import get_project_directory
 

--- a/scripts/memory_sync/mcp_client.py
+++ b/scripts/memory_sync/mcp_client.py
@@ -12,10 +12,10 @@ import collections
 import json
 import logging
 import os
-import select
+import queue
 import subprocess
-import sys
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +24,10 @@ _logger = logging.getLogger(__name__)
 FORGETFUL_DB_PATH = Path.home() / ".local" / "share" / "forgetful" / "forgetful.db"
 DEFAULT_TIMEOUT = 10.0
 MCP_COMMAND = ["uvx", "forgetful-ai"]
+
+# Sentinel enqueued by the stdout reader thread when the subprocess closes its
+# stdout (EOF) or the read fails. Distinguishes a real close from a read timeout.
+_STDOUT_EOF = object()
 
 
 class McpError(Exception):
@@ -55,6 +59,15 @@ class McpClient:
             target=self._drain_stderr, daemon=True
         )
         self._stderr_thread.start()
+        # Blocking os.read runs on a daemon thread that feeds this queue, so the
+        # reader is decoupled from the deadline check. This gives every platform
+        # (including Windows, where select on a pipe fd is unavailable) a real
+        # read timeout via queue.Queue.get(timeout=...).
+        self._read_queue: queue.Queue[Any] = queue.Queue()
+        self._stdout_thread = threading.Thread(
+            target=self._drain_stdout, daemon=True
+        )
+        self._stdout_thread.start()
 
     @classmethod
     def create(
@@ -195,21 +208,20 @@ class McpClient:
     def _read_response(self, expected_id: int) -> dict[str, Any]:
         """Read a JSON-RPC response matching the expected ID.
 
-        Uses os.read on the raw file descriptor with select for timeouts.
-        This avoids the buffered I/O + select incompatibility where
-        BufferedReader consumes data from the fd into its internal buffer,
-        making subsequent select calls miss available data.
+        Bytes arrive from a daemon reader thread via ``self._read_queue`` (the
+        thread does the blocking ``os.read`` on the raw fd, avoiding the buffered
+        I/O incompatibility where a BufferedReader pulls data into its internal
+        buffer). A single overall deadline of ``self._timeout`` seconds bounds
+        the entire wait for this response, so streaming notifications or a stream
+        of id-mismatched responses cannot loop forever.
         """
-        stdout = self._process.stdout
-        if stdout is None:
-            raise McpError("Process stdout is not available")
-        fd = stdout.fileno()
+        deadline = time.monotonic() + self._timeout
 
         buf = b""
         while True:
             header_end = buf.find(b"\r\n\r\n")
             while header_end == -1:
-                buf += self._read_bytes(fd)
+                buf += self._read_bytes(deadline - time.monotonic())
                 header_end = buf.find(b"\r\n\r\n")
 
             header = buf[:header_end + 4].decode("utf-8")
@@ -217,7 +229,7 @@ class McpClient:
             body_start = header_end + 4
 
             while len(buf) - body_start < content_length:
-                buf += self._read_bytes(fd)
+                buf += self._read_bytes(deadline - time.monotonic())
 
             body = buf[body_start:body_start + content_length]
             buf = buf[body_start + content_length:]
@@ -238,21 +250,52 @@ class McpClient:
 
             return response
 
-    def _read_bytes(self, fd: int) -> bytes:
-        """Read available bytes from fd with timeout."""
-        if sys.platform != "win32":
-            ready, _, _ = select.select([fd], [], [], self._timeout)
-            if not ready:
-                raise McpError(
-                    f"Timeout waiting for response (>{self._timeout}s)"
-                )
-        chunk = os.read(fd, 4096)
-        if not chunk:
+    def _read_bytes(self, remaining: float) -> bytes:
+        """Return the next chunk from the reader thread within ``remaining`` seconds.
+
+        Raises McpError if the overall deadline has passed (``remaining`` <= 0),
+        if no chunk arrives before ``remaining`` elapses, or if the subprocess
+        closed its stdout (EOF sentinel).
+        """
+        if remaining <= 0:
+            raise McpError(f"Timeout waiting for response (>{self._timeout}s)")
+        try:
+            chunk = self._read_queue.get(timeout=remaining)
+        except queue.Empty:
+            raise McpError(
+                f"Timeout waiting for response (>{self._timeout}s)"
+            ) from None
+        if not isinstance(chunk, bytes):
+            # The _STDOUT_EOF sentinel (or any non-bytes marker) means the
+            # reader thread saw stdout close or fail.
             stderr_tail = list(self._stderr_lines)[-10:]
             if stderr_tail:
                 _logger.debug("MCP server stderr: %s", "\n".join(stderr_tail))
             raise McpError("MCP server closed stdout unexpectedly")
         return chunk
+
+    def _drain_stdout(self) -> None:
+        """Read stdout on a background thread, feeding chunks to the read queue.
+
+        Runs blocking ``os.read`` on the raw fd so the deadline logic in
+        ``_read_response`` never blocks on the pipe. On EOF or read error, an
+        ``_STDOUT_EOF`` sentinel is enqueued so a waiting reader unblocks.
+        """
+        stdout = self._process.stdout
+        if stdout is None:
+            self._read_queue.put(_STDOUT_EOF)
+            return
+        try:
+            fd = stdout.fileno()
+            while True:
+                chunk = os.read(fd, 4096)
+                if not chunk:
+                    break
+                self._read_queue.put(chunk)
+        except (OSError, ValueError):
+            pass
+        finally:
+            self._read_queue.put(_STDOUT_EOF)
 
     @staticmethod
     def _parse_content_length(header: str) -> int:

--- a/scripts/quality_gate/check_infrastructure_failures.py
+++ b/scripts/quality_gate/check_infrastructure_failures.py
@@ -68,12 +68,13 @@ class InfraFinding:
 def _read_raw(path: Path) -> str | None:
     """Return the file text, or None only when the file is genuinely missing.
 
-    A present-but-unreadable flag file (permission error, IO error, bad
-    encoding surfacing as OSError) must NOT be swallowed: returning None there
-    would let ``detect_failures`` treat an infrastructure-failure flag it could
-    not read as "no failure", silently downgrading a safety signal. Only
-    FileNotFoundError (ENOENT) maps to the intended missing-file semantics; any
-    other OSError propagates to ``main`` and fails the step loudly (exit 3).
+    A present-but-unreadable flag file (permission or IO error surfacing as
+    OSError, invalid UTF-8 surfacing as UnicodeDecodeError) must NOT be
+    swallowed: returning None there would let ``detect_failures`` treat an
+    infrastructure-failure flag it could not read as "no failure", silently
+    downgrading a safety signal. Only FileNotFoundError (ENOENT) maps to the
+    intended missing-file semantics; any other OSError or a UnicodeDecodeError
+    propagates to ``main`` and fails the step loudly (exit 3).
     """
 
     try:

--- a/scripts/quality_gate/check_infrastructure_failures.py
+++ b/scripts/quality_gate/check_infrastructure_failures.py
@@ -31,6 +31,8 @@ Args:
 Exit codes (ADR-035):
     0 - detection ran (label add is best-effort; failures do not fail the step)
     1 - unsafe results directory
+    3 - a flag file exists but could not be read (external/IO error); the step
+        fails loud rather than treating the unreadable flag as no-failure
 """
 
 from __future__ import annotations
@@ -64,9 +66,19 @@ class InfraFinding:
 
 
 def _read_raw(path: Path) -> str | None:
+    """Return the file text, or None only when the file is genuinely missing.
+
+    A present-but-unreadable flag file (permission error, IO error, bad
+    encoding surfacing as OSError) must NOT be swallowed: returning None there
+    would let ``detect_failures`` treat an infrastructure-failure flag it could
+    not read as "no failure", silently downgrading a safety signal. Only
+    FileNotFoundError (ENOENT) maps to the intended missing-file semantics; any
+    other OSError propagates to ``main`` and fails the step loudly (exit 3).
+    """
+
     try:
         return path.read_text(encoding="utf-8")
-    except OSError:
+    except FileNotFoundError:
         return None
 
 
@@ -163,7 +175,14 @@ def main(argv: list[str] | None = None) -> int:
         print(f"::error::{exc}", file=sys.stderr)
         return 1
 
-    findings = detect_failures(results_dir)
+    try:
+        findings = detect_failures(results_dir)
+    except OSError as exc:
+        print(
+            f"::error::Cannot read infrastructure-failure flag file: {exc}",
+            file=sys.stderr,
+        )
+        return 3
 
     for finding in findings:
         print(

--- a/scripts/quality_gate/check_infrastructure_failures.py
+++ b/scripts/quality_gate/check_infrastructure_failures.py
@@ -177,7 +177,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         findings = detect_failures(results_dir)
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         print(
             f"::error::Cannot read infrastructure-failure flag file: {exc}",
             file=sys.stderr,

--- a/scripts/quality_gate/load_review_results.py
+++ b/scripts/quality_gate/load_review_results.py
@@ -127,7 +127,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         rows = collect(results_dir)
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         print(f"error: cannot read verdict/infra file: {exc}", file=sys.stderr)
         return 3
 

--- a/scripts/quality_gate/load_review_results.py
+++ b/scripts/quality_gate/load_review_results.py
@@ -33,6 +33,8 @@ Exit codes (ADR-035):
     0 - all outputs written
     1 - unsafe results directory
     2 - GITHUB_OUTPUT is not set (config error)
+    3 - a verdict/infra file exists but could not be read (external/IO error);
+        the step fails loud rather than emitting a default from an unread flag
 """
 
 from __future__ import annotations
@@ -54,11 +56,20 @@ from quality_gate_agents import QUALITY_GATE_AGENTS  # noqa: E402
 
 
 def _read_raw(path: Path) -> str | None:
-    """Return file text, or None when the file is absent (mirrors Test-Path)."""
+    """Return file text, or None only when the file is absent (Test-Path).
+
+    A genuinely missing verdict/infra file returns None, which the callers map
+    to the intended missing-file semantics (verdict -> NEEDS_REVIEW, infra ->
+    "false"). A present-but-unreadable file (permission/IO error) is NOT
+    swallowed: swallowing it would write ``<agent>_infra=false`` to
+    GITHUB_OUTPUT from a flag the step could not read, silently downgrading a
+    safety signal. Non-ENOENT OSError propagates to ``main`` and fails the step
+    loudly (exit 3).
+    """
 
     try:
         return path.read_text(encoding="utf-8")
-    except OSError:
+    except FileNotFoundError:
         return None
 
 
@@ -114,7 +125,11 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    rows = collect(results_dir)
+    try:
+        rows = collect(results_dir)
+    except OSError as exc:
+        print(f"error: cannot read verdict/infra file: {exc}", file=sys.stderr)
+        return 3
 
     print("Loaded verdicts:")
     for agent, verdict, infra in rows:

--- a/scripts/security/invoke_precommit_security.py
+++ b/scripts/security/invoke_precommit_security.py
@@ -16,6 +16,7 @@ Per ADR-042: Python-first for new scripts.
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import re
 import subprocess
@@ -222,6 +223,7 @@ class PreCommitSecurityCheck:
                 capture_output=True,
                 text=True,
                 check=False,
+                timeout=30,
             )
 
             if result.returncode != 0:
@@ -237,8 +239,6 @@ class PreCommitSecurityCheck:
             if not result.stdout.strip() or result.stdout.strip() == "[]":
                 logger.info("No open CodeQL alerts for branch: %s", branch)
                 return []
-
-            import json
 
             alerts_data = json.loads(result.stdout)
             alerts = [
@@ -356,7 +356,11 @@ class PreCommitSecurityCheck:
 
             # Step 6: Stage the security report
             if not self.dry_run:
-                self._stage_security_report(report_path)
+                if not self._stage_security_report(report_path):
+                    logger.error(
+                        "[FAIL] Failed to stage security report; commit blocked"
+                    )
+                    return 1
 
         # Step 7: Verify security report exists
         if not self._verify_security_report(report_path):
@@ -421,6 +425,7 @@ class PreCommitSecurityCheck:
                 capture_output=True,
                 text=True,
                 check=False,
+                timeout=60,
             )
 
             if "PSScriptAnalyzer" in result.stdout:
@@ -438,10 +443,17 @@ class PreCommitSecurityCheck:
                 capture_output=True,
                 text=True,
                 check=False,
+                timeout=120,
             )
 
             return install_result.returncode == 0
 
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "PSScriptAnalyzer availability check timed out; "
+                "treating as unavailable"
+            )
+            return False
         except FileNotFoundError:
             logger.error("[FAIL] PowerShell (pwsh) not found in PATH")
             return False
@@ -481,8 +493,6 @@ class PreCommitSecurityCheck:
                     continue
 
                 # Parse JSON output
-                import json
-
                 try:
                     analyzer_findings = json.loads(result.stdout)
 

--- a/scripts/security/run_semgrep.py
+++ b/scripts/security/run_semgrep.py
@@ -15,6 +15,7 @@ Exit Codes:
     0: Pass (no blocking findings)
     1: Fail (HIGH/CRITICAL findings or errors)
     2: Configuration error
+    3: External tool failure (semgrep timed out before completing)
 
 Per ADR-042: Python-first for new scripts.
 Per issue #939: Recommended semgrep over CodeQL for faster local feedback (<1 minute).
@@ -37,6 +38,15 @@ logging.basicConfig(
     format="%(message)s",
 )
 logger = logging.getLogger(__name__)
+
+
+class SemgrepScanError(Exception):
+    """Raised when the semgrep scan cannot complete (e.g. timeout).
+
+    Signals a fail-closed condition: unlike a clean empty-findings return, this
+    means the scan did not run to completion and its result must not be treated
+    as "no findings". ``run()`` maps it to exit code 3 (external tool failure).
+    """
 
 
 @dataclass
@@ -70,6 +80,11 @@ class SemgrepScanner:
         "WARNING": 2,
         "INFO": 3,
     }
+
+    # Wall-clock ceiling for a single semgrep invocation. A wedged scan must not
+    # hang the pre-push hook indefinitely; on timeout the scan fails closed
+    # (exit 3) rather than reporting a clean pass.
+    SCAN_TIMEOUT_SECONDS = 300
 
     def __init__(
         self,
@@ -172,6 +187,7 @@ class SemgrepScanner:
                 text=True,
                 cwd=self.repo_root,
                 check=False,
+                timeout=self.SCAN_TIMEOUT_SECONDS,
             )
 
             if result.returncode not in (0, 1):
@@ -210,6 +226,14 @@ class SemgrepScanner:
 
             return findings
 
+        except subprocess.TimeoutExpired as e:
+            logger.error(
+                "Semgrep timed out after %ds; failing scan",
+                self.SCAN_TIMEOUT_SECONDS,
+            )
+            raise SemgrepScanError(
+                f"Semgrep timed out after {self.SCAN_TIMEOUT_SECONDS}s"
+            ) from e
         except (subprocess.SubprocessError, json.JSONDecodeError) as e:
             logger.error("Semgrep scan failed: %s", e)
             return []
@@ -238,7 +262,11 @@ class SemgrepScanner:
 
         logger.info("Scanning %d file(s)", len(changed_files))
 
-        findings = self._run_semgrep(changed_files)
+        try:
+            findings = self._run_semgrep(changed_files)
+        except SemgrepScanError as e:
+            logger.error("FAIL: %s", e)
+            return 3
 
         if not findings:
             logger.info("PASS: No security findings")

--- a/scripts/validate_skill_format.py
+++ b/scripts/validate_skill_format.py
@@ -106,7 +106,7 @@ def main(argv: list[str] | None = None) -> int:
     for file_path in files:
         try:
             content = file_path.read_text(encoding="utf-8")
-        except OSError as exc:
+        except (OSError, UnicodeDecodeError) as exc:
             # A present-but-unreadable file must not silently pass: a bundled
             # skill hidden behind a read error would otherwise validate clean.
             print(f"  UNREADABLE: {file_path.name} ({exc})")

--- a/scripts/validate_skill_format.py
+++ b/scripts/validate_skill_format.py
@@ -8,7 +8,8 @@ Enforces ADR-017 skill format requirements:
 
 EXIT CODES:
   0  - Success: All skill files follow atomic format and naming convention
-  1  - Error: Bundled format or naming violations detected (CI mode only)
+  1  - Error: Bundled format or naming violations detected, OR a file existed
+       but could not be read (CI mode only)
 
 See: ADR-035 Exit Code Standardization
 """
@@ -100,11 +101,16 @@ def main(argv: list[str] | None = None) -> int:
 
     bundled_files: list[tuple[str, int]] = []
     prefix_violations: list[str] = []
+    unreadable: list[str] = []
 
     for file_path in files:
         try:
             content = file_path.read_text(encoding="utf-8")
-        except OSError:
+        except OSError as exc:
+            # A present-but-unreadable file must not silently pass: a bundled
+            # skill hidden behind a read error would otherwise validate clean.
+            print(f"  UNREADABLE: {file_path.name} ({exc})")
+            unreadable.append(file_path.name)
             continue
 
         matches = SKILL_HEADER_RE.findall(content)
@@ -144,12 +150,25 @@ def main(argv: list[str] | None = None) -> int:
         print("Rename files to use domain prefix (e.g., pr-001-reviewer-enumeration.md).")
         print()
 
+    if unreadable:
+        print("=== Unreadable Files ===")
+        print("The following files exist but could not be read:")
+        for name in unreadable:
+            print(f"  - {name}")
+        print()
+        print("Fix permissions/encoding so the validator can inspect them.")
+        print()
+
     if has_issues:
         if args.ci:
             print("Result: FAILED")
             return 1
         print("Result: WARNING (non-blocking for local development)")
         return 0
+
+    if unreadable and args.ci:
+        print("Result: FAILED (unreadable skill files cannot be validated)")
+        return 1
 
     print("Result: PASSED - All skill files follow atomic format and naming convention")
     return 0

--- a/scripts/validation/check_canonical_citations.py
+++ b/scripts/validation/check_canonical_citations.py
@@ -25,7 +25,7 @@ to upgrade warnings to a hard FAIL (exit 1).
 EXIT CODES:
   0 - Success (no violations; OR violations only in soft-warn mode; OR no
       scan roots present, which prints `[SKIP] no scan roots present` and
-      treats the absence as benign — vendor installs without `.claude/`
+      treats the absence as benign: vendor installs without `.claude/`
       should not be a hard failure here)
   1 - Violations found AND STRICT_CANONICAL_CHECK=1
   2 - Configuration error (currently unused; reserved for future paths
@@ -73,6 +73,16 @@ _PATH_REF: re.Pattern[str] = re.compile(
     r"|templates/[\w./-]+"
     r"|[\w./-]+\.(?:py|ps1|md|json|yaml|yml|sh)\b"
     r")"
+)
+
+# Fallback module-docstring extractor for source that does not parse as Python
+# (ast.parse raised SyntaxError). Grabs the first leading triple-quoted string,
+# skipping an optional shebang and any blank/comment lines before it. Handles
+# both triple-double and triple-single quotes and the r/b/u/f string prefixes.
+_MODULE_DOCSTRING_RE: re.Pattern[str] = re.compile(
+    r"\A(?:\#![^\n]*\n)?(?:[ \t]*(?:\#[^\n]*)?\n)*"
+    r"[ \t]*[rRbBuUfF]{0,2}(?P<quote>\"\"\"|''')(?P<body>.*?)(?P=quote)",
+    re.DOTALL,
 )
 
 
@@ -139,7 +149,19 @@ def _extract_docstring_and_top_comments(source: str) -> str:
         if module_doc:
             docstring = module_doc
     except SyntaxError:
-        pass
+        # File does not parse (partial edit, mixed content). Fall back to a
+        # regex grab of the leading triple-quoted module docstring so a
+        # mirror-claim living only in that docstring is still scanned instead of
+        # silently dropped. Top-of-file comments above are already collected
+        # without parsing, so they are unaffected.
+        match = _MODULE_DOCSTRING_RE.search(source)
+        if match:
+            docstring = match.group("body")
+        else:
+            print(
+                "[SKIP] unparseable, module docstring not scanned",
+                file=sys.stderr,
+            )
 
     return "\n".join(top_comments + [docstring])
 
@@ -166,7 +188,12 @@ def scan_file(path: Path) -> Violation | None:
     """
     try:
         source = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+    except (OSError, UnicodeDecodeError) as exc:
+        # The file exists but cannot be read/decoded. A silent skip here would
+        # let an uncited mirror-claim in an unreadable file pass unseen. This is
+        # a heuristic gate (violations stay empty to avoid false positives on an
+        # undecodable blob), but the skipped path is surfaced so CI logs it.
+        print(f"[SKIP] unreadable, not scanned: {path}: {exc}", file=sys.stderr)
         return None
 
     text = _extract_docstring_and_top_comments(source)

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -250,7 +250,7 @@ def validate_exit_code_docs(
 
     try:
         content = full_path.read_text(encoding="utf-8")
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         # The script exists (is_file passed above) but cannot be read. Returning
         # None here would treat an unreadable blocking hook as "docs present",
         # so flag it instead of silently passing the contract check.

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -250,8 +250,16 @@ def validate_exit_code_docs(
 
     try:
         content = full_path.read_text(encoding="utf-8")
-    except OSError:
-        return None
+    except OSError as exc:
+        # The script exists (is_file passed above) but cannot be read. Returning
+        # None here would treat an unreadable blocking hook as "docs present",
+        # so flag it instead of silently passing the contract check.
+        return Violation(
+            hook_type=entry.hook_type,
+            script=entry.script_path,
+            category="unreadable_script",
+            message=f"Hook script exists but cannot be read: {exc}",
+        )
 
     # Only check the docstring area (first 30 lines)
     header = "\n".join(content.splitlines()[:30])

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.254",
+  "version": "0.5.255",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -288,8 +288,17 @@ def _original_main(stdin_bytes):
 
             hook_input = json.loads(input_json)
         except (json.JSONDecodeError, ValueError) as exc:
-            print(f"branch_protection_guard: Failed to parse input JSON: {exc}", file=sys.stderr)
-            return 0
+            # Fail closed to match this file's contract: the git-error and generic
+            # exception paths below both block (return 2 via write_block_response).
+            # Unparseable input means branch safety cannot be verified, so block
+            # rather than allow a possibly-protected-branch commit or push.
+            msg = (
+                f"branch_protection_guard: Failed to parse input JSON: {exc}. "
+                "Cannot verify branch safety; blocking."
+            )
+            print(msg, file=sys.stderr)
+            write_block_response(msg)
+            return 2
 
         cwd = get_working_directory(hook_input)
 

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_push_0e93bf.py
@@ -288,8 +288,17 @@ def _original_main(stdin_bytes):
 
             hook_input = json.loads(input_json)
         except (json.JSONDecodeError, ValueError) as exc:
-            print(f"branch_protection_guard: Failed to parse input JSON: {exc}", file=sys.stderr)
-            return 0
+            # Fail closed to match this file's contract: the git-error and generic
+            # exception paths below both block (return 2 via write_block_response).
+            # Unparseable input means branch safety cannot be verified, so block
+            # rather than allow a possibly-protected-branch commit or push.
+            msg = (
+                f"branch_protection_guard: Failed to parse input JSON: {exc}. "
+                "Cannot verify branch safety; blocking."
+            )
+            print(msg, file=sys.stderr)
+            write_block_response(msg)
+            return 2
 
         cwd = get_working_directory(hook_input)
 

--- a/src/copilot-cli/hooks/PreToolUse/push_guard_base.py
+++ b/src/copilot-cli/hooks/PreToolUse/push_guard_base.py
@@ -381,25 +381,40 @@ def _detect_default_base_ref(cwd: str) -> str:
     return "origin/main"
 
 
-def _read_stdin_command() -> str | None:
+def _read_stdin_command(name: str) -> str | None:
+    """Parse the tool command from hook stdin, or return None.
+
+    Fail-open with telemetry: every anomalous stdin shape (oversize, unparseable
+    JSON, non-object payload, missing/mistyped tool_input, missing/mistyped
+    command) emits a structured ``EVENT=...`` fail-open line via _emit_fail_open
+    and still returns None, preserving the framework's documented allow-but-observe
+    contract (see the module docstring, "Operations and telemetry"). The isatty
+    and empty-stdin paths are legitimate no-ops (interactive terminal, nothing
+    piped) and do NOT emit an event.
+    """
     if sys.stdin.isatty():
         return None
     raw = sys.stdin.read(MAX_STDIN_BYTES + 1)
     if len(raw) > MAX_STDIN_BYTES:
+        _emit_fail_open(name, "bad_stdin", f"stdin exceeds {MAX_STDIN_BYTES} bytes")
         return None
     if not raw.strip():
         return None
     try:
         payload = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError) as exc:
+        _emit_fail_open(name, "bad_stdin", f"unparseable JSON: {type(exc).__name__}")
         return None
     if not isinstance(payload, dict):
+        _emit_fail_open(name, "bad_stdin", "payload not a JSON object")
         return None
     tool_input = payload.get("tool_input")
     if not isinstance(tool_input, dict):
+        _emit_fail_open(name, "bad_stdin", "tool_input missing/not object")
         return None
     command = tool_input.get("command")
     if not isinstance(command, str) or not command:
+        _emit_fail_open(name, "bad_stdin", "command missing/not non-empty string")
         return None
     return command
 
@@ -481,7 +496,7 @@ def run_guard(
     if skip_if_consumer_repo(name):
         return 0
     try:
-        command = _read_stdin_command()
+        command = _read_stdin_command(name)
         if command is None:
             return 0
         # Defense in depth: even when the harness matcher is `Bash(git push*)`,

--- a/src/copilot-cli/lib/hook_utilities/guards.py
+++ b/src/copilot-cli/lib/hook_utilities/guards.py
@@ -1,10 +1,16 @@
 """Canonical: scripts/hook_utilities/guards.py. Sync via scripts/sync_plugin_lib.py."""
 
+import json
 import os
 import shutil
 import subprocess
 import sys
 from typing import Literal
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback path
+    tomllib = None  # type: ignore[assignment]
 
 from .utilities import get_project_directory
 
@@ -90,6 +96,58 @@ def is_project_repo() -> bool:
     return _project_repo_identity() == "project"
 
 
+def _project_repo_corroborated(project_root: str) -> bool:
+    """Second cheap signal that ``project_root`` is the ai-agents project repo.
+
+    Used only when the git origin remote is unavailable (identity "unknown").
+    Reads ``pyproject.toml``'s ``[project].name``: the ai-agents project repo
+    declares ``name = "ai-agents"`` (verified in the repo-root pyproject.toml),
+    while a consumer repo that vendors the plugin declares its own name, so this
+    stays False there. A missing file, unavailable tomllib (Python 3.10), or a
+    parse error yields False so the caller still fails open outside the project.
+    """
+    if tomllib is None:
+        return False
+    pyproject = os.path.join(project_root, "pyproject.toml")
+    try:
+        with open(pyproject, "rb") as handle:
+            data = tomllib.load(handle)
+    except (OSError, ValueError):
+        return False
+    project = data.get("project")
+    if not isinstance(project, dict):
+        return False
+    name = project.get("name")
+    return isinstance(name, str) and name.strip().lower() == _PROJECT_REPO_NAME
+
+
+def _emit_skip_event(hook_name: str, reason: str, detail: str) -> None:
+    """Emit a structured ``EVENT=...`` line when an unknown-identity checkout
+    skips every internal guard, so a silent whole-surface fail-open is
+    observable in telemetry.
+
+    Mirrors the fail-open EVENT shape emitted by
+    ``.claude/hooks/PreToolUse/push_guard_base.py::_emit_fail_open``:
+        event = {
+            "guard": name,
+            "code": f"E_{code}",
+            "outcome": "fail_open",
+            "reason": reason,
+            "detail": detail,
+        }
+        print(f"EVENT={json.dumps(event, separators=(',', ':'))}", file=sys.stderr)
+    """
+    code = hook_name.upper().replace("-", "_")
+    event = {
+        "guard": hook_name,
+        "code": f"E_{code}",
+        "outcome": "fail_open",
+        "reason": reason,
+        "detail": detail,
+    }
+    print(f"EVENT={json.dumps(event, separators=(',', ':'))}", file=sys.stderr)
+
+
 def skip_if_consumer_repo(hook_name: str) -> bool:
     """Print skip message and return True unless this is confirmed project repo."""
     identity = _project_repo_identity()
@@ -100,6 +158,18 @@ def skip_if_consumer_repo(hook_name: str) -> bool:
         )
         return True
     if identity == "unknown":
+        # Git origin is unavailable, so identity is indeterminate. Before
+        # skipping every internal guard (a silent whole-surface fail-open),
+        # corroborate with a second cheap signal: pyproject.toml's
+        # [project].name. Only the ai-agents project repo declares that name,
+        # so a consumer repo that vendors the plugin still skips here.
+        if _project_repo_corroborated(get_project_directory()):
+            return False
+        _emit_skip_event(
+            hook_name,
+            "identity_unknown",
+            "git origin unavailable and pyproject name corroboration absent",
+        )
         print(
             f"[SKIP] {hook_name}: cannot verify ai-agents project repo identity; "
             "treating as consumer repo",

--- a/src/copilot-cli/lib/hook_utilities/guards.py
+++ b/src/copilot-cli/lib/hook_utilities/guards.py
@@ -7,10 +7,10 @@ import subprocess
 import sys
 from typing import Literal
 
-try:
-    import tomllib  # Python 3.11+
-except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback path
-    tomllib = None  # type: ignore[assignment]
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - 3.10 fallback path
+    tomllib = None
 
 from .utilities import get_project_directory
 

--- a/src/copilot-cli/skills/adr-generator/SKILL.md
+++ b/src/copilot-cli/skills/adr-generator/SKILL.md
@@ -2,7 +2,7 @@
 name: adr-generator
 version: 1.1.0
 model: claude-opus-4-6
-description: Create comprehensive Architectural Decision Records (ADRs). Researches the destination directory to detect existing template conventions, gathers context, determines next ADR number, generates the ADR, validates completeness, and saves. Supports multiple ADR formats (MADR, Nygard, Alexandrian, project canonical). Use when documenting technical decisions or creating new ADR files. Use when you say "write an ADR", "document this decision". Do NOT use to debate or review an existing ADR (use adr-review).
+description: Create comprehensive Architectural Decision Records (ADRs). Researches the destination directory to detect existing template conventions, gathers context, determines next ADR number, generates the ADR, validates completeness, and saves. Supports multiple ADR formats (MADR, Nygard, Alexandrian, project canonical). Use when documenting technical decisions, creating new ADR files, or capturing rationale so future readers can revisit a choice. Use when you say "write an ADR", "document this decision", "document these design choices", "record why we chose this", "capture the rationale", or "for future maintainers", or when creating an ADR-like markdown file under docs/decisions/, docs/adr/, docs/architecture/, architecture/decisions/, or .agents/architecture/. Do NOT use to debate or review an existing ADR (use adr-review).
 license: MIT
 user-invocable: true
 metadata:
@@ -24,7 +24,7 @@ Create well-structured Architectural Decision Records that document technical de
 | `generate ADR` | Full ADR generation workflow |
 | `write an architecture decision record` | Full ADR generation workflow |
 | `new ADR for` | Targeted ADR for a specific decision |
-| `document this architecture decision` | Full ADR generation workflow |
+| `document these design choices` | Full ADR generation workflow (paraphrase) |
 
 ---
 
@@ -36,6 +36,7 @@ create an ADR for database selection
 new ADR for authentication strategy
 document this architecture decision about event sourcing
 generate ADR for switching from REST to gRPC
+document these design choices for future us to revisit as models change
 ```
 
 ---
@@ -84,7 +85,7 @@ Explore the codebase to find where ADRs live. Do not assume a fixed location.
 3. **Check for ADR tooling config**: Look for `.adr-dir` files (used by `adr-tools`) or ADR references in README, CONTRIBUTING, or project documentation
 4. **If user specifies a location**: Use that, regardless of what exists elsewhere
 
-Note: `.agents/architecture/` and `docs/architecture/` are monitored by `adr-review` for auto-triggered review. ADRs in other directories require manual `adr-review` invocation.
+Note: `.agents/architecture/` and `docs/architecture/` are monitored by `adr-review` for auto-triggered review. ADRs written to `docs/decisions/`, `docs/adr/`, or `architecture/decisions/` are NOT auto-monitored; after saving to any of these, explicitly recommend the user invoke `adr-review` manually. This keeps this skill's discovered path list aligned with `adr-review`'s real auto-trigger coverage.
 
 #### Step 2: Detect template from existing ADRs
 

--- a/src/copilot-cli/skills/adr-review/SKILL.md
+++ b/src/copilot-cli/skills/adr-review/SKILL.md
@@ -2,7 +2,7 @@
 name: adr-review
 version: 1.1.0
 model: claude-opus-4-6
-description: Multi-agent debate orchestration for Architecture Decision Records. Automatically triggers on ADR create/edit/delete. Coordinates architect, critic, independent-thinker, security, analyst, and high-level-advisor agents in structured debate rounds until consensus. Use when you say "review this ADR", or on ADR create/edit. Do NOT use to author a new ADR (use adr-generator).
+description: Multi-agent debate orchestration for Architecture Decision Records. Automatically triggers on ADR create/edit/delete. Coordinates architect, critic, independent-thinker, security, analyst, and high-level-advisor agents in structured debate rounds until consensus. Use when you say "review this ADR", when an ADR is created/edited/deleted, or when reviewing, accepting, or updating a decision file under .agents/architecture/, docs/architecture/, docs/decisions/, docs/adr/, or architecture/decisions/ (only .agents/architecture and docs/architecture auto-trigger; the rest need manual invocation). Do NOT use to author a new ADR (use adr-generator).
 license: MIT
 metadata:
   subagent_model: claude-opus-4-6

--- a/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -35,7 +35,7 @@ import sys
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 # Sibling helpers must import when this file is loaded by path in tests.
 # Keep any sys.path change scoped to this import block.
@@ -103,9 +103,9 @@ class ScanResult:
         default_factory=lambda: datetime.now(UTC).isoformat()
     )
     files_scanned: int = 0
-    vulnerabilities: list = field(default_factory=list)
-    suppressed: list = field(default_factory=list)
-    errors: list = field(default_factory=list)
+    vulnerabilities: list[Any] = field(default_factory=list)
+    suppressed: list[Any] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
 
 
 def get_language(file_path: str) -> str | None:

--- a/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -164,7 +164,23 @@ def get_staged_files() -> list[str]:
             check=True,
         )
         return [f for f in result.stdout.strip().split("\n") if f]
-    except subprocess.CalledProcessError:
+    except FileNotFoundError:
+        # git binary missing on PATH: distinct from a non-zero git exit. Emit a
+        # clear diagnostic and return [] so _collect_files_to_scan fails closed
+        # (prints "No files to scan" and exits EXIT_ERROR), never fail-open.
+        print(
+            "ERROR: git executable not found on PATH; cannot enumerate staged files.",
+            file=sys.stderr,
+        )
+        return []
+    except subprocess.CalledProcessError as exc:
+        # git ran but returned non-zero. Report the failure explicitly; return []
+        # so the caller reports no files and exits with error (fail-closed).
+        print(
+            f"ERROR: git staged-file enumeration failed ({exc}); "
+            "scan will report no files and exit with error.",
+            file=sys.stderr,
+        )
         return []
 
 

--- a/tests/hooks/test_branch_protection_guard.py
+++ b/tests/hooks/test_branch_protection_guard.py
@@ -99,24 +99,30 @@ class TestMain:
         result = invoke_branch_protection_guard.main()
         assert result == 0
 
-    def test_exits_0_on_empty_input(self, mock_stdin: "Callable[[str], None]"):
+    def test_exits_0_on_empty_input(self, mock_stdin: Callable[[str], None]):
         mock_stdin("")
         result = invoke_branch_protection_guard.main()
         assert result == 0
 
-    def test_exits_0_on_whitespace_input(self, mock_stdin: "Callable[[str], None]"):
+    def test_exits_0_on_whitespace_input(self, mock_stdin: Callable[[str], None]):
         mock_stdin("   ")
         result = invoke_branch_protection_guard.main()
         assert result == 0
 
-    def test_exits_0_on_invalid_json(self, mock_stdin: "Callable[[str], None]"):
+    def test_blocks_on_invalid_json(
+        self, mock_stdin: Callable[[str], None], capsys
+    ):
+        """Unparseable JSON cannot verify branch safety; fail closed (block)."""
         mock_stdin("not json")
         result = invoke_branch_protection_guard.main()
-        assert result == 0
+        assert result == 2
+        captured = capsys.readouterr()
+        data = json.loads(captured.out.strip())
+        assert data["decision"] == "block"
 
     @patch("invoke_branch_protection_guard.subprocess.run")
     def test_exits_0_on_feature_branch(
-        self, mock_run, mock_stdin: "Callable[[str], None]"
+        self, mock_run, mock_stdin: Callable[[str], None]
     ):
         mock_run.return_value = MagicMock(
             returncode=0, stdout="feature/my-feature\n", stderr=""
@@ -127,7 +133,7 @@ class TestMain:
 
     @patch("invoke_branch_protection_guard.subprocess.run")
     def test_blocks_on_main_branch(
-        self, mock_run, mock_stdin: "Callable[[str], None]", capsys
+        self, mock_run, mock_stdin: Callable[[str], None], capsys
     ):
         mock_run.return_value = MagicMock(
             returncode=0, stdout="main\n", stderr=""
@@ -142,7 +148,7 @@ class TestMain:
 
     @patch("invoke_branch_protection_guard.subprocess.run")
     def test_blocks_on_master_branch(
-        self, mock_run, mock_stdin: "Callable[[str], None]", capsys
+        self, mock_run, mock_stdin: Callable[[str], None], capsys
     ):
         mock_run.return_value = MagicMock(
             returncode=0, stdout="master\n", stderr=""
@@ -157,7 +163,7 @@ class TestMain:
 
     @patch("invoke_branch_protection_guard.subprocess.run")
     def test_blocks_on_unexpected_exception(
-        self, mock_run, mock_stdin: "Callable[[str], None]", capsys
+        self, mock_run, mock_stdin: Callable[[str], None], capsys
     ):
         mock_run.side_effect = RuntimeError("unexpected")
         mock_stdin(json.dumps({"cwd": "/test", "tool_name": "Bash"}))
@@ -170,7 +176,7 @@ class TestMain:
 
     @patch("invoke_branch_protection_guard.subprocess.run")
     def test_blocks_on_exit_code_128(
-        self, mock_run, mock_stdin: "Callable[[str], None]", capsys
+        self, mock_run, mock_stdin: Callable[[str], None], capsys
     ):
         mock_run.return_value = MagicMock(
             returncode=128, stdout="", stderr="fatal: not a git repository"
@@ -181,7 +187,7 @@ class TestMain:
 
     @patch("invoke_branch_protection_guard.subprocess.run")
     def test_blocks_on_nonzero_exit_code(
-        self, mock_run, mock_stdin: "Callable[[str], None]"
+        self, mock_run, mock_stdin: Callable[[str], None]
     ):
         mock_run.return_value = MagicMock(
             returncode=1, stdout="", stderr="git error"
@@ -192,7 +198,7 @@ class TestMain:
 
     @patch("invoke_branch_protection_guard.subprocess.run")
     def test_blocks_when_git_not_found(
-        self, mock_run, mock_stdin: "Callable[[str], None]"
+        self, mock_run, mock_stdin: Callable[[str], None]
     ):
         mock_run.side_effect = FileNotFoundError("git not found")
         mock_stdin(json.dumps({"cwd": "/some/path", "tool_name": "Bash"}))
@@ -200,7 +206,7 @@ class TestMain:
         assert result == 2
 
     @patch("invoke_branch_protection_guard.subprocess.run")
-    def test_blocks_on_timeout(self, mock_run, mock_stdin: "Callable[[str], None]"):
+    def test_blocks_on_timeout(self, mock_run, mock_stdin: Callable[[str], None]):
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=10)
         mock_stdin(json.dumps({"cwd": "/some/path", "tool_name": "Bash"}))
         result = invoke_branch_protection_guard.main()

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -437,6 +437,27 @@ class TestValidateExitCodeDocs:
         )
         assert hook_contracts.validate_exit_code_docs(entry, tmp_path) is None
 
+    def test_unreadable_script_flagged(self, tmp_path, monkeypatch):
+        # The script exists (is_file() is true) but cannot be read. Returning
+        # None here would treat it as "docs present"; instead it must flag an
+        # unreadable_script violation (issue #2809).
+        script = tmp_path / "hook.py"
+        script.write_text('"""Guard hook."""\n')
+
+        def _raise(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+            raise PermissionError("permission denied")
+
+        monkeypatch.setattr(hook_contracts.Path, "read_text", _raise)
+        entry = hook_contracts.HookEntry(
+            hook_type="PreToolUse",
+            script_path="hook.py",
+            command="python3 hook.py",
+        )
+        violation = hook_contracts.validate_exit_code_docs(entry, tmp_path)
+        assert violation is not None
+        assert violation.category == "unreadable_script"
+        assert "cannot be read" in violation.message
+
 
 # ---------------------------------------------------------------------------
 # validate_duplicate_entries

--- a/tests/hooks/test_invoke_codeql_quick_scan.py
+++ b/tests/hooks/test_invoke_codeql_quick_scan.py
@@ -455,3 +455,31 @@ class TestModuleAsScript:
         with pytest.raises(SystemExit) as exc_info:
             runpy.run_path(hook_path, run_name="__main__")
         assert exc_info.value.code == 0
+
+
+class TestMainNonDictInput:
+    """Finding 3 (#2806): a non-object top-level payload is reported on stderr
+    and returns 0 instead of raising an AttributeError swallowed by the
+    catch-all; unexpected exceptions are surfaced, not silently swallowed."""
+
+    def test_list_payload_reports_and_returns_zero(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps([1, 2, 3])))
+        assert invoke_codeql_quick_scan.main() == 0
+        assert "not an object" in capsys.readouterr().err
+
+    def test_unexpected_exception_reports_on_stderr(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        py_file = tmp_path / "test.py"
+        py_file.write_text("x = 1")
+        input_data = json.dumps({
+            "tool_input": {"file_path": str(py_file)},
+            "cwd": str(tmp_path),
+        })
+        monkeypatch.setattr("sys.stdin", io.StringIO(input_data))
+        with patch.object(
+            invoke_codeql_quick_scan, "_is_codeql_installed",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert invoke_codeql_quick_scan.main() == 0
+        assert "unexpected RuntimeError" in capsys.readouterr().err

--- a/tests/hooks/test_push_guard_base.py
+++ b/tests/hooks/test_push_guard_base.py
@@ -21,6 +21,7 @@ import pytest
 HOOK_DIR = Path(__file__).resolve().parents[2] / ".claude" / "hooks" / "PreToolUse"
 sys.path.insert(0, str(HOOK_DIR))
 
+import push_guard_base  # noqa: E402
 from push_guard_base import (  # noqa: E402
     _filter_by_globs,
     _match_glob,
@@ -1003,3 +1004,79 @@ class TestMatchGlob:
         assert "templates/agents/sub/y.md" not in matched
         assert "src/foo.py" not in matched
         assert "docs/a.md" not in matched
+
+
+class TestStdinFailOpenTelemetry:
+    """Finding 1 (#2806): anomalous stdin shapes still fail open (rc 0) but now
+    emit a structured ``EVENT=...`` fail_open line; legitimate no-ops (tty and
+    empty stdin) stay silent."""
+
+    @staticmethod
+    def _events(stderr_text: str) -> list[dict]:
+        return [
+            json.loads(line[len("EVENT="):])
+            for line in stderr_text.splitlines()
+            if line.startswith("EVENT=")
+        ]
+
+    def _run(self, monkeypatch: pytest.MonkeyPatch, payload_text: str) -> int:
+        monkeypatch.setattr("sys.stdin", io.StringIO(payload_text))
+        return run_guard(_always_violates, ["*.md"], "test-guard")
+
+    def test_invalid_json_emits_fail_open_event(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        assert self._run(monkeypatch, "{not json") == 0
+        events = self._events(capsys.readouterr().err)
+        assert len(events) == 1
+        assert events[0]["outcome"] == "fail_open"
+        assert events[0]["reason"] == "bad_stdin"
+        assert events[0]["guard"] == "test-guard"
+        assert events[0]["code"] == "E_TEST_GUARD"
+
+    def test_non_dict_payload_emits_fail_open_event(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        assert self._run(monkeypatch, json.dumps([1, 2, 3])) == 0
+        events = self._events(capsys.readouterr().err)
+        assert len(events) == 1
+        assert "not a JSON object" in events[0]["detail"]
+
+    def test_missing_tool_input_emits_fail_open_event(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        assert self._run(monkeypatch, json.dumps({"tool_name": "Bash"})) == 0
+        events = self._events(capsys.readouterr().err)
+        assert len(events) == 1
+        assert "tool_input" in events[0]["detail"]
+
+    def test_command_not_string_emits_fail_open_event(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        assert self._run(monkeypatch, json.dumps({"tool_input": {"command": 123}})) == 0
+        events = self._events(capsys.readouterr().err)
+        assert len(events) == 1
+        assert "command" in events[0]["detail"]
+
+    def test_oversize_stdin_emits_fail_open_event(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        big = "x" * (push_guard_base.MAX_STDIN_BYTES + 5)
+        assert self._run(monkeypatch, big) == 0
+        events = self._events(capsys.readouterr().err)
+        assert len(events) == 1
+        assert "exceeds" in events[0]["detail"]
+
+    def test_empty_stdin_emits_no_event(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        assert self._run(monkeypatch, "") == 0
+        assert self._events(capsys.readouterr().err) == []
+
+    def test_tty_emits_no_event(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with patch("push_guard_base.sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            assert run_guard(_always_violates, ["*.md"], "test-guard") == 0
+        assert self._events(capsys.readouterr().err) == []

--- a/tests/hooks/test_push_guard_base.py
+++ b/tests/hooks/test_push_guard_base.py
@@ -14,6 +14,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -1012,7 +1013,7 @@ class TestStdinFailOpenTelemetry:
     empty stdin) stay silent."""
 
     @staticmethod
-    def _events(stderr_text: str) -> list[dict]:
+    def _events(stderr_text: str) -> list[dict[str, Any]]:
         return [
             json.loads(line[len("EVENT="):])
             for line in stderr_text.splitlines()
@@ -1021,7 +1022,8 @@ class TestStdinFailOpenTelemetry:
 
     def _run(self, monkeypatch: pytest.MonkeyPatch, payload_text: str) -> int:
         monkeypatch.setattr("sys.stdin", io.StringIO(payload_text))
-        return run_guard(_always_violates, ["*.md"], "test-guard")
+        result: int = run_guard(_always_violates, ["*.md"], "test-guard")
+        return result
 
     def test_invalid_json_emits_fail_open_event(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/quality_gate/test_check_infrastructure_failures.py
+++ b/tests/quality_gate/test_check_infrastructure_failures.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from scripts.quality_gate import check_infrastructure_failures as mod
 from scripts.quality_gate.check_infrastructure_failures import (
+    _read_raw,
     detect_failures,
     main,
 )
@@ -187,3 +190,45 @@ class TestMainWithFailures:
         main(["--results-dir", str(results)])
         out = capsys.readouterr().out
         assert "::notice::Infrastructure failure detected for security agent (retries: 2)" in out
+
+
+# ---------------------------------------------------------------------------
+# _read_raw fail-loud on unreadable files (issue #2809)
+# ---------------------------------------------------------------------------
+
+
+class TestReadRawFailLoud:
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        # ENOENT is the intended missing-file semantics: None (no failure).
+        assert _read_raw(tmp_path / "absent.txt") is None
+
+    def test_present_readable_file_returns_text(self, tmp_path: Path) -> None:
+        target = tmp_path / "flag.txt"
+        target.write_text("true", encoding="utf-8")
+        assert _read_raw(target) == "true"
+
+    def test_unreadable_file_raises_oserror(self, tmp_path: Path) -> None:
+        # A directory read raises IsADirectoryError (an OSError subclass), a
+        # concrete stand-in for a present-but-unreadable file. It must NOT be
+        # swallowed into None (which would read as "no infra failure").
+        unreadable = tmp_path / "flag.txt"
+        unreadable.mkdir()
+        with pytest.raises(OSError):
+            _read_raw(unreadable)
+
+    def test_detect_failures_propagates_unreadable_flag(self, tmp_path: Path) -> None:
+        # The security infra flag exists but cannot be read.
+        (tmp_path / "security-infrastructure-failure.txt").mkdir()
+        with pytest.raises(OSError):
+            detect_failures(tmp_path)
+
+    def test_main_returns_three_on_unreadable_flag(
+        self, tmp_path, capsys
+    ) -> None:
+        results = tmp_path / "ai-review-results"
+        results.mkdir()
+        (results / "security-infrastructure-failure.txt").mkdir()
+        rc = main(["--results-dir", str(results)])
+        assert rc == 3
+        err = capsys.readouterr().err
+        assert "::error::Cannot read infrastructure-failure flag file" in err

--- a/tests/quality_gate/test_load_review_results.py
+++ b/tests/quality_gate/test_load_review_results.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from scripts.quality_gate.load_review_results import (
+    _read_raw,
     collect,
     main,
     read_infra,
@@ -156,3 +159,48 @@ class TestMain:
         text = output.read_text(encoding="utf-8")
         assert "security_verdict=NEEDS_REVIEW" in text
         assert "security_infra=false" in text
+
+
+# ---------------------------------------------------------------------------
+# _read_raw fail-loud on unreadable files (issue #2809)
+# ---------------------------------------------------------------------------
+
+
+class TestReadRawFailLoud:
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        assert _read_raw(tmp_path / "absent.txt") is None
+
+    def test_present_readable_file_returns_text(self, tmp_path: Path) -> None:
+        target = tmp_path / "verdict.txt"
+        target.write_text("PASS", encoding="utf-8")
+        assert _read_raw(target) == "PASS"
+
+    def test_unreadable_file_raises_oserror(self, tmp_path: Path) -> None:
+        # Directory read raises IsADirectoryError (OSError subclass): a
+        # present-but-unreadable file must not be swallowed into None.
+        unreadable = tmp_path / "verdict.txt"
+        unreadable.mkdir()
+        with pytest.raises(OSError):
+            _read_raw(unreadable)
+
+    def test_read_infra_missing_still_false(self, tmp_path: Path) -> None:
+        # Genuinely missing infra file keeps the intended default.
+        assert read_infra(tmp_path, "security") == "false"
+
+    def test_collect_propagates_unreadable_infra(self, tmp_path: Path) -> None:
+        (tmp_path / "security-infrastructure-failure.txt").mkdir()
+        with pytest.raises(OSError):
+            collect(tmp_path)
+
+    def test_main_returns_three_on_unreadable_file(
+        self, tmp_path, monkeypatch, capsys
+    ) -> None:
+        results = tmp_path / "ai-review-results"
+        results.mkdir()
+        (results / "security-infrastructure-failure.txt").mkdir()
+        # GITHUB_OUTPUT is irrelevant: collect() fails before it is read.
+        monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+        rc = main(["--results-dir", str(results)])
+        assert rc == 3
+        err = capsys.readouterr().err
+        assert "cannot read verdict/infra file" in err

--- a/tests/test_generate_quality_report.py
+++ b/tests/test_generate_quality_report.py
@@ -29,6 +29,7 @@ build_parser = _mod.build_parser
 _AGENTS = _mod._AGENTS
 _AGENT_DISPLAY_NAMES = _mod._AGENT_DISPLAY_NAMES
 _build_action_required_section = _mod._build_action_required_section
+_build_findings_sections = _mod._build_findings_sections
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -270,19 +271,27 @@ class TestMain:
 
 class TestBuildActionRequiredSection:
     def test_returns_empty_when_no_author(self):
-        result = _build_action_required_section("", "FAIL", {"security": "FAIL"})
+        result = _build_action_required_section(
+            "", "FAIL", {"security": "FAIL"}, {"security": "CODE_QUALITY"}
+        )
         assert result == ""
 
     def test_returns_empty_when_no_failures(self):
         result = _build_action_required_section(
-            "user", "PASS", {a: "PASS" for a in _AGENTS}
+            "user",
+            "PASS",
+            {a: "PASS" for a in _AGENTS},
+            {a: "N/A" for a in _AGENTS},
         )
         assert result == ""
 
     def test_mentions_author_on_critical_fail(self):
         verdicts = {a: "PASS" for a in _AGENTS}
         verdicts["security"] = "CRITICAL_FAIL"
-        result = _build_action_required_section("bot-user", "CRITICAL_FAIL", verdicts)
+        categories = {a: "CODE_QUALITY" for a in _AGENTS}
+        result = _build_action_required_section(
+            "bot-user", "CRITICAL_FAIL", verdicts, categories
+        )
         assert "@bot-user" in result
         assert "**Security** review flagged issues" in result
 
@@ -290,7 +299,62 @@ class TestBuildActionRequiredSection:
         verdicts = {a: "PASS" for a in _AGENTS}
         verdicts["security"] = "FAIL"
         verdicts["qa"] = "NEEDS_REVIEW"
-        result = _build_action_required_section("author", "FAIL", verdicts)
+        categories = {a: "CODE_QUALITY" for a in _AGENTS}
+        result = _build_action_required_section("author", "FAIL", verdicts, categories)
         assert "**Security**" in result
         assert "**QA**" in result
         assert "**Analyst**" not in result
+
+    def test_excludes_infrastructure_failed_agent(self):
+        # An agent that never ran (Copilot CLI unavailable) is downgraded to a
+        # NEEDS_REVIEW verdict with category INFRASTRUCTURE. It must not appear
+        # in Action Required (issue #2818).
+        verdicts = {a: "PASS" for a in _AGENTS}
+        verdicts["security"] = "NEEDS_REVIEW"
+        categories = {a: "N/A" for a in _AGENTS}
+        categories["security"] = "INFRASTRUCTURE"
+        result = _build_action_required_section(
+            "author", "WARN", verdicts, categories
+        )
+        assert result == ""
+
+    def test_lists_real_failure_but_not_infra_failure(self):
+        verdicts = {a: "PASS" for a in _AGENTS}
+        verdicts["qa"] = "FAIL"
+        verdicts["security"] = "NEEDS_REVIEW"
+        categories = {a: "N/A" for a in _AGENTS}
+        categories["qa"] = "CODE_QUALITY"
+        categories["security"] = "INFRASTRUCTURE"
+        result = _build_action_required_section("author", "FAIL", verdicts, categories)
+        assert "**QA** review flagged issues" in result
+        assert "**Security**" not in result
+
+
+class TestBuildFindingsSections:
+    def test_infra_empty_file_shows_did_not_run(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        findings_dir = Path("ai-review-results")
+        findings_dir.mkdir(parents=True, exist_ok=True)
+        (findings_dir / "security-findings.txt").write_text("")
+        categories = {a: "N/A" for a in _AGENTS}
+        categories["security"] = "INFRASTRUCTURE"
+        result = _build_findings_sections(categories)
+        assert "did not run: Copilot CLI unavailable" in result
+        assert "No findings available (empty file)" not in result
+
+    def test_non_infra_empty_file_shows_no_findings(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        findings_dir = Path("ai-review-results")
+        findings_dir.mkdir(parents=True, exist_ok=True)
+        (findings_dir / "security-findings.txt").write_text("")
+        categories = {a: "N/A" for a in _AGENTS}
+        result = _build_findings_sections(categories)
+        assert "No findings available (empty file)" in result
+        assert "did not run" not in result
+
+    def test_missing_file_shows_not_found(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        Path("ai-review-results").mkdir(parents=True, exist_ok=True)
+        categories = {a: "N/A" for a in _AGENTS}
+        result = _build_findings_sections(categories)
+        assert "Findings file not found" in result

--- a/tests/test_hook_plugin_guards.py
+++ b/tests/test_hook_plugin_guards.py
@@ -6,6 +6,7 @@ Verifies that project-specific hooks skip gracefully in consumer repos
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -247,3 +248,83 @@ class TestSyncPluginLib:
 
         result = sync_mod.main(["--check"])
         assert result == 1
+
+
+def _parse_events(stderr_text: str) -> list[dict]:
+    return [
+        json.loads(line[len("EVENT="):])
+        for line in stderr_text.splitlines()
+        if line.startswith("EVENT=")
+    ]
+
+
+class TestUnknownIdentityCorroboration:
+    """Finding 4 (#2806): when the git origin is unavailable, corroborate project
+    identity via pyproject [project].name before skipping every guard, and emit a
+    structured fail_open EVENT when the whole-surface skip still happens."""
+
+    def _force_unknown(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        monkeypatch.delenv("AI_AGENTS_PROJECT_REPO", raising=False)
+        guards._origin_repo_cache.clear()
+        monkeypatch.setattr(guards, "get_project_directory", lambda: str(project_dir))
+        monkeypatch.setattr(guards, "_remote_repo_name", lambda _root: None)
+
+    def test_pyproject_name_corroborates_project_repo(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "ai-agents"\n')
+        self._force_unknown(monkeypatch, tmp_path)
+        assert skip_if_consumer_repo("test-hook") is False
+
+    def test_other_pyproject_name_skips_and_emits_event(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "other-repo"\n')
+        self._force_unknown(monkeypatch, tmp_path)
+        assert skip_if_consumer_repo("test-hook") is True
+        events = _parse_events(capsys.readouterr().err)
+        assert len(events) == 1
+        assert events[0]["outcome"] == "fail_open"
+        assert events[0]["reason"] == "identity_unknown"
+        assert events[0]["guard"] == "test-hook"
+        assert events[0]["code"] == "E_TEST_HOOK"
+
+    def test_missing_pyproject_skips_and_emits_event(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        self._force_unknown(monkeypatch, tmp_path)
+        assert skip_if_consumer_repo("test-hook") is True
+        events = _parse_events(capsys.readouterr().err)
+        assert len(events) == 1
+        assert events[0]["reason"] == "identity_unknown"
+
+
+class TestProjectRepoCorroborated:
+    """_project_repo_corroborated reads pyproject [project].name defensively."""
+
+    def test_true_for_ai_agents_name(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "ai-agents"\n')
+        assert guards._project_repo_corroborated(str(tmp_path)) is True
+
+    def test_false_for_other_name(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\n')
+        assert guards._project_repo_corroborated(str(tmp_path)) is False
+
+    def test_false_when_missing(self, tmp_path: Path) -> None:
+        assert guards._project_repo_corroborated(str(tmp_path)) is False
+
+    def test_false_when_malformed(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project\nname = broken")
+        assert guards._project_repo_corroborated(str(tmp_path)) is False
+
+    def test_false_when_no_project_table(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[tool.other]\nkey = "v"\n')
+        assert guards._project_repo_corroborated(str(tmp_path)) is False

--- a/tests/test_hook_plugin_guards.py
+++ b/tests/test_hook_plugin_guards.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -250,7 +251,7 @@ class TestSyncPluginLib:
         assert result == 1
 
 
-def _parse_events(stderr_text: str) -> list[dict]:
+def _parse_events(stderr_text: str) -> list[dict[str, Any]]:
     return [
         json.loads(line[len("EVENT="):])
         for line in stderr_text.splitlines()

--- a/tests/test_invoke_branch_protection_guard.py
+++ b/tests/test_invoke_branch_protection_guard.py
@@ -87,11 +87,17 @@ class TestMainAllowPath:
             assert main() == 0
 
     @patch("invoke_branch_protection_guard.sys.stdin", new_callable=StringIO)
-    def test_allows_on_invalid_json(self, mock_stdin: StringIO) -> None:
+    def test_blocks_on_invalid_json(
+        self, mock_stdin: StringIO, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Unparseable JSON cannot verify branch safety; fail closed (block)."""
         mock_stdin.write("not json")
         mock_stdin.seek(0)
         with patch.object(mock_stdin, "isatty", return_value=False):
-            assert main() == 0
+            assert main() == 2
+        captured = capsys.readouterr()
+        data = json.loads(captured.out.strip())
+        assert data["decision"] == "block"
 
 
 class TestMainBlockPath:

--- a/tests/test_invoke_precommit_security.py
+++ b/tests/test_invoke_precommit_security.py
@@ -1,0 +1,173 @@
+"""Tests for pre-commit security gate timeout + fail-closed staging (issue #2810).
+
+Scope (behavior changed by the fix):
+
+1. ``_ensure_psscriptanalyzer`` now passes ``timeout=`` to both pwsh calls and
+   returns False on ``subprocess.TimeoutExpired`` instead of hanging.
+2. ``_fetch_codeql_alerts`` now passes ``timeout=`` to the ``gh api`` call; a
+   timeout degrades to skip-with-warning (returns []) via the existing
+   ``SubprocessError`` handler.
+3. ``run()`` now blocks the commit (exit 1) when ``_stage_security_report``
+   fails, closing the fail-open gap where the on-disk report satisfied
+   ``_verify_security_report`` even though ``git add`` failed.
+
+The git/gh/pwsh subprocesses and the report I/O are mocked; nothing external
+runs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.security.invoke_precommit_security import (
+    PreCommitResult,
+    PreCommitSecurityCheck,
+)
+
+
+@pytest.fixture
+def check() -> PreCommitSecurityCheck:
+    """A check instance with a stubbed repo root (no git call at init)."""
+    with patch.object(
+        PreCommitSecurityCheck, "_find_repo_root", return_value=Path("/repo")
+    ):
+        return PreCommitSecurityCheck(skip_codeql=True)
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+class TestEnsurePsscriptanalyzerTimeout:
+    """pwsh calls must time out rather than hang the commit forever."""
+
+    def test_get_module_check_passes_timeout(
+        self, check: PreCommitSecurityCheck
+    ) -> None:
+        with patch(
+            "scripts.security.invoke_precommit_security.subprocess.run",
+            return_value=_completed(0, stdout="PSScriptAnalyzer 1.0"),
+        ) as run_mock:
+            assert check._ensure_psscriptanalyzer() is True
+        assert run_mock.call_args.kwargs["timeout"] == 60
+
+    def test_get_module_timeout_returns_false(
+        self, check: PreCommitSecurityCheck
+    ) -> None:
+        with patch(
+            "scripts.security.invoke_precommit_security.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["pwsh"], timeout=60),
+        ):
+            assert check._ensure_psscriptanalyzer() is False
+
+    def test_install_timeout_returns_false(
+        self, check: PreCommitSecurityCheck
+    ) -> None:
+        # First call (Get-Module) succeeds but reports module absent; second
+        # call (Install-Module) times out.
+        side_effects = [
+            _completed(0, stdout="no module here"),
+            subprocess.TimeoutExpired(cmd=["pwsh"], timeout=120),
+        ]
+        with patch(
+            "scripts.security.invoke_precommit_security.subprocess.run",
+            side_effect=side_effects,
+        ):
+            assert check._ensure_psscriptanalyzer() is False
+
+    def test_pwsh_not_found_returns_false(
+        self, check: PreCommitSecurityCheck
+    ) -> None:
+        with patch(
+            "scripts.security.invoke_precommit_security.subprocess.run",
+            side_effect=FileNotFoundError("pwsh"),
+        ):
+            assert check._ensure_psscriptanalyzer() is False
+
+
+class TestFetchCodeqlAlertsTimeout:
+    """The gh api network call must be time-bounded and degrade gracefully."""
+
+    def test_gh_api_timeout_returns_empty(
+        self, check: PreCommitSecurityCheck
+    ) -> None:
+        side_effects = [
+            _completed(0, stdout="gh version 2.60"),  # gh --version probe
+            subprocess.TimeoutExpired(cmd=["gh", "api"], timeout=30),  # gh api
+        ]
+        with (
+            patch.object(
+                check, "_get_github_context", return_value=("o", "r", "main")
+            ),
+            patch(
+                "scripts.security.invoke_precommit_security.subprocess.run",
+                side_effect=side_effects,
+            ) as run_mock,
+        ):
+            assert check._fetch_codeql_alerts() == []
+        # The gh api call (second invocation) carries an explicit timeout.
+        assert run_mock.call_args_list[1].kwargs["timeout"] == 30
+
+
+class TestRunStagingFailClosed:
+    """A staging failure must block the commit, not pass on the on-disk file."""
+
+    def _wire_common(self, check: PreCommitSecurityCheck) -> None:
+        check._get_staged_powershell_files = MagicMock(  # type: ignore[method-assign]
+            return_value=[Path("/repo/a.ps1")]
+        )
+        check._check_critical_patterns = MagicMock(return_value=[])  # type: ignore[method-assign]
+        check._ensure_psscriptanalyzer = MagicMock(return_value=True)  # type: ignore[method-assign]
+        check._run_psscriptanalyzer = MagicMock(  # type: ignore[method-assign]
+            return_value=PreCommitResult(
+                passed=True, findings=[], report_path=None
+            )
+        )
+        check._generate_security_report = MagicMock(  # type: ignore[method-assign]
+            return_value=Path("/repo/.agents/security/SR-x.md")
+        )
+
+    def test_staging_failure_blocks_commit(
+        self, check: PreCommitSecurityCheck
+    ) -> None:
+        self._wire_common(check)
+        check._stage_security_report = MagicMock(return_value=False)  # type: ignore[method-assign]
+        assert check.run() == 1
+
+    def test_staging_success_passes(
+        self, check: PreCommitSecurityCheck
+    ) -> None:
+        self._wire_common(check)
+        check._stage_security_report = MagicMock(return_value=True)  # type: ignore[method-assign]
+        check._verify_security_report = MagicMock(return_value=True)  # type: ignore[method-assign]
+        assert check.run() == 0
+
+
+class TestStageSecurityReport:
+    """Direct coverage of the staging helper's success/failure contract."""
+
+    def test_returns_true_on_success(
+        self, check: PreCommitSecurityCheck
+    ) -> None:
+        with patch(
+            "scripts.security.invoke_precommit_security.subprocess.run",
+            return_value=_completed(0),
+        ):
+            assert check._stage_security_report(Path("/repo/x.md")) is True
+
+    def test_returns_false_on_git_add_failure(
+        self, check: PreCommitSecurityCheck
+    ) -> None:
+        with patch(
+            "scripts.security.invoke_precommit_security.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "git add"),
+        ):
+            assert check._stage_security_report(Path("/repo/x.md")) is False

--- a/tests/test_invoke_precommit_security.py
+++ b/tests/test_invoke_precommit_security.py
@@ -121,17 +121,17 @@ class TestRunStagingFailClosed:
     """A staging failure must block the commit, not pass on the on-disk file."""
 
     def _wire_common(self, check: PreCommitSecurityCheck) -> None:
-        check._get_staged_powershell_files = MagicMock(  # type: ignore[method-assign]
+        check.__dict__["_get_staged_powershell_files"] = MagicMock(
             return_value=[Path("/repo/a.ps1")]
         )
-        check._check_critical_patterns = MagicMock(return_value=[])  # type: ignore[method-assign]
-        check._ensure_psscriptanalyzer = MagicMock(return_value=True)  # type: ignore[method-assign]
-        check._run_psscriptanalyzer = MagicMock(  # type: ignore[method-assign]
+        check.__dict__["_check_critical_patterns"] = MagicMock(return_value=[])
+        check.__dict__["_ensure_psscriptanalyzer"] = MagicMock(return_value=True)
+        check.__dict__["_run_psscriptanalyzer"] = MagicMock(
             return_value=PreCommitResult(
                 passed=True, findings=[], report_path=None
             )
         )
-        check._generate_security_report = MagicMock(  # type: ignore[method-assign]
+        check.__dict__["_generate_security_report"] = MagicMock(
             return_value=Path("/repo/.agents/security/SR-x.md")
         )
 
@@ -139,15 +139,15 @@ class TestRunStagingFailClosed:
         self, check: PreCommitSecurityCheck
     ) -> None:
         self._wire_common(check)
-        check._stage_security_report = MagicMock(return_value=False)  # type: ignore[method-assign]
+        check.__dict__["_stage_security_report"] = MagicMock(return_value=False)
         assert check.run() == 1
 
     def test_staging_success_passes(
         self, check: PreCommitSecurityCheck
     ) -> None:
         self._wire_common(check)
-        check._stage_security_report = MagicMock(return_value=True)  # type: ignore[method-assign]
-        check._verify_security_report = MagicMock(return_value=True)  # type: ignore[method-assign]
+        check.__dict__["_stage_security_report"] = MagicMock(return_value=True)
+        check.__dict__["_verify_security_report"] = MagicMock(return_value=True)
         assert check.run() == 0
 
 

--- a/tests/test_memory_sync/test_mcp_client.py
+++ b/tests/test_memory_sync/test_mcp_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import queue
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,7 +17,7 @@ from scripts.memory_sync.mcp_client import (
 )
 
 
-def _frame(payload: dict) -> bytes:
+def _frame(payload: dict[str, Any]) -> bytes:
     """Encode a dict as one Content-Length framed JSON-RPC message."""
     body = json.dumps(payload).encode("utf-8")
     header = f"Content-Length: {len(body)}\r\n\r\n".encode()

--- a/tests/test_memory_sync/test_mcp_client.py
+++ b/tests/test_memory_sync/test_mcp_client.py
@@ -3,15 +3,41 @@
 from __future__ import annotations
 
 import json
+import queue
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from scripts.memory_sync.mcp_client import (
+    _STDOUT_EOF,
     McpClient,
     McpError,
 )
+
+
+def _frame(payload: dict) -> bytes:
+    """Encode a dict as one Content-Length framed JSON-RPC message."""
+    body = json.dumps(payload).encode("utf-8")
+    header = f"Content-Length: {len(body)}\r\n\r\n".encode()
+    return header + body
+
+
+def _detached_client(timeout: float = 0.2) -> McpClient:
+    """Build a client whose subprocess I/O is inert, with a fresh read queue.
+
+    ``stdout``/``stderr`` are None so the drain threads exit immediately; the
+    test then owns ``_read_queue`` directly.
+    """
+    process = MagicMock()
+    process.stdout = None
+    process.stderr = None
+    client = McpClient(process, timeout=timeout)
+    # Let the init-spawned reader thread finish putting its EOF into the
+    # original queue, then swap in a fresh queue the test fully controls.
+    client._stdout_thread.join(timeout=1.0)
+    client._read_queue = queue.Queue()
+    return client
 
 
 class TestMcpClientCreate:
@@ -128,3 +154,102 @@ class TestIsAvailable:
             Path("/nonexistent/path/forgetful.db"),
         ):
             assert not McpClient.is_available()
+
+
+class TestReadBytesTimeout:
+    """``_read_bytes`` enforces a timeout on every platform (issue #2810).
+
+    Before the fix the timeout was skipped entirely on Windows (the select
+    branch was guarded by ``sys.platform != "win32"``), so ``os.read`` could
+    block forever. The queue-based reader has no platform branch, so these
+    tests exercise the single cross-platform path.
+    """
+
+    def test_returns_chunk_when_available(self) -> None:
+        client = _detached_client()
+        client._read_queue.put(b"payload")
+        assert client._read_bytes(1.0) == b"payload"
+
+    def test_nonpositive_remaining_raises_timeout(self) -> None:
+        client = _detached_client()
+        with pytest.raises(McpError, match="Timeout waiting for response"):
+            client._read_bytes(0.0)
+
+    def test_empty_queue_raises_timeout(self) -> None:
+        client = _detached_client(timeout=0.05)
+        with pytest.raises(McpError, match="Timeout waiting for response"):
+            client._read_bytes(0.05)
+
+    def test_eof_sentinel_raises_closed_error(self) -> None:
+        client = _detached_client()
+        client._read_queue.put(_STDOUT_EOF)
+        with pytest.raises(McpError, match="closed stdout"):
+            client._read_bytes(1.0)
+
+
+class TestReadResponseDeadline:
+    """``_read_response`` bounds the whole wait, not just each read (issue #2810).
+
+    Without an overall deadline, a server streaming notifications or replying
+    with mismatched ids would loop forever. The deadline makes both cases
+    terminate with a timeout.
+    """
+
+    def test_matching_response_returned(self) -> None:
+        client = _detached_client(timeout=1.0)
+        client._read_queue.put(_frame({"jsonrpc": "2.0", "id": 1, "result": {}}))
+        response = client._read_response(1)
+        assert response["id"] == 1
+
+    def test_notification_stream_times_out(self) -> None:
+        client = _detached_client(timeout=0.2)
+        for _ in range(3):
+            client._read_queue.put(
+                _frame({"jsonrpc": "2.0", "method": "notifications/progress"})
+            )
+        with pytest.raises(McpError, match="Timeout waiting for response"):
+            client._read_response(1)
+
+    def test_id_mismatch_stream_times_out(self) -> None:
+        client = _detached_client(timeout=0.2)
+        client._read_queue.put(
+            _frame({"jsonrpc": "2.0", "id": 999, "result": {}})
+        )
+        with pytest.raises(McpError, match="Timeout waiting for response"):
+            client._read_response(1)
+
+
+class TestDrainStdout:
+    """The reader thread feeds chunks then an EOF sentinel."""
+
+    def test_none_stdout_enqueues_eof(self) -> None:
+        client = _detached_client()
+        client._process.stdout = None
+        client._drain_stdout()
+        assert client._read_queue.get_nowait() is _STDOUT_EOF
+
+    def test_reads_chunks_then_eof(self) -> None:
+        client = _detached_client()
+        fake_stdout = MagicMock()
+        fake_stdout.fileno.return_value = 3
+        client._process.stdout = fake_stdout
+        with patch(
+            "scripts.memory_sync.mcp_client.os.read",
+            side_effect=[b"chunk-a", b"chunk-b", b""],
+        ):
+            client._drain_stdout()
+        assert client._read_queue.get_nowait() == b"chunk-a"
+        assert client._read_queue.get_nowait() == b"chunk-b"
+        assert client._read_queue.get_nowait() is _STDOUT_EOF
+
+    def test_read_error_enqueues_eof(self) -> None:
+        client = _detached_client()
+        fake_stdout = MagicMock()
+        fake_stdout.fileno.return_value = 3
+        client._process.stdout = fake_stdout
+        with patch(
+            "scripts.memory_sync.mcp_client.os.read",
+            side_effect=OSError("pipe error"),
+        ):
+            client._drain_stdout()
+        assert client._read_queue.get_nowait() is _STDOUT_EOF

--- a/tests/test_run_semgrep.py
+++ b/tests/test_run_semgrep.py
@@ -1,0 +1,144 @@
+"""Tests for the semgrep scanner timeout / fail-closed behavior (issue #2810).
+
+Scope: the subprocess timeout added to ``SemgrepScanner._run_semgrep`` and the
+fail-closed mapping to exit code 3 in ``run()``. A wedged semgrep process must
+not hang the pre-push hook forever, and a timeout must NOT be reported as a
+clean "no findings" pass (the pre-existing fail-open path for a generic error
+is preserved and asserted separately as a regression guard).
+
+External boundary (the semgrep subprocess) is mocked; no real semgrep runs.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.security.run_semgrep import (
+    SemgrepScanError,
+    SemgrepScanner,
+)
+
+
+@pytest.fixture
+def scanner() -> SemgrepScanner:
+    """A scanner instance with a stubbed repo root (no git call)."""
+    with patch.object(
+        SemgrepScanner, "_find_repo_root", return_value=Path("/repo")
+    ):
+        return SemgrepScanner()
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+class TestRunSemgrepTimeout:
+    """Timeout path: fail closed, never a silent clean pass."""
+
+    def test_timeout_raises_scan_error(self, scanner: SemgrepScanner) -> None:
+        with patch(
+            "scripts.security.run_semgrep.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["semgrep"], timeout=300),
+        ):
+            with pytest.raises(SemgrepScanError, match="timed out"):
+                scanner._run_semgrep([Path("/repo/a.py")])
+
+    def test_subprocess_called_with_timeout(self, scanner: SemgrepScanner) -> None:
+        with patch(
+            "scripts.security.run_semgrep.subprocess.run",
+            return_value=_completed(0, stdout='{"results": []}'),
+        ) as run_mock:
+            scanner._run_semgrep([Path("/repo/a.py")])
+        assert run_mock.call_args.kwargs["timeout"] == (
+            SemgrepScanner.SCAN_TIMEOUT_SECONDS
+        )
+
+    def test_run_maps_timeout_to_exit_3(self, scanner: SemgrepScanner) -> None:
+        with (
+            patch.object(scanner, "_check_semgrep_installed", return_value=True),
+            patch.object(
+                scanner, "_get_changed_files", return_value=[Path("/repo/a.py")]
+            ),
+            patch.object(
+                scanner,
+                "_run_semgrep",
+                side_effect=SemgrepScanError("Semgrep timed out after 300s"),
+            ),
+        ):
+            assert scanner.run() == 3
+
+
+class TestRunSemgrepHappyPath:
+    """Positive: findings are parsed from semgrep JSON output."""
+
+    def test_parses_findings(self, scanner: SemgrepScanner) -> None:
+        payload = {
+            "results": [
+                {
+                    "check_id": "python.lang.security.audit.dangerous-exec",
+                    "path": "a.py",
+                    "start": {"line": 12},
+                    "extra": {
+                        "severity": "ERROR",
+                        "message": "dangerous exec",
+                        "metadata": {"cwe": ["CWE-78"], "owasp": ["A03"]},
+                    },
+                }
+            ]
+        }
+        with patch(
+            "scripts.security.run_semgrep.subprocess.run",
+            return_value=_completed(1, stdout=json.dumps(payload)),
+        ):
+            findings = scanner._run_semgrep([Path("/repo/a.py")])
+        assert len(findings) == 1
+        assert findings[0].check_id.endswith("dangerous-exec")
+        assert findings[0].severity == "ERROR"
+        assert findings[0].cwe == ["CWE-78"]
+
+
+class TestRunSemgrepFailOpenPreserved:
+    """Negative / edge: non-timeout error paths keep the prior fail-open shape.
+
+    These assert the timeout handler did NOT change the generic-error behavior
+    (returncode not in {0,1} and generic SubprocessError both still return []).
+    """
+
+    def test_empty_file_list_returns_empty(self, scanner: SemgrepScanner) -> None:
+        with patch("scripts.security.run_semgrep.subprocess.run") as run_mock:
+            assert scanner._run_semgrep([]) == []
+        run_mock.assert_not_called()
+
+    def test_execution_error_returncode_returns_empty(
+        self, scanner: SemgrepScanner
+    ) -> None:
+        with patch(
+            "scripts.security.run_semgrep.subprocess.run",
+            return_value=_completed(2, stderr="boom"),
+        ):
+            assert scanner._run_semgrep([Path("/repo/a.py")]) == []
+
+    def test_generic_subprocess_error_returns_empty(
+        self, scanner: SemgrepScanner
+    ) -> None:
+        with patch(
+            "scripts.security.run_semgrep.subprocess.run",
+            side_effect=subprocess.SubprocessError("generic failure"),
+        ):
+            assert scanner._run_semgrep([Path("/repo/a.py")]) == []
+
+    def test_invalid_json_returns_empty(self, scanner: SemgrepScanner) -> None:
+        with patch(
+            "scripts.security.run_semgrep.subprocess.run",
+            return_value=_completed(0, stdout="not json"),
+        ):
+            assert scanner._run_semgrep([Path("/repo/a.py")]) == []

--- a/tests/test_security_scan_git_enumeration.py
+++ b/tests/test_security_scan_git_enumeration.py
@@ -1,0 +1,88 @@
+"""Tests for get_staged_files git-enumeration error handling (issue #2807).
+
+The scanner enumerates staged files via `git diff --staged --name-only`. When
+that enumeration fails, get_staged_files MUST fail closed: return [] so the
+caller (_collect_files_to_scan) prints "No files to scan" and exits EXIT_ERROR,
+and emit a distinct stderr diagnostic instead of a raw traceback.
+
+Canonical source mirrored by these tests:
+`.claude/skills/security-scan/scripts/scan_vulnerabilities.py::get_staged_files`
+(byte-identical mirror at
+`src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py`). Loaded
+by path, matching the loader in tests/test_security_scan_vulnerabilities.py; the
+scanner imports only stdlib, so a path-based load is safe.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCANNER_PATH = (
+    REPO_ROOT
+    / ".claude"
+    / "skills"
+    / "security-scan"
+    / "scripts"
+    / "scan_vulnerabilities.py"
+)
+
+
+def _load_scanner() -> ModuleType:
+    """Load the scanner module by path (it is not on the package tree)."""
+    spec = importlib.util.spec_from_file_location(
+        "scan_vulnerabilities_git_enum", SCANNER_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+scanner = _load_scanner()
+
+
+def test_get_staged_files_returns_filenames_from_git(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Happy path plus the blank-line edge: trailing empty entries are dropped.
+    class _Result:
+        stdout = "a.py\nb.py\n\n"
+
+    monkeypatch.setattr(scanner.subprocess, "run", lambda *a, **k: _Result())
+    assert scanner.get_staged_files() == ["a.py", "b.py"]
+
+
+def test_get_staged_files_git_missing_returns_empty_with_diagnostic(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # git binary absent: FileNotFoundError must be caught, a distinct diagnostic
+    # emitted, and [] returned so the caller fails closed (exits EXIT_ERROR).
+    def _raise_not_found(*_args: object, **_kwargs: object) -> object:
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(scanner.subprocess, "run", _raise_not_found)
+    result = scanner.get_staged_files()
+    captured = capsys.readouterr()
+    assert result == []
+    assert "git executable not found" in captured.err
+
+
+def test_get_staged_files_git_nonzero_returns_empty_with_diagnostic(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # git ran but exited non-zero: CalledProcessError must be reported and []
+    # returned (fail-closed), not a raw traceback.
+    def _raise_called_process(*_args: object, **_kwargs: object) -> object:
+        raise subprocess.CalledProcessError(1, ["git", "diff", "--staged"])
+
+    monkeypatch.setattr(scanner.subprocess, "run", _raise_called_process)
+    result = scanner.get_staged_files()
+    captured = capsys.readouterr()
+    assert result == []
+    assert "git staged-file enumeration failed" in captured.err

--- a/tests/test_validate_skill_format.py
+++ b/tests/test_validate_skill_format.py
@@ -83,6 +83,14 @@ class TestUnreadableFiles:
         assert rc == 1
         assert "UNREADABLE" in capsys.readouterr().out
 
+    def test_undecodable_file_fails_in_ci(self, tmp_path: Path, capsys) -> None:
+        # Invalid UTF-8 bytes make read_text raise UnicodeDecodeError (a
+        # ValueError, not an OSError); the widened except must still flag it.
+        (tmp_path / "bad.md").write_bytes(b"# Skill \xff\xfe not utf-8")
+        rc = main(["--path", str(tmp_path), "--ci"])
+        assert rc == 1
+        assert "UNREADABLE" in capsys.readouterr().out
+
     def test_unreadable_file_warns_but_passes_local(
         self, tmp_path: Path, capsys
     ) -> None:

--- a/tests/test_validate_skill_format.py
+++ b/tests/test_validate_skill_format.py
@@ -67,3 +67,37 @@ class TestMain:
     def test_prefix_violation_fails_in_ci(self, tmp_path: Path) -> None:
         (tmp_path / "skill-bad-name.md").write_text("# Content", encoding="utf-8")
         assert main(["--path", str(tmp_path), "--ci"]) == 1
+
+
+class TestUnreadableFiles:
+    """A file that exists but cannot be read must not silently pass (#2809).
+
+    ``dir.md`` is a directory whose name matches the ``*.md`` glob, so it is
+    collected as a candidate; ``read_text`` on it raises IsADirectoryError (an
+    OSError subclass), a concrete stand-in for a present-but-unreadable file.
+    """
+
+    def test_unreadable_file_fails_in_ci(self, tmp_path: Path, capsys) -> None:
+        (tmp_path / "weird.md").mkdir()
+        rc = main(["--path", str(tmp_path), "--ci"])
+        assert rc == 1
+        assert "UNREADABLE" in capsys.readouterr().out
+
+    def test_unreadable_file_warns_but_passes_local(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        (tmp_path / "weird.md").mkdir()
+        rc = main(["--path", str(tmp_path)])
+        assert rc == 0
+        assert "UNREADABLE" in capsys.readouterr().out
+
+    def test_readable_files_alongside_unreadable_still_flag(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "weird.md").mkdir()
+        (tmp_path / "testing-001-ok.md").write_text(
+            "# Testing\n\nSingle skill.",
+            encoding="utf-8",
+        )
+        # CI still fails because of the unreadable entry.
+        assert main(["--path", str(tmp_path), "--ci"]) == 1

--- a/tests/validation/test_check_canonical_citations.py
+++ b/tests/validation/test_check_canonical_citations.py
@@ -344,3 +344,62 @@ def test_main_no_scan_roots_skips(
     assert rc == 0
     out = capsys.readouterr().out
     assert "[SKIP]" in out
+
+
+# --- Unreadable / unparseable files signal instead of silent skip (#2809) ---
+
+
+def test_unreadable_file_emits_skip_to_stderr(
+    fake_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An undecodable file stays unflagged (heuristic) but logs a SKIP to
+    stderr instead of vanishing silently."""
+    target = _write_file(
+        fake_repo,
+        ".claude/hooks/bin.py",
+        '"""matches the foo bar."""\n',
+    )
+    target.write_bytes(b"\xff\xfe\x00\x00")
+    violations = ccc.collect_violations(fake_repo)
+    assert violations == []
+    err = capsys.readouterr().err
+    assert "[SKIP] unreadable" in err
+
+
+def test_syntax_error_docstring_mirror_claim_flagged(fake_repo: Path) -> None:
+    """A mirror-claim living ONLY in the module docstring of an unparseable
+    file is still flagged via the regex fallback (not dropped by ast.parse)."""
+    _write_file(
+        fake_repo,
+        ".claude/hooks/brokendoc.py",
+        '"""Matches the validator with no path here."""\n'
+        "def (((:\n",
+    )
+    violations = ccc.collect_violations(fake_repo)
+    assert len(violations) == 1
+    assert violations[0].matched_token == "matches the"
+
+
+def test_syntax_error_docstring_with_path_not_flagged(fake_repo: Path) -> None:
+    """The regex fallback still honors a path citation: a docstring that names
+    a canonical path in an unparseable file is not a violation."""
+    _write_file(
+        fake_repo,
+        ".claude/hooks/okdoc.py",
+        '"""Matches scripts/validation/hook_contracts.py exactly."""\n'
+        "def (((:\n",
+    )
+    violations = ccc.collect_violations(fake_repo)
+    assert violations == []
+
+
+def test_syntax_error_no_docstring_emits_skip(
+    fake_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An unparseable file with no docstring and no top comment logs a SKIP for
+    the un-scanned docstring and produces no violation."""
+    _write_file(fake_repo, ".claude/hooks/nodoc.py", "def (((:\n")
+    violations = ccc.collect_violations(fake_repo)
+    assert violations == []
+    err = capsys.readouterr().err
+    assert "[SKIP] unparseable" in err

--- a/tests/workflows/test_workflow_fail_open_guards.py
+++ b/tests/workflows/test_workflow_fail_open_guards.py
@@ -32,7 +32,8 @@ _WORKFLOWS = Path(__file__).resolve().parents[2] / ".github" / "workflows"
 
 def _load_workflow(name: str) -> dict[str, Any]:
     with (_WORKFLOWS / name).open(encoding="utf-8") as handle:
-        return yaml.safe_load(handle)
+        loaded: dict[str, Any] = yaml.safe_load(handle)
+        return loaded
 
 
 def _job_steps(workflow: Any, job: str) -> list[dict[str, Any]]:

--- a/tests/workflows/test_workflow_fail_open_guards.py
+++ b/tests/workflows/test_workflow_fail_open_guards.py
@@ -1,0 +1,244 @@
+"""Contract tests for the fail-open fixes in four CI workflows (Issue #2808).
+
+Each of these workflows had a step meant to DETECT a problem that converted its
+own crash (or findings) into a green run via `|| true`, `2>/dev/null`, or a
+default-to-pass parse branch. These tests pin the hardened contract so a later
+edit cannot silently reintroduce the suppression without a test failing first.
+
+Covered:
+  - audit-hook-bypass.yml: detection step classifies exit code, fails on >=2,
+    and treats missing JSON as a failure (not indicator_count=0).
+  - pytest.yml (security job): bandit gates on high severity/confidence with no
+    `|| true`, the job has security-events: write, and a codeql upload-sarif
+    step publishes findings with if: always().
+  - memory-validation.yml: verify step captures the exit code before pipefail
+    aborts, and the parse step fails on a missing/empty results file instead of
+    posting a green Pass.
+  - drift-detection.yml: the JSON re-run stops swallowing stderr and the exit
+    code, failing only on exit >=2 (config/crash) since exit 1 is the expected
+    drift path for this step.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_WORKFLOWS = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+
+
+def _load_workflow(name: str) -> dict[str, Any]:
+    with (_WORKFLOWS / name).open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _job_steps(workflow: Any, job: str) -> list[dict[str, Any]]:
+    """Return the step mappings for a job, tolerating malformed shapes."""
+    if not isinstance(workflow, dict):
+        return []
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+    job_def = jobs.get(job)
+    if not isinstance(job_def, dict):
+        return []
+    steps = job_def.get("steps")
+    if not isinstance(steps, list):
+        return []
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _command_text(run: str) -> str:
+    """Drop comment-only lines so token checks target the actual commands.
+
+    The hardened steps document `|| true` and `2>/dev/null` in explanatory
+    comments; the suppression assertions must inspect the executable lines only.
+    """
+    lines = [line for line in run.splitlines() if not line.lstrip().startswith("#")]
+    return "\n".join(lines)
+
+
+def _find_step_by_run(steps: list[dict[str, Any]], needle: str) -> dict[str, Any] | None:
+    for step in steps:
+        run = step.get("run")
+        if isinstance(run, str) and needle in run:
+            return step
+    return None
+
+
+def _find_step_by_uses(steps: list[dict[str, Any]], needle: str) -> dict[str, Any] | None:
+    for step in steps:
+        uses = step.get("uses")
+        if isinstance(uses, str) and needle in uses:
+            return step
+    return None
+
+
+def _job_permissions(workflow: dict[str, Any], job: str) -> dict[str, Any]:
+    jobs = workflow.get("jobs") or {}
+    job_def = jobs.get(job) or {}
+    perms = job_def.get("permissions")
+    return perms if isinstance(perms, dict) else {}
+
+
+class TestStepExtractionEdges:
+    """Edge: malformed workflow shapes yield empty steps, not exceptions."""
+
+    def test_non_mapping_inputs_return_empty(self) -> None:
+        assert _job_steps(None, "test") == []
+        assert _job_steps({"jobs": None}, "test") == []
+        assert _job_steps({"jobs": {"test": None}}, "test") == []
+        assert _job_steps({"jobs": {"test": {"steps": None}}}, "test") == []
+
+    def test_missing_job_returns_empty(self) -> None:
+        wf = {"jobs": {"other": {"steps": [{"run": "echo hi"}]}}}
+        assert _job_steps(wf, "test") == []
+
+    def test_non_mapping_steps_are_filtered(self) -> None:
+        wf = {"jobs": {"test": {"steps": ["scalar", {"run": "echo hi"}]}}}
+        assert _job_steps(wf, "test") == [{"run": "echo hi"}]
+
+    def test_find_helpers_return_none_when_absent(self) -> None:
+        assert _find_step_by_run([{"run": "echo hi"}], "missing") is None
+        assert _find_step_by_uses([{"uses": "actions/checkout"}], "missing") is None
+        # Steps without the queried key must not raise.
+        assert _find_step_by_run([{"uses": "x"}], "echo") is None
+        assert _find_step_by_uses([{"run": "x"}], "actions") is None
+
+
+class TestAuditHookBypass:
+    """audit-hook-bypass.yml detection step must not mask the crash path."""
+
+    def _detect_step(self) -> dict[str, Any]:
+        steps = _job_steps(_load_workflow("audit-hook-bypass.yml"), "detect-bypass")
+        step = _find_step_by_run(steps, "detect_hook_bypass.py")
+        assert step is not None
+        return step
+
+    def test_no_blanket_true_suppression(self) -> None:
+        assert "|| true" not in _command_text(self._detect_step()["run"])
+
+    def test_captures_and_hard_fails_on_crash(self) -> None:
+        run = self._detect_step()["run"]
+        assert "|| rc=$?" in run
+        assert 'if [ "$rc" -ge 2 ]' in run
+        assert 'exit "$rc"' in run
+
+    def test_missing_json_is_a_failure_not_zero_indicators(self) -> None:
+        run = self._detect_step()["run"]
+        # The else branch must fail instead of reporting a clean audit.
+        assert "indicator_count=0" not in run
+        assert "exit 1" in run
+
+
+class TestPytestBanditSecurity:
+    """pytest.yml security job must fail on real findings and publish SARIF."""
+
+    def _workflow(self) -> dict[str, Any]:
+        return _load_workflow("pytest.yml")
+
+    def _bandit_step(self) -> dict[str, Any]:
+        steps = _job_steps(self._workflow(), "security")
+        step = _find_step_by_run(steps, "bandit -r")
+        assert step is not None
+        return step
+
+    def test_bandit_has_no_true_suppression(self) -> None:
+        assert "|| true" not in _command_text(self._bandit_step()["run"])
+
+    def test_bandit_gates_on_high_severity_and_confidence(self) -> None:
+        run = self._bandit_step()["run"]
+        assert "--severity-level high" in run
+        assert "--confidence-level high" in run
+
+    def test_security_job_grants_security_events_write(self) -> None:
+        perms = _job_permissions(self._workflow(), "security")
+        assert perms.get("security-events") == "write"
+
+    def test_sarif_uploaded_to_code_scanning_always(self) -> None:
+        steps = _job_steps(self._workflow(), "security")
+        step = _find_step_by_uses(steps, "github/codeql-action/upload-sarif")
+        assert step is not None
+        assert step.get("if") == "always()"
+        assert step.get("with", {}).get("sarif_file") == "artifacts/bandit-results.sarif"
+
+    def test_sarif_upload_action_pinned_to_sha(self) -> None:
+        steps = _job_steps(self._workflow(), "security")
+        step = _find_step_by_uses(steps, "github/codeql-action/upload-sarif")
+        assert step is not None
+        ref = step["uses"].split("@", 1)[1].split()[0]
+        # 40-char commit SHA, not a floating tag (universal.md MUST-6).
+        assert len(ref) == 40
+        assert all(c in "0123456789abcdef" for c in ref)
+
+
+class TestMemoryValidation:
+    """memory-validation.yml must not post a green Pass on a crashed run."""
+
+    def _workflow(self) -> dict[str, Any]:
+        return _load_workflow("memory-validation.yml")
+
+    def _verify_step(self) -> dict[str, Any]:
+        steps = _job_steps(self._workflow(), "validate-memories")
+        step = _find_step_by_run(steps, "verify-all --json")
+        assert step is not None
+        return step
+
+    def _parse_step(self) -> dict[str, Any]:
+        steps = _job_steps(self._workflow(), "validate-memories")
+        step = _find_step_by_run(steps, "memory-validation-results.json")
+        # The verify step also references the results file; pick the parser.
+        for candidate in _job_steps(self._workflow(), "validate-memories"):
+            run = candidate.get("run")
+            if isinstance(run, str) and "jq 'length'" in run:
+                return candidate
+        raise AssertionError("parse step not found")
+
+    def test_verify_captures_exit_code_before_pipefail(self) -> None:
+        run = self._verify_step()["run"]
+        assert "|| rc=$?" in run
+        assert "exit_code=$rc" in run
+        # The buggy form captured $? on a separate line after the redirect.
+        assert 'echo "exit_code=$?"' not in run
+
+    def test_parse_treats_empty_results_as_failure(self) -> None:
+        run = self._parse_step()["run"]
+        assert "-s memory-validation-results.json" in run
+        assert "exit 1" in run
+
+    def test_parse_does_not_default_missing_file_to_pass(self) -> None:
+        run = self._parse_step()["run"]
+        # The else branch previously set has_stale=false on a missing file.
+        # has_stale=false legitimately remains in the zero-stale branch, so key
+        # on the error signal that must now precede any exit in the else path.
+        assert "::error::memory-validation-results.json missing or empty" in run
+
+
+class TestDriftDetection:
+    """drift-detection.yml JSON re-run must surface crashes, not swallow them."""
+
+    def _collect_step(self) -> dict[str, Any]:
+        steps = _job_steps(_load_workflow("drift-detection.yml"), "detect-drift")
+        step = _find_step_by_run(steps, "--output-format json")
+        assert step is not None
+        return step
+
+    def test_stderr_not_discarded(self) -> None:
+        assert "2>/dev/null" not in _command_text(self._collect_step()["run"])
+
+    def test_no_blanket_true_suppression(self) -> None:
+        assert "|| true" not in _command_text(self._collect_step()["run"])
+
+    def test_fails_only_on_config_or_crash(self) -> None:
+        run = self._collect_step()["run"]
+        # exit 1 is the expected drift path for this step; only >=2 fails.
+        assert "|| rc=$?" in run
+        assert 'if [ "$rc" -ge 2 ]' in run
+        assert 'exit "$rc"' in run
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-x", "-q"]))

--- a/tests/workflows/test_workflow_fail_open_guards.py
+++ b/tests/workflows/test_workflow_fail_open_guards.py
@@ -136,7 +136,11 @@ class TestAuditHookBypass:
 
 
 class TestPytestBanditSecurity:
-    """pytest.yml security job must fail on real findings and publish SARIF."""
+    """pytest.yml security job must fail on real findings (JSON artifact).
+
+    The code-scanning SARIF surfacing needs the bandit-sarif-formatter dep and
+    is deferred to a focused follow-up PR (see Run Bandit comment).
+    """
 
     def _workflow(self) -> dict[str, Any]:
         return _load_workflow("pytest.yml")
@@ -155,25 +159,16 @@ class TestPytestBanditSecurity:
         assert "--severity-level high" in run
         assert "--confidence-level high" in run
 
-    def test_security_job_grants_security_events_write(self) -> None:
-        perms = _job_permissions(self._workflow(), "security")
-        assert perms.get("security-events") == "write"
+    def test_bandit_writes_json_artifact(self) -> None:
+        # JSON is a built-in bandit formatter (no extra dep); the scan is
+        # self-contained and the artifact is uploaded below.
+        run = self._bandit_step()["run"]
+        assert "-f json" in run
+        assert "artifacts/bandit-results.json" in run
 
-    def test_sarif_uploaded_to_code_scanning_always(self) -> None:
-        steps = _job_steps(self._workflow(), "security")
-        step = _find_step_by_uses(steps, "github/codeql-action/upload-sarif")
-        assert step is not None
-        assert step.get("if") == "always()"
-        assert step.get("with", {}).get("sarif_file") == "artifacts/bandit-results.sarif"
-
-    def test_sarif_upload_action_pinned_to_sha(self) -> None:
-        steps = _job_steps(self._workflow(), "security")
-        step = _find_step_by_uses(steps, "github/codeql-action/upload-sarif")
-        assert step is not None
-        ref = step["uses"].split("@", 1)[1].split()[0]
-        # 40-char commit SHA, not a floating tag (universal.md MUST-6).
-        assert len(ref) == 40
-        assert all(c in "0123456789abcdef" for c in ref)
+    def test_bandit_excludes_test_paths(self) -> None:
+        # Test-only B324 SHA1-for-module-name false positives must not gate CI.
+        assert "-x" in self._bandit_step()["run"]
 
 
 class TestMemoryValidation:


### PR DESCRIPTION
## Summary

### What

Triaged all 19 open issues and shipped verified fixes for 7 of them here. Each fix was verified against live code and implemented with positive/negative/edge tests.

| Issue | Pri | Fix |
|-------|-----|-----|
| #2809 | P1 | quality-gate validators fail loud (exit 3) on unreadable and undecodable files instead of treating them as pass |
| #2806 | P2 | push-guard and branch-protection guards fail closed and emit fail-open telemetry on malformed stdin |
| #2807 | P3 | CWE-78 scanner distinguishes git-enumeration failure from "no staged files" |
| #2808 | P2 | four CI workflows stop suppressing their own failures; bandit now runs a scoped high/high hard gate |
| #2810 | P2 | pre-commit security gate and MCP client get timeouts and a win32 deadline |
| #2818 | P2 | AI-review jobs emit a neutral did-not-run signal on Copilot infra failure instead of red checks |
| #2805 | P3 | adr-generator and adr-review broaden trigger selection to intent-level paraphrases and ADR paths |

### Why

The 2026-07-02 read-only safety audit filed 11 fail-open, timeout, and boundary issues; the referenced report was never committed, so each finding was re-verified against current code.

## Changes

- Fail-loud / fail-closed error handling in CI validators, hook guards, and the CWE-78 scanner.
- Removed unconditional-success masks from four workflows.
- Subprocess timeouts on pre-commit security network calls plus an MCP client deadline.
- Neutral check conclusion for AI-review infrastructure failure.
- Broadened the two ADR skills' trigger metadata (plus two router fixtures).
- A quality commit resolves standalone-mypy type debt and the security-suppression gate without masking (version-guard for the optional tomllib import, explicit generics, dict-based mock assignment, targeted mypy overrides for a pre-existing try/except import pattern).

Platform mirrors under `src/copilot-cli` and `.claude/lib` were regenerated; both plugin manifests bumped.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] Infrastructure/CI change

## Testing

- [x] Tests added/updated (positive, negative, edge per touched behavior)
- [x] Full suite green locally (one pre-existing environment-only failure needing an API key, reproduced on clean HEAD)

## Notes for Reviewers

**Scope note:** this was a "fix all 19 open issues" request, but the repo's 50-file-per-PR scope gate plus the single-branch constraint cap this PR at 49 files. So six already-implemented fixes are shipped in a separate follow-up PR: #2811, #2812, #2813, #2790, #2791, #2792 (the mirror-obligation epic #2789 children are in PR #2822).

**Triaged as keep-open** (justification posted on each): #1944, #2789, #2796, #2814, #2815, #2816. Filed #2821 (new P1) for a confirmed security-axis WARN-downgrade concern found inside #2814.

## Related Issues

Fixes #2806
Fixes #2807
Fixes #2808
Fixes #2809
Fixes #2810
Fixes #2818
Fixes #2805

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wbb9jpubgid3eYuSxRtb38