### PR TITLE
fix(reliability): subprocess timeouts for remaining gh/git/npx/pip call sites (#2811)

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-03-session-2603-issue-2811-pr-b-subprocess-timeouts.json
+++ b/.agents/memory/episodes/episode-2026-07-03-session-2603-issue-2811-pr-b-subprocess-timeouts.json
@@ -69,6 +69,14 @@
       "content": "Commit: f13f73f",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 05a16e6",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-03-session-2603-issue-2811-pr-b-subprocess-timeouts.json
+++ b/.agents/memory/episodes/episode-2026-07-03-session-2603-issue-2811-pr-b-subprocess-timeouts.json
@@ -1,0 +1,83 @@
+{
+  "id": "episode-2026-07-03-session-2603-issue-2811-pr-b-subprocess-timeouts",
+  "session": "2026-07-03-session-2603-issue-2811-pr-b-subprocess-timeouts",
+  "timestamp": "2026-07-03T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Issue #2811 PR-B: subprocess timeouts for the remaining gh/git/npx/pip call sites (reactions, item milestone, copilot assignment, merge-resolver wrapper plus dash-ref guard, worktree identity, batch/install/gate wrappers, installers, security retrospective, homework scanner, slash-command lint). Hook sites deferred (pre-existing bootstrap type debt, same precedent as #2812).",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added gh timeouts with defined degradation to add_comment_reaction (per-item failure), set_item_milestone (exit 3), invoke_copilot_assignment (warn/exit 3); typed the files' pre-existing bare-dict annotations to dict[str, Any] (annotation-only, no cascade).",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "merge-resolver _run_git: 60s timeout returning a synthetic exit-124 result so returncode-checking callers handle hangs; resolve_conflicts_runner rejects dash-leading refs (git refs cannot start with a dash; the triage plan's checkout -- suggestion was wrong because -- switches checkout to pathspec mode).",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Wrapper timeouts with synthetic-124 pattern: invoke_batch_pr_review run_git/run_gh, install_git_hooks _run_git, invoke_session_start_gate run_git; worktree_identity git config timeout=10 (check-aware, loud expiry) synced to both lib mirrors.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "install_semgrep pip install timeout=300 (existing SubprocessError except covers expiry); invoke_security_retrospective gh --paginate timeout=120 plus two var annotations; homework_scanner per-create timeout=60 with error entry; validate_slash_command npx timeout=120 with non-blocking skip note.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Deferred: three hook sites (observation_sync, adr_review_guard, session_initialization_enforcer) whose files carry the pre-existing bootstrap assignment/no-any-return mypy debt; same deferral precedent as the #2812 hook sites. Also deferred: homework_scanner search-before-create idempotency (resumability improvement beyond the timeout scope).",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verification: uv run pytest tests/skills/github tests/skills/merge-resolver 428 passed; tests/test_timeout_hardening_2811b.py 6 passed; mypy no issues in 12 source files.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "test",
+      "content": "Verification: uv run pytest tests/skills/github tests/skills/merge-resolver 428 passed; tests/test_timeout_hardening_2811b.py 6 passed; mypy no issues in 12 source files.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: f13f73f",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 4
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-03-session-2603-issue-2811-pr-b-subprocess-timeouts.json
+++ b/.agents/sessions/2026-07-03-session-2603-issue-2811-pr-b-subprocess-timeouts.json
@@ -121,7 +121,7 @@
     "Deferred: three hook sites (observation_sync, adr_review_guard, session_initialization_enforcer) whose files carry the pre-existing bootstrap assignment/no-any-return mypy debt; same deferral precedent as the #2812 hook sites. Also deferred: homework_scanner search-before-create idempotency (resumability improvement beyond the timeout scope).",
     "Verification: uv run pytest tests/skills/github tests/skills/merge-resolver 428 passed; tests/test_timeout_hardening_2811b.py 6 passed; mypy no issues in 12 source files."
   ],
-  "endingCommit": "f13f73f",
+  "endingCommit": "05a16e6",
   "nextSteps": [
     "Open draft PR-B referencing #2811; note deferred hook sites and homework idempotency.",
     "PR-C candidate: the three deferred hook sites once the hook-bootstrap type debt is settled."

--- a/.agents/sessions/2026-07-03-session-2603-issue-2811-pr-b-subprocess-timeouts.json
+++ b/.agents/sessions/2026-07-03-session-2603-issue-2811-pr-b-subprocess-timeouts.json
@@ -1,0 +1,129 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2603,
+    "date": "2026-07-03",
+    "branch": "claude/subprocess-timeouts-2811-b",
+    "startingCommit": "f13f73f",
+    "objective": "Issue #2811 PR-B: subprocess timeouts for the remaining gh/git/npx/pip call sites (reactions, item milestone, copilot assignment, merge-resolver wrapper plus dash-ref guard, worktree identity, batch/install/gate wrappers, installers, security retrospective, homework scanner, slash-command lint). Hook sites deferred (pre-existing bootstrap type debt, same precedent as #2812)."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "LSP-first read/grep guards and topical-memory hooks enforced file access, confirming the Serena enforcement layer active."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena initial-instructions contract in effect; per-turn re-assertion hook firing."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-injected by the SessionStart context loader (read-only dashboard)."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Located new_session_log.py, sync_plugin_lib.py, build_all.py, validate_session_json.py via ls/find."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read the #2811 triage fix_plan and every target call site (sed context reads) before each patch."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md and .claude/rules/* injected each turn; python.md, release-it.md, universal.md reviewed."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "PreToolUse topical-memory hooks surfaced github-pr1873, error-recovery-obligations, prompting scope-discipline observations."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "claude/subprocess-timeouts-2811-b"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On claude/subprocess-timeouts-2811-b"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "f13f73f"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart and sessionEnd MUST items populated with honest evidence."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md untouched (read-only per ADR-014); git status confirms."
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No new cross-session decision beyond the deferral precedent already recorded in the #2812 decision memory; the PR body documents the deferred hook sites."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Ran markdownlint-cli2 convention check; zero lintable markdown changed (all edits are Python; log is JSON)."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All changes committed on branch claude/subprocess-timeouts-2811-b before push (atomic commits, five files or fewer each)."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Ran `uv run pytest` tests/skills/github tests/skills/merge-resolver: 428 passed; tests/test_timeout_hardening_2811b.py: 6 passed; mypy clean across the 12 changed source files; sync_plugin_lib and build_all mirrors regenerated; suppression scan clean."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Task tracker: PR-B in progress to shipped; deferred hook sites noted for follow-up."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not invoked; mechanical hardening slice of an in-flight epic."
+      }
+    }
+  },
+  "workLog": [
+    "Added gh timeouts with defined degradation to add_comment_reaction (per-item failure), set_item_milestone (exit 3), invoke_copilot_assignment (warn/exit 3); typed the files' pre-existing bare-dict annotations to dict[str, Any] (annotation-only, no cascade).",
+    "merge-resolver _run_git: 60s timeout returning a synthetic exit-124 result so returncode-checking callers handle hangs; resolve_conflicts_runner rejects dash-leading refs (git refs cannot start with a dash; the triage plan's checkout -- suggestion was wrong because -- switches checkout to pathspec mode).",
+    "Wrapper timeouts with synthetic-124 pattern: invoke_batch_pr_review run_git/run_gh, install_git_hooks _run_git, invoke_session_start_gate run_git; worktree_identity git config timeout=10 (check-aware, loud expiry) synced to both lib mirrors.",
+    "install_semgrep pip install timeout=300 (existing SubprocessError except covers expiry); invoke_security_retrospective gh --paginate timeout=120 plus two var annotations; homework_scanner per-create timeout=60 with error entry; validate_slash_command npx timeout=120 with non-blocking skip note.",
+    "Deferred: three hook sites (observation_sync, adr_review_guard, session_initialization_enforcer) whose files carry the pre-existing bootstrap assignment/no-any-return mypy debt; same deferral precedent as the #2812 hook sites. Also deferred: homework_scanner search-before-create idempotency (resumability improvement beyond the timeout scope).",
+    "Verification: uv run pytest tests/skills/github tests/skills/merge-resolver 428 passed; tests/test_timeout_hardening_2811b.py 6 passed; mypy no issues in 12 source files."
+  ],
+  "endingCommit": "f13f73f",
+  "nextSteps": [
+    "Open draft PR-B referencing #2811; note deferred hook sites and homework idempotency.",
+    "PR-C candidate: the three deferred hook sites once the hook-bootstrap type debt is settled."
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.254",
+  "version": "0.5.255",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/lib/github_core/worktree_identity.py
+++ b/.claude/lib/github_core/worktree_identity.py
@@ -42,6 +42,7 @@ def _run_git_config(
         errors="replace",
         env=env,
         check=check,
+        timeout=10,
     )
 
 

--- a/.claude/skills/github/scripts/issue/invoke_copilot_assignment.py
+++ b/.claude/skills/github/scripts/issue/invoke_copilot_assignment.py
@@ -122,7 +122,7 @@ def _load_synthesis_config(config_path: str) -> dict[str, Any]:
         try:
             result = subprocess.run(
                 ["git", "rev-parse", "--git-common-dir"],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True, encoding="utf-8", errors="replace", timeout=10,
             )
             if result.returncode == 0:
                 git_common = Path(result.stdout.strip())
@@ -400,7 +400,7 @@ def _assign_copilot(owner: str, repo: str, issue_number: int) -> bool:
                 "--repo", f"{owner}/{repo}",
                 "--add-assignee", "copilot-swe-agent",
             ],
-            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            capture_output=True, encoding="utf-8", errors="replace", timeout=GH_TIMEOUT_SECONDS,
             check=False,
         )
     except subprocess.TimeoutExpired:
@@ -533,7 +533,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
     try:
         issue_result = subprocess.run(
             ["gh", "api", f"repos/{owner}/{repo}/issues/{issue_number}"],
-            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            capture_output=True, encoding="utf-8", errors="replace", timeout=GH_TIMEOUT_SECONDS,
             check=False,
         )
     except subprocess.TimeoutExpired:

--- a/.claude/skills/github/scripts/issue/invoke_copilot_assignment.py
+++ b/.claude/skills/github/scripts/issue/invoke_copilot_assignment.py
@@ -26,6 +26,7 @@ import sys
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
 _workspace = os.environ.get("GITHUB_WORKSPACE")
@@ -62,7 +63,7 @@ from github_core.output import (  # noqa: E402
 # Configuration
 # ---------------------------------------------------------------------------
 
-_DEFAULT_CONFIG: dict = {
+_DEFAULT_CONFIG: dict[str, Any] = {
     "trusted_sources": {
         "maintainers": [],
         "ai_agents": [],
@@ -82,6 +83,10 @@ _DEFAULT_CONFIG: dict = {
         "marker": "<!-- COPILOT-CONTEXT-SYNTHESIS -->",
     },
 }
+
+
+# Upper bound (seconds) for each gh network call.
+GH_TIMEOUT_SECONDS = 30
 
 
 def _extract_yaml_list(content: str, key: str) -> list[str]:
@@ -107,7 +112,7 @@ def _extract_yaml_list(content: str, key: str) -> list[str]:
     return items
 
 
-def _load_synthesis_config(config_path: str) -> dict:
+def _load_synthesis_config(config_path: str) -> dict[str, Any]:
     """Load copilot-synthesis.yml configuration or return empty defaults.
 
     When the config file is missing, returns empty trusted_sources lists.
@@ -137,7 +142,7 @@ def _load_synthesis_config(config_path: str) -> dict:
 
     try:
         content = Path(config_path).read_text(encoding="utf-8")
-        config: dict = json.loads(json.dumps(_DEFAULT_CONFIG))
+        config: dict[str, Any] = json.loads(json.dumps(_DEFAULT_CONFIG))
 
         # Extract maintainers (line-by-line to avoid ReDoS)
         config["trusted_sources"]["maintainers"] = [
@@ -174,7 +179,7 @@ def _load_synthesis_config(config_path: str) -> dict:
 
 
 def _get_maintainer_guidance(
-    comments: list[dict], maintainers: list[str],
+    comments: list[dict[str, Any]], maintainers: list[str],
 ) -> list[str]:
     """Extract key decisions from maintainer comments.
 
@@ -217,8 +222,8 @@ def _get_maintainer_guidance(
 
 
 def _get_coderabbit_plan(
-    comments: list[dict], patterns: dict,
-) -> dict | None:
+    comments: list[dict[str, Any]], patterns: dict[str, Any],
+) -> dict[str, Any] | None:
     """Extract implementation plan from CodeRabbit comments."""
     rabbit_comments = [
         c for c in comments if c.get("user", {}).get("login") == patterns["username"]
@@ -226,7 +231,7 @@ def _get_coderabbit_plan(
     if not rabbit_comments:
         return None
 
-    plan: dict = {"implementation": None, "related_issues": [], "related_prs": []}
+    plan: dict[str, Any] = {"implementation": None, "related_issues": [], "related_prs": []}
 
     impl_pattern = re.escape(patterns["implementation_plan"])
     issues_raw = re.escape(patterns["related_issues"])
@@ -267,8 +272,8 @@ def _get_coderabbit_plan(
 
 
 def _get_ai_triage_info(
-    comments: list[dict], triage_marker: str,
-) -> dict | None:
+    comments: list[dict[str, Any]], triage_marker: str,
+) -> dict[str, Any] | None:
     """Extract triage information from AI Triage comments."""
     escaped_marker = re.escape(triage_marker)
     triage_comment = None
@@ -305,8 +310,8 @@ def _get_ai_triage_info(
 
 def _has_synthesizable_content(
     maintainer_guidance: list[str],
-    coderabbit_plan: dict | None,
-    ai_triage: dict | None,
+    coderabbit_plan: dict[str, Any] | None,
+    ai_triage: dict[str, Any] | None,
 ) -> bool:
     """Check if there is content worth synthesizing."""
     if maintainer_guidance:
@@ -330,8 +335,8 @@ def _has_synthesizable_content(
 def _build_synthesis_comment(
     marker: str,
     maintainer_guidance: list[str],
-    coderabbit_plan: dict | None,
-    ai_triage: dict | None,
+    coderabbit_plan: dict[str, Any] | None,
+    ai_triage: dict[str, Any] | None,
 ) -> str:
     """Generate the synthesis comment body."""
     timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
@@ -376,8 +381,8 @@ def _build_synthesis_comment(
 
 
 def _find_existing_synthesis(
-    comments: list[dict], marker: str,
-) -> dict | None:
+    comments: list[dict[str, Any]], marker: str,
+) -> dict[str, Any] | None:
     """Find existing synthesis comment by marker."""
     escaped = re.escape(marker)
     for c in comments:
@@ -388,14 +393,22 @@ def _find_existing_synthesis(
 
 def _assign_copilot(owner: str, repo: str, issue_number: int) -> bool:
     """Assign copilot-swe-agent to the issue."""
-    result = subprocess.run(
-        [
-            "gh", "issue", "edit", str(issue_number),
-            "--repo", f"{owner}/{repo}",
-            "--add-assignee", "copilot-swe-agent",
-        ],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "edit", str(issue_number),
+                "--repo", f"{owner}/{repo}",
+                "--add-assignee", "copilot-swe-agent",
+            ],
+            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"WARNING: copilot assign timed out after {GH_TIMEOUT_SECONDS}s",
+            file=sys.stderr,
+        )
+        return False
     if result.returncode != 0:
         print(f"WARNING: Failed to assign copilot-swe-agent: {result.stderr}", file=sys.stderr)
         return False
@@ -403,7 +416,7 @@ def _assign_copilot(owner: str, repo: str, issue_number: int) -> bool:
 
 
 def _create_context_file(
-    issue: dict, trusted_comments: list[dict], issue_number: int,
+    issue: dict[str, Any], trusted_comments: list[dict[str, Any]], issue_number: int,
 ) -> str:
     """Create a context file for AI synthesis."""
     context_file = os.path.join(tempfile.gettempdir(), f"issue-{issue_number}-context.md")
@@ -517,10 +530,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         )
 
     # Fetch issue details
-    issue_result = subprocess.run(
-        ["gh", "api", f"repos/{owner}/{repo}/issues/{issue_number}"],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        issue_result = subprocess.run(
+            ["gh", "api", f"repos/{owner}/{repo}/issues/{issue_number}"],
+            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        error_and_exit(
+            f"Issue fetch timed out after {GH_TIMEOUT_SECONDS}s", 3
+        )
     if issue_result.returncode != 0:
         error_str = issue_result.stderr.strip() or issue_result.stdout.strip()
         if "Not Found" in error_str:

--- a/.claude/skills/github/scripts/milestone/set_item_milestone.py
+++ b/.claude/skills/github/scripts/milestone/set_item_milestone.py
@@ -120,7 +120,7 @@ def _get_item_milestone(owner: str, repo: str, number: int) -> str | None:
     try:
         result = subprocess.run(
             ["gh", "api", f"repos/{owner}/{repo}/issues/{number}"],
-            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            capture_output=True, encoding="utf-8", errors="replace", timeout=GH_TIMEOUT_SECONDS,
             check=False,
         )
     except subprocess.TimeoutExpired:
@@ -169,7 +169,7 @@ def _assign_milestone(owner: str, repo: str, number: int, milestone_title: str) 
                 "--repo", f"{owner}/{repo}",
                 "--milestone", milestone_title,
             ],
-            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            capture_output=True, encoding="utf-8", errors="replace", timeout=GH_TIMEOUT_SECONDS,
             check=False,
         )
     except subprocess.TimeoutExpired:

--- a/.claude/skills/github/scripts/milestone/set_item_milestone.py
+++ b/.claude/skills/github/scripts/milestone/set_item_milestone.py
@@ -53,6 +53,10 @@ from github_core.output import (  # noqa: E402
 _SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
 
 
+# Upper bound (seconds) for each gh network call.
+GH_TIMEOUT_SECONDS = 30
+
+
 def _parse_semver_tuple(version: str) -> tuple[int, ...]:
     return tuple(int(part) for part in version.split("."))
 
@@ -113,10 +117,16 @@ def _write_result(
 
 def _get_item_milestone(owner: str, repo: str, number: int) -> str | None:
     """Return the current milestone title for a PR/issue, or None."""
-    result = subprocess.run(
-        ["gh", "api", f"repos/{owner}/{repo}/issues/{number}"],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{owner}/{repo}/issues/{number}"],
+            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        error_and_exit(
+            f"Query for item #{number} timed out after {GH_TIMEOUT_SECONDS}s", 3
+        )
     if result.returncode != 0:
         error_str = result.stderr.strip() or result.stdout.strip()
         error_and_exit(f"Failed to query item #{number}: {error_str}", 3)
@@ -132,7 +142,7 @@ def _get_item_milestone(owner: str, repo: str, number: int) -> str | None:
     return None
 
 
-def _get_latest_semantic_milestone(owner: str, repo: str) -> dict:
+def _get_latest_semantic_milestone(owner: str, repo: str) -> dict[str, object]:
     """Detect the latest open semantic version milestone."""
     endpoint = f"repos/{owner}/{repo}/milestones?state=open"
     milestones = gh_api_paginated(endpoint)
@@ -152,14 +162,20 @@ def _get_latest_semantic_milestone(owner: str, repo: str) -> dict:
 
 def _assign_milestone(owner: str, repo: str, number: int, milestone_title: str) -> None:
     """Assign a milestone to a PR/issue via gh CLI."""
-    result = subprocess.run(
-        [
-            "gh", "issue", "edit", str(number),
-            "--repo", f"{owner}/{repo}",
-            "--milestone", milestone_title,
-        ],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "edit", str(number),
+                "--repo", f"{owner}/{repo}",
+                "--milestone", milestone_title,
+            ],
+            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        error_and_exit(
+            f"Milestone assign for #{number} timed out after {GH_TIMEOUT_SECONDS}s", 3
+        )
     if result.returncode != 0:
         error_str = result.stderr.strip() or result.stdout.strip()
         error_and_exit(

--- a/.claude/skills/github/scripts/reactions/add_comment_reaction.py
+++ b/.claude/skills/github/scripts/reactions/add_comment_reaction.py
@@ -114,7 +114,7 @@ def main(argv: list[str] | None = None) -> int:
         try:
             result = subprocess.run(
                 ["gh", "api", endpoint, "-X", "POST", "-f", f"content={args.reaction}"],
-                capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+                capture_output=True, encoding="utf-8", errors="replace", timeout=GH_TIMEOUT_SECONDS,
                 check=False,
             )
         except subprocess.TimeoutExpired:

--- a/.claude/skills/github/scripts/reactions/add_comment_reaction.py
+++ b/.claude/skills/github/scripts/reactions/add_comment_reaction.py
@@ -59,6 +59,10 @@ REACTION_EMOJI: dict[str, str] = {
 VALID_REACTIONS = list(REACTION_EMOJI.keys())
 
 
+# Upper bound (seconds) for each gh network call.
+GH_TIMEOUT_SECONDS = 30
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Add a reaction to one or more GitHub comments.",
@@ -99,7 +103,7 @@ def main(argv: list[str] | None = None) -> int:
     emoji = REACTION_EMOJI.get(args.reaction, args.reaction)
     succeeded = 0
     failed = 0
-    results: list[dict] = []
+    results: list[dict[str, object]] = []
 
     for cid in args.comment_id:
         if args.comment_type == "review":
@@ -107,10 +111,21 @@ def main(argv: list[str] | None = None) -> int:
         else:
             endpoint = f"repos/{owner}/{repo}/issues/comments/{cid}/reactions"
 
-        result = subprocess.run(
-            ["gh", "api", endpoint, "-X", "POST", "-f", f"content={args.reaction}"],
-            capture_output=True, text=True, check=False,
-        )
+        try:
+            result = subprocess.run(
+                ["gh", "api", endpoint, "-X", "POST", "-f", f"content={args.reaction}"],
+                capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            # One hung reaction must not stall the whole loop.
+            failed += 1
+            results.append({
+                "success": False,
+                "comment_id": cid,
+                "error": f"gh api timed out after {GH_TIMEOUT_SECONDS}s",
+            })
+            continue
 
         # Duplicate reactions are OK (idempotent)
         success = result.returncode == 0 or "already reacted" in (result.stderr + result.stdout)

--- a/.claude/skills/merge-resolver/scripts/resolve_pr_conflicts.py
+++ b/.claude/skills/merge-resolver/scripts/resolve_pr_conflicts.py
@@ -273,14 +273,30 @@ def _resolve_conflicted_file(
     return "resolved"
 
 
-def _run_git(*args: str, cwd: str | None = None) -> subprocess.CompletedProcess[str]:
-    """Run a git command and return the result."""
-    return subprocess.run(
-        ["git", *args],
-        capture_output=True,
-        text=True,
-        cwd=cwd,
-    )
+def _run_git(
+    *args: str, cwd: str | None = None, timeout: int = 60
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command and return the result.
+
+    A timeout returns a synthetic nonzero result instead of raising, so
+    every caller's returncode check handles a hung fetch/push the same way
+    as any other git failure.
+    """
+    try:
+        return subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=["git", *args],
+            returncode=124,
+            stdout="",
+            stderr=f"git {args[0]} timed out after {timeout}s",
+        )
 
 
 def resolve_conflicts_runner(
@@ -295,6 +311,11 @@ def resolve_conflicts_runner(
         "files_resolved": [],
         "files_blocked": [],
     }
+
+    for ref in (branch_name, target_branch):
+        if ref.startswith("-"):
+            result["message"] = f"Invalid ref (leading dash): {ref}"
+            return result
 
     if dry_run:
         result["message"] = (

--- a/.claude/skills/merge-resolver/scripts/resolve_pr_conflicts.py
+++ b/.claude/skills/merge-resolver/scripts/resolve_pr_conflicts.py
@@ -138,7 +138,7 @@ def get_repo_info() -> RepoInfo:
         result = subprocess.run(
             ["git", "remote", "get-url", "origin"],
             capture_output=True,
-            text=True,
+            encoding="utf-8", errors="replace",
             check=True,
             timeout=10,
         )
@@ -286,7 +286,7 @@ def _run_git(
         return subprocess.run(
             ["git", *args],
             capture_output=True,
-            text=True,
+            encoding="utf-8", errors="replace",
             cwd=cwd,
             timeout=timeout,
         )

--- a/.claude/skills/slashcommandcreator/scripts/validate_slash_command.py
+++ b/.claude/skills/slashcommandcreator/scripts/validate_slash_command.py
@@ -135,11 +135,17 @@ def _validate_length(content: str, violations: list[str]) -> None:
 def _validate_lint(path: str, violations: list[str]) -> None:
     """Run markdownlint-cli2 on the file."""
     print("Running markdownlint-cli2...")
-    result = subprocess.run(
-        ["npx", "markdownlint-cli2", "--", path],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["npx", "markdownlint-cli2", "--", path],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        # First run may fetch the package; a hang must not block validation.
+        print("WARNING: markdownlint-cli2 timed out after 120s; lint skipped")
+        return
 
     if result.returncode != 0:
         violations.append("BLOCKING: Markdown lint errors:")

--- a/.claude/skills/slashcommandcreator/scripts/validate_slash_command.py
+++ b/.claude/skills/slashcommandcreator/scripts/validate_slash_command.py
@@ -139,7 +139,7 @@ def _validate_lint(path: str, violations: list[str]) -> None:
         result = subprocess.run(
             ["npx", "markdownlint-cli2", "--", path],
             capture_output=True,
-            text=True,
+            encoding="utf-8", errors="replace",
             timeout=120,
         )
     except subprocess.TimeoutExpired:

--- a/scripts/github_core/worktree_identity.py
+++ b/scripts/github_core/worktree_identity.py
@@ -42,6 +42,7 @@ def _run_git_config(
         errors="replace",
         env=env,
         check=check,
+        timeout=10,
     )
 
 

--- a/scripts/homework_scanner.py
+++ b/scripts/homework_scanner.py
@@ -221,25 +221,32 @@ def create_issues(
             )
             continue
 
-        result = subprocess.run(
-            [
-                "gh",
-                "issue",
-                "create",
-                "--repo",
-                f"{owner}/{repo}",
-                "--title",
-                title,
-                "--body",
-                body,
-                "--label",
-                "homework,enhancement",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-            shell=False,
-        )
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "create",
+                    "--repo",
+                    f"{owner}/{repo}",
+                    "--title",
+                    title,
+                    "--body",
+                    body,
+                    "--label",
+                    "homework,enhancement",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                shell=False,
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            created.append(
+                {"title": title, "error": "gh issue create timed out after 60s"}
+            )
+            continue
         if result.returncode == 0:
             issue_url = result.stdout.strip()
             created.append({"title": title, "url": issue_url})

--- a/scripts/homework_scanner.py
+++ b/scripts/homework_scanner.py
@@ -237,7 +237,7 @@ def create_issues(
                     "homework,enhancement",
                 ],
                 capture_output=True,
-                text=True,
+                encoding="utf-8", errors="replace",
                 check=False,
                 shell=False,
                 timeout=60,

--- a/scripts/install_git_hooks.py
+++ b/scripts/install_git_hooks.py
@@ -52,14 +52,23 @@ def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
     repository override variables the caller may have inherited.
     """
     env = {k: v for k, v in os.environ.items() if k not in ("GIT_DIR", "GIT_WORK_TREE")}
-    return subprocess.run(
-        ["git", "-C", str(cwd), *args],
-        cwd=str(cwd),
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-    )
+    try:
+        return subprocess.run(
+            ["git", "-C", str(cwd), *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=["git", "-C", str(cwd), *args],
+            returncode=124,
+            stdout="",
+            stderr="git command timed out after 10s",
+        )
 
 
 def find_repo_root(start: Path) -> Path | None:

--- a/scripts/install_git_hooks.py
+++ b/scripts/install_git_hooks.py
@@ -57,7 +57,7 @@ def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
             ["git", "-C", str(cwd), *args],
             cwd=str(cwd),
             capture_output=True,
-            text=True,
+            encoding="utf-8", errors="replace",
             check=False,
             env=env,
             timeout=10,

--- a/scripts/install_semgrep.py
+++ b/scripts/install_semgrep.py
@@ -45,7 +45,7 @@ class SemgrepInstaller:
             result = subprocess.run(
                 ["semgrep", "--version"],
                 capture_output=True,
-                text=True,
+                encoding="utf-8", errors="replace",
                 check=False,
             )
             if result.returncode == 0:
@@ -64,7 +64,7 @@ class SemgrepInstaller:
             result = subprocess.run(
                 [sys.executable, "-m", "pip", "install", "semgrep"],
                 capture_output=True,
-                text=True,
+                encoding="utf-8", errors="replace",
                 check=False,
                 timeout=300,
             )

--- a/scripts/install_semgrep.py
+++ b/scripts/install_semgrep.py
@@ -66,6 +66,7 @@ class SemgrepInstaller:
                 capture_output=True,
                 text=True,
                 check=False,
+                timeout=300,
             )
 
             if result.returncode == 0:

--- a/scripts/invoke_batch_pr_review.py
+++ b/scripts/invoke_batch_pr_review.py
@@ -39,7 +39,7 @@ def run_git(
             args=['git', *args],
             returncode=124,
             stdout="",
-            stderr="git command timed out after 30s",
+            stderr=f"git command timed out after {timeout}s",
         )
 
 
@@ -56,7 +56,7 @@ def run_gh(*args: str, timeout: int = 60) -> subprocess.CompletedProcess[str]:
             args=['gh', *args],
             returncode=124,
             stdout="",
-            stderr="gh command timed out after 60s",
+            stderr=f"gh command timed out after {timeout}s",
         )
 
 

--- a/scripts/invoke_batch_pr_review.py
+++ b/scripts/invoke_batch_pr_review.py
@@ -23,21 +23,41 @@ from scripts.github_core.repo import get_repo_root
 from scripts.github_core.worktree_identity import reset_worktree_identity
 
 
-def run_git(*args: str, cwd: str | Path | None = None) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["git", *args],
-        capture_output=True,
-        text=True,
-        cwd=cwd,
-    )
+def run_git(
+    *args: str, cwd: str | Path | None = None, timeout: int = 30
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=['git', *args],
+            returncode=124,
+            stdout="",
+            stderr=f"git command timed out after 30s",
+        )
 
 
-def run_gh(*args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["gh", *args],
-        capture_output=True,
-        text=True,
-    )
+def run_gh(*args: str, timeout: int = 60) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=['gh', *args],
+            returncode=124,
+            stdout="",
+            stderr=f"gh command timed out after 60s",
+        )
 
 
 def get_pr_branch(pr_number: int) -> str | None:

--- a/scripts/invoke_batch_pr_review.py
+++ b/scripts/invoke_batch_pr_review.py
@@ -30,7 +30,7 @@ def run_git(
         return subprocess.run(
             ["git", *args],
             capture_output=True,
-            text=True,
+            encoding="utf-8", errors="replace",
             cwd=cwd,
             timeout=timeout,
         )
@@ -48,7 +48,7 @@ def run_gh(*args: str, timeout: int = 60) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             ["gh", *args],
             capture_output=True,
-            text=True,
+            encoding="utf-8", errors="replace",
             timeout=timeout,
         )
     except subprocess.TimeoutExpired:

--- a/scripts/invoke_batch_pr_review.py
+++ b/scripts/invoke_batch_pr_review.py
@@ -39,7 +39,7 @@ def run_git(
             args=['git', *args],
             returncode=124,
             stdout="",
-            stderr=f"git command timed out after 30s",
+            stderr="git command timed out after 30s",
         )
 
 
@@ -56,7 +56,7 @@ def run_gh(*args: str, timeout: int = 60) -> subprocess.CompletedProcess[str]:
             args=['gh', *args],
             returncode=124,
             stdout="",
-            stderr=f"gh command timed out after 60s",
+            stderr="gh command timed out after 60s",
         )
 
 

--- a/scripts/invoke_session_start_gate.py
+++ b/scripts/invoke_session_start_gate.py
@@ -32,7 +32,7 @@ from scripts.github_core.repo import get_repo_root
 def run_git(*args: str, timeout: int = 10) -> subprocess.CompletedProcess[str]:
     try:
         return subprocess.run(
-            ["git", *args], capture_output=True, text=True, timeout=timeout
+            ["git", *args], capture_output=True, encoding="utf-8", errors="replace", timeout=timeout
         )
     except subprocess.TimeoutExpired:
         return subprocess.CompletedProcess(

--- a/scripts/invoke_session_start_gate.py
+++ b/scripts/invoke_session_start_gate.py
@@ -29,8 +29,18 @@ from pathlib import Path
 from scripts.github_core.repo import get_repo_root
 
 
-def run_git(*args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(["git", *args], capture_output=True, text=True)
+def run_git(*args: str, timeout: int = 10) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["git", *args], capture_output=True, text=True, timeout=timeout
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=['git', *args],
+            returncode=124,
+            stdout="",
+            stderr="git command timed out after 10s",
+        )
 
 
 def check_memory_gate(repo_root: Path) -> bool:

--- a/scripts/invoke_session_start_gate.py
+++ b/scripts/invoke_session_start_gate.py
@@ -39,7 +39,7 @@ def run_git(*args: str, timeout: int = 10) -> subprocess.CompletedProcess[str]:
             args=['git', *args],
             returncode=124,
             stdout="",
-            stderr="git command timed out after 10s",
+            stderr=f"git command timed out after {timeout}s",
         )
 
 

--- a/scripts/security/invoke_security_retrospective.py
+++ b/scripts/security/invoke_security_retrospective.py
@@ -129,8 +129,8 @@ class SecurityRetrospective:
             len(self.false_negatives),
         )
 
-        # Step 4: Store in memory systems
-        forgetful_success = self._store_in_forgetful()
+        # Step 4: Store in memory systems (Forgetful is best-effort, Serena blocks)
+        self._store_in_forgetful()
         serena_success = self._store_in_serena()
 
         # Serena is BLOCKING per plan requirements
@@ -204,7 +204,7 @@ class SecurityRetrospective:
                     "--paginate",
                 ],
                 capture_output=True,
-                text=True,
+                encoding="utf-8", errors="replace",
                 check=False,
                 timeout=120,
             )
@@ -272,7 +272,7 @@ class SecurityRetrospective:
             result = subprocess.run(
                 ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
                 capture_output=True,
-                text=True,
+                encoding="utf-8", errors="replace",
                 check=True,
             )
             return result.stdout.strip()

--- a/scripts/security/invoke_security_retrospective.py
+++ b/scripts/security/invoke_security_retrospective.py
@@ -165,7 +165,7 @@ class SecurityRetrospective:
 
     def _load_security_reports(self) -> list[dict[str, Any]]:
         """Load security reports from .agents/security/SR-*.md files."""
-        reports = []
+        reports: list[dict[str, object]] = []
         security_dir = self.repo_root / ".agents" / "security"
 
         if not security_dir.exists():
@@ -206,6 +206,7 @@ class SecurityRetrospective:
                 capture_output=True,
                 text=True,
                 check=False,
+                timeout=120,
             )
 
             if result.returncode != 0:
@@ -285,7 +286,7 @@ class SecurityRetrospective:
     ) -> None:
         """Compare agent findings with external review to identify misses."""
         # Extract CWE IDs from security reports
-        agent_cwes = set()
+        agent_cwes: set[str] = set()
         for report in security_reports:
             content = report.get("content", "")
             # Simple CWE extraction pattern

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.254",
+  "version": "0.5.255",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/lib/github_core/worktree_identity.py
+++ b/src/copilot-cli/lib/github_core/worktree_identity.py
@@ -42,6 +42,7 @@ def _run_git_config(
         errors="replace",
         env=env,
         check=check,
+        timeout=10,
     )
 
 

--- a/src/copilot-cli/skills/github/scripts/issue/invoke_copilot_assignment.py
+++ b/src/copilot-cli/skills/github/scripts/issue/invoke_copilot_assignment.py
@@ -122,7 +122,7 @@ def _load_synthesis_config(config_path: str) -> dict[str, Any]:
         try:
             result = subprocess.run(
                 ["git", "rev-parse", "--git-common-dir"],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True, encoding="utf-8", errors="replace", timeout=10,
             )
             if result.returncode == 0:
                 git_common = Path(result.stdout.strip())
@@ -400,7 +400,7 @@ def _assign_copilot(owner: str, repo: str, issue_number: int) -> bool:
                 "--repo", f"{owner}/{repo}",
                 "--add-assignee", "copilot-swe-agent",
             ],
-            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            capture_output=True, encoding="utf-8", errors="replace", timeout=GH_TIMEOUT_SECONDS,
             check=False,
         )
     except subprocess.TimeoutExpired:
@@ -533,7 +533,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
     try:
         issue_result = subprocess.run(
             ["gh", "api", f"repos/{owner}/{repo}/issues/{issue_number}"],
-            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            capture_output=True, encoding="utf-8", errors="replace", timeout=GH_TIMEOUT_SECONDS,
             check=False,
         )
     except subprocess.TimeoutExpired:

--- a/src/copilot-cli/skills/github/scripts/issue/invoke_copilot_assignment.py
+++ b/src/copilot-cli/skills/github/scripts/issue/invoke_copilot_assignment.py
@@ -21,6 +21,8 @@ import argparse
 import json
 import os
 import re
+from typing import Any
+
 import subprocess
 import sys
 import tempfile
@@ -62,7 +64,7 @@ from github_core.output import (  # noqa: E402
 # Configuration
 # ---------------------------------------------------------------------------
 
-_DEFAULT_CONFIG: dict = {
+_DEFAULT_CONFIG: dict[str, Any] = {
     "trusted_sources": {
         "maintainers": [],
         "ai_agents": [],
@@ -82,6 +84,10 @@ _DEFAULT_CONFIG: dict = {
         "marker": "<!-- COPILOT-CONTEXT-SYNTHESIS -->",
     },
 }
+
+
+# Upper bound (seconds) for each gh network call.
+GH_TIMEOUT_SECONDS = 30
 
 
 def _extract_yaml_list(content: str, key: str) -> list[str]:
@@ -107,7 +113,7 @@ def _extract_yaml_list(content: str, key: str) -> list[str]:
     return items
 
 
-def _load_synthesis_config(config_path: str) -> dict:
+def _load_synthesis_config(config_path: str) -> dict[str, Any]:
     """Load copilot-synthesis.yml configuration or return empty defaults.
 
     When the config file is missing, returns empty trusted_sources lists.
@@ -137,7 +143,7 @@ def _load_synthesis_config(config_path: str) -> dict:
 
     try:
         content = Path(config_path).read_text(encoding="utf-8")
-        config: dict = json.loads(json.dumps(_DEFAULT_CONFIG))
+        config: dict[str, Any] = json.loads(json.dumps(_DEFAULT_CONFIG))
 
         # Extract maintainers (line-by-line to avoid ReDoS)
         config["trusted_sources"]["maintainers"] = [
@@ -174,7 +180,7 @@ def _load_synthesis_config(config_path: str) -> dict:
 
 
 def _get_maintainer_guidance(
-    comments: list[dict], maintainers: list[str],
+    comments: list[dict[str, Any]], maintainers: list[str],
 ) -> list[str]:
     """Extract key decisions from maintainer comments.
 
@@ -217,8 +223,8 @@ def _get_maintainer_guidance(
 
 
 def _get_coderabbit_plan(
-    comments: list[dict], patterns: dict,
-) -> dict | None:
+    comments: list[dict[str, Any]], patterns: dict[str, Any],
+) -> dict[str, Any] | None:
     """Extract implementation plan from CodeRabbit comments."""
     rabbit_comments = [
         c for c in comments if c.get("user", {}).get("login") == patterns["username"]
@@ -226,7 +232,7 @@ def _get_coderabbit_plan(
     if not rabbit_comments:
         return None
 
-    plan: dict = {"implementation": None, "related_issues": [], "related_prs": []}
+    plan: dict[str, Any] = {"implementation": None, "related_issues": [], "related_prs": []}
 
     impl_pattern = re.escape(patterns["implementation_plan"])
     issues_raw = re.escape(patterns["related_issues"])
@@ -267,8 +273,8 @@ def _get_coderabbit_plan(
 
 
 def _get_ai_triage_info(
-    comments: list[dict], triage_marker: str,
-) -> dict | None:
+    comments: list[dict[str, Any]], triage_marker: str,
+) -> dict[str, Any] | None:
     """Extract triage information from AI Triage comments."""
     escaped_marker = re.escape(triage_marker)
     triage_comment = None
@@ -305,8 +311,8 @@ def _get_ai_triage_info(
 
 def _has_synthesizable_content(
     maintainer_guidance: list[str],
-    coderabbit_plan: dict | None,
-    ai_triage: dict | None,
+    coderabbit_plan: dict[str, Any] | None,
+    ai_triage: dict[str, Any] | None,
 ) -> bool:
     """Check if there is content worth synthesizing."""
     if maintainer_guidance:
@@ -330,8 +336,8 @@ def _has_synthesizable_content(
 def _build_synthesis_comment(
     marker: str,
     maintainer_guidance: list[str],
-    coderabbit_plan: dict | None,
-    ai_triage: dict | None,
+    coderabbit_plan: dict[str, Any] | None,
+    ai_triage: dict[str, Any] | None,
 ) -> str:
     """Generate the synthesis comment body."""
     timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
@@ -376,8 +382,8 @@ def _build_synthesis_comment(
 
 
 def _find_existing_synthesis(
-    comments: list[dict], marker: str,
-) -> dict | None:
+    comments: list[dict[str, Any]], marker: str,
+) -> dict[str, Any] | None:
     """Find existing synthesis comment by marker."""
     escaped = re.escape(marker)
     for c in comments:
@@ -388,14 +394,22 @@ def _find_existing_synthesis(
 
 def _assign_copilot(owner: str, repo: str, issue_number: int) -> bool:
     """Assign copilot-swe-agent to the issue."""
-    result = subprocess.run(
-        [
-            "gh", "issue", "edit", str(issue_number),
-            "--repo", f"{owner}/{repo}",
-            "--add-assignee", "copilot-swe-agent",
-        ],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "edit", str(issue_number),
+                "--repo", f"{owner}/{repo}",
+                "--add-assignee", "copilot-swe-agent",
+            ],
+            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"WARNING: copilot assign timed out after {GH_TIMEOUT_SECONDS}s",
+            file=sys.stderr,
+        )
+        return False
     if result.returncode != 0:
         print(f"WARNING: Failed to assign copilot-swe-agent: {result.stderr}", file=sys.stderr)
         return False
@@ -403,7 +417,7 @@ def _assign_copilot(owner: str, repo: str, issue_number: int) -> bool:
 
 
 def _create_context_file(
-    issue: dict, trusted_comments: list[dict], issue_number: int,
+    issue: dict[str, Any], trusted_comments: list[dict[str, Any]], issue_number: int,
 ) -> str:
     """Create a context file for AI synthesis."""
     context_file = os.path.join(tempfile.gettempdir(), f"issue-{issue_number}-context.md")
@@ -517,10 +531,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 - faithful port of
         )
 
     # Fetch issue details
-    issue_result = subprocess.run(
-        ["gh", "api", f"repos/{owner}/{repo}/issues/{issue_number}"],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        issue_result = subprocess.run(
+            ["gh", "api", f"repos/{owner}/{repo}/issues/{issue_number}"],
+            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        error_and_exit(
+            f"Issue fetch timed out after {GH_TIMEOUT_SECONDS}s", 3
+        )
     if issue_result.returncode != 0:
         error_str = issue_result.stderr.strip() or issue_result.stdout.strip()
         if "Not Found" in error_str:

--- a/src/copilot-cli/skills/github/scripts/issue/invoke_copilot_assignment.py
+++ b/src/copilot-cli/skills/github/scripts/issue/invoke_copilot_assignment.py
@@ -21,13 +21,12 @@ import argparse
 import json
 import os
 import re
-from typing import Any
-
 import subprocess
 import sys
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
 _workspace = os.environ.get("GITHUB_WORKSPACE")

--- a/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
+++ b/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
@@ -120,7 +120,7 @@ def _get_item_milestone(owner: str, repo: str, number: int) -> str | None:
     try:
         result = subprocess.run(
             ["gh", "api", f"repos/{owner}/{repo}/issues/{number}"],
-            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            capture_output=True, encoding="utf-8", errors="replace", timeout=GH_TIMEOUT_SECONDS,
             check=False,
         )
     except subprocess.TimeoutExpired:
@@ -169,7 +169,7 @@ def _assign_milestone(owner: str, repo: str, number: int, milestone_title: str) 
                 "--repo", f"{owner}/{repo}",
                 "--milestone", milestone_title,
             ],
-            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            capture_output=True, encoding="utf-8", errors="replace", timeout=GH_TIMEOUT_SECONDS,
             check=False,
         )
     except subprocess.TimeoutExpired:

--- a/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
+++ b/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
@@ -53,6 +53,10 @@ from github_core.output import (  # noqa: E402
 _SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
 
 
+# Upper bound (seconds) for each gh network call.
+GH_TIMEOUT_SECONDS = 30
+
+
 def _parse_semver_tuple(version: str) -> tuple[int, ...]:
     return tuple(int(part) for part in version.split("."))
 
@@ -113,10 +117,16 @@ def _write_result(
 
 def _get_item_milestone(owner: str, repo: str, number: int) -> str | None:
     """Return the current milestone title for a PR/issue, or None."""
-    result = subprocess.run(
-        ["gh", "api", f"repos/{owner}/{repo}/issues/{number}"],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{owner}/{repo}/issues/{number}"],
+            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        error_and_exit(
+            f"Query for item #{number} timed out after {GH_TIMEOUT_SECONDS}s", 3
+        )
     if result.returncode != 0:
         error_str = result.stderr.strip() or result.stdout.strip()
         error_and_exit(f"Failed to query item #{number}: {error_str}", 3)
@@ -132,7 +142,7 @@ def _get_item_milestone(owner: str, repo: str, number: int) -> str | None:
     return None
 
 
-def _get_latest_semantic_milestone(owner: str, repo: str) -> dict:
+def _get_latest_semantic_milestone(owner: str, repo: str) -> dict[str, object]:
     """Detect the latest open semantic version milestone."""
     endpoint = f"repos/{owner}/{repo}/milestones?state=open"
     milestones = gh_api_paginated(endpoint)
@@ -152,14 +162,20 @@ def _get_latest_semantic_milestone(owner: str, repo: str) -> dict:
 
 def _assign_milestone(owner: str, repo: str, number: int, milestone_title: str) -> None:
     """Assign a milestone to a PR/issue via gh CLI."""
-    result = subprocess.run(
-        [
-            "gh", "issue", "edit", str(number),
-            "--repo", f"{owner}/{repo}",
-            "--milestone", milestone_title,
-        ],
-        capture_output=True, text=True, check=False,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "edit", str(number),
+                "--repo", f"{owner}/{repo}",
+                "--milestone", milestone_title,
+            ],
+            capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        error_and_exit(
+            f"Milestone assign for #{number} timed out after {GH_TIMEOUT_SECONDS}s", 3
+        )
     if result.returncode != 0:
         error_str = result.stderr.strip() or result.stdout.strip()
         error_and_exit(

--- a/src/copilot-cli/skills/github/scripts/reactions/add_comment_reaction.py
+++ b/src/copilot-cli/skills/github/scripts/reactions/add_comment_reaction.py
@@ -114,7 +114,7 @@ def main(argv: list[str] | None = None) -> int:
         try:
             result = subprocess.run(
                 ["gh", "api", endpoint, "-X", "POST", "-f", f"content={args.reaction}"],
-                capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+                capture_output=True, encoding="utf-8", errors="replace", timeout=GH_TIMEOUT_SECONDS,
                 check=False,
             )
         except subprocess.TimeoutExpired:

--- a/src/copilot-cli/skills/github/scripts/reactions/add_comment_reaction.py
+++ b/src/copilot-cli/skills/github/scripts/reactions/add_comment_reaction.py
@@ -59,6 +59,10 @@ REACTION_EMOJI: dict[str, str] = {
 VALID_REACTIONS = list(REACTION_EMOJI.keys())
 
 
+# Upper bound (seconds) for each gh network call.
+GH_TIMEOUT_SECONDS = 30
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Add a reaction to one or more GitHub comments.",
@@ -99,7 +103,7 @@ def main(argv: list[str] | None = None) -> int:
     emoji = REACTION_EMOJI.get(args.reaction, args.reaction)
     succeeded = 0
     failed = 0
-    results: list[dict] = []
+    results: list[dict[str, object]] = []
 
     for cid in args.comment_id:
         if args.comment_type == "review":
@@ -107,10 +111,21 @@ def main(argv: list[str] | None = None) -> int:
         else:
             endpoint = f"repos/{owner}/{repo}/issues/comments/{cid}/reactions"
 
-        result = subprocess.run(
-            ["gh", "api", endpoint, "-X", "POST", "-f", f"content={args.reaction}"],
-            capture_output=True, text=True, check=False,
-        )
+        try:
+            result = subprocess.run(
+                ["gh", "api", endpoint, "-X", "POST", "-f", f"content={args.reaction}"],
+                capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            # One hung reaction must not stall the whole loop.
+            failed += 1
+            results.append({
+                "success": False,
+                "comment_id": cid,
+                "error": f"gh api timed out after {GH_TIMEOUT_SECONDS}s",
+            })
+            continue
 
         # Duplicate reactions are OK (idempotent)
         success = result.returncode == 0 or "already reacted" in (result.stderr + result.stdout)

--- a/src/copilot-cli/skills/slashcommandcreator/scripts/validate_slash_command.py
+++ b/src/copilot-cli/skills/slashcommandcreator/scripts/validate_slash_command.py
@@ -135,11 +135,17 @@ def _validate_length(content: str, violations: list[str]) -> None:
 def _validate_lint(path: str, violations: list[str]) -> None:
     """Run markdownlint-cli2 on the file."""
     print("Running markdownlint-cli2...")
-    result = subprocess.run(
-        ["npx", "markdownlint-cli2", "--", path],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["npx", "markdownlint-cli2", "--", path],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        # First run may fetch the package; a hang must not block validation.
+        print("WARNING: markdownlint-cli2 timed out after 120s; lint skipped")
+        return
 
     if result.returncode != 0:
         violations.append("BLOCKING: Markdown lint errors:")

--- a/src/copilot-cli/skills/slashcommandcreator/scripts/validate_slash_command.py
+++ b/src/copilot-cli/skills/slashcommandcreator/scripts/validate_slash_command.py
@@ -139,7 +139,7 @@ def _validate_lint(path: str, violations: list[str]) -> None:
         result = subprocess.run(
             ["npx", "markdownlint-cli2", "--", path],
             capture_output=True,
-            text=True,
+            encoding="utf-8", errors="replace",
             timeout=120,
         )
     except subprocess.TimeoutExpired:

--- a/tests/test_timeout_hardening_2811b.py
+++ b/tests/test_timeout_hardening_2811b.py
@@ -1,0 +1,76 @@
+"""Subprocess timeout hardening, PR-B slice (issue #2811).
+
+Wrappers that callers drive by returncode must convert a hung subprocess
+into a synthetic nonzero result (exit 124) rather than raising, and the
+merge-resolver must reject dash-leading refs before handing them to git.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def _import_script(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_resolver = _import_script(
+    "resolve_pr_conflicts",
+    _REPO / ".claude" / "skills" / "merge-resolver" / "scripts" / "resolve_pr_conflicts.py",
+)
+
+import scripts.invoke_batch_pr_review as batch  # noqa: E402
+import scripts.invoke_session_start_gate as gate  # noqa: E402
+
+
+def test_resolver_run_git_timeout_returns_synthetic_124() -> None:
+    timeout = subprocess.TimeoutExpired(cmd="git", timeout=60)
+    with patch("subprocess.run", side_effect=timeout):
+        result = _resolver._run_git("fetch", "origin", "main")
+    assert result.returncode == 124
+    assert "timed out" in result.stderr
+
+
+def test_resolver_rejects_dash_leading_branch() -> None:
+    result = _resolver.resolve_conflicts_runner("--upload-pack=evil", "main")
+    assert result["success"] is False
+    assert "Invalid ref" in result["message"]
+
+
+def test_resolver_rejects_dash_leading_target() -> None:
+    result = _resolver.resolve_conflicts_runner("feature/x", "-otherflag")
+    assert result["success"] is False
+    assert "Invalid ref" in result["message"]
+
+
+def test_batch_run_git_timeout_returns_synthetic_124() -> None:
+    timeout = subprocess.TimeoutExpired(cmd="git", timeout=30)
+    with patch("subprocess.run", side_effect=timeout):
+        result = batch.run_git("fetch", "origin")
+    assert result.returncode == 124
+
+
+def test_batch_run_gh_timeout_returns_synthetic_124() -> None:
+    timeout = subprocess.TimeoutExpired(cmd="gh", timeout=60)
+    with patch("subprocess.run", side_effect=timeout):
+        result = batch.run_gh("pr", "view", "1")
+    assert result.returncode == 124
+
+
+def test_gate_run_git_timeout_returns_synthetic_124() -> None:
+    timeout = subprocess.TimeoutExpired(cmd="git", timeout=10)
+    with patch("subprocess.run", side_effect=timeout):
+        result = gate.run_git("rev-parse", "HEAD")
+    assert result.returncode == 124


### PR DESCRIPTION
## Summary

### What

Second slice of issue #2811: bound the remaining unbounded subprocess calls
across the github skill scripts, the merge-resolver, thin git wrappers, the
installers, the security retrospective, the homework scanner, and the
slash-command lint runner. Every site gets an explicit timeout with a defined
degradation instead of an indefinite hang.

### Why

A wedged gh, git, npx, or pip call tied up an agent hook, a batch loop, or a
CI step with no upper bound. This slice completes the timeout coverage that
PR #2824 (PR-A) started for the issue scripts.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #2811 | Missing subprocess timeouts on gh/network calls |

## Changes

- `.claude/skills/github/scripts/reactions/add_comment_reaction.py`: 30s per
  reaction; expiry is a per-item failure so one hung call cannot stall the loop.
- `.claude/skills/github/scripts/milestone/set_item_milestone.py`: 30s on both
  gh calls; expiry exits 3.
- `.claude/skills/github/scripts/issue/invoke_copilot_assignment.py`: 30s on
  the assign (warn, return False) and issue-fetch (exit 3) calls; the file's
  bare-dict annotations are typed as `dict[str, Any]`.
- `.claude/skills/merge-resolver/scripts/resolve_pr_conflicts.py`: `_run_git`
  gets a 60s timeout returning a synthetic exit-124 result so
  returncode-checking callers treat a hang as failure;
  `resolve_conflicts_runner` rejects dash-leading refs. Deviation from the
  issue's suggested fix: a `checkout --` separator would switch checkout to
  pathspec mode (restoring a file, not switching branches), and git refs
  cannot legally begin with a dash, so the entry guard is the correct
  hardening.
- `.claude/skills/slashcommandcreator/scripts/validate_slash_command.py`: 120s
  npx timeout; expiry prints a non-blocking lint-skipped note.
- `scripts/github_core/worktree_identity.py`: `timeout=10` on the git config
  helper (check-aware; expiry raises loudly), synced to both lib mirrors.
- `scripts/invoke_batch_pr_review.py`, `scripts/install_git_hooks.py`,
  `scripts/invoke_session_start_gate.py`: wrapper timeouts (30s/60s gh, 10s
  git) with the synthetic exit-124 pattern.
- `scripts/install_semgrep.py`: 300s on pip install (existing SubprocessError
  handler covers expiry). `scripts/homework_scanner.py`: 60s per issue
  creation with a per-title error entry.
  `scripts/security/invoke_security_retrospective.py`: 120s on the paginated
  gh fetch, plus two variable annotations.
- `tests/test_timeout_hardening_2811b.py`: 6 regression tests for the
  synthetic-timeout wrappers and the dash-ref guard.

### Deferred (tracked)

- Three hook sites (observation sync, ADR review guard, session
  initialization enforcer) carry the pre-existing hook-bootstrap mypy debt
  that already forced the #2812 hook deferrals; they land once that debt is
  settled, same precedent.
- Homework-scanner search-before-create idempotency: a resumability
  improvement beyond the timeout scope of this issue.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: the synthetic exit-124 wrapper pattern (hang becomes an
ordinary failure for returncode-checking callers) and the merge-resolver
dash-ref guard rationale.

## Testing

Deliverables in this PR:

- [x] Tests added/updated

Ran the affected suites: 428 passed (github + merge-resolver skill families);
6 passed in the new timeout tests. mypy clean across the 12 changed source
files. Mirrors regenerated via the sync and build pipelines; suppression scan
clean.

## Agent Review

### Security Review

- [x] Security patterns applied (dash-ref guard closes an argument-injection
  shape; timeouts treat expiry as failure, not silent pass)

**Files requiring security review:**

- `scripts/security/invoke_security_retrospective.py`
- `.claude/skills/merge-resolver/scripts/resolve_pr_conflicts.py`

## Author Pre-flight

- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed
- [x] No new warnings introduced

## Related Issues

Refs #2811

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wbb9jpubgid3eYuSxRtb38)_