### PR TITLE
fix(quality-gate): distinct "security review did not run" annotation (#2821)

### DIFF
--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -8277,6 +8277,69 @@
         "episode-2026-06-30-session-2600-skill-tooling-hygiene-taste-lints-naming"
       ],
       "created": "2026-06-30T16:56:20.064285+00:00"
+    },
+    {
+      "id": "910da7b3cdf1",
+      "type": "milestone",
+      "label": "milestone: Read issue #2821 and its discourse; owner has not picked an option, so implemented the recommended option c (additive visibility, keeps the deliberate WARN policy intact) as a draft PR for the owner to accept or reject",
+      "episodes": [
+        "episode-2026-07-03-session-2605"
+      ],
+      "created": "2026-07-03T16:17:16.373258+00:00"
+    },
+    {
+      "id": "eac5b587de3f",
+      "type": "milestone",
+      "label": "milestone: aggregate_quality_verdicts.py: emit ::warning annotation and a security_review_ran output when the security axis category is INFRASTRUCTURE, including the no-verdicts CRITICAL_FAIL branch",
+      "episodes": [
+        "episode-2026-07-03-session-2605"
+      ],
+      "created": "2026-07-03T16:17:16.373319+00:00"
+    },
+    {
+      "id": "a9c342770ad5",
+      "type": "milestone",
+      "label": "milestone: generate_quality_report.py: render a distinct CAUTION block under the final verdict when the security axis hit an infrastructure failure",
+      "episodes": [
+        "episode-2026-07-03-session-2605"
+      ],
+      "created": "2026-07-03T16:17:16.373356+00:00"
+    },
+    {
+      "id": "f5ec7a6f06ee",
+      "type": "milestone",
+      "label": "milestone: Added 8 regression tests (5 aggregate: infra-failure, all-pass, code-quality-failure, no-verdicts, nonsecurity-infra; 3 report: caution-present, caution-absent, nonsecurity-infra). uv run pytest: 42 passed across both suites",
+      "episodes": [
+        "episode-2026-07-03-session-2605"
+      ],
+      "created": "2026-07-03T16:17:16.373391+00:00"
+    },
+    {
+      "id": "57d6b6d72657",
+      "type": "test",
+      "label": "test: Added 8 regression tests (5 aggregate: infra-failure, all-pass, code-quality-failure, no-verdicts, nonsecurity-infra; 3 report: caution-present, caution-absent, nonsecurity-infra). uv run pytest: 42 passed across both suites",
+      "episodes": [
+        "episode-2026-07-03-session-2605"
+      ],
+      "created": "2026-07-03T16:17:16.373426+00:00"
+    },
+    {
+      "id": "b93aa9153be7",
+      "type": "commit",
+      "label": "commit: Commit: e5392ba",
+      "episodes": [
+        "episode-2026-07-03-session-2605"
+      ],
+      "created": "2026-07-03T16:17:16.373459+00:00"
+    },
+    {
+      "id": "8f0d460f7184",
+      "type": "outcome",
+      "label": "Outcome: success - Implement issue 2821 option c: distinct security-review-did-not-run annotation in the AI quality gate",
+      "episodes": [
+        "episode-2026-07-03-session-2605"
+      ],
+      "created": "2026-07-03T16:17:16.373493+00:00"
     }
   ],
   "patterns": [
@@ -8326,7 +8389,7 @@
       "trigger": "Testing second",
       "action": "Second",
       "success_rate": 1.0,
-      "occurrences": 43,
+      "occurrences": 44,
       "created": "2026-06-02T04:20:23.788442+00:00"
     },
     {
@@ -8335,7 +8398,7 @@
       "trigger": "Designing first",
       "action": "First",
       "success_rate": 1.0,
-      "occurrences": 86,
+      "occurrences": 88,
       "created": "2026-06-02T04:20:23.788446+00:00"
     },
     {
@@ -8344,7 +8407,7 @@
       "trigger": "When unknown decision needed",
       "action": "AVOID: Adopted a Draft PR policy for in-progress changes to maintain CI visibility without blocking merges.",
       "success_rate": 0.0,
-      "occurrences": 172,
+      "occurrences": 176,
       "created": "2026-06-02T04:20:23.789116+00:00"
     },
     {
@@ -8353,7 +8416,7 @@
       "trigger": "When implementation decision needed",
       "action": "Fail-closed (Option 2)",
       "success_rate": 1.0,
-      "occurrences": 258,
+      "occurrences": 264,
       "created": "2026-06-02T04:20:23.790649+00:00"
     }
   ],
@@ -8363,7 +8426,7 @@
       "target": "e48b42cae949",
       "type": "causes",
       "weight": 0.8,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.788737+00:00"
     },
     {
@@ -8371,7 +8434,7 @@
       "target": "bb2f794f5458",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.789096+00:00"
     },
     {
@@ -8379,7 +8442,7 @@
       "target": "6d984ffaf0ee",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.789110+00:00"
     },
     {
@@ -8387,7 +8450,7 @@
       "target": "b66bebe4f3cf",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790269+00:00"
     },
     {
@@ -8395,7 +8458,7 @@
       "target": "5a282fa7b7b7",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790282+00:00"
     },
     {
@@ -8403,7 +8466,7 @@
       "target": "1936e5d3b5e9",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790294+00:00"
     },
     {
@@ -8411,7 +8474,7 @@
       "target": "7085549bb5c8",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790306+00:00"
     },
     {
@@ -8419,7 +8482,7 @@
       "target": "62d968c016dc",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790318+00:00"
     },
     {
@@ -8427,7 +8490,7 @@
       "target": "c8e97015e15b",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790338+00:00"
     },
     {
@@ -8435,7 +8498,7 @@
       "target": "7085549bb5c8",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790349+00:00"
     },
     {
@@ -8443,7 +8506,7 @@
       "target": "a3772a33bb03",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790361+00:00"
     },
     {
@@ -8451,7 +8514,7 @@
       "target": "bbc919c9bfc3",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790373+00:00"
     },
     {
@@ -8459,7 +8522,7 @@
       "target": "1f3126121fa6",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790386+00:00"
     },
     {
@@ -8467,7 +8530,7 @@
       "target": "fdae8ee91ca3",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790403+00:00"
     },
     {
@@ -8475,7 +8538,7 @@
       "target": "d2f77552356c",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790426+00:00"
     },
     {
@@ -8483,7 +8546,7 @@
       "target": "b9bad794636c",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790439+00:00"
     },
     {
@@ -8491,7 +8554,7 @@
       "target": "b6c846324241",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790452+00:00"
     },
     {
@@ -8499,7 +8562,7 @@
       "target": "9ddffc4e2ea1",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790465+00:00"
     },
     {
@@ -8507,7 +8570,7 @@
       "target": "92d7f3738a9c",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790478+00:00"
     },
     {
@@ -8515,7 +8578,7 @@
       "target": "f6bbf604116c",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790491+00:00"
     },
     {
@@ -8523,7 +8586,7 @@
       "target": "b78663b0692a",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790504+00:00"
     },
     {
@@ -8531,7 +8594,7 @@
       "target": "cac4c97f7f07",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790517+00:00"
     },
     {
@@ -8539,7 +8602,7 @@
       "target": "0aebe2e20ff6",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790530+00:00"
     },
     {
@@ -8547,7 +8610,7 @@
       "target": "c3972fe69c57",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790544+00:00"
     },
     {
@@ -8555,7 +8618,7 @@
       "target": "e7a73b5ce937",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790560+00:00"
     },
     {
@@ -8563,7 +8626,7 @@
       "target": "68146e743ee2",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790573+00:00"
     },
     {
@@ -8571,7 +8634,7 @@
       "target": "37d27c11246f",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790586+00:00"
     },
     {
@@ -8579,7 +8642,7 @@
       "target": "35616517f846",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790602+00:00"
     },
     {
@@ -8587,7 +8650,7 @@
       "target": "7d5c82a09967",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790616+00:00"
     },
     {
@@ -8595,7 +8658,7 @@
       "target": "a161caf62b41",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790629+00:00"
     },
     {
@@ -8603,7 +8666,7 @@
       "target": "23e284592db9",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.790644+00:00"
     },
     {
@@ -8611,7 +8674,7 @@
       "target": "1d01daa399d3",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.792469+00:00"
     },
     {
@@ -8619,7 +8682,7 @@
       "target": "06a9fb26b021",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.792491+00:00"
     },
     {
@@ -8627,7 +8690,7 @@
       "target": "1d01daa399d3",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.792513+00:00"
     },
     {
@@ -8635,7 +8698,7 @@
       "target": "e4ea7a7ef7fe",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.792533+00:00"
     },
     {
@@ -8643,7 +8706,7 @@
       "target": "5d3bf45f7c53",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.792552+00:00"
     },
     {
@@ -8651,7 +8714,7 @@
       "target": "1d01daa399d3",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.792577+00:00"
     },
     {
@@ -8659,7 +8722,7 @@
       "target": "b3c23d1a4efb",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.796850+00:00"
     },
     {
@@ -8667,7 +8730,7 @@
       "target": "1dbff77adf4d",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.796885+00:00"
     },
     {
@@ -8675,7 +8738,7 @@
       "target": "ce38b87c4381",
       "type": "causes",
       "weight": 0.6,
-      "evidence_count": 43,
+      "evidence_count": 44,
       "created": "2026-06-02T04:20:23.796919+00:00"
     }
   ]

--- a/.agents/memory/episodes/episode-2026-07-03-session-2605.json
+++ b/.agents/memory/episodes/episode-2026-07-03-session-2605.json
@@ -45,6 +45,14 @@
       "content": "Added 8 regression tests (5 aggregate: infra-failure, all-pass, code-quality-failure, no-verdicts, nonsecurity-infra; 3 report: caution-present, caution-absent, nonsecurity-infra). uv run pytest: 42 passed across both suites",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: e5392ba",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -52,7 +60,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 3,
     "files_changed": 6
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-03-session-2605.json
+++ b/.agents/memory/episodes/episode-2026-07-03-session-2605.json
@@ -1,0 +1,59 @@
+{
+  "id": "episode-2026-07-03-session-2605",
+  "session": "2026-07-03-session-2605",
+  "timestamp": "2026-07-03T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Implement issue 2821 option c: distinct security-review-did-not-run annotation in the AI quality gate",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read issue #2821 and its discourse; owner has not picked an option, so implemented the recommended option c (additive visibility, keeps the deliberate WARN policy intact) as a draft PR for the owner to accept or reject",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "aggregate_quality_verdicts.py: emit ::warning annotation and a security_review_ran output when the security axis category is INFRASTRUCTURE, including the no-verdicts CRITICAL_FAIL branch",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "generate_quality_report.py: render a distinct CAUTION block under the final verdict when the security axis hit an infrastructure failure",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added 8 regression tests (5 aggregate: infra-failure, all-pass, code-quality-failure, no-verdicts, nonsecurity-infra; 3 report: caution-present, caution-absent, nonsecurity-infra). uv run pytest: 42 passed across both suites",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "test",
+      "content": "Added 8 regression tests (5 aggregate: infra-failure, all-pass, code-quality-failure, no-verdicts, nonsecurity-infra; 3 report: caution-present, caution-absent, nonsecurity-infra). uv run pytest: 42 passed across both suites",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 6
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-03-session-2606-pr-2836-babysitter.json
+++ b/.agents/memory/episodes/episode-2026-07-03-session-2606-pr-2836-babysitter.json
@@ -45,6 +45,14 @@
       "content": "Commit: d5c4d63a1",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: c16297e77",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/sessions/2026-07-03-session-2605.json
+++ b/.agents/sessions/2026-07-03-session-2605.json
@@ -94,7 +94,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Atomic commit: aggregate_quality_verdicts.py, generate_quality_report.py, two test files, this session log (5 files at the ceiling)"
+        "Evidence": "Commits 22e4b4f (gate scripts + tests + this log), db14eaf (loader guard), e5392ba (test encoding); final code commit e5392ba recorded as endingCommit"
       },
       "validationPassed": {
         "level": "MUST",
@@ -131,7 +131,7 @@
       "action": "Added 8 regression tests (5 aggregate: infra-failure, all-pass, code-quality-failure, no-verdicts, nonsecurity-infra; 3 report: caution-present, caution-absent, nonsecurity-infra). uv run pytest: 42 passed across both suites"
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "e5392ba",
   "nextSteps": [
     "Push branch, open draft PR for #2821 owner review"
   ]

--- a/.agents/sessions/2026-07-03-session-2605.json
+++ b/.agents/sessions/2026-07-03-session-2605.json
@@ -1,0 +1,138 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2605,
+    "date": "2026-07-03",
+    "branch": "claude/security-axis-annotation-2821",
+    "startingCommit": "f13f73f",
+    "objective": "Implement issue 2821 option c: distinct security-review-did-not-run annotation in the AI quality gate"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP absent from this remote harness; fallback per AGENTS.md: topical .serena/memories surfaced via PreToolUse hooks (quality-gates, enforcement-patterns)"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Fallback path per AGENTS.md Serena Init: memory guidance consumed through hook-injected context for the gate script edits"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-loaded read-only by SessionStart context loader; issue #2821 discourse read in full before implementing"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "session-init scripts used for this log; quality-gate scripts inventoried under .github/scripts and scripts/quality_gate"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "usage-mandatory memory reviewed in the parent triage session this working day; constraints unchanged"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "PROJECT-CONSTRAINTS and universal rules in session context; ADR-006 honored: logic stays in Python scripts, zero YAML edits"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "quality/quality-gates-observations and enforcement-patterns memories surfaced via hooks before editing gate scripts"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "claude/security-axis-annotation-2821"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On claude/security-axis-annotation-2821"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status clean at branch creation from origin/main"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "f13f73f"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart and sessionEnd MUST items carry evidence in this log"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md untouched (read-only per ADR-014); PR body carries the handoff context"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Durable cross-session record: option-c rationale and trade-offs live in issue #2821 comment thread and the PR body; test docstrings encode the policy"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Zero markdown files changed on this branch; lint scoped to changed files per AGENTS.md"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Atomic commit: aggregate_quality_verdicts.py, generate_quality_report.py, two test files, this session log (5 files at the ceiling)"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run pytest tests/test_aggregate_quality_verdicts.py tests/test_generate_quality_report.py: 42 passed in 0.30s; mypy clean on both changed scripts; ruff clean"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Task #13 tracks this implementation"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Deferred: parent triage session retro covers this follow-up branch"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "timestamp": "2026-07-03T16:05:00Z",
+      "action": "Read issue #2821 and its discourse; owner has not picked an option, so implemented the recommended option c (additive visibility, keeps the deliberate WARN policy intact) as a draft PR for the owner to accept or reject"
+    },
+    {
+      "timestamp": "2026-07-03T16:15:00Z",
+      "action": "aggregate_quality_verdicts.py: emit ::warning annotation and a security_review_ran output when the security axis category is INFRASTRUCTURE, including the no-verdicts CRITICAL_FAIL branch"
+    },
+    {
+      "timestamp": "2026-07-03T16:20:00Z",
+      "action": "generate_quality_report.py: render a distinct CAUTION block under the final verdict when the security axis hit an infrastructure failure"
+    },
+    {
+      "timestamp": "2026-07-03T16:25:00Z",
+      "action": "Added 8 regression tests (5 aggregate: infra-failure, all-pass, code-quality-failure, no-verdicts, nonsecurity-infra; 3 report: caution-present, caution-absent, nonsecurity-infra). uv run pytest: 42 passed across both suites"
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Push branch, open draft PR for #2821 owner review"
+  ]
+}

--- a/.agents/sessions/2026-07-03-session-2606-pr-2836-babysitter.json
+++ b/.agents/sessions/2026-07-03-session-2606-pr-2836-babysitter.json
@@ -94,7 +94,7 @@
    "changesCommitted": {
     "level": "MUST",
     "Complete": true,
-    "Evidence": "Merge-resolution commit d5c4d63a1 created in dedicated PR worktree"
+    "Evidence": "Merge-resolution commit c16297e77 created in dedicated PR worktree"
    },
    "validationPassed": {
     "level": "MUST",
@@ -127,7 +127,7 @@
    "evidence": "uv run pytest tests/test_generate_quality_report.py -x: 23 passed; byte check found zero conflict markers and zero prohibited dash bytes in tests/test_generate_quality_report.py."
   }
  ],
- "endingCommit": "d5c4d63a1",
+ "endingCommit": "c16297e77",
  "nextSteps": [
   "Commit and push the merge resolution, then re-enable auto-merge if GitHub cleared it.",
   "Poll PR #2836 until state is MERGED; do not report merge before observing it."

--- a/.github/scripts/aggregate_quality_verdicts.py
+++ b/.github/scripts/aggregate_quality_verdicts.py
@@ -86,6 +86,7 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         write_output("final_verdict", "CRITICAL_FAIL")
+        write_output("security_review_ran", "false")
         for agent in _AGENTS:
             write_output(f"{agent}_verdict", "")
             write_output(f"{agent}_category", "N/A")
@@ -105,6 +106,21 @@ def main(argv: list[str] | None = None) -> int:
     if final in FAIL_VERDICTS and not code_quality_failures:
         write_log("All failures are INFRASTRUCTURE - downgrading to WARN")
         final = "WARN"
+
+    # Issue #2821 option c: the WARN downgrade is owner policy, but a security
+    # review that never ran must not be indistinguishable from one that
+    # passed. Surface a distinct annotation and a dedicated output so the PR
+    # comment and downstream tooling can render a non-ignorable notice.
+    security_review_ran = categories.get("security") != "INFRASTRUCTURE"
+    if not security_review_ran:
+        write_log("Security review did not run (infrastructure failure)")
+        print(
+            "::warning title=Security review did not run::The AI security "
+            "review hit an infrastructure failure and did not evaluate this "
+            "PR. The gate verdict does not certify a security review; re-run "
+            "the gate or review security manually before merge (issue #2821)."
+        )
+    write_output("security_review_ran", "true" if security_review_ran else "false")
 
     write_output("final_verdict", final)
     for agent in _AGENTS:

--- a/.github/scripts/generate_quality_report.py
+++ b/.github/scripts/generate_quality_report.py
@@ -222,6 +222,22 @@ def main(argv: list[str] | None = None) -> int:
         f"> [!{alert_type}]",
         f"> {final_emoji} **Final Verdict: {final_verdict}**",
         "",
+    ]
+
+    # Issue #2821 option c: when the security axis hit an infrastructure
+    # failure, the review never ran; say so in a distinct alert instead of
+    # letting the generic WARN read as a passed security review.
+    if categories.get("security") == "INFRASTRUCTURE":
+        lines += [
+            "> [!CAUTION]",
+            "> **Security review did not run.** The security axis hit an"
+            " infrastructure failure, so this verdict does not certify a"
+            " security review. Re-run the gate or review security manually"
+            " before merge. Refs #2821.",
+            "",
+        ]
+
+    lines += [
         "<details>",
         "<summary>Walkthrough</summary>",
         "",

--- a/tests/test_aggregate_quality_verdicts.py
+++ b/tests/test_aggregate_quality_verdicts.py
@@ -16,6 +16,8 @@ _SCRIPTS_DIR = Path(__file__).resolve().parents[1] / ".github" / "scripts"
 
 def _import_script(name: str):
     spec = importlib.util.spec_from_file_location(name, _SCRIPTS_DIR / f"{name}.py")
+    assert spec is not None, f"Could not load spec for {name}"
+    assert spec.loader is not None, f"Spec for {name} has no loader"
     mod = importlib.util.module_from_spec(spec)
     sys.modules[name] = mod
     spec.loader.exec_module(mod)

--- a/tests/test_aggregate_quality_verdicts.py
+++ b/tests/test_aggregate_quality_verdicts.py
@@ -223,3 +223,91 @@ class TestMain:
         outputs = _read_outputs(output_file)
         # Real WARN outranks UNKNOWN per merge_verdicts severity order.
         assert outputs["final_verdict"] == "WARN"
+
+
+# ---------------------------------------------------------------------------
+# Tests: security_review_ran output (issue #2821 option c)
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityReviewRan:
+    """A security-axis infrastructure failure must be visibly distinct from a
+    security review that actually ran (issue #2821, option c)."""
+
+    def test_security_infra_failure_sets_ran_false_and_annotates(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        output_file = _capture_outputs(tmp_path, monkeypatch)
+        verdicts = {a: "PASS" for a in _AGENTS}
+        verdicts["security"] = "NEEDS_REVIEW"
+        infra = {a: "false" for a in _AGENTS}
+        infra["security"] = "true"
+
+        rc = main(_make_argv(verdicts, infra))
+
+        assert rc == 0
+        outputs = _read_outputs(output_file)
+        assert outputs["security_review_ran"] == "false"
+        assert outputs["final_verdict"] == "WARN"
+        captured = capsys.readouterr()
+        assert "::warning title=Security review did not run::" in captured.out
+
+    def test_all_pass_sets_ran_true_without_annotation(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        output_file = _capture_outputs(tmp_path, monkeypatch)
+        verdicts = {a: "PASS" for a in _AGENTS}
+        infra = {a: "false" for a in _AGENTS}
+
+        rc = main(_make_argv(verdicts, infra))
+
+        assert rc == 0
+        outputs = _read_outputs(output_file)
+        assert outputs["security_review_ran"] == "true"
+        captured = capsys.readouterr()
+        assert "Security review did not run" not in captured.out
+
+    def test_security_code_quality_failure_counts_as_ran(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        output_file = _capture_outputs(tmp_path, monkeypatch)
+        verdicts = {a: "PASS" for a in _AGENTS}
+        verdicts["security"] = "CRITICAL_FAIL"
+        infra = {a: "false" for a in _AGENTS}
+
+        rc = main(_make_argv(verdicts, infra))
+
+        assert rc == 0
+        outputs = _read_outputs(output_file)
+        assert outputs["security_review_ran"] == "true"
+        assert outputs["final_verdict"] != "WARN"
+        captured = capsys.readouterr()
+        assert "Security review did not run" not in captured.out
+
+    def test_no_verdicts_sets_ran_false(self, tmp_path, monkeypatch):
+        output_file = _capture_outputs(tmp_path, monkeypatch)
+        verdicts = {a: "" for a in _AGENTS}
+
+        rc = main(_make_argv(verdicts))
+
+        assert rc == 1
+        outputs = _read_outputs(output_file)
+        assert outputs["security_review_ran"] == "false"
+
+    def test_nonsecurity_infra_failure_keeps_ran_true(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        output_file = _capture_outputs(tmp_path, monkeypatch)
+        verdicts = {a: "PASS" for a in _AGENTS}
+        verdicts["qa"] = "NEEDS_REVIEW"
+        infra = {a: "false" for a in _AGENTS}
+        infra["qa"] = "true"
+
+        rc = main(_make_argv(verdicts, infra))
+
+        assert rc == 0
+        outputs = _read_outputs(output_file)
+        assert outputs["security_review_ran"] == "true"
+        assert outputs["final_verdict"] == "WARN"
+        captured = capsys.readouterr()
+        assert "Security review did not run" not in captured.out

--- a/tests/test_generate_quality_report.py
+++ b/tests/test_generate_quality_report.py
@@ -294,3 +294,54 @@ class TestBuildActionRequiredSection:
         assert "**Security**" in result
         assert "**QA**" in result
         assert "**Analyst**" not in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: security did-not-run notice (issue #2821 option c)
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityNotice:
+    """The report renders a distinct CAUTION block when the security axis hit
+    an infrastructure failure (issue #2821, option c)."""
+
+    def _render(self, tmp_path, monkeypatch, **argv_kwargs) -> str:
+        output_file = _setup_output(tmp_path, monkeypatch)
+        report_dir = tmp_path / "ai-review-results"
+        with patch(
+            "generate_quality_report.initialize_ai_review",
+            return_value=str(report_dir),
+        ):
+            report_dir.mkdir(parents=True, exist_ok=True)
+            rc = main(_make_argv(**argv_kwargs))
+        assert rc == 0
+        outputs = _read_outputs(output_file)
+        return Path(outputs["report_file"]).read_text()
+
+    def test_caution_block_when_security_infrastructure(self, tmp_path, monkeypatch):
+        content = self._render(
+            tmp_path,
+            monkeypatch,
+            final_verdict="WARN",
+            verdicts={"security": "NEEDS_REVIEW"},
+            categories={"security": "INFRASTRUCTURE"},
+        )
+        assert "[!CAUTION]" in content
+        assert "Security review did not run." in content
+        assert "#2821" in content
+
+    def test_no_caution_block_when_security_ran(self, tmp_path, monkeypatch):
+        content = self._render(tmp_path, monkeypatch)
+        assert "Security review did not run." not in content
+
+    def test_no_caution_block_for_nonsecurity_infrastructure(
+        self, tmp_path, monkeypatch
+    ):
+        content = self._render(
+            tmp_path,
+            monkeypatch,
+            final_verdict="WARN",
+            verdicts={"qa": "NEEDS_REVIEW"},
+            categories={"qa": "INFRASTRUCTURE"},
+        )
+        assert "Security review did not run." not in content

--- a/tests/test_generate_quality_report.py
+++ b/tests/test_generate_quality_report.py
@@ -316,7 +316,7 @@ class TestSecurityNotice:
             rc = main(_make_argv(**argv_kwargs))
         assert rc == 0
         outputs = _read_outputs(output_file)
-        return Path(outputs["report_file"]).read_text()
+        return Path(outputs["report_file"]).read_text(encoding="utf-8")
 
     def test_caution_block_when_security_infrastructure(self, tmp_path, monkeypatch):
         content = self._render(


### PR DESCRIPTION
## Summary

### What

Implements option c from issue #2821: when the security axis of the AI
quality gate hits an infrastructure failure, the gate now says so
distinctly instead of letting the generic WARN read as a passed security
review. Merge semantics are unchanged.

### Why

The WARN downgrade on all-infrastructure failures is deliberate owner
policy, but it made a security review that never ran indistinguishable
from one that passed: the suppressed-scanner failure mode the 2026-07-02
safety audit flagged. Option c adds visibility without re-introducing
infra flakiness as a merge blocker; options a/b (blocking semantics)
remain available once the AI-review infrastructure (#2818) is stable.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2821 | Security-axis infra failure silently WARN-passes |

## Changes

- `.github/scripts/aggregate_quality_verdicts.py`: emit a
  `::warning title=Security review did not run::...` annotation and a new
  `security_review_ran` output when the security axis category is
  INFRASTRUCTURE; the no-verdicts CRITICAL_FAIL branch also reports
  `security_review_ran=false`.
- `.github/scripts/generate_quality_report.py`: render a distinct CAUTION
  alert under the final verdict when the security axis hit an
  infrastructure failure, so the PR comment cannot read as a passed
  security review.
- `tests/test_aggregate_quality_verdicts.py`: 5 new tests
  (infra-failure annotates and sets ran=false; all-pass sets ran=true with
  no annotation; a code-quality security failure counts as ran; no-verdicts
  sets ran=false; a non-security infra failure keeps ran=true). Also guards
  the pre-existing module-loader spec against None (the scoped pre-push
  mypy pulled this file in once the tests were appended).
- `tests/test_generate_quality_report.py`: 3 new tests (caution block
  present for security INFRASTRUCTURE, absent when security ran, absent for
  non-security infrastructure failures).
- `.agents/sessions/2026-07-03-session-2605.json`: session log.

No workflow YAML changes: the annotation prints from the existing
aggregate step and the CAUTION block renders from categories the report
generator already receives (ADR-006).

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: policy-visibility change on the
security axis; owner sign-off is the point of this PR. #2821 framed the
direction as an owner decision; this implements the recommended option c
(additive visibility, no merge-semantics change). If you prefer option a
(neutralize merge signal) or b (require re-run), say so and this PR
becomes the base for it.

**Focus areas**: the `security_review_ran` condition
(`categories["security"] == "INFRASTRUCTURE"`) and the CAUTION block
wording.

## Testing

Deliverables in this PR:

- [x] Tests added/updated

`uv run pytest tests/test_aggregate_quality_verdicts.py
tests/test_generate_quality_report.py`: 42 passed. mypy clean on all four
changed files; ruff clean. Full pre-push suite passed at push time.

## Agent Review

### Security Review

- [x] Security patterns applied (closes an alarm-suppression gap: a
  security review that did not run is now visibly distinct from one that
  passed; CWE-778 insufficient logging class)

**Files requiring security review:**

- `.github/scripts/aggregate_quality_verdicts.py`
- `.github/scripts/generate_quality_report.py`

## Author Pre-flight

- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed
- [x] No new warnings introduced


## Merge Resolution Artifacts

Added by PR babysitter while resolving stale main drift:

- `.agents/sessions/2026-07-03-session-2606-pr-2836-babysitter.json`
- `.agents/memory/episodes/episode-2026-07-03-session-2606-pr-2836-babysitter.json`
- `.agents/memory/causality/causal-graph.json`

These files document the required session log and generated memory artifacts for the merge-resolution commit.

## Related Issues

Fixes #2821
Refs #2814, #2818

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wbb9jpubgid3eYuSxRtb38)_
