### PR TITLE
fix(ci): default ai-review model to auto, unblock all PRs from retired claude-opus-4.5

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-03-session-2605-fix-ai-review-model-auto.json
+++ b/.agents/memory/episodes/episode-2026-07-03-session-2605-fix-ai-review-model-auto.json
@@ -1,0 +1,70 @@
+{
+  "id": "episode-2026-07-03-session-2605-fix-ai-review-model-auto",
+  "session": "2026-07-03-session-2605-fix-ai-review-model-auto",
+  "timestamp": "2026-07-03T00:00:00+00:00",
+  "outcome": "success",
+  "task": "unblock Renovate and all open PRs: retired claude-opus-4.5 default hard-fails ai-review; default to auto and reclassify retired-model errors as infra (Refs #2818)",
+  "decisions": [
+    {
+      "id": "d001",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "design",
+      "context": "Fix ai-review default model to auto and reclassify retired-model errors as infrastructure failure",
+      "chosen": "Fix ai-review default model to auto and reclassify retired-model errors as infrastructure failure",
+      "rationale": ".github/actions/ai-review/action.yml: default claude-opus-4.5 -> auto (a meta-selector cannot be retired); added 'not available' to the stderr infra regex so retired-model errors become non-blocking (downstream agent-review/action.yml:314-323 exits 0 on CRITICAL_FAIL + infrastructure-failure=true). Re-synced test-infrastructure-failure.sh regex to match. ai-issue-triage.yml:237 copilot-model -> auto. New tests/test_infrastructure_failure_classification.py (11 tests, all pass) locks the classifier; verified genuine stdout verdicts (VERDICT: FAIL) are NOT masked. Committed as 1cdf33eb. Refs #2818, shares code path with #2814.",
+      "outcome": "success",
+      "effects": []
+    }
+  ],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Root-cause the Renovate/PR-wide ai-review block to the retired claude-opus-4.5 default model",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fix ai-review default model to auto and reclassify retired-model errors as infrastructure failure",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Bump .github/agents copilot agent model claude-opus-4.5 -> claude-opus-4.6 across 18 files",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Resolve pre-existing em-dashes in touched agent files to satisfy the dash-prohibition guard",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 52c76a8c",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 6,
+    "files_changed": 18
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-03-session-2605-fix-ai-review-model-auto.json
+++ b/.agents/sessions/2026-07-03-session-2605-fix-ai-review-model-auto.json
@@ -1,0 +1,59 @@
+{
+ "schemaVersion": "1.0",
+ "session": {
+  "number": 2605,
+  "date": "2026-07-03",
+  "branch": "fix/ai-review-model-auto-renovate",
+  "startingCommit": "f13f73ff",
+  "objective": "unblock Renovate and all open PRs: retired claude-opus-4.5 default hard-fails ai-review; default to auto and reclassify retired-model errors as infra (Refs #2818)"
+ },
+ "protocolCompliance": {
+  "sessionStart": {
+   "serenaActivated": {"level": "MUST", "Complete": true, "Evidence": "Serena project active this worktree"},
+   "serenaInstructions": {"level": "MUST", "Complete": true, "Evidence": "initial_instructions read"},
+   "handoffRead": {"level": "MUST", "Complete": true, "Evidence": "HANDOFF.md auto-loaded"},
+   "sessionLogCreated": {"level": "MUST", "Complete": true, "Evidence": "This file"},
+   "skillScriptsListed": {"level": "MUST", "Complete": true, "Evidence": "pr-autofix + analyze skills used earlier in session"},
+   "usageMandatoryRead": {"level": "MUST", "Complete": true, "Evidence": "AGENTS.md + universal/generated-artifacts rules read"},
+   "constraintsRead": {"level": "MUST", "Complete": true, "Evidence": "universal.md dash rule, generated-artifacts rule reviewed"},
+   "memoriesLoaded": {"level": "MUST", "Complete": true, "Evidence": "plugin-versioning, agent-frontmatter, tooling memories loaded"},
+   "branchVerified": {"level": "MUST", "Complete": true, "Evidence": "fix/ai-review-model-auto-renovate"},
+   "notOnMain": {"level": "MUST", "Complete": true, "Evidence": "On fix/ai-review-model-auto-renovate off main"},
+   "gitStatusVerified": {"level": "SHOULD", "Complete": true, "Evidence": "worktree off main f13f73ff"},
+   "startingCommitNoted": {"level": "SHOULD", "Complete": true, "Evidence": "f13f73ff"}
+  },
+  "sessionEnd": {
+   "checklistComplete": {"level": "MUST", "Complete": true, "Evidence": "start/end MUSTs recorded"},
+   "handoffPreserved": {"level": "MUST", "Complete": true, "Evidence": "HANDOFF.md untouched"},
+   "serenaMemoryUpdated": {"level": "MUST", "Complete": true, "Evidence": "root cause + fix rationale logged in commit bodies and PR description"},
+   "markdownLintRun": {"level": "MUST", "Complete": true, "Evidence": "pre-commit markdownlint ran on each agent-file commit; 0 errors"},
+   "changesCommitted": {"level": "MUST", "Complete": true, "Evidence": "5 commits: 1 CI-fix core (4 files) + 4 agent-model-bump chunks (18 files)"},
+   "validationPassed": {"level": "MUST", "Complete": true, "Evidence": "pytest tests/test_infrastructure_failure_classification.py -> 11 passed; install-parity OK; agent-drift none; copilot frontmatter 26 PASS; regen produced no tracked diff; actionlint clean on ai-review action"},
+   "tasksUpdated": {"level": "SHOULD", "Complete": true, "Evidence": "pr-autofix flow tracked in session narrative"},
+   "retrospectiveInvoked": {"level": "SHOULD", "Complete": false, "Evidence": "deferred to post-merge Renovate re-check"}
+  }
+ },
+ "workLog": [
+  {
+   "summary": "Root-cause the Renovate/PR-wide ai-review block to the retired claude-opus-4.5 default model",
+   "evidence": "Copilot CLI 1.0.x (pinned via PR #2635 / commit 87183dea) retired claude-opus-4.5. ai-review/action.yml default was claude-opus-4.5, so the CLI exits 1 with empty stdout and stderr 'Model \"claude-opus-4.5\" from --model flag is not available.'; is_infrastructure_failure returned 1 (regex miss) -> exit 1 -> all 10 required ai-review checks red -> branch protection blocks every open PR incl. Renovate #2826/#2825/#2819/#2804/#2803. Verified locally on Copilot CLI 1.0.69-0 that claude-opus-4.6 and auto work, claude-opus-4.5 is retired."
+  },
+  {
+   "summary": "Fix ai-review default model to auto and reclassify retired-model errors as infrastructure failure",
+   "evidence": ".github/actions/ai-review/action.yml: default claude-opus-4.5 -> auto (a meta-selector cannot be retired); added 'not available' to the stderr infra regex so retired-model errors become non-blocking (downstream agent-review/action.yml:314-323 exits 0 on CRITICAL_FAIL + infrastructure-failure=true). Re-synced test-infrastructure-failure.sh regex to match. ai-issue-triage.yml:237 copilot-model -> auto. New tests/test_infrastructure_failure_classification.py (11 tests, all pass) locks the classifier; verified genuine stdout verdicts (VERDICT: FAIL) are NOT masked. Committed as 1cdf33eb. Refs #2818, shares code path with #2814."
+  },
+  {
+   "summary": "Bump .github/agents copilot agent model claude-opus-4.5 -> claude-opus-4.6 across 18 files",
+   "evidence": ".github/agents/*.agent.md carried 18 stale claude-opus-4.5 refs while sibling trees src/copilot-cli/agents and src/vs-code-agents were already at 4.6 (drift). Bumped all 18 to like-for-like claude-opus-4.6 (preserves Opus tier), committed in 4 chunks of <=5 files (59fa4d20, 18f36d70, 02f117eb, 52c76a8c). Regen (build/generate_agents.py) produced no tracked diff; install-parity OK; agent-drift none; frontmatter 26 PASS."
+  },
+  {
+   "summary": "Resolve pre-existing em-dashes in touched agent files to satisfy the dash-prohibition guard",
+   "evidence": "The pre-commit dash guard scans full staged-file content, so pre-existing U+2014 in architect, high-level-advisor, pr-comment-responder (.agent and .prompt), and qa blocked the model-bump commits. Byte-verified counts, replaced each U+2014 with comma phrasing matching the already-clean src/copilot-cli mirror (convergence, not divergence). Byte-verified all touched files 0/0 dashes afterward."
+  }
+ ],
+ "endingCommit": "52c76a8c",
+ "nextSteps": [
+  "After merge, confirm Renovate PRs #2826/#2825/#2819/#2804/#2803 and PR #2793 re-run green on ai-review.",
+  "Consider a follow-up implementing #2818 recommended direction: emit a NEUTRAL check conclusion (not failure) and 'did not run: Copilot CLI unavailable' aggregate wording."
+ ]
+}

--- a/.github/actions/ai-review/action.yml
+++ b/.github/actions/ai-review/action.yml
@@ -48,11 +48,13 @@ inputs:
     default: ''
   copilot-model:
     description: |
-      AI model to use (e.g., choices: "claude-sonnet-4.5", "claude-haiku-4.5", "claude-opus-4.5",
-      "claude-sonnet-4", "gpt-5", "gpt-5.1", "gpt-5.1-codex-mini", "gpt-5.1-codex-max",
-      "gpt-5.1-codex", "gpt-5-mini", "gpt-4.1", "gemini-3-pro-preview")'
+      AI model to use. Default "auto" lets Copilot CLI pick an available model,
+      which stays valid when a specific model name is retired (e.g. the
+      claude-opus-4.5 retirement that broke required review checks). Pin an
+      explicit name only when a job needs a specific model (e.g. "claude-sonnet-4.5",
+      "claude-haiku-4.5", "claude-opus-4.6", "gpt-5.1", "gemini-3-pro-preview").
     required: false
-    default: 'claude-opus-4.5'
+    default: 'auto'
   enable-diagnostics:
     description: |
       Enable Copilot CLI diagnostic test before main invocation.
@@ -690,9 +692,13 @@ runs:
             return 0
           fi
 
-          # Check stderr for infrastructure keywords
+          # Check stderr for infrastructure keywords.
+          # "not available" catches retired/unknown model names (e.g. a bumped
+          # Copilot CLI rejecting a pinned model): treat as infra so the review
+          # degrades to a non-blocking warning instead of hard-failing required
+          # checks. Downstream (agent-review) exits 0 on CRITICAL_FAIL + infra.
           if [ -n "$stderr" ]; then
-            if echo "$stderr" | grep -qiE "(rate limit|timeout|network error|connection refused|connection reset|ECONNREFUSED|ETIMEDOUT|503|502|504|No authentication|authentication failed|auth.*error)"; then
+            if echo "$stderr" | grep -qiE "(rate limit|timeout|network error|connection refused|connection reset|ECONNREFUSED|ETIMEDOUT|503|502|504|No authentication|authentication failed|auth.*error|not available)"; then
               return 0
             fi
           fi

--- a/.github/actions/ai-review/action.yml
+++ b/.github/actions/ai-review/action.yml
@@ -693,11 +693,13 @@ runs:
           fi
 
           # Check stderr for infrastructure keywords.
-          # "not available" catches retired/unknown model names (e.g. a bumped
-          # Copilot CLI rejecting a pinned model): treat as infra so the review
-          # degrades to a non-blocking warning instead of hard-failing required
-          # checks. Downstream (agent-review) exits 0 on CRITICAL_FAIL + infra.
-          if [ -n "$stderr" ]; then
+          # Skip this branch when stdout already carries a genuine VERDICT:.
+          # Reclassifying a real review result as infra would overwrite it with
+          # a synthetic CRITICAL_FAIL that downstream treats as non-blocking,
+          # masking a failing review. "not available" catches retired/unknown
+          # model names (e.g. a bumped Copilot CLI rejecting a pinned model), so
+          # a real infra failure with empty stdout still degrades to a warning.
+          if [ -n "$stderr" ] && ! echo "$output" | grep -qE "VERDICT:"; then
             if echo "$stderr" | grep -qiE "(rate limit|timeout|network error|connection refused|connection reset|ECONNREFUSED|ETIMEDOUT|503|502|504|No authentication|authentication failed|auth.*error|not available)"; then
               return 0
             fi

--- a/.github/actions/ai-review/test-infrastructure-failure.sh
+++ b/.github/actions/ai-review/test-infrastructure-failure.sh
@@ -21,7 +21,7 @@ is_infrastructure_failure() {
 
   # Check stderr for infrastructure keywords
   if [ -n "$stderr" ]; then
-    if echo "$stderr" | grep -qiE "(rate limit|timeout|network error|connection refused|connection reset|ECONNREFUSED|ETIMEDOUT|503|502|504)"; then
+    if echo "$stderr" | grep -qiE "(rate limit|timeout|network error|connection refused|connection reset|ECONNREFUSED|ETIMEDOUT|503|502|504|No authentication|authentication failed|auth.*error|not available)"; then
       return 0
     fi
   fi

--- a/.github/actions/ai-review/test-infrastructure-failure.sh
+++ b/.github/actions/ai-review/test-infrastructure-failure.sh
@@ -19,8 +19,11 @@ is_infrastructure_failure() {
     return 0
   fi
 
-  # Check stderr for infrastructure keywords
-  if [ -n "$stderr" ]; then
+  # Check stderr for infrastructure keywords.
+  # Skip this branch when stdout already carries a genuine VERDICT:, so a real
+  # review result is never masked behind an infra reclassification. Mirrors the
+  # guard in action.yml is_infrastructure_failure().
+  if [ -n "$stderr" ] && ! echo "$output" | grep -qE "VERDICT:"; then
     if echo "$stderr" | grep -qiE "(rate limit|timeout|network error|connection refused|connection reset|ECONNREFUSED|ETIMEDOUT|503|502|504|No authentication|authentication failed|auth.*error|not available)"; then
       return 0
     fi

--- a/.github/agents/analyst.agent.md
+++ b/.github/agents/analyst.agent.md
@@ -21,7 +21,7 @@ tools:
   - context7/*
   - perplexity/*
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: integration
 ---
 

--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -8,7 +8,7 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: expert
 ---
 # Architect Agent
@@ -38,7 +38,7 @@ Agent-specific requirements:
 
 **Keywords**: Design, Governance, ADR, Coherence, Patterns, Boundaries, Principles, Decisions, Integration, Technical-authority, Review, Compliance, Impact, Abstraction, Layers, Separation, Extensibility, Consistency, Trade-offs, Blueprint
 
-**Summon**: I need to speak with the technical authority on system design—the architect who guards architectural coherence, enforces patterns, and maintains boundaries. You're the one who creates ADRs, conducts design reviews, and ensures every decision aligns with principles of separation, extensibility, and consistency. I'm not looking for code; I'm looking for governance, trade-off analysis, and a blueprint that protects the system's long-term health. Challenge my technical choices if they compromise the architecture.
+**Summon**: I need to speak with the technical authority on system design, the architect who guards architectural coherence, enforces patterns, and maintains boundaries. You're the one who creates ADRs, conducts design reviews, and ensures every decision aligns with principles of separation, extensibility, and consistency. I'm not looking for code; I'm looking for governance, trade-off analysis, and a blueprint that protects the system's long-term health. Challenge my technical choices if they compromise the architecture.
 
 ## Strategic Knowledge Available
 

--- a/.github/agents/backlog-generator.agent.md
+++ b/.github/agents/backlog-generator.agent.md
@@ -13,7 +13,7 @@ tools:
   - github/search_pull_requests
   - github/search_repositories
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: integration
 ---
 

--- a/.github/agents/critic.agent.md
+++ b/.github/agents/critic.agent.md
@@ -8,7 +8,7 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: manager
 ---
 

--- a/.github/agents/devops.agent.md
+++ b/.github/agents/devops.agent.md
@@ -21,7 +21,7 @@ tools:
   - github/search_issues
   - github/search_repositories
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: builder
 ---
 # DevOps Agent

--- a/.github/agents/high-level-advisor.agent.md
+++ b/.github/agents/high-level-advisor.agent.md
@@ -1,6 +1,6 @@
 ---
 name: high-level-advisor
-description: Brutally honest strategic advisor who cuts through comfort and delivers unfiltered truth. Prioritizes ruthlessly, challenges assumptions, exposes blind spots, and resolves decision paralysis with clear verdicts. Use when you need P0 priorities, not options—clarity and action, not validation.
+description: Brutally honest strategic advisor who cuts through comfort and delivers unfiltered truth. Prioritizes ruthlessly, challenges assumptions, exposes blind spots, and resolves decision paralysis with clear verdicts. Use when you need P0 priorities, not options, clarity and action, not validation.
 argument-hint: Describe the strategic decision or conflict needing advice
 tools:
   - read
@@ -8,7 +8,7 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: expert
 ---
 # High-Level Advisor Agent
@@ -51,7 +51,7 @@ Key requirements:
 
 **Keywords**: Strategic, Ruthless, Prioritization, Verdict, Unfiltered, Triage, Decision, Cut, Challenge, Assumptions, Blind-spots, Direction, P0, Continue, Pivot, Kill, Clarity, Blockers, Paralysis, Action
 
-**Summon**: I need brutally honest strategic advice from someone willing to cut through comfort and deliver unfiltered truth. You prioritize ruthlessly, challenge assumptions, expose blind spots, and resolve decision paralysis with clear verdicts—not hedge words. Tell me what to do, what to stop doing, and what I'm avoiding. Give me a P0 priority, not a list of options. I don't need validation; I need clarity and action.
+**Summon**: I need brutally honest strategic advice from someone willing to cut through comfort and deliver unfiltered truth. You prioritize ruthlessly, challenge assumptions, expose blind spots, and resolve decision paralysis with clear verdicts, not hedge words. Tell me what to do, what to stop doing, and what I'm avoiding. Give me a P0 priority, not a list of options. I don't need validation; I need clarity and action.
 
 ## Strategic Knowledge Available
 

--- a/.github/agents/implementer.agent.md
+++ b/.github/agents/implementer.agent.md
@@ -19,7 +19,7 @@ tools:
   - github/search_code
   - github/search_issues
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: builder
 # Implements code in an isolated workspace with tool access and branch-local state.
 isolation_required: true

--- a/.github/agents/independent-thinker.agent.md
+++ b/.github/agents/independent-thinker.agent.md
@@ -11,7 +11,7 @@ tools:
   - cloudmcp-manager/*
   - perplexity/*
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: expert
 ---
 # Independent Thinker Agent

--- a/.github/agents/milestone-planner.agent.md
+++ b/.github/agents/milestone-planner.agent.md
@@ -8,7 +8,7 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: manager
 ---
 

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -23,7 +23,7 @@ tools:
   - github/get_workflow_run
   - cloudmcp-manager/*
   - serena/*
-model: Claude Opus 4.5 (copilot)
+model: claude-opus-4.6
 tier: manager
 ---
 

--- a/.github/agents/pr-comment-responder.agent.md
+++ b/.github/agents/pr-comment-responder.agent.md
@@ -10,7 +10,7 @@ tools:
   - cloudmcp-manager/*
   - github.vscode-pull-request-github/*
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: manager
 ---
 # PR Comment Responder Agent
@@ -47,7 +47,7 @@ Key requirements:
 
 **Keywords**: PR, Comments, Review, Triage, Feedback, Reviewers, Resolution, Thread, Commits, Acknowledgment, Context, Bot, Actionable, Classification, Implementation, Reply, Track, Map, Addressed, Conversation
 
-**Summon**: I need a PR review coordinator who gathers comment context, acknowledges every piece of feedback, and ensures all reviewer comments are addressed systematically. You triage by actionability, track thread conversations, and map each comment to a resolution status. Classify each comment—quick fix, standard, or strategic—then delegate appropriately. Leave no comment unaddressed, no reviewer ignored.
+**Summon**: I need a PR review coordinator who gathers comment context, acknowledges every piece of feedback, and ensures all reviewer comments are addressed systematically. You triage by actionability, track thread conversations, and map each comment to a resolution status. Classify each comment, quick fix, standard, or strategic, then delegate appropriately. Leave no comment unaddressed, no reviewer ignored.
 
 ## Workflow Paths Reference
 
@@ -688,7 +688,7 @@ Save to: `.agents/pr-comments/PR-[number]/comments.md`
 
 For each comment, delegate to orchestrator with full context. Do NOT implement custom routing logic.
 
-**Critical**: Each comment is analyzed and routed independently. Do not merge, combine, or aggregate comments that touch the same file—even if 10 comments reference the same line. Each gets its own triage path (Quick Fix, Standard, or Strategic) and task. Comment independence prevents grouping-bias errors.
+**Critical**: Each comment is analyzed and routed independently. Do not merge, combine, or aggregate comments that touch the same file, even if 10 comments reference the same line. Each gets its own triage path (Quick Fix, Standard, or Strategic) and task. Comment independence prevents grouping-bias errors.
 
 #### Step 3.1: Prepare Context for Orchestrator
 

--- a/.github/agents/pr-comment-responder.prompt.md
+++ b/.github/agents/pr-comment-responder.prompt.md
@@ -10,7 +10,7 @@ tools:
   - cloudmcp-manager/*
   - github.vscode-pull-request-github/*
   - serena/*
-model: Claude Opus 4.5 (anthropic)
+model: Claude Opus 4.6 (anthropic)
 ---
 # PR Comment Responder Agent
 
@@ -46,7 +46,7 @@ Key requirements:
 
 **Keywords**: PR, Comments, Review, Triage, Feedback, Reviewers, Resolution, Thread, Commits, Acknowledgment, Context, Bot, Actionable, Classification, Implementation, Reply, Track, Map, Addressed, Conversation
 
-**Summon**: I need a PR review coordinator who gathers comment context, acknowledges every piece of feedback, and ensures all reviewer comments are addressed systematically. You triage by actionability, track thread conversations, and map each comment to a resolution status. Classify each comment—quick fix, standard, or strategic—then delegate appropriately. Leave no comment unaddressed, no reviewer ignored.
+**Summon**: I need a PR review coordinator who gathers comment context, acknowledges every piece of feedback, and ensures all reviewer comments are addressed systematically. You triage by actionability, track thread conversations, and map each comment to a resolution status. Classify each comment, quick fix, standard, or strategic, then delegate appropriately. Leave no comment unaddressed, no reviewer ignored.
 
 ## Workflow Paths Reference
 
@@ -682,7 +682,7 @@ Save to: `.agents/pr-comments/PR-[number]/comments.md`
 
 For each comment, delegate to orchestrator with full context. Do NOT implement custom routing logic.
 
-**Critical**: Each comment is analyzed and routed independently. Do not merge, combine, or aggregate comments that touch the same file—even if 10 comments reference the same line. Each gets its own triage path (Quick Fix, Standard, or Strategic) and task. Comment independence prevents grouping-bias errors.
+**Critical**: Each comment is analyzed and routed independently. Do not merge, combine, or aggregate comments that touch the same file, even if 10 comments reference the same line. Each gets its own triage path (Quick Fix, Standard, or Strategic) and task. Comment independence prevents grouping-bias errors.
 
 #### Step 3.1: Prepare Context for Orchestrator
 

--- a/.github/agents/qa.agent.md
+++ b/.github/agents/qa.agent.md
@@ -1,6 +1,6 @@
 ---
 name: qa
-description: Quality assurance specialist who verifies implementations work correctly for real users—not just passing tests. Designs test strategies, validates coverage against acceptance criteria, and reports results with evidence. Use when you need confidence through verification, regression testing, edge-case coverage, or user-scenario validation.
+description: Quality assurance specialist who verifies implementations work correctly for real users, not just passing tests. Designs test strategies, validates coverage against acceptance criteria, and reports results with evidence. Use when you need confidence through verification, regression testing, edge-case coverage, or user-scenario validation.
 argument-hint: Provide the implementation or feature to verify
 tools:
   - shell
@@ -9,7 +9,7 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: builder
 ---
 # QA Agent
@@ -22,7 +22,7 @@ tier: builder
 
 **Keywords**: Testing, Verification, Coverage, Quality, User-scenarios, Strategy, Assertions, Pass, Fail, Regression, Edge-cases, Integration, Unit-tests, Acceptance, Metrics, Report, Defects, Validation, Behavior, Confidence
 
-**Summon**: I need a quality assurance specialist who verifies implementations work correctly for real users—not just passing tests. You design test strategies, validate coverage against acceptance criteria, and report results with evidence. Approach testing from the user's perspective first, code perspective second. If tests pass but users would hit bugs, that's a failure. Give me confidence that this actually works.
+**Summon**: I need a quality assurance specialist who verifies implementations work correctly for real users, not just passing tests. You design test strategies, validate coverage against acceptance criteria, and report results with evidence. Approach testing from the user's perspective first, code perspective second. If tests pass but users would hit bugs, that's a failure. Give me confidence that this actually works.
 
 ## Core Mission
 

--- a/.github/agents/retrospective.agent.md
+++ b/.github/agents/retrospective.agent.md
@@ -9,7 +9,7 @@ tools:
   - agent
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: integration
 ---
 # Retrospective Agent (Reflector)

--- a/.github/agents/roadmap.agent.md
+++ b/.github/agents/roadmap.agent.md
@@ -7,7 +7,7 @@ tools:
   - edit
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: expert
 ---
 

--- a/.github/agents/security.agent.md
+++ b/.github/agents/security.agent.md
@@ -15,7 +15,7 @@ tools:
   - github/search_code
   - serena/*
   - perplexity/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: builder
 ---
 # Security Agent

--- a/.github/agents/skillbook.agent.md
+++ b/.github/agents/skillbook.agent.md
@@ -8,7 +8,7 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: integration
 ---
 

--- a/.github/agents/task-decomposer.agent.md
+++ b/.github/agents/task-decomposer.agent.md
@@ -8,7 +8,7 @@ tools:
   - search
   - cloudmcp-manager/*
   - serena/*
-model: claude-opus-4.5
+model: claude-opus-4.6
 tier: integration
 ---
 # Task Decomposer Agent

--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -234,7 +234,7 @@ jobs:
           timeout-minutes: 15
           bot-pat: ${{ secrets.BOT_PAT }}
           copilot-token: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          copilot-model: 'claude-opus-4.5'
+          copilot-model: 'auto'
 
       # ADR-005 SECURITY: Single PowerShell step for PRD comment generation and posting
       # Eliminates bash shell usage to prevent command injection from AI-generated content

--- a/tests/test_infrastructure_failure_classification.py
+++ b/tests/test_infrastructure_failure_classification.py
@@ -38,7 +38,8 @@ def _classify(exit_code: int, stdout: str, stderr: str) -> str:
     result = subprocess.run(
         ["bash", str(_SCRIPT), str(exit_code), stdout, stderr],
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         check=True,
     )
     return result.stdout.strip()
@@ -83,6 +84,14 @@ def test_infrastructure_failures_classified_true(
         # findings would be silently downgraded.
         (1, "VERDICT: FAIL\nMESSAGE: real code issue", ""),
         (1, "VERDICT: CRITICAL_FAIL\nMESSAGE: blocking defect", ""),
+        # Do-not-mask-verdicts contract: a real verdict on stdout must win even
+        # when stderr also carries an infrastructure keyword. Without this the
+        # retry loop would overwrite the genuine verdict with a synthetic
+        # CRITICAL_FAIL that downstream treats as non-blocking, letting a
+        # failing review pass. Locks the guard against future regex broadening.
+        (1, "VERDICT: FAIL\nMESSAGE: real code issue", _MODEL_UNAVAILABLE_STDERR),
+        (1, "VERDICT: CRITICAL_FAIL\nMESSAGE: blocking defect", "connection refused"),
+        (0, "VERDICT: PASS", "warning: auth error in unrelated log line"),
     ],
 )
 def test_non_infrastructure_outcomes_classified_false(

--- a/tests/test_infrastructure_failure_classification.py
+++ b/tests/test_infrastructure_failure_classification.py
@@ -1,0 +1,92 @@
+"""Tests for the ai-review infrastructure-failure classifier.
+
+The classifier lives in ``.github/actions/ai-review/action.yml`` as the
+``is_infrastructure_failure`` Bash function. The same logic is mirrored in
+``.github/actions/ai-review/test-infrastructure-failure.sh`` (a standalone
+harness explicitly "extracted from action.yml for testability"). These tests
+drive that harness so the classification contract is guarded by CI.
+
+Regression focus (Renovate CI block): a retired/unknown model name makes the
+Copilot CLI exit non-zero with a stderr like
+``Error: Model "X" from --model flag is not available.`` and empty stdout. That
+must classify as an infrastructure failure so the review degrades to a
+non-blocking warning instead of hard-failing every required review check.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / ".github"
+    / "actions"
+    / "ai-review"
+    / "test-infrastructure-failure.sh"
+)
+
+_MODEL_UNAVAILABLE_STDERR = (
+    'Error: Model "claude-opus-4.5" from --model flag is not available.'
+)
+
+
+def _classify(exit_code: int, stdout: str, stderr: str) -> str:
+    """Return the harness verdict ("true"/"false") for the given inputs."""
+    result = subprocess.run(
+        ["bash", str(_SCRIPT), str(exit_code), stdout, stderr],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def test_script_exists() -> None:
+    """The extracted classifier harness is present."""
+    assert _SCRIPT.is_file(), f"missing classifier harness: {_SCRIPT}"
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "stdout", "stderr"),
+    [
+        # Retired/unknown model name (the Renovate CI block). Non-zero exit,
+        # empty stdout, model error on stderr.
+        (1, "", _MODEL_UNAVAILABLE_STDERR),
+        # Timeout is exit code 124.
+        (124, "", ""),
+        # Non-zero exit with no output at all indicates infrastructure trouble.
+        (1, "", ""),
+        # Known infrastructure stderr keywords.
+        (1, "", "Error: rate limit exceeded, retry later"),
+        (1, "", "connection refused"),
+        (1, "", "No authentication token provided"),
+        (1, "", "HTTP 503 Service Unavailable"),
+    ],
+)
+def test_infrastructure_failures_classified_true(
+    exit_code: int, stdout: str, stderr: str
+) -> None:
+    """Infrastructure-style failures classify as infra (non-blocking)."""
+    assert _classify(exit_code, stdout, stderr) == "true"
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "stdout", "stderr"),
+    [
+        # Clean success.
+        (0, "VERDICT: PASS", ""),
+        # Genuine code-quality failure: a real verdict on stdout with no
+        # infrastructure stderr must NOT be masked as infra, or blocking
+        # findings would be silently downgraded.
+        (1, "VERDICT: FAIL\nMESSAGE: real code issue", ""),
+        (1, "VERDICT: CRITICAL_FAIL\nMESSAGE: blocking defect", ""),
+    ],
+)
+def test_non_infrastructure_outcomes_classified_false(
+    exit_code: int, stdout: str, stderr: str
+) -> None:
+    """Success and genuine code-quality failures are not infra failures."""
+    assert _classify(exit_code, stdout, stderr) == "false"


### PR DESCRIPTION
## Summary

### What

Fixes the CI failure blocking every open PR (including all Renovate PRs). The
pinned Copilot CLI 1.0.x retired the default model `claude-opus-4.5`, so all 10
required `ai-review` checks hard-failed and branch protection blocked every PR.

### Why

`ai-review/action.yml` defaulted `--model` to `claude-opus-4.5`. In Copilot CLI
1.0.x that model is gone, so the CLI exits 1 with `Model "claude-opus-4.5" from
--model flag is not available.` That stderr was not classified as an
infrastructure failure, so the check turned red instead of neutral, and every
required `ai-review` check failed.

## Changes

- `.github/actions/ai-review/action.yml`: default model `claude-opus-4.5` ->
  `auto` (a meta-selector cannot be retired). Added `not available` to the
  stderr infra-failure regex so retired-model errors are reclassified as
  infrastructure failures (non-blocking) instead of red checks. Genuine stdout
  verdicts (`VERDICT: FAIL`) are still surfaced and NOT masked.
- `.github/workflows/ai-issue-triage.yml`: `copilot-model` -> `auto`.
- `.github/actions/ai-review/test-infrastructure-failure.sh`: classifier regex
  re-synced to the action.
- `tests/test_infrastructure_failure_classification.py`: NEW, 11 tests locking
  the classifier and the model-not-available reclassification.
- `.github/agents/*.agent.md` (18 files): bump stale model refs `claude-opus-4.5`
  -> `claude-opus-4.6` (like-for-like Opus, matching the already-clean
  Copilot CLI and VS Code agent mirrors).
- Em-dash cleanup in 5 agent files (architect, high-level-advisor,
  pr-comment-responder.agent, pr-comment-responder.prompt, qa): required to pass
  the dash guard; converges `.github/agents` toward the clean mirror phrasing.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Testing

- [x] `tests/test_infrastructure_failure_classification.py` (11 passing)
- [x] Pre-PR validation all green (25 checks)
- [x] `actionlint` + `gh act -n` pass on the changed workflow; full `gh act`
  cannot run locally because the workflow requires `secrets.BOT_PAT` and
  `secrets.COPILOT_GITHUB_TOKEN` (sanctioned `SKIP_WORKFLOW_LOCAL_TEST=true`).
- [x] Full agent regeneration produces no tracked diff;
  install-parity, agent-drift, and copilot-frontmatter all pass.

## Affected Renovate / open PRs (should re-run green after merge)

#2826, #2825, #2819, #2804, #2803, and #2793.

## Related Issues

Refs #2818
Refs #2814
