### PR TITLE
fix(secgate): fail closed on infra failure across security gates, hooks, and CI

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-03-session-2606-pr-2846-babysit.json
+++ b/.agents/memory/episodes/episode-2026-07-03-session-2606-pr-2846-babysit.json
@@ -93,6 +93,14 @@
       "content": "Commit: f7c1b1f8ef2d",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e012",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rebased onto origin/main and rebumped plugin manifests after version race advanced",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-03-session-2606-pr-2846-babysit.json
+++ b/.agents/memory/episodes/episode-2026-07-03-session-2606-pr-2846-babysit.json
@@ -1,0 +1,107 @@
+{
+  "id": "episode-2026-07-03-session-2606-pr-2846-babysit",
+  "session": "2026-07-03-session-2606-pr-2846-babysit",
+  "timestamp": "2026-07-03T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Drive PR #2846 fix/cluster-secgate to merged. Work only in dedicated worktree.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Created dedicated PR worktree and assessed failing checks",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rebased fix/cluster-secgate onto origin/main and resolved conflicts",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fixed Python test and security-gate defects",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "test",
+      "content": "Full suite passed: uv run pytest tests/ -x reported 13431 passed, 20 skipped, 45 xfailed before final session-log commit.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Regenerated generated artifacts and bumped plugin manifests",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Updated PR body and resolved review feedback with fixes",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Stabilized LSP read-guard tests under context-mode environment variables",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "test",
+      "content": "tests/hooks/test_invoke_lsp_read_guard*.py now clear TMPDIR and pin CLAUDE_PROJECT_DIR in autouse fixtures. Targeted LSP guard tests passed: 67 passed.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran final validation before push",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "test",
+      "content": "uv run pytest tests/ -x passed: 13299 passed, 20 deselected-by-marker, 45 expected failures, 3 warnings. Scoped uv run ruff check on 31 PR Python files passed. Full repo ruff still has unrelated baseline violations.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: f7c1b1f8ef2d",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 4
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-03-session-2606-pr-2846-babysit.json
+++ b/.agents/memory/episodes/episode-2026-07-03-session-2606-pr-2846-babysit.json
@@ -101,6 +101,22 @@
       "content": "Rebased onto origin/main and rebumped plugin manifests after version race advanced",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e013",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Aligned aggregate quality verdict test with fail-closed security infra policy",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e014",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "test",
+      "content": "tests/test_aggregate_quality_verdicts.py now expects DID_NOT_RUN when the security review hits infrastructure failure without code-quality findings. Targeted aggregate tests passed: 25 passed.",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-03-session-2606-pr-2846-babysit.json
+++ b/.agents/memory/episodes/episode-2026-07-03-session-2606-pr-2846-babysit.json
@@ -133,6 +133,22 @@
       "content": "Commit: 50a2e768074a",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e017",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rebased onto latest origin/main and rebumped plugin manifests to stay ahead of main",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e018",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 4c0e1881b0c0",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-03-session-2606-pr-2846-babysit.json
+++ b/.agents/memory/episodes/episode-2026-07-03-session-2606-pr-2846-babysit.json
@@ -117,6 +117,22 @@
       "content": "tests/test_aggregate_quality_verdicts.py now expects DID_NOT_RUN when the security review hits infrastructure failure without code-quality findings. Targeted aggregate tests passed: 25 passed.",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e015",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rebased onto latest origin/main and rebumped plugin manifests again",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e016",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 50a2e768074a",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -124,7 +140,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
+    "commits": 2,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/sessions/2026-07-03-session-2606-pr-2846-babysit.json
+++ b/.agents/sessions/2026-07-03-session-2606-pr-2846-babysit.json
@@ -84,7 +84,7 @@
    "changesCommitted": {
     "level": "MUST",
     "Complete": true,
-    "Evidence": "Final branch includes rebase onto origin/main and plugin manifest rebump to 0.5.259; commit follows this session-log update."
+    "Evidence": "Final branch includes rebase onto origin/main, plugin manifest rebump to 0.5.259, LSP test fixture stabilization, and aggregate verdict expectation alignment; commit follows this session-log update."
    },
    "validationPassed": {
     "level": "MUST",
@@ -125,6 +125,10 @@
   {
    "summary": "Rebased onto origin/main and rebumped plugin manifests after version race advanced",
    "evidence": "origin/main advanced both plugin manifests to 0.5.258. Local branch rebased successfully and both manifests were set to 0.5.259."
+  },
+  {
+   "summary": "Aligned aggregate quality verdict test with fail-closed security infra policy",
+   "evidence": "tests/test_aggregate_quality_verdicts.py now expects DID_NOT_RUN when the security review hits infrastructure failure without code-quality findings. Targeted aggregate tests passed: 25 passed."
   }
  ],
  "endingCommit": "f7c1b1f8ef2d",

--- a/.agents/sessions/2026-07-03-session-2606-pr-2846-babysit.json
+++ b/.agents/sessions/2026-07-03-session-2606-pr-2846-babysit.json
@@ -1,0 +1,130 @@
+{
+ "schemaVersion": "1.0",
+ "session": {
+  "number": 2606,
+  "date": "2026-07-03",
+  "branch": "fix/cluster-secgate",
+  "startingCommit": "a1c6fd54",
+  "objective": "Drive PR #2846 fix/cluster-secgate to merged. Work only in dedicated worktree."
+ },
+ "protocolCompliance": {
+  "sessionStart": {
+   "serenaActivated": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Serena MCP project context was available through initial instructions and write_memory in this Copilot session."
+   },
+   "serenaInstructions": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "serena initial_instructions loaded"
+   },
+   "handoffRead": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": ".agents/HANDOFF.md read as read-only reference"
+   },
+   "sessionLogCreated": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": ".agents/sessions/2026-07-03-session-2606-pr-2846-babysit.json"
+   },
+   "usageMandatoryRead": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": ".serena/memories/usage-mandatory.md read"
+   },
+   "constraintsRead": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read"
+   },
+   "memoriesLoaded": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "memory-index, skills-github-cli-index, skills-pr-review-index, skills-security-index, validation-pr-gates read"
+   },
+   "branchVerified": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "fix/cluster-secgate"
+   },
+   "notOnMain": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "fix/cluster-secgate"
+   },
+   "dedicatedWorktree": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "/home/richard/src/GitHub/rjmurillo/ai-agents4-pr-2846"
+   }
+  },
+  "sessionEnd": {
+   "checklistComplete": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Session log records work outcomes, decisions, validation evidence, review-thread outcomes, and next steps."
+   },
+   "handoffPreserved": {
+    "level": "MUST NOT",
+    "Complete": false,
+    "Evidence": ".agents/HANDOFF.md was preserved as read-only reference."
+   },
+   "serenaMemoryUpdated": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Serena memory pr-2846-babysit-status written with current PR state and next actions."
+   },
+   "markdownLintRun": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "No markdown files changed; scoped markdownlint had an empty input set."
+   },
+   "changesCommitted": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Implementation commits through f7c1b1f8ef2d; final test-fixture and session-log commit follows this file update."
+   },
+   "validationPassed": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "uv run pytest tests/ -x passed: 13299 passed, 20 deselected-by-marker, 45 expected failures, 3 warnings. Scoped uv run ruff check on 31 PR Python files passed."
+   }
+  }
+ },
+ "workLog": [
+  {
+   "summary": "Created dedicated PR worktree and assessed failing checks",
+   "evidence": "PR #2846 open, mergeStateStatus CONFLICTING, failing checks included Validate PR, generated files, plugin version, Python tests, and Python security."
+  },
+  {
+   "summary": "Rebased fix/cluster-secgate onto origin/main and resolved conflicts",
+   "evidence": "Resolved conflicts in security gates, hook guards, workflow fail-closed behavior, validator unreadable-file handling, and Copilot security-scan generated twin."
+  },
+  {
+   "summary": "Fixed Python test and security-gate defects",
+   "evidence": "Full suite passed: uv run pytest tests/ -x reported 13431 passed, 20 skipped, 45 xfailed before final session-log commit."
+  },
+  {
+   "summary": "Regenerated generated artifacts and bumped plugin manifests",
+   "evidence": "python3 build/scripts/build_all.py passed. Both plugin manifests were set to 0.5.258, greater than origin/main 0.5.257 at the time of bump."
+  },
+  {
+   "summary": "Updated PR body and resolved review feedback with fixes",
+   "evidence": "Validate PR passed with warnings only. Review threads PRRT_kwDOQoWRls6OSDtD, PRRT_kwDOQoWRls6OSEhY, and PRRT_kwDOQoWRls6OSEhc were fixed, replied to, and resolved."
+  },
+  {
+   "summary": "Stabilized LSP read-guard tests under context-mode environment variables",
+   "evidence": "tests/hooks/test_invoke_lsp_read_guard*.py now clear TMPDIR and pin CLAUDE_PROJECT_DIR in autouse fixtures. Targeted LSP guard tests passed: 67 passed."
+  },
+  {
+   "summary": "Ran final validation before push",
+   "evidence": "uv run pytest tests/ -x passed: 13299 passed, 20 deselected-by-marker, 45 expected failures, 3 warnings. Scoped uv run ruff check on 31 PR Python files passed. Full repo ruff still has unrelated baseline violations."
+  }
+ ],
+ "endingCommit": "f7c1b1f8ef2d",
+ "nextSteps": [
+  "Push fix/cluster-secgate, monitor PR #2846 checks, rebump plugin manifests if the version race advances, enable auto-merge, and remove the dedicated worktree after merge."
+ ]
+}

--- a/.agents/sessions/2026-07-03-session-2606-pr-2846-babysit.json
+++ b/.agents/sessions/2026-07-03-session-2606-pr-2846-babysit.json
@@ -84,7 +84,7 @@
    "changesCommitted": {
     "level": "MUST",
     "Complete": true,
-    "Evidence": "Final branch includes rebase onto latest origin/main, plugin manifest rebump to 0.5.260, LSP test fixture stabilization, and aggregate verdict expectation alignment; commit follows this session-log update."
+    "Evidence": "Final branch includes rebase onto latest origin/main, plugin manifest rebump to 0.5.261, pre-push mypy fixes, and aggregate verdict expectation alignment; commit follows this session-log update."
    },
    "validationPassed": {
     "level": "MUST",
@@ -133,9 +133,13 @@
   {
    "summary": "Rebased onto latest origin/main and rebumped plugin manifests again",
    "evidence": "origin/main advanced to cc1b4969f415 with plugin manifests at 0.5.259. Local branch rebased successfully and both manifests were set to 0.5.260."
+  },
+  {
+   "summary": "Rebased onto latest origin/main and rebumped plugin manifests to stay ahead of main",
+   "evidence": "origin/main plugin manifests were at 0.5.260 after rebase. Both local manifests were set to 0.5.261."
   }
  ],
- "endingCommit": "50a2e768074a",
+ "endingCommit": "4c0e1881b0c0",
  "nextSteps": [
   "Push fix/cluster-secgate, monitor PR #2846 checks, rebump plugin manifests if the version race advances, enable auto-merge, and remove the dedicated worktree after merge."
  ]

--- a/.agents/sessions/2026-07-03-session-2606-pr-2846-babysit.json
+++ b/.agents/sessions/2026-07-03-session-2606-pr-2846-babysit.json
@@ -84,7 +84,7 @@
    "changesCommitted": {
     "level": "MUST",
     "Complete": true,
-    "Evidence": "Final branch includes rebase onto origin/main, plugin manifest rebump to 0.5.259, LSP test fixture stabilization, and aggregate verdict expectation alignment; commit follows this session-log update."
+    "Evidence": "Final branch includes rebase onto latest origin/main, plugin manifest rebump to 0.5.260, LSP test fixture stabilization, and aggregate verdict expectation alignment; commit follows this session-log update."
    },
    "validationPassed": {
     "level": "MUST",
@@ -129,9 +129,13 @@
   {
    "summary": "Aligned aggregate quality verdict test with fail-closed security infra policy",
    "evidence": "tests/test_aggregate_quality_verdicts.py now expects DID_NOT_RUN when the security review hits infrastructure failure without code-quality findings. Targeted aggregate tests passed: 25 passed."
+  },
+  {
+   "summary": "Rebased onto latest origin/main and rebumped plugin manifests again",
+   "evidence": "origin/main advanced to cc1b4969f415 with plugin manifests at 0.5.259. Local branch rebased successfully and both manifests were set to 0.5.260."
   }
  ],
- "endingCommit": "f7c1b1f8ef2d",
+ "endingCommit": "50a2e768074a",
  "nextSteps": [
   "Push fix/cluster-secgate, monitor PR #2846 checks, rebump plugin manifests if the version race advances, enable auto-merge, and remove the dedicated worktree after merge."
  ]

--- a/.agents/sessions/2026-07-03-session-2606-pr-2846-babysit.json
+++ b/.agents/sessions/2026-07-03-session-2606-pr-2846-babysit.json
@@ -84,7 +84,7 @@
    "changesCommitted": {
     "level": "MUST",
     "Complete": true,
-    "Evidence": "Implementation commits through f7c1b1f8ef2d; final test-fixture and session-log commit follows this file update."
+    "Evidence": "Final branch includes rebase onto origin/main and plugin manifest rebump to 0.5.259; commit follows this session-log update."
    },
    "validationPassed": {
     "level": "MUST",
@@ -121,6 +121,10 @@
   {
    "summary": "Ran final validation before push",
    "evidence": "uv run pytest tests/ -x passed: 13299 passed, 20 deselected-by-marker, 45 expected failures, 3 warnings. Scoped uv run ruff check on 31 PR Python files passed. Full repo ruff still has unrelated baseline violations."
+  },
+  {
+   "summary": "Rebased onto origin/main and rebumped plugin manifests after version race advanced",
+   "evidence": "origin/main advanced both plugin manifests to 0.5.258. Local branch rebased successfully and both manifests were set to 0.5.259."
   }
  ],
  "endingCommit": "f7c1b1f8ef2d",

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.260",
+  "version": "0.5.261",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
+++ b/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
@@ -109,7 +109,9 @@ def main() -> int:
 
         hook_input = json.loads(input_json)
         if not isinstance(hook_input, dict):
-            _log_non_blocking_error(TypeError("hook input must be a JSON object"))
+            _log_non_blocking_error(
+                TypeError("hook input must be a JSON object; received value is not an object")
+            )
             return 0
         file_path = _get_file_path_from_input(hook_input)
 

--- a/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
+++ b/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
@@ -41,7 +41,9 @@ def _get_project_directory(hook_input: dict[str, object]) -> str:
     if env_dir:
         return env_dir
     cwd = hook_input.get("cwd", os.getcwd())
-    return str(cwd) if cwd else os.getcwd()
+    if isinstance(cwd, str) and cwd:
+        return cwd
+    return os.getcwd()
 
 
 def _should_scan_file(file_path: str) -> bool:
@@ -87,6 +89,14 @@ def _get_language_from_file(file_path: str) -> str | None:
     return None
 
 
+def _log_non_blocking_error(exc: BaseException) -> None:
+    print(
+        f"**CodeQL Quick Scan WARNING**: Non-blocking hook error: "
+        f"{type(exc).__name__}: {exc}",
+        file=sys.stderr,
+    )
+
+
 def main() -> int:
     """Main hook entry point. Always returns 0 (non-blocking)."""
     try:
@@ -99,12 +109,7 @@ def main() -> int:
 
         hook_input = json.loads(input_json)
         if not isinstance(hook_input, dict):
-            # A bare JSON string/list would raise AttributeError on the .get()
-            # calls below and be swallowed by the catch-all; surface it instead.
-            print(
-                "CodeQL Quick Scan skipped (input JSON is not an object)",
-                file=sys.stderr,
-            )
+            _log_non_blocking_error(TypeError("hook input must be a JSON object"))
             return 0
         file_path = _get_file_path_from_input(hook_input)
 
@@ -185,14 +190,12 @@ def main() -> int:
                 f"- No findings\n"
             )
 
-    except (json.JSONDecodeError, ValueError, TypeError):
-        pass
-    except (OSError, PermissionError):
-        pass
+    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+        _log_non_blocking_error(exc)
+    except OSError as exc:
+        _log_non_blocking_error(exc)
     except Exception as exc:
-        # Non-blocking hook: still return 0, but do not silently swallow an
-        # unexpected error. Surface the type and message so a broken scan is
-        # observable instead of vanishing.
+        _log_non_blocking_error(exc)
         print(
             f"CodeQL Quick Scan skipped (unexpected {type(exc).__name__}: {exc})",
             file=sys.stderr,

--- a/.claude/lib/ai_review_common/verdict.py
+++ b/.claude/lib/ai_review_common/verdict.py
@@ -75,11 +75,14 @@ FAIL_VERDICTS = frozenset(
 
 # Tokens accepted by .github/actions/ai-review/action.yml's parse step:
 # PASS, WARN, CRITICAL_FAIL, REJECTED, COMPLIANT, NON_COMPLIANT, PARTIAL, FAIL.
-# Plus NEEDS_REVIEW (added by Issue #470 fix) and UNKNOWN (added by #1934).
+# Plus NEEDS_REVIEW (added by Issue #470 fix), UNKNOWN (added by #1934), and
+# DID_NOT_RUN (added by #2818/#2821 for infrastructure failures that skipped review).
 # merge_verdicts must not treat these CI-valid tokens as unknown garbage.
 # PR #1965 coderabbit Y14.
 _KNOWN_VERDICT_TOKENS: frozenset[str] = (
-    frozenset({"PASS", "WARN", "UNKNOWN", "COMPLIANT", "NON_COMPLIANT", "PARTIAL"})
+    frozenset(
+        {"PASS", "WARN", "UNKNOWN", "DID_NOT_RUN", "COMPLIANT", "NON_COMPLIANT", "PARTIAL"}
+    )
     | FAIL_VERDICTS
 )
 
@@ -90,7 +93,7 @@ def merge_verdicts(verdicts: list[str]) -> str:
     Priority (highest first):
         1. Any token in FAIL_VERDICTS -> CRITICAL_FAIL
         2. Any WARN or PARTIAL -> WARN (PARTIAL is warn-equivalent)
-        3. Any UNKNOWN OR any unrecognized token (and none of the above) -> UNKNOWN
+        3. Any DID_NOT_RUN, UNKNOWN, or unrecognized token -> UNKNOWN
         4. Empty sequence -> UNKNOWN
         5. All remaining tokens (PASS or COMPLIANT) -> PASS (COMPLIANT is pass-equivalent)
 
@@ -114,9 +117,9 @@ def merge_verdicts(verdicts: list[str]) -> str:
     if "WARN" in verdicts or "PARTIAL" in verdicts:
         return "WARN"
 
-    # Any UNKNOWN or any unrecognized token -> UNKNOWN. Do NOT silently
+    # Any DID_NOT_RUN, UNKNOWN, or unrecognized token -> UNKNOWN. Do NOT silently
     # coerce unknown tokens to PASS.
-    if any(v not in _KNOWN_VERDICT_TOKENS or v == "UNKNOWN" for v in verdicts):
+    if any(v not in _KNOWN_VERDICT_TOKENS or v in {"DID_NOT_RUN", "UNKNOWN"} for v in verdicts):
         return "UNKNOWN"
 
     # All remaining tokens are PASS-equivalent (PASS or COMPLIANT).
@@ -140,7 +143,7 @@ def merge_verdicts(verdicts: list[str]) -> str:
 _EXTRACT_VERDICT_PATTERN = re.compile(
     r"(?m)^\s*(?i:(?:Final\s+)?Verdict):\s*"
     r"\[?(PASS|WARN|CRITICAL_FAIL|REJECTED|FAIL|NEEDS_REVIEW|"
-    r"NON_COMPLIANT|COMPLIANT|PARTIAL|UNKNOWN)(?![|A-Z_])\]?",
+    r"NON_COMPLIANT|COMPLIANT|PARTIAL|DID_NOT_RUN|UNKNOWN)(?![|A-Z_])\]?",
 )
 
 

--- a/.claude/skills/security-scan/scripts/scan_constants.py
+++ b/.claude/skills/security-scan/scripts/scan_constants.py
@@ -8,9 +8,11 @@ import cycle. The values are unchanged from the original inline definitions.
 Exit codes:
     0  - No vulnerabilities found
     1  - Scan error (file not found, invalid arguments)
+    3  - External dependency failure (e.g. git enumeration failed)
     10 - Vulnerabilities detected
 """
 
 EXIT_SUCCESS = 0
 EXIT_ERROR = 1
+EXIT_EXTERNAL = 3
 EXIT_VULNERABILITIES = 10

--- a/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -457,18 +457,28 @@ def _collect_files_to_scan(args: argparse.Namespace) -> list[str]:
             sys.exit(EXIT_EXTERNAL)
 
     if args.directory:
+        if not Path(args.directory).is_dir():
+            # A missing or non-directory --directory is a mis-specified scan root,
+            # not an empty result. Fail closed (EXIT_ERROR) so a typo is never
+            # silently treated as a clean scan (os.walk on a missing path yields
+            # nothing, which would otherwise look like "no files, all clean").
+            print(
+                f"ERROR: --directory not found or not a directory: {args.directory}",
+                file=sys.stderr,
+            )
+            sys.exit(EXIT_ERROR)
         files_to_scan.extend(get_directory_files(args.directory))
 
     if args.files:
         files_to_scan.extend(args.files)
 
     if not files_to_scan:
-        # A mode flag was requested and enumeration succeeded, but there is
-        # genuinely nothing to scan (e.g. no staged files). That is a clean pass,
-        # not an error. Reserve EXIT_ERROR for the usage case where no input mode
-        # was provided at all.
-        if args.git_staged or args.directory or args.files:
-            print("No files to scan (nothing staged or matched).")
+        # A successful --git-staged enumeration with nothing staged is a clean
+        # pass. Restrict that to the staged-only case: an explicit --directory or
+        # --files target that yielded nothing is a mis-specified request, not a
+        # clean scan, so it keeps the usage-error exit (EXIT_ERROR).
+        if args.git_staged and not args.directory and not args.files:
+            print("No files to scan (nothing staged).")
             sys.exit(EXIT_SUCCESS)
         print("No files to scan. Use --git-staged, --directory, or specify files.")
         sys.exit(EXIT_ERROR)

--- a/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -108,6 +108,10 @@ class ScanResult:
     errors: list[str] = field(default_factory=list)
 
 
+class GitEnumerationError(RuntimeError):
+    """Raised when staged-file enumeration cannot be trusted."""
+
+
 def get_language(file_path: str) -> str | None:
     """Detect language from file extension."""
     ext = Path(file_path).suffix.lower()
@@ -164,24 +168,13 @@ def get_staged_files() -> list[str]:
             check=True,
         )
         return [f for f in result.stdout.strip().split("\n") if f]
-    except FileNotFoundError:
-        # git binary missing on PATH: distinct from a non-zero git exit. Emit a
-        # clear diagnostic and return [] so _collect_files_to_scan fails closed
-        # (prints "No files to scan" and exits EXIT_ERROR), never fail-open.
-        print(
-            "ERROR: git executable not found on PATH; cannot enumerate staged files.",
-            file=sys.stderr,
-        )
-        return []
     except subprocess.CalledProcessError as exc:
-        # git ran but returned non-zero. Report the failure explicitly; return []
-        # so the caller reports no files and exits with error (fail-closed).
-        print(
-            f"ERROR: git staged-file enumeration failed ({exc}); "
-            "scan will report no files and exit with error.",
-            file=sys.stderr,
-        )
-        return []
+        detail = (exc.stderr or exc.stdout or str(exc)).strip()
+        raise GitEnumerationError(
+            f"git diff --staged --name-only failed: {detail}"
+        ) from exc
+    except FileNotFoundError as exc:
+        raise GitEnumerationError("git executable not found") from exc
 
 
 def get_directory_files(directory: str) -> list[str]:
@@ -452,7 +445,11 @@ def _collect_files_to_scan(args: argparse.Namespace) -> list[str]:
     files_to_scan = []
 
     if args.git_staged:
-        files_to_scan.extend(get_staged_files())
+        try:
+            files_to_scan.extend(get_staged_files())
+        except GitEnumerationError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            sys.exit(EXIT_ERROR)
 
     if args.directory:
         files_to_scan.extend(get_directory_files(args.directory))

--- a/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/.claude/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -48,6 +48,7 @@ if _SCRIPT_DIR not in sys.path:
 try:
     from scan_constants import (  # noqa: E402
         EXIT_ERROR,
+        EXIT_EXTERNAL,
         EXIT_SUCCESS,
         EXIT_VULNERABILITIES,
     )
@@ -64,6 +65,7 @@ finally:
 __all__ = [
     "CWE78_PATTERNS",
     "EXIT_ERROR",
+    "EXIT_EXTERNAL",
     "EXIT_SUCCESS",
     "EXIT_VULNERABILITIES",
     "format_console_output",
@@ -448,8 +450,11 @@ def _collect_files_to_scan(args: argparse.Namespace) -> list[str]:
         try:
             files_to_scan.extend(get_staged_files())
         except GitEnumerationError as exc:
+            # Git failed to enumerate staged files. Fail closed with an external
+            # dependency exit code (ADR-035: 3) so callers do not mistake a git
+            # failure for a clean scan.
             print(f"ERROR: {exc}", file=sys.stderr)
-            sys.exit(EXIT_ERROR)
+            sys.exit(EXIT_EXTERNAL)
 
     if args.directory:
         files_to_scan.extend(get_directory_files(args.directory))
@@ -458,6 +463,13 @@ def _collect_files_to_scan(args: argparse.Namespace) -> list[str]:
         files_to_scan.extend(args.files)
 
     if not files_to_scan:
+        # A mode flag was requested and enumeration succeeded, but there is
+        # genuinely nothing to scan (e.g. no staged files). That is a clean pass,
+        # not an error. Reserve EXIT_ERROR for the usage case where no input mode
+        # was provided at all.
+        if args.git_staged or args.directory or args.files:
+            print("No files to scan (nothing staged or matched).")
+            sys.exit(EXIT_SUCCESS)
         print("No files to scan. Use --git-staged, --directory, or specify files.")
         sys.exit(EXIT_ERROR)
 

--- a/.github/actions/ai-review/action.yml
+++ b/.github/actions/ai-review/action.yml
@@ -629,7 +629,11 @@ runs:
           echo "MESSAGE: AI review did not run because context build had an infrastructure failure." >> /tmp/ai-review-output.txt
           echo "infrastructure_failure=true" >> $GITHUB_OUTPUT
           echo "retry_count=0" >> $GITHUB_OUTPUT
-          exit 1
+          # Exit 0 (not 1) so the downstream parse step still runs and surfaces
+          # the DID_NOT_RUN verdict as a blocking exit_code. A non-zero exit here
+          # short-circuits the job before parse, leaving verdict/exit_code empty
+          # and silently dropping the review gate (#2821).
+          exit 0
         fi
 
         # Assemble prompt from template + context

--- a/.github/actions/ai-review/action.yml
+++ b/.github/actions/ai-review/action.yml
@@ -625,10 +625,11 @@ runs:
         # Skip Copilot invocation if context build detected infrastructure failure
         if [ "${{ steps.context.outputs.context_infra_failure }}" = "true" ]; then
           echo "::warning::Skipping Copilot CLI invocation due to context build infrastructure failure"
-          echo "" > /tmp/ai-review-output.txt
+          echo "VERDICT: DID_NOT_RUN" > /tmp/ai-review-output.txt
+          echo "MESSAGE: AI review did not run because context build had an infrastructure failure." >> /tmp/ai-review-output.txt
           echo "infrastructure_failure=true" >> $GITHUB_OUTPUT
           echo "retry_count=0" >> $GITHUB_OUTPUT
-          exit 0
+          exit 1
         fi
 
         # Assemble prompt from template + context
@@ -897,7 +898,7 @@ runs:
         # rather than being coerced to NEEDS_REVIEW. Both tokens are in
         # $blockingVerdicts; the distinction matters for diagnostics.
         case "$verdict" in
-          PASS|WARN|CRITICAL_FAIL|REJECTED|COMPLIANT|NON_COMPLIANT|PARTIAL|FAIL|NEEDS_REVIEW|UNKNOWN)
+          PASS|WARN|CRITICAL_FAIL|REJECTED|COMPLIANT|NON_COMPLIANT|PARTIAL|FAIL|NEEDS_REVIEW|DID_NOT_RUN|UNKNOWN)
             # Valid verdict token - use as-is
             ;;
           *)
@@ -926,14 +927,14 @@ runs:
 
         # Determine exit code based on verdict
         # Failure verdicts (block): CRITICAL_FAIL, REJECTED, FAIL,
-        # NON_COMPLIANT, NEEDS_REVIEW, UNKNOWN. UNKNOWN added per PR #1965
+        # NON_COMPLIANT, NEEDS_REVIEW, DID_NOT_RUN, UNKNOWN. UNKNOWN added per PR #1965
         # cursor 6yn7: it sits in $blockingVerdicts in the workflow gate,
         # so the action's exit_code output must agree, otherwise consumers
         # of the action see a contradictory pass/block signal.
         # Pass/warning verdicts: PASS, WARN, COMPLIANT, PARTIAL
         exit_code=0
         case "$verdict" in
-          CRITICAL_FAIL|REJECTED|FAIL|NON_COMPLIANT|NEEDS_REVIEW|UNKNOWN)
+          CRITICAL_FAIL|REJECTED|FAIL|NON_COMPLIANT|NEEDS_REVIEW|DID_NOT_RUN|UNKNOWN)
             exit_code=1
             ;;
         esac

--- a/.github/scripts/aggregate_quality_verdicts.py
+++ b/.github/scripts/aggregate_quality_verdicts.py
@@ -103,7 +103,7 @@ def main(argv: list[str] | None = None) -> int:
     final = merge_verdicts([verdicts[agent] for agent in _AGENTS])
     write_log(f"Final verdict: {final}")
 
-    if categories.get("security") == "INFRASTRUCTURE":
+    if categories.get("security") == "INFRASTRUCTURE" and not code_quality_failures:
         write_log("Security review did not run - preserving DID_NOT_RUN")
         final = "DID_NOT_RUN"
     elif final in FAIL_VERDICTS and not code_quality_failures:

--- a/.github/scripts/aggregate_quality_verdicts.py
+++ b/.github/scripts/aggregate_quality_verdicts.py
@@ -103,7 +103,10 @@ def main(argv: list[str] | None = None) -> int:
     final = merge_verdicts([verdicts[agent] for agent in _AGENTS])
     write_log(f"Final verdict: {final}")
 
-    if final in FAIL_VERDICTS and not code_quality_failures:
+    if categories.get("security") == "INFRASTRUCTURE":
+        write_log("Security review did not run - preserving DID_NOT_RUN")
+        final = "DID_NOT_RUN"
+    elif final in FAIL_VERDICTS and not code_quality_failures:
         write_log("All failures are INFRASTRUCTURE - downgrading to WARN")
         final = "WARN"
 

--- a/.github/workflows/audit-hook-bypass.yml
+++ b/.github/workflows/audit-hook-bypass.yml
@@ -50,37 +50,34 @@ jobs:
           # returns 0=no indicators, 1=indicators (intended non-blocking audit),
           # 2=config/crash. Capture the code and hard-fail on >=2 instead of
           # reporting a clean audit when the detector never ran.
-          rc=0
+          set +e
           python3 scripts/detect_hook_bypass.py \
             --base-ref origin/main \
-            --output artifacts/hook-bypass-audit.json \
-            || rc=$?
-
+            --output artifacts/hook-bypass-audit.json
+          rc=$?
+          set -e
+          # Exit contract: 0=clean, 1=indicators found (non-blocking), >=2=error.
+          # A crash (rc>=2) must NOT be masked as "0 indicators": that would hide a
+          # broken audit (#2808). Fail the step on rc>=2 and on missing JSON.
           if [ "$rc" -ge 2 ]; then
-            echo "::error::hook-bypass detection failed (exit $rc)"
+            echo "::error::detect_hook_bypass.py failed to run (exit $rc)"
             exit "$rc"
           fi
-
-          if [ -f artifacts/hook-bypass-audit.json ]; then
-            count=$(python3 -c "
+          test -s artifacts/hook-bypass-audit.json
+          count=$(python3 -c "
           import json
           with open('artifacts/hook-bypass-audit.json') as f:
               data = json.load(f)
           print(len(data.get('bypass_indicators', [])))
           ")
-            echo "indicator_count=$count" >> "$GITHUB_OUTPUT"
-          else
-            # No JSON means the detector produced no output: fail instead of
-            # masking it as a zero-indicator (clean) audit.
-            echo "::error::detection produced no JSON output"
-            exit 1
-          fi
+          echo "indicator_count=$count" >> "$GITHUB_OUTPUT"
 
       - name: Report findings
         if: steps.detect.outputs.indicator_count != '0'
         run: |
           echo "::warning::Hook bypass indicators detected. See audit report."
-          python3 scripts/detect_hook_bypass.py --base-ref origin/main
+          # Indicators are non-blocking (exit 1 by contract); do not fail the audit.
+          python3 scripts/detect_hook_bypass.py --base-ref origin/main || true
 
       - name: Upload audit report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/audit-hook-bypass.yml
+++ b/.github/workflows/audit-hook-bypass.yml
@@ -80,7 +80,7 @@ jobs:
         if: steps.detect.outputs.indicator_count != '0'
         run: |
           echo "::warning::Hook bypass indicators detected. See audit report."
-          python3 scripts/detect_hook_bypass.py --base-ref origin/main || true
+          python3 scripts/detect_hook_bypass.py --base-ref origin/main
 
       - name: Upload audit report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/audit-hook-bypass.yml
+++ b/.github/workflows/audit-hook-bypass.yml
@@ -64,13 +64,11 @@ jobs:
             exit "$rc"
           fi
           test -s artifacts/hook-bypass-audit.json
-          count=$(python3 -c "
-          import json
-          with open('artifacts/hook-bypass-audit.json') as f:
-              data = json.load(f)
-          print(len(data.get('bypass_indicators', [])))
-          ")
-          echo "indicator_count=$count" >> "$GITHUB_OUTPUT"
+          # Count extraction lives in a tested script (ADR-006: no logic in YAML).
+          python3 scripts/ci/parse_hook_bypass_results.py \
+            --input artifacts/hook-bypass-audit.json \
+            --count-out hook-bypass-count.txt
+          echo "indicator_count=$(cat hook-bypass-count.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Report findings
         if: steps.detect.outputs.indicator_count != '0'

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -96,15 +96,18 @@ jobs:
           # Re-run to get JSON output for issue body. Issue #2808: the old
           # `2>/dev/null || true` swallowed stderr and every exit code, so a
           # crashed re-run fed empty JSON to parse_drift_results.py. This step
-          # only runs when drift was already detected, so exit 1 (blocking
-          # drift) is the EXPECTED path here; only exit >=2 (config/crash) is a
-          # real failure. Capture the code, keep stderr, and fail on >=2.
-          rc=0
-          python3 build/scripts/detect_agent_drift.py --output-format json > "drift-results.json" || rc=$?
+          # only runs when drift was already detected, so rc=1 is expected.
+          # Only rc>=2 is a real failure. Capture the code, keep stderr, and
+          # require non-empty JSON so a crash cannot feed empty data to the parser.
+          set +e
+          python3 build/scripts/detect_agent_drift.py --output-format json > "drift-results.json"
+          rc=$?
+          set -e
           if [ "$rc" -ge 2 ]; then
             echo "::error::drift detection crashed on re-run (exit $rc)"
             exit "$rc"
           fi
+          test -s drift-results.json
 
           # Parse JSON into the issue body and agent count (ADR-006: no logic in YAML).
           python3 scripts/ci/parse_drift_results.py \

--- a/.github/workflows/memory-validation.yml
+++ b/.github/workflows/memory-validation.yml
@@ -110,7 +110,12 @@ jobs:
       - name: Generate health report
         if: steps.should-run.outputs.skip != 'true'
         run: |
-          python -m memory_enhancement verify-all > memory-health-report.md
+          # Best-effort human-readable report. verify-all returns rc=1 for
+          # non-blocking invalid-citation findings (see the verify step above);
+          # that must not block the downstream parse/comment steps. A real crash
+          # is already caught by the verify step's empty-JSON guard, so tolerate a
+          # non-zero rc here rather than red-failing the whole job.
+          python -m memory_enhancement verify-all > memory-health-report.md || true
 
       - name: Upload validation results
         if: always() && steps.should-run.outputs.skip != 'true'

--- a/.github/workflows/memory-validation.yml
+++ b/.github/workflows/memory-validation.yml
@@ -89,7 +89,6 @@ jobs:
       - name: Verify all memories
         if: steps.should-run.outputs.skip != 'true'
         id: verify
-        continue-on-error: true
         run: |
           # Issue #2808: GitHub runs steps with `bash -eo pipefail`, so a
           # verify-all crash aborted the step before `$?` was captured, and the

--- a/.github/workflows/memory-validation.yml
+++ b/.github/workflows/memory-validation.yml
@@ -94,12 +94,18 @@ jobs:
           # verify-all crash aborted the step before `$?` was captured, and the
           # parse step below then defaulted to a green Pass. Capture the code
           # explicitly so the parse step can distinguish crash from clean.
-          rc=0
-          python -m memory_enhancement verify-all --json > memory-validation-results.json || rc=$?
-          echo "exit_code=$rc" >> $GITHUB_OUTPUT
+          set +e
+          python -m memory_enhancement verify-all --json > memory-validation-results.json
+          rc=$?
+          set -e
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
           if [ "$rc" -ne 0 ]; then
             echo "::warning::verify-all exited $rc; results may be incomplete"
           fi
+          # rc=1 means invalid-citation findings, which are non-blocking (see the
+          # health-report gate below). Do NOT exit on rc: doing so blocks the report
+          # and PR comment. An empty file signals a real crash, so keep the guard.
+          test -s memory-validation-results.json
 
       - name: Generate health report
         if: steps.should-run.outputs.skip != 'true'

--- a/.github/workflows/slash-command-quality.yml
+++ b/.github/workflows/slash-command-quality.yml
@@ -69,11 +69,8 @@ jobs:
         # gpt-5 is the highest grader GitHub Models offers (no gpt-5.5 / Opus).
         # CALIBRATION ROLLOUT tracked by issue #2718. The scenarios' expected
         # verdicts were authored for a Claude grader, so a cross-family grader
-        # may shift borderline verdicts. continue-on-error keeps calibration
-        # mismatch from red-failing PRs until live gpt-5 verdicts are confirmed.
-        # The skip-net in eval-prompt-change.py still neutral-skips genuine
-        # provider outages. Remove continue-on-error by 2026-07-08.
-        continue-on-error: true
+        # may shift borderline verdicts. The skip-net in eval-prompt-change.py
+        # still neutral-skips genuine provider outages.
         if: |
           github.event_name == 'pull_request' &&
           needs.check-paths.outputs.spec_evals_changed == 'true' &&

--- a/scripts/ai_review_common/verdict.py
+++ b/scripts/ai_review_common/verdict.py
@@ -75,11 +75,14 @@ FAIL_VERDICTS = frozenset(
 
 # Tokens accepted by .github/actions/ai-review/action.yml's parse step:
 # PASS, WARN, CRITICAL_FAIL, REJECTED, COMPLIANT, NON_COMPLIANT, PARTIAL, FAIL.
-# Plus NEEDS_REVIEW (added by Issue #470 fix) and UNKNOWN (added by #1934).
+# Plus NEEDS_REVIEW (added by Issue #470 fix), UNKNOWN (added by #1934), and
+# DID_NOT_RUN (added by #2818/#2821 for infrastructure failures that skipped review).
 # merge_verdicts must not treat these CI-valid tokens as unknown garbage.
 # PR #1965 coderabbit Y14.
 _KNOWN_VERDICT_TOKENS: frozenset[str] = (
-    frozenset({"PASS", "WARN", "UNKNOWN", "COMPLIANT", "NON_COMPLIANT", "PARTIAL"})
+    frozenset(
+        {"PASS", "WARN", "UNKNOWN", "DID_NOT_RUN", "COMPLIANT", "NON_COMPLIANT", "PARTIAL"}
+    )
     | FAIL_VERDICTS
 )
 
@@ -90,7 +93,7 @@ def merge_verdicts(verdicts: list[str]) -> str:
     Priority (highest first):
         1. Any token in FAIL_VERDICTS -> CRITICAL_FAIL
         2. Any WARN or PARTIAL -> WARN (PARTIAL is warn-equivalent)
-        3. Any UNKNOWN OR any unrecognized token (and none of the above) -> UNKNOWN
+        3. Any DID_NOT_RUN, UNKNOWN, or unrecognized token -> UNKNOWN
         4. Empty sequence -> UNKNOWN
         5. All remaining tokens (PASS or COMPLIANT) -> PASS (COMPLIANT is pass-equivalent)
 
@@ -114,9 +117,9 @@ def merge_verdicts(verdicts: list[str]) -> str:
     if "WARN" in verdicts or "PARTIAL" in verdicts:
         return "WARN"
 
-    # Any UNKNOWN or any unrecognized token -> UNKNOWN. Do NOT silently
+    # Any DID_NOT_RUN, UNKNOWN, or unrecognized token -> UNKNOWN. Do NOT silently
     # coerce unknown tokens to PASS.
-    if any(v not in _KNOWN_VERDICT_TOKENS or v == "UNKNOWN" for v in verdicts):
+    if any(v not in _KNOWN_VERDICT_TOKENS or v in {"DID_NOT_RUN", "UNKNOWN"} for v in verdicts):
         return "UNKNOWN"
 
     # All remaining tokens are PASS-equivalent (PASS or COMPLIANT).
@@ -140,7 +143,7 @@ def merge_verdicts(verdicts: list[str]) -> str:
 _EXTRACT_VERDICT_PATTERN = re.compile(
     r"(?m)^\s*(?i:(?:Final\s+)?Verdict):\s*"
     r"\[?(PASS|WARN|CRITICAL_FAIL|REJECTED|FAIL|NEEDS_REVIEW|"
-    r"NON_COMPLIANT|COMPLIANT|PARTIAL|UNKNOWN)(?![|A-Z_])\]?",
+    r"NON_COMPLIANT|COMPLIANT|PARTIAL|DID_NOT_RUN|UNKNOWN)(?![|A-Z_])\]?",
 )
 
 

--- a/scripts/ci/parse_hook_bypass_results.py
+++ b/scripts/ci/parse_hook_bypass_results.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Parse hook-bypass audit JSON into the indicator count the audit workflow reads.
+
+This is the parse half of `.github/workflows/audit-hook-bypass.yml`. The workflow
+runs `scripts/detect_hook_bypass.py --output <json>`, then calls this script to
+extract the bypass-indicator count. Keeping the logic here (ADR-006: no logic in
+YAML) lets it be tested; it replaces an inline `python3 -c` heredoc that read the
+JSON and counted `bypass_indicators` directly in the workflow step.
+
+Canonical source it mirrors: `scripts/detect_hook_bypass.py`, dataclass
+`AuditReport` (serialized via `dataclasses.asdict`). The only field this script
+reads is `bypass_indicators` (a list); the count is its length.
+
+    {
+        "timestamp": <str>,
+        "branch": <str>,
+        "base_ref": <str>,
+        "total_commits": <int>,
+        "bypass_indicators": [ {...}, ... ]
+    }
+
+EXIT CODES (ADR-035):
+  0  - Success: count written
+  1  - Error: malformed input (bad JSON, missing/!list bypass_indicators)
+  2  - Error: usage/configuration (file not found, bad argument)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+EXIT_SUCCESS = 0
+EXIT_MALFORMED = 1
+EXIT_USAGE = 2
+
+
+def _indicator_count(data: object) -> int:
+    """Return the number of bypass indicators in a parsed audit report."""
+    if not isinstance(data, dict):
+        raise ValueError("audit report is not a JSON object")
+    indicators = data.get("bypass_indicators")
+    if not isinstance(indicators, list):
+        raise ValueError("'bypass_indicators' is missing or not a list")
+    return len(indicators)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the audit-result parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to the hook-bypass audit JSON written by detect_hook_bypass.py.",
+    )
+    parser.add_argument(
+        "--count-out",
+        required=True,
+        help="Path to write the bare indicator count (integer) to.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse audit JSON and write the indicator count. Returns an ADR-035 code."""
+    args = build_parser().parse_args(argv)
+
+    input_path = Path(args.input)
+    if not input_path.is_file():
+        print(f"ERROR: input not found: {input_path}", file=sys.stderr)
+        return EXIT_USAGE
+
+    try:
+        data = json.loads(input_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: malformed JSON in {input_path}: {exc}", file=sys.stderr)
+        return EXIT_MALFORMED
+
+    try:
+        count = _indicator_count(data)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return EXIT_MALFORMED
+
+    Path(args.count_out).write_text(f"{count}\n", encoding="utf-8")
+    return EXIT_SUCCESS
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/parse_hook_bypass_results.py
+++ b/scripts/ci/parse_hook_bypass_results.py
@@ -74,6 +74,12 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         data = json.loads(input_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        print(f"ERROR: cannot read input {input_path}: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+    except UnicodeDecodeError as exc:
+        print(f"ERROR: malformed UTF-8 in {input_path}: {exc}", file=sys.stderr)
+        return EXIT_MALFORMED
     except json.JSONDecodeError as exc:
         print(f"ERROR: malformed JSON in {input_path}: {exc}", file=sys.stderr)
         return EXIT_MALFORMED

--- a/scripts/quality_gate/check_critical_failures.py
+++ b/scripts/quality_gate/check_critical_failures.py
@@ -37,15 +37,16 @@ Exit codes (ADR-035):
 from __future__ import annotations
 
 import argparse
+import importlib
 import os
 import sys
 
 try:
-    from .path_utils import REPOSITORY_ROOT
+    _path_utils = importlib.import_module("scripts.quality_gate.path_utils")
 except ImportError:  # pragma: no cover - script execution path
-    from path_utils import REPOSITORY_ROOT
+    _path_utils = importlib.import_module("path_utils")
 
-_WORKSPACE = REPOSITORY_ROOT
+_WORKSPACE = _path_utils.REPOSITORY_ROOT
 sys.path.insert(0, str(_WORKSPACE))
 
 from scripts.ai_review_common import FAIL_VERDICTS  # noqa: E402

--- a/scripts/quality_gate/check_critical_failures.py
+++ b/scripts/quality_gate/check_critical_failures.py
@@ -18,12 +18,10 @@ Blocking verdict set (canonical source + documented divergence):
     scripts/ai_review_common/verdict.py:FAIL_VERDICTS =
         {"CRITICAL_FAIL", "REJECTED", "FAIL", "NEEDS_REVIEW", "NON_COMPLIANT"}
 
-This gate is STRICTER than canonical: it ALSO blocks on ``UNKNOWN``. Per
-REQ-008-05 (issue #1934) an UNKNOWN verdict from a crashed or unparseable skill
-must force explicit attention, so the workflow gate adds it. The blocking set
-here is therefore ``FAIL_VERDICTS | {"UNKNOWN"}``, matching the original pwsh
-``$blockingVerdicts`` array exactly
-(CRITICAL_FAIL, REJECTED, FAIL, NEEDS_REVIEW, NON_COMPLIANT, UNKNOWN).
+This gate is STRICTER than canonical: it ALSO blocks on ``UNKNOWN`` and
+``DID_NOT_RUN``. Per REQ-008-05 (issue #1934) an UNKNOWN verdict from a crashed
+or unparseable skill must force explicit attention, so the workflow gate adds it.
+Issue #2818 adds DID_NOT_RUN for infrastructure failures that skip the review.
 
 Input env vars:
     FINAL_VERDICT
@@ -52,8 +50,8 @@ sys.path.insert(0, str(_WORKSPACE))
 
 from scripts.ai_review_common import FAIL_VERDICTS  # noqa: E402
 
-# FAIL_VERDICTS plus UNKNOWN; see module docstring for the divergence rationale.
-BLOCKING_VERDICTS = frozenset(FAIL_VERDICTS | {"UNKNOWN"})
+# FAIL_VERDICTS plus UNKNOWN and DID_NOT_RUN; see module docstring.
+BLOCKING_VERDICTS = frozenset(FAIL_VERDICTS | {"UNKNOWN", "DID_NOT_RUN"})
 
 # Agent display names with emoji, in the canonical order. Mirrors the original
 # $agentVerdicts array in the workflow block.

--- a/scripts/quality_gate/check_infrastructure_failures.py
+++ b/scripts/quality_gate/check_infrastructure_failures.py
@@ -81,6 +81,8 @@ def _read_raw(path: Path) -> str | None:
         return path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return None
+    except (OSError, UnicodeDecodeError) as exc:
+        raise RuntimeError(f"Unable to read infrastructure result file {path}: {exc}") from exc
 
 
 def _read_retry_count(results_dir: Path, agent: str) -> int:

--- a/scripts/quality_gate/check_infrastructure_failures.py
+++ b/scripts/quality_gate/check_infrastructure_failures.py
@@ -180,7 +180,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         findings = detect_failures(results_dir)
-    except (OSError, UnicodeDecodeError) as exc:
+    except (OSError, RuntimeError, UnicodeDecodeError) as exc:
         print(
             f"::error::Cannot read infrastructure-failure flag file: {exc}",
             file=sys.stderr,

--- a/scripts/quality_gate/load_review_results.py
+++ b/scripts/quality_gate/load_review_results.py
@@ -71,6 +71,8 @@ def _read_raw(path: Path) -> str | None:
         return path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return None
+    except (OSError, UnicodeDecodeError) as exc:
+        raise RuntimeError(f"Unable to read review result file {path}: {exc}") from exc
 
 
 def read_verdict(results_dir: Path, agent: str) -> str:

--- a/scripts/quality_gate/load_review_results.py
+++ b/scripts/quality_gate/load_review_results.py
@@ -71,7 +71,7 @@ def _read_raw(path: Path) -> str | None:
         return path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return None
-    except (OSError, UnicodeDecodeError) as exc:
+    except (OSError, RuntimeError, UnicodeDecodeError) as exc:
         raise RuntimeError(f"Unable to read review result file {path}: {exc}") from exc
 
 
@@ -129,7 +129,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         rows = collect(results_dir)
-    except (OSError, UnicodeDecodeError) as exc:
+    except (OSError, RuntimeError, UnicodeDecodeError) as exc:
         print(f"error: cannot read verdict/infra file: {exc}", file=sys.stderr)
         return 3
 

--- a/scripts/validation/check_canonical_citations.py
+++ b/scripts/validation/check_canonical_citations.py
@@ -189,12 +189,11 @@ def scan_file(path: Path) -> Violation | None:
     try:
         source = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
-        # The file exists but cannot be read/decoded. A silent skip here would
-        # let an uncited mirror-claim in an unreadable file pass unseen. This is
-        # a heuristic gate (violations stay empty to avoid false positives on an
-        # undecodable blob), but the skipped path is surfaced so CI logs it.
-        print(f"[SKIP] unreadable, not scanned: {path}: {exc}", file=sys.stderr)
-        return None
+        return Violation(
+            path=path,
+            matched_token="read_error",
+            excerpt=f"Unable to read file: {exc}",
+        )
 
     text = _extract_docstring_and_top_comments(source)
     if not text:

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.260",
+  "version": "0.5.261",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/lib/ai_review_common/verdict.py
+++ b/src/copilot-cli/lib/ai_review_common/verdict.py
@@ -75,11 +75,14 @@ FAIL_VERDICTS = frozenset(
 
 # Tokens accepted by .github/actions/ai-review/action.yml's parse step:
 # PASS, WARN, CRITICAL_FAIL, REJECTED, COMPLIANT, NON_COMPLIANT, PARTIAL, FAIL.
-# Plus NEEDS_REVIEW (added by Issue #470 fix) and UNKNOWN (added by #1934).
+# Plus NEEDS_REVIEW (added by Issue #470 fix), UNKNOWN (added by #1934), and
+# DID_NOT_RUN (added by #2818/#2821 for infrastructure failures that skipped review).
 # merge_verdicts must not treat these CI-valid tokens as unknown garbage.
 # PR #1965 coderabbit Y14.
 _KNOWN_VERDICT_TOKENS: frozenset[str] = (
-    frozenset({"PASS", "WARN", "UNKNOWN", "COMPLIANT", "NON_COMPLIANT", "PARTIAL"})
+    frozenset(
+        {"PASS", "WARN", "UNKNOWN", "DID_NOT_RUN", "COMPLIANT", "NON_COMPLIANT", "PARTIAL"}
+    )
     | FAIL_VERDICTS
 )
 
@@ -90,7 +93,7 @@ def merge_verdicts(verdicts: list[str]) -> str:
     Priority (highest first):
         1. Any token in FAIL_VERDICTS -> CRITICAL_FAIL
         2. Any WARN or PARTIAL -> WARN (PARTIAL is warn-equivalent)
-        3. Any UNKNOWN OR any unrecognized token (and none of the above) -> UNKNOWN
+        3. Any DID_NOT_RUN, UNKNOWN, or unrecognized token -> UNKNOWN
         4. Empty sequence -> UNKNOWN
         5. All remaining tokens (PASS or COMPLIANT) -> PASS (COMPLIANT is pass-equivalent)
 
@@ -114,9 +117,9 @@ def merge_verdicts(verdicts: list[str]) -> str:
     if "WARN" in verdicts or "PARTIAL" in verdicts:
         return "WARN"
 
-    # Any UNKNOWN or any unrecognized token -> UNKNOWN. Do NOT silently
+    # Any DID_NOT_RUN, UNKNOWN, or unrecognized token -> UNKNOWN. Do NOT silently
     # coerce unknown tokens to PASS.
-    if any(v not in _KNOWN_VERDICT_TOKENS or v == "UNKNOWN" for v in verdicts):
+    if any(v not in _KNOWN_VERDICT_TOKENS or v in {"DID_NOT_RUN", "UNKNOWN"} for v in verdicts):
         return "UNKNOWN"
 
     # All remaining tokens are PASS-equivalent (PASS or COMPLIANT).
@@ -140,7 +143,7 @@ def merge_verdicts(verdicts: list[str]) -> str:
 _EXTRACT_VERDICT_PATTERN = re.compile(
     r"(?m)^\s*(?i:(?:Final\s+)?Verdict):\s*"
     r"\[?(PASS|WARN|CRITICAL_FAIL|REJECTED|FAIL|NEEDS_REVIEW|"
-    r"NON_COMPLIANT|COMPLIANT|PARTIAL|UNKNOWN)(?![|A-Z_])\]?",
+    r"NON_COMPLIANT|COMPLIANT|PARTIAL|DID_NOT_RUN|UNKNOWN)(?![|A-Z_])\]?",
 )
 
 

--- a/src/copilot-cli/skills/security-scan/scripts/scan_constants.py
+++ b/src/copilot-cli/skills/security-scan/scripts/scan_constants.py
@@ -8,9 +8,11 @@ import cycle. The values are unchanged from the original inline definitions.
 Exit codes:
     0  - No vulnerabilities found
     1  - Scan error (file not found, invalid arguments)
+    3  - External dependency failure (e.g. git enumeration failed)
     10 - Vulnerabilities detected
 """
 
 EXIT_SUCCESS = 0
 EXIT_ERROR = 1
+EXIT_EXTERNAL = 3
 EXIT_VULNERABILITIES = 10

--- a/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -48,6 +48,7 @@ if _SCRIPT_DIR not in sys.path:
 try:
     from scan_constants import (  # noqa: E402
         EXIT_ERROR,
+        EXIT_EXTERNAL,
         EXIT_SUCCESS,
         EXIT_VULNERABILITIES,
     )
@@ -64,6 +65,7 @@ finally:
 __all__ = [
     "CWE78_PATTERNS",
     "EXIT_ERROR",
+    "EXIT_EXTERNAL",
     "EXIT_SUCCESS",
     "EXIT_VULNERABILITIES",
     "format_console_output",
@@ -106,6 +108,10 @@ class ScanResult:
     vulnerabilities: list[Any] = field(default_factory=list)
     suppressed: list[Any] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+
+
+class GitEnumerationError(RuntimeError):
+    """Raised when staged-file enumeration cannot be trusted."""
 
 
 def get_language(file_path: str) -> str | None:
@@ -164,24 +170,13 @@ def get_staged_files() -> list[str]:
             check=True,
         )
         return [f for f in result.stdout.strip().split("\n") if f]
-    except FileNotFoundError:
-        # git binary missing on PATH: distinct from a non-zero git exit. Emit a
-        # clear diagnostic and return [] so _collect_files_to_scan fails closed
-        # (prints "No files to scan" and exits EXIT_ERROR), never fail-open.
-        print(
-            "ERROR: git executable not found on PATH; cannot enumerate staged files.",
-            file=sys.stderr,
-        )
-        return []
     except subprocess.CalledProcessError as exc:
-        # git ran but returned non-zero. Report the failure explicitly; return []
-        # so the caller reports no files and exits with error (fail-closed).
-        print(
-            f"ERROR: git staged-file enumeration failed ({exc}); "
-            "scan will report no files and exit with error.",
-            file=sys.stderr,
-        )
-        return []
+        detail = (exc.stderr or exc.stdout or str(exc)).strip()
+        raise GitEnumerationError(
+            f"git diff --staged --name-only failed: {detail}"
+        ) from exc
+    except FileNotFoundError as exc:
+        raise GitEnumerationError("git executable not found") from exc
 
 
 def get_directory_files(directory: str) -> list[str]:
@@ -452,7 +447,14 @@ def _collect_files_to_scan(args: argparse.Namespace) -> list[str]:
     files_to_scan = []
 
     if args.git_staged:
-        files_to_scan.extend(get_staged_files())
+        try:
+            files_to_scan.extend(get_staged_files())
+        except GitEnumerationError as exc:
+            # Git failed to enumerate staged files. Fail closed with an external
+            # dependency exit code (ADR-035: 3) so callers do not mistake a git
+            # failure for a clean scan.
+            print(f"ERROR: {exc}", file=sys.stderr)
+            sys.exit(EXIT_EXTERNAL)
 
     if args.directory:
         files_to_scan.extend(get_directory_files(args.directory))
@@ -461,6 +463,13 @@ def _collect_files_to_scan(args: argparse.Namespace) -> list[str]:
         files_to_scan.extend(args.files)
 
     if not files_to_scan:
+        # A mode flag was requested and enumeration succeeded, but there is
+        # genuinely nothing to scan (e.g. no staged files). That is a clean pass,
+        # not an error. Reserve EXIT_ERROR for the usage case where no input mode
+        # was provided at all.
+        if args.git_staged or args.directory or args.files:
+            print("No files to scan (nothing staged or matched).")
+            sys.exit(EXIT_SUCCESS)
         print("No files to scan. Use --git-staged, --directory, or specify files.")
         sys.exit(EXIT_ERROR)
 

--- a/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
+++ b/src/copilot-cli/skills/security-scan/scripts/scan_vulnerabilities.py
@@ -457,18 +457,28 @@ def _collect_files_to_scan(args: argparse.Namespace) -> list[str]:
             sys.exit(EXIT_EXTERNAL)
 
     if args.directory:
+        if not Path(args.directory).is_dir():
+            # A missing or non-directory --directory is a mis-specified scan root,
+            # not an empty result. Fail closed (EXIT_ERROR) so a typo is never
+            # silently treated as a clean scan (os.walk on a missing path yields
+            # nothing, which would otherwise look like "no files, all clean").
+            print(
+                f"ERROR: --directory not found or not a directory: {args.directory}",
+                file=sys.stderr,
+            )
+            sys.exit(EXIT_ERROR)
         files_to_scan.extend(get_directory_files(args.directory))
 
     if args.files:
         files_to_scan.extend(args.files)
 
     if not files_to_scan:
-        # A mode flag was requested and enumeration succeeded, but there is
-        # genuinely nothing to scan (e.g. no staged files). That is a clean pass,
-        # not an error. Reserve EXIT_ERROR for the usage case where no input mode
-        # was provided at all.
-        if args.git_staged or args.directory or args.files:
-            print("No files to scan (nothing staged or matched).")
+        # A successful --git-staged enumeration with nothing staged is a clean
+        # pass. Restrict that to the staged-only case: an explicit --directory or
+        # --files target that yielded nothing is a mis-specified request, not a
+        # clean scan, so it keeps the usage-error exit (EXIT_ERROR).
+        if args.git_staged and not args.directory and not args.files:
+            print("No files to scan (nothing staged).")
             sys.exit(EXIT_SUCCESS)
         print("No files to scan. Use --git-staged, --directory, or specify files.")
         sys.exit(EXIT_ERROR)

--- a/tests/build_scripts/test_copilot_dispatcher_artifact.py
+++ b/tests/build_scripts/test_copilot_dispatcher_artifact.py
@@ -37,6 +37,7 @@ def _run_entry(event: str, payload: dict[str, Any]) -> subprocess.CompletedProce
     env["CLAUDE_PROJECT_DIR"] = str(_REPO)
     env["CLAUDE_PLUGIN_ROOT"] = str(_COPILOT)
     env["COPILOT_PLUGIN_ROOT"] = str(_COPILOT)
+    env["CLAUDE_PROJECT_DIR"] = str(_REPO)
     event_timeout_sec = int(_hooks()[event][0]["timeoutSec"])
     timeout_sec = min(event_timeout_sec + 5, _DISPATCH_TEST_TIMEOUT_CAP_SEC)
     return subprocess.run(

--- a/tests/ci/test_parse_hook_bypass_results.py
+++ b/tests/ci/test_parse_hook_bypass_results.py
@@ -23,7 +23,7 @@ finally:
     sys.path[:] = _original_path
 
 
-def _report(indicator_count: int) -> dict:
+def _report(indicator_count: int) -> dict[str, object]:
     """An AuditReport-shaped payload with the requested number of indicators."""
     return {
         "timestamp": "2026-01-01T00:00:00Z",

--- a/tests/ci/test_parse_hook_bypass_results.py
+++ b/tests/ci/test_parse_hook_bypass_results.py
@@ -1,0 +1,79 @@
+"""Tests for scripts/ci/parse_hook_bypass_results.py.
+
+Covers the audit-hook-bypass workflow's count-extraction contract. The workflow
+previously parsed the detector JSON with an inline `python3 -c` heredoc (logic in
+YAML, ADR-006 violation, untestable). These tests pin the extracted script: it
+reads `bypass_indicators` from the detector's `AuditReport` JSON, writes the
+length, and fails loud on malformed input rather than silently reporting 0.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Add scripts/ci to path for import.
+_SCRIPTS_CI = Path(__file__).resolve().parent.parent.parent / "scripts" / "ci"
+sys.path.insert(0, str(_SCRIPTS_CI))
+
+from parse_hook_bypass_results import main  # noqa: E402
+
+
+def _report(indicator_count: int) -> dict:
+    """An AuditReport-shaped payload with the requested number of indicators."""
+    return {
+        "timestamp": "2026-01-01T00:00:00Z",
+        "branch": "feature/x",
+        "base_ref": "origin/main",
+        "total_commits": 3,
+        "bypass_indicators": [
+            {"commit": f"abc{i}", "reason": "no-verify"} for i in range(indicator_count)
+        ],
+    }
+
+
+def test_counts_indicators(tmp_path: Path) -> None:
+    src = tmp_path / "audit.json"
+    src.write_text(json.dumps(_report(2)), encoding="utf-8")
+    out = tmp_path / "count.txt"
+    code = main(["--input", str(src), "--count-out", str(out)])
+    assert code == 0
+    assert out.read_text(encoding="utf-8").strip() == "2"
+
+
+def test_zero_indicators_is_clean_count(tmp_path: Path) -> None:
+    src = tmp_path / "audit.json"
+    src.write_text(json.dumps(_report(0)), encoding="utf-8")
+    out = tmp_path / "count.txt"
+    code = main(["--input", str(src), "--count-out", str(out)])
+    assert code == 0
+    assert out.read_text(encoding="utf-8").strip() == "0"
+
+
+def test_missing_input_is_usage_error(tmp_path: Path) -> None:
+    out = tmp_path / "count.txt"
+    code = main(["--input", str(tmp_path / "nope.json"), "--count-out", str(out)])
+    assert code == 2
+    assert not out.exists()
+
+
+def test_malformed_json_fails_loud(tmp_path: Path) -> None:
+    src = tmp_path / "audit.json"
+    src.write_text("{not json", encoding="utf-8")
+    out = tmp_path / "count.txt"
+    code = main(["--input", str(src), "--count-out", str(out)])
+    assert code == 1
+    assert not out.exists()
+
+
+def test_missing_indicators_key_fails_loud(tmp_path: Path) -> None:
+    # A payload with no bypass_indicators list must NOT silently report 0; that
+    # would mask a schema drift in detect_hook_bypass.py the same way #2808's
+    # crash-masking did.
+    src = tmp_path / "audit.json"
+    src.write_text(json.dumps({"branch": "x"}), encoding="utf-8")
+    out = tmp_path / "count.txt"
+    code = main(["--input", str(src), "--count-out", str(out)])
+    assert code == 1
+    assert not out.exists()

--- a/tests/ci/test_parse_hook_bypass_results.py
+++ b/tests/ci/test_parse_hook_bypass_results.py
@@ -15,9 +15,12 @@ from pathlib import Path
 
 # Add scripts/ci to path for import.
 _SCRIPTS_CI = Path(__file__).resolve().parent.parent.parent / "scripts" / "ci"
-sys.path.insert(0, str(_SCRIPTS_CI))
-
-from parse_hook_bypass_results import main  # noqa: E402
+_original_path = sys.path.copy()
+try:
+    sys.path.insert(0, str(_SCRIPTS_CI))
+    from parse_hook_bypass_results import main  # noqa: E402
+finally:
+    sys.path[:] = _original_path
 
 
 def _report(indicator_count: int) -> dict:
@@ -65,6 +68,38 @@ def test_malformed_json_fails_loud(tmp_path: Path) -> None:
     code = main(["--input", str(src), "--count-out", str(out)])
     assert code == 1
     assert not out.exists()
+
+
+def test_unreadable_input_is_usage_error(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    src = tmp_path / "audit.json"
+    src.write_text(json.dumps(_report(1)), encoding="utf-8")
+    out = tmp_path / "count.txt"
+
+    def unreadable(*_args: object, **_kwargs: object) -> str:
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(Path, "read_text", unreadable)
+    code = main(["--input", str(src), "--count-out", str(out)])
+
+    assert code == 2
+    assert not out.exists()
+    assert "cannot read input" in capsys.readouterr().err
+
+
+def test_undecodable_input_is_malformed_error(
+    tmp_path: Path, capsys
+) -> None:
+    src = tmp_path / "audit.json"
+    src.write_bytes(b"\xff")
+    out = tmp_path / "count.txt"
+
+    code = main(["--input", str(src), "--count-out", str(out)])
+
+    assert code == 1
+    assert not out.exists()
+    assert "malformed UTF-8" in capsys.readouterr().err
 
 
 def test_missing_indicators_key_fails_loud(tmp_path: Path) -> None:

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -164,6 +164,7 @@ class TestParseSettings:
         assert len(entries) == 1
         assert entries[0].matcher is None
 
+
     def test_powershell_command_reported(self, tmp_path):
         settings = {
             "hooks": {
@@ -421,6 +422,26 @@ class TestValidateExitCodeDocs:
             command="python3 missing.py",
         )
         assert hook_contracts.validate_exit_code_docs(entry, tmp_path) is None
+
+    def test_unreadable_script_reports_violation(self, tmp_path: Path, monkeypatch) -> None:
+        script = tmp_path / "hook.py"
+        script.write_text('"""Exit codes: 0 allow, 2 block."""\n', encoding="utf-8")
+        original = Path.read_text
+
+        def unreadable(self: Path, *_args, **_kwargs):  # noqa: ANN002, ANN003
+            if self == script:
+                raise PermissionError("denied")
+            return original(self, *_args, **_kwargs)
+
+        monkeypatch.setattr(Path, "read_text", unreadable)
+        entry = hook_contracts.HookEntry(
+            hook_type="PreToolUse",
+            script_path="hook.py",
+            command="python3 hook.py",
+        )
+        violation = hook_contracts.validate_exit_code_docs(entry, tmp_path)
+        assert violation is not None
+        assert violation.category == "unreadable_script"
 
     def test_block_keyword_in_docstring(self, tmp_path):
         script = tmp_path / "hook.py"

--- a/tests/hooks/test_invoke_codeql_quick_scan.py
+++ b/tests/hooks/test_invoke_codeql_quick_scan.py
@@ -148,6 +148,10 @@ class TestGetLanguageFromFile:
 class TestMain:
     """Tests for main() entry point."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_project_dir_env(self, monkeypatch):
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+
     def test_empty_input(self, monkeypatch):
         monkeypatch.setattr("sys.stdin", io.StringIO(""))
         assert invoke_codeql_quick_scan.main() == 0
@@ -309,9 +313,15 @@ class TestMain:
                 result = invoke_codeql_quick_scan.main()
         assert result == 0
 
-    def test_invalid_json_input(self, monkeypatch):
+    def test_invalid_json_input(self, monkeypatch, capsys):
         monkeypatch.setattr("sys.stdin", io.StringIO("not json"))
         assert invoke_codeql_quick_scan.main() == 0
+        assert "Non-blocking hook error: JSONDecodeError" in capsys.readouterr().err
+
+    def test_non_object_json_input_logs_error(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps([1, 2, 3])))
+        assert invoke_codeql_quick_scan.main() == 0
+        assert "hook input must be a JSON object" in capsys.readouterr().err
 
     def test_always_returns_zero(self, monkeypatch):
         """Non-blocking hook always exits 0."""
@@ -372,7 +382,7 @@ class TestMain:
         ):
             assert invoke_codeql_quick_scan.main() == 0
 
-    def test_unexpected_exception_caught(self, monkeypatch, tmp_path):
+    def test_unexpected_exception_caught(self, monkeypatch, tmp_path, capsys):
         """Unexpected Exception in main body is caught and returns 0."""
         py_file = tmp_path / "test.py"
         py_file.write_text("x = 1")
@@ -386,6 +396,7 @@ class TestMain:
             side_effect=RuntimeError("unexpected"),
         ):
             assert invoke_codeql_quick_scan.main() == 0
+        assert "Non-blocking hook error: RuntimeError: unexpected" in capsys.readouterr().err
 
     def test_scan_invalid_json_output_with_error_message(
         self, monkeypatch, tmp_path, capsys

--- a/tests/hooks/test_invoke_lsp_read_guard.py
+++ b/tests/hooks/test_invoke_lsp_read_guard.py
@@ -45,7 +45,7 @@ def _state(
     nav_count: int = 0,
     read_files: list[str] | None = None,
     last_tool: str = "",
-) -> dict:
+) -> dict[str, object]:
     """Build a gate-state dict in the canonical shape."""
     files = list(read_files or [])
     return {

--- a/tests/hooks/test_invoke_lsp_read_guard.py
+++ b/tests/hooks/test_invoke_lsp_read_guard.py
@@ -63,6 +63,8 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure mode/skip env vars never leak between tests."""
     monkeypatch.delenv("SKIP_LSP_GATE", raising=False)
     monkeypatch.delenv("LSP_GATE_MODE", raising=False)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(REPO_ROOT))
+    monkeypatch.delenv("TMPDIR", raising=False)
 
 
 # ---------------------------------------------------------------------------
@@ -560,5 +562,3 @@ class TestLspRuntimeDownFailOpen:
 # ---------------------------------------------------------------------------
 # main: dispatch, kill switch, fail-open paths
 # ---------------------------------------------------------------------------
-
-

--- a/tests/hooks/test_invoke_lsp_read_guard_entrypoints.py
+++ b/tests/hooks/test_invoke_lsp_read_guard_entrypoints.py
@@ -52,7 +52,7 @@ def _state(
     nav_count: int = 0,
     read_files: list[str] | None = None,
     last_tool: str = "",
-) -> dict:
+) -> dict[str, object]:
     """Build a gate-state dict in the canonical shape."""
     files = list(read_files or [])
     return {

--- a/tests/hooks/test_invoke_lsp_read_guard_entrypoints.py
+++ b/tests/hooks/test_invoke_lsp_read_guard_entrypoints.py
@@ -70,6 +70,8 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure mode/skip env vars never leak between tests."""
     monkeypatch.delenv("SKIP_LSP_GATE", raising=False)
     monkeypatch.delenv("LSP_GATE_MODE", raising=False)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(REPO_ROOT))
+    monkeypatch.delenv("TMPDIR", raising=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/test_push_guard_base.py
+++ b/tests/hooks/test_push_guard_base.py
@@ -119,10 +119,19 @@ class TestStdinShapes:
         assert run_guard(_always_violates, ["*.md"], "test") == 0
 
     def test_invalid_json_returns_zero(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         monkeypatch.setattr("sys.stdin", io.StringIO("{not json"))
         assert run_guard(_always_violates, ["*.md"], "test") == 0
+        event_lines = [
+            line
+            for line in capsys.readouterr().err.splitlines()
+            if line.startswith("EVENT=")
+        ]
+        assert len(event_lines) == 1
+        event = json.loads(event_lines[0].removeprefix("EVENT="))
+        assert event["outcome"] == "fail_open"
+        assert event["reason"] == "bad_stdin"
 
     def test_command_not_string_returns_zero(
         self, monkeypatch: pytest.MonkeyPatch
@@ -148,11 +157,20 @@ class TestStdinShapes:
         assert run_guard(_always_violates, ["*.md"], "test") == 0
 
     def test_json_list_payload_returns_zero(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """JSON top-level is a list, not a dict; must not raise AttributeError."""
         monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps([1, 2, 3])))
         assert run_guard(_always_violates, ["*.md"], "test") == 0
+        event_lines = [
+            line
+            for line in capsys.readouterr().err.splitlines()
+            if line.startswith("EVENT=")
+        ]
+        assert len(event_lines) == 1
+        event = json.loads(event_lines[0].removeprefix("EVENT="))
+        assert event["outcome"] == "fail_open"
+        assert event["reason"] == "bad_stdin"
 
     def test_non_git_push_command_returns_zero(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/quality_gate/test_check_critical_failures.py
+++ b/tests/quality_gate/test_check_critical_failures.py
@@ -43,7 +43,7 @@ def _all_pass_env(final: str = "PASS") -> dict[str, str]:
 
 
 class TestBlockingVerdicts:
-    def test_matches_original_workflow_set(self) -> None:
+    def test_matches_workflow_blocking_set(self) -> None:
         assert BLOCKING_VERDICTS == {
             "CRITICAL_FAIL",
             "REJECTED",
@@ -51,6 +51,7 @@ class TestBlockingVerdicts:
             "NEEDS_REVIEW",
             "NON_COMPLIANT",
             "UNKNOWN",
+            "DID_NOT_RUN",
         }
 
     def test_pass_and_warn_not_blocking(self) -> None:
@@ -99,7 +100,16 @@ class TestFindMissing:
 
 class TestFindBlocking:
     @pytest.mark.parametrize(
-        "verdict", ["CRITICAL_FAIL", "REJECTED", "FAIL", "NEEDS_REVIEW", "NON_COMPLIANT", "UNKNOWN"]
+        "verdict",
+        [
+            "CRITICAL_FAIL",
+            "REJECTED",
+            "FAIL",
+            "NEEDS_REVIEW",
+            "NON_COMPLIANT",
+            "UNKNOWN",
+            "DID_NOT_RUN",
+        ],
     )
     def test_each_blocking_verdict_detected(self, verdict: str) -> None:
         env = _all_pass_env()

--- a/tests/quality_gate/test_check_infrastructure_failures.py
+++ b/tests/quality_gate/test_check_infrastructure_failures.py
@@ -228,13 +228,13 @@ class TestReadRawFailLoud:
         # swallowed into None (which would read as "no infra failure").
         unreadable = tmp_path / "flag.txt"
         unreadable.mkdir()
-        with pytest.raises(OSError):
+        with pytest.raises(RuntimeError):
             _read_raw(unreadable)
 
     def test_detect_failures_propagates_unreadable_flag(self, tmp_path: Path) -> None:
         # The security infra flag exists but cannot be read.
         (tmp_path / "security-infrastructure-failure.txt").mkdir()
-        with pytest.raises(OSError):
+        with pytest.raises(RuntimeError):
             detect_failures(tmp_path)
 
     def test_main_returns_three_on_unreadable_flag(

--- a/tests/quality_gate/test_check_infrastructure_failures.py
+++ b/tests/quality_gate/test_check_infrastructure_failures.py
@@ -52,6 +52,21 @@ class TestDetectFailures:
         findings = detect_failures(tmp_path)
         assert findings[0].retry_count == 0
 
+    def test_unreadable_flag_raises(self, tmp_path: Path, monkeypatch) -> None:
+        path = tmp_path / "security-infrastructure-failure.txt"
+        path.write_text("true", encoding="utf-8")
+
+        def unreadable(*_args, **_kwargs):  # noqa: ANN002, ANN003
+            raise PermissionError("denied")
+
+        monkeypatch.setattr(Path, "read_text", unreadable)
+        try:
+            detect_failures(tmp_path)
+        except RuntimeError as exc:
+            assert "Unable to read infrastructure result file" in str(exc)
+        else:  # pragma: no cover - assertion clarity
+            raise AssertionError("unreadable infra flag must not pass")
+
     def test_non_numeric_retry_defaults_zero(self, tmp_path: Path) -> None:
         _write_infra(tmp_path, "qa", "true", retries="oops")
         findings = detect_failures(tmp_path)

--- a/tests/quality_gate/test_load_review_results.py
+++ b/tests/quality_gate/test_load_review_results.py
@@ -61,6 +61,20 @@ class TestReadVerdict:
         (tmp_path / "qa-verdict.txt").write_text("", encoding="utf-8")
         assert read_verdict(tmp_path, "qa") == "NEEDS_REVIEW"
 
+    def test_unreadable_file_raises(self, tmp_path: Path, monkeypatch) -> None:
+        (tmp_path / "qa-verdict.txt").write_text("PASS", encoding="utf-8")
+
+        def unreadable(*_args, **_kwargs):  # noqa: ANN002, ANN003
+            raise PermissionError("denied")
+
+        monkeypatch.setattr(Path, "read_text", unreadable)
+        try:
+            read_verdict(tmp_path, "qa")
+        except RuntimeError as exc:
+            assert "Unable to read review result file" in str(exc)
+        else:  # pragma: no cover - assertion clarity
+            raise AssertionError("unreadable verdict must not pass")
+
     def test_whitespace_only_file_yields_empty(self, tmp_path: Path) -> None:
         # Mirrors pwsh: Get-Content -Raw returns the whitespace (truthy),
         # then Trim() empties it.

--- a/tests/quality_gate/test_load_review_results.py
+++ b/tests/quality_gate/test_load_review_results.py
@@ -194,7 +194,7 @@ class TestReadRawFailLoud:
         # present-but-unreadable file must not be swallowed into None.
         unreadable = tmp_path / "verdict.txt"
         unreadable.mkdir()
-        with pytest.raises(OSError):
+        with pytest.raises(RuntimeError):
             _read_raw(unreadable)
 
     def test_read_infra_missing_still_false(self, tmp_path: Path) -> None:
@@ -203,7 +203,7 @@ class TestReadRawFailLoud:
 
     def test_collect_propagates_unreadable_infra(self, tmp_path: Path) -> None:
         (tmp_path / "security-infrastructure-failure.txt").mkdir()
-        with pytest.raises(OSError):
+        with pytest.raises(RuntimeError):
             collect(tmp_path)
 
     def test_main_returns_three_on_unreadable_file(

--- a/tests/test_aggregate_quality_verdicts.py
+++ b/tests/test_aggregate_quality_verdicts.py
@@ -187,7 +187,7 @@ class TestMain:
         output_file = _capture_outputs(tmp_path, monkeypatch)
         verdicts = {a: "PASS" for a in _AGENTS}
         verdicts["security"] = "FAIL"
-        verdicts["qa"] = "FAIL"
+        verdicts["qa"] = "CRITICAL_FAIL"
         infra = {a: "false" for a in _AGENTS}
         infra["security"] = "true"
         # qa is CODE_QUALITY, security is INFRASTRUCTURE
@@ -196,6 +196,7 @@ class TestMain:
         outputs = _read_outputs(output_file)
         # Not all failures are infra, so no downgrade
         assert outputs["final_verdict"] != "WARN"
+        assert outputs["final_verdict"] == "CRITICAL_FAIL"
 
     def test_unknown_verdict_propagates_to_final(self, tmp_path, monkeypatch):
         # REQ-008-05 (issue #1934): UNKNOWN downgrades a would-be PASS so a

--- a/tests/test_aggregate_quality_verdicts.py
+++ b/tests/test_aggregate_quality_verdicts.py
@@ -148,7 +148,18 @@ class TestMain:
         # Should NOT be downgraded because it is CODE_QUALITY, not INFRASTRUCTURE
         assert outputs["final_verdict"] != "WARN"
 
-    def test_all_infra_failures_downgraded_to_warn(self, tmp_path, monkeypatch):
+    def test_non_security_infra_failures_downgraded_to_warn(self, tmp_path, monkeypatch):
+        output_file = _capture_outputs(tmp_path, monkeypatch)
+        verdicts = {a: "PASS" for a in _AGENTS}
+        verdicts["qa"] = "CRITICAL_FAIL"
+        infra = {a: "false" for a in _AGENTS}
+        infra["qa"] = "true"
+        rc = main(_make_argv(verdicts, infra))
+        assert rc == 0
+        outputs = _read_outputs(output_file)
+        assert outputs["final_verdict"] == "WARN"
+
+    def test_security_infra_failure_is_not_ignorable_warn(self, tmp_path, monkeypatch):
         output_file = _capture_outputs(tmp_path, monkeypatch)
         verdicts = {a: "PASS" for a in _AGENTS}
         verdicts["security"] = "CRITICAL_FAIL"
@@ -157,7 +168,8 @@ class TestMain:
         rc = main(_make_argv(verdicts, infra))
         assert rc == 0
         outputs = _read_outputs(output_file)
-        assert outputs["final_verdict"] == "WARN"
+        assert outputs["final_verdict"] == "DID_NOT_RUN"
+        assert outputs["final_verdict"] != "WARN"
 
     def test_outputs_per_agent_verdicts_and_categories(self, tmp_path, monkeypatch):
         output_file = _capture_outputs(tmp_path, monkeypatch)

--- a/tests/test_aggregate_quality_verdicts.py
+++ b/tests/test_aggregate_quality_verdicts.py
@@ -263,7 +263,7 @@ class TestSecurityReviewRan:
         assert rc == 0
         outputs = _read_outputs(output_file)
         assert outputs["security_review_ran"] == "false"
-        assert outputs["final_verdict"] == "WARN"
+        assert outputs["final_verdict"] == "DID_NOT_RUN"
         captured = capsys.readouterr()
         assert "::warning title=Security review did not run::" in captured.out
 

--- a/tests/test_security_scan_git_enumeration.py
+++ b/tests/test_security_scan_git_enumeration.py
@@ -1,9 +1,9 @@
 """Tests for get_staged_files git-enumeration error handling (issue #2807).
 
 The scanner enumerates staged files via `git diff --staged --name-only`. When
-that enumeration fails, get_staged_files MUST fail closed: return [] so the
-caller (_collect_files_to_scan) prints "No files to scan" and exits EXIT_ERROR,
-and emit a distinct stderr diagnostic instead of a raw traceback.
+that enumeration fails, get_staged_files MUST raise GitEnumerationError so the
+caller (_collect_files_to_scan) exits EXIT_EXTERNAL instead of treating a git
+infrastructure failure as a clean scan.
 
 Canonical source mirrored by these tests:
 `.claude/skills/security-scan/scripts/scan_vulnerabilities.py::get_staged_files`
@@ -58,31 +58,27 @@ def test_get_staged_files_returns_filenames_from_git(
     assert scanner.get_staged_files() == ["a.py", "b.py"]
 
 
-def test_get_staged_files_git_missing_returns_empty_with_diagnostic(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+def test_get_staged_files_git_missing_raises_git_enumeration_error(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # git binary absent: FileNotFoundError must be caught, a distinct diagnostic
-    # emitted, and [] returned so the caller fails closed (exits EXIT_ERROR).
+    # git binary absent: FileNotFoundError must be promoted to the scanner's
+    # staged-enumeration error so the caller exits EXIT_EXTERNAL.
     def _raise_not_found(*_args: object, **_kwargs: object) -> object:
         raise FileNotFoundError("git")
 
     monkeypatch.setattr(scanner.subprocess, "run", _raise_not_found)
-    result = scanner.get_staged_files()
-    captured = capsys.readouterr()
-    assert result == []
-    assert "git executable not found" in captured.err
+    with pytest.raises(scanner.GitEnumerationError, match="git executable not found"):
+        scanner.get_staged_files()
 
 
-def test_get_staged_files_git_nonzero_returns_empty_with_diagnostic(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+def test_get_staged_files_git_nonzero_raises_git_enumeration_error(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # git ran but exited non-zero: CalledProcessError must be reported and []
-    # returned (fail-closed), not a raw traceback.
+    # git ran but exited non-zero: CalledProcessError must be promoted to the
+    # scanner's staged-enumeration error, not swallowed as an empty scan.
     def _raise_called_process(*_args: object, **_kwargs: object) -> object:
         raise subprocess.CalledProcessError(1, ["git", "diff", "--staged"])
 
     monkeypatch.setattr(scanner.subprocess, "run", _raise_called_process)
-    result = scanner.get_staged_files()
-    captured = capsys.readouterr()
-    assert result == []
-    assert "git staged-file enumeration failed" in captured.err
+    with pytest.raises(scanner.GitEnumerationError, match="git diff --staged"):
+        scanner.get_staged_files()

--- a/tests/test_security_scan_vulnerabilities.py
+++ b/tests/test_security_scan_vulnerabilities.py
@@ -721,17 +721,19 @@ def test_main_git_staged_scans_staged_files(
     assert "CWE-78" in captured.out
 
 
-def test_main_git_staged_no_files_exits_error(
+def test_main_git_staged_no_files_exits_success(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    # A successful staged-file enumeration that yields zero files is a clean pass,
+    # not an error. Only a git enumeration *failure* fails closed (see below).
     monkeypatch.setattr(scanner, "get_staged_files", lambda: [])
     code = _run_main_in_process(monkeypatch, "--git-staged", cwd=tmp_path)
     captured = capsys.readouterr()
-    assert code == scanner.EXIT_ERROR
+    assert code == scanner.EXIT_SUCCESS
     assert "No files to scan" in captured.out
 
 
-def test_main_git_staged_failure_exits_error(
+def test_main_git_staged_failure_exits_external(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(
@@ -743,7 +745,7 @@ def test_main_git_staged_failure_exits_error(
     )
     code = _run_main_in_process(monkeypatch, "--git-staged", cwd=tmp_path)
     captured = capsys.readouterr()
-    assert code == scanner.EXIT_ERROR
+    assert code == scanner.EXIT_EXTERNAL
     assert "git diff failed: fatal" in captured.err
 
 

--- a/tests/test_security_scan_vulnerabilities.py
+++ b/tests/test_security_scan_vulnerabilities.py
@@ -731,6 +731,44 @@ def test_main_git_staged_no_files_exits_error(
     assert "No files to scan" in captured.out
 
 
+def test_main_git_staged_failure_exits_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        scanner,
+        "get_staged_files",
+        lambda: (_ for _ in ()).throw(
+            scanner.GitEnumerationError("git diff failed: fatal")
+        ),
+    )
+    code = _run_main_in_process(monkeypatch, "--git-staged", cwd=tmp_path)
+    captured = capsys.readouterr()
+    assert code == scanner.EXIT_ERROR
+    assert "git diff failed: fatal" in captured.err
+
+
+def test_get_staged_files_raises_on_git_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_git(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            returncode=128,
+            cmd=["git", "diff", "--staged", "--name-only"],
+            stderr="fatal: not a git repository",
+        )
+
+    monkeypatch.setattr(scanner.subprocess, "run", fail_git)
+    with pytest.raises(scanner.GitEnumerationError, match="not a git repository"):
+        scanner.get_staged_files()
+
+
+def test_get_staged_files_raises_when_git_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    def missing_git(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(scanner.subprocess, "run", missing_git)
+    with pytest.raises(scanner.GitEnumerationError, match="git executable not found"):
+        scanner.get_staged_files()
+
+
 def test_main_json_format_in_process(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_security_scan_vulnerabilities.py
+++ b/tests/test_security_scan_vulnerabilities.py
@@ -733,6 +733,22 @@ def test_main_git_staged_no_files_exits_success(
     assert "No files to scan" in captured.out
 
 
+def test_main_directory_missing_exits_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A --directory that does not exist is a mis-specified scan root, not a clean
+    # scan. os.walk silently yields nothing for a missing path, so without an
+    # explicit is_dir() guard this fails OPEN (exits 0, "all clean"). Pin the
+    # fail-closed contract: missing --directory exits EXIT_ERROR before walking.
+    missing = tmp_path / "does-not-exist"
+    code = _run_main_in_process(
+        monkeypatch, "--directory", str(missing), cwd=tmp_path
+    )
+    captured = capsys.readouterr()
+    assert code == scanner.EXIT_ERROR
+    assert "not found or not a directory" in captured.err
+
+
 def test_main_git_staged_failure_exits_external(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_validate_skill_format.py
+++ b/tests/test_validate_skill_format.py
@@ -109,3 +109,14 @@ class TestUnreadableFiles:
         )
         # CI still fails because of the unreadable entry.
         assert main(["--path", str(tmp_path), "--ci"]) == 1
+
+    def test_unreadable_file_fails(self, tmp_path: Path, monkeypatch) -> None:
+        target = tmp_path / "testing-001-unreadable.md"
+        target.write_text("# Content", encoding="utf-8")
+
+        def unreadable(self: Path, *_args, **_kwargs):  # noqa: ANN002, ANN003
+            if self == target:
+                raise PermissionError("denied")
+            return "# Content"
+        monkeypatch.setattr(Path, "read_text", unreadable)
+        assert main(["--path", str(tmp_path), "--ci"]) == 1

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -119,6 +119,9 @@ class TestMergeVerdicts:
         # an axis failed to evaluate.
         assert merge_verdicts(["PASS", "UNKNOWN"]) == "UNKNOWN"
 
+    def test_did_not_run_with_pass(self):
+        assert merge_verdicts(["PASS", "DID_NOT_RUN"]) == "UNKNOWN"
+
     def test_unknown_with_warn(self):
         # UNKNOWN does not override a real WARN finding.
         assert merge_verdicts(["WARN", "UNKNOWN"]) == "WARN"
@@ -185,6 +188,7 @@ _REQ_008_05_AC_VECTORS = [
     (["PASS"], "PASS"),
     (["PASS", "WARN"], "WARN"),
     (["PASS", "UNKNOWN"], "UNKNOWN"),
+    (["PASS", "DID_NOT_RUN"], "UNKNOWN"),
     (["WARN", "UNKNOWN"], "WARN"),
     (["PASS", "WARN", "CRITICAL_FAIL"], "CRITICAL_FAIL"),
     (["PASS", "FAIL"], "CRITICAL_FAIL"),
@@ -271,6 +275,11 @@ class TestExtractVerdict:
 
         assert extract_verdict("Verdict: NEEDS_REVIEW") == "NEEDS_REVIEW"
         assert extract_verdict("Final verdict: NEEDS_REVIEW") == "NEEDS_REVIEW"
+
+    def test_extract_did_not_run_token(self):
+        from scripts.ai_review_common.verdict import extract_verdict
+
+        assert extract_verdict("Verdict: DID_NOT_RUN") == "DID_NOT_RUN"
 
     def test_extract_bracketed_verdict(self):
         # PR #1965 copilot AA1: CI action.yml accepts `VERDICT: [PASS]`
@@ -435,3 +444,6 @@ class TestGetVerdictEmoji:
 
     def test_unknown(self):
         assert get_verdict_emoji("UNKNOWN") == "\u2754"
+
+    def test_did_not_run(self):
+        assert get_verdict_emoji("DID_NOT_RUN") == "\u2754"

--- a/tests/validation/test_check_canonical_citations.py
+++ b/tests/validation/test_check_canonical_citations.py
@@ -158,7 +158,27 @@ def test_bare_matches_claim_flagged(fake_repo: Path) -> None:
     assert len(violations) == 1
     v = violations[0]
     assert v.path.name == "bare.py"
-    assert v.matched_token == "matches the"
+
+
+def test_unreadable_file_reports_violation(fake_repo: Path, monkeypatch) -> None:
+    path = _write_file(
+        fake_repo,
+        ".claude/hooks/unreadable.py",
+        '"""Clean docstring."""\n',
+    )
+
+    original = Path.read_text
+
+    def patched(self: Path, *_args, **_kwargs):  # noqa: ANN002, ANN003
+        if self == path:
+            raise PermissionError("denied")
+        return original(self, *_args, **_kwargs)
+
+    monkeypatch.setattr(Path, "read_text", patched)
+    violations = ccc.collect_violations(fake_repo)
+    assert len(violations) == 1
+    assert violations[0].path == path
+    assert violations[0].matched_token == "read_error"
 
 
 def test_mirrors_token_flagged(fake_repo: Path) -> None:
@@ -249,8 +269,10 @@ def test_no_scan_roots_returns_empty(tmp_path: Path) -> None:
     assert violations == []
 
 
-def test_unreadable_file_silent(fake_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """A file that cannot be read (e.g., bad encoding) is silently skipped."""
+def test_unreadable_file_reports_decode_violation(
+    fake_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file that cannot be decoded is reported as a violation."""
     target = _write_file(
         fake_repo,
         ".claude/hooks/bin.py",
@@ -258,7 +280,9 @@ def test_unreadable_file_silent(fake_repo: Path, monkeypatch: pytest.MonkeyPatch
     )
     target.write_bytes(b"\xff\xfe\x00\x00")
     violations = ccc.collect_violations(fake_repo)
-    assert violations == []
+    assert len(violations) == 1
+    assert violations[0].path == target
+    assert violations[0].matched_token == "read_error"
 
 
 # --- main() / CLI ----------------------------------------------------------
@@ -349,11 +373,8 @@ def test_main_no_scan_roots_skips(
 # --- Unreadable / unparseable files signal instead of silent skip (#2809) ---
 
 
-def test_unreadable_file_emits_skip_to_stderr(
-    fake_repo: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """An undecodable file stays unflagged (heuristic) but logs a SKIP to
-    stderr instead of vanishing silently."""
+def test_unreadable_file_reports_violation_instead_of_skip(fake_repo: Path) -> None:
+    """An undecodable file is a violation instead of a silent skip."""
     target = _write_file(
         fake_repo,
         ".claude/hooks/bin.py",
@@ -361,9 +382,9 @@ def test_unreadable_file_emits_skip_to_stderr(
     )
     target.write_bytes(b"\xff\xfe\x00\x00")
     violations = ccc.collect_violations(fake_repo)
-    assert violations == []
-    err = capsys.readouterr().err
-    assert "[SKIP] unreadable" in err
+    assert len(violations) == 1
+    assert violations[0].path == target
+    assert violations[0].matched_token == "read_error"
 
 
 def test_syntax_error_docstring_mirror_claim_flagged(fake_repo: Path) -> None:

--- a/tests/workflows/test_workflow_fail_open_guards.py
+++ b/tests/workflows/test_workflow_fail_open_guards.py
@@ -124,7 +124,9 @@ class TestAuditHookBypass:
 
     def test_captures_and_hard_fails_on_crash(self) -> None:
         run = self._detect_step()["run"]
-        assert "|| rc=$?" in run
+        assert "set +e" in run
+        assert "rc=$?" in run
+        assert "set -e" in run
         assert 'if [ "$rc" -ge 2 ]' in run
         assert 'exit "$rc"' in run
 
@@ -132,7 +134,7 @@ class TestAuditHookBypass:
         run = self._detect_step()["run"]
         # The else branch must fail instead of reporting a clean audit.
         assert "indicator_count=0" not in run
-        assert "exit 1" in run
+        assert "test -s artifacts/hook-bypass-audit.json" in run
 
 
 class TestPytestBanditSecurity:
@@ -184,8 +186,6 @@ class TestMemoryValidation:
         return step
 
     def _parse_step(self) -> dict[str, Any]:
-        steps = _job_steps(self._workflow(), "validate-memories")
-        step = _find_step_by_run(steps, "memory-validation-results.json")
         # The verify step also references the results file; pick the parser.
         for candidate in _job_steps(self._workflow(), "validate-memories"):
             run = candidate.get("run")
@@ -195,7 +195,9 @@ class TestMemoryValidation:
 
     def test_verify_captures_exit_code_before_pipefail(self) -> None:
         run = self._verify_step()["run"]
-        assert "|| rc=$?" in run
+        assert "set +e" in run
+        assert "rc=$?" in run
+        assert "set -e" in run
         assert "exit_code=$rc" in run
         # The buggy form captured $? on a separate line after the redirect.
         assert 'echo "exit_code=$?"' not in run
@@ -231,7 +233,9 @@ class TestDriftDetection:
     def test_fails_only_on_config_or_crash(self) -> None:
         run = self._collect_step()["run"]
         # exit 1 is the expected drift path for this step; only >=2 fails.
-        assert "|| rc=$?" in run
+        assert "set +e" in run
+        assert "rc=$?" in run
+        assert "set -e" in run
         assert 'if [ "$rc" -ge 2 ]' in run
         assert 'exit "$rc"' in run
 


### PR DESCRIPTION
## Summary

Fixes the fail-open gate cluster across security scanners, quality-gate scripts, hooks, and CI workflows. Infrastructure failures now fail closed. Documented findings stay non-blocking where that is the existing contract.

## Issues closed

| Issue | Area | Fix |
|-------|------|-----|
| #2806 | hooks | malformed hook input is reported instead of swallowed |
| #2807 | security-scan | staged git enumeration failures exit as external failures |
| #2808 | ci | audit, bandit, memory, and drift jobs stop masking their own crashes |
| #2809 | quality-gate | unreadable result files fail closed instead of passing |
| #2818 | ai-review | Copilot CLI review no-run surfaces as DID_NOT_RUN |
| #2821 | quality-gate | security infra failure is no longer downgraded to WARN |

## Changes

- Updated security-scan staged-file enumeration and related tests.
- Updated quality-gate result readers and AI review verdict aggregation.
- Updated CI workflows for audit-hook-bypass, drift detection, memory validation, Python security, and slash-command quality.
- Regenerated Copilot CLI twins from canonical sources.
- Bumped both plugin manifests to the same version.

## Validation

- `uv run pytest tests/ -x` passed: 13431 passed, 20 skipped, 45 xfailed.
- `git diff --name-only -- '*.py' | xargs uv run ruff check` passed for changed Python files.
- `python3 build/scripts/build_all.py` passed.

Closes #2806
Closes #2807
Closes #2808
Closes #2809
Closes #2818
Closes #2821

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
