### PR TITLE
fix(tests): isolate pytest abort reporting to stop pre-push suite flake

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-03-session-2607.json
+++ b/.agents/memory/episodes/episode-2026-07-03-session-2607.json
@@ -1,0 +1,51 @@
+{
+  "id": "episode-2026-07-03-session-2607",
+  "session": "2026-07-03-session-2607",
+  "timestamp": "2026-07-03T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Clear PR 2848 review blockers and merge issue 2827 fix",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Assessed PR 2848 block state",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Identified unresolved review threads as the blocker",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verified review feedback against current source",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-03T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fixed test subprocess and environment isolation",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-03-session-2606.json
+++ b/.agents/sessions/2026-07-03-session-2606.json
@@ -1,0 +1,142 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2606,
+    "date": "2026-07-03",
+    "branch": "fix/test-isolation-2827",
+    "startingCommit": "07649da0",
+    "objective": "Diagnose and fix issue 2827 intermittent pytest isolation flake"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP tool schemas loaded for repository worktree; project path /home/richard/src/GitHub/rjmurillo/ai-agents-work used for operations"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena-initial_instructions executed at session start"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md lines 1-116; confirmed read-only protocol"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded context-mode skill and inspected session-init generator availability"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read AGENTS.md-derived runtime instructions and test/security scoped instructions"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .github/instructions/testing.instructions.md and security.instructions.md for touched paths"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Relevant correction memories surfaced by hooks; wrote issue-2827-pytest-abort-classification memory"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/test-isolation-2827"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/test-isolation-2827"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status checked on fix/test-isolation-2827 at 07649da0"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "07649da0"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All session-end MUST items completed before final response; commit created with scoped pathspec"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read only and unchanged"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory issue-2827-pytest-abort-classification written"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown files changed; markdownlint not applicable"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Committed scoped issue #2827 hook fix, tests, and session log on fix/test-isolation-2827 as 8c1efc10"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "python3 scripts/validate_session_json.py .agents/sessions/2026-07-03-session-2606.json passed before commit; bash -n and targeted pytest passed; full pytest passed after fix"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "No PROJECT-PLAN task in scope for issue #2827"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not invoked; scoped hook fix with tests"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "summary": "Checked ordering mechanism and victim tests",
+      "evidence": "pyproject.toml/conftest.py/tests/conftest.py have no pytest-randomly config; python3 -m pytest --help | grep -i random returned no random plugin output; importlib found pytest_randomly_installed=False. Both named victim tests passed in isolation under python3 -m pytest."
+    },
+    {
+      "summary": "Could not reproduce the alleged setup/teardown ERROR or shared-state pollution",
+      "evidence": "Full suite before hook change passed in a clean Bash environment: 13339 passed, 20 skipped, 45 xfailed. Neighbor/window runs around both victims passed. Full suite after hook change passed: 13341 passed, 20 skipped, 45 xfailed. No ERROR traceback was produced."
+    },
+    {
+      "summary": "Identified live issue root cause as pre-push misclassification of an aborted pytest stream",
+      "evidence": "gh issue view 2827 comments state the pytest stream truncated with no traceback, no short summary, and no session summary. The hook appended ERROR: Python tests failed to the last streamed test line, making innocent tests look like failures."
+    },
+    {
+      "summary": "Fixed .githooks/pre-push to distinguish aborted pytest runs from real test failures",
+      "evidence": "Added pytest_output_has_session_summary and pytest_exit_was_signal. No-summary exits now report Python tests aborted before pytest summary and preserve fail-closed behavior. Summary-bearing pytest failures still report Python tests failed."
+    },
+    {
+      "summary": "Validated behavior and security posture",
+      "evidence": "Before/after fixture: origin/main hook prints ERROR: Python tests failed after last streamed victim; fixed hook prints ERROR: Python tests aborted before pytest summary (exit 137, signal 9). Targeted tests: 31 passed. Full pytest after fix: 13341 passed, 20 skipped, 45 xfailed. security-review agent found no vulnerabilities."
+    }
+  ],
+  "endingCommit": "8c1efc10",
+  "nextSteps": [
+    "Push was intentionally not performed per user instruction."
+  ]
+}

--- a/.agents/sessions/2026-07-03-session-2607.json
+++ b/.agents/sessions/2026-07-03-session-2607.json
@@ -1,0 +1,143 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2607,
+    "date": "2026-07-03",
+    "branch": "fix/test-isolation-2827",
+    "startingCommit": "c9d921e2",
+    "objective": "Clear PR 2848 review blockers and merge issue 2827 fix"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP instructions were loaded after tool schema discovery; code edits used the dedicated PR worktree."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena-initial_instructions executed before code changes."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md lines 1-116; confirmed read only protocol."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Created .agents/sessions/2026-07-03-session-2607.json in the PR worktree."
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded github skill context and used PR review thread script for PR 2848."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read active repository instructions and scoped test and Python rules before editing."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .github/instructions/testing.instructions.md, python.instructions.md, working-with-legacy-code.instructions.md, refactoring.instructions.md, and unified-software-engineering.instructions.md."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Relevant correction memories were supplied by hooks; memory index listing was attempted and specific PR review memories were applied."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Dedicated worktree branch fix/test-isolation-2827 at c9d921e2."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Work performed only on fix/test-isolation-2827 worktree."
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Root status checked before worktree creation; worktree status checked before edit."
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "c9d921e2"
+      },
+      "issueHandoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No .agents/sessions/handoffs/*2827*handoff.md file existed in the root checkout."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Session end checklist completed after PR 2848 blocker work."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md was read only and unchanged."
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Repository memory recorded the PR blocker pattern: green checks can still leave mergeStateStatus BLOCKED when review threads remain unresolved."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown files changed."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This session log and the test helper isolation fix are included in the final branch commit for PR 2848."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run pytest tests/test_pre_push_pytest_abort_detection.py -q passed with 2 tests; changed file dash byte checks returned zero; session JSON validation passed."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "PR babysitter task scoped to PR 2848; no planning artifact update required."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not invoked; scoped PR babysitting and review thread fix."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "summary": "Assessed PR 2848 block state",
+      "evidence": "gh pr view showed state OPEN, mergeStateStatus BLOCKED, mergeable MERGEABLE, auto merge enabled, and no failing checks. gh pr checks showed all checks passing or skipped."
+    },
+    {
+      "summary": "Identified unresolved review threads as the blocker",
+      "evidence": "get_pr_review_threads.py --pull-request 2848 --unresolved-only returned four unresolved threads on tests/test_pre_push_pytest_abort_detection.py."
+    },
+    {
+      "summary": "Verified review feedback against current source",
+      "evidence": "Read tests/test_pre_push_pytest_abort_detection.py lines 1-139 and byte checked em and en dash count as zero."
+    },
+    {
+      "summary": "Fixed test subprocess and environment isolation",
+      "evidence": "Added explicit UTF-8 decoding with replacement for subprocess helpers, normalized environment keys, and scrubbed inherited GIT_ variables before invoking copied hooks."
+    }
+  ],
+  "endingCommit": "final branch commit for PR 2848",
+  "nextSteps": [
+    "Push final commit, resolve four review threads with fix evidence, enable auto squash merge, and poll PR 2848 until merged."
+  ]
+}

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -86,6 +86,16 @@ record_skip() {
     echo_info "SKIP: $1"
 }
 
+pytest_output_has_session_summary() {
+    # A killed pytest process can leave the stream ending on the last test name.
+    # Treat that as an aborted run, not as proof the last streamed test failed.
+    grep -Eq '(^=+ (short test summary info|.*(passed|failed|error|errors|skipped|xfailed|xpassed|warnings).*) =+$)' "$1"
+}
+
+pytest_exit_was_signal() {
+    [ "$1" -ge 128 ] && [ "$1" -le 255 ]
+}
+
 # Temp file cleanup on exit (handles Ctrl+C, early exit, normal exit)
 TEMP_FILES=()
 # Auto-retro suppression sentinel (Issue #2327). Set once REPO_ROOT is known.
@@ -1197,11 +1207,23 @@ fi
                     rm -f "$TEST_OUTPUT"
                     record_pass "Python tests (pytest)"
                 else
+                    PYTEST_RC=$?
                     echo_info "  Test output (last 30 lines):"
                     tail -30 "$TEST_OUTPUT"
+                    if pytest_output_has_session_summary "$TEST_OUTPUT"; then
+                        record_fail "Python tests failed"
+                        echo_info "  Fix failing tests before pushing."
+                    else
+                        if pytest_exit_was_signal "$PYTEST_RC"; then
+                            PYTEST_SIGNAL=$((PYTEST_RC - 128))
+                            record_fail "Python tests aborted before pytest summary (exit $PYTEST_RC, signal $PYTEST_SIGNAL)"
+                        else
+                            record_fail "Python tests aborted before pytest summary (exit $PYTEST_RC)"
+                        fi
+                        echo_info "  Pytest did not print a session summary; the last streamed test may be innocent."
+                        echo_info "  Retry once. If it repeats, inspect resource kills or leaked threads."
+                    fi
                     rm -f "$TEST_OUTPUT"
-                    record_fail "Python tests failed"
-                    echo_info "  Fix failing tests before pushing."
                 fi
             else
                 record_skip "Python tests (tests/ directory not found)"

--- a/tests/test_pre_push_pytest_abort_detection.py
+++ b/tests/test_pre_push_pytest_abort_detection.py
@@ -17,7 +17,8 @@ def _run_git(repo: Path, *args: str) -> str:
         cwd=repo,
         capture_output=True,
         check=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
     return result.stdout.strip()
@@ -68,7 +69,9 @@ fi
 if [ "$1" = "-m" ] && [ "$2" = "pytest" ]; then
     case "$PYTEST_FAKE_MODE" in
         aborted)
-            printf 'tests/test_security_scan_vulnerabilities.py::test_get_language_shebang_fallback[#!/bin/bash\\n-bash] '
+            printf '%s%s' \
+                'tests/test_security_scan_vulnerabilities.py::' \
+                'test_get_language_shebang_fallback[#!/bin/bash\\n-bash] '
             exit 137
             ;;
         failed)
@@ -89,7 +92,11 @@ exit 0
 
     scratch = tmp_path / "scratch"
     scratch.mkdir()
-    env = os.environ.copy()
+    env = {
+        key.upper(): value
+        for key, value in os.environ.items()
+        if not key.upper().startswith("GIT_")
+    }
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
     env["PYTEST_FAKE_MODE"] = pytest_mode
     env["TMPDIR"] = str(scratch)
@@ -108,7 +115,8 @@ def _run_pre_push(
         input=f"refs/heads/feature/pytest-abort {head_sha} "
         f"refs/heads/feature/pytest-abort {base_sha}\n",
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         env=env,
         timeout=60,
     )

--- a/tests/test_pre_push_pytest_abort_detection.py
+++ b/tests/test_pre_push_pytest_abort_detection.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Regression coverage for issue #2827 pre-push pytest abort reporting."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PRE_PUSH = REPO_ROOT / ".githooks" / "pre-push"
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+        text=True,
+        timeout=30,
+    )
+    return result.stdout.strip()
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _make_repo(tmp_path: Path, *, pytest_mode: str) -> tuple[Path, str, str, dict[str, str]]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run_git(repo, "init")
+    _run_git(repo, "checkout", "-b", "main")
+    _run_git(repo, "config", "user.name", "Pre Push Test")
+    _run_git(repo, "config", "user.email", "pre-push-test@example.invalid")
+
+    hook_dir = repo / ".githooks"
+    hook_dir.mkdir()
+    _write_executable(hook_dir / "pre-push", PRE_PUSH.read_text(encoding="utf-8"))
+
+    (repo / "README.md").write_text("# fixture\n", encoding="utf-8")
+    _run_git(repo, "add", ".")
+    _run_git(repo, "commit", "-m", "test: base")
+    base_sha = _run_git(repo, "rev-parse", "HEAD")
+    _run_git(repo, "update-ref", "refs/remotes/origin/main", base_sha)
+    _run_git(repo, "checkout", "-b", "feature/pytest-abort")
+
+    (repo / "pkg.py").write_text("value = 1\n", encoding="utf-8")
+    (repo / "tests").mkdir()
+    (repo / "tests" / "test_pkg.py").write_text("def test_pkg(): pass\n", encoding="utf-8")
+    _run_git(repo, "add", ".")
+    _run_git(repo, "commit", "-m", "test: add python change")
+    head_sha = _run_git(repo, "rev-parse", "HEAD")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(bin_dir / "uv", "#!/usr/bin/env bash\nexit 1\n")
+    _write_executable(bin_dir / "ruff", "#!/usr/bin/env bash\nexit 0\n")
+    _write_executable(bin_dir / "mypy", "#!/usr/bin/env bash\nexit 0\n")
+    _write_executable(
+        bin_dir / "python3",
+        """#!/usr/bin/env bash
+if [ "$1" = "-c" ]; then
+    exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pytest" ]; then
+    case "$PYTEST_FAKE_MODE" in
+        aborted)
+            printf 'tests/test_security_scan_vulnerabilities.py::test_get_language_shebang_fallback[#!/bin/bash\\n-bash] '
+            exit 137
+            ;;
+        failed)
+            cat <<'OUT'
+============================= test session starts ==============================
+tests/test_pkg.py F
+=========================== short test summary info ============================
+FAILED tests/test_pkg.py::test_pkg - AssertionError
+========================= 1 failed, 1 passed in 0.10s ==========================
+OUT
+            exit 1
+            ;;
+    esac
+fi
+exit 0
+""",
+    )
+
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["PYTEST_FAKE_MODE"] = pytest_mode
+    env["TMPDIR"] = str(scratch)
+    return repo, base_sha, head_sha, env
+
+
+def _run_pre_push(
+    repo: Path,
+    base_sha: str,
+    head_sha: str,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(repo / ".githooks" / "pre-push")],
+        cwd=repo,
+        input=f"refs/heads/feature/pytest-abort {head_sha} "
+        f"refs/heads/feature/pytest-abort {base_sha}\n",
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+def test_aborted_pytest_reports_aborted_run_not_failed_test(tmp_path: Path) -> None:
+    repo, base_sha, head_sha, env = _make_repo(tmp_path, pytest_mode="aborted")
+
+    result = _run_pre_push(repo, base_sha, head_sha, env)
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 1, output
+    assert "ERROR: Python tests aborted before pytest summary (exit 137, signal 9)" in output
+    assert "last streamed test may be innocent" in output
+    assert "Fix failing tests before pushing." not in output
+
+
+def test_pytest_failure_with_summary_keeps_test_failure_guidance(tmp_path: Path) -> None:
+    repo, base_sha, head_sha, env = _make_repo(tmp_path, pytest_mode="failed")
+
+    result = _run_pre_push(repo, base_sha, head_sha, env)
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 1, output
+    assert "ERROR: Python tests failed" in output
+    assert "Fix failing tests before pushing." in output
+    assert "Python tests aborted before pytest summary" not in output


### PR DESCRIPTION
## Summary

Fixes the pre-push hook flake where a killed pytest run (OOM, signal, resource kill) was misreported as "Python tests failed" and blamed the last streamed test name, even though that test was innocent.

Root cause: `.githooks/pre-push` treated any non-zero pytest exit as a test failure and printed "Fix failing tests before pushing," including the case where pytest was aborted before it printed a session summary. The last line streamed under `-v` is a test node id, so the operator saw an innocent test blamed for an abort.

## Fix

- Add `pytest_output_has_session_summary()`: detect whether pytest printed a real session summary line (`==== N passed/failed/error ... ====` or `short test summary info`).
- Add `pytest_exit_was_signal()`: classify exit codes 128-255 as signal-terminated.
- Capture the real pytest exit code (`PYTEST_RC=$?`) at the top of the else branch (the `if` condition is the pytest invocation itself, so `$?` is pytest's code).
- Branch:
  - Summary present -> `record_fail "Python tests failed"` + "Fix failing tests before pushing." (unchanged behavior for real failures).
  - No summary -> `record_fail "Python tests aborted before pytest summary (exit N[, signal M])"` + guidance to retry once and inspect resource kills or leaked threads.

Both paths still `record_fail` (exit 1). The hook remains fail-closed: an abort never becomes a pass.

## Tests

`tests/test_pre_push_pytest_abort_detection.py` (new):
- `test_aborted_pytest_reports_aborted_run_not_failed_test`: exit 137 (SIGKILL) -> returncode 1, message "aborted before pytest summary (exit 137, signal 9)", "last streamed test may be innocent", and does NOT print "Fix failing tests before pushing."
- `test_pytest_failure_with_summary_keeps_test_failure_guidance`: real failure with summary -> "Python tests failed" + "Fix failing tests before pushing.", and does NOT print the abort message.

Full local suite: 13341 passed.

Closes #2827

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
