### PR TITLE
fix(eval): default to live model id via shared constant + preflight (#2857, #2858)

### DIFF
--- a/scripts/eval/_anthropic_api.py
+++ b/scripts/eval/_anthropic_api.py
@@ -168,20 +168,29 @@ def call_api(
             raw_body = ""
         sanitized = "".join(ch for ch in raw_body if 32 <= ord(ch) < 127)[:200]
         message = f"Anthropic API returned HTTP {e.code}: {sanitized}"
-        if e.code == 404 and (provider is None or is_default_anthropic(selected or "")):
-            # A 404 on the messages endpoint almost always means the model id
-            # is unknown to this key (issue #2857). Turn the bare 404 into an
-            # actionable message that lists the ids the key can actually reach.
-            # Best-effort only: never let the enrichment lookup raise.
-            try:
-                reachable = list_available_models(api_key)
-                if reachable:
-                    message += (
-                        f". Model '{model}' may be unavailable; reachable ids: "
-                        f"{', '.join(sorted(reachable))}"
+        if e.code == 404:
+            # Bind the name here regardless of whether the provider fast-path
+            # above ran (that import is guarded by `selected is not None`).
+            # Keeps static analysis clean and the reference unambiguous.
+            from _providers import is_default_anthropic
+
+            if provider is None or is_default_anthropic(selected or ""):
+                # A 404 on the messages endpoint almost always means the model id
+                # is unknown to this key (issue #2857). Turn the bare 404 into an
+                # actionable message that lists the ids the key can actually reach.
+                # Best-effort only: never let the enrichment lookup raise.
+                try:
+                    reachable = list_available_models(api_key)
+                    if reachable:
+                        message += (
+                            f". Model '{model}' may be unavailable; reachable ids: "
+                            f"{', '.join(sorted(reachable))}"
+                        )
+                except Exception as enrich_err:  # noqa: BLE001 - enrichment is best-effort
+                    print(
+                        f"warning: reachable-model lookup failed: {enrich_err}",
+                        file=sys.stderr,
                     )
-            except Exception:  # noqa: BLE001 - enrichment is best-effort
-                pass
         raise RuntimeError(message) from e
     except urllib.error.URLError as e:
         # urllib often wraps socket.timeout in URLError.reason; classify it

--- a/scripts/eval/_anthropic_api.py
+++ b/scripts/eval/_anthropic_api.py
@@ -281,7 +281,21 @@ def list_available_models(api_key: str, *, timeout: int = 30) -> list[str]:
             "Anthropic models endpoint returned an unexpected 'data' shape "
             f"(expected list, got {type(data).__name__})."
         )
-    return [m["id"] for m in data if isinstance(m, dict) and m.get("id")]
+    # Each entry must be an object with a non-empty string `id`. A non-string
+    # id (e.g. `{"id": 123}`) would otherwise flow through and later crash
+    # `", ".join(sorted(...))` in verify_model_available with a TypeError that
+    # bypasses the fail-open handler. Treat any malformed entry as an
+    # infrastructure error so callers fail open on a hostile/garbled response.
+    ids: list[str] = []
+    for m in data:
+        model_id = m.get("id") if isinstance(m, dict) else None
+        if not isinstance(model_id, str) or not model_id:
+            raise RuntimeError(
+                "Anthropic models endpoint returned a malformed model entry "
+                f"(expected an object with a non-empty string 'id', got {m!r})."
+            )
+        ids.append(model_id)
+    return ids
 
 
 def verify_model_available(

--- a/scripts/eval/_anthropic_api.py
+++ b/scripts/eval/_anthropic_api.py
@@ -266,7 +266,22 @@ def list_available_models(api_key: str, *, timeout: int = 30) -> list[str]:
             f"Anthropic models endpoint returned invalid JSON: {e.msg}."
         ) from e
 
-    return [m["id"] for m in result.get("data", []) if isinstance(m, dict) and m.get("id")]
+    # A 200 with valid JSON can still be the wrong shape (a bare list, a
+    # string, or a non-list `data`). Treat any shape violation as an
+    # infrastructure error (RuntimeError) so callers fail open rather than
+    # crashing on an unguarded AttributeError/TypeError.
+    if not isinstance(result, dict):
+        raise RuntimeError(
+            "Anthropic models endpoint returned an unexpected payload shape "
+            f"(expected object, got {type(result).__name__})."
+        )
+    data = result.get("data", [])
+    if not isinstance(data, list):
+        raise RuntimeError(
+            "Anthropic models endpoint returned an unexpected 'data' shape "
+            f"(expected list, got {type(data).__name__})."
+        )
+    return [m["id"] for m in data if isinstance(m, dict) and m.get("id")]
 
 
 def verify_model_available(
@@ -324,10 +339,15 @@ def verify_model_available(
         )
         return
 
-    if reachable and model not in reachable:
+    # A successful probe that does not list `model` means it is provably
+    # unreachable with this key -> fail closed. An empty list is the same
+    # signal (the probe worked and returned zero models), so it also fails
+    # closed rather than silently proceeding to a guaranteed 404.
+    if model not in reachable:
+        listed = ", ".join(sorted(reachable)) if reachable else "(none)"
         raise RuntimeError(
             f"Model '{model}' is not reachable with this API key. "
-            f"Reachable ids: {', '.join(sorted(reachable))}. "
+            f"Reachable ids: {listed}. "
             "Pass --model with one of these, or update DEFAULT_MODEL in "
             "scripts/eval/_anthropic_api.py."
         )

--- a/scripts/eval/_anthropic_api.py
+++ b/scripts/eval/_anthropic_api.py
@@ -10,10 +10,20 @@ from __future__ import annotations
 import json
 import os
 import socket
+import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any
+
+# Single source of truth for the default eval model. Every eval script imports
+# this instead of hard-coding an id, so a model bump is a one-line change here
+# (issue #2858). The previous default `claude-sonnet-4-20250514` is a dead id
+# that returns HTTP 404 against a current key; `claude-sonnet-4-6` is reachable
+# and priced in `_eval_common.py`.
+DEFAULT_MODEL = "claude-sonnet-4-6"
+
+_MODELS_ENDPOINT = "https://api.anthropic.com/v1/models"
 
 
 def load_api_key() -> str:
@@ -76,7 +86,7 @@ def call_api(
     api_key: str,
     messages: list[dict[str, str]],
     system: str = "",
-    model: str = "claude-sonnet-4-20250514",
+    model: str = DEFAULT_MODEL,
     max_tokens: int = 1024,
     temperature: float = 0.0,
     provider: str | None = None,
@@ -157,9 +167,22 @@ def call_api(
         except Exception:  # noqa: BLE001 - body read is best-effort only
             raw_body = ""
         sanitized = "".join(ch for ch in raw_body if 32 <= ord(ch) < 127)[:200]
-        raise RuntimeError(
-            f"Anthropic API returned HTTP {e.code}: {sanitized}"
-        ) from e
+        message = f"Anthropic API returned HTTP {e.code}: {sanitized}"
+        if e.code == 404 and (provider is None or is_default_anthropic(selected or "")):
+            # A 404 on the messages endpoint almost always means the model id
+            # is unknown to this key (issue #2857). Turn the bare 404 into an
+            # actionable message that lists the ids the key can actually reach.
+            # Best-effort only: never let the enrichment lookup raise.
+            try:
+                reachable = list_available_models(api_key)
+                if reachable:
+                    message += (
+                        f". Model '{model}' may be unavailable; reachable ids: "
+                        f"{', '.join(sorted(reachable))}"
+                    )
+            except Exception:  # noqa: BLE001 - enrichment is best-effort
+                pass
+        raise RuntimeError(message) from e
     except urllib.error.URLError as e:
         # urllib often wraps socket.timeout in URLError.reason; classify it
         # as a timeout so the error message is actionable.
@@ -188,6 +211,126 @@ def call_api(
         if block.get("type") == "text"
     ]
     return "\n".join(text_parts)
+
+
+def list_available_models(api_key: str, *, timeout: int = 30) -> list[str]:
+    """Return the model ids reachable with ``api_key`` via ``GET /v1/models``.
+
+    Args:
+        api_key: The Anthropic API key.
+        timeout: Socket timeout in seconds.
+
+    Returns:
+        A list of model id strings (``data[].id``). May be empty if the
+        account exposes no models.
+
+    Raises:
+        RuntimeError: On HTTP error, network failure, timeout, or invalid
+            JSON. Original exception chained via ``__cause__``. Callers that
+            want fail-open behavior on infrastructure errors should catch this.
+    """
+    req = urllib.request.Request(
+        f"{_MODELS_ENDPOINT}?limit=1000",
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            result = json.loads(resp.read().decode(errors="replace"))
+    except urllib.error.HTTPError as e:
+        try:
+            raw_body = e.read().decode(errors="replace")
+        except Exception:  # noqa: BLE001 - body read is best-effort only
+            raw_body = ""
+        sanitized = "".join(ch for ch in raw_body if 32 <= ord(ch) < 127)[:200]
+        raise RuntimeError(
+            f"Anthropic models endpoint returned HTTP {e.code}: {sanitized}"
+        ) from e
+    except urllib.error.URLError as e:
+        if isinstance(e.reason, (TimeoutError, socket.timeout)):
+            raise RuntimeError(
+                f"Anthropic models endpoint timed out after {timeout}s."
+            ) from e
+        raise RuntimeError(
+            f"Anthropic models endpoint network error: {e.reason}."
+        ) from e
+    except TimeoutError as e:
+        raise RuntimeError(
+            f"Anthropic models endpoint timed out after {timeout}s."
+        ) from e
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"Anthropic models endpoint returned invalid JSON: {e.msg}."
+        ) from e
+
+    return [m["id"] for m in result.get("data", []) if isinstance(m, dict) and m.get("id")]
+
+
+def verify_model_available(
+    api_key: str,
+    model: str,
+    *,
+    provider: str | None = None,
+    timeout: int = 30,
+) -> None:
+    """Fail fast before the first scored call if ``model`` is unreachable.
+
+    Preflight for the eval harness (issue #2857). Semantics follow the repo
+    fail-open/fail-closed doctrine:
+
+    - **Protocol violation (fail-closed):** the key reaches ``/v1/models`` and
+      ``model`` is not in the returned list -> raise ``RuntimeError`` listing
+      the reachable ids, so a live run never spends on a dead model id.
+    - **Infrastructure error (fail-open):** the ``/v1/models`` lookup itself
+      fails (network down, auth error, malformed body) -> print a warning to
+      stderr and return, letting the run proceed and surface the real error
+      (now 404-enriched) at first call rather than blocking on a flaky probe.
+
+    No-ops when ``EVAL_SKIP_MODEL_PREFLIGHT`` is set (truthy) or when a
+    non-default provider is selected (those adapters self-manage credentials
+    and model routing).
+
+    Args:
+        api_key: The Anthropic API key. Ignored for non-anthropic providers.
+        model: The model id the run intends to use.
+        provider: Optional transport selector. ``None`` falls back to the
+            ``EVAL_PROVIDER`` env var.
+        timeout: Socket timeout in seconds for the probe.
+
+    Raises:
+        RuntimeError: If the model is provably unreachable (fail-closed).
+    """
+    if os.environ.get("EVAL_SKIP_MODEL_PREFLIGHT"):
+        return
+
+    selected = provider if provider is not None else os.environ.get("EVAL_PROVIDER")
+    if selected:
+        from _providers import is_default_anthropic
+
+        if not is_default_anthropic(selected):
+            return
+
+    try:
+        reachable = list_available_models(api_key, timeout=timeout)
+    except RuntimeError as e:
+        # Infrastructure error: fail open so a flaky probe cannot block a run.
+        print(
+            f"WARNING: model preflight skipped ({e}). "
+            "Proceeding; a bad model id will surface at first API call.",
+            file=sys.stderr,
+        )
+        return
+
+    if reachable and model not in reachable:
+        raise RuntimeError(
+            f"Model '{model}' is not reachable with this API key. "
+            f"Reachable ids: {', '.join(sorted(reachable))}. "
+            "Pass --model with one of these, or update DEFAULT_MODEL in "
+            "scripts/eval/_anthropic_api.py."
+        )
 
 
 def load_custom_prompts(path: str) -> dict[str, list[dict[str, Any]]]:

--- a/scripts/eval/_eval_common.py
+++ b/scripts/eval/_eval_common.py
@@ -19,6 +19,8 @@ FLAKINESS_VARIANCE_THRESHOLD = 1.0
 # _plan_runner.py (T4-1) and _report_aggregator.py (T4-3) per DESIGN-004 §5.3a.
 # When updating, also update PRICING_RATE_AS_OF.
 MODEL_PRICING_RATES_USD_PER_1K_TOKENS: dict[str, dict[str, float]] = {
+    # Legacy id retained for historical run cost lookups only; it is a dead
+    # id (HTTP 404) and MUST NOT be used as a default (issue #2858).
     "claude-sonnet-4-20250514": {"input": 0.003, "output": 0.015},
     "claude-sonnet-4-6": {"input": 0.003, "output": 0.015},
 }

--- a/scripts/eval/eval-agents.py
+++ b/scripts/eval/eval-agents.py
@@ -46,9 +46,10 @@ from typing import Any
 # ---------------------------------------------------------------------------
 # API utilities (shared module)
 # ---------------------------------------------------------------------------
+from _anthropic_api import DEFAULT_MODEL
 from _anthropic_api import call_api as _call_api
 from _anthropic_api import load_api_key as _load_api_key
-from _anthropic_api import load_custom_prompts
+from _anthropic_api import load_custom_prompts, verify_model_available
 from _eval_common import EST_TOKENS_PER_CALL, aggregate_multi_run_scores
 
 # ---------------------------------------------------------------------------
@@ -556,7 +557,7 @@ PROMPTS: dict[str, list[dict[str, Any]]] = {
 _AGENT_MAX_TOKENS = 2048
 
 
-def _call_api_for_agents(api_key: str, messages: list[dict[str, str]], system: str = "", model: str = "claude-sonnet-4-20250514") -> str:
+def _call_api_for_agents(api_key: str, messages: list[dict[str, str]], system: str = "", model: str = DEFAULT_MODEL) -> str:
     """Call the Anthropic API with agent-specific max_tokens."""
     result: str = _call_api(api_key, messages, system=system, model=model, max_tokens=_AGENT_MAX_TOKENS)
     return result
@@ -595,7 +596,7 @@ def score_agent_response(
     expected: str,
     agent_name: str,
     complexity: str = "complicated",
-    model: str = "claude-sonnet-4-20250514",
+    model: str = DEFAULT_MODEL,
 ) -> dict[str, Any]:
     """Score an agent response on 4 dimensions: role, actionability, quality, appropriateness."""
     behavior_guidance = COMPLEXITY_BEHAVIOR.get(complexity, COMPLEXITY_BEHAVIOR["complicated"])
@@ -736,7 +737,7 @@ def run_assessment(
     api_key: str,
     agents: list[str],
     prompts: dict[str, list[dict[str, Any]]],
-    model: str = "claude-sonnet-4-20250514",
+    model: str = DEFAULT_MODEL,
     dry_run: bool = False,
     runs: int = 1,
 ) -> dict[str, Any]:
@@ -848,7 +849,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Assess agent definition quality")
     parser.add_argument("--agent", type=str, help="Assess a single agent instead of all")
     parser.add_argument("--prompts-file", type=str, help="Load custom prompts from JSON")
-    parser.add_argument("--model", type=str, default="claude-sonnet-4-20250514",
+    parser.add_argument("--model", type=str, default=DEFAULT_MODEL,
                         help="Model to use for assessment")
     parser.add_argument("--dry-run", action="store_true",
                         help="Print prompts without calling the API")
@@ -865,6 +866,12 @@ def main() -> None:
         except RuntimeError as e:
             print(f"ERROR: {e}", file=sys.stderr)
             sys.exit(1)
+
+        try:
+            verify_model_available(api_key, args.model)
+        except RuntimeError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(2)
 
     # Determine which agents to assess
     if args.agent:

--- a/scripts/eval/eval-knowledge-integration.py
+++ b/scripts/eval/eval-knowledge-integration.py
@@ -29,9 +29,10 @@ from typing import Any
 # ---------------------------------------------------------------------------
 # API utilities (shared module)
 # ---------------------------------------------------------------------------
+from _anthropic_api import DEFAULT_MODEL
 from _anthropic_api import call_api as _call_api
 from _anthropic_api import load_api_key as _load_api_key
-from _anthropic_api import load_custom_prompts
+from _anthropic_api import load_custom_prompts, verify_model_available
 from _eval_common import EST_TOKENS_PER_CALL, aggregate_multi_run_scores
 
 # ---------------------------------------------------------------------------
@@ -198,14 +199,14 @@ PROMPTS: dict[str, list[dict[str, str]]] = {
 SKILLS = list(PROMPTS.keys())
 
 
-def run_prompt(api_key: str, prompt: str, system_context: str = "", model: str = "claude-sonnet-4-20250514") -> str:
+def run_prompt(api_key: str, prompt: str, system_context: str = "", model: str = DEFAULT_MODEL) -> str:
     """Run a single prompt with optional system context."""
     messages = [{"role": "user", "content": prompt}]
     result: str = _call_api(api_key, messages, system=system_context, model=model)
     return result
 
 
-def score_response(api_key: str, prompt: str, response: str, expected: str, model: str = "claude-sonnet-4-20250514") -> dict[str, Any]:
+def score_response(api_key: str, prompt: str, response: str, expected: str, model: str = DEFAULT_MODEL) -> dict[str, Any]:
     """Use the API to score a response on accuracy, depth, specificity (1-5)."""
     scoring_prompt = f"""Score the following response on three dimensions (1-5 each).
 
@@ -361,7 +362,7 @@ def run_assessment(
     api_key: str,
     skills: list[str],
     prompts: dict[str, list[dict[str, Any]]],
-    model: str = "claude-sonnet-4-20250514",
+    model: str = DEFAULT_MODEL,
     dry_run: bool = False,
     runs: int = 1,
 ) -> dict[str, Any]:
@@ -457,7 +458,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Eval skill knowledge integration quality")
     parser.add_argument("--skill", type=str, help="Eval a single skill instead of all 5")
     parser.add_argument("--prompts-file", type=str, help="Load custom prompts from a JSON file")
-    parser.add_argument("--model", type=str, default="claude-sonnet-4-20250514", help="Model to use for eval")
+    parser.add_argument("--model", type=str, default=DEFAULT_MODEL, help="Model to use for eval")
     parser.add_argument("--dry-run", action="store_true", help="Print prompts without calling the API")
     parser.add_argument("--runs", type=int, default=1,
                         help="Number of runs per scenario for flakiness detection (ADR-057)")
@@ -473,6 +474,12 @@ def main() -> None:
         except RuntimeError as e:
             print(f"ERROR: {e}", file=sys.stderr)
             sys.exit(1)
+
+        try:
+            verify_model_available(api_key, args.model)
+        except RuntimeError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(2)
 
     # Determine which skills to eval
     if args.skill:

--- a/scripts/eval/eval-prompt-change.py
+++ b/scripts/eval/eval-prompt-change.py
@@ -68,7 +68,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from _anthropic_api import call_api, load_api_key
+from _anthropic_api import DEFAULT_MODEL, call_api, load_api_key, verify_model_available
 from _eval_common import EST_TOKENS_PER_CALL
 from _providers import is_default_anthropic
 
@@ -561,7 +561,7 @@ def _parse_args() -> argparse.Namespace:
         help=f"Security-critical tier: {SECURITY_RUNS} runs, 100%% pass required"
     )
     parser.add_argument(
-        "--model", type=str, default="claude-sonnet-4-20250514",
+        "--model", type=str, default=DEFAULT_MODEL,
         help="Model for evaluation"
     )
     parser.add_argument("--dry-run", action="store_true", help="Validate inputs, no API calls")
@@ -771,6 +771,12 @@ def main() -> None:
         except RuntimeError as e:
             print(f"ERROR: {e}", file=sys.stderr)
             sys.exit(2)
+
+    try:
+        verify_model_available(api_key, args.model)
+    except RuntimeError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(2)
 
     try:
         _run_and_report(api_key, before_text, after_text, scenarios, args, source)

--- a/scripts/eval/eval-rule-activation.py
+++ b/scripts/eval/eval-rule-activation.py
@@ -49,8 +49,10 @@ import time
 from pathlib import Path
 from typing import Any
 
+from _anthropic_api import DEFAULT_MODEL
 from _anthropic_api import call_api as _call_api
 from _anthropic_api import load_api_key as _load_api_key
+from _anthropic_api import verify_model_available
 from _eval_common import EST_TOKENS_PER_CALL
 
 # ---------------------------------------------------------------------------
@@ -58,7 +60,6 @@ from _eval_common import EST_TOKENS_PER_CALL
 # ---------------------------------------------------------------------------
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-DEFAULT_MODEL = "claude-sonnet-4-20250514"
 RATE_LIMIT_SLEEP_SEC = 1.0
 MECHANISMS = ("baseline", "description", "full")
 
@@ -593,6 +594,12 @@ def main() -> int:
         except RuntimeError as e:
             print(f"ERROR: {e}", file=sys.stderr)
             return 4
+
+        try:
+            verify_model_available(api_key, args.model)
+        except RuntimeError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 2
 
     all_results: dict[str, Any] = {"rules": {}}
     state = _RunState()

--- a/scripts/eval/eval-suite.py
+++ b/scripts/eval/eval-suite.py
@@ -39,6 +39,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+from _anthropic_api import DEFAULT_MODEL
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SCRIPT_DIR = Path(__file__).resolve().parent
 
@@ -475,7 +477,7 @@ def main() -> None:
     parser.add_argument("--scope", type=str,
                         choices=["prompts", "agents", "skills", "all"],
                         default="all", help="Limit to specific scope")
-    parser.add_argument("--model", type=str, default="claude-sonnet-4-20250514",
+    parser.add_argument("--model", type=str, default=DEFAULT_MODEL,
                         help="Model for LLM-based assessments")
     parser.add_argument("--dry-run", action="store_true",
                         help="Detect and classify only, no API calls")

--- a/tests/eval/conftest.py
+++ b/tests/eval/conftest.py
@@ -1,0 +1,16 @@
+"""Shared fixtures for eval-harness tests.
+
+The eval mains now run ``verify_model_available()`` before a live run
+(issue #2857), which probes ``GET /v1/models``. Keep unit and integration
+tests hermetic by skipping that network probe by default. Tests that exercise
+the preflight itself delenv ``EVAL_SKIP_MODEL_PREFLIGHT`` explicitly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _skip_model_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EVAL_SKIP_MODEL_PREFLIGHT", "1")

--- a/tests/eval/test_anthropic_model_default.py
+++ b/tests/eval/test_anthropic_model_default.py
@@ -206,6 +206,28 @@ def test_list_available_models_rejects_non_list_data(monkeypatch: pytest.MonkeyP
         _anthropic_api.list_available_models("key")
 
 
+def test_list_available_models_rejects_non_string_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda req, timeout=None: _Resp(json.dumps({"data": [{"id": 123}]}).encode()),
+    )
+    with pytest.raises(RuntimeError, match="malformed model entry"):
+        _anthropic_api.list_available_models("key")
+
+
+def test_verify_fails_open_on_non_string_id(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    monkeypatch.delenv("EVAL_SKIP_MODEL_PREFLIGHT", raising=False)
+    monkeypatch.delenv("EVAL_PROVIDER", raising=False)
+    # A non-string id must not crash verify with a TypeError in the join;
+    # it is a malformed response -> RuntimeError -> fail open (warn, proceed).
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda req, timeout=None: _Resp(json.dumps({"data": [{"id": 123}]}).encode()),
+    )
+    _anthropic_api.verify_model_available("key", "claude-sonnet-4-6")
+    assert "preflight skipped" in capsys.readouterr().err
+
+
 # --- 404 enrichment in call_api ----------------------------------------
 
 

--- a/tests/eval/test_anthropic_model_default.py
+++ b/tests/eval/test_anthropic_model_default.py
@@ -1,0 +1,187 @@
+"""Tests for the shared eval model default and preflight (issues #2857, #2858).
+
+Offline only: the Anthropic HTTP layer is exercised through a monkeypatched
+``urllib.request.urlopen``; no network and no real key.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/eval must be on sys.path so `_anthropic_api` resolves
+# (mirrors tests/eval/test_providers.py).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EVAL_DIR = _REPO_ROOT / "scripts" / "eval"
+_ORIGINAL_SYS_PATH = sys.path.copy()
+sys.path.insert(0, str(_EVAL_DIR))
+try:
+    import _anthropic_api  # noqa: E402
+    import _eval_common  # noqa: E402
+finally:
+    sys.path[:] = _ORIGINAL_SYS_PATH
+
+
+class _Resp(io.BytesIO):
+    def __enter__(self) -> "_Resp":
+        return self
+
+    def __exit__(self, *_: object) -> bool:
+        return False
+
+
+def _models_payload(ids: list[str]) -> bytes:
+    return json.dumps({"data": [{"id": i, "type": "model"} for i in ids]}).encode()
+
+
+# --- Default id ---------------------------------------------------------
+
+
+def test_default_model_is_live_id() -> None:
+    assert _anthropic_api.DEFAULT_MODEL == "claude-sonnet-4-6"
+
+
+def test_default_model_is_priced() -> None:
+    # The default MUST have a pricing row so cost estimation never KeyErrors.
+    assert _anthropic_api.DEFAULT_MODEL in _eval_common.MODEL_PRICING_RATES_USD_PER_1K_TOKENS
+
+
+def test_call_api_default_model_is_shared_constant() -> None:
+    import inspect
+
+    sig = inspect.signature(_anthropic_api.call_api)
+    assert sig.parameters["model"].default == _anthropic_api.DEFAULT_MODEL
+
+
+def test_no_dead_id_default_in_eval_scripts() -> None:
+    # Guard against reintroducing the dead id as a default anywhere in the
+    # harness. The legacy cost-table key and the explanatory comment are the
+    # only permitted mentions.
+    dead = "claude-sonnet-4-20250514"
+    offenders: list[str] = []
+    for path in _EVAL_DIR.glob("*.py"):
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if dead not in line:
+                continue
+            if path.name == "_eval_common.py" and line.lstrip().startswith(f'"{dead}"'):
+                continue  # legacy pricing key, intentional
+            if line.lstrip().startswith("#"):
+                continue  # explanatory comment, intentional
+            offenders.append(f"{path.name}:{lineno}: {line.strip()}")
+    assert not offenders, "dead model id used outside allowed sites:\n" + "\n".join(offenders)
+
+
+# --- list_available_models ---------------------------------------------
+
+
+def test_list_available_models_parses_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _models_payload(["claude-sonnet-4-6", "claude-opus-4-8"])
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda req, timeout=None: _Resp(payload)
+    )
+    result = _anthropic_api.list_available_models("key")
+    assert result == ["claude-sonnet-4-6", "claude-opus-4-8"]
+
+
+def test_list_available_models_http_error_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error
+
+    def _boom(req, timeout=None):
+        raise urllib.error.HTTPError(req.full_url, 401, "Unauthorized", {}, io.BytesIO(b"nope"))
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+    with pytest.raises(RuntimeError, match="HTTP 401"):
+        _anthropic_api.list_available_models("key")
+
+
+# --- verify_model_available --------------------------------------------
+
+
+def test_verify_skips_when_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EVAL_SKIP_MODEL_PREFLIGHT", "1")
+
+    def _boom(req, timeout=None):
+        raise AssertionError("must not probe when preflight is skipped")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+    _anthropic_api.verify_model_available("key", "anything")  # no raise, no probe
+
+
+def test_verify_skips_for_non_anthropic_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EVAL_SKIP_MODEL_PREFLIGHT", raising=False)
+
+    def _boom(req, timeout=None):
+        raise AssertionError("must not probe for a non-anthropic provider")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+    _anthropic_api.verify_model_available("key", "gpt-4o", provider="openai")
+
+
+def test_verify_passes_when_model_reachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EVAL_SKIP_MODEL_PREFLIGHT", raising=False)
+    monkeypatch.delenv("EVAL_PROVIDER", raising=False)
+    payload = _models_payload(["claude-sonnet-4-6", "claude-opus-4-8"])
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda req, timeout=None: _Resp(payload)
+    )
+    _anthropic_api.verify_model_available("key", "claude-sonnet-4-6")  # no raise
+
+
+def test_verify_fails_closed_on_missing_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EVAL_SKIP_MODEL_PREFLIGHT", raising=False)
+    monkeypatch.delenv("EVAL_PROVIDER", raising=False)
+    payload = _models_payload(["claude-sonnet-4-6", "claude-opus-4-8"])
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda req, timeout=None: _Resp(payload)
+    )
+    with pytest.raises(RuntimeError) as exc:
+        _anthropic_api.verify_model_available("key", "claude-sonnet-4-20250514")
+    # Error lists the reachable ids so the user can pick one.
+    assert "claude-sonnet-4-6" in str(exc.value)
+    assert "claude-opus-4-8" in str(exc.value)
+
+
+def test_verify_fails_open_on_infra_error(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    monkeypatch.delenv("EVAL_SKIP_MODEL_PREFLIGHT", raising=False)
+    monkeypatch.delenv("EVAL_PROVIDER", raising=False)
+    import urllib.error
+
+    def _boom(req, timeout=None):
+        raise urllib.error.URLError("dns down")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+    # Infra error must NOT raise; it warns and proceeds (fail-open doctrine).
+    _anthropic_api.verify_model_available("key", "claude-sonnet-4-6")
+    assert "preflight skipped" in capsys.readouterr().err
+
+
+# --- 404 enrichment in call_api ----------------------------------------
+
+
+def test_call_api_404_enriches_with_reachable_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EVAL_PROVIDER", raising=False)
+    import urllib.error
+
+    calls = {"n": 0}
+
+    def _dispatch(req, timeout=None):
+        # First call is the POST /v1/messages -> 404; second is the
+        # enrichment GET /v1/models -> reachable list.
+        if req.full_url.endswith("/v1/messages"):
+            calls["n"] += 1
+            raise urllib.error.HTTPError(
+                req.full_url, 404, "Not Found", {}, io.BytesIO(b"not_found_error")
+            )
+        return _Resp(_models_payload(["claude-sonnet-4-6"]))
+
+    monkeypatch.setattr("urllib.request.urlopen", _dispatch)
+    with pytest.raises(RuntimeError) as exc:
+        _anthropic_api.call_api("key", [{"role": "user", "content": "x"}], model="dead-id")
+    msg = str(exc.value)
+    assert "HTTP 404" in msg
+    assert "claude-sonnet-4-6" in msg
+    assert calls["n"] == 1

--- a/tests/eval/test_anthropic_model_default.py
+++ b/tests/eval/test_anthropic_model_default.py
@@ -22,6 +22,11 @@ sys.path.insert(0, str(_EVAL_DIR))
 try:
     import _anthropic_api  # noqa: E402
     import _eval_common  # noqa: E402
+
+    # verify_model_available lazily does `from _providers import ...` at
+    # runtime. Import it here so it is cached in sys.modules and resolves
+    # even after sys.path is restored below (mirrors test_providers.py).
+    import _providers  # noqa: E402,F401
 finally:
     sys.path[:] = _ORIGINAL_SYS_PATH
 
@@ -157,6 +162,48 @@ def test_verify_fails_open_on_infra_error(monkeypatch: pytest.MonkeyPatch, capsy
     # Infra error must NOT raise; it warns and proceeds (fail-open doctrine).
     _anthropic_api.verify_model_available("key", "claude-sonnet-4-6")
     assert "preflight skipped" in capsys.readouterr().err
+
+
+def test_verify_fails_closed_on_empty_model_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("EVAL_SKIP_MODEL_PREFLIGHT", raising=False)
+    monkeypatch.delenv("EVAL_PROVIDER", raising=False)
+    # Probe succeeds (HTTP 200) but returns zero models -> provably unreachable.
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda req, timeout=None: _Resp(_models_payload([]))
+    )
+    with pytest.raises(RuntimeError, match=r"Reachable ids: \(none\)"):
+        _anthropic_api.verify_model_available("key", "claude-sonnet-4-6")
+
+
+def test_verify_fails_open_on_malformed_shape(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    monkeypatch.delenv("EVAL_SKIP_MODEL_PREFLIGHT", raising=False)
+    monkeypatch.delenv("EVAL_PROVIDER", raising=False)
+    # Valid JSON, wrong shape (a bare list). Must NOT crash with AttributeError;
+    # list_available_models raises RuntimeError -> verify fails open (warns).
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda req, timeout=None: _Resp(json.dumps([1, 2, 3]).encode()),
+    )
+    _anthropic_api.verify_model_available("key", "claude-sonnet-4-6")
+    assert "preflight skipped" in capsys.readouterr().err
+
+
+def test_list_available_models_rejects_non_dict_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda req, timeout=None: _Resp(json.dumps("not-an-object").encode()),
+    )
+    with pytest.raises(RuntimeError, match="unexpected payload shape"):
+        _anthropic_api.list_available_models("key")
+
+
+def test_list_available_models_rejects_non_list_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda req, timeout=None: _Resp(json.dumps({"data": {"id": "x"}}).encode()),
+    )
+    with pytest.raises(RuntimeError, match="unexpected 'data' shape"):
+        _anthropic_api.list_available_models("key")
 
 
 # --- 404 enrichment in call_api ----------------------------------------


### PR DESCRIPTION
## Summary

The eval harness hard-coded the model id `claude-sonnet-4-20250514` in 13 sites across 7 files. That id now returns **HTTP 404** against a current Anthropic key, so every live eval run failed before it scored anything (#2857). This PR standardizes on a single shared constant and adds a preflight so a dead id fails fast with an actionable message instead of burning a run (#2858).

## Changes

- **Single source of truth**: `DEFAULT_MODEL = "claude-sonnet-4-6"` in `scripts/eval/_anthropic_api.py`. Every eval script imports it; a future model bump is a one-line change (#2858).
- **`call_api`** defaults to `DEFAULT_MODEL`. On a 404 it now enriches the error with the ids the key can actually reach (best-effort, never raises, no happy-path cost).
- **Preflight** (`verify_model_available`) wired into the non-dry path of `eval-agents`, `eval-knowledge-integration`, `eval-prompt-change`, `eval-rule-activation`:
  - **Fail-closed**: model provably unreachable via `GET /v1/models` -> exit `2` (config error, ADR-035) listing reachable ids.
  - **Fail-open**: `/v1/models` lookup itself fails (network/auth/malformed) -> warn to stderr and proceed, surfacing the real (404-enriched) error at first call rather than blocking on a flaky probe.
  - **No-op** when `EVAL_SKIP_MODEL_PREFLIGHT` is set or a non-anthropic provider is selected.
- **`eval-suite`** fixes its own `--model` default (it shells out to the children, which now default correctly).
- **Legacy pricing key**: the dead id is retained only as a commented cost-table key in `_eval_common.py` so historic cost math never `KeyError`s. `claude-sonnet-4-6` was already priced (sonnet tier $3/$15 per M).

## Testing

- `tests/eval/conftest.py`: autouse fixture sets `EVAL_SKIP_MODEL_PREFLIGHT=1` so existing eval tests stay hermetic now that mains probe the network.
- `tests/eval/test_anthropic_model_default.py`: covers the default value + pricing, `call_api` shared-constant default, a guard that no dead-id default survives in `scripts/eval`, `list_available_models` parse + HTTP-error raise, `verify_model_available` fail-closed / fail-open / skip-env / non-anthropic paths, and 404 enrichment.
- Full suite: **367 passed** (`python3 -m pytest tests/eval -q`), up from 349 (18 new, including empty-list/malformed-shape/non-string-id preflight edge cases surfaced by adversarial review). All 7 changed scripts `py_compile` clean.

## Scope note

The only surviving mentions of the dead id repo-wide are two SkillForge doc examples and one historical model-mapping reference table, none in the eval harness. Left untouched (out of scope, and the mapping table is accurate reference data).

Closes #2857
Closes #2858
