### PR TITLE
ci: install eval extra before /spec behavioral eval grader

### DIFF
--- a/.github/workflows/slash-command-quality.yml
+++ b/.github/workflows/slash-command-quality.yml
@@ -62,6 +62,18 @@ jobs:
       - name: Validate slash commands
         run: python3 -c "from scripts.modules.slash_command_validator import invoke_slash_command_validation; raise SystemExit(invoke_slash_command_validation())"
 
+      - name: Install eval extra (openai grader)
+        # setup-code-env installs only .[dev]; the github provider grader needs
+        # the openai package from .[eval]. Without this, eval-prompt-change.py
+        # exits 3 (missing package is not a provider outage, so the skip-net
+        # does not neutral-skip it). Gated on the same condition as the eval so
+        # it only runs when the /spec eval actually fires.
+        if: |
+          github.event_name == 'pull_request' &&
+          needs.check-paths.outputs.spec_evals_changed == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        run: uv pip install --system -e ".[eval]"
+
       - name: Run /spec behavioral evals
         # Grader: openai/gpt-5 via GitHub Models (the COPILOT_GITHUB_TOKEN CI
         # already uses), reachable as a reasoning model after #2712. The default


### PR DESCRIPTION
## Summary

The `validate-slash-commands` check red-fails on any PR that touches a spec-eval
trigger file, because the `/spec` behavioral eval runs the github-provider grader
(`openai/gpt-5` via GitHub Models) but the shared setup action installs only the
`dev` extra. The grader needs the `openai` package from the `eval` extra. When it
is absent, the eval exits 3: a missing package is not a provider outage, so the
neutral-skip net does not catch it, and the job goes red.

This adds a gated install step that runs only when the `/spec` eval actually fires
(same condition as the eval step), so the extra is present exactly when needed and
costs nothing on unrelated runs.

## Change

Add an "Install eval extra (openai grader)" step before the eval step, gated on
`spec_evals_changed == 'true'` and same-repo pull_request.

## Background

Surfaced while landing an eval-model change whose diff included a spec-eval
trigger file. The setup action installs only the dev extra; the eval extra
carries the openai grader dependency. The neutral-skip path only covers genuine
provider outages, not a missing local package, so the job hard-failed.

## Evidence

Files referenced (not in this diff, listed for context only):

```
.github/actions/setup-code-env/action.yml   installs only the dev extra
scripts/eval/eval-prompt-change.py           exits 3 on missing package
pyproject.toml                               eval extra provides openai
```

## Test Plan

- YAML parses (`yaml.safe_load`).
- Step condition matches the existing eval step so it only runs on spec-eval PRs.
- On the next spec-eval PR, `validate-slash-commands` runs the grader instead of
  exiting 3.
