### PR TITLE
docs(memory): remove dead reference to deleted session-init command

### DIFF
--- a/.serena/memories/session/session-init-pattern.md
+++ b/.serena/memories/session/session-init-pattern.md
@@ -82,8 +82,7 @@ Agents MUST use the `/session-init` skill which:
 
 ## Related
 
-- `.claude/skills/session-init/SKILL.md` - Skill documentation
-- `.claude/commands/session-init.md` - Slash command documentation
+- `.claude/skills/session-init/SKILL.md` - Skill documentation; the skill fires directly as `/session-init` (no separate command file)
 - `.claude/skills/session-log-fixer/SKILL.md` - Reactive fix (use session-init instead)
 - `.agents/SESSION-PROTOCOL.md` - Canonical template source (lines 494-612)
 - `scripts/validate_session_json.py` - Validation script


### PR DESCRIPTION
## Summary

Remove a dangling reference to the deleted `session-init` command file, which PR #1123 removed as a duplicate registration. The `session-init` skill already fires as `/session-init`; a separate command file was redundant. The `session-init-pattern` Serena memory still listed the deleted file under Related.

## Root cause

A user hit `failed to parse YAML frontmatter: did not find expected key at line 2 column 37` when their harness tried to load a stale local copy of the deleted command file. That file is not in the repo (removed in #1123), so the fix here is limited to removing the one live dangling reference. The stale local file was removed out-of-band.

## Verification

- `git grep 'commands/session-init'` on the tree now returns only archived session logs (intentionally immutable history).
- `/session-init` continues to resolve via the session-init skill at `.claude/skills/session-init/SKILL.md`.

## References

- Deleted duplicate command file: `.claude/commands/session-init.md` (removed in #1123).
- See #2870 for the follow-up hardening issue (strict frontmatter parse validator).
