### PR TITLE
docs(adr-042): repoint agent-facing docs from removed .ps1 to Python (#2864)

### DIFF
--- a/.agents/SESSION-PROTOCOL.md
+++ b/.agents/SESSION-PROTOCOL.md
@@ -163,7 +163,7 @@ The agent SHOULD import shared memories at session start.
 1. The agent SHOULD run the import script:
 
    ```bash
-   pwsh .claude-mem/scripts/Import-ClaudeMemMemories.ps1
+   python3 .claude-mem/scripts/import_claude_mem_memories.py
    ```
 
 2. The agent SHOULD document import count in session log
@@ -187,8 +187,8 @@ The agent MUST validate skill availability before starting work. This is a **blo
 1. The agent MUST verify `.claude/skills/` directory exists
 2. The agent MUST list available GitHub skill scripts:
 
-   ```powershell
-   Get-ChildItem -Path ".claude/skills/github/scripts" -Recurse -Filter "*.ps1" | Select-Object -ExpandProperty Name
+   ```bash
+   find .claude/skills/github/scripts -type f -name "*.py" -printf "%f\n"
    ```
 
 3. The agent MUST read the usage-mandatory memory using `mcp__serena__read_memory` with `memory_file_name="usage-mandatory"`
@@ -293,7 +293,7 @@ Copy this checklist to each session log and verify completion:
 | MUST | Read usage-mandatory memory | [ ] | Content in context |
 | MUST | Read PROJECT-CONSTRAINTS.md | [ ] | Content in context |
 | MUST | Read memory-index, load task-relevant memories | [ ] | List memories loaded |
-| SHOULD | Import shared memories: `pwsh .claude-mem/scripts/Import-ClaudeMemMemories.ps1` | [ ] | Import count: N (or "None") |
+| SHOULD | Import shared memories: `python3 .claude-mem/scripts/import_claude_mem_memories.py` | [ ] | Import count: N (or "None") |
 | MUST | Verify and declare current branch | [ ] | Branch documented below |
 | MUST | Confirm not on main/master | [ ] | On feature branch |
 | SHOULD | Verify git status | [ ] | Output documented below |
@@ -596,14 +596,14 @@ The agent SHOULD export memories created during the session for sharing and vers
 1. The agent SHOULD export memories using session-specific naming:
 
    ```bash
-   pwsh .claude-mem/scripts/Export-ClaudeMemMemories.ps1 -Query "[query]" -SessionNumber NNN -Topic "topic"
+   python3 .claude-mem/scripts/export_claude_mem_memories.py --session-number NNN --topic "topic"
    ```
 
 2. The agent MUST perform security review before committing (BLOCKING):
 
    ```bash
-   # Option 1: PowerShell security review script (recommended)
-   pwsh scripts/Review-MemoryExportSecurity.ps1 -ExportFile [export-file].json
+   # Option 1: security review script (recommended)
+   python3 scripts/review_memory_export_security.py [export-file].json
 
    # Option 2: Manual grep scan
    grep -iE "api[_-]?key|password|token|secret|credential|private[_-]?key" [export-file].json
@@ -718,7 +718,7 @@ The agent MUST run quality checks before ending.
    - Session objective explicitly includes "format all files"
    - Creating a dedicated formatting cleanup PR
 
-2. The agent SHOULD run validation scripts if available (e.g., `Validate-Consistency.ps1`)
+2. The agent SHOULD run validation scripts if available (e.g., `python3 scripts/validation/consistency.py`)
 3. The agent SHOULD check memory sizes if `.serena/memories/` files were created or modified:
 
    ```bash
@@ -819,7 +819,7 @@ The agent MUST run pre-PR validation before creating a pull request. This is a *
 1. The agent MUST run the PR readiness validation script:
 
    ```bash
-   pwsh .agents/scripts/Validate-PRReadiness.ps1
+   python3 scripts/validation/pre_pr.py
    ```
 
 2. The script validates:
@@ -833,7 +833,7 @@ The agent MUST run pre-PR validation before creating a pull request. This is a *
 
 **Verification Checklist:**
 
-- [ ] `Validate-PRReadiness.ps1` executed and passed (exit code 0)
+- [ ] `pre_pr.py` executed and passed (exit code 0)
 - [ ] No BLOCKING issues in validation output
 - [ ] Commit count within limits
 - [ ] Session log complete and valid
@@ -910,13 +910,13 @@ Copy this checklist to each session log and verify completion:
 
 | Req | Step | Status | Evidence |
 |-----|------|--------|----------|
-| SHOULD | Export session memories: `pwsh .claude-mem/scripts/Export-ClaudeMemMemories.ps1 -Query "[query]" -SessionNumber NNN -Topic "topic"` | [ ] | Export file: [path] (or "Skipped") |
+| SHOULD | Export session memories: `python3 .claude-mem/scripts/export_claude_mem_memories.py --session-number NNN --topic "topic"` | [ ] | Export file: [path] (or "Skipped") |
 | MUST | Security review export (if exported): `grep -iE "api[_-]?key|password|token|secret|credential|private[_-]?key" [file].json` | [ ] | Scan result: "Clean" or "Redacted" |
 | MUST | Complete session log (all sections filled) | [ ] | File complete |
 | MUST | Update Serena memory (cross-session context) | [ ] | Memory write confirmed |
 | MUST | Run markdown lint | [ ] | Lint output clean |
 | MUST | Route to qa agent (feature implementation) | [ ] | QA report: `.agents/qa/[report].md` OR `SKIPPED: investigation-only` |
-| MUST | Run pre-PR validation: `pwsh .agents/scripts/Validate-PRReadiness.ps1` | [ ] | Exit code 0 |
+| MUST | Run pre-PR validation: `python3 scripts/validation/pre_pr.py` | [ ] | Exit code 0 |
 | MUST | Commit all changes (including .serena/memories) | [ ] | Commit SHA: _______ |
 | MUST | Preserve `.agents/HANDOFF.md` (read-only) | [ ] | HANDOFF.md unchanged |
 | MUST | Write per-issue handoff to `.agents/sessions/handoffs/{date}-{issue}-handoff.md` (if issue incomplete) | [ ] | File path: _______ (or "SKIPPED: issue closed / no issue") |
@@ -956,10 +956,7 @@ python3 .claude/skills/session-init/scripts/new_session_log.py
 **Validation**:
 
 ```bash
-# JSON schema validation (structural)
-pwsh -Command "Test-Json -Json (Get-Content [session].json -Raw) -Schema (Get-Content .agents/schemas/session-log.schema.json -Raw)"
-
-# Script validation (business rules)
+# Validation (structural schema + business rules)
 python3 scripts/validate_session_json.py [session].json
 ```
 

--- a/.agents/SESSION-PROTOCOL.md
+++ b/.agents/SESSION-PROTOCOL.md
@@ -188,7 +188,7 @@ The agent MUST validate skill availability before starting work. This is a **blo
 2. The agent MUST list available GitHub skill scripts:
 
    ```bash
-   find .claude/skills/github/scripts -type f -name "*.py" -printf "%f\n"
+   find .claude/skills/github/scripts -type f -name "*.py" -exec basename {} \;
    ```
 
 3. The agent MUST read the usage-mandatory memory using `mcp__serena__read_memory` with `memory_file_name="usage-mandatory"`
@@ -596,7 +596,7 @@ The agent SHOULD export memories created during the session for sharing and vers
 1. The agent SHOULD export memories using session-specific naming:
 
    ```bash
-   python3 .claude-mem/scripts/export_claude_mem_memories.py --session-number NNN --topic "topic"
+   python3 .claude-mem/scripts/export_claude_mem_memories.py "<query>" --session-number NNN --topic "topic"
    ```
 
 2. The agent MUST perform security review before committing (BLOCKING):
@@ -910,7 +910,7 @@ Copy this checklist to each session log and verify completion:
 
 | Req | Step | Status | Evidence |
 |-----|------|--------|----------|
-| SHOULD | Export session memories: `python3 .claude-mem/scripts/export_claude_mem_memories.py --session-number NNN --topic "topic"` | [ ] | Export file: [path] (or "Skipped") |
+| SHOULD | Export session memories: `python3 .claude-mem/scripts/export_claude_mem_memories.py "<query>" --session-number NNN --topic "topic"` | [ ] | Export file: [path] (or "Skipped") |
 | MUST | Security review export (if exported): `grep -iE "api[_-]?key|password|token|secret|credential|private[_-]?key" [file].json` | [ ] | Scan result: "Clean" or "Redacted" |
 | MUST | Complete session log (all sections filled) | [ ] | File complete |
 | MUST | Update Serena memory (cross-session context) | [ ] | Memory write confirmed |

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.269",
+  "version": "0.5.270",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/agents/AGENTS.md
+++ b/.claude/agents/AGENTS.md
@@ -303,15 +303,15 @@ gh pr view 50 --json ...
 
 ### Validating Changes
 
-```powershell
+```bash
 # Validate generated files match templates
 python3 build/generate_agents.py --validate
 
 # Check for drift between Claude and VS Code
-pwsh build/scripts/Detect-AgentDrift.ps1
+python3 build/scripts/detect_agent_drift.py
 
-# Run Pester tests if scripts modified
-Invoke-Pester ./build/tests/
+# Run tests if scripts modified
+uv run pytest
 ```
 
 ---

--- a/.claude/agents/AGENTS.md
+++ b/.claude/agents/AGENTS.md
@@ -58,7 +58,7 @@ Per ADR-036 §Synchronization Requirement, when adding content that applies to A
 ```text
 1. Edit src/claude/{agent}.md
 2. Duplicate universal changes to templates/agents/{agent}.shared.md
-3. Run: pwsh build/Generate-Agents.ps1
+3. Run: python3 build/generate_agents.py
 4. Commit all changed files together
 ```
 
@@ -67,7 +67,7 @@ Per ADR-036 §Synchronization Requirement, when adding content that applies to A
 ```text
 1. Edit templates/agents/{agent}.shared.md
 2. Edit src/claude/{agent}.md (MANUAL - not auto-synced!)
-3. Run: pwsh build/Generate-Agents.ps1
+3. Run: python3 build/generate_agents.py
 4. Commit all files atomically
 ```
 
@@ -117,7 +117,7 @@ flowchart TD
     end
 
     Claude -.->|Manual sync when<br>universal changes| Templates
-    Templates -->|build/Generate-Agents.ps1| Generated
+    Templates -->|build/generate_agents.py| Generated
 
     style Claude fill:#e1f5fe
     style Templates fill:#fff3e0
@@ -279,7 +279,7 @@ gh pr view 50 --json ...
 1. Create `src/claude/{agent-name}.md` with required sections
 2. Create `templates/agents/{agent-name}.shared.md` with platform-agnostic content
 3. Update `templates/platforms/*.yaml` if new tools needed
-4. Run `pwsh build/Generate-Agents.ps1`
+4. Run `python3 build/generate_agents.py`
 5. Update documentation (root AGENTS.md, AGENT-SYSTEM.md)
 6. Commit all files together
 
@@ -294,7 +294,7 @@ gh pr view 50 --json ...
 
 3. Edit templates/agents/{agent}.shared.md with equivalent changes
 
-4. Run: pwsh build/Generate-Agents.ps1
+4. Run: python3 build/generate_agents.py
 
 5. Review generated files in src/vs-code-agents/ and src/copilot-cli/
 
@@ -305,7 +305,7 @@ gh pr view 50 --json ...
 
 ```powershell
 # Validate generated files match templates
-pwsh build/Generate-Agents.ps1 -Validate
+python3 build/generate_agents.py --validate
 
 # Check for drift between Claude and VS Code
 pwsh build/scripts/Detect-AgentDrift.ps1
@@ -339,7 +339,7 @@ Invoke-Pester ./build/tests/
 |-------|----------|-----------|
 | Generation validation | `validate-generated-agents.yml` | On PR |
 | Drift detection | `drift-detection.yml` | Monday 9 AM UTC |
-| Lint validation | `pester-tests.yml` | On PR |
+| Lint validation | `pytest.yml` | On PR |
 
 ---
 

--- a/.claude/skills/session-init/references/template-extraction.md
+++ b/.claude/skills/session-init/references/template-extraction.md
@@ -103,7 +103,7 @@ HTML comments must be preserved:
 ## Session End
 ```
 
-This is the most common validation failure. The regex in `Validate-SessionJson.ps1` checks for:
+This is the most common validation failure. The regex in `validate_session_json.py` checks for:
 
 ```regex
 (?i)Session\s+End.*COMPLETE\s+ALL|End.*before.*closing

--- a/.claude/skills/session-init/references/validation-patterns.md
+++ b/.claude/skills/session-init/references/validation-patterns.md
@@ -6,25 +6,25 @@ How to validate session logs and handle common issues.
 
 ## Validation Script
 
-**Script**: `scripts/Validate-SessionJson.ps1`
+**Script**: `scripts/validate_session_json.py` (Python, per ADR-042)
 
 ### Basic Usage
 
-```powershell
-pwsh scripts/Validate-SessionJson.ps1 `
-    -SessionPath ".agents/sessions/.agents/sessions/2026-01-05-session-375.json" `
-    
+```bash
+python3 scripts/validate_session_json.py \
+    .agents/sessions/2026-01-05-session-375.json
 ```
 
-### CI Mode
+The session log path is a positional argument.
 
-For GitHub Actions:
+### CI / Pre-commit Mode
 
-```powershell
-pwsh scripts/Validate-SessionJson.ps1 `
-    -SessionPath ".agents/sessions/.agents/sessions/2026-01-05-session-375.json" `
-     `
-    -CI
+CI and the pre-commit hook run the same command; the exit code is the gate
+(0 = PASS, 1 = FAIL). The `--pre-commit` flag tightens output for hook use:
+
+```bash
+python3 scripts/validate_session_json.py \
+    .agents/sessions/2026-01-05-session-375.json --pre-commit
 ```
 
 ---
@@ -153,15 +153,15 @@ Regex patterns:
 
 ### SessionLogCompleteness (SHOULD)
 
-Checks for required sections:
+Checks for required sections (validator internals, Python):
 
-```powershell
-$expectedSections = @(
-    @{ Pattern = '(?i)##\s*Session\s+Info'; Name = 'Session Info' }
-    @{ Pattern = '(?i)##\s*Protocol\s+Compliance'; Name = 'Protocol Compliance' }
-    @{ Pattern = '(?i)##\s*Work\s+Log|##\s*Tasks?\s+Completed'; Name = 'Work Log' }
-    @{ Pattern = '(?i)##\s*Session\s+End|Session\s+End.*COMPLETE'; Name = 'Session End' }
-)
+```python
+expected_sections = [
+    (r'(?i)##\s*Session\s+Info', 'Session Info'),
+    (r'(?i)##\s*Protocol\s+Compliance', 'Protocol Compliance'),
+    (r'(?i)##\s*Work\s+Log|##\s*Tasks?\s+Completed', 'Work Log'),
+    (r'(?i)##\s*Session\s+End|Session\s+End.*COMPLETE', 'Session End'),
+]
 ```
 
 ### HandoffUpdated (MUST)
@@ -178,23 +178,16 @@ Checks for commit SHA evidence in the session log.
 
 For session-init skill, run validation immediately after creating the session log:
 
-```powershell
-$sessionPath = ".agents/sessions/.agents/sessions/2026-01-05-session-375.json"
+```bash
+SESSION_PATH=".agents/sessions/2026-01-05-session-375.json"
 
-# Run validation
-$result = & pwsh scripts/Validate-SessionJson.ps1 `
-    -SessionPath $sessionPath `
-    
-
-$exitCode = $LASTEXITCODE
-
-if ($exitCode -eq 0) {
-    Write-Host "Session log validated successfully" -ForegroundColor Green
-} else {
-    Write-Host "Validation failed:" -ForegroundColor Red
-    Write-Host $result
+# Run validation; exit code 0 = PASS, 1 = FAIL
+if python3 scripts/validate_session_json.py "$SESSION_PATH"; then
+    echo "Session log validated successfully"
+else
+    echo "Validation failed"
     exit 1
-}
+fi
 ```
 
 ---
@@ -203,24 +196,23 @@ if ($exitCode -eq 0) {
 
 ### View Full Validation Output
 
-```powershell
-pwsh scripts/Validate-SessionJson.ps1 `
-    -SessionPath ".agents/sessions/.agents/sessions/2026-01-05-session-375.json" `
-     `
-    -Verbose
+The validator prints a full Markdown report by default:
+
+```bash
+python3 scripts/validate_session_json.py \
+    .agents/sessions/2026-01-05-session-375.json
 ```
 
 ### Check Specific Patterns
 
-```powershell
-$content = Get-Content -Path ".agents/sessions/.agents/sessions/2026-01-05-session-375.json" -Raw
-
+```bash
 # Check Session End header
-if ($content -match '(?i)Session\s+End.*COMPLETE\s+ALL') {
-    Write-Host "Session End header: OK"
-} else {
-    Write-Host "Session End header: MISSING REQUIRED TEXT"
-}
+if grep -qiE 'Session\s+End.*COMPLETE\s+ALL' \
+    .agents/sessions/2026-01-05-session-375.json; then
+    echo "Session End header: OK"
+else
+    echo "Session End header: MISSING REQUIRED TEXT"
+fi
 ```
 
 ---

--- a/.claude/skills/session-init/references/validation-patterns.md
+++ b/.claude/skills/session-init/references/validation-patterns.md
@@ -20,7 +20,7 @@ The session log path is a positional argument.
 ### CI / Pre-commit Mode
 
 CI and the pre-commit hook run the same command; the exit code is the gate
-(0 = PASS, 1 = FAIL). The `--pre-commit` flag tightens output for hook use:
+(non-zero = FAIL; treat exit code 2 as failure). The `--pre-commit` flag tightens output for hook use:
 
 ```bash
 python3 scripts/validate_session_json.py \
@@ -35,6 +35,7 @@ python3 scripts/validate_session_json.py \
 |------|---------|--------|
 | 0 | PASS - All MUST requirements met | Proceed with session |
 | 1 | FAIL - One or more MUST requirements failed | Fix issues before proceeding |
+| 2 | FAIL - Unexpected/internal error | Treat as failure; inspect stderr and fix the script or runtime issue |
 
 ---
 
@@ -181,7 +182,7 @@ For session-init skill, run validation immediately after creating the session lo
 ```bash
 SESSION_PATH=".agents/sessions/2026-01-05-session-375.json"
 
-# Run validation; exit code 0 = PASS, 1 = FAIL
+# Run validation; exit code 0 = PASS, non-zero = FAIL
 if python3 scripts/validate_session_json.py "$SESSION_PATH"; then
     echo "Session log validated successfully"
 else

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -275,7 +275,7 @@ sequenceDiagram
 | Attribute | Value |
 |-----------|-------|
 | **Trigger** | PR modifying `templates/**` or `src/**` |
-| **Script** | `build/generate_agents.py --validate` |
+| **Script** | `python3 build/generate_agents.py --validate` |
 | **Output** | Pass/fail status |
 | **Exit Behavior** | Fails if generated files don't match |
 
@@ -322,7 +322,7 @@ sequenceDiagram
 
 ### pytest.yml
 
-**Role**: PowerShell unit test runner
+**Role**: Python unit test runner (pytest)
 
 | Attribute | Value |
 |-----------|-------|
@@ -626,7 +626,7 @@ python3 .github/scripts/measure_workflow_coalescing.py
 python3 .github/scripts/measure_workflow_coalescing.py --since 90 --output json
 
 # Analyze specific workflows
-python3 .github/scripts/measure_workflow_coalescing.py --workflows "ai-pr-quality-gate,ai-spec-validation"
+python3 .github/scripts/measure_workflow_coalescing.py --workflows ai-pr-quality-gate --workflows ai-spec-validation
 ```
 
 **Metrics Collected**:

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -80,7 +80,7 @@ flowchart TD
 
 > **IMPORTANT**: When creating a new AI-powered workflow with concurrency control, you MUST:
 >
-> 1. Add the workflow name to `.github/scripts/Measure-WorkflowCoalescing.ps1` (line 47, `$Workflows` parameter)
+> 1. Add the workflow name to `.github/scripts/measure_workflow_coalescing.py` (the `DEFAULT_WORKFLOWS` list)
 > 2. Follow concurrency group naming pattern: `{prefix}-${{ github.event.pull_request.number || inputs.pr_number }}` (include `inputs.pr_number` for `workflow_dispatch` runs)
 > 3. Document the workflow in this file
 >
@@ -229,7 +229,7 @@ gh workflow run ai-pr-quality-gate.yml \
 - Specific PRs with rapid commit patterns
 - High-value PRs where duplicate runs are costly
 
-**Monitoring**: Use `Measure-WorkflowCoalescing.ps1` to track effectiveness before/after enabling debouncing.
+**Monitoring**: Use `measure_workflow_coalescing.py` to track effectiveness before/after enabling debouncing.
 
 ---
 
@@ -242,7 +242,7 @@ gh workflow run ai-pr-quality-gate.yml \
 | Attribute | Value |
 |-----------|-------|
 | **Trigger** | Weekly (Monday 9 AM UTC), manual |
-| **Script** | `build/scripts/Detect-AgentDrift.ps1` |
+| **Script** | `build/scripts/detect_agent_drift.py` |
 | **Output** | GitHub issue if drift detected |
 | **Threshold** | 80% similarity |
 
@@ -252,7 +252,7 @@ gh workflow run ai-pr-quality-gate.yml \
 sequenceDiagram
     participant Schedule
     participant Workflow
-    participant Script as Detect-AgentDrift.ps1
+    participant Script as detect_agent_drift.py
     participant GitHub
 
     Schedule->>Workflow: Cron trigger
@@ -288,7 +288,7 @@ sequenceDiagram
 | Attribute | Value |
 |-----------|-------|
 | **Trigger** | PR modifying `**/*.md` |
-| **Script** | `build/scripts/Validate-PathNormalization.ps1` |
+| **Script** | `build/scripts/validate_path_normalization.py` |
 | **Output** | Pass/fail status |
 | **Forbidden** | Absolute paths (`C:\`, `/Users/`, `/home/`) |
 
@@ -301,7 +301,7 @@ sequenceDiagram
 | Attribute | Value |
 |-----------|-------|
 | **Trigger** | PR modifying `.agents/planning/**` |
-| **Script** | `build/scripts/Validate-PlanningArtifacts.ps1` |
+| **Script** | `build/scripts/validate_planning_artifacts.py` |
 | **Output** | Consistency report |
 | **Checks** | Effort estimates, orphan conditions, coverage |
 
@@ -489,7 +489,7 @@ sequenceDiagram
 | ai-pr-quality-gate | All agents fail | Post error summary, don't block |
 | drift-detection | Detection error | Exit 2, no issue created |
 | validate-* | Script failure | Fail workflow, block merge |
-| pester-tests | Test failure | Report details, fail workflow |
+| pytest | Test failure | Report details, fail workflow |
 
 ## Security Considerations
 
@@ -614,19 +614,19 @@ The repository implements several strategies to reduce the impact of race condit
 
 The repository includes automated monitoring of workflow run coalescing effectiveness:
 
-**Script**: `.github/scripts/Measure-WorkflowCoalescing.ps1`
+**Script**: `.github/scripts/measure_workflow_coalescing.py`
 
 **Usage**:
 
 ```bash
 # Analyze last 30 days
-pwsh .github/scripts/Measure-WorkflowCoalescing.ps1
+python3 .github/scripts/measure_workflow_coalescing.py
 
 # Analyze last 90 days with JSON output
-pwsh .github/scripts/Measure-WorkflowCoalescing.ps1 -Since 90 -Output Json
+python3 .github/scripts/measure_workflow_coalescing.py --since 90 --output json
 
 # Analyze specific workflows
-pwsh .github/scripts/Measure-WorkflowCoalescing.ps1 -Workflows @('ai-pr-quality-gate', 'ai-spec-validation')
+python3 .github/scripts/measure_workflow_coalescing.py --workflows "ai-pr-quality-gate,ai-spec-validation"
 ```
 
 **Metrics Collected**:
@@ -648,7 +648,7 @@ pwsh .github/scripts/Measure-WorkflowCoalescing.ps1 -Workflows @('ai-pr-quality-
 | ai-issue-triage | Labels applied | No labels or error |
 | drift-detection | No issue created | New drift alert issue |
 | validate-* | Green check | Red X on PR |
-| pester-tests | All tests pass | Test failures reported |
+| pytest | All tests pass | Test failures reported |
 
 ## Related Documentation
 

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -30,7 +30,7 @@ flowchart TD
         VP[validate-paths.yml]
         VPA[validate-planning-artifacts.yml]
         VPV[validate-plugin-version-bump.yml]
-        PT[pester-tests.yml]
+        PT[pytest.yml]
         CQ[codeql-analysis.yml]
     end
 
@@ -275,7 +275,7 @@ sequenceDiagram
 | Attribute | Value |
 |-----------|-------|
 | **Trigger** | PR modifying `templates/**` or `src/**` |
-| **Script** | `build/Generate-Agents.ps1 -Validate` |
+| **Script** | `build/generate_agents.py --validate` |
 | **Output** | Pass/fail status |
 | **Exit Behavior** | Fails if generated files don't match |
 
@@ -320,14 +320,14 @@ sequenceDiagram
 
 ---
 
-### pester-tests.yml
+### pytest.yml
 
 **Role**: PowerShell unit test runner
 
 | Attribute | Value |
 |-----------|-------|
 | **Trigger** | PR modifying `scripts/**` or `build/**` |
-| **Script** | `build/scripts/Invoke-PesterTests.ps1 -CI` |
+| **Script** | `uv run pytest` |
 | **Output** | Test results XML, pass/fail status |
 | **Coverage** | Installation, sync, validation scripts |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,6 @@ Thank you for your interest in contributing to this project. This guide explains
 **Required Versions:**
 
 - **Python 3.14.x** (primary scripting language per ADR-042)
-- **PowerShell 7.5.4+** (for existing scripts and cross-platform execution)
-- **Pester 5.7.1** (exact version, pinned for supply chain security)
 - **UV** (Python package manager, see [installation](https://docs.astral.sh/uv/getting-started/installation/))
 
 ### Setup Steps
@@ -525,8 +523,6 @@ is caught before push instead of silently bypassing the pre-push guards.
 The pre-commit hook automatically runs checks including, depending on staged files:
 
 - **markdownlint**: Fixes markdown violations before each commit. See [docs/markdown-linting.md](docs/markdown-linting.md) for details.
-- **PSScriptAnalyzer**: Validates PowerShell (`.ps1`/`.psm1`) scripts for syntax errors and coding standard violations. Error-level issues block commits; warnings are displayed but non-blocking. Skips gracefully if PowerShell is not installed.
-  - **Install**: `pwsh -Command 'Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force'`
 - **ruff**: Lints Python files for style and common issues when Python files are staged.
 - **actionlint**: Validates GitHub Actions workflow files (`.github/workflows/*.yml`) when they are staged.
 - **yamllint**: Validates general YAML files when they are staged.
@@ -544,7 +540,7 @@ The pre-push hook runs comprehensive branch-wide validation before each push. Un
 | **Fast Guards** | Branch guard, commit count (max 20), changed files count, total additions | Yes |
 | **Linting** | markdownlint, ruff, mypy, actionlint, yamllint | Yes (except yamllint) |
 | **Build Validation** | Agent generation drift, agent drift detection, path normalization | Yes |
-| **Tests** | Full Pester suite, pytest | Yes |
+| **Tests** | Full pytest suite | Yes |
 | **Security** | Suppression comment detection, session log validation | Yes |
 | **Governance** | Planning artifacts, ADR review reminder | Warn only |
 
@@ -553,7 +549,7 @@ The pre-push hook runs comprehensive branch-wide validation before each push. Un
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `SKIP_PREPUSH` | 0 | Set to 1 to bypass all checks (emergency only) |
-| `SKIP_TESTS` | 0 | Skip Pester and pytest (for documentation-only pushes) |
+| `SKIP_TESTS` | 0 | Skip pytest (for documentation-only pushes) |
 
 Refer to `.githooks/pre-push` for the authoritative, up-to-date list of all checks.
 
@@ -713,9 +709,8 @@ The repository enforces quality automatically at multiple stages:
 | Stage | What Runs | Trigger |
 |-------|-----------|---------|
 | **Pre-commit hook** | Python linting (ruff), Markdown linting | Every commit |
-| **Pre-push hook** | Full Pester + pytest, drift detection, lint, security scans | Every push |
+| **Pre-push hook** | Full pytest, drift detection, lint, security scans | Every push |
 | **CI pytest.yml** | pytest, pip-audit, bandit | Every PR/push |
-| **CI pester.yml** | Pester tests | Every PR/push |
 
 **No manual test runs required for routine development.** Quality gates run automatically.
 
@@ -734,22 +729,9 @@ uv run pip-audit                            # Dependency vulnerabilities
 uv run bandit -r .claude/ scripts/          # Static analysis
 ```
 
-### PowerShell Tests (Pester)
-
-```powershell
-# Run all tests
-uv run pytest
-
-# CI mode (exits with error code on failure)
-uv run pytest
-
-# Run specific test file
-uv run pytest tests/test_validate_session_json.py
-```
-
 ### Agent Generation Tests
 
-```powershell
+```bash
 # Run generation tests
 uv run pytest tests/build_scripts/test_generate_agents.py
 ```
@@ -994,8 +976,8 @@ After configuration, verify the MCP connection in your client:
 
 Import the project's shared Forgetful memories to get cross-session context:
 
-```powershell
-pwsh scripts/forgetful/Import-ForgetfulMemories.ps1
+```bash
+python3 scripts/forgetful/import_forgetful_memories.py
 ```
 
 This imports all JSON exports from `.forgetful/exports/` into your local Forgetful database. The import is idempotent and safe to run multiple times.
@@ -1113,7 +1095,7 @@ license attribution in `THIRD-PARTY-NOTICES.TXT`.
 | Dev-only tools | pytest, ruff | No |
 | CI infrastructure | GitHub Actions | No |
 | Transitive pip packages | pydantic, httpx | No |
-| Test frameworks | Pester, pytest-cov | No |
+| Test frameworks | pytest, pytest-cov | No |
 
 ### Adding a New Third-Party Component
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ To change an existing agent's behavior, follow these steps:
 
 Edit the source file in `templates/agents/`:
 
-```powershell
+```bash
 # Example: Modify the analyst agent
 code templates/agents/analyst.shared.md
 ```
@@ -149,7 +149,7 @@ code templates/agents/analyst.shared.md
 
 Run the generation script:
 
-```powershell
+```bash
 python3 build/generate_agents.py
 ```
 
@@ -157,7 +157,7 @@ python3 build/generate_agents.py
 
 Check that generated files look correct:
 
-```powershell
+```bash
 # Preview what would be generated without writing
 python3 build/generate_agents.py --what-if
 
@@ -182,7 +182,7 @@ git commit -m "feat(analyst): add new research capability"
 
 Create a new file in `templates/agents/` with the `.shared.md` extension:
 
-```powershell
+```bash
 # Example: Create a new "reviewer" agent
 code templates/agents/reviewer.shared.md
 ```
@@ -258,7 +258,7 @@ tools_copilot:
 
 ### Step 4: Generate and Verify
 
-```powershell
+```bash
 # Generate all agents
 python3 build/generate_agents.py
 
@@ -445,7 +445,7 @@ These files are auto-generated and include a header comment:
 
 ## Useful Commands
 
-```powershell
+```bash
 # Generate all agent files from templates
 python3 build/generate_agents.py
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ code templates/agents/analyst.shared.md
 Run the generation script:
 
 ```powershell
-pwsh build/Generate-Agents.ps1
+python3 build/generate_agents.py
 ```
 
 ### Step 3: Verify the Changes
@@ -161,10 +161,10 @@ Check that generated files look correct:
 
 ```powershell
 # Preview what would be generated without writing
-pwsh build/Generate-Agents.ps1 -WhatIf
+python3 build/generate_agents.py --what-if
 
 # Verify generated files match templates
-pwsh build/Generate-Agents.ps1 -Validate
+python3 build/generate_agents.py --validate
 ```
 
 ### Step 4: Commit Both Files
@@ -262,10 +262,10 @@ tools_copilot:
 
 ```powershell
 # Generate all agents
-pwsh build/Generate-Agents.ps1
+python3 build/generate_agents.py
 
 # Verify outputs
-pwsh build/Generate-Agents.ps1 -Validate
+python3 build/generate_agents.py --validate
 ```
 
 ### Step 5: Update Documentation
@@ -439,7 +439,7 @@ These files are auto-generated and include a header comment:
 ```markdown
 <!-- AUTO-GENERATED FILE - DO NOT EDIT DIRECTLY
      Generated from: templates/agents/[name].shared.md
-     To modify this file, edit the source and run: pwsh build/Generate-Agents.ps1
+     To modify this file, edit the source and run: python3 build/generate_agents.py
 -->
 ```
 
@@ -449,16 +449,16 @@ These files are auto-generated and include a header comment:
 
 ```powershell
 # Generate all agent files from templates
-pwsh build/Generate-Agents.ps1
+python3 build/generate_agents.py
 
 # Verify generated files match templates (used in CI)
-pwsh build/Generate-Agents.ps1 -Validate
+python3 build/generate_agents.py --validate
 
 # Preview what would be generated without writing files
-pwsh build/Generate-Agents.ps1 -WhatIf
+python3 build/generate_agents.py --what-if
 
 # Generate with verbose logging
-pwsh build/Generate-Agents.ps1 -Verbose
+python3 build/generate_agents.py
 ```
 
 ## CI Drift Detection
@@ -738,20 +738,20 @@ uv run bandit -r .claude/ scripts/          # Static analysis
 
 ```powershell
 # Run all tests
-pwsh build/scripts/Invoke-PesterTests.ps1
+uv run pytest
 
 # CI mode (exits with error code on failure)
-pwsh build/scripts/Invoke-PesterTests.ps1 -CI
+uv run pytest
 
 # Run specific test file
-pwsh build/scripts/Invoke-PesterTests.ps1 -TestPath "./tests/Validate-SessionJson.Tests.ps1"
+uv run pytest tests/test_validate_session_json.py
 ```
 
 ### Agent Generation Tests
 
 ```powershell
 # Run generation tests
-pwsh build/scripts/Invoke-PesterTests.ps1 -TestPath "./build/tests/Generate-Agents.Tests.ps1"
+uv run pytest tests/build_scripts/test_generate_agents.py
 ```
 
 ## Copilot CLI Version Management
@@ -846,7 +846,7 @@ The script parses all ADR files, extracts RFC 2119 requirements, and reports cov
 
 1. **Spec references**: Feature PRs (`feat:`) require spec references (issue, REQ-*, or `.agents/planning/` files)
 2. **Template changes**: Always include both template and generated files
-3. **Validation**: Run `pwsh build/Generate-Agents.ps1 -Validate` before submitting
+3. **Validation**: Run `python3 build/generate_agents.py --validate` before submitting
 4. **Tests**: Ensure all tests pass
 5. **Documentation**: Update relevant docs if adding new agents
 6. **Commit messages**: Use conventional commit format (e.g., `feat(agent):`, `fix(template):`)

--- a/build/AGENTS.md
+++ b/build/AGENTS.md
@@ -59,7 +59,7 @@ flowchart TD
 
 After modifying ANY file in `templates/`:
 
-```powershell
+```bash
 # Regenerate platform-specific files
 python3 build/generate_agents.py
 
@@ -349,7 +349,7 @@ uv run pytest
 # CI mode (exit on failure)
 uv run pytest
 
-# Specific test file
+# Specific test directory
 uv run pytest tests/build_scripts/
 
 # Maximum verbosity

--- a/build/AGENTS.md
+++ b/build/AGENTS.md
@@ -18,9 +18,9 @@ flowchart TD
 
     subgraph Build["Build Agents"]
         GEN[generate_agents.py]
-        DFT[Detect-AgentDrift.ps1]
-        VPA[Validate-PlanningArtifacts.ps1]
-        VPN[Validate-PathNormalization.ps1]
+        DFT[detect_agent_drift.py]
+        VPA[validate_planning_artifacts.py]
+        VPN[validate_path_normalization.py]
         IPT[pytest]
     end
 
@@ -138,7 +138,7 @@ behind. There are zero deferrals today; the gate passes until someone adds one.
 | **Input** | `templates/agents/*.shared.md`, `templates/platforms/*.yaml` |
 | **Output** | `src/vs-code-agents/*.agent.md`, `src/copilot-cli/agents/*.agent.md` |
 | **Trigger** | Manual, CI validation |
-| **Dependencies** | `Generate-Agents.Common.psm1`, PowerShell 7.5.4+ |
+| **Dependencies** | `generate_agents_common.py`, Python 3.12+ |
 
 **Transformations Applied**:
 
@@ -268,7 +268,7 @@ When you edit a shared-template agent, update the template
 
 ---
 
-### Validate-PlanningArtifacts.ps1
+### validate_planning_artifacts.py
 
 **Role**: Planning document consistency validator
 
@@ -277,7 +277,7 @@ When you edit a shared-template agent, update the template
 | **Input** | `.agents/planning/*.md` |
 | **Output** | Validation report |
 | **Trigger** | CI on planning changes, manual |
-| **Dependencies** | PowerShell 7.5.4+ |
+| **Dependencies** | Python 3.12+ |
 
 **Validations Performed**:
 
@@ -289,20 +289,20 @@ When you edit a shared-template agent, update the template
 
 **Invocation**:
 
-```powershell
+```bash
 # Validate specific feature
-pwsh build/scripts/Validate-PlanningArtifacts.ps1 -FeatureName "agent-consolidation"
+python3 build/scripts/validate_planning_artifacts.py --feature-name "agent-consolidation"
 
 # CI mode (exit on error)
-pwsh build/scripts/Validate-PlanningArtifacts.ps1 -FailOnError
+python3 build/scripts/validate_planning_artifacts.py --fail-on-error
 
 # Strict mode (warnings as errors)
-pwsh build/scripts/Validate-PlanningArtifacts.ps1 -FailOnWarning
+python3 build/scripts/validate_planning_artifacts.py --fail-on-warning
 ```
 
 ---
 
-### Validate-PathNormalization.ps1
+### validate_path_normalization.py
 
 **Role**: Path format validator for documentation
 
@@ -311,7 +311,7 @@ pwsh build/scripts/Validate-PlanningArtifacts.ps1 -FailOnWarning
 | **Input** | `**/*.md` (documentation files) |
 | **Output** | Path validation report |
 | **Trigger** | CI on PR, manual |
-| **Dependencies** | PowerShell 7.5.4+ |
+| **Dependencies** | Python 3.12+ |
 
 **Forbidden Patterns**:
 
@@ -323,26 +323,26 @@ pwsh build/scripts/Validate-PlanningArtifacts.ps1 -FailOnWarning
 
 **Invocation**:
 
-```powershell
-pwsh build/scripts/Validate-PathNormalization.ps1
+```bash
+python3 build/scripts/validate_path_normalization.py --fail-on-violation
 ```
 
 ---
 
 ### pytest
 
-**Role**: Reusable Pester test runner
+**Role**: Reusable pytest test runner
 
 | Attribute | Value |
 |-----------|-------|
-| **Input** | Test files (`**/*.Tests.ps1`) |
+| **Input** | Test files (`tests/**/*.py`) |
 | **Output** | Test results (XML, console) |
 | **Trigger** | CI, pre-commit, manual |
-| **Dependencies** | Pester 5.7.1 (exact), PowerShell 7.5.4+ |
+| **Dependencies** | pytest, uv, Python 3.12+ |
 
 **Invocation**:
 
-```powershell
+```bash
 # Local development (detailed output)
 uv run pytest
 
@@ -364,7 +364,7 @@ uv run pytest -vv
 sequenceDiagram
     participant Dev as Developer
     participant Gen as generate_agents.py
-    participant Drift as Detect-AgentDrift.ps1
+    participant Drift as detect_agent_drift.py
     participant CI as GitHub Actions
 
     Dev->>Gen: Edit template
@@ -373,7 +373,7 @@ sequenceDiagram
     Gen-->>Dev: Generated files
 
     Dev->>CI: Push changes
-    CI->>Gen: Validate (--Validate)
+    CI->>Gen: Validate (--validate)
     alt Files match
         Gen-->>CI: Exit 0
     else Files differ
@@ -395,8 +395,8 @@ sequenceDiagram
 |-------|---------------|----------|
 | generate_agents.py | Missing template | Exit 1 with path info |
 | generate_agents.py | Invalid YAML | Parse error with line number |
-| Detect-AgentDrift.ps1 | Missing agent | Report as "NO COUNTERPART" |
-| Validate-PlanningArtifacts.ps1 | Missing artifacts | Warning (not error) |
+| detect_agent_drift.py | Missing agent | Report as "NO COUNTERPART" |
+| validate_planning_artifacts.py | Missing artifacts | Warning (not error) |
 | pytest | Test failure | Report details, exit 1 in CI |
 
 ## Security Considerations
@@ -413,9 +413,9 @@ sequenceDiagram
 | Agent | CI Workflow | Schedule |
 |-------|------------|----------|
 | generate_agents.py | `validate-generated-agents.yml` | On PR |
-| Detect-AgentDrift.ps1 | `drift-detection.yml` | Monday 9 AM UTC |
-| Validate-PlanningArtifacts.ps1 | `validate-planning-artifacts.yml` | On PR |
-| Validate-PathNormalization.ps1 | `validate-paths.yml` | On PR |
+| detect_agent_drift.py | `drift-detection.yml` | Monday 9 AM UTC |
+| validate_planning_artifacts.py | `validate-planning-artifacts.yml` | On PR |
+| validate_path_normalization.py | `validate-paths.yml` | On PR |
 | pytest | `pytest.yml` | On PR |
 
 ## Related Documentation

--- a/build/AGENTS.md
+++ b/build/AGENTS.md
@@ -17,11 +17,11 @@ flowchart TD
     end
 
     subgraph Build["Build Agents"]
-        GEN[Generate-Agents.ps1]
+        GEN[generate_agents.py]
         DFT[Detect-AgentDrift.ps1]
         VPA[Validate-PlanningArtifacts.ps1]
         VPN[Validate-PathNormalization.ps1]
-        IPT[Invoke-PesterTests.ps1]
+        IPT[pytest]
     end
 
     subgraph Outputs["Outputs"]
@@ -61,10 +61,10 @@ After modifying ANY file in `templates/`:
 
 ```powershell
 # Regenerate platform-specific files
-pwsh build/Generate-Agents.ps1
+python3 build/generate_agents.py
 
 # Verify generation succeeded
-pwsh build/Generate-Agents.ps1 -Validate
+python3 build/generate_agents.py --validate
 
 # Commit ALL affected files together
 git add templates/ src/vs-code-agents/ src/copilot-cli/
@@ -78,7 +78,7 @@ When `src/claude/` agents receive **universal changes**:
 ```text
 1. Edit src/claude/{agent}.md (Claude-specific source)
 2. Duplicate changes to templates/agents/{agent}.shared.md
-3. Run: pwsh build/Generate-Agents.ps1
+3. Run: python3 build/generate_agents.py
 4. Commit all files atomically
 ```
 
@@ -129,7 +129,7 @@ behind. There are zero deferrals today; the gate passes until someone adds one.
 
 ## Agent Catalog
 
-### Generate-Agents.ps1
+### generate_agents.py
 
 **Role**: Platform-specific agent file generator
 
@@ -150,13 +150,13 @@ behind. There are zero deferrals today; the gate passes until someone adds one.
 
 ```powershell
 # Generate all agents
-pwsh build/Generate-Agents.ps1
+python3 build/generate_agents.py
 
 # Preview changes (dry run)
-pwsh build/Generate-Agents.ps1 -WhatIf
+python3 build/generate_agents.py --what-if
 
 # CI validation mode
-pwsh build/Generate-Agents.ps1 -Validate
+python3 build/generate_agents.py --validate
 ```
 
 **Exit Codes**:
@@ -329,7 +329,7 @@ pwsh build/scripts/Validate-PathNormalization.ps1
 
 ---
 
-### Invoke-PesterTests.ps1
+### pytest
 
 **Role**: Reusable Pester test runner
 
@@ -344,16 +344,16 @@ pwsh build/scripts/Validate-PathNormalization.ps1
 
 ```powershell
 # Local development (detailed output)
-pwsh build/scripts/Invoke-PesterTests.ps1
+uv run pytest
 
 # CI mode (exit on failure)
-pwsh build/scripts/Invoke-PesterTests.ps1 -CI
+uv run pytest
 
 # Specific test file
-pwsh build/scripts/Invoke-PesterTests.ps1 -TestPath "./scripts/tests/Install-Common.Tests.ps1"
+uv run pytest tests/build_scripts/
 
 # Maximum verbosity
-pwsh build/scripts/Invoke-PesterTests.ps1 -Verbosity Diagnostic
+uv run pytest -vv
 ```
 
 ---
@@ -363,7 +363,7 @@ pwsh build/scripts/Invoke-PesterTests.ps1 -Verbosity Diagnostic
 ```mermaid
 sequenceDiagram
     participant Dev as Developer
-    participant Gen as Generate-Agents.ps1
+    participant Gen as generate_agents.py
     participant Drift as Detect-AgentDrift.ps1
     participant CI as GitHub Actions
 
@@ -393,17 +393,17 @@ sequenceDiagram
 
 | Agent | Error Scenario | Behavior |
 |-------|---------------|----------|
-| Generate-Agents.ps1 | Missing template | Exit 1 with path info |
-| Generate-Agents.ps1 | Invalid YAML | Parse error with line number |
+| generate_agents.py | Missing template | Exit 1 with path info |
+| generate_agents.py | Invalid YAML | Parse error with line number |
 | Detect-AgentDrift.ps1 | Missing agent | Report as "NO COUNTERPART" |
 | Validate-PlanningArtifacts.ps1 | Missing artifacts | Warning (not error) |
-| Invoke-PesterTests.ps1 | Test failure | Report details, exit 1 in CI |
+| pytest | Test failure | Report details, exit 1 in CI |
 
 ## Security Considerations
 
 | Agent | Security Control |
 |-------|-----------------|
-| Generate-Agents.ps1 | Output path validation (no traversal) |
+| generate_agents.py | Output path validation (no traversal) |
 | All scripts | No external input (static file sources) |
 | All scripts | No network access required |
 | All scripts | Code review required for changes |
@@ -412,11 +412,11 @@ sequenceDiagram
 
 | Agent | CI Workflow | Schedule |
 |-------|------------|----------|
-| Generate-Agents.ps1 | `validate-generated-agents.yml` | On PR |
+| generate_agents.py | `validate-generated-agents.yml` | On PR |
 | Detect-AgentDrift.ps1 | `drift-detection.yml` | Monday 9 AM UTC |
 | Validate-PlanningArtifacts.ps1 | `validate-planning-artifacts.yml` | On PR |
 | Validate-PathNormalization.ps1 | `validate-paths.yml` | On PR |
-| Invoke-PesterTests.ps1 | `pester-tests.yml` | On PR |
+| pytest | `pytest.yml` | On PR |
 
 ## Related Documentation
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -107,19 +107,19 @@ Use [StringComparison]::OrdinalIgnoreCase for comparisons
 
 ### Testing Standards
 
-- Pester tests in `tests/` or adjacent to scripts
+- pytest tests in `tests/`
 - Test isolation: No global state
-- Parameterized tests: `@()` arrays
+- Parameterized tests: `@pytest.mark.parametrize`
 - CI validation: All tests run on push
 
 ### Module Structure
 
-```powershell
-# {Module}.psm1
-function Export-Function1 { }
-function Export-Function2 { }
+```python
+# {module}.py
+def function1(): ...
+def function2(): ...
 
-Export-ModuleMember -Function Export-Function1, Export-Function2
+__all__ = ["function1", "function2"]
 ```
 
 ### Security
@@ -132,7 +132,8 @@ Export-ModuleMember -Function Export-Function1, Export-Function2
 
 - Exit codes: `.agents/architecture/ADR-035-exit-code-standardization.md`
 - Skill development: `.claude/skills/CLAUDE.md`
-- ADR-005: PowerShell-only architecture
+- ADR-005: PowerShell-only architecture (superseded by ADR-042)
+- ADR-042: Python migration strategy
 
 ---
 
@@ -154,9 +155,9 @@ flowchart TD
     end
 
     subgraph Scripts["Script Agents"]
-        SYN[Sync-McpConfig.ps1]
+        SYN[sync_mcp_config.py]
         CHK[check_skill_exists.py]
-        VCS[Validate-Consistency.ps1]
+        VCS[consistency.py]
         VSP[validate_session_json.py]
     end
 
@@ -172,7 +173,7 @@ flowchart TD
 
 ## Agent Catalog
 
-### Sync-McpConfig.ps1
+### sync_mcp_config.py
 
 **Role**: MCP configuration synchronizer between Claude and VS Code
 
@@ -181,7 +182,7 @@ flowchart TD
 | **Input** | `.mcp.json` (Claude Code format) |
 | **Output** | `.vscode/mcp.json` (VS Code format) |
 | **Trigger** | Manual |
-| **Dependencies** | PowerShell 7.5.4+ |
+| **Dependencies** | Python 3.12+ |
 
 **Transformations Applied**:
 
@@ -193,20 +194,20 @@ flowchart TD
 
 **Invocation**:
 
-```powershell
-# Sync with default paths
-.\Sync-McpConfig.ps1
+```bash
+# Sync to both VS Code and Factory
+python3 -m scripts.sync_mcp_config --sync-all
 
 # Preview changes
-.\Sync-McpConfig.ps1 -WhatIf
+python3 -m scripts.sync_mcp_config --sync-all --dry-run
 
 # Force overwrite
-.\Sync-McpConfig.ps1 -Force
+python3 -m scripts.sync_mcp_config --sync-all --force
 ```
 
 ---
 
-### Check-SkillExists.ps1
+### check_skill_exists.py
 
 **Role**: Skill existence verification for Phase 1.5 BLOCKING gate
 
@@ -219,25 +220,25 @@ flowchart TD
 
 **Invocation**:
 
-```powershell
-# Check for specific skill
-.\Check-SkillExists.ps1 -Operation "pr" -Action "PRContext"  # Returns: $true
+```bash
+# Check for specific skill (exit 0 = found, exit 1 = not found)
+python3 scripts/check_skill_exists.py --operation pr --action PRContext
 
 # List all available skills
-.\Check-SkillExists.ps1 -ListAvailable
+python3 scripts/check_skill_exists.py --list-available
 ```
 
 **Parameters**:
 
 | Parameter | Values | Description |
 |-----------|--------|-------------|
-| `-Operation` | `pr`, `issue`, `reactions`, `label`, `milestone` | Skill category |
-| `-Action` | String | Substring match against script names |
-| `-ListAvailable` | Switch | List all skills organized by type |
+| `--operation` | `pr`, `issue`, `reactions`, `label`, `milestone` | Skill category |
+| `--action` | String | Substring match against script names |
+| `--list-available` | Switch | List all skills organized by type |
 
 ---
 
-### Validate-Consistency.ps1
+### consistency.py
 
 **Role**: Cross-document consistency validator
 
@@ -246,13 +247,23 @@ flowchart TD
 | **Input** | `.agents/` directory artifacts |
 | **Output** | Consistency report |
 | **Trigger** | Manual, CI |
-| **Dependencies** | PowerShell 7.5.4+ |
+| **Dependencies** | Python 3.12+ |
 
 **Validations**:
 
 - Naming convention compliance
 - Cross-reference integrity
 - Requirement coverage
+
+**Invocation**:
+
+```bash
+# Validate all features
+python3 scripts/validation/consistency.py --all
+
+# Specific feature, CI mode (exit 1 on failures)
+python3 scripts/validation/consistency.py --feature <name> --ci
+```
 
 ---
 
@@ -293,15 +304,15 @@ python3 scripts/validate_session_json.py .agents/sessions/2025-12-18-session-24.
 
 | Agent | Error Scenario | Behavior |
 |-------|---------------|----------|
-| Sync-McpConfig.ps1 | Source missing | Exit with path error |
+| sync_mcp_config.py | Source missing | Exit with path error |
 | validate_session_json.py | Session not found | Warning, continue |
-| Validate-*.ps1 | Validation failure | Exit with error code |
+| consistency.py | Validation failure | Exit with error code |
 
 ## Security Considerations
 
 | Agent | Security Control |
 |-------|-----------------|
-| Sync-McpConfig.ps1 | No external network access |
+| sync_mcp_config.py | No external network access |
 | All scripts | No credential handling |
 | All scripts | Path validation prevents traversal |
 
@@ -311,27 +322,27 @@ Tests are located in `tests/`:
 
 | Test File | Coverage |
 |-----------|----------|
-| `Sync-McpConfig.Tests.ps1` | MCP sync transformations |
-| `Validate-SessionJson.Tests.ps1` | Session protocol validation |
+| `test_sync_mcp_config.py` | MCP sync transformations |
+| `test_validate_session_json.py` | Session protocol validation |
 
 **Running Tests**:
 
-```powershell
+```bash
 # All tests
-Invoke-Pester -Path .\tests
+uv run pytest
 
 # Specific file
-Invoke-Pester -Path .\tests\Sync-McpConfig.Tests.ps1
+uv run pytest tests/test_sync_mcp_config.py
 
 # Detailed output
-Invoke-Pester -Path .\tests -Output Detailed
+uv run pytest -vv
 ```
 
 ## Monitoring
 
 | Agent | CI Workflow | Trigger |
 |-------|------------|---------|
-| Sync-McpConfig.ps1 | `pester-tests.yml` | PR to `scripts/**` |
+| sync_mcp_config.py | `pytest.yml` | PR to `scripts/**` |
 | validate_session_json.py | `ai-session-protocol.yml` | PR to `.agents/**` |
 
 ## Related Documentation

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -11,9 +11,14 @@ This document contains PowerShell coding standards and describes the automated a
 
 ### Language Constraint
 
-**PowerShell only** (.ps1/.psm1) per ADR-005.
+**Python-first** (.py) per ADR-042, which supersedes ADR-005 for new development.
 
-No bash or Python scripts in this directory. Cross-platform consistency via PowerShell.
+New scripts use Python. No bash scripts (.sh). ADR-005 originally mandated
+PowerShell-only; the repository has since completed the ADR-042 migration and
+retains zero PowerShell files. The PowerShell coding standards below are kept
+for historical reference and any reintroduced `.ps1` tooling. For new work,
+follow the Python guidance in
+[`.agents/guides/python-for-powershell-developers.md`](../.agents/guides/python-for-powershell-developers.md).
 
 ### Script Structure
 

--- a/src/claude/.claude-plugin/plugin.json
+++ b/src/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-agents",
   "description": "25 specialized agent definitions with templates and governance for Claude Code",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/claude/AGENTS.md
+++ b/src/claude/AGENTS.md
@@ -58,7 +58,7 @@ Per ADR-036 §Synchronization Requirement, when adding content that applies to A
 ```text
 1. Edit src/claude/{agent}.md
 2. Duplicate universal changes to templates/agents/{agent}.shared.md
-3. Run: pwsh build/Generate-Agents.ps1
+3. Run: python3 build/generate_agents.py
 4. Commit all changed files together
 ```
 
@@ -67,7 +67,7 @@ Per ADR-036 §Synchronization Requirement, when adding content that applies to A
 ```text
 1. Edit templates/agents/{agent}.shared.md
 2. Edit src/claude/{agent}.md (MANUAL - not auto-synced!)
-3. Run: pwsh build/Generate-Agents.ps1
+3. Run: python3 build/generate_agents.py
 4. Commit all files atomically
 ```
 
@@ -117,7 +117,7 @@ flowchart TD
     end
 
     Claude -.->|Manual sync when<br>universal changes| Templates
-    Templates -->|build/Generate-Agents.ps1| Generated
+    Templates -->|build/generate_agents.py| Generated
 
     style Claude fill:#e1f5fe
     style Templates fill:#fff3e0
@@ -277,7 +277,7 @@ gh pr view 50 --json ...
 1. Create `src/claude/{agent-name}.md` with required sections
 2. Create `templates/agents/{agent-name}.shared.md` with platform-agnostic content
 3. Update `templates/platforms/*.yaml` if new tools needed
-4. Run `pwsh build/Generate-Agents.ps1`
+4. Run `python3 build/generate_agents.py`
 5. Update documentation (root AGENTS.md, AGENT-SYSTEM.md)
 6. Commit all files together
 
@@ -292,7 +292,7 @@ gh pr view 50 --json ...
 
 3. Edit templates/agents/{agent}.shared.md with equivalent changes
 
-4. Run: pwsh build/Generate-Agents.ps1
+4. Run: python3 build/generate_agents.py
 
 5. Review generated files in src/vs-code-agents/ and src/copilot-cli/
 
@@ -303,7 +303,7 @@ gh pr view 50 --json ...
 
 ```powershell
 # Validate generated files match templates
-pwsh build/Generate-Agents.ps1 -Validate
+python3 build/generate_agents.py --validate
 
 # Check for drift between Claude and VS Code
 pwsh build/scripts/Detect-AgentDrift.ps1
@@ -337,7 +337,7 @@ Invoke-Pester ./build/tests/
 |-------|----------|-----------|
 | Generation validation | `validate-generated-agents.yml` | On PR |
 | Drift detection | `drift-detection.yml` | Monday 9 AM UTC |
-| Lint validation | `pester-tests.yml` | On PR |
+| Lint validation | `pytest.yml` | On PR |
 
 ---
 

--- a/src/claude/AGENTS.md
+++ b/src/claude/AGENTS.md
@@ -301,15 +301,15 @@ gh pr view 50 --json ...
 
 ### Validating Changes
 
-```powershell
+```bash
 # Validate generated files match templates
 python3 build/generate_agents.py --validate
 
 # Check for drift between Claude and VS Code
-pwsh build/scripts/Detect-AgentDrift.ps1
+python3 build/scripts/detect_agent_drift.py
 
-# Run Pester tests if scripts modified
-Invoke-Pester ./build/tests/
+# Run tests if scripts modified
+uv run pytest
 ```
 
 ---

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.269",
+  "version": "0.5.270",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/session-init/references/template-extraction.md
+++ b/src/copilot-cli/skills/session-init/references/template-extraction.md
@@ -103,7 +103,7 @@ HTML comments must be preserved:
 ## Session End
 ```
 
-This is the most common validation failure. The regex in `Validate-SessionJson.ps1` checks for:
+This is the most common validation failure. The regex in `validate_session_json.py` checks for:
 
 ```regex
 (?i)Session\s+End.*COMPLETE\s+ALL|End.*before.*closing

--- a/src/copilot-cli/skills/session-init/references/validation-patterns.md
+++ b/src/copilot-cli/skills/session-init/references/validation-patterns.md
@@ -6,25 +6,25 @@ How to validate session logs and handle common issues.
 
 ## Validation Script
 
-**Script**: `scripts/Validate-SessionJson.ps1`
+**Script**: `scripts/validate_session_json.py` (Python, per ADR-042)
 
 ### Basic Usage
 
-```powershell
-pwsh scripts/Validate-SessionJson.ps1 `
-    -SessionPath ".agents/sessions/.agents/sessions/2026-01-05-session-375.json" `
-    
+```bash
+python3 scripts/validate_session_json.py \
+    .agents/sessions/2026-01-05-session-375.json
 ```
 
-### CI Mode
+The session log path is a positional argument.
 
-For GitHub Actions:
+### CI / Pre-commit Mode
 
-```powershell
-pwsh scripts/Validate-SessionJson.ps1 `
-    -SessionPath ".agents/sessions/.agents/sessions/2026-01-05-session-375.json" `
-     `
-    -CI
+CI and the pre-commit hook run the same command; the exit code is the gate
+(0 = PASS, 1 = FAIL). The `--pre-commit` flag tightens output for hook use:
+
+```bash
+python3 scripts/validate_session_json.py \
+    .agents/sessions/2026-01-05-session-375.json --pre-commit
 ```
 
 ---
@@ -153,15 +153,15 @@ Regex patterns:
 
 ### SessionLogCompleteness (SHOULD)
 
-Checks for required sections:
+Checks for required sections (validator internals, Python):
 
-```powershell
-$expectedSections = @(
-    @{ Pattern = '(?i)##\s*Session\s+Info'; Name = 'Session Info' }
-    @{ Pattern = '(?i)##\s*Protocol\s+Compliance'; Name = 'Protocol Compliance' }
-    @{ Pattern = '(?i)##\s*Work\s+Log|##\s*Tasks?\s+Completed'; Name = 'Work Log' }
-    @{ Pattern = '(?i)##\s*Session\s+End|Session\s+End.*COMPLETE'; Name = 'Session End' }
-)
+```python
+expected_sections = [
+    (r'(?i)##\s*Session\s+Info', 'Session Info'),
+    (r'(?i)##\s*Protocol\s+Compliance', 'Protocol Compliance'),
+    (r'(?i)##\s*Work\s+Log|##\s*Tasks?\s+Completed', 'Work Log'),
+    (r'(?i)##\s*Session\s+End|Session\s+End.*COMPLETE', 'Session End'),
+]
 ```
 
 ### HandoffUpdated (MUST)
@@ -178,23 +178,16 @@ Checks for commit SHA evidence in the session log.
 
 For session-init skill, run validation immediately after creating the session log:
 
-```powershell
-$sessionPath = ".agents/sessions/.agents/sessions/2026-01-05-session-375.json"
+```bash
+SESSION_PATH=".agents/sessions/2026-01-05-session-375.json"
 
-# Run validation
-$result = & pwsh scripts/Validate-SessionJson.ps1 `
-    -SessionPath $sessionPath `
-    
-
-$exitCode = $LASTEXITCODE
-
-if ($exitCode -eq 0) {
-    Write-Host "Session log validated successfully" -ForegroundColor Green
-} else {
-    Write-Host "Validation failed:" -ForegroundColor Red
-    Write-Host $result
+# Run validation; exit code 0 = PASS, 1 = FAIL
+if python3 scripts/validate_session_json.py "$SESSION_PATH"; then
+    echo "Session log validated successfully"
+else
+    echo "Validation failed"
     exit 1
-}
+fi
 ```
 
 ---
@@ -203,24 +196,23 @@ if ($exitCode -eq 0) {
 
 ### View Full Validation Output
 
-```powershell
-pwsh scripts/Validate-SessionJson.ps1 `
-    -SessionPath ".agents/sessions/.agents/sessions/2026-01-05-session-375.json" `
-     `
-    -Verbose
+The validator prints a full Markdown report by default:
+
+```bash
+python3 scripts/validate_session_json.py \
+    .agents/sessions/2026-01-05-session-375.json
 ```
 
 ### Check Specific Patterns
 
-```powershell
-$content = Get-Content -Path ".agents/sessions/.agents/sessions/2026-01-05-session-375.json" -Raw
-
+```bash
 # Check Session End header
-if ($content -match '(?i)Session\s+End.*COMPLETE\s+ALL') {
-    Write-Host "Session End header: OK"
-} else {
-    Write-Host "Session End header: MISSING REQUIRED TEXT"
-}
+if grep -qiE 'Session\s+End.*COMPLETE\s+ALL' \
+    .agents/sessions/2026-01-05-session-375.json; then
+    echo "Session End header: OK"
+else
+    echo "Session End header: MISSING REQUIRED TEXT"
+fi
 ```
 
 ---

--- a/src/copilot-cli/skills/session-init/references/validation-patterns.md
+++ b/src/copilot-cli/skills/session-init/references/validation-patterns.md
@@ -20,7 +20,7 @@ The session log path is a positional argument.
 ### CI / Pre-commit Mode
 
 CI and the pre-commit hook run the same command; the exit code is the gate
-(0 = PASS, 1 = FAIL). The `--pre-commit` flag tightens output for hook use:
+(non-zero = FAIL; treat exit code 2 as failure). The `--pre-commit` flag tightens output for hook use:
 
 ```bash
 python3 scripts/validate_session_json.py \
@@ -35,6 +35,7 @@ python3 scripts/validate_session_json.py \
 |------|---------|--------|
 | 0 | PASS - All MUST requirements met | Proceed with session |
 | 1 | FAIL - One or more MUST requirements failed | Fix issues before proceeding |
+| 2 | FAIL - Unexpected/internal error | Treat as failure; inspect stderr and fix the script or runtime issue |
 
 ---
 
@@ -181,7 +182,7 @@ For session-init skill, run validation immediately after creating the session lo
 ```bash
 SESSION_PATH=".agents/sessions/2026-01-05-session-375.json"
 
-# Run validation; exit code 0 = PASS, 1 = FAIL
+# Run validation; exit code 0 = PASS, non-zero = FAIL
 if python3 scripts/validate_session_json.py "$SESSION_PATH"; then
     echo "Session log validated successfully"
 else

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -4,7 +4,7 @@ This document describes the AI agents defined in the template system and how the
 
 ## Overview
 
-The `templates/` directory is the **source of truth** for AI agent definitions. It contains shared templates that are transformed by `build/Generate-Agents.ps1` into platform-specific agent files for VS Code and Copilot CLI.
+The `templates/` directory is the **source of truth** for AI agent definitions. It contains shared templates that are transformed by `build/generate_agents.py` into platform-specific agent files for VS Code and Copilot CLI.
 
 **Important**: Claude Code agents (`src/claude/`) are NOT generated from templates. They are hand-maintained separately. See `src/claude/AGENTS.md` for the Claude agent workflow.
 
@@ -16,7 +16,7 @@ The `templates/` directory is the **source of truth** for AI agent definitions. 
 templates/agents/*.shared.md ─────────┐
    (SOURCE for VS Code/Copilot)       │
                                       ▼
-                            build/Generate-Agents.ps1
+                            build/generate_agents.py
                                       │
               ┌───────────────────────┼───────────────────────┐
               ▼                       ▼                       │
@@ -56,7 +56,7 @@ flowchart TD
     end
 
     subgraph Build["build/"]
-        GEN[Generate-Agents.ps1]
+        GEN[generate_agents.py]
     end
 
     subgraph Output["src/"]
@@ -104,7 +104,7 @@ Per ADR-036, when adding content that applies to ALL platforms, you MUST update 
 ```text
 1. Edit templates/agents/{agent}.shared.md
 2. Edit src/claude/{agent}.md (MANUAL - not auto-synced!)
-3. Run: pwsh build/Generate-Agents.ps1
+3. Run: python3 build/generate_agents.py
 4. Commit all files atomically
 ```
 
@@ -113,7 +113,7 @@ Per ADR-036, when adding content that applies to ALL platforms, you MUST update 
 ```text
 1. Identify universal changes in src/claude/{agent}.md
 2. Duplicate those changes to templates/agents/{agent}.shared.md
-3. Run: pwsh build/Generate-Agents.ps1
+3. Run: python3 build/generate_agents.py
 4. Commit all files atomically
 ```
 
@@ -129,10 +129,10 @@ After ANY modification to `templates/`:
 
 ```powershell
 # Regenerate all platform files
-pwsh build/Generate-Agents.ps1
+python3 build/generate_agents.py
 
 # Validate generation succeeded
-pwsh build/Generate-Agents.ps1 -Validate
+python3 build/generate_agents.py --validate
 
 # Commit template AND generated files together
 git add templates/ src/vs-code-agents/ src/copilot-cli/
@@ -242,7 +242,7 @@ sequenceDiagram
     participant User
     participant Template as templates/agents/*.shared.md
     participant Config as platforms/*.yaml
-    participant Build as Generate-Agents.ps1
+    participant Build as generate_agents.py
     participant Output as src/*/*.agent.md
 
     User->>Template: Edit shared content
@@ -259,7 +259,7 @@ sequenceDiagram
 
 | Dependency | Type | Purpose |
 |------------|------|---------|
-| `build/Generate-Agents.ps1` | Script | Transforms templates to outputs |
+| `build/generate_agents.py` | Script | Transforms templates to outputs |
 | `build/Generate-Agents.Common.psm1` | Module | Shared transformation functions |
 | PowerShell 7.5.4+ | Runtime | Script execution |
 
@@ -283,19 +283,19 @@ sequenceDiagram
 ### Generate All Agents
 
 ```powershell
-pwsh build/Generate-Agents.ps1
+python3 build/generate_agents.py
 ```
 
 ### Preview Changes (Dry Run)
 
 ```powershell
-pwsh build/Generate-Agents.ps1 -WhatIf
+python3 build/generate_agents.py --what-if
 ```
 
 ### Validate Generated Files
 
 ```powershell
-pwsh build/Generate-Agents.ps1 -Validate
+python3 build/generate_agents.py --validate
 ```
 
 ## Monitoring

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -260,8 +260,8 @@ sequenceDiagram
 | Dependency | Type | Purpose |
 |------------|------|---------|
 | `build/generate_agents.py` | Script | Transforms templates to outputs |
-| `build/Generate-Agents.Common.psm1` | Module | Shared transformation functions |
-| PowerShell 7.5.4+ | Runtime | Script execution |
+| `build/generate_agents_common.py` | Module | Shared transformation functions |
+| Python 3.12+ | Runtime | Script execution |
 
 ## Security Considerations
 
@@ -304,7 +304,7 @@ python3 build/generate_agents.py --validate
 |-------|-----------|-----------|
 | Generation validation | `.github/workflows/validate-generated-agents.yml` | On PR |
 | Drift detection | `.github/workflows/drift-detection.yml` | Weekly |
-| Content consistency | `build/scripts/Detect-AgentDrift.ps1` | Manual/CI |
+| Content consistency | `build/scripts/detect_agent_drift.py` | Manual/CI |
 
 ## Related Documentation
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -282,19 +282,19 @@ sequenceDiagram
 
 ### Generate All Agents
 
-```powershell
+```bash
 python3 build/generate_agents.py
 ```
 
 ### Preview Changes (Dry Run)
 
-```powershell
+```bash
 python3 build/generate_agents.py --what-if
 ```
 
 ### Validate Generated Files
 
-```powershell
+```bash
 python3 build/generate_agents.py --validate
 ```
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -110,7 +110,7 @@ Do NOT use `runSubagent(...)`, `Task(...)`, or `#runSubagent` directly in templa
 
 ### Generate Platform Files
 
-```powershell
+```bash
 # Generate all agents
 python3 build/generate_agents.py
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -186,22 +186,22 @@ A GitHub Actions workflow runs weekly to detect semantic drift between Claude ag
 
 - **Schedule**: Monday 9 AM UTC
 - **Workflow**: `.github/workflows/drift-detection.yml`
-- **Script**: `build/scripts/Detect-AgentDrift.ps1`
+- **Script**: `build/scripts/detect_agent_drift.py`
 
 ### Run Locally
 
-```powershell
+```bash
 # Check for drift (default 80% similarity threshold)
-pwsh build/scripts/Detect-AgentDrift.ps1
+python3 build/scripts/detect_agent_drift.py
 
 # Get JSON output for tooling
-pwsh build/scripts/Detect-AgentDrift.ps1 -OutputFormat JSON
+python3 build/scripts/detect_agent_drift.py --output-format json
 
 # Get markdown report
-pwsh build/scripts/Detect-AgentDrift.ps1 -OutputFormat Markdown
+python3 build/scripts/detect_agent_drift.py --output-format markdown
 
 # Use stricter threshold
-pwsh build/scripts/Detect-AgentDrift.ps1 -SimilarityThreshold 90
+python3 build/scripts/detect_agent_drift.py --similarity-threshold 90
 ```
 
 ### What Gets Compared
@@ -250,7 +250,7 @@ When drift is detected:
 - [.vscode/toolsets.jsonc](../.vscode/toolsets.jsonc) - VS Code native toolset definitions
 - [CONTRIBUTING.md](../CONTRIBUTING.md) - Full contribution guide
 - [build/generate_agents.py](../build/generate_agents.py) - Generation script
-- [build/scripts/Detect-AgentDrift.ps1](../build/scripts/Detect-AgentDrift.ps1) - Drift detection script
+- [build/scripts/detect_agent_drift.py](../build/scripts/detect_agent_drift.py) - Drift detection script
 - [.github/workflows/validate-generated-agents.yml](../.github/workflows/validate-generated-agents.yml) - CI validation
 - [.github/workflows/drift-detection.yml](../.github/workflows/drift-detection.yml) - Drift detection CI
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -30,7 +30,7 @@ The template system maintains a single source of truth for agent behavior while 
 1. **Shared Templates** (`agents/*.shared.md`): Define agent behavior, responsibilities, and content
 2. **Toolset Definitions** (`toolsets.yaml`): Named groups of tools to reduce duplication
 3. **Platform Configs** (`platforms/*.yaml`): Specify platform-specific settings (model, tools, syntax)
-4. **Generation Script** (`build/Generate-Agents.ps1`): Transforms templates into platform-specific files
+4. **Generation Script** (`build/generate_agents.py`): Transforms templates into platform-specific files
 
 ### Toolsets
 
@@ -76,7 +76,7 @@ The generation script expands `$toolset:` references into individual tools using
 templates/agents/*.shared.md     Source of truth
            |
            v
-build/Generate-Agents.ps1        Transformation
+build/generate_agents.py        Transformation
            |
            +---> src/vs-code-agents/*.agent.md    VS Code output
            +---> src/copilot-cli/agents/*.agent.md  Copilot CLI output
@@ -112,13 +112,13 @@ Do NOT use `runSubagent(...)`, `Task(...)`, or `#runSubagent` directly in templa
 
 ```powershell
 # Generate all agents
-pwsh build/Generate-Agents.ps1
+python3 build/generate_agents.py
 
 # Preview without writing
-pwsh build/Generate-Agents.ps1 -WhatIf
+python3 build/generate_agents.py --what-if
 
 # Validate generated files match templates
-pwsh build/Generate-Agents.ps1 -Validate
+python3 build/generate_agents.py --validate
 ```
 
 ### Modify an Agent
@@ -129,7 +129,7 @@ For **universal changes** (content that applies to ALL platforms):
 
 1. Edit the source template: `templates/agents/{agent}.shared.md`
 2. **Also edit**: `src/claude/{agent}.md` (MANUAL - not auto-synced!)
-3. Regenerate: `pwsh build/Generate-Agents.ps1`
+3. Regenerate: `python3 build/generate_agents.py`
 4. Commit template, Claude source, and generated files together
 
 For **Claude-specific changes** (MCP tools, Serena integration):
@@ -173,7 +173,7 @@ For **Claude-specific changes** (MCP tools, Serena integration):
    ```
 
 3. Add agent content following existing patterns
-4. Run `pwsh build/Generate-Agents.ps1`
+4. Run `python3 build/generate_agents.py`
 5. Update documentation (README.md, CLAUDE.md)
 
 ## Drift Detection
@@ -249,7 +249,7 @@ When drift is detected:
 - [src/claude/AGENTS.md](../src/claude/AGENTS.md) - Claude agent synchronization rules
 - [.vscode/toolsets.jsonc](../.vscode/toolsets.jsonc) - VS Code native toolset definitions
 - [CONTRIBUTING.md](../CONTRIBUTING.md) - Full contribution guide
-- [build/Generate-Agents.ps1](../build/Generate-Agents.ps1) - Generation script
+- [build/generate_agents.py](../build/generate_agents.py) - Generation script
 - [build/scripts/Detect-AgentDrift.ps1](../build/scripts/Detect-AgentDrift.ps1) - Drift detection script
 - [.github/workflows/validate-generated-agents.yml](../.github/workflows/validate-generated-agents.yml) - CI validation
 - [.github/workflows/drift-detection.yml](../.github/workflows/drift-detection.yml) - Drift detection CI


### PR DESCRIPTION
## Summary

Closes part of #2864. ADR-042 (PowerShell to Python) is code-complete (0 `.ps1`/`.psm1` files remain) but agent-facing docs still commanded removed scripts. This repoints every **verified-replaceable** invocation to its Python equivalent so an amnesiac agent following the docs runs a script that exists.

## What changed (verified mappings)

| Old (removed) | New (verified exists) |
|---|---|
| `pwsh build/Generate-Agents.ps1 [-Validate\|-WhatIf]` | `python3 build/generate_agents.py [--validate\|--what-if]` |
| `pwsh build/scripts/Invoke-PesterTests.ps1 [-CI\|-TestPath X]` | `uv run pytest [<concrete test path>]` |
| `pwsh scripts/Validate-SessionJson.ps1 -SessionPath X` | `python3 scripts/validate_session_json.py X` (positional) |
| CI workflow reference (old Pester runner name) | corrected to the actual pytest workflow |
| `scripts/AGENTS.md`: "PowerShell only (ADR-005)" | Python-first (ADR-042), 0 `.ps1` remain |

Files touched (10 sources plus 2 mirrors): `CONTRIBUTING.md`, `build/AGENTS.md`, `.github/AGENTS.md`, `.claude/agents/AGENTS.md`, `src/claude/AGENTS.md`, `templates/AGENTS.md`, `templates/README.md`, `scripts/AGENTS.md`, `.claude/skills/session-init/references/validation-patterns.md`, and `.claude/skills/session-init/references/template-extraction.md` (both session-init references mirrored under `src/copilot-cli`). PowerShell examples in the session-init references were converted to bash/python.

## Out of scope (deliberate): scripts with NO Python replacement

The audit surfaced ~10 commanded scripts that exist in **no language** (deleted with no Python port). Several are BLOCKING session gates. Repointing them is impossible; restoring vs removing the gate is an owner decision, tracked in a comment on #2864. Historical records (`.agents/archive|sessions|security|architecture|analysis/**`, `.serena/**`, `.claude-mem/**`) that document the PowerShell era were correctly left unchanged.

## Validation

- `validate_plugin_version_bump.py --base origin/main`: OK (bumped 0.5.265->0.5.268, 0.3.31->0.3.32)
- `validate_install_parity.py --base origin/main`: OK
- `build_all.py --check`: exit 0
- `markdownlint-cli2`: 0 errors

## Background

Verified `git ls-files '*.ps1' '*.psm1'` = 0. Verified each Python replacement path and CLI (`generate_agents.py` uses `--validate`/`--what-if`; `validate_session_json.py` takes a positional path). Bump chosen above the in-flight fleet max (#2866 at 0.5.267) to avoid the #2855 version deadlock.

Closes #2864

