### PR TITLE
docs(adr-042): repoint residual dead Generate-Agents.ps1 refs (#2862)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,7 +142,7 @@ ai-agents/
 │   ├── agents/               # Shared agent templates (edit these)
 │   └── platforms/            # Platform generation config
 ├── build/
-│   └── Generate-Agents.ps1  # Template-to-platform generator
+│   └── generate_agents.py   # Template-to-platform generator
 ├── src/
 │   ├── claude/               # Claude Code agents
 │   ├── copilot-cli/          # Copilot CLI agents

--- a/docs/patterns/prompt-vs-agent.md
+++ b/docs/patterns/prompt-vs-agent.md
@@ -127,7 +127,7 @@ The `.github/agents/` directory contains both `.agent.md` and `.prompt.md` files
 
 | You want to... | Create a... |
 |----------------|-------------|
-| Add a new specialized agent | `.shared.md` in `templates/agents/`, then run `generate_agents.py` |
+| Add a new specialized agent | `.shared.md` in `templates/agents/`, then run `python3 build/generate_agents.py` |
 | Add a user-facing slash command | `.prompt.md` in `.github/prompts/` or `.github/agents/` |
 | Add an orchestration entry point | `.prompt.md` that delegates to agents via the `agent` tool |
 | Modify agent behavior | Edit the `.shared.md` source, then regenerate |

--- a/docs/patterns/prompt-vs-agent.md
+++ b/docs/patterns/prompt-vs-agent.md
@@ -78,11 +78,11 @@ This agent is callable by other agents. The orchestrator can route work to it. I
 
 ## Generation Pipeline
 
-Shared templates in `templates/agents/` contain the prompt body and platform-neutral frontmatter. The `build/Generate-Agents.ps1` script reads each `.shared.md` file, applies platform-specific transformations, and writes the output files.
+Shared templates in `templates/agents/` contain the prompt body and platform-neutral frontmatter. The `build/generate_agents.py` script reads each `.shared.md` file, applies platform-specific transformations, and writes the output files.
 
 ```mermaid
 flowchart LR
-    S["analyst.shared.md\n(templates/agents/)"] --> G["Generate-Agents.ps1\n(build/)"]
+    S["analyst.shared.md\n(templates/agents/)"] --> G["generate_agents.py\n(build/)"]
     C1["vscode.yaml\n(templates/platforms/)"] --> G
     C2["copilot-cli.yaml\n(templates/platforms/)"] --> G
     G --> V["analyst.agent.md\n(src/vs-code-agents/)"]
@@ -127,7 +127,7 @@ The `.github/agents/` directory contains both `.agent.md` and `.prompt.md` files
 
 | You want to... | Create a... |
 |----------------|-------------|
-| Add a new specialized agent | `.shared.md` in `templates/agents/`, then run `Generate-Agents.ps1` |
+| Add a new specialized agent | `.shared.md` in `templates/agents/`, then run `generate_agents.py` |
 | Add a user-facing slash command | `.prompt.md` in `.github/prompts/` or `.github/agents/` |
 | Add an orchestration entry point | `.prompt.md` that delegates to agents via the `agent` tool |
 | Modify agent behavior | Edit the `.shared.md` source, then regenerate |
@@ -137,7 +137,7 @@ The `.github/agents/` directory contains both `.agent.md` and `.prompt.md` files
 Run the generator in validate mode to verify generated files match their templates:
 
 ```bash
-pwsh build/Generate-Agents.ps1 -Validate
+python3 build/generate_agents.py --validate
 ```
 
 This compares each generated file against what the current templates would produce. CI runs this check to prevent drift between templates and generated output.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -30,7 +30,7 @@ ai-agents/
 │   └── platforms/            # Platform-specific generation config (YAML)
 │
 ├── build/                    # Build + generation scripts
-│   └── Generate-Agents.ps1   # Regenerates platform agent files from templates
+│   └── generate_agents.py    # Regenerates platform agent files from templates
 │
 ├── src/                      # GENERATED agent files for distribution
 │   ├── vs-code-agents/       # Generated VS Code prompt/agent files (don’t edit)
@@ -64,8 +64,8 @@ Edit the shared template:
 
 Then regenerate:
 
-```powershell
-pwsh build/Generate-Agents.ps1
+```bash
+python3 build/generate_agents.py
 ```
 
 Commit both the template and the generated outputs.


### PR DESCRIPTION
## Summary

Closes #2862 (residual). The generator is `python3 build/generate_agents.py`; the dead PowerShell entrypoint it replaced does not exist anywhere in the tree (verified). This repoints the last agent-facing `docs/` files that still commanded that removed script.

### Issue #2862 had two defects
1. **Contradiction** (src/claude described as generated vs hand-maintained): already RESOLVED by #2863; the hand-maintained wording is already in place.
2. **Dead command refs**: the contributor guide is fixed by #2871 (0 remaining). This PR fixes the 3 remaining `docs/` files (no overlap with #2871, so no conflict).

### Changes
- `docs/project-structure.md`: tree comment + code block (`powershell`→`bash`)
- `docs/patterns/prompt-vs-agent.md`: prose, mermaid node, table, `-Validate`→`--validate`
- `docs/architecture.md`: generator comment

### Not touched (intentional)
- `.serena/memories/*` retain historical PowerShell generator mentions as dated evidence of past PRs; they are not live build instructions.

## Test Plan
- `grep -rn 'Generate-Agents' docs/` → 0 hits after change
- `markdownlint-cli2` on changed files → 0 errors
- No plugin source_dir touched → `validate_plugin_version_bump.py` OK (no bump)

## Related
- #2863 (merged) resolved the core contradiction
- #2871 fixes `CONTRIBUTING.md`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
