### PR TITLE
feat(validation): argument-hint frontmatter safety validator (#2870)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.5.271",
+  "version": "0.5.272",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/commands/forgetful/memory-list.md
+++ b/.claude/commands/forgetful/memory-list.md
@@ -1,6 +1,6 @@
 ---
 description: "DEPRECATED: Use Serena list_memories instead. Lists recent memories from Forgetful with optional project filtering."
-argument-hint: [project-name]
+argument-hint: '[project-name]'
 allowed-tools:
   - mcp__forgetful__*
 ---

--- a/.claude/commands/forgetful/memory-save.md
+++ b/.claude/commands/forgetful/memory-save.md
@@ -1,6 +1,6 @@
 ---
 description: "DEPRECATED: Use Serena write_memory instead. Save current context as atomic memory in Forgetful."
-argument-hint: [optional guidance for what to save]
+argument-hint: '[optional guidance for what to save]'
 allowed-tools:
   - mcp__forgetful__*
 ---

--- a/.claude/commands/pr-quality/all.md
+++ b/.claude/commands/pr-quality/all.md
@@ -1,6 +1,6 @@
 ---
 description: Use when running all 6 PR quality gate agents locally before pushing. Provides comprehensive pre-push validation across security, QA, analysis, architecture, DevOps, and roadmap.
-argument-hint: [BASE_BRANCH]
+argument-hint: '[BASE_BRANCH]'
 allowed-tools:
   - Bash(git:*)
   - Skill

--- a/.claude/commands/pr-quality/analyst.md
+++ b/.claude/commands/pr-quality/analyst.md
@@ -1,6 +1,6 @@
 ---
 description: Use when performing local analyst review before pushing PR changes. Assesses code quality, impact analysis, and maintainability.
-argument-hint: [BASE_BRANCH]
+argument-hint: '[BASE_BRANCH]'
 allowed-tools:
   - Bash(git:*)
   - Read

--- a/.claude/commands/pr-quality/architect.md
+++ b/.claude/commands/pr-quality/architect.md
@@ -1,6 +1,6 @@
 ---
 description: Use when performing local architecture review before pushing PR changes. Reviews design patterns, system boundaries, coupling/cohesion, and ADR compliance.
-argument-hint: [BASE_BRANCH]
+argument-hint: '[BASE_BRANCH]'
 allowed-tools:
   - Bash(git:*)
   - Read

--- a/.claude/commands/pr-quality/devops.md
+++ b/.claude/commands/pr-quality/devops.md
@@ -1,6 +1,6 @@
 ---
 description: Use when performing local DevOps review before pushing PR changes. Evaluates CI/CD, build pipelines, and infrastructure changes.
-argument-hint: [BASE_BRANCH]
+argument-hint: '[BASE_BRANCH]'
 allowed-tools:
   - Bash(git:*)
   - Read

--- a/.claude/commands/pr-quality/qa.md
+++ b/.claude/commands/pr-quality/qa.md
@@ -1,6 +1,6 @@
 ---
 description: Use when performing local QA review before pushing PR changes. Evaluates test coverage, error handling, and code quality.
-argument-hint: [BASE_BRANCH]
+argument-hint: '[BASE_BRANCH]'
 allowed-tools:
   - Bash(git:*)
   - Read

--- a/.claude/commands/pr-quality/roadmap.md
+++ b/.claude/commands/pr-quality/roadmap.md
@@ -1,6 +1,6 @@
 ---
 description: Use when performing local roadmap review before pushing PR changes. Assesses strategic alignment, feature scope, and user value.
-argument-hint: [BASE_BRANCH]
+argument-hint: '[BASE_BRANCH]'
 allowed-tools:
   - Bash(git:*)
   - Read

--- a/.claude/commands/pr-quality/security.md
+++ b/.claude/commands/pr-quality/security.md
@@ -1,6 +1,6 @@
 ---
 description: Use when performing local security review before pushing PR changes. Scans for vulnerabilities, secrets exposure, and security anti-patterns per OWASP Top 10.
-argument-hint: [BASE_BRANCH]
+argument-hint: '[BASE_BRANCH]'
 allowed-tools:
   - Bash(git:*)
   - Read

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(python3:*), Task, Skill, Read, Write, Edit, Glob, Grep
-argument-hint: '<PR_NUMBERS> [--parallel] [--cleanup] [--dry-run]'
+argument-hint: '<PR_NUMBERS> [--parallel --cleanup --dry-run]'
 description: Use when responding to PR review comments for specified pull request(s)
 ---
 

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(python3:*), Task, Skill, Read, Write, Edit, Glob, Grep
-argument-hint: <PR_NUMBERS> [--parallel] [--cleanup] [--dry-run]
+argument-hint: '<PR_NUMBERS> [--parallel] [--cleanup] [--dry-run]'
 description: Use when responding to PR review comments for specified pull request(s)
 ---
 

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -1,5 +1,5 @@
 ---
-argument-hint: '<PR_NUMBERS> [--parallel] [--cleanup] [--dry-run]'
+argument-hint: '<PR_NUMBERS> [--parallel --cleanup --dry-run]'
 description: Use when responding to PR review comments for specified pull request(s)
 tools:
   - vscode

--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -1,5 +1,5 @@
 ---
-argument-hint: <PR_NUMBERS> [--parallel] [--cleanup] [--dry-run]
+argument-hint: '<PR_NUMBERS> [--parallel] [--cleanup] [--dry-run]'
 description: Use when responding to PR review comments for specified pull request(s)
 tools:
   - vscode

--- a/.github/workflows/validate-generated-agents.yml
+++ b/.github/workflows/validate-generated-agents.yml
@@ -64,6 +64,7 @@ jobs:
               - '.claude/rules/**'
               - '.github/agents/**'
               - '.github/instructions/**'
+              - '.github/prompts/**'
               - '.github/workflows/validate-generated-agents.yml'
 
       - name: Determine if validation should run
@@ -191,6 +192,7 @@ jobs:
           echo "Validating Copilot agent frontmatter..."
           python3 -m pip install 'PyYAML==6.0.3'
           python3 scripts/validation/validate_copilot_agent_frontmatter.py
+          python3 scripts/validation/validate_argument_hint.py
 
       - name: Show diff on failure
         if: failure() && steps.should-run.outputs.skip != 'true'

--- a/.github/workflows/validate-generated-agents.yml
+++ b/.github/workflows/validate-generated-agents.yml
@@ -57,6 +57,7 @@ jobs:
               - 'build/generate_agents.py'
               - 'build/generate_agent_catalog.py'
               - 'build/scripts/**'
+              - 'scripts/validation/**'
               - '.claude/agents/**'
               - '.claude/skills/**'
               - '.claude/hooks/**'

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -115,6 +115,7 @@ from validate_design_review import (  # noqa: E402, F401
 from validate_no_orphaned_build_deferrals import (  # noqa: E402, F401
     validate_no_orphaned_build_deferrals,
 )
+from validate_argument_hint import validate_argument_hint  # noqa: E402, F401
 from validate_python_syntax import validate_python_syntax  # noqa: E402, F401
 from yaml_utils import _parse_yaml_frontmatter  # noqa: E402, F401
 
@@ -480,6 +481,15 @@ def main(argv: list[str] | None = None) -> int:
         "Copilot Agent Frontmatter",
         state,
         lambda: validate_copilot_agent_frontmatter(repo_root),
+    )
+
+    # 6c4. Argument-hint frontmatter must be a bracket-safe string scalar: adjacent
+    # optional groups (e.g. ``[a] [b]``) make Copilot CLI parse separate flow nodes.
+    # Mirrors the CI gate in validate-generated-agents.yml for local fast feedback.
+    run_validation(
+        "Argument-Hint Frontmatter",
+        state,
+        lambda: validate_argument_hint(repo_root),
     )
 
     # 6d. Git Hooks Installed (local clone must run the canonical .githooks;

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -485,7 +485,10 @@ def main(argv: list[str] | None = None) -> int:
 
     # 6c4. Argument-hint frontmatter must be a bracket-safe string scalar: adjacent
     # optional groups (e.g. ``[a] [b]``) make Copilot CLI parse separate flow nodes.
-    # Mirrors the CI gate in validate-generated-agents.yml for local fast feedback.
+    # Canonical CI source: .github/workflows/validate-generated-agents.yml, step
+    # "Validate Copilot agent frontmatter (issues #2491-#2497, #2500)", which runs
+    # verbatim: ``python3 scripts/validation/validate_argument_hint.py``. This local
+    # check calls validate_argument_hint() over the same default scan surface.
     run_validation(
         "Argument-Hint Frontmatter",
         state,

--- a/scripts/validation/validate_argument_hint.py
+++ b/scripts/validation/validate_argument_hint.py
@@ -227,7 +227,15 @@ def _default_scan_paths(repo_root: Path) -> list[Path]:
 def _resolve_target(repo_root: Path, target: str) -> list[Path]:
     candidate = Path(target)
     if any(char in target for char in _GLOB_CHARS):
-        return sorted(repo_root.glob(target))
+        repo_resolved = repo_root.resolve()
+        # Reject glob matches that escape the repo root (CWE-22). A pattern with
+        # ``..`` segments (e.g. ``../**/*.md``) traverses above repo_root just
+        # like a literal path, so the containment guard must cover this branch too.
+        return sorted(
+            match
+            for match in repo_root.glob(target)
+            if match.resolve().is_relative_to(repo_resolved)
+        )
 
     path = (candidate if candidate.is_absolute() else repo_root / candidate).expanduser().resolve()
     if not path.is_relative_to(repo_root.resolve()):
@@ -259,7 +267,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "targets",
         nargs="*",
-        help="Optional file, directory, or glob target(s). Defaults to command and skill markdown.",
+        help=(
+            "Optional file, directory, or glob target(s). Defaults to the scan "
+            "surface in _matches_default_scan: .claude/commands/**, "
+            ".github/prompts/**, any SKILL.md, and src/copilot-cli/** markdown."
+        ),
     )
     parser.add_argument(
         "--repo-root",
@@ -284,11 +296,20 @@ def _print_violation_report(
 
 
 def validate_argument_hint(repo_root: Path) -> bool:
-    """Scan default command/skill markdown; return True when all hints are safe.
+    """Scan the default command/skill markdown; True when all hints are safe.
 
-    Convenience wrapper for the local shift-left runner (``pre_pr.py``) so the
-    ``argument-hint`` gate matches the CI check in
-    ``validate-generated-agents.yml`` and gives contributors fast feedback.
+    Convenience wrapper for the local shift-left runner (``pre_pr.py``).
+
+    Canonical CI source: ``.github/workflows/validate-generated-agents.yml``,
+    step "Validate Copilot agent frontmatter (issues #2491-#2497, #2500)", which
+    runs verbatim::
+
+        python3 scripts/validation/validate_argument_hint.py
+
+    Different than canonical: that CI invocation runs ``main([])`` and returns a
+    process exit code (0/1). This wrapper scans the identical default surface
+    (``_default_scan_paths``) via the shared ``find_argument_hint_violations``
+    and returns a bool for ``run_validation``; detection logic is not duplicated.
     """
 
     paths = _default_scan_paths(repo_root)

--- a/scripts/validation/validate_argument_hint.py
+++ b/scripts/validation/validate_argument_hint.py
@@ -16,6 +16,7 @@ Exit codes follow ADR-035:
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -34,6 +35,7 @@ _DEFAULT_PATTERNS = (
 )
 _MARKDOWN_SUFFIXES = (".md", ".mdx")
 _GLOB_CHARS = "*?["
+_ADJACENT_BRACKET_GROUPS = re.compile(r"\]\s+\[")
 
 
 @dataclass(frozen=True, slots=True)
@@ -114,6 +116,12 @@ def _has_unbalanced_square_brackets(value: str) -> bool:
     return depth != 0
 
 
+def _collapse_adjacent_bracket_groups(value: str) -> str:
+    """Collapse adjacent optional groups into one bracket group."""
+
+    return _ADJACENT_BRACKET_GROUPS.sub(" ", value)
+
+
 def _argument_hint_error(raw_value: str) -> tuple[str, str] | None:
     """Return ``(reason, intended_value)`` for an unsafe hint."""
 
@@ -135,11 +143,11 @@ def _argument_hint_error(raw_value: str) -> tuple[str, str] | None:
     if _has_unbalanced_square_brackets(parsed):
         return ("argument-hint contains unbalanced square brackets", parsed)
 
-    if not _is_quoted_scalar(stripped) and "] [" in parsed:
+    if _ADJACENT_BRACKET_GROUPS.search(parsed):
         return (
-            "unquoted argument-hint contains adjacent bracket groups that "
-            "Copilot CLI can parse as flow nodes",
-            parsed,
+            "argument-hint contains adjacent bracket groups that Copilot CLI parses "
+            "as separate flow nodes; combine them into a single bracket group",
+            _collapse_adjacent_bracket_groups(parsed),
         )
 
     return None

--- a/scripts/validation/validate_argument_hint.py
+++ b/scripts/validation/validate_argument_hint.py
@@ -72,11 +72,6 @@ def _raw_frontmatter_lines(text: str) -> list[str] | None:
     return None
 
 
-def _is_quoted_scalar(raw_value: str) -> bool:
-    stripped = raw_value.strip()
-    return len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}
-
-
 def _strip_inline_comment(raw_value: str) -> str:
     """Return ``raw_value`` without a trailing YAML comment."""
 
@@ -165,7 +160,11 @@ def find_argument_hint_violations(paths: list[Path]) -> list[ArgumentHintViolati
         if frontmatter_lines is None:
             continue
         for offset, line in enumerate(frontmatter_lines, start=2):
-            if not line.startswith("argument-hint:"):
+            # Fast-path anchors on a column-0 ``argument-hint`` key. Match without
+            # the colon so ``argument-hint : [x]`` (YAML permits whitespace before
+            # the colon) is not silently skipped; the partition check below still
+            # enforces the exact top-level key name.
+            if not line.startswith("argument-hint"):
                 continue
             prefix, separator, raw_value = line.partition(":")
             if separator != ":" or prefix.strip() != "argument-hint":
@@ -270,6 +269,34 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _print_violation_report(
+    paths: list[Path], violations: list[ArgumentHintViolation]
+) -> None:
+    """Print the shared PASS/FAIL report for a scan result."""
+
+    if violations:
+        print(f"[FAIL] {len(violations)} unsafe argument-hint value(s) found:")
+        for violation in violations:
+            print(f"  - {violation.path}:{violation.line}:{violation.column}: {violation.reason}")
+            print(f"    Fix: {violation.suggestion}")
+        return
+    print(f"[PASS] All argument-hint values are safe strings in {len(paths)} scanned file(s).")
+
+
+def validate_argument_hint(repo_root: Path) -> bool:
+    """Scan default command/skill markdown; return True when all hints are safe.
+
+    Convenience wrapper for the local shift-left runner (``pre_pr.py``) so the
+    ``argument-hint`` gate matches the CI check in
+    ``validate-generated-agents.yml`` and gives contributors fast feedback.
+    """
+
+    paths = _default_scan_paths(repo_root)
+    violations = find_argument_hint_violations(paths)
+    _print_violation_report(paths, violations)
+    return not violations
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     repo_root = Path(args.repo_root).resolve()
@@ -284,15 +311,8 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     violations = find_argument_hint_violations(paths)
-    if violations:
-        print(f"[FAIL] {len(violations)} unsafe argument-hint value(s) found:")
-        for violation in violations:
-            print(f"  - {violation.path}:{violation.line}:{violation.column}: {violation.reason}")
-            print(f"    Fix: {violation.suggestion}")
-        return 1
-
-    print(f"[PASS] All argument-hint values are safe strings in {len(paths)} scanned file(s).")
-    return 0
+    _print_violation_report(paths, violations)
+    return 1 if violations else 0
 
 
 if __name__ == "__main__":

--- a/scripts/validation/validate_argument_hint.py
+++ b/scripts/validation/validate_argument_hint.py
@@ -7,7 +7,8 @@ the loader can interpret adjacent ``[...]`` groups as flow nodes and fail at
 load time. PyYAML also parses an unquoted ``[VALUE]`` hint as a sequence, not a
 string. This gate blocks both shapes before they ship.
 
-Exit codes follow ADR-035:
+Exit codes follow ADR-035
+(`.agents/architecture/ADR-035-exit-code-standardization.md`):
     0 - All scanned argument-hint values are safe strings
     1 - One or more argument-hint values are unsafe
     2 - Config error
@@ -197,12 +198,17 @@ def _matches_default_scan(path: Path) -> bool:
 
 
 def _git_tracked_files(repo_root: Path) -> list[Path] | None:
-    result = subprocess.run(
-        ["git", "-C", str(repo_root), "ls-files"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-files"],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    except FileNotFoundError:
+        # git is not installed or not on PATH; fall back to glob scanning.
+        return None
     if result.returncode != 0:
         return None
     return [repo_root / line for line in result.stdout.splitlines() if line]
@@ -224,7 +230,10 @@ def _resolve_target(repo_root: Path, target: str) -> list[Path]:
     if any(char in target for char in _GLOB_CHARS):
         return sorted(repo_root.glob(target))
 
-    path = candidate if candidate.is_absolute() else repo_root / candidate
+    path = (candidate if candidate.is_absolute() else repo_root / candidate).expanduser().resolve()
+    if not path.is_relative_to(repo_root.resolve()):
+        # Reject paths outside the repository root (CWE-22 path traversal).
+        return []
     if path.is_dir():
         return sorted(p for p in path.rglob("*") if p.suffix in _MARKDOWN_SUFFIXES)
     if path.exists():

--- a/scripts/validation/validate_argument_hint.py
+++ b/scripts/validation/validate_argument_hint.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Validate ``argument-hint`` YAML frontmatter values.
+
+Copilot CLI's command loader is stricter than PyYAML for bracket-bearing
+``argument-hint`` values. PyYAML accepts some unquoted hints as strings, while
+the loader can interpret adjacent ``[...]`` groups as flow nodes and fail at
+load time. PyYAML also parses an unquoted ``[VALUE]`` hint as a sequence, not a
+string. This gate blocks both shapes before they ship.
+
+Exit codes follow ADR-035:
+    0 - All scanned argument-hint values are safe strings
+    1 - One or more argument-hint values are unsafe
+    2 - Config error
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPT_DIR.parents[1]
+
+_DEFAULT_PATTERNS = (
+    ".claude/commands/**/*.md",
+    ".github/prompts/**/*.md",
+    "**/SKILL.md",
+    "src/copilot-cli/**/*.md",
+)
+_MARKDOWN_SUFFIXES = (".md", ".mdx")
+_GLOB_CHARS = "*?["
+
+
+@dataclass(frozen=True, slots=True)
+class ArgumentHintViolation:
+    """A single unsafe ``argument-hint`` value."""
+
+    path: Path
+    line: int
+    column: int
+    value: str
+    reason: str
+
+    @property
+    def suggestion(self) -> str:
+        return f"argument-hint: '{_single_quote_text(self.value)}'"
+
+
+def _single_quote_text(value: str) -> str:
+    """Return text safe for a YAML single-quoted scalar."""
+
+    return value.replace("'", "''")
+
+
+def _raw_frontmatter_lines(text: str) -> list[str] | None:
+    """Return frontmatter lines without fences, or None when absent."""
+
+    lines = text.splitlines()
+    if not lines or lines[0] != "---":
+        return None
+    for index in range(1, len(lines)):
+        if lines[index] == "---":
+            return lines[1:index]
+    return None
+
+
+def _is_quoted_scalar(raw_value: str) -> bool:
+    stripped = raw_value.strip()
+    return len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}
+
+
+def _strip_inline_comment(raw_value: str) -> str:
+    """Return ``raw_value`` without a trailing YAML comment."""
+
+    quote: str | None = None
+    first_scalar_index = len(raw_value) - len(raw_value.lstrip())
+    index = 0
+    while index < len(raw_value):
+        char = raw_value[index]
+        if quote is None:
+            if index == first_scalar_index and char in {"'", '"'}:
+                quote = char
+            elif char == "#" and (index == 0 or raw_value[index - 1].isspace()):
+                return raw_value[:index].strip()
+        elif char == quote:
+            if quote == "'" and index + 1 < len(raw_value) and raw_value[index + 1] == "'":
+                index += 1
+            else:
+                quote = None
+        index += 1
+    return raw_value.strip()
+
+
+def _parsed_argument_hint(raw_value: str) -> object:
+    """Parse one ``argument-hint`` value as YAML."""
+
+    return yaml.safe_load(f"argument-hint: {raw_value}").get("argument-hint")
+
+
+def _has_unbalanced_square_brackets(value: str) -> bool:
+    depth = 0
+    for char in value:
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+            if depth < 0:
+                return True
+    return depth != 0
+
+
+def _argument_hint_error(raw_value: str) -> tuple[str, str] | None:
+    """Return ``(reason, intended_value)`` for an unsafe hint."""
+
+    stripped = _strip_inline_comment(raw_value)
+    try:
+        parsed = _parsed_argument_hint(stripped)
+    except yaml.YAMLError as exc:
+        return (
+            f"invalid YAML argument-hint scalar: {str(exc).replace(chr(10), ' ').strip()}",
+            stripped,
+        )
+
+    if not isinstance(parsed, str):
+        return (
+            f"argument-hint must be a string scalar, but YAML parsed {type(parsed).__name__}",
+            stripped,
+        )
+
+    if _has_unbalanced_square_brackets(parsed):
+        return ("argument-hint contains unbalanced square brackets", parsed)
+
+    if not _is_quoted_scalar(stripped) and "] [" in parsed:
+        return (
+            "unquoted argument-hint contains adjacent bracket groups that "
+            "Copilot CLI can parse as flow nodes",
+            parsed,
+        )
+
+    return None
+
+
+def find_argument_hint_violations(paths: list[Path]) -> list[ArgumentHintViolation]:
+    """Return every unsafe ``argument-hint`` in the supplied markdown files."""
+
+    violations: list[ArgumentHintViolation] = []
+    for path in sorted(set(paths)):
+        if not path.is_file():
+            continue
+        frontmatter_lines = _raw_frontmatter_lines(path.read_text(encoding="utf-8"))
+        if frontmatter_lines is None:
+            continue
+        for offset, line in enumerate(frontmatter_lines, start=2):
+            if not line.startswith("argument-hint:"):
+                continue
+            prefix, separator, raw_value = line.partition(":")
+            if separator != ":" or prefix.strip() != "argument-hint":
+                continue
+            error = _argument_hint_error(raw_value)
+            if error is None:
+                continue
+            reason, intended_value = error
+            value_column = line.index(raw_value) + len(raw_value) - len(raw_value.lstrip()) + 1
+            violations.append(
+                ArgumentHintViolation(
+                    path=path,
+                    line=offset,
+                    column=value_column,
+                    value=intended_value,
+                    reason=reason,
+                )
+            )
+    return violations
+
+
+def _matches_default_scan(path: Path) -> bool:
+    normalized = path.as_posix()
+    return (
+        (normalized.startswith(".claude/commands/") and path.suffix in _MARKDOWN_SUFFIXES)
+        or (normalized.startswith(".github/prompts/") and path.suffix in _MARKDOWN_SUFFIXES)
+        or path.name == "SKILL.md"
+        or (normalized.startswith("src/copilot-cli/") and path.suffix in _MARKDOWN_SUFFIXES)
+    )
+
+
+def _git_tracked_files(repo_root: Path) -> list[Path] | None:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return [repo_root / line for line in result.stdout.splitlines() if line]
+
+
+def _default_scan_paths(repo_root: Path) -> list[Path]:
+    tracked = _git_tracked_files(repo_root)
+    if tracked is not None:
+        return [path for path in tracked if _matches_default_scan(path.relative_to(repo_root))]
+
+    paths: set[Path] = set()
+    for pattern in _DEFAULT_PATTERNS:
+        paths.update(repo_root.glob(pattern))
+    return sorted(paths)
+
+
+def _resolve_target(repo_root: Path, target: str) -> list[Path]:
+    candidate = Path(target)
+    if any(char in target for char in _GLOB_CHARS):
+        return sorted(repo_root.glob(target))
+
+    path = candidate if candidate.is_absolute() else repo_root / candidate
+    if path.is_dir():
+        return sorted(p for p in path.rglob("*") if p.suffix in _MARKDOWN_SUFFIXES)
+    if path.exists():
+        return [path]
+    raise FileNotFoundError(target)
+
+
+def collect_scan_paths(repo_root: Path, targets: list[str]) -> list[Path]:
+    """Collect markdown files to scan."""
+
+    if not targets:
+        return _default_scan_paths(repo_root)
+
+    paths: set[Path] = set()
+    for target in targets:
+        paths.update(_resolve_target(repo_root, target))
+    return sorted(path for path in paths if path.suffix in _MARKDOWN_SUFFIXES)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate bracket-safe YAML argument-hint frontmatter values.",
+    )
+    parser.add_argument(
+        "targets",
+        nargs="*",
+        help="Optional file, directory, or glob target(s). Defaults to command and skill markdown.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(_REPO_ROOT),
+        help="Repository root for resolving relative targets.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = Path(args.repo_root).resolve()
+    if not repo_root.is_dir():
+        print(f"[FAIL] repository root not found: {repo_root}", file=sys.stderr)
+        return 2
+
+    try:
+        paths = collect_scan_paths(repo_root, args.targets)
+    except FileNotFoundError as exc:
+        print(f"[FAIL] target not found: {exc}", file=sys.stderr)
+        return 2
+
+    violations = find_argument_hint_violations(paths)
+    if violations:
+        print(f"[FAIL] {len(violations)} unsafe argument-hint value(s) found:")
+        for violation in violations:
+            print(f"  - {violation.path}:{violation.line}:{violation.column}: {violation.reason}")
+            print(f"    Fix: {violation.suggestion}")
+        return 1
+
+    print(f"[PASS] All argument-hint values are safe strings in {len(paths)} scanned file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.5.271",
+  "version": "0.5.272",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-review
 description: Use when responding to PR review comments for specified pull request(s)
-argument-hint: '<PR_NUMBERS> [--parallel] [--cleanup] [--dry-run]'
+argument-hint: <PR_NUMBERS> [--parallel --cleanup --dry-run]
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(python3:*), Task, Skill, Read, Write, Edit, Glob, Grep
 user-invocable: true
 ---

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-review
 description: Use when responding to PR review comments for specified pull request(s)
-argument-hint: <PR_NUMBERS> [--parallel] [--cleanup] [--dry-run]
+argument-hint: '<PR_NUMBERS> [--parallel] [--cleanup] [--dry-run]'
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(python3:*), Task, Skill, Read, Write, Edit, Glob, Grep
 user-invocable: true
 ---

--- a/tests/validation/test_validate_argument_hint.py
+++ b/tests/validation/test_validate_argument_hint.py
@@ -138,3 +138,31 @@ def test_real_repo_argument_hints_pass(capsys) -> None:
 
     assert result == 0
     assert "[PASS]" in capsys.readouterr().out
+
+
+def test_resolve_target_rejects_paths_outside_repo_root(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    outside = tmp_path / "outside" / "evil.md"
+    _write(outside, "argument-hint: '[a] [b]'\n")
+
+    # An absolute path outside the repo root must resolve to nothing
+    # (CWE-22 path-traversal guard) rather than reading arbitrary files.
+    assert v.collect_scan_paths(repo_root, [str(outside)]) == []
+
+
+def test_git_tracked_files_falls_back_when_git_missing(tmp_path: Path, monkeypatch) -> None:
+    def _raise(*_args, **_kwargs):
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(v.subprocess, "run", _raise)
+
+    command = tmp_path / ".claude" / "commands" / "bad.md"
+    _write(command, "argument-hint: '[a] [b]'\n")
+
+    # git absent -> glob fallback still finds and flags the offender.
+    paths = v.collect_scan_paths(tmp_path, [])
+    violations = v.find_argument_hint_violations(paths)
+
+    assert command in paths
+    assert len(violations) == 1

--- a/tests/validation/test_validate_argument_hint.py
+++ b/tests/validation/test_validate_argument_hint.py
@@ -166,3 +166,30 @@ def test_git_tracked_files_falls_back_when_git_missing(tmp_path: Path, monkeypat
 
     assert command in paths
     assert len(violations) == 1
+
+
+def test_whitespace_before_colon_is_not_bypassed(tmp_path: Path) -> None:
+    command = tmp_path / ".claude" / "commands" / "spaced.md"
+    # YAML permits whitespace before the colon; the key is still ``argument-hint``.
+    _write(command, "argument-hint : '[a] [b]'\n")
+
+    violations = v.find_argument_hint_violations([command])
+
+    assert len(violations) == 1
+    assert "adjacent bracket groups" in violations[0].reason
+
+
+def test_validate_argument_hint_wrapper_passes_on_clean_repo(tmp_path: Path, capsys) -> None:
+    command = tmp_path / ".claude" / "commands" / "good.md"
+    _write(command, "argument-hint: '[BASE_BRANCH]'\n")
+
+    assert v.validate_argument_hint(tmp_path) is True
+    assert "[PASS]" in capsys.readouterr().out
+
+
+def test_validate_argument_hint_wrapper_fails_on_violation(tmp_path: Path, capsys) -> None:
+    command = tmp_path / ".claude" / "commands" / "bad.md"
+    _write(command, "argument-hint: '[a] [b]'\n")
+
+    assert v.validate_argument_hint(tmp_path) is False
+    assert "[FAIL]" in capsys.readouterr().out

--- a/tests/validation/test_validate_argument_hint.py
+++ b/tests/validation/test_validate_argument_hint.py
@@ -151,6 +151,17 @@ def test_resolve_target_rejects_paths_outside_repo_root(tmp_path: Path) -> None:
     assert v.collect_scan_paths(repo_root, [str(outside)]) == []
 
 
+def test_resolve_target_glob_rejects_traversal_outside_repo_root(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    outside = tmp_path / "outside" / "evil.md"
+    _write(outside, "argument-hint: '[a] [b]'\n")
+
+    # A glob pattern with ``..`` must not escape the repo root either
+    # (CWE-22 guard covers the glob branch, not only literal paths).
+    assert v.collect_scan_paths(repo_root, ["../**/*.md"]) == []
+
+
 def test_git_tracked_files_falls_back_when_git_missing(tmp_path: Path, monkeypatch) -> None:
     def _raise(*_args, **_kwargs):
         raise FileNotFoundError("git")

--- a/tests/validation/test_validate_argument_hint.py
+++ b/tests/validation/test_validate_argument_hint.py
@@ -43,7 +43,38 @@ def test_unquoted_adjacent_bracket_groups_fail(tmp_path: Path) -> None:
     assert "adjacent bracket groups" in violations[0].reason
     assert (
         violations[0].suggestion
-        == "argument-hint: '<PR_NUMBERS> [--parallel] [--cleanup]'"
+        == "argument-hint: '<PR_NUMBERS> [--parallel --cleanup]'"
+    )
+
+
+def test_quoted_adjacent_bracket_groups_fail(tmp_path: Path) -> None:
+    command = tmp_path / ".claude" / "commands" / "bad.md"
+    _write(command, "argument-hint: '[a] [b]'\n")
+
+    violations = v.find_argument_hint_violations([command])
+
+    assert len(violations) == 1
+    assert "adjacent bracket groups" in violations[0].reason
+    assert violations[0].suggestion == "argument-hint: '[a b]'"
+
+
+def test_quoted_single_bracket_group_passes(tmp_path: Path) -> None:
+    command = tmp_path / ".claude" / "commands" / "good.md"
+    _write(command, "argument-hint: '[BASE_BRANCH]'\n")
+
+    assert v.find_argument_hint_violations([command]) == []
+
+
+def test_quoted_pr_review_triple_group_suggests_single_group(tmp_path: Path) -> None:
+    command = tmp_path / ".claude" / "commands" / "bad.md"
+    _write(command, "argument-hint: '<PR_NUMBERS> [--parallel] [--cleanup] [--dry-run]'\n")
+
+    violations = v.find_argument_hint_violations([command])
+
+    assert len(violations) == 1
+    assert (
+        violations[0].suggestion
+        == "argument-hint: '<PR_NUMBERS> [--parallel --cleanup --dry-run]'"
     )
 
 

--- a/tests/validation/test_validate_argument_hint.py
+++ b/tests/validation/test_validate_argument_hint.py
@@ -1,0 +1,109 @@
+"""Tests for scripts.validation.validate_argument_hint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.validation import validate_argument_hint as v
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write(path: Path, frontmatter: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\n{frontmatter}---\n\nBody.\n", encoding="utf-8")
+
+
+def test_good_quoted_scalar_passes(tmp_path: Path) -> None:
+    command = tmp_path / ".claude" / "commands" / "good.md"
+    _write(command, "argument-hint: '[BASE_BRANCH]'\n")
+
+    assert v.find_argument_hint_violations([command]) == []
+
+
+def test_unquoted_flow_sequence_fails(tmp_path: Path) -> None:
+    command = tmp_path / ".claude" / "commands" / "bad.md"
+    _write(command, "argument-hint: [BASE_BRANCH]\n")
+
+    violations = v.find_argument_hint_violations([command])
+
+    assert len(violations) == 1
+    assert violations[0].line == 2
+    assert "YAML parsed list" in violations[0].reason
+    assert violations[0].suggestion == "argument-hint: '[BASE_BRANCH]'"
+
+
+def test_unquoted_adjacent_bracket_groups_fail(tmp_path: Path) -> None:
+    command = tmp_path / ".claude" / "commands" / "bad.md"
+    _write(command, "argument-hint: <PR_NUMBERS> [--parallel] [--cleanup]\n")
+
+    violations = v.find_argument_hint_violations([command])
+
+    assert len(violations) == 1
+    assert "adjacent bracket groups" in violations[0].reason
+    assert (
+        violations[0].suggestion
+        == "argument-hint: '<PR_NUMBERS> [--parallel] [--cleanup]'"
+    )
+
+
+def test_default_scan_includes_github_prompts(tmp_path: Path) -> None:
+    prompt = tmp_path / ".github" / "prompts" / "pr-review.prompt.md"
+    _write(prompt, "argument-hint: <PR_NUMBERS> [--parallel] [--cleanup]\n")
+
+    paths = v.collect_scan_paths(tmp_path, [])
+    violations = v.find_argument_hint_violations(paths)
+
+    assert prompt in paths
+    assert len(violations) == 1
+    assert violations[0].path == prompt
+
+
+def test_unbalanced_brackets_fail_even_when_quoted(tmp_path: Path) -> None:
+    command = tmp_path / ".claude" / "commands" / "bad.md"
+    _write(command, "argument-hint: '<PR_NUMBERS> [--parallel'\n")
+
+    violations = v.find_argument_hint_violations([command])
+
+    assert len(violations) == 1
+    assert "unbalanced square brackets" in violations[0].reason
+
+
+def test_indented_block_scalar_argument_hint_text_is_ignored(tmp_path: Path) -> None:
+    command = tmp_path / ".claude" / "commands" / "description.md"
+    _write(command, "description: |\n  argument-hint: [BASE_BRANCH]\n")
+
+    assert v.find_argument_hint_violations([command]) == []
+
+
+def test_quoted_scalar_with_trailing_comment_passes(tmp_path: Path) -> None:
+    command = tmp_path / ".claude" / "commands" / "safe.md"
+    _write(command, "argument-hint: '<PR_NUMBERS> [--parallel]' # safe comment\n")
+
+    assert v.find_argument_hint_violations([command]) == []
+
+
+def test_unquoted_flow_sequence_with_trailing_comment_suggests_value_only(
+    tmp_path: Path,
+) -> None:
+    command = tmp_path / ".claude" / "commands" / "bad.md"
+    _write(command, "argument-hint: [BASE_BRANCH] # optional\n")
+
+    violations = v.find_argument_hint_violations([command])
+
+    assert len(violations) == 1
+    assert violations[0].suggestion == "argument-hint: '[BASE_BRANCH]'"
+
+
+def test_missing_argument_hint_is_fine(tmp_path: Path) -> None:
+    command = tmp_path / ".claude" / "commands" / "no-hint.md"
+    _write(command, "description: No hint here.\n")
+
+    assert v.find_argument_hint_violations([command]) == []
+
+
+def test_real_repo_argument_hints_pass(capsys) -> None:
+    result = v.main(["--repo-root", str(REPO_ROOT)])
+
+    assert result == 0
+    assert "[PASS]" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Adds `scripts/validation/validate_argument_hint.py` enforcing that `argument-hint` frontmatter values are quoted string scalars, not YAML lists. Unquoted `[BRACKET]` groups parse as YAML lists and corrupt agent argument parsing.

- Normalizes 11 existing offenders (single-quote wrap)
- Wires the check into `.github/workflows/validate-generated-agents.yml`
- Extends coverage to `.github/prompts/**`

## Adversarial review (GPT-5.5)

Round 1, hardened per 3 real findings:
1. HIGH: closed coverage gap that missed a live unsafe hint in `.github/prompts/pr-review.prompt.md`
2. MEDIUM: reject indented block-scalar false positives (top-level key only)
3. MEDIUM: quote-aware trailing-comment handling (no false positive, clean suggestion)

Round 2, quoting-agnostic detection + subprocess/path hardening:
1. flag adjacent bracket groups regardless of quoting (`'[a] [b]'` now fails)
2. UTF-8 git decode; `FileNotFoundError` fallback when git is absent
3. CWE-22 path-traversal guard in `_resolve_target`

Round 3 (this revision):
1. removed dead `_is_quoted_scalar`
2. match `argument-hint : [x]` (whitespace before colon is valid YAML)
3. wired `validate_argument_hint` into the local `scripts/validation/pre_pr.py` shift-left runner

## Validation

- 18 pytest pass
- self-scan exits 0 on 522 files
- detection still catches unquoted values (exit 1 with collapse suggestion)
- version-bump validator: OK (`.claude` + `src/copilot-cli` -> 0.5.271)

Closes #2870
