### PR TITLE
fix(validation): resolve 4 pre-existing mypy type errors (#2880)

### DIFF
--- a/scripts/validation/check_dual_priority_labels.py
+++ b/scripts/validation/check_dual_priority_labels.py
@@ -124,7 +124,7 @@ def _fetch_labels(kind: str, number: int) -> tuple[int, list[str] | None, str]:
 
     labels_field = payload.get("labels")
     labels = labels_field if isinstance(labels_field, list) else []
-    names = [item.get("name") for item in labels if isinstance(item, dict) and item.get("name")]
+    names = [str(item["name"]) for item in labels if isinstance(item, dict) and item.get("name")]
     return EXIT_OK, names, ""
 
 

--- a/scripts/validation/memory_index.py
+++ b/scripts/validation/memory_index.py
@@ -529,9 +529,9 @@ def check_memory_index_references(
     file_refs = list({ref.strip() for ref in file_refs})
     for file_name in file_refs:
         # Parse markdown link syntax
-        link_match = _MARKDOWN_LINK_PATTERN.search(file_name)
-        if link_match:
-            link_target = link_match.group(2)
+        parsed_link = _MARKDOWN_LINK_PATTERN.search(file_name)
+        if parsed_link:
+            link_target = parsed_link.group(2)
             file_name = re.sub(r"\.md$", "", link_target)
 
         ref_path = memory_path / f"{file_name}.md"

--- a/scripts/validation/validate_agent_catalog.py
+++ b/scripts/validation/validate_agent_catalog.py
@@ -51,8 +51,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"Error: cannot import build/generate_agent_catalog.py: {exc}", file=sys.stderr)
         return 2
 
-    return generate_agent_catalog.main(
-        ["--check", "--templates-path", str(templates_dir), "--output", str(output_path)]
+    return int(
+        generate_agent_catalog.main(
+            ["--check", "--templates-path", str(templates_dir), "--output", str(output_path)]
+        )
     )
 
 

--- a/scripts/validation/validate_agent_catalog.py
+++ b/scripts/validation/validate_agent_catalog.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -51,10 +51,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"Error: cannot import build/generate_agent_catalog.py: {exc}", file=sys.stderr)
         return 2
 
-    return int(
+    return cast(
+        int,
         generate_agent_catalog.main(
             ["--check", "--templates-path", str(templates_dir), "--output", str(output_path)]
-        )
+        ),
     )
 
 

--- a/scripts/validation/validate_hook_anchoring.py
+++ b/scripts/validation/validate_hook_anchoring.py
@@ -34,7 +34,7 @@ import re
 import sys
 from pathlib import Path
 from types import ModuleType
-from typing import Any
+from typing import Any, cast
 
 # Legacy fallback: the Copilot-CLI artifact path. Superseded by platform-
 # config discovery (_find_platform_hook_artifacts) which reads this value
@@ -120,7 +120,7 @@ def _load_generator(repo_root: Path) -> ModuleType:
         sys.path.insert(0, str(scripts_dir))
     import generate_hooks  # noqa: PLC0415
 
-    return generate_hooks
+    return cast(ModuleType, generate_hooks)
 
 
 def _script_name(command: str) -> str | None:


### PR DESCRIPTION
## Summary

Resolves the 4 pre-existing mypy errors tracked in #2880. These are orthogonal to the #2876 hook change that first surfaced them under the per-file `MYPYPATH` pass. All fixes are behavior-preserving.

## Changes

- `scripts/validation/check_dual_priority_labels.py`: use `str(item["name"])` so the comprehension yields `list[str]` instead of `list[Any | None]`. The items are already filtered on a truthy `name`, so indexing is safe and `str()` is a no-op on the existing string.
- `scripts/validation/memory_index.py`: rename the inner `search()` result to `parsed_link` so it no longer shadows the `finditer()` loop variable (`Match[str]`) with a `Match[str] | None`.
- `scripts/validation/validate_agent_catalog.py`: wrap the delegated call in `int(...)` because the dynamically imported catalog generator is untyped and returns `Any`.
- `scripts/validation/validate_hook_anchoring.py`: `cast(ModuleType, generate_hooks)` for the untyped dynamic import.

## Evidence

> [!NOTE]
> Verified with `mypy` under `MYPYPATH` (the same per-file pass added for #2876): all four files report `Success: no issues found`. The four module test suites pass (115 tests). `ruff check` reports no issues. `run_plugin_version_bump_ci.py` returns OK (validation scripts are not plugin source, so no manifest bump is required).

## Out of Scope

> [!NOTE]
> The hook wiring that made these visible shipped separately in the #2876 PR. This PR only corrects the four flagged type errors.

Closes #2880

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>