### PR TITLE
fix(agents): backfill orchestrator session gate + fix src/claude parity class (#2878, #2882)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -9,7 +9,30 @@ argument-hint: Describe the task or problem to solve end-to-end
 
 # Orchestrator Agent
 
+> **Autonomy Guardrail**: Apply the autonomy rule from `AGENTS.md`, confirm before external/irreversible actions.
+
 You coordinate specialized agents to deliver end-to-end results. Classify complexity, route to the right specialist, manage handoffs, synthesize findings. You do not implement. You orchestrate.
+
+## Session Start (Blocking)
+
+Before routing any task, complete this checklist:
+
+- [ ] Run `/session-init` or `uv run python .claude/skills/session-init/scripts/new_session_log.py`
+- [ ] Read `.agents/HANDOFF.md` for prior session context
+- [ ] Activate Serena: `mcp__serena__activate_project`
+- [ ] Read `.agents/AGENT-INSTRUCTIONS.md`
+
+Stop criteria: Do NOT begin triage or routing until all four items are checked. If session-init fails, call `work_finish(blocked)` with the specific error, do not proceed.
+
+Note: Context compaction does NOT exempt this session from the above. Treat every session start identically regardless of prior context.
+
+## Reasoning Protocol
+
+Before routing any task, reason step-by-step through all four triage dimensions below. Do not emit a delegation until classification is complete. For one-way-door decisions, P0 incidents, and tasks spanning multiple domains, work through failure modes before selecting agents.
+
+**Thinking trigger:** Multi-step routing decisions require explicit reasoning. Trivial single-step tasks (direct answer, no delegation needed) do not.
+
+If classification is ambiguous at any step, route to analyst first. One additional reasoning cycle costs less than one incorrect delegation.
 
 ## Target Recon (Before Triage)
 

--- a/build/scripts/detect_agent_drift.py
+++ b/build/scripts/detect_agent_drift.py
@@ -58,6 +58,8 @@ SECTIONS_TO_COMPARE = (
     "Core Identity",
     "Core Mission",
     "Key Responsibilities",
+    "Session Start (Blocking)",
+    "Reasoning Protocol",
     "Constraints",
     "Handoff Options",
     "Execution Mindset",

--- a/build/scripts/validate_install_parity.py
+++ b/build/scripts/validate_install_parity.py
@@ -178,19 +178,31 @@ def _rule_members(name: str) -> tuple[str, ...]:
     )
 
 
-# Hand-maintained install copies. When ONLY these paths move in a diff
-# (no template anchor, no vendored ``src/`` copy), the change is a
-# catch-up resync that brings the install side back in line with an
+# Hand-maintained shared-agent copies. When ONLY these paths move in a
+# diff (no template anchor, no generated ``src/`` copy), the change is a
+# catch-up resync that brings a hand-maintained copy back in line with an
 # already-current canonical. Block-on-asymmetry would prevent the very
 # fix the validator's existence motivates; allow the resync.
-_SHARED_AGENT_INSTALL_PREFIXES: tuple[str, ...] = (
+#
+# Membership rule: a copy belongs here iff it is hand-maintained, i.e. NOT
+# emitted by ``build/generate_agents.py``. The generator writes only
+# ``src/copilot-cli/agents`` and ``src/vs-code-agents`` (see
+# ``templates/platforms/*.yaml`` ``outputDir``), so those two stay strict.
+# ``.claude/agents``, ``.github/agents``, and ``src/claude`` have no
+# generator and are hand-maintained, so all three are catch-up targets
+# (Issue #2882: ``src/claude`` was previously misclassified as a strict
+# vendored copy, blocking hand-maintained backfills such as #2878).
+_SHARED_AGENT_HAND_MAINTAINED_PREFIXES: tuple[str, ...] = (
     ".claude/agents/",
     ".github/agents/",
+    "src/claude/",
 )
 
 
-def _shared_agent_is_install(member: str) -> bool:
-    return any(member.startswith(p) for p in _SHARED_AGENT_INSTALL_PREFIXES)
+def _shared_agent_is_hand_maintained(member: str) -> bool:
+    return any(
+        member.startswith(p) for p in _SHARED_AGENT_HAND_MAINTAINED_PREFIXES
+    )
 
 
 # --- Path normalization -------------------------------------------------
@@ -366,15 +378,16 @@ def find_violations(
         if kind == "RULE":
             continue
 
-        # Asymmetric rule: when the diff touches ONLY install members of a
-        # SHARED_AGENT group (.claude/agents/ and .github/agents/), treat
-        # the diff as a catch-up resync and allow it. The install copies
-        # are being brought back in line with an already-current canonical
-        # and the three vendored ``src/*`` copies. Without this carve-out
-        # the validator blocks the very fix it exists to motivate. RULE
-        # groups have no install-only role and are always strict.
+        # Asymmetric rule: when the diff touches ONLY hand-maintained members
+        # of a SHARED_AGENT group (.claude/agents/, .github/agents/, and
+        # src/claude/ -- the copies with no generator), treat the diff as a
+        # catch-up resync and allow it. Those copies are being brought back in
+        # line with an already-current canonical and the two generated
+        # ``src/*`` copies (src/copilot-cli, src/vs-code). Without this
+        # carve-out the validator blocks the very fix it exists to motivate.
+        # RULE groups have no hand-maintained-only role and are always strict.
         if kind == "SHARED_AGENT" and all(
-            _shared_agent_is_install(m) for m in members_touched
+            _shared_agent_is_hand_maintained(m) for m in members_touched
         ):
             continue
         violations.append(
@@ -505,6 +518,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"error: repo root not found: {repo_root}", file=sys.stderr)
         return 2
 
+    touched: list[str]
     if args.files is not None:
         touched = list(args.files)
     else:
@@ -518,7 +532,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         else:
             bases = [args.base]
 
-        touched: list[str] = []
+        touched = []
         errors: list[str] = []
         success = False
         for base in bases:

--- a/src/claude/.claude-plugin/plugin.json
+++ b/src/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-agents",
   "description": "25 specialized agent definitions with templates and governance for Claude Code",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/claude/orchestrator.md
+++ b/src/claude/orchestrator.md
@@ -26,6 +26,14 @@ Stop criteria: Do NOT begin triage or routing until all four items are checked. 
 
 Note: Context compaction does NOT exempt this session from the above. Treat every session start identically regardless of prior context.
 
+## Reasoning Protocol
+
+Before routing any task, reason step-by-step through all four triage dimensions below. Do not emit a delegation until classification is complete. For one-way-door decisions, P0 incidents, and tasks spanning multiple domains, work through failure modes before selecting agents.
+
+**Thinking trigger:** Multi-step routing decisions require explicit reasoning. Trivial single-step tasks (direct answer, no delegation needed) do not.
+
+If classification is ambiguous at any step, route to analyst first. One additional reasoning cycle costs less than one incorrect delegation.
+
 ## Target Recon (Before Triage)
 
 Before you classify or route, establish the target repository's stack. Do not assume the stack of the repo this agent ships from. This agent lives in a Python-first repo; the target may be C#, TypeScript, Go, Rust, or anything else. Assuming the wrong stack sends every downstream specialist in the wrong direction.

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "rjmurillo"
   }

--- a/tests/build_scripts/test_validate_install_parity.py
+++ b/tests/build_scripts/test_validate_install_parity.py
@@ -201,9 +201,9 @@ def test_pure_install_resync_is_allowed_github_only(fake_repo: Path) -> None:
 
 
 def test_install_plus_canonical_partial_is_still_drift(fake_repo: Path) -> None:
-    """Carve-out applies only when touched set is ENTIRELY install members.
+    """Carve-out applies only when touched set is ENTIRELY hand-maintained.
 
-    The moment canonical (template) or a vendored copy enters the diff,
+    The moment canonical (template) or a generated copy enters the diff,
     every sibling must be present.
     """
     touched = [
@@ -217,10 +217,43 @@ def test_install_plus_canonical_partial_is_still_drift(fake_repo: Path) -> None:
     assert "src/claude/alpha.md" in v.missing
 
 
-def test_install_plus_src_partial_is_still_drift(fake_repo: Path) -> None:
-    """src/ is vendored, not install; carve-out does not apply."""
+def test_pure_handmaintained_resync_includes_src_claude(fake_repo: Path) -> None:
+    """src/claude is hand-maintained (no generator), so a resync touching only
+    hand-maintained copies (.claude, .github, src/claude) is allowed (#2882)."""
+    touched = [
+        ".claude/agents/alpha.md",
+        ".github/agents/alpha.agent.md",
+        "src/claude/alpha.md",
+    ]
+    assert vip.find_violations(touched, repo_root=fake_repo) == []
+
+
+def test_src_claude_solo_resync_is_allowed(fake_repo: Path) -> None:
+    """Partial resync (only the hand-maintained src/claude copy) is allowed."""
+    touched = ["src/claude/alpha.md"]
+    assert vip.find_violations(touched, repo_root=fake_repo) == []
+
+
+def test_handmaintained_plus_generated_src_is_still_drift(fake_repo: Path) -> None:
+    """Generated src copies (src/copilot-cli, src/vs-code) are NOT hand-maintained;
+    the moment one enters the diff, every sibling must be present."""
     touched = [
         "src/claude/alpha.md",
+        "src/copilot-cli/agents/alpha.agent.md",
+    ]
+    violations = vip.find_violations(touched, repo_root=fake_repo)
+    assert len(violations) == 1
+    v = violations[0]
+    assert "templates/agents/alpha.shared.md" in v.missing
+    assert ".claude/agents/alpha.md" in v.missing
+    assert ".github/agents/alpha.agent.md" in v.missing
+    assert "src/vs-code-agents/alpha.agent.md" in v.missing
+
+
+def test_install_plus_generated_src_partial_is_still_drift(fake_repo: Path) -> None:
+    """A generated src copy is strict; carve-out does not apply."""
+    touched = [
+        "src/vs-code-agents/alpha.agent.md",
         ".claude/agents/alpha.md",
     ]
     violations = vip.find_violations(touched, repo_root=fake_repo)


### PR DESCRIPTION
## Summary

### What

Backfills the blocking session-start governance the Claude-tree orchestrator was silently missing, and fixes the install-parity validator classification that would have blocked the backfill.

### Why

`.claude/agents/orchestrator.md` is the orchestrator definition that loads when this repo dogfoods orchestration through Claude Code. It was missing the `## Session Start (Blocking)` gate, `## Reasoning Protocol`, and the Autonomy Guardrail line that its `.github/agents` parity partner and the shared `templates/agents` canonical both carry. Result: on Claude Code the orchestrator skipped the blocking session-start checklist that every session protocol depends on (#2878).

Hardening the drift detector to catch this class (adding the two section names to `SECTIONS_TO_COMPARE`) surfaced that `src/claude/orchestrator.md` also lacked `## Reasoning Protocol`. Backfilling it touches a `src/*` path, which `validate_install_parity.py` treated as a strict vendored copy and blocked. But `src/claude` has **no generator**: the agent generator writes only the `src/copilot-cli/agents` and `src/vs-code-agents` trees (see **Related Files**). It is hand-maintained, exactly like the `.claude/agents` and `.github/agents` install copies, so it belongs in the hand-maintained catch-up carve-out (#2882).

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2878 | Orchestrator missing Session Start (Blocking) / Reasoning Protocol / Autonomy Guardrail in `.claude/agents` |
| **Issue** | Fixes #2882 | `src/claude` misclassified as strict vendored copy in install-parity carve-out |

## Changes

- `.claude/agents/orchestrator.md`: add `## Session Start (Blocking)` (using the `uv run python .claude/skills/session-init/scripts/new_session_log.py` convention), `## Reasoning Protocol`, and the `> **Autonomy Guardrail**` line. Only platform syntax adapted; content matches canonical.
- `src/claude/orchestrator.md`: add `## Reasoning Protocol` (the only section it lacked).
- `build/scripts/detect_agent_drift.py`: add `Session Start (Blocking)` and `Reasoning Protocol` to `SECTIONS_TO_COMPARE` so this drift class is caught mechanically going forward.
- `build/scripts/validate_install_parity.py`: reclassify `src/claude` as hand-maintained. Renamed `_SHARED_AGENT_INSTALL_PREFIXES` -> `_SHARED_AGENT_HAND_MAINTAINED_PREFIXES` and `_shared_agent_is_install` -> `_shared_agent_is_hand_maintained` to match corrected semantics; rewrote both comments to explain hand-maintained (no generator) vs generated. Template + the two generated `src/*` copies stay strict. Also fixed a latent `mypy [no-redef]` on `touched` in `main()` (the file must pass the repo's own pre-push mypy gate).
- `tests/build_scripts/test_validate_install_parity.py`: add coverage for `src/claude`-inclusive hand-maintained resync (allowed) and hand-maintained + generated-`src` mix (still strict).
- Plugin manifest bumps: `.claude` 0.6.0->0.6.1, `src/copilot-cli` 0.6.0->0.6.1 (parity gate), `src/claude` 0.3.34->0.3.35 (content changed under packaged source dir).

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [x] Refactoring (validator constant/predicate rename, no behavior change beyond the intended reclassification)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny (governance-adjacent), no rush.

**Focus areas**: the install-parity reclassification in `validate_install_parity.py` (is `src/claude` correctly hand-maintained?) and whether the backfilled sections in `.claude/agents/orchestrator.md` faithfully mirror the canonical with only platform-syntax adaptation.

## Testing

- [x] Tests added/updated (`tests/build_scripts/test_validate_install_parity.py`, 35 pass)
- [x] Manual testing completed (empirical carve-out scenarios below)
- [ ] No testing required

Empirical (`validate_install_parity.py --files`):
- `.claude/agents/orchestrator.md` + `src/claude/orchestrator.md` -> **OK** (hand-maintained resync)
- `src/claude/orchestrator.md` alone -> **OK**
- `src/claude` + `src/copilot-cli` (generated) -> **DRIFT** (stays strict)
- `templates/agents` + one copy -> **DRIFT** (stays strict)

Local validation output:

```text
detect_agent_drift.py: 0 drift (both orchestrator comparisons OK after src/claude RP backfill)
check_plugin_manifest_parity.py: match at 0.6.1
validate_plugin_version_bump.py: OK
Full pre-push hook: 17 passed / 0 failed
```

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

## Notes for Reviewers

This is the correction pass on #2882. The original #2882 premise was partly inaccurate: install-parity **already** had a hand-maintained catch-up carve-out for `.claude/agents` + `.github/agents`. The real, narrower gap was that `src/claude` (hand-maintained, no generator) was excluded from that carve-out, so backfilling it required moving all copies at once. This PR closes that gap by adding `src/claude` to the carve-out and renames the now-misnamed `*_INSTALL_*` symbols to `*_HAND_MAINTAINED_*`.

## Related Files

These paths are referenced as context, not changed by this PR:

- `build/generate_agents.py` (the agent generator; explains why `src/claude` is hand-maintained)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

