### PR TITLE
fix(hooks): skip session-log requirement on merge commits (#2883)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1240,14 +1240,28 @@ if [ -n "$STAGED_AGENTS_FILES" ]; then
         echo_error "Session Protocol validation blocked: script not found at $SESSION_VALIDATE_SCRIPT"
         EXIT_STATUS=1
     else
+        # Merge commits are mechanical: conflict resolution routinely touches
+        # shared .agents/ state (e.g. .agents/retrospective/INDEX.md,
+        # .agents/memory/causality/causal-graph.json) but a merge is NOT an
+        # agent work session, so it must not be forced to carry a fresh
+        # staged session log. CI's Session Protocol Validation still checks
+        # the branch independently. Precedent: #1319 established that merge
+        # commits skip upstream-file validation. Related: #2883.
+        IS_MERGE_COMMIT=0
+        if git rev-parse -q --verify MERGE_HEAD > /dev/null 2>&1; then
+            IS_MERGE_COMMIT=1
+        fi
+
         # Require a staged session log (JSON format)
         STAGED_SESSION_LOG=$(echo "$STAGED_FILES" | grep -E '^\.agents/sessions/[0-9]{4}-[0-9]{2}-[0-9]{2}-session-[0-9]+.*\.json$' | tail -n 1)
-        if [ -z "$STAGED_SESSION_LOG" ]; then
+        if [ -z "$STAGED_SESSION_LOG" ] && [ "$IS_MERGE_COMMIT" = "0" ]; then
             # Activation prompt: 5-word cloud to trigger correct behavior
             echo_error "BLOCKED: Create session log NOW"
             echo_info "  → git add .agents/sessions/YYYY-MM-DD-session-NN.json"
             echo_info "  Protocol: JSON session log required for all agent sessions"
             EXIT_STATUS=1
+        elif [ -z "$STAGED_SESSION_LOG" ]; then
+            echo_info "Merge commit detected (MERGE_HEAD present); session-log staged requirement skipped. CI validates session protocol independently. Related: #2883."
         fi
 
         # Only run validation if session log is present


### PR DESCRIPTION
## Summary

### What

The pre-commit session-protocol gate no longer forces a staged session log for **merge commits**. It detects an in-progress merge via `MERGE_HEAD` and skips only the "no staged log -> block" branch.

### Why

The gate fires whenever a staged `.agents/` file is present, then requires a staged session log (`.githooks/pre-commit`, the `STAGED_AGENTS_FILES` / `STAGED_SESSION_LOG` block). Merge commits routinely touch shared `.agents/` state during conflict resolution (see **Related Files** for examples), but a merge is mechanical, not an agent work session. With `--no-verify` prohibited by repo policy and no scoped bypass, contributors had to rebase instead of merge (encountered on #2817). #1319 already established the precedent that merge commits skip upstream-file validation; the session gate simply was not included.

**Diagnosis correction:** the original #2883 report attributed the block to a `MERGE_BASE...HEAD` branch filter dropping the staged log. That filter no longer exists on `main`. I verified the staged log **is** visible in `git diff --cached` during a merge, so the gate was technically satisfiable by fabricating a log. The real residual issue is that a mechanical merge should not require a session log at all. This PR fixes that directly (issue's suggested fix option 1).

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #2883 | pre-commit session-log gate false-blocks merge commits touching `.agents/` |

## Changes

- `.githooks/pre-commit`: in the Session Protocol block, detect merge via `git rev-parse -q --verify MERGE_HEAD` (`IS_MERGE_COMMIT`). Skip the block-on-missing-log branch when it is a merge; emit an informational note instead. Validation still runs if a log is staged; non-merge commits are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Infrastructure/CI change (git hook)
- [ ] Refactoring

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny (git hook / gate relaxation), no rush.

**Focus areas**: is skipping the staged-log requirement on merges safe? Rationale: (1) CI's Session Protocol Validation checks the branch independently, (2) non-merge commits are unaffected, (3) the branch already carries its committed session log. `MERGE_HEAD` is present during `git commit` finalizing a merge, so detection is reliable (including octopus merges).

## Testing

- [x] Manual testing completed (isolated-repo empirical validation)
- [ ] Tests added/updated (no shell test harness exists for `.githooks/pre-commit`; validated empirically)
- [ ] No testing required

Verified empirically by replicating the exact gate branch in throwaway repos:
- merge touching `.agents/`, **no** staged log -> **ALLOWED** (was the false-block)
- non-merge, `.agents/` staged, **no** log -> **BLOCKED** (protection preserved)
- non-merge, `.agents/` staged, **with** log -> **ALLOWED** (unchanged)

`bash -n .githooks/pre-commit`: syntax OK. Full pre-push hook: 9 passed / 0 failed.

## Agent Review

### Security Review

- [x] Security agent reviewed infrastructure changes

The change only *relaxes* a gate for merge commits and adds no input handling, no secret surface, and no new external calls. `MERGE_HEAD` is a git-internal ref, not attacker-controlled. Non-merge enforcement is byte-for-byte unchanged.

**Files requiring security review:**
- `.githooks/pre-commit`

## Related Files

Referenced as examples of merge-touched shared state, not changed by this PR:

- `.agents/retrospective/INDEX.md`
- `.agents/memory/causality/*.json`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

