### PR TITLE
refactor(hooks): reuse worktree-safe IS_MERGE in session-log gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1247,14 +1247,14 @@ if [ -n "$STAGED_AGENTS_FILES" ]; then
         # staged session log. CI's Session Protocol Validation still checks
         # the branch independently. Precedent: #1319 established that merge
         # commits skip upstream-file validation. Related: #2883.
-        IS_MERGE_COMMIT=0
-        if git rev-parse -q --verify MERGE_HEAD > /dev/null 2>&1; then
-            IS_MERGE_COMMIT=1
-        fi
+        # Reuse the worktree-safe IS_MERGE computed earlier in this hook (via
+        # `git rev-parse --git-path MERGE_HEAD`, #2376); do not re-detect.
 
-        # Require a staged session log (JSON format)
-        STAGED_SESSION_LOG=$(echo "$STAGED_FILES" | grep -E '^\.agents/sessions/[0-9]{4}-[0-9]{2}-[0-9]{2}-session-[0-9]+.*\.json$' | tail -n 1)
-        if [ -z "$STAGED_SESSION_LOG" ] && [ "$IS_MERGE_COMMIT" = "0" ]; then
+        # Require a staged session log (JSON format).
+        # `|| true` guards against set -e (#2258) if the pipeline is refactored
+        # or pipefail is introduced; grep exits nonzero when there is no match.
+        STAGED_SESSION_LOG=$(echo "$STAGED_FILES" | grep -E '^\.agents/sessions/[0-9]{4}-[0-9]{2}-[0-9]{2}-session-[0-9]+.*\.json$' | tail -n 1 || true)
+        if [ -z "$STAGED_SESSION_LOG" ] && [ "$IS_MERGE" = "0" ]; then
             # Activation prompt: 5-word cloud to trigger correct behavior
             echo_error "BLOCKED: Create session log NOW"
             echo_info "  → git add .agents/sessions/YYYY-MM-DD-session-NN.json"


### PR DESCRIPTION
## Summary

Follow-up cleanup to the merge-commit session-log gate (#2883, landed via !2885). The reviews on !2885 (gemini-code-assist + copilot-pull-request-reviewer) flagged a DRY issue that merged before the fix was applied: the session-log gate re-detected merges with a redundant `IS_MERGE_COMMIT` variable via `git rev-parse --verify MERGE_HEAD`.

## Change

The hook already computes a worktree-safe `IS_MERGE` (0/1) near the top via `git rev-parse --git-path MERGE_HEAD` (#2376, handles linked worktrees where `.git` is a file), and already reuses it in the markdown-lint gate. This reuses it in the session-log gate too:

- Removes the redundant `IS_MERGE_COMMIT` detection block.
- Reuses the existing `IS_MERGE` global.
- Drops one subprocess per commit and the drift risk of two merge detectors.

No behavior change: `IS_MERGE=0` is equivalent to the removed `IS_MERGE_COMMIT=0`.

## Validation

- `bash -n .githooks/pre-commit` passes.
- Confirmed `IS_MERGE` is a top-level (non-`local`) global in scope at the gate.

## Related

- Addresses the unmerged DRY review from !2885.
- #2883 (original merge-commit gate), #2376 (worktree-safe merge detection).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
