### PR TITLE
fix(agents): python3 not uv run in .claude orchestrator session gate

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -17,7 +17,7 @@ You coordinate specialized agents to deliver end-to-end results. Classify comple
 
 Before routing any task, complete this checklist:
 
-- [ ] Run `/session-init` or `uv run python .claude/skills/session-init/scripts/new_session_log.py`
+- [ ] Run `/session-init` or `python3 .claude/skills/session-init/scripts/new_session_log.py`
 - [ ] Read `.agents/HANDOFF.md` for prior session context
 - [ ] Activate Serena: `mcp__serena__activate_project`
 - [ ] Read `.agents/AGENT-INSTRUCTIONS.md`
@@ -201,7 +201,7 @@ Only after these three steps complete does reasoning about the response begin. S
 1. Verify all delegations have returned or been explicitly abandoned.
 2. Verify synthesis is complete and TODOs logged for deferred work.
 3. Verify delegation count is within budget (fewer than 15); if budget limit was reached, produce a budget-exhaustion summary.
-4. Run `uv run python .claude/skills/session-end/scripts/complete_session_log.py`.
+4. Run `python3 .claude/skills/session-end/scripts/complete_session_log.py`.
 5. Verify `protocolCompliance.sessionEnd` fields are all `Complete: true` in the session JSON.
 6. Verify HANDOFF.md was preserved (read-only per ADR-014). Outcomes and next steps recorded in the session log.
 7. **Write per-issue handoff** to `.agents/sessions/handoffs/{YYYY-MM-DD}-{ISSUE_NUMBER}-handoff.md` from the template at `.agents/templates/HANDOFF.md` when the associated issue is not closed in this session. Fill every section; leave no `{placeholder}` tokens. See SESSION-PROTOCOL.md § Session End Phase 1.5. Distinct from `.agents/HANDOFF.md`, which stays read-only.

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "rjmurillo"
   }


### PR DESCRIPTION
## Summary

Backfill a parity fix that the reviewer flagged on the PR which merged before the fix landed (#2878). The install copy `.claude/agents/orchestrator.md` invoked `uv run python` in the session-init (line 20) and session-end (line 204) steps, while the canonical copy and every other agent copy use `python3`.

## Change

- `.claude/agents/orchestrator.md`: `uv run python` -> `python3` (lines 20, 204). `python3` is the portable form and does not depend on `uv` being installed.
- Bump the Claude + Copilot-CLI plugin manifests 0.6.1 -> 0.6.2 (the enforced parity pair), since a plugin source file changed.

## Validation

`python3` matches the canonical source; agent-drift check reports 0 drift, install-parity OK. Pre-push: markdown lint, agent drift, plugin version bump, plugin-load e2e all pass.

## Related Files

Context only, not changed by this PR:

- `src/claude/orchestrator.md` (canonical source the install copy mirrors)
- `build/scripts/check_plugin_manifest_parity.py` (enforces the version parity pair)

## Related

Addresses the unmerged parity review from #2878.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
