### PR TITLE
fix(models): pin bare `haiku` alias to claude-haiku-4-5 (#2840 down-payment)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/commands/pr-quality/all.md
+++ b/.claude/commands/pr-quality/all.md
@@ -4,7 +4,7 @@ argument-hint: '[BASE_BRANCH]'
 allowed-tools:
   - Bash(git:*)
   - Skill
-model: haiku
+model: claude-haiku-4-5
 ---
 
 # PR Quality Gate - All Agents

--- a/.claude/skills/guard-maturity/SKILL.md
+++ b/.claude/skills/guard-maturity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: guard-maturity
 version: 1.0.0
-model: haiku
+model: claude-haiku-4-5
 description: Classify push guards by Hook Maturity Model tier. Aggregates EVENT lines emitted by push_guard_base.py and assigns each guard a tier (Budding, Growing, Mature, Proficient, Inert, Harmful) based on age, intercept count, and fitness derived from block rate. Use to decide when to promote a new guard, when to prune dead weight, and when to remove a harmful one. Triggers `guard maturity report`, `classify push guards`, `hook maturity tiers`.
 license: MIT
 ---

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/guard-maturity/SKILL.md
+++ b/src/copilot-cli/skills/guard-maturity/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: guard-maturity
 version: 1.0.0
-model: haiku
+model: claude-haiku-4-5
 description: Classify push guards by Hook Maturity Model tier. Aggregates EVENT lines emitted by push_guard_base.py and assigns each guard a tier (Budding, Growing, Mature, Proficient, Inert, Harmful) based on age, intercept count, and fitness derived from block rate. Use to decide when to promote a new guard, when to prune dead weight, and when to remove a harmful one. Triggers `guard maturity report`, `classify push guards`, `hook maturity tiers`.
 license: MIT
 ---


### PR DESCRIPTION
## Summary

Scoped interim de-risk for #2840. Pins the bare `model: haiku` alias to the in-repo canonical `claude-haiku-4-5` in the two source files that used it, and regenerates the copilot-cli skill copy.

The bare `haiku` alias silently repoints whenever the harness default changes. That is the highest-risk CI-break class in the pin audit (same failure mode that motivated the #2839 retired-id fix). `claude-haiku-4-5` is already the canonical haiku id used by 6 other skills in the repo, so this aligns the two stragglers with existing convention.

## Scope (intentionally bounded)

This does **not**:
- Touch the keep-or-remove-pin policy decision (blocked on the #2859 eval).
- Normalize the broader dot/hyphen model-id spelling drift (separate change, format-per-platform judgment).

#2840 stays open after this lands; this is a down-payment on its highest-risk item only.

## Changes

| File | Kind | Change |
|------|------|--------|
| `.claude/skills/guard-maturity/SKILL.md` | source | `model: haiku` -> `claude-haiku-4-5` |
| `.claude/commands/pr-quality/all.md` | source | `model: haiku` -> `claude-haiku-4-5` |
| `src/copilot-cli/skills/guard-maturity/SKILL.md` | generated | regenerated skill copy |
| `.claude/.claude-plugin/plugin.json` | manifest | 0.6.2 -> 0.6.3 (skill source changed) |
| `src/copilot-cli/.claude-plugin/plugin.json` | manifest | 0.6.2 -> 0.6.3 (parity pair) |

## Verification

```
python3 build/scripts/build_all.py         # regenerated copilot skill copy
python3 build/scripts/build_all.py --check  # reports no drift
grep -rn 'model: haiku' .claude/ src/       # zero matches
```

Pre-push: 11 passed / 0 failed (build staleness, plugin version bump, plugin-load e2e all PASS).

## Notes

The ADR-057 pre-commit warning fires on any skill-file edit. This change is model-id metadata normalization with no prompt-body behavioral change, so the behavioral-eval recommendation is a heuristic false-positive here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>