### PR TITLE
fix(build): keep .claude/** scope in .github/instructions so in-repo Copilot auto-loads rules (#2892)

### DIFF
--- a/.github/instructions/canonical-source-mirror.instructions.md
+++ b/.github/instructions/canonical-source-mirror.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: scripts/validation/**,build/scripts/**,.github/prompts/**
+applyTo: .claude/hooks/**,scripts/validation/**,build/scripts/**,.claude/skills/**,.claude/review-axes/**,.github/prompts/**
 ---
 
 # Canonical Source Mirror Rule

--- a/.github/instructions/claude-agents.instructions.md
+++ b/.github/instructions/claude-agents.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: src/claude/**
+applyTo: src/claude/**,.claude/agents/**,.claude/skills/**,.claude/commands/**
 ---
 
 # Claude Agent and Skill Rules

--- a/.github/instructions/generated-artifacts.instructions.md
+++ b/.github/instructions/generated-artifacts.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: build/scripts/**,templates/**,src/copilot-cli/**,.github/instructions/**,tests/build_scripts/**,tests/e2e/**
+applyTo: build/scripts/**,templates/**,src/copilot-cli/**,.github/instructions/**,.claude/hooks/**,.claude/rules/**,tests/build_scripts/**,tests/e2e/**
 ---
 
 # Customer-Facing Generated Artifacts

--- a/.github/instructions/governance.instructions.md
+++ b/.github/instructions/governance.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: '**'
+applyTo: .agents/governance/**
 ---
 
 # Governance File Rules

--- a/.github/instructions/plugin-version-bump.instructions.md
+++ b/.github/instructions/plugin-version-bump.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: src/copilot-cli/**,src/claude/**,**/.claude-plugin/plugin.json
+applyTo: .claude/**,src/copilot-cli/**,src/claude/**,**/.claude-plugin/plugin.json
 ---
 
 # Plugin Version Bump and the Parallel-PR Deadlock

--- a/.github/instructions/retros.instructions.md
+++ b/.github/instructions/retros.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: docs/retros/**
+applyTo: .agents/retrospective/**,docs/retros/**
 ---
 
 # Retrospective File Rules

--- a/.github/instructions/secret-redaction.instructions.md
+++ b/.github/instructions/secret-redaction.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: '**'
+applyTo: .claude/commands/spec.md,.agents/sessions/**,.agents/retrospective/**,.claude/skills/session-init/**,.claude/skills/session-end/**,.claude/rules/secret-redaction.md
 ---
 
 # Secret and PII Redaction Before Emit

--- a/.github/instructions/security.instructions.md
+++ b/.github/instructions/security.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: '**/Auth/**,*.env*,**/*.secrets.*,.github/workflows/**,.githooks/**'
+applyTo: .agents/security/**,**/Auth/**,*.env*,**/*.secrets.*,.github/workflows/**,.githooks/**,.claude/rules/security.md
 ---
 
 # Security File Rules

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: tests/**,**/*.Tests.ps1,**/tests/**
+applyTo: tests/**,**/*.Tests.ps1,**/tests/**,.claude/skills/**/tests/**,.agents/security/benchmarks/**,.claude/rules/testing.md
 ---
 
 # Test File Rules

--- a/build/scripts/generate_rules.py
+++ b/build/scripts/generate_rules.py
@@ -146,7 +146,24 @@ def _resolve_paths(
     return repo_root / source_dir, resolved_outputs
 
 
-def _read_output_dirs(stanza: dict) -> list[str]:
+def _canonical_output_dir(repo_root: Path, value: str) -> str:
+    """Canonical repo-relative form used to compare output dirs.
+
+    The driver computes each `destination` as
+    `str((repo_root / cfg).relative_to(repo_root))`, which normalizes away
+    trailing slashes and `.` segments. `keepInternalGlobsFor` entries must be
+    canonicalized through the SAME pipeline, otherwise a schema-valid config
+    like `.github/instructions/` (trailing slash) silently fails the
+    `destination in keep_internal_dirs` check and the internal-glob strip runs
+    anyway (issue #2892: the exact silent-failure class this fix removes).
+    """
+    try:
+        return (repo_root / value).relative_to(repo_root).as_posix()
+    except ValueError:
+        return value
+
+
+def _read_output_dirs(stanza: dict[str, object]) -> list[str]:
     """Parse `outputDir` (string) or `outputDirs` (list) from the rules stanza.
 
     Backward-compatible: existing configs and tests use `outputDir`. New
@@ -258,6 +275,8 @@ def _remap_frontmatter(
     frontmatter: dict[str, str | None],
     remap: dict[str, str],
     drop: set[str],
+    *,
+    keep_internal: bool = False,
 ) -> dict[str, str | None]:
     """Apply ``frontmatterRemap`` and ``frontmatterDrop`` rules; ensure
     the output declares ``applyTo`` (synthesizing universal scope when
@@ -272,6 +291,16 @@ def _remap_frontmatter(
     every glob in the source is internal, the universal scope is
     synthesized so the rule still applies somewhere in the vendor tree
     rather than being dropped entirely.
+
+    ``keep_internal`` (issue #2892): when True, the internal-glob filter is
+    skipped so ``.claude/**`` and siblings survive verbatim. This is set for
+    output destinations that coexist with the internal dirs in the same repo
+    (the in-repo ``.github/instructions`` tree), where the in-repo Copilot
+    agent edits ``.claude/`` sources and needs those rules to auto-load.
+    Distributed destinations (the plugin ``src/copilot-cli/instructions``
+    tree, installed where ``.claude/`` does not exist) keep filtering so they
+    do not carry dead references. The serialized-list flatten still runs in
+    both modes so a source ``paths:`` block always emits a comma string.
     """
     had_scope = _has_path_scope(frontmatter)
     result: dict[str, str | None] = {}
@@ -289,24 +318,22 @@ def _remap_frontmatter(
             # string, so flatten the array to that shape before the
             # internal-glob filter (which splits on ",") and before emit.
             value = _flatten_serialized_scope_list(value)
-            value, dropped = _filter_internal_globs(value)
-            for entry in dropped:
-                # Visible warning per dropped entry so plugin authors
-                # see what was filtered (and why) without grepping the
-                # generator source.
-                print(
-                    f"  WARNING: dropped internal-only glob from applyTo: {entry!r}",
-                    file=sys.stderr,
-                )
+            if not keep_internal:
+                value, dropped = _filter_internal_globs(value)
+                for entry in dropped:
+                    # Visible warning per dropped entry so plugin authors
+                    # see what was filtered (and why) without grepping the
+                    # generator source.
+                    print(
+                        f"  WARNING: dropped internal-only glob from applyTo: {entry!r}",
+                        file=sys.stderr,
+                    )
         result[new_key] = value
     # If the post-filter applyTo is empty but the source had a scope,
     # the source was entirely internal-only globs. Synthesize universal
     # scope so the rule still ships rather than landing with applyTo: "".
-    if (
-        had_scope
-        and isinstance(result.get("applyTo"), str)
-        and not result["applyTo"].strip()
-    ):
+    applyto_value = result.get("applyTo")
+    if had_scope and isinstance(applyto_value, str) and not applyto_value.strip():
         result["applyTo"] = _UNIVERSAL_SCOPE
     if not had_scope and "applyTo" not in result:
         # Universal-scope default for unscoped rules. Insert at the top
@@ -361,6 +388,7 @@ def _process_rule(
     remap: dict[str, str],
     drop: set[str],
     what_if: bool,
+    keep_internal: bool = False,
 ) -> tuple[str, str, str]:
     """Process one rule. Round 3: every rule emits.
 
@@ -384,7 +412,9 @@ def _process_rule(
 
     target_name = f"{name}{output_suffix}"
     target = output_dir / target_name
-    transformed = _remap_frontmatter(source_fm, remap, drop)
+    transformed = _remap_frontmatter(
+        source_fm, remap, drop, keep_internal=keep_internal
+    )
     written = _write_instruction(target, transformed, body, what_if=what_if)
     if not written:
         return ("sentinel-skipped", name, "NO-REGEN")
@@ -459,6 +489,34 @@ def generate_rules(
         return 2, result
     drop: set[str] = {str(item) for item in raw_drop}
 
+    # issue #2892: destinations that coexist with the internal dirs
+    # (`.agents/`, `.claude/`, `.serena/`) in the same repository. For these
+    # the internal-glob filter is skipped so `.claude/**`-scoped rules keep
+    # their scope and the in-repo Copilot agent auto-loads them. Any output
+    # dir NOT listed here keeps filtering (distributed plugin trees installed
+    # where the internal dirs do not exist).
+    raw_keep = stanza.get("keepInternalGlobsFor") or []
+    if not isinstance(raw_keep, list):
+        print(
+            "Error: `artifacts.rules.keepInternalGlobsFor` must be a list",
+            file=sys.stderr,
+        )
+        return 2, result
+    # Type-strict like `_read_output_dirs`: a non-string entry would be
+    # coerced by `str(item)` to `"None"`/`"42"` and silently match nothing,
+    # re-introducing the class of silent failure #2892 fixes.
+    for idx, item in enumerate(raw_keep):
+        if not isinstance(item, str):
+            print(
+                f"Error: `artifacts.rules.keepInternalGlobsFor[{idx}]` must be "
+                f"a string (got {type(item).__name__})",
+                file=sys.stderr,
+            )
+            return 2, result
+    keep_internal_dirs: set[str] = {
+        _canonical_output_dir(repo_root, item) for item in raw_keep
+    }
+
     try:
         source_dir, output_dirs = _resolve_paths(
             repo_root, source_dir_str, output_dir_strs
@@ -497,6 +555,18 @@ def generate_rules(
         # Process once per output target. The audit records each
         # write separately so callers can see all destinations.
         for output_dir in output_dirs:
+            try:
+                destination = str(output_dir.relative_to(repo_root))
+            except ValueError:
+                destination = str(output_dir)
+            # Compare on a POSIX-normalized key so the match is stable on
+            # Windows (where `str(Path)` uses backslashes but config paths and
+            # `keep_internal_dirs` use forward slashes). #2892 review finding.
+            try:
+                destination_key = output_dir.relative_to(repo_root).as_posix()
+            except ValueError:
+                destination_key = output_dir.as_posix()
+            keep_internal = destination_key in keep_internal_dirs
             action, name_out, reason = _process_rule(
                 src,
                 output_dir,
@@ -505,11 +575,8 @@ def generate_rules(
                 remap=remap,
                 drop=drop,
                 what_if=what_if,
+                keep_internal=keep_internal,
             )
-            try:
-                destination = str(output_dir.relative_to(repo_root))
-            except ValueError:
-                destination = str(output_dir)
             result.entries.append(
                 RuleAuditEntry(
                     name=name_out,

--- a/build/scripts/generate_rules.py
+++ b/build/scripts/generate_rules.py
@@ -495,7 +495,11 @@ def generate_rules(
     # their scope and the in-repo Copilot agent auto-loads them. Any output
     # dir NOT listed here keeps filtering (distributed plugin trees installed
     # where the internal dirs do not exist).
-    raw_keep = stanza.get("keepInternalGlobsFor") or []
+    # Use `.get(key, [])` (not `... or []`) so a wrong-typed value such as
+    # `0`/`false`/`""` reaches the list-check below and returns rc=2, instead
+    # of being silently coerced to "not set" (the silent-misconfig class #2892
+    # eliminates). Absent key defaults to an empty keep-list (backward-compat).
+    raw_keep = stanza.get("keepInternalGlobsFor", [])
     if not isinstance(raw_keep, list):
         print(
             "Error: `artifacts.rules.keepInternalGlobsFor` must be a list",

--- a/build/scripts/validate_templates_schema.py
+++ b/build/scripts/validate_templates_schema.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from yaml_loader import (
     ConfigError,
@@ -73,6 +73,7 @@ RULES_KEYS = {
     "outputSuffix",
     "frontmatterRemap",
     "frontmatterDrop",
+    "keepInternalGlobsFor",
 }
 HOOKS_KEYS = {
     "settingsSource",
@@ -111,7 +112,8 @@ AUDIT_POLICY_KEYS = {"pathBlocklist", "output"}
 
 def _validate_path_value(field: str, value: object) -> list[str]:
     """Backwards-compat wrapper around yaml_loader.validate_relative_path."""
-    return validate_relative_path(field, value)
+    errors: list[str] = validate_relative_path(field, value)
+    return errors
 
 
 # --- Structural complexity ------------------------------------------------
@@ -179,6 +181,43 @@ def _validate_artifact_stanza(name: str, stanza: object) -> list[str]:
                 f"`artifacts.{name}`: `outputDir` and `outputDirs` are "
                 f"mutually exclusive"
             )
+    # keepInternalGlobsFor (issue #2892): output dirs that coexist with the
+    # internal dirs and keep `.claude/**`-style scope. Each entry must be a
+    # relative path AND must appear in outputDirs, else it silently matches
+    # nothing and the intended in-repo scope is never preserved.
+    if name == "rules" and "keepInternalGlobsFor" in stanza:
+        keep = stanza.get("keepInternalGlobsFor")
+        if not isinstance(keep, list):
+            errors.append(
+                f"`artifacts.{name}.keepInternalGlobsFor`: must be a list of paths"
+            )
+        else:
+            declared = set()
+            raw_dirs = stanza.get("outputDirs")
+            if isinstance(raw_dirs, list):
+                declared = {d for d in raw_dirs if isinstance(d, str)}
+            single = stanza.get("outputDir")
+            if isinstance(single, str):
+                declared.add(single)
+            # Compare on a canonical form so a trailing slash or `.` segment
+            # difference between outputDirs and keepInternalGlobsFor does not
+            # false-reject a config that the generator would treat as a match
+            # (issue #2892).
+            declared_norm = {PurePosixPath(d).as_posix() for d in declared}
+            for idx, item in enumerate(keep):
+                errors.extend(
+                    _validate_path_value(
+                        f"artifacts.{name}.keepInternalGlobsFor[{idx}]", item
+                    )
+                )
+                if (
+                    isinstance(item, str)
+                    and PurePosixPath(item).as_posix() not in declared_norm
+                ):
+                    errors.append(
+                        f"`artifacts.{name}.keepInternalGlobsFor[{idx}]`: "
+                        f"{item!r} is not one of the declared output dirs"
+                    )
     return errors
 
 

--- a/templates/platforms/copilot-cli.yaml
+++ b/templates/platforms/copilot-cli.yaml
@@ -30,6 +30,14 @@ artifacts:
     outputDirs:
       - ".github/instructions"
       - "src/copilot-cli/instructions"
+    # issue #2892: `.github/instructions` lives in this repo alongside
+    # `.claude/`, so keep `.claude/**`-scoped globs here; the in-repo Copilot
+    # agent edits `.claude/` sources and must auto-load those rules. The
+    # distributed `src/copilot-cli/instructions` tree (installed where
+    # `.claude/` does not exist) is intentionally omitted, so it keeps
+    # filtering internal-only globs to avoid dead references.
+    keepInternalGlobsFor:
+      - ".github/instructions"
     sourceSuffix: ".md"
     outputSuffix: ".instructions.md"
     frontmatterRemap:

--- a/tests/build_scripts/test_generate_rules.py
+++ b/tests/build_scripts/test_generate_rules.py
@@ -514,9 +514,17 @@ def test_main_missing_config_returns_2(tmp_path: Path) -> None:
 # Multi-output (outputDirs) --------------------------------------------------
 
 
-def _write_multi_output_config(tmp_path: Path, outputs: list[str]) -> Path:
+def _write_multi_output_config(
+    tmp_path: Path,
+    outputs: list[str],
+    keep_internal_for: list[str] | None = None,
+) -> Path:
     cfg = tmp_path / "platform.yaml"
     outputs_yaml = "\n".join(f'      - "{o}"' for o in outputs)
+    keep_yaml = ""
+    if keep_internal_for is not None:
+        keep_items = "\n".join(f'      - "{k}"' for k in keep_internal_for)
+        keep_yaml = f"    keepInternalGlobsFor:\n{keep_items}\n"
     cfg.write_text(
         f"""\
 schemaVersion: "1.0"
@@ -526,7 +534,7 @@ artifacts:
     sourceDir: "rules_src"
     outputDirs:
 {outputs_yaml}
-    sourceSuffix: ".md"
+{keep_yaml}    sourceSuffix: ".md"
     outputSuffix: ".instructions.md"
     frontmatterRemap:
       paths: applyTo
@@ -688,3 +696,181 @@ def test_outputDirs_prunes_orphans_in_every_target(tmp_path: Path) -> None:
         assert not (tmp_path / sub / "stale.instructions.md").exists(), (
             f"orphan not pruned in {sub}"
         )
+
+
+# issue #2892: keepInternalGlobsFor per-destination internal-scope retention --
+
+
+def test_keep_internal_globs_for_preserves_scope_in_listed_dir(tmp_path: Path) -> None:
+    """A dir in keepInternalGlobsFor keeps `.claude/**`; others still strip it.
+
+    Why it matters: the in-repo `.github/instructions` tree coexists with
+    `.claude/`, so the in-repo Copilot agent needs `.claude/**`-scoped rules
+    to auto-load. The distributed `src/copilot-cli/instructions` tree does
+    not carry `.claude/` and must keep filtering to avoid dead references.
+    """
+    _write_rule(
+        tmp_path / "rules_src",
+        "pvb",
+        frontmatter='paths: ".claude/**,src/copilot-cli/**,docs/**"\n',
+        body="body\n",
+    )
+    cfg = _write_multi_output_config(
+        tmp_path, ["keep_dir", "strip_dir"], keep_internal_for=["keep_dir"]
+    )
+    rc, _ = generate_rules.generate_rules(cfg, tmp_path)
+    assert rc == 0
+
+    kept = (tmp_path / "keep_dir" / "pvb.instructions.md").read_text(encoding="utf-8")
+    kept_fm = kept.split("---")[1]
+    assert ".claude/**" in kept_fm  # internal scope retained
+    assert "docs/**" in kept_fm  # non-internal preserved
+
+    stripped = (tmp_path / "strip_dir" / "pvb.instructions.md").read_text(
+        encoding="utf-8"
+    )
+    stripped_fm = stripped.split("---")[1]
+    assert ".claude/**" not in stripped_fm  # internal scope filtered
+    assert "docs/**" in stripped_fm  # non-internal preserved
+
+
+def test_keep_internal_absent_still_strips_all_dirs(tmp_path: Path) -> None:
+    """Without keepInternalGlobsFor, every target strips internal globs.
+
+    Regression guard: the new flag must default off so existing distributed
+    behavior is unchanged when the config omits it.
+    """
+    _write_rule(
+        tmp_path / "rules_src",
+        "pvb",
+        frontmatter='paths: ".claude/**,docs/**"\n',
+        body="body\n",
+    )
+    cfg = _write_multi_output_config(tmp_path, ["out_a", "out_b"])
+    rc, _ = generate_rules.generate_rules(cfg, tmp_path)
+    assert rc == 0
+    for sub in ("out_a", "out_b"):
+        fm = (tmp_path / sub / "pvb.instructions.md").read_text(
+            encoding="utf-8"
+        ).split("---")[1]
+        assert ".claude/**" not in fm
+        assert "docs/**" in fm
+
+
+def test_remap_frontmatter_keep_internal_true_skips_filter() -> None:
+    """Unit: keep_internal=True keeps internal globs; False drops them."""
+    fm = {"paths": ".claude/**,docs/**"}
+    kept = generate_rules._remap_frontmatter(
+        fm, {"paths": "applyTo"}, set(), keep_internal=True
+    )
+    assert kept["applyTo"] == ".claude/**,docs/**"
+    stripped = generate_rules._remap_frontmatter(
+        fm, {"paths": "applyTo"}, set(), keep_internal=False
+    )
+    assert stripped["applyTo"] == "docs/**"
+
+
+def test_keep_internal_all_internal_still_retained(tmp_path: Path) -> None:
+    """When every glob is internal and the dir is kept, scope is retained
+    verbatim rather than collapsed to universal `**`."""
+    _write_rule(
+        tmp_path / "rules_src",
+        "allint",
+        frontmatter='paths: ".claude/rules/**,.agents/x/**"\n',
+        body="body\n",
+    )
+    cfg = _write_multi_output_config(
+        tmp_path, ["keep_dir"], keep_internal_for=["keep_dir"]
+    )
+    rc, _ = generate_rules.generate_rules(cfg, tmp_path)
+    assert rc == 0
+    fm = (tmp_path / "keep_dir" / "allint.instructions.md").read_text(
+        encoding="utf-8"
+    ).split("---")[1]
+    assert ".claude/rules/**" in fm
+    assert ".agents/x/**" in fm
+    assert "applyTo: '**'" not in fm
+
+
+def test_keep_internal_trailing_slash_still_matches(tmp_path: Path) -> None:
+    """A trailing slash in outputDirs/keepInternalGlobsFor must still match.
+
+    Regression for #2892 review finding: `destination` is normalized via
+    `Path.relative_to` (strips the trailing slash), so the raw config string
+    must be canonicalized the same way. Otherwise `.github/instructions/`
+    passes schema yet silently disables the fix and internal globs get
+    stripped anyway.
+    """
+    _write_rule(
+        tmp_path / "rules_src",
+        "pvb",
+        frontmatter='paths: ".claude/**,docs/**"\n',
+        body="body\n",
+    )
+    cfg = _write_multi_output_config(
+        tmp_path, ["keep_dir/"], keep_internal_for=["keep_dir/"]
+    )
+    rc, _ = generate_rules.generate_rules(cfg, tmp_path)
+    assert rc == 0
+    fm = (tmp_path / "keep_dir" / "pvb.instructions.md").read_text(
+        encoding="utf-8"
+    ).split("---")[1]
+    assert ".claude/**" in fm  # internal scope retained despite trailing slash
+    assert "docs/**" in fm
+
+
+def test_canonical_output_dir_normalizes_trailing_slash(tmp_path: Path) -> None:
+    """Unit: keep-dir canonicalization matches the driver's destination form."""
+    assert (
+        generate_rules._canonical_output_dir(tmp_path, ".github/instructions/")
+        == ".github/instructions"
+    )
+    assert (
+        generate_rules._canonical_output_dir(tmp_path, ".github/instructions")
+        == ".github/instructions"
+    )
+
+
+def test_canonical_output_dir_returns_posix_form(tmp_path: Path) -> None:
+    """Unit: canonical form is always forward-slash (POSIX) so the driver's
+    `destination_key` comparison matches on Windows too (#2892 review finding).
+    """
+    result = generate_rules._canonical_output_dir(tmp_path, "a/b/c")
+    assert "\\" not in result
+    assert result == "a/b/c"
+
+
+def test_keep_internal_non_string_entry_rejected(tmp_path: Path) -> None:
+    """A non-string keepInternalGlobsFor entry is a config error (rc 2).
+
+    Matches `_read_output_dirs` type-strictness: `str(item)` would coerce
+    `42`/`null` to `"42"`/`"None"` and silently match nothing, re-introducing
+    the #2892 silent-failure class. The generator can run standalone (without
+    the schema validator), so it must reject non-strings itself.
+    """
+    _write_rule(
+        tmp_path / "rules_src",
+        "pvb",
+        frontmatter='paths: ".claude/**"\n',
+        body="body\n",
+    )
+    cfg = tmp_path / "platform.yaml"
+    cfg.write_text(
+        """\
+schemaVersion: "1.0"
+provider: "test"
+artifacts:
+  rules:
+    sourceDir: "rules_src"
+    outputDirs:
+      - "out_dir"
+    keepInternalGlobsFor:
+      - 42
+    sourceSuffix: ".md"
+    outputSuffix: ".instructions.md"
+    frontmatterRemap:
+      paths: applyTo
+"""
+    )
+    rc, _ = generate_rules.generate_rules(cfg, tmp_path)
+    assert rc == 2

--- a/tests/build_scripts/test_generate_rules.py
+++ b/tests/build_scripts/test_generate_rules.py
@@ -874,3 +874,38 @@ artifacts:
     )
     rc, _ = generate_rules.generate_rules(cfg, tmp_path)
     assert rc == 2
+
+
+def test_keep_internal_falsy_non_list_rejected(tmp_path: Path) -> None:
+    """A falsy non-list value (0/false/"") is a config error (rc 2).
+
+    Guards the `stanza.get(key, [])` read: an earlier `... or []` would have
+    coerced `0`/`false`/`""` to `[]` *before* the list-check, silently treating
+    the misconfig as "not set" and filtering anyway. That is the exact
+    silent-misconfig class #2892 eliminates, so it must return rc 2.
+    """
+    _write_rule(
+        tmp_path / "rules_src",
+        "pvb",
+        frontmatter='paths: ".claude/**"\n',
+        body="body\n",
+    )
+    cfg = tmp_path / "platform.yaml"
+    cfg.write_text(
+        """\
+schemaVersion: "1.0"
+provider: "test"
+artifacts:
+  rules:
+    sourceDir: "rules_src"
+    outputDirs:
+      - "out_dir"
+    keepInternalGlobsFor: 0
+    sourceSuffix: ".md"
+    outputSuffix: ".instructions.md"
+    frontmatterRemap:
+      paths: applyTo
+"""
+    )
+    rc, _ = generate_rules.generate_rules(cfg, tmp_path)
+    assert rc == 2

--- a/tests/build_scripts/test_validate_templates_schema.py
+++ b/tests/build_scripts/test_validate_templates_schema.py
@@ -324,3 +324,101 @@ def test_main_no_files_returns_two(tmp_path: Path) -> None:
     (tmp_path / "templates" / "platforms").mkdir(parents=True)
     rc = vts.main(["--root", str(tmp_path)])
     assert rc == 2
+
+
+# issue #2892: keepInternalGlobsFor validation ------------------------------
+
+_KEEP_VALID = """\
+schemaVersion: "1.0"
+provider: "copilot-cli"
+artifacts:
+  rules:
+    sourceDir: ".claude/rules"
+    outputDirs:
+      - ".github/instructions"
+      - "src/copilot-cli/instructions"
+    keepInternalGlobsFor:
+      - ".github/instructions"
+    sourceSuffix: ".md"
+    outputSuffix: ".instructions.md"
+    frontmatterRemap:
+      paths: applyTo
+"""
+
+_KEEP_NOT_IN_OUTPUTDIRS = """\
+schemaVersion: "1.0"
+provider: "copilot-cli"
+artifacts:
+  rules:
+    sourceDir: ".claude/rules"
+    outputDirs:
+      - ".github/instructions"
+    keepInternalGlobsFor:
+      - "src/copilot-cli/instructions"
+    sourceSuffix: ".md"
+    outputSuffix: ".instructions.md"
+    frontmatterRemap:
+      paths: applyTo
+"""
+
+_KEEP_NOT_A_LIST = """\
+schemaVersion: "1.0"
+provider: "copilot-cli"
+artifacts:
+  rules:
+    sourceDir: ".claude/rules"
+    outputDirs:
+      - ".github/instructions"
+    keepInternalGlobsFor: ".github/instructions"
+    sourceSuffix: ".md"
+    outputSuffix: ".instructions.md"
+    frontmatterRemap:
+      paths: applyTo
+"""
+
+
+_KEEP_TRAILING_SLASH = """\
+schemaVersion: "1.0"
+provider: "copilot-cli"
+artifacts:
+  rules:
+    sourceDir: ".claude/rules"
+    outputDirs:
+      - ".github/instructions/"
+    keepInternalGlobsFor:
+      - ".github/instructions"
+    sourceSuffix: ".md"
+    outputSuffix: ".instructions.md"
+    frontmatterRemap:
+      paths: applyTo
+"""
+
+
+def test_keep_internal_globs_for_valid(tmp_path: Path) -> None:
+    target = _write(tmp_path, _KEEP_VALID)
+    errors, _ = vts.validate_file(target)
+    assert errors == [], f"unexpected errors: {errors}"
+
+
+def test_keep_internal_globs_for_not_in_outputdirs_rejected(tmp_path: Path) -> None:
+    target = _write(tmp_path, _KEEP_NOT_IN_OUTPUTDIRS)
+    errors, _ = vts.validate_file(target)
+    assert any("not one of the declared output dirs" in e for e in errors), errors
+
+
+def test_keep_internal_globs_for_non_list_rejected(tmp_path: Path) -> None:
+    target = _write(tmp_path, _KEEP_NOT_A_LIST)
+    errors, _ = vts.validate_file(target)
+    assert any("must be a list" in e for e in errors), errors
+
+
+def test_keep_internal_globs_for_trailing_slash_tolerated(tmp_path: Path) -> None:
+    """A trailing-slash difference between the two keys must not false-reject.
+
+    Regression for #2892 review finding: schema and generator both canonicalize
+    output-dir paths, so `.github/instructions/` and `.github/instructions`
+    are treated as the same declared dir.
+    """
+    target = _write(tmp_path, _KEEP_TRAILING_SLASH)
+    errors, _ = vts.validate_file(target)
+    assert errors == [], f"unexpected errors: {errors}"


### PR DESCRIPTION
Fixes #2892 (proposed option-2 implementation).

## Problem

The `generate_rules` pipeline strips internal-path globs (`.agents/`, `.claude/`, `.serena/`) from rule frontmatter via `_filter_internal_globs` (M7-T4). That filter is correct for **distributed** consumers (`src/copilot-cli/instructions/`), who would otherwise ship dead references to paths that do not exist in a consumer repo.

But the filter ran **unconditionally**, so it also stripped those globs from the **in-repo** mirror (`.github/instructions/`), which the in-repo Copilot agent auto-loads by `applyTo`. Result: 7 rules silently lost all `.claude/**`-scoped coverage in this repo. Live symptom: the `plugin-version-bump` rule no longer matched `.claude/**` edits, so an amnesiac agent editing plugin source would not auto-load the version-bump rule.

## Fix (option 2)

Make the internal-glob filter opt-out **per output dir** via a new config key `keepInternalGlobsFor`. `copilot-cli.yaml` now lists `.github/instructions` so the in-repo mirror keeps internal scope while the distributed tree keeps stripping. Default empty = fully backward-compatible. Preserves the Chesterton's-fence purpose of the original filter (distributed consumers still get clean references).

## Changes

- `generate_rules.py`: thread `keep_internal` through `_process_rule` / `_remap_frontmatter`; gate `_filter_internal_globs` behind it. Also fixed 3 pre-existing latent mypy errors surfaced by the whole-file gate (from PRs !2066 / !1819): `dict` type-arg, `str | None` narrowing, `no-any-return` wrapper.
- `validate_templates_schema.py`: allow `keepInternalGlobsFor`; validate each entry is a declared output dir.
- `copilot-cli.yaml`: `keepInternalGlobsFor: [.github/instructions]`.
- Regenerated 9 `.github/instructions/*.md`.
- Tests: 7 new (4 generator, 3 schema).

## Verification

The distributed tree is byte-identical after regeneration (checksummed before/after). Only the in-repo mirror changed. No plugin version bump required because plugin source (`.claude/**`, `src/copilot-cli/**`) is unchanged; the pre-push `Plugin version bump` gate confirmed PASS.

```text
# distributed tree unchanged:
md5sum -c dist_before.txt   # all src/copilot-cli/instructions/* OK
# in-repo rule regained scope:
.github/instructions/plugin-version-bump.instructions.md applyTo now leads with .claude/**
```

Full suite: 751 build_scripts tests pass; pre-push gate all-green (mypy clean on 4 files, pytest, plugin-load e2e, semgrep).

## Owner decision

This implements the option recommended in #2892, but the issue was flagged as an owner design decision. Auto-merge is intentionally **not** armed; leaving the final merge call to the owner.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>