### PR TITLE
chore(lib): dedupe comment-domain classifier into github_core (#2816)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/lib/github_core/comment_classification.py
+++ b/.claude/lib/github_core/comment_classification.py
@@ -1,0 +1,59 @@
+"""Canonical: scripts/github_core/comment_classification.py. Sync via scripts/sync_plugin_lib.py.
+
+Shared, single-source-of-truth for the keyword-based triage that sorts a
+comment body into one of five domains (security, bug, style, summary,
+general). Previously this logic (the compiled patterns plus ``classify_domain``)
+was duplicated verbatim in ``get_pr_review_comments.py`` and
+``get_unaddressed_comments.py`` (Issue #2816, finding 4).
+
+NOTE: Plugin-distributed copy at .claude/lib/github_core/ and
+src/copilot-cli/lib/github_core/. Run ``python3 scripts/sync_plugin_lib.py``
+(and the build) to sync changes.
+"""
+
+from __future__ import annotations
+
+import re
+
+_SECURITY_PATTERN = re.compile(
+    r"cwe-\d+|vulnerability|vulnerabilities|injection|xss|sql|csrf"
+    r"|\bauth(?:entication|orization|enticat|orized)?\b"
+    r"|secrets?|credentials?|toctou|symlink|traversal|sanitiz"
+    r"|\bescap(?:e|ing)\b",
+    re.IGNORECASE,
+)
+_BUG_PATTERN = re.compile(
+    r"throws?\s+error|error\s+(?:occurs?|occurred|happens?|when|while)"
+    r"|\bcrash(?:es|ed|ing)?\b|\bexception(?:s)?\b|\bfail(?:ed|s|ure|ing)\b"
+    r"|null\s+(?:pointer|reference|ref)\b|undefined\s+(?:behavior|reference|variable)\b"
+    r"|race\s+condition|deadlock|memory\s+leak",
+    re.IGNORECASE,
+)
+_STYLE_PATTERN = re.compile(
+    r"formatting|naming|indentation|whitespace|convention|code\s*style"
+    r"|stylistic|readability|cleanup|refactor|refactoring",
+    re.IGNORECASE,
+)
+_SUMMARY_PATTERN = re.compile(
+    r"(?m)^\s*#{1,3}\s*(?:summary|overview|changes|walkthrough)",
+    re.IGNORECASE,
+)
+
+
+def classify_domain(body: str) -> str:
+    """Classify a comment into a domain based on keyword matching.
+
+    Non-string input (for example a JSON ``null`` body surfaced as ``None``)
+    is treated as unclassifiable and returns ``"general"``.
+    """
+    if not isinstance(body, str) or not body.strip():
+        return "general"
+    if _SECURITY_PATTERN.search(body):
+        return "security"
+    if _BUG_PATTERN.search(body):
+        return "bug"
+    if _STYLE_PATTERN.search(body):
+        return "style"
+    if _SUMMARY_PATTERN.search(body):
+        return "summary"
+    return "general"

--- a/.claude/skills/github/scripts/pr/get_pr_review_comments.py
+++ b/.claude/skills/github/scripts/pr/get_pr_review_comments.py
@@ -52,50 +52,7 @@ from github_core.api import (  # noqa: E402
     gh_api_paginated,
     resolve_repo_params,
 )
-
-# ---------------------------------------------------------------------------
-# Domain classification
-# ---------------------------------------------------------------------------
-
-_SECURITY_PATTERN = re.compile(
-    r"cwe-\d+|vulnerability|vulnerabilities|injection|xss|sql|csrf"
-    r"|\bauth(?:entication|orization|enticat|orized)?\b"
-    r"|secrets?|credentials?|toctou|symlink|traversal|sanitiz"
-    r"|\bescap(?:e|ing)\b",
-    re.IGNORECASE,
-)
-_BUG_PATTERN = re.compile(
-    r"throws?\s+error|error\s+(?:occurs?|occurred|happens?|when|while)"
-    r"|\bcrash(?:es|ed|ing)?\b|\bexception(?:s)?\b|\bfail(?:ed|s|ure|ing)\b"
-    r"|null\s+(?:pointer|reference|ref)\b|undefined\s+(?:behavior|reference|variable)\b"
-    r"|race\s+condition|deadlock|memory\s+leak",
-    re.IGNORECASE,
-)
-_STYLE_PATTERN = re.compile(
-    r"formatting|naming|indentation|whitespace|convention|code\s*style"
-    r"|stylistic|readability|cleanup|refactor|refactoring",
-    re.IGNORECASE,
-)
-_SUMMARY_PATTERN = re.compile(
-    r"(?m)^\s*#{1,3}\s*(?:summary|overview|changes|walkthrough)",
-    re.IGNORECASE,
-)
-
-
-def classify_domain(body: str) -> str:
-    """Classify a comment into a domain based on keyword matching."""
-    if not body or not body.strip():
-        return "general"
-    if _SECURITY_PATTERN.search(body):
-        return "security"
-    if _BUG_PATTERN.search(body):
-        return "bug"
-    if _STYLE_PATTERN.search(body):
-        return "style"
-    if _SUMMARY_PATTERN.search(body):
-        return "summary"
-    return "general"
-
+from github_core.comment_classification import classify_domain  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Stale detection helpers

--- a/.claude/skills/github/scripts/pr/get_unaddressed_comments.py
+++ b/.claude/skills/github/scripts/pr/get_unaddressed_comments.py
@@ -48,6 +48,7 @@ from github_core.api import (  # noqa: E402
     gh_api_paginated,
     resolve_repo_params,
 )
+from github_core.comment_classification import classify_domain  # noqa: E402
 from github_core.output import (  # noqa: E402
     add_output_format_arg,
     get_output_format,
@@ -75,31 +76,6 @@ _CLARIFICATION_PATTERN = re.compile(
 _FIX_DESCRIBED_PATTERN = re.compile(
     r"will\s+fix|fixing|updated|changed|modified|addressed"
     r"|implemented|added|removed",
-    re.IGNORECASE,
-)
-
-# Domain classification
-_SECURITY_PATTERN = re.compile(
-    r"cwe-\d+|vulnerability|vulnerabilities|injection|xss|sql|csrf"
-    r"|\bauth(?:entication|orization|enticat|orized)?\b"
-    r"|secrets?|credentials?|toctou|symlink|traversal|sanitiz"
-    r"|\bescap(?:e|ing)\b",
-    re.IGNORECASE,
-)
-_BUG_PATTERN = re.compile(
-    r"throws?\s+error|error\s+(?:occurs?|occurred|happens?|when|while)"
-    r"|\bcrash(?:es|ed|ing)?\b|\bexception(?:s)?\b|\bfail(?:ed|s|ure|ing)\b"
-    r"|null\s+(?:pointer|reference|ref)\b|undefined\s+(?:behavior|reference|variable)\b"
-    r"|race\s+condition|deadlock|memory\s+leak",
-    re.IGNORECASE,
-)
-_STYLE_PATTERN = re.compile(
-    r"formatting|naming|indentation|whitespace|convention|code\s*style"
-    r"|stylistic|readability|cleanup|refactor|refactoring",
-    re.IGNORECASE,
-)
-_SUMMARY_PATTERN = re.compile(
-    r"(?m)^\s*#{1,3}\s*(?:summary|overview|changes|walkthrough)",
     re.IGNORECASE,
 )
 
@@ -146,21 +122,6 @@ def comment_needs_action(lifecycle_state: str, sub_state: str | None) -> bool:
     if lifecycle_state == "IN_DISCUSSION":
         return sub_state not in ("WONT_FIX", "FIX_COMMITTED")
     return True
-
-
-def classify_domain(body: str) -> str:
-    """Classify a comment into a domain based on keyword matching."""
-    if not body or not body.strip():
-        return "general"
-    if _SECURITY_PATTERN.search(body):
-        return "security"
-    if _BUG_PATTERN.search(body):
-        return "bug"
-    if _STYLE_PATTERN.search(body):
-        return "style"
-    if _SUMMARY_PATTERN.search(body):
-        return "summary"
-    return "general"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/github_core/comment_classification.py
+++ b/scripts/github_core/comment_classification.py
@@ -1,0 +1,59 @@
+"""Domain classification for GitHub PR/review comments.
+
+Shared, single-source-of-truth for the keyword-based triage that sorts a
+comment body into one of five domains (security, bug, style, summary,
+general). Previously this logic (the compiled patterns plus ``classify_domain``)
+was duplicated verbatim in ``get_pr_review_comments.py`` and
+``get_unaddressed_comments.py`` (Issue #2816, finding 4).
+
+NOTE: Plugin-distributed copy at .claude/lib/github_core/ and
+src/copilot-cli/lib/github_core/. Run ``python3 scripts/sync_plugin_lib.py``
+(and the build) to sync changes.
+"""
+
+from __future__ import annotations
+
+import re
+
+_SECURITY_PATTERN = re.compile(
+    r"cwe-\d+|vulnerability|vulnerabilities|injection|xss|sql|csrf"
+    r"|\bauth(?:entication|orization|enticat|orized)?\b"
+    r"|secrets?|credentials?|toctou|symlink|traversal|sanitiz"
+    r"|\bescap(?:e|ing)\b",
+    re.IGNORECASE,
+)
+_BUG_PATTERN = re.compile(
+    r"throws?\s+error|error\s+(?:occurs?|occurred|happens?|when|while)"
+    r"|\bcrash(?:es|ed|ing)?\b|\bexception(?:s)?\b|\bfail(?:ed|s|ure|ing)\b"
+    r"|null\s+(?:pointer|reference|ref)\b|undefined\s+(?:behavior|reference|variable)\b"
+    r"|race\s+condition|deadlock|memory\s+leak",
+    re.IGNORECASE,
+)
+_STYLE_PATTERN = re.compile(
+    r"formatting|naming|indentation|whitespace|convention|code\s*style"
+    r"|stylistic|readability|cleanup|refactor|refactoring",
+    re.IGNORECASE,
+)
+_SUMMARY_PATTERN = re.compile(
+    r"(?m)^\s*#{1,3}\s*(?:summary|overview|changes|walkthrough)",
+    re.IGNORECASE,
+)
+
+
+def classify_domain(body: str) -> str:
+    """Classify a comment into a domain based on keyword matching.
+
+    Non-string input (for example a JSON ``null`` body surfaced as ``None``)
+    is treated as unclassifiable and returns ``"general"``.
+    """
+    if not isinstance(body, str) or not body.strip():
+        return "general"
+    if _SECURITY_PATTERN.search(body):
+        return "security"
+    if _BUG_PATTERN.search(body):
+        return "bug"
+    if _STYLE_PATTERN.search(body):
+        return "style"
+    if _SUMMARY_PATTERN.search(body):
+        return "summary"
+    return "general"

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/lib/github_core/comment_classification.py
+++ b/src/copilot-cli/lib/github_core/comment_classification.py
@@ -1,0 +1,59 @@
+"""Canonical: scripts/github_core/comment_classification.py. Sync via scripts/sync_plugin_lib.py.
+
+Shared, single-source-of-truth for the keyword-based triage that sorts a
+comment body into one of five domains (security, bug, style, summary,
+general). Previously this logic (the compiled patterns plus ``classify_domain``)
+was duplicated verbatim in ``get_pr_review_comments.py`` and
+``get_unaddressed_comments.py`` (Issue #2816, finding 4).
+
+NOTE: Plugin-distributed copy at .claude/lib/github_core/ and
+src/copilot-cli/lib/github_core/. Run ``python3 scripts/sync_plugin_lib.py``
+(and the build) to sync changes.
+"""
+
+from __future__ import annotations
+
+import re
+
+_SECURITY_PATTERN = re.compile(
+    r"cwe-\d+|vulnerability|vulnerabilities|injection|xss|sql|csrf"
+    r"|\bauth(?:entication|orization|enticat|orized)?\b"
+    r"|secrets?|credentials?|toctou|symlink|traversal|sanitiz"
+    r"|\bescap(?:e|ing)\b",
+    re.IGNORECASE,
+)
+_BUG_PATTERN = re.compile(
+    r"throws?\s+error|error\s+(?:occurs?|occurred|happens?|when|while)"
+    r"|\bcrash(?:es|ed|ing)?\b|\bexception(?:s)?\b|\bfail(?:ed|s|ure|ing)\b"
+    r"|null\s+(?:pointer|reference|ref)\b|undefined\s+(?:behavior|reference|variable)\b"
+    r"|race\s+condition|deadlock|memory\s+leak",
+    re.IGNORECASE,
+)
+_STYLE_PATTERN = re.compile(
+    r"formatting|naming|indentation|whitespace|convention|code\s*style"
+    r"|stylistic|readability|cleanup|refactor|refactoring",
+    re.IGNORECASE,
+)
+_SUMMARY_PATTERN = re.compile(
+    r"(?m)^\s*#{1,3}\s*(?:summary|overview|changes|walkthrough)",
+    re.IGNORECASE,
+)
+
+
+def classify_domain(body: str) -> str:
+    """Classify a comment into a domain based on keyword matching.
+
+    Non-string input (for example a JSON ``null`` body surfaced as ``None``)
+    is treated as unclassifiable and returns ``"general"``.
+    """
+    if not isinstance(body, str) or not body.strip():
+        return "general"
+    if _SECURITY_PATTERN.search(body):
+        return "security"
+    if _BUG_PATTERN.search(body):
+        return "bug"
+    if _STYLE_PATTERN.search(body):
+        return "style"
+    if _SUMMARY_PATTERN.search(body):
+        return "summary"
+    return "general"

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_review_comments.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_review_comments.py
@@ -52,50 +52,7 @@ from github_core.api import (  # noqa: E402
     gh_api_paginated,
     resolve_repo_params,
 )
-
-# ---------------------------------------------------------------------------
-# Domain classification
-# ---------------------------------------------------------------------------
-
-_SECURITY_PATTERN = re.compile(
-    r"cwe-\d+|vulnerability|vulnerabilities|injection|xss|sql|csrf"
-    r"|\bauth(?:entication|orization|enticat|orized)?\b"
-    r"|secrets?|credentials?|toctou|symlink|traversal|sanitiz"
-    r"|\bescap(?:e|ing)\b",
-    re.IGNORECASE,
-)
-_BUG_PATTERN = re.compile(
-    r"throws?\s+error|error\s+(?:occurs?|occurred|happens?|when|while)"
-    r"|\bcrash(?:es|ed|ing)?\b|\bexception(?:s)?\b|\bfail(?:ed|s|ure|ing)\b"
-    r"|null\s+(?:pointer|reference|ref)\b|undefined\s+(?:behavior|reference|variable)\b"
-    r"|race\s+condition|deadlock|memory\s+leak",
-    re.IGNORECASE,
-)
-_STYLE_PATTERN = re.compile(
-    r"formatting|naming|indentation|whitespace|convention|code\s*style"
-    r"|stylistic|readability|cleanup|refactor|refactoring",
-    re.IGNORECASE,
-)
-_SUMMARY_PATTERN = re.compile(
-    r"(?m)^\s*#{1,3}\s*(?:summary|overview|changes|walkthrough)",
-    re.IGNORECASE,
-)
-
-
-def classify_domain(body: str) -> str:
-    """Classify a comment into a domain based on keyword matching."""
-    if not body or not body.strip():
-        return "general"
-    if _SECURITY_PATTERN.search(body):
-        return "security"
-    if _BUG_PATTERN.search(body):
-        return "bug"
-    if _STYLE_PATTERN.search(body):
-        return "style"
-    if _SUMMARY_PATTERN.search(body):
-        return "summary"
-    return "general"
-
+from github_core.comment_classification import classify_domain  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Stale detection helpers

--- a/src/copilot-cli/skills/github/scripts/pr/get_unaddressed_comments.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_unaddressed_comments.py
@@ -48,6 +48,7 @@ from github_core.api import (  # noqa: E402
     gh_api_paginated,
     resolve_repo_params,
 )
+from github_core.comment_classification import classify_domain  # noqa: E402
 from github_core.output import (  # noqa: E402
     add_output_format_arg,
     get_output_format,
@@ -75,31 +76,6 @@ _CLARIFICATION_PATTERN = re.compile(
 _FIX_DESCRIBED_PATTERN = re.compile(
     r"will\s+fix|fixing|updated|changed|modified|addressed"
     r"|implemented|added|removed",
-    re.IGNORECASE,
-)
-
-# Domain classification
-_SECURITY_PATTERN = re.compile(
-    r"cwe-\d+|vulnerability|vulnerabilities|injection|xss|sql|csrf"
-    r"|\bauth(?:entication|orization|enticat|orized)?\b"
-    r"|secrets?|credentials?|toctou|symlink|traversal|sanitiz"
-    r"|\bescap(?:e|ing)\b",
-    re.IGNORECASE,
-)
-_BUG_PATTERN = re.compile(
-    r"throws?\s+error|error\s+(?:occurs?|occurred|happens?|when|while)"
-    r"|\bcrash(?:es|ed|ing)?\b|\bexception(?:s)?\b|\bfail(?:ed|s|ure|ing)\b"
-    r"|null\s+(?:pointer|reference|ref)\b|undefined\s+(?:behavior|reference|variable)\b"
-    r"|race\s+condition|deadlock|memory\s+leak",
-    re.IGNORECASE,
-)
-_STYLE_PATTERN = re.compile(
-    r"formatting|naming|indentation|whitespace|convention|code\s*style"
-    r"|stylistic|readability|cleanup|refactor|refactoring",
-    re.IGNORECASE,
-)
-_SUMMARY_PATTERN = re.compile(
-    r"(?m)^\s*#{1,3}\s*(?:summary|overview|changes|walkthrough)",
     re.IGNORECASE,
 )
 
@@ -146,21 +122,6 @@ def comment_needs_action(lifecycle_state: str, sub_state: str | None) -> bool:
     if lifecycle_state == "IN_DISCUSSION":
         return sub_state not in ("WONT_FIX", "FIX_COMMITTED")
     return True
-
-
-def classify_domain(body: str) -> str:
-    """Classify a comment into a domain based on keyword matching."""
-    if not body or not body.strip():
-        return "general"
-    if _SECURITY_PATTERN.search(body):
-        return "security"
-    if _BUG_PATTERN.search(body):
-        return "bug"
-    if _STYLE_PATTERN.search(body):
-        return "style"
-    if _SUMMARY_PATTERN.search(body):
-        return "summary"
-    return "general"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_comment_classification.py
+++ b/tests/test_comment_classification.py
@@ -1,0 +1,108 @@
+"""Unit tests for the shared comment-domain classifier (Issue #2816).
+
+Covers the single-source-of-truth ``classify_domain`` extracted from the two
+PR-comment skill scripts into ``scripts/github_core/comment_classification.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.github_core.comment_classification import classify_domain
+
+
+class TestClassifyDomainSecurity:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "CWE-22 path traversal found",
+            "This is a SQL injection vulnerability",
+            "Possible XSS in the render path",
+            "Missing CSRF token check",
+            "This weakens authentication",
+            "authorization bypass here",
+            "hard-coded credentials in the file",
+            "secret token committed",
+            "TOCTOU race on the symlink",
+            "needs input sanitization",
+            "must escape the user string",
+        ],
+    )
+    def test_security(self, body: str) -> None:
+        assert classify_domain(body) == "security"
+
+
+class TestClassifyDomainBug:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "This throws error when empty",
+            "the app crashes on startup",
+            "unhandled exception here",
+            "this fails when input is empty",
+            "null pointer dereference",
+            "undefined behavior in this path",
+            "there is a race condition",
+            "this deadlocks under load",
+            "memory leak in the loop",
+        ],
+    )
+    def test_bug(self, body: str) -> None:
+        assert classify_domain(body) == "bug"
+
+
+class TestClassifyDomainStyle:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "Fix the formatting and indentation",
+            "Consider renaming this variable",
+            "whitespace nit",
+            "does not follow the naming convention",
+            "improve readability here",
+            "small cleanup / refactor",
+        ],
+    )
+    def test_style(self, body: str) -> None:
+        assert classify_domain(body) == "style"
+
+
+class TestClassifyDomainSummary:
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "## Summary\nOverview of changes",
+            "# Overview",
+            "### Walkthrough of the diff",
+            "## Changes",
+        ],
+    )
+    def test_summary(self, body: str) -> None:
+        assert classify_domain(body) == "summary"
+
+
+class TestClassifyDomainGeneral:
+    @pytest.mark.parametrize("body", ["This looks good to me", "LGTM", "thanks!"])
+    def test_general(self, body: str) -> None:
+        assert classify_domain(body) == "general"
+
+    @pytest.mark.parametrize("body", ["", "   ", "\n\t "])
+    def test_empty_or_whitespace(self, body: str) -> None:
+        assert classify_domain(body) == "general"
+
+    @pytest.mark.parametrize("body", [None, 0, 123, ["security"], {"a": 1}])
+    def test_non_string_returns_general(self, body: object) -> None:
+        # Comment bodies come from an external API; a JSON null surfaces as
+        # None. classify_domain must be total, never raising on such input.
+        assert classify_domain(body) == "general"  # type: ignore[arg-type]
+
+
+class TestClassifyDomainPrecedence:
+    def test_security_beats_bug(self) -> None:
+        # Body matches both bug ("crash") and security ("vulnerability");
+        # security wins per the ordered checks.
+        assert classify_domain("crash from a known vulnerability") == "security"
+
+    def test_bug_beats_style(self) -> None:
+        # Body matches both style ("refactor") and bug ("exception").
+        assert classify_domain("refactor to stop the exception") == "bug"


### PR DESCRIPTION
## Summary

Finding 4 of the 2026-07-02 read-only safety audit: the security-triage
comment-classification regexes and the `classify_domain` function were
duplicated verbatim across two skill scripts in both packaged plugin trees
(`.claude` and `src/copilot-cli`). This extracts them to a single
source of truth and imports it everywhere.

## Changes

- New shared module in `scripts/github_core` holding the four compiled
  domain patterns plus `classify_domain`, auto-synced to both plugin
  `lib/github_core` copies by the existing sync/build.
- Both PR-comment skill scripts now import the shared classifier instead
  of carrying their own copy (168 duplicated lines removed).
- New unit tests covering all five domains, empty/whitespace input, and
  check-order precedence (security over bug, bug over style).
- Bumped the two affected plugin versions 0.6.3 to 0.6.4 (packaged plugin
  source changed, so the version-bump gate requires it).

## Validation

- `pytest` for the new suite plus both consumer suites: 84 passed.
- `ruff check` on all touched Python: clean.
- `validate_plugin_version_bump.py`: OK.
- `validate_plugin_manifests.py` and manifest parity: OK (both at 0.6.4).
- `build_all.py`: idempotent, distributed tree consistent.

## Scope

This addresses only finding 4. The other six findings in the audit
(hook bootstrap duplication, unsynced bootstrap copy, review-marker
parity, CWE-22 validators, baseline-comparison boilerplate, resolve-paths
fallback) remain open under the same issue and need their own PRs.

Refs #2816

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
