### PR TITLE
feat(eval): end-to-end delivery eval (plan-rubric proxy) (#2859)

### DIFF
--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -42,7 +42,49 @@ python3 scripts/eval/eval-skill-overlap.py \
 | `eval-rule-activation.py` | `.claude/rules/*.md` activation across baseline / description / full mechanisms. | Complementary |
 | `analyze-pr-churn.py` | Deterministic commit-churn classification across a PR cohort (degenerate vs control) to evaluate instruction/rule changes against historical PRs. No LLM; core in `_pr_churn.py`. | Complementary |
 | `eval-reviewer-asymmetry.py` | Statistical-significance test for `templates/agents/{critic,qa,implementer}.shared.md` reviewer-asymmetry framing. Fisher's exact (verdict-pass) + Mann-Whitney U (findings-count). | Complementary |
+| `eval-e2e-delivery.py` | End-to-end delivery eval (plan-rubric proxy). Feeds a vague germ, captures each agent's plan, LLM-judges it against hidden acceptance criteria. Core in `_e2e_delivery_core.py`. | #2859 |
 | `_anthropic_api.py` | Shared API utilities (key loading, API calls). | N/A |
+
+## End-to-End Delivery Eval
+
+The routing eval (`eval-prompt-change.py`) scores a single classify-and-route
+decision; orchestrator and autoplan both hit the routing ceiling there, which
+proves lane-picking, not delivery. `eval-e2e-delivery.py` measures whether an
+agent can carry an under-specified ask toward done.
+
+This is harness shape 2 from issue #2859 (the cheaper plan-rubric proxy). It
+feeds each agent a deliberately vague germ, captures the plan the agent emits,
+and has an LLM judge score that plan against hidden acceptance criteria on
+five axes (max 11): `scope`, `completeness`, `process_gates`, `decomposition`,
+`correct_stop`.
+
+```bash
+# Validate fixtures + resolve agent prompts; no API calls:
+python3 scripts/eval/eval-e2e-delivery.py \
+    --fixtures scripts/eval/examples/e2e-delivery-fixtures.json --dry-run
+
+# Live run, 3 runs per cell (flakiness protocol), write a report:
+python3 scripts/eval/eval-e2e-delivery.py \
+    --fixtures scripts/eval/examples/e2e-delivery-fixtures.json \
+    --runs 3 --output artifacts/e2e-delivery.json
+```
+
+Ground-truth discipline: for the `feature`/`bug` fixtures the hidden criteria
+are derived from a real merged PR (see each fixture's `provenance`), so they
+are independent of the agent prompts under test. `ambiguous` and
+`multi-domain` fixtures are synthetic process probes (stop-and-ask, or
+coordinated decomposition) and labeled as such.
+
+Honest limits (printed in every report as `caveat`):
+
+- Plan quality is a proxy for delivery. A high score does not prove the code
+  compiles or passes tests; that needs the trace-based shape (#2859 shape 1).
+- The fixtures and criteria are single-author curated, so absolute scores are
+  directional. Trust relative deltas that clear the run-to-run noise band.
+- Same-family judge (the default model judges its own family's output).
+
+`--agents` selects which agents to compare (default `orchestrator,autoplan`);
+`--ref` loads an agent prompt from a git ref if it is not on the working tree.
 
 ## Reviewer-Asymmetry Eval
 

--- a/scripts/eval/_e2e_delivery_core.py
+++ b/scripts/eval/_e2e_delivery_core.py
@@ -1,0 +1,316 @@
+"""Pure core for the end-to-end delivery eval (issue #2859).
+
+The routing eval (`eval-prompt-change.py`) only scores a single classify-
+and-route decision. On 13 routing fixtures orchestrator and autoplan both
+scored 100 percent: it proves they pick the lane, not that either can carry
+an under-specified ask to a correct change with tests, docs, and gates.
+
+This module is the *plan-rubric proxy* (harness shape 2 in the issue). It
+feeds each agent a deliberately vague germ, captures the plan the agent
+emits, and has an LLM judge score that plan against hidden acceptance
+criteria. Every function here is pure and API-free so the scoring, parsing,
+and aggregation logic is unit-testable without a network call; the live
+orchestration lives in `eval-e2e-delivery.py`.
+
+Ground-truth discipline (the load-bearing requirement in #2859): a fixture's
+`hidden_criteria` are derived from a *real merged PR* that closed the source
+issue, not from the phrasing of the agent prompt under test. That keeps the
+criteria independent of the prompts. It does NOT remove the closed-loop
+caveat: the fixtures and criteria are still curated by one author, so
+absolute scores are directional. The report prints this caveat.
+
+Proxy limit: plan quality is a proxy for delivery. A high plan score does
+not prove the resulting code compiles or passes tests. Only the trace-based
+shape (run the agent, grade the diff) proves that; see #2859 shape 1.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+SCHEMA_VERSION: int = 1
+
+# Per-axis maximum points. Total = 11. The axes operationalize the four
+# things the issue says the delivery must be scored on plus the ask-vs-guess
+# boundary it calls out explicitly.
+RUBRIC_AXES: dict[str, int] = {
+    "scope": 3,          # right-sized: not over- or under-engineered
+    "completeness": 3,   # covers behavior + required tests + docs
+    "process_gates": 2,  # acknowledges lint / session log / mirror gates
+    "decomposition": 2,  # sensible, non-inflated task breakdown
+    "correct_stop": 1,   # ask-vs-produce boundary handled correctly
+}
+MAX_SCORE: int = sum(RUBRIC_AXES.values())
+
+# Required fixture keys and the required hidden-criteria sub-keys. A fixture
+# missing any of these is a design error, not a runtime edge case, so we
+# fail loud at load time.
+_REQUIRED_FIXTURE_KEYS = frozenset({"id", "prompt", "kind", "hidden_criteria"})
+_REQUIRED_CRITERIA_KEYS = frozenset(
+    {
+        "behavior",
+        "required_tests",
+        "required_docs",
+        "required_gates",
+        "ambiguous_stop_expected",
+    }
+)
+_VALID_KINDS = frozenset({"feature", "bug", "ambiguous", "multi-domain"})
+
+PARSE_ERROR = "PARSE_ERROR"
+
+
+class FixtureError(ValueError):
+    """Raised when a fixture file fails schema validation."""
+
+
+def validate_fixture(fixture: dict[str, Any]) -> None:
+    """Validate one fixture dict. Raises FixtureError on any violation."""
+    missing = _REQUIRED_FIXTURE_KEYS - fixture.keys()
+    if missing:
+        raise FixtureError(
+            f"fixture {fixture.get('id', '<no id>')!r} missing keys: "
+            f"{sorted(missing)}"
+        )
+    kind = fixture["kind"]
+    if kind not in _VALID_KINDS:
+        raise FixtureError(
+            f"fixture {fixture['id']!r} has invalid kind {kind!r}; "
+            f"expected one of {sorted(_VALID_KINDS)}"
+        )
+    criteria = fixture["hidden_criteria"]
+    if not isinstance(criteria, dict):
+        raise FixtureError(
+            f"fixture {fixture['id']!r} hidden_criteria must be an object"
+        )
+    missing_c = _REQUIRED_CRITERIA_KEYS - criteria.keys()
+    if missing_c:
+        raise FixtureError(
+            f"fixture {fixture['id']!r} hidden_criteria missing: "
+            f"{sorted(missing_c)}"
+        )
+    if not isinstance(criteria["ambiguous_stop_expected"], bool):
+        raise FixtureError(
+            f"fixture {fixture['id']!r} ambiguous_stop_expected must be bool"
+        )
+    # An `ambiguous` fixture that does not expect a stop, or a non-ambiguous
+    # fixture that does, is a self-contradiction that would silently score
+    # the correct_stop axis backwards.
+    if (kind == "ambiguous") != bool(criteria["ambiguous_stop_expected"]):
+        raise FixtureError(
+            f"fixture {fixture['id']!r}: kind={kind!r} disagrees with "
+            f"ambiguous_stop_expected={criteria['ambiguous_stop_expected']!r}"
+        )
+
+
+def load_fixtures(raw: str) -> list[dict[str, Any]]:
+    """Parse and validate a fixtures JSON document.
+
+    Accepts either a bare list of fixtures or an object with a top-level
+    ``fixtures`` array and optional ``schemaVersion``. Every fixture is
+    validated; duplicate ids are rejected.
+    """
+    doc = json.loads(raw)
+    if isinstance(doc, dict):
+        version = doc.get("schemaVersion", SCHEMA_VERSION)
+        if version != SCHEMA_VERSION:
+            raise FixtureError(
+                f"unsupported schemaVersion {version!r}; "
+                f"this harness handles {SCHEMA_VERSION}"
+            )
+        fixtures = doc.get("fixtures")
+    else:
+        fixtures = doc
+    if not isinstance(fixtures, list) or not fixtures:
+        raise FixtureError("fixtures document must contain a non-empty list")
+    seen: set[str] = set()
+    for fx in fixtures:
+        if not isinstance(fx, dict):
+            raise FixtureError("each fixture must be an object")
+        validate_fixture(fx)
+        if fx["id"] in seen:
+            raise FixtureError(f"duplicate fixture id {fx['id']!r}")
+        seen.add(fx["id"])
+    return fixtures
+
+
+def build_agent_user_message(germ: str) -> str:
+    """The user turn handed to an agent: the vague germ plus a plan request.
+
+    The germ is intentionally under-specified. We ask only for the plan the
+    agent would follow, not for the code, because this is the proxy shape.
+    """
+    return (
+        f"{germ.strip()}\n\n"
+        "Produce the plan you would follow to carry this to done. Include: "
+        "the concrete change, the tests you would add (positive, negative, "
+        "edge), the docs or specs you would update, and the gates you would "
+        "run. If the request is too ambiguous to act on safely, say so and "
+        "state the clarifying question you would ask instead of guessing."
+    )
+
+
+def build_judge_system() -> str:
+    """System prompt for the LLM judge. Deterministic, rubric-bound."""
+    axes = "\n".join(
+        f"- {name} (0-{pts}): {desc}"
+        for name, pts, desc in (
+            ("scope", RUBRIC_AXES["scope"],
+             "Is the plan right-sized for the real change? Penalize both "
+             "over-engineering (ADRs, analyzers, broad audits for a tiny fix) "
+             "and under-scoping."),
+            ("completeness", RUBRIC_AXES["completeness"],
+             "Does the plan cover the required behavior, the required tests, "
+             "and the required docs from the criteria?"),
+            ("process_gates", RUBRIC_AXES["process_gates"],
+             "Does the plan acknowledge the required process gates (lint, "
+             "session log, mirror/sync, CI)?"),
+            ("decomposition", RUBRIC_AXES["decomposition"],
+             "Is the task breakdown sensible and proportional, neither a "
+             "single blob nor inflated busywork?"),
+            ("correct_stop", RUBRIC_AXES["correct_stop"],
+             "The ask-vs-produce boundary. If ambiguous_stop_expected is "
+             "true, award 1 only if the plan STOPS and asks a clarifying "
+             "question instead of guessing. If false, award 1 only if the "
+             "plan proceeds without stalling on a false ambiguity."),
+        )
+    )
+    return (
+        "You are a strict, impartial evaluator of engineering plans. You are "
+        "given a vague request, the hidden acceptance criteria that the "
+        "delivery must satisfy (derived from a real merged pull request, not "
+        "shown to the agent), and the plan an agent produced. Score the plan "
+        "against the criteria on these axes:\n"
+        f"{axes}\n\n"
+        "Judge only what the plan says, not what you assume the agent meant. "
+        "Do not reward verbosity. Respond with a JSON object only, no "
+        "surrounding prose:\n"
+        '{"scope": <int>, "completeness": <int>, "process_gates": <int>, '
+        '"decomposition": <int>, "correct_stop": <int>, '
+        '"rationale": "<one or two sentences>"}'
+    )
+
+
+def build_judge_user_message(fixture: dict[str, Any], plan: str) -> str:
+    """Assemble the judge's user turn from a fixture and an emitted plan."""
+    c = fixture["hidden_criteria"]
+    return (
+        f"VAGUE REQUEST:\n{fixture['prompt'].strip()}\n\n"
+        f"HIDDEN ACCEPTANCE CRITERIA (agent did not see these):\n"
+        f"- behavior: {c['behavior']}\n"
+        f"- required_tests: {c['required_tests']}\n"
+        f"- required_docs: {c['required_docs']}\n"
+        f"- required_gates: {c['required_gates']}\n"
+        f"- ambiguous_stop_expected: {c['ambiguous_stop_expected']}\n\n"
+        f"AGENT PLAN:\n{plan.strip()}\n\n"
+        "Score the plan now."
+    )
+
+
+def _extract_json(raw: str) -> dict[str, Any] | None:
+    """Best-effort extraction of a single JSON object from model text."""
+    text = raw.strip()
+    if "```" in text:
+        fenced = re.search(r"```(?:json)?\s*\n(.*?)```", text, re.DOTALL)
+        if fenced:
+            text = fenced.group(1).strip()
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        return None
+    try:
+        parsed = json.loads(match.group())
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def parse_judge_response(raw: str) -> dict[str, Any]:
+    """Parse a judge response into a scored record.
+
+    Returns a dict with each axis clamped to [0, axis_max], an integer
+    ``total``, the ``rationale`` string, and the ``raw`` text. On a parse
+    failure returns ``{"verdict": PARSE_ERROR, ...}`` with ``total`` None so
+    the caller can drop the cell rather than score it as a zero.
+    """
+    parsed = _extract_json(raw)
+    if parsed is None:
+        return {"verdict": PARSE_ERROR, "total": None, "raw": raw}
+    axes: dict[str, int] = {}
+    for name, max_pts in RUBRIC_AXES.items():
+        value = parsed.get(name, 0)
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            value = 0
+        axes[name] = max(0, min(max_pts, value))
+    total = sum(axes.values())
+    return {
+        "verdict": "SCORED",
+        "axes": axes,
+        "total": total,
+        "rationale": str(parsed.get("rationale", "")),
+        "raw": raw,
+    }
+
+
+def _mean(values: list[float]) -> float | None:
+    return round(sum(values) / len(values), 2) if values else None
+
+
+def aggregate(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate scored run records into a comparison report.
+
+    ``records`` are dicts with keys ``fixture_id``, ``agent``, and ``total``
+    (None totals from parse errors are excluded from means). Produces per
+    fixture-and-agent means, per-agent aggregate means, and per-fixture
+    deltas when exactly two agents are present.
+    """
+    agents = sorted({r["agent"] for r in records})
+    fixtures = sorted({r["fixture_id"] for r in records})
+
+    by_cell: dict[tuple[str, str], list[float]] = {}
+    for r in records:
+        if r.get("total") is None:
+            continue
+        by_cell.setdefault((r["fixture_id"], r["agent"]), []).append(r["total"])
+
+    per_fixture: dict[str, dict[str, Any]] = {}
+    for fx in fixtures:
+        row: dict[str, Any] = {}
+        for agent in agents:
+            row[agent] = _mean(by_cell.get((fx, agent), []))
+        if len(agents) == 2:
+            a0, a1 = agents
+            m0, m1 = row.get(a0), row.get(a1)
+            # delta is signed as (later-alphabetical minus earlier-
+            # alphabetical); delta_of names the orientation so a report
+            # reader never has to guess the sign.
+            row["delta"] = (
+                round(m1 - m0, 2) if m0 is not None and m1 is not None else None
+            )
+            row["delta_of"] = f"{a1} - {a0}"
+        per_fixture[fx] = row
+
+    per_agent: dict[str, float | None] = {}
+    for agent in agents:
+        totals = [
+            t
+            for (fx, ag), lst in by_cell.items()
+            if ag == agent
+            for t in lst
+        ]
+        per_agent[agent] = _mean(totals)
+
+    parse_errors = sum(1 for r in records if r.get("total") is None)
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "max_score": MAX_SCORE,
+        "agents": agents,
+        "fixtures": fixtures,
+        "per_fixture": per_fixture,
+        "per_agent_mean": per_agent,
+        "parse_errors": parse_errors,
+        "n_records": len(records),
+    }

--- a/scripts/eval/_e2e_delivery_core.py
+++ b/scripts/eval/_e2e_delivery_core.py
@@ -1,9 +1,9 @@
 """Pure core for the end-to-end delivery eval (issue #2859).
 
-The routing eval (`eval-prompt-change.py`) only scores a single classify-
-and-route decision. On 13 routing fixtures orchestrator and autoplan both
-scored 100 percent: it proves they pick the lane, not that either can carry
-an under-specified ask to a correct change with tests, docs, and gates.
+The routing eval (`eval-prompt-change.py`) only scores a single
+classify-and-route decision. On 13 routing fixtures orchestrator and autoplan
+both scored 100 percent: it proves they pick the lane, not that either can
+carry an under-specified ask to a correct change with tests, docs, and gates.
 
 This module is the *plan-rubric proxy* (harness shape 2 in the issue). It
 feeds each agent a deliberately vague germ, captures the plan the agent
@@ -74,6 +74,12 @@ def validate_fixture(fixture: dict[str, Any]) -> None:
             f"fixture {fixture.get('id', '<no id>')!r} missing keys: "
             f"{sorted(missing)}"
         )
+    if not isinstance(fixture["id"], str):
+        raise FixtureError(
+            f"fixture id must be a string, got {type(fixture['id']).__name__}"
+        )
+    if not isinstance(fixture["prompt"], str):
+        raise FixtureError(f"fixture {fixture['id']!r} prompt must be a string")
     kind = fixture["kind"]
     if kind not in _VALID_KINDS:
         raise FixtureError(
@@ -91,6 +97,14 @@ def validate_fixture(fixture: dict[str, Any]) -> None:
             f"fixture {fixture['id']!r} hidden_criteria missing: "
             f"{sorted(missing_c)}"
         )
+    if not isinstance(criteria["behavior"], str):
+        raise FixtureError(f"fixture {fixture['id']!r} behavior must be a string")
+    for key in ("required_tests", "required_docs", "required_gates"):
+        val = criteria[key]
+        if not isinstance(val, list) or not all(isinstance(x, str) for x in val):
+            raise FixtureError(
+                f"fixture {fixture['id']!r} {key} must be a list of strings"
+            )
     if not isinstance(criteria["ambiguous_stop_expected"], bool):
         raise FixtureError(
             f"fixture {fixture['id']!r} ambiguous_stop_expected must be bool"
@@ -210,20 +224,29 @@ def build_judge_user_message(fixture: dict[str, Any], plan: str) -> str:
 
 
 def _extract_json(raw: str) -> dict[str, Any] | None:
-    """Best-effort extraction of a single JSON object from model text."""
+    """Best-effort extraction of a single JSON object from model text.
+
+    Scans for the first ``{`` that begins a decodable object using
+    ``raw_decode`` rather than a greedy ``{.*}`` match, so trailing braces,
+    prose after the object, or a second object do not over-capture and force
+    an avoidable parse error that would drop the run from the means.
+    """
     text = raw.strip()
     if "```" in text:
         fenced = re.search(r"```(?:json)?\s*\n(.*?)```", text, re.DOTALL)
         if fenced:
             text = fenced.group(1).strip()
-    match = re.search(r"\{.*\}", text, re.DOTALL)
-    if not match:
-        return None
-    try:
-        parsed = json.loads(match.group())
-    except json.JSONDecodeError:
-        return None
-    return parsed if isinstance(parsed, dict) else None
+    decoder = json.JSONDecoder()
+    for idx, ch in enumerate(text):
+        if ch != "{":
+            continue
+        try:
+            obj, _ = decoder.raw_decode(text[idx:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            return obj
+    return None
 
 
 def parse_judge_response(raw: str) -> dict[str, Any]:
@@ -246,11 +269,12 @@ def parse_judge_response(raw: str) -> dict[str, Any]:
             value = 0
         axes[name] = max(0, min(max_pts, value))
     total = sum(axes.values())
+    rationale = parsed.get("rationale", "")
     return {
         "verdict": "SCORED",
         "axes": axes,
         "total": total,
-        "rationale": str(parsed.get("rationale", "")),
+        "rationale": rationale if isinstance(rationale, str) else "",
         "raw": raw,
     }
 

--- a/scripts/eval/eval-e2e-delivery.py
+++ b/scripts/eval/eval-e2e-delivery.py
@@ -3,8 +3,8 @@
 
 Feeds each agent a deliberately vague germ, captures the plan it emits, and
 has an LLM judge score that plan against hidden acceptance criteria derived
-from a real merged PR. This measures whether an agent can carry an under-
-specified ask toward done, not just whether it picks the right lane (the
+from a real merged PR. This measures whether an agent can carry an
+under-specified ask toward done, not just whether it picks the right lane (the
 routing eval already showed both agents tie at the routing ceiling).
 
 This is harness shape 2 from the issue (cheaper, weaker proxy). It scores
@@ -79,7 +79,8 @@ def _load_prompt(rel_path: str, ref: str | None) -> str:
             out = subprocess.run(
                 ["git", "show", f"{ref}:{rel_path}"],
                 capture_output=True,
-                text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=True,
                 timeout=30,
                 cwd=_REPO_ROOT,

--- a/scripts/eval/eval-e2e-delivery.py
+++ b/scripts/eval/eval-e2e-delivery.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""End-to-end delivery eval: plan-rubric proxy (issue #2859).
+
+Feeds each agent a deliberately vague germ, captures the plan it emits, and
+has an LLM judge score that plan against hidden acceptance criteria derived
+from a real merged PR. This measures whether an agent can carry an under-
+specified ask toward done, not just whether it picks the right lane (the
+routing eval already showed both agents tie at the routing ceiling).
+
+This is harness shape 2 from the issue (cheaper, weaker proxy). It scores
+plan quality, NOT delivered code. It cannot prove the change compiles or
+passes tests; graduate to the trace-based shape (#2859 shape 1) for that.
+
+Usage:
+    # Validate fixtures and resolve prompts without any API call:
+    python scripts/eval/eval-e2e-delivery.py \\
+        --fixtures scripts/eval/examples/e2e-delivery-fixtures.json --dry-run
+
+    # Live run, 3 runs per cell (flakiness protocol), write a report:
+    python scripts/eval/eval-e2e-delivery.py \\
+        --fixtures scripts/eval/examples/e2e-delivery-fixtures.json \\
+        --runs 3 --output artifacts/e2e-delivery.json
+
+Ground-truth discipline: fixture criteria come from real merged PRs, so they
+are independent of the agent prompts. They are still single-author curated,
+so absolute scores are directional; trust relative deltas that clear the
+run-to-run noise band. The report header restates this.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# eval-* scripts import sibling helpers by bare name, so the eval dir must be
+# importable when this file runs as a script.
+_EVAL_DIR = Path(__file__).resolve().parent
+if str(_EVAL_DIR) not in sys.path:
+    sys.path.insert(0, str(_EVAL_DIR))
+
+from _anthropic_api import (  # noqa: E402
+    DEFAULT_MODEL,
+    call_api,
+    load_api_key,
+    verify_model_available,
+)
+from _e2e_delivery_core import (  # noqa: E402
+    MAX_SCORE,
+    aggregate,
+    build_agent_user_message,
+    build_judge_system,
+    build_judge_user_message,
+    load_fixtures,
+    parse_judge_response,
+)
+
+_REPO_ROOT = _EVAL_DIR.parents[1]
+
+# Agent prompt sources, relative to the repo root. autoplan is a SKILL
+# (SKILL.md read into context); orchestrator is a subagent system prompt.
+# The issue notes autoplan once lived only on the PR #2829 branch; it has
+# since merged to main, so a file path resolves. `--ref` still lets a run
+# load either prompt from an arbitrary git ref if needed.
+AGENT_REGISTRY: dict[str, str] = {
+    "orchestrator": ".claude/agents/orchestrator.md",
+    "autoplan": ".claude/skills/autoplan/SKILL.md",
+}
+
+
+def _load_prompt(rel_path: str, ref: str | None) -> str:
+    """Load an agent prompt from the working tree or a git ref."""
+    if ref:
+        import subprocess
+
+        try:
+            out = subprocess.run(
+                ["git", "show", f"{ref}:{rel_path}"],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+                cwd=_REPO_ROOT,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                f"cannot load {rel_path} from ref {ref!r}: {exc.stderr.strip()}"
+            ) from exc
+        return out.stdout
+    path = _REPO_ROOT / rel_path
+    if not path.exists():
+        raise RuntimeError(f"agent prompt not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _resolve_agents(names: list[str], ref: str | None) -> dict[str, str]:
+    """Map each requested agent name to its prompt text."""
+    resolved: dict[str, str] = {}
+    for name in names:
+        rel = AGENT_REGISTRY.get(name)
+        if rel is None:
+            raise RuntimeError(
+                f"unknown agent {name!r}; known: {sorted(AGENT_REGISTRY)}"
+            )
+        resolved[name] = _load_prompt(rel, ref)
+    return resolved
+
+
+def _run_cell(
+    api_key: str,
+    agent_prompt: str,
+    fixture: dict,
+    model: str,
+    provider: str | None,
+) -> dict:
+    """One (fixture, agent) run: emit a plan, then judge it."""
+    plan = call_api(
+        api_key,
+        [{"role": "user", "content": build_agent_user_message(fixture["prompt"])}],
+        system=agent_prompt,
+        model=model,
+        max_tokens=2048,
+        provider=provider,
+    )
+    verdict = call_api(
+        api_key,
+        [
+            {
+                "role": "user",
+                "content": build_judge_user_message(fixture, plan),
+            }
+        ],
+        system=build_judge_system(),
+        model=model,
+        max_tokens=1024,
+        provider=provider,
+    )
+    scored = parse_judge_response(verdict)
+    scored["plan_chars"] = len(plan)
+    return scored
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="End-to-end delivery eval (plan-rubric proxy, #2859)."
+    )
+    parser.add_argument(
+        "--fixtures", required=True, help="Path to fixtures JSON file"
+    )
+    parser.add_argument(
+        "--agents",
+        default="orchestrator,autoplan",
+        help="Comma-separated agent names (default: orchestrator,autoplan)",
+    )
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Model id")
+    parser.add_argument(
+        "--runs", type=int, default=3, help="Runs per cell (default 3)"
+    )
+    parser.add_argument("--ref", default=None, help="Git ref for agent prompts")
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Only run the first N fixtures"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate fixtures and resolve prompts; no API calls",
+    )
+    parser.add_argument("--output", default=None, help="Write JSON report here")
+    return parser.parse_args(argv)
+
+
+_CAVEAT = (
+    "PROXY EVAL: scores plan quality, not delivered code. Criteria come from "
+    "real merged PRs (independent of the agent prompts) but are single-author "
+    "curated, so absolute scores are directional; trust deltas that clear the "
+    "run-to-run noise band. Same-family judge. See issue #2859."
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    agent_names = [a.strip() for a in args.agents.split(",") if a.strip()]
+    fixtures = load_fixtures(Path(args.fixtures).read_text(encoding="utf-8"))
+    if args.limit is not None:
+        fixtures = fixtures[: args.limit]
+    agent_prompts = _resolve_agents(agent_names, args.ref)
+
+    if args.dry_run:
+        print(
+            json.dumps(
+                {
+                    "dry_run": True,
+                    "caveat": _CAVEAT,
+                    "max_score": MAX_SCORE,
+                    "fixtures": [f["id"] for f in fixtures],
+                    "agents": agent_names,
+                    "runs_per_cell": args.runs,
+                    "planned_api_calls": len(fixtures)
+                    * len(agent_names)
+                    * args.runs
+                    * 2,  # one generate + one judge per run
+                    "model": args.model,
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    api_key = load_api_key()
+    if not os.environ.get("EVAL_SKIP_MODEL_PREFLIGHT"):
+        verify_model_available(api_key, model=args.model)
+    provider = os.environ.get("EVAL_PROVIDER") or None
+
+    records: list[dict] = []
+    for fixture in fixtures:
+        for agent in agent_names:
+            for run_index in range(args.runs):
+                scored = _run_cell(
+                    api_key,
+                    agent_prompts[agent],
+                    fixture,
+                    args.model,
+                    provider,
+                )
+                records.append(
+                    {
+                        "fixture_id": fixture["id"],
+                        "agent": agent,
+                        "run_index": run_index,
+                        "total": scored.get("total"),
+                        "axes": scored.get("axes"),
+                        "plan_chars": scored.get("plan_chars"),
+                        "verdict": scored.get("verdict"),
+                    }
+                )
+
+    report = aggregate(records)
+    report["caveat"] = _CAVEAT
+    report["model"] = args.model
+    report["runs_per_cell"] = args.runs
+    payload = {"report": report, "records": records}
+    text = json.dumps(payload, indent=2)
+    if args.output:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text, encoding="utf-8")
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/examples/e2e-delivery-fixtures.json
+++ b/scripts/eval/examples/e2e-delivery-fixtures.json
@@ -1,0 +1,97 @@
+{
+  "schemaVersion": 1,
+  "_comment": "End-to-end delivery eval fixtures (issue #2859). Each germ is a deliberately vague, under-specified prompt. hidden_criteria are NOT shown to the agent. For F1-F4 the criteria are ground-truthed to a real merged PR (independent of the agent prompts under test); provenance carries the PR url. Ambiguity and coordination probes are synthetic: their ground truth is a process expectation (stop-and-ask, or multi-domain decomposition), not a single external PR, and are labeled as such. This is a starter set; add more PR-grounded fixtures as real issues land.",
+  "fixtures": [
+    {
+      "id": "F1-wrapped-setup",
+      "kind": "feature",
+      "provenance": "merged-pr:https://github.com/rjmurillo/moq.analyzers/pull/1086",
+      "prompt": "My Moq setups keep getting flagged for not specifying a return value, but they DO return a value: the return comes from a little helper extension method that calls Returns internally. Stop the false positive.",
+      "hidden_criteria": {
+        "behavior": "The MethodSetupShouldSpecifyReturnValue (Moq1203) analyzer must stop flagging a setup when the return value is supplied through an extension method that internally calls Returns, instead of only recognizing a direct .Returns/.ReturnsAsync call.",
+        "required_tests": ["positive: direct Returns still flags when missing", "negative: setup whose return is supplied via a wrapping extension method is NOT flagged", "edge: multiple wrapper families (IReturns/ICallback/ISetup) are recognized"],
+        "required_docs": [],
+        "required_gates": ["dotnet build", "dotnet test (analyzer + known-symbols tests)"],
+        "ambiguous_stop_expected": false
+      }
+    },
+    {
+      "id": "F2-simple-lambda",
+      "kind": "feature",
+      "provenance": "merged-pr:https://github.com/rjmurillo/moq.analyzers/pull/1042",
+      "prompt": "The callback-signature analyzer chokes on single-parameter lambdas written without parentheses, like x => x.Foo(). It only understands the (x) => form. Make it understand both.",
+      "hidden_criteria": {
+        "behavior": "CallbackSignatureShouldMatchMockedMethod analysis and its code fix must handle SimpleLambdaExpressionSyntax (single unparenthesized parameter) in addition to ParenthesizedLambdaExpressionSyntax when validating callback signatures.",
+        "required_tests": ["positive: simple lambda with matching signature passes", "negative: simple lambda with mismatched signature is flagged", "edge: code fix rewrites the simple-lambda form correctly"],
+        "required_docs": [],
+        "required_gates": ["dotnet build", "dotnet test (analyzer + code-fix tests)"],
+        "ambiguous_stop_expected": false
+      }
+    },
+    {
+      "id": "F3-null-guard",
+      "kind": "bug",
+      "provenance": "merged-pr:https://github.com/rjmurillo/moq.analyzers/pull/1027",
+      "prompt": "The DefaultIfNotSingle helper silently returns default when I hand it a null sequence. The BCL throws for a null source. It should behave the same.",
+      "hidden_criteria": {
+        "behavior": "DefaultIfNotSingle (and its parameterless overload that delegates to it) must throw ArgumentNullException when the source is null, matching BCL LINQ behavior, instead of returning default.",
+        "required_tests": ["positive: non-null source still returns the expected single/default value", "negative: null source throws ArgumentNullException with the source parameter name"],
+        "required_docs": [],
+        "required_gates": ["dotnet build", "dotnet test (EnumerableExtensions tests)"],
+        "ambiguous_stop_expected": false
+      }
+    },
+    {
+      "id": "F4-codefix-null-guard",
+      "kind": "bug",
+      "provenance": "merged-pr:https://github.com/rjmurillo/moq.analyzers/pull/1004",
+      "prompt": "The callback code fix sometimes blows up. I think it tries to register even when the symbols it needs are not there yet. Make it not crash.",
+      "hidden_criteria": {
+        "behavior": "The CallbackSignatureShouldMatchMockedMethod code-fix provider must guard its registration so it does not throw (NullReferenceException) when its prerequisite symbols are null; it should simply not offer the fix in that case.",
+        "required_tests": ["positive: fix is still offered and applies when prerequisites are present", "negative: no throw and no fix offered when a prerequisite symbol is null"],
+        "required_docs": [],
+        "required_gates": ["dotnet build", "dotnet test (code-fix tests)"],
+        "ambiguous_stop_expected": false
+      }
+    },
+    {
+      "id": "A1-vague-retry",
+      "kind": "ambiguous",
+      "provenance": "synthetic:ambiguity-probe",
+      "prompt": "Make the retry logic better.",
+      "hidden_criteria": {
+        "behavior": "The request is under-specified: it names no component, no repository, and no definition of 'better' (attempt count? backoff strategy? which failures are retryable? latency budget?). A correct response STOPS and asks a clarifying question instead of guessing a target and a definition of success.",
+        "required_tests": [],
+        "required_docs": [],
+        "required_gates": [],
+        "ambiguous_stop_expected": true
+      }
+    },
+    {
+      "id": "A2-vague-faster",
+      "kind": "ambiguous",
+      "provenance": "synthetic:ambiguity-probe",
+      "prompt": "It feels slow lately. Can you speed it up?",
+      "hidden_criteria": {
+        "behavior": "The request identifies no subsystem, no metric, no baseline, and no target. A correct response STOPS and asks what 'it' is, what 'slow' means quantitatively, and against what baseline, rather than fabricating a profiling target and optimizing blindly.",
+        "required_tests": [],
+        "required_docs": [],
+        "required_gates": [],
+        "ambiguous_stop_expected": true
+      }
+    },
+    {
+      "id": "M1-multi-domain-migration",
+      "kind": "multi-domain",
+      "provenance": "synthetic:coordination-probe",
+      "prompt": "We want to move our two backend services off the old config format onto the new one. It touches how they build and how they deploy, and security will want to look at it.",
+      "hidden_criteria": {
+        "behavior": "A single coherent migration that updates BOTH services to the new config format, updates the build for each, updates the deployment/CI path, and routes the change through a security review gate before ship. The plan must treat this as coordinated multi-domain work, not a single blob.",
+        "required_tests": ["per-service: config parses and services start on the new format", "regression: deploy path succeeds end to end for each service"],
+        "required_docs": ["migration note or spec describing the format change and rollout order"],
+        "required_gates": ["build (both services)", "CI/deploy pipeline", "security sign-off"],
+        "ambiguous_stop_expected": false
+      }
+    }
+  ]
+}

--- a/tests/eval/test_eval_e2e_delivery.py
+++ b/tests/eval/test_eval_e2e_delivery.py
@@ -20,8 +20,8 @@ FIXTURES = EVAL_DIR / "examples" / "e2e-delivery-fixtures.json"
 
 
 def _load(filename: str, module_name: str):
-    path_added = str(EVAL_DIR) not in sys.path
-    if path_added:
+    original_path = sys.path.copy()
+    if str(EVAL_DIR) not in sys.path:
         sys.path.insert(0, str(EVAL_DIR))
     try:
         spec = importlib.util.spec_from_file_location(module_name, EVAL_DIR / filename)
@@ -31,8 +31,7 @@ def _load(filename: str, module_name: str):
         spec.loader.exec_module(mod)
         return mod
     finally:
-        if path_added and str(EVAL_DIR) in sys.path:
-            sys.path.remove(str(EVAL_DIR))
+        sys.path[:] = original_path
 
 
 core = _load("_e2e_delivery_core.py", "_e2e_delivery_core")
@@ -87,6 +86,39 @@ def test_ambiguous_flag_must_be_bool():
     fx = _valid_fixture()
     fx["hidden_criteria"]["ambiguous_stop_expected"] = "yes"
     with pytest.raises(core.FixtureError, match="must be bool"):
+        core.validate_fixture(fx)
+
+
+def test_non_string_id_raises():
+    fx = _valid_fixture()
+    fx["id"] = 7
+    with pytest.raises(core.FixtureError, match="id must be a string"):
+        core.validate_fixture(fx)
+
+
+def test_non_string_prompt_raises():
+    with pytest.raises(core.FixtureError, match="prompt must be a string"):
+        core.validate_fixture(_valid_fixture(prompt=123))
+
+
+def test_non_string_behavior_raises():
+    fx = _valid_fixture()
+    fx["hidden_criteria"]["behavior"] = None
+    with pytest.raises(core.FixtureError, match="behavior must be a string"):
+        core.validate_fixture(fx)
+
+
+def test_required_tests_must_be_list_of_strings():
+    fx = _valid_fixture()
+    fx["hidden_criteria"]["required_tests"] = "t"
+    with pytest.raises(core.FixtureError, match="required_tests must be a list"):
+        core.validate_fixture(fx)
+
+
+def test_required_gates_rejects_non_string_element():
+    fx = _valid_fixture()
+    fx["hidden_criteria"]["required_gates"] = ["ok", 5]
+    with pytest.raises(core.FixtureError, match="required_gates must be a list"):
         core.validate_fixture(fx)
 
 
@@ -200,6 +232,43 @@ def test_parse_garbage_returns_parse_error():
     out = core.parse_judge_response("no json here at all")
     assert out["verdict"] == core.PARSE_ERROR
     assert out["total"] is None
+
+
+def test_parse_first_object_wins_over_trailing_braces():
+    # A greedy {.*} match would span into the trailing brace/prose and fail
+    # json.loads; raw_decode stops at the first complete object.
+    raw = (
+        json.dumps(
+            {
+                "scope": 3,
+                "completeness": 3,
+                "process_gates": 2,
+                "decomposition": 2,
+                "correct_stop": 1,
+                "rationale": "ok",
+            }
+        )
+        + "\n\nnote: some stray } brace and {half object"
+    )
+    out = core.parse_judge_response(raw)
+    assert out["verdict"] == "SCORED"
+    assert out["total"] == 11
+    assert out["rationale"] == "ok"
+
+
+def test_parse_non_string_rationale_coerced_to_empty():
+    raw = json.dumps(
+        {
+            "scope": 1,
+            "completeness": 1,
+            "process_gates": 1,
+            "decomposition": 1,
+            "correct_stop": 1,
+            "rationale": {"nested": "object"},
+        }
+    )
+    out = core.parse_judge_response(raw)
+    assert out["rationale"] == ""
 
 
 def test_max_score_constant():

--- a/tests/eval/test_eval_e2e_delivery.py
+++ b/tests/eval/test_eval_e2e_delivery.py
@@ -1,0 +1,301 @@
+"""Unit tests for the end-to-end delivery eval (issue #2859).
+
+Covers the pure core (fixture validation, judge-response parsing, score
+aggregation) and the CLI dry-run path. No live API calls: the one test that
+touches the runner monkeypatches call_api to prove dry-run never reaches it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVAL_DIR = REPO_ROOT / "scripts" / "eval"
+FIXTURES = EVAL_DIR / "examples" / "e2e-delivery-fixtures.json"
+
+
+def _load(filename: str, module_name: str):
+    path_added = str(EVAL_DIR) not in sys.path
+    if path_added:
+        sys.path.insert(0, str(EVAL_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, EVAL_DIR / filename)
+        assert spec and spec.loader
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        if path_added and str(EVAL_DIR) in sys.path:
+            sys.path.remove(str(EVAL_DIR))
+
+
+core = _load("_e2e_delivery_core.py", "_e2e_delivery_core")
+runner = _load("eval-e2e-delivery.py", "eval_e2e_delivery")
+
+
+def _valid_fixture(**overrides):
+    base = {
+        "id": "T1",
+        "prompt": "vague thing",
+        "kind": "feature",
+        "hidden_criteria": {
+            "behavior": "b",
+            "required_tests": ["t"],
+            "required_docs": [],
+            "required_gates": ["g"],
+            "ambiguous_stop_expected": False,
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+# --------------------------------------------------------------------------
+# Fixture validation
+# --------------------------------------------------------------------------
+
+def test_valid_fixture_passes():
+    core.validate_fixture(_valid_fixture())
+
+
+def test_missing_top_level_key_raises():
+    fx = _valid_fixture()
+    del fx["prompt"]
+    with pytest.raises(core.FixtureError, match="missing keys"):
+        core.validate_fixture(fx)
+
+
+def test_invalid_kind_raises():
+    with pytest.raises(core.FixtureError, match="invalid kind"):
+        core.validate_fixture(_valid_fixture(kind="chore"))
+
+
+def test_missing_criteria_subkey_raises():
+    fx = _valid_fixture()
+    del fx["hidden_criteria"]["required_gates"]
+    with pytest.raises(core.FixtureError, match="hidden_criteria missing"):
+        core.validate_fixture(fx)
+
+
+def test_ambiguous_flag_must_be_bool():
+    fx = _valid_fixture()
+    fx["hidden_criteria"]["ambiguous_stop_expected"] = "yes"
+    with pytest.raises(core.FixtureError, match="must be bool"):
+        core.validate_fixture(fx)
+
+
+def test_kind_and_stop_flag_must_agree():
+    # ambiguous kind with stop=False is a self-contradiction.
+    fx = _valid_fixture(kind="ambiguous")
+    fx["hidden_criteria"]["ambiguous_stop_expected"] = False
+    with pytest.raises(core.FixtureError, match="disagrees"):
+        core.validate_fixture(fx)
+
+
+def test_load_fixtures_rejects_duplicate_ids():
+    doc = json.dumps({"fixtures": [_valid_fixture(), _valid_fixture()]})
+    with pytest.raises(core.FixtureError, match="duplicate fixture id"):
+        core.load_fixtures(doc)
+
+
+def test_load_fixtures_rejects_empty():
+    with pytest.raises(core.FixtureError, match="non-empty"):
+        core.load_fixtures(json.dumps({"fixtures": []}))
+
+
+def test_load_fixtures_rejects_bad_schema_version():
+    doc = json.dumps({"schemaVersion": 99, "fixtures": [_valid_fixture()]})
+    with pytest.raises(core.FixtureError, match="schemaVersion"):
+        core.load_fixtures(doc)
+
+
+def test_load_fixtures_accepts_bare_list():
+    out = core.load_fixtures(json.dumps([_valid_fixture()]))
+    assert out[0]["id"] == "T1"
+
+
+def test_shipped_fixture_file_is_valid():
+    # The in-tree starter set must always pass its own validator.
+    out = core.load_fixtures(FIXTURES.read_text(encoding="utf-8"))
+    assert len(out) >= 5
+    kinds = {f["kind"] for f in out}
+    assert {"feature", "bug", "ambiguous", "multi-domain"} <= kinds
+
+
+# --------------------------------------------------------------------------
+# Judge-response parsing
+# --------------------------------------------------------------------------
+
+def test_parse_clean_json():
+    raw = json.dumps(
+        {
+            "scope": 3,
+            "completeness": 2,
+            "process_gates": 1,
+            "decomposition": 2,
+            "correct_stop": 1,
+            "rationale": "ok",
+        }
+    )
+    out = core.parse_judge_response(raw)
+    assert out["verdict"] == "SCORED"
+    assert out["total"] == 9
+    assert out["axes"]["scope"] == 3
+    assert out["rationale"] == "ok"
+
+
+def test_parse_json_embedded_in_prose_and_fences():
+    raw = "Here is my score:\n```json\n" + json.dumps(
+        {
+            "scope": 1,
+            "completeness": 1,
+            "process_gates": 0,
+            "decomposition": 0,
+            "correct_stop": 0,
+        }
+    ) + "\n```\nDone."
+    out = core.parse_judge_response(raw)
+    assert out["total"] == 2
+
+
+def test_parse_clamps_out_of_range_axes():
+    raw = json.dumps(
+        {
+            "scope": 99,          # clamps to 3
+            "completeness": -5,   # clamps to 0
+            "process_gates": 2,
+            "decomposition": 2,
+            "correct_stop": 7,    # clamps to 1
+        }
+    )
+    out = core.parse_judge_response(raw)
+    assert out["axes"]["scope"] == 3
+    assert out["axes"]["completeness"] == 0
+    assert out["axes"]["correct_stop"] == 1
+    assert out["total"] == 3 + 0 + 2 + 2 + 1
+
+
+def test_parse_non_numeric_axis_becomes_zero():
+    raw = json.dumps(
+        {
+            "scope": "three",
+            "completeness": 2,
+            "process_gates": 1,
+            "decomposition": 1,
+            "correct_stop": 1,
+        }
+    )
+    out = core.parse_judge_response(raw)
+    assert out["axes"]["scope"] == 0
+    assert out["total"] == 5
+
+
+def test_parse_garbage_returns_parse_error():
+    out = core.parse_judge_response("no json here at all")
+    assert out["verdict"] == core.PARSE_ERROR
+    assert out["total"] is None
+
+
+def test_max_score_constant():
+    assert core.MAX_SCORE == 11
+
+
+# --------------------------------------------------------------------------
+# Aggregation
+# --------------------------------------------------------------------------
+
+def _rec(fx, agent, total):
+    return {"fixture_id": fx, "agent": agent, "total": total}
+
+
+def test_aggregate_means_and_delta():
+    records = [
+        _rec("F1", "orchestrator", 6),
+        _rec("F1", "orchestrator", 8),
+        _rec("F1", "autoplan", 9),
+        _rec("F1", "autoplan", 9),
+    ]
+    report = core.aggregate(records)
+    assert report["per_fixture"]["F1"]["orchestrator"] == 7.0
+    assert report["per_fixture"]["F1"]["autoplan"] == 9.0
+    # agents sort alphabetically -> delta is (orchestrator - autoplan).
+    assert report["per_fixture"]["F1"]["delta"] == -2.0
+    assert report["per_fixture"]["F1"]["delta_of"] == "orchestrator - autoplan"
+    assert report["per_agent_mean"]["orchestrator"] == 7.0
+    assert report["per_agent_mean"]["autoplan"] == 9.0
+
+
+def test_aggregate_excludes_parse_errors_from_means():
+    records = [
+        _rec("F1", "orchestrator", 6),
+        _rec("F1", "orchestrator", None),
+        _rec("F1", "autoplan", 9),
+    ]
+    report = core.aggregate(records)
+    assert report["per_fixture"]["F1"]["orchestrator"] == 6.0
+    assert report["parse_errors"] == 1
+    assert report["n_records"] == 3
+
+
+def test_aggregate_no_delta_with_single_agent():
+    report = core.aggregate([_rec("F1", "orchestrator", 5)])
+    assert "delta" not in report["per_fixture"]["F1"]
+
+
+# --------------------------------------------------------------------------
+# Prompt assembly
+# --------------------------------------------------------------------------
+
+def test_agent_message_includes_germ_and_plan_request():
+    msg = core.build_agent_user_message("remember my last flags")
+    assert "remember my last flags" in msg
+    assert "clarifying question" in msg
+
+
+def test_judge_message_includes_criteria_and_plan():
+    fx = _valid_fixture()
+    msg = core.build_judge_user_message(fx, "my plan text")
+    assert "my plan text" in msg
+    assert "ambiguous_stop_expected" in msg
+    assert fx["hidden_criteria"]["behavior"] in msg
+
+
+def test_judge_system_lists_all_axes():
+    system = core.build_judge_system()
+    for axis in core.RUBRIC_AXES:
+        assert axis in system
+
+
+# --------------------------------------------------------------------------
+# CLI dry-run (no API)
+# --------------------------------------------------------------------------
+
+def test_dry_run_makes_no_api_call(monkeypatch, capsys):
+    def _boom(*a, **k):  # pragma: no cover - must never be called
+        raise AssertionError("call_api must not run during --dry-run")
+
+    monkeypatch.setattr(runner, "call_api", _boom)
+    monkeypatch.setattr(runner, "load_api_key", _boom)
+    rc = runner.main(["--fixtures", str(FIXTURES), "--dry-run", "--runs", "2"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["dry_run"] is True
+    # 7 fixtures x 2 agents x 2 runs x 2 calls (generate + judge).
+    assert out["planned_api_calls"] == len(out["fixtures"]) * 2 * 2 * 2
+    assert "orchestrator" in out["agents"]
+
+
+def test_unknown_agent_raises(monkeypatch):
+    with pytest.raises(RuntimeError, match="unknown agent"):
+        runner._resolve_agents(["nope"], None)
+
+
+def test_registry_prompts_exist_in_tree():
+    for rel in runner.AGENT_REGISTRY.values():
+        assert (REPO_ROOT / rel).exists(), rel


### PR DESCRIPTION
## Summary

The routing eval scores a single classify-and-route decision. Orchestrator and autoplan both hit the routing ceiling on 13 fixtures, which proves lane-picking, not delivery. This PR adds harness shape 2 from #2859: feed a deliberately vague germ, capture the plan each agent emits, and have an LLM judge score that plan against hidden acceptance criteria on five axes (scope, completeness, process_gates, decomposition, correct_stop; max 11).

Dependencies are merged: #2860 (live model id + preflight) and #2829 (autoplan skill on main), so the earlier blockers are cleared.

## Changes

- Pure, API-free core with fixture validation, prompt assembly, judge-response parsing with axis clamping, and score aggregation with signed deltas. Fully unit-testable without a network call.
- CLI runner reusing the existing Anthropic helpers. A dry-run mode validates fixtures and resolves agent prompts with zero API calls.
- A seven-fixture starter set. The feature and bug fixtures carry hidden criteria ground-truthed to real merged moq.analyzers PRs (independent of the agent prompts under test); the ambiguity and multi-domain fixtures are labeled synthetic process probes.
- Twenty-six unit tests covering validation, parsing, clamping, aggregation, and the dry-run no-API guarantee. README section added.

## Validation

- `uv run python -m pytest tests/eval/` : 393 passed (26 new).
- `uv run ruff check` on the new modules and test: clean.
- markdownlint on the README: 0 errors.
- Dry-run resolves 84 planned calls across 7 fixtures x 2 agents x 3 runs x 2 calls.
- Live smoke (1 fixture, 1 run, autoplan): generated a 6261-char plan, judge scored all five axes, aggregation produced a real report. Directional only; not a result claim.

## Scope

This is the plan-rubric proxy (shape 2). It scores plan quality, not delivered code, and cannot prove a change compiles or passes tests; the trace-based shape (shape 1) does that. Fixtures and criteria are single-author curated, so absolute scores are directional and the report prints that caveat in every run. The starter fixture set is meant to grow as real issues land. Refs #2859.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
