### PR TITLE
docs(lib): correct setup_hook_lib_path docstring to forbid ADR-047 hook migration

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/lib/bootstrap.py
+++ b/.claude/lib/bootstrap.py
@@ -4,19 +4,19 @@ This module provides setup_hook_lib_path() which locates the plugin's lib
 directory and adds it to sys.path. Designed to be called with __file__ to
 bootstrap hook imports.
 
-Usage in hook files (replaces the ~20-line inline bootstrap with 4 lines):
-
-    import os, sys
-    from pathlib import Path
-    _p = Path(__file__).resolve().parent
-    while _p.parent != _p and not (_p / ".claude-plugin" / "plugin.json").is_file(): _p = _p.parent
-    sys.path.insert(0, str(_p / "lib"))
-    from bootstrap import setup_hook_lib_path; setup_hook_lib_path(__file__, fail_exit_code=2)
-
-    from hook_utilities import get_project_directory  # noqa: E402
+DO NOT use this helper to replace the inline bootstrap in `.claude/hooks/`
+hooks or in skill scripts governed by ADR-047. Those files MUST keep the
+inline `os.environ.get("CLAUDE_PLUGIN_ROOT")` + `os.path.isdir(_lib_dir)`
+literals: `tests/test_plugin_path_resolution.py` grep-asserts them, and the
+only exemption it grants is delegation to `_bootstrap.ensure_plugin_paths`
+(the generated-tree helper, ADR-068), NOT this function. Migrating those
+hooks here removes the literals and fails the ADR-047 test.
+`scripts/migrations/req003_inline_plugin_root_bootstrap.py` exists precisely
+to revert such a migration. See ADR-047 (Path Resolution) for the sanctioned
+inline pattern and issue #2898 for the history.
 
 The setup_hook_lib_path function handles:
-- Checking CLAUDE_PLUGIN_ROOT environment variable  
+- Checking CLAUDE_PLUGIN_ROOT environment variable
 - Walking up directory tree to find .claude-plugin/plugin.json marker
 - Adding the lib directory to sys.path
 - Exiting with specified code if lib not found

--- a/.claude/lib/hook_utilities/bootstrap.py
+++ b/.claude/lib/hook_utilities/bootstrap.py
@@ -4,19 +4,19 @@ This module provides setup_hook_lib_path() which locates the plugin's lib
 directory and adds it to sys.path. Designed to be called with __file__ to
 bootstrap hook imports.
 
-Usage in hook files (replaces the ~20-line inline bootstrap with 4 lines):
-
-    import os, sys
-    from pathlib import Path
-    _p = Path(__file__).resolve().parent
-    while _p.parent != _p and not (_p / ".claude-plugin" / "plugin.json").is_file(): _p = _p.parent
-    sys.path.insert(0, str(_p / "lib"))
-    from bootstrap import setup_hook_lib_path; setup_hook_lib_path(__file__, fail_exit_code=2)
-
-    from hook_utilities import get_project_directory  # noqa: E402
+DO NOT use this helper to replace the inline bootstrap in `.claude/hooks/`
+hooks or in skill scripts governed by ADR-047. Those files MUST keep the
+inline `os.environ.get("CLAUDE_PLUGIN_ROOT")` + `os.path.isdir(_lib_dir)`
+literals: `tests/test_plugin_path_resolution.py` grep-asserts them, and the
+only exemption it grants is delegation to `_bootstrap.ensure_plugin_paths`
+(the generated-tree helper, ADR-068), NOT this function. Migrating those
+hooks here removes the literals and fails the ADR-047 test.
+`scripts/migrations/req003_inline_plugin_root_bootstrap.py` exists precisely
+to revert such a migration. See ADR-047 (Path Resolution) for the sanctioned
+inline pattern and issue #2898 for the history.
 
 The setup_hook_lib_path function handles:
-- Checking CLAUDE_PLUGIN_ROOT environment variable  
+- Checking CLAUDE_PLUGIN_ROOT environment variable
 - Walking up directory tree to find .claude-plugin/plugin.json marker
 - Adding the lib directory to sys.path
 - Exiting with specified code if lib not found

--- a/scripts/hook_utilities/bootstrap.py
+++ b/scripts/hook_utilities/bootstrap.py
@@ -4,19 +4,19 @@ This module provides setup_hook_lib_path() which locates the plugin's lib
 directory and adds it to sys.path. Designed to be called with __file__ to
 bootstrap hook imports.
 
-Usage in hook files (replaces the ~20-line inline bootstrap with 4 lines):
-
-    import os, sys
-    from pathlib import Path
-    _p = Path(__file__).resolve().parent
-    while _p.parent != _p and not (_p / ".claude-plugin" / "plugin.json").is_file(): _p = _p.parent
-    sys.path.insert(0, str(_p / "lib"))
-    from bootstrap import setup_hook_lib_path; setup_hook_lib_path(__file__, fail_exit_code=2)
-
-    from hook_utilities import get_project_directory  # noqa: E402
+DO NOT use this helper to replace the inline bootstrap in `.claude/hooks/`
+hooks or in skill scripts governed by ADR-047. Those files MUST keep the
+inline `os.environ.get("CLAUDE_PLUGIN_ROOT")` + `os.path.isdir(_lib_dir)`
+literals: `tests/test_plugin_path_resolution.py` grep-asserts them, and the
+only exemption it grants is delegation to `_bootstrap.ensure_plugin_paths`
+(the generated-tree helper, ADR-068), NOT this function. Migrating those
+hooks here removes the literals and fails the ADR-047 test.
+`scripts/migrations/req003_inline_plugin_root_bootstrap.py` exists precisely
+to revert such a migration. See ADR-047 (Path Resolution) for the sanctioned
+inline pattern and issue #2898 for the history.
 
 The setup_hook_lib_path function handles:
-- Checking CLAUDE_PLUGIN_ROOT environment variable  
+- Checking CLAUDE_PLUGIN_ROOT environment variable
 - Walking up directory tree to find .claude-plugin/plugin.json marker
 - Adding the lib directory to sys.path
 - Exiting with specified code if lib not found

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/lib/bootstrap.py
+++ b/src/copilot-cli/lib/bootstrap.py
@@ -4,19 +4,19 @@ This module provides setup_hook_lib_path() which locates the plugin's lib
 directory and adds it to sys.path. Designed to be called with __file__ to
 bootstrap hook imports.
 
-Usage in hook files (replaces the ~20-line inline bootstrap with 4 lines):
-
-    import os, sys
-    from pathlib import Path
-    _p = Path(__file__).resolve().parent
-    while _p.parent != _p and not (_p / ".claude-plugin" / "plugin.json").is_file(): _p = _p.parent
-    sys.path.insert(0, str(_p / "lib"))
-    from bootstrap import setup_hook_lib_path; setup_hook_lib_path(__file__, fail_exit_code=2)
-
-    from hook_utilities import get_project_directory  # noqa: E402
+DO NOT use this helper to replace the inline bootstrap in `.claude/hooks/`
+hooks or in skill scripts governed by ADR-047. Those files MUST keep the
+inline `os.environ.get("CLAUDE_PLUGIN_ROOT")` + `os.path.isdir(_lib_dir)`
+literals: `tests/test_plugin_path_resolution.py` grep-asserts them, and the
+only exemption it grants is delegation to `_bootstrap.ensure_plugin_paths`
+(the generated-tree helper, ADR-068), NOT this function. Migrating those
+hooks here removes the literals and fails the ADR-047 test.
+`scripts/migrations/req003_inline_plugin_root_bootstrap.py` exists precisely
+to revert such a migration. See ADR-047 (Path Resolution) for the sanctioned
+inline pattern and issue #2898 for the history.
 
 The setup_hook_lib_path function handles:
-- Checking CLAUDE_PLUGIN_ROOT environment variable  
+- Checking CLAUDE_PLUGIN_ROOT environment variable
 - Walking up directory tree to find .claude-plugin/plugin.json marker
 - Adding the lib directory to sys.path
 - Exiting with specified code if lib not found

--- a/src/copilot-cli/lib/hook_utilities/bootstrap.py
+++ b/src/copilot-cli/lib/hook_utilities/bootstrap.py
@@ -4,19 +4,19 @@ This module provides setup_hook_lib_path() which locates the plugin's lib
 directory and adds it to sys.path. Designed to be called with __file__ to
 bootstrap hook imports.
 
-Usage in hook files (replaces the ~20-line inline bootstrap with 4 lines):
-
-    import os, sys
-    from pathlib import Path
-    _p = Path(__file__).resolve().parent
-    while _p.parent != _p and not (_p / ".claude-plugin" / "plugin.json").is_file(): _p = _p.parent
-    sys.path.insert(0, str(_p / "lib"))
-    from bootstrap import setup_hook_lib_path; setup_hook_lib_path(__file__, fail_exit_code=2)
-
-    from hook_utilities import get_project_directory  # noqa: E402
+DO NOT use this helper to replace the inline bootstrap in `.claude/hooks/`
+hooks or in skill scripts governed by ADR-047. Those files MUST keep the
+inline `os.environ.get("CLAUDE_PLUGIN_ROOT")` + `os.path.isdir(_lib_dir)`
+literals: `tests/test_plugin_path_resolution.py` grep-asserts them, and the
+only exemption it grants is delegation to `_bootstrap.ensure_plugin_paths`
+(the generated-tree helper, ADR-068), NOT this function. Migrating those
+hooks here removes the literals and fails the ADR-047 test.
+`scripts/migrations/req003_inline_plugin_root_bootstrap.py` exists precisely
+to revert such a migration. See ADR-047 (Path Resolution) for the sanctioned
+inline pattern and issue #2898 for the history.
 
 The setup_hook_lib_path function handles:
-- Checking CLAUDE_PLUGIN_ROOT environment variable  
+- Checking CLAUDE_PLUGIN_ROOT environment variable
 - Walking up directory tree to find .claude-plugin/plugin.json marker
 - Adding the lib directory to sys.path
 - Exiting with specified code if lib not found


### PR DESCRIPTION
## Summary

The `setup_hook_lib_path` docstring advertised a usage block claiming it "replaces the ~20-line inline bootstrap with 4 lines" for hook files. That guidance is an anti-goal and was the root cause of issue #2816 finding 1 (which proposed migrating 40 hooks to this helper). This PR corrects the docstring and syncs all packaged copies. Closes #2898.

## Type of Change

Documentation and packaging fix (docstring correction plus lockstep plugin version bump). No executable behavior change.

## Changes

Changed files in this PR:

- `scripts/hook_utilities/bootstrap.py` (canonical): replaced the misleading usage block with a DO-NOT-USE-for-ADR-047-hooks warning.
- `.claude/lib/bootstrap.py` and `.claude/lib/hook_utilities/bootstrap.py`: synced to canonical.
- `src/copilot-cli/lib/bootstrap.py` and `src/copilot-cli/lib/hook_utilities/bootstrap.py`: regenerated mirror of the `.claude` lib tree.
- `.claude/.claude-plugin/plugin.json` and `src/copilot-cli/.claude-plugin/plugin.json`: version 0.6.3 to 0.6.4 in lockstep (packaged lib source changed).

## Validation

```text
scripts/sync_plugin_lib.py --check   -> all plugin lib copies in sync
pytest test_bootstrap + test_plugin_path_resolution + test_req003_migration -> 18 passed
validate_plugin_version_bump.py      -> OK
ruff check                            -> clean
diff scope: 5 bootstrap copies + 2 version bumps (+57/-57), no unrelated drift
```

## Specification References

Issue #2816 finding 1 (anti-goal diagnosis) and issue #2898 (root-cause contradiction).

## Background

Hooks and ADR-047-governed skill scripts must keep the inline `CLAUDE_PLUGIN_ROOT` walk-up literals. The guard test grep-asserts those literals in every lib-importing hook, and the only exemption it grants is delegation to `_bootstrap.ensure_plugin_paths` (the generated-tree helper, ADR-068), not `setup_hook_lib_path`. Migrating hooks to this helper removes the literals and fails the guard test. A dedicated migration script exists to revert exactly that migration, and the helper has zero production callers today. The corrected docstring now cites ADR-047 Path Resolution, REQ-003, and issue #2898 so the next reader does not repeat the migration.
