### PR TITLE
chore(lib): auto-sync top-level .claude/lib/bootstrap.py (#2816 finding 2)

### DIFF
--- a/scripts/sync_plugin_lib.py
+++ b/scripts/sync_plugin_lib.py
@@ -307,7 +307,9 @@ def _imports_scripts_package(tree: ast.Module) -> bool:
     as s``, comma lists ``import os, scripts``, alias-then-comma ``import os as
     o, scripts``, backslash-continued lists, and ``from scripts[.pkg] import``.
     Dynamic imports with a literal string argument are also caught:
-    ``__import__("scripts...")`` and ``importlib.import_module("scripts...")``.
+    ``__import__("scripts...")`` and ``importlib.import_module("scripts...")``,
+    including the ``name=`` keyword form and a bare ``import_module("scripts")``
+    binding from ``from importlib import import_module``.
     A module whose name merely starts with ``scripts`` (``scripts_helper``) is a
     different top-level package and is not matched. Relative imports
     (``from . import x``, ``level > 0``) never reference the ``scripts`` package.
@@ -320,13 +322,28 @@ def _imports_scripts_package(tree: ast.Module) -> bool:
     def _is_scripts(name: str | None) -> bool:
         return bool(name) and (name == "scripts" or name.startswith("scripts."))
 
-    def _is_dynamic_import_call(node: ast.Call) -> bool:
+    def _dynamic_import_target(node: ast.Call) -> str | None:
+        """Return the literal module string of a dynamic import call, else None."""
         target = node.func
-        if isinstance(target, ast.Name):
-            return target.id == "__import__"
-        if isinstance(target, ast.Attribute):
-            return target.attr in {"import_module", "__import__"}
-        return False
+        is_dynamic = (
+            isinstance(target, ast.Name)
+            and target.id in {"__import__", "import_module"}
+        ) or (
+            isinstance(target, ast.Attribute)
+            and target.attr in {"import_module", "__import__"}
+        )
+        if not is_dynamic:
+            return None
+        if node.args:
+            first = node.args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                return first.value
+        for keyword in node.keywords:
+            if keyword.arg == "name" and isinstance(keyword.value, ast.Constant):
+                value = keyword.value.value
+                if isinstance(value, str):
+                    return value
+        return None
 
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
@@ -335,13 +352,9 @@ def _imports_scripts_package(tree: ast.Module) -> bool:
         elif isinstance(node, ast.Import):
             if any(_is_scripts(alias.name) for alias in node.names):
                 return True
-        elif isinstance(node, ast.Call) and node.args and _is_dynamic_import_call(
-            node
-        ):
-            first = node.args[0]
-            if isinstance(first, ast.Constant) and isinstance(first.value, str):
-                if _is_scripts(first.value):
-                    return True
+        elif isinstance(node, ast.Call):
+            if _is_scripts(_dynamic_import_target(node)):
+                return True
     return False
 
 

--- a/scripts/sync_plugin_lib.py
+++ b/scripts/sync_plugin_lib.py
@@ -306,13 +306,27 @@ def _imports_scripts_package(tree: ast.Module) -> bool:
     ``import scripts``, dotted ``import scripts.pkg``, aliased ``import scripts
     as s``, comma lists ``import os, scripts``, alias-then-comma ``import os as
     o, scripts``, backslash-continued lists, and ``from scripts[.pkg] import``.
+    Dynamic imports with a literal string argument are also caught:
+    ``__import__("scripts...")`` and ``importlib.import_module("scripts...")``.
     A module whose name merely starts with ``scripts`` (``scripts_helper``) is a
     different top-level package and is not matched. Relative imports
     (``from . import x``, ``level > 0``) never reference the ``scripts`` package.
+
+    Limitation: a dynamic import whose module name is computed at runtime (not a
+    string literal) cannot be detected statically. Registered sources are small
+    self-contained modules where that pattern does not occur.
     """
 
     def _is_scripts(name: str | None) -> bool:
         return bool(name) and (name == "scripts" or name.startswith("scripts."))
+
+    def _is_dynamic_import_call(node: ast.Call) -> bool:
+        target = node.func
+        if isinstance(target, ast.Name):
+            return target.id == "__import__"
+        if isinstance(target, ast.Attribute):
+            return target.attr in {"import_module", "__import__"}
+        return False
 
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
@@ -321,6 +335,13 @@ def _imports_scripts_package(tree: ast.Module) -> bool:
         elif isinstance(node, ast.Import):
             if any(_is_scripts(alias.name) for alias in node.names):
                 return True
+        elif isinstance(node, ast.Call) and node.args and _is_dynamic_import_call(
+            node
+        ):
+            first = node.args[0]
+            if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                if _is_scripts(first.value):
+                    return True
     return False
 
 

--- a/scripts/sync_plugin_lib.py
+++ b/scripts/sync_plugin_lib.py
@@ -13,6 +13,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import ast
 import re
 import sys
 from pathlib import Path
@@ -298,6 +299,31 @@ def _validate_sync_file_paths(
     return src_path, dst_path, errors
 
 
+def _imports_scripts_package(tree: ast.Module) -> bool:
+    """Return True if the module imports the top-level ``scripts`` package.
+
+    Uses the AST rather than a regex so every import form is covered: bare
+    ``import scripts``, dotted ``import scripts.pkg``, aliased ``import scripts
+    as s``, comma lists ``import os, scripts``, alias-then-comma ``import os as
+    o, scripts``, backslash-continued lists, and ``from scripts[.pkg] import``.
+    A module whose name merely starts with ``scripts`` (``scripts_helper``) is a
+    different top-level package and is not matched. Relative imports
+    (``from . import x``, ``level > 0``) never reference the ``scripts`` package.
+    """
+
+    def _is_scripts(name: str | None) -> bool:
+        return bool(name) and (name == "scripts" or name.startswith("scripts."))
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.level == 0 and _is_scripts(node.module):
+                return True
+        elif isinstance(node, ast.Import):
+            if any(_is_scripts(alias.name) for alias in node.names):
+                return True
+    return False
+
+
 def sync_file(
     src_rel: str,
     dst_rel: str,
@@ -311,6 +337,10 @@ def sync_file(
     package), so package-relative imports would not resolve. The source must be
     import-self-contained; a ``scripts`` package import is rejected because a
     byte copy cannot rewrite it.
+
+    The copy and drift comparison operate on raw bytes so newline style is
+    preserved and CRLF/LF differences are treated as drift, not silently
+    normalized away.
     """
     src_path, dst_path, errors = _validate_sync_file_paths(src_rel, dst_rel)
     if errors:
@@ -325,19 +355,21 @@ def sync_file(
         return [f"[ERROR] Registered source file missing: {src_rel}"], True
 
     try:
-        expected = src_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError) as exc:
+        expected_bytes = src_path.read_bytes()
+    except OSError as exc:
         return [f"[ERROR] Cannot read {src_rel}: {exc}"], True
 
-    # Reject ANY scripts-package import. Covers ``from scripts[...] import``,
-    # bare ``import scripts``, dotted ``import scripts.pkg``, aliased
-    # ``import scripts as s``, and comma lists ``import os, scripts``. The
-    # trailing \b stops after the ``scripts`` token so unrelated modules like
-    # ``scripts_helper`` are not matched. A byte copy cannot rewrite these and
-    # ``scripts`` is not importable from a top-level lib file.
-    if re.search(r"^\s*from\s+scripts\b", expected, re.MULTILINE) or re.search(
-        r"^\s*import\s+([\w.]+\s*,\s*)*scripts\b", expected, re.MULTILINE
-    ):
+    try:
+        source_text = expected_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        return [f"[ERROR] Cannot decode {src_rel} as utf-8: {exc}"], True
+
+    try:
+        tree = ast.parse(source_text, filename=src_rel)
+    except SyntaxError as exc:
+        return [f"[ERROR] Cannot parse {src_rel}: {exc}"], True
+
+    if _imports_scripts_package(tree):
         return [
             f"[ERROR] {src_rel} imports the scripts package and cannot be "
             "byte-copied to a top-level lib file. Make it self-contained or "
@@ -346,10 +378,10 @@ def sync_file(
 
     if dst_path.exists():
         try:
-            current = dst_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError) as exc:
+            current_bytes = dst_path.read_bytes()
+        except OSError as exc:
             return [f"[ERROR] Cannot read {dst_rel}: {exc}"], True
-        if current == expected:
+        if current_bytes == expected_bytes:
             return [], False
         action = "updated"
     else:
@@ -359,7 +391,7 @@ def sync_file(
     if not check_only:
         try:
             dst_path.parent.mkdir(parents=True, exist_ok=True)
-            dst_path.write_text(expected, encoding="utf-8")
+            dst_path.write_bytes(expected_bytes)
         except OSError as exc:
             return [f"  [ERROR] Cannot write {dst_rel}: {exc}"], True
 

--- a/scripts/sync_plugin_lib.py
+++ b/scripts/sync_plugin_lib.py
@@ -29,6 +29,18 @@ SYNC_PAIRS: list[tuple[str, str]] = [
     ("scripts/ai_review_common", ".claude/lib/ai_review_common"),
 ]
 
+# Individual file copies: (source file, destination file). Unlike SYNC_PAIRS
+# (whole-package dir syncs with relative-import rewriting), these are
+# byte-for-byte copies of a single module that lives at the top level of
+# `.claude/lib/` so `from bootstrap import ...` resolves when `.claude/lib` is
+# on sys.path. The source MUST be import-self-contained (no `from scripts.`
+# imports) because a top-level module cannot use the package-relative rewrite.
+# Registering the pair here replaces the previously hand-maintained duplicate
+# (Issue #2816 finding 2) so `--check` enforces parity in CI.
+SYNC_FILE_PAIRS: list[tuple[str, str]] = [
+    ("scripts/hook_utilities/bootstrap.py", ".claude/lib/bootstrap.py"),
+]
+
 IMPORT_CONVERSIONS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"from scripts\.github_core\.(\w+) import"), r"from .\1 import"),
     (re.compile(r"from scripts\.hook_utilities\.(\w+) import"), r"from .\1 import"),
@@ -261,6 +273,86 @@ def sync_pair(
     return changes, had_errors
 
 
+def _validate_sync_file_paths(
+    src_rel: str,
+    dst_rel: str,
+) -> tuple[Path, Path, list[str]]:
+    """Validate and resolve a single source/destination file pair.
+
+    Returns (src_path, dst_path, errors). Non-empty errors means abort.
+    """
+    src_path = (REPO_ROOT / src_rel).resolve()
+    dst_path = (REPO_ROOT / dst_rel).resolve()
+    repo_root_resolved = REPO_ROOT.resolve()
+    errors: list[str] = []
+
+    try:
+        src_path.relative_to(repo_root_resolved)
+    except ValueError:
+        errors.append(f"[ERROR] Source path escapes repo root: {src_rel}")
+    try:
+        dst_path.relative_to(repo_root_resolved)
+    except ValueError:
+        errors.append(f"[ERROR] Destination path escapes repo root: {dst_rel}")
+
+    return src_path, dst_path, errors
+
+
+def sync_file(
+    src_rel: str,
+    dst_rel: str,
+    *,
+    check_only: bool,
+) -> tuple[list[str], bool]:
+    """Byte-copy a single source module to a top-level lib destination.
+
+    Returns a tuple of (change descriptions, had_errors). No import rewriting is
+    performed: the destination lives at the top level of ``.claude/lib`` (not a
+    package), so package-relative imports would not resolve. The source must be
+    import-self-contained; a ``from scripts.`` import is rejected because a
+    byte copy cannot rewrite it.
+    """
+    src_path, dst_path, errors = _validate_sync_file_paths(src_rel, dst_rel)
+    if errors:
+        return errors, True
+
+    if not src_path.is_file():
+        return [f"[WARNING] Source file missing: {src_rel}"], False
+
+    try:
+        expected = src_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return [f"[ERROR] Cannot read {src_rel}: {exc}"], True
+
+    if re.search(r"^\s*(from|import)\s+scripts\.", expected, re.MULTILINE):
+        return [
+            f"[ERROR] {src_rel} imports a scripts.* package and cannot be "
+            "byte-copied to a top-level lib file. Make it self-contained or "
+            "register it as a package via SYNC_PAIRS.",
+        ], True
+
+    if dst_path.exists():
+        try:
+            current = dst_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            return [f"[ERROR] Cannot read {dst_rel}: {exc}"], True
+        if current == expected:
+            return [], False
+        action = "updated"
+    else:
+        action = "created"
+
+    changes = [f"  {action}: {dst_rel}"]
+    if not check_only:
+        try:
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
+            dst_path.write_text(expected, encoding="utf-8")
+        except OSError as exc:
+            return [f"  [ERROR] Cannot write {dst_rel}: {exc}"], True
+
+    return changes, False
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point. Returns 0 on success, 1 if --check finds drift."""
     parser = argparse.ArgumentParser(
@@ -282,6 +374,14 @@ def main(argv: list[str] | None = None) -> int:
         if pair_changes:
             all_changes.append(f"{src_rel} -> {dst_rel}:")
             all_changes.extend(pair_changes)
+
+    for src_rel, dst_rel in SYNC_FILE_PAIRS:
+        file_changes, had_errors = sync_file(src_rel, dst_rel, check_only=args.check)
+        if had_errors:
+            any_errors = True
+        if file_changes:
+            all_changes.append(f"{src_rel} -> {dst_rel}:")
+            all_changes.extend(file_changes)
 
     if not all_changes:
         print("All plugin lib copies are in sync.")

--- a/scripts/sync_plugin_lib.py
+++ b/scripts/sync_plugin_lib.py
@@ -33,7 +33,7 @@ SYNC_PAIRS: list[tuple[str, str]] = [
 # (whole-package dir syncs with relative-import rewriting), these are
 # byte-for-byte copies of a single module that lives at the top level of
 # `.claude/lib/` so `from bootstrap import ...` resolves when `.claude/lib` is
-# on sys.path. The source MUST be import-self-contained (no `from scripts.`
+# on sys.path. The source MUST be import-self-contained (no `scripts` package
 # imports) because a top-level module cannot use the package-relative rewrite.
 # Registering the pair here replaces the previously hand-maintained duplicate
 # (Issue #2816 finding 2) so `--check` enforces parity in CI.
@@ -309,7 +309,7 @@ def sync_file(
     Returns a tuple of (change descriptions, had_errors). No import rewriting is
     performed: the destination lives at the top level of ``.claude/lib`` (not a
     package), so package-relative imports would not resolve. The source must be
-    import-self-contained; a ``from scripts.`` import is rejected because a
+    import-self-contained; a ``scripts`` package import is rejected because a
     byte copy cannot rewrite it.
     """
     src_path, dst_path, errors = _validate_sync_file_paths(src_rel, dst_rel)
@@ -317,16 +317,29 @@ def sync_file(
         return errors, True
 
     if not src_path.is_file():
-        return [f"[WARNING] Source file missing: {src_rel}"], False
+        # A registered pair names a canonical source that MUST exist. Unlike a
+        # missing package directory in sync_pair (which can be a legitimately
+        # absent optional package), a missing single-file source means the
+        # registry is stale or the canonical file was deleted. Fail closed so
+        # --check surfaces it instead of exiting 0.
+        return [f"[ERROR] Registered source file missing: {src_rel}"], True
 
     try:
         expected = src_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         return [f"[ERROR] Cannot read {src_rel}: {exc}"], True
 
-    if re.search(r"^\s*(from|import)\s+scripts\.", expected, re.MULTILINE):
+    # Reject ANY scripts-package import. Covers ``from scripts[...] import``,
+    # bare ``import scripts``, dotted ``import scripts.pkg``, aliased
+    # ``import scripts as s``, and comma lists ``import os, scripts``. The
+    # trailing \b stops after the ``scripts`` token so unrelated modules like
+    # ``scripts_helper`` are not matched. A byte copy cannot rewrite these and
+    # ``scripts`` is not importable from a top-level lib file.
+    if re.search(r"^\s*from\s+scripts\b", expected, re.MULTILINE) or re.search(
+        r"^\s*import\s+([\w.]+\s*,\s*)*scripts\b", expected, re.MULTILINE
+    ):
         return [
-            f"[ERROR] {src_rel} imports a scripts.* package and cannot be "
+            f"[ERROR] {src_rel} imports the scripts package and cannot be "
             "byte-copied to a top-level lib file. Make it self-contained or "
             "register it as a package via SYNC_PAIRS.",
         ], True

--- a/tests/test_hook_plugin_guards.py
+++ b/tests/test_hook_plugin_guards.py
@@ -299,6 +299,8 @@ class TestSyncPluginLib:
             "import scripts",
             "import scripts as s",
             "import os, scripts",
+            "import os as o, scripts",
+            "import os, \\\n    scripts",
         ],
     )
     def test_sync_file_rejects_scripts_import(
@@ -371,6 +373,39 @@ class TestSyncPluginLib:
         assert had_errors is True
         assert any("Registered source file missing" in c for c in changes), changes
         assert not (tmp_path / ".claude" / "lib" / "missing.py").exists()
+
+    def test_sync_file_preserves_bytes_and_detects_newline_drift(
+        self, tmp_path: Path
+    ) -> None:
+        """Copy preserves exact bytes; CRLF-vs-LF is drift, not silent normalization."""
+        import scripts.sync_plugin_lib as sync_mod
+
+        src = tmp_path / "scripts" / "pkg" / "mod.py"
+        src.parent.mkdir(parents=True)
+        src.write_bytes(b'"""Canonical."""\r\nX = 1\r\n')
+        dst = tmp_path / ".claude" / "lib" / "mod.py"
+        dst.parent.mkdir(parents=True)
+        # Same text under universal newlines, but different bytes (LF vs CRLF).
+        dst.write_bytes(b'"""Canonical."""\nX = 1\n')
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sync_mod, "REPO_ROOT", tmp_path)
+            # --check must flag the byte drift even though text decodes equal.
+            check_changes, check_errors = sync_mod.sync_file(
+                "scripts/pkg/mod.py", ".claude/lib/mod.py", check_only=True,
+            )
+            assert check_errors is False, check_changes
+            assert check_changes, "CRLF/LF byte drift should be detected"
+            assert dst.read_bytes() == b'"""Canonical."""\nX = 1\n', (
+                "check_only must not mutate the destination"
+            )
+
+            # Real sync writes the source bytes verbatim (CRLF preserved).
+            sync_mod.sync_file(
+                "scripts/pkg/mod.py", ".claude/lib/mod.py", check_only=False,
+            )
+
+        assert dst.read_bytes() == b'"""Canonical."""\r\nX = 1\r\n'
 
 
 def _parse_events(stderr_text: str) -> list[dict[str, Any]]:

--- a/tests/test_hook_plugin_guards.py
+++ b/tests/test_hook_plugin_guards.py
@@ -304,6 +304,9 @@ class TestSyncPluginLib:
             'x = __import__("scripts.hook_utilities.bootstrap")',
             'import importlib\ny = importlib.import_module("scripts.pkg")',
             'z = __import__("scripts")',
+            'import importlib\ny = importlib.import_module(name="scripts.pkg")',
+            'w = __import__(name="scripts")',
+            'from importlib import import_module\nq = import_module("scripts.pkg")',
         ],
     )
     def test_sync_file_rejects_scripts_import(

--- a/tests/test_hook_plugin_guards.py
+++ b/tests/test_hook_plugin_guards.py
@@ -301,6 +301,9 @@ class TestSyncPluginLib:
             "import os, scripts",
             "import os as o, scripts",
             "import os, \\\n    scripts",
+            'x = __import__("scripts.hook_utilities.bootstrap")',
+            'import importlib\ny = importlib.import_module("scripts.pkg")',
+            'z = __import__("scripts")',
         ],
     )
     def test_sync_file_rejects_scripts_import(
@@ -332,6 +335,8 @@ class TestSyncPluginLib:
             "import scripts_helper",
             "from scripts_util import thing",
             "import scriptsfoo",
+            'x = __import__("scripts_helper")',
+            'import importlib\ny = importlib.import_module("other.pkg")',
         ],
     )
     def test_sync_file_allows_lookalike_module(

--- a/tests/test_hook_plugin_guards.py
+++ b/tests/test_hook_plugin_guards.py
@@ -290,14 +290,27 @@ class TestSyncPluginLib:
             )
             assert sync_mod.main(["--check"]) == 1
 
-    def test_sync_file_rejects_scripts_import(self, tmp_path: Path) -> None:
-        """A source importing a scripts.* package is rejected (cannot byte-copy)."""
+    @pytest.mark.parametrize(
+        "import_line",
+        [
+            "from scripts.pkg.other import thing",
+            "import scripts.pkg.other",
+            "from scripts import other",
+            "import scripts",
+            "import scripts as s",
+            "import os, scripts",
+        ],
+    )
+    def test_sync_file_rejects_scripts_import(
+        self, tmp_path: Path, import_line: str
+    ) -> None:
+        """Any scripts-package import is rejected (a byte copy cannot rewrite it)."""
         import scripts.sync_plugin_lib as sync_mod
 
         src = tmp_path / "scripts" / "pkg" / "mod.py"
         src.parent.mkdir(parents=True)
         src.write_text(
-            '"""Not self-contained."""\nfrom scripts.pkg.other import thing\n',
+            f'"""Not self-contained."""\n{import_line}\n',
             encoding="utf-8",
         )
 
@@ -308,8 +321,56 @@ class TestSyncPluginLib:
             )
 
         assert had_errors is True
-        assert any("scripts.*" in c or "scripts." in c for c in changes), changes
+        assert any("scripts package" in c for c in changes), changes
         assert not (tmp_path / ".claude" / "lib" / "mod.py").exists()
+
+    @pytest.mark.parametrize(
+        "import_line",
+        [
+            "import scripts_helper",
+            "from scripts_util import thing",
+            "import scriptsfoo",
+        ],
+    )
+    def test_sync_file_allows_lookalike_module(
+        self, tmp_path: Path, import_line: str
+    ) -> None:
+        """Modules whose name merely starts with 'scripts' are not the scripts pkg."""
+        import scripts.sync_plugin_lib as sync_mod
+
+        src = tmp_path / "scripts" / "pkg" / "mod.py"
+        src.parent.mkdir(parents=True)
+        src.write_text(
+            f'"""Self-contained."""\n{import_line}\n',
+            encoding="utf-8",
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sync_mod, "REPO_ROOT", tmp_path)
+            changes, had_errors = sync_mod.sync_file(
+                "scripts/pkg/mod.py", ".claude/lib/mod.py", check_only=False,
+            )
+
+        assert had_errors is False, changes
+        assert (tmp_path / ".claude" / "lib" / "mod.py").read_text(
+            encoding="utf-8"
+        ) == src.read_text(encoding="utf-8")
+
+    def test_sync_file_missing_source_fails_closed(self, tmp_path: Path) -> None:
+        """A registered source that does not exist is an error, not a silent pass."""
+        import scripts.sync_plugin_lib as sync_mod
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sync_mod, "REPO_ROOT", tmp_path)
+            changes, had_errors = sync_mod.sync_file(
+                "scripts/pkg/missing.py",
+                ".claude/lib/missing.py",
+                check_only=True,
+            )
+
+        assert had_errors is True
+        assert any("Registered source file missing" in c for c in changes), changes
+        assert not (tmp_path / ".claude" / "lib" / "missing.py").exists()
 
 
 def _parse_events(stderr_text: str) -> list[dict[str, Any]]:

--- a/tests/test_hook_plugin_guards.py
+++ b/tests/test_hook_plugin_guards.py
@@ -250,6 +250,67 @@ class TestSyncPluginLib:
         result = sync_mod.main(["--check"])
         assert result == 1
 
+    def test_sync_file_creates_missing_dest(self, tmp_path: Path) -> None:
+        """sync_file byte-copies the source when the destination is absent."""
+        import scripts.sync_plugin_lib as sync_mod
+
+        src = tmp_path / "scripts" / "pkg" / "mod.py"
+        src.parent.mkdir(parents=True)
+        src.write_text('"""Self-contained module."""\nX = 1\n', encoding="utf-8")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sync_mod, "REPO_ROOT", tmp_path)
+            changes, had_errors = sync_mod.sync_file(
+                "scripts/pkg/mod.py", ".claude/lib/mod.py", check_only=False,
+            )
+
+        assert had_errors is False, changes
+        dst = tmp_path / ".claude" / "lib" / "mod.py"
+        # Byte-identical copy: no canonical-note rewrite for top-level files.
+        assert dst.read_text(encoding="utf-8") == src.read_text(encoding="utf-8")
+
+    def test_sync_file_check_detects_drift(self, tmp_path: Path) -> None:
+        """A drifted top-level lib file makes main(--check) return 1."""
+        import scripts.sync_plugin_lib as sync_mod
+
+        src = tmp_path / "scripts" / "pkg" / "mod.py"
+        src.parent.mkdir(parents=True)
+        src.write_text('"""Canonical."""\nX = 1\n', encoding="utf-8")
+        dst = tmp_path / ".claude" / "lib" / "mod.py"
+        dst.parent.mkdir(parents=True)
+        dst.write_text('"""Stale."""\nX = 2\n', encoding="utf-8")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sync_mod, "REPO_ROOT", tmp_path)
+            mp.setattr(sync_mod, "SYNC_PAIRS", [])
+            mp.setattr(
+                sync_mod,
+                "SYNC_FILE_PAIRS",
+                [("scripts/pkg/mod.py", ".claude/lib/mod.py")],
+            )
+            assert sync_mod.main(["--check"]) == 1
+
+    def test_sync_file_rejects_scripts_import(self, tmp_path: Path) -> None:
+        """A source importing a scripts.* package is rejected (cannot byte-copy)."""
+        import scripts.sync_plugin_lib as sync_mod
+
+        src = tmp_path / "scripts" / "pkg" / "mod.py"
+        src.parent.mkdir(parents=True)
+        src.write_text(
+            '"""Not self-contained."""\nfrom scripts.pkg.other import thing\n',
+            encoding="utf-8",
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sync_mod, "REPO_ROOT", tmp_path)
+            changes, had_errors = sync_mod.sync_file(
+                "scripts/pkg/mod.py", ".claude/lib/mod.py", check_only=False,
+            )
+
+        assert had_errors is True
+        assert any("scripts.*" in c or "scripts." in c for c in changes), changes
+        assert not (tmp_path / ".claude" / "lib" / "mod.py").exists()
+
 
 def _parse_events(stderr_text: str) -> list[dict[str, Any]]:
     return [


### PR DESCRIPTION
## Summary

The top-level bootstrap module under the packaged plugin lib was a hand-maintained byte copy of the canonical hook-utilities bootstrap that no sync or build mechanism covered. `SYNC_PAIRS` in the sync tool lists only package directories, and there was no registry for single top-level lib modules. Drift went undetected until an import broke at runtime (root cause of issue #2816 finding 1, fixed in #2899).

This adds a `SYNC_FILE_PAIRS` registry plus a `sync_file()` byte-copy syncer so `--check` enforces parity in CI going forward. The pair is already in parity, so this is a no-op today.

## Type of Change

- [x] Chore / tooling (no behavior change to shipped plugin content)

## Changes

- `scripts/sync_plugin_lib.py`: added `SYNC_FILE_PAIRS`, `_validate_sync_file_paths()`, and `sync_file()`; wired the pair into `main()` for both sync and `--check`. `sync_file()` byte-copies (no package-relative import rewrite, which would not resolve at the lib top level) and rejects a source that imports a `scripts.*` package.
- `tests/test_hook_plugin_guards.py`: added four `sync_file` tests (create missing dest, drift detection via `--check`, `scripts.*` import rejection, byte-copy no-note guarantee).

## Validation

```text
uv run python -m pytest tests/test_hook_plugin_guards.py::TestSyncPluginLib -q   # 5 passed
uv run python -m pytest tests/validation/test_validate_sync_registry.py tests/test_hook_plugin_guards.py tests/test_github_core.py tests/build_scripts/test_build_all.py -q   # 292 passed
uv run ruff check scripts/sync_plugin_lib.py tests/test_hook_plugin_guards.py   # clean
uv run python scripts/sync_plugin_lib.py --check   # exit 0 (no-op, in parity)
```

## Specification References

Addresses issue #2816 finding 2 (auto-sync the top-level bootstrap.py duplicate). Does not close #2816 (multi-finding issue).

## Background

Canonical source is `scripts/hook_utilities/bootstrap.py`. The `.claude/lib/hook_utilities/bootstrap.py` package variant is already covered by `SYNC_PAIRS`; this registers only the top-level `.claude/lib/bootstrap.py` module. Related root-cause fix: #2899.
