### PR TITLE
feat(eval): model-sweep tooling for #2840 (criterion 2)

### DIFF
--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -239,6 +239,14 @@ computed on the shared stable subset) lives in the pure, unit-tested
 `_model_sweep_core.py`. The orchestrator injects a runner (`ModelEvalRunner`), so
 the KEEP/DROP decision is testable without API spend.
 
+Two guards keep the verdict honest. Each candidate's bootstrap stream is seeded
+from its own model id, so the outcome is independent of `--models` order. When
+more than one candidate is swept, the per-candidate CIs are Bonferroni-widened
+(the two-sided 5% alpha is split across candidates), so sweeping many models does
+not inflate the false-KEEP rate. A sweep with fewer than two shared stable
+fixtures is undecidable (the bootstrap CI collapses onto the point delta) and
+always DROPs; widen the shared `--fixtures` set to decide.
+
 **Prerequisite (freshness gate):** every swept model must have a pricing rate in
 `MODEL_PRICING_RATES_USD_PER_1K_TOKENS` (`_eval_common.py`). The base evaluator
 hard-fails on an unpriced model (#2858), so the sweep pre-checks pricing and

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -43,6 +43,7 @@ python3 scripts/eval/eval-skill-overlap.py \
 | `analyze-pr-churn.py` | Deterministic commit-churn classification across a PR cohort (degenerate vs control) to evaluate instruction/rule changes against historical PRs. No LLM; core in `_pr_churn.py`. | Complementary |
 | `eval-reviewer-asymmetry.py` | Statistical-significance test for `templates/agents/{critic,qa,implementer}.shared.md` reviewer-asymmetry framing. Fisher's exact (verdict-pass) + Mann-Whitney U (findings-count). | Complementary |
 | `eval-e2e-delivery.py` | End-to-end delivery eval (plan-rubric proxy). Feeds a vague germ, captures each agent's plan, LLM-judges it against hidden acceptance criteria. Core in `_e2e_delivery_core.py`. | #2859 |
+| `eval-model-sweep.py` | Sweep one agent's fixtures across candidate models; scored KEEP_PIN/DROP_PIN verdict with effect size. Core in `_model_sweep_core.py`. | #2840 |
 | `_anthropic_api.py` | Shared API utilities (key loading, API calls). | N/A |
 
 ## End-to-End Delivery Eval
@@ -198,6 +199,49 @@ Note on the Issue #1932 Phase 1 pairs: `doc-coverage`, `doc-sync`, and
 the example file targets the surviving overlapping pairs only
 (`memory-enhancement`/`curating-memories`,
 `curating-memories`/`exploring-knowledge-graph`).
+
+## Model Sweep Eval
+
+`eval-model-sweep.py` answers a question the pin registry (#2891) cannot: does a
+`model:` pin actually beat the harness default, or is it cargo-cult config? For
+one agent it runs the existing single-model evaluator (`eval-agent-vs-baseline.py`,
+agent variant) once per candidate model, then compares the per-fixture pass rates
+across models and emits a scored verdict (Issue #2840, acceptance criterion 2).
+
+```bash
+scripts/eval/eval-model-sweep.py \
+  --agent security \
+  --fixtures tests/evals/skills/security \
+  --models claude-sonnet-4-6,claude-opus-4-6 \
+  --n-runs 3
+```
+
+The default model (`claude-sonnet-4-6`) is always added as the comparison anchor.
+The verdict:
+
+- **KEEP_PIN**: a non-default candidate leads the default by at least
+  `--min-effect` (default 0.05) recall AND the paired bootstrap 95% CI on the
+  recall delta excludes 0. Keep the pin and cite the sweep artifact.
+- **DROP_PIN**: the default ranks first, the lead is within noise (CI includes
+  0), or the lead is below `--min-effect`. Drop the pin; inherit `auto`.
+
+Cohen's d_z is reported as a secondary descriptor only; it never gates the
+verdict. The comparison math (paired fixture-id bootstrap, same percentiles as
+the agent-vs-baseline CI) lives in the pure, unit-tested `_model_sweep_core.py`.
+The orchestrator injects a runner (`ModelEvalRunner`), so the KEEP/DROP decision
+is testable without API spend.
+
+**Prerequisite (freshness gate):** every swept model must have a pricing rate in
+`MODEL_PRICING_RATES_USD_PER_1K_TOKENS` (`_eval_common.py`). The base evaluator
+hard-fails on an unpriced model (#2858), so the sweep pre-checks pricing and
+exits `2` with an actionable message naming the unpriced models. It does **not**
+invent pricing. Today only two `claude-sonnet` ids are priced, so a real
+opus/haiku sweep needs a verified pricing entry added first. `--dry-run`
+validates inputs and prints the per-model plan with no API calls.
+
+Output is a JSON artifact (`--output`, default under
+`evals/{agent}-spike/reports/`) with `schema_version`, per-model recall/tokens/
+cost, the winner, `recall_delta`, `ci95`, `cohens_d`, and the `decision`/`reason`.
 
 ## Scenario File Format
 

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -211,25 +211,33 @@ across models and emits a scored verdict (Issue #2840, acceptance criterion 2).
 ```bash
 scripts/eval/eval-model-sweep.py \
   --agent security \
-  --fixtures tests/evals/skills/security \
+  --fixtures evals/security-spike/fixtures \
   --models claude-sonnet-4-6,claude-opus-4-6 \
   --n-runs 3
 ```
 
 The default model (`claude-sonnet-4-6`) is always added as the comparison anchor.
-The verdict:
+The metric is the **unweighted mean per-fixture pass rate** over the fixtures that
+are stable (non-flaky) for *every* swept model (the shared stable subset). The
+same metric drives both the point delta and the CI, so the gate never mixes
+estimands. Every non-default candidate is scored against the default; a noisy
+top-point-estimate model cannot force a KEEP, nor suppress a solid runner-up. The
+verdict:
 
-- **KEEP_PIN**: a non-default candidate leads the default by at least
-  `--min-effect` (default 0.05) recall AND the paired bootstrap 95% CI on the
-  recall delta excludes 0. Keep the pin and cite the sweep artifact.
-- **DROP_PIN**: the default ranks first, the lead is within noise (CI includes
-  0), or the lead is below `--min-effect`. Drop the pin; inherit `auto`.
+- **KEEP_PIN**: some candidate leads the default by at least `--min-effect`
+  (default 0.05) mean recall AND the paired bootstrap 95% CI on the delta
+  excludes 0. Keep that pin and cite the sweep artifact. The strongest such
+  qualifier wins.
+- **DROP_PIN**: no candidate qualifies (the default ranks first, every lead is
+  within noise, or below `--min-effect`). Drop the pin; inherit `auto`.
 
-Cohen's d_z is reported as a secondary descriptor only; it never gates the
-verdict. The comparison math (paired fixture-id bootstrap, same percentiles as
-the agent-vs-baseline CI) lives in the pure, unit-tested `_model_sweep_core.py`.
-The orchestrator injects a runner (`ModelEvalRunner`), so the KEEP/DROP decision
-is testable without API spend.
+The report also carries each model's assertion-weighted `agent_recall` from its
+single-model report as an informational field, but that value never gates the
+verdict. Cohen's d_z is reported as a secondary descriptor only. The comparison
+math (paired fixture-id bootstrap, same percentiles as the agent-vs-baseline CI,
+computed on the shared stable subset) lives in the pure, unit-tested
+`_model_sweep_core.py`. The orchestrator injects a runner (`ModelEvalRunner`), so
+the KEEP/DROP decision is testable without API spend.
 
 **Prerequisite (freshness gate):** every swept model must have a pricing rate in
 `MODEL_PRICING_RATES_USD_PER_1K_TOKENS` (`_eval_common.py`). The base evaluator

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -256,8 +256,9 @@ opus/haiku sweep needs a verified pricing entry added first. `--dry-run`
 validates inputs and prints the per-model plan with no API calls.
 
 Output is a JSON artifact (`--output`, default under
-`evals/{agent}-spike/reports/`) with `schema_version`, per-model recall/tokens/
-cost, the winner, `recall_delta`, `ci95`, `cohens_d`, and the `decision`/`reason`.
+`evals/{agent}-spike/reports/`) with `schemaVersion`, per-model recall/tokens/
+cost, the winner, `recall_delta`, `ci95`, `cohens_d`, `best_candidate_*`, and
+the `decision`/`reason`.
 
 ## Scenario File Format
 

--- a/scripts/eval/_model_sweep_core.py
+++ b/scripts/eval/_model_sweep_core.py
@@ -36,8 +36,27 @@ from _report_aggregator import (
     BOOTSTRAP_ITERATIONS,
     CI_LOWER_PERCENTILE,
     CI_UPPER_PERCENTILE,
-    _percentile,
 )
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Linear-interpolation percentile (local copy; no numpy).
+
+    Duplicated from ``_report_aggregator`` deliberately: importing that
+    module's private ``_percentile`` coupled the sweep to an internal helper
+    that could change without a contract. The math is a stable, standard
+    definition, so an independent copy is safer than the private dependency.
+    """
+    if not values:
+        return 0.0
+    s = sorted(values)
+    if len(s) == 1:
+        return s[0]
+    rank = (pct / 100.0) * (len(s) - 1)
+    lower = int(rank)
+    upper = min(lower + 1, len(s) - 1)
+    frac = rank - lower
+    return s[lower] + frac * (s[upper] - s[lower])
 
 SCHEMA_VERSION = "1"
 DEFAULT_MIN_EFFECT = 0.05
@@ -98,6 +117,15 @@ class SweepDecision:
     cohens_d: float
     decision: str
     reason: str
+    # The top-level recall_delta/ci95/cohens_d always describe winner_model vs
+    # the default (so a DROP_PIN with the default winning reports 0/[0,0]/0).
+    # The leading candidate's stats, when the default wins, live in the
+    # best_candidate_* fields so the artifact stays machine-readable without
+    # conflating "winner" with "best challenger".
+    best_candidate_model: str | None = None
+    best_candidate_delta: float = 0.0
+    best_candidate_ci95: tuple[float, float] = (0.0, 0.0)
+    best_candidate_cohens_d: float = 0.0
 
 
 def check_comparable(results: list[ModelResult]) -> None:
@@ -346,6 +374,10 @@ def decide(
                 f"over {len(ids)} shared fixtures; family-wise CI [{ci[0]:.4f}, "
                 f"{ci[1]:.4f}] excludes 0; keep this pin and cite the artifact"
             ),
+            best_candidate_model=cand.model_id,
+            best_candidate_delta=delta,
+            best_candidate_ci95=ci,
+            best_candidate_cohens_d=cohens_d(cand, default, ids),
         )
 
     positive = [e for e in evaluated if e[1] > 0.0]
@@ -368,11 +400,15 @@ def decide(
             default_model=default_model,
             winner_recall=default_recall,
             default_recall=default_recall,
-            recall_delta=delta,
-            ci95=ci,
-            cohens_d=cohens_d(cand, default, ids),
+            recall_delta=0.0,
+            ci95=(0.0, 0.0),
+            cohens_d=0.0,
             decision=DECISION_DROP,
             reason=reason,
+            best_candidate_model=cand.model_id,
+            best_candidate_delta=delta,
+            best_candidate_ci95=ci,
+            best_candidate_cohens_d=cohens_d(cand, default, ids),
         )
 
     return SweepDecision(
@@ -405,12 +441,13 @@ def build_report(
 
     Downstream consumers (Issue #2840): the CI governance check that fails a
     ``model:`` pin lacking a linked sweep artifact, and the pin-migration that
-    strips DROP_PIN pins. Field names are stable; ``schema_version`` gates
-    future shape changes.
+    strips DROP_PIN pins. Field names are stable; ``schemaVersion`` gates
+    future shape changes (name matches the harness report convention in
+    ``_report_writer.py``).
     """
     ids = common_fixture_ids(results)
     return {
-        "schema_version": SCHEMA_VERSION,
+        "schemaVersion": SCHEMA_VERSION,
         "agent": agent,
         "fixtures_sha": fixtures_sha,
         "default_model": decision.default_model,
@@ -434,6 +471,13 @@ def build_report(
         "recall_delta": round(decision.recall_delta, 6),
         "ci95": [round(decision.ci95[0], 6), round(decision.ci95[1], 6)],
         "cohens_d": round(decision.cohens_d, 6),
+        "best_candidate_model": decision.best_candidate_model,
+        "best_candidate_delta": round(decision.best_candidate_delta, 6),
+        "best_candidate_ci95": [
+            round(decision.best_candidate_ci95[0], 6),
+            round(decision.best_candidate_ci95[1], 6),
+        ],
+        "best_candidate_cohens_d": round(decision.best_candidate_cohens_d, 6),
         "decision": decision.decision,
         "reason": decision.reason,
     }

--- a/scripts/eval/_model_sweep_core.py
+++ b/scripts/eval/_model_sweep_core.py
@@ -27,6 +27,7 @@ Verdict semantics for Issue #2840:
 
 from __future__ import annotations
 
+import hashlib
 import random
 import statistics
 from dataclasses import dataclass
@@ -41,6 +42,11 @@ from _report_aggregator import (
 SCHEMA_VERSION = "1"
 DEFAULT_MIN_EFFECT = 0.05
 DEFAULT_SEED = 42
+
+# A paired bootstrap over fewer than two shared fixtures is degenerate: every
+# resample draws the same fixture(s), so the CI collapses onto the point delta
+# and stops being evidence. Below this floor we never KEEP a pin.
+MIN_SHARED_FIXTURES = 2
 
 DECISION_KEEP = "KEEP_PIN"
 DECISION_DROP = "DROP_PIN"
@@ -121,9 +127,9 @@ def common_fixture_ids(results: list[ModelResult]) -> list[str]:
     cross-model delta, and the bootstrap CI on the same fixtures even when
     individual models excluded different flaky fixtures.
     """
-    sets = [set(r.per_fixture_agent_rates) for r in results if r.per_fixture_agent_rates]
-    if not sets:
+    if not results:
         return []
+    sets = [set(r.per_fixture_agent_rates) for r in results]
     return sorted(set.intersection(*sets))
 
 
@@ -148,14 +154,19 @@ def paired_bootstrap_ci(
     *,
     iterations: int = BOOTSTRAP_ITERATIONS,
     rng: random.Random | None = None,
+    lower_percentile: float = CI_LOWER_PERCENTILE,
+    upper_percentile: float = CI_UPPER_PERCENTILE,
 ) -> tuple[float, float]:
-    """95% paired bootstrap CI on the per-fixture mean-rate delta (winner - default).
+    """Paired bootstrap CI on the per-fixture mean-rate delta (winner - default).
 
     Resamples *ids* (the common stable fixture set) with replacement; for each
     resample takes the mean of per-fixture ``winner - default`` differences;
-    returns the [2.5, 97.5] percentiles of the resampled deltas. Mirrors
-    ``_report_aggregator.pairwise_bootstrap_ci`` (fixture-id resampling, same
-    percentiles), computed on the same fixtures and metric as the point delta.
+    returns the [``lower_percentile``, ``upper_percentile``] percentiles of the
+    resampled deltas. Mirrors ``_report_aggregator.pairwise_bootstrap_ci``
+    (fixture-id resampling), computed on the same fixtures and metric as the
+    point delta. The percentiles default to the two-sided 95% interval but are
+    widened by ``decide`` for a family-wise (Bonferroni) correction when more
+    than one candidate is swept.
     """
     if not ids:
         return (0.0, 0.0)
@@ -169,8 +180,8 @@ def paired_bootstrap_ci(
         delta = sum(w_means[f] - d_means[f] for f in sample) / n
         deltas.append(delta)
     return (
-        _percentile(deltas, CI_LOWER_PERCENTILE),
-        _percentile(deltas, CI_UPPER_PERCENTILE),
+        _percentile(deltas, lower_percentile),
+        _percentile(deltas, upper_percentile),
     )
 
 
@@ -197,6 +208,20 @@ def rank(results: list[ModelResult], ids: list[str]) -> list[ModelResult]:
     return sorted(results, key=lambda r: (-mean_recall_on(r, ids), r.model_id))
 
 
+def _candidate_rng(seed: int, default_model: str, candidate_id: str) -> random.Random:
+    """Independent, deterministic RNG keyed by (seed, default, candidate).
+
+    Each candidate's bootstrap stream is derived from its own id, not from a
+    single RNG advanced in candidate order. This makes the verdict independent
+    of the order candidates appear in (e.g. the ``--models`` argument order),
+    while staying fully reproducible for a given seed.
+    """
+    digest = hashlib.sha256(
+        f"{seed}:{default_model}:{candidate_id}".encode()
+    ).digest()
+    return random.Random(int.from_bytes(digest[:8], "big"))
+
+
 def _evaluate_candidate(
     candidate: ModelResult,
     default: ModelResult,
@@ -204,14 +229,23 @@ def _evaluate_candidate(
     *,
     min_effect: float,
     rng: random.Random,
+    lower_percentile: float,
 ) -> tuple[float, tuple[float, float], bool]:
-    """Return (delta, ci95, qualifies) for one candidate vs the default.
+    """Return (delta, ci, qualifies) for one candidate vs the default.
 
     ``qualifies`` iff the candidate leads by at least ``min_effect`` mean
-    recall AND the paired bootstrap CI on the delta excludes 0.
+    recall AND the (family-wise-adjusted) paired bootstrap CI on the delta
+    excludes 0.
     """
     delta = mean_recall_on(candidate, ids) - mean_recall_on(default, ids)
-    ci_low, ci_high = paired_bootstrap_ci(candidate, default, ids, rng=rng)
+    ci_low, ci_high = paired_bootstrap_ci(
+        candidate,
+        default,
+        ids,
+        rng=rng,
+        lower_percentile=lower_percentile,
+        upper_percentile=100.0 - lower_percentile,
+    )
     qualifies = delta >= min_effect and ci_low > 0.0
     return delta, (ci_low, ci_high), qualifies
 
@@ -221,7 +255,7 @@ def decide(
     *,
     default_model: str,
     min_effect: float = DEFAULT_MIN_EFFECT,
-    rng: random.Random | None = None,
+    seed: int = DEFAULT_SEED,
 ) -> SweepDecision:
     """Decide KEEP_PIN vs DROP_PIN for a set of candidate model results.
 
@@ -231,6 +265,12 @@ def decide(
     strongest such qualifier wins the pin. Otherwise DROP_PIN (a higher
     point-estimate but noisy candidate cannot force a KEEP, and it cannot
     suppress a solid lower-ranked candidate either).
+
+    The verdict is independent of candidate order: each candidate's bootstrap
+    stream is seeded from its own id (not a single RNG advanced in order). When
+    more than one candidate is swept the per-candidate CIs are Bonferroni-
+    widened so the family-wise false-KEEP rate stays near 5% instead of
+    compounding with the number of candidates.
     """
     if not results:
         raise SweepDecisionError("no model results to decide on")
@@ -248,13 +288,40 @@ def decide(
             "no fixtures are shared and stable across all swept models; cannot "
             "compare (check per-model flaky exclusions and the --fixtures set)"
         )
-    rng = rng or random.Random(DEFAULT_SEED)
     default_recall = mean_recall_on(default, ids)
+    candidates = [r for r in results if r.model_id != default_model]
+
+    if len(ids) < MIN_SHARED_FIXTURES:
+        return SweepDecision(
+            winner_model=default_model,
+            default_model=default_model,
+            winner_recall=default_recall,
+            default_recall=default_recall,
+            recall_delta=0.0,
+            ci95=(0.0, 0.0),
+            cohens_d=0.0,
+            decision=DECISION_DROP,
+            reason=(
+                f"only {len(ids)} shared stable fixture(s) across all swept "
+                f"models, below the {MIN_SHARED_FIXTURES}-fixture floor for a "
+                f"meaningful bootstrap CI; cannot justify a pin, inherit the "
+                f"harness default (widen the shared --fixtures set to decide)"
+            ),
+        )
+
+    # Bonferroni: split the family-wise 5% two-sided alpha across candidates so
+    # sweeping many models does not inflate the false-KEEP rate.
+    lower_percentile = CI_LOWER_PERCENTILE / max(len(candidates), 1)
 
     evaluated: list[tuple[ModelResult, float, tuple[float, float], bool]] = []
-    for cand in (r for r in results if r.model_id != default_model):
+    for cand in candidates:
         delta, ci, qualifies = _evaluate_candidate(
-            cand, default, ids, min_effect=min_effect, rng=rng
+            cand,
+            default,
+            ids,
+            min_effect=min_effect,
+            rng=_candidate_rng(seed, default_model, cand.model_id),
+            lower_percentile=lower_percentile,
         )
         evaluated.append((cand, delta, ci, qualifies))
 
@@ -276,7 +343,7 @@ def decide(
             reason=(
                 f"candidate {cand.model_id!r} beats default {default_model!r} by "
                 f"mean-recall delta={delta:.4f} (>= min_effect={min_effect:.4f}) "
-                f"over {len(ids)} shared fixtures; 95% CI [{ci[0]:.4f}, "
+                f"over {len(ids)} shared fixtures; family-wise CI [{ci[0]:.4f}, "
                 f"{ci[1]:.4f}] excludes 0; keep this pin and cite the artifact"
             ),
         )
@@ -287,7 +354,7 @@ def decide(
         if ci[0] <= 0.0:
             reason = (
                 f"best candidate {cand.model_id!r} leads by mean-recall "
-                f"delta={delta:.4f} but 95% CI [{ci[0]:.4f}, {ci[1]:.4f}] "
+                f"delta={delta:.4f} but family-wise CI [{ci[0]:.4f}, {ci[1]:.4f}] "
                 f"includes 0 (within noise); drop the pin and inherit the default"
             )
         else:

--- a/scripts/eval/_model_sweep_core.py
+++ b/scripts/eval/_model_sweep_core.py
@@ -1,0 +1,294 @@
+"""Model-sweep comparison core for eval-model-sweep.py (Issue #2840).
+
+Pure, side-effect-free logic: no I/O, no subprocess, no API. Given one
+``ModelResult`` per candidate model (the ``agent`` variant's per-fixture pass
+rates at that model), decide whether any candidate beats the harness-default
+model by a margin large enough to *justify keeping a model pin*.
+
+Design (AGENTS.md Software Hierarchy: testability first, separate use from
+creation):
+
+    eval-model-sweep.py (CLI, live runs) -> [ModelResult, ...] -> decide() -> SweepDecision
+
+The DECISION is driven by the point-estimate recall delta plus a paired
+bootstrap 95% CI on the shared fixture set (the same resample-fixtures method
+`_report_aggregator.pairwise_bootstrap_ci` uses for the agent-vs-baseline CI,
+reused here across models instead of across prompt variants). Cohen's d_z is
+reported as a secondary descriptor only; it is never the gate, so its
+zero-variance edge case cannot flip a verdict.
+
+Verdict semantics for Issue #2840:
+    KEEP_PIN  -> a specific candidate measurably beats the default; the skill
+                 keeps that model pin and cites the sweep artifact.
+    DROP_PIN  -> the default ranks first, or the lead is within the noise
+                 (CI includes 0) or below ``min_effect``; drop the pin and
+                 inherit the harness default (`auto`).
+"""
+
+from __future__ import annotations
+
+import random
+import statistics
+from dataclasses import dataclass
+
+from _report_aggregator import (
+    BOOTSTRAP_ITERATIONS,
+    CI_LOWER_PERCENTILE,
+    CI_UPPER_PERCENTILE,
+    _percentile,
+)
+
+SCHEMA_VERSION = "1"
+DEFAULT_MIN_EFFECT = 0.05
+DEFAULT_SEED = 42
+
+DECISION_KEEP = "KEEP_PIN"
+DECISION_DROP = "DROP_PIN"
+
+
+class SweepDecisionError(Exception):
+    """Raised when a sweep cannot be decided (e.g. default model absent)."""
+
+
+@dataclass(frozen=True)
+class ModelResult:
+    """One candidate model's ``agent``-variant outcome on a fixture set.
+
+    ``per_fixture_agent_rates`` maps ``fixture_id -> [pass_rate_per_run, ...]``
+    exactly as ``report.json``'s ``per_fixture_pass_rates[fixture_id]["agent"]``
+    carries it. ``agent_recall`` is the report's headline recall for the agent
+    variant (carried through verbatim so the point estimate matches the
+    single-model report and is not silently redefined here).
+    """
+
+    model_id: str
+    agent_recall: float
+    per_fixture_agent_rates: dict[str, list[float]]
+    tokens_in: int = 0
+    tokens_out: int = 0
+    cost_usd: float = 0.0
+    error_count: int = 0
+
+    @property
+    def fixture_means(self) -> dict[str, float]:
+        """Mean pass rate per fixture (over its runs); empty runs score 0.0."""
+        return {
+            fid: (sum(rates) / len(rates) if rates else 0.0)
+            for fid, rates in self.per_fixture_agent_rates.items()
+        }
+
+
+@dataclass(frozen=True)
+class SweepDecision:
+    """Outcome of comparing candidates against the default model."""
+
+    winner_model: str
+    default_model: str
+    winner_recall: float
+    default_recall: float
+    recall_delta: float
+    ci95: tuple[float, float]
+    cohens_d: float
+    decision: str
+    reason: str
+
+
+def _shared_fixture_ids(a: ModelResult, b: ModelResult) -> list[str]:
+    """Sorted intersection of fixture ids present for both models."""
+    return sorted(set(a.fixture_means) & set(b.fixture_means))
+
+
+def paired_bootstrap_ci(
+    winner: ModelResult,
+    default: ModelResult,
+    *,
+    iterations: int = BOOTSTRAP_ITERATIONS,
+    rng: random.Random | None = None,
+) -> tuple[float, float]:
+    """95% paired bootstrap CI on the per-fixture mean-rate delta (winner - default).
+
+    Resamples the shared fixture ids with replacement; for each resample takes
+    the mean of per-fixture ``winner - default`` differences; returns the
+    [2.5, 97.5] percentiles of the resampled deltas. Mirrors
+    ``_report_aggregator.pairwise_bootstrap_ci`` (fixture-id resampling, same
+    percentiles) but compares two *models* rather than two prompt variants.
+    """
+    ids = _shared_fixture_ids(winner, default)
+    if not ids:
+        return (0.0, 0.0)
+    rng = rng or random.Random(DEFAULT_SEED)
+    w_means = winner.fixture_means
+    d_means = default.fixture_means
+    n = len(ids)
+    deltas: list[float] = []
+    for _ in range(iterations):
+        sample = [ids[rng.randrange(n)] for _ in range(n)]
+        delta = sum(w_means[f] - d_means[f] for f in sample) / n
+        deltas.append(delta)
+    return (
+        _percentile(deltas, CI_LOWER_PERCENTILE),
+        _percentile(deltas, CI_UPPER_PERCENTILE),
+    )
+
+
+def cohens_d(winner: ModelResult, default: ModelResult) -> float:
+    """Paired Cohen's d_z on shared per-fixture mean rates (secondary metric).
+
+    d_z = mean(diff) / stdev(diff). Returns 0.0 when fewer than two shared
+    fixtures or when the paired differences have zero spread (the CI, not
+    d_z, is the gate, so a degenerate d_z cannot change a verdict).
+    """
+    ids = _shared_fixture_ids(winner, default)
+    if len(ids) < 2:
+        return 0.0
+    w_means = winner.fixture_means
+    d_means = default.fixture_means
+    diffs = [w_means[f] - d_means[f] for f in ids]
+    spread = statistics.stdev(diffs)
+    if spread == 0.0:
+        return 0.0
+    return statistics.fmean(diffs) / spread
+
+
+def rank(results: list[ModelResult]) -> list[ModelResult]:
+    """Rank by agent_recall descending; break ties by model_id ascending."""
+    return sorted(results, key=lambda r: (-r.agent_recall, r.model_id))
+
+
+def _select_winner(results: list[ModelResult], default_model: str) -> ModelResult:
+    """Highest recall; on a tie at the top, prefer the default, else lexical.
+
+    Preferring the incumbent default on a tie is the conservative choice: a
+    pin must *beat* the default, not merely match it, to be justified.
+    """
+    top_recall = max(r.agent_recall for r in results)
+    tied = [r for r in results if r.agent_recall == top_recall]
+    for r in tied:
+        if r.model_id == default_model:
+            return r
+    return min(tied, key=lambda r: r.model_id)
+
+
+def decide(
+    results: list[ModelResult],
+    *,
+    default_model: str,
+    min_effect: float = DEFAULT_MIN_EFFECT,
+    rng: random.Random | None = None,
+) -> SweepDecision:
+    """Decide KEEP_PIN vs DROP_PIN for a set of candidate model results.
+
+    KEEP_PIN iff a non-default candidate leads by at least ``min_effect`` AND
+    the paired bootstrap CI on the recall delta excludes zero. Otherwise
+    DROP_PIN (default wins/ties, or the lead is within noise).
+    """
+    if not results:
+        raise SweepDecisionError("no model results to decide on")
+    by_id = {r.model_id: r for r in results}
+    if default_model not in by_id:
+        raise SweepDecisionError(
+            f"default model {default_model!r} not among swept models "
+            f"{sorted(by_id)}; include it as a candidate to anchor the comparison"
+        )
+    default = by_id[default_model]
+    winner = _select_winner(results, default_model)
+
+    if winner.model_id == default_model:
+        return SweepDecision(
+            winner_model=default_model,
+            default_model=default_model,
+            winner_recall=default.agent_recall,
+            default_recall=default.agent_recall,
+            recall_delta=0.0,
+            ci95=(0.0, 0.0),
+            cohens_d=0.0,
+            decision=DECISION_DROP,
+            reason=(
+                f"harness default {default_model!r} ranks first "
+                f"(recall={default.agent_recall:.4f}); no candidate beats it, "
+                f"so no model pin is justified"
+            ),
+        )
+
+    delta = winner.agent_recall - default.agent_recall
+    ci_low, ci_high = paired_bootstrap_ci(winner, default, rng=rng)
+    d = cohens_d(winner, default)
+    significant = ci_low > 0.0
+    material = delta >= min_effect
+    keep = significant and material
+
+    if keep:
+        reason = (
+            f"candidate {winner.model_id!r} beats default {default_model!r} by "
+            f"recall_delta={delta:.4f} (>= min_effect={min_effect:.4f}); "
+            f"95% CI [{ci_low:.4f}, {ci_high:.4f}] excludes 0; keep this pin "
+            f"and cite the sweep artifact"
+        )
+    elif not significant:
+        reason = (
+            f"candidate {winner.model_id!r} leads by recall_delta={delta:.4f} "
+            f"but 95% CI [{ci_low:.4f}, {ci_high:.4f}] includes 0 (within noise); "
+            f"drop the pin and inherit the harness default"
+        )
+    else:
+        reason = (
+            f"candidate {winner.model_id!r} leads by recall_delta={delta:.4f} "
+            f"below min_effect={min_effect:.4f}; not material enough to justify "
+            f"a pin; drop it and inherit the harness default"
+        )
+
+    return SweepDecision(
+        winner_model=winner.model_id,
+        default_model=default_model,
+        winner_recall=winner.agent_recall,
+        default_recall=default.agent_recall,
+        recall_delta=delta,
+        ci95=(ci_low, ci_high),
+        cohens_d=d,
+        decision=DECISION_KEEP if keep else DECISION_DROP,
+        reason=reason,
+    )
+
+
+def build_report(
+    *,
+    agent: str,
+    fixtures_sha: str,
+    results: list[ModelResult],
+    decision: SweepDecision,
+    min_effect: float,
+    seed: int,
+) -> dict:
+    """Machine-readable sweep artifact.
+
+    Downstream consumers (Issue #2840): the CI governance check that fails a
+    ``model:`` pin lacking a linked sweep artifact, and the pin-migration that
+    strips DROP_PIN pins. Field names are stable; ``schema_version`` gates
+    future shape changes.
+    """
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "agent": agent,
+        "fixtures_sha": fixtures_sha,
+        "default_model": decision.default_model,
+        "min_effect": min_effect,
+        "seed": seed,
+        "models": [
+            {
+                "model_id": r.model_id,
+                "agent_recall": round(r.agent_recall, 6),
+                "n_fixtures": len(r.per_fixture_agent_rates),
+                "tokens_in": r.tokens_in,
+                "tokens_out": r.tokens_out,
+                "cost_usd": round(r.cost_usd, 4),
+                "error_count": r.error_count,
+            }
+            for r in rank(results)
+        ],
+        "winner": decision.winner_model,
+        "recall_delta": round(decision.recall_delta, 6),
+        "ci95": [round(decision.ci95[0], 6), round(decision.ci95[1], 6)],
+        "cohens_d": round(decision.cohens_d, 6),
+        "decision": decision.decision,
+        "reason": decision.reason,
+    }

--- a/scripts/eval/_model_sweep_core.py
+++ b/scripts/eval/_model_sweep_core.py
@@ -94,11 +94,6 @@ class SweepDecision:
     reason: str
 
 
-def _shared_fixture_ids(a: ModelResult, b: ModelResult) -> list[str]:
-    """Sorted intersection of fixture ids present for both models."""
-    return sorted(set(a.fixture_means) & set(b.fixture_means))
-
-
 def check_comparable(results: list[ModelResult]) -> None:
     """Reject a sweep whose models ran on different fixture sets.
 
@@ -117,22 +112,51 @@ def check_comparable(results: list[ModelResult]) -> None:
         )
 
 
+def common_fixture_ids(results: list[ModelResult]) -> list[str]:
+    """Sorted intersection of fixture ids present (and stable) for every model.
+
+    ``per_fixture_agent_rates`` is already flaky-excluded upstream, so the
+    intersection is the set of fixtures that are stable across ALL swept
+    models. Comparing on this common set keeps every model's recall, the
+    cross-model delta, and the bootstrap CI on the same fixtures even when
+    individual models excluded different flaky fixtures.
+    """
+    sets = [set(r.per_fixture_agent_rates) for r in results if r.per_fixture_agent_rates]
+    if not sets:
+        return []
+    return sorted(set.intersection(*sets))
+
+
+def mean_recall_on(result: ModelResult, ids: list[str]) -> float:
+    """Unweighted mean per-fixture pass rate over *ids* (the sweep metric).
+
+    This is the single estimand used for BOTH the point delta and the
+    bootstrap CI, so the KEEP/DROP gate never mixes metrics. It weights each
+    fixture equally (unlike the report's assertion-weighted ``agent_recall``,
+    which is retained only as an informational per-model field).
+    """
+    if not ids:
+        return 0.0
+    means = result.fixture_means
+    return sum(means[f] for f in ids) / len(ids)
+
+
 def paired_bootstrap_ci(
     winner: ModelResult,
     default: ModelResult,
+    ids: list[str],
     *,
     iterations: int = BOOTSTRAP_ITERATIONS,
     rng: random.Random | None = None,
 ) -> tuple[float, float]:
     """95% paired bootstrap CI on the per-fixture mean-rate delta (winner - default).
 
-    Resamples the shared fixture ids with replacement; for each resample takes
-    the mean of per-fixture ``winner - default`` differences; returns the
-    [2.5, 97.5] percentiles of the resampled deltas. Mirrors
+    Resamples *ids* (the common stable fixture set) with replacement; for each
+    resample takes the mean of per-fixture ``winner - default`` differences;
+    returns the [2.5, 97.5] percentiles of the resampled deltas. Mirrors
     ``_report_aggregator.pairwise_bootstrap_ci`` (fixture-id resampling, same
-    percentiles) but compares two *models* rather than two prompt variants.
+    percentiles), computed on the same fixtures and metric as the point delta.
     """
-    ids = _shared_fixture_ids(winner, default)
     if not ids:
         return (0.0, 0.0)
     rng = rng or random.Random(DEFAULT_SEED)
@@ -150,14 +174,13 @@ def paired_bootstrap_ci(
     )
 
 
-def cohens_d(winner: ModelResult, default: ModelResult) -> float:
-    """Paired Cohen's d_z on shared per-fixture mean rates (secondary metric).
+def cohens_d(winner: ModelResult, default: ModelResult, ids: list[str]) -> float:
+    """Paired Cohen's d_z on the *ids* per-fixture mean rates (secondary metric).
 
     d_z = mean(diff) / stdev(diff). Returns 0.0 when fewer than two shared
     fixtures or when the paired differences have zero spread (the CI, not
     d_z, is the gate, so a degenerate d_z cannot change a verdict).
     """
-    ids = _shared_fixture_ids(winner, default)
     if len(ids) < 2:
         return 0.0
     w_means = winner.fixture_means
@@ -169,23 +192,28 @@ def cohens_d(winner: ModelResult, default: ModelResult) -> float:
     return statistics.fmean(diffs) / spread
 
 
-def rank(results: list[ModelResult]) -> list[ModelResult]:
-    """Rank by agent_recall descending; break ties by model_id ascending."""
-    return sorted(results, key=lambda r: (-r.agent_recall, r.model_id))
+def rank(results: list[ModelResult], ids: list[str]) -> list[ModelResult]:
+    """Rank by mean recall on *ids* descending; break ties by model_id ascending."""
+    return sorted(results, key=lambda r: (-mean_recall_on(r, ids), r.model_id))
 
 
-def _select_winner(results: list[ModelResult], default_model: str) -> ModelResult:
-    """Highest recall; on a tie at the top, prefer the default, else lexical.
+def _evaluate_candidate(
+    candidate: ModelResult,
+    default: ModelResult,
+    ids: list[str],
+    *,
+    min_effect: float,
+    rng: random.Random,
+) -> tuple[float, tuple[float, float], bool]:
+    """Return (delta, ci95, qualifies) for one candidate vs the default.
 
-    Preferring the incumbent default on a tie is the conservative choice: a
-    pin must *beat* the default, not merely match it, to be justified.
+    ``qualifies`` iff the candidate leads by at least ``min_effect`` mean
+    recall AND the paired bootstrap CI on the delta excludes 0.
     """
-    top_recall = max(r.agent_recall for r in results)
-    tied = [r for r in results if r.agent_recall == top_recall]
-    for r in tied:
-        if r.model_id == default_model:
-            return r
-    return min(tied, key=lambda r: r.model_id)
+    delta = mean_recall_on(candidate, ids) - mean_recall_on(default, ids)
+    ci_low, ci_high = paired_bootstrap_ci(candidate, default, ids, rng=rng)
+    qualifies = delta >= min_effect and ci_low > 0.0
+    return delta, (ci_low, ci_high), qualifies
 
 
 def decide(
@@ -197,9 +225,12 @@ def decide(
 ) -> SweepDecision:
     """Decide KEEP_PIN vs DROP_PIN for a set of candidate model results.
 
-    KEEP_PIN iff a non-default candidate leads by at least ``min_effect`` AND
-    the paired bootstrap CI on the recall delta excludes zero. Otherwise
-    DROP_PIN (default wins/ties, or the lead is within noise).
+    Every non-default candidate is evaluated against the default on the common
+    stable fixture set. KEEP_PIN iff at least one candidate leads by
+    ``min_effect`` mean recall AND its paired bootstrap CI excludes 0; the
+    strongest such qualifier wins the pin. Otherwise DROP_PIN (a higher
+    point-estimate but noisy candidate cannot force a KEEP, and it cannot
+    suppress a solid lower-ranked candidate either).
     """
     if not results:
         raise SweepDecisionError("no model results to decide on")
@@ -211,62 +242,86 @@ def decide(
             f"{sorted(by_id)}; include it as a candidate to anchor the comparison"
         )
     default = by_id[default_model]
-    winner = _select_winner(results, default_model)
+    ids = common_fixture_ids(results)
+    if not ids:
+        raise SweepDecisionError(
+            "no fixtures are shared and stable across all swept models; cannot "
+            "compare (check per-model flaky exclusions and the --fixtures set)"
+        )
+    rng = rng or random.Random(DEFAULT_SEED)
+    default_recall = mean_recall_on(default, ids)
 
-    if winner.model_id == default_model:
+    evaluated: list[tuple[ModelResult, float, tuple[float, float], bool]] = []
+    for cand in (r for r in results if r.model_id != default_model):
+        delta, ci, qualifies = _evaluate_candidate(
+            cand, default, ids, min_effect=min_effect, rng=rng
+        )
+        evaluated.append((cand, delta, ci, qualifies))
+
+    qualifiers = [e for e in evaluated if e[3]]
+    if qualifiers:
+        cand, delta, ci, _ = sorted(
+            qualifiers,
+            key=lambda e: (-e[1], -mean_recall_on(e[0], ids), e[0].model_id),
+        )[0]
         return SweepDecision(
-            winner_model=default_model,
+            winner_model=cand.model_id,
             default_model=default_model,
-            winner_recall=default.agent_recall,
-            default_recall=default.agent_recall,
-            recall_delta=0.0,
-            ci95=(0.0, 0.0),
-            cohens_d=0.0,
-            decision=DECISION_DROP,
+            winner_recall=mean_recall_on(cand, ids),
+            default_recall=default_recall,
+            recall_delta=delta,
+            ci95=ci,
+            cohens_d=cohens_d(cand, default, ids),
+            decision=DECISION_KEEP,
             reason=(
-                f"harness default {default_model!r} ranks first "
-                f"(recall={default.agent_recall:.4f}); no candidate beats it, "
-                f"so no model pin is justified"
+                f"candidate {cand.model_id!r} beats default {default_model!r} by "
+                f"mean-recall delta={delta:.4f} (>= min_effect={min_effect:.4f}) "
+                f"over {len(ids)} shared fixtures; 95% CI [{ci[0]:.4f}, "
+                f"{ci[1]:.4f}] excludes 0; keep this pin and cite the artifact"
             ),
         )
 
-    delta = winner.agent_recall - default.agent_recall
-    ci_low, ci_high = paired_bootstrap_ci(winner, default, rng=rng)
-    d = cohens_d(winner, default)
-    significant = ci_low > 0.0
-    material = delta >= min_effect
-    keep = significant and material
-
-    if keep:
-        reason = (
-            f"candidate {winner.model_id!r} beats default {default_model!r} by "
-            f"recall_delta={delta:.4f} (>= min_effect={min_effect:.4f}); "
-            f"95% CI [{ci_low:.4f}, {ci_high:.4f}] excludes 0; keep this pin "
-            f"and cite the sweep artifact"
-        )
-    elif not significant:
-        reason = (
-            f"candidate {winner.model_id!r} leads by recall_delta={delta:.4f} "
-            f"but 95% CI [{ci_low:.4f}, {ci_high:.4f}] includes 0 (within noise); "
-            f"drop the pin and inherit the harness default"
-        )
-    else:
-        reason = (
-            f"candidate {winner.model_id!r} leads by recall_delta={delta:.4f} "
-            f"below min_effect={min_effect:.4f}; not material enough to justify "
-            f"a pin; drop it and inherit the harness default"
+    positive = [e for e in evaluated if e[1] > 0.0]
+    if positive:
+        cand, delta, ci, _ = sorted(positive, key=lambda e: (-e[1], e[0].model_id))[0]
+        if ci[0] <= 0.0:
+            reason = (
+                f"best candidate {cand.model_id!r} leads by mean-recall "
+                f"delta={delta:.4f} but 95% CI [{ci[0]:.4f}, {ci[1]:.4f}] "
+                f"includes 0 (within noise); drop the pin and inherit the default"
+            )
+        else:
+            reason = (
+                f"best candidate {cand.model_id!r} leads by mean-recall "
+                f"delta={delta:.4f} below min_effect={min_effect:.4f}; not "
+                f"material enough to justify a pin; drop it and inherit the default"
+            )
+        return SweepDecision(
+            winner_model=default_model,
+            default_model=default_model,
+            winner_recall=default_recall,
+            default_recall=default_recall,
+            recall_delta=delta,
+            ci95=ci,
+            cohens_d=cohens_d(cand, default, ids),
+            decision=DECISION_DROP,
+            reason=reason,
         )
 
     return SweepDecision(
-        winner_model=winner.model_id,
+        winner_model=default_model,
         default_model=default_model,
-        winner_recall=winner.agent_recall,
-        default_recall=default.agent_recall,
-        recall_delta=delta,
-        ci95=(ci_low, ci_high),
-        cohens_d=d,
-        decision=DECISION_KEEP if keep else DECISION_DROP,
-        reason=reason,
+        winner_recall=default_recall,
+        default_recall=default_recall,
+        recall_delta=0.0,
+        ci95=(0.0, 0.0),
+        cohens_d=0.0,
+        decision=DECISION_DROP,
+        reason=(
+            f"harness default {default_model!r} ranks first over {len(ids)} "
+            f"shared fixtures (mean recall={default_recall:.4f}); no candidate "
+            f"beats it, so no model pin is justified"
+        ),
     )
 
 
@@ -286,6 +341,7 @@ def build_report(
     strips DROP_PIN pins. Field names are stable; ``schema_version`` gates
     future shape changes.
     """
+    ids = common_fixture_ids(results)
     return {
         "schema_version": SCHEMA_VERSION,
         "agent": agent,
@@ -293,9 +349,11 @@ def build_report(
         "default_model": decision.default_model,
         "min_effect": min_effect,
         "seed": seed,
+        "n_shared_fixtures": len(ids),
         "models": [
             {
                 "model_id": r.model_id,
+                "mean_recall": round(mean_recall_on(r, ids), 6),
                 "agent_recall": round(r.agent_recall, 6),
                 "n_fixtures": len(r.per_fixture_agent_rates),
                 "tokens_in": r.tokens_in,
@@ -303,7 +361,7 @@ def build_report(
                 "cost_usd": round(r.cost_usd, 4),
                 "error_count": r.error_count,
             }
-            for r in rank(results)
+            for r in rank(results, ids)
         ],
         "winner": decision.winner_model,
         "recall_delta": round(decision.recall_delta, 6),

--- a/scripts/eval/_model_sweep_core.py
+++ b/scripts/eval/_model_sweep_core.py
@@ -68,6 +68,7 @@ class ModelResult:
     tokens_out: int = 0
     cost_usd: float = 0.0
     error_count: int = 0
+    fixture_set_sha: str = ""
 
     @property
     def fixture_means(self) -> dict[str, float]:
@@ -96,6 +97,24 @@ class SweepDecision:
 def _shared_fixture_ids(a: ModelResult, b: ModelResult) -> list[str]:
     """Sorted intersection of fixture ids present for both models."""
     return sorted(set(a.fixture_means) & set(b.fixture_means))
+
+
+def check_comparable(results: list[ModelResult]) -> None:
+    """Reject a sweep whose models ran on different fixture sets.
+
+    Every model must evaluate the SAME input fixtures for the cross-model
+    delta and CI to mean anything. The base evaluator records the input set
+    as ``fixture_set_sha``; if two models carry different (non-empty) shas the
+    sweep pointed them at different fixtures and the comparison is invalid.
+    Empty shas (e.g. injected test doubles) are ignored.
+    """
+    shas = {r.fixture_set_sha for r in results if r.fixture_set_sha}
+    if len(shas) > 1:
+        raise SweepDecisionError(
+            "models were evaluated on different fixture sets "
+            f"(fixture_set_sha values {sorted(shas)}); sweep all models over "
+            "the same --fixtures so the comparison is valid"
+        )
 
 
 def paired_bootstrap_ci(
@@ -184,6 +203,7 @@ def decide(
     """
     if not results:
         raise SweepDecisionError("no model results to decide on")
+    check_comparable(results)
     by_id = {r.model_id: r for r in results}
     if default_model not in by_id:
         raise SweepDecisionError(

--- a/scripts/eval/eval-model-sweep.py
+++ b/scripts/eval/eval-model-sweep.py
@@ -254,8 +254,18 @@ class SubprocessModelEvalRunner:
         if completed.returncode != EXIT_OK:
             raise ChildRunError(model_id, completed.returncode, completed.stderr)
         report_path = child_report_path(self._agent, run_id)
-        report = json.loads(report_path.read_text(encoding="utf-8"))
-        return parse_report(report, model_id=model_id)
+        # The child exited 0 but its report artifact is an external dependency:
+        # a missing or malformed file is an EXTERNAL failure, not an unhandled
+        # crash. Surface it as ChildRunError so run_sweep maps it per contract.
+        try:
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            return parse_report(report, model_id=model_id)
+        except (OSError, ValueError, KeyError, TypeError) as exc:
+            raise ChildRunError(
+                model_id,
+                EXIT_EXTERNAL,
+                f"child exited 0 but report at {report_path} is unreadable: {exc}",
+            ) from exc
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
@@ -314,10 +324,13 @@ def _plan_lines(agent: str, fixtures: Path, models: list[str], n_runs: int) -> l
 
 def _default_output_path(agent: str) -> Path:
     stamp = _dt.datetime.now(tz=_dt.UTC).strftime("%Y%m%dT%H%M%SZ")
+    # Add a short random suffix so repeated sweeps of the same agent within
+    # the same second do not silently overwrite each other's evidence.
+    suffix = uuid.uuid4().hex[:8]
     return (
         REPO_ROOT
         / REPORTS_DIR_TEMPLATE.format(agent=agent)
-        / f"sweep-{stamp}.json"
+        / f"sweep-{stamp}-{suffix}.json"
     )
 
 

--- a/scripts/eval/eval-model-sweep.py
+++ b/scripts/eval/eval-model-sweep.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import json
+import math
 import os
 import re
 import subprocess  # noqa: S404 - invokes a sibling eval script with a fixed, validated argv
@@ -446,9 +447,10 @@ def run_sweep(args: argparse.Namespace, runner: ModelEvalRunner) -> int:
         )
         return EXIT_CONFIG
 
-    if args.child_timeout <= 0:
+    if not math.isfinite(args.child_timeout) or args.child_timeout <= 0:
         print(
-            f"error: --child-timeout must be > 0 (got {args.child_timeout:g})",
+            "error: --child-timeout must be a finite value > 0 "
+            f"(got {args.child_timeout:g})",
             file=sys.stderr,
         )
         return EXIT_CONFIG

--- a/scripts/eval/eval-model-sweep.py
+++ b/scripts/eval/eval-model-sweep.py
@@ -124,9 +124,18 @@ def _sanitize_for_run_id(model_id: str) -> str:
 
 
 def make_run_id(model_id: str, *, unique: str | None = None) -> str:
-    """Build a path-safe, per-model run id: ``sweep-<model>-<8hex>``."""
+    """Build a path-safe, per-model run id: ``sweep-<model>-<8hex>``.
+
+    The unique suffix is preserved even for long model ids: the sanitized
+    model slug is truncated to fit the 64-char run-id budget so two long ids
+    can never collapse to the same run id (which would collide report dirs).
+    """
     suffix = unique or uuid.uuid4().hex[:8]
-    run_id = f"sweep-{_sanitize_for_run_id(model_id)}-{suffix}"[:64]
+    prefix = "sweep-"
+    # 64 total, minus prefix, minus the "-" joiner, minus the suffix.
+    slug_budget = 64 - len(prefix) - 1 - len(suffix)
+    slug = _sanitize_for_run_id(model_id)[:slug_budget]
+    run_id = f"{prefix}{slug}-{suffix}"
     if not _RUN_ID_RE.match(run_id):
         raise ValueError(f"generated run id is not path-safe: {run_id!r}")
     return run_id
@@ -172,11 +181,19 @@ def child_report_path(agent: str, run_id: str) -> Path:
 
 
 def parse_report(report: dict, *, model_id: str) -> ModelResult:
-    """Extract a ``ModelResult`` (agent variant) from a report.json dict."""
+    """Extract a ``ModelResult`` (agent variant) from a report.json dict.
+
+    Fixtures the base evaluator excluded for flakiness are dropped here too:
+    the report's headline ``agent_recall`` is computed on the STABLE subset
+    (flaky fixtures excluded), so the per-fixture rates feeding the paired CI
+    must exclude the same fixtures or the CI and the point delta would span
+    different fixture sets.
+    """
+    excluded = set(report.get("flaky_fixtures_excluded") or [])
     per_fixture = report.get("per_fixture_pass_rates") or {}
     rates: dict[str, list[float]] = {}
     for fixture_id, variants in per_fixture.items():
-        if not isinstance(variants, dict):
+        if fixture_id in excluded or not isinstance(variants, dict):
             continue
         agent_rates = variants.get("agent")
         if agent_rates is None:
@@ -190,6 +207,7 @@ def parse_report(report: dict, *, model_id: str) -> ModelResult:
         tokens_out=int(report.get("total_tokens_out", 0)),
         cost_usd=float(report.get("cost_estimate_usd", 0.0)),
         error_count=int(report.get("error_count", 0)),
+        fixture_set_sha=str(report.get("fixture_set_sha", "")),
     )
 
 
@@ -197,8 +215,8 @@ class SubprocessModelEvalRunner:
     """Default runner: evaluate one model by shelling out to the base script.
 
     Reuses the fully-tested live path (retry, idempotency, persistence,
-    scoring, aggregation). Returns the parsed ``ModelResult`` plus the report's
-    ``fixture_set_sha`` (so the sweep artifact records which fixtures ran).
+    scoring, aggregation) and parses the resulting ``report.json`` into a
+    ``ModelResult`` (which carries the report's ``fixture_set_sha``).
     """
 
     def __init__(
@@ -215,7 +233,6 @@ class SubprocessModelEvalRunner:
         self._n_runs = n_runs
         self._provider = provider
         self._env = env
-        self.last_fixture_sha: str = ""
 
     def run(self, model_id: str) -> ModelResult:
         run_id = make_run_id(model_id)
@@ -238,7 +255,6 @@ class SubprocessModelEvalRunner:
             raise ChildRunError(model_id, completed.returncode, completed.stderr)
         report_path = child_report_path(self._agent, run_id)
         report = json.loads(report_path.read_text(encoding="utf-8"))
-        self.last_fixture_sha = str(report.get("fixture_set_sha", ""))
         return parse_report(report, model_id=model_id)
 
 
@@ -325,6 +341,12 @@ def run_sweep(args: argparse.Namespace, runner: SubprocessModelEvalRunner) -> in
         )
         return EXIT_CONFIG
 
+    if args.n_runs < 1:
+        print(
+            f"error: --n-runs must be >= 1 (got {args.n_runs})", file=sys.stderr
+        )
+        return EXIT_CONFIG
+
     if not args.fixtures.exists():
         print(f"error: fixtures path not found: {args.fixtures}", file=sys.stderr)
         return EXIT_CONFIG
@@ -340,7 +362,9 @@ def run_sweep(args: argparse.Namespace, runner: SubprocessModelEvalRunner) -> in
             results.append(runner.run(model_id))
         except ChildRunError as exc:
             print(f"error: {exc}", file=sys.stderr)
-            return EXIT_EXTERNAL
+            # A child config failure is a config error for the sweep too;
+            # only non-config child failures are "external" to the sweep.
+            return EXIT_CONFIG if exc.returncode == EXIT_CONFIG else EXIT_EXTERNAL
 
     try:
         decision = decide(
@@ -355,7 +379,7 @@ def run_sweep(args: argparse.Namespace, runner: SubprocessModelEvalRunner) -> in
 
     report = build_report(
         agent=args.agent,
-        fixtures_sha=runner.last_fixture_sha,
+        fixtures_sha=results[0].fixture_set_sha,
         results=results,
         decision=decision,
         min_effect=args.min_effect,

--- a/scripts/eval/eval-model-sweep.py
+++ b/scripts/eval/eval-model-sweep.py
@@ -68,6 +68,10 @@ BASE_EVAL_SCRIPT = EVAL_DIR / "eval-agent-vs-baseline.py"
 DEFAULT_MODEL = "claude-sonnet-4-6"
 REPORTS_DIR_TEMPLATE = "evals/{agent}-spike/reports"
 
+# The child evaluator makes live LLM API calls; a stalled provider must not hang
+# the sweep forever. Bound each child run with a wall-clock timeout (seconds).
+DEFAULT_CHILD_TIMEOUT_S = 1800
+
 _AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]{0,30}$")
 _MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 _RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
@@ -284,12 +288,14 @@ class SubprocessModelEvalRunner:
         fixtures: Path,
         n_runs: int,
         provider: str | None,
+        child_timeout: float = DEFAULT_CHILD_TIMEOUT_S,
         env: dict[str, str] | None = None,
     ) -> None:
         self._agent = agent
         self._fixtures = fixtures
         self._n_runs = n_runs
         self._provider = provider
+        self._child_timeout = child_timeout
         self._env = env
 
     def run(self, model_id: str) -> ModelResult:
@@ -302,14 +308,25 @@ class SubprocessModelEvalRunner:
             run_id=run_id,
             provider=self._provider,
         )
-        completed = subprocess.run(  # noqa: S603 - argv is fixed + validated, shell=False
-            argv,
-            capture_output=True,
-            encoding="utf-8",
-            errors="replace",
-            env=self._env if self._env is not None else os.environ.copy(),
-            check=False,
-        )
+        try:
+            completed = subprocess.run(  # noqa: S603 - argv is fixed + validated, shell=False
+                argv,
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                env=self._env if self._env is not None else os.environ.copy(),
+                check=False,
+                timeout=self._child_timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            # A hung child (e.g. stalled provider) is an EXTERNAL failure, not a
+            # crash of the sweep itself. Surface it so run_sweep maps it to
+            # EXIT_EXTERNAL instead of blocking indefinitely.
+            raise ChildRunError(
+                model_id,
+                EXIT_EXTERNAL,
+                f"child timed out after {self._child_timeout:g}s",
+            ) from exc
         if completed.returncode != EXIT_OK:
             raise ChildRunError(model_id, completed.returncode, completed.stderr)
         report_path = child_report_path(self._agent, run_id)
@@ -358,6 +375,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     parser.add_argument("--provider", default=None)
+    parser.add_argument(
+        "--child-timeout",
+        type=float,
+        default=DEFAULT_CHILD_TIMEOUT_S,
+        help=(
+            "per-model wall-clock timeout in seconds for the base evaluator "
+            f"child process (default {DEFAULT_CHILD_TIMEOUT_S}); a timed-out "
+            "child fails the sweep as EXTERNAL rather than hanging"
+        ),
+    )
     parser.add_argument(
         "--output",
         type=Path,
@@ -416,6 +443,13 @@ def run_sweep(args: argparse.Namespace, runner: ModelEvalRunner) -> int:
     if args.n_runs < 1:
         print(
             f"error: --n-runs must be >= 1 (got {args.n_runs})", file=sys.stderr
+        )
+        return EXIT_CONFIG
+
+    if args.child_timeout <= 0:
+        print(
+            f"error: --child-timeout must be > 0 (got {args.child_timeout:g})",
+            file=sys.stderr,
         )
         return EXIT_CONFIG
 
@@ -487,6 +521,7 @@ def main(argv: list[str] | None = None) -> int:
         fixtures=args.fixtures,
         n_runs=args.n_runs,
         provider=args.provider,
+        child_timeout=args.child_timeout,
     )
     return run_sweep(args, runner)
 

--- a/scripts/eval/eval-model-sweep.py
+++ b/scripts/eval/eval-model-sweep.py
@@ -235,6 +235,14 @@ def parse_report(report: dict, *, model_id: str) -> ModelResult:
     if excluded_raw is None:
         excluded: set = set()
     elif isinstance(excluded_raw, list):
+        # Elements come from an external report artifact and are used as set
+        # membership keys against string fixture ids; a non-string (or an
+        # unhashable dict/list) would either never match or crash set().
+        if not all(isinstance(x, str) for x in excluded_raw):
+            raise ValueError(
+                f"report for {model_id} flaky_fixtures_excluded "
+                "must be a list of strings"
+            )
         excluded = set(excluded_raw)
     else:
         raise ValueError(
@@ -410,7 +418,7 @@ def _plan_lines(agent: str, fixtures: Path, models: list[str], n_runs: int) -> l
 
 
 def _default_output_path(agent: str) -> Path:
-    stamp = _dt.datetime.now(tz=_dt.UTC).strftime("%Y%m%dT%H%M%SZ")
+    stamp = _dt.datetime.now(tz=_dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     # Add a short random suffix so repeated sweeps of the same agent within
     # the same second do not silently overwrite each other's evidence.
     suffix = uuid.uuid4().hex[:8]
@@ -421,8 +429,13 @@ def _default_output_path(agent: str) -> Path:
     )
 
 
-def run_sweep(args: argparse.Namespace, runner: ModelEvalRunner) -> int:
-    """Live path: evaluate each model via *runner*, decide, write artifact."""
+def run_sweep(args: argparse.Namespace, runner: ModelEvalRunner | None = None) -> int:
+    """Live path: evaluate each model via *runner*, decide, write artifact.
+
+    ``runner`` is optional so callers can exercise the input-validation and
+    ``--dry-run`` branches (which never touch it) without constructing one;
+    the live loop below rejects a missing runner explicitly.
+    """
     try:
         models = parse_models_arg(args.models, default_model=args.default_model)
     except argparse.ArgumentTypeError as exc:
@@ -463,6 +476,13 @@ def run_sweep(args: argparse.Namespace, runner: ModelEvalRunner) -> int:
         for line in _plan_lines(args.agent, args.fixtures, models, args.n_runs):
             print(line)
         return EXIT_OK
+
+    if runner is None:
+        print(
+            "error: run_sweep reached live execution without a runner",
+            file=sys.stderr,
+        )
+        return EXIT_CONFIG
 
     results: list[ModelResult] = []
     for model_id in models:

--- a/scripts/eval/eval-model-sweep.py
+++ b/scripts/eval/eval-model-sweep.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Eval model-sweep runner (Issue #2840, acceptance criterion 2).
+
+Sweep one agent's fixtures across several candidate models, score each with
+the existing single-model evaluator, and report a scored winner with effect
+size so a ``model:`` pin can be kept ONLY with evidence (else dropped to the
+harness default).
+
+This is a thin orchestrator. It does NOT re-implement the run loop, scoring,
+persistence, or statistics: each candidate model is evaluated by shelling out
+to the fully-tested ``eval-agent-vs-baseline.py`` (agent variant), then the
+resulting ``report.json`` is compared across models by ``_model_sweep_core``.
+The runner is injected (``ModelEvalRunner``) so the orchestration and the
+KEEP_PIN/DROP_PIN decision are unit-testable without any API spend.
+
+Prerequisite: every swept model must have a pricing rate in
+``MODEL_PRICING_RATES_USD_PER_1K_TOKENS`` (``_eval_common.py``); the base
+evaluator hard-fails on an unpriced model (Issue #2858). The sweep pre-checks
+this and prints an actionable error naming the unpriced models. It does NOT
+invent pricing.
+
+Exit codes (AGENTS.md): 0 ok, 2 config, 3 external (a child run failed).
+
+Usage:
+    eval-model-sweep.py --agent security --fixtures tests/evals/skills/security \\
+        --models claude-sonnet-4-6,claude-opus-4-6 --n-runs 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import random
+import re
+import subprocess  # noqa: S404 - invokes a sibling eval script with a fixed, validated argv
+import sys
+import uuid
+from pathlib import Path
+
+from _eval_common import MODEL_PRICING_RATES_USD_PER_1K_TOKENS
+from _model_sweep_core import (
+    DEFAULT_MIN_EFFECT,
+    DEFAULT_SEED,
+    ModelResult,
+    SweepDecisionError,
+    build_report,
+    decide,
+)
+
+EXIT_OK = 0
+EXIT_CONFIG = 2
+EXIT_EXTERNAL = 3
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVAL_DIR = Path(__file__).resolve().parent
+BASE_EVAL_SCRIPT = EVAL_DIR / "eval-agent-vs-baseline.py"
+
+# Mirrors eval-agent-vs-baseline.DEFAULT_MODEL. The base script's filename has
+# hyphens (not importable as a module), so the value is duplicated here and a
+# drift guard test asserts the two stay equal.
+DEFAULT_MODEL = "claude-sonnet-4-6"
+REPORTS_DIR_TEMPLATE = "evals/{agent}-spike/reports"
+
+_AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]{0,30}$")
+_MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+
+
+class ChildRunError(Exception):
+    """Raised when the base evaluator exits non-zero for a model."""
+
+    def __init__(self, model_id: str, returncode: int, stderr: str) -> None:
+        super().__init__(
+            f"eval-agent-vs-baseline failed for model {model_id!r} "
+            f"(exit {returncode}): {stderr.strip()[:400]}"
+        )
+        self.model_id = model_id
+        self.returncode = returncode
+
+
+def _agent_name_arg(value: str) -> str:
+    if not _AGENT_NAME_RE.match(value):
+        raise argparse.ArgumentTypeError(
+            f"--agent must match {_AGENT_NAME_RE.pattern} (got {value!r})"
+        )
+    return value
+
+
+def parse_models_arg(raw: str, *, default_model: str) -> list[str]:
+    """Parse ``--models`` into a validated, de-duplicated, order-preserving list.
+
+    The default model is always included (appended if absent) because the
+    comparison needs it as the anchor. Each id is path-safe (it becomes part of
+    a run-id joined under REPO_ROOT) and non-empty.
+    """
+    ids: list[str] = []
+    for token in raw.split(","):
+        model = token.strip()
+        if not model:
+            continue
+        if not _MODEL_ID_RE.match(model):
+            raise argparse.ArgumentTypeError(
+                f"model id must match {_MODEL_ID_RE.pattern} (got {model!r})"
+            )
+        if model not in ids:
+            ids.append(model)
+    if not ids:
+        raise argparse.ArgumentTypeError("--models must list at least one model id")
+    if default_model not in ids:
+        ids.append(default_model)
+    return ids
+
+
+def validate_models_priced(models: list[str]) -> list[str]:
+    """Return the subset of *models* lacking a pricing rate (empty == all ok)."""
+    return [m for m in models if m not in MODEL_PRICING_RATES_USD_PER_1K_TOKENS]
+
+
+def _sanitize_for_run_id(model_id: str) -> str:
+    """Map a model id to the run-id charset ([A-Za-z0-9_-]) deterministically."""
+    return re.sub(r"[^A-Za-z0-9_-]", "-", model_id)
+
+
+def make_run_id(model_id: str, *, unique: str | None = None) -> str:
+    """Build a path-safe, per-model run id: ``sweep-<model>-<8hex>``."""
+    suffix = unique or uuid.uuid4().hex[:8]
+    run_id = f"sweep-{_sanitize_for_run_id(model_id)}-{suffix}"[:64]
+    if not _RUN_ID_RE.match(run_id):
+        raise ValueError(f"generated run id is not path-safe: {run_id!r}")
+    return run_id
+
+
+def build_child_argv(
+    *,
+    agent: str,
+    fixtures: Path,
+    model_id: str,
+    n_runs: int,
+    run_id: str,
+    provider: str | None,
+) -> list[str]:
+    """Argv for one base-evaluator invocation (agent variant, one model)."""
+    argv = [
+        sys.executable,
+        str(BASE_EVAL_SCRIPT),
+        "--agent",
+        agent,
+        "--fixtures",
+        str(fixtures),
+        "--model",
+        model_id,
+        "--n-runs",
+        str(n_runs),
+        "--run-id",
+        run_id,
+    ]
+    if provider:
+        argv += ["--provider", provider]
+    return argv
+
+
+def child_report_path(agent: str, run_id: str) -> Path:
+    """Path to the report.json the base evaluator writes for a run."""
+    return (
+        REPO_ROOT
+        / REPORTS_DIR_TEMPLATE.format(agent=agent)
+        / run_id
+        / "report.json"
+    )
+
+
+def parse_report(report: dict, *, model_id: str) -> ModelResult:
+    """Extract a ``ModelResult`` (agent variant) from a report.json dict."""
+    per_fixture = report.get("per_fixture_pass_rates") or {}
+    rates: dict[str, list[float]] = {}
+    for fixture_id, variants in per_fixture.items():
+        if not isinstance(variants, dict):
+            continue
+        agent_rates = variants.get("agent")
+        if agent_rates is None:
+            continue
+        rates[fixture_id] = [float(r) for r in agent_rates]
+    return ModelResult(
+        model_id=model_id,
+        agent_recall=float(report.get("agent_recall", 0.0)),
+        per_fixture_agent_rates=rates,
+        tokens_in=int(report.get("total_tokens_in", 0)),
+        tokens_out=int(report.get("total_tokens_out", 0)),
+        cost_usd=float(report.get("cost_estimate_usd", 0.0)),
+        error_count=int(report.get("error_count", 0)),
+    )
+
+
+class SubprocessModelEvalRunner:
+    """Default runner: evaluate one model by shelling out to the base script.
+
+    Reuses the fully-tested live path (retry, idempotency, persistence,
+    scoring, aggregation). Returns the parsed ``ModelResult`` plus the report's
+    ``fixture_set_sha`` (so the sweep artifact records which fixtures ran).
+    """
+
+    def __init__(
+        self,
+        *,
+        agent: str,
+        fixtures: Path,
+        n_runs: int,
+        provider: str | None,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        self._agent = agent
+        self._fixtures = fixtures
+        self._n_runs = n_runs
+        self._provider = provider
+        self._env = env
+        self.last_fixture_sha: str = ""
+
+    def run(self, model_id: str) -> ModelResult:
+        run_id = make_run_id(model_id)
+        argv = build_child_argv(
+            agent=self._agent,
+            fixtures=self._fixtures,
+            model_id=model_id,
+            n_runs=self._n_runs,
+            run_id=run_id,
+            provider=self._provider,
+        )
+        completed = subprocess.run(  # noqa: S603 - argv is fixed + validated, shell=False
+            argv,
+            capture_output=True,
+            text=True,
+            env=self._env or os.environ.copy(),
+            check=False,
+        )
+        if completed.returncode != EXIT_OK:
+            raise ChildRunError(model_id, completed.returncode, completed.stderr)
+        report_path = child_report_path(self._agent, run_id)
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        self.last_fixture_sha = str(report.get("fixture_set_sha", ""))
+        return parse_report(report, model_id=model_id)
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="eval-model-sweep",
+        description=(
+            "Sweep an agent's fixtures across candidate models; report a "
+            "scored winner with effect size (KEEP_PIN / DROP_PIN)."
+        ),
+    )
+    parser.add_argument("--agent", required=True, type=_agent_name_arg)
+    parser.add_argument("--fixtures", required=True, type=Path)
+    parser.add_argument(
+        "--models",
+        required=True,
+        help=(
+            "comma-separated candidate model ids; the default model is added "
+            "automatically as the comparison anchor"
+        ),
+    )
+    parser.add_argument("--default-model", default=DEFAULT_MODEL)
+    parser.add_argument("--n-runs", type=int, default=3)
+    parser.add_argument(
+        "--min-effect",
+        type=float,
+        default=DEFAULT_MIN_EFFECT,
+        help=(
+            "minimum recall lead over the default to justify a pin "
+            f"(default {DEFAULT_MIN_EFFECT})"
+        ),
+    )
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--provider", default=None)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="path for the JSON sweep artifact (default: under the reports dir)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="validate inputs and print the per-model plan; no API calls",
+    )
+    return parser
+
+
+def _plan_lines(agent: str, fixtures: Path, models: list[str], n_runs: int) -> list[str]:
+    lines = [
+        f"sweep plan: agent={agent} fixtures={fixtures} n_runs={n_runs}",
+        f"models ({len(models)}):",
+    ]
+    lines += [f"  - {m}" for m in models]
+    return lines
+
+
+def _default_output_path(agent: str) -> Path:
+    stamp = _dt.datetime.now(tz=_dt.UTC).strftime("%Y%m%dT%H%M%SZ")
+    return (
+        REPO_ROOT
+        / REPORTS_DIR_TEMPLATE.format(agent=agent)
+        / f"sweep-{stamp}.json"
+    )
+
+
+def run_sweep(args: argparse.Namespace, runner: SubprocessModelEvalRunner) -> int:
+    """Live path: evaluate each model via *runner*, decide, write artifact."""
+    try:
+        models = parse_models_arg(args.models, default_model=args.default_model)
+    except argparse.ArgumentTypeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    unpriced = validate_models_priced(models)
+    if unpriced:
+        print(
+            "error: no pricing rate for model(s): "
+            + ", ".join(sorted(unpriced))
+            + ". Add them to MODEL_PRICING_RATES_USD_PER_1K_TOKENS in "
+            "scripts/eval/_eval_common.py (with a verified rate) before "
+            "sweeping; the base evaluator refuses unpriced models (#2858).",
+            file=sys.stderr,
+        )
+        return EXIT_CONFIG
+
+    if not args.fixtures.exists():
+        print(f"error: fixtures path not found: {args.fixtures}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    if args.dry_run:
+        for line in _plan_lines(args.agent, args.fixtures, models, args.n_runs):
+            print(line)
+        return EXIT_OK
+
+    results: list[ModelResult] = []
+    for model_id in models:
+        try:
+            results.append(runner.run(model_id))
+        except ChildRunError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return EXIT_EXTERNAL
+
+    try:
+        decision = decide(
+            results,
+            default_model=args.default_model,
+            min_effect=args.min_effect,
+            rng=random.Random(args.seed),
+        )
+    except SweepDecisionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    report = build_report(
+        agent=args.agent,
+        fixtures_sha=runner.last_fixture_sha,
+        results=results,
+        decision=decision,
+        min_effect=args.min_effect,
+        seed=args.seed,
+    )
+    output = args.output or _default_output_path(args.agent)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+
+    print(f"{decision.decision}: {decision.reason}")
+    print(f"artifact: {output}")
+    return EXIT_OK
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    runner = SubprocessModelEvalRunner(
+        agent=args.agent,
+        fixtures=args.fixtures,
+        n_runs=args.n_runs,
+        provider=args.provider,
+    )
+    return run_sweep(args, runner)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval/eval-model-sweep.py
+++ b/scripts/eval/eval-model-sweep.py
@@ -10,8 +10,9 @@ This is a thin orchestrator. It does NOT re-implement the run loop, scoring,
 persistence, or statistics: each candidate model is evaluated by shelling out
 to the fully-tested ``eval-agent-vs-baseline.py`` (agent variant), then the
 resulting ``report.json`` is compared across models by ``_model_sweep_core``.
-The runner is injected (``ModelEvalRunner``) so the orchestration and the
-KEEP_PIN/DROP_PIN decision are unit-testable without any API spend.
+The runner is injected (``ModelEvalRunner``, a structural Protocol) so the
+orchestration and the KEEP_PIN/DROP_PIN decision are unit-testable without
+any API spend; the live implementation is ``SubprocessModelEvalRunner``.
 
 Prerequisite: every swept model must have a pricing rate in
 ``MODEL_PRICING_RATES_USD_PER_1K_TOKENS`` (``_eval_common.py``); the base
@@ -19,7 +20,9 @@ evaluator hard-fails on an unpriced model (Issue #2858). The sweep pre-checks
 this and prints an actionable error naming the unpriced models. It does NOT
 invent pricing.
 
-Exit codes (AGENTS.md): 0 ok, 2 config, 3 external (a child run failed).
+Exit codes (AGENTS.md): 0 ok, 1 logic, 2 config, 3 external, 4 auth. A child
+run's exit-code class (1/2/4) is preserved; any other child failure surfaces
+as 3 (external) to the sweep.
 
 Usage:
     eval-model-sweep.py --agent security --fixtures tests/evals/skills/security \\
@@ -37,6 +40,7 @@ import subprocess  # noqa: S404 - invokes a sibling eval script with a fixed, va
 import sys
 import uuid
 from pathlib import Path
+from typing import Protocol
 
 from _eval_common import MODEL_PRICING_RATES_USD_PER_1K_TOKENS
 from _model_sweep_core import (
@@ -49,6 +53,7 @@ from _model_sweep_core import (
 )
 
 EXIT_OK = 0
+EXIT_LOGIC = 1
 EXIT_CONFIG = 2
 EXIT_EXTERNAL = 3
 EXIT_AUTH = 4
@@ -108,6 +113,11 @@ def parse_models_arg(raw: str, *, default_model: str) -> list[str]:
             ids.append(model)
     if not ids:
         raise argparse.ArgumentTypeError("--models must list at least one model id")
+    if not _MODEL_ID_RE.match(default_model):
+        raise argparse.ArgumentTypeError(
+            f"--default-model must match {_MODEL_ID_RE.pattern} "
+            f"(got {default_model!r})"
+        )
     if default_model not in ids:
         ids.append(default_model)
     return ids
@@ -213,7 +223,18 @@ def parse_report(report: dict, *, model_id: str) -> ModelResult:
         raise ValueError(
             f"report for {model_id} per_fixture_pass_rates is not an object"
         )
-    excluded = set(report.get("flaky_fixtures_excluded") or [])
+    excluded_raw = report.get("flaky_fixtures_excluded")
+    # Must be a list of fixture ids. A bare string would make set() iterate
+    # characters (silently excluding fixtures whose id is a single char),
+    # so reject anything that is not a list before building the set.
+    if excluded_raw is None:
+        excluded: set = set()
+    elif isinstance(excluded_raw, list):
+        excluded = set(excluded_raw)
+    else:
+        raise ValueError(
+            f"report for {model_id} flaky_fixtures_excluded is not a list"
+        )
     rates: dict[str, list[float]] = {}
     for fixture_id, variants in per_fixture.items():
         if fixture_id in excluded or not isinstance(variants, dict):
@@ -232,6 +253,20 @@ def parse_report(report: dict, *, model_id: str) -> ModelResult:
         error_count=int(report.get("error_count", 0)),
         fixture_set_sha=str(fixture_set_sha),
     )
+
+
+class ModelEvalRunner(Protocol):
+    """Structural type for the per-model evaluation step (dependency injection).
+
+    ``run_sweep`` depends on this Protocol, not the concrete
+    ``SubprocessModelEvalRunner``, so tests inject a fake runner with no API
+    spend while the live path stays the only subprocess caller. A conforming
+    runner evaluates one model id and returns its ``ModelResult`` or raises
+    ``ChildRunError`` (carrying the child exit-code class).
+    """
+
+    def run(self, model_id: str) -> ModelResult:
+        ...
 
 
 class SubprocessModelEvalRunner:
@@ -270,7 +305,8 @@ class SubprocessModelEvalRunner:
         completed = subprocess.run(  # noqa: S603 - argv is fixed + validated, shell=False
             argv,
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             env=self._env if self._env is not None else os.environ.copy(),
             check=False,
         )
@@ -357,7 +393,7 @@ def _default_output_path(agent: str) -> Path:
     )
 
 
-def run_sweep(args: argparse.Namespace, runner: SubprocessModelEvalRunner) -> int:
+def run_sweep(args: argparse.Namespace, runner: ModelEvalRunner) -> int:
     """Live path: evaluate each model via *runner*, decide, write artifact."""
     try:
         models = parse_models_arg(args.models, default_model=args.default_model)
@@ -399,12 +435,10 @@ def run_sweep(args: argparse.Namespace, runner: SubprocessModelEvalRunner) -> in
         except ChildRunError as exc:
             print(f"error: {exc}", file=sys.stderr)
             # Preserve the child's exit-code class per the repo contract
-            # (2=config, 4=auth); any other child failure is "external"
-            # (3) to the sweep.
-            if exc.returncode == EXIT_CONFIG:
-                return EXIT_CONFIG
-            if exc.returncode == EXIT_AUTH:
-                return EXIT_AUTH
+            # (1=logic, 2=config, 4=auth); any other child failure is
+            # "external" (3) to the sweep.
+            if exc.returncode in (EXIT_LOGIC, EXIT_CONFIG, EXIT_AUTH):
+                return exc.returncode
             return EXIT_EXTERNAL
 
     try:
@@ -420,7 +454,9 @@ def run_sweep(args: argparse.Namespace, runner: SubprocessModelEvalRunner) -> in
 
     report = build_report(
         agent=args.agent,
-        fixtures_sha=results[0].fixture_set_sha,
+        fixtures_sha=next(
+            (r.fixture_set_sha for r in results if r.fixture_set_sha), ""
+        ),
         results=results,
         decision=decision,
         min_effect=args.min_effect,

--- a/scripts/eval/eval-model-sweep.py
+++ b/scripts/eval/eval-model-sweep.py
@@ -32,7 +32,6 @@ import argparse
 import datetime as _dt
 import json
 import os
-import random
 import re
 import subprocess  # noqa: S404 - invokes a sibling eval script with a fixed, validated argv
 import sys
@@ -371,7 +370,7 @@ def run_sweep(args: argparse.Namespace, runner: SubprocessModelEvalRunner) -> in
             results,
             default_model=args.default_model,
             min_effect=args.min_effect,
-            rng=random.Random(args.seed),
+            seed=args.seed,
         )
     except SweepDecisionError as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/scripts/eval/eval-model-sweep.py
+++ b/scripts/eval/eval-model-sweep.py
@@ -51,6 +51,7 @@ from _model_sweep_core import (
 EXIT_OK = 0
 EXIT_CONFIG = 2
 EXIT_EXTERNAL = 3
+EXIT_AUTH = 4
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EVAL_DIR = Path(__file__).resolve().parent
@@ -361,9 +362,14 @@ def run_sweep(args: argparse.Namespace, runner: SubprocessModelEvalRunner) -> in
             results.append(runner.run(model_id))
         except ChildRunError as exc:
             print(f"error: {exc}", file=sys.stderr)
-            # A child config failure is a config error for the sweep too;
-            # only non-config child failures are "external" to the sweep.
-            return EXIT_CONFIG if exc.returncode == EXIT_CONFIG else EXIT_EXTERNAL
+            # Preserve the child's exit-code class per the repo contract
+            # (2=config, 4=auth); any other child failure is "external"
+            # (3) to the sweep.
+            if exc.returncode == EXIT_CONFIG:
+                return EXIT_CONFIG
+            if exc.returncode == EXIT_AUTH:
+                return EXIT_AUTH
+            return EXIT_EXTERNAL
 
     try:
         decision = decide(

--- a/scripts/eval/eval-model-sweep.py
+++ b/scripts/eval/eval-model-sweep.py
@@ -188,9 +188,32 @@ def parse_report(report: dict, *, model_id: str) -> ModelResult:
     (flaky fixtures excluded), so the per-fixture rates feeding the paired CI
     must exclude the same fixtures or the CI and the point delta would span
     different fixture sets.
+
+    A child that exits 0 but writes a schema-invalid report (e.g. ``{}`` or a
+    non-object) is an EXTERNAL failure, not a valid empty result. The consumed
+    identity fields (``fixture_set_sha``, ``agent_recall``,
+    ``per_fixture_pass_rates``) are therefore required; a missing/mistyped one
+    raises so the runner maps it to ``EXIT_EXTERNAL`` instead of silently
+    producing a degenerate ``ModelResult``.
     """
+    if not isinstance(report, dict):
+        raise ValueError(f"report for {model_id} is not a JSON object")
+    for field in ("fixture_set_sha", "agent_recall", "per_fixture_pass_rates"):
+        if field not in report:
+            raise KeyError(
+                f"report for {model_id} missing required field: {field}"
+            )
+    fixture_set_sha = report["fixture_set_sha"]
+    if not isinstance(fixture_set_sha, str) or not fixture_set_sha:
+        raise ValueError(
+            f"report for {model_id} has empty/invalid fixture_set_sha"
+        )
+    per_fixture = report["per_fixture_pass_rates"]
+    if not isinstance(per_fixture, dict):
+        raise ValueError(
+            f"report for {model_id} per_fixture_pass_rates is not an object"
+        )
     excluded = set(report.get("flaky_fixtures_excluded") or [])
-    per_fixture = report.get("per_fixture_pass_rates") or {}
     rates: dict[str, list[float]] = {}
     for fixture_id, variants in per_fixture.items():
         if fixture_id in excluded or not isinstance(variants, dict):
@@ -201,13 +224,13 @@ def parse_report(report: dict, *, model_id: str) -> ModelResult:
         rates[fixture_id] = [float(r) for r in agent_rates]
     return ModelResult(
         model_id=model_id,
-        agent_recall=float(report.get("agent_recall", 0.0)),
+        agent_recall=float(report["agent_recall"]),
         per_fixture_agent_rates=rates,
         tokens_in=int(report.get("total_tokens_in", 0)),
         tokens_out=int(report.get("total_tokens_out", 0)),
         cost_usd=float(report.get("cost_estimate_usd", 0.0)),
         error_count=int(report.get("error_count", 0)),
-        fixture_set_sha=str(report.get("fixture_set_sha", "")),
+        fixture_set_sha=str(fixture_set_sha),
     )
 
 

--- a/scripts/eval/eval-model-sweep.py
+++ b/scripts/eval/eval-model-sweep.py
@@ -427,10 +427,18 @@ def run_sweep(args: argparse.Namespace, runner: SubprocessModelEvalRunner) -> in
         seed=args.seed,
     )
     output = args.output or _default_output_path(args.agent)
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
-
+    # Emit the verdict before persisting so an artifact-write failure does not
+    # also cost the operator the KEEP/DROP result.
     print(f"{decision.decision}: {decision.reason}")
+    try:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(
+            json.dumps(report, indent=2, sort_keys=True), encoding="utf-8"
+        )
+    except OSError as exc:
+        print(f"error: could not write artifact to {output}: {exc}", file=sys.stderr)
+        return EXIT_EXTERNAL
+
     print(f"artifact: {output}")
     return EXIT_OK
 

--- a/scripts/eval/eval-model-sweep.py
+++ b/scripts/eval/eval-model-sweep.py
@@ -271,7 +271,7 @@ class SubprocessModelEvalRunner:
             argv,
             capture_output=True,
             text=True,
-            env=self._env or os.environ.copy(),
+            env=self._env if self._env is not None else os.environ.copy(),
             check=False,
         )
         if completed.returncode != EXIT_OK:

--- a/tests/eval/test_eval_model_sweep_cli.py
+++ b/tests/eval/test_eval_model_sweep_cli.py
@@ -45,6 +45,7 @@ class _FakeRunner:
 
 
 def _result(model_id, rate, **kw):
+    kw.setdefault("fixture_set_sha", "fakesha")
     return core.ModelResult(
         model_id=model_id,
         agent_recall=rate,
@@ -172,7 +173,29 @@ def test_parse_report_extracts_agent_rates():
     assert result.error_count == 2
 
 
-def test_child_report_path_shape():
+def test_parse_report_excludes_flaky_fixtures():
+    report = {
+        "agent_recall": 1.0,
+        "per_fixture_pass_rates": {
+            "stable": {"agent": [1.0]},
+            "flaky": {"agent": [0.0, 1.0]},
+        },
+        "flaky_fixtures_excluded": ["flaky"],
+        "fixture_set_sha": "sha1",
+    }
+    result = sweep.parse_report(report, model_id="m1")
+    assert set(result.per_fixture_agent_rates) == {"stable"}
+    assert result.fixture_set_sha == "sha1"
+
+
+def test_make_run_id_preserves_suffix_for_long_model_id():
+    long_id = "z" * 64
+    a = sweep.make_run_id(long_id, unique="aaaaaaaa")
+    b = sweep.make_run_id(long_id, unique="bbbbbbbb")
+    assert a != b
+    assert a.endswith("-aaaaaaaa")
+    assert b.endswith("-bbbbbbbb")
+    assert len(a) <= 64 and len(b) <= 64
     path = sweep.child_report_path("security", "sweep-x-1")
     assert path.name == "report.json"
     assert path.parent.name == "sweep-x-1"
@@ -250,8 +273,6 @@ def test_run_sweep_child_failure_is_external_error(capsys):
     priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
 
     class _Boom:
-        last_fixture_sha = ""
-
         def run(self, model_id):
             raise sweep.ChildRunError(model_id, 3, "boom")
 
@@ -259,6 +280,41 @@ def test_run_sweep_child_failure_is_external_error(capsys):
     rc = sweep.run_sweep(args, runner=_Boom())
     assert rc == sweep.EXIT_EXTERNAL
     assert "boom" in capsys.readouterr().err
+
+
+def test_run_sweep_child_config_failure_maps_to_config(capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
+
+    class _ConfigBoom:
+        def run(self, model_id):
+            raise sweep.ChildRunError(model_id, sweep.EXIT_CONFIG, "bad fixtures")
+
+    args = _args(models=priced, default_model=priced)
+    rc = sweep.run_sweep(args, runner=_ConfigBoom())
+    assert rc == sweep.EXIT_CONFIG
+
+
+def test_run_sweep_rejects_zero_n_runs(capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
+    args = _args(models=priced, default_model=priced, n_runs=0)
+    rc = sweep.run_sweep(args, runner=None)
+    assert rc == sweep.EXIT_CONFIG
+    assert "--n-runs must be >= 1" in capsys.readouterr().err
+
+
+def test_run_sweep_mismatched_fixture_sha_is_config_error(capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)
+    if len(priced) < 2:
+        return
+    default_id, candidate_id = priced[0], priced[1]
+    results = {
+        default_id: _result(default_id, 0.5, fixture_set_sha="shaA"),
+        candidate_id: _result(candidate_id, 0.9, fixture_set_sha="shaB"),
+    }
+    args = _args(models=f"{default_id},{candidate_id}", default_model=default_id)
+    rc = sweep.run_sweep(args, runner=_FakeRunner(results))
+    assert rc == sweep.EXIT_CONFIG
+    assert "different fixture sets" in capsys.readouterr().err
 
 
 # --- drift guard ----------------------------------------------------------

--- a/tests/eval/test_eval_model_sweep_cli.py
+++ b/tests/eval/test_eval_model_sweep_cli.py
@@ -14,6 +14,8 @@ import re
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EVAL_DIR = REPO_ROOT / "scripts" / "eval"
 SWEEP_SCRIPT = EVAL_DIR / "eval-model-sweep.py"
@@ -304,6 +306,32 @@ def test_run_sweep_child_auth_failure_maps_to_auth(capsys):
     args = _args(models=priced, default_model=priced)
     rc = sweep.run_sweep(args, runner=_AuthBoom())
     assert rc == sweep.EXIT_AUTH
+
+
+def test_runner_unreadable_report_raises_external_child_error(tmp_path, monkeypatch):
+    runner = sweep.SubprocessModelEvalRunner(
+        agent="security", fixtures=tmp_path, n_runs=1, provider=None, env={}
+    )
+
+    class _Completed:
+        returncode = sweep.EXIT_OK
+        stderr = ""
+
+    monkeypatch.setattr(sweep.subprocess, "run", lambda *a, **k: _Completed())
+    # Point at a report path that does not exist -> read_text raises OSError.
+    monkeypatch.setattr(
+        sweep, "child_report_path", lambda agent, run_id: tmp_path / "missing.json"
+    )
+    with pytest.raises(sweep.ChildRunError) as excinfo:
+        runner.run("claude-sonnet-4")
+    assert excinfo.value.returncode == sweep.EXIT_EXTERNAL
+
+
+def test_default_output_path_is_unique_within_same_second():
+    a = sweep._default_output_path("security")
+    b = sweep._default_output_path("security")
+    assert a != b
+    assert a.name.startswith("sweep-") and a.name.endswith(".json")
 
 
 def test_run_sweep_rejects_zero_n_runs(capsys):

--- a/tests/eval/test_eval_model_sweep_cli.py
+++ b/tests/eval/test_eval_model_sweep_cli.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -76,6 +77,7 @@ def _args(**overrides):
         provider=None,
         output=None,
         dry_run=False,
+        child_timeout=sweep.DEFAULT_CHILD_TIMEOUT_S,
     )
     base.update(overrides)
     return type("Args", (), base)()
@@ -463,6 +465,49 @@ def test_runner_honors_explicit_empty_env(tmp_path, monkeypatch):
         runner.run("claude-sonnet-4")
     # An explicit empty env must NOT be replaced by the parent environment.
     assert captured["env"] == {}
+
+
+def test_runner_timeout_maps_to_external_child_error(tmp_path, monkeypatch):
+    runner = sweep.SubprocessModelEvalRunner(
+        agent="security",
+        fixtures=tmp_path,
+        n_runs=1,
+        provider=None,
+        child_timeout=0.01,
+        env={},
+    )
+
+    def _raise_timeout(argv, **kwargs):
+        # The runner must forward its configured timeout to subprocess.run.
+        assert kwargs.get("timeout") == 0.01
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=kwargs.get("timeout"))
+
+    monkeypatch.setattr(sweep.subprocess, "run", _raise_timeout)
+    with pytest.raises(sweep.ChildRunError) as excinfo:
+        runner.run("claude-sonnet-4")
+    assert excinfo.value.returncode == sweep.EXIT_EXTERNAL
+    assert "timed out" in str(excinfo.value)
+
+
+def test_run_sweep_rejects_nonpositive_child_timeout(capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
+
+    class _NeverRuns:
+        def run(self, model_id):  # pragma: no cover - must not be reached
+            raise AssertionError("runner invoked despite bad timeout")
+
+    args = _args(models=priced, default_model=priced, child_timeout=0)
+    rc = sweep.run_sweep(args, runner=_NeverRuns())
+    assert rc == sweep.EXIT_CONFIG
+    assert "child-timeout" in capsys.readouterr().err
+
+
+def test_arg_parser_child_timeout_defaults(monkeypatch):
+    parser = sweep._build_arg_parser()
+    args = parser.parse_args(
+        ["--agent", "security", "--fixtures", str(EVAL_DIR), "--models", "x"]
+    )
+    assert args.child_timeout == sweep.DEFAULT_CHILD_TIMEOUT_S
 
 
 def test_default_output_path_is_unique_within_same_second():

--- a/tests/eval/test_eval_model_sweep_cli.py
+++ b/tests/eval/test_eval_model_sweep_cli.py
@@ -155,6 +155,7 @@ def test_build_child_argv_omits_provider_when_absent():
 def test_parse_report_extracts_agent_rates():
     report = {
         "agent_recall": 0.75,
+        "fixture_set_sha": "sha-abc",
         "per_fixture_pass_rates": {
             "f1": {"agent": [1.0, 0.5], "baseline": [0.0]},
             "f2": {"agent": [0.5]},
@@ -173,6 +174,27 @@ def test_parse_report_extracts_agent_rates():
     assert result.tokens_out == 200
     assert result.cost_usd == 0.05
     assert result.error_count == 2
+
+
+@pytest.mark.parametrize(
+    "bad_report",
+    [
+        {},  # empty object: missing every required field
+        [],  # not a JSON object
+        {"agent_recall": 0.5, "per_fixture_pass_rates": {}},  # no sha
+        {"agent_recall": 0.5, "fixture_set_sha": "", "per_fixture_pass_rates": {}},
+        {"fixture_set_sha": "s", "per_fixture_pass_rates": {}},  # no recall
+        {"fixture_set_sha": "s", "agent_recall": 0.5},  # no per_fixture
+        {
+            "fixture_set_sha": "s",
+            "agent_recall": 0.5,
+            "per_fixture_pass_rates": [],  # wrong type
+        },
+    ],
+)
+def test_parse_report_rejects_schema_invalid(bad_report):
+    with pytest.raises((KeyError, ValueError)):
+        sweep.parse_report(bad_report, model_id="m1")
 
 
 def test_parse_report_excludes_flaky_fixtures():

--- a/tests/eval/test_eval_model_sweep_cli.py
+++ b/tests/eval/test_eval_model_sweep_cli.py
@@ -1,0 +1,271 @@
+"""Unit tests for scripts/eval/eval-model-sweep.py (Issue #2840).
+
+Covers the orchestrator's pure seams (argv builder, report parser, model-id
+parsing, pricing pre-check) and an end-to-end sweep with an injected fake
+runner (no API, no subprocess). Also guards DEFAULT_MODEL against drift from
+the base evaluator.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVAL_DIR = REPO_ROOT / "scripts" / "eval"
+SWEEP_SCRIPT = EVAL_DIR / "eval-model-sweep.py"
+BASE_SCRIPT = EVAL_DIR / "eval-agent-vs-baseline.py"
+
+if str(EVAL_DIR) not in sys.path:
+    sys.path.insert(0, str(EVAL_DIR))
+
+# The script filename has hyphens, so import it by path.
+_spec = importlib.util.spec_from_file_location("eval_model_sweep", SWEEP_SCRIPT)
+assert _spec and _spec.loader
+sweep = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sweep)
+
+core = sys.modules["_model_sweep_core"]
+
+
+class _FakeRunner:
+    """Injectable runner returning canned ModelResults; records call order."""
+
+    def __init__(self, results_by_model):
+        self._by_model = results_by_model
+        self.calls = []
+        self.last_fixture_sha = "fakesha"
+
+    def run(self, model_id):
+        self.calls.append(model_id)
+        return self._by_model[model_id]
+
+
+def _result(model_id, rate, **kw):
+    return core.ModelResult(
+        model_id=model_id,
+        agent_recall=rate,
+        per_fixture_agent_rates={f"f{i}": [rate] for i in range(8)},
+        **kw,
+    )
+
+
+def _args(**overrides):
+    base = dict(
+        agent="security",
+        fixtures=EVAL_DIR,  # any existing path
+        models="",
+        default_model=sweep.DEFAULT_MODEL,
+        n_runs=3,
+        min_effect=0.05,
+        seed=42,
+        provider=None,
+        output=None,
+        dry_run=False,
+    )
+    base.update(overrides)
+    return type("Args", (), base)()
+
+
+# --- pure seams -----------------------------------------------------------
+
+
+def test_parse_models_dedupes_and_adds_default():
+    models = sweep.parse_models_arg(
+        "claude-opus-4-6, claude-opus-4-6 ,",
+        default_model="claude-sonnet-4-6",
+    )
+    assert models == ["claude-opus-4-6", "claude-sonnet-4-6"]
+
+
+def test_parse_models_keeps_default_position_if_present():
+    models = sweep.parse_models_arg(
+        "claude-sonnet-4-6,claude-opus-4-6",
+        default_model="claude-sonnet-4-6",
+    )
+    assert models == ["claude-sonnet-4-6", "claude-opus-4-6"]
+
+
+def test_parse_models_rejects_bad_id():
+    import argparse
+
+    try:
+        sweep.parse_models_arg("bad id!", default_model="d")
+    except argparse.ArgumentTypeError:
+        return
+    raise AssertionError("expected ArgumentTypeError for invalid model id")
+
+
+def test_parse_models_rejects_empty():
+    import argparse
+
+    try:
+        sweep.parse_models_arg("  , ", default_model="d")
+    except argparse.ArgumentTypeError:
+        return
+    raise AssertionError("expected ArgumentTypeError for empty --models")
+
+
+def test_validate_models_priced_flags_unpriced():
+    priced = next(iter(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS))
+    unpriced = sweep.validate_models_priced([priced, "made-up-model"])
+    assert unpriced == ["made-up-model"]
+
+
+def test_make_run_id_is_path_safe():
+    run_id = sweep.make_run_id("claude-opus-4.6", unique="abcd1234")
+    assert re.match(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$", run_id)
+    assert run_id == "sweep-claude-opus-4-6-abcd1234"
+
+
+def test_build_child_argv_includes_run_id_and_provider():
+    argv = sweep.build_child_argv(
+        agent="security",
+        fixtures=Path("tests/evals/x"),
+        model_id="claude-sonnet-4-6",
+        n_runs=5,
+        run_id="sweep-x-1",
+        provider="anthropic",
+    )
+    assert str(BASE_SCRIPT) in argv
+    assert argv[argv.index("--model") + 1] == "claude-sonnet-4-6"
+    assert argv[argv.index("--n-runs") + 1] == "5"
+    assert argv[argv.index("--run-id") + 1] == "sweep-x-1"
+    assert argv[argv.index("--provider") + 1] == "anthropic"
+
+
+def test_build_child_argv_omits_provider_when_absent():
+    argv = sweep.build_child_argv(
+        agent="security",
+        fixtures=Path("tests/evals/x"),
+        model_id="claude-sonnet-4-6",
+        n_runs=1,
+        run_id="sweep-x-1",
+        provider=None,
+    )
+    assert "--provider" not in argv
+
+
+def test_parse_report_extracts_agent_rates():
+    report = {
+        "agent_recall": 0.75,
+        "per_fixture_pass_rates": {
+            "f1": {"agent": [1.0, 0.5], "baseline": [0.0]},
+            "f2": {"agent": [0.5]},
+            "f3": {"baseline": [0.0]},  # no agent variant -> skipped
+        },
+        "total_tokens_in": 100,
+        "total_tokens_out": 200,
+        "cost_estimate_usd": 0.05,
+        "error_count": 2,
+    }
+    result = sweep.parse_report(report, model_id="m1")
+    assert result.model_id == "m1"
+    assert result.agent_recall == 0.75
+    assert result.per_fixture_agent_rates == {"f1": [1.0, 0.5], "f2": [0.5]}
+    assert result.tokens_in == 100
+    assert result.tokens_out == 200
+    assert result.cost_usd == 0.05
+    assert result.error_count == 2
+
+
+def test_child_report_path_shape():
+    path = sweep.child_report_path("security", "sweep-x-1")
+    assert path.name == "report.json"
+    assert path.parent.name == "sweep-x-1"
+    assert "security-spike" in str(path)
+
+
+# --- orchestration (fake runner) ------------------------------------------
+
+
+def test_run_sweep_dry_run_lists_plan_and_exits_ok(capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[:1]
+    args = _args(models=",".join(priced), default_model=priced[0], dry_run=True)
+    rc = sweep.run_sweep(args, runner=None)
+    out = capsys.readouterr().out
+    assert rc == sweep.EXIT_OK
+    assert "sweep plan" in out
+    assert priced[0] in out
+
+
+def test_run_sweep_unpriced_model_is_config_error(capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
+    args = _args(models=f"{priced},totally-made-up", default_model=priced)
+    rc = sweep.run_sweep(args, runner=None)
+    err = capsys.readouterr().err
+    assert rc == sweep.EXIT_CONFIG
+    assert "no pricing rate" in err
+    assert "totally-made-up" in err
+
+
+def test_run_sweep_missing_fixtures_is_config_error(capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
+    args = _args(
+        models=priced,
+        default_model=priced,
+        fixtures=Path("/nonexistent/path/xyz"),
+    )
+    rc = sweep.run_sweep(args, runner=None)
+    assert rc == sweep.EXIT_CONFIG
+    assert "fixtures path not found" in capsys.readouterr().err
+
+
+def test_run_sweep_keep_pin_end_to_end(tmp_path, capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)
+    default_id = priced[0]
+    # Candidate id must also be priced to pass the pre-check; reuse a second
+    # priced id if available, else fabricate results keyed on the same set.
+    candidate_id = priced[1] if len(priced) > 1 else None
+    if candidate_id is None:
+        # Only one priced model exists; skip the two-model live assertion but
+        # still exercise the default-wins path below.
+        return
+    results = {
+        default_id: _result(default_id, 0.10),
+        candidate_id: _result(candidate_id, 0.90, cost_usd=0.2, error_count=0),
+    }
+    runner = _FakeRunner(results)
+    output = tmp_path / "sweep.json"
+    args = _args(
+        models=f"{default_id},{candidate_id}",
+        default_model=default_id,
+        output=output,
+    )
+    rc = sweep.run_sweep(args, runner=runner)
+    out = capsys.readouterr().out
+    assert rc == sweep.EXIT_OK
+    assert runner.calls == [default_id, candidate_id]
+    assert core.DECISION_KEEP in out
+    artifact = json.loads(output.read_text())
+    assert artifact["winner"] == candidate_id
+    assert artifact["decision"] == core.DECISION_KEEP
+    assert artifact["fixtures_sha"] == "fakesha"
+
+
+def test_run_sweep_child_failure_is_external_error(capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
+
+    class _Boom:
+        last_fixture_sha = ""
+
+        def run(self, model_id):
+            raise sweep.ChildRunError(model_id, 3, "boom")
+
+    args = _args(models=priced, default_model=priced)
+    rc = sweep.run_sweep(args, runner=_Boom())
+    assert rc == sweep.EXIT_EXTERNAL
+    assert "boom" in capsys.readouterr().err
+
+
+# --- drift guard ----------------------------------------------------------
+
+
+def test_default_model_matches_base_evaluator():
+    text = BASE_SCRIPT.read_text(encoding="utf-8")
+    match = re.search(r'^DEFAULT_MODEL\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    assert match, "could not find DEFAULT_MODEL in eval-agent-vs-baseline.py"
+    assert match.group(1) == sweep.DEFAULT_MODEL

--- a/tests/eval/test_eval_model_sweep_cli.py
+++ b/tests/eval/test_eval_model_sweep_cli.py
@@ -489,14 +489,19 @@ def test_runner_timeout_maps_to_external_child_error(tmp_path, monkeypatch):
     assert "timed out" in str(excinfo.value)
 
 
-def test_run_sweep_rejects_nonpositive_child_timeout(capsys):
+@pytest.mark.parametrize(
+    "bad_timeout", [0, -1, -0.5, float("nan"), float("inf"), float("-inf")]
+)
+def test_run_sweep_rejects_nonpositive_or_nonfinite_child_timeout(
+    bad_timeout, capsys
+):
     priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
 
     class _NeverRuns:
         def run(self, model_id):  # pragma: no cover - must not be reached
             raise AssertionError("runner invoked despite bad timeout")
 
-    args = _args(models=priced, default_model=priced, child_timeout=0)
+    args = _args(models=priced, default_model=priced, child_timeout=bad_timeout)
     rc = sweep.run_sweep(args, runner=_NeverRuns())
     assert rc == sweep.EXIT_CONFIG
     assert "child-timeout" in capsys.readouterr().err

--- a/tests/eval/test_eval_model_sweep_cli.py
+++ b/tests/eval/test_eval_model_sweep_cli.py
@@ -349,6 +349,30 @@ def test_runner_unreadable_report_raises_external_child_error(tmp_path, monkeypa
     assert excinfo.value.returncode == sweep.EXIT_EXTERNAL
 
 
+def test_runner_honors_explicit_empty_env(tmp_path, monkeypatch):
+    runner = sweep.SubprocessModelEvalRunner(
+        agent="security", fixtures=tmp_path, n_runs=1, provider=None, env={}
+    )
+    captured = {}
+
+    class _Completed:
+        returncode = sweep.EXIT_OK
+        stderr = ""
+
+    def _fake_run(argv, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return _Completed()
+
+    monkeypatch.setattr(sweep.subprocess, "run", _fake_run)
+    monkeypatch.setattr(
+        sweep, "child_report_path", lambda agent, run_id: tmp_path / "missing.json"
+    )
+    with pytest.raises(sweep.ChildRunError):
+        runner.run("claude-sonnet-4")
+    # An explicit empty env must NOT be replaced by the parent environment.
+    assert captured["env"] == {}
+
+
 def test_default_output_path_is_unique_within_same_second():
     a = sweep._default_output_path("security")
     b = sweep._default_output_path("security")

--- a/tests/eval/test_eval_model_sweep_cli.py
+++ b/tests/eval/test_eval_model_sweep_cli.py
@@ -293,6 +293,33 @@ def test_run_sweep_keep_pin_end_to_end(tmp_path, capsys):
     assert artifact["fixtures_sha"] == "fakesha"
 
 
+def test_run_sweep_artifact_write_failure_maps_to_external(tmp_path, capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)
+    if len(priced) < 2:
+        return
+    default_id, candidate_id = priced[0], priced[1]
+    results = {
+        default_id: _result(default_id, 0.10),
+        candidate_id: _result(candidate_id, 0.90, cost_usd=0.2, error_count=0),
+    }
+    # Use a regular file as a directory component so mkdir(parents=True) raises
+    # NotADirectoryError (an OSError) on a valid, non-decision path.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("x", encoding="utf-8")
+    output = blocker / "sub" / "sweep.json"
+    args = _args(
+        models=f"{default_id},{candidate_id}",
+        default_model=default_id,
+        output=output,
+    )
+    rc = sweep.run_sweep(args, runner=_FakeRunner(results))
+    captured = capsys.readouterr()
+    assert rc == sweep.EXIT_EXTERNAL
+    # The verdict is still emitted to stdout before the write is attempted.
+    assert core.DECISION_KEEP in captured.out
+    assert "could not write artifact" in captured.err
+
+
 def test_run_sweep_child_failure_is_external_error(capsys):
     priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
 

--- a/tests/eval/test_eval_model_sweep_cli.py
+++ b/tests/eval/test_eval_model_sweep_cli.py
@@ -200,6 +200,18 @@ def test_parse_report_extracts_agent_rates():
             "per_fixture_pass_rates": {},
             "flaky_fixtures_excluded": "f1",  # string, not a list of ids
         },
+        {
+            "fixture_set_sha": "s",
+            "agent_recall": 0.5,
+            "per_fixture_pass_rates": {},
+            "flaky_fixtures_excluded": ["f1", 7],  # non-string element
+        },
+        {
+            "fixture_set_sha": "s",
+            "agent_recall": 0.5,
+            "per_fixture_pass_rates": {},
+            "flaky_fixtures_excluded": [["nested"]],  # unhashable element
+        },
     ],
 )
 def test_parse_report_rejects_schema_invalid(bad_report):
@@ -304,6 +316,16 @@ def test_run_sweep_dry_run_lists_plan_and_exits_ok(capsys):
     assert rc == sweep.EXIT_OK
     assert "sweep plan" in out
     assert priced[0] in out
+
+
+def test_run_sweep_live_path_without_runner_is_config_error(capsys, tmp_path):
+    # All inputs valid + not dry-run => the live loop is reached; a missing
+    # runner must fail cleanly (EXIT_CONFIG), not AttributeError on None.run().
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
+    args = _args(models=priced, default_model=priced, fixtures=tmp_path)
+    rc = sweep.run_sweep(args, runner=None)
+    assert rc == sweep.EXIT_CONFIG
+    assert "without a runner" in capsys.readouterr().err
 
 
 def test_run_sweep_unpriced_model_is_config_error(capsys):

--- a/tests/eval/test_eval_model_sweep_cli.py
+++ b/tests/eval/test_eval_model_sweep_cli.py
@@ -21,14 +21,22 @@ EVAL_DIR = REPO_ROOT / "scripts" / "eval"
 SWEEP_SCRIPT = EVAL_DIR / "eval-model-sweep.py"
 BASE_SCRIPT = EVAL_DIR / "eval-agent-vs-baseline.py"
 
-if str(EVAL_DIR) not in sys.path:
+# eval-model-sweep.py imports sibling modules via plain `from X import Y`, so
+# EVAL_DIR must be on sys.path while it loads. Scope the mutation to the load
+# and remove it afterward so we do not change import resolution for other
+# test modules.
+_path_added = str(EVAL_DIR) not in sys.path
+if _path_added:
     sys.path.insert(0, str(EVAL_DIR))
-
-# The script filename has hyphens, so import it by path.
-_spec = importlib.util.spec_from_file_location("eval_model_sweep", SWEEP_SCRIPT)
-assert _spec and _spec.loader
-sweep = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(sweep)
+try:
+    # The script filename has hyphens, so import it by path.
+    _spec = importlib.util.spec_from_file_location("eval_model_sweep", SWEEP_SCRIPT)
+    assert _spec and _spec.loader
+    sweep = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(sweep)
+finally:
+    if _path_added and str(EVAL_DIR) in sys.path:
+        sys.path.remove(str(EVAL_DIR))
 
 core = sys.modules["_model_sweep_core"]
 
@@ -95,21 +103,15 @@ def test_parse_models_keeps_default_position_if_present():
 def test_parse_models_rejects_bad_id():
     import argparse
 
-    try:
+    with pytest.raises(argparse.ArgumentTypeError):
         sweep.parse_models_arg("bad id!", default_model="d")
-    except argparse.ArgumentTypeError:
-        return
-    raise AssertionError("expected ArgumentTypeError for invalid model id")
 
 
 def test_parse_models_rejects_empty():
     import argparse
 
-    try:
+    with pytest.raises(argparse.ArgumentTypeError):
         sweep.parse_models_arg("  , ", default_model="d")
-    except argparse.ArgumentTypeError:
-        return
-    raise AssertionError("expected ArgumentTypeError for empty --models")
 
 
 def test_validate_models_priced_flags_unpriced():
@@ -190,11 +192,74 @@ def test_parse_report_extracts_agent_rates():
             "agent_recall": 0.5,
             "per_fixture_pass_rates": [],  # wrong type
         },
+        {
+            "fixture_set_sha": "s",
+            "agent_recall": 0.5,
+            "per_fixture_pass_rates": {},
+            "flaky_fixtures_excluded": "f1",  # string, not a list of ids
+        },
     ],
 )
 def test_parse_report_rejects_schema_invalid(bad_report):
     with pytest.raises((KeyError, ValueError)):
         sweep.parse_report(bad_report, model_id="m1")
+
+
+def test_parse_report_accepts_list_flaky_exclusions():
+    report = {
+        "agent_recall": 1.0,
+        "fixture_set_sha": "sha-abc",
+        "per_fixture_pass_rates": {
+            "f1": {"agent": [1.0]},
+            "f2": {"agent": [0.5]},
+        },
+        "flaky_fixtures_excluded": ["f2"],
+    }
+    result = sweep.parse_report(report, model_id="m1")
+    assert result.per_fixture_agent_rates == {"f1": [1.0]}
+
+
+def test_parse_models_rejects_bad_default_model():
+    import argparse
+
+    with pytest.raises(argparse.ArgumentTypeError, match="default-model"):
+        sweep.parse_models_arg("claude-opus-4-6", default_model="bad id!")
+
+
+def test_run_sweep_preserves_child_logic_exit(capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
+
+    class _LogicBoom:
+        def run(self, model_id):
+            raise sweep.ChildRunError(model_id, sweep.EXIT_LOGIC, "empty run")
+
+    args = _args(models=priced, default_model=priced)
+    rc = sweep.run_sweep(args, runner=_LogicBoom())
+    assert rc == sweep.EXIT_LOGIC
+
+
+def test_run_sweep_preserves_child_auth_exit(capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
+
+    class _AuthBoom:
+        def run(self, model_id):
+            raise sweep.ChildRunError(model_id, sweep.EXIT_AUTH, "401")
+
+    args = _args(models=priced, default_model=priced)
+    rc = sweep.run_sweep(args, runner=_AuthBoom())
+    assert rc == sweep.EXIT_AUTH
+
+
+def test_run_sweep_unknown_child_exit_maps_to_external(capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
+
+    class _WeirdBoom:
+        def run(self, model_id):
+            raise sweep.ChildRunError(model_id, 99, "who knows")
+
+    args = _args(models=priced, default_model=priced)
+    rc = sweep.run_sweep(args, runner=_WeirdBoom())
+    assert rc == sweep.EXIT_EXTERNAL
 
 
 def test_parse_report_excludes_flaky_fixtures():
@@ -268,9 +333,9 @@ def test_run_sweep_keep_pin_end_to_end(tmp_path, capsys):
     # priced id if available, else fabricate results keyed on the same set.
     candidate_id = priced[1] if len(priced) > 1 else None
     if candidate_id is None:
-        # Only one priced model exists; skip the two-model live assertion but
-        # still exercise the default-wins path below.
-        return
+        pytest.skip(
+            "needs >=2 priced models to exercise the two-model KEEP path"
+        )
     results = {
         default_id: _result(default_id, 0.10),
         candidate_id: _result(candidate_id, 0.90, cost_usd=0.2, error_count=0),
@@ -287,7 +352,7 @@ def test_run_sweep_keep_pin_end_to_end(tmp_path, capsys):
     assert rc == sweep.EXIT_OK
     assert runner.calls == [default_id, candidate_id]
     assert core.DECISION_KEEP in out
-    artifact = json.loads(output.read_text())
+    artifact = json.loads(output.read_text(encoding="utf-8"))
     assert artifact["winner"] == candidate_id
     assert artifact["decision"] == core.DECISION_KEEP
     assert artifact["fixtures_sha"] == "fakesha"
@@ -296,7 +361,7 @@ def test_run_sweep_keep_pin_end_to_end(tmp_path, capsys):
 def test_run_sweep_artifact_write_failure_maps_to_external(tmp_path, capsys):
     priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)
     if len(priced) < 2:
-        return
+        pytest.skip("needs >=2 priced models to reach the artifact-write step")
     default_id, candidate_id = priced[0], priced[1]
     results = {
         default_id: _result(default_id, 0.10),
@@ -418,7 +483,7 @@ def test_run_sweep_rejects_zero_n_runs(capsys):
 def test_run_sweep_mismatched_fixture_sha_is_config_error(capsys):
     priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)
     if len(priced) < 2:
-        return
+        pytest.skip("needs >=2 priced models to build a mismatched-sha pair")
     default_id, candidate_id = priced[0], priced[1]
     results = {
         default_id: _result(default_id, 0.5, fixture_set_sha="shaA"),

--- a/tests/eval/test_eval_model_sweep_cli.py
+++ b/tests/eval/test_eval_model_sweep_cli.py
@@ -294,6 +294,18 @@ def test_run_sweep_child_config_failure_maps_to_config(capsys):
     assert rc == sweep.EXIT_CONFIG
 
 
+def test_run_sweep_child_auth_failure_maps_to_auth(capsys):
+    priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
+
+    class _AuthBoom:
+        def run(self, model_id):
+            raise sweep.ChildRunError(model_id, sweep.EXIT_AUTH, "bad api key")
+
+    args = _args(models=priced, default_model=priced)
+    rc = sweep.run_sweep(args, runner=_AuthBoom())
+    assert rc == sweep.EXIT_AUTH
+
+
 def test_run_sweep_rejects_zero_n_runs(capsys):
     priced = list(sweep.MODEL_PRICING_RATES_USD_PER_1K_TOKENS)[0]
     args = _args(models=priced, default_model=priced, n_runs=0)

--- a/tests/eval/test_model_sweep_core.py
+++ b/tests/eval/test_model_sweep_core.py
@@ -7,7 +7,6 @@ the artifact shape, and the SweepDecisionError guards.
 
 from __future__ import annotations
 
-import random
 import sys
 from pathlib import Path
 
@@ -86,7 +85,7 @@ def test_decide_picks_qualifying_second_candidate_over_noisy_top():
         [default, noisy_top, solid],
         default_model="default",
         min_effect=0.05,
-        rng=random.Random(7),
+        seed=7,
     )
     assert decision.decision == core.DECISION_KEEP
     assert decision.winner_model == "solid"
@@ -136,7 +135,7 @@ def test_decide_keeps_pin_on_large_consistent_lead():
     decision = core.decide(
         [default, candidate],
         default_model="default",
-        rng=random.Random(1),
+        seed=1,
     )
     assert decision.decision == core.DECISION_KEEP
     assert decision.winner_model == "candidate"
@@ -159,7 +158,7 @@ def test_decide_drops_pin_when_lead_below_min_effect():
         [default, candidate],
         default_model="default",
         min_effect=0.05,
-        rng=random.Random(1),
+        seed=1,
     )
     # 0.02 lead is real (CI excludes 0) but below min_effect -> drop.
     assert decision.decision == core.DECISION_DROP
@@ -184,7 +183,7 @@ def test_decide_drops_pin_when_ci_includes_zero():
         [default, candidate],
         default_model="default",
         min_effect=0.0,
-        rng=random.Random(3),
+        seed=3,
     )
     assert decision.decision == core.DECISION_DROP
     assert decision.ci95[0] <= 0.0 <= decision.ci95[1]
@@ -217,13 +216,17 @@ def test_cohens_d_nonzero_when_diffs_vary():
 
 
 def test_build_report_shape():
-    default = _result("default", {"f1": [0.5]}, recall=0.5, tokens_in=10, tokens_out=20)
+    default = _result(
+        "default", {"f1": [0.5], "f2": [0.5]}, recall=0.5, tokens_in=10, tokens_out=20
+    )
     candidate = _result(
-        "candidate", {"f1": [0.9]}, recall=0.9, cost_usd=0.1234567, error_count=1
+        "candidate",
+        {"f1": [0.9], "f2": [0.9]},
+        recall=0.9,
+        cost_usd=0.1234567,
+        error_count=1,
     )
-    decision = core.decide(
-        [default, candidate], default_model="default", rng=random.Random(1)
-    )
+    decision = core.decide([default, candidate], default_model="default", seed=1)
     report = core.build_report(
         agent="security",
         fixtures_sha="abc123",
@@ -238,7 +241,71 @@ def test_build_report_shape():
     assert report["default_model"] == "default"
     assert report["winner"] == decision.winner_model
     assert report["decision"] == decision.decision
+    assert report["n_shared_fixtures"] == 2
     assert [m["model_id"] for m in report["models"]] == ["candidate", "default"]
+    assert report["models"][0]["mean_recall"] == 0.9
+    assert report["models"][0]["agent_recall"] == 0.9
     assert report["models"][1]["tokens_in"] == 10
     assert report["models"][0]["error_count"] == 1
     assert len(report["ci95"]) == 2
+
+
+def test_common_fixture_ids_empty_model_yields_no_shared():
+    # R3 F2: a model with no stable fixtures collapses the intersection instead
+    # of being silently dropped from it (which previously KeyError'd downstream).
+    a = _result("a", {"f1": [1.0]}, recall=1.0)
+    b = _result("b", {}, recall=0.0)
+    assert core.common_fixture_ids([a, b]) == []
+
+
+def test_decide_empty_fixture_model_raises():
+    # R3 F2 regression: an empty-fixture candidate must hit the no-shared config
+    # error, not crash in mean_recall_on with a KeyError.
+    default = _result("default", {"f1": [0.5], "f2": [0.5]}, recall=0.5)
+    empty = _result("empty", {}, recall=0.0)
+    try:
+        core.decide([default, empty], default_model="default")
+    except core.SweepDecisionError as exc:
+        assert "shared" in str(exc)
+        return
+    raise AssertionError("expected SweepDecisionError when a model has no fixtures")
+
+
+def test_decide_single_shared_fixture_drops():
+    # R3 F3 regression: one shared fixture makes the bootstrap CI degenerate
+    # ([delta, delta]); never KEEP a pin on that. Floor forces DROP.
+    default = _result("default", {"f1": [0.1]}, recall=0.1)
+    candidate = _result("candidate", {"f1": [0.9]}, recall=0.9)
+    decision = core.decide([default, candidate], default_model="default", seed=1)
+    assert decision.decision == core.DECISION_DROP
+    assert decision.winner_model == "default"
+    assert "floor" in decision.reason
+
+
+def test_decide_is_order_independent():
+    # R3 F1 regression: per-candidate seeding makes the verdict (and each CI)
+    # invariant to candidate order, so --models ordering cannot flip it.
+    default = _result("default", {f"f{i}": [0.30] for i in range(8)})
+    noisy = _result("noisy", {f"f{i}": ([1.0] if i < 2 else [0.30]) for i in range(8)})
+    solid = _result("solid", {f"f{i}": [0.42] for i in range(8)})
+    d1 = core.decide([default, noisy, solid], default_model="default", seed=11)
+    d2 = core.decide([default, solid, noisy], default_model="default", seed=11)
+    d3 = core.decide([solid, default, noisy], default_model="default", seed=11)
+    assert d1.decision == d2.decision == d3.decision
+    assert d1.winner_model == d2.winner_model == d3.winner_model
+    assert d1.ci95 == d2.ci95 == d3.ci95
+
+
+def test_paired_bootstrap_ci_bonferroni_widens_lower_bound():
+    # R3 F4: the Bonferroni knob (smaller lower percentile) must widen the CI,
+    # i.e. push the lower bound down, so sweeping more candidates raises the bar.
+    w = _result("w", {f"f{i}": ([1.0] if i < 6 else [0.0]) for i in range(8)})
+    d = _result("d", {f"f{i}": [0.3] for i in range(8)})
+    ids = core.common_fixture_ids([w, d])
+    wide = core.paired_bootstrap_ci(
+        w, d, ids, lower_percentile=2.5 / 3, upper_percentile=100 - 2.5 / 3
+    )
+    narrow = core.paired_bootstrap_ci(
+        w, d, ids, lower_percentile=2.5, upper_percentile=97.5
+    )
+    assert wide[0] <= narrow[0]

--- a/tests/eval/test_model_sweep_core.py
+++ b/tests/eval/test_model_sweep_core.py
@@ -1,0 +1,209 @@
+"""Unit tests for scripts/eval/_model_sweep_core.py (Issue #2840).
+
+Pure comparison core: no I/O, no API. Covers the KEEP_PIN/DROP_PIN decision
+gate, the paired bootstrap CI, Cohen's d_z edge cases, ranking/tie-breaking,
+the artifact shape, and the SweepDecisionError guards.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVAL_DIR = REPO_ROOT / "scripts" / "eval"
+if str(EVAL_DIR) not in sys.path:
+    sys.path.insert(0, str(EVAL_DIR))
+
+import _model_sweep_core as core  # noqa: E402
+
+
+def _result(model_id, rates, *, recall=None, **kw):
+    """Build a ModelResult; recall defaults to the mean of all per-fixture means."""
+    means = [sum(v) / len(v) if v else 0.0 for v in rates.values()] if rates else []
+    if recall is None:
+        recall = sum(means) / len(means) if means else 0.0
+    return core.ModelResult(
+        model_id=model_id,
+        agent_recall=recall,
+        per_fixture_agent_rates=rates,
+        **kw,
+    )
+
+
+def test_fixture_means_empty_runs_score_zero():
+    r = _result("m", {"f1": [1.0, 0.0], "f2": []}, recall=0.5)
+    assert r.fixture_means == {"f1": 0.5, "f2": 0.0}
+
+
+def test_rank_orders_by_recall_then_id():
+    a = _result("b-model", {}, recall=0.9)
+    b = _result("a-model", {}, recall=0.9)
+    c = _result("c-model", {}, recall=0.5)
+    ranked = core.rank([c, a, b])
+    assert [r.model_id for r in ranked] == ["a-model", "b-model", "c-model"]
+
+
+def test_select_winner_tie_prefers_default():
+    default = _result("default", {}, recall=0.8)
+    other = _result("aaa", {}, recall=0.8)
+    winner = core._select_winner([other, default], "default")
+    assert winner.model_id == "default"
+
+
+def test_select_winner_tie_without_default_is_lexical():
+    x = _result("zzz", {}, recall=0.8)
+    y = _result("aaa", {}, recall=0.8)
+    winner = core._select_winner([x, y], "default")
+    assert winner.model_id == "aaa"
+
+
+def test_decide_empty_results_raises():
+    try:
+        core.decide([], default_model="default")
+    except core.SweepDecisionError:
+        return
+    raise AssertionError("expected SweepDecisionError for empty results")
+
+
+def test_decide_default_absent_raises():
+    r = _result("other", {"f1": [1.0]}, recall=1.0)
+    try:
+        core.decide([r], default_model="default")
+    except core.SweepDecisionError as exc:
+        assert "default model" in str(exc)
+        return
+    raise AssertionError("expected SweepDecisionError when default is absent")
+
+
+def test_decide_default_wins_drops_pin():
+    default = _result("default", {"f1": [0.9], "f2": [0.9]}, recall=0.9)
+    weaker = _result("other", {"f1": [0.5], "f2": [0.5]}, recall=0.5)
+    decision = core.decide([default, weaker], default_model="default")
+    assert decision.decision == core.DECISION_DROP
+    assert decision.winner_model == "default"
+    assert decision.recall_delta == 0.0
+
+
+def test_decide_keeps_pin_on_large_consistent_lead():
+    # Candidate beats default on every shared fixture by a wide, consistent
+    # margin -> delta >> min_effect and the paired CI excludes 0.
+    default = _result(
+        "default",
+        {f"f{i}": [0.1] for i in range(8)},
+        recall=0.1,
+    )
+    candidate = _result(
+        "candidate",
+        {f"f{i}": [0.9] for i in range(8)},
+        recall=0.9,
+    )
+    decision = core.decide(
+        [default, candidate],
+        default_model="default",
+        rng=random.Random(1),
+    )
+    assert decision.decision == core.DECISION_KEEP
+    assert decision.winner_model == "candidate"
+    assert decision.ci95[0] > 0.0
+    assert decision.recall_delta >= 0.05
+
+
+def test_decide_drops_pin_when_lead_below_min_effect():
+    default = _result(
+        "default",
+        {f"f{i}": [0.80] for i in range(8)},
+        recall=0.80,
+    )
+    candidate = _result(
+        "candidate",
+        {f"f{i}": [0.82] for i in range(8)},
+        recall=0.82,
+    )
+    decision = core.decide(
+        [default, candidate],
+        default_model="default",
+        min_effect=0.05,
+        rng=random.Random(1),
+    )
+    # 0.02 lead is real (CI excludes 0) but below min_effect -> drop.
+    assert decision.decision == core.DECISION_DROP
+    assert "below min_effect" in decision.reason
+
+
+def test_decide_drops_pin_when_ci_includes_zero():
+    # Candidate wins on point recall but the per-fixture signal is noisy:
+    # it beats default on half the fixtures and loses on the other half, so
+    # the paired CI straddles 0 even though the headline recall is higher.
+    default = _result(
+        "default",
+        {"a": [0.0], "b": [1.0], "c": [0.0], "d": [1.0]},
+        recall=0.50,
+    )
+    candidate = _result(
+        "candidate",
+        {"a": [1.0], "b": [0.0], "c": [1.0], "d": [0.0]},
+        recall=0.60,
+    )
+    decision = core.decide(
+        [default, candidate],
+        default_model="default",
+        min_effect=0.0,
+        rng=random.Random(3),
+    )
+    assert decision.decision == core.DECISION_DROP
+    assert decision.ci95[0] <= 0.0 <= decision.ci95[1]
+
+
+def test_paired_bootstrap_ci_no_shared_fixtures_is_zero():
+    w = _result("w", {"a": [1.0]}, recall=1.0)
+    d = _result("d", {"b": [0.0]}, recall=0.0)
+    assert core.paired_bootstrap_ci(w, d) == (0.0, 0.0)
+
+
+def test_cohens_d_fewer_than_two_fixtures_is_zero():
+    w = _result("w", {"a": [1.0]}, recall=1.0)
+    d = _result("d", {"a": [0.0]}, recall=0.0)
+    assert core.cohens_d(w, d) == 0.0
+
+
+def test_cohens_d_zero_variance_is_zero():
+    # Constant per-fixture difference -> stdev(diffs) == 0 -> guarded to 0.0.
+    w = _result("w", {"a": [0.6], "b": [0.6]}, recall=0.6)
+    d = _result("d", {"a": [0.5], "b": [0.5]}, recall=0.5)
+    assert core.cohens_d(w, d) == 0.0
+
+
+def test_cohens_d_nonzero_when_diffs_vary():
+    w = _result("w", {"a": [0.9], "b": [0.6]}, recall=0.75)
+    d = _result("d", {"a": [0.1], "b": [0.5]}, recall=0.30)
+    assert core.cohens_d(w, d) > 0.0
+
+
+def test_build_report_shape():
+    default = _result("default", {"f1": [0.5]}, recall=0.5, tokens_in=10, tokens_out=20)
+    candidate = _result(
+        "candidate", {"f1": [0.9]}, recall=0.9, cost_usd=0.1234567, error_count=1
+    )
+    decision = core.decide(
+        [default, candidate], default_model="default", rng=random.Random(1)
+    )
+    report = core.build_report(
+        agent="security",
+        fixtures_sha="abc123",
+        results=[default, candidate],
+        decision=decision,
+        min_effect=0.05,
+        seed=42,
+    )
+    assert report["schema_version"] == core.SCHEMA_VERSION
+    assert report["agent"] == "security"
+    assert report["fixtures_sha"] == "abc123"
+    assert report["default_model"] == "default"
+    assert report["winner"] == decision.winner_model
+    assert report["decision"] == decision.decision
+    assert [m["model_id"] for m in report["models"]] == ["candidate", "default"]
+    assert report["models"][1]["tokens_in"] == 10
+    assert report["models"][0]["error_count"] == 1
+    assert len(report["ci95"]) == 2

--- a/tests/eval/test_model_sweep_core.py
+++ b/tests/eval/test_model_sweep_core.py
@@ -178,18 +178,14 @@ def test_decide_drops_pin_when_lead_below_min_effect():
 
 
 def test_decide_drops_pin_when_ci_includes_zero():
-    # Candidate wins on point recall but the per-fixture signal is noisy:
-    # it beats default on half the fixtures and loses on the other half, so
-    # the paired CI straddles 0 even though the headline recall is higher.
-    default = _result(
-        "default",
-        {"a": [0.0], "b": [1.0], "c": [0.0], "d": [1.0]},
-        recall=0.50,
-    )
+    # Candidate leads on mean recall but the lead is concentrated in a minority
+    # of fixtures, so the paired bootstrap CI straddles 0. This enters the
+    # positive-but-noisy DROP branch: the default wins (top-level effect zeroed)
+    # while the challenger's real lead is preserved in best_candidate_*.
+    default = _result("default", {f"f{i}": [0.30] for i in range(8)})
     candidate = _result(
         "candidate",
-        {"a": [1.0], "b": [0.0], "c": [1.0], "d": [0.0]},
-        recall=0.60,
+        {f"f{i}": ([1.0] if i < 2 else [0.30]) for i in range(8)},
     )
     decision = core.decide(
         [default, candidate],
@@ -198,7 +194,15 @@ def test_decide_drops_pin_when_ci_includes_zero():
         seed=3,
     )
     assert decision.decision == core.DECISION_DROP
-    assert decision.ci95[0] <= 0.0 <= decision.ci95[1]
+    assert "within noise" in decision.reason
+    assert decision.winner_model == "default"
+    # Winner (default) drives the top-level effect stats -> all zero.
+    assert decision.recall_delta == 0.0
+    assert decision.ci95 == (0.0, 0.0)
+    # The challenger genuinely led on mean recall, but its CI straddles 0.
+    assert decision.best_candidate_model == "candidate"
+    assert decision.best_candidate_delta > 0.0
+    assert decision.best_candidate_ci95[0] <= 0.0 <= decision.best_candidate_ci95[1]
 
 
 def test_paired_bootstrap_ci_no_shared_fixtures_is_zero():

--- a/tests/eval/test_model_sweep_core.py
+++ b/tests/eval/test_model_sweep_core.py
@@ -10,12 +10,23 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EVAL_DIR = REPO_ROOT / "scripts" / "eval"
-if str(EVAL_DIR) not in sys.path:
-    sys.path.insert(0, str(EVAL_DIR))
 
-import _model_sweep_core as core  # noqa: E402
+# _model_sweep_core imports sibling modules via plain `from X import Y`, so
+# EVAL_DIR must be on sys.path while it loads. Scope the mutation to the load
+# and remove it afterward so we do not change import resolution for other
+# test modules.
+_path_added = str(EVAL_DIR) not in sys.path
+if _path_added:
+    sys.path.insert(0, str(EVAL_DIR))
+try:
+    import _model_sweep_core as core  # noqa: E402
+finally:
+    if _path_added and str(EVAL_DIR) in sys.path:
+        sys.path.remove(str(EVAL_DIR))
 
 
 def _result(model_id, rates, *, recall=None, **kw):
@@ -46,12 +57,8 @@ def test_check_comparable_ignores_empty_sha():
 def test_check_comparable_rejects_divergent_sha():
     a = _result("a", {"f": [1.0]}, recall=1.0, fixture_set_sha="s1")
     b = _result("b", {"f": [0.5]}, recall=0.5, fixture_set_sha="s2")
-    try:
+    with pytest.raises(core.SweepDecisionError, match="different fixture sets"):
         core.check_comparable([a, b])
-    except core.SweepDecisionError as exc:
-        assert "different fixture sets" in str(exc)
-        return
-    raise AssertionError("expected SweepDecisionError for divergent fixture shas")
 
 
 def test_fixture_means_empty_runs_score_zero():
@@ -93,21 +100,14 @@ def test_decide_picks_qualifying_second_candidate_over_noisy_top():
 
 
 def test_decide_empty_results_raises():
-    try:
+    with pytest.raises(core.SweepDecisionError):
         core.decide([], default_model="default")
-    except core.SweepDecisionError:
-        return
-    raise AssertionError("expected SweepDecisionError for empty results")
 
 
 def test_decide_default_absent_raises():
     r = _result("other", {"f1": [1.0]}, recall=1.0)
-    try:
+    with pytest.raises(core.SweepDecisionError, match="default model"):
         core.decide([r], default_model="default")
-    except core.SweepDecisionError as exc:
-        assert "default model" in str(exc)
-        return
-    raise AssertionError("expected SweepDecisionError when default is absent")
 
 
 def test_decide_default_wins_drops_pin():
@@ -141,6 +141,9 @@ def test_decide_keeps_pin_on_large_consistent_lead():
     assert decision.winner_model == "candidate"
     assert decision.ci95[0] > 0.0
     assert decision.recall_delta >= 0.05
+    # On KEEP the winner IS the best candidate, so the two describe the same model.
+    assert decision.best_candidate_model == "candidate"
+    assert decision.best_candidate_delta == decision.recall_delta
 
 
 def test_decide_drops_pin_when_lead_below_min_effect():
@@ -163,6 +166,15 @@ def test_decide_drops_pin_when_lead_below_min_effect():
     # 0.02 lead is real (CI excludes 0) but below min_effect -> drop.
     assert decision.decision == core.DECISION_DROP
     assert "below min_effect" in decision.reason
+    # DROP means the default wins, so the top-level effect stats describe the
+    # winner (default) and MUST be zeroed; the leading candidate's real lead is
+    # preserved separately so the artifact stays consistent (Issue #2840).
+    assert decision.winner_model == "default"
+    assert decision.recall_delta == 0.0
+    assert decision.ci95 == (0.0, 0.0)
+    assert decision.cohens_d == 0.0
+    assert decision.best_candidate_model == "candidate"
+    assert decision.best_candidate_delta > 0.0
 
 
 def test_decide_drops_pin_when_ci_includes_zero():
@@ -235,7 +247,7 @@ def test_build_report_shape():
         min_effect=0.05,
         seed=42,
     )
-    assert report["schema_version"] == core.SCHEMA_VERSION
+    assert report["schemaVersion"] == core.SCHEMA_VERSION
     assert report["agent"] == "security"
     assert report["fixtures_sha"] == "abc123"
     assert report["default_model"] == "default"
@@ -248,6 +260,8 @@ def test_build_report_shape():
     assert report["models"][1]["tokens_in"] == 10
     assert report["models"][0]["error_count"] == 1
     assert len(report["ci95"]) == 2
+    assert report["best_candidate_model"] == decision.best_candidate_model
+    assert len(report["best_candidate_ci95"]) == 2
 
 
 def test_common_fixture_ids_empty_model_yields_no_shared():
@@ -263,12 +277,8 @@ def test_decide_empty_fixture_model_raises():
     # error, not crash in mean_recall_on with a KeyError.
     default = _result("default", {"f1": [0.5], "f2": [0.5]}, recall=0.5)
     empty = _result("empty", {}, recall=0.0)
-    try:
+    with pytest.raises(core.SweepDecisionError, match="shared"):
         core.decide([default, empty], default_model="default")
-    except core.SweepDecisionError as exc:
-        assert "shared" in str(exc)
-        return
-    raise AssertionError("expected SweepDecisionError when a model has no fixtures")
 
 
 def test_decide_single_shared_fixture_drops():

--- a/tests/eval/test_model_sweep_core.py
+++ b/tests/eval/test_model_sweep_core.py
@@ -61,25 +61,36 @@ def test_fixture_means_empty_runs_score_zero():
 
 
 def test_rank_orders_by_recall_then_id():
-    a = _result("b-model", {}, recall=0.9)
-    b = _result("a-model", {}, recall=0.9)
-    c = _result("c-model", {}, recall=0.5)
-    ranked = core.rank([c, a, b])
+    a = _result("b-model", {"f": [0.9]}, recall=0.9)
+    b = _result("a-model", {"f": [0.9]}, recall=0.9)
+    c = _result("c-model", {"f": [0.5]}, recall=0.5)
+    ids = core.common_fixture_ids([a, b, c])
+    ranked = core.rank([c, a, b], ids)
     assert [r.model_id for r in ranked] == ["a-model", "b-model", "c-model"]
 
 
-def test_select_winner_tie_prefers_default():
-    default = _result("default", {}, recall=0.8)
-    other = _result("aaa", {}, recall=0.8)
-    winner = core._select_winner([other, default], "default")
-    assert winner.model_id == "default"
-
-
-def test_select_winner_tie_without_default_is_lexical():
-    x = _result("zzz", {}, recall=0.8)
-    y = _result("aaa", {}, recall=0.8)
-    winner = core._select_winner([x, y], "default")
-    assert winner.model_id == "aaa"
+def test_decide_picks_qualifying_second_candidate_over_noisy_top():
+    # R2-1 regression: the top point-estimate model is noisy (its lead is
+    # concentrated in a minority of fixtures, so the paired CI straddles 0)
+    # and does NOT qualify. A lower-point-estimate candidate that beats the
+    # default consistently DOES qualify and must not be suppressed.
+    default = _result("default", {f"f{i}": [0.30] for i in range(8)})
+    # Noisy top: mean 0.475 (highest) but the lead lives in only 2 fixtures.
+    noisy_top = _result(
+        "noisy-top",
+        {f"f{i}": ([1.0] if i < 2 else [0.30]) for i in range(8)},
+    )
+    # Solid: mean 0.42 (lower) but beats default on EVERY fixture -> CI > 0.
+    solid = _result("solid", {f"f{i}": [0.42] for i in range(8)})
+    decision = core.decide(
+        [default, noisy_top, solid],
+        default_model="default",
+        min_effect=0.05,
+        rng=random.Random(7),
+    )
+    assert decision.decision == core.DECISION_KEEP
+    assert decision.winner_model == "solid"
+    assert decision.ci95[0] > 0.0
 
 
 def test_decide_empty_results_raises():
@@ -182,26 +193,27 @@ def test_decide_drops_pin_when_ci_includes_zero():
 def test_paired_bootstrap_ci_no_shared_fixtures_is_zero():
     w = _result("w", {"a": [1.0]}, recall=1.0)
     d = _result("d", {"b": [0.0]}, recall=0.0)
-    assert core.paired_bootstrap_ci(w, d) == (0.0, 0.0)
+    ids = core.common_fixture_ids([w, d])
+    assert core.paired_bootstrap_ci(w, d, ids) == (0.0, 0.0)
 
 
 def test_cohens_d_fewer_than_two_fixtures_is_zero():
     w = _result("w", {"a": [1.0]}, recall=1.0)
     d = _result("d", {"a": [0.0]}, recall=0.0)
-    assert core.cohens_d(w, d) == 0.0
+    assert core.cohens_d(w, d, ["a"]) == 0.0
 
 
 def test_cohens_d_zero_variance_is_zero():
     # Constant per-fixture difference -> stdev(diffs) == 0 -> guarded to 0.0.
     w = _result("w", {"a": [0.6], "b": [0.6]}, recall=0.6)
     d = _result("d", {"a": [0.5], "b": [0.5]}, recall=0.5)
-    assert core.cohens_d(w, d) == 0.0
+    assert core.cohens_d(w, d, ["a", "b"]) == 0.0
 
 
 def test_cohens_d_nonzero_when_diffs_vary():
     w = _result("w", {"a": [0.9], "b": [0.6]}, recall=0.75)
     d = _result("d", {"a": [0.1], "b": [0.5]}, recall=0.30)
-    assert core.cohens_d(w, d) > 0.0
+    assert core.cohens_d(w, d, ["a", "b"]) > 0.0
 
 
 def test_build_report_shape():

--- a/tests/eval/test_model_sweep_core.py
+++ b/tests/eval/test_model_sweep_core.py
@@ -32,6 +32,29 @@ def _result(model_id, rates, *, recall=None, **kw):
     )
 
 
+def test_check_comparable_passes_matching_sha():
+    a = _result("a", {"f": [1.0]}, recall=1.0, fixture_set_sha="s")
+    b = _result("b", {"f": [0.5]}, recall=0.5, fixture_set_sha="s")
+    core.check_comparable([a, b])  # no raise
+
+
+def test_check_comparable_ignores_empty_sha():
+    a = _result("a", {"f": [1.0]}, recall=1.0)
+    b = _result("b", {"f": [0.5]}, recall=0.5)
+    core.check_comparable([a, b])  # empty shas ignored -> no raise
+
+
+def test_check_comparable_rejects_divergent_sha():
+    a = _result("a", {"f": [1.0]}, recall=1.0, fixture_set_sha="s1")
+    b = _result("b", {"f": [0.5]}, recall=0.5, fixture_set_sha="s2")
+    try:
+        core.check_comparable([a, b])
+    except core.SweepDecisionError as exc:
+        assert "different fixture sets" in str(exc)
+        return
+    raise AssertionError("expected SweepDecisionError for divergent fixture shas")
+
+
 def test_fixture_means_empty_runs_score_zero():
     r = _result("m", {"f1": [1.0, 0.0], "f2": []}, recall=0.5)
     assert r.fixture_means == {"f1": 0.5, "f2": 0.0}


### PR DESCRIPTION
## What

Delivers **acceptance criterion 2** of #2840: an eval **model-sweep** tool that
scores whether an agent's `model:` pin actually beats the harness default.

`scripts/eval/eval-model-sweep.py` runs the existing single-model evaluator
(agent variant) once per candidate model, then compares per-fixture pass rates
across models and emits a scored verdict:

- **KEEP_PIN**: a non-default candidate leads the default by `>= --min-effect`
  (default 0.05) recall AND the paired bootstrap 95% CI on the recall delta
  excludes 0. Keep the pin, cite the artifact.
- **DROP_PIN**: default ranks first, the lead is within noise (CI includes 0),
  or the lead is below `--min-effect`. Drop the pin, inherit `auto`.

Cohen's d_z is a secondary descriptor only. It never gates the verdict.

## Design

Follows testability-first and separate-use-from-creation:

- **Pure core** `scripts/eval/_model_sweep_core.py`, no I/O or API. `decide()`,
  `paired_bootstrap_ci()` (same fixture-id resample plus percentiles as the
  agent-vs-baseline CI), `cohens_d()`, `rank()`, `build_report()`.
- **Thin orchestrator** `scripts/eval/eval-model-sweep.py` with an injectable
  `ModelEvalRunner`. Default `SubprocessModelEvalRunner` shells to the tested
  live path and parses the emitted report. Tests inject a fake runner for full
  coverage with zero API spend.

## Hardening

- Child runs are bounded by a configurable `--child-timeout` (default 1800s).
  A stalled child maps to `EXIT_EXTERNAL`; non-finite or non-positive values
  are rejected with `EXIT_CONFIG`.
- `run_sweep` fails closed with `EXIT_CONFIG` when the live path is reached
  with no runner injected.
- Timestamps use `datetime.timezone.utc` for portability across the supported
  interpreter range.
- Flaky-fixture parsing rejects non-string elements before set construction.

## Pricing gate (freshness)

Swept models must be priced in `MODEL_PRICING_RATES_USD_PER_1K_TOKENS`; the base
evaluator hard-fails on unpriced models (#2858). The sweep pre-checks and exits
`2` with an actionable message. It does not fabricate pricing. Today only two
`claude-sonnet` ids are priced, so a real opus or haiku sweep needs a verified
pricing entry added first (tracked in #2902).

## Scope

This is criterion 2 tooling only. Remaining #2840 criteria (do NOT close on
merge): ADR policy for pins, CI governance check (fail a pin lacking a linked
sweep artifact), pin-migration, and actually running sweeps (needs verified
non-sonnet pricing plus API budget).

## Tests

`tests/eval/test_model_sweep_core.py` plus `tests/eval/test_eval_model_sweep_cli.py`:
KEEP/DROP/default-wins/tie, CI-includes-0, below-min-effect, bootstrap and d_z
edge cases (<2 fixtures, zero variance), argv and report-parse pure fns,
unpriced->exit 2, missing-fixtures->exit 2, child-failure->exit 3,
child-timeout->exit 3, non-finite-timeout->exit 2, missing-runner->exit 2, and a
`DEFAULT_MODEL` drift guard against the base evaluator. `ruff` clean; 71 passed.

Closes-criterion: #2840 (criterion 2 of 5)

## References

The following paths are cited for context and are not changed by this PR:

- `scripts/eval/eval-agent-vs-baseline.py` (the single-model evaluator this tool shells to)
- `scripts/eval/_eval_common.py` (owns the pricing table)
- `report.json` (the per-run artifact the orchestrator parses)
