### PR TITLE
fix(hooks): prevent PreToolUse bash-hook wedge (fail-closed on host timeout)

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-07-session-2609.json
+++ b/.agents/memory/episodes/episode-2026-07-07-session-2609.json
@@ -1,0 +1,59 @@
+{
+  "id": "episode-2026-07-07-session-2609",
+  "session": "2026-07-07-session-2609",
+  "timestamp": "2026-07-07T00:00:00+00:00",
+  "outcome": "success",
+  "task": "RCA and structural fix for PreToolUse bash-hook wedge (git subprocess timeout exceeded host hook timeout -> SIGKILL -> every bash command hard-denied); then resume open-issue backlog.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-07T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Confirmed bash-hook wedge cleared after Copilot restart reloaded .claude/settings.json hooks.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-07T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Regression test caught my own error: git timeout 2s not strictly < tightest host timeout; topical-memory-injection hook is 2s, a guard-caller.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-07T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Lowered git remote lookup timeout 2s -> 1s across all three synced guards.py copies; corrected comment to cite the real 2s binding constraint.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-07T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Validated: 62 guard tests pass; isolated invoke_skill_learning timeout is flaky under full-suite load, passes in 3s alone, unrelated to git-timeout change.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-07T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Bumped .claude and src/copilot-cli plugin.json 0.6.4 -> 0.6.5 in lockstep for packaged-lib + hook-source change.",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 6
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-07-session-2609.json
+++ b/.agents/memory/episodes/episode-2026-07-07-session-2609.json
@@ -45,6 +45,14 @@
       "content": "Bumped .claude and src/copilot-cli plugin.json 0.6.4 -> 0.6.5 in lockstep for packaged-lib + hook-source change.",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-07T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 16219bc89333d8c020943f5cdc08c3f275968aaf",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -52,7 +60,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 6
   },
   "lessons": []

--- a/.agents/sessions/2026-07-07-session-2609.json
+++ b/.agents/sessions/2026-07-07-session-2609.json
@@ -1,0 +1,143 @@
+{
+ "schemaVersion": "1.0",
+ "session": {
+  "number": 2609,
+  "date": "2026-07-07",
+  "branch": "fix/pretooluse-bash-hook-wedge",
+  "startingCommit": "e632550a3c",
+  "objective": "RCA and structural fix for PreToolUse bash-hook wedge (git subprocess timeout exceeded host hook timeout -> SIGKILL -> every bash command hard-denied); then resume open-issue backlog."
+ },
+ "protocolCompliance": {
+  "sessionStart": {
+   "serenaActivated": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "serena-initial_instructions loaded this session; serena-* MCP tools live on this local Copilot CLI."
+   },
+   "serenaInstructions": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Serena Instructions Manual read via serena-initial_instructions."
+   },
+   "handoffRead": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Prior HANDOFF context carried in autopilot session summary and checkpoints."
+   },
+   "sessionLogCreated": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "This file."
+   },
+   "skillScriptsListed": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "github skill pr scripts used for PR/issue ops; llm-council skill for prior ADR-079 deliberation."
+   },
+   "usageMandatoryRead": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "gh used via github skill scripts where a skill exists; raw gh only for read-only issue listing."
+   },
+   "constraintsRead": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Dash prohibition, atomic-commit, plugin-version-bump, generated-artifact discipline applied."
+   },
+   "memoriesLoaded": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Repository and user memories surfaced in prompt; plugin-versioning, hook-bootstrap, and timeout-hardening memories applied."
+   },
+   "branchVerified": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "fix/pretooluse-bash-hook-wedge created from up-to-date origin/main."
+   },
+   "notOnMain": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "On fix/pretooluse-bash-hook-wedge, not main."
+   },
+   "gitStatusVerified": {
+    "level": "SHOULD",
+    "Complete": true,
+    "Evidence": "git status checked before staging; serena/project.yml auto-churn discarded."
+   },
+   "startingCommitNoted": {
+    "level": "SHOULD",
+    "Complete": true,
+    "Evidence": "e632550a3c"
+   }
+  },
+  "sessionEnd": {
+   "checklistComplete": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "All sessionStart and sessionEnd MUST fields completed with evidence."
+   },
+   "handoffPreserved": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": ".agents/HANDOFF.md not modified this session."
+   },
+   "serenaMemoryUpdated": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Added .serena/memories/root-cause-pretooluse-bash-hook-wedge.md (RootCause-Hooks-001)."
+   },
+   "markdownLintRun": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Pre-commit runs markdownlint on staged markdown; RCA memory passes."
+   },
+   "changesCommitted": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Committed guards.py timeout fix, correction_applier scan budget, regression test, e2e shadow-cleanup, plugin bump, RCA memory."
+   },
+   "validationPassed": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "pytest tests/test_hook_plugin_guards.py PASS (63/63 incl. new invariant test); byte-level dash count zero."
+   },
+   "tasksUpdated": {
+    "level": "SHOULD",
+    "Complete": true,
+    "Evidence": "Autopilot 47-issue backlog tracked in session DB; hook-wedge side quest closed first."
+   },
+   "retrospectiveInvoked": {
+    "level": "SHOULD",
+    "Complete": true,
+    "Evidence": "Auto-retro generated for 2026-07-07; RCA memory captures the structural lesson."
+   }
+  }
+ },
+ "workLog": [
+  {
+   "time": "2026-07-07T21:50:00Z",
+   "entry": "Confirmed bash-hook wedge cleared after Copilot restart reloaded .claude/settings.json hooks."
+  },
+  {
+   "time": "2026-07-07T21:55:00Z",
+   "entry": "Regression test caught my own error: git timeout 2s not strictly < tightest host timeout; topical-memory-injection hook is 2s, a guard-caller."
+  },
+  {
+   "time": "2026-07-07T22:00:00Z",
+   "entry": "Lowered git remote lookup timeout 2s -> 1s across all three synced guards.py copies; corrected comment to cite the real 2s binding constraint."
+  },
+  {
+   "time": "2026-07-07T22:05:00Z",
+   "entry": "Validated: 62 guard tests pass; isolated invoke_skill_learning timeout is flaky under full-suite load, passes in 3s alone, unrelated to git-timeout change."
+  },
+  {
+   "time": "2026-07-07T22:10:00Z",
+   "entry": "Bumped .claude and src/copilot-cli plugin.json 0.6.4 -> 0.6.5 in lockstep for packaged-lib + hook-source change."
+  }
+ ],
+ "endingCommit": "",
+ "nextSteps": [
+  "Push fix/pretooluse-bash-hook-wedge, open PR referencing the wedge-class issue, drive to merge.",
+  "Resume open-issue backlog: 2814, 2840, 2855, 2902, 2903, 2909, 2910-2946."
+ ]
+}

--- a/.agents/sessions/2026-07-07-session-2609.json
+++ b/.agents/sessions/2026-07-07-session-2609.json
@@ -135,7 +135,7 @@
    "entry": "Bumped .claude and src/copilot-cli plugin.json 0.6.4 -> 0.6.5 in lockstep for packaged-lib + hook-source change."
   }
  ],
- "endingCommit": "",
+ "endingCommit": "16219bc89333d8c020943f5cdc08c3f275968aaf",
  "nextSteps": [
   "Push fix/pretooluse-bash-hook-wedge, open PR referencing the wedge-class issue, drive to merge.",
   "Resume open-issue backlog: 2814, 2840, 2855, 2902, 2903, 2909, 2910-2946."

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PreToolUse/invoke_correction_applier.py
+++ b/.claude/hooks/PreToolUse/invoke_correction_applier.py
@@ -182,6 +182,29 @@ def find_matching_corrections(
     return matches
 
 
+def _collect_memory_files(memories_dir: Path, deadline: float) -> list[Path]:
+    """Return up to ``_MAX_FILES_SCANNED`` ``*.md`` paths, bounded by ``deadline``.
+
+    ``Path.rglob`` returns a lazy generator; iterating it drives the directory
+    walk. The count and deadline checks run DURING iteration so a huge or slow
+    ``.serena/memories/`` tree cannot blow the host hook timeout before the read
+    loop is even entered. Sorting the whole ``rglob`` result up front (the prior
+    behavior) materialized and ordered the entire tree first, defeating the very
+    wedge this hook exists to prevent. The bounded result is sorted afterward so
+    ordering is deterministic within the cap; when the corpus fits under the cap
+    (the normal case) ordering is fully deterministic.
+    """
+    collected: list[Path] = []
+    for md_file in memories_dir.rglob("*.md"):
+        if len(collected) >= _MAX_FILES_SCANNED:
+            break
+        if time.monotonic() >= deadline:
+            break
+        collected.append(md_file)
+    collected.sort()
+    return collected
+
+
 def scan_memories(project_root: str, deadline: float | None = None) -> list[tuple[str, str]]:
     """Scan .serena/memories/ for HIGH confidence corrections.
 
@@ -192,8 +215,10 @@ def scan_memories(project_root: str, deadline: float | None = None) -> list[tupl
     wedge every Bash command (fail-closed-on-timeout regression).
 
     Files are visited in sorted order for determinism. ``deadline`` is an
-    absolute ``time.monotonic()`` value; when omitted it is derived from
-    ``_SCAN_DEADLINE_SECONDS``.
+    absolute ``time.monotonic()`` value. When a caller passes a larger hook-wide
+    deadline (``_HOOK_WALL_BUDGET_SECONDS`` from ``main()``), the scan still caps
+    itself at ``_SCAN_DEADLINE_SECONDS`` so it never consumes the whole hook
+    budget, matching the "stops after ``_SCAN_DEADLINE_SECONDS``" contract above.
 
     Returns list of (source_file, correction_text) tuples.
     """
@@ -201,15 +226,14 @@ def scan_memories(project_root: str, deadline: float | None = None) -> list[tupl
     if not memories_dir.is_dir():
         return []
 
-    if deadline is None:
-        deadline = time.monotonic() + _SCAN_DEADLINE_SECONDS
+    scan_deadline = time.monotonic() + _SCAN_DEADLINE_SECONDS
+    deadline = scan_deadline if deadline is None else min(deadline, scan_deadline)
 
     all_corrections: list[tuple[str, str]] = []
-    files_scanned = 0
     total_bytes = 0
 
-    for md_file in sorted(memories_dir.rglob("*.md")):
-        if files_scanned >= _MAX_FILES_SCANNED or total_bytes >= _MAX_TOTAL_BYTES:
+    for md_file in _collect_memory_files(memories_dir, deadline):
+        if total_bytes >= _MAX_TOTAL_BYTES:
             break
         if time.monotonic() >= deadline:
             break
@@ -217,7 +241,6 @@ def scan_memories(project_root: str, deadline: float | None = None) -> list[tupl
             content = md_file.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        files_scanned += 1
         total_bytes += len(content)
         corrections = extract_high_corrections(content)
         for c in corrections:

--- a/.claude/hooks/PreToolUse/invoke_correction_applier.py
+++ b/.claude/hooks/PreToolUse/invoke_correction_applier.py
@@ -22,6 +22,7 @@ import json
 import os
 import re
 import sys
+import time
 from pathlib import Path
 
 # Bootstrap: find lib directory via env var or manifest walk-up.
@@ -79,6 +80,24 @@ _HEADING_RE = re.compile(r"^##\s+")
 MAX_CORRECTIONS = 3
 # Minimum keyword length to avoid false positives
 MIN_KEYWORD_LENGTH = 4
+# Scan bounds (issue: advisory PreToolUse hook must never wedge the session).
+# This hook runs on EVERY Bash command with a tight host timeout (3s in
+# .claude/settings.json). A host timeout kills the process (SIGKILL), which
+# the try/except in main() cannot catch, so the "advisory, never blocks"
+# contract silently becomes fail-CLOSED and denies every command once the
+# memory corpus grows past the budget. These caps keep the scan best-effort
+# and bounded so wall-clock stays well under the host timeout regardless of
+# how large .serena/memories/ becomes.
+_SCAN_DEADLINE_SECONDS = 1.5
+_MAX_FILES_SCANNED = 500
+_MAX_TOTAL_BYTES = 5_000_000
+# Total wall-clock budget for the whole hook body, anchored at main() start and
+# kept under the 3s host timeout (.claude/settings.json). skip_if_consumer_repo()
+# may spend up to its git subprocess timeout before the scan runs, so anchoring
+# the scan deadline here (not at scan start) makes a slow git shrink the scan
+# window instead of pushing total wall-clock past the host timeout and tripping
+# a SIGKILL-into-"hook errored" deny.
+_HOOK_WALL_BUDGET_SECONDS = 2.5
 
 
 def parse_command(stdin_data: str) -> str | None:
@@ -156,8 +175,18 @@ def find_matching_corrections(
     return matches
 
 
-def scan_memories(project_root: str) -> list[tuple[str, str]]:
+def scan_memories(project_root: str, deadline: float | None = None) -> list[tuple[str, str]]:
     """Scan .serena/memories/ for HIGH confidence corrections.
+
+    Best-effort and bounded: stops after ``_SCAN_DEADLINE_SECONDS`` wall clock,
+    ``_MAX_FILES_SCANNED`` files, or ``_MAX_TOTAL_BYTES`` read, whichever comes
+    first. This is advisory context, so surfacing a subset is acceptable; the
+    hard requirement is that the scan cannot exceed the host hook timeout and
+    wedge every Bash command (fail-closed-on-timeout regression).
+
+    Files are visited in sorted order for determinism. ``deadline`` is an
+    absolute ``time.monotonic()`` value; when omitted it is derived from
+    ``_SCAN_DEADLINE_SECONDS``.
 
     Returns list of (source_file, correction_text) tuples.
     """
@@ -165,13 +194,24 @@ def scan_memories(project_root: str) -> list[tuple[str, str]]:
     if not memories_dir.is_dir():
         return []
 
-    all_corrections: list[tuple[str, str]] = []
+    if deadline is None:
+        deadline = time.monotonic() + _SCAN_DEADLINE_SECONDS
 
-    for md_file in memories_dir.rglob("*.md"):
+    all_corrections: list[tuple[str, str]] = []
+    files_scanned = 0
+    total_bytes = 0
+
+    for md_file in sorted(memories_dir.rglob("*.md")):
+        if files_scanned >= _MAX_FILES_SCANNED or total_bytes >= _MAX_TOTAL_BYTES:
+            break
+        if time.monotonic() >= deadline:
+            break
         try:
             content = md_file.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
+        files_scanned += 1
+        total_bytes += len(content)
         corrections = extract_high_corrections(content)
         for c in corrections:
             all_corrections.append((md_file.name, c))
@@ -182,6 +222,7 @@ def scan_memories(project_root: str) -> list[tuple[str, str]]:
 def main() -> int:
     """Main entry point. Always returns 0 (advisory, never blocks)."""
     hook_name = "correction-applier"
+    deadline = time.monotonic() + _HOOK_WALL_BUDGET_SECONDS
     try:
         if skip_if_consumer_repo(hook_name):
             return 0
@@ -202,7 +243,7 @@ def main() -> int:
             return 0
 
         project_root = get_project_directory()
-        all_corrections = scan_memories(project_root)
+        all_corrections = scan_memories(project_root, deadline=deadline)
         if not all_corrections:
             return 0
 

--- a/.claude/hooks/PreToolUse/invoke_correction_applier.py
+++ b/.claude/hooks/PreToolUse/invoke_correction_applier.py
@@ -32,7 +32,7 @@ from pathlib import Path
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
 if _plugin_root:
-    _lib_dir = str(Path(_plugin_root).resolve() / "lib")
+    _lib_dir: str | None = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
     _lib_dir = None
@@ -44,7 +44,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     # Non-blocking hook: exit 0 on bootstrap failure (intentional, not a typo)
     sys.exit(0)
 if _lib_dir not in sys.path:
@@ -111,8 +115,11 @@ def parse_command(stdin_data: str) -> str | None:
         try:
             tool_input = json.loads(tool_input)
         except (json.JSONDecodeError, TypeError):
-            return tool_input
-    return tool_input.get("command") if isinstance(tool_input, dict) else None
+            return tool_input if isinstance(tool_input, str) else None
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command")
+        return command if isinstance(command, str) else None
+    return None
 
 
 def extract_high_corrections(content: str) -> list[str]:

--- a/.claude/lib/hook_utilities/guards.py
+++ b/.claude/lib/hook_utilities/guards.py
@@ -49,7 +49,18 @@ def _remote_repo_name(project_root: str) -> str | None:
             capture_output=True,
             encoding="utf-8",
             errors="replace",
-            timeout=5,
+            # skip_if_consumer_repo() runs this on every tool use. The tightest
+            # host hook timeout that invokes it is 2s (topical-memory-injection
+            # in .claude/settings.json), so keep this subprocess timeout strictly
+            # below that: a slow or hung git must degrade to None here, not let
+            # the host SIGKILL the whole hook. A SIGKILL cannot be caught by the
+            # caller's fail-open try/except, so it surfaces as a hard "hook
+            # errored" deny of the command (repo-settings Bash-hook wedge RCA).
+            # A local `git remote get-url origin` reads .git/config in <10ms;
+            # 1s only trips on a genuine hang, which is exactly when we want to
+            # degrade fast. Enforced by tests/test_hook_plugin_guards.py::
+            # test_origin_lookup_timeout_under_host_budget.
+            timeout=1,
             check=True,
         )
     except (OSError, subprocess.SubprocessError):

--- a/.serena/memories/root-cause-pretooluse-bash-hook-wedge.md
+++ b/.serena/memories/root-cause-pretooluse-bash-hook-wedge.md
@@ -32,9 +32,10 @@ exception) can still fail CLOSED and deny every command, because:
 2. When that work exceeds the host timeout, the host sends **SIGKILL**. A SIGKILL cannot be
    caught by the hook's internal `try/except` fail-open path, so the "advisory" contract is
    silently violated and the non-zero exit becomes a hard deny.
-3. Concrete mismatch found: `_remote_repo_name` used `subprocess.run(..., timeout=5)` while the
-   correction-applier host timeout is 3s (`.claude/settings.json`). Internal timeout (5s) >
-   host timeout (3s) guarantees a SIGKILL before the internal timeout can return gracefully.
+3. Concrete mismatch found: `_remote_repo_name` used `subprocess.run(..., timeout=5)`. The guard
+   runs under multiple PreToolUse hosts; the tightest is topical-memory-injection at 2s
+   (`.claude/settings.json`), and the correction-applier host is 3s. Internal timeout (5s) >
+   tightest host timeout (2s) guarantees a SIGKILL before the internal timeout can return gracefully.
 
 ## Five Whys
 
@@ -45,7 +46,7 @@ exception) can still fail CLOSED and deny every command, because:
 - Q4: Why does the fail-open path not save it? -> A SIGKILL is uncatchable; `try/except` only
   covers in-process exceptions, not host-timeout kills.
 - Q5: Why was the internal timeout larger than the host timeout? -> The subprocess timeout (5s)
-  was set without reference to the tightest host hook timeout (3s) that invokes it.
+  was set without reference to the tightest host hook timeout (2s) that invokes it.
 
 ## Invariant (the durable lesson)
 
@@ -58,17 +59,19 @@ subprocess (git) runs *before* the scan under the same host budget. Anchor the d
 hook's entry (`main()` start) and pass it through, so a slow subprocess shrinks the scan window
 instead of pushing total wall-clock past the host timeout.
 
-## Fixes applied (this session, uncommitted; require Copilot restart to take effect)
+## Fixes applied (this session, committed in this PR)
 
 - `scripts/hook_utilities/guards.py` (+ synced copies `.claude/lib/...`,
-  `src/copilot-cli/lib/...`): `_remote_repo_name` git subprocess `timeout=5` -> `timeout=2`, so
-  the per-tool-call git lookup stays under the 3s tightest host timeout. Failure still degrades to
+  `src/copilot-cli/lib/...`): `_remote_repo_name` git subprocess `timeout=5` -> `timeout=1`, so
+  the per-tool-call git lookup stays under the 2s tightest host timeout (topical-memory-injection
+  in `.claude/settings.json`). Failure still degrades to
   None -> identity "unknown" -> pyproject `[project].name` corroboration keeps project identity
   correct. No generator run needed (straight lib sync; all three copies edited identically).
 - `.claude/hooks/PreToolUse/invoke_correction_applier.py`: bounded the `.serena/memories` scan
   (`_MAX_FILES_SCANNED`, `_MAX_TOTAL_BYTES`, wall-clock deadline) AND anchored a
   `_HOOK_WALL_BUDGET_SECONDS = 2.5` deadline at `main()` entry, passed into `scan_memories`, so
-  git-time + scan-time together stay under the 3s host timeout. Single copy (no generated mirror).
+  git-time + scan-time together stay under the correction-applier host timeout (3s). Single copy
+  (no generated mirror).
 - `tests/test_hook_plugin_guards.py::test_origin_lookup_timeout_under_host_budget`: regression
   guard. Reads `.claude/settings.json`, takes the minimum explicit PreToolUse hook timeout, and
   asserts the git lookup timeout is strictly less than it. Catches both a future git-timeout

--- a/.serena/memories/root-cause-pretooluse-bash-hook-wedge.md
+++ b/.serena/memories/root-cause-pretooluse-bash-hook-wedge.md
@@ -1,0 +1,111 @@
+# Root Cause Pattern: PreToolUse Bash Hook Wedge (fail-closed on host timeout)
+
+**Pattern ID**: RootCause-Hooks-001
+**Category**: Fail-Safe Failure (advisory hook becomes hard deny)
+**Created**: 2026-07-08
+**Source**: Live wedge during large agentic batch; Copilot CLI session denied every bash command.
+
+## Symptom
+
+Every Bash/shell command returns:
+
+```
+Denied by preToolUse hook from "repo settings" (hook errored)
+```
+
+- "repo settings" = Copilot CLI reads Claude Code's `.claude/settings.json` hooks and labels
+  them "repo settings". These are Claude-style hooks (stdin JSON, exit 2 = block).
+- "(hook errored)" = a hook exited non-zero WITHOUT a valid structured decision
+  (crash / exception / spawn-fail / SIGKILL on host timeout). Copilot surfaces any non-zero
+  repo-hook exit on a benign command as a hard deny.
+- Onset correlates with large agentic batches (many concurrent sessions, degraded git state,
+  grown `.serena/memories/` corpus). "If you're wedged, a customer is likely wedged too."
+
+## Root Cause (structural class)
+
+A per-tool-call PreToolUse hook that is designed to be advisory ("never blocks", fail-open on
+exception) can still fail CLOSED and deny every command, because:
+
+1. It does per-call work that can exceed the host hook timeout: a `git` subprocess (repo-identity
+   via `skip_if_consumer_repo` -> `_remote_repo_name`) and/or an unbounded FS scan
+   (`.serena/memories/**/*.md`, 800+ files).
+2. When that work exceeds the host timeout, the host sends **SIGKILL**. A SIGKILL cannot be
+   caught by the hook's internal `try/except` fail-open path, so the "advisory" contract is
+   silently violated and the non-zero exit becomes a hard deny.
+3. Concrete mismatch found: `_remote_repo_name` used `subprocess.run(..., timeout=5)` while the
+   correction-applier host timeout is 3s (`.claude/settings.json`). Internal timeout (5s) >
+   host timeout (3s) guarantees a SIGKILL before the internal timeout can return gracefully.
+
+## Five Whys
+
+- Q1: Why is bash denied? -> A repo-settings PreToolUse hook exits non-zero on a benign command.
+- Q2: Why non-zero on benign command? -> The host SIGKILLs the hook at its timeout.
+- Q3: Why does it hit the timeout? -> It runs a git subprocess (and/or scans 800+ memory files)
+  whose worst-case wall-clock exceeds the host timeout.
+- Q4: Why does the fail-open path not save it? -> A SIGKILL is uncatchable; `try/except` only
+  covers in-process exceptions, not host-timeout kills.
+- Q5: Why was the internal timeout larger than the host timeout? -> The subprocess timeout (5s)
+  was set without reference to the tightest host hook timeout (3s) that invokes it.
+
+## Invariant (the durable lesson)
+
+> A per-tool-call hook's total wall-clock, including every subprocess it spawns and every FS
+> scan it performs, MUST stay strictly under the tightest host hook timeout that invokes it.
+> Otherwise a host SIGKILL turns a fail-open hook into a hard "hook errored" deny of every command.
+
+Corollary: bounding a scan with a deadline anchored at *scan start* is insufficient when a
+subprocess (git) runs *before* the scan under the same host budget. Anchor the deadline at the
+hook's entry (`main()` start) and pass it through, so a slow subprocess shrinks the scan window
+instead of pushing total wall-clock past the host timeout.
+
+## Fixes applied (this session, uncommitted; require Copilot restart to take effect)
+
+- `scripts/hook_utilities/guards.py` (+ synced copies `.claude/lib/...`,
+  `src/copilot-cli/lib/...`): `_remote_repo_name` git subprocess `timeout=5` -> `timeout=2`, so
+  the per-tool-call git lookup stays under the 3s tightest host timeout. Failure still degrades to
+  None -> identity "unknown" -> pyproject `[project].name` corroboration keeps project identity
+  correct. No generator run needed (straight lib sync; all three copies edited identically).
+- `.claude/hooks/PreToolUse/invoke_correction_applier.py`: bounded the `.serena/memories` scan
+  (`_MAX_FILES_SCANNED`, `_MAX_TOTAL_BYTES`, wall-clock deadline) AND anchored a
+  `_HOOK_WALL_BUDGET_SECONDS = 2.5` deadline at `main()` entry, passed into `scan_memories`, so
+  git-time + scan-time together stay under the 3s host timeout. Single copy (no generated mirror).
+- `tests/test_hook_plugin_guards.py::test_origin_lookup_timeout_under_host_budget`: regression
+  guard. Reads `.claude/settings.json`, takes the minimum explicit PreToolUse hook timeout, and
+  asserts the git lookup timeout is strictly less than it. Catches both a future git-timeout
+  increase and a host-timeout decrease. Mirrors the #2811 `call_args.kwargs["timeout"]` pattern.
+
+## What was NOT confirmed
+
+The EXACT live crasher was not pinpointed by static analysis alone (bash/gh were wedged, so no
+hook could be executed to capture the actual error). Two on-disk edits during the wedge did NOT
+unblock the running session, which indicates Copilot snapshots repo hooks at session start:
+**only a Copilot CLI restart reloads `.claude/settings.json` + hooks and clears the wedge.**
+
+## Post-restart diagnostic (pinpoint in seconds once bash works)
+
+Feed a benign payload to each configured Bash-matcher hook and check exit code + duration:
+
+```
+echo '{"tool_name":"Bash","tool_input":{"command":"echo diagnostic"}}' \
+  | timeout 10 python3 .claude/hooks/PreToolUse/<hook>.py ; echo "exit=$?"
+```
+
+Any hook that exits non-zero (or is killed by `timeout`) on this benign input is the crasher.
+
+## Detection Signals
+
+- Every bash command denied with "(hook errored)" from "repo settings".
+- Harness reports "Not a git repository" or `.git` is degraded/bloated.
+- `.serena/memories/` has grown large (hundreds/thousands of files).
+- Onset immediately after a large multi-session agentic batch.
+
+## Related
+
+- Timeout-hardening convention: `tests/test_timeout_hardening_2811.py`,
+  `tests/test_security_gate_timeouts_2810.py` (issues #2810/#2811): subprocess calls must pass a
+  timeout and degrade `TimeoutExpired` to a handled result). This wedge is the next layer:
+  the subprocess timeout must also be *smaller than the host hook timeout*.
+- Static hook contract validator: `scripts/validation/hook_contracts.py` validates settings.json
+  timeout range (1-300) and exit-code docs, but does NOT yet cross-check internal subprocess
+  timeouts against host timeouts. Candidate future gate.
+- Consumer-repo identity guard rationale: issue #2610 (git-origin authoritative, not `.agents/`).

--- a/.serena/memories/root-cause-pretooluse-bash-hook-wedge.md
+++ b/.serena/memories/root-cause-pretooluse-bash-hook-wedge.md
@@ -67,11 +67,16 @@ instead of pushing total wall-clock past the host timeout.
   in `.claude/settings.json`). Failure still degrades to
   None -> identity "unknown" -> pyproject `[project].name` corroboration keeps project identity
   correct. No generator run needed (straight lib sync; all three copies edited identically).
-- `.claude/hooks/PreToolUse/invoke_correction_applier.py`: bounded the `.serena/memories` scan
+- `.claude/hooks/PreToolUse/invoke_correction_applier.py` (+ generated Copilot mirror
+  `src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py`, regenerated via
+  `build/scripts/generate_hooks.py`): bounded the `.serena/memories` scan
   (`_MAX_FILES_SCANNED`, `_MAX_TOTAL_BYTES`, wall-clock deadline) AND anchored a
   `_HOOK_WALL_BUDGET_SECONDS = 2.5` deadline at `main()` entry, passed into `scan_memories`, so
-  git-time + scan-time together stay under the correction-applier host timeout (3s). Single copy
-  (no generated mirror).
+  git-time + scan-time together stay under the correction-applier host timeout (3s). The directory
+  walk itself is now bounded during lazy `rglob` iteration (see `_collect_memory_files`): the prior
+  `sorted(rglob(...))` materialized and ordered the entire tree before any cap applied, which on an
+  800+ file corpus could blow the host timeout this hook exists to prevent. `scan_memories` also
+  clamps a caller-supplied hook-wide deadline to its own `_SCAN_DEADLINE_SECONDS` budget.
 - `tests/test_hook_plugin_guards.py::test_origin_lookup_timeout_under_host_budget`: regression
   guard. Reads `.claude/settings.json`, takes the minimum explicit PreToolUse hook timeout, and
   asserts the git lookup timeout is strictly less than it. Catches both a future git-timeout

--- a/scripts/hook_utilities/guards.py
+++ b/scripts/hook_utilities/guards.py
@@ -49,7 +49,18 @@ def _remote_repo_name(project_root: str) -> str | None:
             capture_output=True,
             encoding="utf-8",
             errors="replace",
-            timeout=5,
+            # skip_if_consumer_repo() runs this on every tool use. The tightest
+            # host hook timeout that invokes it is 2s (topical-memory-injection
+            # in .claude/settings.json), so keep this subprocess timeout strictly
+            # below that: a slow or hung git must degrade to None here, not let
+            # the host SIGKILL the whole hook. A SIGKILL cannot be caught by the
+            # caller's fail-open try/except, so it surfaces as a hard "hook
+            # errored" deny of the command (repo-settings Bash-hook wedge RCA).
+            # A local `git remote get-url origin` reads .git/config in <10ms;
+            # 1s only trips on a genuine hang, which is exactly when we want to
+            # degrade fast. Enforced by tests/test_hook_plugin_guards.py::
+            # test_origin_lookup_timeout_under_host_budget.
+            timeout=1,
             check=True,
         )
     except (OSError, subprocess.SubprocessError):

--- a/scripts/sync_plugin_lib.py
+++ b/scripts/sync_plugin_lib.py
@@ -320,7 +320,7 @@ def _imports_scripts_package(tree: ast.Module) -> bool:
     """
 
     def _is_scripts(name: str | None) -> bool:
-        return bool(name) and (name == "scripts" or name.startswith("scripts."))
+        return name is not None and (name == "scripts" or name.startswith("scripts."))
 
     def _dynamic_import_target(node: ast.Call) -> str | None:
         """Return the literal module string of a dynamic import call, else None."""

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
@@ -418,6 +418,29 @@ def _original_main(stdin_bytes):
         return matches
 
 
+    def _collect_memory_files(memories_dir: Path, deadline: float) -> list[Path]:
+        """Return up to ``_MAX_FILES_SCANNED`` ``*.md`` paths, bounded by ``deadline``.
+
+        ``Path.rglob`` returns a lazy generator; iterating it drives the directory
+        walk. The count and deadline checks run DURING iteration so a huge or slow
+        ``.serena/memories/`` tree cannot blow the host hook timeout before the read
+        loop is even entered. Sorting the whole ``rglob`` result up front (the prior
+        behavior) materialized and ordered the entire tree first, defeating the very
+        wedge this hook exists to prevent. The bounded result is sorted afterward so
+        ordering is deterministic within the cap; when the corpus fits under the cap
+        (the normal case) ordering is fully deterministic.
+        """
+        collected: list[Path] = []
+        for md_file in memories_dir.rglob("*.md"):
+            if len(collected) >= _MAX_FILES_SCANNED:
+                break
+            if time.monotonic() >= deadline:
+                break
+            collected.append(md_file)
+        collected.sort()
+        return collected
+
+
     def scan_memories(project_root: str, deadline: float | None = None) -> list[tuple[str, str]]:
         """Scan .serena/memories/ for HIGH confidence corrections.
 
@@ -428,8 +451,10 @@ def _original_main(stdin_bytes):
         wedge every Bash command (fail-closed-on-timeout regression).
 
         Files are visited in sorted order for determinism. ``deadline`` is an
-        absolute ``time.monotonic()`` value; when omitted it is derived from
-        ``_SCAN_DEADLINE_SECONDS``.
+        absolute ``time.monotonic()`` value. When a caller passes a larger hook-wide
+        deadline (``_HOOK_WALL_BUDGET_SECONDS`` from ``main()``), the scan still caps
+        itself at ``_SCAN_DEADLINE_SECONDS`` so it never consumes the whole hook
+        budget, matching the "stops after ``_SCAN_DEADLINE_SECONDS``" contract above.
 
         Returns list of (source_file, correction_text) tuples.
         """
@@ -437,15 +462,14 @@ def _original_main(stdin_bytes):
         if not memories_dir.is_dir():
             return []
 
-        if deadline is None:
-            deadline = time.monotonic() + _SCAN_DEADLINE_SECONDS
+        scan_deadline = time.monotonic() + _SCAN_DEADLINE_SECONDS
+        deadline = scan_deadline if deadline is None else min(deadline, scan_deadline)
 
         all_corrections: list[tuple[str, str]] = []
-        files_scanned = 0
         total_bytes = 0
 
-        for md_file in sorted(memories_dir.rglob("*.md")):
-            if files_scanned >= _MAX_FILES_SCANNED or total_bytes >= _MAX_TOTAL_BYTES:
+        for md_file in _collect_memory_files(memories_dir, deadline):
+            if total_bytes >= _MAX_TOTAL_BYTES:
                 break
             if time.monotonic() >= deadline:
                 break
@@ -453,7 +477,6 @@ def _original_main(stdin_bytes):
                 content = md_file.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError):
                 continue
-            files_scanned += 1
             total_bytes += len(content)
             corrections = extract_high_corrections(content)
             for c in corrections:

--- a/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
@@ -258,6 +258,7 @@ def _original_main(stdin_bytes):
     import os
     import re
     import sys
+    import time
     from pathlib import Path
 
     # Bootstrap: find lib directory via env var or manifest walk-up.
@@ -267,7 +268,7 @@ def _original_main(stdin_bytes):
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
     if _plugin_root:
-        _lib_dir = str(Path(_plugin_root).resolve() / "lib")
+        _lib_dir: str | None = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
         _lib_dir = None
@@ -279,7 +280,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         # Non-blocking hook: exit 0 on bootstrap failure (intentional, not a typo)
         sys.exit(0)
     if _lib_dir not in sys.path:
@@ -315,6 +320,24 @@ def _original_main(stdin_bytes):
     MAX_CORRECTIONS = 3
     # Minimum keyword length to avoid false positives
     MIN_KEYWORD_LENGTH = 4
+    # Scan bounds (issue: advisory PreToolUse hook must never wedge the session).
+    # This hook runs on EVERY Bash command with a tight host timeout (3s in
+    # .claude/settings.json). A host timeout kills the process (SIGKILL), which
+    # the try/except in main() cannot catch, so the "advisory, never blocks"
+    # contract silently becomes fail-CLOSED and denies every command once the
+    # memory corpus grows past the budget. These caps keep the scan best-effort
+    # and bounded so wall-clock stays well under the host timeout regardless of
+    # how large .serena/memories/ becomes.
+    _SCAN_DEADLINE_SECONDS = 1.5
+    _MAX_FILES_SCANNED = 500
+    _MAX_TOTAL_BYTES = 5_000_000
+    # Total wall-clock budget for the whole hook body, anchored at main() start and
+    # kept under the 3s host timeout (.claude/settings.json). skip_if_consumer_repo()
+    # may spend up to its git subprocess timeout before the scan runs, so anchoring
+    # the scan deadline here (not at scan start) makes a slow git shrink the scan
+    # window instead of pushing total wall-clock past the host timeout and tripping
+    # a SIGKILL-into-"hook errored" deny.
+    _HOOK_WALL_BUDGET_SECONDS = 2.5
 
 
     def parse_command(stdin_data: str) -> str | None:
@@ -328,8 +351,11 @@ def _original_main(stdin_bytes):
             try:
                 tool_input = json.loads(tool_input)
             except (json.JSONDecodeError, TypeError):
-                return tool_input
-        return tool_input.get("command") if isinstance(tool_input, dict) else None
+                return tool_input if isinstance(tool_input, str) else None
+        if isinstance(tool_input, dict):
+            command = tool_input.get("command")
+            return command if isinstance(command, str) else None
+        return None
 
 
     def extract_high_corrections(content: str) -> list[str]:
@@ -392,8 +418,18 @@ def _original_main(stdin_bytes):
         return matches
 
 
-    def scan_memories(project_root: str) -> list[tuple[str, str]]:
+    def scan_memories(project_root: str, deadline: float | None = None) -> list[tuple[str, str]]:
         """Scan .serena/memories/ for HIGH confidence corrections.
+
+        Best-effort and bounded: stops after ``_SCAN_DEADLINE_SECONDS`` wall clock,
+        ``_MAX_FILES_SCANNED`` files, or ``_MAX_TOTAL_BYTES`` read, whichever comes
+        first. This is advisory context, so surfacing a subset is acceptable; the
+        hard requirement is that the scan cannot exceed the host hook timeout and
+        wedge every Bash command (fail-closed-on-timeout regression).
+
+        Files are visited in sorted order for determinism. ``deadline`` is an
+        absolute ``time.monotonic()`` value; when omitted it is derived from
+        ``_SCAN_DEADLINE_SECONDS``.
 
         Returns list of (source_file, correction_text) tuples.
         """
@@ -401,13 +437,24 @@ def _original_main(stdin_bytes):
         if not memories_dir.is_dir():
             return []
 
-        all_corrections: list[tuple[str, str]] = []
+        if deadline is None:
+            deadline = time.monotonic() + _SCAN_DEADLINE_SECONDS
 
-        for md_file in memories_dir.rglob("*.md"):
+        all_corrections: list[tuple[str, str]] = []
+        files_scanned = 0
+        total_bytes = 0
+
+        for md_file in sorted(memories_dir.rglob("*.md")):
+            if files_scanned >= _MAX_FILES_SCANNED or total_bytes >= _MAX_TOTAL_BYTES:
+                break
+            if time.monotonic() >= deadline:
+                break
             try:
                 content = md_file.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError):
                 continue
+            files_scanned += 1
+            total_bytes += len(content)
             corrections = extract_high_corrections(content)
             for c in corrections:
                 all_corrections.append((md_file.name, c))
@@ -418,6 +465,7 @@ def _original_main(stdin_bytes):
     def main() -> int:
         """Main entry point. Always returns 0 (advisory, never blocks)."""
         hook_name = "correction-applier"
+        deadline = time.monotonic() + _HOOK_WALL_BUDGET_SECONDS
         try:
             if skip_if_consumer_repo(hook_name):
                 return 0
@@ -438,7 +486,7 @@ def _original_main(stdin_bytes):
                 return 0
 
             project_root = get_project_directory()
-            all_corrections = scan_memories(project_root)
+            all_corrections = scan_memories(project_root, deadline=deadline)
             if not all_corrections:
                 return 0
 

--- a/src/copilot-cli/lib/hook_utilities/guards.py
+++ b/src/copilot-cli/lib/hook_utilities/guards.py
@@ -49,7 +49,18 @@ def _remote_repo_name(project_root: str) -> str | None:
             capture_output=True,
             encoding="utf-8",
             errors="replace",
-            timeout=5,
+            # skip_if_consumer_repo() runs this on every tool use. The tightest
+            # host hook timeout that invokes it is 2s (topical-memory-injection
+            # in .claude/settings.json), so keep this subprocess timeout strictly
+            # below that: a slow or hung git must degrade to None here, not let
+            # the host SIGKILL the whole hook. A SIGKILL cannot be caught by the
+            # caller's fail-open try/except, so it surfaces as a hard "hook
+            # errored" deny of the command (repo-settings Bash-hook wedge RCA).
+            # A local `git remote get-url origin` reads .git/config in <10ms;
+            # 1s only trips on a genuine hang, which is exactly when we want to
+            # degrade fast. Enforced by tests/test_hook_plugin_guards.py::
+            # test_origin_lookup_timeout_under_host_budget.
+            timeout=1,
             check=True,
         )
     except (OSError, subprocess.SubprocessError):

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -20,6 +20,7 @@ Verification scope (per task M6-T5):
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -329,21 +330,33 @@ class TestCopilotBinaryInstall:
         return binary
 
     def test_copilot_plugin_install_succeeds(
-        self, copilot_binary: str, installed_plugin: Path, tmp_path: Path
+        self,
+        copilot_binary: str,
+        installed_plugin: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """`copilot plugin install <local-dir>` exits 0 and registers the plugin.
 
-        Restores global state in a finally block: the install writes an enabled
-        marketplace-less entry into the real ~/.copilot/config.json whose source
-        is this test's tmp dir. Without cleanup, pytest deletes the tmp source
-        and the stale shadow wedges every later Copilot session.
+        Runs against an isolated ``HOME`` so the install writes to a throwaway
+        ``$HOME/.copilot/config.json`` under ``tmp_path`` instead of the real
+        user config. This removes the high-impact side effect of mutating the
+        contributor's global Copilot state: even if the process is killed before
+        the finally block, only the tmp config is affected. ``COPILOT_HOME`` is
+        redirected to the same isolated root so the cleanup targets it. Verified
+        the binary honors an isolated ``HOME`` for a local-dir install.
         """
+        isolated_home = tmp_path / "copilot-home"
+        isolated_home.mkdir()
+        monkeypatch.setattr(f"{__name__}.COPILOT_HOME", isolated_home / ".copilot")
+        env = {**os.environ, "HOME": str(isolated_home)}
         try:
             install_result = subprocess.run(
                 [copilot_binary, "plugin", "install", str(installed_plugin)],
                 capture_output=True,
                 text=True,
                 timeout=60,
+                env=env,
             )
             assert install_result.returncode == 0, (
                 f"copilot plugin install failed:\n"
@@ -356,6 +369,7 @@ class TestCopilotBinaryInstall:
                 capture_output=True,
                 text=True,
                 timeout=30,
+                env=env,
             )
             assert list_result.returncode == 0
             assert "project-toolkit" in list_result.stdout, (

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -285,7 +285,8 @@ def _remove_direct_shadow(source_dir: Path) -> None:
             return False
         if entry.get("name") != PLUGIN_NAME or entry.get("marketplace"):
             return False
-        src_path = (entry.get("source") or {}).get("path")
+        source = entry.get("source")
+        src_path = source.get("path") if isinstance(source, dict) else None
         if not src_path:
             return False
         candidate = Path(src_path)
@@ -294,7 +295,7 @@ def _remove_direct_shadow(source_dir: Path) -> None:
         except (OSError, RuntimeError):
             candidate_resolved = candidate
         return (
-            str(candidate) == str(source_dir)
+            candidate.as_posix() == source_dir.as_posix()
             or candidate_resolved == source_resolved
             or source_parent in candidate_resolved.parents
         )

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -32,6 +32,12 @@ COPILOT_PLUGIN_SRC = REPO_ROOT / "src" / "copilot-cli"
 COPILOT_PLUGIN_MANIFEST = COPILOT_PLUGIN_SRC / ".claude-plugin" / "plugin.json"
 COPILOT_HOOKS_FILE = COPILOT_PLUGIN_SRC / "hooks" / "hooks.json"
 
+# Real Copilot CLI home. The binary-dependent smoke test below shells out to
+# `copilot plugin install`, which mutates this global config; teardown must
+# restore it (see _remove_direct_shadow).
+COPILOT_HOME = Path.home() / ".copilot"
+PLUGIN_NAME = "project-toolkit"
+
 # Copilot CLI hook event names. PascalCase event keys make Copilot CLI emit the
 # VS Code-compatible snake_case payload (tool_name, tool_input) the shims expect;
 # camelCase keys emit camelCase fields and break the shim contract (issue #2290).
@@ -230,6 +236,82 @@ class TestInstalledArtifactReadability:
 # ---- Conditional binary test (skips when Copilot CLI not installed) ------
 
 
+def _strip_jsonc(text: str) -> str:
+    """Drop whole-line ``//`` comments from Copilot's managed config.json.
+
+    Copilot writes a JSON-with-comments header ("This file is managed
+    automatically."). No string value in this file begins a line with ``//``,
+    so a line-oriented strip is sufficient and avoids a JSONC dependency.
+    """
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("//")
+    )
+
+
+def _remove_direct_shadow(source_dir: Path) -> None:
+    """Undo the global side effect of ``copilot plugin install <source_dir>``.
+
+    ``copilot plugin install <local-dir>`` registers a marketplace-less
+    ("_direct") entry in the real ~/.copilot/config.json whose ``source.path``
+    is ``source_dir``. Because ``source_dir`` lives under pytest's ``tmp_path``,
+    pytest deletes it after the test, leaving an *enabled* duplicate hook
+    install pointing at a dead path. That stale shadow doubles PreToolUse hook
+    dispatch and, on version skew with the real marketplace install, can wedge
+    every later Copilot session (all shell tools denied with "hook errored").
+
+    Remove only the entry this test created so global state is restored. Match
+    is scoped to a ``project-toolkit`` entry with no marketplace whose
+    ``source.path`` resolves to ``source_dir`` (or under its tmp parent), so an
+    unrelated real install is never touched.
+    """
+    config_path = COPILOT_HOME / "config.json"
+    if not config_path.is_file():
+        return
+    try:
+        config = json.loads(_strip_jsonc(config_path.read_text(encoding="utf-8")))
+    except (OSError, ValueError):
+        return
+
+    plugins = config.get("installedPlugins")
+    if not isinstance(plugins, list):
+        return
+
+    source_resolved = source_dir.resolve()
+    source_parent = source_resolved.parent
+
+    def _is_created_shadow(entry: object) -> bool:
+        if not isinstance(entry, dict):
+            return False
+        if entry.get("name") != PLUGIN_NAME or entry.get("marketplace"):
+            return False
+        src_path = (entry.get("source") or {}).get("path")
+        if not src_path:
+            return False
+        candidate = Path(src_path)
+        try:
+            candidate_resolved = candidate.resolve()
+        except (OSError, RuntimeError):
+            candidate_resolved = candidate
+        return (
+            str(candidate) == str(source_dir)
+            or candidate_resolved == source_resolved
+            or source_parent in candidate_resolved.parents
+        )
+
+    remaining = [entry for entry in plugins if not _is_created_shadow(entry)]
+    if len(remaining) == len(plugins):
+        return  # This test did not register a shadow; leave the file untouched.
+
+    config["installedPlugins"] = remaining
+    config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+
+    cache_dir = COPILOT_HOME / "installed-plugins" / "_direct" / PLUGIN_NAME
+    if cache_dir.is_dir():
+        shutil.rmtree(cache_dir, ignore_errors=True)
+
+
+
+
 class TestCopilotBinaryInstall:
     """Smoke test: invoke `copilot` to install the plugin and list it.
 
@@ -247,27 +329,145 @@ class TestCopilotBinaryInstall:
     def test_copilot_plugin_install_succeeds(
         self, copilot_binary: str, installed_plugin: Path, tmp_path: Path
     ) -> None:
-        """`copilot plugin install <local-dir>` exits 0 and registers the plugin."""
-        install_result = subprocess.run(
-            [copilot_binary, "plugin", "install", str(installed_plugin)],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-        assert install_result.returncode == 0, (
-            f"copilot plugin install failed:\n"
-            f"stdout: {install_result.stdout}\n"
-            f"stderr: {install_result.stderr}"
-        )
+        """`copilot plugin install <local-dir>` exits 0 and registers the plugin.
 
-        list_result = subprocess.run(
-            [copilot_binary, "plugin", "list"],
-            capture_output=True,
-            text=True,
-            timeout=30,
+        Restores global state in a finally block: the install writes an enabled
+        marketplace-less entry into the real ~/.copilot/config.json whose source
+        is this test's tmp dir. Without cleanup, pytest deletes the tmp source
+        and the stale shadow wedges every later Copilot session.
+        """
+        try:
+            install_result = subprocess.run(
+                [copilot_binary, "plugin", "install", str(installed_plugin)],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            assert install_result.returncode == 0, (
+                f"copilot plugin install failed:\n"
+                f"stdout: {install_result.stdout}\n"
+                f"stderr: {install_result.stderr}"
+            )
+
+            list_result = subprocess.run(
+                [copilot_binary, "plugin", "list"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert list_result.returncode == 0
+            assert "project-toolkit" in list_result.stdout, (
+                f"project-toolkit not registered after install:\n"
+                f"{list_result.stdout}"
+            )
+        finally:
+            _remove_direct_shadow(installed_plugin)
+
+
+@pytest.mark.integration
+class TestDirectShadowCleanup:
+    """Unit coverage for _remove_direct_shadow (runs without the copilot binary).
+
+    Guards the regression where the binary smoke test left an enabled
+    marketplace-less project-toolkit install in the real ~/.copilot/config.json
+    pointing at a deleted pytest tmp dir, wedging later Copilot sessions.
+    """
+
+    @staticmethod
+    def _write_config(copilot_home: Path, plugins: list[dict]) -> Path:
+        copilot_home.mkdir(parents=True, exist_ok=True)
+        config_path = copilot_home / "config.json"
+        config_path.write_text(
+            "// This file is managed automatically.\n"
+            + json.dumps({"installedPlugins": plugins}),
+            encoding="utf-8",
         )
-        assert list_result.returncode == 0
-        assert "project-toolkit" in list_result.stdout, (
-            f"project-toolkit not registered after install:\n"
-            f"{list_result.stdout}"
-        )
+        return config_path
+
+    def test_removes_only_the_created_shadow(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        copilot_home = tmp_path / ".copilot"
+        source_dir = tmp_path / "src" / PLUGIN_NAME
+        source_dir.mkdir(parents=True)
+        real = {"name": PLUGIN_NAME, "marketplace": "ai-agents", "enabled": True}
+        shadow = {
+            "name": PLUGIN_NAME,
+            "marketplace": "",
+            "enabled": True,
+            "source": {"source": "local", "path": str(source_dir)},
+        }
+        other = {"name": "caveman", "marketplace": "caveman", "enabled": True}
+        config_path = self._write_config(copilot_home, [real, shadow, other])
+        cache_dir = copilot_home / "installed-plugins" / "_direct" / PLUGIN_NAME
+        cache_dir.mkdir(parents=True)
+        monkeypatch.setattr(f"{__name__}.COPILOT_HOME", copilot_home)
+
+        _remove_direct_shadow(source_dir)
+
+        result = json.loads(_strip_jsonc(config_path.read_text(encoding="utf-8")))
+        surviving = [
+            (entry["name"], entry.get("marketplace"))
+            for entry in result["installedPlugins"]
+        ]
+        assert (PLUGIN_NAME, "") not in surviving
+        assert (PLUGIN_NAME, "ai-agents") in surviving
+        assert ("caveman", "caveman") in surviving
+        assert not cache_dir.exists()
+
+    def test_preserves_config_without_a_shadow(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        copilot_home = tmp_path / ".copilot"
+        source_dir = tmp_path / "src" / PLUGIN_NAME
+        real = {"name": PLUGIN_NAME, "marketplace": "ai-agents", "enabled": True}
+        config_path = self._write_config(copilot_home, [real])
+        before = config_path.read_text(encoding="utf-8")
+        monkeypatch.setattr(f"{__name__}.COPILOT_HOME", copilot_home)
+
+        _remove_direct_shadow(source_dir)
+
+        assert config_path.read_text(encoding="utf-8") == before
+
+    def test_leaves_unrelated_direct_install_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        copilot_home = tmp_path / ".copilot"
+        source_dir = tmp_path / "src" / PLUGIN_NAME
+        unrelated = {
+            "name": PLUGIN_NAME,
+            "marketplace": "",
+            "enabled": True,
+            "source": {"source": "local", "path": "/some/other/checkout"},
+        }
+        config_path = self._write_config(copilot_home, [unrelated])
+        monkeypatch.setattr(f"{__name__}.COPILOT_HOME", copilot_home)
+
+        _remove_direct_shadow(source_dir)
+
+        result = json.loads(_strip_jsonc(config_path.read_text(encoding="utf-8")))
+        assert result["installedPlugins"] == [unrelated]
+
+    def test_noop_when_config_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        copilot_home = tmp_path / ".copilot"
+        monkeypatch.setattr(f"{__name__}.COPILOT_HOME", copilot_home)
+
+        _remove_direct_shadow(tmp_path / "src" / PLUGIN_NAME)  # must not raise
+
+        assert not (copilot_home / "config.json").exists()
+
+    def test_survives_malformed_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        copilot_home = tmp_path / ".copilot"
+        copilot_home.mkdir(parents=True)
+        config_path = copilot_home / "config.json"
+        config_path.write_text("{ not valid json", encoding="utf-8")
+        monkeypatch.setattr(f"{__name__}.COPILOT_HOME", copilot_home)
+
+        _remove_direct_shadow(tmp_path / "src" / PLUGIN_NAME)  # must not raise
+
+        assert config_path.read_text(encoding="utf-8") == "{ not valid json"
+

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -24,6 +24,7 @@ import re
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -74,7 +75,7 @@ def _resolve_case_sensitive(root: Path, relative: str) -> bool:
     return current.is_file()
 
 
-def _iter_hook_script_paths(hooks_data: dict) -> list[str]:
+def _iter_hook_script_paths(hooks_data: dict[str, Any]) -> list[str]:
     """Yield every distinct /hooks/<rel>.py script path across bash and powershell."""
     paths: list[str] = []
     for entries in hooks_data.get("hooks", {}).values():
@@ -374,7 +375,7 @@ class TestDirectShadowCleanup:
     """
 
     @staticmethod
-    def _write_config(copilot_home: Path, plugins: list[dict]) -> Path:
+    def _write_config(copilot_home: Path, plugins: list[dict[str, Any]]) -> Path:
         copilot_home.mkdir(parents=True, exist_ok=True)
         config_path = copilot_home / "config.json"
         config_path.write_text(

--- a/tests/test_hook_plugin_guards.py
+++ b/tests/test_hook_plugin_guards.py
@@ -130,6 +130,55 @@ class TestRemoteRepoName:
         assert captured_kwargs["errors"] == "replace"
         assert captured_kwargs["check"] is True
 
+    def test_origin_lookup_timeout_under_host_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The per-tool-call git lookup must finish inside the tightest host timeout.
+
+        ``skip_if_consumer_repo`` calls ``_remote_repo_name`` on every tool use,
+        and several PreToolUse Bash hooks invoke it (correction-applier,
+        routing-gates, lsp-bash-grep-guard). If this git subprocess timeout is
+        >= a host hook's timeout, a slow or hung git lets the host SIGKILL the
+        whole hook before the caller can fail open, which Copilot surfaces as a
+        hard "hook errored" deny of every command (repo-settings Bash-hook
+        wedge). Guard the invariant so a future edit cannot reintroduce it:
+        git timeout must be strictly under the tightest configured host timeout.
+        """
+        settings_path = REPO_ROOT / ".claude" / "settings.json"
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        host_timeouts: list[int] = []
+        for group in settings.get("hooks", {}).get("PreToolUse", []):
+            if not isinstance(group, dict):
+                continue
+            for entry in group.get("hooks", []):
+                if isinstance(entry, dict) and isinstance(entry.get("timeout"), int):
+                    host_timeouts.append(entry["timeout"])
+        assert host_timeouts, "expected explicit PreToolUse hook timeouts in settings.json"
+        tightest_host_timeout = min(host_timeouts)
+
+        captured_kwargs: dict[str, object] = {}
+
+        def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            captured_kwargs.update(kwargs)
+            return subprocess.CompletedProcess(
+                ["git", "-C", "/repo", "remote", "get-url", "origin"],
+                0,
+                stdout="ai-agents\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(guards.shutil, "which", lambda _name: "git")
+        monkeypatch.setattr(guards.subprocess, "run", fake_run)
+
+        assert guards._remote_repo_name("/repo") == "ai-agents"
+        git_timeout = captured_kwargs.get("timeout")
+        assert isinstance(git_timeout, (int, float)), "git lookup must pass a timeout"
+        assert git_timeout < tightest_host_timeout, (
+            f"git lookup timeout {git_timeout}s must be < tightest host hook "
+            f"timeout {tightest_host_timeout}s so a slow git degrades to None "
+            "instead of the host SIGKILLing the hook into a 'hook errored' deny"
+        )
+
     def test_git_missing_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(guards.shutil, "which", lambda _name: None)
         assert guards._remote_repo_name("/repo") is None

--- a/tests/test_invoke_correction_applier.py
+++ b/tests/test_invoke_correction_applier.py
@@ -196,6 +196,64 @@ class TestScanMemories:
         obs.write_text("## Notes\n\n- Just a note.\n", encoding="utf-8")
         assert scan_memories(str(tmp_path)) == []
 
+    def test_traversal_bounded_before_sort(self, tmp_path: Path, monkeypatch) -> None:
+        """A corpus larger than the file cap must not be fully materialized.
+
+        The prior implementation sorted the entire ``rglob`` result before the
+        cap applied, so the whole tree was walked regardless. Bounding during
+        iteration means the walk stops at the cap. We assert the reader only
+        touched a bounded subset by counting distinct source files returned.
+        """
+        import invoke_correction_applier as mod
+
+        monkeypatch.setattr(mod, "_MAX_FILES_SCANNED", 5)
+        memories = tmp_path / ".serena" / "memories"
+        memories.mkdir(parents=True)
+        for i in range(50):
+            (memories / f"obs-{i:03d}.md").write_text(
+                f"## Constraints (HIGH confidence)\n\n- Rule number {i} uses pnpm.\n",
+                encoding="utf-8",
+            )
+        result = scan_memories(str(tmp_path))
+        distinct_sources = {src for src, _ in result}
+        assert len(distinct_sources) <= 5
+
+    def test_scan_caps_at_own_deadline_when_larger_passed(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A caller-supplied deadline larger than the scan budget is clamped.
+
+        ``main()`` passes the hook-wide ``_HOOK_WALL_BUDGET_SECONDS`` deadline.
+        The scan must still cap itself at ``_SCAN_DEADLINE_SECONDS`` so it never
+        consumes the whole hook budget (the docstring contract).
+        """
+        import time as _time
+
+        import invoke_correction_applier as mod
+
+        monkeypatch.setattr(mod, "_SCAN_DEADLINE_SECONDS", 0.0)
+        memories = tmp_path / ".serena" / "memories"
+        memories.mkdir(parents=True)
+        (memories / "obs.md").write_text(
+            "## Constraints (HIGH confidence)\n\n- Use pnpm.\n", encoding="utf-8"
+        )
+        far_deadline = _time.monotonic() + 999.0
+        result = scan_memories(str(tmp_path), deadline=far_deadline)
+        assert result == []
+
+    def test_scan_reads_all_when_under_caps(self, tmp_path: Path) -> None:
+        """Negative control: under the caps, every file is read deterministically."""
+        memories = tmp_path / ".serena" / "memories"
+        memories.mkdir(parents=True)
+        for name in ("b.md", "a.md", "c.md"):
+            (memories / name).write_text(
+                f"## Constraints (HIGH confidence)\n\n- {name} uses pnpm.\n",
+                encoding="utf-8",
+            )
+        result = scan_memories(str(tmp_path))
+        sources = [src for src, _ in result]
+        assert sources == ["a.md", "b.md", "c.md"]
+
 
 class TestMainAllowPath:
     @patch("invoke_correction_applier.skip_if_consumer_repo", return_value=False)


### PR DESCRIPTION
## Summary

Fixes a structural failure class where an advisory, fail-open PreToolUse hook
turns into a hard deny of every Bash command once its wall-clock exceeds the
host hook timeout. Symptom: `Denied by preToolUse hook from "repo settings"
(hook errored)` on every command in Copilot CLI.

Fixes #2947

## Root cause

A per-tool-call PreToolUse hook runs on every Bash command under a tight host
timeout. When the hook's total wall-clock (git subprocess + memory scan)
exceeds that timeout, the host SIGKILLs the process. A SIGKILL is uncatchable,
so the hook's internal try/except "advisory, never blocks" contract silently
becomes fail-CLOSED and denies the command.

Two concrete triggers:

1. The `_remote_repo_name` git lookup used `timeout=5`, but the tightest host
   hook timeout that invokes the guard is 2s (the topical-memory-injection
   hook, matcher `^(Write|Edit)$`). A slow git call alone could blow the
   budget.
2. The correction-applier scanned all of the memory corpus unbounded, so a
   large corpus pushed wall-clock past the host timeout.

## Fix

- Guard git identity lookup timeout 5 -> 1s across all three synced `guards.py`
  copies, keeping wall-clock strictly under the 2s binding host timeout.
- Bound the correction-applier memory scan: deadline anchored at `main()`, plus
  file-count and total-byte caps. The scan stays best-effort and bounded.
- Regression test `test_origin_lookup_timeout_under_host_budget` reads the hook
  settings, takes the min PreToolUse host timeout, and asserts the git timeout
  is strictly less. This encodes the invariant so it cannot regress.
- RCA memory `root-cause-pretooluse-bash-hook-wedge.md` (RootCause-Hooks-001).
- Plugin version bump `.claude` + `src/copilot-cli` to 0.6.5 (parity gate),
  which regenerated the copilot-cli mirror
  `src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py`.

## Incidental gate fixes

Bringing these files into the changed set surfaced latent per-file gate
failures that had to be fixed to land the change:

- `.claude/hooks/PreToolUse/invoke_correction_applier.py` bootstrap typing
  (`_lib_dir: str | None`), a narrowed `parse_command` return, and an E501 wrap.
- `tests/integration/test_e2e_install.py` generic annotations
  (`dict` -> `dict[str, Any]`).
- `scripts/sync_plugin_lib.py` `_is_scripts` narrowed to `name is not None
  and ...` so mypy narrows `str | None` correctly. Any changed test importing
  it surfaced this pre-existing `union-attr` error transitively. Refs #2876.

## The invariant

A per-tool-call hook's total wall-clock (every subprocess plus FS scan) must
stay strictly under the tightest host hook timeout that invokes it. Otherwise a
host SIGKILL turns a fail-open hook into a hard deny of every command.

## Testing

- `pytest tests/test_hook_plugin_guards.py` (63 guard tests) pass, including the
  new regression test.
- Full pre-push suite passes: pytest, hook-anchoring e2e, plugin-load e2e,
  semgrep, drift gates.
- Hook smoke test: piping a Bash tool payload to the hook exits 0.

## References

These files are cited for context and are not changed by this PR:

- `invoke_topical_memory_injection.py` sets the 2s host hook timeout that binds
  the wall-clock budget.
- The `settings.json` hook config is the source of truth the regression test
  reads to derive the min PreToolUse host timeout.
