### PR TITLE
fix(hooks): bound git subprocess timeouts and dedupe homework scanner (#2943, #2944)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PostToolUse/invoke_observation_sync.py
+++ b/.claude/hooks/PostToolUse/invoke_observation_sync.py
@@ -103,7 +103,10 @@ def _get_repo_root() -> str | None:
             check=False,
             timeout=5,
         )
-    except subprocess.TimeoutExpired:
+    except (subprocess.TimeoutExpired, OSError):
+        # TimeoutExpired: git hung. OSError (incl. FileNotFoundError): git
+        # missing or not executable. Either way, degrade to cwd like a
+        # non-zero exit rather than surfacing as a hook error.
         return os.getcwd()
     if result.returncode == 0:
         return result.stdout.strip()

--- a/.claude/hooks/PostToolUse/invoke_observation_sync.py
+++ b/.claude/hooks/PostToolUse/invoke_observation_sync.py
@@ -38,11 +38,11 @@ if not _SECURITY_LOG.handlers:
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/PostToolUse/invoke_observation_sync.py
+++ b/.claude/hooks/PostToolUse/invoke_observation_sync.py
@@ -95,12 +95,16 @@ def _get_repo_root() -> str | None:
             return None
         return env_dir
     # Fixed argv, no user data. Safe.
-    result = subprocess.run(  # nosemgrep: dangerous-subprocess-use-tainted-env-args
-        ["git", "rev-parse", "--show-toplevel"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(  # nosemgrep: dangerous-subprocess-use-tainted-env-args
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired:
+        return os.getcwd()
     if result.returncode == 0:
         return result.stdout.strip()
     return os.getcwd()

--- a/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
@@ -150,11 +150,16 @@ def get_staged_adr_changes() -> list[str]:
 
     Raises on git errors to maintain fail-closed posture for security.
     """
-    result = subprocess.run(
-        ["git", "diff", "--cached", "--name-only"],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired as exc:
+        msg = "git diff --cached timed out after 5s"
+        raise RuntimeError(msg) from exc
     if result.returncode != 0:
         stderr = result.stderr.strip()
         msg = f"git diff --cached failed with exit code {result.returncode}: {stderr}"

--- a/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
@@ -33,11 +33,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")
@@ -263,7 +263,7 @@ def _read_git_commit_command() -> str | None:
         return None
     if not is_git_commit_command(command):
         return None
-    return command
+    return str(command)
 
 
 def _staged_adr_changes_or_block() -> tuple[list[str] | None, int | None]:

--- a/.claude/hooks/SessionStart/invoke_session_initialization_enforcer.py
+++ b/.claude/hooks/SessionStart/invoke_session_initialization_enforcer.py
@@ -68,10 +68,11 @@ def get_current_branch() -> str | None:
             capture_output=True,
             text=True,
             check=False,
+            timeout=5,
         )
         if result.returncode == 0:
             return result.stdout.strip()
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         pass
     return None
 

--- a/.claude/hooks/SessionStart/invoke_session_initialization_enforcer.py
+++ b/.claude/hooks/SessionStart/invoke_session_initialization_enforcer.py
@@ -33,11 +33,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")
@@ -90,7 +90,7 @@ def get_session_status(project_dir: str) -> str:
     session_log = get_today_session_log(sessions_dir)
     if session_log is None:
         return "none (run /session-init)"
-    return session_log.name
+    return str(session_log.name)
 
 
 def main() -> int:

--- a/scripts/detect_test_coverage_gaps.py
+++ b/scripts/detect_test_coverage_gaps.py
@@ -49,11 +49,15 @@ def load_ignore_patterns(ignore_file: str) -> list[str]:
 
 
 def get_staged_ps1_files(repo_root: Path) -> list[str]:
-    result = subprocess.run(
-        ["git", "-C", str(repo_root), "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return []
     if result.returncode != 0:
         return []
     files = [

--- a/scripts/homework_scanner.py
+++ b/scripts/homework_scanner.py
@@ -222,7 +222,7 @@ def find_existing_issue(title: str, owner: str, repo: str) -> int | None:
             shell=False,
             timeout=60,
         )
-    except subprocess.TimeoutExpired:
+    except (subprocess.TimeoutExpired, OSError):
         return None
     if result.returncode != 0:
         return None

--- a/scripts/homework_scanner.py
+++ b/scripts/homework_scanner.py
@@ -193,6 +193,51 @@ def build_issue_body(item: HomeworkItem, owner: str, repo: str) -> str:
     )
 
 
+def find_existing_issue(title: str, owner: str, repo: str) -> int | None:
+    """Return the number of an open-or-closed homework issue whose title matches
+    exactly, else None. Fails open (returns None) on timeout or gh error so a
+    lookup failure never blocks issue creation.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                f"{owner}/{repo}",
+                "--label",
+                "homework",
+                "--state",
+                "all",
+                "--search",
+                title,
+                "--json",
+                "number,title",
+            ],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            shell=False,
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        rows = json.loads(result.stdout or "[]")
+    except (json.JSONDecodeError, ValueError):
+        return None
+    for row in rows:
+        if isinstance(row, dict) and row.get("title") == title:
+            number = row.get("number")
+            if isinstance(number, int):
+                return number
+    return None
+
+
 def create_issues(
     items: list[HomeworkItem], owner: str, repo: str, *, dry_run: bool = False
 ) -> list[dict[str, Any]]:
@@ -218,6 +263,13 @@ def create_issues(
                     "labels": ["homework", "enhancement"],
                     "dry_run": True,
                 }
+            )
+            continue
+
+        existing = find_existing_issue(title, owner, repo)
+        if existing is not None:
+            created.append(
+                {"title": title, "skipped": f"existing issue #{existing}"}
             )
             continue
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
@@ -339,7 +339,10 @@ def _original_main(stdin_bytes):
                 check=False,
                 timeout=5,
             )
-        except subprocess.TimeoutExpired:
+        except (subprocess.TimeoutExpired, OSError):
+            # TimeoutExpired: git hung. OSError (incl. FileNotFoundError): git
+            # missing or not executable. Either way, degrade to cwd like a
+            # non-zero exit rather than surfacing as a hook error.
             return os.getcwd()
         if result.returncode == 0:
             return result.stdout.strip()

--- a/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
@@ -331,12 +331,16 @@ def _original_main(stdin_bytes):
                 return None
             return env_dir
         # Fixed argv, no user data. Safe.
-        result = subprocess.run(  # nosemgrep: dangerous-subprocess-use-tainted-env-args
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        try:
+            result = subprocess.run(  # nosemgrep: dangerous-subprocess-use-tainted-env-args
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+        except subprocess.TimeoutExpired:
+            return os.getcwd()
         if result.returncode == 0:
             return result.stdout.strip()
         return os.getcwd()

--- a/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
@@ -274,11 +274,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -386,11 +386,16 @@ def _original_main(stdin_bytes):
 
         Raises on git errors to maintain fail-closed posture for security.
         """
-        result = subprocess.run(
-            ["git", "diff", "--cached", "--name-only"],
-            capture_output=True,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                ["git", "diff", "--cached", "--name-only"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except subprocess.TimeoutExpired as exc:
+            msg = "git diff --cached timed out after 5s"
+            raise RuntimeError(msg) from exc
         if result.returncode != 0:
             stderr = result.stderr.strip()
             msg = f"git diff --cached failed with exit code {result.returncode}: {stderr}"

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -269,11 +269,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")
@@ -499,7 +499,7 @@ def _original_main(stdin_bytes):
             return None
         if not is_git_commit_command(command):
             return None
-        return command
+        return str(command)
 
 
     def _staged_adr_changes_or_block() -> tuple[list[str] | None, int | None]:

--- a/src/copilot-cli/hooks/SessionStart/invoke_session_initialization_enforcer.py
+++ b/src/copilot-cli/hooks/SessionStart/invoke_session_initialization_enforcer.py
@@ -68,10 +68,11 @@ def get_current_branch() -> str | None:
             capture_output=True,
             text=True,
             check=False,
+            timeout=5,
         )
         if result.returncode == 0:
             return result.stdout.strip()
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         pass
     return None
 

--- a/src/copilot-cli/hooks/SessionStart/invoke_session_initialization_enforcer.py
+++ b/src/copilot-cli/hooks/SessionStart/invoke_session_initialization_enforcer.py
@@ -33,11 +33,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")
@@ -90,7 +90,7 @@ def get_session_status(project_dir: str) -> str:
     session_log = get_today_session_log(sessions_dir)
     if session_log is None:
         return "none (run /session-init)"
-    return session_log.name
+    return str(session_log.name)
 
 
 def main() -> int:

--- a/tests/hooks/test_adr_review_guard.py
+++ b/tests/hooks/test_adr_review_guard.py
@@ -316,13 +316,13 @@ class TestGetStagedADRChangesSubprocessErrors:
             with pytest.raises(FileNotFoundError, match="git not found"):
                 invoke_adr_review_guard.get_staged_adr_changes()
 
-    def test_timeout_expired_bubbles_up(self):
-        """TimeoutExpired propagates to caller."""
+    def test_timeout_expired_converts_to_runtime_error(self):
+        """TimeoutExpired is converted to a fail-closed RuntimeError (issue #2943)."""
         with patch(
             "subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd="git", timeout=30),
+            side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5),
         ):
-            with pytest.raises(subprocess.TimeoutExpired):
+            with pytest.raises(RuntimeError, match="timed out"):
                 invoke_adr_review_guard.get_staged_adr_changes()
 
 

--- a/tests/test_homework_scanner.py
+++ b/tests/test_homework_scanner.py
@@ -229,6 +229,25 @@ class TestCreateIssuesDedupe:
         assert any("create" in c for c in calls)
         assert created[0]["url"] == "https://github.com/o/r/issues/9"
 
+    def test_search_oserror_proceeds_to_create(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            if "list" in cmd:
+                raise FileNotFoundError("gh not found")
+            return MagicMock(
+                returncode=0,
+                stdout="https://github.com/o/r/issues/11",
+                stderr="",
+            )
+
+        with patch("scripts.homework_scanner.subprocess.run", side_effect=fake_run):
+            created = create_issues([self._item()], "o", "r", dry_run=False)
+
+        assert any("create" in c for c in calls)
+        assert created[0]["url"] == "https://github.com/o/r/issues/11"
+
     def test_near_miss_title_still_creates(self) -> None:
         def fake_run(cmd, *args, **kwargs):
             if "list" in cmd:

--- a/tests/test_homework_scanner.py
+++ b/tests/test_homework_scanner.py
@@ -175,6 +175,82 @@ class TestCreateIssuesTimeout:
         assert "timed out" in created[0]["error"]
 
 
+class TestCreateIssuesDedupe:
+    """Search-before-create idempotency (issue #2944, deferred #2811 item 10)."""
+
+    def _item(self) -> HomeworkItem:
+        return HomeworkItem(
+            pr_number=42,
+            comment_id=123,
+            author="reviewer",
+            body_excerpt="Deferred to follow-up",
+            matched_pattern="deferred",
+            comment_url="https://github.com/o/r/pull/42#discussion_r123",
+            source_type="review_comment",
+        )
+
+    def _expected_title(self) -> str:
+        return "Homework: Deferred to follow-up"
+
+    def test_existing_issue_skips_create(self) -> None:
+        title = self._expected_title()
+
+        def fake_run(cmd, *args, **kwargs):
+            if "list" in cmd:
+                return MagicMock(
+                    returncode=0,
+                    stdout=json.dumps([{"number": 7, "title": title}]),
+                    stderr="",
+                )
+            raise AssertionError("gh issue create must not be called for a dupe")
+
+        with patch("scripts.homework_scanner.subprocess.run", side_effect=fake_run):
+            created = create_issues([self._item()], "o", "r", dry_run=False)
+
+        assert len(created) == 1
+        assert created[0]["skipped"] == "existing issue #7"
+
+    def test_search_timeout_proceeds_to_create(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            if "list" in cmd:
+                raise subprocess.TimeoutExpired(cmd="gh", timeout=60)
+            return MagicMock(
+                returncode=0,
+                stdout="https://github.com/o/r/issues/9",
+                stderr="",
+            )
+
+        with patch("scripts.homework_scanner.subprocess.run", side_effect=fake_run):
+            created = create_issues([self._item()], "o", "r", dry_run=False)
+
+        assert any("create" in c for c in calls)
+        assert created[0]["url"] == "https://github.com/o/r/issues/9"
+
+    def test_near_miss_title_still_creates(self) -> None:
+        def fake_run(cmd, *args, **kwargs):
+            if "list" in cmd:
+                return MagicMock(
+                    returncode=0,
+                    stdout=json.dumps(
+                        [{"number": 5, "title": "Homework: Deferred to follow-up LATER"}]
+                    ),
+                    stderr="",
+                )
+            return MagicMock(
+                returncode=0,
+                stdout="https://github.com/o/r/issues/10",
+                stderr="",
+            )
+
+        with patch("scripts.homework_scanner.subprocess.run", side_effect=fake_run):
+            created = create_issues([self._item()], "o", "r", dry_run=False)
+
+        assert created[0]["url"] == "https://github.com/o/r/issues/10"
+
+
 # --- Scan PR tests ---
 
 

--- a/tests/test_timeout_hardening_2811c.py
+++ b/tests/test_timeout_hardening_2811c.py
@@ -61,6 +61,19 @@ def test_observation_sync_timeout_degrades_to_cwd() -> None:
     assert result == _obs.os.getcwd()
 
 
+def test_observation_sync_missing_git_degrades_to_cwd() -> None:
+    # git binary absent: subprocess.run raises FileNotFoundError (an OSError).
+    # The helper must degrade to cwd, not surface the OSError to the hook.
+    with (
+        patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": ""}),
+        patch.object(
+            _obs.subprocess, "run", side_effect=FileNotFoundError("git")
+        ),
+    ):
+        result = _obs._get_repo_root()
+    assert result == _obs.os.getcwd()
+
+
 # --- adr_review_guard.get_staged_adr_changes ------------------------------
 
 

--- a/tests/test_timeout_hardening_2811c.py
+++ b/tests/test_timeout_hardening_2811c.py
@@ -1,0 +1,104 @@
+"""Subprocess timeout hardening, residual hook sites (issue #2943, deferred #2811).
+
+Every git call on a hook path (SessionStart / PreToolUse / PostToolUse) and the
+staged-file scan in detect_test_coverage_gaps must pass a timeout kwarg and
+degrade gracefully when the subprocess hangs, so a wedged git call can never
+hang the agent session. See issue #2943.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_REPO = Path(__file__).resolve().parents[1]
+_HOOKS = _REPO / ".claude" / "hooks"
+
+# Match the import convention used by tests/hooks/* so every test shares one
+# module object per hook (avoids sys.modules pollution across the session).
+for _sub in ("PostToolUse", "PreToolUse", "SessionStart"):
+    _p = str(_HOOKS / _sub)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import invoke_adr_review_guard as _adr  # noqa: E402
+import invoke_observation_sync as _obs  # noqa: E402
+import invoke_session_initialization_enforcer as _sess  # noqa: E402
+
+import scripts.detect_test_coverage_gaps as _cov  # noqa: E402
+
+
+def _ok_result(stdout: str = "") -> MagicMock:
+    result = MagicMock()
+    result.returncode = 0
+    result.stdout = stdout
+    result.stderr = ""
+    return result
+
+
+# --- observation_sync._get_repo_root --------------------------------------
+
+
+def test_observation_sync_passes_timeout() -> None:
+    with patch.object(_obs.subprocess, "run", return_value=_ok_result("/repo")) as run:
+        _obs._get_repo_root()
+    assert run.call_args.kwargs.get("timeout") == 5
+
+
+def test_observation_sync_timeout_degrades_to_cwd() -> None:
+    timeout = subprocess.TimeoutExpired(cmd="git", timeout=5)
+    with patch.object(_obs.subprocess, "run", side_effect=timeout):
+        result = _obs._get_repo_root()
+    assert result == _obs.os.getcwd()
+
+
+# --- adr_review_guard.get_staged_adr_changes ------------------------------
+
+
+def test_adr_guard_passes_timeout() -> None:
+    with patch.object(_adr.subprocess, "run", return_value=_ok_result("")) as run:
+        _adr.get_staged_adr_changes()
+    assert run.call_args.kwargs.get("timeout") == 5
+
+
+def test_adr_guard_timeout_raises_runtime_error() -> None:
+    timeout = subprocess.TimeoutExpired(cmd="git", timeout=5)
+    with patch.object(_adr.subprocess, "run", side_effect=timeout):
+        try:
+            _adr.get_staged_adr_changes()
+        except RuntimeError as exc:
+            assert "timed out" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError on timeout")
+
+
+# --- session_initialization_enforcer.get_current_branch -------------------
+
+
+def test_session_enforcer_passes_timeout() -> None:
+    with patch.object(_sess.subprocess, "run", return_value=_ok_result("main")) as run:
+        _sess.get_current_branch()
+    assert run.call_args.kwargs.get("timeout") == 5
+
+
+def test_session_enforcer_timeout_returns_none() -> None:
+    timeout = subprocess.TimeoutExpired(cmd="git", timeout=5)
+    with patch.object(_sess.subprocess, "run", side_effect=timeout):
+        assert _sess.get_current_branch() is None
+
+
+# --- detect_test_coverage_gaps.get_staged_ps1_files -----------------------
+
+
+def test_coverage_gaps_passes_timeout(tmp_path: Path) -> None:
+    with patch.object(_cov.subprocess, "run", return_value=_ok_result("")) as run:
+        _cov.get_staged_ps1_files(tmp_path)
+    assert run.call_args.kwargs.get("timeout") == 10
+
+
+def test_coverage_gaps_timeout_returns_empty(tmp_path: Path) -> None:
+    timeout = subprocess.TimeoutExpired(cmd="git", timeout=10)
+    with patch.object(_cov.subprocess, "run", side_effect=timeout):
+        assert _cov.get_staged_ps1_files(tmp_path) == []

--- a/tests/test_timeout_hardening_2811c.py
+++ b/tests/test_timeout_hardening_2811c.py
@@ -8,6 +8,7 @@ hang the agent session. See issue #2943.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -42,14 +43,20 @@ def _ok_result(stdout: str = "") -> MagicMock:
 
 
 def test_observation_sync_passes_timeout() -> None:
-    with patch.object(_obs.subprocess, "run", return_value=_ok_result("/repo")) as run:
+    with (
+        patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": ""}),
+        patch.object(_obs.subprocess, "run", return_value=_ok_result("/repo")) as run,
+    ):
         _obs._get_repo_root()
     assert run.call_args.kwargs.get("timeout") == 5
 
 
 def test_observation_sync_timeout_degrades_to_cwd() -> None:
     timeout = subprocess.TimeoutExpired(cmd="git", timeout=5)
-    with patch.object(_obs.subprocess, "run", side_effect=timeout):
+    with (
+        patch.dict(os.environ, {"CLAUDE_PROJECT_DIR": ""}),
+        patch.object(_obs.subprocess, "run", side_effect=timeout),
+    ):
         result = _obs._get_repo_root()
     assert result == _obs.os.getcwd()
 


### PR DESCRIPTION
## Summary

Hardens hook subprocess calls against hangs and makes the homework scanner idempotent.

- **Fixes #2943**: bound every `git` subprocess call on hook execution paths with an explicit `timeout=`, and degrade gracefully when the call times out or fails, so a slow or wedged git invocation cannot hang a session.
  - `invoke_observation_sync.py`: `timeout=5`, degrade to `os.getcwd()`.
  - `invoke_adr_review_guard.py`: `timeout=5`, fail closed (`RuntimeError`).
  - `invoke_session_initialization_enforcer.py`: `timeout=5`, fail open (`None`).
  - `scripts/detect_test_coverage_gaps.py`: `timeout=10`, return `[]`.
- **Fixes #2944**: `homework_scanner.py` now searches for an existing open issue before calling `gh issue create`, so a re-run does not file duplicate homework issues. Dedupe fails open (a search error does not block creation).

## Incidental

While bounding the timeouts, the three edited hook files surfaced pre-existing latent mypy errors (the pre-push changed-files trap, same class as #2876): a `_lib_dir` `None`-vs-`str` assignment in the plugin-root bootstrap, and two `Any`-typed returns. Fixed in-file (annotate `_lib_dir: str | None`, coerce returns with `str(...)`). The same latent pattern exists in 29 other hooks that this PR does not touch; filed as #2949 for a mechanical sweep plus a whole-tree mypy gate.

## Tests

- New `tests/test_timeout_hardening_2811c.py` (8 tests) covering timeout, degrade, and fail-open/closed paths.
- Extended `tests/test_homework_scanner.py` for the dedupe path.
- Updated `tests/hooks/test_adr_review_guard.py`.

## Generated artifacts

Regenerated the three `src/copilot-cli/hooks/**` mirrors; `build_all.py --check` clean. Plugin manifests `.claude` and `src/copilot-cli` bumped 0.6.4 -> 0.6.5 (parity gate).

## References

- `tests/test_plugin_path_resolution.py` (unchanged; still green after the bootstrap annotation)
- `scripts/detect_test_coverage_gaps.py` timeout hardening
- Follow-up issue: #2949
- Parent tracking issue: #2811

