### PR TITLE
docs(copilot-instructions): add Gotchas section for recurring PR/tooling frictions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,8 +102,8 @@ These recur across PRs and are not covered by AGENTS.md.
 
 The "Validate PR" check (`scripts/validation/pr_description.py --ci`) blocks merge on:
 
-- Any file path in the PR body that is not in the diff: CRITICAL "file mentioned but not in diff". **Inline backticks do NOT silence it.** To silence: reword to drop the filename, move it under a `## References`/`## Related Files`/`## Notes` H2, or put it in a fenced block.
-- Any em-dash (U+2014) or en-dash (U+2013) in the body: CRITICAL. Byte-verify: `python3 -c "import sys;print(open(sys.argv[1],'rb').read().count('\u2014'.encode()))" body.md`.
+- Any file path in the PR body that is not in the diff: CRITICAL "file mentioned but not in diff". **Inline backticks do NOT silence it.** To silence: reword to drop the filename, move it under a `## References`/`## Related Files`/`## Notes` H2, put it in a fenced block, or place it inside a GitHub admonition (`> [!NOTE]`), which the validator strips before extracting mentions.
+- Any em-dash (U+2014) or en-dash (U+2013) in the body: CRITICAL. Byte-verify both: `python3 -c "import sys;d=open(sys.argv[1],'rb').read();print(sum(d.count(c.encode()) for c in ('\u2014','\u2013')))" body.md`.
 
 Editing the body re-triggers the gate (`pull_request: edited`); no new commit needed. Verify bot-flagged claims at byte level before editing; false positives happen.
 
@@ -113,7 +113,7 @@ Never place a literal `|` inside a table cell. Escape it (`\|`) or reword. A bar
 
 ### Invoking skill and hook scripts
 
-- Use `uv run python`, not bare `python3`. The scripts import `github_core`, which imports `yaml` at load; bare `python3` fails `ModuleNotFoundError: No module named 'yaml'`.
+- Use `uv run python`, not bare `python3`. These scripts import project packages and third-party deps (for example `yaml`) that resolve only in the project venv; bare `python3` can fail `ModuleNotFoundError`. `uv run python` selects the project venv deterministically.
 - Reference scripts by env-var-qualified plugin root, not a bare `.claude/skills/...` path: `"${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/..."`. Bare `.claude/skills` paths fail under Copilot CLI and trip `check_skill_md_exec_portability.py`.
 
 ## Key Documents

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,7 +102,7 @@ These recur across PRs and are not covered by AGENTS.md.
 
 The "Validate PR" check (`scripts/validation/pr_description.py --ci`) blocks merge on:
 
-- A bare file path in the PR body that is not in the diff: CRITICAL "file mentioned but not in diff". A plain inline-backtick mention (`` `app.js` ``) is still flagged. Silence it the way the validator recognizes: prefix with a citation cue (`` see `path` ``), use a fenced code block, a GitHub admonition (`> [!NOTE]`), or a contextual H2 (`## References`, `## Related Files`, `## See Also`, `## Notes`, `## Background`).
+- A file-looking path (one with a known extension) that appears in inline code, bold, a list item, or a Markdown link and is not in the diff: CRITICAL "file mentioned but not in diff". The validator extracts paths only from those Markdown shapes, not from arbitrary prose, so a path mentioned in a plain sentence does not trip it, but an inline-backtick mention (`` `app.js` ``) does. Silence a real mention the way the validator recognizes: prefix with a citation cue (`` see `path` ``), use a fenced code block, a GitHub admonition (`> [!NOTE]`), or a contextual H2 (`## References`, `## Related Files`, `## See Also`, `## Notes`, `## Background`).
 - Any em-dash (U+2014) or en-dash (U+2013) in the body: CRITICAL. Byte-verify both: `python3 -c "import sys;d=open(sys.argv[1],'rb').read();print(sum(d.count(c.encode()) for c in ('\u2014','\u2013')))" body.md`.
 
 Editing the body re-triggers the gate (`pull_request: edited`); no new commit needed. Verify bot-flagged claims at byte level before editing; false positives happen.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,6 +94,28 @@ Serena MCP tools available → MUST call FIRST:
 4. Commit all changes
 5. Run `python3 scripts/validate_session_json.py [log]`
 
+## Gotchas (non-obvious, save cycles)
+
+These recur across PRs and are not covered by AGENTS.md.
+
+### PR description gate
+
+The "Validate PR" check (`scripts/validation/pr_description.py --ci`) blocks merge on:
+
+- Any file path in the PR body that is not in the diff: CRITICAL "file mentioned but not in diff". **Inline backticks do NOT silence it.** To silence: reword to drop the filename, move it under a `## References`/`## Related Files`/`## Notes` H2, or put it in a fenced block.
+- Any em-dash (U+2014) or en-dash (U+2013) in the body: CRITICAL. Byte-verify: `python3 -c "import sys;print(open(sys.argv[1],'rb').read().count('\u2014'.encode()))" body.md`.
+
+Editing the body re-triggers the gate (`pull_request: edited`); no new commit needed. Verify bot-flagged claims at byte level before editing; false positives happen.
+
+### Markdown tables
+
+Never place a literal `|` inside a table cell. Escape it (`\|`) or reword. A bare pipe breaks rendering and trips bot table-format flags.
+
+### Invoking skill and hook scripts
+
+- Use `uv run python`, not bare `python3`. The scripts import `github_core`, which imports `yaml` at load; bare `python3` fails `ModuleNotFoundError: No module named 'yaml'`.
+- Reference scripts by env-var-qualified plugin root, not a bare `.claude/skills/...` path: `"${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/..."`. Bare `.claude/skills` paths fail under Copilot CLI and trip `check_skill_md_exec_portability.py`.
+
 ## Key Documents
 
 1. **AGENTS.md** - Primary reference (read first)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,9 +100,9 @@ These recur across PRs and are not covered by AGENTS.md.
 
 ### PR description gate
 
-The "Validate PR" check (`scripts/validation/pr_description.py --ci`) blocks merge on:
+The "PR Validation" workflow's description gate (`scripts/validation/pr_description.py --ci`, shown in branch protection as `PR Validation / Validate PR`) blocks merge on:
 
-- A file-looking path (one with a known extension) that appears in inline code, bold, a list item, or a Markdown link and is not in the diff: CRITICAL "file mentioned but not in diff". The validator extracts paths only from those Markdown shapes, not from arbitrary prose, so a path mentioned in a plain sentence does not trip it, but an inline-backtick mention (`` `app.js` ``) does. Silence a real mention the way the validator recognizes: prefix with a citation cue (`` see `path` ``), use a fenced code block, a GitHub admonition (`> [!NOTE]`), or a contextual H2 (`## References`, `## Related Files`, `## See Also`, `## Notes`, `## Background`).
+- A file-looking path (one with a known extension) that appears in inline code, bold, a list item, or a Markdown link and is not in the diff: CRITICAL "file mentioned but not in diff". The validator extracts paths only from those Markdown shapes, not from arbitrary prose, so a path mentioned in a plain sentence does not trip it, but an inline-backtick mention (`` `app.js` ``) does. Silence a real mention the way the validator recognizes: prefix with a citation cue (`` see `path` ``), use a fenced code block, a GitHub admonition (`> [!NOTE]`), or a contextual H2 (`## References`, `## Related Files`, `## See Also`, `## Notes`, `## Background`, and other proof or reference headings such as `## Evidence`, `## Out of Scope`, `## Prior Art`; see `_CONTEXTUAL_SECTION_NAMES` and `_REFERENCE_SECTION_PREFIXES` in the validator for the full set).
 - Any em-dash (U+2014) or en-dash (U+2013) in the body: CRITICAL. Byte-verify both: `python3 -c "import sys;d=open(sys.argv[1],'rb').read();print(sum(d.count(c.encode()) for c in ('\u2014','\u2013')))" body.md`.
 
 Editing the body re-triggers the gate (`pull_request: edited`); no new commit needed. Verify bot-flagged claims at byte level before editing; false positives happen.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,7 +102,7 @@ These recur across PRs and are not covered by AGENTS.md.
 
 The "Validate PR" check (`scripts/validation/pr_description.py --ci`) blocks merge on:
 
-- Any file path in the PR body that is not in the diff: CRITICAL "file mentioned but not in diff". **Inline backticks do NOT silence it.** To silence: reword to drop the filename, move it under a `## References`/`## Related Files`/`## Notes` H2, put it in a fenced block, or place it inside a GitHub admonition (`> [!NOTE]`), which the validator strips before extracting mentions.
+- A bare file path in the PR body that is not in the diff: CRITICAL "file mentioned but not in diff". A plain inline-backtick mention (`` `app.js` ``) is still flagged. Silence it the way the validator recognizes: prefix with a citation cue (`` see `path` ``), use a fenced code block, a GitHub admonition (`> [!NOTE]`), or a contextual H2 (`## References`, `## Related Files`, `## See Also`, `## Notes`, `## Background`).
 - Any em-dash (U+2014) or en-dash (U+2013) in the body: CRITICAL. Byte-verify both: `python3 -c "import sys;d=open(sys.argv[1],'rb').read();print(sum(d.count(c.encode()) for c in ('\u2014','\u2013')))" body.md`.
 
 Editing the body re-triggers the gate (`pull_request: edited`); no new commit needed. Verify bot-flagged claims at byte level before editing; false positives happen.
@@ -113,7 +113,7 @@ Never place a literal `|` inside a table cell. Escape it (`\|`) or reword. A bar
 
 ### Invoking skill and hook scripts
 
-- Use `uv run python`, not bare `python3`. These scripts import project packages and third-party deps (for example `yaml`) that resolve only in the project venv; bare `python3` can fail `ModuleNotFoundError`. `uv run python` selects the project venv deterministically.
+- Prefer `uv run python` over bare `python3` for scripts that import project or third-party deps (for example `yaml`). Those resolve only in the project venv, so bare `python3` can fail `ModuleNotFoundError`; `uv run python` selects the venv deterministically. Dependency-free scripts run fine under either.
 - Reference scripts by env-var-qualified plugin root, not a bare `.claude/skills/...` path: `"${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/..."`. Bare `.claude/skills` paths fail under Copilot CLI and trip `check_skill_md_exec_portability.py`.
 
 ## Key Documents


### PR DESCRIPTION
## Summary

Adds a compact "Gotchas" section to `.github/copilot-instructions.md` capturing three recurring, non-obvious frictions surfaced by `/chronicle improve` session analysis. Each is confirmed by multiple prior sessions and none duplicate existing guidance.

## Changes

- `.github/copilot-instructions.md`: new "Gotchas (non-obvious, save cycles)" section with three subsections:
  1. PR description gate: the file-path-not-in-diff CRITICAL is not silenced by inline backticks; the body is byte-checked for em/en dashes; editing the body re-triggers the gate.
  2. Markdown tables: never place a literal pipe character inside a table cell.
  3. Skill and hook script invocation: use `uv run python` and the env-var-qualified plugin root, not bare `python3` or bare `.claude/skills` paths.

## Verification

- Zero em-dashes and zero en-dashes in the file (byte-verified).
- Single file changed; no generated artifacts affected.

## References

- Frictions sourced from recurring corrections across sessions: PRs #2901, #2907, #2908 for the description gate; script-portability work in #2838 and #2831 for invocation.

Refs #2953

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
