### PR TITLE
fix(hooks): post-merge hardening for correction-applier byte cap and coverage-gaps git degrade

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PreToolUse/invoke_correction_applier.py
+++ b/.claude/hooks/PreToolUse/invoke_correction_applier.py
@@ -241,7 +241,7 @@ def scan_memories(project_root: str, deadline: float | None = None) -> list[tupl
             content = md_file.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        total_bytes += len(content)
+        total_bytes += len(content.encode("utf-8"))
         corrections = extract_high_corrections(content)
         for c in corrections:
             all_corrections.append((md_file.name, c))

--- a/.claude/hooks/PreToolUse/invoke_correction_applier.py
+++ b/.claude/hooks/PreToolUse/invoke_correction_applier.py
@@ -238,10 +238,11 @@ def scan_memories(project_root: str, deadline: float | None = None) -> list[tupl
         if time.monotonic() >= deadline:
             break
         try:
-            content = md_file.read_text(encoding="utf-8")
+            content_bytes = md_file.read_bytes()
+            content = content_bytes.decode("utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        total_bytes += len(content.encode("utf-8"))
+        total_bytes += len(content_bytes)
         corrections = extract_high_corrections(content)
         for c in corrections:
             all_corrections.append((md_file.name, c))

--- a/scripts/detect_test_coverage_gaps.py
+++ b/scripts/detect_test_coverage_gaps.py
@@ -56,7 +56,9 @@ def get_staged_ps1_files(repo_root: Path) -> list[str]:
             text=True,
             timeout=10,
         )
-    except subprocess.TimeoutExpired:
+    except (subprocess.TimeoutExpired, OSError):
+        # OSError (incl. FileNotFoundError for a missing/non-executable git)
+        # degrades to "no files", matching the non-zero-exit fallback below.
         return []
     if result.returncode != 0:
         return []

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
@@ -474,10 +474,11 @@ def _original_main(stdin_bytes):
             if time.monotonic() >= deadline:
                 break
             try:
-                content = md_file.read_text(encoding="utf-8")
+                content_bytes = md_file.read_bytes()
+                content = content_bytes.decode("utf-8")
             except (OSError, UnicodeDecodeError):
                 continue
-            total_bytes += len(content.encode("utf-8"))
+            total_bytes += len(content_bytes)
             corrections = extract_high_corrections(content)
             for c in corrections:
                 all_corrections.append((md_file.name, c))

--- a/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_correction_applier__Bash_f620ca.py
@@ -477,7 +477,7 @@ def _original_main(stdin_bytes):
                 content = md_file.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError):
                 continue
-            total_bytes += len(content)
+            total_bytes += len(content.encode("utf-8"))
             corrections = extract_high_corrections(content)
             for c in corrections:
                 all_corrections.append((md_file.name, c))

--- a/tests/test_invoke_correction_applier.py
+++ b/tests/test_invoke_correction_applier.py
@@ -254,6 +254,34 @@ class TestScanMemories:
         sources = [src for src, _ in result]
         assert sources == ["a.md", "b.md", "c.md"]
 
+    def test_byte_cap_counts_utf8_bytes_not_chars(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """The total-bytes cap must measure UTF-8 bytes, not Python characters.
+
+        ``_MAX_TOTAL_BYTES`` is a byte budget. Non-ASCII memory files have more
+        bytes than characters, so a char-based accumulator undercounts and reads
+        past the budget. We set the cap to exactly the first file's byte length:
+        a byte-correct accumulator stops after file ``a`` (skipping ``b``); a
+        char-based accumulator stays under the cap and reads ``b`` too.
+        """
+        import invoke_correction_applier as mod
+
+        memories = tmp_path / ".serena" / "memories"
+        memories.mkdir(parents=True)
+        # 200 two-byte characters -> bytes far exceed char count.
+        content_a = "## Constraints (HIGH confidence)\n\n- " + ("é" * 200) + " pnpm.\n"
+        (memories / "a.md").write_text(content_a, encoding="utf-8")
+        (memories / "b.md").write_text(
+            "## Constraints (HIGH confidence)\n\n- b.md uses pnpm.\n", encoding="utf-8"
+        )
+        byte_len = len(content_a.encode("utf-8"))
+        assert byte_len > len(content_a)  # sanity: multibyte content present
+        monkeypatch.setattr(mod, "_MAX_TOTAL_BYTES", byte_len)
+        result = scan_memories(str(tmp_path))
+        distinct_sources = {src for src, _ in result}
+        assert distinct_sources == {"a.md"}
+
 
 class TestMainAllowPath:
     @patch("invoke_correction_applier.skip_if_consumer_repo", return_value=False)

--- a/tests/test_timeout_hardening_2811c.py
+++ b/tests/test_timeout_hardening_2811c.py
@@ -122,3 +122,10 @@ def test_coverage_gaps_timeout_returns_empty(tmp_path: Path) -> None:
     timeout = subprocess.TimeoutExpired(cmd="git", timeout=10)
     with patch.object(_cov.subprocess, "run", side_effect=timeout):
         assert _cov.get_staged_ps1_files(tmp_path) == []
+
+
+def test_coverage_gaps_missing_git_returns_empty(tmp_path: Path) -> None:
+    # A missing or non-executable git raises FileNotFoundError (an OSError
+    # subclass); it must degrade to "no files", not crash the scanner.
+    with patch.object(_cov.subprocess, "run", side_effect=FileNotFoundError("git")):
+        assert _cov.get_staged_ps1_files(tmp_path) == []


### PR DESCRIPTION
## Summary

Two post-merge hardening fixes for hook review threads flagged by bots after #2948 and #2950 auto-merged. The fixes missed the merge window because the branches merged before the thread comments could be pushed, so they were re-applied here as a clean follow-up.

Refs #2947
Refs #2943

## Changes

1. **`invoke_correction_applier.py`: count UTF-8 bytes for the scan byte cap** (from #2948 review). The cap used `len(content)` (character count), which under-counts multibyte UTF-8 content and lets oversized payloads through. Now counts `len(content.encode("utf-8"))`. Mirror `invoke_correction_applier__Bash_f620ca.py` updated in lockstep.

2. **`detect_test_coverage_gaps.py`: degrade to no-files when git is missing** (from #2950 review). The subprocess call caught only `subprocess.TimeoutExpired`, so a missing `git` binary raised `FileNotFoundError` and crashed the scan. Now also catches `OSError`, degrading to an empty file set (fail-open, same as timeout).

## Tests

- `tests/test_invoke_correction_applier.py`: byte-cap coverage (multibyte content).
- `tests/test_timeout_hardening_2811c.py`: OSError degrade path.
- Full suite green in pre-push (17 checks passed).

## Notes

- Paired plugin version bumped to 0.6.7 (0.6.6 reserved for #2951; both above main's 0.6.5, so PR-time monotonic gate passes in either merge order).
- No new capability surface; pure hardening of existing hooks.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
