### PR TITLE
docs(diffray): reconcile rules with ADR-042 python-first (#2917)

### DIFF
--- a/.diffray/README.md
+++ b/.diffray/README.md
@@ -31,7 +31,7 @@ Diffray provides intelligent, context-aware code review using AI agents. This co
 
 Rules directly enforce architectural decisions:
 
-- **ADR-005**: No bash/Python scripts (PowerShell only)
+- **ADR-042**: Python-first internal automation, with PowerShell grandfathered
 - **ADR-006**: Thin workflows, testable modules
 - **ADR-014**: HANDOFF.md is read-only
 
@@ -47,11 +47,11 @@ Rules directly enforce architectural decisions:
 
 ### 3. Quality Gates
 
-- PowerShell best practices (CmdletBinding, validation)
+- Python-first script policy, plus PowerShell best practices for grandfathered scripts
 - Skill usage enforcement (no raw gh commands)
 - Atomic commits and proper git history
 - Test-first development patterns
-- Pester coverage for modules
+- pytest/Pester coverage where applicable
 - Git hook discipline (never --no-verify)
 
 ### 4. Template Protection
@@ -102,11 +102,11 @@ Excluded paths:
 
 ## Rule Categories
 
-### PowerShell Patterns (5 rules)
+### Script and PowerShell Patterns (5 rules)
 
 | Rule ID | Importance | Focus |
 |---------|------------|-------|
-| `ps_no_bash_python_scripts` | 9 | ADR-005 enforcement |
+| `script_python_first_new_scripts` | 9 | ADR-042 enforcement |
 | `ps_cmdletbinding_required` | 7 | Parameter handling |
 | `ps_error_handling_required` | 8 | Try-catch in external calls |
 | `ps_avoid_write_host_in_modules` | 6 | Testability |
@@ -209,13 +209,13 @@ yamllint .diffray/config.yaml .diffray/rules/*.yaml
 
 ### Common Validation Scenarios
 
-**Test bash script detection**:
+**Test script policy detection**:
 
 ```bash
-# Should trigger ps_no_bash_python_scripts
-git checkout -b test-bash-detection
-echo '#!/bin/bash' > test.sh
-git add test.sh && git commit -m "test: bash detection"
+# Should trigger script_python_first_new_scripts
+git checkout -b test-script-policy
+printf '[CmdletBinding()]\nparam()\n' > build.ps1
+git add build.ps1 && git commit -m "test: script policy detection"
 ```
 
 **Test workflow logic detection**:

--- a/.diffray/rules/naming-conventions.yaml
+++ b/.diffray/rules/naming-conventions.yaml
@@ -24,7 +24,7 @@ rules:
         ADR-042-use_oauth.md           # Underscores instead of hyphens
         adr-042-use-oauth.md           # Lowercase prefix
       good: |
-        ADR-005-use-oauth-for-auth.md  # Correct format
+        ADR-007-use-oauth-for-auth.md  # Correct format
         ADR-042-powershell-only.md     # Correct format
 
     tags:

--- a/.diffray/rules/powershell-patterns.yaml
+++ b/.diffray/rules/powershell-patterns.yaml
@@ -17,7 +17,7 @@ rules:
         - "!.github/actions/**/*.sh"  # External actions may have shell
 
     checklist:
-      - "Flag new .sh, .ps1, or .psm1 script files"
+      - "Flag newly ADDED .sh, .ps1, or .psm1 script files, not edits to existing grandfathered scripts"
       - "Verify this isn't an existing PowerShell script edit or approved exception"
       - "Suggest a Python implementation for new internal automation"
       - "Reference ADR-042 for rationale"

--- a/.diffray/rules/powershell-patterns.yaml
+++ b/.diffray/rules/powershell-patterns.yaml
@@ -1,47 +1,50 @@
 rules:
-  - id: ps_no_bash_python_scripts
+  - id: script_python_first_new_scripts
     agent: quality
-    title: "No bash or Python scripts allowed (ADR-005)"
+    title: "New scripts should be Python-first (ADR-042)"
     description: |
-      This project uses PowerShell exclusively per ADR-005.
-      All scripting must be done in .ps1 or .psm1 files for consistency,
-      testability with Pester, and cross-platform compatibility.
+      ADR-042 supersedes ADR-005 for new development.
+      New internal automation scripts should be Python. PowerShell scripts are
+      grandfathered and may be edited or migrated over time.
     importance: 9
 
     match:
       file_glob:
         - "**/*.sh"
-        - "**/*.py"
+        - "**/*.ps1"
+        - "**/*.psm1"
         - "!.githooks/**"      # Git hooks are pre-existing exception
         - "!.github/actions/**/*.sh"  # External actions may have shell
 
     checklist:
-      - "Flag any new .sh or .py file creation"
-      - "Verify this isn't a legitimate exception (git hook, external action)"
-      - "Suggest PowerShell equivalent implementation"
-      - "Reference ADR-005 for rationale"
+      - "Flag new .sh, .ps1, or .psm1 script files"
+      - "Verify this isn't an existing PowerShell script edit or approved exception"
+      - "Suggest a Python implementation for new internal automation"
+      - "Reference ADR-042 for rationale"
 
     examples:
       bad: |
-        #!/bin/bash
-        # build.sh
-        docker build -t myapp .
-      good: |
         # build.ps1
         [CmdletBinding()]
         param()
         docker build -t myapp .
+      good: |
+        # build.py
+        import subprocess
+
+        subprocess.run(["docker", "build", "-t", "myapp", "."], check=True)
 
     tags:
       - architecture
+      - python
       - powershell
       - compliance
 
     why_important: |
-      Single language reduces context switching, enables unified testing
-      with Pester, and ensures all scripts work cross-platform.
+      Python is the primary language for new internal automation, while
+      existing PowerShell remains supported during the migration.
 
-    link: .agents/architecture/ADR-005-powershell-only-scripting.md
+    link: .agents/architecture/ADR-042-python-migration-strategy.md
 
 
   - id: ps_cmdletbinding_required


### PR DESCRIPTION
## Summary
- Updates `.diffray/rules/powershell-patterns.yaml` so the script rule follows ADR-042 Python-first guidance for new internal automation.
- Updates `.diffray/README.md` to describe PowerShell as grandfathered, not mandatory.
- Keeps the real agent generator command as `python3 build/generate_agents.py`.

## Validation
- `python3` YAML safe_load check passed for `.diffray/config.yaml` and `.diffray/rules/*.yaml`.
- Changed-file byte checks returned 0 prohibited dash bytes.
- `npx markdownlint-cli2 .diffray/README.md` reported 0 errors.
- `SKIP_CLI_E2E=true git push -u origin agent/diffray` passed pre-push checks.

## References
- See `.agents/architecture/ADR-042-python-migration-strategy.md`.
- See `.agents/architecture/ADR-005-powershell-only-scripting.md`.
- See `CONTRIBUTING.md`.
- See `build/generate_agents.py`.

Fixes #2917