### PR TITLE
test(eval): author remaining oneshot-vs-shipped corpus (#2937)

### DIFF
--- a/evals/oneshot-vs-shipped/README.md
+++ b/evals/oneshot-vs-shipped/README.md
@@ -43,8 +43,8 @@ agent-vs-baseline fixture schema.
 
 ## Corpus status
 
-The seed fixture (`moq1208-1091.json`) is a curated summary of the Sample 1
-example named in #2788 (Moq1208 #1091: PARTIAL, matched root cause, missed a
-valid-suppression edge). The remaining issue->fix pairs from
-`rjmurillo/moq.analyzers` are authored incrementally; the full corpus and the
-calibrated live run require API spend and are owner-gated follow-up work.
+The corpus has 21 curated `rjmurillo/moq.analyzers` issue->fix fixtures:
+the seed fixture (`moq1208-1091.json`) named in #2788 plus 20 remaining
+released issue->fix pairs from the follow-up sweep. Corpus authoring is
+complete. The calibrated live run still requires API spend and remains the
+one owner-gated follow-up step.

--- a/evals/oneshot-vs-shipped/corpus/mockbehavior-1257.json
+++ b/evals/oneshot-vs-shipped/corpus/mockbehavior-1257.json
@@ -1,0 +1,14 @@
+{
+  "id": "mockbehavior-1257",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1257,
+  "title": "MockBehavior code fix throws on stale diagnostic shapes",
+  "discourse": "Reported: MockBehavior code fixes assume every diagnostic carries a current and valid DiagnosticEditProperties payload. Stale diagnostic shapes or undefined EditType values can reach the fixer during IDE updates and cause an exception rather than declining the fix. The issue was first referenced by the broad #1288 hardening PR, then fixed by a focused follow-up for the MockBehavior fixer. A valid answer must guard malformed diagnostic properties and avoid returning a success-shaped unchanged edit when the diagnostic cannot be trusted.",
+  "shipped_fix": "PR #1295 guarded the MockBehavior fixer against stale diagnostic payloads. It validates DiagnosticEditProperties and EditType before applying a change, declines unsupported shapes, and adds regression coverage for malformed or undefined edit requests.",
+  "edges_named_in_discourse": [
+    "stale diagnostic payloads do not throw",
+    "undefined EditType values are rejected",
+    "unsupported diagnostic shapes decline the fix instead of editing code"
+  ],
+  "difficulty": 3
+}

--- a/evals/oneshot-vs-shipped/corpus/mockbehavior-1257.json
+++ b/evals/oneshot-vs-shipped/corpus/mockbehavior-1257.json
@@ -3,7 +3,7 @@
   "source_repo": "rjmurillo/moq.analyzers",
   "issue_number": 1257,
   "title": "MockBehavior code fix throws on stale diagnostic shapes",
-  "discourse": "Reported: MockBehavior code fixes assume every diagnostic carries a current and valid DiagnosticEditProperties payload. Stale diagnostic shapes or undefined EditType values can reach the fixer during IDE updates and cause an exception rather than declining the fix. The issue was first referenced by the broad #1288 hardening PR, then fixed by a focused follow-up for the MockBehavior fixer. A valid answer must guard malformed diagnostic properties and avoid returning a success-shaped unchanged edit when the diagnostic cannot be trusted.",
+  "discourse": "Reported: MockBehavior code fixes assume every diagnostic carries a current and valid DiagnosticEditProperties payload. Stale diagnostic shapes or undefined EditType values can reach the fixer during IDE updates and cause an exception rather than declining the fix. A valid answer must guard malformed diagnostic properties and avoid returning a success-shaped unchanged edit when the diagnostic cannot be trusted.",
   "shipped_fix": "PR #1295 guarded the MockBehavior fixer against stale diagnostic payloads. It validates DiagnosticEditProperties and EditType before applying a change, declines unsupported shapes, and adds regression coverage for malformed or undefined edit requests.",
   "edges_named_in_discourse": [
     "stale diagnostic payloads do not throw",

--- a/evals/oneshot-vs-shipped/corpus/moq1001-1245.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1001-1245.json
@@ -1,0 +1,14 @@
+{
+  "id": "moq1001-1245",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1245,
+  "title": "Moq1001 and Moq1002 miss target-typed new object creation",
+  "discourse": "Reported: ConstructorArgumentsShouldMatchAnalyzer registers only SyntaxKind.ObjectCreationExpression. Target-typed new uses SyntaxKind.ImplicitObjectCreationExpression, so Mock<IFoo> m = new(42); is never analyzed. The issue body says this is a high-confidence false negative on common C# 9 syntax, and it names the bounded fix: register implicit object creation and move the handler to BaseObjectCreationExpressionSyntax. A full IOperation migration was explicitly out of scope.",
+  "shipped_fix": "PR #1301 added the implicit object creation syntax kind, changed the analyzer path to handle BaseObjectCreationExpressionSyntax, and added tests showing Moq1001 and Moq1002 fire on target-typed Mock<T> creation while existing object creation behavior remains intact.",
+  "edges_named_in_discourse": [
+    "target-typed new Mock<T> creation is analyzed",
+    "existing explicit object creation remains analyzed",
+    "the fix does not require a full IOperation migration"
+  ],
+  "difficulty": 3
+}

--- a/evals/oneshot-vs-shipped/corpus/moq1002-1241.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1002-1241.json
@@ -1,0 +1,15 @@
+{
+  "id": "moq1002-1241",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1241,
+  "title": "ConstructorArgumentsShouldMatchAnalyzer crashes on C# 13 params collections",
+  "discourse": "Reported: ConstructorArgumentsShouldMatchAnalyzer for Moq1001/Moq1002 casts every params parameter type to IArrayTypeSymbol. C# 13 params collections can be ReadOnlySpan<T>, IEnumerable<T>, List<T>, or another collection shape, so the cast throws InvalidCastException and Roslyn reports AD0001. The issue body calls this critical because an analyzer crash disables the analyzer in the compiler or IDE session. The discussion named two required edges: normal-form calls that pass one collection argument must still be accepted, while expanded-form calls must validate each trailing argument against the derived element type. Exotic collection shapes should fail open instead of crashing or producing false positives.",
+  "shipped_fix": "PR #1288 rewrote params-tail validation in AllParamsArgumentsMatch. It accepts a single trailing argument convertible to the whole params type, validates expanded arguments against an element type derived from arrays, Span<T>, ReadOnlySpan<T>, and IEnumerable<T>, and skips unmodeled collection shapes. It added shared symbol helpers and regression coverage for C# 13 params collections instead of assuming IArrayTypeSymbol.",
+  "edges_named_in_discourse": [
+    "C# 13 params collections must not crash the analyzer",
+    "normal-form params collection arguments remain accepted",
+    "expanded-form params arguments validate against the collection element type",
+    "unmodeled params collection shapes fail open"
+  ],
+  "difficulty": 5
+}

--- a/evals/oneshot-vs-shipped/corpus/moq1100-1242.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1100-1242.json
@@ -1,0 +1,14 @@
+{
+  "id": "moq1100-1242",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1242,
+  "title": "Moq1100 code fix crashes when Setup has no arguments",
+  "discourse": "Reported: SemanticModelExtensions.GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation indexes ArgumentList.Arguments[0] without checking whether a Setup invocation has an argument. The Moq1100 code fix reaches this helper for mid-edit code such as mock.Setup().Callback(...), then throws ArgumentOutOfRangeException while computing a fix. Maintainer discussion first questioned whether PR #1288 fixed the bug, then corrected that the shared helper guard did cover the core defect. The follow-up PR pinned the regression so the empty-argument Setup guard cannot regress.",
+  "shipped_fix": "PR #1291 added a Moq1100 regression test for the empty-argument Setup guard introduced in the shared SemanticModelExtensions helper. The accepted behavior is that an argument-less or malformed Setup invocation returns no mocked method symbols and the code fix pipeline does not throw.",
+  "edges_named_in_discourse": [
+    "mock.Setup().Callback(...) must not throw during code-fix computation",
+    "malformed or mid-edit Setup calls return no candidate symbols",
+    "the shared helper guard protects Moq1100 callers"
+  ],
+  "difficulty": 3
+}

--- a/evals/oneshot-vs-shipped/corpus/moq1100-1242.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1100-1242.json
@@ -3,7 +3,7 @@
   "source_repo": "rjmurillo/moq.analyzers",
   "issue_number": 1242,
   "title": "Moq1100 code fix crashes when Setup has no arguments",
-  "discourse": "Reported: SemanticModelExtensions.GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation indexes ArgumentList.Arguments[0] without checking whether a Setup invocation has an argument. The Moq1100 code fix reaches this helper for mid-edit code such as mock.Setup().Callback(...), then throws ArgumentOutOfRangeException while computing a fix. Maintainer discussion first questioned whether PR #1288 fixed the bug, then corrected that the shared helper guard did cover the core defect. The follow-up PR pinned the regression so the empty-argument Setup guard cannot regress.",
+  "discourse": "Reported: SemanticModelExtensions.GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation indexes ArgumentList.Arguments[0] without checking whether a Setup invocation has an argument. The Moq1100 code fix reaches this helper for mid-edit code such as mock.Setup().Callback(...), then throws ArgumentOutOfRangeException while computing a fix. A valid fix must handle argument-less or malformed Setup invocations as no candidate symbols instead of throwing during code-fix computation.",
   "shipped_fix": "PR #1291 added a Moq1100 regression test for the empty-argument Setup guard introduced in the shared SemanticModelExtensions helper. The accepted behavior is that an argument-less or malformed Setup invocation returns no mocked method symbols and the code fix pipeline does not throw.",
   "edges_named_in_discourse": [
     "mock.Setup().Callback(...) must not throw during code-fix computation",

--- a/evals/oneshot-vs-shipped/corpus/moq1100-1262.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1100-1262.json
@@ -1,0 +1,14 @@
+{
+  "id": "moq1100-1262",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1262,
+  "title": "Moq1100 misclassifies scoped ref and ref readonly lambda parameters",
+  "discourse": "Reported: CallbackSignatureShouldMatchMockedMethodAnalyzer determines a callback lambda parameter ref kind by inspecting only parameter.Modifiers[0]. That misclassifies multi-token modifier lists such as scoped ref and ref readonly. The issue says the analyzer should stop deriving ref kind from syntax tokens because it already resolves the lambda parameter symbol. The fix must use semantic ref-kind information and cover both scoped ref and ref readonly without regressing normal ref, out, in, and value parameters.",
+  "shipped_fix": "PR #1293 replaced the first-token modifier read with semantic ref-kind handling for lambda parameters. It added Moq1100 coverage for scoped ref and ref readonly callback parameters along with the existing ref-kind cases.",
+  "edges_named_in_discourse": [
+    "scoped ref callback parameters are classified correctly",
+    "ref readonly callback parameters are classified correctly",
+    "existing ref, out, in, and value parameter cases still work"
+  ],
+  "difficulty": 3
+}

--- a/evals/oneshot-vs-shipped/corpus/moq1200-1264.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1200-1264.json
@@ -1,0 +1,15 @@
+{
+  "id": "moq1200-1264",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1264,
+  "title": "Moq1200, Moq1207, and Moq1210 miss sealed default interface members",
+  "discourse": "Reported: ISymbolExtensions.IsOverridable treats every non-static interface member as overridable. A sealed default interface method is not interceptable by Moq, so Setup, SetupSequence, and Verify against it throw NotSupportedException at runtime. The issue adds that fixing IsOverridable alone would not work, because the analyzers bail out on interface members before consulting it. It also notes Setup helper gates on IsGenericMethod, which hides void method setups. A valid fix must stop skipping sealed interface members, handle void setup shapes, and preserve legitimate overridable interface members.",
+  "shipped_fix": "PR #1299 corrected interface-member overridability for sealed default interface methods, removed the analyzer skips that prevented Moq1200, Moq1207, and Moq1210 from seeing them, and adjusted setup helper recognition so void method setups are analyzed. It added regression tests for sealed default interface methods and kept legal interface members unreported.",
+  "edges_named_in_discourse": [
+    "sealed default interface members are reported as non-overridable",
+    "void method setups are recognized",
+    "Moq1200, Moq1207, and Moq1210 all see the interface-member case",
+    "legitimate overridable interface members are not flagged"
+  ],
+  "difficulty": 5
+}

--- a/evals/oneshot-vs-shipped/corpus/moq1202-1248.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1202-1248.json
@@ -1,0 +1,14 @@
+{
+  "id": "moq1202-1248",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1248,
+  "title": "Moq1202 and Moq1204 flag valid EventHandler-shaped raises",
+  "discourse": "Reported: the shared event-signature validation for Moq1202 Raise and Moq1204 Raises falsely flags canonical EventHandler usage. For event System.EventHandler Closed, Moq supplies the sender argument, so mock.Raise(m => m.Closed += null, EventArgs.Empty) is valid even though the delegate has two parameters. The same shape applies to custom object sender plus event-args delegates. The issue also names a mid-edit edge: unresolved or non-delegate event types should be skipped, not treated as zero-parameter delegates and flagged.",
+  "shipped_fix": "PR #1297 modeled Moq runtime overload selection for Raise and Raises. It recognizes EventHandler-shaped delegates where Moq supplies sender, validates custom two-parameter event delegates correctly, and fails open for unresolved or non-delegate event types. It added regression tests for Moq1202 and Moq1204 valid one-argument raises and unresolved delegate inputs.",
+  "edges_named_in_discourse": [
+    "EventHandler one-argument Raise is not flagged",
+    "custom object-sender event delegates follow the same sender-supplying rule",
+    "unresolved or non-delegate event types fail open"
+  ],
+  "difficulty": 4
+}

--- a/evals/oneshot-vs-shipped/corpus/moq1203-1243.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1203-1243.json
@@ -1,0 +1,14 @@
+{
+  "id": "moq1203-1243",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1243,
+  "title": "Moq1203 false negative when name fallback fires for non-Moq symbols",
+  "discourse": "Reported: MethodSetupShouldSpecifyReturnValueAnalyzer uses a string-name fallback for ReturnsAsync and ThrowsAsync even when the chained method resolves to a non-Moq symbol. That lets a non-Moq extension method with the same name suppress Moq1203, so a setup with no real return-value specification is missed. The issue also names the reason the fallback existed: Moq delegate-based ReturnsAsync overloads live on Moq.GeneratedReturnsExtensions and were not present in MoqKnownSymbols. A valid fix must register the real Moq extension container and stop accepting same-name methods from unrelated types.",
+  "shipped_fix": "PR #1303 registered Moq.GeneratedReturnsExtensions in MoqKnownSymbols and used symbol-based checks for ReturnsAsync and ThrowsAsync. The fix lets real Moq delegate overloads count as return-value specifications while rejecting unrelated same-name methods that previously triggered the fallback.",
+  "edges_named_in_discourse": [
+    "real Moq GeneratedReturnsExtensions overloads are recognized",
+    "unrelated same-name ReturnsAsync or ThrowsAsync methods do not suppress Moq1203",
+    "the fix stays symbol-based instead of broad string matching"
+  ],
+  "difficulty": 4
+}

--- a/evals/oneshot-vs-shipped/corpus/moq1210-1256.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1210-1256.json
@@ -1,0 +1,15 @@
+{
+  "id": "moq1210-1256",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1256,
+  "title": "Moq1210 Make member virtual fix emits non-compiling code",
+  "discourse": "Reported: VerifyOverridableMembersFixer offers the Make member virtual code fix when virtual cannot legally compile. The issue names static members, members inside sealed classes, and struct members. Those edits produce code such as static virtual or virtual inside a sealed type. The fix must withhold the code fix for illegal targets while still offering it for members that can become virtual. It shares the PR with a sealed default interface member analyzer fix, so a good answer must not confuse diagnostic reporting with code-fix availability.",
+  "shipped_fix": "PR #1299 added code-fix eligibility checks before offering Make member virtual. It blocks static members, sealed containing types, struct members, and other targets where virtual cannot compile, while keeping the fix for legal class members. The same PR also adjusted overridability analysis for sealed default interface members.",
+  "edges_named_in_discourse": [
+    "no Make member virtual fix for static members",
+    "no Make member virtual fix inside sealed classes",
+    "no Make member virtual fix for struct members",
+    "legal class members still get the code fix"
+  ],
+  "difficulty": 4
+}

--- a/evals/oneshot-vs-shipped/corpus/moq1210-1263.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1210-1263.json
@@ -1,0 +1,15 @@
+{
+  "id": "moq1210-1263",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1263,
+  "title": "Moq1210 skips Verify calls when named arguments are reordered",
+  "discourse": "Reported: VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer and MoqVerificationHelpers extract the verification lambda by reading IInvocationOperation.Arguments[0]. Roslyn stores invocation arguments in source order, not parameter order. A call like mock.Verify(times: Times.Once(), expression: x => x.DoSomething()) puts Times.Once() first, so the helper returns null and Moq1210 misses a non-overridable member. The issue points to existing setup helpers that bind by parameter identity instead of position. A valid fix must resolve named and reordered arguments for Verify, VerifyGet, and VerifySet.",
+  "shipped_fix": "PR #1302 changed MoqVerificationHelpers to locate the expression argument by parameter identity instead of source position. It added tests for reordered named arguments in Verify, VerifyGet, and VerifySet so non-overridable members are still diagnosed.",
+  "edges_named_in_discourse": [
+    "Verify named-argument reordering is analyzed",
+    "VerifyGet named-argument reordering is analyzed",
+    "VerifySet named-argument reordering is analyzed",
+    "the helper binds by parameter identity instead of source position"
+  ],
+  "difficulty": 4
+}

--- a/evals/oneshot-vs-shipped/corpus/moq1300-1251.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1300-1251.json
@@ -1,0 +1,14 @@
+{
+  "id": "moq1300-1251",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1251,
+  "title": "Moq1300 flags unresolved and open generic As<T> type arguments",
+  "discourse": "Reported: AsShouldBeUsedOnlyForInterfaceAnalyzer reports Moq1300 for any As<T>() type argument whose TypeKind is not Interface. Two named TypeKind cases should not be flagged: Error, which appears in mid-edit code or missing references, and TypeParameter, which is valid in a generic helper when T may be an interface at the call site. The issue notes Moq1300 is Error severity, so these false positives are costly. It also asks for broader test coverage beyond the thin existing rows.",
+  "shipped_fix": "PR #1289 made Moq1300 constraint-aware. It skips unresolved error types, allows open type parameters that have an interface-compatible constraint path, and keeps reporting concrete non-interface types. The PR added tests for unresolved symbols, generic type parameters, interface constraints, and concrete invalid types.",
+  "edges_named_in_discourse": [
+    "unresolved Error type arguments are skipped",
+    "generic type parameters that may be interfaces are not flagged",
+    "concrete non-interface As<T> arguments still report Moq1300"
+  ],
+  "difficulty": 4
+}

--- a/evals/oneshot-vs-shipped/corpus/moq1302-1261.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1302-1261.json
@@ -1,0 +1,15 @@
+{
+  "id": "moq1302-1261",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1261,
+  "title": "Moq1302 unbounded recursion can overflow the stack",
+  "discourse": "Reported: LinqToMocksExpressionShouldBeValidAnalyzer walks Mock.Of<T>(...) expressions through mutually recursive AnalyzeLambdaBody and AnalyzeMemberOperations calls. A generated predicate with thousands of chained clauses can overflow the stack, and StackOverflowException kills the compiler or IDE process rather than being reported as an analyzer failure. The issue also names a performance defect: per-member SemanticModel.GetDiagnostics(span) forces repeated binding. The fix must bound recursion and reduce repeated binding while preserving valid invalid-member diagnostics.",
+  "shipped_fix": "PR #1294 added an explicit recursion-depth boundary to the Moq1302 operation walk and pinned the exact boundary with tests. It also reduced the costly per-candidate diagnostics path so the analyzer can reject pathological input without stack overflow or repeated full rebinds.",
+  "edges_named_in_discourse": [
+    "deep generated Mock.Of predicates do not overflow the stack",
+    "the recursion-depth boundary is tested",
+    "valid invalid-member diagnostics still report",
+    "per-member diagnostics work is reduced"
+  ],
+  "difficulty": 5
+}

--- a/evals/oneshot-vs-shipped/corpus/moq1400-1255.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1400-1255.json
@@ -1,0 +1,14 @@
+{
+  "id": "moq1400-1255",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1255,
+  "title": "Moq1400 and Moq1410 compare boxed MockBehavior constants by reference",
+  "discourse": "Reported: SetExplicitMockBehaviorAnalyzer and SetStrictMockBehaviorAnalyzer compare compile-time constants using == and != on object operands. Those operands are independently boxed enum underlying values from IOperation.ConstantValue.Value. Reference equality is not a value comparison, so a valid MockBehavior local or field can be flagged as if it had the wrong value. The issue warns that small enum values may appear to work due to runtime interning, but that is an implementation detail. The analyzer must compare value semantics and preserve existing direct-constant behavior.",
+  "shipped_fix": "PR #1298 changed the MockBehavior analyzers to compare constant values by value rather than object reference. It added regression coverage for local constants and other boxed enum paths that previously depended on accidental reference identity.",
+  "edges_named_in_discourse": [
+    "boxed enum constants compare by value",
+    "MockBehavior locals and constants do not produce false positives",
+    "direct literal MockBehavior cases remain covered"
+  ],
+  "difficulty": 3
+}

--- a/evals/oneshot-vs-shipped/corpus/moq1500-1253.json
+++ b/evals/oneshot-vs-shipped/corpus/moq1500-1253.json
@@ -1,0 +1,15 @@
+{
+  "id": "moq1500-1253",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1253,
+  "title": "Moq1500 misses constructor setup patterns and walks declarations twice",
+  "discourse": "Reported: MockRepositoryVerifyAnalyzer uses GetContainingMember with only MethodBody and a dead PropertyReference branch. A local MockRepository declared in a constructor roots at a constructor body, so the analyzer skips the xUnit constructor setup pattern and misses Moq1500. The issue also names initializer bodies and a performance flaw: two helper paths walk Descendants() for the same containing member per declarator. A valid fix must detect constructor and initializer scopes and avoid duplicate tree walks.",
+  "shipped_fix": "PR #1304 corrected Moq1500 scope resolution for constructor and initializer bodies. It replaced the narrow containing-member lookup with logic that sees the relevant method, constructor, and initializer roots, removed the dead property-reference path, and consolidated the local analysis so repository and verify calls can be found without duplicate declaration walks.",
+  "edges_named_in_discourse": [
+    "MockRepository locals in constructors are analyzed",
+    "initializer-body declarations are handled",
+    "dead PropertyReference logic is removed or bypassed",
+    "the containing member is walked once for both repository and verify facts"
+  ],
+  "difficulty": 4
+}

--- a/evals/oneshot-vs-shipped/corpus/moqknownsymbols-1250.json
+++ b/evals/oneshot-vs-shipped/corpus/moqknownsymbols-1250.json
@@ -1,0 +1,14 @@
+{
+  "id": "moqknownsymbols-1250",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1250,
+  "title": "MoqKnownSymbols Lazy cache is poisoned by duplicate MockBehavior members",
+  "discourse": "Reported: MoqKnownSymbols.CreateLazySingleField uses SingleOrDefault inside a Lazy<T>. If a compilation defines a source MockBehavior type with duplicate members, SingleOrDefault throws inside the cached Lazy. LazyThreadSafetyMode.ExecutionAndPublication then caches the exception, so every analyzer access rethrows for the whole compilation. Maintainer confirmation says the fix replaced SingleOrDefault with DefaultIfNotSingle so duplicate members resolve to null and analyzers skip instead of throwing.",
+  "shipped_fix": "PR #1288 replaced the throwing SingleOrDefault path in MoqKnownSymbols with DefaultIfNotSingle. Duplicate or ambiguous MockBehavior members now produce a null symbol and a deterministic skip path instead of a cached exception that poisons the analyzer session.",
+  "edges_named_in_discourse": [
+    "duplicate MockBehavior members do not throw inside Lazy initialization",
+    "ambiguous symbols resolve to null and skip safely",
+    "the Lazy cache is not permanently poisoned by one bad compilation shape"
+  ],
+  "difficulty": 4
+}

--- a/evals/oneshot-vs-shipped/corpus/moqknownsymbols-1250.json
+++ b/evals/oneshot-vs-shipped/corpus/moqknownsymbols-1250.json
@@ -3,7 +3,7 @@
   "source_repo": "rjmurillo/moq.analyzers",
   "issue_number": 1250,
   "title": "MoqKnownSymbols Lazy cache is poisoned by duplicate MockBehavior members",
-  "discourse": "Reported: MoqKnownSymbols.CreateLazySingleField uses SingleOrDefault inside a Lazy<T>. If a compilation defines a source MockBehavior type with duplicate members, SingleOrDefault throws inside the cached Lazy. LazyThreadSafetyMode.ExecutionAndPublication then caches the exception, so every analyzer access rethrows for the whole compilation. Maintainer confirmation says the fix replaced SingleOrDefault with DefaultIfNotSingle so duplicate members resolve to null and analyzers skip instead of throwing.",
+  "discourse": "Reported: MoqKnownSymbols.CreateLazySingleField uses SingleOrDefault inside a Lazy<T>. If a compilation defines a source MockBehavior type with duplicate members, SingleOrDefault throws inside the cached Lazy. LazyThreadSafetyMode.ExecutionAndPublication then caches the exception, so every analyzer access rethrows for the whole compilation. A valid fix must avoid throwing during Lazy initialization when duplicate or ambiguous members exist, so one bad compilation shape does not poison every analyzer access.",
   "shipped_fix": "PR #1288 replaced the throwing SingleOrDefault path in MoqKnownSymbols with DefaultIfNotSingle. Duplicate or ambiguous MockBehavior members now produce a null symbol and a deterministic skip path instead of a cached exception that poisons the analyzer session.",
   "edges_named_in_discourse": [
     "duplicate MockBehavior members do not throw inside Lazy initialization",

--- a/evals/oneshot-vs-shipped/corpus/perfdiff-1265.json
+++ b/evals/oneshot-vs-shipped/corpus/perfdiff-1265.json
@@ -1,0 +1,14 @@
+{
+  "id": "perfdiff-1265",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1265,
+  "title": "PerfDiff ETL verdict is never propagated",
+  "discourse": "Reported: EtlDiffer.TryCompareETL computes and prints an ETL overweight report but never sets its regression out-parameter. PerfDiff.CompareAsync treats a successful ETL comparison with etlRegressionDetected false as proof that a BenchmarkDotNet regression was noise and exits 0, even with failOnRegression enabled. The issue ties this to the CI merge gate because ComparePerfResults runs PerfDiff with failOnRegression. A valid fix must propagate ETL regression verdicts and keep real noise-suppression behavior from hiding BenchmarkDotNet regressions.",
+  "shipped_fix": "PR #1309 extracted a testable ETL HasRegression verdict and wires it into PerfDiff so any ETL row with positive delta and interest reports a regression. The fix prevents ETL traces from downgrading a real BenchmarkDotNet regression to noise and adds coverage in the PerfDiff regression cluster.",
+  "edges_named_in_discourse": [
+    "ETL overweight findings set the regression verdict",
+    "BenchmarkDotNet regressions are not hidden by ETL success",
+    "failOnRegression exits nonzero when ETL regression evidence exists"
+  ],
+  "difficulty": 4
+}

--- a/evals/oneshot-vs-shipped/corpus/perfdiff-1266.json
+++ b/evals/oneshot-vs-shipped/corpus/perfdiff-1266.json
@@ -3,7 +3,7 @@
   "source_repo": "rjmurillo/moq.analyzers",
   "issue_number": 1266,
   "title": "PerfDiff silently intersects mismatched or empty benchmark sets",
-  "discourse": "Reported: BenchmarkDotNetDiffer compares only the intersection of baseline and current benchmark names. If a PR breaks the benchmark harness, renames benchmarks, or produces an empty result set, the regression strategies see no comparable rows, print no regressions detected, and exit 0. The issue also names silent filtering of failed benchmarks with null Statistics. Maintainer confirmation says the fix implemented HaveMatchingBenchmarkNames so mismatched baseline and current name sets fail the gate instead of passing vacuously.",
+  "discourse": "Reported: BenchmarkDotNetDiffer compares only the intersection of baseline and current benchmark names. If a PR breaks the benchmark harness, renames benchmarks, or produces an empty result set, the regression strategies see no comparable rows, print no regressions detected, and exit 0. The issue also names silent filtering of failed benchmarks with null Statistics. A valid fix must treat mismatched baseline/current benchmark sets, empty intersections, and failed rows as gate failures instead of success.",
   "shipped_fix": "PR #1309 added benchmark-set validation before regression strategies run. It fails the PerfDiff gate when baseline and current benchmark names do not match, when the comparison set is empty, or when failed benchmark rows would otherwise be dropped without evidence.",
   "edges_named_in_discourse": [
     "empty benchmark intersections fail the gate",

--- a/evals/oneshot-vs-shipped/corpus/perfdiff-1266.json
+++ b/evals/oneshot-vs-shipped/corpus/perfdiff-1266.json
@@ -1,0 +1,14 @@
+{
+  "id": "perfdiff-1266",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1266,
+  "title": "PerfDiff silently intersects mismatched or empty benchmark sets",
+  "discourse": "Reported: BenchmarkDotNetDiffer compares only the intersection of baseline and current benchmark names. If a PR breaks the benchmark harness, renames benchmarks, or produces an empty result set, the regression strategies see no comparable rows, print no regressions detected, and exit 0. The issue also names silent filtering of failed benchmarks with null Statistics. Maintainer confirmation says the fix implemented HaveMatchingBenchmarkNames so mismatched baseline and current name sets fail the gate instead of passing vacuously.",
+  "shipped_fix": "PR #1309 added benchmark-set validation before regression strategies run. It fails the PerfDiff gate when baseline and current benchmark names do not match, when the comparison set is empty, or when failed benchmark rows would otherwise be dropped without evidence.",
+  "edges_named_in_discourse": [
+    "empty benchmark intersections fail the gate",
+    "renamed or missing benchmark names fail the gate",
+    "failed benchmark rows with null Statistics are not silently treated as success"
+  ],
+  "difficulty": 4
+}

--- a/evals/oneshot-vs-shipped/corpus/perfdiff-1267.json
+++ b/evals/oneshot-vs-shipped/corpus/perfdiff-1267.json
@@ -1,0 +1,14 @@
+{
+  "id": "perfdiff-1267",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1267,
+  "title": "PerfDiff absolute-budget strategies classify on the current run alone",
+  "discourse": "Reported: RegressionStrategyHelper.FindRegressions powers the P95 250 ms and Mean 100 ms absolute-budget strategies, but it classifies each benchmark by looking only at the current run. That permanently blocks any benchmark that is already over budget on main, even when the PR is byte-identical to the baseline. It also misses slowdowns that stay under the absolute budget. A valid fix must compare baseline and current measurements, not just current values, and avoid turning a stable over-budget baseline into a fresh regression.",
+  "shipped_fix": "PR #1309 corrected the absolute-budget regression verdict logic so strategies account for baseline and current measurements. The new tests cover stable over-budget cases, true regressions, and under-budget slowdowns so the gate blocks deltas rather than pre-existing baseline cost alone.",
+  "edges_named_in_discourse": [
+    "unchanged over-budget benchmarks do not fail every PR",
+    "current measurements are compared against baseline measurements",
+    "slowdowns that remain under an absolute budget are still evaluated as deltas"
+  ],
+  "difficulty": 4
+}

--- a/evals/oneshot-vs-shipped/corpus/perfdiff-1268.json
+++ b/evals/oneshot-vs-shipped/corpus/perfdiff-1268.json
@@ -1,0 +1,15 @@
+{
+  "id": "perfdiff-1268",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1268,
+  "title": "PerfDiff drops infinite ratios and lets NaN poison geomeans",
+  "discourse": "Reported: the Mann-Whitney ratio strategies remove infinite median ratios from the regression verdict. When a baseline median is zero and the current run is slower, the ratio can be positive infinity, the most extreme regression, yet it is filtered out and PerfDiff can exit 0. The same area lets NaN ratios flow into Math.Log10 and poison geometric mean summaries, and divides geomeans by the pre-filter count. Maintainer confirmation says PR #1309 added boundary tests for NaN, infinity, and empty sets.",
+  "shipped_fix": "PR #1309 made ratio and geomean handling defensive. Positive infinity is treated as regression evidence instead of being excluded, NaN and invalid ratios are filtered without poisoning summaries, and geomean denominators use the valid post-filter set.",
+  "edges_named_in_discourse": [
+    "positive infinity ratios count as severe regressions",
+    "NaN ratios do not poison geometric means",
+    "geomeans divide by the valid post-filter count",
+    "empty ratio sets are handled safely"
+  ],
+  "difficulty": 5
+}

--- a/evals/oneshot-vs-shipped/corpus/perfdiff-1268.json
+++ b/evals/oneshot-vs-shipped/corpus/perfdiff-1268.json
@@ -3,7 +3,7 @@
   "source_repo": "rjmurillo/moq.analyzers",
   "issue_number": 1268,
   "title": "PerfDiff drops infinite ratios and lets NaN poison geomeans",
-  "discourse": "Reported: the Mann-Whitney ratio strategies remove infinite median ratios from the regression verdict. When a baseline median is zero and the current run is slower, the ratio can be positive infinity, the most extreme regression, yet it is filtered out and PerfDiff can exit 0. The same area lets NaN ratios flow into Math.Log10 and poison geometric mean summaries, and divides geomeans by the pre-filter count. Maintainer confirmation says PR #1309 added boundary tests for NaN, infinity, and empty sets.",
+  "discourse": "Reported: the Mann-Whitney ratio strategies remove infinite median ratios from the regression verdict. When a baseline median is zero and the current run is slower, the ratio can be positive infinity, the most extreme regression, yet it is filtered out and PerfDiff can exit 0. The same area lets NaN ratios flow into Math.Log10 and poison geometric mean summaries, and divides geomeans by the pre-filter count. A valid fix must preserve positive infinity as regression evidence, keep NaN out of summaries, and compute geomeans over valid ratios only.",
   "shipped_fix": "PR #1309 made ratio and geomean handling defensive. Positive infinity is treated as regression evidence instead of being excluded, NaN and invalid ratios are filtered without poisoning summaries, and geomean denominators use the valid post-filter set.",
   "edges_named_in_discourse": [
     "positive infinity ratios count as severe regressions",

--- a/evals/oneshot-vs-shipped/corpus/perfdiff-1269.json
+++ b/evals/oneshot-vs-shipped/corpus/perfdiff-1269.json
@@ -1,0 +1,15 @@
+{
+  "id": "perfdiff-1269",
+  "source_repo": "rjmurillo/moq.analyzers",
+  "issue_number": 1269,
+  "title": "PerfDiff input robustness defects crash or hide bad benchmark data",
+  "discourse": "Reported: PerfDiff ingestion has multiple input-robustness defects. Empty or single-sample measurement sets can throw through Pragmastat, duplicate FullNames collapse rows, zero-Operations measurements distort ratios, and null-deserialized files can crash with raw stack traces. Maintainer confirmation says #1309 hardened these paths and added InputRobustnessTests. A valid fix must classify malformed input as a gate failure with clear diagnostics instead of crashing or reporting no regressions detected.",
+  "shipped_fix": "PR #1309 hardened BenchmarkDotNet ingestion for empty samples, single samples, duplicate benchmark names, zero-operation measurements, and null or malformed files. It reports actionable validation failures or safe skips where appropriate and covers the cases in InputRobustnessTests.",
+  "edges_named_in_discourse": [
+    "empty and single-sample measurements do not crash with raw stack traces",
+    "duplicate FullName rows are detected",
+    "zero-Operations measurements do not distort ratios",
+    "null or malformed deserialized files fail with clear diagnostics"
+  ],
+  "difficulty": 5
+}

--- a/evals/oneshot-vs-shipped/corpus/perfdiff-1269.json
+++ b/evals/oneshot-vs-shipped/corpus/perfdiff-1269.json
@@ -3,7 +3,7 @@
   "source_repo": "rjmurillo/moq.analyzers",
   "issue_number": 1269,
   "title": "PerfDiff input robustness defects crash or hide bad benchmark data",
-  "discourse": "Reported: PerfDiff ingestion has multiple input-robustness defects. Empty or single-sample measurement sets can throw through Pragmastat, duplicate FullNames collapse rows, zero-Operations measurements distort ratios, and null-deserialized files can crash with raw stack traces. Maintainer confirmation says #1309 hardened these paths and added InputRobustnessTests. A valid fix must classify malformed input as a gate failure with clear diagnostics instead of crashing or reporting no regressions detected.",
+  "discourse": "Reported: PerfDiff ingestion has multiple input-robustness defects. Empty or single-sample measurement sets can throw through Pragmastat, duplicate FullNames collapse rows, zero-Operations measurements distort ratios, and null-deserialized files can crash with raw stack traces. A valid fix must classify malformed input as a gate failure with clear diagnostics instead of crashing or reporting no regressions detected.",
   "shipped_fix": "PR #1309 hardened BenchmarkDotNet ingestion for empty samples, single samples, duplicate benchmark names, zero-operation measurements, and null or malformed files. It reports actionable validation failures or safe skips where appropriate and covers the cases in InputRobustnessTests.",
   "edges_named_in_discourse": [
     "empty and single-sample measurements do not crash with raw stack traces",


### PR DESCRIPTION
## Summary

Authored 20 remaining input fixtures for the oneshot-vs-shipped eval corpus. The corpus now has 21 valid fixtures, including the seed.

Updated the corpus status to say authoring is complete. The calibrated live run still needs owner authorization and API spend.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| Issue | Fixes #2937 | Author the remaining oneshot-vs-shipped input corpus fixtures. |

## Type of Change

- [x] Test data and eval documentation only.

## Changes

- Added 20 schema-consistent input fixtures for closed rjmurillo/moq.analyzers issue and fix pairs.
- Kept the live calibrated benchmark out of scope because it needs owner authorization and API spend.
- Updated the corpus status to mark fixture authoring complete.

## Validation

- JSON fixture load passed for every corpus file.
- Dash byte check returned 0 for the README and every corpus fixture.
- Dry run passed with 21 fixtures and 42 planned API calls, with zero spend.
- Pytest passed for the oneshot eval tests: 47 passed.
- Pre-push passed with SKIP_CLI_E2E=true.

The live calibrated benchmark was not run.

## References

scripts/eval/eval-oneshot-vs-shipped.py
scripts/eval/_oneshot_bench_core.py
tests/eval/test_oneshot_bench_core.py
tests/eval/test_eval_oneshot_vs_shipped.py