### PR TITLE
fix(build): stop copilot_body_translation from corrupting $ARGUMENTS (#2932)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "author": {
     "name": "rjmurillo"
   }

--- a/build/scripts/copilot_body_translation.py
+++ b/build/scripts/copilot_body_translation.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Callable
 from pathlib import Path
 
 _PLUGIN_MANIFEST_RELATIVE = Path(".claude-plugin") / "plugin.json"
@@ -45,8 +46,10 @@ _DEFAULT_PLUGIN_NAME = "project-toolkit"
 # skill/persona name; trailing args are ignored for the mapping.
 _SKILL_CALL_RE = re.compile(r"Skill\(\s*skill\s*=\s*['\"]([^'\"]+)['\"]")
 _TASK_CALL_RE = re.compile(r"Task\(\s*subagent_type\s*=\s*['\"]([^'\"]+)['\"]")
-_INCLUDE_LINE_RE = re.compile(r"^@([A-Za-z0-9_.\-/]+)\s*$", re.MULTILINE)
+_INCLUDE_LINE_RE = re.compile(r"^@([A-Za-z0-9_.\-/]+\.md)\s*$", re.MULTILINE)
 _ARGUMENTS_TOKEN = "$ARGUMENTS"
+_FENCED_CODE_BLOCK_RE = re.compile(r"(```.*?```)", re.DOTALL)
+_INLINE_CODE_SPAN_RE = re.compile(r"(`+[^`\n]*`+)")
 
 _FRONTMATTER_RE = re.compile(r"\A(---\r?\n.*?\r?\n---\r?\n)(.*)\Z", re.DOTALL)
 
@@ -73,6 +76,16 @@ def resolve_plugin_name(skills_output_dir: Path) -> str:
     return name if isinstance(name, str) and name else _DEFAULT_PLUGIN_NAME
 
 
+def _translate_outside_fenced_code(
+    body: str,
+    translate_segment: Callable[[str], str],
+) -> str:
+    parts = _FENCED_CODE_BLOCK_RE.split(body)
+    for index in range(0, len(parts), 2):
+        parts[index] = translate_segment(parts[index])
+    return "".join(parts)
+
+
 def _translate_includes(body: str) -> str:
     """Replace Claude ``@file`` standalone include lines with a Copilot note."""
 
@@ -83,7 +96,25 @@ def _translate_includes(body: str) -> str:
             "plugin instructions tree; no include directive needed. -->"
         )
 
-    return _INCLUDE_LINE_RE.sub(_replace, body)
+    return _translate_outside_fenced_code(
+        body,
+        lambda segment: _INCLUDE_LINE_RE.sub(_replace, segment),
+    )
+
+
+def _replace_arguments_outside_inline_code(line: str, replacement: str) -> str:
+    parts = _INLINE_CODE_SPAN_RE.split(line)
+    for index, part in enumerate(parts):
+        if not _INLINE_CODE_SPAN_RE.fullmatch(part):
+            parts[index] = part.replace(_ARGUMENTS_TOKEN, replacement)
+    return "".join(parts)
+
+
+def _replace_arguments_in_segment(segment: str, replacement: str) -> str:
+    lines = segment.splitlines(keepends=True)
+    return "".join(
+        _replace_arguments_outside_inline_code(line, replacement) for line in lines
+    )
 
 
 def _translate_arguments(body: str) -> str:
@@ -94,7 +125,10 @@ def _translate_arguments(body: str) -> str:
         "the problem statement from the conversation (under Copilot CLI the "
         "skill tool takes no argument vector, so state it in your message)"
     )
-    return body.replace(_ARGUMENTS_TOKEN, replacement)
+    return _translate_outside_fenced_code(
+        body,
+        lambda segment: _replace_arguments_in_segment(segment, replacement),
+    )
 
 
 def _build_invocation_appendix(body: str, plugin_name: str) -> str:

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/checkpoint/SKILL.md
+++ b/src/copilot-cli/skills/checkpoint/SKILL.md
@@ -61,7 +61,7 @@ the JSON.
     `session.branch` equals the current branch. Normalize `session.branch` by
     trimming whitespace and removing one matching pair of surrounding backticks.
     That file is the active session log.
-   - If `the problem statement from the conversation (under Copilot CLI the skill tool takes no argument vector, so state it in your message)` is empty after trimming, derive the label from the active
+   - If `$ARGUMENTS` is empty after trimming, derive the label from the active
     session log's `session.objective`. If no active session log exists, derive
     it from the current branch. If that is empty, use `checkpoint`.
 

--- a/src/copilot-cli/skills/retro/SKILL.md
+++ b/src/copilot-cli/skills/retro/SKILL.md
@@ -26,14 +26,14 @@ See Issue #2079.
 
 ## Arguments
 
-`the problem statement from the conversation (under Copilot CLI the skill tool takes no argument vector, so state it in your message)` carries the operation and the date, for example `fill 2026-06-03`.
+`$ARGUMENTS` carries the operation and the date, for example `fill 2026-06-03`.
 
 - `fill <YYYY-MM-DD>`: fill the skeleton at
   `.agents/retrospective/<YYYY-MM-DD>-auto-retro.md`.
 
 ## Process
 
-1. Parse `the problem statement from the conversation (under Copilot CLI the skill tool takes no argument vector, so state it in your message)`. The first token is the operation; for `fill`, the second
+1. Parse `$ARGUMENTS`. The first token is the operation; for `fill`, the second
    token is the date in `YYYY-MM-DD` form.
    - If no operation is given, list pending skeletons: glob
      `.agents/retrospective/*.md`, read each only to check whether the body

--- a/src/copilot-cli/skills/slashcommandcreator/SKILL.md
+++ b/src/copilot-cli/skills/slashcommandcreator/SKILL.md
@@ -49,7 +49,7 @@ Create production-ready custom slash commands following ai-agents quality standa
 
 1. Command naming (namespace conventions)
 2. Argument design:
-   - Simple commands: use `the problem statement from the conversation (under Copilot CLI the skill tool takes no argument vector, so state it in your message)`
+   - Simple commands: use `$ARGUMENTS`
    - Complex commands: use `$1`, `$2`, `$3` (positional)
 3. Frontmatter schema:
    - `description` (trigger-based per creator-001)

--- a/tests/build_scripts/test_generate_commands_copilot_contract.py
+++ b/tests/build_scripts/test_generate_commands_copilot_contract.py
@@ -21,6 +21,7 @@ fails when the translation is wrong (a raw body still carries the tokens).
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -31,6 +32,8 @@ sys.path.insert(0, str(REPO_ROOT / "build"))
 import copilot_body_translation  # noqa: E402
 
 _COPILOT_SKILLS = REPO_ROOT / "src" / "copilot-cli" / "skills"
+_FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_SPAN_RE = re.compile(r"`+[^`\n]*`+")
 
 _CLAUDE_BODY = (
     "@CLAUDE.md\n"
@@ -55,6 +58,34 @@ def test_arguments_token_removed(tmp_path: Path) -> None:
     assert "$ARGUMENTS" in _CLAUDE_BODY
 
 
+def test_arguments_token_preserved_inside_inline_code_span(tmp_path: Path) -> None:
+    """Literal authoring docs keep `$ARGUMENTS` inside inline code spans."""
+    body = "- Simple commands: use `$ARGUMENTS`\n"
+
+    out = copilot_body_translation.translate_body(body, tmp_path)
+
+    assert out == body
+
+
+def test_arguments_token_preserved_inside_fenced_code_block(tmp_path: Path) -> None:
+    """Literal slash-command examples keep `$ARGUMENTS` inside fenced code."""
+    body = "```text\nUse $ARGUMENTS here.\n```\n"
+
+    out = copilot_body_translation.translate_body(body, tmp_path)
+
+    assert out == body
+
+
+def test_arguments_token_translated_in_prose(tmp_path: Path) -> None:
+    """Invocation contracts still translate prose `$ARGUMENTS` references."""
+    body = "Spec: $ARGUMENTS\n"
+
+    out = copilot_body_translation.translate_body(body, tmp_path)
+
+    assert "$ARGUMENTS" not in out
+    assert "the problem statement from the conversation" in out
+
+
 def test_include_line_replaced_with_note(tmp_path: Path) -> None:
     """`@CLAUDE.md` standalone include becomes a Copilot note, not literal text."""
     out = copilot_body_translation.translate_body(_CLAUDE_BODY, tmp_path)
@@ -63,6 +94,25 @@ def test_include_line_replaced_with_note(tmp_path: Path) -> None:
     assert "load via the plugin instructions tree" in out
     # Negative control: the raw body starts with the literal include.
     assert _CLAUDE_BODY.startswith("@CLAUDE.md")
+
+
+def test_standalone_decorator_line_is_preserved(tmp_path: Path) -> None:
+    """Standalone Python decorator lines are not Claude include directives."""
+    body = "```python\n@dataclass\nclass Config:\n    pass\n```\n"
+
+    out = copilot_body_translation.translate_body(body, tmp_path)
+
+    assert out == body
+
+
+def test_markdown_include_line_still_replaced(tmp_path: Path) -> None:
+    """Markdown include directives remain the only translated @ lines."""
+    body = "@CLAUDE.md\n"
+
+    out = copilot_body_translation.translate_body(body, tmp_path)
+
+    assert "@CLAUDE.md" not in out
+    assert "load via the plugin instructions tree" in out
 
 
 def test_skill_call_mapped_in_appendix(tmp_path: Path) -> None:
@@ -224,9 +274,19 @@ def _committed_bodies() -> list[tuple[str, str]]:
     ]
 
 
-def test_committed_skills_have_no_arguments_token() -> None:
-    """No shipped Copilot skill body may carry the unresolved `$ARGUMENTS`."""
-    offenders = [name for name, body in _committed_bodies() if "$ARGUMENTS" in body]
+def _contains_untranslated_arguments_token(body: str) -> bool:
+    body_without_fences = _FENCED_CODE_BLOCK_RE.sub("", body)
+    body_without_code_spans = _INLINE_CODE_SPAN_RE.sub("", body_without_fences)
+    return "$ARGUMENTS" in body_without_code_spans
+
+
+def test_committed_skills_have_no_untranslated_arguments_token() -> None:
+    """No shipped Copilot skill body may carry unresolved `$ARGUMENTS` prose."""
+    offenders = [
+        name
+        for name, body in _committed_bodies()
+        if _contains_untranslated_arguments_token(body)
+    ]
     assert not offenders, f"$ARGUMENTS present in: {offenders}"
 
 


### PR DESCRIPTION
## Summary
Fixes #2932

Preserves literal `$ARGUMENTS` in inline code and fenced examples.

Limits include translation to markdown include lines.

Regenerates Copilot CLI skill mirrors.

## Tests
uv run pytest tests/build_scripts/ with focused selector passed, 22 tests.

Pre push hook passed, 15 checks.

## References
Issue #2932
