### PR TITLE
feat(ci): add skill overlap eval cron

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-08-session-01-ci2933.json
+++ b/.agents/memory/episodes/episode-2026-07-08-session-01-ci2933.json
@@ -1,0 +1,67 @@
+{
+  "id": "episode-2026-07-08-session-01-ci2933",
+  "session": "2026-07-08-session-01-ci2933",
+  "timestamp": "2026-07-08T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Fix issue #2933 by adding a quarterly skill-overlap eval workflow.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-08T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verified worktree branch",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-08T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read issue #2933 and eval CLI",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-08T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read workflow patterns",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-08T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added scheduled workflow",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-08T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Validated workflow wiring",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-08T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Completed security review",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-08-session-01-ci2933.json
+++ b/.agents/sessions/2026-07-08-session-01-ci2933.json
@@ -1,0 +1,146 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 1,
+    "date": "2026-07-08",
+    "branch": "agent/ci2933",
+    "startingCommit": "76c9be1575c9",
+    "objective": "Fix issue #2933 by adding a quarterly skill-overlap eval workflow."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena initial instructions loaded; project context came from cwd /home/richard/src/GitHub/rjmurillo/ai-agents/.wt/ci2933."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena-initial_instructions returned the Serena manual."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md lines 1-120 read as read-only reference."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This JSON session log was created for the work."
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "GitHub skill context loaded; PR creation script identified."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md and matching .github instructions loaded through repository context."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Workflow, security, CI script, and universal rules read before editing."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Hook surfaced relevant GitHub and eval harness observations before work."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current returned agent/ci2933."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Branch is agent/ci2933."
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status --short showed only the new workflow and this session log."
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Starting commit recorded as 76c9be1575c9."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Issue #2933 workflow added, validated, reviewed, committed, pushed, and opened as a PR."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md was read and left unchanged."
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No durable new codebase convention was discovered; no Serena memory update was needed."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "pre_pr.py ran repository markdown and style validation after the workflow edit."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Changes were committed on branch agent/ci2933 with a conventional commit."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "YAML parse, actionlint, SHA pinning, dash byte check, eval dry-run, pre_pr.py, and session JSON validation passed."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "PR description uses Fixes #2933 for GitHub issue linkage."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Single-workflow implementation task; no retrospective was warranted."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Verified worktree branch",
+      "detail": "git branch --show-current returned agent/ci2933."
+    },
+    {
+      "action": "Read issue #2933 and eval CLI",
+      "detail": "Issue requires a quarterly scheduled workflow. eval-skill-overlap.py requires --pairs, supports --run-id, writes evals/reports/overlap-<run-id>, and fails closed when ANTHROPIC_API_KEY is missing."
+    },
+    {
+      "action": "Read workflow patterns",
+      "detail": "Copied SHA-pinned checkout, setup-python, setup-uv, and upload-artifact patterns from existing workflows. Used contents: read and persist-credentials: false."
+    },
+    {
+      "action": "Added scheduled workflow",
+      "detail": ".github/workflows/skill-overlap-eval.yml runs quarterly and on workflow_dispatch, wires ANTHROPIC_API_KEY, uses SHA-pinned actions, and uploads the report directory."
+    },
+    {
+      "action": "Validated workflow wiring",
+      "detail": "YAML parse passed. actionlint emitted no findings. sha_pinning.py reported all GitHub Actions are SHA-pinned. Dash byte check returned 0. Eval dry-run validated 2 pairs with no API calls."
+    },
+    {
+      "action": "Completed security review",
+      "detail": "Security agent reported PASS: least privilege, SHA pinning, credential persistence, secret handling, command injection surface, artifact path, and trigger surface passed."
+    }
+  ],
+  "endingCommit": null,
+  "nextSteps": [
+    "Monitor the PR checks after auto-merge is armed."
+  ]
+}

--- a/.github/workflows/skill-overlap-eval.yml
+++ b/.github/workflows/skill-overlap-eval.yml
@@ -1,0 +1,52 @@
+name: Skill Overlap Eval
+
+on:
+  schedule:
+    - cron: '0 6 1 */3 *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: skill-overlap-eval
+  cancel-in-progress: true
+
+jobs:
+  run-eval:
+    name: Run skill overlap eval
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        with:
+          enable-cache: true
+
+      - name: Run skill overlap eval
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: >-
+          uv run python scripts/eval/eval-skill-overlap.py
+          --pairs scripts/eval/examples/overlap-pairs-issue-1949.json
+          --run-id quarterly-${{ github.run_id }}
+
+      - name: Upload overlap report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: skill-overlap-eval-${{ github.run_id }}
+          path: evals/reports/overlap-quarterly-${{ github.run_id }}
+          retention-days: 90
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
Adds the missing quarterly cron for the skill overlap eval. This closes the AC5 gap from issue #2933 and keeps skill catalog drift visible between manual sweeps.

Fixes #2933

## Specification References
| Issue | Coverage |
|-------|----------|
| #2933 | Adds the scheduled workflow requested by the issue. |
| #1950 | Restores AC5 quarterly eval coverage. |

## Type of Change
- [x] Feature
- [x] CI automation

## Changes
- Adds a scheduled workflow with quarterly cron and manual dispatch.
- Wires the Anthropic API key through step environment only.
- Uses SHA-pinned actions, least-privilege permissions, and credential persistence off.
- Uploads the generated overlap report as a workflow artifact.

## Testing
- `uv run python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/skill-overlap-eval.yml'))"`
- `actionlint .github/workflows/skill-overlap-eval.yml`
- `python3 scripts/validation/sha_pinning.py --ci`
- `python3 -c "d=open('F','rb').read();print(d.count(b'\\xe2\\x80\\x94')+d.count(b'\\xe2\\x80\\x93'))"` with F set to the new workflow, result 0
- `uv run python scripts/eval/eval-skill-overlap.py --pairs scripts/eval/examples/overlap-pairs-issue-1949.json --run-id quarterly-dry-run --dry-run`
- `uv run python scripts/validation/pre_pr.py`
- `uv run python scripts/validate_session_json.py .agents/sessions/2026-07-08-session-01-ci2933.json`
- Security review passed with no findings.
- Pre-push hook passed. Workflow local run was skipped because the secret is absent locally; CI runs with repository secrets.

## References
- `.github/workflows/skill-overlap-eval.yml`
- `.agents/sessions/2026-07-08-session-01-ci2933.json`
- `.agents/memory/episodes/episode-2026-07-08-session-01-ci2933.json`
- `scripts/eval/eval-skill-overlap.py`
- `scripts/eval/examples/overlap-pairs-issue-1949.json`