### PR TITLE
test(evals): add memory routing fixtures

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-08-session-2614.json
+++ b/.agents/memory/episodes/episode-2026-07-08-session-2614.json
@@ -1,0 +1,75 @@
+{
+  "id": "episode-2026-07-08-session-2614",
+  "session": "2026-07-08-session-2614",
+  "timestamp": "2026-07-08T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Fix issue #2926 by adding memory-search and memory-reflexion routing fixtures, then running and recording the ADR-063 kill-gate eval.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-08T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verified branch agent/eval2926 and read HANDOFF.md.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-08T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read issue #2926, triage fixture schema, memory-search SKILL.md, memory-reflexion SKILL.md, ADR-063, and eval harness docs.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-08T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added six memory-search and six memory-reflexion routing prompts to tests/evals/skills/triage-prompts.json.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-08T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Validated JSON and ran zero-cost dry runs for both sibling skills.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-08T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran live ADR-063 kill-gate evals with ANTHROPIC_API_KEY exported from .env. memory-search PROCEED delta 2.83; memory-reflexion PROCEED delta 2.89.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-08T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Recorded eval outputs under evals/reports/adr-063-kill-gate-20260708/.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-08T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran scoped markdownlint, dash checks, targeted pytest, diff check, pre-PR validation, and build check.",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 6
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-08-session-2614.json
+++ b/.agents/sessions/2026-07-08-session-2614.json
@@ -1,0 +1,151 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2614,
+    "date": "2026-07-08",
+    "branch": "agent/eval2926",
+    "startingCommit": "76c9be15",
+    "objective": "Fix issue #2926 by adding memory-search and memory-reflexion routing fixtures, then running and recording the ADR-063 kill-gate eval."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP tools available; initial instructions loaded via serena-initial_instructions."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena Instructions Manual read before repo edits."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read lines 1-120; read-only rule observed."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file created during the session."
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "github skill loaded for issue and PR workflow; eval harness read from scripts/eval."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "GitHub issue context read through github skill script; gh used only where the user explicitly requested gh issue view context."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md, testing, scripts, and dash prohibition rules loaded by prompt and path instructions."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Relevant self-improving memories surfaced by hooks and applied, including eval harness and dash byte checks."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current returned agent/eval2926."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Branch is agent/eval2926, not main or master."
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status checked before and after edits."
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "76c9be15"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart and sessionEnd MUST fields carry evidence."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md was read but not modified."
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No durable repo convention changed; eval results recorded in evals/reports/adr-063-kill-gate-20260708/."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "npx markdownlint-cli2 --fix evals/reports/adr-063-kill-gate-20260708/REPORT.md exited 0."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Final commit includes the fixture additions, eval report artifacts, and this session log."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "JSON fixture parse passed; dash byte checks passed; targeted dash pytest passed; git diff --check passed; scripts/validation/pre_pr.py passed; build/scripts/build_all.py --check exited 0."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue #2926 task steps tracked in this work log."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not required for this fixture and eval artifact change."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "2026-07-08T09:04:00Z",
+      "entry": "Verified branch agent/eval2926 and read HANDOFF.md."
+    },
+    {
+      "time": "2026-07-08T09:10:00Z",
+      "entry": "Read issue #2926, triage fixture schema, memory-search SKILL.md, memory-reflexion SKILL.md, ADR-063, and eval harness docs."
+    },
+    {
+      "time": "2026-07-08T09:20:00Z",
+      "entry": "Added six memory-search and six memory-reflexion routing prompts to tests/evals/skills/triage-prompts.json."
+    },
+    {
+      "time": "2026-07-08T09:25:00Z",
+      "entry": "Validated JSON and ran zero-cost dry runs for both sibling skills."
+    },
+    {
+      "time": "2026-07-08T09:38:00Z",
+      "entry": "Ran live ADR-063 kill-gate evals with ANTHROPIC_API_KEY exported from .env. memory-search PROCEED delta 2.83; memory-reflexion PROCEED delta 2.89."
+    },
+    {
+      "time": "2026-07-08T09:45:00Z",
+      "entry": "Recorded eval outputs under evals/reports/adr-063-kill-gate-20260708/."
+    },
+    {
+      "time": "2026-07-08T10:05:00Z",
+      "entry": "Ran scoped markdownlint, dash checks, targeted pytest, diff check, pre-PR validation, and build check."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Run scoped lint and validation.",
+    "Commit, push, open PR, and arm auto-merge for issue #2926."
+  ]
+}

--- a/evals/reports/adr-063-kill-gate-20260708/REPORT.md
+++ b/evals/reports/adr-063-kill-gate-20260708/REPORT.md
@@ -1,0 +1,30 @@
+# ADR-063 Kill Gate Eval
+
+Issue: #2926
+Date: 2026-07-08
+Model: claude-sonnet-4-6
+Harness: scripts/eval/eval-knowledge-integration.py
+Prompts: tests/evals/skills/triage-prompts.json
+
+## Commands
+
+```bash
+export ANTHROPIC_API_KEY=$(grep -E '^ANTHROPIC_API_KEY=' .env | cut -d= -f2-)
+python3 scripts/eval/eval-knowledge-integration.py --prompts-file tests/evals/skills/triage-prompts.json --skill memory-search --dry-run
+python3 scripts/eval/eval-knowledge-integration.py --prompts-file tests/evals/skills/triage-prompts.json --skill memory-reflexion --dry-run
+python3 scripts/eval/eval-knowledge-integration.py --prompts-file tests/evals/skills/triage-prompts.json --skill memory-search --output evals/reports/adr-063-kill-gate-20260708/memory-search.json
+python3 scripts/eval/eval-knowledge-integration.py --prompts-file tests/evals/skills/triage-prompts.json --skill memory-reflexion --output evals/reports/adr-063-kill-gate-20260708/memory-reflexion.json
+```
+
+## Results
+
+| Skill | Verdict | Baseline avg | Enhanced avg | Delta | Context chars |
+|-------|---------|--------------|--------------|-------|---------------|
+| memory-search | PROCEED | 1.78 | 4.61 | 2.83 | 6210 |
+| memory-reflexion | PROCEED | 2.06 | 4.94 | 2.89 | 33367 |
+
+## Kill Criteria
+
+Both sibling skills pass the eval-knowledge-integration kill gate. No regression was reported. The ADR-063 behavior-change kill criterion did not fire.
+
+The hot path context target applies to router plus hot-path sub-skill. This run measured memory-search at 6210 chars. The combined router path was not remeasured in this fixture-only issue.

--- a/evals/reports/adr-063-kill-gate-20260708/memory-reflexion.json
+++ b/evals/reports/adr-063-kill-gate-20260708/memory-reflexion.json
@@ -1,0 +1,141 @@
+{
+  "model": "claude-sonnet-4-6",
+  "skills_evaluated": [
+    "memory-reflexion"
+  ],
+  "total_prompts": 6,
+  "results": {
+    "memory-reflexion": {
+      "context_chars": 33367,
+      "baseline_avg": {
+        "accuracy": 1.17,
+        "depth": 2.83,
+        "specificity": 2.17
+      },
+      "enhanced_avg": {
+        "accuracy": 4.83,
+        "depth": 5.0,
+        "specificity": 5.0
+      },
+      "baseline_detail": [
+        {
+          "accuracy": 1,
+          "depth": 2,
+          "specificity": 2,
+          "reasoning": "The response completely misses the expected answer's core concepts: memory-reflexion, extract_session_episode.py, update_causal_graph.py, and the Tier 2/Tier 3 episodic-to-causal pipeline architecture. Instead of recognizing the specific toolchain and memory architecture required, the agent defaulted to generic file-reading tool calls and then offered a vague, generic explanation of what 'extract and fold into memory' might mean. No mention of the tiered memory system, causal graphs, or the specific scripts. The depth is minimal \u2014 it shows no understanding of the underlying memory architecture. Specificity is low because the concrete details provided (generic JSON structure, vector index mentions) are not aligned with the actual system described in the expected answer.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 1,
+          "depth": 4,
+          "specificity": 3,
+          "reasoning": "The response completely misses the expected answer, which was a routing instruction to memory-reflexion and its specific update_causal_graph.py path with dry-run capability. Instead, it provides a from-scratch Python implementation of a causal graph system. While the implementation is technically deep and shows genuine understanding of causal graph concepts (decay factors, confidence thresholds, lag windows, batch processing), it is entirely wrong in context \u2014 this appears to be a system navigation/routing question, not a code generation request. The specificity score is moderate because the code uses precise ML/graph terminology, but none of it maps to the actual system components mentioned in the expected answer (memory-reflexion, Tier 3, update_causal_graph.py, dry-run).",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 1,
+          "depth": 2,
+          "specificity": 1,
+          "reasoning": "The response completely misses the expected answer's core concepts: memory-reflexion, the write path, extracting from session logs, folding episodes into a causal graph, and the distinction between memory-reflexion and memory-search for write operations. The actual response assumes a general-purpose AI with no memory system, while the expected answer presupposes a specific agentic architecture with named components (memory-reflexion, causal graph, memory-search). The response shows some depth in reasoning about its own limitations, but this reasoning is entirely irrelevant to the expected answer's domain. No specialized terminology from the target system is used anywhere.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 1,
+          "depth": 2,
+          "specificity": 2,
+          "reasoning": "The response is fundamentally incorrect - it says 'Yes' when the correct answer is 'No'. It completely misses the core concepts: that memory-reflexion only works with COMPLETED sessions, that partial sessions create incomplete episode data, and that this pollutes the causal graph. The response treats this as a generic software/logging question rather than addressing the specific memory-reflexion system constraints. While it shows some depth in discussing general memory episode extraction approaches and provides a JSON structure example, this depth is misapplied to the wrong answer. The specificity score is low because it uses generic terminology rather than the precise domain-specific concepts (completed sessions, causal graph pollution) that the correct answer requires.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 1,
+          "depth": 4,
+          "specificity": 3,
+          "reasoning": "The response completely misses the expected answer, which is a simple, specific instruction: use memory-reflexion and run update_causal_graph.py with --dry-run flag. Instead, the response builds a custom Python framework from scratch with no mention of the actual tool (update_causal_graph.py), the --dry-run flag, or memory-reflexion. While the response demonstrates deep understanding of causal graph diffing concepts and shows technical sophistication, it answers a different question entirely \u2014 how to build a preview system rather than how to use the existing one. Specificity is moderate because it uses precise graph terminology and concrete code, but it's specific to the wrong solution.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 2,
+          "depth": 3,
+          "specificity": 2,
+          "reasoning": "The response correctly says 'No' but misses the critical specific concepts from the expected answer: memory-search as the correct Tier 1 lookup tool, and the precise explanation that memory-reflexion is for episode extraction and causal-graph writes after sessions complete. Instead, the response gives generic advice about Notion/Confluence/grep/RAG, which shows no awareness of the actual memory system architecture being referenced. The depth is moderate as it explains reasoning for the 'No' answer, but the specificity is low because it substitutes vague general tools for the precise system-specific terminology (memory-search, Tier 1 lookup, episode extraction, causal-graph writes) that the expected answer requires.",
+          "model_used": "claude-sonnet-4-6"
+        }
+      ],
+      "enhanced_detail": [
+        {
+          "accuracy": 5,
+          "depth": 5,
+          "specificity": 5,
+          "reasoning": "The response correctly identifies both required scripts (extract_session_episode.py and update_causal_graph.py), the Tier 2/Tier 3 memory architecture, and the directional data flow from episode data to causal patterns \u2014 matching all key concepts in the expected answer. Depth is exceptional: it explains the purpose of each step, adds a dry-run recommendation, includes a verification table, provides an ordering diagram, and warns about edge cases (incomplete sessions, zero-delta re-runs, permission issues). Specificity is equally strong: exact file paths, CLI flags (--dry-run, --episode-path), expected output formats, and references to specific config files like reflexion-memory.md are all concrete and precise.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 4,
+          "depth": 5,
+          "specificity": 5,
+          "reasoning": "Accuracy is 4 because the response correctly identifies update_causal_graph.py and the dry-run capability, matching the expected answer's core concepts, but it doesn't explicitly mention routing to 'memory-reflexion' as the owning skill or frame it as a routing decision. Depth is 5 because the response goes well beyond surface-level with troubleshooting tables, anti-patterns, verification checklists, and edge case handling (zero-delta runs, scoped episode paths). Specificity is 5 because it uses precise file paths, exact script names, concrete CLI flags, specific JSON field names, and exact output format examples.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 5,
+          "depth": 5,
+          "specificity": 5,
+          "reasoning": "The response correctly identifies the memory-reflexion write path, explicitly avoids memory-search for this write operation, extracts from the completed session log, and folds the episode into the causal graph \u2014 all key elements from the expected answer. Depth is excellent: it breaks the operation into discrete verified steps, explains what each produces, and includes guard conditions (e.g., do not proceed if session is incomplete). Specificity is high throughout: concrete script paths, exact CLI flags (--dry-run), precise field names in the episode record, git commit conventions, and references to ADR-007. The response goes well beyond surface-level and demonstrates genuine understanding of the two-step reflexion write operation.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 5,
+          "depth": 5,
+          "specificity": 5,
+          "reasoning": "The response nails all three core concepts from the expected answer: the prohibition on in-progress extraction, the completed session requirement, and the causal graph pollution risk. It goes well beyond surface-level by explaining WHY each element matters (terminal outcome field, skewed success rates, missing causal edges), and uses highly specific terminology (episode schema, outcome field values, exact script names and paths, causal graph update pipeline). The correct workflow diagram and mid-session alternative add practical depth not present in the expected answer but entirely consistent with it.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 5,
+          "depth": 5,
+          "specificity": 5,
+          "reasoning": "The response perfectly captures all key concepts from the expected answer: memory-reflexion skill, update_causal_graph.py script, --dry-run flag, prints changes, writes nothing. It goes far beyond surface-level by explaining the internal mechanics (read episodes, compute diff, print, write nothing), providing realistic expected output with concrete examples of nodes/edges/patterns, offering scoping options with --episode-path and --since flags, and including a verification checklist. Specificity is excellent with precise file paths (.claude/skills/memory/scripts/, .agents/memory/causality/causal-graph.json), concrete node types (decision, event, error), edge types (causes, prevents), and weight values.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 5,
+          "depth": 5,
+          "specificity": 5,
+          "reasoning": "The response correctly identifies memory-search as the right tool and memory-reflexion as the write path for episode extraction and causal-graph updates after sessions complete \u2014 matching the expected answer precisely. It goes beyond surface-level by explaining the architectural distinction between read and write paths, citing the skill's own documentation with direct quotes. Specificity is high: it names the exact skill names, references Tier 1 semantic lookup terminology, mentions the causal graph, and ties the recommendation directly to the ADR-038 use case.",
+          "model_used": "claude-sonnet-4-6"
+        }
+      ]
+    }
+  },
+  "kill_gate": {
+    "passed": true,
+    "verdict": "PROCEED",
+    "failures": [],
+    "summary": {
+      "memory-reflexion": {
+        "baseline_avg": {
+          "accuracy": 1.17,
+          "depth": 2.83,
+          "specificity": 2.17
+        },
+        "enhanced_avg": {
+          "accuracy": 4.83,
+          "depth": 5.0,
+          "specificity": 5.0
+        },
+        "delta": {
+          "accuracy": 3.66,
+          "depth": 2.17,
+          "specificity": 2.83
+        },
+        "overall_delta": 2.89,
+        "passed": true,
+        "regressed": false
+      }
+    },
+    "total_skills": 1,
+    "proceed_threshold": 1,
+    "conditional_threshold": 1,
+    "skills_passing": 1
+  }
+}

--- a/evals/reports/adr-063-kill-gate-20260708/memory-search.json
+++ b/evals/reports/adr-063-kill-gate-20260708/memory-search.json
@@ -1,0 +1,141 @@
+{
+  "model": "claude-sonnet-4-6",
+  "skills_evaluated": [
+    "memory-search"
+  ],
+  "total_prompts": 6,
+  "results": {
+    "memory-search": {
+      "context_chars": 6210,
+      "baseline_avg": {
+        "accuracy": 1.0,
+        "depth": 2.33,
+        "specificity": 2.0
+      },
+      "enhanced_avg": {
+        "accuracy": 4.17,
+        "depth": 4.83,
+        "specificity": 4.83
+      },
+      "baseline_detail": [
+        {
+          "accuracy": 1,
+          "depth": 2,
+          "specificity": 1,
+          "reasoning": "The response completely misses the expected answer, which describes a specific procedural workflow: using memory-search for Tier 1 semantic lookup, running search_memory.py, prioritizing Serena-first memory with Forgetful as supplementary, and reading relevant index entries. Instead, the response treats this as a general AI limitation question and explains it has no memory. It doesn't mention any of the correct concepts (Tier 1 semantic lookup, search_memory.py, Serena memory, Forgetful memory system, index entries). The depth score gets a 2 only because the response is coherent and structured, but it's deeply wrong in direction. Specificity is 1 because none of the precise terminology from the expected answer appears.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 1,
+          "depth": 2,
+          "specificity": 3,
+          "reasoning": "The response completely misses the expected behavior, which was to route the query to a memory-search function for retrieving stored facts and patterns from prior sessions. Instead, the model treats this as a direct technical question and disclaims any memory capability, then pivots to general git hook troubleshooting advice. The accuracy score is 1 because the core concept \u2014 recognizing this as a memory-search routing task \u2014 is entirely absent. Depth is 2 because while the response shows some understanding of git hooks technically, it fails to engage with the meta-level intent of the prompt (session memory retrieval). Specificity is 3 because the technical content about git hooks is reasonably concrete with named hooks and tools like husky and pre-commit, but this specificity is applied to the wrong problem entirely.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 1,
+          "depth": 2,
+          "specificity": 1,
+          "reasoning": "The response completely misses the expected answer's concepts. The expected answer describes a specific workflow: using memory-search, Tier 1 search with progressive disclosure, reading matching memories, then reasoning about the validator. The actual response instead interprets the prompt as a manipulation attempt and refuses to engage, providing no relevant concepts like memory-search, tiered search strategies, or progressive disclosure. While the response shows some depth in explaining its reasoning for refusal, it scores low on accuracy and specificity because it contains none of the correct terminology or concrete procedures from the expected answer.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 1,
+          "depth": 2,
+          "specificity": 2,
+          "reasoning": "The response completely misses the key concepts from the expected answer: memory-search with lexical-only fallback, Serena as canonical source, and the coverage note vs. hard failure distinction. The actual response treats 'Forgetful' as a generic plugin and offers generic troubleshooting advice (check GitHub, scroll up in chat, check local files) rather than addressing the specific memory/plugin architecture described in the expected answer. It shows no understanding of the system being referenced. The depth is surface-level generic advice, and while it uses some specific terminology (CHANGELOG.md, package.json), none of it is relevant to the actual question's context.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 1,
+          "depth": 2,
+          "specificity": 2,
+          "reasoning": "The response completely misses the expected answer, which was to identify 'memory-search' as the specific Tier 1 semantic memory lookup sub-skill. Instead, the response assumes no named skill system exists and pivots to explaining third-party frameworks (Semantic Kernel, LangChain, etc.). This is a fundamental accuracy failure. While the response shows some depth by providing a framework comparison table and an actual ARM cost fact, it demonstrates depth in the wrong direction entirely. Specificity is low for the actual question \u2014 the precise term 'memory-search' as a Tier 1 sub-skill is never mentioned \u2014 though it does use specific framework names and a concrete cost figure for the tangential ARM pricing answer.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 1,
+          "depth": 4,
+          "specificity": 3,
+          "reasoning": "The response completely misses the expected answer, which is a clear architectural rule: memory-search is lookup-only, and updates belong to memory-reflexion (episode extraction/causal-graph updates) and memory-enhancement (citations/confidence metadata). Instead of stating this system-specific constraint, the response treats it as an open design question and explores both sides philosophically. On accuracy, it scores 1 because it never mentions the correct answer or the specific modules (memory-reflexion, memory-enhancement) that handle these responsibilities. On depth, it scores 4 because the analysis of provenance vs. causal graphs, the tension between retrieval mechanics and domain causality, and the two-structure proposal show genuine analytical thinking. On specificity, it scores 3 because while it uses some precise terminology (provenance graph, causal graph, epistemological provenance), it lacks the system-specific terminology from the expected answer and the concrete module names that would make it truly specific to the actual architecture in question.",
+          "model_used": "claude-sonnet-4-6"
+        }
+      ],
+      "enhanced_detail": [
+        {
+          "accuracy": 4,
+          "depth": 5,
+          "specificity": 5,
+          "reasoning": "The response correctly identifies the core concepts from the expected answer: Tier 1 semantic lookup, search_memory.py as the canonical script, Serena as primary/canonical with Forgetful as supplementary, and graceful degradation when Forgetful is unreachable. It loses one accuracy point for not explicitly framing the workflow as 'shared' and for not mentioning reading only relevant index entries as a distinct step. Depth is excellent - it elaborates on graceful degradation mechanics, tier boundaries, progressive disclosure rationale, and cross-references to other ADRs. Specificity is strong throughout with precise tool names, script paths, token budget tables, constraint classifications, and source attribution tables.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 3,
+          "depth": 4,
+          "specificity": 4,
+          "reasoning": "Accuracy is middling: the response correctly identifies memory-search as the right route and follows the progressive disclosure pattern, but it over-engineers the answer with fallback chains and general knowledge padding when the expected answer simply confirms 'route to memory-search, this is a lookup over stored facts.' It correctly avoids fabrication and logs a zero-result outcome, which aligns with the spirit of the expected answer. Depth is high: the response demonstrates genuine understanding of the memory-search skill's architecture (Phase 1/2/3, progressive disclosure, Serena/Forgetful distinction, lexical-only fallback). Specificity is high: it uses precise tool names (Serena, Forgetful, search_memory.py), concrete fallback key names, and a structured table of git hook timeout patterns with specific examples like GIT_HOOK_TIMEOUT and timeout wrapping patterns.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 4,
+          "depth": 5,
+          "specificity": 5,
+          "reasoning": "Accuracy is high (4) because the response correctly identifies the core concepts: memory search, progressive/tiered disclosure starting with focused queries before escalating, and reading only matching memories before reasoning. It loses one point because it doesn't explicitly label the tiers as 'Tier 1' focused search per the expected answer's framing. Depth is excellent (5) \u2014 the response goes well beyond surface level, explaining the fallback path, why each context category matters before making changes, and includes an anti-pattern guard rationale. Specificity is excellent (5) \u2014 it uses precise terminology (progressive disclosure, atomic entries, domain index, root index), concrete tool names (read_memory, search_memory.py), specific memory key guesses, and a structured table of context categories with justifications.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 5,
+          "depth": 5,
+          "specificity": 5,
+          "reasoning": "The response nails all three concepts from the expected answer: lexical-only fallback, Serena as canonical store traveling with the repo, and graceful degradation returning a coverage note rather than a hard failure. It goes well beyond surface-level by explaining the rationale, failure modes, and even adds a progressive disclosure workflow. Specificity is high with exact command syntax, flag names, table breakdowns, and a reference to ADR-007.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 5,
+          "depth": 5,
+          "specificity": 5,
+          "reasoning": "The response correctly identifies memory-search as the handling skill, matches the expected answer's core concepts (Tier 1, semantic lookup, facts/patterns/constraints), and goes well beyond surface-level by explaining why memory-search is preferred over the memory router, showing the actual execution command, referencing ADR-063, and explaining progressive disclosure. Terminology is precise and concrete examples (token cost range, bash command, trigger pattern quote) are included throughout.",
+          "model_used": "claude-sonnet-4-6"
+        },
+        {
+          "accuracy": 4,
+          "depth": 5,
+          "specificity": 5,
+          "reasoning": "Accuracy is 4 rather than 5 because the response routes causal graph updates to 'memory' router generically, while the expected answer specifically names 'memory-reflexion' for episode extraction and causal graph updates \u2014 the actual response misses this specific skill name. Depth is 5: the response goes well beyond the expected answer, explaining the architectural rationale (single-responsibility, degradation contract, tier coupling, ADR-063) and providing a correct sequenced workflow. Specificity is 5: the response uses precise terminology (Tier 1, progressive disclosure, lexical-only fallback, read-only vs write operations, skill decomposition) and concrete structured examples including a table and numbered workflow.",
+          "model_used": "claude-sonnet-4-6"
+        }
+      ]
+    }
+  },
+  "kill_gate": {
+    "passed": true,
+    "verdict": "PROCEED",
+    "failures": [],
+    "summary": {
+      "memory-search": {
+        "baseline_avg": {
+          "accuracy": 1.0,
+          "depth": 2.33,
+          "specificity": 2.0
+        },
+        "enhanced_avg": {
+          "accuracy": 4.17,
+          "depth": 4.83,
+          "specificity": 4.83
+        },
+        "delta": {
+          "accuracy": 3.17,
+          "depth": 2.5,
+          "specificity": 2.83
+        },
+        "overall_delta": 2.83,
+        "passed": true,
+        "regressed": false
+      }
+    },
+    "total_skills": 1,
+    "proceed_threshold": 1,
+    "conditional_threshold": 1,
+    "skills_passing": 1
+  }
+}

--- a/tests/evals/skills/triage-prompts.json
+++ b/tests/evals/skills/triage-prompts.json
@@ -148,6 +148,58 @@
         "expected": "Query memory before reasoning. Pre-training is last resort. Read first, reason second. Evidence in session log."
       }
     ],
+    "memory-search": [
+      {
+        "prompt": "Search memory for prior decisions about ADR-007 and summarize the relevant constraints.",
+        "expected": "Use memory-search for Tier 1 semantic lookup. Run the shared search_memory.py workflow across Serena-first memory, with Forgetful as supplementary when reachable, then read only relevant index entries."
+      },
+      {
+        "prompt": "What do we know about git hook timeout failures from prior sessions?",
+        "expected": "Route to memory-search. This is a what do we know about X lookup over stored facts and patterns, not episode extraction or causal-graph update."
+      },
+      {
+        "prompt": "Recall prior context before changing the session protocol validator.",
+        "expected": "Use memory-search to recall prior context. Start with focused Tier 1 search and progressive disclosure, then read only matching memories before reasoning about the validator."
+      },
+      {
+        "prompt": "Forgetful is unreachable. How should I still search memory for plugin versioning rules?",
+        "expected": "Use memory-search with the lexical-only fallback. Serena remains canonical and travels with the repo; losing Forgetful returns a coverage note, not a hard failure."
+      },
+      {
+        "prompt": "I need one fact from memory about ARM runner cost. Which skill handles that?",
+        "expected": "Use memory-search. It is the focused Tier 1 semantic memory lookup sub-skill for facts, patterns, and constraints."
+      },
+      {
+        "prompt": "Should memory-search update the causal graph after it finds relevant memories?",
+        "expected": "No. memory-search is lookup only. Use memory-reflexion for episode extraction and causal-graph updates, and memory-enhancement for citations or confidence metadata."
+      }
+    ],
+    "memory-reflexion": [
+      {
+        "prompt": "Extract an episode from .agents/sessions/2026-07-08-session-2613.json and fold it into memory.",
+        "expected": "Use memory-reflexion. First run extract_session_episode.py against the completed session log, then update_causal_graph.py so Tier 2 episode data feeds Tier 3 causal patterns."
+      },
+      {
+        "prompt": "Update the causal graph after a batch of completed session episodes.",
+        "expected": "Route to memory-reflexion. It owns the Tier 3 causal-graph update path via update_causal_graph.py, with dry-run available before writing."
+      },
+      {
+        "prompt": "Record what happened this session so future decisions can learn from it.",
+        "expected": "Use memory-reflexion for the full write path. Extract from the completed session log, then fold the episode into the causal graph; do not use memory-search for this write operation."
+      },
+      {
+        "prompt": "Can I extract a memory episode from an in-progress session log?",
+        "expected": "No. memory-reflexion only extracts from COMPLETED sessions. A partial session creates incomplete episode data and pollutes the causal graph."
+      },
+      {
+        "prompt": "Preview causal-graph changes before applying a reflexion update.",
+        "expected": "Use memory-reflexion and run update_causal_graph.py with --dry-run. The dry run prints graph changes and writes nothing."
+      },
+      {
+        "prompt": "I only need to search whether we have prior ADR-038 notes. Should I use memory-reflexion?",
+        "expected": "No. Use memory-search for Tier 1 lookup. memory-reflexion is for episode extraction and causal-graph writes after sessions complete."
+      }
+    ],
     "memory-documentary": [
       {
         "prompt": "Generate a documentary on how this repo decided to use Python over PowerShell for new scripts.",


### PR DESCRIPTION
## Summary

Adds missing routing fixtures for the memory-search and memory-reflexion skills, then records the ADR 063 kill gate eval output for issue #2926.

## Specification References

| Type | Reference |
|------|-----------|
| Issue | #2926 |

## Type of Change

- [x] Test fixtures and eval artifacts

## Changes

- Added six memory-search prompts and six memory-reflexion prompts to the skill triage fixture set.
- Recorded machine-readable eval outputs for both skills.
- Recorded a short report with commands, scores, and verdicts.

## Testing

JSON fixture parse passed.
Dry runs for both skills validated the fixture plan with zero API calls.
Live ADR 063 kill gate eval results:

| Skill | Verdict | Baseline avg | Enhanced avg | Delta | Context chars |
|-------|---------|--------------|--------------|-------|---------------|
| memory-search | PROCEED | 1.78 | 4.61 | 2.83 | 6210 |
| memory-reflexion | PROCEED | 2.06 | 4.94 | 2.89 | 33367 |

Validation passed:

| Check | Result |
|-------|--------|
| python3 scripts/validate_session_json.py .agents/sessions/2026-07-08-session-2614.json | PASS |
| uv run pytest tests/evals/test_no_unicode_dashes.py -q | PASS, 9 tests |
| git diff --check | PASS |
| uv run python scripts/validation/pre_pr.py | PASS |
| SKIP_CLI_E2E=true git push origin agent/eval2926 | PASS |

Fixes #2926

## References

tests/evals/skills/triage-prompts.json
evals/reports/adr-063-kill-gate-20260708/REPORT.md
evals/reports/adr-063-kill-gate-20260708/memory-search.json
evals/reports/adr-063-kill-gate-20260708/memory-reflexion.json