### PR TITLE
fix(git): repair packed-refs blanks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -56,6 +56,32 @@ echo_action() {
     echo -e "${CYAN}FIXING:${NC} $1"
 }
 
+run_packed_refs_repair() {
+    local hook_dir
+    hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+    local repair_script="$hook_dir/../scripts/maintenance/repair_packed_refs.py"
+    local python_bin=""
+
+    if [ ! -f "$repair_script" ]; then
+        return 0
+    fi
+    if command -v python3 > /dev/null 2>&1; then
+        python_bin="python3"
+    elif command -v python > /dev/null 2>&1; then
+        python_bin="python"
+    else
+        echo_error "Python is required to repair git packed-refs before commit validation"
+        exit 2
+    fi
+
+    "$python_bin" "$repair_script" || {
+        echo_error "Failed to repair git packed-refs"
+        exit 1
+    }
+}
+
+run_packed_refs_repair
+
 # Print the number of non-empty lines in $1 on stdout, as a single integer
 # with no trailing whitespace. Always exits 0; never emits more than one
 # line. Empty input prints 0.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -58,6 +58,32 @@ echo_phase() {
     echo -e "${CYAN}=== $1 ===${NC}"
 }
 
+run_packed_refs_repair() {
+    local hook_dir
+    hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+    local repair_script="$hook_dir/../scripts/maintenance/repair_packed_refs.py"
+    local python_bin=""
+
+    if [ ! -f "$repair_script" ]; then
+        return 0
+    fi
+    if command -v python3 > /dev/null 2>&1; then
+        python_bin="python3"
+    elif command -v python > /dev/null 2>&1; then
+        python_bin="python"
+    else
+        echo_error "Python is required to repair git packed-refs before push validation"
+        exit 2
+    fi
+
+    "$python_bin" "$repair_script" || {
+        echo_error "Failed to repair git packed-refs"
+        exit 1
+    }
+}
+
+run_packed_refs_repair
+
 # Track overall exit status and counters
 EXIT_STATUS=0
 PASS_COUNT=0

--- a/docs/troubleshooting-packed-refs.md
+++ b/docs/troubleshooting-packed-refs.md
@@ -1,0 +1,38 @@
+# Git packed-refs blank-line repair
+
+Issue #2903 tracks a session-init failure where external C# language tooling
+can insert a blank line into `.git/packed-refs`. Git rejects that file with:
+
+```text
+fatal: unexpected line in .git/packed-refs
+```
+
+The observed corruption is a lone `0x0a` blank line between the
+`# pack-refs with: ...` header and the first ref record. Git's parser also
+rejects blank lines elsewhere in `packed-refs`.
+
+## Automatic repair
+
+The repository hooks run `scripts/maintenance/repair_packed_refs.py` before
+their first git ref operation:
+
+- `.githooks/pre-commit`
+- `.githooks/pre-push`
+
+The helper resolves normal repositories and linked worktrees, locates the
+common git directory, and reads `packed-refs` directly. If it finds blank
+lines, it backs up the original file beside it, removes only blank records,
+rewrites the file, and runs `git for-each-ref` to verify that git can parse the
+result.
+
+Clean repositories and repositories without `packed-refs` stay silent. The
+hook prints only when it repairs the file or when an unexpected failure occurs.
+
+## Manual run
+
+```bash
+uv run python scripts/maintenance/repair_packed_refs.py
+```
+
+The command exits `0` when the file is clean, missing, or repaired. It exits
+nonzero only when an unexpected failure prevents verification.

--- a/scripts/maintenance/repair_packed_refs.py
+++ b/scripts/maintenance/repair_packed_refs.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Repair blank-line corruption in git packed-refs files.
+
+Issue #2903 records an external C# LSP session-init path that can insert a
+blank line into ``packed-refs``. Git rejects any blank line in that file, so
+the guard removes only blank records, preserves every real ref record, and
+verifies refs after a rewrite.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+_GIT_TIMEOUT_SECONDS = 15
+
+
+@dataclass(frozen=True, slots=True)
+class RepairResult:
+    """Outcome from one packed-refs repair pass."""
+
+    packed_refs_path: Path | None
+    status: str
+    removed_blank_lines: int = 0
+    backup_path: Path | None = None
+
+
+def find_worktree_root(start_path: Path) -> Path | None:
+    """Return the nearest ancestor containing a .git marker."""
+    current = start_path.resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def resolve_common_git_dir(worktree_root: Path) -> Path:
+    """Resolve the common git directory for normal and linked worktrees."""
+    git_marker = worktree_root / ".git"
+    git_dir = _resolve_git_dir(git_marker, worktree_root)
+    common_dir_file = git_dir / "commondir"
+    if not common_dir_file.exists():
+        return git_dir
+
+    common_dir_text = common_dir_file.read_text(encoding="utf-8").strip()
+    common_dir = Path(common_dir_text)
+    if not common_dir.is_absolute():
+        common_dir = git_dir / common_dir
+    return common_dir.resolve()
+
+
+def normalize_packed_refs(data: bytes) -> tuple[bytes, int]:
+    """Remove blank lines while preserving all non-blank packed-refs records."""
+    kept_lines: list[bytes] = []
+    removed_blank_lines = 0
+
+    for line in data.splitlines(keepends=True):
+        if line.rstrip(b"\r\n") == b"":
+            removed_blank_lines += 1
+            continue
+        kept_lines.append(line)
+
+    return b"".join(kept_lines), removed_blank_lines
+
+
+def verify_git_refs(worktree_root: Path) -> None:
+    """Verify git can parse refs after repair."""
+    env = os.environ.copy()
+    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"):
+        env.pop(key, None)
+
+    try:
+        result = subprocess.run(
+            ["git", "for-each-ref", "--format=%(refname)"],
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            cwd=worktree_root,
+            env=env,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"git for-each-ref failed: {exc}") from exc
+
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"git for-each-ref failed: {message}")
+
+
+def repair_packed_refs(
+    start_path: Path,
+    verifier: Callable[[Path], None] = verify_git_refs,
+) -> RepairResult:
+    """Repair a packed-refs file when blank lines are present."""
+    worktree_root = find_worktree_root(start_path)
+    if worktree_root is None:
+        return RepairResult(packed_refs_path=None, status="not-a-git-worktree")
+
+    packed_refs_path = resolve_common_git_dir(worktree_root) / "packed-refs"
+    if not packed_refs_path.exists():
+        return RepairResult(packed_refs_path=packed_refs_path, status="missing")
+
+    original = packed_refs_path.read_bytes()
+    repaired, removed_blank_lines = normalize_packed_refs(original)
+    if removed_blank_lines == 0:
+        return RepairResult(packed_refs_path=packed_refs_path, status="clean")
+
+    backup_path = _backup_packed_refs(packed_refs_path)
+    _write_repaired_packed_refs(packed_refs_path, repaired)
+    try:
+        verifier(worktree_root)
+    except Exception:
+        shutil.copy2(backup_path, packed_refs_path)
+        raise
+
+    return RepairResult(
+        packed_refs_path=packed_refs_path,
+        status="repaired",
+        removed_blank_lines=removed_blank_lines,
+        backup_path=backup_path,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=Path.cwd(),
+        help="Worktree path to inspect. Defaults to the current directory.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the packed-refs repair guard."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        result = repair_packed_refs(args.path)
+    except Exception as exc:
+        print(f"ERROR: packed-refs repair failed: {exc}", file=sys.stderr)
+        return 1
+
+    if result.status == "repaired":
+        print(
+            "Repaired git packed-refs: "
+            f"removed {result.removed_blank_lines} blank line(s) from "
+            f"{result.packed_refs_path}; backup: {result.backup_path}"
+        )
+    return 0
+
+
+def _resolve_git_dir(git_marker: Path, worktree_root: Path) -> Path:
+    if git_marker.is_dir():
+        return git_marker.resolve()
+
+    text = git_marker.read_text(encoding="utf-8").strip()
+    prefix = "gitdir:"
+    if not text.lower().startswith(prefix):
+        raise ValueError(f"invalid .git file at {git_marker}")
+
+    git_dir = Path(text[len(prefix) :].strip())
+    if not git_dir.is_absolute():
+        git_dir = worktree_root / git_dir
+    return git_dir.resolve()
+
+
+def _backup_packed_refs(packed_refs_path: Path) -> Path:
+    backup_path = packed_refs_path.with_name(f"{packed_refs_path.name}.before-repair")
+    if backup_path.exists():
+        for suffix in range(1, 1000):
+            candidate = packed_refs_path.with_name(
+                f"{packed_refs_path.name}.before-repair.{suffix}"
+            )
+            if not candidate.exists():
+                backup_path = candidate
+                break
+        else:
+            raise RuntimeError("could not choose a packed-refs backup path")
+
+    shutil.copy2(packed_refs_path, backup_path)
+    return backup_path
+
+
+def _write_repaired_packed_refs(packed_refs_path: Path, repaired: bytes) -> None:
+    temporary_path = packed_refs_path.with_name(f"{packed_refs_path.name}.repairing")
+    temporary_path.write_bytes(repaired)
+    temporary_path.replace(packed_refs_path)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_repair_packed_refs.py
+++ b/tests/test_repair_packed_refs.py
@@ -1,0 +1,124 @@
+"""Tests for packed-refs repair."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.maintenance.repair_packed_refs import repair_packed_refs
+
+PACKED_REFS_HEADER = b"# pack-refs with: peeled fully-peeled sorted\n"
+REF_LINE = b"72015a50526a72200973a9a3e817195727f15f96 refs/remotes/origin/main\n"
+PEELED_LINE = b"^1111111111111111111111111111111111111111\n"
+
+
+def test_repairs_corrupted_packed_refs_and_preserves_refs(tmp_path: Path) -> None:
+    """Blank lines are removed and real ref records remain unchanged."""
+    worktree = _create_normal_worktree(tmp_path)
+    packed_refs = worktree / ".git" / "packed-refs"
+    original = PACKED_REFS_HEADER + b"\n" + REF_LINE + PEELED_LINE + b"\n"
+    packed_refs.write_bytes(original)
+    verified_roots: list[Path] = []
+
+    result = repair_packed_refs(worktree, verifier=verified_roots.append)
+
+    assert result.status == "repaired"
+    assert result.removed_blank_lines == 2
+    assert packed_refs.read_bytes() == PACKED_REFS_HEADER + REF_LINE + PEELED_LINE
+    assert result.backup_path is not None
+    assert result.backup_path.read_bytes() == original
+    assert verified_roots == [worktree]
+
+
+def test_leaves_clean_packed_refs_byte_identical(tmp_path: Path) -> None:
+    """Clean packed-refs content is not rewritten or backed up."""
+    worktree = _create_normal_worktree(tmp_path)
+    packed_refs = worktree / ".git" / "packed-refs"
+    original = PACKED_REFS_HEADER + REF_LINE
+    packed_refs.write_bytes(original)
+    verifier_called = False
+
+    def verifier(_worktree: Path) -> None:
+        nonlocal verifier_called
+        verifier_called = True
+
+    result = repair_packed_refs(worktree, verifier=verifier)
+
+    assert result.status == "clean"
+    assert packed_refs.read_bytes() == original
+    assert not (worktree / ".git" / "packed-refs.before-repair").exists()
+    assert verifier_called is False
+
+
+def test_missing_packed_refs_is_clean_noop(tmp_path: Path) -> None:
+    """A repository without packed-refs exits without creating a file."""
+    worktree = _create_normal_worktree(tmp_path)
+    verifier_called = False
+
+    def verifier(_worktree: Path) -> None:
+        nonlocal verifier_called
+        verifier_called = True
+
+    result = repair_packed_refs(worktree, verifier=verifier)
+
+    assert result.status == "missing"
+    assert result.packed_refs_path == worktree / ".git" / "packed-refs"
+    assert not result.packed_refs_path.exists()
+    assert verifier_called is False
+
+
+def test_resolves_linked_worktree_common_git_dir(tmp_path: Path) -> None:
+    """Linked worktrees repair packed-refs in the common git directory."""
+    common_git = tmp_path / "repo" / ".git"
+    linked_git = common_git / "worktrees" / "feature"
+    linked_worktree = tmp_path / "feature"
+    linked_git.mkdir(parents=True)
+    linked_worktree.mkdir()
+    (linked_git / "commondir").write_text("../..", encoding="utf-8")
+    (linked_worktree / ".git").write_text(f"gitdir: {linked_git}\n", encoding="utf-8")
+    packed_refs = common_git / "packed-refs"
+    packed_refs.write_bytes(PACKED_REFS_HEADER + b"\n" + REF_LINE)
+
+    result = repair_packed_refs(linked_worktree, verifier=lambda _worktree: None)
+
+    assert result.status == "repaired"
+    assert result.packed_refs_path == packed_refs
+    assert packed_refs.read_bytes() == PACKED_REFS_HEADER + REF_LINE
+
+
+def test_header_only_packed_refs_is_clean_noop(tmp_path: Path) -> None:
+    """A packed-refs file with a header and no refs is valid."""
+    worktree = _create_normal_worktree(tmp_path)
+    packed_refs = worktree / ".git" / "packed-refs"
+    packed_refs.write_bytes(PACKED_REFS_HEADER)
+
+    result = repair_packed_refs(worktree, verifier=lambda _worktree: None)
+
+    assert result.status == "clean"
+    assert packed_refs.read_bytes() == PACKED_REFS_HEADER
+    assert not (worktree / ".git" / "packed-refs.before-repair").exists()
+
+
+def test_restores_backup_when_verification_fails(tmp_path: Path) -> None:
+    """A failed git verification restores the original packed-refs bytes."""
+    worktree = _create_normal_worktree(tmp_path)
+    packed_refs = worktree / ".git" / "packed-refs"
+    original = PACKED_REFS_HEADER + b"\n" + REF_LINE
+    packed_refs.write_bytes(original)
+
+    def fail_verifier(_worktree: Path) -> None:
+        raise RuntimeError("git rejected refs")
+
+    with pytest.raises(RuntimeError, match="git rejected refs"):
+        repair_packed_refs(worktree, verifier=fail_verifier)
+
+    assert packed_refs.read_bytes() == original
+    assert (worktree / ".git" / "packed-refs.before-repair").read_bytes() == original
+
+
+def _create_normal_worktree(parent: Path) -> Path:
+    worktree = parent / "repo"
+    git_dir = worktree / ".git"
+    git_dir.mkdir(parents=True)
+    return worktree


### PR DESCRIPTION
## Summary

- Adds `scripts/maintenance/repair_packed_refs.py` to remove blank records from git `packed-refs`, back up the original file, and verify refs after repair.
- Wires `.githooks/pre-commit` and `.githooks/pre-push` to run the repair before their first git ref operation.
- Adds pytest coverage for corrupted, clean, missing, linked-worktree, header-only, and verification-failure cases.
- Documents the failure mode and auto-repair in `docs/troubleshooting-packed-refs.md`.

## Validation

- `uv run pytest tests/test_repair_packed_refs.py -x`, 6 passed.
- `uv run ruff check scripts/maintenance/repair_packed_refs.py tests/test_repair_packed_refs.py`, passed.
- `git diff --check`, passed.
- Dash byte check returned 0 for every edited file.
- `SKIP_CLI_E2E=true git push origin agent/packedrefs2903`, pre-push passed and branch pushed.

## References

- Fixes #2903
- Related context: rjmurillo/moq.analyzers#1083
- External git state repaired at runtime: `.git/packed-refs`
