### PR TITLE
refactor(lib): dedupe #2816 audit-family duplication (#2910 #2911 #2912 #2913)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/lib/hook_utilities/path_safety.py
+++ b/.claude/lib/hook_utilities/path_safety.py
@@ -1,0 +1,30 @@
+"""Canonical: scripts/hook_utilities/path_safety.py. Sync via scripts/sync_plugin_lib.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
+    """Validate a path against CWE-22 traversal attacks.
+
+    Relative paths must resolve inside the current working directory. Absolute
+    paths are allowed because operating-system permissions decide access.
+    """
+    del context
+    path_str = str(path)
+    if ".." in path_str:
+        raise PermissionError(
+            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
+        )
+
+    resolved = path.resolve()
+    if not path.is_absolute():
+        try:
+            resolved.relative_to(Path.cwd().resolve())
+        except ValueError as exc:
+            raise PermissionError(
+                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
+            ) from exc
+
+    return resolved

--- a/.claude/lib/hook_utilities/path_safety.py
+++ b/.claude/lib/hook_utilities/path_safety.py
@@ -11,11 +11,11 @@ def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
     Relative paths must resolve inside the current working directory. Absolute
     paths are allowed because operating-system permissions decide access.
     """
-    del context
     path_str = str(path)
     if ".." in path_str:
         raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
+            f"Path traversal attempt detected in {context}: "
+            f"'{path}' contains prohibited '..' sequence."
         )
 
     resolved = path.resolve()
@@ -24,7 +24,8 @@ def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
             resolved.relative_to(Path.cwd().resolve())
         except ValueError as exc:
             raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
+                f"Path traversal attempt detected in {context}: "
+                f"'{path}' resolves outside the working directory."
             ) from exc
 
     return resolved

--- a/.claude/skills/chaos-experiment/scripts/generate_experiment.py
+++ b/.claude/skills/chaos-experiment/scripts/generate_experiment.py
@@ -58,8 +58,8 @@ class Result:
 
     success: bool
     message: str
-    data: dict | None = None
-    errors: list | None = None
+    data: dict[str, object] | None = None
+    errors: list[str] | None = None
 
 
 def generate_experiment_id(name: str) -> str:

--- a/.claude/skills/chaos-experiment/scripts/generate_experiment.py
+++ b/.claude/skills/chaos-experiment/scripts/generate_experiment.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 def _resolve_paths_lib_dir() -> Path:
     """Resolve the plugin path-helper lib directory or fail with context."""
+    # ADR-047 keeps this bootstrap inline because imports need sys.path first.
     plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
     if plugin_root:
         lib_dir = Path(plugin_root) / "lib"
@@ -27,7 +28,7 @@ def _resolve_paths_lib_dir() -> Path:
     else:
         lib_dir = Path(__file__).resolve().parents[3] / "lib"
 
-    if not lib_dir.is_dir():
+    if not os.path.isdir(lib_dir):
         raise RuntimeError(
             "Expected portability helper lib directory not found: "
             f"{lib_dir}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
@@ -44,6 +45,8 @@ try:
     import paths  # noqa: E402
 except ImportError as exc:  # pragma: no cover - guarded by explicit path check
     raise RuntimeError(f"Failed to import portability helper paths.py from {_LIB_DIR}") from exc
+
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 # Default artifact subdirectory written under the artifact root (Issue #2050).
 _CHAOS_SUBDIR = "chaos"
@@ -112,34 +115,6 @@ def generate_document(
         document = document.replace(placeholder, value)
 
     return document
-
-
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection).
-
-    This prevents directory traversal attacks like '../../../etc/passwd' while
-    still allowing legitimate absolute paths and paths within the working directory.
-    """
-    # Check for traversal patterns in the path string
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
-
-    # Resolve the path and check it doesn't escape when resolved
-    resolved = path.resolve()
-
-    # If original path was relative, ensure resolved doesn't escape cwd
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
 
 
 def save_document(content: str, output_dir: Path, name: str) -> Path:

--- a/.claude/skills/chaos-experiment/scripts/validate_experiment.py
+++ b/.claude/skills/chaos-experiment/scripts/validate_experiment.py
@@ -15,10 +15,29 @@ Exit Codes:
 """
 
 import argparse
+import os
 import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
+
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 
 @dataclass
@@ -57,34 +76,6 @@ INCOMPLETE_PATTERNS = [
     (r"TODO", "TODO marker found"),
     (r"\[FILL IN\]", "Fill-in marker found"),
 ]
-
-
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection).
-
-    This prevents directory traversal attacks like '../../../etc/passwd' while
-    still allowing legitimate absolute paths and paths within the working directory.
-    """
-    # Check for traversal patterns in the path string
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
-
-    # Resolve the path and check it doesn't escape when resolved
-    resolved = path.resolve()
-
-    # If original path was relative, ensure resolved doesn't escape cwd
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
 
 
 def load_document(path: Path) -> str:

--- a/.claude/skills/chaos-experiment/scripts/validate_experiment.py
+++ b/.claude/skills/chaos-experiment/scripts/validate_experiment.py
@@ -46,8 +46,8 @@ class ValidationResult:
 
     success: bool
     message: str
-    errors: list = field(default_factory=list)
-    warnings: list = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
     score: int = 0  # 0-100
 
 
@@ -90,7 +90,10 @@ def load_document(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def check_section_presence(content: str, sections: list) -> tuple[list, list]:
+def check_section_presence(
+    content: str,
+    sections: list[tuple[str, str]],
+) -> tuple[list[str], list[str]]:
     """Check which sections are present and which are missing."""
     present = []
     missing = []
@@ -104,7 +107,7 @@ def check_section_presence(content: str, sections: list) -> tuple[list, list]:
     return present, missing
 
 
-def check_incomplete_markers(content: str) -> list:
+def check_incomplete_markers(content: str) -> list[str]:
     """Find incomplete content markers."""
     issues = []
 
@@ -120,7 +123,7 @@ def check_incomplete_markers(content: str) -> list:
     return issues
 
 
-def check_hypothesis_quality(content: str) -> tuple[bool, list]:
+def check_hypothesis_quality(content: str) -> tuple[bool, list[str]]:
     """Check if hypothesis follows the proper format."""
     warnings = []
 
@@ -153,7 +156,7 @@ def check_hypothesis_quality(content: str) -> tuple[bool, list]:
     return is_complete, warnings
 
 
-def check_rollback_procedure(content: str) -> tuple[bool, list]:
+def check_rollback_procedure(content: str) -> tuple[bool, list[str]]:
     """Check if rollback procedure is documented."""
     warnings = []
 
@@ -181,7 +184,7 @@ def check_rollback_procedure(content: str) -> tuple[bool, list]:
     return len(warnings) == 0, warnings
 
 
-def check_metrics_defined(content: str) -> tuple[bool, list]:
+def check_metrics_defined(content: str) -> tuple[bool, list[str]]:
     """Check if baseline metrics are defined."""
     warnings = []
 

--- a/.claude/skills/chestertons-fence/scripts/investigate.py
+++ b/.claude/skills/chestertons-fence/scripts/investigate.py
@@ -7,32 +7,30 @@ to document why something exists before proposing changes.
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
 
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection)."""
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
-    resolved = path.resolve()
-
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 
 @dataclass

--- a/.claude/skills/memory/scripts/count_memory_tokens.py
+++ b/.claude/skills/memory/scripts/count_memory_tokens.py
@@ -8,31 +8,28 @@ Uses cl100k_base encoding (GPT-4). Approximate for Claude. Caches results for pe
 import argparse
 import hashlib
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
 
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
 
-def validate_path_no_traversal(path: Path) -> Path:
-    """Validate path has no traversal patterns (CWE-22 protection).
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
-    Rejects '..' components and resolves to canonical form.
-    Relative paths must resolve within the current working directory.
-    Absolute paths are allowed (OS permissions provide access control).
-    """
-    if ".." in str(path):
-        raise PermissionError(
-            f"Path traversal detected: '{path}' contains '..'"
-        )
-    resolved = path.resolve()
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as exc:
-            raise PermissionError(
-                f"Path '{path}' resolves outside working directory"
-            ) from exc
-    return resolved
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 _HAS_TIKTOKEN = False
 try:

--- a/.claude/skills/memory/scripts/count_memory_tokens.py
+++ b/.claude/skills/memory/scripts/count_memory_tokens.py
@@ -55,7 +55,7 @@ def load_cache(cache_path: Path) -> dict[str, Any]:
         return {}
 
 
-def save_cache(cache_path: Path, cache: dict[str, dict]) -> None:
+def save_cache(cache_path: Path, cache: dict[str, Any]) -> None:
     """Save token count cache to JSON."""
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     cache_path.write_text(json.dumps(cache, indent=2))
@@ -146,7 +146,7 @@ def count_directory(
     if not directory.exists():
         raise FileNotFoundError(f"Directory not found: {directory}")
 
-    results = {}
+    results: dict[str, int] = {}
     failed = 0
     for file_path in sorted(directory.glob(pattern)):
         if file_path.is_file():

--- a/.claude/skills/memory/scripts/test_memory_size.py
+++ b/.claude/skills/memory/scripts/test_memory_size.py
@@ -9,32 +9,29 @@ Enforces atomicity constraints from memory-size-001-decomposition-thresholds:
 """
 
 import argparse
+import os
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
 
-def validate_path_no_traversal(path: Path) -> Path:
-    """Validate path has no traversal patterns (CWE-22 protection).
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
-    Rejects '..' components and resolves to canonical form.
-    Relative paths must resolve within the current working directory.
-    Absolute paths are allowed (OS permissions provide access control).
-    """
-    if ".." in str(path):
-        raise PermissionError(
-            f"Path traversal detected: '{path}' contains '..'"
-        )
-    resolved = path.resolve()
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as exc:
-            raise PermissionError(
-                f"Path '{path}' resolves outside working directory"
-            ) from exc
-    return resolved
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 
 @dataclass

--- a/.claude/skills/retrospective/scripts/extract_evidence.py
+++ b/.claude/skills/retrospective/scripts/extract_evidence.py
@@ -77,7 +77,7 @@ def _artifact_root_is_set() -> bool:
 def _artifact_dir(project_dir: Path, subdir: str) -> Path:
     """Resolve an artifact directory without creating it during evidence reads."""
     if _artifact_root_is_set() or project_dir.resolve() == Path.cwd().resolve():
-        return resolve_artifact_root(subdir)
+        return Path(resolve_artifact_root(subdir))
     return project_dir / ".agents" / subdir
 
 # Bound the git call so a wedged repo cannot hang the retrospective.

--- a/.claude/skills/retrospective/scripts/extract_evidence.py
+++ b/.claude/skills/retrospective/scripts/extract_evidence.py
@@ -41,6 +41,7 @@ UTC = timezone.utc  # noqa: UP017 - Python 3.10 compatibility
 
 def _resolve_paths_lib_dir() -> Path:
     """Return the lib directory that contains the portability helper."""
+    # ADR-047 keeps this bootstrap inline because imports need sys.path first.
     plugin_root = (
         os.environ.get("COPILOT_PLUGIN_ROOT")
         or os.environ.get("CLAUDE_PLUGIN_ROOT")
@@ -52,7 +53,7 @@ def _resolve_paths_lib_dir() -> Path:
     else:
         lib_dir = Path(__file__).resolve().parents[3] / "lib"
 
-    if not lib_dir.is_dir():
+    if not os.path.isdir(lib_dir):
         raise RuntimeError(
             "Expected portability helper lib directory not found: "
             f"{lib_dir}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "

--- a/.claude/skills/retrospective/scripts/run_retrospective.py
+++ b/.claude/skills/retrospective/scripts/run_retrospective.py
@@ -46,6 +46,7 @@ _SCRIPT_DIR = Path(__file__).resolve().parent
 
 def _resolve_paths_lib_dir() -> Path:
     """Resolve the plugin path-helper lib directory or fail with context."""
+    # ADR-047 keeps this bootstrap inline because imports need sys.path first.
     plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
     if plugin_root:
         lib_dir = Path(plugin_root) / "lib"
@@ -54,7 +55,7 @@ def _resolve_paths_lib_dir() -> Path:
     else:
         lib_dir = Path(__file__).resolve().parents[3] / "lib"
 
-    if not lib_dir.is_dir():
+    if not os.path.isdir(lib_dir):
         raise RuntimeError(
             "Expected portability helper lib directory not found: "
             f"{lib_dir}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "

--- a/.claude/skills/retrospective/scripts/run_retrospective.py
+++ b/.claude/skills/retrospective/scripts/run_retrospective.py
@@ -82,7 +82,7 @@ def _artifact_root_is_set() -> bool:
 def _artifact_dir(project_dir: Path, subdir: str) -> Path:
     """Resolve an artifact directory while preserving explicit project-dir tests."""
     if _artifact_root_is_set() or project_dir.resolve() == Path.cwd().resolve():
-        return paths.resolve_artifact_root(subdir)
+        return Path(paths.resolve_artifact_root(subdir))
     return project_dir / ".agents" / subdir
 
 

--- a/.claude/skills/session-end/scripts/complete_session_log.py
+++ b/.claude/skills/session-end/scripts/complete_session_log.py
@@ -23,31 +23,32 @@ from pathlib import Path
 from types import ModuleType
 
 
-def _resolve_paths_lib_dir() -> str:
+def _resolve_paths_lib_dir() -> Path:
     """Resolve the vendor-portable path-helper lib directory (Issue #2050)."""
+    # ADR-047 keeps this bootstrap inline because imports need sys.path first.
     plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
     if plugin_root:
         lib_dir = Path(plugin_root).expanduser().resolve() / "lib"
-        if not lib_dir.is_dir():
+        if not os.path.isdir(lib_dir):
             print(f"Plugin lib directory not found: {lib_dir}", file=sys.stderr)
             sys.exit(2)
-        return str(lib_dir)
+        return lib_dir
     candidates: list[Path] = []
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if workspace:
         candidates.append(Path(workspace).expanduser().resolve() / ".claude" / "lib")
     candidates.append(Path(__file__).resolve().parents[3] / "lib")
     for lib_dir in candidates:
-        if lib_dir.is_dir():
-            return str(lib_dir)
+        if os.path.isdir(lib_dir):
+            return lib_dir.resolve()
     checked = ", ".join(str(candidate) for candidate in candidates)
     print(f"Plugin lib directory not found. Checked: {checked}", file=sys.stderr)
     sys.exit(2)
 
 
 _LIB_DIR = _resolve_paths_lib_dir()
-if _LIB_DIR not in sys.path:
-    sys.path.insert(0, _LIB_DIR)
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
 from paths import resolve_artifact_root  # noqa: E402
 

--- a/.claude/skills/session-init/scripts/new_session_log.py
+++ b/.claude/skills/session-init/scripts/new_session_log.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, cast
 
 _WORKSPACE = os.environ.get(
     "GITHUB_WORKSPACE",
@@ -195,20 +196,23 @@ def _build_session_data(
     session_number: int,
     objective: str,
     current_date: str,
-) -> dict:
+) -> dict[str, Any]:
     """Build the session JSON data structure via the shared builder."""
-    return build_session_log(
-        branch=git_info["branch"],
-        commit=git_info["commit"],
-        session_number=session_number,
-        objective=objective,
-        current_date=current_date,
+    return cast(
+        dict[str, Any],
+        build_session_log(
+            branch=git_info["branch"],
+            commit=git_info["commit"],
+            session_number=session_number,
+            objective=objective,
+            current_date=current_date,
+        ),
     )
 
 
 def _write_session_file(
     sessions_dir: str,
-    session_data: dict,
+    session_data: dict[str, Any],
     current_date: str,
     objective: str,
 ) -> tuple[str, int]:

--- a/.claude/skills/session-init/scripts/new_session_log.py
+++ b/.claude/skills/session-init/scripts/new_session_log.py
@@ -35,31 +35,32 @@ _WORKSPACE = os.environ.get(
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
-def _resolve_paths_lib_dir() -> str:
+def _resolve_paths_lib_dir() -> Path:
     """Resolve the vendor-portable path-helper lib directory (Issue #2050)."""
+    # ADR-047 keeps this bootstrap inline because imports need sys.path first.
     plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
     if plugin_root:
         lib_dir = Path(plugin_root).expanduser().resolve() / "lib"
-        if not lib_dir.is_dir():
+        if not os.path.isdir(lib_dir):
             print(f"Plugin lib directory not found: {lib_dir}", file=sys.stderr)
             sys.exit(2)
-        return str(lib_dir)
+        return lib_dir
     candidates: list[Path] = []
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if workspace:
         candidates.append(Path(workspace).expanduser().resolve() / ".claude" / "lib")
     candidates.append(Path(__file__).resolve().parents[3] / "lib")
     for lib_dir in candidates:
-        if lib_dir.is_dir():
-            return str(lib_dir)
+        if os.path.isdir(lib_dir):
+            return lib_dir.resolve()
     checked = ", ".join(str(candidate) for candidate in candidates)
     print(f"Plugin lib directory not found. Checked: {checked}", file=sys.stderr)
     sys.exit(2)
 
 
 _LIB_DIR = _resolve_paths_lib_dir()
-if _LIB_DIR not in sys.path:
-    sys.path.insert(0, _LIB_DIR)
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
 from paths import resolve_artifact_root  # noqa: E402
 from session_init.git_helpers import get_git_info  # noqa: E402

--- a/.claude/skills/session-init/scripts/new_session_log_json.py
+++ b/.claude/skills/session-init/scripts/new_session_log_json.py
@@ -31,31 +31,32 @@ if _SESSION_INIT_DIR not in sys.path:
     sys.path.insert(0, _SESSION_INIT_DIR)
 
 
-def _resolve_paths_lib_dir() -> str:
+def _resolve_paths_lib_dir() -> Path:
     """Resolve the vendor-portable path-helper lib directory (Issue #2050)."""
+    # ADR-047 keeps this bootstrap inline because imports need sys.path first.
     plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
     if plugin_root:
         lib_dir = Path(plugin_root).expanduser().resolve() / "lib"
-        if not lib_dir.is_dir():
+        if not os.path.isdir(lib_dir):
             print(f"Plugin lib directory not found: {lib_dir}", file=sys.stderr)
             sys.exit(2)
-        return str(lib_dir)
+        return lib_dir
     candidates: list[Path] = []
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if workspace:
         candidates.append(Path(workspace).expanduser().resolve() / ".claude" / "lib")
     candidates.append(Path(__file__).resolve().parents[3] / "lib")
     for lib_dir in candidates:
-        if lib_dir.is_dir():
-            return str(lib_dir)
+        if os.path.isdir(lib_dir):
+            return lib_dir.resolve()
     checked = ", ".join(str(candidate) for candidate in candidates)
     print(f"Plugin lib directory not found. Checked: {checked}", file=sys.stderr)
     sys.exit(2)
 
 
 _LIB_DIR = _resolve_paths_lib_dir()
-if _LIB_DIR not in sys.path:
-    sys.path.insert(0, _LIB_DIR)
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
 from paths import resolve_artifact_root  # noqa: E402
 from session_init.session_structure import build_session_log  # noqa: E402

--- a/.claude/skills/slo-designer/scripts/generate_slo_document.py
+++ b/.claude/skills/slo-designer/scripts/generate_slo_document.py
@@ -11,10 +11,29 @@ Exit Codes:
 """
 
 import argparse
+import os
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
+
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 try:
     import yaml
@@ -87,34 +106,6 @@ def format_downtime(minutes: float) -> str:
         hours = int(minutes // 60)
         remaining_minutes = int(minutes % 60)
         return f"{hours}h {remaining_minutes}m"
-
-
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection).
-
-    This prevents directory traversal attacks like '../../../etc/passwd' while
-    still allowing legitimate absolute paths and paths within the working directory.
-    """
-    # Check for traversal patterns in the path string
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
-
-    # Resolve the path and check it doesn't escape when resolved
-    resolved = path.resolve()
-
-    # If original path was relative, ensure resolved doesn't escape cwd
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
 
 
 def parse_yaml_config(config_path: Path) -> SLOConfig:

--- a/.claude/skills/threat-modeling/scripts/generate_mitigation_roadmap.py
+++ b/.claude/skills/threat-modeling/scripts/generate_mitigation_roadmap.py
@@ -44,7 +44,7 @@ class Threat:
     impact: str
     risk: str
     status: str = "Planned"
-    mitigations: list = field(default_factory=list)
+    mitigations: list[str] = field(default_factory=list)
 
 
 RISK_ORDER = {"Critical": 0, "High": 1, "Medium": 2, "Low": 3}
@@ -135,7 +135,7 @@ def parse_threat_matrix(content: str) -> list[Threat]:
     Returns:
         List of Threat objects
     """
-    threats = []
+    threats: list[Threat] = []
 
     # Find threat matrix table
     table_pattern = r'\| ID \| Element \| STRIDE \| Threat \|.*?\n((?:\|.*\n)*)'
@@ -178,7 +178,7 @@ def categorize_by_risk(threats: list[Threat]) -> dict[str, list[Threat]]:
     Returns:
         Dictionary mapping risk level to threats
     """
-    categories = {"Critical": [], "High": [], "Medium": [], "Low": []}
+    categories: dict[str, list[Threat]] = {"Critical": [], "High": [], "Medium": [], "Low": []}
 
     for threat in threats:
         risk = threat.risk

--- a/.claude/skills/threat-modeling/scripts/generate_mitigation_roadmap.py
+++ b/.claude/skills/threat-modeling/scripts/generate_mitigation_roadmap.py
@@ -6,40 +6,30 @@ a prioritized mitigation roadmap.
 """
 
 import argparse
+import os
 import re
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
 
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection).
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
-    This prevents directory traversal attacks like '../../../etc/passwd' while
-    still allowing legitimate absolute paths and paths within the working directory.
-    """
-    # Check for traversal patterns in the path string
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
-
-    # Resolve the path and check it doesn't escape when resolved
-    resolved = path.resolve()
-
-    # If original path was relative, ensure resolved doesn't escape cwd
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 
 @dataclass

--- a/.claude/skills/threat-modeling/scripts/generate_threat_matrix.py
+++ b/.claude/skills/threat-modeling/scripts/generate_threat_matrix.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E501
 """Generate a structured threat matrix document.
 
 Creates a markdown threat model template with STRIDE categories
@@ -6,38 +7,28 @@ and risk rating structure.
 """
 
 import argparse
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
 
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
 
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection).
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
-    This prevents directory traversal attacks like '../../../etc/passwd' while
-    still allowing legitimate absolute paths and paths within the working directory.
-    """
-    # Check for traversal patterns in the path string
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
-
-    # Resolve the path and check it doesn't escape when resolved
-    resolved = path.resolve()
-
-    # If original path was relative, ensure resolved doesn't escape cwd
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
-
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 STRIDE_CATEGORIES = [
     ("S", "Spoofing", "Pretending to be something or someone else"),

--- a/.claude/skills/threat-modeling/scripts/validate_threat_model.py
+++ b/.claude/skills/threat-modeling/scripts/validate_threat_model.py
@@ -6,38 +6,29 @@ categories, and proper risk ratings.
 """
 
 import argparse
+import os
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
 
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection).
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
-    This prevents directory traversal attacks like '../../../etc/passwd' while
-    still allowing legitimate absolute paths and paths within the working directory.
-    """
-    # Check for traversal patterns in the path string
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
-
-    # Resolve the path and check it doesn't escape when resolved
-    resolved = path.resolve()
-
-    # If original path was relative, ensure resolved doesn't escape cwd
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 
 @dataclass

--- a/scripts/hook_utilities/path_safety.py
+++ b/scripts/hook_utilities/path_safety.py
@@ -11,11 +11,11 @@ def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
     Relative paths must resolve inside the current working directory. Absolute
     paths are allowed because operating-system permissions decide access.
     """
-    del context
     path_str = str(path)
     if ".." in path_str:
         raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
+            f"Path traversal attempt detected in {context}: "
+            f"'{path}' contains prohibited '..' sequence."
         )
 
     resolved = path.resolve()
@@ -24,7 +24,8 @@ def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
             resolved.relative_to(Path.cwd().resolve())
         except ValueError as exc:
             raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
+                f"Path traversal attempt detected in {context}: "
+                f"'{path}' resolves outside the working directory."
             ) from exc
 
     return resolved

--- a/scripts/hook_utilities/path_safety.py
+++ b/scripts/hook_utilities/path_safety.py
@@ -1,0 +1,30 @@
+"""Path safety helpers for plugin-distributed scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
+    """Validate a path against CWE-22 traversal attacks.
+
+    Relative paths must resolve inside the current working directory. Absolute
+    paths are allowed because operating-system permissions decide access.
+    """
+    del context
+    path_str = str(path)
+    if ".." in path_str:
+        raise PermissionError(
+            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
+        )
+
+    resolved = path.resolve()
+    if not path.is_absolute():
+        try:
+            resolved.relative_to(Path.cwd().resolve())
+        except ValueError as exc:
+            raise PermissionError(
+                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
+            ) from exc
+
+    return resolved

--- a/scripts/sync_plugin_lib.py
+++ b/scripts/sync_plugin_lib.py
@@ -40,6 +40,10 @@ SYNC_PAIRS: list[tuple[str, str]] = [
 # (Issue #2816 finding 2) so `--check` enforces parity in CI.
 SYNC_FILE_PAIRS: list[tuple[str, str]] = [
     ("scripts/hook_utilities/bootstrap.py", ".claude/lib/bootstrap.py"),
+    (
+        "scripts/validation/validate_review_marker.py",
+        ".claude/skills/review/scripts/validate_review_marker.py",
+    ),
 ]
 
 IMPORT_CONVERSIONS: list[tuple[re.Pattern[str], str]] = [

--- a/scripts/validation/check_skill_md_portability.py
+++ b/scripts/validation/check_skill_md_portability.py
@@ -57,6 +57,23 @@ import re
 import sys
 from pathlib import Path
 
+from scripts.validation.portability_common import (
+    build_portability_parser,
+    write_baseline,
+)
+from scripts.validation.portability_common import (
+    diff_against_baseline as _diff_against_baseline,
+)
+from scripts.validation.portability_common import (
+    load_baseline as _load_baseline,
+)
+from scripts.validation.portability_common import (
+    resolve_baseline_path as _common_resolve_baseline_path,
+)
+from scripts.validation.portability_common import (
+    resolve_root as _common_resolve_root,
+)
+
 # Upstream-only runtime path prefixes. Companion to check_skill_portability.py
 # which covers script files; this validator covers .md files. The .claude/skills/
 # pattern is excluded here: in prose a bare reference to a sibling skill by
@@ -86,15 +103,6 @@ _FENCE_OPEN_PATTERN = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})")
 _DEFAULT_BASELINE_NAME = "skill_md_portability_baseline.json"
 
 MARKDOWN_SUFFIX = ".md"
-
-
-def _repo_root(start: Path) -> Path:
-    """Walk up from ``start`` to the repo root (the dir containing .claude/skills)."""
-    base = start if start.is_dir() else start.parent
-    for ancestor in (base, *base.parents):
-        if (ancestor / ".claude" / "skills").is_dir():
-            return ancestor
-    return base
 
 
 def has_portability_marker(text: str) -> bool:
@@ -195,25 +203,13 @@ def scan_skill_markdown(skills_dir: Path) -> dict[str, int]:
     return counts
 
 
-def _load_baseline(path: Path) -> dict[str, int]:
-    if not path.is_file():
-        raise FileNotFoundError(f"Baseline file not found: {path}")
-    data = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(data, dict):
-        raise ValueError("Baseline must be a JSON object")
-    files = data["files"] if "files" in data else data
-    if not isinstance(files, dict):
-        raise ValueError("Baseline 'files' must be a JSON object")
-
-    baseline: dict[str, int] = {}
-    for key, value in files.items():
-        if value is None:
-            raise ValueError(f"Baseline count for {key!r} is null")
-        try:
-            baseline[str(key)] = int(value)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(f"Baseline count for {key!r} is not an integer") from exc
-    return baseline
+def _markdown_regression_message(rel: str, count: int, allowed: int) -> str:
+    return (
+        f"{rel}: {count} upstream-path refs in prose (baseline {allowed}). "
+        "Resolve via plugin/skill root or consumer cwd, or declare the "
+        "dependency with an HTML comment marker "
+        "'<!-- vendor-portability: ... -->' (issue #2050)."
+    )
 
 
 def diff_against_baseline(
@@ -225,92 +221,37 @@ def diff_against_baseline(
     references that is absent from the baseline. An improvement is a file whose
     count dropped (including to zero / removed).
     """
-    regressions: list[str] = []
-    for rel, n in sorted(current.items()):
-        allowed = baseline.get(rel, 0)
-        if n > allowed:
-            regressions.append(
-                f"{rel}: {n} upstream-path refs in prose (baseline {allowed}). "
-                "Resolve via plugin/skill root or consumer cwd, or declare the "
-                "dependency with an HTML comment marker "
-                "'<!-- vendor-portability: ... -->' (issue #2050)."
-            )
-    improvements: list[str] = []
-    for rel, allowed in sorted(baseline.items()):
-        n = current.get(rel, 0)
-        if n < allowed:
-            improvements.append(f"{rel}: {n} refs (baseline {allowed})")
-    return regressions, improvements
+    return _diff_against_baseline(current, baseline, _markdown_regression_message)
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root (default: walk up for .claude/skills).",
-    )
-    parser.add_argument(
-        "--baseline",
-        type=Path,
-        default=None,
-        help=f"Baseline JSON (default: scripts/validation/{_DEFAULT_BASELINE_NAME}).",
-    )
-    parser.add_argument(
-        "--update-baseline",
-        action="store_true",
-        help="Rewrite the baseline to the current state and exit 0.",
-    )
-    parser.add_argument(
-        "--output-format",
-        choices=("human", "json"),
-        default="human",
-    )
-    return parser
+    return build_portability_parser(__doc__, _DEFAULT_BASELINE_NAME)
 
 
 def _resolve_root(repo_root: Path | None) -> Path:
-    if repo_root:
-        return repo_root.resolve()
-    return _repo_root(Path(__file__).resolve())
+    return _common_resolve_root(repo_root, Path(__file__).resolve(), require_repo_marker=False)
 
 
 def _resolve_baseline_path(root: Path, baseline: Path | None) -> Path:
-    if baseline is None:
-        return root / "scripts" / "validation" / _DEFAULT_BASELINE_NAME
-    resolved = (
-        baseline.expanduser().resolve()
-        if baseline.is_absolute()
-        else (root / baseline).expanduser().resolve()
+    return _common_resolve_baseline_path(
+        root, baseline, _DEFAULT_BASELINE_NAME, reject_outside_root=True
     )
-    if not resolved.is_relative_to(root.resolve()):
-        return Path("")
-    return resolved
 
 
 def _write_baseline(baseline_path: Path, current: dict[str, int]) -> int:
-    total = sum(current.values())
-    baseline_path.write_text(
-        json.dumps(
-            {
-                "_comment": (
-                    "Vendor-portability ratchet baseline for skill Markdown "
-                    "(issue #2050). Counts of upstream-only path references per "
-                    ".md file (fenced code stripped; inline paths counted; files with a "
-                    "'<!-- vendor-portability: ... -->' marker excluded). "
-                    "Generated by check_skill_md_portability.py --update-baseline. "
-                    "Lower is better; review count increases before committing."
-                ),
-                "files": dict(sorted(current.items())),
-            },
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
+    return write_baseline(
+        baseline_path,
+        current,
+        (
+            "Vendor-portability ratchet baseline for skill Markdown "
+            "(issue #2050). Counts of upstream-only path references per "
+            ".md file (fenced code stripped; inline paths counted; files with a "
+            "'<!-- vendor-portability: ... -->' marker excluded). "
+            "Generated by check_skill_md_portability.py --update-baseline. "
+            "Lower is better; review count increases before committing."
+        ),
+        "refs",
     )
-    print(f"Baseline written: {len(current)} files, {total} refs.")
-    return 0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/validation/check_skill_portability.py
+++ b/scripts/validation/check_skill_portability.py
@@ -46,6 +46,23 @@ import sys
 import tokenize
 from pathlib import Path
 
+from scripts.validation.portability_common import (
+    build_portability_parser,
+    write_baseline,
+)
+from scripts.validation.portability_common import (
+    diff_against_baseline as _diff_against_baseline,
+)
+from scripts.validation.portability_common import (
+    load_baseline as _load_baseline,
+)
+from scripts.validation.portability_common import (
+    resolve_baseline_path as _common_resolve_baseline_path,
+)
+from scripts.validation.portability_common import (
+    resolve_root as _common_resolve_root,
+)
+
 # Upstream-only runtime path prefixes. A skill script that references these as
 # runtime paths assumes the upstream checkout layout and breaks in a vendored
 # install. ``.claude/skills/`` is included because a script reaching into a
@@ -81,21 +98,6 @@ _FSTRING_TOKEN_TYPES: frozenset[int] = frozenset(
 ) - {-1}
 
 _DEFAULT_BASELINE_NAME = "skill_portability_baseline.json"
-
-
-def _repo_root(start: Path) -> Path:
-    """Walk up from ``start`` to the repo root."""
-    base = start if start.is_dir() else start.parent
-    for ancestor in (base, *base.parents):
-        has_skills = (ancestor / ".claude" / "skills").is_dir()
-        has_repo_marker = (
-            (ancestor / ".git").exists()
-            or (ancestor / "pyproject.toml").is_file()
-            or (ancestor / "AGENTS.md").is_file()
-        )
-        if has_skills and has_repo_marker:
-            return ancestor
-    return base
 
 
 _PYTHON_DOCSTRING_NODES = (
@@ -201,6 +203,11 @@ def _is_skippable_string_token(token: tokenize.TokenInfo) -> bool:
     return False
 
 
+def _repo_root(start: Path) -> Path:
+    """Walk up from ``start`` to the repo root."""
+    return _common_resolve_root(None, start, require_repo_marker=True)
+
+
 def _runtime_text(text: str, suffix: str) -> str:
     if suffix != ".py":
         return _strip_hash_comments(text)
@@ -251,25 +258,12 @@ def scan_skill_scripts(skills_dir: Path) -> dict[str, int]:
     return counts
 
 
-def _load_baseline(path: Path) -> dict[str, int]:
-    if not path.is_file():
-        raise FileNotFoundError(f"Baseline file not found: {path}")
-    data = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(data, dict):
-        raise ValueError("Baseline must be a JSON object")
-    files = data["files"] if "files" in data else data
-    if not isinstance(files, dict):
-        raise ValueError("Baseline 'files' must be a JSON object")
-
-    baseline: dict[str, int] = {}
-    for key, value in files.items():
-        if value is None:
-            raise ValueError(f"Baseline count for {key!r} is null")
-        try:
-            baseline[str(key)] = int(value)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(f"Baseline count for {key!r} is not an integer") from exc
-    return baseline
+def _script_regression_message(rel: str, count: int, allowed: int) -> str:
+    return (
+        f"{rel}: {count} upstream-path refs (baseline {allowed}). "
+        "Resolve via plugin/skill root or consumer cwd, not a hard-coded "
+        "upstream path (issue #2050)."
+    )
 
 
 def diff_against_baseline(
@@ -281,62 +275,21 @@ def diff_against_baseline(
     references that is absent from the baseline. An improvement is a file whose
     count dropped (including to zero / removed).
     """
-    regressions: list[str] = []
-    for rel, n in sorted(current.items()):
-        allowed = baseline.get(rel, 0)
-        if n > allowed:
-            regressions.append(
-                f"{rel}: {n} upstream-path refs (baseline {allowed}). "
-                "Resolve via plugin/skill root or consumer cwd, not a hard-coded "
-                "upstream path (issue #2050)."
-            )
-    improvements: list[str] = []
-    for rel, allowed in sorted(baseline.items()):
-        n = current.get(rel, 0)
-        if n < allowed:
-            improvements.append(f"{rel}: {n} refs (baseline {allowed})")
-    return regressions, improvements
+    return _diff_against_baseline(current, baseline, _script_regression_message)
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root (default: walk up for .claude/skills).",
-    )
-    parser.add_argument(
-        "--baseline",
-        type=Path,
-        default=None,
-        help=f"Baseline JSON (default: scripts/validation/{_DEFAULT_BASELINE_NAME}).",
-    )
-    parser.add_argument(
-        "--update-baseline",
-        action="store_true",
-        help="Rewrite the baseline to the current state and exit 0.",
-    )
-    parser.add_argument(
-        "--output-format",
-        choices=("human", "json"),
-        default="human",
-    )
-    return parser
+    return build_portability_parser(__doc__, _DEFAULT_BASELINE_NAME)
 
 
 def _resolve_root(repo_root: Path | None) -> Path:
-    if repo_root:
-        return repo_root.resolve()
-    return _repo_root(Path(__file__).resolve())
+    return _common_resolve_root(repo_root, Path(__file__).resolve(), require_repo_marker=True)
 
 
 def _resolve_baseline_path(root: Path, baseline: Path | None) -> Path:
-    if baseline is None:
-        return root / "scripts" / "validation" / _DEFAULT_BASELINE_NAME
-    if baseline.is_absolute():
-        return baseline
-    return root / baseline
+    return _common_resolve_baseline_path(
+        root, baseline, _DEFAULT_BASELINE_NAME, reject_outside_root=False
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -355,26 +308,18 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     if args.update_baseline:
-        total = sum(current.values())
-        baseline_path.write_text(
-            json.dumps(
-                {
-                    "_comment": (
-                        "Vendor-portability ratchet baseline for skill scripts "
-                        "(issue #2050). Counts of upstream-only path references "
-                        "per script. Generated by check_skill_portability.py "
-                        "--update-baseline. Lower is better; review count "
-                        "increases before committing."
-                    ),
-                    "files": dict(sorted(current.items())),
-                },
-                indent=2,
-            )
-            + "\n",
-            encoding="utf-8",
+        return write_baseline(
+            baseline_path,
+            current,
+            (
+                "Vendor-portability ratchet baseline for skill scripts "
+                "(issue #2050). Counts of upstream-only path references "
+                "per script. Generated by check_skill_portability.py "
+                "--update-baseline. Lower is better; review count "
+                "increases before committing."
+            ),
+            "refs",
         )
-        print(f"Baseline written: {len(current)} files, {total} refs.")
-        return 0
 
     try:
         baseline = _load_baseline(baseline_path)

--- a/scripts/validation/portability_common.py
+++ b/scripts/validation/portability_common.py
@@ -1,0 +1,145 @@
+"""Shared baseline helpers for skill portability validators."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+RegressionMessageFactory = Callable[[str, int, int], str]
+
+
+def load_baseline(path: Path) -> dict[str, int]:
+    """Read and validate a portability ratchet baseline."""
+    if not path.is_file():
+        raise FileNotFoundError(f"Baseline file not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Baseline must be a JSON object")
+    files = data["files"] if "files" in data else data
+    if not isinstance(files, dict):
+        raise ValueError("Baseline 'files' must be a JSON object")
+
+    baseline: dict[str, int] = {}
+    for key, value in files.items():
+        if value is None:
+            raise ValueError(f"Baseline count for {key!r} is null")
+        try:
+            baseline[str(key)] = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Baseline count for {key!r} is not an integer") from exc
+    return baseline
+
+
+def diff_against_baseline(
+    current: dict[str, int],
+    baseline: dict[str, int],
+    regression_message: RegressionMessageFactory,
+) -> tuple[list[str], list[str]]:
+    """Return regressions and improvements for a baseline comparison."""
+    regressions: list[str] = []
+    for rel, count in sorted(current.items()):
+        allowed = baseline.get(rel, 0)
+        if count > allowed:
+            regressions.append(regression_message(rel, count, allowed))
+
+    improvements: list[str] = []
+    for rel, allowed in sorted(baseline.items()):
+        count = current.get(rel, 0)
+        if count < allowed:
+            improvements.append(f"{rel}: {count} refs (baseline {allowed})")
+    return regressions, improvements
+
+
+def build_portability_parser(
+    description: str | None, default_baseline_name: str
+) -> argparse.ArgumentParser:
+    """Build the common CLI parser for portability ratchets."""
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: walk up for .claude/skills).",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help=f"Baseline JSON (default: scripts/validation/{default_baseline_name}).",
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Rewrite the baseline to the current state and exit 0.",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=("human", "json"),
+        default="human",
+    )
+    return parser
+
+
+def resolve_root(repo_root: Path | None, start: Path, require_repo_marker: bool) -> Path:
+    """Resolve the repository root for a portability scan."""
+    if repo_root:
+        return repo_root.resolve()
+
+    base = start if start.is_dir() else start.parent
+    for ancestor in (base, *base.parents):
+        has_skills = (ancestor / ".claude" / "skills").is_dir()
+        if not has_skills:
+            continue
+        has_repo_marker = (
+            (ancestor / ".git").exists()
+            or (ancestor / "pyproject.toml").is_file()
+            or (ancestor / "AGENTS.md").is_file()
+        )
+        if has_repo_marker or not require_repo_marker:
+            return ancestor
+    return base
+
+
+def resolve_baseline_path(
+    root: Path,
+    baseline: Path | None,
+    default_baseline_name: str,
+    reject_outside_root: bool,
+) -> Path:
+    """Resolve the baseline path, optionally rejecting root escapes."""
+    if baseline is None:
+        return root / "scripts" / "validation" / default_baseline_name
+    if not reject_outside_root:
+        return baseline if baseline.is_absolute() else root / baseline
+
+    root_resolved = root.resolve()
+    resolved = (
+        baseline.expanduser().resolve()
+        if baseline.is_absolute()
+        else (root / baseline).expanduser().resolve()
+    )
+    if not resolved.is_relative_to(root_resolved):
+        return Path("")
+    return resolved
+
+
+def write_baseline(
+    baseline_path: Path, current: dict[str, int], comment: str, label: str
+) -> int:
+    """Write a sorted portability baseline and print a standard summary."""
+    total = sum(current.values())
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "_comment": comment,
+                "files": dict(sorted(current.items())),
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"Baseline written: {len(current)} files, {total} {label}.")
+    return 0

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/lib/hook_utilities/path_safety.py
+++ b/src/copilot-cli/lib/hook_utilities/path_safety.py
@@ -1,0 +1,30 @@
+"""Canonical: scripts/hook_utilities/path_safety.py. Sync via scripts/sync_plugin_lib.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
+    """Validate a path against CWE-22 traversal attacks.
+
+    Relative paths must resolve inside the current working directory. Absolute
+    paths are allowed because operating-system permissions decide access.
+    """
+    del context
+    path_str = str(path)
+    if ".." in path_str:
+        raise PermissionError(
+            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
+        )
+
+    resolved = path.resolve()
+    if not path.is_absolute():
+        try:
+            resolved.relative_to(Path.cwd().resolve())
+        except ValueError as exc:
+            raise PermissionError(
+                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
+            ) from exc
+
+    return resolved

--- a/src/copilot-cli/lib/hook_utilities/path_safety.py
+++ b/src/copilot-cli/lib/hook_utilities/path_safety.py
@@ -11,11 +11,11 @@ def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
     Relative paths must resolve inside the current working directory. Absolute
     paths are allowed because operating-system permissions decide access.
     """
-    del context
     path_str = str(path)
     if ".." in path_str:
         raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
+            f"Path traversal attempt detected in {context}: "
+            f"'{path}' contains prohibited '..' sequence."
         )
 
     resolved = path.resolve()
@@ -24,7 +24,8 @@ def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
             resolved.relative_to(Path.cwd().resolve())
         except ValueError as exc:
             raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
+                f"Path traversal attempt detected in {context}: "
+                f"'{path}' resolves outside the working directory."
             ) from exc
 
     return resolved

--- a/src/copilot-cli/skills/chaos-experiment/scripts/generate_experiment.py
+++ b/src/copilot-cli/skills/chaos-experiment/scripts/generate_experiment.py
@@ -58,8 +58,8 @@ class Result:
 
     success: bool
     message: str
-    data: dict | None = None
-    errors: list | None = None
+    data: dict[str, object] | None = None
+    errors: list[str] | None = None
 
 
 def generate_experiment_id(name: str) -> str:

--- a/src/copilot-cli/skills/chaos-experiment/scripts/generate_experiment.py
+++ b/src/copilot-cli/skills/chaos-experiment/scripts/generate_experiment.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 def _resolve_paths_lib_dir() -> Path:
     """Resolve the plugin path-helper lib directory or fail with context."""
+    # ADR-047 keeps this bootstrap inline because imports need sys.path first.
     plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
     if plugin_root:
         lib_dir = Path(plugin_root) / "lib"
@@ -27,7 +28,7 @@ def _resolve_paths_lib_dir() -> Path:
     else:
         lib_dir = Path(__file__).resolve().parents[3] / "lib"
 
-    if not lib_dir.is_dir():
+    if not os.path.isdir(lib_dir):
         raise RuntimeError(
             "Expected portability helper lib directory not found: "
             f"{lib_dir}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
@@ -44,6 +45,8 @@ try:
     import paths  # noqa: E402
 except ImportError as exc:  # pragma: no cover - guarded by explicit path check
     raise RuntimeError(f"Failed to import portability helper paths.py from {_LIB_DIR}") from exc
+
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 # Default artifact subdirectory written under the artifact root (Issue #2050).
 _CHAOS_SUBDIR = "chaos"
@@ -112,34 +115,6 @@ def generate_document(
         document = document.replace(placeholder, value)
 
     return document
-
-
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection).
-
-    This prevents directory traversal attacks like '../../../etc/passwd' while
-    still allowing legitimate absolute paths and paths within the working directory.
-    """
-    # Check for traversal patterns in the path string
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
-
-    # Resolve the path and check it doesn't escape when resolved
-    resolved = path.resolve()
-
-    # If original path was relative, ensure resolved doesn't escape cwd
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
 
 
 def save_document(content: str, output_dir: Path, name: str) -> Path:

--- a/src/copilot-cli/skills/chaos-experiment/scripts/validate_experiment.py
+++ b/src/copilot-cli/skills/chaos-experiment/scripts/validate_experiment.py
@@ -15,10 +15,29 @@ Exit Codes:
 """
 
 import argparse
+import os
 import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
+
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 
 @dataclass
@@ -57,34 +76,6 @@ INCOMPLETE_PATTERNS = [
     (r"TODO", "TODO marker found"),
     (r"\[FILL IN\]", "Fill-in marker found"),
 ]
-
-
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection).
-
-    This prevents directory traversal attacks like '../../../etc/passwd' while
-    still allowing legitimate absolute paths and paths within the working directory.
-    """
-    # Check for traversal patterns in the path string
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
-
-    # Resolve the path and check it doesn't escape when resolved
-    resolved = path.resolve()
-
-    # If original path was relative, ensure resolved doesn't escape cwd
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
 
 
 def load_document(path: Path) -> str:

--- a/src/copilot-cli/skills/chaos-experiment/scripts/validate_experiment.py
+++ b/src/copilot-cli/skills/chaos-experiment/scripts/validate_experiment.py
@@ -46,8 +46,8 @@ class ValidationResult:
 
     success: bool
     message: str
-    errors: list = field(default_factory=list)
-    warnings: list = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
     score: int = 0  # 0-100
 
 
@@ -90,7 +90,10 @@ def load_document(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def check_section_presence(content: str, sections: list) -> tuple[list, list]:
+def check_section_presence(
+    content: str,
+    sections: list[tuple[str, str]],
+) -> tuple[list[str], list[str]]:
     """Check which sections are present and which are missing."""
     present = []
     missing = []
@@ -104,7 +107,7 @@ def check_section_presence(content: str, sections: list) -> tuple[list, list]:
     return present, missing
 
 
-def check_incomplete_markers(content: str) -> list:
+def check_incomplete_markers(content: str) -> list[str]:
     """Find incomplete content markers."""
     issues = []
 
@@ -120,7 +123,7 @@ def check_incomplete_markers(content: str) -> list:
     return issues
 
 
-def check_hypothesis_quality(content: str) -> tuple[bool, list]:
+def check_hypothesis_quality(content: str) -> tuple[bool, list[str]]:
     """Check if hypothesis follows the proper format."""
     warnings = []
 
@@ -153,7 +156,7 @@ def check_hypothesis_quality(content: str) -> tuple[bool, list]:
     return is_complete, warnings
 
 
-def check_rollback_procedure(content: str) -> tuple[bool, list]:
+def check_rollback_procedure(content: str) -> tuple[bool, list[str]]:
     """Check if rollback procedure is documented."""
     warnings = []
 
@@ -181,7 +184,7 @@ def check_rollback_procedure(content: str) -> tuple[bool, list]:
     return len(warnings) == 0, warnings
 
 
-def check_metrics_defined(content: str) -> tuple[bool, list]:
+def check_metrics_defined(content: str) -> tuple[bool, list[str]]:
     """Check if baseline metrics are defined."""
     warnings = []
 

--- a/src/copilot-cli/skills/chestertons-fence/scripts/investigate.py
+++ b/src/copilot-cli/skills/chestertons-fence/scripts/investigate.py
@@ -7,32 +7,30 @@ to document why something exists before proposing changes.
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
 
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection)."""
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
-    resolved = path.resolve()
-
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 
 @dataclass

--- a/src/copilot-cli/skills/memory/scripts/count_memory_tokens.py
+++ b/src/copilot-cli/skills/memory/scripts/count_memory_tokens.py
@@ -8,31 +8,28 @@ Uses cl100k_base encoding (GPT-4). Approximate for Claude. Caches results for pe
 import argparse
 import hashlib
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
 
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
 
-def validate_path_no_traversal(path: Path) -> Path:
-    """Validate path has no traversal patterns (CWE-22 protection).
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
-    Rejects '..' components and resolves to canonical form.
-    Relative paths must resolve within the current working directory.
-    Absolute paths are allowed (OS permissions provide access control).
-    """
-    if ".." in str(path):
-        raise PermissionError(
-            f"Path traversal detected: '{path}' contains '..'"
-        )
-    resolved = path.resolve()
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as exc:
-            raise PermissionError(
-                f"Path '{path}' resolves outside working directory"
-            ) from exc
-    return resolved
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 _HAS_TIKTOKEN = False
 try:

--- a/src/copilot-cli/skills/memory/scripts/count_memory_tokens.py
+++ b/src/copilot-cli/skills/memory/scripts/count_memory_tokens.py
@@ -55,7 +55,7 @@ def load_cache(cache_path: Path) -> dict[str, Any]:
         return {}
 
 
-def save_cache(cache_path: Path, cache: dict[str, dict]) -> None:
+def save_cache(cache_path: Path, cache: dict[str, Any]) -> None:
     """Save token count cache to JSON."""
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     cache_path.write_text(json.dumps(cache, indent=2))
@@ -146,7 +146,7 @@ def count_directory(
     if not directory.exists():
         raise FileNotFoundError(f"Directory not found: {directory}")
 
-    results = {}
+    results: dict[str, int] = {}
     failed = 0
     for file_path in sorted(directory.glob(pattern)):
         if file_path.is_file():

--- a/src/copilot-cli/skills/memory/scripts/test_memory_size.py
+++ b/src/copilot-cli/skills/memory/scripts/test_memory_size.py
@@ -9,32 +9,29 @@ Enforces atomicity constraints from memory-size-001-decomposition-thresholds:
 """
 
 import argparse
+import os
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
 
-def validate_path_no_traversal(path: Path) -> Path:
-    """Validate path has no traversal patterns (CWE-22 protection).
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
-    Rejects '..' components and resolves to canonical form.
-    Relative paths must resolve within the current working directory.
-    Absolute paths are allowed (OS permissions provide access control).
-    """
-    if ".." in str(path):
-        raise PermissionError(
-            f"Path traversal detected: '{path}' contains '..'"
-        )
-    resolved = path.resolve()
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as exc:
-            raise PermissionError(
-                f"Path '{path}' resolves outside working directory"
-            ) from exc
-    return resolved
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 
 @dataclass

--- a/src/copilot-cli/skills/retrospective/scripts/extract_evidence.py
+++ b/src/copilot-cli/skills/retrospective/scripts/extract_evidence.py
@@ -77,7 +77,7 @@ def _artifact_root_is_set() -> bool:
 def _artifact_dir(project_dir: Path, subdir: str) -> Path:
     """Resolve an artifact directory without creating it during evidence reads."""
     if _artifact_root_is_set() or project_dir.resolve() == Path.cwd().resolve():
-        return resolve_artifact_root(subdir)
+        return Path(resolve_artifact_root(subdir))
     return project_dir / ".agents" / subdir
 
 # Bound the git call so a wedged repo cannot hang the retrospective.

--- a/src/copilot-cli/skills/retrospective/scripts/extract_evidence.py
+++ b/src/copilot-cli/skills/retrospective/scripts/extract_evidence.py
@@ -41,6 +41,7 @@ UTC = timezone.utc  # noqa: UP017 - Python 3.10 compatibility
 
 def _resolve_paths_lib_dir() -> Path:
     """Return the lib directory that contains the portability helper."""
+    # ADR-047 keeps this bootstrap inline because imports need sys.path first.
     plugin_root = (
         os.environ.get("COPILOT_PLUGIN_ROOT")
         or os.environ.get("CLAUDE_PLUGIN_ROOT")
@@ -52,7 +53,7 @@ def _resolve_paths_lib_dir() -> Path:
     else:
         lib_dir = Path(__file__).resolve().parents[3] / "lib"
 
-    if not lib_dir.is_dir():
+    if not os.path.isdir(lib_dir):
         raise RuntimeError(
             "Expected portability helper lib directory not found: "
             f"{lib_dir}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "

--- a/src/copilot-cli/skills/retrospective/scripts/run_retrospective.py
+++ b/src/copilot-cli/skills/retrospective/scripts/run_retrospective.py
@@ -46,6 +46,7 @@ _SCRIPT_DIR = Path(__file__).resolve().parent
 
 def _resolve_paths_lib_dir() -> Path:
     """Resolve the plugin path-helper lib directory or fail with context."""
+    # ADR-047 keeps this bootstrap inline because imports need sys.path first.
     plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
     if plugin_root:
         lib_dir = Path(plugin_root) / "lib"
@@ -54,7 +55,7 @@ def _resolve_paths_lib_dir() -> Path:
     else:
         lib_dir = Path(__file__).resolve().parents[3] / "lib"
 
-    if not lib_dir.is_dir():
+    if not os.path.isdir(lib_dir):
         raise RuntimeError(
             "Expected portability helper lib directory not found: "
             f"{lib_dir}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "

--- a/src/copilot-cli/skills/retrospective/scripts/run_retrospective.py
+++ b/src/copilot-cli/skills/retrospective/scripts/run_retrospective.py
@@ -82,7 +82,7 @@ def _artifact_root_is_set() -> bool:
 def _artifact_dir(project_dir: Path, subdir: str) -> Path:
     """Resolve an artifact directory while preserving explicit project-dir tests."""
     if _artifact_root_is_set() or project_dir.resolve() == Path.cwd().resolve():
-        return paths.resolve_artifact_root(subdir)
+        return Path(paths.resolve_artifact_root(subdir))
     return project_dir / ".agents" / subdir
 
 

--- a/src/copilot-cli/skills/session-end/scripts/complete_session_log.py
+++ b/src/copilot-cli/skills/session-end/scripts/complete_session_log.py
@@ -23,31 +23,32 @@ from pathlib import Path
 from types import ModuleType
 
 
-def _resolve_paths_lib_dir() -> str:
+def _resolve_paths_lib_dir() -> Path:
     """Resolve the vendor-portable path-helper lib directory (Issue #2050)."""
+    # ADR-047 keeps this bootstrap inline because imports need sys.path first.
     plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
     if plugin_root:
         lib_dir = Path(plugin_root).expanduser().resolve() / "lib"
-        if not lib_dir.is_dir():
+        if not os.path.isdir(lib_dir):
             print(f"Plugin lib directory not found: {lib_dir}", file=sys.stderr)
             sys.exit(2)
-        return str(lib_dir)
+        return lib_dir
     candidates: list[Path] = []
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if workspace:
         candidates.append(Path(workspace).expanduser().resolve() / ".claude" / "lib")
     candidates.append(Path(__file__).resolve().parents[3] / "lib")
     for lib_dir in candidates:
-        if lib_dir.is_dir():
-            return str(lib_dir)
+        if os.path.isdir(lib_dir):
+            return lib_dir.resolve()
     checked = ", ".join(str(candidate) for candidate in candidates)
     print(f"Plugin lib directory not found. Checked: {checked}", file=sys.stderr)
     sys.exit(2)
 
 
 _LIB_DIR = _resolve_paths_lib_dir()
-if _LIB_DIR not in sys.path:
-    sys.path.insert(0, _LIB_DIR)
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
 from paths import resolve_artifact_root  # noqa: E402
 

--- a/src/copilot-cli/skills/session-init/scripts/new_session_log.py
+++ b/src/copilot-cli/skills/session-init/scripts/new_session_log.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, cast
 
 _WORKSPACE = os.environ.get(
     "GITHUB_WORKSPACE",
@@ -195,20 +196,23 @@ def _build_session_data(
     session_number: int,
     objective: str,
     current_date: str,
-) -> dict:
+) -> dict[str, Any]:
     """Build the session JSON data structure via the shared builder."""
-    return build_session_log(
-        branch=git_info["branch"],
-        commit=git_info["commit"],
-        session_number=session_number,
-        objective=objective,
-        current_date=current_date,
+    return cast(
+        dict[str, Any],
+        build_session_log(
+            branch=git_info["branch"],
+            commit=git_info["commit"],
+            session_number=session_number,
+            objective=objective,
+            current_date=current_date,
+        ),
     )
 
 
 def _write_session_file(
     sessions_dir: str,
-    session_data: dict,
+    session_data: dict[str, Any],
     current_date: str,
     objective: str,
 ) -> tuple[str, int]:

--- a/src/copilot-cli/skills/session-init/scripts/new_session_log.py
+++ b/src/copilot-cli/skills/session-init/scripts/new_session_log.py
@@ -35,31 +35,32 @@ _WORKSPACE = os.environ.get(
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
-def _resolve_paths_lib_dir() -> str:
+def _resolve_paths_lib_dir() -> Path:
     """Resolve the vendor-portable path-helper lib directory (Issue #2050)."""
+    # ADR-047 keeps this bootstrap inline because imports need sys.path first.
     plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
     if plugin_root:
         lib_dir = Path(plugin_root).expanduser().resolve() / "lib"
-        if not lib_dir.is_dir():
+        if not os.path.isdir(lib_dir):
             print(f"Plugin lib directory not found: {lib_dir}", file=sys.stderr)
             sys.exit(2)
-        return str(lib_dir)
+        return lib_dir
     candidates: list[Path] = []
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if workspace:
         candidates.append(Path(workspace).expanduser().resolve() / ".claude" / "lib")
     candidates.append(Path(__file__).resolve().parents[3] / "lib")
     for lib_dir in candidates:
-        if lib_dir.is_dir():
-            return str(lib_dir)
+        if os.path.isdir(lib_dir):
+            return lib_dir.resolve()
     checked = ", ".join(str(candidate) for candidate in candidates)
     print(f"Plugin lib directory not found. Checked: {checked}", file=sys.stderr)
     sys.exit(2)
 
 
 _LIB_DIR = _resolve_paths_lib_dir()
-if _LIB_DIR not in sys.path:
-    sys.path.insert(0, _LIB_DIR)
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
 from paths import resolve_artifact_root  # noqa: E402
 from session_init.git_helpers import get_git_info  # noqa: E402

--- a/src/copilot-cli/skills/session-init/scripts/new_session_log_json.py
+++ b/src/copilot-cli/skills/session-init/scripts/new_session_log_json.py
@@ -31,31 +31,32 @@ if _SESSION_INIT_DIR not in sys.path:
     sys.path.insert(0, _SESSION_INIT_DIR)
 
 
-def _resolve_paths_lib_dir() -> str:
+def _resolve_paths_lib_dir() -> Path:
     """Resolve the vendor-portable path-helper lib directory (Issue #2050)."""
+    # ADR-047 keeps this bootstrap inline because imports need sys.path first.
     plugin_root = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
     if plugin_root:
         lib_dir = Path(plugin_root).expanduser().resolve() / "lib"
-        if not lib_dir.is_dir():
+        if not os.path.isdir(lib_dir):
             print(f"Plugin lib directory not found: {lib_dir}", file=sys.stderr)
             sys.exit(2)
-        return str(lib_dir)
+        return lib_dir
     candidates: list[Path] = []
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if workspace:
         candidates.append(Path(workspace).expanduser().resolve() / ".claude" / "lib")
     candidates.append(Path(__file__).resolve().parents[3] / "lib")
     for lib_dir in candidates:
-        if lib_dir.is_dir():
-            return str(lib_dir)
+        if os.path.isdir(lib_dir):
+            return lib_dir.resolve()
     checked = ", ".join(str(candidate) for candidate in candidates)
     print(f"Plugin lib directory not found. Checked: {checked}", file=sys.stderr)
     sys.exit(2)
 
 
 _LIB_DIR = _resolve_paths_lib_dir()
-if _LIB_DIR not in sys.path:
-    sys.path.insert(0, _LIB_DIR)
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
 from paths import resolve_artifact_root  # noqa: E402
 from session_init.session_structure import build_session_log  # noqa: E402

--- a/src/copilot-cli/skills/slo-designer/scripts/generate_slo_document.py
+++ b/src/copilot-cli/skills/slo-designer/scripts/generate_slo_document.py
@@ -11,10 +11,29 @@ Exit Codes:
 """
 
 import argparse
+import os
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
+
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 try:
     import yaml
@@ -87,34 +106,6 @@ def format_downtime(minutes: float) -> str:
         hours = int(minutes // 60)
         remaining_minutes = int(minutes % 60)
         return f"{hours}h {remaining_minutes}m"
-
-
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection).
-
-    This prevents directory traversal attacks like '../../../etc/passwd' while
-    still allowing legitimate absolute paths and paths within the working directory.
-    """
-    # Check for traversal patterns in the path string
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
-
-    # Resolve the path and check it doesn't escape when resolved
-    resolved = path.resolve()
-
-    # If original path was relative, ensure resolved doesn't escape cwd
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
 
 
 def parse_yaml_config(config_path: Path) -> SLOConfig:

--- a/src/copilot-cli/skills/threat-modeling/scripts/generate_mitigation_roadmap.py
+++ b/src/copilot-cli/skills/threat-modeling/scripts/generate_mitigation_roadmap.py
@@ -44,7 +44,7 @@ class Threat:
     impact: str
     risk: str
     status: str = "Planned"
-    mitigations: list = field(default_factory=list)
+    mitigations: list[str] = field(default_factory=list)
 
 
 RISK_ORDER = {"Critical": 0, "High": 1, "Medium": 2, "Low": 3}
@@ -135,7 +135,7 @@ def parse_threat_matrix(content: str) -> list[Threat]:
     Returns:
         List of Threat objects
     """
-    threats = []
+    threats: list[Threat] = []
 
     # Find threat matrix table
     table_pattern = r'\| ID \| Element \| STRIDE \| Threat \|.*?\n((?:\|.*\n)*)'
@@ -178,7 +178,7 @@ def categorize_by_risk(threats: list[Threat]) -> dict[str, list[Threat]]:
     Returns:
         Dictionary mapping risk level to threats
     """
-    categories = {"Critical": [], "High": [], "Medium": [], "Low": []}
+    categories: dict[str, list[Threat]] = {"Critical": [], "High": [], "Medium": [], "Low": []}
 
     for threat in threats:
         risk = threat.risk

--- a/src/copilot-cli/skills/threat-modeling/scripts/generate_mitigation_roadmap.py
+++ b/src/copilot-cli/skills/threat-modeling/scripts/generate_mitigation_roadmap.py
@@ -6,40 +6,30 @@ a prioritized mitigation roadmap.
 """
 
 import argparse
+import os
 import re
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
 
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection).
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
-    This prevents directory traversal attacks like '../../../etc/passwd' while
-    still allowing legitimate absolute paths and paths within the working directory.
-    """
-    # Check for traversal patterns in the path string
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
-
-    # Resolve the path and check it doesn't escape when resolved
-    resolved = path.resolve()
-
-    # If original path was relative, ensure resolved doesn't escape cwd
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 
 @dataclass

--- a/src/copilot-cli/skills/threat-modeling/scripts/generate_threat_matrix.py
+++ b/src/copilot-cli/skills/threat-modeling/scripts/generate_threat_matrix.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E501
 """Generate a structured threat matrix document.
 
 Creates a markdown threat model template with STRIDE categories
@@ -6,38 +7,28 @@ and risk rating structure.
 """
 
 import argparse
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
 
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
 
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection).
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
-    This prevents directory traversal attacks like '../../../etc/passwd' while
-    still allowing legitimate absolute paths and paths within the working directory.
-    """
-    # Check for traversal patterns in the path string
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
-
-    # Resolve the path and check it doesn't escape when resolved
-    resolved = path.resolve()
-
-    # If original path was relative, ensure resolved doesn't escape cwd
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
-
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 STRIDE_CATEGORIES = [
     ("S", "Spoofing", "Pretending to be something or someone else"),

--- a/src/copilot-cli/skills/threat-modeling/scripts/validate_threat_model.py
+++ b/src/copilot-cli/skills/threat-modeling/scripts/validate_threat_model.py
@@ -6,38 +6,29 @@ categories, and proper risk ratings.
 """
 
 import argparse
+import os
 import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+# ADR-047 keeps this bootstrap inline because imports need sys.path first.
+_PLUGIN_ROOT = os.environ.get("COPILOT_PLUGIN_ROOT") or os.environ.get("CLAUDE_PLUGIN_ROOT")
+if _PLUGIN_ROOT:
+    _LIB_DIR = Path(_PLUGIN_ROOT) / "lib"
+else:
+    _LIB_DIR = Path(__file__).resolve().parents[3] / "lib"
 
-def validate_path_no_traversal(path: Path, context: str = "path") -> Path:
-    """Validate that path does not contain traversal patterns (CWE-22 protection).
+if not os.path.isdir(_LIB_DIR):
+    raise RuntimeError(
+        "Expected portability helper lib directory not found: "
+        f"{_LIB_DIR}. Set COPILOT_PLUGIN_ROOT or CLAUDE_PLUGIN_ROOT to the "
+        "plugin root, or run from an ai-agents checkout."
+    )
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
 
-    This prevents directory traversal attacks like '../../../etc/passwd' while
-    still allowing legitimate absolute paths and paths within the working directory.
-    """
-    # Check for traversal patterns in the path string
-    path_str = str(path)
-    if ".." in path_str:
-        raise PermissionError(
-            f"Path traversal attempt detected: '{path}' contains prohibited '..' sequence."
-        )
-
-    # Resolve the path and check it doesn't escape when resolved
-    resolved = path.resolve()
-
-    # If original path was relative, ensure resolved doesn't escape cwd
-    if not path.is_absolute():
-        try:
-            resolved.relative_to(Path.cwd().resolve())
-        except ValueError as e:
-            raise PermissionError(
-                f"Path traversal attempt detected: '{path}' resolves outside the working directory."
-            ) from e
-
-    return resolved
+from hook_utilities.path_safety import validate_path_no_traversal  # noqa: E402
 
 
 @dataclass

--- a/tests/test_chaos_experiment_scripts.py
+++ b/tests/test_chaos_experiment_scripts.py
@@ -73,6 +73,25 @@ def _import_generate_experiment_with_env(env: dict[str, str]) -> subprocess.Comp
     )
 
 
+def _write_plugin_lib(root: Path, source: str) -> None:
+    lib_dir = root / "lib"
+    lib_dir.mkdir(parents=True)
+    (lib_dir / "paths.py").write_text(
+        f"SOURCE = {source!r}\n"
+        "def resolve_artifact_root(subdir):\n"
+        "    raise AssertionError('not called')\n",
+        encoding="utf-8",
+    )
+    package = lib_dir / "hook_utilities"
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "path_safety.py").write_text(
+        "def validate_path_no_traversal(path, context='path'):\n"
+        "    return path\n",
+        encoding="utf-8",
+    )
+
+
 class TestGenerateExperimentPathBootstrap:
     """Tests for importing the vendor-portable path helper."""
 
@@ -80,14 +99,7 @@ class TestGenerateExperimentPathBootstrap:
         copilot_root = tmp_path / "copilot"
         claude_root = tmp_path / "claude"
         for root, source in ((copilot_root, "copilot"), (claude_root, "claude")):
-            lib_dir = root / "lib"
-            lib_dir.mkdir(parents=True)
-            (lib_dir / "paths.py").write_text(
-                f"SOURCE = {source!r}\n"
-                "def resolve_artifact_root(subdir):\n"
-                "    raise AssertionError('not called')\n",
-                encoding="utf-8",
-            )
+            _write_plugin_lib(root, source)
         env = os.environ.copy()
         env["COPILOT_PLUGIN_ROOT"] = str(copilot_root)
         env["CLAUDE_PLUGIN_ROOT"] = str(claude_root)

--- a/tests/test_chaos_experiment_scripts.py
+++ b/tests/test_chaos_experiment_scripts.py
@@ -51,7 +51,7 @@ from validate_experiment import (
 )
 
 
-def _import_generate_experiment_with_env(env: dict[str, str]) -> subprocess.CompletedProcess:
+def _import_generate_experiment_with_env(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     script = SKILL_SCRIPTS_PATH / "generate_experiment.py"
     code = "\n".join(
         [

--- a/tests/test_hook_plugin_guards.py
+++ b/tests/test_hook_plugin_guards.py
@@ -464,6 +464,16 @@ class TestSyncPluginLib:
 
         assert dst.read_bytes() == b'"""Canonical."""\r\nX = 1\r\n'
 
+    def test_validate_review_marker_pair_is_registered(self) -> None:
+        """sync_file --check now enforces the review marker skill copy."""
+        import scripts.sync_plugin_lib as sync_mod
+
+        pair = (
+            "scripts/validation/validate_review_marker.py",
+            ".claude/skills/review/scripts/validate_review_marker.py",
+        )
+        assert pair in sync_mod.SYNC_FILE_PAIRS
+
 
 def _parse_events(stderr_text: str) -> list[dict[str, Any]]:
     return [

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.hook_utilities.path_safety import validate_path_no_traversal
+
+
+def test_valid_relative_path_resolves_inside_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "safe.txt"
+    target.write_text("safe\n", encoding="utf-8")
+    monkeypatch.chdir(repo)
+
+    assert validate_path_no_traversal(Path("safe.txt")) == target.resolve()
+
+
+def test_traversal_attempt_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+
+    with pytest.raises(PermissionError, match="prohibited"):
+        validate_path_no_traversal(Path("../outside.txt"))
+
+
+def test_relative_symlink_escape_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside\n", encoding="utf-8")
+    link = repo / "link.txt"
+    try:
+        link.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable: {exc}")
+    monkeypatch.chdir(repo)
+
+    with pytest.raises(PermissionError, match="outside the working directory"):
+        validate_path_no_traversal(Path("link.txt"))
+
+
+def test_absolute_path_is_allowed(tmp_path: Path) -> None:
+    target = tmp_path / "absolute.txt"
+    target.write_text("safe\n", encoding="utf-8")
+
+    assert validate_path_no_traversal(target) == target.resolve()

--- a/tests/validation/test_portability_common.py
+++ b/tests/validation/test_portability_common.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.validation import portability_common as common
+
+
+def _message(rel: str, count: int, allowed: int) -> str:
+    return f"{rel}: {count} refs (baseline {allowed})"
+
+
+def test_load_baseline_accepts_wrapped_files_object(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"files": {"skills/a.py": "2"}}), encoding="utf-8")
+
+    assert common.load_baseline(baseline) == {"skills/a.py": 2}
+
+
+def test_load_baseline_rejects_null_count(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"files": {"skills/a.py": None}}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="null"):
+        common.load_baseline(baseline)
+
+
+def test_diff_against_baseline_reports_regression_and_improvement() -> None:
+    regressions, improvements = common.diff_against_baseline(
+        {"a.py": 3, "b.py": 1},
+        {"a.py": 2, "b.py": 2},
+        _message,
+    )
+
+    assert regressions == ["a.py: 3 refs (baseline 2)"]
+    assert improvements == ["b.py: 1 refs (baseline 2)"]
+
+
+def test_resolve_baseline_rejects_path_outside_repo(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    outside = tmp_path / "baseline.json"
+    outside.write_text("{}", encoding="utf-8")
+
+    assert (
+        common.resolve_baseline_path(
+            root,
+            outside,
+            "default.json",
+            reject_outside_root=True,
+        )
+        == Path("")
+    )


### PR DESCRIPTION
## Summary
This PR resolves the four #2816 audit duplicate code findings in one branch to avoid plugin version conflicts.

Fixes #2910
Fixes #2911
Fixes #2912
Fixes #2913

## Changes
1. Registers the review marker validator pair in SYNC_FILE_PAIRS.
2. Moves CWE 22 path traversal checks into one shared helper and updates all nine skill scripts.
3. Shares portability baseline parsing and compare logic between the two validation scripts.
4. Keeps the #2913 path bootstrap inline.

## #2913 determination
I determined _resolve_paths_lib_dir is the ADR 047 sanctioned inline bootstrap. It must run before shared imports can load, so centralizing it would break the reason ADR 047 exists. I kept the bootstrap inline, added ADR 047 comments at each copy, and normalized the return type to Path.

## Validation
1. Mirrors regenerated with build_all.py.
2. Plugin manifests are both 0.6.8.
3. Pre PR validation passed.
4. Pre push validation passed with SKIP_CLI_E2E=true.
5. Pytest result: 13907 passed, 20 skipped, 45 xfailed.

## References
ADR 047 and ADR 068 informed the #2913 decision.
