### PR TITLE
fix(git): harden packed-refs repair guard

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -78,15 +78,16 @@ run_packed_refs_repair() {
         fi
         python_cmd=(uv run --frozen python)
     elif command -v python3 > /dev/null 2>&1 &&
-        python3 -c 'import sys; exit(0 if sys.version_info >= (3,) else 1)' > /dev/null 2>&1; then
+        python3 -c 'import sys; exit(0 if sys.version_info >= (3, 10) else 1)' > /dev/null 2>&1; then
         python_cmd=(python3)
     elif command -v python > /dev/null 2>&1 &&
-        python -c 'import sys; exit(0 if sys.version_info >= (3,) else 1)' > /dev/null 2>&1; then
+        python -c 'import sys; exit(0 if sys.version_info >= (3, 10) else 1)' > /dev/null 2>&1; then
         python_cmd=(python)
-    elif command -v py > /dev/null 2>&1 && py -3 -c 'import sys' > /dev/null 2>&1; then
+    elif command -v py > /dev/null 2>&1 &&
+        py -3 -c 'import sys; exit(0 if sys.version_info >= (3, 10) else 1)' > /dev/null 2>&1; then
         python_cmd=(py -3)
     else
-        echo_error "Python 3 is required to repair git packed-refs before commit validation"
+        echo_error "Python 3.10+ is required to repair git packed-refs before commit validation"
         exit 2
     fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -78,12 +78,16 @@ run_packed_refs_repair() {
             exit 2
         fi
         python_cmd=(uv run --frozen python)
-    elif command -v python3 > /dev/null 2>&1; then
+    elif command -v python3 > /dev/null 2>&1 &&
+        python3 -c 'import sys; exit(0 if sys.version_info >= (3,) else 1)' > /dev/null 2>&1; then
         python_cmd=(python3)
-    elif command -v python > /dev/null 2>&1; then
+    elif command -v python > /dev/null 2>&1 &&
+        python -c 'import sys; exit(0 if sys.version_info >= (3,) else 1)' > /dev/null 2>&1; then
         python_cmd=(python)
+    elif command -v py > /dev/null 2>&1 && py -3 -c 'import sys' > /dev/null 2>&1; then
+        python_cmd=(py -3)
     else
-        echo_error "Python is required to repair git packed-refs before commit validation"
+        echo_error "Python 3 is required to repair git packed-refs before commit validation"
         exit 2
     fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -65,7 +65,7 @@ run_packed_refs_repair() {
     if [ ! -f "$repair_script" ]; then
         return 0
     fi
-    if [ -f "$repo_root/uv.lock" ] || [ -f "$repo_root/pyproject.toml" ]; then
+    if [ -f "$repo_root/uv.lock" ]; then
         if ! command -v uv > /dev/null 2>&1; then
             echo_error "Python environment: uv is required for this checkout"
             echo_info "  Install uv so pre-commit can repair packed-refs from uv.lock instead of system Python."
@@ -73,7 +73,7 @@ run_packed_refs_repair() {
         fi
         if ! (cd "$repo_root" && uv run --frozen python -c 'import sys' > /dev/null 2>&1); then
             echo_error "Python environment: uv run --frozen python failed"
-            echo_info "  Refusing system Python fallback in a uv-managed checkout; fix uv.lock or pyproject.toml."
+            echo_info "  Refusing system Python fallback in a uv-managed checkout; fix uv.lock."
             exit 2
         fi
         python_cmd=(uv run --frozen python)

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -59,22 +59,25 @@ echo_action() {
 run_packed_refs_repair() {
     local hook_dir
     hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+    local repo_root="$hook_dir/.."
     local repair_script="$hook_dir/../scripts/maintenance/repair_packed_refs.py"
-    local python_bin=""
+    local python_cmd=()
 
     if [ ! -f "$repair_script" ]; then
         return 0
     fi
-    if command -v python3 > /dev/null 2>&1; then
-        python_bin="python3"
+    if command -v uv > /dev/null 2>&1 && (cd "$repo_root" && uv run python -c 'import sys' > /dev/null 2>&1); then
+        python_cmd=(uv run python)
+    elif command -v python3 > /dev/null 2>&1; then
+        python_cmd=(python3)
     elif command -v python > /dev/null 2>&1; then
-        python_bin="python"
+        python_cmd=(python)
     else
         echo_error "Python is required to repair git packed-refs before commit validation"
         exit 2
     fi
 
-    "$python_bin" "$repair_script" || {
+    (cd "$repo_root" && "${python_cmd[@]}" "$repair_script") || {
         echo_error "Failed to repair git packed-refs"
         exit 1
     }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -66,8 +66,18 @@ run_packed_refs_repair() {
     if [ ! -f "$repair_script" ]; then
         return 0
     fi
-    if command -v uv > /dev/null 2>&1 && (cd "$repo_root" && uv run python -c 'import sys' > /dev/null 2>&1); then
-        python_cmd=(uv run python)
+    if [ -f "$repo_root/uv.lock" ] || [ -f "$repo_root/pyproject.toml" ]; then
+        if ! command -v uv > /dev/null 2>&1; then
+            echo_error "Python environment: uv is required for this checkout"
+            echo_info "  Install uv so pre-commit can repair packed-refs from uv.lock instead of system Python."
+            exit 2
+        fi
+        if ! (cd "$repo_root" && uv run --frozen python -c 'import sys' > /dev/null 2>&1); then
+            echo_error "Python environment: uv run --frozen python failed"
+            echo_info "  Refusing system Python fallback in a uv-managed checkout; fix uv.lock or pyproject.toml."
+            exit 2
+        fi
+        python_cmd=(uv run --frozen python)
     elif command -v python3 > /dev/null 2>&1; then
         python_cmd=(python3)
     elif command -v python > /dev/null 2>&1; then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -58,7 +58,10 @@ echo_action() {
 
 run_packed_refs_repair() {
     local repo_root
-    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)
+    repo_root=$(pwd -P)
+    while [ "$repo_root" != "/" ] && [ ! -f "$repo_root/scripts/maintenance/repair_packed_refs.py" ]; do
+        repo_root=$(dirname "$repo_root")
+    done
     local repair_script="$repo_root/scripts/maintenance/repair_packed_refs.py"
     local python_cmd=()
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -57,10 +57,9 @@ echo_action() {
 }
 
 run_packed_refs_repair() {
-    local hook_dir
-    hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
-    local repo_root="$hook_dir/.."
-    local repair_script="$hook_dir/../scripts/maintenance/repair_packed_refs.py"
+    local repo_root
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)
+    local repair_script="$repo_root/scripts/maintenance/repair_packed_refs.py"
     local python_cmd=()
 
     if [ ! -f "$repair_script" ]; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -60,7 +60,10 @@ echo_phase() {
 
 run_packed_refs_repair() {
     local repo_root
-    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)
+    repo_root=$(pwd -P)
+    while [ "$repo_root" != "/" ] && [ ! -f "$repo_root/scripts/maintenance/repair_packed_refs.py" ]; do
+        repo_root=$(dirname "$repo_root")
+    done
     local repair_script="$repo_root/scripts/maintenance/repair_packed_refs.py"
     local python_cmd=()
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -59,10 +59,9 @@ echo_phase() {
 }
 
 run_packed_refs_repair() {
-    local hook_dir
-    hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
-    local repo_root="$hook_dir/.."
-    local repair_script="$hook_dir/../scripts/maintenance/repair_packed_refs.py"
+    local repo_root
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd -P)
+    local repair_script="$repo_root/scripts/maintenance/repair_packed_refs.py"
     local python_cmd=()
 
     if [ ! -f "$repair_script" ]; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -61,22 +61,35 @@ echo_phase() {
 run_packed_refs_repair() {
     local hook_dir
     hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+    local repo_root="$hook_dir/.."
     local repair_script="$hook_dir/../scripts/maintenance/repair_packed_refs.py"
-    local python_bin=""
+    local python_cmd=()
 
     if [ ! -f "$repair_script" ]; then
         return 0
     fi
-    if command -v python3 > /dev/null 2>&1; then
-        python_bin="python3"
+    if [ -f "$repo_root/uv.lock" ] || [ -f "$repo_root/pyproject.toml" ]; then
+        if ! command -v uv > /dev/null 2>&1; then
+            echo_error "Python environment: uv is required for this checkout"
+            echo_info "  Install uv so pre-push can repair packed-refs from uv.lock instead of system Python."
+            exit 2
+        fi
+        if ! (cd "$repo_root" && uv run --frozen python -c 'import sys' > /dev/null 2>&1); then
+            echo_error "Python environment: uv run --frozen python failed"
+            echo_info "  Refusing system Python fallback in a uv-managed checkout; fix uv.lock or pyproject.toml."
+            exit 2
+        fi
+        python_cmd=(uv run --frozen python)
+    elif command -v python3 > /dev/null 2>&1; then
+        python_cmd=(python3)
     elif command -v python > /dev/null 2>&1; then
-        python_bin="python"
+        python_cmd=(python)
     else
         echo_error "Python is required to repair git packed-refs before push validation"
         exit 2
     fi
 
-    "$python_bin" "$repair_script" || {
+    (cd "$repo_root" && "${python_cmd[@]}" "$repair_script") || {
         echo_error "Failed to repair git packed-refs"
         exit 1
     }

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -80,15 +80,16 @@ run_packed_refs_repair() {
         fi
         python_cmd=(uv run --frozen python)
     elif command -v python3 > /dev/null 2>&1 &&
-        python3 -c 'import sys; exit(0 if sys.version_info >= (3,) else 1)' > /dev/null 2>&1; then
+        python3 -c 'import sys; exit(0 if sys.version_info >= (3, 10) else 1)' > /dev/null 2>&1; then
         python_cmd=(python3)
     elif command -v python > /dev/null 2>&1 &&
-        python -c 'import sys; exit(0 if sys.version_info >= (3,) else 1)' > /dev/null 2>&1; then
+        python -c 'import sys; exit(0 if sys.version_info >= (3, 10) else 1)' > /dev/null 2>&1; then
         python_cmd=(python)
-    elif command -v py > /dev/null 2>&1 && py -3 -c 'import sys' > /dev/null 2>&1; then
+    elif command -v py > /dev/null 2>&1 &&
+        py -3 -c 'import sys; exit(0 if sys.version_info >= (3, 10) else 1)' > /dev/null 2>&1; then
         python_cmd=(py -3)
     else
-        echo_error "Python 3 is required to repair git packed-refs before push validation"
+        echo_error "Python 3.10+ is required to repair git packed-refs before push validation"
         exit 2
     fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -67,7 +67,7 @@ run_packed_refs_repair() {
     if [ ! -f "$repair_script" ]; then
         return 0
     fi
-    if [ -f "$repo_root/uv.lock" ] || [ -f "$repo_root/pyproject.toml" ]; then
+    if [ -f "$repo_root/uv.lock" ]; then
         if ! command -v uv > /dev/null 2>&1; then
             echo_error "Python environment: uv is required for this checkout"
             echo_info "  Install uv so pre-push can repair packed-refs from uv.lock instead of system Python."
@@ -75,7 +75,7 @@ run_packed_refs_repair() {
         fi
         if ! (cd "$repo_root" && uv run --frozen python -c 'import sys' > /dev/null 2>&1); then
             echo_error "Python environment: uv run --frozen python failed"
-            echo_info "  Refusing system Python fallback in a uv-managed checkout; fix uv.lock or pyproject.toml."
+            echo_info "  Refusing system Python fallback in a uv-managed checkout; fix uv.lock."
             exit 2
         fi
         python_cmd=(uv run --frozen python)

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -80,12 +80,16 @@ run_packed_refs_repair() {
             exit 2
         fi
         python_cmd=(uv run --frozen python)
-    elif command -v python3 > /dev/null 2>&1; then
+    elif command -v python3 > /dev/null 2>&1 &&
+        python3 -c 'import sys; exit(0 if sys.version_info >= (3,) else 1)' > /dev/null 2>&1; then
         python_cmd=(python3)
-    elif command -v python > /dev/null 2>&1; then
+    elif command -v python > /dev/null 2>&1 &&
+        python -c 'import sys; exit(0 if sys.version_info >= (3,) else 1)' > /dev/null 2>&1; then
         python_cmd=(python)
+    elif command -v py > /dev/null 2>&1 && py -3 -c 'import sys' > /dev/null 2>&1; then
+        python_cmd=(py -3)
     else
-        echo_error "Python is required to repair git packed-refs before push validation"
+        echo_error "Python 3 is required to repair git packed-refs before push validation"
         exit 2
     fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,10 @@ Read first.
 
 ## Gates
 
-**Start**: Init Serena|Read HANDOFF.md + latest issue handoff + resume verify|Session log|Search memories|Verify git
+**Start**: Init Serena|Read HANDOFF+latest issue handoff|Resume check|Log|Search mem|Verify git
 **Mid**: `git rev-list --count HEAD ^origin/main` <=20, warn >15 (ADR-008)
 **Pre-PR**: `python3 scripts/validation/pre_pr.py`|No BLOCKING|Security scan|Style `.gemini/styleguide.md`
-**End**: Complete log|Preserve HANDOFF.md|Issue handoff if open|Update Serena|Lint|Commit|Validate
+**End**: Complete log|Keep HANDOFF|Issue handoff if open|Update Serena|Lint|Commit|Check
 
 ## Boundaries
 
@@ -54,4 +54,4 @@ Tests (BLOCKING): pos+neg+edge|branches|mock I/O|CLI exits. See `.agents/governa
 
 ## Stack
 
-Python 3.14 dev; floor: pyproject|UV|PowerShell 7.5.4+|Node LTS|Pester 5.7.1|pytest 8+|gh 2.60+
+Py 3.14 dev; floor: pyproject|UV|PS 7.5+|Node LTS|Pester 5.7+|pytest 8+|gh 2.60+

--- a/scripts/maintenance/repair_packed_refs.py
+++ b/scripts/maintenance/repair_packed_refs.py
@@ -197,17 +197,21 @@ def _backup_packed_refs(packed_refs_path: Path) -> Path:
 
 
 def _write_repaired_packed_refs(packed_refs_path: Path, repaired: bytes) -> None:
-    with tempfile.NamedTemporaryFile(dir=packed_refs_path.parent, delete=False) as temp_file:
-        temporary_path = Path(temp_file.name)
-        try:
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=packed_refs_path.parent, delete=False) as temp_file:
+            temporary_path = Path(temp_file.name)
             temp_file.write(repaired)
             temp_file.flush()
             os.fsync(temp_file.fileno())
             shutil.copymode(packed_refs_path, temporary_path)
-        except Exception:
+    except Exception:
+        if temporary_path is not None:
             temporary_path.unlink(missing_ok=True)
-            raise
+        raise
 
+    if temporary_path is None:
+        raise RuntimeError("temporary packed-refs path was not created")
     os.replace(temporary_path, packed_refs_path)
 
 

--- a/scripts/maintenance/repair_packed_refs.py
+++ b/scripts/maintenance/repair_packed_refs.py
@@ -203,8 +203,8 @@ def _write_repaired_packed_refs(packed_refs_path: Path, repaired: bytes) -> None
             temporary_path = Path(temp_file.name)
             temp_file.write(repaired)
             temp_file.flush()
-            os.fsync(temp_file.fileno())
             shutil.copymode(packed_refs_path, temporary_path)
+            os.fsync(temp_file.fileno())
     except Exception:
         if temporary_path is not None:
             temporary_path.unlink(missing_ok=True)

--- a/scripts/maintenance/repair_packed_refs.py
+++ b/scripts/maintenance/repair_packed_refs.py
@@ -14,6 +14,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -196,9 +197,18 @@ def _backup_packed_refs(packed_refs_path: Path) -> Path:
 
 
 def _write_repaired_packed_refs(packed_refs_path: Path, repaired: bytes) -> None:
-    temporary_path = packed_refs_path.with_name(f"{packed_refs_path.name}.repairing")
-    temporary_path.write_bytes(repaired)
-    temporary_path.replace(packed_refs_path)
+    with tempfile.NamedTemporaryFile(dir=packed_refs_path.parent, delete=False) as temp_file:
+        temporary_path = Path(temp_file.name)
+        try:
+            temp_file.write(repaired)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+            shutil.copymode(packed_refs_path, temporary_path)
+        except Exception:
+            temporary_path.unlink(missing_ok=True)
+            raise
+
+    os.replace(temporary_path, packed_refs_path)
 
 
 if __name__ == "__main__":

--- a/scripts/maintenance/repair_packed_refs.py
+++ b/scripts/maintenance/repair_packed_refs.py
@@ -212,7 +212,11 @@ def _write_repaired_packed_refs(packed_refs_path: Path, repaired: bytes) -> None
 
     if temporary_path is None:
         raise RuntimeError("temporary packed-refs path was not created")
-    os.replace(temporary_path, packed_refs_path)
+    try:
+        os.replace(temporary_path, packed_refs_path)
+    except OSError:
+        temporary_path.unlink(missing_ok=True)
+        raise
 
 
 if __name__ == "__main__":

--- a/tests/test_repair_packed_refs.py
+++ b/tests/test_repair_packed_refs.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from scripts.maintenance import repair_packed_refs as repair_module
 from scripts.maintenance.repair_packed_refs import repair_packed_refs
 
 PACKED_REFS_HEADER = b"# pack-refs with: peeled fully-peeled sorted\n"
@@ -130,6 +131,60 @@ def test_repair_preserves_packed_refs_permissions(tmp_path: Path) -> None:
 
     assert result.status == "repaired"
     assert stat.S_IMODE(packed_refs.stat().st_mode) == original_mode
+
+
+def test_write_failure_unlinks_temp_after_file_is_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Failed temp writes clean up after the context manager closes the file."""
+    packed_refs = tmp_path / "packed-refs"
+    packed_refs.write_bytes(PACKED_REFS_HEADER)
+    temp_closed = False
+
+    class FailingTempFile:
+        def __init__(self, directory: Path) -> None:
+            self.path = directory / "repair.tmp"
+            self.name = str(self.path)
+            self.handle = self.path.open("wb")
+
+        def __enter__(self) -> FailingTempFile:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            nonlocal temp_closed
+            self.handle.close()
+            temp_closed = True
+
+        def write(self, _data: bytes) -> int:
+            raise OSError("write failed")
+
+        def flush(self) -> None:
+            self.handle.flush()
+
+        def fileno(self) -> int:
+            return self.handle.fileno()
+
+    def fake_named_temporary_file(*, dir: Path, delete: bool) -> FailingTempFile:
+        assert delete is False
+        return FailingTempFile(Path(dir))
+
+    original_unlink = Path.unlink
+
+    def assert_closed_before_unlink(path: Path, missing_ok: bool = False) -> None:
+        if path.name == "repair.tmp":
+            assert temp_closed is True
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(
+        repair_module.tempfile, "NamedTemporaryFile", fake_named_temporary_file
+    )
+    monkeypatch.setattr(Path, "unlink", assert_closed_before_unlink)
+
+    with pytest.raises(OSError, match="write failed"):
+        repair_module._write_repaired_packed_refs(packed_refs, REF_LINE)
+
+    assert not (tmp_path / "repair.tmp").exists()
+    assert packed_refs.read_bytes() == PACKED_REFS_HEADER
 
 
 def _create_normal_worktree(parent: Path) -> Path:

--- a/tests/test_repair_packed_refs.py
+++ b/tests/test_repair_packed_refs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import stat
 from pathlib import Path
 
@@ -119,6 +120,7 @@ def test_restores_backup_when_verification_fails(tmp_path: Path) -> None:
     assert (worktree / ".git" / "packed-refs.before-repair").read_bytes() == original
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits differ on Windows")
 def test_repair_preserves_packed_refs_permissions(tmp_path: Path) -> None:
     """Repair keeps the original packed-refs file mode."""
     worktree = _create_normal_worktree(tmp_path)
@@ -185,6 +187,25 @@ def test_write_failure_unlinks_temp_after_file_is_closed(
 
     assert not (tmp_path / "repair.tmp").exists()
     assert packed_refs.read_bytes() == PACKED_REFS_HEADER
+
+
+def test_replace_failure_unlinks_temp_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Failed replacement removes the closed temp file."""
+    packed_refs = tmp_path / "packed-refs"
+    packed_refs.write_bytes(PACKED_REFS_HEADER)
+
+    def fail_replace(_source: Path, _destination: Path) -> None:
+        raise PermissionError("replace failed")
+
+    monkeypatch.setattr(repair_module.os, "replace", fail_replace)
+
+    with pytest.raises(PermissionError, match="replace failed"):
+        repair_module._write_repaired_packed_refs(packed_refs, REF_LINE)
+
+    assert packed_refs.read_bytes() == PACKED_REFS_HEADER
+    assert sorted(path.name for path in tmp_path.iterdir()) == ["packed-refs"]
 
 
 def _create_normal_worktree(parent: Path) -> Path:

--- a/tests/test_repair_packed_refs.py
+++ b/tests/test_repair_packed_refs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import stat
 from pathlib import Path
 
 import pytest
@@ -115,6 +116,20 @@ def test_restores_backup_when_verification_fails(tmp_path: Path) -> None:
 
     assert packed_refs.read_bytes() == original
     assert (worktree / ".git" / "packed-refs.before-repair").read_bytes() == original
+
+
+def test_repair_preserves_packed_refs_permissions(tmp_path: Path) -> None:
+    """Repair keeps the original packed-refs file mode."""
+    worktree = _create_normal_worktree(tmp_path)
+    packed_refs = worktree / ".git" / "packed-refs"
+    original_mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP
+    packed_refs.write_bytes(PACKED_REFS_HEADER + b"\n" + REF_LINE)
+    packed_refs.chmod(original_mode)
+
+    result = repair_packed_refs(worktree, verifier=lambda _worktree: None)
+
+    assert result.status == "repaired"
+    assert stat.S_IMODE(packed_refs.stat().st_mode) == original_mode
 
 
 def _create_normal_worktree(parent: Path) -> Path:


### PR DESCRIPTION
## Summary

Follow-up to PR #2975. The original PR merged before the bot review fixes reached the remote branch.

This PR keeps the packed-refs guard but adds the verified review fixes:

- Use the uv-aware Python path in `.githooks/pre-commit` and `.githooks/pre-push` before repair runs.
- Rewrite `packed-refs` through a secure temp file, preserve mode, fsync data, and replace atomically.
- Keep `AGENTS.md` under the workspace budget gate that origin/main currently fails.

## Validation

- `uv run pytest tests/test_repair_packed_refs.py tests/test_validate_workspace_budget.py tests/test_workspace_limits.py -q`, 29 passed.
- `uv run ruff check scripts/maintenance/repair_packed_refs.py tests/test_repair_packed_refs.py`, passed.
- `python3 scripts/validate_workspace_budget.py`, passed.
- Changed-file em and en dash byte counts, 0.
- `SKIP_CLI_E2E=true git push origin agent/packedrefs2903-followup`, full pre-push passed.

## References

- Refs #2903
- Follow-up to #2975