### PR TITLE
fix(hooks): boundary-validation and cross-model reconciliation guards

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
+++ b/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
@@ -168,10 +168,12 @@ def main() -> int:
         findings_count = 0
         try:
             lines = result.stdout.strip().splitlines()
-            json_lines = [line for line in lines if line.strip().startswith("{")]
+            json_lines = [line for line in lines if line.strip().startswith(("{", "["))]
             if json_lines:
                 json_output = "\n".join(json_lines)
                 scan_result = json.loads(json_output)
+                if not isinstance(scan_result, dict):
+                    raise TypeError("scan output must be a JSON object")
                 findings_count = scan_result.get("TotalFindings", 0)
         except (json.JSONDecodeError, KeyError, TypeError):
             print(

--- a/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
+++ b/.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
@@ -164,17 +164,23 @@ def main() -> int:
             )
             return 0
 
-        # Parse JSON output for findings count
+        # Parse JSON output for findings count.
+        # The scan may emit log noise around the JSON blob, and the JSON may be
+        # pretty-printed across multiple lines. Locate the first '{' or '[' and
+        # decode from there so multi-line JSON is not truncated to its first line.
         findings_count = 0
         try:
-            lines = result.stdout.strip().splitlines()
-            json_lines = [line for line in lines if line.strip().startswith(("{", "["))]
-            if json_lines:
-                json_output = "\n".join(json_lines)
-                scan_result = json.loads(json_output)
-                if not isinstance(scan_result, dict):
-                    raise TypeError("scan output must be a JSON object")
-                findings_count = scan_result.get("TotalFindings", 0)
+            stdout = result.stdout
+            start = min(
+                (i for i in (stdout.find("{"), stdout.find("[")) if i != -1),
+                default=-1,
+            )
+            if start == -1:
+                raise json.JSONDecodeError("no JSON object found", stdout, 0)
+            scan_result, _ = json.JSONDecoder().raw_decode(stdout[start:])
+            if not isinstance(scan_result, dict):
+                raise TypeError("scan output must be a JSON object")
+            findings_count = scan_result.get("TotalFindings", 0)
         except (json.JSONDecodeError, KeyError, TypeError):
             print(
                 "\n**CodeQL Quick Scan ERROR**: Scan output invalid. "

--- a/.claude/hooks/invoke_adr_change_detection.py
+++ b/.claude/hooks/invoke_adr_change_detection.py
@@ -146,6 +146,12 @@ def main() -> int:
             return 2
 
         detection = json.loads(result.stdout)
+        if not isinstance(detection, dict):
+            print(
+                "ADR detection returned non-object JSON; expected object",
+                file=sys.stderr,
+            )
+            return 2
 
         if not detection.get("HasChanges"):
             return 0  # No output if no changes
@@ -163,6 +169,15 @@ def main() -> int:
         created = detection.get("Created", [])
         modified = detection.get("Modified", [])
         deleted = detection.get("Deleted", [])
+        if not all(
+            isinstance(items, list) and all(isinstance(item, str) for item in items)
+            for items in (created, modified, deleted)
+        ):
+            print(
+                "ADR detection returned invalid change lists; expected string arrays",
+                file=sys.stderr,
+            )
+            return 2
 
         if created:
             lines.append(f"**Created**: {', '.join(created)}")

--- a/.claude/hooks/invoke_session_start_memory_first.py
+++ b/.claude/hooks/invoke_session_start_memory_first.py
@@ -68,9 +68,21 @@ def read_forgetful_config(mcp_config_path: str) -> tuple[str, int]:
 
     try:
         config = json.loads(config_path.read_text(encoding="utf-8"))
+        if not isinstance(config, dict):
+            msg = "MCP config root must be a JSON object"
+            raise ValueError(msg)
         servers = config.get("mcpServers", {})
+        if not isinstance(servers, dict):
+            msg = "mcpServers must be a JSON object"
+            raise ValueError(msg)
         forgetful = servers.get("forgetful", {})
+        if not isinstance(forgetful, dict):
+            msg = "forgetful server config must be a JSON object"
+            raise ValueError(msg)
         url_str = forgetful.get("url", "")
+        if not isinstance(url_str, str):
+            msg = "forgetful server url must be a string"
+            raise ValueError(msg)
         if url_str:
             parsed = urlparse(url_str)
             if parsed.hostname:

--- a/scripts/compute_health_status.py
+++ b/scripts/compute_health_status.py
@@ -319,15 +319,18 @@ def compute_session_health(sessions_dir: Path, limit: int = 50) -> list[Componen
     failed_sessions = 0
     eligible_orchestrations = 0
     skipped_context_retrieval = 0
+    skipped_logs = 0
 
     for log_path in log_files:
         try:
             content = log_path.read_text(encoding="utf-8")
             session = json.loads(content)
         except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+            skipped_logs += 1
             continue
 
         if not isinstance(session, dict):
+            skipped_logs += 1
             continue
 
         total_sessions += 1
@@ -349,6 +352,9 @@ def compute_session_health(sessions_dir: Path, limit: int = 50) -> list[Componen
     if total_sessions > 0:
         failure_rate = failed_sessions / total_sessions
         failure_threshold = DEFAULT_THRESHOLDS["session_failure_rate"]
+        detail = f"{failed_sessions}/{total_sessions} sessions failed"
+        if skipped_logs:
+            detail += f" ({skipped_logs} unreadable logs skipped)"
         components.append(
             ComponentHealth(
                 name="session_failure_rate",
@@ -356,8 +362,14 @@ def compute_session_health(sessions_dir: Path, limit: int = 50) -> list[Componen
                 value=failure_rate,
                 threshold_warning=failure_threshold.warning,
                 threshold_error=failure_threshold.error,
-                detail=f"{failed_sessions}/{total_sessions} sessions failed",
+                detail=detail,
             )
+        )
+
+    if skipped_logs:
+        print(
+            f"WARNING: Skipped {skipped_logs} unreadable session log(s).",
+            file=sys.stderr,
         )
 
     # Context-retrieval skip rate

--- a/scripts/consensus/decision_recorder.py
+++ b/scripts/consensus/decision_recorder.py
@@ -7,6 +7,7 @@ Stores decisions as JSON files in .agents/decisions/ directory.
 from __future__ import annotations
 
 import json
+import sys
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -124,10 +125,7 @@ class DecisionRecorder:
         if not filepath.exists():
             return None
 
-        with filepath.open(encoding="utf-8") as f:
-            data = json.load(f)
-
-        return Decision(**data)
+        return self._load_decision_file(filepath)
 
     def list_decisions(
         self, limit: int | None = None, topic_filter: str | None = None
@@ -157,21 +155,34 @@ class DecisionRecorder:
 
         decisions = []
         for filepath in files:
-            with filepath.open(encoding="utf-8") as f:
-                data = json.load(f)
-                decision = Decision(**data)
+            decision = self._load_decision_file(filepath)
+            if decision is None:
+                continue
 
-                # Apply topic filter
-                if topic_filter and topic_filter.lower() not in decision.topic.lower():
-                    continue
+            # Apply topic filter
+            if topic_filter and topic_filter.lower() not in decision.topic.lower():
+                continue
 
-                decisions.append(decision)
+            decisions.append(decision)
 
-                # Apply limit
-                if limit is not None and len(decisions) >= limit:
-                    break
+            # Apply limit
+            if limit is not None and len(decisions) >= limit:
+                break
 
         return decisions
+
+    def _load_decision_file(self, filepath: Path) -> Decision | None:
+        """Load a decision file, returning None for malformed stored data."""
+        try:
+            with filepath.open(encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                msg = f"decision JSON root must be an object, got {type(data).__name__}"
+                raise TypeError(msg)
+            return Decision(**data)
+        except (json.JSONDecodeError, OSError, TypeError, UnicodeDecodeError) as exc:
+            print(f"Skipping decision file {filepath}: {exc}", file=sys.stderr)
+            return None
 
     def _generate_id(self, timestamp: str) -> str:
         """Generate unique decision ID from timestamp.

--- a/scripts/generate_third_party_notices.py
+++ b/scripts/generate_third_party_notices.py
@@ -137,10 +137,12 @@ def load_marketplace_config(project_root: Path) -> list[dict[str, str]]:
     if plugins is None:
         return []
     if not isinstance(plugins, list) or not all(
-        isinstance(plugin, dict) for plugin in plugins
+        isinstance(plugin, dict) and isinstance(plugin.get("source", ""), str)
+        for plugin in plugins
     ):
         print(
-            f"ERROR: {marketplace_path} plugins must be a JSON array of objects.",
+            f"ERROR: {marketplace_path} plugins must be a JSON array of objects "
+            "whose 'source' field, when present, is a string.",
             file=sys.stderr,
         )
         sys.exit(2)

--- a/scripts/generate_third_party_notices.py
+++ b/scripts/generate_third_party_notices.py
@@ -116,10 +116,36 @@ def load_marketplace_config(project_root: Path) -> list[dict[str, str]]:
         )
         sys.exit(2)
 
-    with open(marketplace_path) as f:
-        data = json.load(f)
+    try:
+        with marketplace_path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
+        print(
+            f"ERROR: Failed to read {marketplace_path}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
-    return data.get("plugins", [])
+    if not isinstance(data, dict):
+        print(
+            f"ERROR: {marketplace_path} root must be a JSON object.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    plugins = data.get("plugins")
+    if plugins is None:
+        return []
+    if not isinstance(plugins, list) or not all(
+        isinstance(plugin, dict) for plugin in plugins
+    ):
+        print(
+            f"ERROR: {marketplace_path} plugins must be a JSON array of objects.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    return plugins
 
 
 def get_shipped_source_paths(project_root: Path, plugins: list[dict[str, str]]) -> list[Path]:

--- a/scripts/quality_gate/generate_test_summary.py
+++ b/scripts/quality_gate/generate_test_summary.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import argparse
 import os
-import random
+import secrets
 import sys
 from pathlib import Path
 
@@ -42,7 +42,7 @@ def build_summary(pytest_status: str, pytest_summary: str) -> str:
 def write_summary(output_path: Path, summary: str) -> None:
     """Append a ``test_summary`` multiline output using a heredoc delimiter."""
 
-    delimiter = f"EOF_SUMMARY_{random.randint(1000, 9999)}"
+    delimiter = f"EOF_SUMMARY_{secrets.token_hex(16)}"
     with output_path.open("a", encoding="utf-8") as handle:
         handle.write(f"test_summary<<{delimiter}\n")
         handle.write(summary)

--- a/scripts/update_reviewer_signal_stats.py
+++ b/scripts/update_reviewer_signal_stats.py
@@ -278,7 +278,10 @@ def get_actionability_score(
                 score += float(heuristics["no_reply_after_days"])
                 reasons.append("NoReplyAfterDays")
         except (ValueError, TypeError):
-            pass
+            logger.debug(
+                "Skipping no-reply heuristic date parse miss for created_at=%r",
+                comment_data.created_at,
+            )
 
     # Clamp score between 0 and 1
     score = max(0.0, min(1.0, score))
@@ -410,7 +413,11 @@ def get_reviewer_signal_stats(
                     if score_result.is_actionable:
                         last_30_days_actionable += 1
             except (ValueError, TypeError):
-                pass
+                logger.debug(
+                    "Skipping reviewer signal date parse miss for reviewer=%s created_at=%r",
+                    reviewer,
+                    comment.created_at,
+                )
 
         signal_rate = (
             round(actionable_count / stats.total_comments, 2)

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/SessionStart/invoke_adr_change_detection.py
+++ b/src/copilot-cli/hooks/SessionStart/invoke_adr_change_detection.py
@@ -146,6 +146,12 @@ def main() -> int:
             return 2
 
         detection = json.loads(result.stdout)
+        if not isinstance(detection, dict):
+            print(
+                "ADR detection returned non-object JSON; expected object",
+                file=sys.stderr,
+            )
+            return 2
 
         if not detection.get("HasChanges"):
             return 0  # No output if no changes
@@ -163,6 +169,15 @@ def main() -> int:
         created = detection.get("Created", [])
         modified = detection.get("Modified", [])
         deleted = detection.get("Deleted", [])
+        if not all(
+            isinstance(items, list) and all(isinstance(item, str) for item in items)
+            for items in (created, modified, deleted)
+        ):
+            print(
+                "ADR detection returned invalid change lists; expected string arrays",
+                file=sys.stderr,
+            )
+            return 2
 
         if created:
             lines.append(f"**Created**: {', '.join(created)}")

--- a/src/copilot-cli/hooks/SessionStart/invoke_session_start_memory_first.py
+++ b/src/copilot-cli/hooks/SessionStart/invoke_session_start_memory_first.py
@@ -68,9 +68,21 @@ def read_forgetful_config(mcp_config_path: str) -> tuple[str, int]:
 
     try:
         config = json.loads(config_path.read_text(encoding="utf-8"))
+        if not isinstance(config, dict):
+            msg = "MCP config root must be a JSON object"
+            raise ValueError(msg)
         servers = config.get("mcpServers", {})
+        if not isinstance(servers, dict):
+            msg = "mcpServers must be a JSON object"
+            raise ValueError(msg)
         forgetful = servers.get("forgetful", {})
+        if not isinstance(forgetful, dict):
+            msg = "forgetful server config must be a JSON object"
+            raise ValueError(msg)
         url_str = forgetful.get("url", "")
+        if not isinstance(url_str, str):
+            msg = "forgetful server url must be a string"
+            raise ValueError(msg)
         if url_str:
             parsed = urlparse(url_str)
             if parsed.hostname:

--- a/tests/hooks/test_adr_change_detection.py
+++ b/tests/hooks/test_adr_change_detection.py
@@ -206,6 +206,36 @@ class TestMain:
 
     @patch("invoke_adr_change_detection.subprocess.run")
     @patch("invoke_adr_change_detection.get_project_root")
+    def test_exits_2_on_non_object_json(
+        self, mock_root, mock_run, project_with_detect_script, capsys
+    ):
+        mock_root.return_value = str(project_with_detect_script)
+        mock_run.return_value = MagicMock(returncode=0, stdout="[]", stderr="")
+
+        result = invoke_adr_change_detection.main()
+
+        assert result == 2
+        assert "non-object JSON" in capsys.readouterr().err
+
+    @patch("invoke_adr_change_detection.subprocess.run")
+    @patch("invoke_adr_change_detection.get_project_root")
+    def test_exits_2_on_invalid_change_list(
+        self, mock_root, mock_run, project_with_detect_script, capsys
+    ):
+        mock_root.return_value = str(project_with_detect_script)
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"HasChanges": True, "Created": [123]}),
+            stderr="",
+        )
+
+        result = invoke_adr_change_detection.main()
+
+        assert result == 2
+        assert "invalid change lists" in capsys.readouterr().err
+
+    @patch("invoke_adr_change_detection.subprocess.run")
+    @patch("invoke_adr_change_detection.get_project_root")
     def test_exits_2_on_subprocess_timeout(
         self, mock_root, mock_run, project_with_detect_script, capsys
     ):

--- a/tests/hooks/test_invoke_codeql_quick_scan.py
+++ b/tests/hooks/test_invoke_codeql_quick_scan.py
@@ -290,6 +290,33 @@ class TestMain:
         captured = capsys.readouterr()
         assert "No findings" in captured.out
 
+    def test_scan_array_json_output_logs_invalid(self, monkeypatch, tmp_path, capsys):
+        py_file = tmp_path / "test.py"
+        py_file.write_text("x = 1")
+        scan_dir = tmp_path / ".codeql" / "scripts"
+        scan_dir.mkdir(parents=True)
+        (scan_dir / "Invoke-CodeQLScan.ps1").write_text("# scan")
+        input_data = json.dumps({
+            "tool_input": {"file_path": str(py_file)},
+            "cwd": str(tmp_path),
+        })
+        monkeypatch.setattr("sys.stdin", io.StringIO(input_data))
+        with patch.object(
+            invoke_codeql_quick_scan, "_is_codeql_installed", return_value=True
+        ):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = subprocess.CompletedProcess(
+                    args=[],
+                    returncode=0,
+                    stdout=json.dumps([]),
+                    stderr="",
+                )
+                result = invoke_codeql_quick_scan.main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Scan output invalid" in captured.out
+
     def test_scan_invalid_json_output(self, monkeypatch, tmp_path, capsys):
         py_file = tmp_path / "test.py"
         py_file.write_text("x = 1")

--- a/tests/hooks/test_session_start_memory_first.py
+++ b/tests/hooks/test_session_start_memory_first.py
@@ -96,6 +96,45 @@ class TestReadForgetfulConfig:
         assert host == "localhost"
         assert port == 8020
 
+    def test_returns_defaults_when_root_is_not_object(self, tmp_path, capsys):
+        config_file = tmp_path / ".mcp.json"
+        config_file.write_text(json.dumps([]), encoding="utf-8")
+
+        host, port = invoke_session_start_memory_first.read_forgetful_config(
+            str(config_file)
+        )
+
+        assert host == "localhost"
+        assert port == 8020
+        assert "MCP config root must be a JSON object" in capsys.readouterr().err
+
+    def test_returns_defaults_when_mcp_servers_is_not_object(self, tmp_path, capsys):
+        config_file = tmp_path / ".mcp.json"
+        config_file.write_text(json.dumps({"mcpServers": []}), encoding="utf-8")
+
+        host, port = invoke_session_start_memory_first.read_forgetful_config(
+            str(config_file)
+        )
+
+        assert host == "localhost"
+        assert port == 8020
+        assert "mcpServers must be a JSON object" in capsys.readouterr().err
+
+    def test_returns_defaults_when_forgetful_config_is_not_object(self, tmp_path, capsys):
+        config_file = tmp_path / ".mcp.json"
+        config_file.write_text(
+            json.dumps({"mcpServers": {"forgetful": []}}),
+            encoding="utf-8",
+        )
+
+        host, port = invoke_session_start_memory_first.read_forgetful_config(
+            str(config_file)
+        )
+
+        assert host == "localhost"
+        assert port == 8020
+        assert "forgetful server config must be a JSON object" in capsys.readouterr().err
+
 
 # ---------------------------------------------------------------------------
 # Unit tests for main

--- a/tests/quality_gate/test_generate_test_summary.py
+++ b/tests/quality_gate/test_generate_test_summary.py
@@ -5,6 +5,7 @@ Pins the behavior of the extracted ``Generate test summary`` workflow step.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from scripts.quality_gate.generate_test_summary import (
@@ -12,7 +13,6 @@ from scripts.quality_gate.generate_test_summary import (
     main,
     write_summary,
 )
-
 
 # ---------------------------------------------------------------------------
 # build_summary
@@ -50,6 +50,7 @@ class TestWriteSummary:
         lines = text.splitlines()
         assert lines[0].startswith("test_summary<<EOF_SUMMARY_")
         delimiter = lines[0].split("<<", 1)[1]
+        assert re.fullmatch(r"EOF_SUMMARY_[0-9a-f]{32}", delimiter)
         assert "BODY" in lines
         # Heredoc must be closed by the same delimiter token.
         assert lines[-1] == delimiter

--- a/tests/test_compute_health_status.py
+++ b/tests/test_compute_health_status.py
@@ -46,8 +46,9 @@ class TestThreshold:
 
     def test_frozen(self) -> None:
         t = Threshold(warning=0.1, error=0.25)
+        mutable_threshold: Any = t
         with pytest.raises(AttributeError):
-            t.warning = 0.5
+            mutable_threshold.warning = 0.5
 
     def test_defaults(self) -> None:
         t = Threshold(warning=0.1, error=0.25)

--- a/tests/test_compute_health_status.py
+++ b/tests/test_compute_health_status.py
@@ -47,7 +47,7 @@ class TestThreshold:
     def test_frozen(self) -> None:
         t = Threshold(warning=0.1, error=0.25)
         with pytest.raises(AttributeError):
-            t.warning = 0.5  # type: ignore[misc]
+            t.warning = 0.5
 
     def test_defaults(self) -> None:
         t = Threshold(warning=0.1, error=0.25)

--- a/tests/test_compute_health_status.py
+++ b/tests/test_compute_health_status.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -193,7 +194,7 @@ class TestHealthStatusReport:
                 threshold_warning=0.1, threshold_error=0.25,
             ),
         ])
-        d = report.to_dict()
+        d = cast(dict[str, Any], report.to_dict())
         assert "checked_at" in d
         assert d["overall"] == "healthy"
         assert d["summary"]["total"] == 1
@@ -424,7 +425,51 @@ class TestComputeSessionHealth:
             (c for c in result if c.name == "session_failure_rate"), None
         )
         assert failure_comp is not None
-        assert failure_comp.detail == "0/1 sessions failed"
+        assert failure_comp.detail == "0/1 sessions failed (1 unreadable logs skipped)"
+
+    def test_invalid_json_skip_count_logged(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        sess_dir = tmp_path / "sessions"
+        sess_dir.mkdir()
+        (sess_dir / "bad.json").write_text("not json", encoding="utf-8")
+        (sess_dir / "good.json").write_text(
+            json.dumps({"status": "completed"}), encoding="utf-8"
+        )
+
+        result = compute_session_health(sess_dir)
+
+        failure_comp = next(c for c in result if c.name == "session_failure_rate")
+        assert "1 unreadable logs skipped" in failure_comp.detail
+        assert "Skipped 1 unreadable session log" in capsys.readouterr().err
+
+    def test_non_object_root_skip_count_logged(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        sess_dir = tmp_path / "sessions"
+        sess_dir.mkdir()
+        (sess_dir / "array.json").write_text("[]", encoding="utf-8")
+        (sess_dir / "good.json").write_text(
+            json.dumps({"status": "completed"}), encoding="utf-8"
+        )
+
+        result = compute_session_health(sess_dir)
+
+        failure_comp = next(c for c in result if c.name == "session_failure_rate")
+        assert failure_comp.detail == "0/1 sessions failed (1 unreadable logs skipped)"
+        assert "Skipped 1 unreadable session log" in capsys.readouterr().err
+
+    def test_only_unreadable_logs_emit_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        sess_dir = tmp_path / "sessions"
+        sess_dir.mkdir()
+        (sess_dir / "bad.json").write_text("not json", encoding="utf-8")
+
+        result = compute_session_health(sess_dir)
+
+        assert result == []
+        assert "Skipped 1 unreadable session log" in capsys.readouterr().err
 
     def test_limit_respected(self, tmp_path: Path) -> None:
         sess_dir = tmp_path / "sessions"

--- a/tests/test_consensus.py
+++ b/tests/test_consensus.py
@@ -405,6 +405,68 @@ class TestDecisionRecorder:
 
         assert decision is None
 
+    def test_get_decision_skips_malformed_json(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Malformed decision JSON is skipped with a diagnostic."""
+        recorder = DecisionRecorder(tmp_path)
+        (tmp_path / "bad.json").write_text("{", encoding="utf-8")
+
+        decision = recorder.get_decision("bad")
+
+        assert decision is None
+        assert "Skipping decision file" in capsys.readouterr().err
+
+    def test_get_decision_skips_non_object_root(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Array-root decision JSON is skipped with a diagnostic."""
+        recorder = DecisionRecorder(tmp_path)
+        (tmp_path / "array.json").write_text("[]", encoding="utf-8")
+
+        decision = recorder.get_decision("array")
+
+        assert decision is None
+        assert "root must be an object" in capsys.readouterr().err
+
+    def test_get_decision_skips_missing_required_key(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Decision JSON missing required fields is skipped."""
+        recorder = DecisionRecorder(tmp_path)
+        (tmp_path / "missing.json").write_text(
+            json.dumps({"id": "missing"}),
+            encoding="utf-8",
+        )
+
+        decision = recorder.get_decision("missing")
+
+        assert decision is None
+        assert "Skipping decision file" in capsys.readouterr().err
+
+    def test_get_decision_skips_extra_key(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Decision JSON with unexpected fields is skipped."""
+        recorder = DecisionRecorder(tmp_path)
+        (tmp_path / "extra.json").write_text(
+            json.dumps({
+                "id": "extra",
+                "timestamp": "2026-01-01T00:00:00+00:00",
+                "topic": "Topic",
+                "context": "Context",
+                "votes": [],
+                "result": {},
+                "unexpected": True,
+            }),
+            encoding="utf-8",
+        )
+
+        decision = recorder.get_decision("extra")
+
+        assert decision is None
+        assert "Skipping decision file" in capsys.readouterr().err
+
     def test_list_decisions(self, tmp_path: Path) -> None:
         """List returns all recorded decisions."""
         recorder = DecisionRecorder(tmp_path)
@@ -422,6 +484,23 @@ class TestDecisionRecorder:
         decisions = recorder.list_decisions()
 
         assert len(decisions) == 2
+
+    def test_list_decisions_skips_corrupt_files(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """List ignores corrupt decision files and returns valid decisions."""
+        recorder = DecisionRecorder(tmp_path)
+        votes = [Vote("architect", "approve", "Good", 0.9)]
+        result = majority_consensus(votes)
+        recorder.record_decision(
+            topic="Valid decision", context="Test", votes=votes, result=result
+        )
+        (tmp_path / "bad.json").write_text("not json", encoding="utf-8")
+
+        decisions = recorder.list_decisions()
+
+        assert [decision.topic for decision in decisions] == ["Valid decision"]
+        assert "Skipping decision file" in capsys.readouterr().err
 
     def test_list_with_limit(self, tmp_path: Path) -> None:
         """List respects limit parameter."""

--- a/tests/test_generate_third_party_notices.py
+++ b/tests/test_generate_third_party_notices.py
@@ -64,7 +64,10 @@ class TestLoadMarketplaceConfig:
         assert exc_info.value.code == 2
         assert "root must be a JSON object" in capsys.readouterr().err
 
-    @pytest.mark.parametrize("plugins", [{}, [1]])
+    @pytest.mark.parametrize(
+        "plugins",
+        [{}, [1], [{"source": 123}], [{"source": []}], [{"source": None}]],
+    )
     def test_wrong_plugins_type_exits_two(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str], plugins: object
     ) -> None:

--- a/tests/test_generate_third_party_notices.py
+++ b/tests/test_generate_third_party_notices.py
@@ -1,0 +1,91 @@
+"""Tests for scripts/generate_third_party_notices.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.generate_third_party_notices import load_marketplace_config
+
+
+class TestLoadMarketplaceConfig:
+    """Tests for marketplace config boundary parsing."""
+
+    def test_returns_plugins_from_valid_config(self, tmp_path: Path) -> None:
+        marketplace_dir = tmp_path / ".claude-plugin"
+        marketplace_dir.mkdir()
+        plugins = [{"name": "tool", "path": ".claude"}]
+        (marketplace_dir / "marketplace.json").write_text(
+            json.dumps({"plugins": plugins}),
+            encoding="utf-8",
+        )
+
+        result = load_marketplace_config(tmp_path)
+
+        assert result == plugins
+
+    def test_missing_plugins_key_returns_empty_list(self, tmp_path: Path) -> None:
+        marketplace_dir = tmp_path / ".claude-plugin"
+        marketplace_dir.mkdir()
+        (marketplace_dir / "marketplace.json").write_text(
+            json.dumps({"other": []}),
+            encoding="utf-8",
+        )
+
+        result = load_marketplace_config(tmp_path)
+
+        assert result == []
+
+    def test_malformed_json_exits_two(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        marketplace_dir = tmp_path / ".claude-plugin"
+        marketplace_dir.mkdir()
+        (marketplace_dir / "marketplace.json").write_text("{", encoding="utf-8")
+
+        with pytest.raises(SystemExit) as exc_info:
+            load_marketplace_config(tmp_path)
+
+        assert exc_info.value.code == 2
+        assert "Failed to read" in capsys.readouterr().err
+
+    def test_non_object_root_exits_two(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        marketplace_dir = tmp_path / ".claude-plugin"
+        marketplace_dir.mkdir()
+        (marketplace_dir / "marketplace.json").write_text("[]", encoding="utf-8")
+
+        with pytest.raises(SystemExit) as exc_info:
+            load_marketplace_config(tmp_path)
+
+        assert exc_info.value.code == 2
+        assert "root must be a JSON object" in capsys.readouterr().err
+
+    @pytest.mark.parametrize("plugins", [{}, [1]])
+    def test_wrong_plugins_type_exits_two(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], plugins: object
+    ) -> None:
+        marketplace_dir = tmp_path / ".claude-plugin"
+        marketplace_dir.mkdir()
+        (marketplace_dir / "marketplace.json").write_text(
+            json.dumps({"plugins": plugins}),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            load_marketplace_config(tmp_path)
+
+        assert exc_info.value.code == 2
+        assert "plugins must be a JSON array of objects" in capsys.readouterr().err
+
+    def test_empty_object_returns_empty_list(self, tmp_path: Path) -> None:
+        marketplace_dir = tmp_path / ".claude-plugin"
+        marketplace_dir.mkdir()
+        (marketplace_dir / "marketplace.json").write_text("{}", encoding="utf-8")
+
+        result = load_marketplace_config(tmp_path)
+
+        assert result == []

--- a/tests/test_generate_third_party_notices.py
+++ b/tests/test_generate_third_party_notices.py
@@ -16,7 +16,7 @@ class TestLoadMarketplaceConfig:
     def test_returns_plugins_from_valid_config(self, tmp_path: Path) -> None:
         marketplace_dir = tmp_path / ".claude-plugin"
         marketplace_dir.mkdir()
-        plugins = [{"name": "tool", "path": ".claude"}]
+        plugins = [{"name": "tool", "source": ".claude"}]
         (marketplace_dir / "marketplace.json").write_text(
             json.dumps({"plugins": plugins}),
             encoding="utf-8",

--- a/tests/test_invoke_session_start_memory_first.py
+++ b/tests/test_invoke_session_start_memory_first.py
@@ -52,6 +52,18 @@ class TestReadForgetfulConfig:
         assert host == "localhost"
         assert port == 8020
 
+    def test_falls_back_on_non_object_root(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        config_file = tmp_path / ".mcp.json"
+        config_file.write_text(json.dumps([]), encoding="utf-8")
+
+        host, port = hook.read_forgetful_config(str(config_file))
+
+        assert host == "localhost"
+        assert port == 8020
+        assert "MCP config root must be a JSON object" in capsys.readouterr().err
+
     def test_falls_back_on_empty_url(self, tmp_path: Path) -> None:
         config: dict[str, object] = {"mcpServers": {"forgetful": {"url": ""}}}
         config_file = tmp_path / ".mcp.json"

--- a/tests/test_update_reviewer_signal_stats.py
+++ b/tests/test_update_reviewer_signal_stats.py
@@ -379,6 +379,22 @@ class TestReviewerSignalStats:
         result = get_reviewer_signal_stats(reviewer_stats)
         assert result["reviewer1"].prs_with_comments == 2
 
+    def test_logs_date_parse_miss(self, caplog: pytest.LogCaptureFixture) -> None:
+        reviewer_stats = {
+            "reviewer1": ReviewerStats(
+                total_comments=1,
+                prs_with_comments={1},
+                comments=[_make_comment("Critical bug", created_at="not-a-date")],
+            ),
+        }
+        caplog.set_level("DEBUG", logger="scripts.update_reviewer_signal_stats")
+
+        result = get_reviewer_signal_stats(reviewer_stats)
+
+        assert result["reviewer1"].last_30_days_comments == 0
+        assert "Skipping reviewer signal date parse miss" in caplog.text
+        assert "not-a-date" in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # Serena memory update tests


### PR DESCRIPTION
## Summary

Hardens agent hook and script input-shape handling for two boundary-validation
gaps surfaced by the read-only safety audit.

- Fixes #2945: boundary-validation guards for decision_recorder, third-party
  notices generation, health-status computation, and the ADR-change-detection
  and CodeQL-quick-scan hooks. Each now validates its input shape at the
  boundary and fails closed on malformed payloads instead of raising.
- Fixes #2946: cross-model reconciliation robustness. Consensus parsing,
  MCP-config shape checks, and CodeQL scan-shape handling tolerate the real
  payload variants observed across Claude and Copilot CLI harnesses.

Adds positive, negative, and edge tests for each guard.

## Testing

- `uv run pytest` (targeted hook and script suites) green
- Full pre-push gate green (13 passed, 15 skipped, 1 non-blocking naming warning)

## References

- `.agents/audits/2026-07-02-safety-audit.md`
