### PR TITLE
fix(hooks): resolve latent mypy errors and harden install_git_hooks test isolation

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.10",
+  "version": "0.6.14",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PostToolUse/invoke_adr_lifecycle_hook.py
+++ b/.claude/hooks/PostToolUse/invoke_adr_lifecycle_hook.py
@@ -46,7 +46,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)

--- a/.claude/hooks/PostToolUse/invoke_adr_lifecycle_hook.py
+++ b/.claude/hooks/PostToolUse/invoke_adr_lifecycle_hook.py
@@ -33,11 +33,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/PostToolUse/invoke_lsp_read_tracker.py
+++ b/.claude/hooks/PostToolUse/invoke_lsp_read_tracker.py
@@ -30,11 +30,11 @@ from pathlib import Path
 
 # Bootstrap: find lib directory via env var or manifest walk-up.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/PostToolUse/invoke_lsp_usage_tracker.py
+++ b/.claude/hooks/PostToolUse/invoke_lsp_usage_tracker.py
@@ -102,11 +102,11 @@ from pathlib import Path
 # The in-process import always takes the walk-up else branch (which is
 # measured) because pytest runs with CLAUDE_PLUGIN_ROOT unset.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:  # pragma: no cover - harness-set env path; covered via subprocess
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")
@@ -184,7 +184,7 @@ def _gate_mode() -> str:
     return "warn" if os.environ.get("LSP_GATE_MODE", "").strip() == "warn" else "block"
 
 
-def _emit_warn_message(tool_name: str, state: dict) -> None:
+def _emit_warn_message(tool_name: str, state: dict[str, object]) -> None:
     """Emit the warn-mode guidance as an exit-0 systemMessage.
 
     In ``LSP_GATE_MODE=warn`` the tracker still records navigation but also

--- a/.claude/hooks/PreToolUse/invoke_adr_architect_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_adr_architect_gate.py
@@ -36,11 +36,11 @@ from pathlib import Path, PurePosixPath
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/PreToolUse/invoke_branch_context_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_branch_context_guard.py
@@ -40,7 +40,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     # Non-blocking hook: exit 0 on bootstrap failure (intentional, not a typo)
     sys.exit(0)
 if _lib_dir not in sys.path:

--- a/.claude/hooks/PreToolUse/invoke_branch_context_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_branch_context_guard.py
@@ -27,11 +27,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/PreToolUse/invoke_lsp_bash_grep_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_bash_grep_guard.py
@@ -62,6 +62,7 @@ import os
 import re
 import sys
 from pathlib import Path
+from typing import TypedDict
 
 # Bootstrap: find lib directory via env var or manifest walk-up.
 # CLAUDE_PLUGIN_ROOT honored when set; otherwise walk up from __file__
@@ -69,11 +70,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")
@@ -109,6 +110,13 @@ from hook_utilities.lsp_symbols import (  # noqa: E402
     is_git_grep,
     is_grep_search,
 )
+
+
+class _CommandDecision(TypedDict):
+    """A gated grep decision: the code symbols and the navigable target."""
+
+    symbols: list[str]
+    target: str
 
 # File-like tokens in a grep command: a dotted path segment ending in a known
 # extension. Used to find a candidate navigable target without a shell parse.
@@ -310,7 +318,7 @@ def _navigable_target_with_provider(
     return None
 
 
-def evaluate_command(command: str, project_dir: str) -> dict | None:
+def evaluate_command(command: str, project_dir: str) -> _CommandDecision | None:
     """Decide whether a bash command is a gated grep symbol search.
 
     Returns a decision dict ``{"symbols": [...], "target": str}`` when the

--- a/.claude/hooks/PreToolUse/invoke_lsp_glob_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_glob_guard.py
@@ -65,11 +65,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:  # pragma: no cover - deployment layout (env set), not test env
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")
@@ -162,13 +162,13 @@ def resolve_providers(pattern: str, project_dir: str) -> list[str]:
     """
     extension = glob_extension(pattern)
     if extension:
-        return detect_providers(f"x{extension}", SYMBOL_NAVIGATION, project_dir)
+        return list(detect_providers(f"x{extension}", SYMBOL_NAVIGATION, project_dir))
     for probe_ext, language in EXTENSION_TO_SERENA_LANGUAGE.items():
         if language not in PROGRAMMING_SERENA_LANGUAGES:
             continue
         providers = detect_providers(f"x{probe_ext}", SYMBOL_NAVIGATION, project_dir)
         if providers:
-            return providers
+            return list(providers)
     return []
 
 
@@ -233,7 +233,9 @@ def _bypassed() -> bool:
     return False
 
 
-def _evaluate(hook_input: dict) -> tuple[str, list[str], list[str]] | None:
+def _evaluate(
+    hook_input: dict[str, object],
+) -> tuple[str, list[str], list[str]] | None:
     """Decide whether a Glob call should block.
 
     Returns ``(pattern, symbols, providers)`` when the pattern carries a code

--- a/.claude/hooks/PreToolUse/invoke_lsp_grep_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_grep_guard.py
@@ -76,11 +76,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:  # pragma: no cover - deployment layout (env set), not test env
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")
@@ -254,7 +254,7 @@ def _bypassed() -> bool:
     return False
 
 
-def _evaluate(hook_input: dict) -> tuple[list[str], list[str]] | None:
+def _evaluate(hook_input: dict[str, object]) -> tuple[list[str], list[str]] | None:
     """Decide whether a Grep call should block.
 
     Returns ``(symbols, providers)`` when the call is a code-symbol Grep on a

--- a/.claude/hooks/PreToolUse/invoke_lsp_pre_delegation_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_pre_delegation_guard.py
@@ -100,11 +100,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/PreToolUse/invoke_lsp_pre_delegation_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_pre_delegation_guard.py
@@ -113,7 +113,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     # Fail-open: a navigation guard must never wedge a turn on bootstrap failure.
     sys.exit(0)
 if _lib_dir not in sys.path:

--- a/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_lsp_read_guard.py
@@ -83,11 +83,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/PreToolUse/invoke_prompt_eval_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_prompt_eval_gate.py
@@ -32,11 +32,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/PreToolUse/invoke_prompt_eval_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_prompt_eval_gate.py
@@ -45,7 +45,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)

--- a/.claude/hooks/PreToolUse/invoke_retrospective_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_retrospective_gate.py
@@ -40,11 +40,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/PreToolUse/invoke_retrospective_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_retrospective_gate.py
@@ -53,7 +53,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     # Non-blocking hook: exit 0 on bootstrap failure (intentional, not a typo)
     sys.exit(0)
 if _lib_dir not in sys.path:

--- a/.claude/hooks/PreToolUse/invoke_session_log_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_session_log_guard.py
@@ -29,11 +29,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/PreToolUse/invoke_session_log_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_session_log_guard.py
@@ -42,7 +42,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)

--- a/.claude/hooks/PreToolUse/invoke_skill_first_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_skill_first_guard.py
@@ -30,11 +30,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/PreToolUse/invoke_skill_first_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_skill_first_guard.py
@@ -43,7 +43,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)
@@ -88,11 +92,17 @@ SKILL_MAPPINGS: dict[str, dict[str, dict[str, str]]] = {
         },
         "merge": {
             "script": "merge_pr.py",
-            "example": "uv run python .claude/skills/github/scripts/pr/merge_pr.py --pull-request 123",
+            "example": (
+                "uv run python .claude/skills/github/scripts/pr/"
+                "merge_pr.py --pull-request 123"
+            ),
         },
         "close": {
             "script": "close_pr.py",
-            "example": "uv run python .claude/skills/github/scripts/pr/close_pr.py --pull-request 123",
+            "example": (
+                "uv run python .claude/skills/github/scripts/pr/"
+                "close_pr.py --pull-request 123"
+            ),
         },
         "checks": {
             "script": "get_pr_checks.py",
@@ -264,7 +274,11 @@ def parse_gh_command(command: str) -> dict[str, str] | None:
         if gh_args is None:
             continue
         positional = [tok for tok in gh_args if not tok.startswith("-")]
-        if len(positional) >= 2 and _OPERAND_RE.match(positional[0]) and _OPERAND_RE.match(positional[1]):
+        if (
+            len(positional) >= 2
+            and _OPERAND_RE.match(positional[0])
+            and _OPERAND_RE.match(positional[1])
+        ):
             return {
                 "operation": positional[0],
                 "action": positional[1],

--- a/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
+++ b/.claude/hooks/PreToolUse/invoke_topical_memory_injection.py
@@ -31,11 +31,11 @@ from pathlib import Path
 # .claude/hooks/PreToolUse/invoke_correction_applier.py so the hook works in both
 # the deeper src/<provider>/hooks/<event>/ copy).
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/SessionStart/invoke_lsp_session_reset.py
+++ b/.claude/hooks/SessionStart/invoke_lsp_session_reset.py
@@ -76,11 +76,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/SessionStart/invoke_memory_first_enforcer.py
+++ b/.claude/hooks/SessionStart/invoke_memory_first_enforcer.py
@@ -46,11 +46,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/SessionStart/invoke_memory_first_enforcer.py
+++ b/.claude/hooks/SessionStart/invoke_memory_first_enforcer.py
@@ -59,7 +59,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)

--- a/.claude/hooks/Stop/invoke_skill_learning.py
+++ b/.claude/hooks/Stop/invoke_skill_learning.py
@@ -67,11 +67,11 @@ if not _SECURITY_LOG.handlers:
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/Stop/invoke_skill_learning.py
+++ b/.claude/hooks/Stop/invoke_skill_learning.py
@@ -80,7 +80,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)
@@ -252,7 +256,9 @@ def _get_safe_root_from_env(env_value: str) -> Path:
         # Security note: path validation precedes resolution
         # JUSTIFICATION: Input has passed _validate_path_string, and the resulting
         # Path is immediately constrained to SAFE_BASE_DIR via _is_relative_to.
-        candidate_root = Path(validated_root).expanduser().resolve(strict=False)  # Path validated before resolution
+        candidate_root = Path(validated_root).expanduser().resolve(
+            strict=False
+        )  # Path validated before resolution
     except Exception:
         # If the environment value cannot be parsed as a path, fall back to SAFE_BASE_DIR
         return SAFE_BASE_DIR
@@ -332,7 +338,10 @@ def write_learning_notification(skill_name: str, high_count: int, med_count: int
     """Write silent notification about learnings extracted."""
     total = high_count + med_count + low_count
     if total > 0:
-        print(f"✔️ learned from session ➡️ {skill_name} ({high_count} HIGH, {med_count} MED, {low_count} LOW)")
+        print(
+            f"✔️ learned from session ➡️ {skill_name} "
+            f"({high_count} HIGH, {med_count} MED, {low_count} LOW)"
+        )
 
 
 def get_project_directory(hook_input: dict) -> str:
@@ -369,7 +378,8 @@ def get_project_directory(hook_input: dict) -> str:
         #   2. ROOT ANCHORING: All user input is interpreted under SAFE_BASE_DIR
         #   3. POST-VALIDATION: _is_relative_to() enforces SAFE_BASE_DIR boundary
         #   4. FALLBACK: Returns SAFE_BASE_DIR on any validation failure
-        # See: .github/codeql/suppressions.yml and .agents/analysis/908-codeql-path-traversal-analysis.md
+        # See: .github/codeql/suppressions.yml and
+        # .agents/analysis/908-codeql-path-traversal-analysis.md
 
         base_path = SAFE_BASE_DIR
 
@@ -380,7 +390,9 @@ def get_project_directory(hook_input: dict) -> str:
         if user_path.is_absolute():
             candidate = user_path.resolve(strict=False)  # Path validated before resolution
         else:
-            candidate = (base_path / user_path).resolve(strict=False)  # Path validated before resolution
+            candidate = (base_path / user_path).resolve(
+                strict=False
+            )  # Path validated before resolution
     except Exception:
         # Fall back to safe base directory on any resolution error
         return str(SAFE_BASE_DIR)
@@ -444,7 +456,11 @@ def detect_skill_usage(messages: list[dict]) -> dict[str, int]:
     Uses COMMAND_TO_SKILL (module-level) for slash command resolution.
     """
     detected_skills = {}
-    conversation_text = ' '.join(msg.get('content', '') for msg in messages if isinstance(msg.get('content'), str))
+    conversation_text = ' '.join(
+        msg.get('content', '')
+        for msg in messages
+        if isinstance(msg.get('content'), str)
+    )
 
     # Detect skills from .claude/skills/{skill-name} references
     skill_path_pattern = re.compile(r'\.claude[/\\]skills[/\\]([a-z0-9-]+)')
@@ -543,36 +559,39 @@ def classify_learning_by_llm(
     try:
         client = Anthropic(api_key=api_key)
 
-        prompt = f"""Analyze this conversation exchange for skill-related learnings about the "{skill_name}" skill.
-
-Assistant said:
-{assistant_msg[:500]}
-
-User responded:
-{user_response}
-
-Is this a learning signal? If yes, extract the learning and classify it:
-
-Categories:
-- HIGH (correction): Strong user corrections ("no", "wrong", "never do", "must use")
-- HIGH (chestertons_fence): Removed something without understanding why
-- HIGH (immediate_correction): User immediately asked to debug/fix right after
-- MED (preference): Tool/approach preferences ("instead of using", "prefer to", "should use X")
-- MED (success): Success patterns ("perfect", "excellent", "exactly", "that's it") - no qualifiers like "but"
-- MED (edge_case): Important edge cases ("what if the/this", "ensure that", "make sure")
-- MED (documentation): Documentation feedback ("update the docs", "needs documentation")
-- MED (question): Short clarifying question (may indicate confusion)
-- LOW (command_pattern): Repeated command patterns
-
-Respond in JSON format:
-{{
-  "is_learning": true/false,
-  "type": "correction|preference|success|edge_case|documentation|question|command_pattern|chestertons_fence|immediate_correction",
-  "confidence": 0.0-1.0,
-  "category": "High|Med|Low",
-  "extracted_learning": "The key lesson learned",
-  "reasoning": "Why this is/isn't a learning"
-}}"""
+        prompt = (
+            f'Analyze this conversation exchange for skill-related learnings about the '
+            f'"{skill_name}" skill.\n\n'
+            f"Assistant said:\n{assistant_msg[:500]}\n\n"
+            f"User responded:\n{user_response}\n\n"
+            "Is this a learning signal? If yes, extract the learning and classify it:\n\n"
+            "Categories:\n"
+            '- HIGH (correction): Strong user corrections '
+            '("no", "wrong", "never do", "must use")\n'
+            "- HIGH (chestertons_fence): Removed something without understanding why\n"
+            "- HIGH (immediate_correction): User immediately asked to debug/fix "
+            "right after\n"
+            '- MED (preference): Tool/approach preferences '
+            '("instead of using", "prefer to", "should use X")\n'
+            '- MED (success): Success patterns '
+            '("perfect", "excellent", "exactly", "that\'s it") - no qualifiers like "but"\n'
+            '- MED (edge_case): Important edge cases '
+            '("what if the/this", "ensure that", "make sure")\n'
+            '- MED (documentation): Documentation feedback '
+            '("update the docs", "needs documentation")\n'
+            "- MED (question): Short clarifying question (may indicate confusion)\n"
+            "- LOW (command_pattern): Repeated command patterns\n\n"
+            "Respond in JSON format:\n"
+            "{\n"
+            '  "is_learning": true/false,\n'
+            '  "type": "correction|preference|success|edge_case|documentation|question|'
+            'command_pattern|chestertons_fence|immediate_correction",\n'
+            '  "confidence": 0.0-1.0,\n'
+            '  "category": "High|Med|Low",\n'
+            '  "extracted_learning": "The key lesson learned",\n'
+            '  "reasoning": "Why this is/isn\'t a learning"\n'
+            "}"
+        )
 
         # M7-T6: timeout bounds the synchronous call so a stalled API
         # cannot wedge the SessionEnd hook indefinitely. The Anthropic
@@ -667,8 +686,25 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
         learning = None
 
         # HIGH: Strong corrections (confidence 0.85-0.95)
-        if re.search(r'(?i)\b(no\b|nope|not like that|that\'s wrong|incorrect|never do|always do|don\'t ever|must use|should not|avoid|stop)\b', user_response):
-            confidence = 0.9 if len(re.findall(r'(?i)\b(no|wrong|never|must)\b', user_response)) > 1 else 0.85
+        correction_pattern = (
+            r"(?i)\b(no\b|nope|not like that|that\'s wrong|incorrect|"
+            r"never do|always do|don\'t ever|must use|should not|avoid|stop)\b"
+        )
+        chestertons_fence_pattern = (
+            r"(?i)(trashed without understanding|removed without knowing|"
+            r"deleted without checking|why was this here)"
+        )
+        immediate_correction_pattern = (
+            r"(?i)\b(debug|root cause|correct|fix all|address|broken|"
+            r"error|issue|problem)\b"
+        )
+
+        if re.search(correction_pattern, user_response):
+            strong_correction_hits = re.findall(
+                r"(?i)\b(no|wrong|never|must)\b",
+                user_response,
+            )
+            confidence = 0.9 if len(strong_correction_hits) > 1 else 0.85
             learning = {
                 "type": "correction",
                 "source": user_response[:150],
@@ -678,7 +714,7 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
             }
 
         # HIGH: Chesterton's Fence (confidence 0.95)
-        elif re.search(r'(?i)(trashed without understanding|removed without knowing|deleted without checking|why was this here)', user_response):
+        elif re.search(chestertons_fence_pattern, user_response):
             learning = {
                 "type": "chestertons_fence",
                 "source": user_response[:150],
@@ -688,7 +724,10 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
             }
 
         # HIGH: Immediate corrections (confidence 0.8-0.85)
-        elif re.search(r'(?i)\b(debug|root cause|correct|fix all|address|broken|error|issue|problem)\b', user_response) and len(user_response) < 200:
+        elif (
+            re.search(immediate_correction_pattern, user_response)
+            and len(user_response) < 200
+        ):
             confidence = 0.85 if len(user_response) < 50 else 0.8
             learning = {
                 "type": "immediate_correction",
@@ -732,7 +771,8 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
             r'exactly(?:!|\s*$)|'  # "exactly!" or end of string
             r"that's\s+(?:it|right|correct)|"  # "that's it/right/correct"
             r'good\s+job|well\s+done|'  # "good job", "well done"
-            r'works(?:\s+great|\s+perfectly|!)(?!\s+(?:but|however|except))|'  # "works great/perfectly!" not followed by "but"
+            # "works great/perfectly!" not followed by "but"
+            r'works(?:\s+great|\s+perfectly|!)(?!\s+(?:but|however|except))|'
             r'(?:yes|correct|right)(?:\s*[!.])?$'  # "yes/correct/right" at end
             r')',
             user_response
@@ -763,7 +803,11 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
             r'(?i)\b(lunch|dinner|coffee|meeting|call|later|tomorrow)\b',
             user_response
         ):
-            confidence = 0.65 if re.search(r'(?i)\b(ensure|make sure|verify)\b', user_response) else 0.6
+            confidence = (
+                0.65
+                if re.search(r'(?i)\b(ensure|make sure|verify)\b', user_response)
+                else 0.6
+            )
             learning = {
                 "type": "edge_case",
                 "source": user_response[:150],
@@ -785,7 +829,11 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
             r')\b',
             user_response
         ):
-            confidence = 0.65 if re.search(r'(?i)\b(must|should|needs?)\b', user_response) else 0.6
+            confidence = (
+                0.65
+                if re.search(r'(?i)\b(must|should|needs?)\b', user_response)
+                else 0.6
+            )
             learning = {
                 "type": "documentation",
                 "source": user_response[:150],
@@ -795,7 +843,14 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
             }
 
         # MED: Clarifying questions (confidence 0.55-0.6)
-        elif re.search(r'\?', user_response) and len(user_response) < 50 and re.search(r'(?i)^(why|how|what|when|where|can|does|is|are)\b', user_response):
+        elif (
+            re.search(r'\?', user_response)
+            and len(user_response) < 50
+            and re.search(
+                r'(?i)^(why|how|what|when|where|can|does|is|are)\b',
+                user_response,
+            )
+        ):
             confidence = 0.6 if len(user_response) < 30 else 0.55
             learning = {
                 "type": "question",
@@ -818,7 +873,8 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
         # LOW: Short acknowledgements without substance (confidence 0.35-0.45)
         # These may indicate workflow patterns worth tracking
         elif re.search(
-            r'(?i)^(?:ok|okay|sure|got it|sounds good|thanks|thank you|yep|yeah|alright|fine|k|kk)(?:[.!,]?\s*)?$',
+            r'(?i)^(?:ok|okay|sure|got it|sounds good|thanks|thank you|yep|yeah|'
+            r'alright|fine|k|kk)(?:[.!,]?\s*)?$',
             user_response.strip()
         ) and len(user_response.strip()) < 30:
             learning = {
@@ -895,10 +951,17 @@ def update_skill_memory(
         allowed_dir = project_dir.resolve(strict=False)
         # Validate project_dir looks like a real directory path
         if not allowed_dir.is_absolute():
-            print(f"Invalid project directory: '{project_dir}' does not resolve to absolute path", file=sys.stderr)
+            print(
+                f"Invalid project directory: '{project_dir}' does not resolve to absolute path",
+                file=sys.stderr,
+            )
             return False
         if not _is_relative_to(allowed_dir, SAFE_BASE_DIR):
-            print(f"Path traversal attempt detected: '{allowed_dir}' is outside safe base directory", file=sys.stderr)
+            print(
+                f"Path traversal attempt detected: '{allowed_dir}' "
+                "is outside safe base directory",
+                file=sys.stderr,
+            )
             return False
     except Exception as e:
         print(f"Path validation error for project_dir: {e}", file=sys.stderr)
@@ -908,7 +971,10 @@ def update_skill_memory(
     # This prevents attacks via skill names like "../../../etc/passwd" or "..\\attack"
     # Regex allowlist: only alphanumeric, underscore, and hyphen characters permitted
     if not re.fullmatch(r"[A-Za-z0-9_-]+", skill_name):
-        print(f"Invalid skill name: '{skill_name}' contains unsupported characters", file=sys.stderr)
+        print(
+            f"Invalid skill name: '{skill_name}' contains unsupported characters",
+            file=sys.stderr,
+        )
         return False
 
     # Step 3: Construct paths using validated allowed_dir
@@ -927,7 +993,11 @@ def update_skill_memory(
         # Include directory separator to prevent prefix attacks
         # e.g., "/home/user" should not match "/home/usermalicious"
         if not str(resolved_path).startswith(str(allowed_dir) + os.sep):
-            print(f"Path traversal attempt detected: '{resolved_path}' is outside project directory", file=sys.stderr)
+            print(
+                f"Path traversal attempt detected: '{resolved_path}' "
+                "is outside project directory",
+                file=sys.stderr,
+            )
             return False
     except Exception as e:
         print(f"Path validation error for memory_path: {e}", file=sys.stderr)
@@ -1030,7 +1100,10 @@ def update_skill_memory(
                 source = escape_replacement_string(learning["source"])
                 learning_type = learning["type"]
                 method_tag = " [LLM]" if learning.get("method") == "haiku-llm" else ""
-                other_med_items += f"- [{learning_type}] {source}{method_tag} (Session {session_id}, {today})\n"
+                other_med_items += (
+                    f"- [{learning_type}] {source}{method_tag} "
+                    f"(Session {session_id}, {today})\n"
+                )
 
         if other_med_items:
             pattern = r'(## Preferences \(MED confidence\)\r?\n)'
@@ -1103,7 +1176,8 @@ def main():
 
         # Get session ID from today's session log
         # Path validated before resolution
-        # CodeQL suppression: project_dir is validated against safe root and used only for reading session logs
+        # CodeQL suppression: project_dir is validated against safe root and used
+        # only for reading session logs
         sessions_dir = safe_project_path / ".agents" / "sessions"
         today = datetime.now().strftime("%Y-%m-%d")
 

--- a/.claude/hooks/SubagentStop/invoke_qa_agent_validator.py
+++ b/.claude/hooks/SubagentStop/invoke_qa_agent_validator.py
@@ -39,7 +39,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)

--- a/.claude/hooks/SubagentStop/invoke_qa_agent_validator.py
+++ b/.claude/hooks/SubagentStop/invoke_qa_agent_validator.py
@@ -26,11 +26,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
+++ b/.claude/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
@@ -30,11 +30,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
+++ b/.claude/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
@@ -43,7 +43,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)

--- a/.claude/hooks/UserPromptSubmit/invoke_research_then_implement.py
+++ b/.claude/hooks/UserPromptSubmit/invoke_research_then_implement.py
@@ -25,11 +25,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/UserPromptSubmit/invoke_research_then_implement.py
+++ b/.claude/hooks/UserPromptSubmit/invoke_research_then_implement.py
@@ -48,7 +48,7 @@ try:
     from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
 except ImportError:
 
-    def skip_if_consumer_repo(hook_name: str) -> bool:  # type: ignore[misc]
+    def skip_if_consumer_repo(hook_name: str) -> bool:
         """Fallback: skip when .agents/ directory is absent."""
         project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "").strip() or str(Path.cwd())
         if not Path(project_dir, ".agents").is_dir():

--- a/.claude/hooks/UserPromptSubmit/invoke_research_then_implement.py
+++ b/.claude/hooks/UserPromptSubmit/invoke_research_then_implement.py
@@ -38,7 +38,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     # Non-blocking hook: exit 0 on bootstrap failure (intentional, not a typo)
     sys.exit(0)
 if _lib_dir not in sys.path:

--- a/.claude/hooks/UserPromptSubmit/invoke_serena_reassertion.py
+++ b/.claude/hooks/UserPromptSubmit/invoke_serena_reassertion.py
@@ -76,7 +76,7 @@ try:
     from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
 except ImportError:
 
-    def skip_if_consumer_repo(hook_name: str) -> bool:  # type: ignore[misc]
+    def skip_if_consumer_repo(hook_name: str) -> bool:
         """Fallback: skip when .agents/ directory is absent.
 
         Resolves CLAUDE_PROJECT_DIR with expanduser().resolve() to avoid

--- a/.claude/hooks/UserPromptSubmit/invoke_serena_reassertion.py
+++ b/.claude/hooks/UserPromptSubmit/invoke_serena_reassertion.py
@@ -66,7 +66,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     # Non-blocking hook: exit 0 on bootstrap failure (intentional, not a typo)
     sys.exit(0)
 if _lib_dir not in sys.path:

--- a/.claude/hooks/UserPromptSubmit/invoke_serena_reassertion.py
+++ b/.claude/hooks/UserPromptSubmit/invoke_serena_reassertion.py
@@ -53,11 +53,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/invoke_routing_gates.py
+++ b/.claude/hooks/invoke_routing_gates.py
@@ -55,11 +55,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/invoke_routing_gates.py
+++ b/.claude/hooks/invoke_routing_gates.py
@@ -68,7 +68,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)

--- a/.claude/hooks/invoke_session_start_memory_first.py
+++ b/.claude/hooks/invoke_session_start_memory_first.py
@@ -38,7 +38,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)

--- a/.claude/hooks/invoke_session_start_memory_first.py
+++ b/.claude/hooks/invoke_session_start_memory_first.py
@@ -25,11 +25,11 @@ from urllib.parse import urlparse
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/.claude/hooks/invoke_user_prompt_memory_check.py
+++ b/.claude/hooks/invoke_user_prompt_memory_check.py
@@ -44,7 +44,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)

--- a/.claude/hooks/invoke_user_prompt_memory_check.py
+++ b/.claude/hooks/invoke_user_prompt_memory_check.py
@@ -31,11 +31,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.10",
+  "version": "0.6.14",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Bash_f620ca.py
@@ -282,7 +282,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         sys.exit(2)
     if _lib_dir not in sys.path:
         sys.path.insert(0, _lib_dir)

--- a/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Bash_f620ca.py
@@ -269,11 +269,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
@@ -282,7 +282,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         sys.exit(2)
     if _lib_dir not in sys.path:
         sys.path.insert(0, _lib_dir)

--- a/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
@@ -269,11 +269,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
@@ -266,11 +266,11 @@ def _original_main(stdin_bytes):
 
     # Bootstrap: find lib directory via env var or manifest walk-up.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PostToolUse/invoke_lsp_usage_tracker__mcp_serena_find_symbol_find_referencing_symbols_34dc50.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_lsp_usage_tracker__mcp_serena_find_symbol_find_referencing_symbols_34dc50.py
@@ -338,11 +338,11 @@ def _original_main(stdin_bytes):
     # The in-process import always takes the walk-up else branch (which is
     # measured) because pytest runs with CLAUDE_PLUGIN_ROOT unset.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:  # pragma: no cover - harness-set env path; covered via subprocess
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")
@@ -420,7 +420,7 @@ def _original_main(stdin_bytes):
         return "warn" if os.environ.get("LSP_GATE_MODE", "").strip() == "warn" else "block"
 
 
-    def _emit_warn_message(tool_name: str, state: dict) -> None:
+    def _emit_warn_message(tool_name: str, state: dict[str, object]) -> None:
         """Emit the warn-mode guidance as an exit-0 systemMessage.
 
         In ``LSP_GATE_MODE=warn`` the tracker still records navigation but also

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
@@ -272,11 +272,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -263,11 +263,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -276,7 +276,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         # Non-blocking hook: exit 0 on bootstrap failure (intentional, not a typo)
         sys.exit(0)
     if _lib_dir not in sys.path:

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_push_0e93bf.py
@@ -263,11 +263,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_push_0e93bf.py
@@ -276,7 +276,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         # Non-blocking hook: exit 0 on bootstrap failure (intentional, not a typo)
         sys.exit(0)
     if _lib_dir not in sys.path:

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_bash_grep_guard__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_bash_grep_guard__Bash_f620ca.py
@@ -298,6 +298,7 @@ def _original_main(stdin_bytes):
     import re
     import sys
     from pathlib import Path
+    from typing import TypedDict
 
     # Bootstrap: find lib directory via env var or manifest walk-up.
     # CLAUDE_PLUGIN_ROOT honored when set; otherwise walk up from __file__
@@ -305,11 +306,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")
@@ -345,6 +346,13 @@ def _original_main(stdin_bytes):
         is_git_grep,
         is_grep_search,
     )
+
+
+    class _CommandDecision(TypedDict):
+        """A gated grep decision: the code symbols and the navigable target."""
+
+        symbols: list[str]
+        target: str
 
     # File-like tokens in a grep command: a dotted path segment ending in a known
     # extension. Used to find a candidate navigable target without a shell parse.
@@ -546,7 +554,7 @@ def _original_main(stdin_bytes):
         return None
 
 
-    def evaluate_command(command: str, project_dir: str) -> dict | None:
+    def evaluate_command(command: str, project_dir: str) -> _CommandDecision | None:
         """Decide whether a bash command is a gated grep symbol search.
 
         Returns a decision dict ``{"symbols": [...], "target": str}`` when the

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_glob_guard__Glob_181cd6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_glob_guard__Glob_181cd6.py
@@ -301,11 +301,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:  # pragma: no cover - deployment layout (env set), not test env
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")
@@ -398,13 +398,13 @@ def _original_main(stdin_bytes):
         """
         extension = glob_extension(pattern)
         if extension:
-            return detect_providers(f"x{extension}", SYMBOL_NAVIGATION, project_dir)
+            return list(detect_providers(f"x{extension}", SYMBOL_NAVIGATION, project_dir))
         for probe_ext, language in EXTENSION_TO_SERENA_LANGUAGE.items():
             if language not in PROGRAMMING_SERENA_LANGUAGES:
                 continue
             providers = detect_providers(f"x{probe_ext}", SYMBOL_NAVIGATION, project_dir)
             if providers:
-                return providers
+                return list(providers)
         return []
 
 
@@ -469,7 +469,9 @@ def _original_main(stdin_bytes):
         return False
 
 
-    def _evaluate(hook_input: dict) -> tuple[str, list[str], list[str]] | None:
+    def _evaluate(
+        hook_input: dict[str, object],
+    ) -> tuple[str, list[str], list[str]] | None:
         """Decide whether a Glob call should block.
 
         Returns ``(pattern, symbols, providers)`` when the pattern carries a code

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_grep_guard__Grep_2589b1.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_grep_guard__Grep_2589b1.py
@@ -312,11 +312,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:  # pragma: no cover - deployment layout (env set), not test env
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")
@@ -490,7 +490,7 @@ def _original_main(stdin_bytes):
         return False
 
 
-    def _evaluate(hook_input: dict) -> tuple[list[str], list[str]] | None:
+    def _evaluate(hook_input: dict[str, object]) -> tuple[list[str], list[str]] | None:
         """Decide whether a Grep call should block.
 
         Returns ``(symbols, providers)`` when the call is a code-symbol Grep on a

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
@@ -349,7 +349,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         # Fail-open: a navigation guard must never wedge a turn on bootstrap failure.
         sys.exit(0)
     if _lib_dir not in sys.path:

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
@@ -336,11 +336,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
@@ -349,7 +349,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         # Fail-open: a navigation guard must never wedge a turn on bootstrap failure.
         sys.exit(0)
     if _lib_dir not in sys.path:

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
@@ -336,11 +336,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
@@ -319,11 +319,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_git_commit_git_ci_fb3f5a.py
@@ -281,7 +281,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         sys.exit(2)
     if _lib_dir not in sys.path:
         sys.path.insert(0, _lib_dir)

--- a/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_git_commit_git_ci_fb3f5a.py
@@ -268,11 +268,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PreToolUse/invoke_retrospective_gate__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_retrospective_gate__Bash_git_push_0e93bf.py
@@ -289,7 +289,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         # Non-blocking hook: exit 0 on bootstrap failure (intentional, not a typo)
         sys.exit(0)
     if _lib_dir not in sys.path:

--- a/src/copilot-cli/hooks/PreToolUse/invoke_retrospective_gate__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_retrospective_gate__Bash_git_push_0e93bf.py
@@ -276,11 +276,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PreToolUse/invoke_routing_gates__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_routing_gates__Bash_f620ca.py
@@ -304,7 +304,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         sys.exit(2)
     if _lib_dir not in sys.path:
         sys.path.insert(0, _lib_dir)

--- a/src/copilot-cli/hooks/PreToolUse/invoke_routing_gates__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_routing_gates__Bash_f620ca.py
@@ -291,11 +291,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gh_pr_create_be117f.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gh_pr_create_be117f.py
@@ -278,7 +278,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         sys.exit(2)
     if _lib_dir not in sys.path:
         sys.path.insert(0, _lib_dir)

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gh_pr_create_be117f.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gh_pr_create_be117f.py
@@ -265,11 +265,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -278,7 +278,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         sys.exit(2)
     if _lib_dir not in sys.path:
         sys.path.insert(0, _lib_dir)

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_git_commit_git_ci_fb3f5a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_git_commit_git_ci_fb3f5a.py
@@ -265,11 +265,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PreToolUse/invoke_skill_first_guard__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_skill_first_guard__Bash_f620ca.py
@@ -279,7 +279,11 @@ def _original_main(stdin_bytes):
                 break
             _cur = _cur.parent
     if _lib_dir is None or not os.path.isdir(_lib_dir):
-        print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+        print(
+            f"Plugin lib directory not found: {_lib_dir} "
+            f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+            file=sys.stderr,
+        )
         sys.exit(2)
     if _lib_dir not in sys.path:
         sys.path.insert(0, _lib_dir)
@@ -324,11 +328,17 @@ def _original_main(stdin_bytes):
             },
             "merge": {
                 "script": "merge_pr.py",
-                "example": "uv run python .claude/skills/github/scripts/pr/merge_pr.py --pull-request 123",
+                "example": (
+                    "uv run python .claude/skills/github/scripts/pr/"
+                    "merge_pr.py --pull-request 123"
+                ),
             },
             "close": {
                 "script": "close_pr.py",
-                "example": "uv run python .claude/skills/github/scripts/pr/close_pr.py --pull-request 123",
+                "example": (
+                    "uv run python .claude/skills/github/scripts/pr/"
+                    "close_pr.py --pull-request 123"
+                ),
             },
             "checks": {
                 "script": "get_pr_checks.py",
@@ -500,7 +510,11 @@ def _original_main(stdin_bytes):
             if gh_args is None:
                 continue
             positional = [tok for tok in gh_args if not tok.startswith("-")]
-            if len(positional) >= 2 and _OPERAND_RE.match(positional[0]) and _OPERAND_RE.match(positional[1]):
+            if (
+                len(positional) >= 2
+                and _OPERAND_RE.match(positional[0])
+                and _OPERAND_RE.match(positional[1])
+            ):
                 return {
                     "operation": positional[0],
                     "action": positional[1],

--- a/src/copilot-cli/hooks/PreToolUse/invoke_skill_first_guard__Bash_f620ca.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_skill_first_guard__Bash_f620ca.py
@@ -266,11 +266,11 @@ def _original_main(stdin_bytes):
     # lib/ is the plugin's lib dir. Layout-independent: works in source
     # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_topical_memory_injection__Write_Edit_c39898.py
@@ -267,11 +267,11 @@ def _original_main(stdin_bytes):
     # .claude/hooks/PreToolUse/invoke_correction_applier.py so the hook works in both
     # the deeper src/<provider>/hooks/<event>/ copy).
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    _lib_dir: str | None = None
     if _plugin_root:
         _lib_dir = str(Path(_plugin_root).resolve() / "lib")
     else:
         _cur = Path(__file__).resolve().parent
-        _lib_dir = None
         while True:
             if (_cur / ".claude-plugin" / "plugin.json").is_file():
                 _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/SessionEnd/invoke_skill_learning.py
+++ b/src/copilot-cli/hooks/SessionEnd/invoke_skill_learning.py
@@ -67,11 +67,11 @@ if not _SECURITY_LOG.handlers:
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/SessionEnd/invoke_skill_learning.py
+++ b/src/copilot-cli/hooks/SessionEnd/invoke_skill_learning.py
@@ -80,7 +80,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)
@@ -252,7 +256,9 @@ def _get_safe_root_from_env(env_value: str) -> Path:
         # Security note: path validation precedes resolution
         # JUSTIFICATION: Input has passed _validate_path_string, and the resulting
         # Path is immediately constrained to SAFE_BASE_DIR via _is_relative_to.
-        candidate_root = Path(validated_root).expanduser().resolve(strict=False)  # Path validated before resolution
+        candidate_root = Path(validated_root).expanduser().resolve(
+            strict=False
+        )  # Path validated before resolution
     except Exception:
         # If the environment value cannot be parsed as a path, fall back to SAFE_BASE_DIR
         return SAFE_BASE_DIR
@@ -332,7 +338,10 @@ def write_learning_notification(skill_name: str, high_count: int, med_count: int
     """Write silent notification about learnings extracted."""
     total = high_count + med_count + low_count
     if total > 0:
-        print(f"✔️ learned from session ➡️ {skill_name} ({high_count} HIGH, {med_count} MED, {low_count} LOW)")
+        print(
+            f"✔️ learned from session ➡️ {skill_name} "
+            f"({high_count} HIGH, {med_count} MED, {low_count} LOW)"
+        )
 
 
 def get_project_directory(hook_input: dict) -> str:
@@ -369,7 +378,8 @@ def get_project_directory(hook_input: dict) -> str:
         #   2. ROOT ANCHORING: All user input is interpreted under SAFE_BASE_DIR
         #   3. POST-VALIDATION: _is_relative_to() enforces SAFE_BASE_DIR boundary
         #   4. FALLBACK: Returns SAFE_BASE_DIR on any validation failure
-        # See: .github/codeql/suppressions.yml and .agents/analysis/908-codeql-path-traversal-analysis.md
+        # See: .github/codeql/suppressions.yml and
+        # .agents/analysis/908-codeql-path-traversal-analysis.md
 
         base_path = SAFE_BASE_DIR
 
@@ -380,7 +390,9 @@ def get_project_directory(hook_input: dict) -> str:
         if user_path.is_absolute():
             candidate = user_path.resolve(strict=False)  # Path validated before resolution
         else:
-            candidate = (base_path / user_path).resolve(strict=False)  # Path validated before resolution
+            candidate = (base_path / user_path).resolve(
+                strict=False
+            )  # Path validated before resolution
     except Exception:
         # Fall back to safe base directory on any resolution error
         return str(SAFE_BASE_DIR)
@@ -444,7 +456,11 @@ def detect_skill_usage(messages: list[dict]) -> dict[str, int]:
     Uses COMMAND_TO_SKILL (module-level) for slash command resolution.
     """
     detected_skills = {}
-    conversation_text = ' '.join(msg.get('content', '') for msg in messages if isinstance(msg.get('content'), str))
+    conversation_text = ' '.join(
+        msg.get('content', '')
+        for msg in messages
+        if isinstance(msg.get('content'), str)
+    )
 
     # Detect skills from .claude/skills/{skill-name} references
     skill_path_pattern = re.compile(r'\.claude[/\\]skills[/\\]([a-z0-9-]+)')
@@ -543,36 +559,39 @@ def classify_learning_by_llm(
     try:
         client = Anthropic(api_key=api_key)
 
-        prompt = f"""Analyze this conversation exchange for skill-related learnings about the "{skill_name}" skill.
-
-Assistant said:
-{assistant_msg[:500]}
-
-User responded:
-{user_response}
-
-Is this a learning signal? If yes, extract the learning and classify it:
-
-Categories:
-- HIGH (correction): Strong user corrections ("no", "wrong", "never do", "must use")
-- HIGH (chestertons_fence): Removed something without understanding why
-- HIGH (immediate_correction): User immediately asked to debug/fix right after
-- MED (preference): Tool/approach preferences ("instead of using", "prefer to", "should use X")
-- MED (success): Success patterns ("perfect", "excellent", "exactly", "that's it") - no qualifiers like "but"
-- MED (edge_case): Important edge cases ("what if the/this", "ensure that", "make sure")
-- MED (documentation): Documentation feedback ("update the docs", "needs documentation")
-- MED (question): Short clarifying question (may indicate confusion)
-- LOW (command_pattern): Repeated command patterns
-
-Respond in JSON format:
-{{
-  "is_learning": true/false,
-  "type": "correction|preference|success|edge_case|documentation|question|command_pattern|chestertons_fence|immediate_correction",
-  "confidence": 0.0-1.0,
-  "category": "High|Med|Low",
-  "extracted_learning": "The key lesson learned",
-  "reasoning": "Why this is/isn't a learning"
-}}"""
+        prompt = (
+            f'Analyze this conversation exchange for skill-related learnings about the '
+            f'"{skill_name}" skill.\n\n'
+            f"Assistant said:\n{assistant_msg[:500]}\n\n"
+            f"User responded:\n{user_response}\n\n"
+            "Is this a learning signal? If yes, extract the learning and classify it:\n\n"
+            "Categories:\n"
+            '- HIGH (correction): Strong user corrections '
+            '("no", "wrong", "never do", "must use")\n'
+            "- HIGH (chestertons_fence): Removed something without understanding why\n"
+            "- HIGH (immediate_correction): User immediately asked to debug/fix "
+            "right after\n"
+            '- MED (preference): Tool/approach preferences '
+            '("instead of using", "prefer to", "should use X")\n'
+            '- MED (success): Success patterns '
+            '("perfect", "excellent", "exactly", "that\'s it") - no qualifiers like "but"\n'
+            '- MED (edge_case): Important edge cases '
+            '("what if the/this", "ensure that", "make sure")\n'
+            '- MED (documentation): Documentation feedback '
+            '("update the docs", "needs documentation")\n'
+            "- MED (question): Short clarifying question (may indicate confusion)\n"
+            "- LOW (command_pattern): Repeated command patterns\n\n"
+            "Respond in JSON format:\n"
+            "{\n"
+            '  "is_learning": true/false,\n'
+            '  "type": "correction|preference|success|edge_case|documentation|question|'
+            'command_pattern|chestertons_fence|immediate_correction",\n'
+            '  "confidence": 0.0-1.0,\n'
+            '  "category": "High|Med|Low",\n'
+            '  "extracted_learning": "The key lesson learned",\n'
+            '  "reasoning": "Why this is/isn\'t a learning"\n'
+            "}"
+        )
 
         # M7-T6: timeout bounds the synchronous call so a stalled API
         # cannot wedge the SessionEnd hook indefinitely. The Anthropic
@@ -667,8 +686,25 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
         learning = None
 
         # HIGH: Strong corrections (confidence 0.85-0.95)
-        if re.search(r'(?i)\b(no\b|nope|not like that|that\'s wrong|incorrect|never do|always do|don\'t ever|must use|should not|avoid|stop)\b', user_response):
-            confidence = 0.9 if len(re.findall(r'(?i)\b(no|wrong|never|must)\b', user_response)) > 1 else 0.85
+        correction_pattern = (
+            r"(?i)\b(no\b|nope|not like that|that\'s wrong|incorrect|"
+            r"never do|always do|don\'t ever|must use|should not|avoid|stop)\b"
+        )
+        chestertons_fence_pattern = (
+            r"(?i)(trashed without understanding|removed without knowing|"
+            r"deleted without checking|why was this here)"
+        )
+        immediate_correction_pattern = (
+            r"(?i)\b(debug|root cause|correct|fix all|address|broken|"
+            r"error|issue|problem)\b"
+        )
+
+        if re.search(correction_pattern, user_response):
+            strong_correction_hits = re.findall(
+                r"(?i)\b(no|wrong|never|must)\b",
+                user_response,
+            )
+            confidence = 0.9 if len(strong_correction_hits) > 1 else 0.85
             learning = {
                 "type": "correction",
                 "source": user_response[:150],
@@ -678,7 +714,7 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
             }
 
         # HIGH: Chesterton's Fence (confidence 0.95)
-        elif re.search(r'(?i)(trashed without understanding|removed without knowing|deleted without checking|why was this here)', user_response):
+        elif re.search(chestertons_fence_pattern, user_response):
             learning = {
                 "type": "chestertons_fence",
                 "source": user_response[:150],
@@ -688,7 +724,10 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
             }
 
         # HIGH: Immediate corrections (confidence 0.8-0.85)
-        elif re.search(r'(?i)\b(debug|root cause|correct|fix all|address|broken|error|issue|problem)\b', user_response) and len(user_response) < 200:
+        elif (
+            re.search(immediate_correction_pattern, user_response)
+            and len(user_response) < 200
+        ):
             confidence = 0.85 if len(user_response) < 50 else 0.8
             learning = {
                 "type": "immediate_correction",
@@ -732,7 +771,8 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
             r'exactly(?:!|\s*$)|'  # "exactly!" or end of string
             r"that's\s+(?:it|right|correct)|"  # "that's it/right/correct"
             r'good\s+job|well\s+done|'  # "good job", "well done"
-            r'works(?:\s+great|\s+perfectly|!)(?!\s+(?:but|however|except))|'  # "works great/perfectly!" not followed by "but"
+            # "works great/perfectly!" not followed by "but"
+            r'works(?:\s+great|\s+perfectly|!)(?!\s+(?:but|however|except))|'
             r'(?:yes|correct|right)(?:\s*[!.])?$'  # "yes/correct/right" at end
             r')',
             user_response
@@ -763,7 +803,11 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
             r'(?i)\b(lunch|dinner|coffee|meeting|call|later|tomorrow)\b',
             user_response
         ):
-            confidence = 0.65 if re.search(r'(?i)\b(ensure|make sure|verify)\b', user_response) else 0.6
+            confidence = (
+                0.65
+                if re.search(r'(?i)\b(ensure|make sure|verify)\b', user_response)
+                else 0.6
+            )
             learning = {
                 "type": "edge_case",
                 "source": user_response[:150],
@@ -785,7 +829,11 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
             r')\b',
             user_response
         ):
-            confidence = 0.65 if re.search(r'(?i)\b(must|should|needs?)\b', user_response) else 0.6
+            confidence = (
+                0.65
+                if re.search(r'(?i)\b(must|should|needs?)\b', user_response)
+                else 0.6
+            )
             learning = {
                 "type": "documentation",
                 "source": user_response[:150],
@@ -795,7 +843,14 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
             }
 
         # MED: Clarifying questions (confidence 0.55-0.6)
-        elif re.search(r'\?', user_response) and len(user_response) < 50 and re.search(r'(?i)^(why|how|what|when|where|can|does|is|are)\b', user_response):
+        elif (
+            re.search(r'\?', user_response)
+            and len(user_response) < 50
+            and re.search(
+                r'(?i)^(why|how|what|when|where|can|does|is|are)\b',
+                user_response,
+            )
+        ):
             confidence = 0.6 if len(user_response) < 30 else 0.55
             learning = {
                 "type": "question",
@@ -818,7 +873,8 @@ def extract_learnings(messages: list[dict], skill_name: str) -> dict[str, list[d
         # LOW: Short acknowledgements without substance (confidence 0.35-0.45)
         # These may indicate workflow patterns worth tracking
         elif re.search(
-            r'(?i)^(?:ok|okay|sure|got it|sounds good|thanks|thank you|yep|yeah|alright|fine|k|kk)(?:[.!,]?\s*)?$',
+            r'(?i)^(?:ok|okay|sure|got it|sounds good|thanks|thank you|yep|yeah|'
+            r'alright|fine|k|kk)(?:[.!,]?\s*)?$',
             user_response.strip()
         ) and len(user_response.strip()) < 30:
             learning = {
@@ -895,10 +951,17 @@ def update_skill_memory(
         allowed_dir = project_dir.resolve(strict=False)
         # Validate project_dir looks like a real directory path
         if not allowed_dir.is_absolute():
-            print(f"Invalid project directory: '{project_dir}' does not resolve to absolute path", file=sys.stderr)
+            print(
+                f"Invalid project directory: '{project_dir}' does not resolve to absolute path",
+                file=sys.stderr,
+            )
             return False
         if not _is_relative_to(allowed_dir, SAFE_BASE_DIR):
-            print(f"Path traversal attempt detected: '{allowed_dir}' is outside safe base directory", file=sys.stderr)
+            print(
+                f"Path traversal attempt detected: '{allowed_dir}' "
+                "is outside safe base directory",
+                file=sys.stderr,
+            )
             return False
     except Exception as e:
         print(f"Path validation error for project_dir: {e}", file=sys.stderr)
@@ -908,7 +971,10 @@ def update_skill_memory(
     # This prevents attacks via skill names like "../../../etc/passwd" or "..\\attack"
     # Regex allowlist: only alphanumeric, underscore, and hyphen characters permitted
     if not re.fullmatch(r"[A-Za-z0-9_-]+", skill_name):
-        print(f"Invalid skill name: '{skill_name}' contains unsupported characters", file=sys.stderr)
+        print(
+            f"Invalid skill name: '{skill_name}' contains unsupported characters",
+            file=sys.stderr,
+        )
         return False
 
     # Step 3: Construct paths using validated allowed_dir
@@ -927,7 +993,11 @@ def update_skill_memory(
         # Include directory separator to prevent prefix attacks
         # e.g., "/home/user" should not match "/home/usermalicious"
         if not str(resolved_path).startswith(str(allowed_dir) + os.sep):
-            print(f"Path traversal attempt detected: '{resolved_path}' is outside project directory", file=sys.stderr)
+            print(
+                f"Path traversal attempt detected: '{resolved_path}' "
+                "is outside project directory",
+                file=sys.stderr,
+            )
             return False
     except Exception as e:
         print(f"Path validation error for memory_path: {e}", file=sys.stderr)
@@ -1030,7 +1100,10 @@ def update_skill_memory(
                 source = escape_replacement_string(learning["source"])
                 learning_type = learning["type"]
                 method_tag = " [LLM]" if learning.get("method") == "haiku-llm" else ""
-                other_med_items += f"- [{learning_type}] {source}{method_tag} (Session {session_id}, {today})\n"
+                other_med_items += (
+                    f"- [{learning_type}] {source}{method_tag} "
+                    f"(Session {session_id}, {today})\n"
+                )
 
         if other_med_items:
             pattern = r'(## Preferences \(MED confidence\)\r?\n)'
@@ -1103,7 +1176,8 @@ def main():
 
         # Get session ID from today's session log
         # Path validated before resolution
-        # CodeQL suppression: project_dir is validated against safe root and used only for reading session logs
+        # CodeQL suppression: project_dir is validated against safe root and used
+        # only for reading session logs
         sessions_dir = safe_project_path / ".agents" / "sessions"
         today = datetime.now().strftime("%Y-%m-%d")
 

--- a/src/copilot-cli/hooks/SessionStart/invoke_lsp_session_reset.py
+++ b/src/copilot-cli/hooks/SessionStart/invoke_lsp_session_reset.py
@@ -76,11 +76,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/SessionStart/invoke_memory_first_enforcer.py
+++ b/src/copilot-cli/hooks/SessionStart/invoke_memory_first_enforcer.py
@@ -46,11 +46,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/SessionStart/invoke_memory_first_enforcer.py
+++ b/src/copilot-cli/hooks/SessionStart/invoke_memory_first_enforcer.py
@@ -59,7 +59,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)

--- a/src/copilot-cli/hooks/SessionStart/invoke_session_start_memory_first.py
+++ b/src/copilot-cli/hooks/SessionStart/invoke_session_start_memory_first.py
@@ -38,7 +38,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)

--- a/src/copilot-cli/hooks/SessionStart/invoke_session_start_memory_first.py
+++ b/src/copilot-cli/hooks/SessionStart/invoke_session_start_memory_first.py
@@ -25,11 +25,11 @@ from urllib.parse import urlparse
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
+++ b/src/copilot-cli/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
@@ -30,11 +30,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
+++ b/src/copilot-cli/hooks/UserPromptSubmit/invoke_autonomous_execution_detector.py
@@ -43,7 +43,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)

--- a/src/copilot-cli/hooks/UserPromptSubmit/invoke_research_then_implement.py
+++ b/src/copilot-cli/hooks/UserPromptSubmit/invoke_research_then_implement.py
@@ -25,11 +25,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/UserPromptSubmit/invoke_research_then_implement.py
+++ b/src/copilot-cli/hooks/UserPromptSubmit/invoke_research_then_implement.py
@@ -48,7 +48,7 @@ try:
     from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
 except ImportError:
 
-    def skip_if_consumer_repo(hook_name: str) -> bool:  # type: ignore[misc]
+    def skip_if_consumer_repo(hook_name: str) -> bool:
         """Fallback: skip when .agents/ directory is absent."""
         project_dir = os.environ.get("CLAUDE_PROJECT_DIR", "").strip() or str(Path.cwd())
         if not Path(project_dir, ".agents").is_dir():

--- a/src/copilot-cli/hooks/UserPromptSubmit/invoke_research_then_implement.py
+++ b/src/copilot-cli/hooks/UserPromptSubmit/invoke_research_then_implement.py
@@ -38,7 +38,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     # Non-blocking hook: exit 0 on bootstrap failure (intentional, not a typo)
     sys.exit(0)
 if _lib_dir not in sys.path:

--- a/src/copilot-cli/hooks/UserPromptSubmit/invoke_serena_reassertion.py
+++ b/src/copilot-cli/hooks/UserPromptSubmit/invoke_serena_reassertion.py
@@ -76,7 +76,7 @@ try:
     from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
 except ImportError:
 
-    def skip_if_consumer_repo(hook_name: str) -> bool:  # type: ignore[misc]
+    def skip_if_consumer_repo(hook_name: str) -> bool:
         """Fallback: skip when .agents/ directory is absent.
 
         Resolves CLAUDE_PROJECT_DIR with expanduser().resolve() to avoid

--- a/src/copilot-cli/hooks/UserPromptSubmit/invoke_serena_reassertion.py
+++ b/src/copilot-cli/hooks/UserPromptSubmit/invoke_serena_reassertion.py
@@ -66,7 +66,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     # Non-blocking hook: exit 0 on bootstrap failure (intentional, not a typo)
     sys.exit(0)
 if _lib_dir not in sys.path:

--- a/src/copilot-cli/hooks/UserPromptSubmit/invoke_serena_reassertion.py
+++ b/src/copilot-cli/hooks/UserPromptSubmit/invoke_serena_reassertion.py
@@ -53,11 +53,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/src/copilot-cli/hooks/UserPromptSubmit/invoke_user_prompt_memory_check.py
+++ b/src/copilot-cli/hooks/UserPromptSubmit/invoke_user_prompt_memory_check.py
@@ -44,7 +44,11 @@ else:
             break
         _cur = _cur.parent
 if _lib_dir is None or not os.path.isdir(_lib_dir):
-    print(f"Plugin lib directory not found: {_lib_dir} (CLAUDE_PLUGIN_ROOT={_plugin_root!r})", file=sys.stderr)
+    print(
+        f"Plugin lib directory not found: {_lib_dir} "
+        f"(CLAUDE_PLUGIN_ROOT={_plugin_root!r})",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)

--- a/src/copilot-cli/hooks/UserPromptSubmit/invoke_user_prompt_memory_check.py
+++ b/src/copilot-cli/hooks/UserPromptSubmit/invoke_user_prompt_memory_check.py
@@ -31,11 +31,11 @@ from pathlib import Path
 # lib/ is the plugin's lib dir. Layout-independent: works in source
 # tree (.claude/) and in the deeper src/<provider>/hooks/<event>/ copy.
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+_lib_dir: str | None = None
 if _plugin_root:
     _lib_dir = str(Path(_plugin_root).resolve() / "lib")
 else:
     _cur = Path(__file__).resolve().parent
-    _lib_dir = None
     while True:
         if (_cur / ".claude-plugin" / "plugin.json").is_file():
             _lib_dir = str(_cur / "lib")

--- a/tests/test_install_git_hooks.py
+++ b/tests/test_install_git_hooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import stat
 import subprocess
 import sys
@@ -13,6 +14,21 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts import install_git_hooks as igh  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_git_global_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ignore developer and leaked global/system git config.
+
+    install_git_hooks reads core.hooksPath via git config --get, which merges
+    local, global, and system scopes. Pointing the global and system config at
+    os.devnull keeps these tests hermetic: a real ~/.gitconfig hooksPath, or one
+    leaked by an earlier test in the same process, cannot make an unconfigured
+    temp repo look configured. Without this, test_check_fails_when_unconfigured
+    is order-dependent and fails in the full suite while passing in isolation.
+    """
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
 
 
 def _make_hook(path: Path, *, executable: bool = True) -> None:

--- a/tests/test_install_git_hooks.py
+++ b/tests/test_install_git_hooks.py
@@ -18,17 +18,35 @@ from scripts import install_git_hooks as igh  # noqa: E402
 
 @pytest.fixture(autouse=True)
 def _isolate_git_global_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Ignore developer and leaked global/system git config.
+    """Ignore developer and leaked git config from every scope.
 
     install_git_hooks reads core.hooksPath via git config --get, which merges
-    local, global, and system scopes. Pointing the global and system config at
-    os.devnull keeps these tests hermetic: a real ~/.gitconfig hooksPath, or one
-    leaked by an earlier test in the same process, cannot make an unconfigured
-    temp repo look configured. Without this, test_check_fails_when_unconfigured
-    is order-dependent and fails in the full suite while passing in isolation.
+    the local, global, system, and env-injected scopes. git resolves config
+    from three sources this fixture must neutralize to stay hermetic:
+
+    1. Global and system files (~/.gitconfig, /etc/gitconfig): pointed at
+       os.devnull.
+    2. Env-injected config (GIT_CONFIG_COUNT + GIT_CONFIG_KEY_n/VALUE_n): git
+       reads these regardless of GIT_CONFIG_GLOBAL, so devnull alone does not
+       cover them. tests/conftest.py sets GIT_CONFIG_COUNT/KEY_0 for commit
+       signing, and an earlier test can leak a higher count carrying a relative
+       core.hooksPath. Delete the whole family here; these tests never commit.
+    3. GIT_CONFIG_PARAMETERS (the -c flag transport): cleared for the same
+       reason.
+
+    Without this, test_check_fails_when_unconfigured is order-dependent: a
+    leaked relative hooksPath makes an unconfigured temp repo look configured,
+    so --check returns EXIT_OK instead of EXIT_LOGIC. Absolute leaked paths are
+    already rejected by hooks_path_points_at_canonical; only a relative
+    ".githooks" leak reproduces the failure.
     """
     monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
     monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    monkeypatch.delenv("GIT_CONFIG_PARAMETERS", raising=False)
+    for name in [k for k in os.environ if k.startswith("GIT_CONFIG_")]:
+        if name in ("GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM"):
+            continue
+        monkeypatch.delenv(name, raising=False)
 
 
 def _make_hook(path: Path, *, executable: bool = True) -> None:


### PR DESCRIPTION
## Summary

Resolves the latent mypy failures in the hook bootstrap blocks (the #2876
changed-files trap) and makes the install_git_hooks test suite hermetic so it
no longer breaks under full-suite git-config pollution.

- Fixes #2949: dropped the unnecessary `# type: ignore[misc]` from the four
  consumer-repo fallback stub blocks (two source hooks in
  `.claude/hooks/UserPromptSubmit/`, two generated mirrors in
  `src/copilot-cli/hooks/UserPromptSubmit/`) that mypy flagged as unused once
  the bootstrap types resolved. Regenerated the Copilot CLI mirror tree.
- Fixes #2984: hardened the autouse isolation fixture in
  `test_install_git_hooks.py` to strip the whole `GIT_CONFIG_*` env-injection
  family (COUNT, KEY_n, VALUE_n, PARAMETERS) in addition to pointing the global
  and system config files at `os.devnull`. git merges env-injected config
  regardless of `GIT_CONFIG_GLOBAL`, so the devnull files alone did not stop an
  earlier test from leaking a relative `core.hooksPath=.githooks` into the
  process and making an unconfigured temp repo look configured.

## Root cause (#2984)

`test_check_fails_when_unconfigured` was order-dependent. In the full suite an
earlier test could leak `GIT_CONFIG_COUNT=1` + `GIT_CONFIG_KEY_0=core.hooksPath`
+ `GIT_CONFIG_VALUE_0=.githooks` into the process environment. Because the
leaked value is relative, `hooks_path_points_at_canonical` accepts it (absolute
paths are rejected), so `--check` returned `EXIT_OK` instead of `EXIT_LOGIC`.

Proven with positive and negative controls: without the strip, a fresh repo
carrying that env returns `EXIT_OK` (repro); with it, `EXIT_LOGIC`.

## Testing

- `uv run python -m pytest tests/test_install_git_hooks.py -q` -> 13 passed.
- Full pre-push suite (the only reproduction environment) passed: Phase 4
  pytest green, mypy green (26 files), plugin-load and hook-anchoring e2e green.

Refs #2876

## References

- `.claude/hooks/UserPromptSubmit/`
- `src/copilot-cli/hooks/UserPromptSubmit/`
- `tests/test_install_git_hooks.py`
- `scripts/install_git_hooks.py`
