### PR TITLE
fix(session): lock investigation allowlist to canonical module (#2966)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/session/scripts/test_investigation_eligibility.py
+++ b/.claude/skills/session/scripts/test_investigation_eligibility.py
@@ -15,8 +15,13 @@ import json
 import re
 import subprocess
 
-# Investigation allowlist patterns (single source of truth per Issue #840)
-# Matches InvestigationAllowlist.psm1 patterns
+# Investigation allowlist patterns. Canonical source of truth is
+# scripts/modules/investigation_allowlist.py (ADR-034 amendment, PR #2958).
+# This packaged skill script cannot import that repo-relative module at
+# runtime because it also ships to installed-plugin trees where scripts/
+# is absent, so it keeps a verbatim copy. A drift test
+# (tests/test_investigation_allowlist.py::TestSessionSkillAllowlistParity)
+# fails CI if this copy diverges from the module. Keep the two in lockstep.
 _ALLOWLIST_PATTERNS = [
     r"^\.agents/sessions/",
     r"^\.agents/analysis/",
@@ -26,7 +31,6 @@ _ALLOWLIST_PATTERNS = [
     r"^\.agents/memory/",
     r"^\.agents/architecture/REVIEW-",
     r"^\.agents/critique/",
-    r"^\.agents/memory/episodes/",
 ]
 
 _ALLOWLIST_DISPLAY = [
@@ -38,7 +42,6 @@ _ALLOWLIST_DISPLAY = [
     ".agents/memory/",
     ".agents/architecture/REVIEW-*",
     ".agents/critique/",
-    ".agents/memory/episodes/",
 ]
 
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/session/scripts/test_investigation_eligibility.py
+++ b/src/copilot-cli/skills/session/scripts/test_investigation_eligibility.py
@@ -15,8 +15,13 @@ import json
 import re
 import subprocess
 
-# Investigation allowlist patterns (single source of truth per Issue #840)
-# Matches InvestigationAllowlist.psm1 patterns
+# Investigation allowlist patterns. Canonical source of truth is
+# scripts/modules/investigation_allowlist.py (ADR-034 amendment, PR #2958).
+# This packaged skill script cannot import that repo-relative module at
+# runtime because it also ships to installed-plugin trees where scripts/
+# is absent, so it keeps a verbatim copy. A drift test
+# (tests/test_investigation_allowlist.py::TestSessionSkillAllowlistParity)
+# fails CI if this copy diverges from the module. Keep the two in lockstep.
 _ALLOWLIST_PATTERNS = [
     r"^\.agents/sessions/",
     r"^\.agents/analysis/",
@@ -26,7 +31,6 @@ _ALLOWLIST_PATTERNS = [
     r"^\.agents/memory/",
     r"^\.agents/architecture/REVIEW-",
     r"^\.agents/critique/",
-    r"^\.agents/memory/episodes/",
 ]
 
 _ALLOWLIST_DISPLAY = [
@@ -38,7 +42,6 @@ _ALLOWLIST_DISPLAY = [
     ".agents/memory/",
     ".agents/architecture/REVIEW-*",
     ".agents/critique/",
-    ".agents/memory/episodes/",
 ]
 
 

--- a/tests/test_investigation_allowlist.py
+++ b/tests/test_investigation_allowlist.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+from functools import lru_cache
 from pathlib import Path
 from types import ModuleType
 
@@ -60,12 +61,14 @@ class TestFileMatchesAllowlist:
         assert file_matches_allowlist(".agents/architecture/ADR-001.md") is False
 
 
+@lru_cache(maxsize=1)
 def _load_session_skill_module() -> ModuleType:
     """Load the packaged session-skill eligibility script by path.
 
     The script ships to installed-plugin trees, so it keeps a verbatim copy
     of the allowlist instead of importing the repo-relative module. This
-    loader lets the parity test compare the two in-repo.
+    loader lets the parity test compare the two in-repo. The result is cached
+    so the script executes once across the whole test class.
     """
     script = (
         Path(__file__).resolve().parents[1]
@@ -75,8 +78,11 @@ def _load_session_skill_module() -> ModuleType:
         / "scripts"
         / "test_investigation_eligibility.py"
     )
+    assert script.is_file(), f"session-skill eligibility script missing: {script}"
     spec = importlib.util.spec_from_file_location("_session_eligibility", script)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None and spec.loader is not None, (
+        f"could not build import spec for {script}"
+    )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/tests/test_investigation_allowlist.py
+++ b/tests/test_investigation_allowlist.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
 from scripts.modules.investigation_allowlist import (
     get_investigation_allowlist,
     get_investigation_allowlist_display,
@@ -54,3 +58,57 @@ class TestFileMatchesAllowlist:
 
     def test_rejects_architecture_adr(self) -> None:
         assert file_matches_allowlist(".agents/architecture/ADR-001.md") is False
+
+
+def _load_session_skill_module() -> ModuleType:
+    """Load the packaged session-skill eligibility script by path.
+
+    The script ships to installed-plugin trees, so it keeps a verbatim copy
+    of the allowlist instead of importing the repo-relative module. This
+    loader lets the parity test compare the two in-repo.
+    """
+    script = (
+        Path(__file__).resolve().parents[1]
+        / ".claude"
+        / "skills"
+        / "session"
+        / "scripts"
+        / "test_investigation_eligibility.py"
+    )
+    spec = importlib.util.spec_from_file_location("_session_eligibility", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestSessionSkillAllowlistParity:
+    """Lock the session-skill allowlist copy to the canonical module (#2966).
+
+    The session skill cannot import scripts.modules.investigation_allowlist at
+    runtime because it is packaged into plugin trees where scripts/ is absent.
+    These tests fail CI if the verbatim copy drifts from the module, which is
+    the DRY gap the ADR-034 amendment deferred.
+    """
+
+    def test_patterns_match_module(self) -> None:
+        skill = _load_session_skill_module()
+        assert list(skill._ALLOWLIST_PATTERNS) == get_investigation_allowlist()
+
+    def test_display_matches_module(self) -> None:
+        skill = _load_session_skill_module()
+        assert list(skill._ALLOWLIST_DISPLAY) == get_investigation_allowlist_display()
+
+    def test_match_behavior_matches_module(self) -> None:
+        skill = _load_session_skill_module()
+        samples = [
+            ".agents/sessions/log.json",
+            ".agents/memory/episodes/ep.json",
+            ".serena/memories/note.md",
+            ".agents/architecture/REVIEW-1.md",
+            ".agents/architecture/ADR-1.md",
+            "src/main.py",
+            "scripts/build.py",
+        ]
+        for path in samples:
+            assert skill._file_matches_allowlist(path) == file_matches_allowlist(path), path


### PR DESCRIPTION
## Summary

The packaged session-skill eligibility script carried an extra allowlist pattern the canonical module lacks, so the two copies had drifted. This locks the session skill's investigation allowlist to the canonical module and removes the redundant pattern.

## Changes

- Remove redundant `^\.agents/memory/episodes/` pattern and its display entry from the session-skill script so it matches the canonical 8-pattern module exactly.
- Add a drift-lock test class that loads the packaged script by path and asserts its patterns, display list, and match behavior equal the canonical module. Divergence fails the suite.
- Regenerate the Copilot CLI skill mirror.
- Serial plugin bump 0.6.17 to 0.6.18 (both manifests identical, parity gate).

## Why a drift test, not a runtime import

The packaged skill script ships to plugin trees where `scripts/` is absent, so it cannot import the canonical module at runtime. Convergence is enforced by an in-repo drift test (importlib load by path plus list equality), preserving portability.

## Validation

- 15 tests pass; negative control confirms the drift lock fails on injected divergence.
- ruff clean, mypy clean, plugin version bump and manifest parity checks pass.

Fixes #2966
