### PR TITLE
fix(build): stop false-positive write guard and clear imported-file lint debt (#2992)

### DIFF
--- a/build/generate_agents.py
+++ b/build/generate_agents.py
@@ -48,8 +48,8 @@ from generate_agents_common import (  # noqa: E402
     read_toolset_definitions,
     read_yaml_frontmatter,
 )
-from yaml_loader import ConfigError, load_platform_config  # noqa: E402
 from regen_guard import detect_reason as regen_detect_reason  # noqa: E402
+from yaml_loader import ConfigError, load_platform_config  # noqa: E402
 
 
 def read_artifacts_stanza(config_path: Path, artifact: str) -> dict[str, object] | None:
@@ -252,12 +252,18 @@ def generate_agents(
             #   2. artifacts.agents.{outputDir,outputSuffix} (REQ-003-001 schema)
             #   3. platform top-level (oldest fallback)
             platform_name = str(platform.get("provider", platform.get("platform", "")))
-            legacy = platform.get("legacy") if isinstance(platform.get("legacy"), dict) else {}
-            stanza = platform.get("__agents_stanza__") if isinstance(platform.get("__agents_stanza__"), dict) else {}
+            _legacy_raw = platform.get("legacy")
+            legacy: dict[str, object] = (
+                _legacy_raw if isinstance(_legacy_raw, dict) else {}
+            )
+            _stanza_raw = platform.get("__agents_stanza__")
+            agents_stanza: dict[str, object] = (
+                _stanza_raw if isinstance(_stanza_raw, dict) else {}
+            )
             output_dir_relative = str(
                 legacy.get(
                     "outputDir",
-                    stanza.get("outputDir", platform.get("outputDir", "")),
+                    agents_stanza.get("outputDir", platform.get("outputDir", "")),
                 )
             )
 
@@ -270,7 +276,7 @@ def generate_agents(
             file_ext = str(
                 legacy.get(
                     "fileExtension",
-                    stanza.get("outputSuffix", platform.get("fileExtension", ".md")),
+                    agents_stanza.get("outputSuffix", platform.get("fileExtension", ".md")),
                 )
             )
             output_file = output_dir / f"{agent_name}{file_ext}"
@@ -291,7 +297,11 @@ def generate_agents(
             # Expand toolset references
             # Use toolsFrom alias if set (e.g., visual-studio reuses vscode tools)
             tools_value = transformed_fm.get("tools")
-            tools_from_val = legacy.get("toolsFrom") if legacy.get("toolsFrom") else platform.get("toolsFrom")
+            tools_from_val = (
+                legacy.get("toolsFrom")
+                if legacy.get("toolsFrom")
+                else platform.get("toolsFrom")
+            )
             toolset_platform = str(tools_from_val) if tools_from_val else platform_name
             if (
                 toolsets
@@ -303,8 +313,14 @@ def generate_agents(
                 )
 
             # Transform body
-            handoff_syntax = str(legacy.get("handoffSyntax", platform.get("handoffSyntax", "")))
-            memory_prefix = str(legacy.get("memoryPrefix", platform.get("memoryPrefix", "cloudmcp-manager/")))
+            handoff_syntax = str(
+                legacy.get("handoffSyntax", platform.get("handoffSyntax", ""))
+            )
+            memory_prefix = str(
+                legacy.get(
+                    "memoryPrefix", platform.get("memoryPrefix", "cloudmcp-manager/")
+                )
+            )
 
             transformed_body = convert_handoff_syntax(body, handoff_syntax)
             transformed_body = convert_memory_prefix(transformed_body, memory_prefix)

--- a/build/scripts/build_all.py
+++ b/build/scripts/build_all.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -643,7 +644,9 @@ def assert_no_claude_writes(
 
     Returns the sorted list of offending paths (empty when compliant).
     """
-    current = _snapshot_owned_prefixes(repo_root, CLAUDE_GUARD_PREFIX)
+    current = _snapshot_owned_prefixes(
+        repo_root, CLAUDE_GUARD_PREFIX, exclude_ignored=True
+    )
     offending: set[Path] = set()
     for path, content in current.items():
         if baseline.get(path) != content:
@@ -722,8 +725,61 @@ def _select_platform_configs(
 OWNED_PREFIXES: tuple[str, ...] = ("src/", ".github/instructions/", "docs/agent-catalog.md")
 
 
+def _ignored_paths(repo_root: Path, prefixes: tuple[str, ...]) -> set[Path]:
+    """Return absolute paths of gitignored files under ``prefixes``.
+
+    Runtime artifacts such as ``.claude/hooks/audit.log`` and the
+    ``__pycache__/*.pyc`` bytecode caches are gitignored. Generators never
+    emit gitignored files, so the REQ-003-010 guard must exclude them: a
+    session hook appending to ``audit.log`` or CPython writing bytecode
+    during the build window would otherwise register as a spurious
+    generator write and fail the build nondeterministically (issue #2992).
+
+    Uses ``git ls-files --others --ignored --exclude-standard`` (one call
+    per prefix, NUL-delimited). A git failure returns whatever was gathered
+    so far: the guard then falls back to snapshotting those paths, which is
+    safe but not race-immune. Paths are built as ``repo_root / rel`` without
+    ``resolve()`` so they compare equal to the ``rglob`` output in
+    :func:`_snapshot_owned_prefixes`.
+    """
+    ignored: set[Path] = set()
+    for prefix in prefixes:
+        argv = [
+            "git",
+            "-C",
+            str(repo_root),
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "-z",
+            "--",
+            prefix,
+        ]
+        try:
+            proc = subprocess.run(
+                argv,
+                capture_output=True,
+                check=False,
+                timeout=30,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if proc.returncode != 0:
+            continue
+        for raw in proc.stdout.split(b"\x00"):
+            if not raw:
+                continue
+            rel = os.fsdecode(raw)
+            ignored.add(repo_root / rel)
+    return ignored
+
+
 def _snapshot_owned_prefixes(
-    repo_root: Path, prefixes: tuple[str, ...]
+    repo_root: Path,
+    prefixes: tuple[str, ...],
+    *,
+    exclude_ignored: bool = False,
 ) -> dict[Path, bytes]:
     """Snapshot every file under ``prefixes`` into an in-memory dict.
 
@@ -738,11 +794,19 @@ def _snapshot_owned_prefixes(
     not in scope today: generators only emit regular files, and treating
     them as such matches the existing copytree semantics in
     :func:`_build_directory_copy`.
+
+    When ``exclude_ignored`` is set, gitignored runtime artifacts (see
+    :func:`_ignored_paths`) are omitted. The REQ-003-010 guard passes this
+    so a concurrent hook write to ``.claude/hooks/audit.log`` or a bytecode
+    recompile does not read as a generator write (issue #2992).
     """
+    ignored = _ignored_paths(repo_root, prefixes) if exclude_ignored else set()
     snapshot: dict[Path, bytes] = {}
     for prefix in prefixes:
         root = repo_root / prefix
         if root.is_file() and not root.is_symlink():
+            if root in ignored:
+                continue
             try:
                 snapshot[root] = root.read_bytes()
             except OSError:
@@ -754,6 +818,8 @@ def _snapshot_owned_prefixes(
             continue
         for path in root.rglob("*"):
             if not path.is_file() or path.is_symlink():
+                continue
+            if path in ignored:
                 continue
             try:
                 snapshot[path] = path.read_bytes()
@@ -901,7 +967,9 @@ def run(
     # REQ-003-010 (issue #2613): snapshot the .claude/ tree before any
     # generator runs so the no-write guard attributes only writes the
     # generators made, not pre-build drift such as a .claude/lib sync.
-    claude_baseline = _snapshot_owned_prefixes(repo_root, CLAUDE_GUARD_PREFIX)
+    claude_baseline = _snapshot_owned_prefixes(
+        repo_root, CLAUDE_GUARD_PREFIX, exclude_ignored=True
+    )
 
     try:
         return _run_generators(

--- a/tests/build_scripts/test_build_all.py
+++ b/tests/build_scripts/test_build_all.py
@@ -1338,3 +1338,155 @@ def test_run_check_returns_2_when_skill_mirror_is_stale(
         f"--check should restore the src/ mirror and leave only the source "
         f"edit dirty; got:\n{porcelain}"
     )
+
+
+# _ignored_paths + exclude_ignored guard filtering (issue #2992) -------------
+
+
+def test_ignored_paths_lists_gitignored_files(tmp_path: Path) -> None:
+    """git-ignored runtime artifacts must appear in the ignored set."""
+    import subprocess
+
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text(
+        ".claude/hooks/audit.log\n__pycache__/\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "-C", str(repo), "add", ".gitignore"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "ignore"], check=True
+    )
+    hooks = repo / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    audit = hooks / "audit.log"
+    audit.write_text("runtime append\n", encoding="utf-8")
+    pyc_dir = hooks / "__pycache__"
+    pyc_dir.mkdir()
+    pyc = pyc_dir / "mod.cpython-314.pyc"
+    pyc.write_bytes(b"\x00bytecode")
+
+    ignored = build_all._ignored_paths(repo, build_all.CLAUDE_GUARD_PREFIX)
+    assert audit in ignored
+    assert pyc in ignored
+
+
+def test_ignored_paths_excludes_tracked_files(tmp_path: Path) -> None:
+    """A tracked .claude/ file is NOT gitignored, so it stays out of the set."""
+    import subprocess
+
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    tracked = repo / ".claude" / "agents" / "real.md"
+    tracked.parent.mkdir(parents=True)
+    tracked.write_text("# real agent\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "add", ".claude/agents/real.md"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "add"], check=True
+    )
+
+    ignored = build_all._ignored_paths(repo, build_all.CLAUDE_GUARD_PREFIX)
+    assert tracked not in ignored
+
+
+def test_ignored_paths_empty_when_not_a_git_repo(tmp_path: Path) -> None:
+    """Outside a git repo, ls-files fails and the set is empty (safe fallback)."""
+    claude = tmp_path / ".claude" / "hooks"
+    claude.mkdir(parents=True)
+    (claude / "audit.log").write_text("noise\n", encoding="utf-8")
+
+    ignored = build_all._ignored_paths(tmp_path, build_all.CLAUDE_GUARD_PREFIX)
+    assert ignored == set()
+
+
+def test_snapshot_excludes_ignored_runtime_artifacts(tmp_path: Path) -> None:
+    """exclude_ignored omits gitignored files from the snapshot."""
+    import subprocess
+
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text(
+        ".claude/hooks/audit.log\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "-C", str(repo), "add", ".gitignore"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "ignore"], check=True
+    )
+    hooks = repo / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    audit = hooks / "audit.log"
+    audit.write_text("v1\n", encoding="utf-8")
+    tracked = repo / ".claude" / "agents" / "a.md"
+    tracked.parent.mkdir(parents=True)
+    tracked.write_text("a\n", encoding="utf-8")
+
+    snap = build_all._snapshot_owned_prefixes(
+        repo, build_all.CLAUDE_GUARD_PREFIX, exclude_ignored=True
+    )
+    assert audit not in snap
+    assert tracked in snap
+
+
+def test_assert_no_claude_writes_ignores_audit_log_churn(tmp_path: Path) -> None:
+    """REQ-003-010 false positive fix (#2992): a gitignored audit.log that
+    changes DURING the build window must NOT be attributed to a generator.
+
+    Reproduces the intermittent push blocker: a session hook appends to
+    .claude/hooks/audit.log between the baseline snapshot and the post-build
+    re-read. Before the fix, that byte difference tripped the guard.
+    """
+    import subprocess
+
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text(
+        ".claude/hooks/audit.log\n__pycache__/\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "-C", str(repo), "add", ".gitignore"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "ignore"], check=True
+    )
+    hooks = repo / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    audit = hooks / "audit.log"
+    audit.write_text("before build\n", encoding="utf-8")
+
+    baseline = build_all._snapshot_owned_prefixes(
+        repo, build_all.CLAUDE_GUARD_PREFIX, exclude_ignored=True
+    )
+    # Session hook appends to the gitignored log mid-build (the race).
+    audit.write_text("before build\nappended during build\n", encoding="utf-8")
+
+    assert build_all.assert_no_claude_writes(repo, baseline) == []
+
+
+def test_assert_no_claude_writes_still_flags_real_write_in_git_repo(
+    tmp_path: Path,
+) -> None:
+    """The gitignore filter must NOT mask a genuine generator write to a
+    non-ignored .claude/ path (#2992 negative control)."""
+    import subprocess
+
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    (repo / ".gitignore").write_text(
+        ".claude/hooks/audit.log\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "-C", str(repo), "add", ".gitignore"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "ignore"], check=True
+    )
+    (repo / ".claude" / "agents").mkdir(parents=True)
+
+    baseline = build_all._snapshot_owned_prefixes(
+        repo, build_all.CLAUDE_GUARD_PREFIX, exclude_ignored=True
+    )
+    # Generator writes a NON-ignored file after the snapshot.
+    (repo / ".claude" / "agents" / "leak.md").write_text(
+        "generated", encoding="utf-8"
+    )
+
+    assert build_all.assert_no_claude_writes(repo, baseline) == [
+        ".claude/agents/leak.md"
+    ]


### PR DESCRIPTION
## Summary

Fixes two build-tooling push blockers that intermittently reject ALL pushes after heavy agentic sessions.

### Blocker 1: gitignore-blind write guard (the #2992 RCA)

`build_all.py`'s `assert_no_claude_writes` guard snapshots the `.claude/` tree before and after generators run and flags any new path as a generator write. It did not exclude gitignored runtime artifacts. When `.claude/hooks/audit.log` or `__pycache__/*.pyc` churned mid-build (which happens whenever a hook fires during the build), the guard misread them as generator writes, exited 2, and blocked the push at pre-push Phase 3.

Fix: `_snapshot_owned_prefixes` gains an `exclude_ignored` kwarg. A new `_ignored_paths` helper runs `git ls-files --others --ignored --exclude-standard -z` per owned prefix and subtracts those paths from the snapshot. Real generator writes to non-ignored files are still caught (a new tracked-or-untracked-but-not-ignored file is not in the ignored set). Outside a git repo the helper returns an empty set, preserving prior behavior.

### Blocker 2: pre-existing mypy + ruff debt in an imported file

`build_all.py` imports `generate_agents.py`. The pre-push mypy gate runs per-file with follow-imports, so touching `build_all.py` dragged 8 pre-existing type errors in `generate_agents.py` into the gate and rejected the push. Clearing those brought `generate_agents.py` into ruff's changed-file scope, surfacing 3 more pre-existing violations. Both cleared so the guard fix can land. No behavior change.

This cascade is the structural trap tracked in #2993 (627 latent ruff violations repo-wide, invisible until you touch a file).

## Testing

- 6 new tests in `tests/build_scripts/test_build_all.py` (positive: audit.log churn does not trip the guard; negative: a real non-ignored `.claude/` write still trips it; edge: no-git-repo returns empty).
- `uv run pytest tests/build_scripts/` = 769 passed.
- Full pre-push suite green (ruff, mypy, build staleness `--check` rc=0, plugin version bump, full pytest).

## Notes

Not plugin source (only `build/` and `tests/` touched), so no plugin.json bump required; the version-bump gate passed.

Fixes #2992
Refs #2876, #2993
