### PR TITLE
fix(tests): isolate leaked core.hooksPath git config in pytest suite (#2996)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,26 +14,41 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts.validation.models import ValidationResult  # noqa: E402
+from tests.git_config_isolation import (  # noqa: E402
+    restore_git_config_env,
+    snapshot_git_config_env,
+    strip_git_config_hooks_path,
+)
 
 
 @pytest.fixture(autouse=True, scope="session")
-def _disable_commit_signing_for_test_git() -> Iterator[None]:
-    """Neutralize host ``commit.gpgsign`` for all git subprocesses in the suite.
+def _isolate_git_config_for_test_git() -> Iterator[None]:
+    """Make git-config hermetic for all git subprocesses in the suite.
 
-    Some environments (e.g. Claude web containers) set a global
-    ``commit.gpgsign`` backed by a signing server that rejects commits made in
-    ``tmp_path`` fixture repos with HTTP 400, breaking the ~57 tests that create
-    commits (adr-review, metrics, merge-resolver, worktree tests, ...). Injecting
-    ``commit.gpgsign=false`` via ``GIT_CONFIG_COUNT`` gives it command-line
-    precedence over host config, so fixtures commit cleanly without per-fixture
-    edits (issue #2548). The signing-sensitive tests still RUN (they are not
-    skipped); only the signing requirement is removed.
+    Two host-environment leaks break ``tmp_path`` fixture commits, so both are
+    neutralized here (the whole ``GIT_CONFIG*`` namespace is snapshotted and
+    restored on teardown):
 
-    No test sets ``GIT_CONFIG_COUNT``, so index 0 is free; if some outer process
-    already uses the indexed mechanism, this fixture leaves it untouched.
+    1. ``commit.gpgsign`` (issue #2548). Some environments (e.g. Claude web
+       containers) set a global ``commit.gpgsign`` backed by a signing server
+       that rejects fixture commits with HTTP 400, breaking the ~57 tests that
+       create commits. Injecting ``commit.gpgsign=false`` via
+       ``GIT_CONFIG_COUNT`` gives it command-line precedence over host config.
+
+    2. ``core.hooksPath`` (issue #2996). ``git -c core.hooksPath=/abs push``
+       re-exports the override to child processes via ``GIT_CONFIG_PARAMETERS``.
+       An *absolute* hooks path (used when pushing from a linked worktree)
+       resolves inside every fixture repo, so each ``git commit`` runs the real
+       pre-commit hook and fails outside the repo (~84 failures observed on the
+       #2925 push). ``GIT_CONFIG_PARAMETERS`` outranks the indexed form, so an
+       empty override cannot win; the leaked key is stripped instead.
+
+    No test sets ``GIT_CONFIG_COUNT``, so index 0 is free after the strip; if
+    some outer process already uses the indexed mechanism, gpgsign injection is
+    skipped and left to that process.
     """
-    keys = ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0")
-    prior = {k: os.environ.get(k) for k in keys}
+    snapshot = snapshot_git_config_env(os.environ)
+    strip_git_config_hooks_path(os.environ)
     if not os.environ.get("GIT_CONFIG_COUNT"):
         os.environ["GIT_CONFIG_COUNT"] = "1"
         os.environ["GIT_CONFIG_KEY_0"] = "commit.gpgsign"
@@ -41,11 +56,7 @@ def _disable_commit_signing_for_test_git() -> Iterator[None]:
     try:
         yield
     finally:
-        for key, value in prior.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
+        restore_git_config_env(os.environ, snapshot)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/git_config_isolation.py
+++ b/tests/git_config_isolation.py
@@ -1,0 +1,149 @@
+"""Hermetic git-config isolation helpers for the test suite (issue #2996).
+
+``git -c core.hooksPath=/abs <cmd>`` re-exports the override to child processes
+via ``GIT_CONFIG_PARAMETERS`` (and, for the indexed form, ``GIT_CONFIG_COUNT`` +
+``GIT_CONFIG_KEY_n`` / ``GIT_CONFIG_VALUE_n``). When the pre-push hook is invoked
+that way with an *absolute* hooks path (which happens when a push is launched
+from a linked worktree, where ``-c core.hooksPath=.githooks`` relative would not
+resolve), the absolute path resolves inside every ``tmp_path`` git repo the
+suite creates. Each fixture ``git commit`` then runs the *real* pre-commit hook,
+which fails outside the repo, producing dozens of
+``subprocess.CalledProcessError: git commit ... exit status 1`` failures that
+have nothing to do with the code under test.
+
+Stripping ``core.hooksPath`` from the inherited git-config env makes the suite
+hermetic regardless of how the launcher configured hooks. This module holds the
+pure, unit-tested string manipulation; ``conftest.py`` wires it into a
+session-scoped autouse fixture.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import MutableMapping
+
+# Git normalizes config keys case-insensitively; core.hooksPath compares equal to
+# CORE.HOOKSPATH. Store the comparison target in canonical lowercase.
+_HOOKS_PATH_KEY = "core.hookspath"
+
+# One single-quoted run in GIT_CONFIG_PARAMETERS. Git escapes an embedded single
+# quote as '\'' (close quote, literal backslash-quote, reopen quote), so a run is
+# any mix of non-quote characters and that escape sequence, wrapped in quotes.
+_QUOTED_RUN = r"'(?:[^']|'\\'')*'"
+
+
+def _unquote_git_param_key(token: str) -> str:
+    """Return the lowercased config key from a GIT_CONFIG_PARAMETERS token.
+
+    A token is ``'section.key'`` or ``'section.key'='value'``. The key is the
+    first single-quoted run. Embedded ``'\\''`` escapes collapse to a single
+    quote.
+    """
+    match = re.match(_QUOTED_RUN, token)
+    if match is None:
+        return token.lower()
+    inner = match.group(0)[1:-1]
+    return inner.replace("'\\''", "'").lower()
+
+
+def _split_git_config_parameters(raw: str) -> list[str]:
+    """Split GIT_CONFIG_PARAMETERS into its space-separated tokens.
+
+    Spaces inside single-quoted runs do not separate tokens.
+    """
+    tokens: list[str] = []
+    i, n = 0, len(raw)
+    while i < n:
+        while i < n and raw[i] == " ":
+            i += 1
+        if i >= n:
+            break
+        start = i
+        in_quote = False
+        while i < n:
+            char = raw[i]
+            if char == "'":
+                in_quote = not in_quote
+            elif char == " " and not in_quote:
+                break
+            i += 1
+        tokens.append(raw[start:i])
+    return tokens
+
+
+def _strip_from_parameters(environ: MutableMapping[str, str]) -> None:
+    """Drop core.hooksPath tokens from GIT_CONFIG_PARAMETERS in place."""
+    raw = environ.get("GIT_CONFIG_PARAMETERS")
+    if not raw:
+        return
+    kept = [
+        token
+        for token in _split_git_config_parameters(raw)
+        if _unquote_git_param_key(token) != _HOOKS_PATH_KEY
+    ]
+    if kept:
+        environ["GIT_CONFIG_PARAMETERS"] = " ".join(kept)
+    else:
+        environ.pop("GIT_CONFIG_PARAMETERS", None)
+
+
+def _strip_from_indexed(environ: MutableMapping[str, str]) -> None:
+    """Drop core.hooksPath entries from the GIT_CONFIG_COUNT family in place.
+
+    Surviving entries are renumbered contiguously so git still reads them.
+    """
+    raw_count = environ.get("GIT_CONFIG_COUNT")
+    if raw_count is None:
+        return
+    try:
+        count = int(raw_count)
+    except ValueError:
+        return
+
+    kept: list[tuple[str | None, str | None]] = []
+    for idx in range(count):
+        key = environ.get(f"GIT_CONFIG_KEY_{idx}")
+        value = environ.get(f"GIT_CONFIG_VALUE_{idx}")
+        if key is not None and key.lower() == _HOOKS_PATH_KEY:
+            continue
+        kept.append((key, value))
+
+    for idx in range(count):
+        environ.pop(f"GIT_CONFIG_KEY_{idx}", None)
+        environ.pop(f"GIT_CONFIG_VALUE_{idx}", None)
+
+    if not kept:
+        environ.pop("GIT_CONFIG_COUNT", None)
+        return
+
+    environ["GIT_CONFIG_COUNT"] = str(len(kept))
+    for new_idx, (key, value) in enumerate(kept):
+        if key is not None:
+            environ[f"GIT_CONFIG_KEY_{new_idx}"] = key
+        if value is not None:
+            environ[f"GIT_CONFIG_VALUE_{new_idx}"] = value
+
+
+def strip_git_config_hooks_path(environ: MutableMapping[str, str]) -> None:
+    """Remove any inherited ``core.hooksPath`` from git-config env injection.
+
+    Mutates ``environ`` in place, handling both the ``GIT_CONFIG_PARAMETERS``
+    token form (used by ``git -c``) and the ``GIT_CONFIG_COUNT`` indexed form.
+    Leaves every other git-config entry intact. Idempotent.
+    """
+    _strip_from_parameters(environ)
+    _strip_from_indexed(environ)
+
+
+def snapshot_git_config_env(environ: MutableMapping[str, str]) -> dict[str, str]:
+    """Capture the current ``GIT_CONFIG*`` namespace for later restoration."""
+    return {k: v for k, v in environ.items() if k.startswith("GIT_CONFIG")}
+
+
+def restore_git_config_env(
+    environ: MutableMapping[str, str], snapshot: dict[str, str]
+) -> None:
+    """Restore the ``GIT_CONFIG*`` namespace from a prior snapshot in place."""
+    for key in [k for k in environ if k.startswith("GIT_CONFIG")]:
+        del environ[key]
+    environ.update(snapshot)

--- a/tests/test_git_config_isolation.py
+++ b/tests/test_git_config_isolation.py
@@ -1,0 +1,230 @@
+"""Tests for hermetic git-config isolation helpers (issue #2996)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from tests.git_config_isolation import (
+    restore_git_config_env,
+    snapshot_git_config_env,
+    strip_git_config_hooks_path,
+)
+
+# --- GIT_CONFIG_PARAMETERS form (git -c) ------------------------------------
+
+
+def test_strips_hooks_path_from_parameters() -> None:
+    env = {"GIT_CONFIG_PARAMETERS": "'core.hooksPath'='/abs/.githooks'"}
+    strip_git_config_hooks_path(env)
+    assert "GIT_CONFIG_PARAMETERS" not in env
+
+
+def test_strips_hooks_path_keeps_other_parameters() -> None:
+    env = {
+        "GIT_CONFIG_PARAMETERS": (
+            "'core.hooksPath'='/abs/.githooks' 'user.name'='Jane Doe'"
+        )
+    }
+    strip_git_config_hooks_path(env)
+    assert env["GIT_CONFIG_PARAMETERS"] == "'user.name'='Jane Doe'"
+
+
+def test_parameters_case_insensitive_key() -> None:
+    env = {"GIT_CONFIG_PARAMETERS": "'CORE.HOOKSPATH'='/abs'"}
+    strip_git_config_hooks_path(env)
+    assert "GIT_CONFIG_PARAMETERS" not in env
+
+
+def test_parameters_bool_key_without_value() -> None:
+    # A boolean-true parameter has no '=value' suffix.
+    env = {"GIT_CONFIG_PARAMETERS": "'core.hooksPath' 'feature.flag'='1'"}
+    strip_git_config_hooks_path(env)
+    assert env["GIT_CONFIG_PARAMETERS"] == "'feature.flag'='1'"
+
+
+def test_parameters_value_with_embedded_space() -> None:
+    env = {
+        "GIT_CONFIG_PARAMETERS": (
+            "'core.hooksPath'='/path with space/.githooks' 'user.name'='x'"
+        )
+    }
+    strip_git_config_hooks_path(env)
+    assert env["GIT_CONFIG_PARAMETERS"] == "'user.name'='x'"
+
+
+# --- GIT_CONFIG_COUNT indexed form ------------------------------------------
+
+
+def test_strips_hooks_path_from_indexed() -> None:
+    env = {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "core.hooksPath",
+        "GIT_CONFIG_VALUE_0": "/abs/.githooks",
+    }
+    strip_git_config_hooks_path(env)
+    assert "GIT_CONFIG_COUNT" not in env
+    assert "GIT_CONFIG_KEY_0" not in env
+    assert "GIT_CONFIG_VALUE_0" not in env
+
+
+def test_indexed_renumbers_survivors() -> None:
+    env = {
+        "GIT_CONFIG_COUNT": "3",
+        "GIT_CONFIG_KEY_0": "commit.gpgsign",
+        "GIT_CONFIG_VALUE_0": "false",
+        "GIT_CONFIG_KEY_1": "core.hooksPath",
+        "GIT_CONFIG_VALUE_1": "/abs/.githooks",
+        "GIT_CONFIG_KEY_2": "user.name",
+        "GIT_CONFIG_VALUE_2": "Jane",
+    }
+    strip_git_config_hooks_path(env)
+    assert env["GIT_CONFIG_COUNT"] == "2"
+    assert env["GIT_CONFIG_KEY_0"] == "commit.gpgsign"
+    assert env["GIT_CONFIG_VALUE_0"] == "false"
+    assert env["GIT_CONFIG_KEY_1"] == "user.name"
+    assert env["GIT_CONFIG_VALUE_1"] == "Jane"
+    assert "GIT_CONFIG_KEY_2" not in env
+    assert "GIT_CONFIG_VALUE_2" not in env
+
+
+def test_indexed_case_insensitive_key() -> None:
+    env = {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "Core.HooksPath",
+        "GIT_CONFIG_VALUE_0": "/abs",
+    }
+    strip_git_config_hooks_path(env)
+    assert "GIT_CONFIG_COUNT" not in env
+
+
+def test_indexed_malformed_count_left_untouched() -> None:
+    env = {"GIT_CONFIG_COUNT": "notanint", "GIT_CONFIG_KEY_0": "core.hooksPath"}
+    strip_git_config_hooks_path(env)
+    assert env["GIT_CONFIG_COUNT"] == "notanint"
+    assert env["GIT_CONFIG_KEY_0"] == "core.hooksPath"
+
+
+# --- Negative / no-op cases -------------------------------------------------
+
+
+def test_no_hooks_path_is_noop() -> None:
+    env = {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "commit.gpgsign",
+        "GIT_CONFIG_VALUE_0": "false",
+        "GIT_CONFIG_PARAMETERS": "'user.name'='x'",
+        "UNRELATED": "keep",
+    }
+    before = dict(env)
+    strip_git_config_hooks_path(env)
+    assert env == before
+
+
+def test_empty_environ_is_noop() -> None:
+    env: dict[str, str] = {}
+    strip_git_config_hooks_path(env)
+    assert env == {}
+
+
+def test_idempotent() -> None:
+    env = {
+        "GIT_CONFIG_PARAMETERS": "'core.hooksPath'='/abs' 'user.name'='x'",
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "core.hooksPath",
+        "GIT_CONFIG_VALUE_0": "/abs",
+    }
+    strip_git_config_hooks_path(env)
+    once = dict(env)
+    strip_git_config_hooks_path(env)
+    assert env == once
+
+
+# --- snapshot / restore -----------------------------------------------------
+
+
+def test_snapshot_and_restore_roundtrip() -> None:
+    env = {
+        "GIT_CONFIG_PARAMETERS": "'core.hooksPath'='/abs'",
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "core.hooksPath",
+        "GIT_CONFIG_VALUE_0": "/abs",
+        "PATH": "/usr/bin",
+    }
+    snapshot = snapshot_git_config_env(env)
+    strip_git_config_hooks_path(env)
+    # gpgsign injection would happen here in the real fixture.
+    env["GIT_CONFIG_COUNT"] = "1"
+    env["GIT_CONFIG_KEY_0"] = "commit.gpgsign"
+    env["GIT_CONFIG_VALUE_0"] = "false"
+    restore_git_config_env(env, snapshot)
+    assert env["GIT_CONFIG_PARAMETERS"] == "'core.hooksPath'='/abs'"
+    assert env["GIT_CONFIG_KEY_0"] == "core.hooksPath"
+    assert env["PATH"] == "/usr/bin"
+
+
+def test_restore_removes_injected_keys() -> None:
+    env: dict[str, str] = {"PATH": "/usr/bin"}
+    snapshot = snapshot_git_config_env(env)
+    env["GIT_CONFIG_COUNT"] = "1"
+    env["GIT_CONFIG_KEY_0"] = "commit.gpgsign"
+    env["GIT_CONFIG_VALUE_0"] = "false"
+    restore_git_config_env(env, snapshot)
+    assert "GIT_CONFIG_COUNT" not in env
+    assert env == {"PATH": "/usr/bin"}
+
+
+# --- Behavioral: prove a leaked absolute hooksPath no longer fires ----------
+
+
+def test_leaked_absolute_hooks_path_no_longer_runs_hook(tmp_path: Path) -> None:
+    """Reproduce the #2925 push failure and prove the strip neutralizes it.
+
+    Without the strip, a leaked absolute ``core.hooksPath`` makes ``git commit``
+    in a fresh repo run the real (failing) pre-commit hook. After the strip, the
+    commit succeeds.
+    """
+    hooks = tmp_path / "realhooks"
+    hooks.mkdir()
+    pre_commit = hooks / "pre-commit"
+    pre_commit.write_text("#!/bin/sh\necho HOOK_RAN >&2\nexit 1\n")
+    pre_commit.chmod(0o755)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+
+    leaked_env = {
+        "PATH": os.environ["PATH"],
+        "HOME": str(tmp_path),
+        "GIT_CONFIG_PARAMETERS": f"'core.hooksPath'='{hooks}'",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    commit_cmd = [
+        "git",
+        "-c",
+        "user.name=t",
+        "-c",
+        "user.email=t@t.com",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "probe",
+    ]
+
+    # Positive control: with the leak, the hook runs and the commit fails.
+    polluted = subprocess.run(
+        commit_cmd, cwd=repo, env=leaked_env, capture_output=True, encoding="utf-8"
+    )
+    assert polluted.returncode != 0
+    assert "HOOK_RAN" in polluted.stderr
+
+    # After the strip, the hook does not run and the commit succeeds.
+    strip_git_config_hooks_path(leaked_env)
+    cleaned = subprocess.run(
+        commit_cmd, cwd=repo, env=leaked_env, capture_output=True, encoding="utf-8"
+    )
+    assert cleaned.returncode == 0, cleaned.stderr
+    assert "HOOK_RAN" not in cleaned.stderr


### PR DESCRIPTION
## Summary

Makes the pytest suite hermetic against a leaked `core.hooksPath` git config value. When a push is invoked with an absolute `-c core.hooksPath=<abs>/.githooks` override (as happens when pushing from a git worktree), git re-exports that override to child processes via `GIT_CONFIG_PARAMETERS`. The pre-push hook runs pytest as a child, so every temp-repo `git commit` fixture inherited the absolute hooksPath and ran the real (failing) pre-commit hook, producing 84 failures and 41 collection errors that were pure environment pollution, unrelated to the code under test.

## Root cause

`git -c KEY=VALUE <cmd>` re-exports the override to child processes as `GIT_CONFIG_PARAMETERS='KEY'='VALUE'`. Config-FILE values are not re-exported, only `-c` overrides. A relative `.githooks` resolves to `<tmpdir>/.githooks` (missing) inside a temp-repo fixture, so hooks are silently skipped and commits pass. An absolute path resolves to the real hooks dir and every fixture commit fails. `GIT_CONFIG_PARAMETERS` also takes precedence over the `GIT_CONFIG_COUNT` indexed family, so an empty override cannot neutralize the leak. The value must be stripped.

## Fix

- New `tests/git_config_isolation.py`: pure, testable helpers that strip `core.hooksPath` from both the `GIT_CONFIG_PARAMETERS` token form and the `GIT_CONFIG_COUNT` indexed family (renumbering survivors), plus full-namespace snapshot and restore.
- `tests/conftest.py`: the session-scoped autouse fixture now strips `core.hooksPath` before injecting `commit.gpgsign=false`, with snapshot and restore over the whole `GIT_CONFIG*` namespace.
- New `tests/test_git_config_isolation.py`: 15 tests (positive, negative, edge) including a behavioral control that reproduces the leaked absolute hooksPath and proves the strip fixes it.

## Verification

Local: 15 new tests pass, ruff clean, mypy clean. This branch pushed through the full pre-push suite (Phase 4 full pytest) with zero pollution failures, which is the fix proving itself.

Fixes #2996

## References

Reference-only paths:

- `tests/git_config_isolation.py`
- `tests/conftest.py`
- `tests/test_git_config_isolation.py`
- `.githooks/pre-push`
