### PR TITLE
fix(code-qualities-assessment): language-aware heuristics and coupling gate direction

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/code-qualities-assessment/README.md
+++ b/.claude/skills/code-qualities-assessment/README.md
@@ -45,11 +45,11 @@ Create `.qualityrc.json` in your project root:
 ```json
 {
   "thresholds": {
-    "cohesion": { "min": 7, "warn": 5 },
-    "coupling": { "max": 3, "warn": 5 },
-    "encapsulation": { "min": 7, "warn": 5 },
-    "testability": { "min": 6, "warn": 4 },
-    "nonRedundancy": { "min": 8, "warn": 6 }
+    "cohesion": { "min": 7 },
+    "coupling": { "min": 7 },
+    "encapsulation": { "min": 7 },
+    "testability": { "min": 6 },
+    "nonRedundancy": { "min": 8 }
   },
   "ignore": ["**/generated/**", "**/*.pb.py"]
 }

--- a/.claude/skills/code-qualities-assessment/SKILL.md
+++ b/.claude/skills/code-qualities-assessment/SKILL.md
@@ -143,11 +143,11 @@ Create `.qualityrc.json` to customize thresholds:
 ```json
 {
   "thresholds": {
-    "cohesion": { "min": 7, "warn": 5 },
-    "coupling": { "min": 7, "warn": 5 },
-    "encapsulation": { "min": 7, "warn": 5 },
-    "testability": { "min": 6, "warn": 4 },
-    "nonRedundancy": { "min": 8, "warn": 6 }
+    "cohesion": { "min": 7 },
+    "coupling": { "min": 7 },
+    "encapsulation": { "min": 7 },
+    "testability": { "min": 6 },
+    "nonRedundancy": { "min": 8 }
   },
   "context": {
     "test": {
@@ -280,7 +280,7 @@ Output:
 
 ## Summary
 - **Cohesion**: 8/10
-- **Coupling**: 4/10 (warning)
+- **Coupling**: 4/10
 - **Encapsulation**: 9/10
 - **Testability**: 7/10
 - **Non-Redundancy**: 9/10

--- a/.claude/skills/code-qualities-assessment/SKILL.md
+++ b/.claude/skills/code-qualities-assessment/SKILL.md
@@ -144,7 +144,7 @@ Create `.qualityrc.json` to customize thresholds:
 {
   "thresholds": {
     "cohesion": { "min": 7, "warn": 5 },
-    "coupling": { "max": 3, "warn": 5 },
+    "coupling": { "min": 7, "warn": 5 },
     "encapsulation": { "min": 7, "warn": 5 },
     "testability": { "min": 6, "warn": 4 },
     "nonRedundancy": { "min": 8, "warn": 6 }

--- a/.claude/skills/code-qualities-assessment/scripts/assess.py
+++ b/.claude/skills/code-qualities-assessment/scripts/assess.py
@@ -25,8 +25,8 @@ from pathlib import Path
 from typing import Any
 
 # Language detection by file suffix. Only languages with tuned heuristics are
-# listed; anything else is analyzed with generic fallbacks and reduced
-# confidence so the gate never fails a file it cannot actually score.
+# listed. Unsupported files are reported as unscored for gate purposes so the
+# gate never fails a file it cannot actually score.
 _LANGUAGE_BY_SUFFIX = {
     ".py": "python",
     ".ts": "typescript",
@@ -59,14 +59,17 @@ _IMPORT_PATTERNS = {
     "typescript": re.compile(r"^\s*import\s+|\brequire\s*\("),
     "csharp": re.compile(r"^\s*using\s+[A-Za-z_]"),
     "java": re.compile(r"^\s*import\s+[A-Za-z_]"),
-    "go": re.compile(r'^\s*import\s+(?:[\w.]+\s+)?"|^\s+(?:[\w.]+\s+)?"[^"]+"\s*$'),
+    "go": re.compile(
+        r'^\s*import\s+(?:(?:[A-Za-z_]\w*|\.)\s+)?"[^"]+"\s*$'
+        r'|^\s+(?:(?:[A-Za-z_]\w*|\.)\s+)?"[^"]+"\s*$'
+    ),
 }
 
 # Generic import fallback for languages without a tuned pattern.
 _GENERIC_IMPORT_PATTERN = re.compile(r"^\s*(?:import|from|using|require|#include)\b")
 
 # Per-language definition patterns (types, functions, methods) for the cohesion
-# heuristic. More top-level definitions plus larger size means lower cohesion.
+# heuristic. More definitions plus larger size means lower cohesion.
 _DEFINITION_PATTERNS = {
     "python": re.compile(r"^\s*(?:async\s+)?def\s+\w|^\s*class\s+\w"),
     "javascript": re.compile(
@@ -109,14 +112,33 @@ def _count_web_global_state(lines: list[str]) -> int:
     patterns = (
         re.compile(r"\bglobalThis\b"),
         re.compile(r"\bwindow\.\w+\s*="),
-        re.compile(r"^var\s+\w"),
+        re.compile(r"^(?:var|let|const)\s+\w"),
     )
     return sum(1 for line in lines if any(p.search(line) for p in patterns))
 
 
 def _count_go_global_state(lines: list[str]) -> int:
     # Package-level (unindented) var declarations are mutable global state.
-    return sum(1 for line in lines if re.match(r"^var\s+\w", line))
+    count = 0
+    in_package_var_block = False
+    for line in lines:
+        stripped = line.strip()
+        if in_package_var_block:
+            if stripped == ")":
+                in_package_var_block = False
+                continue
+            if not stripped or stripped.startswith("//"):
+                continue
+            if re.match(r"^[A-Za-z_]\w*(?:\s|,|=)", stripped):
+                count += 1
+            continue
+
+        if re.match(r"^var\s+\(", line):
+            in_package_var_block = True
+            continue
+        if re.match(r"^var\s+\w", line):
+            count += 1
+    return count
 
 
 def _immutable_static(stripped: str, immutable_keywords: tuple[str, ...]) -> bool:
@@ -164,9 +186,13 @@ _GLOBAL_STATE_COUNTERS = {
 
 def _count_python_public_fields(lines: list[str]) -> int:
     pattern = re.compile(r"(?<!\w)self\.([A-Za-z]\w*)\s*=(?!=)")
-    return sum(
-        1 for line in lines for m in pattern.finditer(line) if not m.group(1).startswith("_")
-    )
+    fields = {
+        m.group(1)
+        for line in lines
+        for m in pattern.finditer(line)
+        if not m.group(1).startswith("_")
+    }
+    return len(fields)
 
 
 def _count_public_fields_by_modifier(lines: list[str]) -> int:
@@ -187,6 +213,8 @@ def _count_public_fields_by_modifier(lines: list[str]) -> int:
             kw in stripped
             for kw in ("class ", "interface ", "struct ", "enum ", "record ")
         ):
+            continue
+        if any(kw in stripped.split() for kw in ("const", "readonly", "final")):
             continue
         if stripped.endswith(";") or "=" in stripped:
             count += 1
@@ -229,14 +257,21 @@ class FileAssessment:
 
     @property
     def overall(self) -> float:
-        """Weighted average of all qualities"""
-        return (
-            self.cohesion.value +
-            self.coupling.value +
-            self.encapsulation.value +
-            self.testability.value +
-            self.non_redundancy.value
-        ) / 5
+        """Average of scored qualities only."""
+        scored_values = [
+            score.value
+            for score in (
+                self.cohesion,
+                self.coupling,
+                self.encapsulation,
+                self.testability,
+                self.non_redundancy,
+            )
+            if score.confidence > 0.0
+        ]
+        if not scored_values:
+            return 0.0
+        return sum(scored_values) / len(scored_values)
 
 
 def parse_args() -> argparse.Namespace:
@@ -287,7 +322,7 @@ def parse_args() -> argparse.Namespace:
 def load_config(config_path: str) -> dict[str, Any]:
     """Load configuration or return defaults"""
     try:
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             config: dict[str, Any] = json.load(f)
             return config
     except FileNotFoundError:
@@ -339,7 +374,7 @@ def get_files_to_assess(target: str, changed_only: bool) -> list[Path]:
 
 
 def _score_cohesion(language: str | None, code_lines: list[str], loc: int) -> QualityScore:
-    """Approximate cohesion from size plus top-level definition count.
+    """Approximate cohesion from size plus definition count.
 
     This is a size+definition approximation, not a true LCOM cohesion metric.
     More definitions packed into a larger file suggests the file is doing many
@@ -351,11 +386,14 @@ def _score_cohesion(language: str | None, code_lines: list[str], loc: int) -> Qu
     )
     score = 10.0 - (loc / 120.0) - max(0, def_count - 1) * 0.3
     score = max(1.0, min(10.0, score))
-    confidence = 0.4 if pattern else 0.3
+    confidence = 0.4 if pattern else 0.0
     reasons = [
-        f"{loc} LOC, {def_count} top-level definitions "
+        f"{loc} LOC, {def_count} definitions "
         "(size+definition approximation, not LCOM)",
         (
+            "Definition count not scored for this language"
+            if pattern is None
+            else
             "Large file with many definitions suggests low cohesion"
             if score < 7
             else "Size and definition count are reasonable"
@@ -458,16 +496,17 @@ def _score_testability(language: str | None, code_lines: list[str]) -> QualitySc
     return QualityScore(value=round(score, 1), confidence=0.5, reasons=reasons)
 
 
-def _score_non_redundancy(lines: list[str]) -> QualityScore:
+def _score_non_redundancy(lines: list[str], scored: bool) -> QualityScore:
     """Approximate non-redundancy from the ratio of unique to total lines.
 
     This is language-agnostic and unchanged in spirit from the original
     heuristic.
     """
+    confidence = 0.5 if scored else 0.0
     non_blank = [line.strip() for line in lines if line.strip()]
     if not non_blank:
         return QualityScore(
-            value=10.0, confidence=0.5, reasons=["Empty file, no duplication"]
+            value=10.0, confidence=confidence, reasons=["Empty file, no duplication"]
         )
     unique_lines = len(set(non_blank))
     score = (unique_lines / len(non_blank)) * 10.0
@@ -475,7 +514,9 @@ def _score_non_redundancy(lines: list[str]) -> QualityScore:
         f"{unique_lines}/{len(non_blank)} unique non-blank lines",
         "High duplication detected" if score < 7 else "Low duplication",
     ]
-    return QualityScore(value=round(score, 1), confidence=0.5, reasons=reasons)
+    if not scored:
+        reasons.append("Non-redundancy not scored for this language")
+    return QualityScore(value=round(score, 1), confidence=confidence, reasons=reasons)
 
 
 def _unreadable_assessment(file_path: Path, reason: str) -> FileAssessment:
@@ -537,8 +578,37 @@ def assess_file(file_path: Path, context: str, use_serena: bool) -> FileAssessme
         coupling=_score_coupling(language, code_lines),
         encapsulation=_score_encapsulation(language, code_lines),
         testability=_score_testability(language, code_lines),
-        non_redundancy=_score_non_redundancy(lines),
+        non_redundancy=_score_non_redundancy(lines, language is not None),
     )
+
+
+def _average_scored(scores: list[QualityScore]) -> float | None:
+    values = [score.value for score in scores if score.confidence > 0.0]
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _format_average(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.1f}/10"
+
+
+def _format_quality_score(score: QualityScore) -> str:
+    if score.confidence == 0.0:
+        return "unscored (n/a)"
+    return f"{score.value:.1f}/10"
+
+
+def _threshold_min(thresholds: dict[str, Any], key: str) -> float | None:
+    threshold = thresholds.get(key, {})
+    value = threshold.get("min")
+    return float(value) if value is not None else None
+
+
+def _score_below_threshold(score: QualityScore, threshold: float | None) -> bool:
+    return threshold is not None and score.confidence > 0.0 and score.value < threshold
 
 
 def generate_markdown_report(assessments: list[FileAssessment], config: dict[str, Any]) -> str:
@@ -549,69 +619,62 @@ def generate_markdown_report(assessments: list[FileAssessment], config: dict[str
     if not assessments:
         return "No files assessed."
 
-    avg_cohesion = sum(a.cohesion.value for a in assessments) / len(assessments)
-    avg_coupling = sum(a.coupling.value for a in assessments) / len(assessments)
-    avg_encap = sum(a.encapsulation.value for a in assessments) / len(assessments)
-    avg_test = sum(a.testability.value for a in assessments) / len(assessments)
-    avg_nonred = sum(a.non_redundancy.value for a in assessments) / len(assessments)
+    avg_cohesion = _average_scored([a.cohesion for a in assessments])
+    avg_coupling = _average_scored([a.coupling for a in assessments])
+    avg_encap = _average_scored([a.encapsulation for a in assessments])
+    avg_test = _average_scored([a.testability for a in assessments])
+    avg_nonred = _average_scored([a.non_redundancy for a in assessments])
+    thresholds = config["thresholds"]
 
     report.append("## Summary\n")
     report.append(f"**Files Assessed**: {len(assessments)}\n")
-    report.append(f"**Average Cohesion**: {avg_cohesion:.1f}/10")
-    report.append(f"**Average Coupling**: {avg_coupling:.1f}/10")
-    report.append(f"**Average Encapsulation**: {avg_encap:.1f}/10")
-    report.append(f"**Average Testability**: {avg_test:.1f}/10")
-    report.append(f"**Average Non-Redundancy**: {avg_nonred:.1f}/10\n")
+    report.append(f"**Average Cohesion**: {_format_average(avg_cohesion)}")
+    report.append(f"**Average Coupling**: {_format_average(avg_coupling)}")
+    report.append(f"**Average Encapsulation**: {_format_average(avg_encap)}")
+    report.append(f"**Average Testability**: {_format_average(avg_test)}")
+    report.append(f"**Average Non-Redundancy**: {_format_average(avg_nonred)}\n")
 
     # Per-file breakdown
     report.append("## File Assessments\n")
     for assessment in sorted(assessments, key=lambda a: a.overall):
         report.append(f"### {assessment.file_path}\n")
-        report.append(f"**Overall**: {assessment.overall:.1f}/10\n")
-        report.append(f"- **Cohesion**: {assessment.cohesion.value}/10")
-        report.append(f"- **Coupling**: {assessment.coupling.value}/10")
-        report.append(f"- **Encapsulation**: {assessment.encapsulation.value}/10")
-        report.append(f"- **Testability**: {assessment.testability.value}/10")
-        report.append(f"- **Non-Redundancy**: {assessment.non_redundancy.value}/10\n")
+        overall = _format_average(assessment.overall if assessment.overall > 0 else None)
+        report.append(f"**Overall**: {overall}\n")
+        quality_rows = (
+            ("Cohesion", "cohesion", assessment.cohesion),
+            ("Coupling", "coupling", assessment.coupling),
+            ("Encapsulation", "encapsulation", assessment.encapsulation),
+            ("Testability", "testability", assessment.testability),
+            ("Non-Redundancy", "nonRedundancy", assessment.non_redundancy),
+        )
+        for label, _, score in quality_rows:
+            report.append(f"- **{label}**: {_format_quality_score(score)}")
+        report.append("")
 
         # Show reasons for low scores
-        if assessment.cohesion.value < 7:
-            report.append("**Cohesion Issues**:")
-            for reason in assessment.cohesion.reasons:
-                report.append(f"  - {reason}")
-            report.append("")
-
-        if assessment.coupling.value < 7:
-            report.append("**Coupling Issues**:")
-            for reason in assessment.coupling.reasons:
-                report.append(f"  - {reason}")
-            report.append("")
+        for label, threshold_key, score in quality_rows:
+            if _score_below_threshold(score, _threshold_min(thresholds, threshold_key)):
+                report.append(f"**{label} Issues**:")
+                for reason in score.reasons:
+                    report.append(f"  - {reason}")
+                report.append("")
 
     return "\n".join(report)
 
 
 def generate_json_report(assessments: list[FileAssessment]) -> str:
     """Generate JSON report"""
-    count = len(assessments) if assessments else 1
     return json.dumps({
         "files": [asdict(a) for a in assessments],
         "summary": {
             "file_count": len(assessments),
             "average_scores": {
-                "cohesion": (
-                    sum(a.cohesion.value for a in assessments) / count if assessments else 0
-                ),
-                "coupling": (
-                    sum(a.coupling.value for a in assessments) / count if assessments else 0
-                ),
-                "encapsulation": (
-                    sum(a.encapsulation.value for a in assessments) / count if assessments else 0
-                ),
-                "testability": (
-                    sum(a.testability.value for a in assessments) / count if assessments else 0
-                ),
-                "non_redundancy": (
-                    sum(a.non_redundancy.value for a in assessments) / count if assessments else 0
+                "cohesion": _average_scored([a.cohesion for a in assessments]),
+                "coupling": _average_scored([a.coupling for a in assessments]),
+                "encapsulation": _average_scored([a.encapsulation for a in assessments]),
+                "testability": _average_scored([a.testability for a in assessments]),
+                "non_redundancy": _average_scored(
+                    [a.non_redundancy for a in assessments]
                 ),
             }
         }

--- a/.claude/skills/code-qualities-assessment/scripts/assess.py
+++ b/.claude/skills/code-qualities-assessment/scripts/assess.py
@@ -152,6 +152,8 @@ def _count_csharp_static_state(lines: list[str]) -> int:
         stripped = line.strip()
         if "static" not in stripped or "(" in stripped:
             continue
+        if stripped.startswith("using "):
+            continue
         if _immutable_static(stripped, ("readonly", "const ")):
             continue
         if stripped.endswith(";") or "=" in stripped:
@@ -164,6 +166,8 @@ def _count_java_static_state(lines: list[str]) -> int:
     for line in lines:
         stripped = line.strip()
         if "static" not in stripped or "(" in stripped:
+            continue
+        if stripped.startswith("import "):
             continue
         if _immutable_static(stripped, ("final",)):
             continue

--- a/.claude/skills/code-qualities-assessment/scripts/assess.py
+++ b/.claude/skills/code-qualities-assessment/scripts/assess.py
@@ -59,7 +59,7 @@ _IMPORT_PATTERNS = {
     "typescript": re.compile(r"^\s*import\s+|\brequire\s*\("),
     "csharp": re.compile(r"^\s*using\s+[A-Za-z_]"),
     "java": re.compile(r"^\s*import\s+[A-Za-z_]"),
-    "go": re.compile(r'^\s*import\s+[("]|^\s+_?\s*"[^"]+"\s*$'),
+    "go": re.compile(r'^\s*import\s+"|^\s+_?\s*"[^"]+"\s*$'),
 }
 
 # Generic import fallback for languages without a tuned pattern.
@@ -109,7 +109,7 @@ def _count_web_global_state(lines: list[str]) -> int:
     patterns = (
         re.compile(r"\bglobalThis\b"),
         re.compile(r"\bwindow\.\w+\s*="),
-        re.compile(r"^\s*var\s+\w"),
+        re.compile(r"^var\s+\w"),
     )
     return sum(1 for line in lines if any(p.search(line) for p in patterns))
 
@@ -326,11 +326,11 @@ def get_files_to_assess(target: str, changed_only: bool) -> list[Path]:
         if target_path.is_file():
             files = [target_path]
         elif target_path.is_dir():
-            files = list(target_path.rglob("*.py")) + \
-                    list(target_path.rglob("*.ts")) + \
-                    list(target_path.rglob("*.js")) + \
-                    list(target_path.rglob("*.cs")) + \
-                    list(target_path.rglob("*.java"))
+            files = [
+                f
+                for suffix in _LANGUAGE_BY_SUFFIX
+                for f in target_path.rglob(f"*{suffix}")
+            ]
         else:
             # Glob pattern
             files = [Path(f) for f in glob(target, recursive=True)]

--- a/.claude/skills/code-qualities-assessment/scripts/assess.py
+++ b/.claude/skills/code-qualities-assessment/scripts/assess.py
@@ -207,7 +207,12 @@ def _count_public_fields_by_modifier(lines: list[str]) -> int:
         stripped = line.strip()
         if not stripped.startswith("public "):
             continue
-        if "(" in stripped or "{" in stripped:  # method, ctor, property, or type body
+        if "(" in stripped:  # method or constructor
+            continue
+        brace_idx = stripped.find("{")
+        if brace_idx != -1 and "=" not in stripped[:brace_idx]:
+            # Property (`{ get; set; }`) or type body, not a brace initializer
+            # such as `public int[] xs = {1, 2};`, which is still a public field.
             continue
         if any(
             kw in stripped
@@ -470,7 +475,11 @@ def _score_encapsulation(language: str | None, code_lines: list[str]) -> Quality
 
 
 def _score_testability(language: str | None, code_lines: list[str]) -> QualityScore:
-    """Approximate testability from the amount of mutable global/static state.
+    """Approximate testability from the amount of global/static state.
+
+    The per-language counters flag global and static references. Some of these
+    (for example JS/TS ``const``) are not reassignable, so the label is
+    "global/static", not "mutable".
 
     Languages without a global-state counter are left unscored (confidence
     0.0) rather than defaulting to a perfect constant, which previously made
@@ -486,7 +495,7 @@ def _score_testability(language: str | None, code_lines: list[str]) -> QualitySc
     global_count = counter(code_lines)
     score = max(1.0, 10.0 - global_count * 2)
     reasons = [
-        f"{global_count} mutable global/static references",
+        f"{global_count} global/static references",
         (
             "Global state hinders testability"
             if global_count > 0
@@ -526,18 +535,22 @@ def _unreadable_assessment(file_path: Path, reason: str) -> FileAssessment:
     rather than passing it on meaningless scores derived from empty content.
     The reason is carried so the report explains why the file was not scored.
     """
-    unscored = QualityScore(
-        value=10.0,
-        confidence=0.0,
-        reasons=[f"Not scored ({reason})"],
-    )
+    def _unscored() -> QualityScore:
+        # A fresh instance (and reasons list) per quality so a later mutation
+        # of one metric cannot alias into the others.
+        return QualityScore(
+            value=10.0,
+            confidence=0.0,
+            reasons=[f"Not scored ({reason})"],
+        )
+
     return FileAssessment(
         file_path=str(file_path),
-        cohesion=unscored,
-        coupling=unscored,
-        encapsulation=unscored,
-        testability=unscored,
-        non_redundancy=unscored,
+        cohesion=_unscored(),
+        coupling=_unscored(),
+        encapsulation=_unscored(),
+        testability=_unscored(),
+        non_redundancy=_unscored(),
     )
 
 

--- a/.claude/skills/code-qualities-assessment/scripts/assess.py
+++ b/.claude/skills/code-qualities-assessment/scripts/assess.py
@@ -22,6 +22,7 @@ import re
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Any
 
 # Language detection by file suffix. Only languages with tuned heuristics are
 # listed; anything else is analyzed with generic fallbacks and reduced
@@ -283,11 +284,11 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def load_config(config_path: str) -> dict[str, Any]:
     """Load configuration or return defaults"""
     try:
         with open(config_path) as f:
-            config: dict = json.load(f)
+            config: dict[str, Any] = json.load(f)
             return config
     except FileNotFoundError:
         # Default configuration
@@ -508,7 +509,7 @@ def assess_file(file_path: Path, context: str, use_serena: bool) -> FileAssessme
     )
 
 
-def generate_markdown_report(assessments: list[FileAssessment], config: dict) -> str:
+def generate_markdown_report(assessments: list[FileAssessment], config: dict[str, Any]) -> str:
     """Generate markdown report"""
     report = ["# Code Quality Assessment Report\n"]
 
@@ -585,7 +586,9 @@ def generate_json_report(assessments: list[FileAssessment]) -> str:
     }, indent=2)
 
 
-def check_thresholds(assessments: list[FileAssessment], config: dict, context: str) -> int:
+def check_thresholds(
+    assessments: list[FileAssessment], config: dict[str, Any], context: str
+) -> int:
     """
     Check if quality scores meet configured thresholds.
 

--- a/.claude/skills/code-qualities-assessment/scripts/assess.py
+++ b/.claude/skills/code-qualities-assessment/scripts/assess.py
@@ -18,14 +18,199 @@ Exit codes:
 
 import argparse
 import json
+import re
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+# Language detection by file suffix. Only languages with tuned heuristics are
+# listed; anything else is analyzed with generic fallbacks and reduced
+# confidence so the gate never fails a file it cannot actually score.
+_LANGUAGE_BY_SUFFIX = {
+    ".py": "python",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".cs": "csharp",
+    ".java": "java",
+    ".go": "go",
+}
+
+# Single-line comment prefixes, used to exclude comment lines from the
+# lines-of-code count. Block comments are intentionally not stripped: this is an
+# approximation, not a parser.
+_LINE_COMMENT_PREFIXES = {
+    "python": ("#",),
+    "typescript": ("//",),
+    "javascript": ("//",),
+    "csharp": ("//",),
+    "java": ("//",),
+    "go": ("//",),
+}
+
+# Per-language import / dependency line patterns for the coupling heuristic.
+_IMPORT_PATTERNS = {
+    "python": re.compile(r"^\s*(?:import\s+\S|from\s+\S+\s+import\s+)"),
+    "javascript": re.compile(r"^\s*import\s+|\brequire\s*\("),
+    "typescript": re.compile(r"^\s*import\s+|\brequire\s*\("),
+    "csharp": re.compile(r"^\s*using\s+[A-Za-z_]"),
+    "java": re.compile(r"^\s*import\s+[A-Za-z_]"),
+    "go": re.compile(r'^\s*import\s+[("]|^\s+_?\s*"[^"]+"\s*$'),
+}
+
+# Generic import fallback for languages without a tuned pattern.
+_GENERIC_IMPORT_PATTERN = re.compile(r"^\s*(?:import|from|using|require|#include)\b")
+
+# Per-language definition patterns (types, functions, methods) for the cohesion
+# heuristic. More top-level definitions plus larger size means lower cohesion.
+_DEFINITION_PATTERNS = {
+    "python": re.compile(r"^\s*(?:async\s+)?def\s+\w|^\s*class\s+\w"),
+    "javascript": re.compile(
+        r"^\s*(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s+\w"
+        r"|^\s*(?:export\s+)?class\s+\w"
+        r"|=\s*(?:async\s*)?\([^)]*\)\s*=>"
+    ),
+    "typescript": re.compile(
+        r"^\s*(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s+\w"
+        r"|^\s*(?:export\s+)?(?:abstract\s+)?class\s+\w"
+        r"|^\s*(?:export\s+)?interface\s+\w"
+        r"|=\s*(?:async\s*)?\([^)]*\)\s*=>"
+    ),
+    "csharp": re.compile(
+        r"^\s*(?:public|private|protected|internal)\b[^;={]*\([^)]*\)\s*(?:\{|=>|$)"
+        r"|^\s*(?:public|private|protected|internal)\s+"
+        r"(?:static\s+|abstract\s+|sealed\s+|partial\s+)*"
+        r"(?:class|interface|struct|record|enum)\s+\w"
+    ),
+    "java": re.compile(
+        r"^\s*(?:public|private|protected)\b[^;={]*\([^)]*\)\s*(?:\{|throws\b|$)"
+        r"|^\s*(?:public|private|protected)\s+"
+        r"(?:static\s+|abstract\s+|final\s+)*"
+        r"(?:class|interface|enum|record)\s+\w"
+    ),
+    "go": re.compile(r"^\s*func\s+|^\s*type\s+\w+\s+(?:struct|interface)\b"),
+}
+
+
+def detect_language(file_path: Path) -> str | None:
+    """Return the tuned-heuristic language for a path, or None if unsupported."""
+    return _LANGUAGE_BY_SUFFIX.get(file_path.suffix.lower())
+
+
+def _count_python_global_state(lines: list[str]) -> int:
+    return sum(1 for line in lines if line.strip().startswith("global "))
+
+
+def _count_web_global_state(lines: list[str]) -> int:
+    patterns = (
+        re.compile(r"\bglobalThis\b"),
+        re.compile(r"\bwindow\.\w+\s*="),
+        re.compile(r"^\s*var\s+\w"),
+    )
+    return sum(1 for line in lines if any(p.search(line) for p in patterns))
+
+
+def _count_go_global_state(lines: list[str]) -> int:
+    # Package-level (unindented) var declarations are mutable global state.
+    return sum(1 for line in lines if re.match(r"^var\s+\w", line))
+
+
+def _immutable_static(stripped: str, immutable_keywords: tuple[str, ...]) -> bool:
+    type_decls = ("class ", "struct ", "interface ", "enum ", "record ")
+    return any(kw in stripped for kw in immutable_keywords + type_decls)
+
+
+def _count_csharp_static_state(lines: list[str]) -> int:
+    count = 0
+    for line in lines:
+        stripped = line.strip()
+        if "static" not in stripped or "(" in stripped:
+            continue
+        if _immutable_static(stripped, ("readonly", "const ")):
+            continue
+        if stripped.endswith(";") or "=" in stripped:
+            count += 1
+    return count
+
+
+def _count_java_static_state(lines: list[str]) -> int:
+    count = 0
+    for line in lines:
+        stripped = line.strip()
+        if "static" not in stripped or "(" in stripped:
+            continue
+        if _immutable_static(stripped, ("final",)):
+            continue
+        if stripped.endswith(";") or "=" in stripped:
+            count += 1
+    return count
+
+
+# Mutable-global-state counters keyed by language. A missing language means
+# "cannot score testability here"; the caller marks it unscored.
+_GLOBAL_STATE_COUNTERS = {
+    "python": _count_python_global_state,
+    "javascript": _count_web_global_state,
+    "typescript": _count_web_global_state,
+    "go": _count_go_global_state,
+    "csharp": _count_csharp_static_state,
+    "java": _count_java_static_state,
+}
+
+
+def _count_python_public_fields(lines: list[str]) -> int:
+    pattern = re.compile(r"(?<!\w)self\.([A-Za-z]\w*)\s*=(?!=)")
+    return sum(
+        1 for line in lines for m in pattern.finditer(line) if not m.group(1).startswith("_")
+    )
+
+
+def _count_public_fields_by_modifier(lines: list[str]) -> int:
+    """Count public field declarations in a C#/Java style source.
+
+    Public methods are the API and are fine; public *fields* expose mutable
+    state and break encapsulation. Properties (`{ get; set; }`) and type
+    declarations are excluded.
+    """
+    count = 0
+    for line in lines:
+        stripped = line.strip()
+        if not stripped.startswith("public "):
+            continue
+        if "(" in stripped or "{" in stripped:  # method, ctor, property, or type body
+            continue
+        if any(
+            kw in stripped
+            for kw in ("class ", "interface ", "struct ", "enum ", "record ")
+        ):
+            continue
+        if stripped.endswith(";") or "=" in stripped:
+            count += 1
+    return count
+
+
+# Public-field counters keyed by language. A missing language means
+# encapsulation cannot be scored reliably (for example JavaScript, where
+# visibility is largely conventional); the caller marks it unscored.
+_PUBLIC_FIELD_COUNTERS = {
+    "python": _count_python_public_fields,
+    "csharp": _count_public_fields_by_modifier,
+    "java": _count_public_fields_by_modifier,
+}
+
 
 @dataclass
 class QualityScore:
-    """Individual quality score with confidence"""
+    """Individual quality score with confidence.
+
+    A confidence of 0.0 means the metric could not be scored for this file
+    (for example, an unsupported language). The threshold gate skips any
+    quality whose confidence is 0.0 rather than failing a file it could not
+    measure.
+    """
     value: float  # 1-10
     confidence: float  # 0-1
     reasons: list[str]
@@ -109,7 +294,7 @@ def load_config(config_path: str) -> dict:
         return {
             "thresholds": {
                 "cohesion": {"min": 7, "warn": 5},
-                "coupling": {"max": 3, "warn": 5},
+                "coupling": {"min": 7, "warn": 5},
                 "encapsulation": {"min": 7, "warn": 5},
                 "testability": {"min": 6, "warn": 4},
                 "nonRedundancy": {"min": 8, "warn": 6}
@@ -152,114 +337,174 @@ def get_files_to_assess(target: str, changed_only: bool) -> list[Path]:
     return [f for f in files if f.exists()]
 
 
+def _score_cohesion(language: str | None, code_lines: list[str], loc: int) -> QualityScore:
+    """Approximate cohesion from size plus top-level definition count.
+
+    This is a size+definition approximation, not a true LCOM cohesion metric.
+    More definitions packed into a larger file suggests the file is doing many
+    things (lower cohesion). Confidence is deliberately low.
+    """
+    pattern = _DEFINITION_PATTERNS.get(language) if language else None
+    def_count = (
+        sum(1 for line in code_lines if pattern.search(line)) if pattern else 0
+    )
+    score = 10.0 - (loc / 120.0) - max(0, def_count - 1) * 0.3
+    score = max(1.0, min(10.0, score))
+    confidence = 0.4 if pattern else 0.3
+    reasons = [
+        f"{loc} LOC, {def_count} top-level definitions "
+        "(size+definition approximation, not LCOM)",
+        (
+            "Large file with many definitions suggests low cohesion"
+            if score < 7
+            else "Size and definition count are reasonable"
+        ),
+    ]
+    return QualityScore(value=round(score, 1), confidence=confidence, reasons=reasons)
+
+
+def _score_coupling(language: str | None, code_lines: list[str]) -> QualityScore:
+    """Approximate coupling from the number of import/dependency statements.
+
+    A high score means loose coupling (few imports), which is good, matching
+    the rubric where 10 is best.
+    """
+    pattern = _IMPORT_PATTERNS.get(language) if language else None
+    if pattern is not None:
+        import_count = sum(1 for line in code_lines if pattern.search(line))
+        confidence = 0.6
+    else:
+        import_count = sum(
+            1 for line in code_lines if _GENERIC_IMPORT_PATTERN.search(line)
+        )
+        confidence = 0.3
+    score = max(1.0, min(10.0, 10.0 - import_count))
+    reasons = [
+        f"{import_count} import/dependency statements",
+        (
+            "High import count suggests high coupling"
+            if import_count > 10
+            else "Import count is reasonable"
+        ),
+    ]
+    return QualityScore(value=round(score, 1), confidence=confidence, reasons=reasons)
+
+
+def _score_encapsulation(language: str | None, code_lines: list[str]) -> QualityScore:
+    """Approximate encapsulation from the number of exposed public fields.
+
+    Public methods are the intended API and are not penalized; public mutable
+    *fields* break encapsulation and lower the score. Languages without a
+    reliable visibility signal (for example JavaScript, where privacy is
+    conventional) are left unscored (confidence 0.0) so the gate does not fail
+    a file it cannot measure.
+    """
+    counter = _PUBLIC_FIELD_COUNTERS.get(language) if language else None
+    if counter is None:
+        return QualityScore(
+            value=10.0,
+            confidence=0.0,
+            reasons=[
+                "Encapsulation not scored for this language "
+                "(no reliable visibility signal)"
+            ],
+        )
+    public_fields = counter(code_lines)
+    score = 10.0 if public_fields == 0 else max(1.0, 10.0 - public_fields * 2.5)
+    reasons = [
+        f"{public_fields} exposed public field(s)",
+        (
+            "Exposed public state weakens encapsulation"
+            if public_fields > 0
+            else "No exposed public fields detected"
+        ),
+    ]
+    return QualityScore(value=round(score, 1), confidence=0.5, reasons=reasons)
+
+
+def _score_testability(language: str | None, code_lines: list[str]) -> QualityScore:
+    """Approximate testability from the amount of mutable global/static state.
+
+    Languages without a global-state counter are left unscored (confidence
+    0.0) rather than defaulting to a perfect constant, which previously made
+    every non-Python file look maximally testable.
+    """
+    counter = _GLOBAL_STATE_COUNTERS.get(language) if language else None
+    if counter is None:
+        return QualityScore(
+            value=10.0,
+            confidence=0.0,
+            reasons=["Testability not scored for this language (no global-state model)"],
+        )
+    global_count = counter(code_lines)
+    score = max(1.0, 10.0 - global_count * 2)
+    reasons = [
+        f"{global_count} mutable global/static references",
+        (
+            "Global state hinders testability"
+            if global_count > 0
+            else "No global state detected"
+        ),
+    ]
+    return QualityScore(value=round(score, 1), confidence=0.5, reasons=reasons)
+
+
+def _score_non_redundancy(lines: list[str]) -> QualityScore:
+    """Approximate non-redundancy from the ratio of unique to total lines.
+
+    This is language-agnostic and unchanged in spirit from the original
+    heuristic.
+    """
+    non_blank = [line.strip() for line in lines if line.strip()]
+    if not non_blank:
+        return QualityScore(
+            value=10.0, confidence=0.5, reasons=["Empty file, no duplication"]
+        )
+    unique_lines = len(set(non_blank))
+    score = (unique_lines / len(non_blank)) * 10.0
+    reasons = [
+        f"{unique_lines}/{len(non_blank)} unique non-blank lines",
+        "High duplication detected" if score < 7 else "Low duplication",
+    ]
+    return QualityScore(value=round(score, 1), confidence=0.5, reasons=reasons)
+
+
 def assess_file(file_path: Path, context: str, use_serena: bool) -> FileAssessment:
     """
     Assess a single file for all 5 qualities.
 
-    This is a simplified implementation. In production, this would:
-    1. Parse the file to extract symbols (using Serena if available)
-    2. Calculate metrics for each quality
-    3. Apply scoring rubrics
-    4. Return FileAssessment with scores and rationale
+    This is a heuristic implementation. It detects the language from the file
+    suffix and applies language-aware approximations for each quality. Metrics
+    that cannot be scored for a given language are returned with confidence
+    0.0, and the threshold gate skips any quality with confidence 0.0 rather
+    than failing a file it could not measure. A production implementation would
+    parse symbols (using Serena if available) instead of scanning lines.
     """
-    # Placeholder implementation - real version would analyze actual code
-    # For demonstration, return sample scores
+    language = detect_language(file_path)
+    comment_prefixes = _LINE_COMMENT_PREFIXES.get(language, ()) if language else ()
 
-    # Read file to get basic metrics
     try:
         with open(file_path, encoding='utf-8') as f:
             content = f.read()
-            lines = content.split('\n')
-            loc = len(
-                [line for line in lines if line.strip() and not line.strip().startswith('#')]
-            )
     except Exception:
-        loc = 0
+        content = ""
 
-    # Heuristic scoring based on file size (simplified)
-    # Real implementation would use proper static analysis
-
-    # Cohesion: penalize large files (likely low cohesion)
-    cohesion_score = max(1, min(10, 10 - (loc / 100)))
-
-    # Coupling: heuristic based on imports (simplified)
-    import_count = len([line for line in lines if 'import ' in line])
-    coupling_score = max(1, min(10, 10 - import_count))
-
-    # Encapsulation: check for private vs public (simplified)
-    public_methods = len([line for line in lines if 'def ' in line and 'def _' not in line])
-    private_methods = len([line for line in lines if 'def _' in line])
-    if public_methods + private_methods > 0:
-        encap_score = (private_methods / (public_methods + private_methods)) * 10
-    else:
-        encap_score = 10
-
-    # Testability: check for global state, hard-coded values
-    global_vars = len([line for line in lines if line.strip().startswith('global ')])
-    testability_score = max(1, 10 - global_vars * 2)
-
-    # Non-redundancy: basic duplication check (simplified)
-    # Real version would use token-based clone detection
-    unique_lines = len(set([line.strip() for line in lines if line.strip()]))
-    if len(lines) > 0:
-        redundancy_score = (unique_lines / len(lines)) * 10
-    else:
-        redundancy_score = 10
+    lines = content.split('\n')
+    code_lines = [
+        line
+        for line in lines
+        if line.strip()
+        and not (comment_prefixes and line.strip().startswith(comment_prefixes))
+    ]
+    loc = len(code_lines)
 
     return FileAssessment(
         file_path=str(file_path),
-        cohesion=QualityScore(
-            value=round(cohesion_score, 1),
-            confidence=0.7,
-            reasons=[
-                f"File has {loc} LOC",
-                (
-                    "Large files often indicate low cohesion" if loc > 200
-                    else "File size is reasonable"
-                )
-            ]
-        ),
-        coupling=QualityScore(
-            value=round(coupling_score, 1),
-            confidence=0.6,
-            reasons=[
-                f"File has {import_count} imports",
-                (
-                    "High import count suggests high coupling" if import_count > 10
-                    else "Import count is reasonable"
-                )
-            ]
-        ),
-        encapsulation=QualityScore(
-            value=round(encap_score, 1),
-            confidence=0.8,
-            reasons=[
-                f"{private_methods} private methods, {public_methods} public methods",
-                (
-                    "Good balance of private vs public" if encap_score > 7
-                    else "Too many public methods"
-                )
-            ]
-        ),
-        testability=QualityScore(
-            value=round(testability_score, 1),
-            confidence=0.7,
-            reasons=[
-                f"Found {global_vars} global variable references",
-                (
-                    "Global state hinders testability" if global_vars > 0
-                    else "No global state detected"
-                )
-            ]
-        ),
-        non_redundancy=QualityScore(
-            value=round(redundancy_score, 1),
-            confidence=0.5,
-            reasons=[
-                f"{unique_lines}/{len(lines)} unique lines",
-                "High duplication detected" if redundancy_score < 7 else "Low duplication"
-            ]
-        )
+        cohesion=_score_cohesion(language, code_lines, loc),
+        coupling=_score_coupling(language, code_lines),
+        encapsulation=_score_encapsulation(language, code_lines),
+        testability=_score_testability(language, code_lines),
+        non_redundancy=_score_non_redundancy(lines),
     )
 
 
@@ -356,7 +601,10 @@ def check_thresholds(assessments: list[FileAssessment], config: dict, context: s
         thresholds = {**thresholds, **context_thresholds}
 
     for assessment in assessments:
-        if assessment.cohesion.value < thresholds["cohesion"]["min"]:
+        if (
+            assessment.cohesion.confidence > 0.0
+            and assessment.cohesion.value < thresholds["cohesion"]["min"]
+        ):
             print(
                 f"❌ {assessment.file_path}: Cohesion {assessment.cohesion.value} "
                 f"< {thresholds['cohesion']['min']}",
@@ -364,15 +612,26 @@ def check_thresholds(assessments: list[FileAssessment], config: dict, context: s
             )
             return 11
 
-        if assessment.coupling.value > thresholds["coupling"]["max"]:
+        # Coupling uses "min" semantics: higher score = looser coupling = better.
+        # Legacy configs that only specify "max" are skipped rather than gated
+        # incorrectly.
+        coupling_min = thresholds["coupling"].get("min")
+        if (
+            coupling_min is not None
+            and assessment.coupling.confidence > 0.0
+            and assessment.coupling.value < coupling_min
+        ):
             print(
                 f"❌ {assessment.file_path}: Coupling {assessment.coupling.value} "
-                f"> {thresholds['coupling']['max']}",
+                f"< {coupling_min}",
                 file=sys.stderr
             )
             return 11
 
-        if assessment.encapsulation.value < thresholds["encapsulation"]["min"]:
+        if (
+            assessment.encapsulation.confidence > 0.0
+            and assessment.encapsulation.value < thresholds["encapsulation"]["min"]
+        ):
             print(
                 f"❌ {assessment.file_path}: Encapsulation {assessment.encapsulation.value} "
                 f"< {thresholds['encapsulation']['min']}",
@@ -380,7 +639,10 @@ def check_thresholds(assessments: list[FileAssessment], config: dict, context: s
             )
             return 11
 
-        if assessment.testability.value < thresholds["testability"]["min"]:
+        if (
+            assessment.testability.confidence > 0.0
+            and assessment.testability.value < thresholds["testability"]["min"]
+        ):
             print(
                 f"❌ {assessment.file_path}: Testability {assessment.testability.value} "
                 f"< {thresholds['testability']['min']}",
@@ -388,7 +650,10 @@ def check_thresholds(assessments: list[FileAssessment], config: dict, context: s
             )
             return 11
 
-        if assessment.non_redundancy.value < thresholds["nonRedundancy"]["min"]:
+        if (
+            assessment.non_redundancy.confidence > 0.0
+            and assessment.non_redundancy.value < thresholds["nonRedundancy"]["min"]
+        ):
             print(
                 f"❌ {assessment.file_path}: Non-Redundancy {assessment.non_redundancy.value} "
                 f"< {thresholds['nonRedundancy']['min']}",

--- a/.claude/skills/code-qualities-assessment/scripts/assess.py
+++ b/.claude/skills/code-qualities-assessment/scripts/assess.py
@@ -329,11 +329,11 @@ def load_config(config_path: str) -> dict[str, Any]:
         # Default configuration
         return {
             "thresholds": {
-                "cohesion": {"min": 7, "warn": 5},
-                "coupling": {"min": 7, "warn": 5},
-                "encapsulation": {"min": 7, "warn": 5},
-                "testability": {"min": 6, "warn": 4},
-                "nonRedundancy": {"min": 8, "warn": 6}
+                "cohesion": {"min": 7},
+                "coupling": {"min": 7},
+                "encapsulation": {"min": 7},
+                "testability": {"min": 6},
+                "nonRedundancy": {"min": 8}
             },
             "context": {
                 "test": {"testability": {"min": 3}}

--- a/.claude/skills/code-qualities-assessment/scripts/assess.py
+++ b/.claude/skills/code-qualities-assessment/scripts/assess.py
@@ -59,7 +59,7 @@ _IMPORT_PATTERNS = {
     "typescript": re.compile(r"^\s*import\s+|\brequire\s*\("),
     "csharp": re.compile(r"^\s*using\s+[A-Za-z_]"),
     "java": re.compile(r"^\s*import\s+[A-Za-z_]"),
-    "go": re.compile(r'^\s*import\s+"|^\s+_?\s*"[^"]+"\s*$'),
+    "go": re.compile(r'^\s*import\s+(?:[\w.]+\s+)?"|^\s+(?:[\w.]+\s+)?"[^"]+"\s*$'),
 }
 
 # Generic import fallback for languages without a tuned pattern.
@@ -368,25 +368,33 @@ def _score_coupling(language: str | None, code_lines: list[str]) -> QualityScore
     """Approximate coupling from the number of import/dependency statements.
 
     A high score means loose coupling (few imports), which is good, matching
-    the rubric where 10 is best.
+    the rubric where 10 is best. Languages without a tuned import pattern are
+    counted with a generic fallback for the report but returned at confidence
+    0.0 so the threshold gate does not fail a file scored only by that
+    untuned heuristic (matches the file-header contract).
     """
     pattern = _IMPORT_PATTERNS.get(language) if language else None
     if pattern is not None:
         import_count = sum(1 for line in code_lines if pattern.search(line))
         confidence = 0.6
+        tuned = True
     else:
         import_count = sum(
             1 for line in code_lines if _GENERIC_IMPORT_PATTERN.search(line)
         )
-        confidence = 0.3
+        confidence = 0.0
+        tuned = False
     score = max(1.0, min(10.0, 10.0 - import_count))
+    detail = (
+        "High import count suggests high coupling"
+        if import_count > 10
+        else "Import count is reasonable"
+    )
+    if not tuned:
+        detail = "Generic import approximation (untuned language); not gated"
     reasons = [
         f"{import_count} import/dependency statements",
-        (
-            "High import count suggests high coupling"
-            if import_count > 10
-            else "Import count is reasonable"
-        ),
+        detail,
     ]
     return QualityScore(value=round(score, 1), confidence=confidence, reasons=reasons)
 
@@ -470,6 +478,28 @@ def _score_non_redundancy(lines: list[str]) -> QualityScore:
     return QualityScore(value=round(score, 1), confidence=0.5, reasons=reasons)
 
 
+def _unreadable_assessment(file_path: Path, reason: str) -> FileAssessment:
+    """Return an all-unscored assessment for a file that could not be read.
+
+    Every quality is confidence 0.0 so ``check_thresholds`` skips the file
+    rather than passing it on meaningless scores derived from empty content.
+    The reason is carried so the report explains why the file was not scored.
+    """
+    unscored = QualityScore(
+        value=10.0,
+        confidence=0.0,
+        reasons=[f"Not scored ({reason})"],
+    )
+    return FileAssessment(
+        file_path=str(file_path),
+        cohesion=unscored,
+        coupling=unscored,
+        encapsulation=unscored,
+        testability=unscored,
+        non_redundancy=unscored,
+    )
+
+
 def assess_file(file_path: Path, context: str, use_serena: bool) -> FileAssessment:
     """
     Assess a single file for all 5 qualities.
@@ -487,8 +517,10 @@ def assess_file(file_path: Path, context: str, use_serena: bool) -> FileAssessme
     try:
         with open(file_path, encoding='utf-8') as f:
             content = f.read()
-    except Exception:
-        content = ""
+    except OSError as exc:
+        return _unreadable_assessment(file_path, f"read failed: {exc}")
+    except UnicodeDecodeError as exc:
+        return _unreadable_assessment(file_path, f"decode failed: {exc}")
 
     lines = content.split('\n')
     code_lines = [

--- a/.claude/skills/code-qualities-assessment/scripts/assess.py
+++ b/.claude/skills/code-qualities-assessment/scripts/assess.py
@@ -60,8 +60,8 @@ _IMPORT_PATTERNS = {
     "csharp": re.compile(r"^\s*using\s+[A-Za-z_]"),
     "java": re.compile(r"^\s*import\s+[A-Za-z_]"),
     "go": re.compile(
-        r'^\s*import\s+(?:(?:[A-Za-z_]\w*|\.)\s+)?"[^"]+"\s*$'
-        r'|^\s+(?:(?:[A-Za-z_]\w*|\.)\s+)?"[^"]+"\s*$'
+        r'^\s*import\s+(?:(?:[A-Za-z_]\w*|\.)\s+)?"[^"]+"\s*(?://.*)?$'
+        r'|^\s+(?:(?:[A-Za-z_]\w*|\.)\s+)?"[^"]+"\s*(?://.*)?$'
     ),
 }
 

--- a/.claude/skills/code-qualities-assessment/templates/.qualityrc.json
+++ b/.claude/skills/code-qualities-assessment/templates/.qualityrc.json
@@ -5,7 +5,7 @@
       "warn": 5
     },
     "coupling": {
-      "max": 3,
+      "min": 7,
       "warn": 5
     },
     "encapsulation": {

--- a/.claude/skills/code-qualities-assessment/templates/.qualityrc.json
+++ b/.claude/skills/code-qualities-assessment/templates/.qualityrc.json
@@ -1,24 +1,19 @@
 {
   "thresholds": {
     "cohesion": {
-      "min": 7,
-      "warn": 5
+      "min": 7
     },
     "coupling": {
-      "min": 7,
-      "warn": 5
+      "min": 7
     },
     "encapsulation": {
-      "min": 7,
-      "warn": 5
+      "min": 7
     },
     "testability": {
-      "min": 6,
-      "warn": 4
+      "min": 6
     },
     "nonRedundancy": {
-      "min": 8,
-      "warn": 6
+      "min": 8
     }
   },
   "context": {

--- a/.claude/skills/code-qualities-assessment/tests/test_assess.py
+++ b/.claude/skills/code-qualities-assessment/tests/test_assess.py
@@ -258,10 +258,26 @@ def test_gate_legacy_coupling_max_only_config_does_not_crash(tmp_path: Path) -> 
     assessment = assess_file(path, "production", False)
 
     legacy = _default_config()
-    legacy["thresholds"]["coupling"] = {"max": 3, "warn": 5}  # no "min"
+    legacy["thresholds"]["coupling"] = {"max": 3, "warn": 5}  # no "min"; "warn" is an ignored unknown key
 
     rc = check_thresholds([assessment], legacy, "production")
     assert rc == 0
+
+
+def test_default_config_declares_no_unconsumed_threshold_keys() -> None:
+    """The default config must not declare threshold keys the gate never reads.
+
+    Only ``min`` (and legacy ``max`` for coupling) are consumed by
+    ``check_thresholds`` and the report. A ``warn`` tier was declared for every
+    quality but never implemented, which misled users into thinking a warning
+    level existed. This guards the config contract so a future edit does not
+    reintroduce an unimplemented key.
+    """
+    consumed = {"min", "max"}
+    thresholds = _default_config()["thresholds"]
+    for quality, spec in thresholds.items():
+        unconsumed = set(spec) - consumed
+        assert not unconsumed, f"{quality} declares unconsumed keys: {unconsumed}"
 
 
 def test_gate_fails_tightly_coupled_file(tmp_path: Path) -> None:

--- a/.claude/skills/code-qualities-assessment/tests/test_assess.py
+++ b/.claude/skills/code-qualities-assessment/tests/test_assess.py
@@ -258,7 +258,8 @@ def test_gate_legacy_coupling_max_only_config_does_not_crash(tmp_path: Path) -> 
     assessment = assess_file(path, "production", False)
 
     legacy = _default_config()
-    legacy["thresholds"]["coupling"] = {"max": 3, "warn": 5}  # no "min"; "warn" is an ignored unknown key
+    # no "min"; "warn" is an ignored unknown key
+    legacy["thresholds"]["coupling"] = {"max": 3, "warn": 5}
 
     rc = check_thresholds([assessment], legacy, "production")
     assert rc == 0
@@ -529,6 +530,41 @@ def test_unreadable_file_is_unscored_not_passed(tmp_path: Path) -> None:
         assert score.confidence == 0.0
     # An unreadable file must not fail (or pass by scoring) any threshold.
     assert check_thresholds([assessment], _default_config(), "production") == 0
+
+
+def test_csharp_public_brace_initializer_field_lowers_encapsulation(tmp_path: Path) -> None:
+    """A C# public field declared with a brace initializer
+    (``public int[] xs = {1, 2};``) is still exposed public state and must
+    lower encapsulation, not be skipped as a property or type body."""
+    exposed = _write(
+        tmp_path,
+        "Exposed.cs",
+        "public class C\n{\n    public int[] xs = {1, 2};\n}\n",
+    )
+    hidden = _write(
+        tmp_path,
+        "Hidden.cs",
+        "public class C\n{\n    private int[] xs = {1, 2};\n}\n",
+    )
+    assert (
+        assess_file(exposed, "production", False).encapsulation.value
+        < assess_file(hidden, "production", False).encapsulation.value
+    )
+
+
+def test_unreadable_assessment_scores_are_not_aliased(tmp_path: Path) -> None:
+    """Each quality of an unreadable file must be an independent QualityScore;
+    mutating one metric's reasons must not bleed into the others."""
+    missing = tmp_path / "gone.py"  # never created -> open() raises OSError
+    assessment = assess_file(missing, "production", False)
+    assessment.cohesion.reasons.append("mutated")
+    for score in (
+        assessment.coupling,
+        assessment.encapsulation,
+        assessment.testability,
+        assessment.non_redundancy,
+    ):
+        assert "mutated" not in score.reasons
 
 
 def test_read_error_is_reported_as_unscored(

--- a/.claude/skills/code-qualities-assessment/tests/test_assess.py
+++ b/.claude/skills/code-qualities-assessment/tests/test_assess.py
@@ -31,6 +31,7 @@ _spec.loader.exec_module(_mod)
 assess_file = _mod.assess_file
 check_thresholds = _mod.check_thresholds
 detect_language = _mod.detect_language
+get_files_to_assess = _mod.get_files_to_assess
 load_config = _mod.load_config
 
 
@@ -270,3 +271,68 @@ def test_gate_fails_tightly_coupled_file(tmp_path: Path) -> None:
 
     rc = check_thresholds([assessment], _default_config(), "production")
     assert rc == 11
+
+
+# --------------------------------------------------------------------------- #
+# Regression guards for GPT-5.5 adversarial review of PR #3000
+# --------------------------------------------------------------------------- #
+
+
+def test_go_import_block_not_overcounted(tmp_path: Path) -> None:
+    """A Go ``import ( ... )`` block must count only the specs inside it, not
+    the block opener. A 3-import block is 3 imports (coupling 7), not 4."""
+    body = (
+        "package main\n\n"
+        "import (\n"
+        '    "fmt"\n'
+        '    "os"\n'
+        '    "strings"\n'
+        ")\n\n"
+        "func main() {}\n"
+    )
+    path = _write(tmp_path, "main.go", body)
+    coupling = assess_file(path, "production", False).coupling
+    # 10 - 3 imports == 7; the block opener must not add a fourth.
+    assert coupling.value == 7
+
+
+def test_web_indented_local_var_not_counted_as_global(tmp_path: Path) -> None:
+    """An indented function-local ``var`` is not global state; only a
+    module-scope (unindented) ``var`` lowers JS testability."""
+    local_only = _write(
+        tmp_path,
+        "local.js",
+        "function f() {\n    var x = 1;\n    return x;\n}\n",
+    )
+    module_scope = _write(
+        tmp_path,
+        "global.js",
+        "var x = 1;\nfunction f() {\n    return x;\n}\n",
+    )
+    local_score = assess_file(local_only, "production", False).testability
+    global_score = assess_file(module_scope, "production", False).testability
+    # The local-only file has no global state, so it scores strictly higher.
+    assert local_score.value > global_score.value
+
+
+def test_directory_scan_includes_all_supported_suffixes(tmp_path: Path) -> None:
+    """Directory assessment must pick up every suffix detect_language supports,
+    including .go, .tsx, .jsx, .mjs, .cjs (previously omitted)."""
+    for name in ("a.go", "b.tsx", "c.jsx", "d.mjs", "e.cjs", "f.py"):
+        _write(tmp_path, name, "x = 1\n")
+    found = {p.name for p in get_files_to_assess(str(tmp_path), False)}
+    assert {"a.go", "b.tsx", "c.jsx", "d.mjs", "e.cjs", "f.py"} <= found
+
+
+def test_template_qualityrc_uses_coupling_min(tmp_path: Path) -> None:
+    """The shipped template config must use coupling.min (matching
+    check_thresholds), not the legacy coupling.max that disabled the gate."""
+    import json
+
+    template = (
+        Path(__file__).parent.parent / "templates" / ".qualityrc.json"
+    )
+    config = json.loads(template.read_text(encoding="utf-8"))
+    coupling = config["thresholds"]["coupling"]
+    assert "min" in coupling
+    assert "max" not in coupling

--- a/.claude/skills/code-qualities-assessment/tests/test_assess.py
+++ b/.claude/skills/code-qualities-assessment/tests/test_assess.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import builtins
 import importlib.util
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -46,7 +47,13 @@ def _write(tmp_path: Path, name: str, body: str) -> Path:
 
 def _default_config() -> dict[str, Any]:
     # load_config with a nonexistent path returns the built-in defaults.
-    config: dict[str, Any] = load_config(str(Path("/nonexistent/.qualityrc.json")))
+    # Use a path inside a fresh temp dir and assert it is absent so the
+    # FileNotFoundError branch is exercised deterministically, independent
+    # of host filesystem state.
+    with tempfile.TemporaryDirectory() as tmp:
+        missing = Path(tmp) / ".qualityrc.json"
+        assert not missing.exists()
+        config: dict[str, Any] = load_config(str(missing))
     return config
 
 

--- a/.claude/skills/code-qualities-assessment/tests/test_assess.py
+++ b/.claude/skills/code-qualities-assessment/tests/test_assess.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -39,9 +40,10 @@ def _write(tmp_path: Path, name: str, body: str) -> Path:
     return path
 
 
-def _default_config() -> dict:
+def _default_config() -> dict[str, Any]:
     # load_config with a nonexistent path returns the built-in defaults.
-    return load_config(str(Path("/nonexistent/.qualityrc.json")))
+    config: dict[str, Any] = load_config(str(Path("/nonexistent/.qualityrc.json")))
+    return config
 
 
 # --------------------------------------------------------------------------- #

--- a/.claude/skills/code-qualities-assessment/tests/test_assess.py
+++ b/.claude/skills/code-qualities-assessment/tests/test_assess.py
@@ -316,6 +316,36 @@ def test_go_import_block_not_overcounted(tmp_path: Path) -> None:
     assert coupling.value == 7
 
 
+def test_go_imports_with_trailing_comments_counted(tmp_path: Path) -> None:
+    """Go import specs may carry a trailing ``// ...`` line comment, both for a
+    single ``import "x"`` line and inside an ``import ( ... )`` block. The
+    coupling regex must still count them; otherwise a tightly coupled file is
+    under-counted and can slip through the gate."""
+    single = _write(
+        tmp_path,
+        "single.go",
+        'package main\n\nimport "fmt" // formatting\n\nfunc main() {}\n',
+    )
+    # One counted import => coupling 9 (10 - 1); a missed import would score 10.
+    assert assess_file(single, "production", False).coupling.value == 9
+
+    block = _write(
+        tmp_path,
+        "block.go",
+        (
+            "package main\n\n"
+            "import (\n"
+            '    "fmt" // formatting\n'
+            '    "os"  // process env\n'
+            '    _ "github.com/lib/pq" // sql driver, blank import\n'
+            ")\n\n"
+            "func main() {}\n"
+        ),
+    )
+    # Three specs, each with a trailing comment => coupling 7 (10 - 3).
+    assert assess_file(block, "production", False).coupling.value == 7
+
+
 def test_web_indented_local_var_not_counted_as_global(tmp_path: Path) -> None:
     """An indented function-local ``var`` is not global state; only a
     module-scope (unindented) ``var`` lowers JS testability."""

--- a/.claude/skills/code-qualities-assessment/tests/test_assess.py
+++ b/.claude/skills/code-qualities-assessment/tests/test_assess.py
@@ -336,3 +336,60 @@ def test_template_qualityrc_uses_coupling_min(tmp_path: Path) -> None:
     coupling = config["thresholds"]["coupling"]
     assert "min" in coupling
     assert "max" not in coupling
+
+
+# --------------------------------------------------------------------------- #
+# PR #3000 adversarial-review fixes (GPT-5.5 / Copilot findings)
+# --------------------------------------------------------------------------- #
+
+
+def test_go_aliased_and_dot_imports_counted(tmp_path: Path) -> None:
+    """Aliased (`m "math"`) and dot (`. "strings"`) imports in a Go block must
+    count, or coupling is inflated and the gate can pass when it should fail."""
+    body = (
+        "package main\n\n"
+        "import (\n"
+        '    "fmt"\n'
+        '    _ "database/sql"\n'
+        '    m "math"\n'
+        '    . "strings"\n'
+        ")\n\n"
+        "func main() {}\n"
+    )
+    path = _write(tmp_path, "main.go", body)
+    coupling = assess_file(path, "production", False).coupling
+    # 4 import specs: plain, blank, aliased, dot. 10 - 4 == 6.
+    assert coupling.value == 6
+
+
+def test_untuned_language_coupling_not_gated(tmp_path: Path) -> None:
+    """A language without a tuned import pattern is counted only for the report
+    (confidence 0.0), so check_thresholds skips it rather than gating on an
+    untuned heuristic (honors the file-header contract)."""
+    # .rb has no tuned pattern; detect_language returns None.
+    lines = [f"require 'lib{i}'" for i in range(12)]
+    body = "\n".join(lines) + "\n"
+    path = _write(tmp_path, "many_imports.rb", body)
+    coupling = assess_file(path, "production", False).coupling
+    assert coupling.confidence == 0.0
+    # Even a low coupling score must not fail the gate when unscored.
+    config = _default_config()
+    config["thresholds"]["coupling"] = {"min": 7}
+    assert check_thresholds([assess_file(path, "production", False)], config, "production") == 0
+
+
+def test_unreadable_file_is_unscored_not_passed(tmp_path: Path) -> None:
+    """A file that cannot be read must come back all-unscored (confidence 0.0)
+    so the gate skips it, instead of scoring empty content as a perfect 10."""
+    missing = tmp_path / "gone.py"  # never created -> open() raises OSError
+    assessment = assess_file(missing, "production", False)
+    for score in (
+        assessment.cohesion,
+        assessment.coupling,
+        assessment.encapsulation,
+        assessment.testability,
+        assessment.non_redundancy,
+    ):
+        assert score.confidence == 0.0
+    # An unreadable file must not fail (or pass by scoring) any threshold.
+    assert check_thresholds([assessment], _default_config(), "production") == 0

--- a/.claude/skills/code-qualities-assessment/tests/test_assess.py
+++ b/.claude/skills/code-qualities-assessment/tests/test_assess.py
@@ -181,6 +181,52 @@ def test_testability_not_constant_across_languages(tmp_path: Path) -> None:
     assert dirty_score.value < clean_score.value
 
 
+def test_csharp_using_static_not_counted_as_state(tmp_path: Path) -> None:
+    """Regression: `using static` is an import (dependency), not mutable
+    static state, so it must not lower testability."""
+    plain = _write(
+        tmp_path,
+        "Plain.cs",
+        "public class Plain {\n    public int Add(int a, int b) => a + b;\n}\n",
+    )
+    with_static_import = _write(
+        tmp_path,
+        "WithImport.cs",
+        "using static System.Math;\n\n"
+        "public class WithImport {\n"
+        "    public double Hyp(double a, double b) => Sqrt(a * a + b * b);\n"
+        "}\n",
+    )
+
+    plain_score = assess_file(plain, "production", False).testability
+    import_score = assess_file(with_static_import, "production", False).testability
+
+    assert import_score.value == plain_score.value
+
+
+def test_java_import_static_not_counted_as_state(tmp_path: Path) -> None:
+    """Regression: `import static` is an import (dependency), not mutable
+    static state, so it must not lower testability."""
+    plain = _write(
+        tmp_path,
+        "Plain.java",
+        "public class Plain {\n    int add(int a, int b) { return a + b; }\n}\n",
+    )
+    with_static_import = _write(
+        tmp_path,
+        "WithImport.java",
+        "import static org.junit.Assert.assertEquals;\n\n"
+        "public class WithImport {\n"
+        "    void check() { assertEquals(1, 1); }\n"
+        "}\n",
+    )
+
+    plain_score = assess_file(plain, "production", False).testability
+    import_score = assess_file(with_static_import, "production", False).testability
+
+    assert import_score.value == plain_score.value
+
+
 def test_testability_python_global_state(tmp_path: Path) -> None:
     clean = _write(tmp_path, "clean.py", "def f():\n    return 1\n")
     dirty = _write(

--- a/.claude/skills/code-qualities-assessment/tests/test_assess.py
+++ b/.claude/skills/code-qualities-assessment/tests/test_assess.py
@@ -1,0 +1,270 @@
+"""Direction and gate tests for the code-qualities-assessment assess.py heuristics.
+
+These tests pin the SCORE DIRECTION (which of two files should score higher for
+a quality) and the threshold-gate behavior, not exact numeric values. They guard
+the bugs fixed for issue #2994:
+
+- Coupling threshold inversion: loosely coupled files no longer fail the gate.
+- Language-blind testability/encapsulation: non-Python files are no longer
+  scored as a constant 10; unsupported languages are marked unscored
+  (confidence 0.0) and skipped by the gate instead of false-passing or
+  false-failing.
+- Cohesion measured size+definitions instead of size alone.
+- Import counting recognizes C#/Java/Go imports, not just Python.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_DIR = Path(__file__).parent.parent / "scripts"
+
+_spec = importlib.util.spec_from_file_location("assess", _SCRIPT_DIR / "assess.py")
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+assess_file = _mod.assess_file
+check_thresholds = _mod.check_thresholds
+detect_language = _mod.detect_language
+load_config = _mod.load_config
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _default_config() -> dict:
+    # load_config with a nonexistent path returns the built-in defaults.
+    return load_config(str(Path("/nonexistent/.qualityrc.json")))
+
+
+# --------------------------------------------------------------------------- #
+# detect_language
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("a.py", "python"),
+        ("a.ts", "typescript"),
+        ("a.tsx", "typescript"),
+        ("a.js", "javascript"),
+        ("a.cs", "csharp"),
+        ("a.java", "java"),
+        ("a.go", "go"),
+        ("a.rb", None),
+        ("a.txt", None),
+    ],
+)
+def test_detect_language(name: str, expected: str | None) -> None:
+    assert detect_language(Path(name)) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Coupling: direction + threshold is no longer inverted
+# --------------------------------------------------------------------------- #
+
+
+def test_coupling_direction_python(tmp_path: Path) -> None:
+    standalone = _write(tmp_path, "standalone.py", "def f():\n    return 1\n")
+    heavy_body = "".join(f"import mod{i}\n" for i in range(15)) + "def f():\n    return 1\n"
+    heavy = _write(tmp_path, "heavy.py", heavy_body)
+
+    standalone_score = assess_file(standalone, "production", False).coupling.value
+    heavy_score = assess_file(heavy, "production", False).coupling.value
+
+    # Fewer imports => looser coupling => higher score (10 is best).
+    assert standalone_score > heavy_score
+
+
+def test_loosely_coupled_file_passes_gate(tmp_path: Path) -> None:
+    """The inversion bug: a loosely coupled file (coupling score ~10) used to
+    FAIL because the gate compared coupling > max=3. It must now pass."""
+    standalone = _write(tmp_path, "standalone.py", "def f():\n    return 1\n")
+    assessment = assess_file(standalone, "production", False)
+    assert assessment.coupling.value >= 9  # loosely coupled, near-perfect
+
+    rc = check_thresholds([assessment], _default_config(), "production")
+    # Coupling alone must not fail this file. (Other qualities on a trivial
+    # one-function file are all high, so the overall gate passes.)
+    assert rc == 0
+
+
+def test_csharp_imports_counted(tmp_path: Path) -> None:
+    """C# `using` directives count toward coupling; previously only Python
+    `import ` did, so every C# file looked maximally decoupled."""
+    body = (
+        "using System;\n"
+        "using System.Linq;\n"
+        "using System.Collections.Generic;\n"
+        "public class Foo { public int X; }\n"
+    )
+    path = _write(tmp_path, "Foo.cs", body)
+    score = assess_file(path, "production", False).coupling.value
+    # 3 usings => coupling score 7, strictly below the perfect 10.
+    assert score < 10
+
+
+# --------------------------------------------------------------------------- #
+# Cohesion: god object scores lower than a focused class
+# --------------------------------------------------------------------------- #
+
+
+def test_cohesion_god_object_lower_than_focused(tmp_path: Path) -> None:
+    focused = _write(
+        tmp_path,
+        "focused.py",
+        "class Focused:\n"
+        "    def a(self):\n        return 1\n"
+        "    def b(self):\n        return 2\n",
+    )
+    god_methods = "".join(
+        f"    def m{i}(self):\n        x = {i}\n        return x\n" for i in range(40)
+    )
+    god = _write(tmp_path, "god.py", "class God:\n" + god_methods)
+
+    focused_score = assess_file(focused, "production", False).cohesion.value
+    god_score = assess_file(god, "production", False).cohesion.value
+
+    assert god_score < focused_score
+
+
+# --------------------------------------------------------------------------- #
+# Testability: not a constant across languages
+# --------------------------------------------------------------------------- #
+
+
+def test_testability_not_constant_across_languages(tmp_path: Path) -> None:
+    """Regression guard: previously testability was 10 for every non-Python
+    file because global-state detection was Python-only."""
+    clean_cs = _write(
+        tmp_path,
+        "Clean.cs",
+        "public class Clean {\n    public int Add(int a, int b) => a + b;\n}\n",
+    )
+    dirty_cs = _write(
+        tmp_path,
+        "Dirty.cs",
+        "public class Dirty {\n"
+        "    private static int _counter = 0;\n"
+        "    public static string Cache = \"x\";\n"
+        "    public int Next() => _counter++;\n"
+        "}\n",
+    )
+
+    clean_score = assess_file(clean_cs, "production", False).testability
+    dirty_score = assess_file(dirty_cs, "production", False).testability
+
+    assert clean_score.confidence > 0.0
+    assert dirty_score.confidence > 0.0
+    # Mutable static state hurts testability.
+    assert dirty_score.value < clean_score.value
+
+
+def test_testability_python_global_state(tmp_path: Path) -> None:
+    clean = _write(tmp_path, "clean.py", "def f():\n    return 1\n")
+    dirty = _write(
+        tmp_path,
+        "dirty.py",
+        "_x = 0\n\n\ndef f():\n    global _x\n    _x += 1\n    return _x\n",
+    )
+    assert (
+        assess_file(dirty, "production", False).testability.value
+        < assess_file(clean, "production", False).testability.value
+    )
+
+
+def test_testability_unscored_for_unknown_language(tmp_path: Path) -> None:
+    path = _write(tmp_path, "thing.rb", "def foo\n  1\nend\n")
+    score = assess_file(path, "production", False).testability
+    assert score.confidence == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Encapsulation: unscored where visibility cannot be detected reliably
+# --------------------------------------------------------------------------- #
+
+
+def test_encapsulation_unscored_for_javascript(tmp_path: Path) -> None:
+    path = _write(tmp_path, "a.js", "function f() { return 1; }\n")
+    score = assess_file(path, "production", False).encapsulation
+    assert score.confidence == 0.0
+
+
+def test_encapsulation_scored_for_python(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "a.py",
+        "class C:\n    def _helper(self):\n        return 1\n"
+        "    def public(self):\n        return self._helper()\n",
+    )
+    score = assess_file(path, "production", False).encapsulation
+    assert score.confidence > 0.0
+    assert score.value == 10.0  # methods-only API, no exposed fields
+
+
+def test_encapsulation_public_fields_lower_score(tmp_path: Path) -> None:
+    hidden = _write(
+        tmp_path,
+        "hidden.py",
+        "class C:\n    def __init__(self):\n        self._x = 0\n"
+        "    def value(self):\n        return self._x\n",
+    )
+    exposed = _write(
+        tmp_path,
+        "exposed.py",
+        "class C:\n    def __init__(self):\n        self.x = 0\n        self.y = 1\n",
+    )
+    assert (
+        assess_file(exposed, "production", False).encapsulation.value
+        < assess_file(hidden, "production", False).encapsulation.value
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Gate skips unscored qualities (confidence 0.0) instead of false-failing
+# --------------------------------------------------------------------------- #
+
+
+def test_gate_skips_unscored_qualities(tmp_path: Path) -> None:
+    """An unknown-language file leaves testability and encapsulation unscored.
+    The gate must not fail on a quality it could not measure."""
+    path = _write(tmp_path, "thing.rb", "def foo\n  1\nend\n")
+    assessment = assess_file(path, "production", False)
+    assert assessment.testability.confidence == 0.0
+    assert assessment.encapsulation.confidence == 0.0
+
+    rc = check_thresholds([assessment], _default_config(), "production")
+    assert rc == 0
+
+
+def test_gate_legacy_coupling_max_only_config_does_not_crash(tmp_path: Path) -> None:
+    """A legacy config specifying only coupling.max (no min) must not KeyError;
+    coupling gating is simply skipped for it."""
+    path = _write(tmp_path, "standalone.py", "def f():\n    return 1\n")
+    assessment = assess_file(path, "production", False)
+
+    legacy = _default_config()
+    legacy["thresholds"]["coupling"] = {"max": 3, "warn": 5}  # no "min"
+
+    rc = check_thresholds([assessment], legacy, "production")
+    assert rc == 0
+
+
+def test_gate_fails_tightly_coupled_file(tmp_path: Path) -> None:
+    """Positive control: a heavily-imported file scores below coupling.min=7
+    and the gate fails it."""
+    heavy_body = "".join(f"import mod{i}\n" for i in range(9)) + "def f():\n    return 1\n"
+    heavy = _write(tmp_path, "heavy.py", heavy_body)
+    assessment = assess_file(heavy, "production", False)
+    assert assessment.coupling.value < 7
+
+    rc = check_thresholds([assessment], _default_config(), "production")
+    assert rc == 11

--- a/.claude/skills/code-qualities-assessment/tests/test_assess.py
+++ b/.claude/skills/code-qualities-assessment/tests/test_assess.py
@@ -519,7 +519,7 @@ def test_read_error_is_reported_as_unscored(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     path = _write(tmp_path, "broken.py", "def f():\n    return 1\n")
-    real_open = builtins.open
+    real_open: Any = builtins.open
 
     def raise_permission_error(file: Any, *args: Any, **kwargs: Any) -> Any:
         if file == path:

--- a/.claude/skills/code-qualities-assessment/tests/test_assess.py
+++ b/.claude/skills/code-qualities-assessment/tests/test_assess.py
@@ -15,6 +15,7 @@ the bugs fixed for issue #2994:
 
 from __future__ import annotations
 
+import builtins
 import importlib.util
 from pathlib import Path
 from typing import Any
@@ -32,6 +33,8 @@ assess_file = _mod.assess_file
 check_thresholds = _mod.check_thresholds
 detect_language = _mod.detect_language
 get_files_to_assess = _mod.get_files_to_assess
+generate_json_report = _mod.generate_json_report
+generate_markdown_report = _mod.generate_markdown_report
 load_config = _mod.load_config
 
 
@@ -362,6 +365,113 @@ def test_go_aliased_and_dot_imports_counted(tmp_path: Path) -> None:
     assert coupling.value == 6
 
 
+@pytest.mark.parametrize(
+    "import_line",
+    [
+        'import _ "fmt"\n',
+        'import myfmt "fmt"\n',
+        'import . "fmt"\n',
+    ],
+)
+def test_go_single_line_named_blank_and_dot_imports_counted(
+    tmp_path: Path, import_line: str
+) -> None:
+    body = "package main\n\n" + import_line + "\nfunc main() {}\n"
+    path = _write(tmp_path, "main.go", body)
+
+    coupling = assess_file(path, "production", False).coupling
+
+    assert coupling.value == 9
+
+
+def test_go_named_blank_and_dot_imports_counted_inside_block(tmp_path: Path) -> None:
+    body = (
+        "package main\n\n"
+        "import (\n"
+        '    myfmt "fmt"\n'
+        '    _ "database/sql"\n'
+        '    . "strings"\n'
+        ")\n\n"
+        "func main() {}\n"
+    )
+    path = _write(tmp_path, "main.go", body)
+
+    coupling = assess_file(path, "production", False).coupling
+
+    assert coupling.value == 7
+
+
+def test_go_package_var_block_counts_as_global_state(tmp_path: Path) -> None:
+    clean = _write(tmp_path, "clean.go", "package main\n\nfunc main() {}\n")
+    dirty = _write(
+        tmp_path,
+        "dirty.go",
+        "package main\n\n"
+        "var (\n"
+        "    counter int\n"
+        "    cache = map[string]string{}\n"
+        ")\n\n"
+        "func main() {}\n",
+    )
+
+    clean_score = assess_file(clean, "production", False).testability
+    dirty_score = assess_file(dirty, "production", False).testability
+
+    assert dirty_score.value < clean_score.value
+
+
+def test_go_indented_local_var_block_not_counted_as_global_state(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "local.go",
+        "package main\n\n"
+        "func main() {\n"
+        "    var (\n"
+        "        local int\n"
+        "    )\n"
+        "    _ = local\n"
+        "}\n",
+    )
+
+    testability = assess_file(path, "production", False).testability
+
+    assert testability.value == 10
+
+
+def test_python_public_fields_are_deduplicated_by_name(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "fields.py",
+        "class C:\n"
+        "    def first(self):\n"
+        "        self.x = 1\n"
+        "    def second(self):\n"
+        "        self.x = 2\n",
+    )
+
+    encapsulation = assess_file(path, "production", False).encapsulation
+
+    assert encapsulation.reasons[0] == "1 exposed public field(s)"
+
+
+@pytest.mark.parametrize(
+    ("name", "body"),
+    [
+        ("Constants.cs", "public class C {\n    public const int Answer = 42;\n}\n"),
+        ("Readonly.cs", "public class C {\n    public readonly int Answer = 42;\n}\n"),
+        ("Final.java", "public class C {\n    public final int answer = 42;\n}\n"),
+    ],
+)
+def test_public_immutable_fields_do_not_lower_encapsulation(
+    tmp_path: Path, name: str, body: str
+) -> None:
+    path = _write(tmp_path, name, body)
+
+    encapsulation = assess_file(path, "production", False).encapsulation
+
+    assert encapsulation.value == 10
+
+
 def test_untuned_language_coupling_not_gated(tmp_path: Path) -> None:
     """A language without a tuned import pattern is counted only for the report
     (confidence 0.0), so check_thresholds skips it rather than gating on an
@@ -372,6 +482,16 @@ def test_untuned_language_coupling_not_gated(tmp_path: Path) -> None:
     path = _write(tmp_path, "many_imports.rb", body)
     coupling = assess_file(path, "production", False).coupling
     assert coupling.confidence == 0.0
+    assert all(
+        score.confidence == 0.0
+        for score in (
+            assess_file(path, "production", False).cohesion,
+            assess_file(path, "production", False).coupling,
+            assess_file(path, "production", False).encapsulation,
+            assess_file(path, "production", False).testability,
+            assess_file(path, "production", False).non_redundancy,
+        )
+    )
     # Even a low coupling score must not fail the gate when unscored.
     config = _default_config()
     config["thresholds"]["coupling"] = {"min": 7}
@@ -393,3 +513,94 @@ def test_unreadable_file_is_unscored_not_passed(tmp_path: Path) -> None:
         assert score.confidence == 0.0
     # An unreadable file must not fail (or pass by scoring) any threshold.
     assert check_thresholds([assessment], _default_config(), "production") == 0
+
+
+def test_read_error_is_reported_as_unscored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _write(tmp_path, "broken.py", "def f():\n    return 1\n")
+    real_open = builtins.open
+
+    def raise_permission_error(file: Any, *args: Any, **kwargs: Any) -> Any:
+        if file == path:
+            raise PermissionError("blocked")
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", raise_permission_error)
+
+    assessment = assess_file(path, "production", False)
+
+    assert assessment.overall == 0.0
+    assert all(
+        score.confidence == 0.0
+        for score in (
+            assessment.cohesion,
+            assessment.coupling,
+            assessment.encapsulation,
+            assessment.testability,
+            assessment.non_redundancy,
+        )
+    )
+    assert "blocked" in assessment.cohesion.reasons[0]
+    assert check_thresholds([assessment], _default_config(), "production") == 0
+
+
+def test_markdown_report_displays_unscored_metrics_as_na(tmp_path: Path) -> None:
+    path = _write(tmp_path, "unknown.rb", "require 'x'\n")
+    assessment = assess_file(path, "production", False)
+
+    report = generate_markdown_report([assessment], _default_config())
+
+    assert "**Overall**: n/a" in report
+    assert "- **Cohesion**: unscored (n/a)" in report
+    assert "**Average Cohesion**: n/a" in report
+    assert "10.0/10" not in report
+
+
+def test_json_report_excludes_unscored_metrics_from_average(tmp_path: Path) -> None:
+    import json
+
+    path = _write(tmp_path, "unknown.rb", "require 'x'\n")
+    assessment = assess_file(path, "production", False)
+
+    report = json.loads(generate_json_report([assessment]))
+
+    assert report["summary"]["average_scores"]["cohesion"] is None
+
+
+def test_overall_ignores_unscored_metrics(tmp_path: Path) -> None:
+    path = _write(tmp_path, "mixed.py", "def f():\n    return 1\n")
+    assessment = assess_file(path, "production", False)
+    assessment.encapsulation.confidence = 0.0
+    assessment.encapsulation.value = 10.0
+    assessment.coupling.value = 4.0
+
+    scored_values = [
+        assessment.cohesion.value,
+        assessment.coupling.value,
+        assessment.testability.value,
+        assessment.non_redundancy.value,
+    ]
+
+    assert assessment.overall == pytest.approx(sum(scored_values) / len(scored_values))
+
+
+def test_markdown_report_uses_configured_thresholds(tmp_path: Path) -> None:
+    path = _write(tmp_path, "imports.py", "import a\nimport b\n\ndef f():\n    return 1\n")
+    assessment = assess_file(path, "production", False)
+    config = _default_config()
+    config["thresholds"]["coupling"] = {"min": 9}
+
+    report = generate_markdown_report([assessment], config)
+
+    assert "**Coupling Issues**:" in report
+    assert "2 import/dependency statements" in report
+
+
+def test_load_config_reads_utf8_json(tmp_path: Path) -> None:
+    config_path = tmp_path / ".qualityrc.json"
+    config_path.write_text('{"thresholds": {}, "label": "café"}', encoding="utf-8")
+
+    config = load_config(str(config_path))
+
+    assert config["label"] == "café"

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/code-qualities-assessment/README.md
+++ b/src/copilot-cli/skills/code-qualities-assessment/README.md
@@ -45,11 +45,11 @@ Create `.qualityrc.json` in your project root:
 ```json
 {
   "thresholds": {
-    "cohesion": { "min": 7, "warn": 5 },
-    "coupling": { "max": 3, "warn": 5 },
-    "encapsulation": { "min": 7, "warn": 5 },
-    "testability": { "min": 6, "warn": 4 },
-    "nonRedundancy": { "min": 8, "warn": 6 }
+    "cohesion": { "min": 7 },
+    "coupling": { "min": 7 },
+    "encapsulation": { "min": 7 },
+    "testability": { "min": 6 },
+    "nonRedundancy": { "min": 8 }
   },
   "ignore": ["**/generated/**", "**/*.pb.py"]
 }

--- a/src/copilot-cli/skills/code-qualities-assessment/SKILL.md
+++ b/src/copilot-cli/skills/code-qualities-assessment/SKILL.md
@@ -143,11 +143,11 @@ Create `.qualityrc.json` to customize thresholds:
 ```json
 {
   "thresholds": {
-    "cohesion": { "min": 7, "warn": 5 },
-    "coupling": { "min": 7, "warn": 5 },
-    "encapsulation": { "min": 7, "warn": 5 },
-    "testability": { "min": 6, "warn": 4 },
-    "nonRedundancy": { "min": 8, "warn": 6 }
+    "cohesion": { "min": 7 },
+    "coupling": { "min": 7 },
+    "encapsulation": { "min": 7 },
+    "testability": { "min": 6 },
+    "nonRedundancy": { "min": 8 }
   },
   "context": {
     "test": {
@@ -280,7 +280,7 @@ Output:
 
 ## Summary
 - **Cohesion**: 8/10
-- **Coupling**: 4/10 (warning)
+- **Coupling**: 4/10
 - **Encapsulation**: 9/10
 - **Testability**: 7/10
 - **Non-Redundancy**: 9/10

--- a/src/copilot-cli/skills/code-qualities-assessment/SKILL.md
+++ b/src/copilot-cli/skills/code-qualities-assessment/SKILL.md
@@ -144,7 +144,7 @@ Create `.qualityrc.json` to customize thresholds:
 {
   "thresholds": {
     "cohesion": { "min": 7, "warn": 5 },
-    "coupling": { "max": 3, "warn": 5 },
+    "coupling": { "min": 7, "warn": 5 },
     "encapsulation": { "min": 7, "warn": 5 },
     "testability": { "min": 6, "warn": 4 },
     "nonRedundancy": { "min": 8, "warn": 6 }

--- a/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
@@ -25,8 +25,8 @@ from pathlib import Path
 from typing import Any
 
 # Language detection by file suffix. Only languages with tuned heuristics are
-# listed; anything else is analyzed with generic fallbacks and reduced
-# confidence so the gate never fails a file it cannot actually score.
+# listed. Unsupported files are reported as unscored for gate purposes so the
+# gate never fails a file it cannot actually score.
 _LANGUAGE_BY_SUFFIX = {
     ".py": "python",
     ".ts": "typescript",
@@ -59,14 +59,17 @@ _IMPORT_PATTERNS = {
     "typescript": re.compile(r"^\s*import\s+|\brequire\s*\("),
     "csharp": re.compile(r"^\s*using\s+[A-Za-z_]"),
     "java": re.compile(r"^\s*import\s+[A-Za-z_]"),
-    "go": re.compile(r'^\s*import\s+(?:[\w.]+\s+)?"|^\s+(?:[\w.]+\s+)?"[^"]+"\s*$'),
+    "go": re.compile(
+        r'^\s*import\s+(?:(?:[A-Za-z_]\w*|\.)\s+)?"[^"]+"\s*$'
+        r'|^\s+(?:(?:[A-Za-z_]\w*|\.)\s+)?"[^"]+"\s*$'
+    ),
 }
 
 # Generic import fallback for languages without a tuned pattern.
 _GENERIC_IMPORT_PATTERN = re.compile(r"^\s*(?:import|from|using|require|#include)\b")
 
 # Per-language definition patterns (types, functions, methods) for the cohesion
-# heuristic. More top-level definitions plus larger size means lower cohesion.
+# heuristic. More definitions plus larger size means lower cohesion.
 _DEFINITION_PATTERNS = {
     "python": re.compile(r"^\s*(?:async\s+)?def\s+\w|^\s*class\s+\w"),
     "javascript": re.compile(
@@ -109,14 +112,33 @@ def _count_web_global_state(lines: list[str]) -> int:
     patterns = (
         re.compile(r"\bglobalThis\b"),
         re.compile(r"\bwindow\.\w+\s*="),
-        re.compile(r"^var\s+\w"),
+        re.compile(r"^(?:var|let|const)\s+\w"),
     )
     return sum(1 for line in lines if any(p.search(line) for p in patterns))
 
 
 def _count_go_global_state(lines: list[str]) -> int:
     # Package-level (unindented) var declarations are mutable global state.
-    return sum(1 for line in lines if re.match(r"^var\s+\w", line))
+    count = 0
+    in_package_var_block = False
+    for line in lines:
+        stripped = line.strip()
+        if in_package_var_block:
+            if stripped == ")":
+                in_package_var_block = False
+                continue
+            if not stripped or stripped.startswith("//"):
+                continue
+            if re.match(r"^[A-Za-z_]\w*(?:\s|,|=)", stripped):
+                count += 1
+            continue
+
+        if re.match(r"^var\s+\(", line):
+            in_package_var_block = True
+            continue
+        if re.match(r"^var\s+\w", line):
+            count += 1
+    return count
 
 
 def _immutable_static(stripped: str, immutable_keywords: tuple[str, ...]) -> bool:
@@ -164,9 +186,13 @@ _GLOBAL_STATE_COUNTERS = {
 
 def _count_python_public_fields(lines: list[str]) -> int:
     pattern = re.compile(r"(?<!\w)self\.([A-Za-z]\w*)\s*=(?!=)")
-    return sum(
-        1 for line in lines for m in pattern.finditer(line) if not m.group(1).startswith("_")
-    )
+    fields = {
+        m.group(1)
+        for line in lines
+        for m in pattern.finditer(line)
+        if not m.group(1).startswith("_")
+    }
+    return len(fields)
 
 
 def _count_public_fields_by_modifier(lines: list[str]) -> int:
@@ -187,6 +213,8 @@ def _count_public_fields_by_modifier(lines: list[str]) -> int:
             kw in stripped
             for kw in ("class ", "interface ", "struct ", "enum ", "record ")
         ):
+            continue
+        if any(kw in stripped.split() for kw in ("const", "readonly", "final")):
             continue
         if stripped.endswith(";") or "=" in stripped:
             count += 1
@@ -229,14 +257,21 @@ class FileAssessment:
 
     @property
     def overall(self) -> float:
-        """Weighted average of all qualities"""
-        return (
-            self.cohesion.value +
-            self.coupling.value +
-            self.encapsulation.value +
-            self.testability.value +
-            self.non_redundancy.value
-        ) / 5
+        """Average of scored qualities only."""
+        scored_values = [
+            score.value
+            for score in (
+                self.cohesion,
+                self.coupling,
+                self.encapsulation,
+                self.testability,
+                self.non_redundancy,
+            )
+            if score.confidence > 0.0
+        ]
+        if not scored_values:
+            return 0.0
+        return sum(scored_values) / len(scored_values)
 
 
 def parse_args() -> argparse.Namespace:
@@ -287,7 +322,7 @@ def parse_args() -> argparse.Namespace:
 def load_config(config_path: str) -> dict[str, Any]:
     """Load configuration or return defaults"""
     try:
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             config: dict[str, Any] = json.load(f)
             return config
     except FileNotFoundError:
@@ -339,7 +374,7 @@ def get_files_to_assess(target: str, changed_only: bool) -> list[Path]:
 
 
 def _score_cohesion(language: str | None, code_lines: list[str], loc: int) -> QualityScore:
-    """Approximate cohesion from size plus top-level definition count.
+    """Approximate cohesion from size plus definition count.
 
     This is a size+definition approximation, not a true LCOM cohesion metric.
     More definitions packed into a larger file suggests the file is doing many
@@ -351,11 +386,14 @@ def _score_cohesion(language: str | None, code_lines: list[str], loc: int) -> Qu
     )
     score = 10.0 - (loc / 120.0) - max(0, def_count - 1) * 0.3
     score = max(1.0, min(10.0, score))
-    confidence = 0.4 if pattern else 0.3
+    confidence = 0.4 if pattern else 0.0
     reasons = [
-        f"{loc} LOC, {def_count} top-level definitions "
+        f"{loc} LOC, {def_count} definitions "
         "(size+definition approximation, not LCOM)",
         (
+            "Definition count not scored for this language"
+            if pattern is None
+            else
             "Large file with many definitions suggests low cohesion"
             if score < 7
             else "Size and definition count are reasonable"
@@ -458,16 +496,17 @@ def _score_testability(language: str | None, code_lines: list[str]) -> QualitySc
     return QualityScore(value=round(score, 1), confidence=0.5, reasons=reasons)
 
 
-def _score_non_redundancy(lines: list[str]) -> QualityScore:
+def _score_non_redundancy(lines: list[str], scored: bool) -> QualityScore:
     """Approximate non-redundancy from the ratio of unique to total lines.
 
     This is language-agnostic and unchanged in spirit from the original
     heuristic.
     """
+    confidence = 0.5 if scored else 0.0
     non_blank = [line.strip() for line in lines if line.strip()]
     if not non_blank:
         return QualityScore(
-            value=10.0, confidence=0.5, reasons=["Empty file, no duplication"]
+            value=10.0, confidence=confidence, reasons=["Empty file, no duplication"]
         )
     unique_lines = len(set(non_blank))
     score = (unique_lines / len(non_blank)) * 10.0
@@ -475,7 +514,9 @@ def _score_non_redundancy(lines: list[str]) -> QualityScore:
         f"{unique_lines}/{len(non_blank)} unique non-blank lines",
         "High duplication detected" if score < 7 else "Low duplication",
     ]
-    return QualityScore(value=round(score, 1), confidence=0.5, reasons=reasons)
+    if not scored:
+        reasons.append("Non-redundancy not scored for this language")
+    return QualityScore(value=round(score, 1), confidence=confidence, reasons=reasons)
 
 
 def _unreadable_assessment(file_path: Path, reason: str) -> FileAssessment:
@@ -537,8 +578,37 @@ def assess_file(file_path: Path, context: str, use_serena: bool) -> FileAssessme
         coupling=_score_coupling(language, code_lines),
         encapsulation=_score_encapsulation(language, code_lines),
         testability=_score_testability(language, code_lines),
-        non_redundancy=_score_non_redundancy(lines),
+        non_redundancy=_score_non_redundancy(lines, language is not None),
     )
+
+
+def _average_scored(scores: list[QualityScore]) -> float | None:
+    values = [score.value for score in scores if score.confidence > 0.0]
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _format_average(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.1f}/10"
+
+
+def _format_quality_score(score: QualityScore) -> str:
+    if score.confidence == 0.0:
+        return "unscored (n/a)"
+    return f"{score.value:.1f}/10"
+
+
+def _threshold_min(thresholds: dict[str, Any], key: str) -> float | None:
+    threshold = thresholds.get(key, {})
+    value = threshold.get("min")
+    return float(value) if value is not None else None
+
+
+def _score_below_threshold(score: QualityScore, threshold: float | None) -> bool:
+    return threshold is not None and score.confidence > 0.0 and score.value < threshold
 
 
 def generate_markdown_report(assessments: list[FileAssessment], config: dict[str, Any]) -> str:
@@ -549,69 +619,62 @@ def generate_markdown_report(assessments: list[FileAssessment], config: dict[str
     if not assessments:
         return "No files assessed."
 
-    avg_cohesion = sum(a.cohesion.value for a in assessments) / len(assessments)
-    avg_coupling = sum(a.coupling.value for a in assessments) / len(assessments)
-    avg_encap = sum(a.encapsulation.value for a in assessments) / len(assessments)
-    avg_test = sum(a.testability.value for a in assessments) / len(assessments)
-    avg_nonred = sum(a.non_redundancy.value for a in assessments) / len(assessments)
+    avg_cohesion = _average_scored([a.cohesion for a in assessments])
+    avg_coupling = _average_scored([a.coupling for a in assessments])
+    avg_encap = _average_scored([a.encapsulation for a in assessments])
+    avg_test = _average_scored([a.testability for a in assessments])
+    avg_nonred = _average_scored([a.non_redundancy for a in assessments])
+    thresholds = config["thresholds"]
 
     report.append("## Summary\n")
     report.append(f"**Files Assessed**: {len(assessments)}\n")
-    report.append(f"**Average Cohesion**: {avg_cohesion:.1f}/10")
-    report.append(f"**Average Coupling**: {avg_coupling:.1f}/10")
-    report.append(f"**Average Encapsulation**: {avg_encap:.1f}/10")
-    report.append(f"**Average Testability**: {avg_test:.1f}/10")
-    report.append(f"**Average Non-Redundancy**: {avg_nonred:.1f}/10\n")
+    report.append(f"**Average Cohesion**: {_format_average(avg_cohesion)}")
+    report.append(f"**Average Coupling**: {_format_average(avg_coupling)}")
+    report.append(f"**Average Encapsulation**: {_format_average(avg_encap)}")
+    report.append(f"**Average Testability**: {_format_average(avg_test)}")
+    report.append(f"**Average Non-Redundancy**: {_format_average(avg_nonred)}\n")
 
     # Per-file breakdown
     report.append("## File Assessments\n")
     for assessment in sorted(assessments, key=lambda a: a.overall):
         report.append(f"### {assessment.file_path}\n")
-        report.append(f"**Overall**: {assessment.overall:.1f}/10\n")
-        report.append(f"- **Cohesion**: {assessment.cohesion.value}/10")
-        report.append(f"- **Coupling**: {assessment.coupling.value}/10")
-        report.append(f"- **Encapsulation**: {assessment.encapsulation.value}/10")
-        report.append(f"- **Testability**: {assessment.testability.value}/10")
-        report.append(f"- **Non-Redundancy**: {assessment.non_redundancy.value}/10\n")
+        overall = _format_average(assessment.overall if assessment.overall > 0 else None)
+        report.append(f"**Overall**: {overall}\n")
+        quality_rows = (
+            ("Cohesion", "cohesion", assessment.cohesion),
+            ("Coupling", "coupling", assessment.coupling),
+            ("Encapsulation", "encapsulation", assessment.encapsulation),
+            ("Testability", "testability", assessment.testability),
+            ("Non-Redundancy", "nonRedundancy", assessment.non_redundancy),
+        )
+        for label, _, score in quality_rows:
+            report.append(f"- **{label}**: {_format_quality_score(score)}")
+        report.append("")
 
         # Show reasons for low scores
-        if assessment.cohesion.value < 7:
-            report.append("**Cohesion Issues**:")
-            for reason in assessment.cohesion.reasons:
-                report.append(f"  - {reason}")
-            report.append("")
-
-        if assessment.coupling.value < 7:
-            report.append("**Coupling Issues**:")
-            for reason in assessment.coupling.reasons:
-                report.append(f"  - {reason}")
-            report.append("")
+        for label, threshold_key, score in quality_rows:
+            if _score_below_threshold(score, _threshold_min(thresholds, threshold_key)):
+                report.append(f"**{label} Issues**:")
+                for reason in score.reasons:
+                    report.append(f"  - {reason}")
+                report.append("")
 
     return "\n".join(report)
 
 
 def generate_json_report(assessments: list[FileAssessment]) -> str:
     """Generate JSON report"""
-    count = len(assessments) if assessments else 1
     return json.dumps({
         "files": [asdict(a) for a in assessments],
         "summary": {
             "file_count": len(assessments),
             "average_scores": {
-                "cohesion": (
-                    sum(a.cohesion.value for a in assessments) / count if assessments else 0
-                ),
-                "coupling": (
-                    sum(a.coupling.value for a in assessments) / count if assessments else 0
-                ),
-                "encapsulation": (
-                    sum(a.encapsulation.value for a in assessments) / count if assessments else 0
-                ),
-                "testability": (
-                    sum(a.testability.value for a in assessments) / count if assessments else 0
-                ),
-                "non_redundancy": (
-                    sum(a.non_redundancy.value for a in assessments) / count if assessments else 0
+                "cohesion": _average_scored([a.cohesion for a in assessments]),
+                "coupling": _average_scored([a.coupling for a in assessments]),
+                "encapsulation": _average_scored([a.encapsulation for a in assessments]),
+                "testability": _average_scored([a.testability for a in assessments]),
+                "non_redundancy": _average_scored(
+                    [a.non_redundancy for a in assessments]
                 ),
             }
         }

--- a/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
@@ -152,6 +152,8 @@ def _count_csharp_static_state(lines: list[str]) -> int:
         stripped = line.strip()
         if "static" not in stripped or "(" in stripped:
             continue
+        if stripped.startswith("using "):
+            continue
         if _immutable_static(stripped, ("readonly", "const ")):
             continue
         if stripped.endswith(";") or "=" in stripped:
@@ -164,6 +166,8 @@ def _count_java_static_state(lines: list[str]) -> int:
     for line in lines:
         stripped = line.strip()
         if "static" not in stripped or "(" in stripped:
+            continue
+        if stripped.startswith("import "):
             continue
         if _immutable_static(stripped, ("final",)):
             continue

--- a/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
@@ -59,7 +59,7 @@ _IMPORT_PATTERNS = {
     "typescript": re.compile(r"^\s*import\s+|\brequire\s*\("),
     "csharp": re.compile(r"^\s*using\s+[A-Za-z_]"),
     "java": re.compile(r"^\s*import\s+[A-Za-z_]"),
-    "go": re.compile(r'^\s*import\s+[("]|^\s+_?\s*"[^"]+"\s*$'),
+    "go": re.compile(r'^\s*import\s+"|^\s+_?\s*"[^"]+"\s*$'),
 }
 
 # Generic import fallback for languages without a tuned pattern.
@@ -109,7 +109,7 @@ def _count_web_global_state(lines: list[str]) -> int:
     patterns = (
         re.compile(r"\bglobalThis\b"),
         re.compile(r"\bwindow\.\w+\s*="),
-        re.compile(r"^\s*var\s+\w"),
+        re.compile(r"^var\s+\w"),
     )
     return sum(1 for line in lines if any(p.search(line) for p in patterns))
 
@@ -326,11 +326,11 @@ def get_files_to_assess(target: str, changed_only: bool) -> list[Path]:
         if target_path.is_file():
             files = [target_path]
         elif target_path.is_dir():
-            files = list(target_path.rglob("*.py")) + \
-                    list(target_path.rglob("*.ts")) + \
-                    list(target_path.rglob("*.js")) + \
-                    list(target_path.rglob("*.cs")) + \
-                    list(target_path.rglob("*.java"))
+            files = [
+                f
+                for suffix in _LANGUAGE_BY_SUFFIX
+                for f in target_path.rglob(f"*{suffix}")
+            ]
         else:
             # Glob pattern
             files = [Path(f) for f in glob(target, recursive=True)]

--- a/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
@@ -207,7 +207,12 @@ def _count_public_fields_by_modifier(lines: list[str]) -> int:
         stripped = line.strip()
         if not stripped.startswith("public "):
             continue
-        if "(" in stripped or "{" in stripped:  # method, ctor, property, or type body
+        if "(" in stripped:  # method or constructor
+            continue
+        brace_idx = stripped.find("{")
+        if brace_idx != -1 and "=" not in stripped[:brace_idx]:
+            # Property (`{ get; set; }`) or type body, not a brace initializer
+            # such as `public int[] xs = {1, 2};`, which is still a public field.
             continue
         if any(
             kw in stripped
@@ -470,7 +475,11 @@ def _score_encapsulation(language: str | None, code_lines: list[str]) -> Quality
 
 
 def _score_testability(language: str | None, code_lines: list[str]) -> QualityScore:
-    """Approximate testability from the amount of mutable global/static state.
+    """Approximate testability from the amount of global/static state.
+
+    The per-language counters flag global and static references. Some of these
+    (for example JS/TS ``const``) are not reassignable, so the label is
+    "global/static", not "mutable".
 
     Languages without a global-state counter are left unscored (confidence
     0.0) rather than defaulting to a perfect constant, which previously made
@@ -486,7 +495,7 @@ def _score_testability(language: str | None, code_lines: list[str]) -> QualitySc
     global_count = counter(code_lines)
     score = max(1.0, 10.0 - global_count * 2)
     reasons = [
-        f"{global_count} mutable global/static references",
+        f"{global_count} global/static references",
         (
             "Global state hinders testability"
             if global_count > 0
@@ -526,18 +535,22 @@ def _unreadable_assessment(file_path: Path, reason: str) -> FileAssessment:
     rather than passing it on meaningless scores derived from empty content.
     The reason is carried so the report explains why the file was not scored.
     """
-    unscored = QualityScore(
-        value=10.0,
-        confidence=0.0,
-        reasons=[f"Not scored ({reason})"],
-    )
+    def _unscored() -> QualityScore:
+        # A fresh instance (and reasons list) per quality so a later mutation
+        # of one metric cannot alias into the others.
+        return QualityScore(
+            value=10.0,
+            confidence=0.0,
+            reasons=[f"Not scored ({reason})"],
+        )
+
     return FileAssessment(
         file_path=str(file_path),
-        cohesion=unscored,
-        coupling=unscored,
-        encapsulation=unscored,
-        testability=unscored,
-        non_redundancy=unscored,
+        cohesion=_unscored(),
+        coupling=_unscored(),
+        encapsulation=_unscored(),
+        testability=_unscored(),
+        non_redundancy=_unscored(),
     )
 
 

--- a/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
@@ -22,6 +22,7 @@ import re
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Any
 
 # Language detection by file suffix. Only languages with tuned heuristics are
 # listed; anything else is analyzed with generic fallbacks and reduced
@@ -283,11 +284,11 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_config(config_path: str) -> dict:
+def load_config(config_path: str) -> dict[str, Any]:
     """Load configuration or return defaults"""
     try:
         with open(config_path) as f:
-            config: dict = json.load(f)
+            config: dict[str, Any] = json.load(f)
             return config
     except FileNotFoundError:
         # Default configuration
@@ -508,7 +509,7 @@ def assess_file(file_path: Path, context: str, use_serena: bool) -> FileAssessme
     )
 
 
-def generate_markdown_report(assessments: list[FileAssessment], config: dict) -> str:
+def generate_markdown_report(assessments: list[FileAssessment], config: dict[str, Any]) -> str:
     """Generate markdown report"""
     report = ["# Code Quality Assessment Report\n"]
 
@@ -585,7 +586,9 @@ def generate_json_report(assessments: list[FileAssessment]) -> str:
     }, indent=2)
 
 
-def check_thresholds(assessments: list[FileAssessment], config: dict, context: str) -> int:
+def check_thresholds(
+    assessments: list[FileAssessment], config: dict[str, Any], context: str
+) -> int:
     """
     Check if quality scores meet configured thresholds.
 

--- a/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
@@ -18,14 +18,199 @@ Exit codes:
 
 import argparse
 import json
+import re
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+# Language detection by file suffix. Only languages with tuned heuristics are
+# listed; anything else is analyzed with generic fallbacks and reduced
+# confidence so the gate never fails a file it cannot actually score.
+_LANGUAGE_BY_SUFFIX = {
+    ".py": "python",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".cs": "csharp",
+    ".java": "java",
+    ".go": "go",
+}
+
+# Single-line comment prefixes, used to exclude comment lines from the
+# lines-of-code count. Block comments are intentionally not stripped: this is an
+# approximation, not a parser.
+_LINE_COMMENT_PREFIXES = {
+    "python": ("#",),
+    "typescript": ("//",),
+    "javascript": ("//",),
+    "csharp": ("//",),
+    "java": ("//",),
+    "go": ("//",),
+}
+
+# Per-language import / dependency line patterns for the coupling heuristic.
+_IMPORT_PATTERNS = {
+    "python": re.compile(r"^\s*(?:import\s+\S|from\s+\S+\s+import\s+)"),
+    "javascript": re.compile(r"^\s*import\s+|\brequire\s*\("),
+    "typescript": re.compile(r"^\s*import\s+|\brequire\s*\("),
+    "csharp": re.compile(r"^\s*using\s+[A-Za-z_]"),
+    "java": re.compile(r"^\s*import\s+[A-Za-z_]"),
+    "go": re.compile(r'^\s*import\s+[("]|^\s+_?\s*"[^"]+"\s*$'),
+}
+
+# Generic import fallback for languages without a tuned pattern.
+_GENERIC_IMPORT_PATTERN = re.compile(r"^\s*(?:import|from|using|require|#include)\b")
+
+# Per-language definition patterns (types, functions, methods) for the cohesion
+# heuristic. More top-level definitions plus larger size means lower cohesion.
+_DEFINITION_PATTERNS = {
+    "python": re.compile(r"^\s*(?:async\s+)?def\s+\w|^\s*class\s+\w"),
+    "javascript": re.compile(
+        r"^\s*(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s+\w"
+        r"|^\s*(?:export\s+)?class\s+\w"
+        r"|=\s*(?:async\s*)?\([^)]*\)\s*=>"
+    ),
+    "typescript": re.compile(
+        r"^\s*(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s+\w"
+        r"|^\s*(?:export\s+)?(?:abstract\s+)?class\s+\w"
+        r"|^\s*(?:export\s+)?interface\s+\w"
+        r"|=\s*(?:async\s*)?\([^)]*\)\s*=>"
+    ),
+    "csharp": re.compile(
+        r"^\s*(?:public|private|protected|internal)\b[^;={]*\([^)]*\)\s*(?:\{|=>|$)"
+        r"|^\s*(?:public|private|protected|internal)\s+"
+        r"(?:static\s+|abstract\s+|sealed\s+|partial\s+)*"
+        r"(?:class|interface|struct|record|enum)\s+\w"
+    ),
+    "java": re.compile(
+        r"^\s*(?:public|private|protected)\b[^;={]*\([^)]*\)\s*(?:\{|throws\b|$)"
+        r"|^\s*(?:public|private|protected)\s+"
+        r"(?:static\s+|abstract\s+|final\s+)*"
+        r"(?:class|interface|enum|record)\s+\w"
+    ),
+    "go": re.compile(r"^\s*func\s+|^\s*type\s+\w+\s+(?:struct|interface)\b"),
+}
+
+
+def detect_language(file_path: Path) -> str | None:
+    """Return the tuned-heuristic language for a path, or None if unsupported."""
+    return _LANGUAGE_BY_SUFFIX.get(file_path.suffix.lower())
+
+
+def _count_python_global_state(lines: list[str]) -> int:
+    return sum(1 for line in lines if line.strip().startswith("global "))
+
+
+def _count_web_global_state(lines: list[str]) -> int:
+    patterns = (
+        re.compile(r"\bglobalThis\b"),
+        re.compile(r"\bwindow\.\w+\s*="),
+        re.compile(r"^\s*var\s+\w"),
+    )
+    return sum(1 for line in lines if any(p.search(line) for p in patterns))
+
+
+def _count_go_global_state(lines: list[str]) -> int:
+    # Package-level (unindented) var declarations are mutable global state.
+    return sum(1 for line in lines if re.match(r"^var\s+\w", line))
+
+
+def _immutable_static(stripped: str, immutable_keywords: tuple[str, ...]) -> bool:
+    type_decls = ("class ", "struct ", "interface ", "enum ", "record ")
+    return any(kw in stripped for kw in immutable_keywords + type_decls)
+
+
+def _count_csharp_static_state(lines: list[str]) -> int:
+    count = 0
+    for line in lines:
+        stripped = line.strip()
+        if "static" not in stripped or "(" in stripped:
+            continue
+        if _immutable_static(stripped, ("readonly", "const ")):
+            continue
+        if stripped.endswith(";") or "=" in stripped:
+            count += 1
+    return count
+
+
+def _count_java_static_state(lines: list[str]) -> int:
+    count = 0
+    for line in lines:
+        stripped = line.strip()
+        if "static" not in stripped or "(" in stripped:
+            continue
+        if _immutable_static(stripped, ("final",)):
+            continue
+        if stripped.endswith(";") or "=" in stripped:
+            count += 1
+    return count
+
+
+# Mutable-global-state counters keyed by language. A missing language means
+# "cannot score testability here"; the caller marks it unscored.
+_GLOBAL_STATE_COUNTERS = {
+    "python": _count_python_global_state,
+    "javascript": _count_web_global_state,
+    "typescript": _count_web_global_state,
+    "go": _count_go_global_state,
+    "csharp": _count_csharp_static_state,
+    "java": _count_java_static_state,
+}
+
+
+def _count_python_public_fields(lines: list[str]) -> int:
+    pattern = re.compile(r"(?<!\w)self\.([A-Za-z]\w*)\s*=(?!=)")
+    return sum(
+        1 for line in lines for m in pattern.finditer(line) if not m.group(1).startswith("_")
+    )
+
+
+def _count_public_fields_by_modifier(lines: list[str]) -> int:
+    """Count public field declarations in a C#/Java style source.
+
+    Public methods are the API and are fine; public *fields* expose mutable
+    state and break encapsulation. Properties (`{ get; set; }`) and type
+    declarations are excluded.
+    """
+    count = 0
+    for line in lines:
+        stripped = line.strip()
+        if not stripped.startswith("public "):
+            continue
+        if "(" in stripped or "{" in stripped:  # method, ctor, property, or type body
+            continue
+        if any(
+            kw in stripped
+            for kw in ("class ", "interface ", "struct ", "enum ", "record ")
+        ):
+            continue
+        if stripped.endswith(";") or "=" in stripped:
+            count += 1
+    return count
+
+
+# Public-field counters keyed by language. A missing language means
+# encapsulation cannot be scored reliably (for example JavaScript, where
+# visibility is largely conventional); the caller marks it unscored.
+_PUBLIC_FIELD_COUNTERS = {
+    "python": _count_python_public_fields,
+    "csharp": _count_public_fields_by_modifier,
+    "java": _count_public_fields_by_modifier,
+}
+
 
 @dataclass
 class QualityScore:
-    """Individual quality score with confidence"""
+    """Individual quality score with confidence.
+
+    A confidence of 0.0 means the metric could not be scored for this file
+    (for example, an unsupported language). The threshold gate skips any
+    quality whose confidence is 0.0 rather than failing a file it could not
+    measure.
+    """
     value: float  # 1-10
     confidence: float  # 0-1
     reasons: list[str]
@@ -109,7 +294,7 @@ def load_config(config_path: str) -> dict:
         return {
             "thresholds": {
                 "cohesion": {"min": 7, "warn": 5},
-                "coupling": {"max": 3, "warn": 5},
+                "coupling": {"min": 7, "warn": 5},
                 "encapsulation": {"min": 7, "warn": 5},
                 "testability": {"min": 6, "warn": 4},
                 "nonRedundancy": {"min": 8, "warn": 6}
@@ -152,114 +337,174 @@ def get_files_to_assess(target: str, changed_only: bool) -> list[Path]:
     return [f for f in files if f.exists()]
 
 
+def _score_cohesion(language: str | None, code_lines: list[str], loc: int) -> QualityScore:
+    """Approximate cohesion from size plus top-level definition count.
+
+    This is a size+definition approximation, not a true LCOM cohesion metric.
+    More definitions packed into a larger file suggests the file is doing many
+    things (lower cohesion). Confidence is deliberately low.
+    """
+    pattern = _DEFINITION_PATTERNS.get(language) if language else None
+    def_count = (
+        sum(1 for line in code_lines if pattern.search(line)) if pattern else 0
+    )
+    score = 10.0 - (loc / 120.0) - max(0, def_count - 1) * 0.3
+    score = max(1.0, min(10.0, score))
+    confidence = 0.4 if pattern else 0.3
+    reasons = [
+        f"{loc} LOC, {def_count} top-level definitions "
+        "(size+definition approximation, not LCOM)",
+        (
+            "Large file with many definitions suggests low cohesion"
+            if score < 7
+            else "Size and definition count are reasonable"
+        ),
+    ]
+    return QualityScore(value=round(score, 1), confidence=confidence, reasons=reasons)
+
+
+def _score_coupling(language: str | None, code_lines: list[str]) -> QualityScore:
+    """Approximate coupling from the number of import/dependency statements.
+
+    A high score means loose coupling (few imports), which is good, matching
+    the rubric where 10 is best.
+    """
+    pattern = _IMPORT_PATTERNS.get(language) if language else None
+    if pattern is not None:
+        import_count = sum(1 for line in code_lines if pattern.search(line))
+        confidence = 0.6
+    else:
+        import_count = sum(
+            1 for line in code_lines if _GENERIC_IMPORT_PATTERN.search(line)
+        )
+        confidence = 0.3
+    score = max(1.0, min(10.0, 10.0 - import_count))
+    reasons = [
+        f"{import_count} import/dependency statements",
+        (
+            "High import count suggests high coupling"
+            if import_count > 10
+            else "Import count is reasonable"
+        ),
+    ]
+    return QualityScore(value=round(score, 1), confidence=confidence, reasons=reasons)
+
+
+def _score_encapsulation(language: str | None, code_lines: list[str]) -> QualityScore:
+    """Approximate encapsulation from the number of exposed public fields.
+
+    Public methods are the intended API and are not penalized; public mutable
+    *fields* break encapsulation and lower the score. Languages without a
+    reliable visibility signal (for example JavaScript, where privacy is
+    conventional) are left unscored (confidence 0.0) so the gate does not fail
+    a file it cannot measure.
+    """
+    counter = _PUBLIC_FIELD_COUNTERS.get(language) if language else None
+    if counter is None:
+        return QualityScore(
+            value=10.0,
+            confidence=0.0,
+            reasons=[
+                "Encapsulation not scored for this language "
+                "(no reliable visibility signal)"
+            ],
+        )
+    public_fields = counter(code_lines)
+    score = 10.0 if public_fields == 0 else max(1.0, 10.0 - public_fields * 2.5)
+    reasons = [
+        f"{public_fields} exposed public field(s)",
+        (
+            "Exposed public state weakens encapsulation"
+            if public_fields > 0
+            else "No exposed public fields detected"
+        ),
+    ]
+    return QualityScore(value=round(score, 1), confidence=0.5, reasons=reasons)
+
+
+def _score_testability(language: str | None, code_lines: list[str]) -> QualityScore:
+    """Approximate testability from the amount of mutable global/static state.
+
+    Languages without a global-state counter are left unscored (confidence
+    0.0) rather than defaulting to a perfect constant, which previously made
+    every non-Python file look maximally testable.
+    """
+    counter = _GLOBAL_STATE_COUNTERS.get(language) if language else None
+    if counter is None:
+        return QualityScore(
+            value=10.0,
+            confidence=0.0,
+            reasons=["Testability not scored for this language (no global-state model)"],
+        )
+    global_count = counter(code_lines)
+    score = max(1.0, 10.0 - global_count * 2)
+    reasons = [
+        f"{global_count} mutable global/static references",
+        (
+            "Global state hinders testability"
+            if global_count > 0
+            else "No global state detected"
+        ),
+    ]
+    return QualityScore(value=round(score, 1), confidence=0.5, reasons=reasons)
+
+
+def _score_non_redundancy(lines: list[str]) -> QualityScore:
+    """Approximate non-redundancy from the ratio of unique to total lines.
+
+    This is language-agnostic and unchanged in spirit from the original
+    heuristic.
+    """
+    non_blank = [line.strip() for line in lines if line.strip()]
+    if not non_blank:
+        return QualityScore(
+            value=10.0, confidence=0.5, reasons=["Empty file, no duplication"]
+        )
+    unique_lines = len(set(non_blank))
+    score = (unique_lines / len(non_blank)) * 10.0
+    reasons = [
+        f"{unique_lines}/{len(non_blank)} unique non-blank lines",
+        "High duplication detected" if score < 7 else "Low duplication",
+    ]
+    return QualityScore(value=round(score, 1), confidence=0.5, reasons=reasons)
+
+
 def assess_file(file_path: Path, context: str, use_serena: bool) -> FileAssessment:
     """
     Assess a single file for all 5 qualities.
 
-    This is a simplified implementation. In production, this would:
-    1. Parse the file to extract symbols (using Serena if available)
-    2. Calculate metrics for each quality
-    3. Apply scoring rubrics
-    4. Return FileAssessment with scores and rationale
+    This is a heuristic implementation. It detects the language from the file
+    suffix and applies language-aware approximations for each quality. Metrics
+    that cannot be scored for a given language are returned with confidence
+    0.0, and the threshold gate skips any quality with confidence 0.0 rather
+    than failing a file it could not measure. A production implementation would
+    parse symbols (using Serena if available) instead of scanning lines.
     """
-    # Placeholder implementation - real version would analyze actual code
-    # For demonstration, return sample scores
+    language = detect_language(file_path)
+    comment_prefixes = _LINE_COMMENT_PREFIXES.get(language, ()) if language else ()
 
-    # Read file to get basic metrics
     try:
         with open(file_path, encoding='utf-8') as f:
             content = f.read()
-            lines = content.split('\n')
-            loc = len(
-                [line for line in lines if line.strip() and not line.strip().startswith('#')]
-            )
     except Exception:
-        loc = 0
+        content = ""
 
-    # Heuristic scoring based on file size (simplified)
-    # Real implementation would use proper static analysis
-
-    # Cohesion: penalize large files (likely low cohesion)
-    cohesion_score = max(1, min(10, 10 - (loc / 100)))
-
-    # Coupling: heuristic based on imports (simplified)
-    import_count = len([line for line in lines if 'import ' in line])
-    coupling_score = max(1, min(10, 10 - import_count))
-
-    # Encapsulation: check for private vs public (simplified)
-    public_methods = len([line for line in lines if 'def ' in line and 'def _' not in line])
-    private_methods = len([line for line in lines if 'def _' in line])
-    if public_methods + private_methods > 0:
-        encap_score = (private_methods / (public_methods + private_methods)) * 10
-    else:
-        encap_score = 10
-
-    # Testability: check for global state, hard-coded values
-    global_vars = len([line for line in lines if line.strip().startswith('global ')])
-    testability_score = max(1, 10 - global_vars * 2)
-
-    # Non-redundancy: basic duplication check (simplified)
-    # Real version would use token-based clone detection
-    unique_lines = len(set([line.strip() for line in lines if line.strip()]))
-    if len(lines) > 0:
-        redundancy_score = (unique_lines / len(lines)) * 10
-    else:
-        redundancy_score = 10
+    lines = content.split('\n')
+    code_lines = [
+        line
+        for line in lines
+        if line.strip()
+        and not (comment_prefixes and line.strip().startswith(comment_prefixes))
+    ]
+    loc = len(code_lines)
 
     return FileAssessment(
         file_path=str(file_path),
-        cohesion=QualityScore(
-            value=round(cohesion_score, 1),
-            confidence=0.7,
-            reasons=[
-                f"File has {loc} LOC",
-                (
-                    "Large files often indicate low cohesion" if loc > 200
-                    else "File size is reasonable"
-                )
-            ]
-        ),
-        coupling=QualityScore(
-            value=round(coupling_score, 1),
-            confidence=0.6,
-            reasons=[
-                f"File has {import_count} imports",
-                (
-                    "High import count suggests high coupling" if import_count > 10
-                    else "Import count is reasonable"
-                )
-            ]
-        ),
-        encapsulation=QualityScore(
-            value=round(encap_score, 1),
-            confidence=0.8,
-            reasons=[
-                f"{private_methods} private methods, {public_methods} public methods",
-                (
-                    "Good balance of private vs public" if encap_score > 7
-                    else "Too many public methods"
-                )
-            ]
-        ),
-        testability=QualityScore(
-            value=round(testability_score, 1),
-            confidence=0.7,
-            reasons=[
-                f"Found {global_vars} global variable references",
-                (
-                    "Global state hinders testability" if global_vars > 0
-                    else "No global state detected"
-                )
-            ]
-        ),
-        non_redundancy=QualityScore(
-            value=round(redundancy_score, 1),
-            confidence=0.5,
-            reasons=[
-                f"{unique_lines}/{len(lines)} unique lines",
-                "High duplication detected" if redundancy_score < 7 else "Low duplication"
-            ]
-        )
+        cohesion=_score_cohesion(language, code_lines, loc),
+        coupling=_score_coupling(language, code_lines),
+        encapsulation=_score_encapsulation(language, code_lines),
+        testability=_score_testability(language, code_lines),
+        non_redundancy=_score_non_redundancy(lines),
     )
 
 
@@ -356,7 +601,10 @@ def check_thresholds(assessments: list[FileAssessment], config: dict, context: s
         thresholds = {**thresholds, **context_thresholds}
 
     for assessment in assessments:
-        if assessment.cohesion.value < thresholds["cohesion"]["min"]:
+        if (
+            assessment.cohesion.confidence > 0.0
+            and assessment.cohesion.value < thresholds["cohesion"]["min"]
+        ):
             print(
                 f"❌ {assessment.file_path}: Cohesion {assessment.cohesion.value} "
                 f"< {thresholds['cohesion']['min']}",
@@ -364,15 +612,26 @@ def check_thresholds(assessments: list[FileAssessment], config: dict, context: s
             )
             return 11
 
-        if assessment.coupling.value > thresholds["coupling"]["max"]:
+        # Coupling uses "min" semantics: higher score = looser coupling = better.
+        # Legacy configs that only specify "max" are skipped rather than gated
+        # incorrectly.
+        coupling_min = thresholds["coupling"].get("min")
+        if (
+            coupling_min is not None
+            and assessment.coupling.confidence > 0.0
+            and assessment.coupling.value < coupling_min
+        ):
             print(
                 f"❌ {assessment.file_path}: Coupling {assessment.coupling.value} "
-                f"> {thresholds['coupling']['max']}",
+                f"< {coupling_min}",
                 file=sys.stderr
             )
             return 11
 
-        if assessment.encapsulation.value < thresholds["encapsulation"]["min"]:
+        if (
+            assessment.encapsulation.confidence > 0.0
+            and assessment.encapsulation.value < thresholds["encapsulation"]["min"]
+        ):
             print(
                 f"❌ {assessment.file_path}: Encapsulation {assessment.encapsulation.value} "
                 f"< {thresholds['encapsulation']['min']}",
@@ -380,7 +639,10 @@ def check_thresholds(assessments: list[FileAssessment], config: dict, context: s
             )
             return 11
 
-        if assessment.testability.value < thresholds["testability"]["min"]:
+        if (
+            assessment.testability.confidence > 0.0
+            and assessment.testability.value < thresholds["testability"]["min"]
+        ):
             print(
                 f"❌ {assessment.file_path}: Testability {assessment.testability.value} "
                 f"< {thresholds['testability']['min']}",
@@ -388,7 +650,10 @@ def check_thresholds(assessments: list[FileAssessment], config: dict, context: s
             )
             return 11
 
-        if assessment.non_redundancy.value < thresholds["nonRedundancy"]["min"]:
+        if (
+            assessment.non_redundancy.confidence > 0.0
+            and assessment.non_redundancy.value < thresholds["nonRedundancy"]["min"]
+        ):
             print(
                 f"❌ {assessment.file_path}: Non-Redundancy {assessment.non_redundancy.value} "
                 f"< {thresholds['nonRedundancy']['min']}",

--- a/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
@@ -329,11 +329,11 @@ def load_config(config_path: str) -> dict[str, Any]:
         # Default configuration
         return {
             "thresholds": {
-                "cohesion": {"min": 7, "warn": 5},
-                "coupling": {"min": 7, "warn": 5},
-                "encapsulation": {"min": 7, "warn": 5},
-                "testability": {"min": 6, "warn": 4},
-                "nonRedundancy": {"min": 8, "warn": 6}
+                "cohesion": {"min": 7},
+                "coupling": {"min": 7},
+                "encapsulation": {"min": 7},
+                "testability": {"min": 6},
+                "nonRedundancy": {"min": 8}
             },
             "context": {
                 "test": {"testability": {"min": 3}}

--- a/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
@@ -59,7 +59,7 @@ _IMPORT_PATTERNS = {
     "typescript": re.compile(r"^\s*import\s+|\brequire\s*\("),
     "csharp": re.compile(r"^\s*using\s+[A-Za-z_]"),
     "java": re.compile(r"^\s*import\s+[A-Za-z_]"),
-    "go": re.compile(r'^\s*import\s+"|^\s+_?\s*"[^"]+"\s*$'),
+    "go": re.compile(r'^\s*import\s+(?:[\w.]+\s+)?"|^\s+(?:[\w.]+\s+)?"[^"]+"\s*$'),
 }
 
 # Generic import fallback for languages without a tuned pattern.
@@ -368,25 +368,33 @@ def _score_coupling(language: str | None, code_lines: list[str]) -> QualityScore
     """Approximate coupling from the number of import/dependency statements.
 
     A high score means loose coupling (few imports), which is good, matching
-    the rubric where 10 is best.
+    the rubric where 10 is best. Languages without a tuned import pattern are
+    counted with a generic fallback for the report but returned at confidence
+    0.0 so the threshold gate does not fail a file scored only by that
+    untuned heuristic (matches the file-header contract).
     """
     pattern = _IMPORT_PATTERNS.get(language) if language else None
     if pattern is not None:
         import_count = sum(1 for line in code_lines if pattern.search(line))
         confidence = 0.6
+        tuned = True
     else:
         import_count = sum(
             1 for line in code_lines if _GENERIC_IMPORT_PATTERN.search(line)
         )
-        confidence = 0.3
+        confidence = 0.0
+        tuned = False
     score = max(1.0, min(10.0, 10.0 - import_count))
+    detail = (
+        "High import count suggests high coupling"
+        if import_count > 10
+        else "Import count is reasonable"
+    )
+    if not tuned:
+        detail = "Generic import approximation (untuned language); not gated"
     reasons = [
         f"{import_count} import/dependency statements",
-        (
-            "High import count suggests high coupling"
-            if import_count > 10
-            else "Import count is reasonable"
-        ),
+        detail,
     ]
     return QualityScore(value=round(score, 1), confidence=confidence, reasons=reasons)
 
@@ -470,6 +478,28 @@ def _score_non_redundancy(lines: list[str]) -> QualityScore:
     return QualityScore(value=round(score, 1), confidence=0.5, reasons=reasons)
 
 
+def _unreadable_assessment(file_path: Path, reason: str) -> FileAssessment:
+    """Return an all-unscored assessment for a file that could not be read.
+
+    Every quality is confidence 0.0 so ``check_thresholds`` skips the file
+    rather than passing it on meaningless scores derived from empty content.
+    The reason is carried so the report explains why the file was not scored.
+    """
+    unscored = QualityScore(
+        value=10.0,
+        confidence=0.0,
+        reasons=[f"Not scored ({reason})"],
+    )
+    return FileAssessment(
+        file_path=str(file_path),
+        cohesion=unscored,
+        coupling=unscored,
+        encapsulation=unscored,
+        testability=unscored,
+        non_redundancy=unscored,
+    )
+
+
 def assess_file(file_path: Path, context: str, use_serena: bool) -> FileAssessment:
     """
     Assess a single file for all 5 qualities.
@@ -487,8 +517,10 @@ def assess_file(file_path: Path, context: str, use_serena: bool) -> FileAssessme
     try:
         with open(file_path, encoding='utf-8') as f:
             content = f.read()
-    except Exception:
-        content = ""
+    except OSError as exc:
+        return _unreadable_assessment(file_path, f"read failed: {exc}")
+    except UnicodeDecodeError as exc:
+        return _unreadable_assessment(file_path, f"decode failed: {exc}")
 
     lines = content.split('\n')
     code_lines = [

--- a/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/scripts/assess.py
@@ -60,8 +60,8 @@ _IMPORT_PATTERNS = {
     "csharp": re.compile(r"^\s*using\s+[A-Za-z_]"),
     "java": re.compile(r"^\s*import\s+[A-Za-z_]"),
     "go": re.compile(
-        r'^\s*import\s+(?:(?:[A-Za-z_]\w*|\.)\s+)?"[^"]+"\s*$'
-        r'|^\s+(?:(?:[A-Za-z_]\w*|\.)\s+)?"[^"]+"\s*$'
+        r'^\s*import\s+(?:(?:[A-Za-z_]\w*|\.)\s+)?"[^"]+"\s*(?://.*)?$'
+        r'|^\s+(?:(?:[A-Za-z_]\w*|\.)\s+)?"[^"]+"\s*(?://.*)?$'
     ),
 }
 

--- a/src/copilot-cli/skills/code-qualities-assessment/templates/.qualityrc.json
+++ b/src/copilot-cli/skills/code-qualities-assessment/templates/.qualityrc.json
@@ -5,7 +5,7 @@
       "warn": 5
     },
     "coupling": {
-      "max": 3,
+      "min": 7,
       "warn": 5
     },
     "encapsulation": {

--- a/src/copilot-cli/skills/code-qualities-assessment/templates/.qualityrc.json
+++ b/src/copilot-cli/skills/code-qualities-assessment/templates/.qualityrc.json
@@ -1,24 +1,19 @@
 {
   "thresholds": {
     "cohesion": {
-      "min": 7,
-      "warn": 5
+      "min": 7
     },
     "coupling": {
-      "min": 7,
-      "warn": 5
+      "min": 7
     },
     "encapsulation": {
-      "min": 7,
-      "warn": 5
+      "min": 7
     },
     "testability": {
-      "min": 6,
-      "warn": 4
+      "min": 6
     },
     "nonRedundancy": {
-      "min": 8,
-      "warn": 6
+      "min": 8
     }
   },
   "context": {

--- a/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
@@ -258,10 +258,26 @@ def test_gate_legacy_coupling_max_only_config_does_not_crash(tmp_path: Path) -> 
     assessment = assess_file(path, "production", False)
 
     legacy = _default_config()
-    legacy["thresholds"]["coupling"] = {"max": 3, "warn": 5}  # no "min"
+    legacy["thresholds"]["coupling"] = {"max": 3, "warn": 5}  # no "min"; "warn" is an ignored unknown key
 
     rc = check_thresholds([assessment], legacy, "production")
     assert rc == 0
+
+
+def test_default_config_declares_no_unconsumed_threshold_keys() -> None:
+    """The default config must not declare threshold keys the gate never reads.
+
+    Only ``min`` (and legacy ``max`` for coupling) are consumed by
+    ``check_thresholds`` and the report. A ``warn`` tier was declared for every
+    quality but never implemented, which misled users into thinking a warning
+    level existed. This guards the config contract so a future edit does not
+    reintroduce an unimplemented key.
+    """
+    consumed = {"min", "max"}
+    thresholds = _default_config()["thresholds"]
+    for quality, spec in thresholds.items():
+        unconsumed = set(spec) - consumed
+        assert not unconsumed, f"{quality} declares unconsumed keys: {unconsumed}"
 
 
 def test_gate_fails_tightly_coupled_file(tmp_path: Path) -> None:

--- a/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
@@ -258,7 +258,8 @@ def test_gate_legacy_coupling_max_only_config_does_not_crash(tmp_path: Path) -> 
     assessment = assess_file(path, "production", False)
 
     legacy = _default_config()
-    legacy["thresholds"]["coupling"] = {"max": 3, "warn": 5}  # no "min"; "warn" is an ignored unknown key
+    # no "min"; "warn" is an ignored unknown key
+    legacy["thresholds"]["coupling"] = {"max": 3, "warn": 5}
 
     rc = check_thresholds([assessment], legacy, "production")
     assert rc == 0
@@ -529,6 +530,41 @@ def test_unreadable_file_is_unscored_not_passed(tmp_path: Path) -> None:
         assert score.confidence == 0.0
     # An unreadable file must not fail (or pass by scoring) any threshold.
     assert check_thresholds([assessment], _default_config(), "production") == 0
+
+
+def test_csharp_public_brace_initializer_field_lowers_encapsulation(tmp_path: Path) -> None:
+    """A C# public field declared with a brace initializer
+    (``public int[] xs = {1, 2};``) is still exposed public state and must
+    lower encapsulation, not be skipped as a property or type body."""
+    exposed = _write(
+        tmp_path,
+        "Exposed.cs",
+        "public class C\n{\n    public int[] xs = {1, 2};\n}\n",
+    )
+    hidden = _write(
+        tmp_path,
+        "Hidden.cs",
+        "public class C\n{\n    private int[] xs = {1, 2};\n}\n",
+    )
+    assert (
+        assess_file(exposed, "production", False).encapsulation.value
+        < assess_file(hidden, "production", False).encapsulation.value
+    )
+
+
+def test_unreadable_assessment_scores_are_not_aliased(tmp_path: Path) -> None:
+    """Each quality of an unreadable file must be an independent QualityScore;
+    mutating one metric's reasons must not bleed into the others."""
+    missing = tmp_path / "gone.py"  # never created -> open() raises OSError
+    assessment = assess_file(missing, "production", False)
+    assessment.cohesion.reasons.append("mutated")
+    for score in (
+        assessment.coupling,
+        assessment.encapsulation,
+        assessment.testability,
+        assessment.non_redundancy,
+    ):
+        assert "mutated" not in score.reasons
 
 
 def test_read_error_is_reported_as_unscored(

--- a/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
@@ -31,6 +31,7 @@ _spec.loader.exec_module(_mod)
 assess_file = _mod.assess_file
 check_thresholds = _mod.check_thresholds
 detect_language = _mod.detect_language
+get_files_to_assess = _mod.get_files_to_assess
 load_config = _mod.load_config
 
 
@@ -270,3 +271,68 @@ def test_gate_fails_tightly_coupled_file(tmp_path: Path) -> None:
 
     rc = check_thresholds([assessment], _default_config(), "production")
     assert rc == 11
+
+
+# --------------------------------------------------------------------------- #
+# Regression guards for GPT-5.5 adversarial review of PR #3000
+# --------------------------------------------------------------------------- #
+
+
+def test_go_import_block_not_overcounted(tmp_path: Path) -> None:
+    """A Go ``import ( ... )`` block must count only the specs inside it, not
+    the block opener. A 3-import block is 3 imports (coupling 7), not 4."""
+    body = (
+        "package main\n\n"
+        "import (\n"
+        '    "fmt"\n'
+        '    "os"\n'
+        '    "strings"\n'
+        ")\n\n"
+        "func main() {}\n"
+    )
+    path = _write(tmp_path, "main.go", body)
+    coupling = assess_file(path, "production", False).coupling
+    # 10 - 3 imports == 7; the block opener must not add a fourth.
+    assert coupling.value == 7
+
+
+def test_web_indented_local_var_not_counted_as_global(tmp_path: Path) -> None:
+    """An indented function-local ``var`` is not global state; only a
+    module-scope (unindented) ``var`` lowers JS testability."""
+    local_only = _write(
+        tmp_path,
+        "local.js",
+        "function f() {\n    var x = 1;\n    return x;\n}\n",
+    )
+    module_scope = _write(
+        tmp_path,
+        "global.js",
+        "var x = 1;\nfunction f() {\n    return x;\n}\n",
+    )
+    local_score = assess_file(local_only, "production", False).testability
+    global_score = assess_file(module_scope, "production", False).testability
+    # The local-only file has no global state, so it scores strictly higher.
+    assert local_score.value > global_score.value
+
+
+def test_directory_scan_includes_all_supported_suffixes(tmp_path: Path) -> None:
+    """Directory assessment must pick up every suffix detect_language supports,
+    including .go, .tsx, .jsx, .mjs, .cjs (previously omitted)."""
+    for name in ("a.go", "b.tsx", "c.jsx", "d.mjs", "e.cjs", "f.py"):
+        _write(tmp_path, name, "x = 1\n")
+    found = {p.name for p in get_files_to_assess(str(tmp_path), False)}
+    assert {"a.go", "b.tsx", "c.jsx", "d.mjs", "e.cjs", "f.py"} <= found
+
+
+def test_template_qualityrc_uses_coupling_min(tmp_path: Path) -> None:
+    """The shipped template config must use coupling.min (matching
+    check_thresholds), not the legacy coupling.max that disabled the gate."""
+    import json
+
+    template = (
+        Path(__file__).parent.parent / "templates" / ".qualityrc.json"
+    )
+    config = json.loads(template.read_text(encoding="utf-8"))
+    coupling = config["thresholds"]["coupling"]
+    assert "min" in coupling
+    assert "max" not in coupling

--- a/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import builtins
 import importlib.util
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -46,7 +47,13 @@ def _write(tmp_path: Path, name: str, body: str) -> Path:
 
 def _default_config() -> dict[str, Any]:
     # load_config with a nonexistent path returns the built-in defaults.
-    config: dict[str, Any] = load_config(str(Path("/nonexistent/.qualityrc.json")))
+    # Use a path inside a fresh temp dir and assert it is absent so the
+    # FileNotFoundError branch is exercised deterministically, independent
+    # of host filesystem state.
+    with tempfile.TemporaryDirectory() as tmp:
+        missing = Path(tmp) / ".qualityrc.json"
+        assert not missing.exists()
+        config: dict[str, Any] = load_config(str(missing))
     return config
 
 

--- a/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -39,9 +40,10 @@ def _write(tmp_path: Path, name: str, body: str) -> Path:
     return path
 
 
-def _default_config() -> dict:
+def _default_config() -> dict[str, Any]:
     # load_config with a nonexistent path returns the built-in defaults.
-    return load_config(str(Path("/nonexistent/.qualityrc.json")))
+    config: dict[str, Any] = load_config(str(Path("/nonexistent/.qualityrc.json")))
+    return config
 
 
 # --------------------------------------------------------------------------- #

--- a/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
@@ -316,6 +316,36 @@ def test_go_import_block_not_overcounted(tmp_path: Path) -> None:
     assert coupling.value == 7
 
 
+def test_go_imports_with_trailing_comments_counted(tmp_path: Path) -> None:
+    """Go import specs may carry a trailing ``// ...`` line comment, both for a
+    single ``import "x"`` line and inside an ``import ( ... )`` block. The
+    coupling regex must still count them; otherwise a tightly coupled file is
+    under-counted and can slip through the gate."""
+    single = _write(
+        tmp_path,
+        "single.go",
+        'package main\n\nimport "fmt" // formatting\n\nfunc main() {}\n',
+    )
+    # One counted import => coupling 9 (10 - 1); a missed import would score 10.
+    assert assess_file(single, "production", False).coupling.value == 9
+
+    block = _write(
+        tmp_path,
+        "block.go",
+        (
+            "package main\n\n"
+            "import (\n"
+            '    "fmt" // formatting\n'
+            '    "os"  // process env\n'
+            '    _ "github.com/lib/pq" // sql driver, blank import\n'
+            ")\n\n"
+            "func main() {}\n"
+        ),
+    )
+    # Three specs, each with a trailing comment => coupling 7 (10 - 3).
+    assert assess_file(block, "production", False).coupling.value == 7
+
+
 def test_web_indented_local_var_not_counted_as_global(tmp_path: Path) -> None:
     """An indented function-local ``var`` is not global state; only a
     module-scope (unindented) ``var`` lowers JS testability."""

--- a/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
@@ -336,3 +336,60 @@ def test_template_qualityrc_uses_coupling_min(tmp_path: Path) -> None:
     coupling = config["thresholds"]["coupling"]
     assert "min" in coupling
     assert "max" not in coupling
+
+
+# --------------------------------------------------------------------------- #
+# PR #3000 adversarial-review fixes (GPT-5.5 / Copilot findings)
+# --------------------------------------------------------------------------- #
+
+
+def test_go_aliased_and_dot_imports_counted(tmp_path: Path) -> None:
+    """Aliased (`m "math"`) and dot (`. "strings"`) imports in a Go block must
+    count, or coupling is inflated and the gate can pass when it should fail."""
+    body = (
+        "package main\n\n"
+        "import (\n"
+        '    "fmt"\n'
+        '    _ "database/sql"\n'
+        '    m "math"\n'
+        '    . "strings"\n'
+        ")\n\n"
+        "func main() {}\n"
+    )
+    path = _write(tmp_path, "main.go", body)
+    coupling = assess_file(path, "production", False).coupling
+    # 4 import specs: plain, blank, aliased, dot. 10 - 4 == 6.
+    assert coupling.value == 6
+
+
+def test_untuned_language_coupling_not_gated(tmp_path: Path) -> None:
+    """A language without a tuned import pattern is counted only for the report
+    (confidence 0.0), so check_thresholds skips it rather than gating on an
+    untuned heuristic (honors the file-header contract)."""
+    # .rb has no tuned pattern; detect_language returns None.
+    lines = [f"require 'lib{i}'" for i in range(12)]
+    body = "\n".join(lines) + "\n"
+    path = _write(tmp_path, "many_imports.rb", body)
+    coupling = assess_file(path, "production", False).coupling
+    assert coupling.confidence == 0.0
+    # Even a low coupling score must not fail the gate when unscored.
+    config = _default_config()
+    config["thresholds"]["coupling"] = {"min": 7}
+    assert check_thresholds([assess_file(path, "production", False)], config, "production") == 0
+
+
+def test_unreadable_file_is_unscored_not_passed(tmp_path: Path) -> None:
+    """A file that cannot be read must come back all-unscored (confidence 0.0)
+    so the gate skips it, instead of scoring empty content as a perfect 10."""
+    missing = tmp_path / "gone.py"  # never created -> open() raises OSError
+    assessment = assess_file(missing, "production", False)
+    for score in (
+        assessment.cohesion,
+        assessment.coupling,
+        assessment.encapsulation,
+        assessment.testability,
+        assessment.non_redundancy,
+    ):
+        assert score.confidence == 0.0
+    # An unreadable file must not fail (or pass by scoring) any threshold.
+    assert check_thresholds([assessment], _default_config(), "production") == 0

--- a/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
@@ -181,6 +181,52 @@ def test_testability_not_constant_across_languages(tmp_path: Path) -> None:
     assert dirty_score.value < clean_score.value
 
 
+def test_csharp_using_static_not_counted_as_state(tmp_path: Path) -> None:
+    """Regression: `using static` is an import (dependency), not mutable
+    static state, so it must not lower testability."""
+    plain = _write(
+        tmp_path,
+        "Plain.cs",
+        "public class Plain {\n    public int Add(int a, int b) => a + b;\n}\n",
+    )
+    with_static_import = _write(
+        tmp_path,
+        "WithImport.cs",
+        "using static System.Math;\n\n"
+        "public class WithImport {\n"
+        "    public double Hyp(double a, double b) => Sqrt(a * a + b * b);\n"
+        "}\n",
+    )
+
+    plain_score = assess_file(plain, "production", False).testability
+    import_score = assess_file(with_static_import, "production", False).testability
+
+    assert import_score.value == plain_score.value
+
+
+def test_java_import_static_not_counted_as_state(tmp_path: Path) -> None:
+    """Regression: `import static` is an import (dependency), not mutable
+    static state, so it must not lower testability."""
+    plain = _write(
+        tmp_path,
+        "Plain.java",
+        "public class Plain {\n    int add(int a, int b) { return a + b; }\n}\n",
+    )
+    with_static_import = _write(
+        tmp_path,
+        "WithImport.java",
+        "import static org.junit.Assert.assertEquals;\n\n"
+        "public class WithImport {\n"
+        "    void check() { assertEquals(1, 1); }\n"
+        "}\n",
+    )
+
+    plain_score = assess_file(plain, "production", False).testability
+    import_score = assess_file(with_static_import, "production", False).testability
+
+    assert import_score.value == plain_score.value
+
+
 def test_testability_python_global_state(tmp_path: Path) -> None:
     clean = _write(tmp_path, "clean.py", "def f():\n    return 1\n")
     dirty = _write(

--- a/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
@@ -1,0 +1,270 @@
+"""Direction and gate tests for the code-qualities-assessment assess.py heuristics.
+
+These tests pin the SCORE DIRECTION (which of two files should score higher for
+a quality) and the threshold-gate behavior, not exact numeric values. They guard
+the bugs fixed for issue #2994:
+
+- Coupling threshold inversion: loosely coupled files no longer fail the gate.
+- Language-blind testability/encapsulation: non-Python files are no longer
+  scored as a constant 10; unsupported languages are marked unscored
+  (confidence 0.0) and skipped by the gate instead of false-passing or
+  false-failing.
+- Cohesion measured size+definitions instead of size alone.
+- Import counting recognizes C#/Java/Go imports, not just Python.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_DIR = Path(__file__).parent.parent / "scripts"
+
+_spec = importlib.util.spec_from_file_location("assess", _SCRIPT_DIR / "assess.py")
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+assess_file = _mod.assess_file
+check_thresholds = _mod.check_thresholds
+detect_language = _mod.detect_language
+load_config = _mod.load_config
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _default_config() -> dict:
+    # load_config with a nonexistent path returns the built-in defaults.
+    return load_config(str(Path("/nonexistent/.qualityrc.json")))
+
+
+# --------------------------------------------------------------------------- #
+# detect_language
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("a.py", "python"),
+        ("a.ts", "typescript"),
+        ("a.tsx", "typescript"),
+        ("a.js", "javascript"),
+        ("a.cs", "csharp"),
+        ("a.java", "java"),
+        ("a.go", "go"),
+        ("a.rb", None),
+        ("a.txt", None),
+    ],
+)
+def test_detect_language(name: str, expected: str | None) -> None:
+    assert detect_language(Path(name)) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Coupling: direction + threshold is no longer inverted
+# --------------------------------------------------------------------------- #
+
+
+def test_coupling_direction_python(tmp_path: Path) -> None:
+    standalone = _write(tmp_path, "standalone.py", "def f():\n    return 1\n")
+    heavy_body = "".join(f"import mod{i}\n" for i in range(15)) + "def f():\n    return 1\n"
+    heavy = _write(tmp_path, "heavy.py", heavy_body)
+
+    standalone_score = assess_file(standalone, "production", False).coupling.value
+    heavy_score = assess_file(heavy, "production", False).coupling.value
+
+    # Fewer imports => looser coupling => higher score (10 is best).
+    assert standalone_score > heavy_score
+
+
+def test_loosely_coupled_file_passes_gate(tmp_path: Path) -> None:
+    """The inversion bug: a loosely coupled file (coupling score ~10) used to
+    FAIL because the gate compared coupling > max=3. It must now pass."""
+    standalone = _write(tmp_path, "standalone.py", "def f():\n    return 1\n")
+    assessment = assess_file(standalone, "production", False)
+    assert assessment.coupling.value >= 9  # loosely coupled, near-perfect
+
+    rc = check_thresholds([assessment], _default_config(), "production")
+    # Coupling alone must not fail this file. (Other qualities on a trivial
+    # one-function file are all high, so the overall gate passes.)
+    assert rc == 0
+
+
+def test_csharp_imports_counted(tmp_path: Path) -> None:
+    """C# `using` directives count toward coupling; previously only Python
+    `import ` did, so every C# file looked maximally decoupled."""
+    body = (
+        "using System;\n"
+        "using System.Linq;\n"
+        "using System.Collections.Generic;\n"
+        "public class Foo { public int X; }\n"
+    )
+    path = _write(tmp_path, "Foo.cs", body)
+    score = assess_file(path, "production", False).coupling.value
+    # 3 usings => coupling score 7, strictly below the perfect 10.
+    assert score < 10
+
+
+# --------------------------------------------------------------------------- #
+# Cohesion: god object scores lower than a focused class
+# --------------------------------------------------------------------------- #
+
+
+def test_cohesion_god_object_lower_than_focused(tmp_path: Path) -> None:
+    focused = _write(
+        tmp_path,
+        "focused.py",
+        "class Focused:\n"
+        "    def a(self):\n        return 1\n"
+        "    def b(self):\n        return 2\n",
+    )
+    god_methods = "".join(
+        f"    def m{i}(self):\n        x = {i}\n        return x\n" for i in range(40)
+    )
+    god = _write(tmp_path, "god.py", "class God:\n" + god_methods)
+
+    focused_score = assess_file(focused, "production", False).cohesion.value
+    god_score = assess_file(god, "production", False).cohesion.value
+
+    assert god_score < focused_score
+
+
+# --------------------------------------------------------------------------- #
+# Testability: not a constant across languages
+# --------------------------------------------------------------------------- #
+
+
+def test_testability_not_constant_across_languages(tmp_path: Path) -> None:
+    """Regression guard: previously testability was 10 for every non-Python
+    file because global-state detection was Python-only."""
+    clean_cs = _write(
+        tmp_path,
+        "Clean.cs",
+        "public class Clean {\n    public int Add(int a, int b) => a + b;\n}\n",
+    )
+    dirty_cs = _write(
+        tmp_path,
+        "Dirty.cs",
+        "public class Dirty {\n"
+        "    private static int _counter = 0;\n"
+        "    public static string Cache = \"x\";\n"
+        "    public int Next() => _counter++;\n"
+        "}\n",
+    )
+
+    clean_score = assess_file(clean_cs, "production", False).testability
+    dirty_score = assess_file(dirty_cs, "production", False).testability
+
+    assert clean_score.confidence > 0.0
+    assert dirty_score.confidence > 0.0
+    # Mutable static state hurts testability.
+    assert dirty_score.value < clean_score.value
+
+
+def test_testability_python_global_state(tmp_path: Path) -> None:
+    clean = _write(tmp_path, "clean.py", "def f():\n    return 1\n")
+    dirty = _write(
+        tmp_path,
+        "dirty.py",
+        "_x = 0\n\n\ndef f():\n    global _x\n    _x += 1\n    return _x\n",
+    )
+    assert (
+        assess_file(dirty, "production", False).testability.value
+        < assess_file(clean, "production", False).testability.value
+    )
+
+
+def test_testability_unscored_for_unknown_language(tmp_path: Path) -> None:
+    path = _write(tmp_path, "thing.rb", "def foo\n  1\nend\n")
+    score = assess_file(path, "production", False).testability
+    assert score.confidence == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Encapsulation: unscored where visibility cannot be detected reliably
+# --------------------------------------------------------------------------- #
+
+
+def test_encapsulation_unscored_for_javascript(tmp_path: Path) -> None:
+    path = _write(tmp_path, "a.js", "function f() { return 1; }\n")
+    score = assess_file(path, "production", False).encapsulation
+    assert score.confidence == 0.0
+
+
+def test_encapsulation_scored_for_python(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "a.py",
+        "class C:\n    def _helper(self):\n        return 1\n"
+        "    def public(self):\n        return self._helper()\n",
+    )
+    score = assess_file(path, "production", False).encapsulation
+    assert score.confidence > 0.0
+    assert score.value == 10.0  # methods-only API, no exposed fields
+
+
+def test_encapsulation_public_fields_lower_score(tmp_path: Path) -> None:
+    hidden = _write(
+        tmp_path,
+        "hidden.py",
+        "class C:\n    def __init__(self):\n        self._x = 0\n"
+        "    def value(self):\n        return self._x\n",
+    )
+    exposed = _write(
+        tmp_path,
+        "exposed.py",
+        "class C:\n    def __init__(self):\n        self.x = 0\n        self.y = 1\n",
+    )
+    assert (
+        assess_file(exposed, "production", False).encapsulation.value
+        < assess_file(hidden, "production", False).encapsulation.value
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Gate skips unscored qualities (confidence 0.0) instead of false-failing
+# --------------------------------------------------------------------------- #
+
+
+def test_gate_skips_unscored_qualities(tmp_path: Path) -> None:
+    """An unknown-language file leaves testability and encapsulation unscored.
+    The gate must not fail on a quality it could not measure."""
+    path = _write(tmp_path, "thing.rb", "def foo\n  1\nend\n")
+    assessment = assess_file(path, "production", False)
+    assert assessment.testability.confidence == 0.0
+    assert assessment.encapsulation.confidence == 0.0
+
+    rc = check_thresholds([assessment], _default_config(), "production")
+    assert rc == 0
+
+
+def test_gate_legacy_coupling_max_only_config_does_not_crash(tmp_path: Path) -> None:
+    """A legacy config specifying only coupling.max (no min) must not KeyError;
+    coupling gating is simply skipped for it."""
+    path = _write(tmp_path, "standalone.py", "def f():\n    return 1\n")
+    assessment = assess_file(path, "production", False)
+
+    legacy = _default_config()
+    legacy["thresholds"]["coupling"] = {"max": 3, "warn": 5}  # no "min"
+
+    rc = check_thresholds([assessment], legacy, "production")
+    assert rc == 0
+
+
+def test_gate_fails_tightly_coupled_file(tmp_path: Path) -> None:
+    """Positive control: a heavily-imported file scores below coupling.min=7
+    and the gate fails it."""
+    heavy_body = "".join(f"import mod{i}\n" for i in range(9)) + "def f():\n    return 1\n"
+    heavy = _write(tmp_path, "heavy.py", heavy_body)
+    assessment = assess_file(heavy, "production", False)
+    assert assessment.coupling.value < 7
+
+    rc = check_thresholds([assessment], _default_config(), "production")
+    assert rc == 11

--- a/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
@@ -519,7 +519,7 @@ def test_read_error_is_reported_as_unscored(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     path = _write(tmp_path, "broken.py", "def f():\n    return 1\n")
-    real_open = builtins.open
+    real_open: Any = builtins.open
 
     def raise_permission_error(file: Any, *args: Any, **kwargs: Any) -> Any:
         if file == path:

--- a/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
+++ b/src/copilot-cli/skills/code-qualities-assessment/tests/test_assess.py
@@ -15,6 +15,7 @@ the bugs fixed for issue #2994:
 
 from __future__ import annotations
 
+import builtins
 import importlib.util
 from pathlib import Path
 from typing import Any
@@ -32,6 +33,8 @@ assess_file = _mod.assess_file
 check_thresholds = _mod.check_thresholds
 detect_language = _mod.detect_language
 get_files_to_assess = _mod.get_files_to_assess
+generate_json_report = _mod.generate_json_report
+generate_markdown_report = _mod.generate_markdown_report
 load_config = _mod.load_config
 
 
@@ -362,6 +365,113 @@ def test_go_aliased_and_dot_imports_counted(tmp_path: Path) -> None:
     assert coupling.value == 6
 
 
+@pytest.mark.parametrize(
+    "import_line",
+    [
+        'import _ "fmt"\n',
+        'import myfmt "fmt"\n',
+        'import . "fmt"\n',
+    ],
+)
+def test_go_single_line_named_blank_and_dot_imports_counted(
+    tmp_path: Path, import_line: str
+) -> None:
+    body = "package main\n\n" + import_line + "\nfunc main() {}\n"
+    path = _write(tmp_path, "main.go", body)
+
+    coupling = assess_file(path, "production", False).coupling
+
+    assert coupling.value == 9
+
+
+def test_go_named_blank_and_dot_imports_counted_inside_block(tmp_path: Path) -> None:
+    body = (
+        "package main\n\n"
+        "import (\n"
+        '    myfmt "fmt"\n'
+        '    _ "database/sql"\n'
+        '    . "strings"\n'
+        ")\n\n"
+        "func main() {}\n"
+    )
+    path = _write(tmp_path, "main.go", body)
+
+    coupling = assess_file(path, "production", False).coupling
+
+    assert coupling.value == 7
+
+
+def test_go_package_var_block_counts_as_global_state(tmp_path: Path) -> None:
+    clean = _write(tmp_path, "clean.go", "package main\n\nfunc main() {}\n")
+    dirty = _write(
+        tmp_path,
+        "dirty.go",
+        "package main\n\n"
+        "var (\n"
+        "    counter int\n"
+        "    cache = map[string]string{}\n"
+        ")\n\n"
+        "func main() {}\n",
+    )
+
+    clean_score = assess_file(clean, "production", False).testability
+    dirty_score = assess_file(dirty, "production", False).testability
+
+    assert dirty_score.value < clean_score.value
+
+
+def test_go_indented_local_var_block_not_counted_as_global_state(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "local.go",
+        "package main\n\n"
+        "func main() {\n"
+        "    var (\n"
+        "        local int\n"
+        "    )\n"
+        "    _ = local\n"
+        "}\n",
+    )
+
+    testability = assess_file(path, "production", False).testability
+
+    assert testability.value == 10
+
+
+def test_python_public_fields_are_deduplicated_by_name(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "fields.py",
+        "class C:\n"
+        "    def first(self):\n"
+        "        self.x = 1\n"
+        "    def second(self):\n"
+        "        self.x = 2\n",
+    )
+
+    encapsulation = assess_file(path, "production", False).encapsulation
+
+    assert encapsulation.reasons[0] == "1 exposed public field(s)"
+
+
+@pytest.mark.parametrize(
+    ("name", "body"),
+    [
+        ("Constants.cs", "public class C {\n    public const int Answer = 42;\n}\n"),
+        ("Readonly.cs", "public class C {\n    public readonly int Answer = 42;\n}\n"),
+        ("Final.java", "public class C {\n    public final int answer = 42;\n}\n"),
+    ],
+)
+def test_public_immutable_fields_do_not_lower_encapsulation(
+    tmp_path: Path, name: str, body: str
+) -> None:
+    path = _write(tmp_path, name, body)
+
+    encapsulation = assess_file(path, "production", False).encapsulation
+
+    assert encapsulation.value == 10
+
+
 def test_untuned_language_coupling_not_gated(tmp_path: Path) -> None:
     """A language without a tuned import pattern is counted only for the report
     (confidence 0.0), so check_thresholds skips it rather than gating on an
@@ -372,6 +482,16 @@ def test_untuned_language_coupling_not_gated(tmp_path: Path) -> None:
     path = _write(tmp_path, "many_imports.rb", body)
     coupling = assess_file(path, "production", False).coupling
     assert coupling.confidence == 0.0
+    assert all(
+        score.confidence == 0.0
+        for score in (
+            assess_file(path, "production", False).cohesion,
+            assess_file(path, "production", False).coupling,
+            assess_file(path, "production", False).encapsulation,
+            assess_file(path, "production", False).testability,
+            assess_file(path, "production", False).non_redundancy,
+        )
+    )
     # Even a low coupling score must not fail the gate when unscored.
     config = _default_config()
     config["thresholds"]["coupling"] = {"min": 7}
@@ -393,3 +513,94 @@ def test_unreadable_file_is_unscored_not_passed(tmp_path: Path) -> None:
         assert score.confidence == 0.0
     # An unreadable file must not fail (or pass by scoring) any threshold.
     assert check_thresholds([assessment], _default_config(), "production") == 0
+
+
+def test_read_error_is_reported_as_unscored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _write(tmp_path, "broken.py", "def f():\n    return 1\n")
+    real_open = builtins.open
+
+    def raise_permission_error(file: Any, *args: Any, **kwargs: Any) -> Any:
+        if file == path:
+            raise PermissionError("blocked")
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", raise_permission_error)
+
+    assessment = assess_file(path, "production", False)
+
+    assert assessment.overall == 0.0
+    assert all(
+        score.confidence == 0.0
+        for score in (
+            assessment.cohesion,
+            assessment.coupling,
+            assessment.encapsulation,
+            assessment.testability,
+            assessment.non_redundancy,
+        )
+    )
+    assert "blocked" in assessment.cohesion.reasons[0]
+    assert check_thresholds([assessment], _default_config(), "production") == 0
+
+
+def test_markdown_report_displays_unscored_metrics_as_na(tmp_path: Path) -> None:
+    path = _write(tmp_path, "unknown.rb", "require 'x'\n")
+    assessment = assess_file(path, "production", False)
+
+    report = generate_markdown_report([assessment], _default_config())
+
+    assert "**Overall**: n/a" in report
+    assert "- **Cohesion**: unscored (n/a)" in report
+    assert "**Average Cohesion**: n/a" in report
+    assert "10.0/10" not in report
+
+
+def test_json_report_excludes_unscored_metrics_from_average(tmp_path: Path) -> None:
+    import json
+
+    path = _write(tmp_path, "unknown.rb", "require 'x'\n")
+    assessment = assess_file(path, "production", False)
+
+    report = json.loads(generate_json_report([assessment]))
+
+    assert report["summary"]["average_scores"]["cohesion"] is None
+
+
+def test_overall_ignores_unscored_metrics(tmp_path: Path) -> None:
+    path = _write(tmp_path, "mixed.py", "def f():\n    return 1\n")
+    assessment = assess_file(path, "production", False)
+    assessment.encapsulation.confidence = 0.0
+    assessment.encapsulation.value = 10.0
+    assessment.coupling.value = 4.0
+
+    scored_values = [
+        assessment.cohesion.value,
+        assessment.coupling.value,
+        assessment.testability.value,
+        assessment.non_redundancy.value,
+    ]
+
+    assert assessment.overall == pytest.approx(sum(scored_values) / len(scored_values))
+
+
+def test_markdown_report_uses_configured_thresholds(tmp_path: Path) -> None:
+    path = _write(tmp_path, "imports.py", "import a\nimport b\n\ndef f():\n    return 1\n")
+    assessment = assess_file(path, "production", False)
+    config = _default_config()
+    config["thresholds"]["coupling"] = {"min": 9}
+
+    report = generate_markdown_report([assessment], config)
+
+    assert "**Coupling Issues**:" in report
+    assert "2 import/dependency statements" in report
+
+
+def test_load_config_reads_utf8_json(tmp_path: Path) -> None:
+    config_path = tmp_path / ".qualityrc.json"
+    config_path.write_text('{"thresholds": {}, "label": "café"}', encoding="utf-8")
+
+    config = load_config(str(config_path))
+
+    assert config["label"] == "café"


### PR DESCRIPTION
## Summary

`code-qualities-assessment/scripts/assess.py` computed three of five qualities with heuristics that were wrong for non-Python code, and its coupling scorer contradicted its own default threshold. Scores were untrustworthy and the CI gate could fail or pass for the wrong reasons.

## What changed

1. Testability is no longer a constant 10 for non-Python code. The `global ` keyword heuristic is now gated behind language detection. Languages without a real signal are scored via language-appropriate proxies instead of defaulting to 10.
2. Cohesion no longer equals inverse file size alone. The scorer uses language-aware structure signals rather than raw LOC.
3. Coupling scorer and threshold now agree end to end. The default threshold uses `min` semantics (10 = loosely coupled = good), and a confidence-0 language skips the coupling gate instead of flagging the least-coupled files.

## Tests

Added `tests/test_assess.py` with 22 direction-asserting tests: a god-object scores lower cohesion than a focused class, a heavily-imported file scores lower coupling than a standalone one, and per-language testability behaves correctly. Typed the config dicts as `dict[str, Any]` so pre-push mypy passes.

The Copilot CLI skill twin was regenerated in the same change.

Fixes #2994

## References

- `.claude/skills/code-qualities-assessment/scripts/assess.py`
- `.claude/skills/code-qualities-assessment/SKILL.md`
- `.claude/skills/code-qualities-assessment/tests/test_assess.py`
- `src/copilot-cli/skills/code-qualities-assessment/`
