### PR TITLE
refactor(skills): decompose SkillForge SKILL.md via progressive disclosure

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/SkillForge/SKILL.md
+++ b/.claude/skills/SkillForge/SKILL.md
@@ -245,7 +245,7 @@ After creation:
 
 ## Scripts
 
-The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. All scripts use Python 3 standard library, the `Result` dataclass pattern, and shared exit codes: `0`=success, `1`=failure, `10`=validation failure, `11`=verification failure.
+The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. Scripts use the Python 3 standard library and exit `0` on success and non-zero on failure (`1` general; individual scripts add `2` or `3` for specific precondition failures, documented in each script's `--help`).
 
 | Script | Purpose |
 |--------|---------|
@@ -289,26 +289,10 @@ See [references/script-integration-framework.md](references/script-integration-f
 
 ## Related Skills
 
-| Skill | Relationship |
-|-------|--------------|
-| skill-composer | Can orchestrate created skills |
-| claude-authoring-guide | Deeper patterns reference |
-| codereview | Pattern for multi-agent panels |
-| maker-framework | Zero error standard source |
+skill-composer (orchestrate created skills), claude-authoring-guide (deeper patterns), codereview (multi-agent panel pattern), maker-framework (zero-error standard).
 
 ---
 
 ## Extension Points
 
-1. Add thinking models in [references/multi-lens-framework.md](references/multi-lens-framework.md).
-2. Extend panel agents in [references/synthesis-protocol.md](references/synthesis-protocol.md).
-3. Add architecture patterns in [references/architecture-patterns.md](references/architecture-patterns.md).
-4. Add domain templates in `assets/templates/`.
-5. Add script patterns in [references/script-patterns-catalog.md](references/script-patterns-catalog.md).
-6. Extend script categories in [references/script-integration-framework.md](references/script-integration-framework.md).
-
----
-
-## Changelog
-
-See [references/changelog.md](references/changelog.md) for the full version history.
+Add thinking models, panel agents, architecture patterns, or script patterns via the matching `references/*.md`; add domain templates in `assets/templates/`.

--- a/.claude/skills/SkillForge/SKILL.md
+++ b/.claude/skills/SkillForge/SKILL.md
@@ -245,7 +245,7 @@ After creation:
 
 ## Scripts
 
-The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. Scripts use the Python 3 standard library and exit `0` on success and non-zero on failure (`1` general; individual scripts add `2` or `3` for specific precondition failures, documented in each script's `--help`).
+The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. Scripts use the Python 3 standard library. Exit codes: `0` on success and non-zero on failure (`1` general; individual scripts add `2` or `3` for specific precondition failures, documented in each script's `--help`).
 
 | Script | Purpose |
 |--------|---------|
@@ -257,6 +257,8 @@ The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, vali
 | `skill_modularity_audit.py` | Audit SKILL.md size and flag progressive-disclosure violations |
 | `package_skill.py` | Package a completed skill for distribution |
 | `check_docs_safety.py` | Safety scan of generated documentation |
+| `frontmatter.py` | Internal helper module: shared YAML frontmatter parsing (imported, not run directly) |
+| `_constants.py` | Internal helper module: shared constants and thresholds (imported, not run directly) |
 
 See [references/script-integration-framework.md](references/script-integration-framework.md) for when to add scripts and [references/script-patterns-catalog.md](references/script-patterns-catalog.md) for the standard patterns.
 
@@ -290,8 +292,6 @@ See [references/script-integration-framework.md](references/script-integration-f
 ## Related Skills
 
 skill-composer (orchestrate created skills), claude-authoring-guide (deeper patterns), codereview (multi-agent panel pattern), maker-framework (zero-error standard).
-
----
 
 ## Extension Points
 

--- a/.claude/skills/SkillForge/SKILL.md
+++ b/.claude/skills/SkillForge/SKILL.md
@@ -74,7 +74,7 @@ flow and script examples.
 |-------|--------|--------------|
 | Any input | Triage -> Route -> Action | Phase 0 analysis |
 | Explicit create | New skill | Unanimous panel approval |
-| Task or question | Skill recommendation | Match confidence >=60% |
+| Skill question | Skill recommendation | Match confidence >=60% |
 
 ---
 
@@ -122,9 +122,10 @@ local scripts, external facts, or true parallel sub-agent orchestration.
 ## Phase 0: Skill Triage
 
 Classify the input, scan the skill ecosystem, score matches, then route to one
-of five actions. Use existing skills for matches >=80%, improve matches in the
-50-79% range, create below 50%, compose multi-domain requests, and clarify only
-when ambiguity or duplicate risk blocks a safe route.
+of five actions. Recommend existing skills for strong matches (>=80%, or >=60%
+for skill questions), improve matches in the 50-79% range, create below 50%,
+compose multi-domain requests, and clarify only when ambiguity or duplicate risk
+blocks a safe route.
 
 See [references/phase0-triage.md](references/phase0-triage.md) for the decision
 matrix, script examples, ecosystem index, and integration with later phases.
@@ -198,14 +199,13 @@ safety, and packaging. Keep command examples portable when a plugin-root path is
 needed.
 
 ```bash
-# Quick validation (required for packaging)
-python scripts/quick_validate.py ~/.claude/skills/my-skill/
-
-# Full structural validation
-python scripts/validate-skill.py ~/.claude/skills/my-skill/
-
-# Package for distribution
-python scripts/package_skill.py ~/.claude/skills/my-skill/ ./dist
+# Validators enforce a path-traversal guard: the target skill directory must
+# live under your current directory. Run them from an ancestor of the skill.
+cd ~/.claude/skills
+FORGE=~/.claude/skills/SkillForge/scripts   # adjust to your SkillForge install
+python "$FORGE/quick_validate.py" my-skill/     # required before packaging
+python "$FORGE/validate-skill.py" my-skill/     # full structural validation
+python "$FORGE/package_skill.py" my-skill/ ./dist   # package for distribution
 ```
 
 See [references/output-structure.md](references/output-structure.md) for allowed

--- a/.claude/skills/SkillForge/SKILL.md
+++ b/.claude/skills/SkillForge/SKILL.md
@@ -60,7 +60,7 @@ flow and script examples.
 - `create skill`: natural language activation
 - `design skill for {purpose}`: purpose-first creation
 - `ultimate skill`: maximum quality creation path
-- `skillforge --plan-only`: generate specification without execution
+- `SkillForge --plan-only`: generate specification without execution
 
 ### Routing Triggers
 
@@ -245,7 +245,7 @@ After creation:
 
 ## Scripts
 
-The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. Scripts use the Python 3 standard library. Exit codes: `0` on success and non-zero on failure (`1` general; individual scripts add `2` or `3` for specific precondition failures, documented in each script's `--help`).
+The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. Scripts run on the Python 3 standard library; a few use PyYAML for frontmatter parsing when it is installed and fall back to a stdlib parser when it is not. Exit codes: `0` on success and non-zero on failure (`1` general; individual scripts add `2` or `3` for specific precondition failures, documented in each script's `--help`).
 
 | Script | Purpose |
 |--------|---------|

--- a/.claude/skills/SkillForge/SKILL.md
+++ b/.claude/skills/SkillForge/SKILL.md
@@ -19,34 +19,36 @@ metadata:
   outputs: [SKILL.md, references/, scripts/, SKILL_SPEC.md, recommendations]
 ---
 
-# SkillForge 4.1 - Intelligent Skill Router & Creator
+# SkillForge 4.1 - Intelligent Skill Router and Creator
 
-Analyzes ANY input to find, improve, or create the right skill.
+Analyzes any input to find, improve, compose, or create the right skill.
 
 ---
 
 ## Quick Start
 
-**Any input works.** SkillForge will intelligently route to the right action:
+SkillForge accepts direct creation requests, skill improvement requests, skill
+lookup questions, task prompts, error messages, URLs, and code snippets. It
+routes first, then creates only when no existing skill covers the need.
 
-```
-# These all work - SkillForge figures out what you need:
-
+```text
 SkillForge: create a skill for automated code review
-→ Creates new skill (after checking no duplicates exist)
+  -> Creates a new skill after checking for duplicates
 
 help me debug this TypeError
-→ Recommends ErrorExplainer skill (existing)
+  -> Recommends an existing debugging skill
 
 improve the testgen skill to handle React components better
-→ Enters improvement mode for TestGen
+  -> Loads the skill and enters improvement mode
 
 do I have a skill for database migrations?
-→ Recommends DBSchema, database-migration skills
-
-TypeError: Cannot read property 'map' of undefined
-→ Routes to debugging skills (error detected)
+  -> Recommends matching database skills
 ```
+
+See [references/overview-and-triggers.md](references/overview-and-triggers.md)
+for the full examples, triggers, routing diagram, and command summary. See
+[references/phase0-triage.md](references/phase0-triage.md) for the full triage
+flow and script examples.
 
 ---
 
@@ -54,92 +56,54 @@ TypeError: Cannot read property 'map' of undefined
 
 ### Creation Triggers
 
-- `SkillForge: {goal}` - Full autonomous skill creation
-- `create skill` - Natural language activation
-- `design skill for {purpose}` - Purpose-first creation
-- `ultimate skill` - Emphasize maximum quality
-- `skillforge --plan-only` - Generate specification without execution
+- `SkillForge: {goal}`: full autonomous skill creation
+- `create skill`: natural language activation
+- `design skill for {purpose}`: purpose-first creation
+- `ultimate skill`: maximum quality creation path
+- `skillforge --plan-only`: generate specification without execution
 
-### Routing Triggers (NEW in v4.0)
+### Routing Triggers
 
-- `{any input}` - Analyzes and routes automatically
-- `do I have a skill for` - Searches existing skills
-- `which skill` / `what skill` - Recommends matching skills
-- `improve {skill-name} skill` - Enters improvement mode
-- `help me with` / `I need to` - Detects task and routes
+- `{any input}`: analyze and route automatically
+- `do I have a skill for`: search existing skills
+- `which skill` or `what skill`: recommend matching skills
+- `improve {skill-name} skill`: improve an existing skill
+- `help me with` or `I need to`: detect task and route
 
 | Input | Output | Quality Gate |
 |-------|--------|--------------|
-| Any input | Triage → Route → Action | Phase 0 analysis |
+| Any input | Triage -> Route -> Action | Phase 0 analysis |
 | Explicit create | New skill | Unanimous panel approval |
-| Task/question | Skill recommendation | Match confidence ≥60% |
+| Task or question | Skill recommendation | Match confidence >=60% |
 
 ---
 
 ## Process Overview
 
-```
-ANY USER INPUT
-(prompt, error, code, URL, question, task request)
-    │
-    ▼
-┌─────────────────────────────────────────────────────┐
-│ Phase 0: SKILL TRIAGE (NEW)                         │
-│ • Classify input type (create/improve/question/task)│
-│ • Scan 250+ skills in ecosystem                     │
-│ • Match against existing skills with confidence %   │
-│ • Route to: USE | IMPROVE | CREATE | COMPOSE        │
-├─────────────────────────────────────────────────────┤
-│         ↓ USE_EXISTING    ↓ IMPROVE      ↓ CREATE   │
-│      [Recommend]      [Load & Enhance] [Continue]   │
-└─────────────────────────────────────────────────────┘
-    │ (if CREATE_NEW or IMPROVE_EXISTING)
-    ▼
-┌─────────────────────────────────────────────────────┐
-│ Phase 1: DEEP ANALYSIS                              │
-│ • Expand requirements (explicit, implicit, unknown) │
-│ • Apply 11 thinking models + Automation Lens        │
-│ • Question until no new insights (3 empty rounds)   │
-│ • Identify automation/script opportunities          │
-├─────────────────────────────────────────────────────┤
-│ Phase 2: SPECIFICATION                              │
-│ • Generate XML spec with all decisions + WHY        │
-│ • Include scripts section (if applicable)           │
-│ • Validate timelessness score ≥ 7                   │
-├─────────────────────────────────────────────────────┤
-│ Phase 3: GENERATION                                 │
-│ • Write SKILL.md with fresh context                 │
-│ • Generate references/, assets/, and scripts/       │
-├─────────────────────────────────────────────────────┤
-│ Phase 4: SYNTHESIS PANEL                            │
-│ • 3-4 Opus agents review independently              │
-│ • Script Agent added when scripts present           │
-│ • All agents must approve (unanimous)               │
-│ • If rejected → loop back with feedback             │
-└─────────────────────────────────────────────────────┘
-    │
-    ▼
-Production-Ready Agentic Skill
+```text
+Any user input
+  -> Phase 0: Skill triage
+     -> USE_EXISTING, IMPROVE_EXISTING, CREATE_NEW, COMPOSE, or CLARIFY
+  -> Phase 1: Deep analysis when creation or improvement is needed
+  -> Phase 2: Specification with rationale and evolution score
+  -> Phase 3: Generation of SKILL.md, references/, assets/, and scripts/
+  -> Phase 4: Synthesis panel until unanimous approval
+  -> Production-ready agentic skill
 ```
 
-**Key principles:**
+Key principles:
 
-- **Phase 0 prevents duplicates** - Always checks existing skills first
-- Evolution/timelessness is the core lens (score ≥ 7 required)
-- Every decision includes WHY
-- Zero tolerance for errors
-- Autonomous execution at maximum depth
-- Scripts enable self-verification and agentic operation
+- Phase 0 prevents duplicate skills before any creation work starts.
+- Evolution and timelessness scoring stays at the center. Score >=7 is required.
+- Every decision includes WHY.
+- Scripts are added when deterministic automation improves verification.
+- Panel approval is unanimous before finalization.
 
 ### Tool Escalation Policy
 
-Start with least privilege (`Read`, `Glob`, `Grep`, `Write`, `Edit`).
-
-Only add higher-risk tools when explicitly required:
-
-- `Bash` for deterministic local scripts that cannot be replaced with file edits
-- `WebFetch` / `WebSearch` only when external facts are required
-- `Task` only for true parallel sub-agent orchestration
+Start with least privilege: `Read`, `Glob`, `Grep`, `Write`, and `Edit`. Add
+`Bash`, `WebFetch`, `WebSearch`, or `Task` only when the current skill requires
+local scripts, external facts, or true parallel sub-agent orchestration.
 
 ---
 
@@ -149,113 +113,89 @@ Only add higher-risk tools when explicitly required:
 |---------|--------|
 | `SkillForge: {goal}` | Full autonomous execution |
 | `SkillForge --plan-only {goal}` | Generate specification only |
-| `SkillForge --quick {goal}` | Reduced depth (not recommended) |
+| `SkillForge --quick {goal}` | Reduced depth, not recommended |
 | `SkillForge --triage {input}` | Run Phase 0 triage only |
 | `SkillForge --improve {skill}` | Enter improvement mode for existing skill |
 
 ---
 
-## Phase 0: Skill Triage (NEW in v4.0)
+## Phase 0: Skill Triage
 
-Before creating anything, SkillForge intelligently analyzes your input to determine the best action.
+Classify the input, scan the skill ecosystem, score matches, then route to one
+of five actions. Use existing skills for matches >=80%, improve matches in the
+50-79% range, create below 50%, compose multi-domain requests, and clarify only
+when ambiguity or duplicate risk blocks a safe route.
 
-### How It Works
-
-```
-┌────────────────────────────────────────────────────────────────────┐
-│                        ANY USER INPUT                               │
-│  (prompt, error, code, URL, question, task request, anything)      │
-└────────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌────────────────────────────────────────────────────────────────────┐
-│  Step 1: INPUT CLASSIFICATION                                       │
-│  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐       │
-│  │ explicit_create │ │ explicit_improve│ │ skill_question  │       │
-│  │ "create skill"  │ │ "improve skill" │ │ "do I have..."  │       │
-│  └─────────────────┘ └─────────────────┘ └─────────────────┘       │
-│  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐       │
-│  │  task_request   │ │  error_message  │ │  code_snippet   │       │
-│  │ "help me with"  │ │ "TypeError..."  │ │ [pasted code]   │       │
-│  └─────────────────┘ └─────────────────┘ └─────────────────┘       │
-└────────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌────────────────────────────────────────────────────────────────────┐
-│  Step 2: SKILL ECOSYSTEM SCAN                                       │
-│  • Load index of 250+ skills (discover_skills.py)                  │
-│  • Match input against all skills with confidence scoring          │
-│  • Identify top matches with reasons                               │
-└────────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌────────────────────────────────────────────────────────────────────┐
-│  Step 3: DECISION MATRIX                                            │
-│                                                                     │
-│  Match ≥80%  + explicit create → CLARIFY (duplicate warning)       │
-│  Match ≥80%  + other input     → USE_EXISTING (recommend skill)    │
-│  Match 50-79%                  → IMPROVE_EXISTING (enhance match)  │
-│  Match <50%  + explicit create → CREATE_NEW (proceed to Phase 1)   │
-│  Multi-domain detected         → COMPOSE (suggest skill chain)     │
-│  Ambiguous input               → CLARIFY (ask for more info)       │
-└────────────────────────────────────────────────────────────────────┘
-```
-
-### Decision Actions
-
-| Action | When | Result |
-|--------|------|--------|
-| **USE_EXISTING** | Match ≥80% | Recommends existing skill(s) to invoke |
-| **IMPROVE_EXISTING** | Match 50-79% | Loads skill and enters enhancement mode |
-| **CREATE_NEW** | Match <50% | Proceeds to Phase 1 (Deep Analysis) |
-| **COMPOSE** | Multi-domain | Suggests skill chain via SkillComposer |
-| **CLARIFY** | Ambiguous or duplicate | Asks user to clarify intent |
-
-### Triage Script
-
-```bash
-# Run triage on any input
-python scripts/triage_skill_request.py "help me debug this error"
-
-# JSON output for automation
-python scripts/triage_skill_request.py "create a skill for payments" --json
-
-# Examples:
-python scripts/triage_skill_request.py "TypeError: Cannot read property 'map'"
-# → USE_EXISTING: Recommends ErrorExplainer (92%)
-
-python scripts/triage_skill_request.py "create a skill for code review"
-# → CLARIFY: CodeReview skill exists (85%), create anyway?
-
-python scripts/triage_skill_request.py "help me with API and auth and testing"
-# → COMPOSE: Multi-domain, suggests APIDesign + AuthSystem + TestGen chain
-```
-
-### Ecosystem Index
-
-Phase 0 uses a pre-built index of all skills:
-
-```bash
-# Rebuild skill index (run periodically or after installing new skills)
-python scripts/discover_skills.py
-
-# Index location: ~/.cache/skillrecommender/skill_index.json
-# Scans: ~/.claude/skills/, plugins/marketplaces/*, plugins/cache/*
-```
-
-### Integration with Phases 1-4
-
-- **USE_EXISTING**: Exits early, no creation needed
-- **IMPROVE_EXISTING**: Loads existing skill → Phase 1 analyzes gaps → Phase 2-4 enhance
-- **CREATE_NEW**: Full pipeline (Phase 1 → 2 → 3 → 4)
-- **COMPOSE**: Suggests using SkillComposer instead
-- **CLARIFY**: Pauses for user input before proceeding
+See [references/phase0-triage.md](references/phase0-triage.md) for the decision
+matrix, script examples, ecosystem index, and integration with later phases.
 
 ---
 
-## Validation & Packaging
+## Phase 1: Deep Analysis
 
-Before distribution, validate your skill:
+Expand explicit requirements, implicit requirements, unknown unknowns, and
+domain context. Apply all 11 thinking models, run regression questioning until
+three rounds add no new insight, and identify automation opportunities.
+
+See [references/phase1-analysis-deep-dive.md](references/phase1-analysis-deep-dive.md),
+[references/multi-lens-framework.md](references/multi-lens-framework.md), and
+[references/regression-questions.md](references/regression-questions.md).
+
+---
+
+## Phase 2: Specification
+
+Create the XML skill specification with metadata, context, requirements,
+architecture, scripts, evolution analysis, anti-patterns, and success criteria.
+Validate traceability, rationale, extension points, and timelessness before
+writing skill files.
+
+See [references/phase2-specification-deep-dive.md](references/phase2-specification-deep-dive.md)
+and [references/specification-template.md](references/specification-template.md).
+
+---
+
+## Phase 3: Generation
+
+Generate the skill directory in this order: structure, `SKILL.md`, references,
+assets, then scripts when scripts are needed. Keep `SKILL.md` concise and move
+deep detail into progressive-disclosure reference files.
+
+See [references/phase3-generation-deep-dive.md](references/phase3-generation-deep-dive.md),
+[references/output-structure.md](references/output-structure.md),
+[references/script-integration-framework.md](references/script-integration-framework.md),
+and [references/script-patterns-catalog.md](references/script-patterns-catalog.md).
+
+---
+
+## Phase 4: Synthesis Panel
+
+Run 3-4 independent evaluators: design and architecture, audience and usability,
+evolution and timelessness, plus script and automation when scripts exist. All
+agents must approve. Rejections loop back into targeted analysis and generation.
+
+See [references/phase4-synthesis-deep-dive.md](references/phase4-synthesis-deep-dive.md)
+and [references/synthesis-protocol.md](references/synthesis-protocol.md).
+
+---
+
+## Evolution and Architecture Selection
+
+Evaluate each skill across 6-month, 1-year, 2-year, and 5-year horizons. Reject
+transient designs, revise tool-bound designs, and approve principle-based skills
+with extension points. Select the architecture pattern that fits task complexity.
+
+See [references/evolution-scoring.md](references/evolution-scoring.md),
+[references/evolution-timelessness.md](references/evolution-timelessness.md), and
+[references/architecture-patterns.md](references/architecture-patterns.md).
+
+---
+
+## Validation and Packaging
+
+Before distribution, validate structure, frontmatter, scripts, documentation
+safety, and packaging. Keep command examples portable when a plugin-root path is
+needed.
 
 ```bash
 # Quick validation (required for packaging)
@@ -268,181 +208,9 @@ python scripts/validate-skill.py ~/.claude/skills/my-skill/
 python scripts/package_skill.py ~/.claude/skills/my-skill/ ./dist
 ```
 
-### Frontmatter Requirements
-
-Skills must use only these allowed frontmatter properties:
-
-| Property | Required | Description |
-|----------|----------|-------------|
-| `name` | Yes | Hyphen-case, max 64 chars |
-| `description` | Yes | Max 1024 chars, no angle brackets |
-| `license` | No | MIT, Apache-2.0, etc. |
-| `allowed-tools` | No | Restrict tool access (comma-separated or YAML list) |
-| `model` | No | Specific Claude model (e.g., `claude-sonnet-4-20250514`) |
-| `context` | No | Set to `fork` for isolated sub-agent context |
-| `agent` | No | Agent type when `context: fork` (`Explore`, `Plan`, `general-purpose`) |
-| `hooks` | No | Lifecycle hooks (`PreToolUse`, `PostToolUse`, `Stop`) |
-| `user-invocable` | No | Show in slash menu (default: `true`) |
-| `metadata` | No | Custom fields (version, author, domains, etc.) |
-
-**Basic Example:**
-
-```yaml
----
-name: my-skill
-description: What this skill does and when to use it
-license: MIT
-model: claude-opus-4-6
-user-invocable: true
-metadata:
-  version: 1.0.0
-  author: your-name
----
-```
-
-**Advanced Example (with forked context and hooks):**
-
-```yaml
----
-name: isolated-analyzer
-description: Runs analysis in isolated context with validation hooks
-license: MIT
-model: claude-opus-4-6
-context: fork
-agent: Explore
-user-invocable: true
-allowed-tools:
-  - Read
-  - Glob
-  - Grep
-hooks:
-  PreToolUse:
-    - matcher: "Bash"
-      hooks:
-        - type: command
-          command: "./scripts/validate.sh"
-metadata:
-  version: 1.0.0
----
-```
-
-**Field Details:**
-
-| Field | Values | Notes |
-|-------|--------|-------|
-| `context` | `fork` | Creates isolated sub-agent with separate conversation history |
-| `agent` | `Explore`, `Plan`, `general-purpose` | Only valid when `context: fork` |
-| `user-invocable` | `true`, `false` | `false` hides from slash menu but Claude can still auto-invoke |
-| `hooks` | Object | See [Hooks Integration](#hooks-integration) section |
-
----
-
-## Skill Output Structure
-
-```
-~/.claude/skills/{skill-name}/
-├── SKILL.md                    # Main entry point (required)
-├── references/                 # Deep documentation (optional)
-│   ├── patterns.md
-│   └── examples.md
-├── assets/                     # Templates (optional)
-│   └── templates/
-└── scripts/                    # Automation scripts (optional)
-    ├── validate.py             # Validation/verification
-    ├── generate.py             # Artifact generation
-    └── state.py                # State management
-```
-
-### Scripts Directory
-
-Scripts enable skills to be **agentic** - capable of autonomous operation with self-verification.
-
-| Category | Purpose | When to Include |
-|----------|---------|-----------------|
-| **Validation** | Verify outputs meet standards | Skill produces artifacts |
-| **Generation** | Create artifacts from templates | Repeatable artifact creation |
-| **State Management** | Track progress across sessions | Long-running operations |
-| **Transformation** | Convert/process data | Data processing tasks |
-| **Calculation** | Compute metrics/scores | Scoring or analysis |
-
-**Script Requirements:**
-
-- Python 3.x with standard library only (graceful fallbacks for extras)
-- `Result` dataclass pattern for structured returns
-- Exit codes: 0=success, 1=failure, 10=validation failure, 11=verification failure
-- Self-verification where applicable
-- Documented in SKILL.md with usage examples
-
-See: [references/script-integration-framework.md](references/script-integration-framework.md)
-
-### Hooks Integration
-
-Skills can define lifecycle hooks for validation, logging, and safety:
-
-```yaml
----
-name: secure-skill
-hooks:
-  PreToolUse:
-    - matcher: "Bash"
-      hooks:
-        - type: command
-          command: "./scripts/validate-input.sh"
-  PostToolUse:
-    - matcher: "Write"
-      hooks:
-        - type: command
-          command: "./scripts/log-output.sh"
-          once: true
-  Stop:
-    - hooks:
-        - type: command
-          command: "./scripts/cleanup.sh"
----
-```
-
-**Hook Types:**
-
-| Hook | When Triggered | Use Case |
-|------|----------------|----------|
-| `PreToolUse` | Before tool execution | Input validation, security checks |
-| `PostToolUse` | After tool execution | Output logging, verification |
-| `Stop` | When skill completes | Cleanup, state persistence |
-
-**Hook Configuration:**
-
-| Field | Description |
-|-------|-------------|
-| `matcher` | Tool name pattern to match (e.g., "Bash", "Write", "Bash(python:*)") |
-| `type` | Hook type: `command` (shell) or `prompt` (Claude evaluation) |
-| `command` | Shell command to execute (for `type: command`) |
-| `once` | If `true`, run only once per session (default: `false`) |
-
-Read `$TOOL_INPUT` / `$TOOL_OUTPUT` inside hook scripts from environment variables.
-Do not interpolate untrusted tool payloads directly into shell command strings.
-
-**When to Use Hooks:**
-
-| Scenario | Hook Type | Example |
-|----------|-----------|---------|
-| Validate script inputs | PreToolUse | Check parameters before `python scripts/*.py` |
-| Log generated artifacts | PostToolUse | Record files created by Write tool |
-| Security gate | PreToolUse | Block dangerous bash commands |
-| Cleanup temp files | Stop | Remove intermediate artifacts |
-
-**Example: Script Validation Hook**
-
-For skills with scripts, add input validation:
-
-```yaml
-hooks:
-  PreToolUse:
-    - matcher: "Bash(python:scripts/*)"
-      hooks:
-        - type: command
-          command: "python scripts/quick_validate.py . 2>/dev/null || true"
-          once: true
-```
+See [references/output-structure.md](references/output-structure.md) for allowed
+frontmatter fields, directory layout, script categories, hook configuration, and
+output requirements.
 
 ---
 
@@ -452,10 +220,10 @@ hooks:
 |-------|-----|---------|
 | Duplicate skills | Bloats registry | Check existing first |
 | Single trigger | Hard to discover | 3-5 varied phrases |
-| No verification | Can't confirm success | Measurable outcomes |
+| No verification | Cannot confirm success | Measurable outcomes |
 | Over-engineering | Complexity without value | Start simple |
-| Missing WHY | Can't evolve | Document rationale |
-| Invalid frontmatter | Can't package | Use allowed properties only |
+| Missing WHY | Cannot evolve | Document rationale |
+| Invalid frontmatter | Cannot package | Use allowed properties only |
 
 ---
 
@@ -463,491 +231,59 @@ hooks:
 
 After creation:
 
-- [ ] Frontmatter valid (only allowed properties)
-- [ ] Name is hyphen-case, ≤64 chars
-- [ ] Description ≤1024 chars, no `<` or `>`
+- [ ] Frontmatter valid with only allowed properties
+- [ ] Name is hyphen-case and <=64 chars
+- [ ] Description <=1024 chars, with no `<` or `>`
 - [ ] 3-5 trigger phrases defined
-- [ ] Timelessness score ≥ 7
+- [ ] Timelessness score >=7
 - [ ] `python scripts/quick_validate.py` passes
 - [ ] `python scripts/check_docs_safety.py` passes
+- [ ] Reference links resolve
+- [ ] Scripts self-verify when scripts are present
 
 ---
 
-<details>
-<summary><strong>Deep Dive: Phase 1 - Analysis</strong></summary>
-
-### 1A: Input Expansion
-
-Transform user's goal into comprehensive requirements:
-
-```
-USER INPUT: "Create a skill for X"
-                │
-                ▼
-┌─────────────────────────────────────────────────────────┐
-│ EXPLICIT REQUIREMENTS                                    │
-│ • What the user literally asked for                      │
-│ • Direct functionality stated                            │
-├─────────────────────────────────────────────────────────┤
-│ IMPLICIT REQUIREMENTS                                    │
-│ • What they probably expect but didn't say               │
-│ • Standard quality expectations                          │
-│ • Integration with existing patterns                     │
-├─────────────────────────────────────────────────────────┤
-│ UNKNOWN UNKNOWNS                                         │
-│ • What they don't know they need                         │
-│ • Expert-level considerations they'd miss                │
-│ • Future needs they haven't anticipated                  │
-├─────────────────────────────────────────────────────────┤
-│ DOMAIN CONTEXT                                           │
-│ • Related skills that exist                              │
-│ • Patterns from similar skills                           │
-│ • Lessons from skill failures                            │
-└─────────────────────────────────────────────────────────┘
-```
-
-**Check for overlap with existing skills:**
-
-```bash
-ls ~/.claude/skills/
-# Grep for similar triggers in existing SKILL.md files
-```
-
-| Match Score | Action |
-|-------------|--------|
-| >7/10 | Use existing skill instead |
-| 5-7/10 | Clarify distinction before proceeding |
-| <5/10 | Proceed with new skill |
-
-### 1B: Multi-Lens Analysis
-
-Apply all 11 thinking models systematically:
-
-| Lens | Core Question | Application |
-|------|---------------|-------------|
-| **First Principles** | What's fundamentally needed? | Strip convention, find core |
-| **Inversion** | What guarantees failure? | Build anti-patterns |
-| **Second-Order** | What happens after the obvious? | Map downstream effects |
-| **Pre-Mortem** | Why did this fail? | Proactive risk mitigation |
-| **Systems Thinking** | How do parts interact? | Integration mapping |
-| **Devil's Advocate** | Strongest counter-argument? | Challenge every decision |
-| **Constraints** | What's truly fixed? | Separate real from assumed |
-| **Pareto** | Which 20% delivers 80%? | Focus on high-value features |
-| **Root Cause** | Why is this needed? (5 Whys) | Address cause not symptom |
-| **Comparative** | How do options compare? | Weighted decision matrix |
-| **Opportunity Cost** | What are we giving up? | Explicit trade-offs |
-
-**Minimum requirement:** All 11 lenses scanned, at least 5 applied in depth.
-
-See: [references/multi-lens-framework.md](references/multi-lens-framework.md)
-
-### 1C: Regression Questioning
-
-Iterative self-questioning until no new insights emerge:
-
-```
-ROUND N:
-│
-├── "What am I missing?"
-├── "What would an expert in {domain} add?"
-├── "What would make this fail?"
-├── "What will this look like in 2 years?"
-├── "What's the weakest part of this design?"
-└── "Which thinking model haven't I applied?"
-    │
-    └── New insights > 0?
-        │
-        ├── YES → Incorporate and loop
-        └── NO → Check termination criteria
-```
-
-**Termination Criteria:**
-
-- Three consecutive rounds produce no new insights
-- All 11 thinking models have been applied
-- At least 3 simulated expert perspectives considered
-- Evolution/timelessness explicitly evaluated
-- Automation opportunities identified
-
-See: [references/regression-questions.md](references/regression-questions.md)
-
-### 1D: Automation Analysis
-
-Identify opportunities for scripts that enable agentic operation:
-
-```
-FOR EACH operation in the skill:
-│
-├── Is this operation repeatable?
-│   └── YES → Consider generation script
-│
-├── Does this produce verifiable output?
-│   └── YES → Consider validation script
-│
-├── Does this need state across sessions?
-│   └── YES → Consider state management script
-│
-├── Does this involve external tools?
-│   └── YES → Consider integration script
-│
-└── Can Claude verify success autonomously?
-    └── NO → Add self-verification script
-```
-
-**Automation Lens Questions:**
-
-| Question | Script Category if YES |
-|----------|----------------------|
-| What operations will be repeated identically? | Generation |
-| What outputs require validation? | Validation |
-| What state needs to persist? | State Management |
-| Can the skill run overnight autonomously? | All categories |
-| How will Claude verify correct execution? | Verification |
-
-**Decision: Script vs No Script**
-
-| Create Script When | Skip Script When |
-|-------------------|------------------|
-| Operation is deterministic | Requires human judgment |
-| Output can be validated | One-time setup |
-| Will be reused across invocations | Simple text output |
-| Enables autonomous operation | No verification needed |
-| External tool integration | Pure Claude reasoning |
-
-See: [references/script-integration-framework.md](references/script-integration-framework.md)
-
-</details>
-
-<details>
-<summary><strong>Deep Dive: Phase 2 - Specification</strong></summary>
-
-### Specification Structure
-
-The specification captures all analysis insights in XML format:
-
-```xml
-<skill_specification>
-  <metadata>
-    <name>skill-name</name>
-    <analysis_iterations>N</analysis_iterations>
-    <timelessness_score>X/10</timelessness_score>
-  </metadata>
-
-  <context>
-    <problem_statement>What + Why + Who</problem_statement>
-    <existing_landscape>Related skills, distinctiveness</existing_landscape>
-  </context>
-
-  <requirements>
-    <explicit>What user asked for</explicit>
-    <implicit>Expected but unstated</implicit>
-    <discovered>Found through analysis</discovered>
-  </requirements>
-
-  <architecture>
-    <pattern>Selected pattern with WHY</pattern>
-    <phases>Ordered phases with verification</phases>
-    <decision_points>Branches and defaults</decision_points>
-  </architecture>
-
-  <scripts>
-    <decision_summary>needs_scripts + rationale</decision_summary>
-    <script_inventory>name, category, purpose, patterns</script_inventory>
-    <agentic_capabilities>autonomous, self-verify, recovery</agentic_capabilities>
-  </scripts>
-
-  <evolution_analysis>
-    <timelessness_score>X/10</timelessness_score>
-    <extension_points>Where skill can grow</extension_points>
-    <obsolescence_triggers>What would break it</obsolescence_triggers>
-  </evolution_analysis>
-
-  <anti_patterns>
-    <pattern>What to avoid + WHY + alternative</pattern>
-  </anti_patterns>
-
-  <success_criteria>
-    <criterion>Measurable + verification method</criterion>
-  </success_criteria>
-</skill_specification>
-```
-
-See: [references/specification-template.md](references/specification-template.md)
-
-### Specification Validation
-
-Before proceeding to Phase 3:
-
-- [ ] All sections present with no placeholders
-- [ ] Every decision includes WHY
-- [ ] Timelessness score ≥ 7 with justification
-- [ ] At least 2 extension points documented
-- [ ] All requirements traceable to source
-- [ ] Scripts section complete (if applicable)
-- [ ] Agentic capabilities documented (if scripts present)
-
-</details>
-
-<details>
-<summary><strong>Deep Dive: Phase 3 - Generation</strong></summary>
-
-**Context:** Fresh, clean (no analysis artifacts polluting)
-**Standard:** Zero errors—every section verified before proceeding
-
-### Generation Order
-
-```
-1. Create directory structure
-   mkdir -p ~/.claude/skills/{skill-name}/references
-   mkdir -p ~/.claude/skills/{skill-name}/assets/templates
-   mkdir -p ~/.claude/skills/{skill-name}/scripts  # if scripts needed
-
-2. Write SKILL.md
-   • Frontmatter (YAML - allowed properties only)
-   • Title and brief intro
-   • Quick Start section
-   • Triggers (3-5 varied phrases)
-   • Quick Reference table
-   • How It Works overview
-   • Commands
-   • Scripts section (if applicable)
-   • Validation section
-   • Anti-Patterns
-   • Verification criteria
-   • Deep Dive sections (in <details> tags)
-
-3. Generate reference documents (if needed)
-   • Deep documentation for complex topics
-   • Templates for generated artifacts
-   • Checklists for validation
-
-4. Create assets (if needed)
-   • Templates for skill outputs
-
-5. Create scripts (if needed)
-   • Use script-template.py as base
-   • Include Result dataclass pattern
-   • Add self-verification
-   • Document exit codes
-   • Test before finalizing
-```
-
-### Quality Checks During Generation
-
-| Check | Requirement |
-|-------|-------------|
-| Frontmatter | Only allowed properties (name, description, license, allowed-tools, metadata) |
-| Name | Hyphen-case, ≤64 chars |
-| Description | ≤1024 chars, no angle brackets |
-| Triggers | 3-5 distinct, natural language |
-| Phases | 1-3 max, not over-engineered |
-| Verification | Concrete, measurable |
-| Tables over prose | Structured information in tables |
-| No placeholder text | Every section fully written |
-| Scripts (if present) | Shebang, docstring, argparse, exit codes, Result pattern |
-| Script docs | Scripts section in SKILL.md with usage examples |
-
-</details>
-
-<details>
-<summary><strong>Deep Dive: Phase 4 - Multi-Agent Synthesis</strong></summary>
-
-**Panel:** 3-4 Opus agents with distinct evaluative lenses
-**Requirement:** Unanimous approval (all agents)
-**Fallback:** Return to Phase 1 with feedback (max 5 iterations)
-
-### Panel Composition
-
-| Agent | Focus | Key Criteria | When Active |
-|-------|-------|--------------|-------------|
-| **Design/Architecture** | Structure, patterns, correctness | Pattern appropriate, phases logical, no circular deps | Always |
-| **Audience/Usability** | Clarity, discoverability, completeness | Triggers natural, steps unambiguous, no assumed knowledge | Always |
-| **Evolution/Timelessness** | Future-proofing, extension, ecosystem | Score ≥7, extension points clear, ecosystem fit | Always |
-| **Script/Automation** | Agentic capability, verification, quality | Scripts follow patterns, self-verify, documented | When scripts present |
-
-### Script Agent (Conditional)
-
-The Script Agent is activated when the skill includes a `scripts/` directory. Focus areas:
-
-| Criterion | Checks |
-|-----------|--------|
-| **Pattern Compliance** | Result dataclass, argparse, exit codes |
-| **Self-Verification** | Scripts can verify their own output |
-| **Error Handling** | Graceful failures, actionable messages |
-| **Documentation** | Usage examples in SKILL.md |
-| **Agentic Capability** | Scripts complete cleanly without interactive prompts during scoped, user-approved invocations |
-
-**Script Agent Scoring:**
-
-| Score | Meaning |
-|-------|---------|
-| 8-10 | Fully agentic, self-verifying, production-ready |
-| 6-7 | Functional but missing some agentic capabilities |
-| <6 | Requires revision - insufficient automation quality |
-
-### Agent Evaluation
-
-Each agent produces:
-
-```markdown
-## [Agent] Review
-
-### Verdict: APPROVED / CHANGES_REQUIRED
-
-### Scores
-| Criterion | Score (1-10) | Notes |
-|-----------|--------------|-------|
-
-### Strengths
-1. [Specific with evidence]
-
-### Issues (if CHANGES_REQUIRED)
-| Issue | Severity | Required Change |
-|-------|----------|-----------------|
-
-### Recommendations
-1. [Even if approved]
-```
-
-### Consensus Protocol
-
-```
-IF all agents APPROVED (3/3 or 4/4):
-    → Finalize skill
-    → Run validate-skill.py
-    → Update registry
-    → Complete
-
-ELSE:
-    → Collect all issues (including script issues)
-    → Return to Phase 1 with issues as input
-    → Re-apply targeted questioning
-    → Regenerate skill and scripts
-    → Re-submit to panel
-
-IF 5 iterations without consensus:
-    → Flag for human review
-    → Present all agent perspectives
-    → User makes final decision
-```
-
-See: [references/synthesis-protocol.md](references/synthesis-protocol.md)
-
-</details>
-
-<details>
-<summary><strong>Deep Dive: Evolution/Timelessness</strong></summary>
-
-Every skill is evaluated through the evolution lens:
-
-### Temporal Projection
-
-| Timeframe | Key Question |
-|-----------|--------------|
-| 6 months | How will usage patterns evolve? |
-| 1 year | What ecosystem changes are likely? |
-| 2 years | What new capabilities might obsolete this? |
-| 5 years | Is the core problem still relevant? |
-
-### Timelessness Scoring
-
-| Score | Description | Verdict |
-|-------|-------------|---------|
-| 1-3 | Transient, will be obsolete in months | Reject |
-| 4-6 | Moderate, depends on current tooling | Revise |
-| **7-8** | **Solid, principle-based, extensible** | **Approve** |
-| 9-10 | Timeless, addresses fundamental problem | Exemplary |
-
-**Requirement:** All skills must score ≥7.
-
-### Anti-Obsolescence Patterns
-
-| Do | Don't |
-|----|-------|
-| Design around principles | Hardcode implementations |
-| Document the WHY | Only document the WHAT |
-| Include extension points | Create closed systems |
-| Abstract volatile dependencies | Direct coupling |
-| Version-agnostic patterns | Pin specific versions |
-
-See: [references/evolution-scoring.md](references/evolution-scoring.md)
-
-</details>
-
-<details>
-<summary><strong>Architecture Pattern Selection</strong></summary>
-
-Select based on task complexity:
-
-| Pattern | Use When | Structure |
-|---------|----------|-----------|
-| **Single-Phase** | Simple linear tasks | Steps 1-2-3 |
-| **Checklist** | Quality/compliance audits | ☐ Item verification |
-| **Generator** | Creating artifacts | Input → Transform → Output |
-| **Multi-Phase** | Complex ordered workflows | Phase 1 → Phase 2 → Phase 3 |
-| **Multi-Agent Parallel** | Independent subtasks | Launch agents concurrently |
-| **Multi-Agent Sequential** | Dependent subtasks | Agent 1 → Agent 2 → Agent 3 |
-| **Orchestrator** | Coordinating multiple skills | Meta-skill chains |
-
-### Selection Decision Tree
-
-```
-Is it a simple procedure?
-├── Yes → Single-Phase
-└── No → Does it produce artifacts?
-    ├── Yes → Generator
-    └── No → Does it verify/audit?
-        ├── Yes → Checklist
-        └── No → Are subtasks independent?
-            ├── Yes → Multi-Agent Parallel
-            └── No → Multi-Agent Sequential or Multi-Phase
-```
-
-</details>
-
-<details>
-<summary><strong>Configuration</strong></summary>
-
-```yaml
-SKILLCREATOR_CONFIG:
-  mode: autonomous
-  depth: maximum  # always
-  core_lens: evolution_timelessness
-
-  analysis:
-    min_lens_depth: 5
-    max_questioning_rounds: 7
-    termination_empty_rounds: 3
-
-  synthesis:
-    panel_size: 3
-    require_unanimous: true
-    max_iterations: 5
-    escalate_to_human: true
-
-  evolution:
-    min_timelessness_score: 7
-    min_extension_points: 2
-    require_temporal_projection: true
-
-  model:
-    primary: claude-opus-4-6
-    subagents: claude-opus-4-6
-```
-
-</details>
+## Scripts
+
+The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. All scripts use Python 3 standard library, the `Result` dataclass pattern, and shared exit codes: `0`=success, `1`=failure, `10`=validation failure, `11`=verification failure.
+
+| Script | Purpose |
+|--------|---------|
+| `triage_skill_request.py` | Phase 0 triage: classify an input and route to build, improve, or reuse |
+| `discover_skills.py` | Ecosystem scan: enumerate existing skills before creating a new one |
+| `init_skill.py` | Scaffold a new skill directory from the standard structure |
+| `validate-skill.py` | Full validation of a generated skill against SkillForge standards |
+| `quick_validate.py` | Fast structural check of frontmatter and required sections |
+| `skill_modularity_audit.py` | Audit SKILL.md size and flag progressive-disclosure violations |
+| `package_skill.py` | Package a completed skill for distribution |
+| `check_docs_safety.py` | Safety scan of generated documentation |
+
+See [references/script-integration-framework.md](references/script-integration-framework.md) for when to add scripts and [references/script-patterns-catalog.md](references/script-patterns-catalog.md) for the standard patterns.
 
 ---
 
 ## References
 
-- [Regression Questions](references/regression-questions.md) - Complete question bank (7 categories)
-- [Multi-Lens Framework](references/multi-lens-framework.md) - 11 thinking models guide
-- [Specification Template](references/specification-template.md) - XML spec structure
-- [Evolution Scoring](references/evolution-scoring.md) - Timelessness evaluation
-- [Synthesis Protocol](references/synthesis-protocol.md) - Multi-agent panel details
-- [Script Integration Framework](references/script-integration-framework.md) - When and how to create scripts
-- [Script Patterns Catalog](references/script-patterns-catalog.md) - Standard Python patterns
+| Reference | Contents |
+|-----------|----------|
+| [Overview and Triggers](references/overview-and-triggers.md) | Original examples, trigger lists, routing diagram, commands |
+| [Phase 0 Triage](references/phase0-triage.md) | Input classification, ecosystem scan, decision matrix, triage scripts |
+| [Phase 1 Deep Dive](references/phase1-analysis-deep-dive.md) | Input expansion, lens scan, regression questioning, automation analysis |
+| [Multi-Lens Framework](references/multi-lens-framework.md) | 11 thinking models and application guidance |
+| [Regression Questions](references/regression-questions.md) | Complete question bank and termination criteria |
+| [Phase 2 Deep Dive](references/phase2-specification-deep-dive.md) | Specification structure and validation |
+| [Specification Template](references/specification-template.md) | Full XML specification template |
+| [Phase 3 Deep Dive](references/phase3-generation-deep-dive.md) | Generation order and quality checks |
+| [Output Structure](references/output-structure.md) | Frontmatter, directory structure, scripts, hooks |
+| [Script Integration Framework](references/script-integration-framework.md) | When and how to add scripts |
+| [Script Patterns Catalog](references/script-patterns-catalog.md) | Standard Python script patterns |
+| [Phase 4 Deep Dive](references/phase4-synthesis-deep-dive.md) | Panel composition, script agent, evaluation format, consensus loop |
+| [Synthesis Protocol](references/synthesis-protocol.md) | Multi-agent panel execution details |
+| [Evolution Scoring](references/evolution-scoring.md) | Timelessness scoring and evolution rubric |
+| [Evolution Timelessness](references/evolution-timelessness.md) | Temporal projection and anti-obsolescence patterns |
+| [Architecture Patterns](references/architecture-patterns.md) | Pattern selection guide and decision tree |
+| [Configuration](references/configuration.md) | SkillForge configuration defaults |
+| [Changelog](references/changelog.md) | Version history |
 
 ---
 
@@ -964,70 +300,15 @@ SKILLCREATOR_CONFIG:
 
 ## Extension Points
 
-1. **Additional Lenses:** Add new thinking models to `references/multi-lens-framework.md`
-2. **New Synthesis Agents:** Extend panel beyond 4 agents for specific domains
-3. **Custom Patterns:** Add architecture patterns to selection guide
-4. **Domain Templates:** Add domain-specific templates to `assets/templates/`
-5. **Script Patterns:** Add new patterns to `references/script-patterns-catalog.md`
-6. **Script Categories:** Extend the 7 script categories for new use cases
+1. Add thinking models in [references/multi-lens-framework.md](references/multi-lens-framework.md).
+2. Extend panel agents in [references/synthesis-protocol.md](references/synthesis-protocol.md).
+3. Add architecture patterns in [references/architecture-patterns.md](references/architecture-patterns.md).
+4. Add domain templates in `assets/templates/`.
+5. Add script patterns in [references/script-patterns-catalog.md](references/script-patterns-catalog.md).
+6. Extend script categories in [references/script-integration-framework.md](references/script-integration-framework.md).
 
 ---
 
 ## Changelog
 
-### v4.1.0 (Current)
-
-- **Extended frontmatter support** - Full support for `model`, `context`, `agent`, `hooks`, `user-invocable`
-- Created `scripts/_constants.py` for shared validation constants
-- Updated `scripts/quick_validate.py` with extended property validation
-- Updated `scripts/validate-skill.py` with hooks and agent validation
-- Fixed `scripts/discover_skills.py` to extract version from `metadata.version`
-- Added Hooks Integration section to SKILL.md and script-integration-framework.md
-- Added Forked Context documentation to synthesis-protocol.md
-- Updated skill template with modern best practices
-- Expanded frontmatter requirements table with 10 properties
-
-### v4.0.0
-
-- **Phase 0 Skill Triage** - Intelligent routing before creation
-- Universal input handling - any prompt works
-- Skill ecosystem scanning with 250+ skills indexed
-- Decision matrix: USE | IMPROVE | CREATE | COMPOSE
-- Renamed from SkillCreator to SkillForge
-
-### v3.2.0
-
-- Added Script Integration Framework for agentic skills
-- Added 4th Script Agent to synthesis panel (conditional)
-- Added Phase 1D: Automation Analysis
-- Added Automation Lens questions to regression questioning
-- Created `references/script-integration-framework.md`
-- Created `references/script-patterns-catalog.md`
-- Created `assets/templates/script-template.py`
-- Updated skill-spec-template.xml with `<scripts>` section
-- Updated validate-skill.py with script validation
-- Skills can now include self-verifying Python scripts
-
-### v3.1.0
-
-- Added progressive disclosure structure
-- Fixed frontmatter for packaging compatibility
-- Added validation & packaging section
-- Deep dive sections now collapsible
-
-### v3.0.0
-
-- Complete redesign as ultimate meta-skill
-- Added regression questioning loop
-- Added multi-lens analysis framework (11 models)
-- Added evolution/timelessness core lens
-- Added multi-agent synthesis panel
-
-### v2.0.0
-
-- Pattern selection guide
-- Quality standards checklist
-
-### v1.0.0
-
-- Basic skill structure
+See [references/changelog.md](references/changelog.md) for the full version history.

--- a/.claude/skills/SkillForge/references/changelog.md
+++ b/.claude/skills/SkillForge/references/changelog.md
@@ -1,0 +1,58 @@
+## Changelog
+
+### v4.1.0 (Current)
+
+- **Extended frontmatter support** - Full support for `model`, `context`, `agent`, `hooks`, `user-invocable`
+- Created `scripts/_constants.py` for shared validation constants
+- Updated `scripts/quick_validate.py` with extended property validation
+- Updated `scripts/validate-skill.py` with hooks and agent validation
+- Fixed `scripts/discover_skills.py` to extract version from `metadata.version`
+- Added Hooks Integration section to SKILL.md and script-integration-framework.md
+- Added Forked Context documentation to synthesis-protocol.md
+- Updated skill template with modern best practices
+- Expanded frontmatter requirements table with 10 properties
+
+### v4.0.0
+
+- **Phase 0 Skill Triage** - Intelligent routing before creation
+- Universal input handling - any prompt works
+- Skill ecosystem scanning with 250+ skills indexed
+- Decision matrix: USE | IMPROVE | CREATE | COMPOSE
+- Renamed from SkillCreator to SkillForge
+
+### v3.2.0
+
+- Added Script Integration Framework for agentic skills
+- Added 4th Script Agent to synthesis panel (conditional)
+- Added Phase 1D: Automation Analysis
+- Added Automation Lens questions to regression questioning
+- Created `references/script-integration-framework.md`
+- Created `references/script-patterns-catalog.md`
+- Created `assets/templates/script-template.py`
+- Updated skill-spec-template.xml with `<scripts>` section
+- Updated validate-skill.py with script validation
+- Skills can now include self-verifying Python scripts
+
+### v3.1.0
+
+- Added progressive disclosure structure
+- Fixed frontmatter for packaging compatibility
+- Added validation & packaging section
+- Deep dive sections now collapsible
+
+### v3.0.0
+
+- Complete redesign as ultimate meta-skill
+- Added regression questioning loop
+- Added multi-lens analysis framework (11 models)
+- Added evolution/timelessness core lens
+- Added multi-agent synthesis panel
+
+### v2.0.0
+
+- Pattern selection guide
+- Quality standards checklist
+
+### v1.0.0
+
+- Basic skill structure

--- a/.claude/skills/SkillForge/references/evolution-timelessness.md
+++ b/.claude/skills/SkillForge/references/evolution-timelessness.md
@@ -31,4 +31,4 @@ Every skill is evaluated through the evolution lens:
 | Abstract volatile dependencies | Direct coupling |
 | Version-agnostic patterns | Pin specific versions |
 
-See: [references/evolution-scoring.md](evolution-scoring.md)
+See: [evolution-scoring.md](evolution-scoring.md)

--- a/.claude/skills/SkillForge/references/evolution-timelessness.md
+++ b/.claude/skills/SkillForge/references/evolution-timelessness.md
@@ -31,4 +31,4 @@ Every skill is evaluated through the evolution lens:
 | Abstract volatile dependencies | Direct coupling |
 | Version-agnostic patterns | Pin specific versions |
 
-See: [references/evolution-scoring.md](references/evolution-scoring.md)
+See: [references/evolution-scoring.md](evolution-scoring.md)

--- a/.claude/skills/SkillForge/references/output-structure.md
+++ b/.claude/skills/SkillForge/references/output-structure.md
@@ -1,0 +1,179 @@
+# Skill Output Structure and Packaging
+
+### Frontmatter Requirements
+
+Skills must use only these allowed frontmatter properties:
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `name` | Yes | Hyphen-case, max 64 chars |
+| `description` | Yes | Max 1024 chars, no angle brackets |
+| `license` | No | MIT, Apache-2.0, etc. |
+| `allowed-tools` | No | Restrict tool access (comma-separated or YAML list) |
+| `model` | No | Specific Claude model (e.g., `claude-sonnet-4-20250514`) |
+| `context` | No | Set to `fork` for isolated sub-agent context |
+| `agent` | No | Agent type when `context: fork` (`Explore`, `Plan`, `general-purpose`) |
+| `hooks` | No | Lifecycle hooks (`PreToolUse`, `PostToolUse`, `Stop`) |
+| `user-invocable` | No | Show in slash menu (default: `true`) |
+| `metadata` | No | Custom fields (version, author, domains, etc.) |
+
+**Basic Example:**
+
+```yaml
+---
+name: my-skill
+description: What this skill does and when to use it
+license: MIT
+model: claude-opus-4-6
+user-invocable: true
+metadata:
+  version: 1.0.0
+  author: your-name
+---
+```
+
+**Advanced Example (with forked context and hooks):**
+
+```yaml
+---
+name: isolated-analyzer
+description: Runs analysis in isolated context with validation hooks
+license: MIT
+model: claude-opus-4-6
+context: fork
+agent: Explore
+user-invocable: true
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate.sh"
+metadata:
+  version: 1.0.0
+---
+```
+
+**Field Details:**
+
+| Field | Values | Notes |
+|-------|--------|-------|
+| `context` | `fork` | Creates isolated sub-agent with separate conversation history |
+| `agent` | `Explore`, `Plan`, `general-purpose` | Only valid when `context: fork` |
+| `user-invocable` | `true`, `false` | `false` hides from slash menu but Claude can still auto-invoke |
+| `hooks` | Object | See [Hooks Integration](#hooks-integration) section |
+
+---
+
+## Skill Output Structure
+
+```
+~/.claude/skills/{skill-name}/
+├── SKILL.md                    # Main entry point (required)
+├── references/                 # Deep documentation (optional)
+│   ├── patterns.md
+│   └── examples.md
+├── assets/                     # Templates (optional)
+│   └── templates/
+└── scripts/                    # Automation scripts (optional)
+    ├── validate.py             # Validation/verification
+    ├── generate.py             # Artifact generation
+    └── state.py                # State management
+```
+
+### Scripts Directory
+
+Scripts enable skills to be **agentic** - capable of autonomous operation with self-verification.
+
+| Category | Purpose | When to Include |
+|----------|---------|-----------------|
+| **Validation** | Verify outputs meet standards | Skill produces artifacts |
+| **Generation** | Create artifacts from templates | Repeatable artifact creation |
+| **State Management** | Track progress across sessions | Long-running operations |
+| **Transformation** | Convert/process data | Data processing tasks |
+| **Calculation** | Compute metrics/scores | Scoring or analysis |
+
+**Script Requirements:**
+
+- Python 3.x with standard library only (graceful fallbacks for extras)
+- `Result` dataclass pattern for structured returns
+- Exit codes: 0=success, 1=failure, 10=validation failure, 11=verification failure
+- Self-verification where applicable
+- Documented in SKILL.md with usage examples
+
+See: [references/script-integration-framework.md](script-integration-framework.md)
+
+### Hooks Integration
+
+Skills can define lifecycle hooks for validation, logging, and safety:
+
+```yaml
+---
+name: secure-skill
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate-input.sh"
+  PostToolUse:
+    - matcher: "Write"
+      hooks:
+        - type: command
+          command: "./scripts/log-output.sh"
+          once: true
+  Stop:
+    - hooks:
+        - type: command
+          command: "./scripts/cleanup.sh"
+---
+```
+
+**Hook Types:**
+
+| Hook | When Triggered | Use Case |
+|------|----------------|----------|
+| `PreToolUse` | Before tool execution | Input validation, security checks |
+| `PostToolUse` | After tool execution | Output logging, verification |
+| `Stop` | When skill completes | Cleanup, state persistence |
+
+**Hook Configuration:**
+
+| Field | Description |
+|-------|-------------|
+| `matcher` | Tool name pattern to match (e.g., "Bash", "Write", "Bash(python:*)") |
+| `type` | Hook type: `command` (shell) or `prompt` (Claude evaluation) |
+| `command` | Shell command to execute (for `type: command`) |
+| `once` | If `true`, run only once per session (default: `false`) |
+
+Read `$TOOL_INPUT` / `$TOOL_OUTPUT` inside hook scripts from environment variables.
+Do not interpolate untrusted tool payloads directly into shell command strings.
+
+**When to Use Hooks:**
+
+| Scenario | Hook Type | Example |
+|----------|-----------|---------|
+| Validate script inputs | PreToolUse | Check parameters before `python scripts/*.py` |
+| Log generated artifacts | PostToolUse | Record files created by Write tool |
+| Security gate | PreToolUse | Block dangerous bash commands |
+| Cleanup temp files | Stop | Remove intermediate artifacts |
+
+**Example: Script Validation Hook**
+
+For skills with scripts, add input validation:
+
+```yaml
+hooks:
+  PreToolUse:
+    - matcher: "Bash(python:scripts/*)"
+      hooks:
+        - type: command
+          command: "python scripts/quick_validate.py . 2>/dev/null || true"
+          once: true
+```
+
+---

--- a/.claude/skills/SkillForge/references/output-structure.md
+++ b/.claude/skills/SkillForge/references/output-structure.md
@@ -105,7 +105,7 @@ Scripts enable skills to be **agentic** - capable of autonomous operation with s
 - Self-verification where applicable
 - Documented in SKILL.md with usage examples
 
-See: [references/script-integration-framework.md](script-integration-framework.md)
+See: [script-integration-framework.md](script-integration-framework.md)
 
 ### Hooks Integration
 

--- a/.claude/skills/SkillForge/references/output-structure.md
+++ b/.claude/skills/SkillForge/references/output-structure.md
@@ -100,8 +100,8 @@ Scripts enable skills to be **agentic** - capable of autonomous operation with s
 **Script Requirements:**
 
 - Python 3.x with standard library only (graceful fallbacks for extras)
-- `Result` dataclass pattern for structured returns
-- Exit codes: 0=success, 1=failure, 10=validation failure, 11=verification failure
+- `Result` dataclass pattern for structured returns, where a script produces structured output
+- Exit codes follow the repo convention: 0=success, 1=logic error, 2=config error, 3=external error (see AGENTS.md)
 - Self-verification where applicable
 - Documented in SKILL.md with usage examples
 

--- a/.claude/skills/SkillForge/references/overview-and-triggers.md
+++ b/.claude/skills/SkillForge/references/overview-and-triggers.md
@@ -47,7 +47,8 @@ TypeError: Cannot read property 'map' of undefined
 |-------|--------|--------------|
 | Any input | Triage → Route → Action | Phase 0 analysis |
 | Explicit create | New skill | Unanimous panel approval |
-| Task/question | Skill recommendation | Match confidence ≥60% |
+| Skill question | Skill recommendation | Match confidence ≥60% |
+| Task / code / URL | Recommend, improve, or compose | ≥80% recommend; 50-79% improve |
 
 ---
 

--- a/.claude/skills/SkillForge/references/overview-and-triggers.md
+++ b/.claude/skills/SkillForge/references/overview-and-triggers.md
@@ -33,7 +33,7 @@ TypeError: Cannot read property 'map' of undefined
 - `create skill` - Natural language activation
 - `design skill for {purpose}` - Purpose-first creation
 - `ultimate skill` - Emphasize maximum quality
-- `skillforge --plan-only` - Generate specification without execution
+- `SkillForge --plan-only` - Generate specification without execution
 
 ### Routing Triggers (NEW in v4.0)
 

--- a/.claude/skills/SkillForge/references/overview-and-triggers.md
+++ b/.claude/skills/SkillForge/references/overview-and-triggers.md
@@ -1,0 +1,131 @@
+# Overview and Triggers
+
+## Quick Start
+
+**Any input works.** SkillForge will intelligently route to the right action:
+
+```
+# These all work - SkillForge figures out what you need:
+
+SkillForge: create a skill for automated code review
+→ Creates new skill (after checking no duplicates exist)
+
+help me debug this TypeError
+→ Recommends ErrorExplainer skill (existing)
+
+improve the testgen skill to handle React components better
+→ Enters improvement mode for TestGen
+
+do I have a skill for database migrations?
+→ Recommends DBSchema, database-migration skills
+
+TypeError: Cannot read property 'map' of undefined
+→ Routes to debugging skills (error detected)
+```
+
+---
+
+## Triggers
+
+### Creation Triggers
+
+- `SkillForge: {goal}` - Full autonomous skill creation
+- `create skill` - Natural language activation
+- `design skill for {purpose}` - Purpose-first creation
+- `ultimate skill` - Emphasize maximum quality
+- `skillforge --plan-only` - Generate specification without execution
+
+### Routing Triggers (NEW in v4.0)
+
+- `{any input}` - Analyzes and routes automatically
+- `do I have a skill for` - Searches existing skills
+- `which skill` / `what skill` - Recommends matching skills
+- `improve {skill-name} skill` - Enters improvement mode
+- `help me with` / `I need to` - Detects task and routes
+
+| Input | Output | Quality Gate |
+|-------|--------|--------------|
+| Any input | Triage → Route → Action | Phase 0 analysis |
+| Explicit create | New skill | Unanimous panel approval |
+| Task/question | Skill recommendation | Match confidence ≥60% |
+
+---
+
+## Process Overview
+
+```
+ANY USER INPUT
+(prompt, error, code, URL, question, task request)
+    │
+    ▼
+┌─────────────────────────────────────────────────────┐
+│ Phase 0: SKILL TRIAGE (NEW)                         │
+│ • Classify input type (create/improve/question/task)│
+│ • Scan 250+ skills in ecosystem                     │
+│ • Match against existing skills with confidence %   │
+│ • Route to: USE | IMPROVE | CREATE | COMPOSE        │
+├─────────────────────────────────────────────────────┤
+│         ↓ USE_EXISTING    ↓ IMPROVE      ↓ CREATE   │
+│      [Recommend]      [Load & Enhance] [Continue]   │
+└─────────────────────────────────────────────────────┘
+    │ (if CREATE_NEW or IMPROVE_EXISTING)
+    ▼
+┌─────────────────────────────────────────────────────┐
+│ Phase 1: DEEP ANALYSIS                              │
+│ • Expand requirements (explicit, implicit, unknown) │
+│ • Apply 11 thinking models + Automation Lens        │
+│ • Question until no new insights (3 empty rounds)   │
+│ • Identify automation/script opportunities          │
+├─────────────────────────────────────────────────────┤
+│ Phase 2: SPECIFICATION                              │
+│ • Generate XML spec with all decisions + WHY        │
+│ • Include scripts section (if applicable)           │
+│ • Validate timelessness score ≥ 7                   │
+├─────────────────────────────────────────────────────┤
+│ Phase 3: GENERATION                                 │
+│ • Write SKILL.md with fresh context                 │
+│ • Generate references/, assets/, and scripts/       │
+├─────────────────────────────────────────────────────┤
+│ Phase 4: SYNTHESIS PANEL                            │
+│ • 3-4 Opus agents review independently              │
+│ • Script Agent added when scripts present           │
+│ • All agents must approve (unanimous)               │
+│ • If rejected → loop back with feedback             │
+└─────────────────────────────────────────────────────┘
+    │
+    ▼
+Production-Ready Agentic Skill
+```
+
+**Key principles:**
+
+- **Phase 0 prevents duplicates** - Always checks existing skills first
+- Evolution/timelessness is the core lens (score ≥ 7 required)
+- Every decision includes WHY
+- Zero tolerance for errors
+- Autonomous execution at maximum depth
+- Scripts enable self-verification and agentic operation
+
+### Tool Escalation Policy
+
+Start with least privilege (`Read`, `Glob`, `Grep`, `Write`, `Edit`).
+
+Only add higher-risk tools when explicitly required:
+
+- `Bash` for deterministic local scripts that cannot be replaced with file edits
+- `WebFetch` / `WebSearch` only when external facts are required
+- `Task` only for true parallel sub-agent orchestration
+
+---
+
+## Commands
+
+| Command | Action |
+|---------|--------|
+| `SkillForge: {goal}` | Full autonomous execution |
+| `SkillForge --plan-only {goal}` | Generate specification only |
+| `SkillForge --quick {goal}` | Reduced depth (not recommended) |
+| `SkillForge --triage {input}` | Run Phase 0 triage only |
+| `SkillForge --improve {skill}` | Enter improvement mode for existing skill |
+
+---

--- a/.claude/skills/SkillForge/references/phase0-triage.md
+++ b/.claude/skills/SkillForge/references/phase0-triage.md
@@ -38,6 +38,7 @@ Before creating anything, SkillForge intelligently analyzes your input to determ
 │  Step 3: DECISION MATRIX                                            │
 │                                                                     │
 │  Match ≥80%  + explicit create → CLARIFY (duplicate warning)       │
+│  Match ≥60%  + skill question  → USE_EXISTING (recommend skill)    │
 │  Match ≥80%  + other input     → USE_EXISTING (recommend skill)    │
 │  Match 50-79%                  → IMPROVE_EXISTING (enhance match)  │
 │  Match <50%  + explicit create → CREATE_NEW (proceed to Phase 1)   │
@@ -50,7 +51,7 @@ Before creating anything, SkillForge intelligently analyzes your input to determ
 
 | Action | When | Result |
 |--------|------|--------|
-| **USE_EXISTING** | Match ≥80% | Recommends existing skill(s) to invoke |
+| **USE_EXISTING** | Match ≥80% (task, code, URL) or ≥60% (skill question) | Recommends existing skill(s) to invoke |
 | **IMPROVE_EXISTING** | Match 50-79% | Loads skill and enters enhancement mode |
 | **CREATE_NEW** | Match <50% | Proceeds to Phase 1 (Deep Analysis) |
 | **COMPOSE** | Multi-domain | Suggests skill chain via SkillComposer |

--- a/.claude/skills/SkillForge/references/phase0-triage.md
+++ b/.claude/skills/SkillForge/references/phase0-triage.md
@@ -1,0 +1,99 @@
+# Phase 0 Skill Triage
+
+## Phase 0: Skill Triage (NEW in v4.0)
+
+Before creating anything, SkillForge intelligently analyzes your input to determine the best action.
+
+### How It Works
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                        ANY USER INPUT                               │
+│  (prompt, error, code, URL, question, task request, anything)      │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  Step 1: INPUT CLASSIFICATION                                       │
+│  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐       │
+│  │ explicit_create │ │ explicit_improve│ │ skill_question  │       │
+│  │ "create skill"  │ │ "improve skill" │ │ "do I have..."  │       │
+│  └─────────────────┘ └─────────────────┘ └─────────────────┘       │
+│  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐       │
+│  │  task_request   │ │  error_message  │ │  code_snippet   │       │
+│  │ "help me with"  │ │ "TypeError..."  │ │ [pasted code]   │       │
+│  └─────────────────┘ └─────────────────┘ └─────────────────┘       │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  Step 2: SKILL ECOSYSTEM SCAN                                       │
+│  • Load index of 250+ skills (discover_skills.py)                  │
+│  • Match input against all skills with confidence scoring          │
+│  • Identify top matches with reasons                               │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  Step 3: DECISION MATRIX                                            │
+│                                                                     │
+│  Match ≥80%  + explicit create → CLARIFY (duplicate warning)       │
+│  Match ≥80%  + other input     → USE_EXISTING (recommend skill)    │
+│  Match 50-79%                  → IMPROVE_EXISTING (enhance match)  │
+│  Match <50%  + explicit create → CREATE_NEW (proceed to Phase 1)   │
+│  Multi-domain detected         → COMPOSE (suggest skill chain)     │
+│  Ambiguous input               → CLARIFY (ask for more info)       │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### Decision Actions
+
+| Action | When | Result |
+|--------|------|--------|
+| **USE_EXISTING** | Match ≥80% | Recommends existing skill(s) to invoke |
+| **IMPROVE_EXISTING** | Match 50-79% | Loads skill and enters enhancement mode |
+| **CREATE_NEW** | Match <50% | Proceeds to Phase 1 (Deep Analysis) |
+| **COMPOSE** | Multi-domain | Suggests skill chain via SkillComposer |
+| **CLARIFY** | Ambiguous or duplicate | Asks user to clarify intent |
+
+### Triage Script
+
+```bash
+# Run triage on any input
+python scripts/triage_skill_request.py "help me debug this error"
+
+# JSON output for automation
+python scripts/triage_skill_request.py "create a skill for payments" --json
+
+# Examples:
+python scripts/triage_skill_request.py "TypeError: Cannot read property 'map'"
+# → USE_EXISTING: Recommends ErrorExplainer (92%)
+
+python scripts/triage_skill_request.py "create a skill for code review"
+# → CLARIFY: CodeReview skill exists (85%), create anyway?
+
+python scripts/triage_skill_request.py "help me with API and auth and testing"
+# → COMPOSE: Multi-domain, suggests APIDesign + AuthSystem + TestGen chain
+```
+
+### Ecosystem Index
+
+Phase 0 uses a pre-built index of all skills:
+
+```bash
+# Rebuild skill index (run periodically or after installing new skills)
+python scripts/discover_skills.py
+
+# Index location: ~/.cache/skillrecommender/skill_index.json
+# Scans: ~/.claude/skills/, plugins/marketplaces/*, plugins/cache/*
+```
+
+### Integration with Phases 1-4
+
+- **USE_EXISTING**: Exits early, no creation needed
+- **IMPROVE_EXISTING**: Loads existing skill → Phase 1 analyzes gaps → Phase 2-4 enhance
+- **CREATE_NEW**: Full pipeline (Phase 1 → 2 → 3 → 4)
+- **COMPOSE**: Suggests using SkillComposer instead
+- **CLARIFY**: Pauses for user input before proceeding
+
+---

--- a/.claude/skills/SkillForge/references/phase1-analysis-deep-dive.md
+++ b/.claude/skills/SkillForge/references/phase1-analysis-deep-dive.md
@@ -61,7 +61,7 @@ Apply all 11 thinking models systematically:
 
 **Minimum requirement:** All 11 lenses scanned, at least 5 applied in depth.
 
-See: [references/multi-lens-framework.md](references/multi-lens-framework.md)
+See: [references/multi-lens-framework.md](multi-lens-framework.md)
 
 ### 1C: Regression Questioning
 
@@ -91,7 +91,7 @@ ROUND N:
 - Evolution/timelessness explicitly evaluated
 - Automation opportunities identified
 
-See: [references/regression-questions.md](references/regression-questions.md)
+See: [references/regression-questions.md](regression-questions.md)
 
 ### 1D: Automation Analysis
 
@@ -136,4 +136,4 @@ FOR EACH operation in the skill:
 | Enables autonomous operation | No verification needed |
 | External tool integration | Pure Claude reasoning |
 
-See: [references/script-integration-framework.md](references/script-integration-framework.md)
+See: [references/script-integration-framework.md](script-integration-framework.md)

--- a/.claude/skills/SkillForge/references/phase1-analysis-deep-dive.md
+++ b/.claude/skills/SkillForge/references/phase1-analysis-deep-dive.md
@@ -61,7 +61,7 @@ Apply all 11 thinking models systematically:
 
 **Minimum requirement:** All 11 lenses scanned, at least 5 applied in depth.
 
-See: [references/multi-lens-framework.md](multi-lens-framework.md)
+See: [multi-lens-framework.md](multi-lens-framework.md)
 
 ### 1C: Regression Questioning
 
@@ -91,7 +91,7 @@ ROUND N:
 - Evolution/timelessness explicitly evaluated
 - Automation opportunities identified
 
-See: [references/regression-questions.md](regression-questions.md)
+See: [regression-questions.md](regression-questions.md)
 
 ### 1D: Automation Analysis
 
@@ -136,4 +136,4 @@ FOR EACH operation in the skill:
 | Enables autonomous operation | No verification needed |
 | External tool integration | Pure Claude reasoning |
 
-See: [references/script-integration-framework.md](script-integration-framework.md)
+See: [script-integration-framework.md](script-integration-framework.md)

--- a/.claude/skills/SkillForge/references/phase2-specification-deep-dive.md
+++ b/.claude/skills/SkillForge/references/phase2-specification-deep-dive.md
@@ -50,7 +50,7 @@ The specification captures all analysis insights in XML format:
 </skill_specification>
 ```
 
-See: [references/specification-template.md](references/specification-template.md)
+See: [references/specification-template.md](specification-template.md)
 
 ### Specification Validation
 

--- a/.claude/skills/SkillForge/references/phase2-specification-deep-dive.md
+++ b/.claude/skills/SkillForge/references/phase2-specification-deep-dive.md
@@ -50,7 +50,7 @@ The specification captures all analysis insights in XML format:
 </skill_specification>
 ```
 
-See: [references/specification-template.md](specification-template.md)
+See: [specification-template.md](specification-template.md)
 
 ### Specification Validation
 

--- a/.claude/skills/SkillForge/references/phase3-generation-deep-dive.md
+++ b/.claude/skills/SkillForge/references/phase3-generation-deep-dive.md
@@ -1,6 +1,6 @@
 
 **Context:** Fresh, clean (no analysis artifacts polluting)
-**Standard:** Zero errors—every section verified before proceeding
+**Standard:** Zero errors, every section verified before proceeding
 
 ### Generation Order
 

--- a/.claude/skills/SkillForge/references/phase4-synthesis-deep-dive.md
+++ b/.claude/skills/SkillForge/references/phase4-synthesis-deep-dive.md
@@ -22,7 +22,7 @@ The Script Agent is activated when the skill includes a `scripts/` directory. Fo
 | **Self-Verification** | Scripts can verify their own output |
 | **Error Handling** | Graceful failures, actionable messages |
 | **Documentation** | Usage examples in SKILL.md |
-| **Agentic Capability** | Can run autonomously without human intervention |
+| **Agentic Capability** | Scripts complete cleanly without interactive prompts during scoped, user-approved invocations |
 
 **Script Agent Scoring:**
 
@@ -78,4 +78,4 @@ IF 5 iterations without consensus:
     → User makes final decision
 ```
 
-See: [references/synthesis-protocol.md](references/synthesis-protocol.md)
+See: [references/synthesis-protocol.md](synthesis-protocol.md)

--- a/.claude/skills/SkillForge/references/phase4-synthesis-deep-dive.md
+++ b/.claude/skills/SkillForge/references/phase4-synthesis-deep-dive.md
@@ -78,4 +78,4 @@ IF 5 iterations without consensus:
     → User makes final decision
 ```
 
-See: [references/synthesis-protocol.md](synthesis-protocol.md)
+See: [synthesis-protocol.md](synthesis-protocol.md)

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/SkillForge/SKILL.md
+++ b/src/copilot-cli/skills/SkillForge/SKILL.md
@@ -245,7 +245,7 @@ After creation:
 
 ## Scripts
 
-The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. All scripts use Python 3 standard library, the `Result` dataclass pattern, and shared exit codes: `0`=success, `1`=failure, `10`=validation failure, `11`=verification failure.
+The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. Scripts use the Python 3 standard library and exit `0` on success and non-zero on failure (`1` general; individual scripts add `2` or `3` for specific precondition failures, documented in each script's `--help`).
 
 | Script | Purpose |
 |--------|---------|
@@ -289,26 +289,10 @@ See [references/script-integration-framework.md](references/script-integration-f
 
 ## Related Skills
 
-| Skill | Relationship |
-|-------|--------------|
-| skill-composer | Can orchestrate created skills |
-| claude-authoring-guide | Deeper patterns reference |
-| codereview | Pattern for multi-agent panels |
-| maker-framework | Zero error standard source |
+skill-composer (orchestrate created skills), claude-authoring-guide (deeper patterns), codereview (multi-agent panel pattern), maker-framework (zero-error standard).
 
 ---
 
 ## Extension Points
 
-1. Add thinking models in [references/multi-lens-framework.md](references/multi-lens-framework.md).
-2. Extend panel agents in [references/synthesis-protocol.md](references/synthesis-protocol.md).
-3. Add architecture patterns in [references/architecture-patterns.md](references/architecture-patterns.md).
-4. Add domain templates in `assets/templates/`.
-5. Add script patterns in [references/script-patterns-catalog.md](references/script-patterns-catalog.md).
-6. Extend script categories in [references/script-integration-framework.md](references/script-integration-framework.md).
-
----
-
-## Changelog
-
-See [references/changelog.md](references/changelog.md) for the full version history.
+Add thinking models, panel agents, architecture patterns, or script patterns via the matching `references/*.md`; add domain templates in `assets/templates/`.

--- a/src/copilot-cli/skills/SkillForge/SKILL.md
+++ b/src/copilot-cli/skills/SkillForge/SKILL.md
@@ -245,7 +245,7 @@ After creation:
 
 ## Scripts
 
-The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. Scripts use the Python 3 standard library and exit `0` on success and non-zero on failure (`1` general; individual scripts add `2` or `3` for specific precondition failures, documented in each script's `--help`).
+The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. Scripts use the Python 3 standard library. Exit codes: `0` on success and non-zero on failure (`1` general; individual scripts add `2` or `3` for specific precondition failures, documented in each script's `--help`).
 
 | Script | Purpose |
 |--------|---------|
@@ -257,6 +257,8 @@ The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, vali
 | `skill_modularity_audit.py` | Audit SKILL.md size and flag progressive-disclosure violations |
 | `package_skill.py` | Package a completed skill for distribution |
 | `check_docs_safety.py` | Safety scan of generated documentation |
+| `frontmatter.py` | Internal helper module: shared YAML frontmatter parsing (imported, not run directly) |
+| `_constants.py` | Internal helper module: shared constants and thresholds (imported, not run directly) |
 
 See [references/script-integration-framework.md](references/script-integration-framework.md) for when to add scripts and [references/script-patterns-catalog.md](references/script-patterns-catalog.md) for the standard patterns.
 
@@ -290,8 +292,6 @@ See [references/script-integration-framework.md](references/script-integration-f
 ## Related Skills
 
 skill-composer (orchestrate created skills), claude-authoring-guide (deeper patterns), codereview (multi-agent panel pattern), maker-framework (zero-error standard).
-
----
 
 ## Extension Points
 

--- a/src/copilot-cli/skills/SkillForge/SKILL.md
+++ b/src/copilot-cli/skills/SkillForge/SKILL.md
@@ -74,7 +74,7 @@ flow and script examples.
 |-------|--------|--------------|
 | Any input | Triage -> Route -> Action | Phase 0 analysis |
 | Explicit create | New skill | Unanimous panel approval |
-| Task or question | Skill recommendation | Match confidence >=60% |
+| Skill question | Skill recommendation | Match confidence >=60% |
 
 ---
 
@@ -122,9 +122,10 @@ local scripts, external facts, or true parallel sub-agent orchestration.
 ## Phase 0: Skill Triage
 
 Classify the input, scan the skill ecosystem, score matches, then route to one
-of five actions. Use existing skills for matches >=80%, improve matches in the
-50-79% range, create below 50%, compose multi-domain requests, and clarify only
-when ambiguity or duplicate risk blocks a safe route.
+of five actions. Recommend existing skills for strong matches (>=80%, or >=60%
+for skill questions), improve matches in the 50-79% range, create below 50%,
+compose multi-domain requests, and clarify only when ambiguity or duplicate risk
+blocks a safe route.
 
 See [references/phase0-triage.md](references/phase0-triage.md) for the decision
 matrix, script examples, ecosystem index, and integration with later phases.
@@ -198,14 +199,13 @@ safety, and packaging. Keep command examples portable when a plugin-root path is
 needed.
 
 ```bash
-# Quick validation (required for packaging)
-python scripts/quick_validate.py ~/.claude/skills/my-skill/
-
-# Full structural validation
-python scripts/validate-skill.py ~/.claude/skills/my-skill/
-
-# Package for distribution
-python scripts/package_skill.py ~/.claude/skills/my-skill/ ./dist
+# Validators enforce a path-traversal guard: the target skill directory must
+# live under your current directory. Run them from an ancestor of the skill.
+cd ~/.claude/skills
+FORGE=~/.claude/skills/SkillForge/scripts   # adjust to your SkillForge install
+python "$FORGE/quick_validate.py" my-skill/     # required before packaging
+python "$FORGE/validate-skill.py" my-skill/     # full structural validation
+python "$FORGE/package_skill.py" my-skill/ ./dist   # package for distribution
 ```
 
 See [references/output-structure.md](references/output-structure.md) for allowed

--- a/src/copilot-cli/skills/SkillForge/SKILL.md
+++ b/src/copilot-cli/skills/SkillForge/SKILL.md
@@ -60,7 +60,7 @@ flow and script examples.
 - `create skill`: natural language activation
 - `design skill for {purpose}`: purpose-first creation
 - `ultimate skill`: maximum quality creation path
-- `skillforge --plan-only`: generate specification without execution
+- `SkillForge --plan-only`: generate specification without execution
 
 ### Routing Triggers
 
@@ -245,7 +245,7 @@ After creation:
 
 ## Scripts
 
-The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. Scripts use the Python 3 standard library. Exit codes: `0` on success and non-zero on failure (`1` general; individual scripts add `2` or `3` for specific precondition failures, documented in each script's `--help`).
+The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. Scripts run on the Python 3 standard library; a few use PyYAML for frontmatter parsing when it is installed and fall back to a stdlib parser when it is not. Exit codes: `0` on success and non-zero on failure (`1` general; individual scripts add `2` or `3` for specific precondition failures, documented in each script's `--help`).
 
 | Script | Purpose |
 |--------|---------|

--- a/src/copilot-cli/skills/SkillForge/SKILL.md
+++ b/src/copilot-cli/skills/SkillForge/SKILL.md
@@ -19,34 +19,36 @@ metadata:
   outputs: [SKILL.md, references/, scripts/, SKILL_SPEC.md, recommendations]
 ---
 
-# SkillForge 4.1 - Intelligent Skill Router & Creator
+# SkillForge 4.1 - Intelligent Skill Router and Creator
 
-Analyzes ANY input to find, improve, or create the right skill.
+Analyzes any input to find, improve, compose, or create the right skill.
 
 ---
 
 ## Quick Start
 
-**Any input works.** SkillForge will intelligently route to the right action:
+SkillForge accepts direct creation requests, skill improvement requests, skill
+lookup questions, task prompts, error messages, URLs, and code snippets. It
+routes first, then creates only when no existing skill covers the need.
 
-```
-# These all work - SkillForge figures out what you need:
-
+```text
 SkillForge: create a skill for automated code review
-→ Creates new skill (after checking no duplicates exist)
+  -> Creates a new skill after checking for duplicates
 
 help me debug this TypeError
-→ Recommends ErrorExplainer skill (existing)
+  -> Recommends an existing debugging skill
 
 improve the testgen skill to handle React components better
-→ Enters improvement mode for TestGen
+  -> Loads the skill and enters improvement mode
 
 do I have a skill for database migrations?
-→ Recommends DBSchema, database-migration skills
-
-TypeError: Cannot read property 'map' of undefined
-→ Routes to debugging skills (error detected)
+  -> Recommends matching database skills
 ```
+
+See [references/overview-and-triggers.md](references/overview-and-triggers.md)
+for the full examples, triggers, routing diagram, and command summary. See
+[references/phase0-triage.md](references/phase0-triage.md) for the full triage
+flow and script examples.
 
 ---
 
@@ -54,92 +56,54 @@ TypeError: Cannot read property 'map' of undefined
 
 ### Creation Triggers
 
-- `SkillForge: {goal}` - Full autonomous skill creation
-- `create skill` - Natural language activation
-- `design skill for {purpose}` - Purpose-first creation
-- `ultimate skill` - Emphasize maximum quality
-- `skillforge --plan-only` - Generate specification without execution
+- `SkillForge: {goal}`: full autonomous skill creation
+- `create skill`: natural language activation
+- `design skill for {purpose}`: purpose-first creation
+- `ultimate skill`: maximum quality creation path
+- `skillforge --plan-only`: generate specification without execution
 
-### Routing Triggers (NEW in v4.0)
+### Routing Triggers
 
-- `{any input}` - Analyzes and routes automatically
-- `do I have a skill for` - Searches existing skills
-- `which skill` / `what skill` - Recommends matching skills
-- `improve {skill-name} skill` - Enters improvement mode
-- `help me with` / `I need to` - Detects task and routes
+- `{any input}`: analyze and route automatically
+- `do I have a skill for`: search existing skills
+- `which skill` or `what skill`: recommend matching skills
+- `improve {skill-name} skill`: improve an existing skill
+- `help me with` or `I need to`: detect task and route
 
 | Input | Output | Quality Gate |
 |-------|--------|--------------|
-| Any input | Triage → Route → Action | Phase 0 analysis |
+| Any input | Triage -> Route -> Action | Phase 0 analysis |
 | Explicit create | New skill | Unanimous panel approval |
-| Task/question | Skill recommendation | Match confidence ≥60% |
+| Task or question | Skill recommendation | Match confidence >=60% |
 
 ---
 
 ## Process Overview
 
-```
-ANY USER INPUT
-(prompt, error, code, URL, question, task request)
-    │
-    ▼
-┌─────────────────────────────────────────────────────┐
-│ Phase 0: SKILL TRIAGE (NEW)                         │
-│ • Classify input type (create/improve/question/task)│
-│ • Scan 250+ skills in ecosystem                     │
-│ • Match against existing skills with confidence %   │
-│ • Route to: USE | IMPROVE | CREATE | COMPOSE        │
-├─────────────────────────────────────────────────────┤
-│         ↓ USE_EXISTING    ↓ IMPROVE      ↓ CREATE   │
-│      [Recommend]      [Load & Enhance] [Continue]   │
-└─────────────────────────────────────────────────────┘
-    │ (if CREATE_NEW or IMPROVE_EXISTING)
-    ▼
-┌─────────────────────────────────────────────────────┐
-│ Phase 1: DEEP ANALYSIS                              │
-│ • Expand requirements (explicit, implicit, unknown) │
-│ • Apply 11 thinking models + Automation Lens        │
-│ • Question until no new insights (3 empty rounds)   │
-│ • Identify automation/script opportunities          │
-├─────────────────────────────────────────────────────┤
-│ Phase 2: SPECIFICATION                              │
-│ • Generate XML spec with all decisions + WHY        │
-│ • Include scripts section (if applicable)           │
-│ • Validate timelessness score ≥ 7                   │
-├─────────────────────────────────────────────────────┤
-│ Phase 3: GENERATION                                 │
-│ • Write SKILL.md with fresh context                 │
-│ • Generate references/, assets/, and scripts/       │
-├─────────────────────────────────────────────────────┤
-│ Phase 4: SYNTHESIS PANEL                            │
-│ • 3-4 Opus agents review independently              │
-│ • Script Agent added when scripts present           │
-│ • All agents must approve (unanimous)               │
-│ • If rejected → loop back with feedback             │
-└─────────────────────────────────────────────────────┘
-    │
-    ▼
-Production-Ready Agentic Skill
+```text
+Any user input
+  -> Phase 0: Skill triage
+     -> USE_EXISTING, IMPROVE_EXISTING, CREATE_NEW, COMPOSE, or CLARIFY
+  -> Phase 1: Deep analysis when creation or improvement is needed
+  -> Phase 2: Specification with rationale and evolution score
+  -> Phase 3: Generation of SKILL.md, references/, assets/, and scripts/
+  -> Phase 4: Synthesis panel until unanimous approval
+  -> Production-ready agentic skill
 ```
 
-**Key principles:**
+Key principles:
 
-- **Phase 0 prevents duplicates** - Always checks existing skills first
-- Evolution/timelessness is the core lens (score ≥ 7 required)
-- Every decision includes WHY
-- Zero tolerance for errors
-- Autonomous execution at maximum depth
-- Scripts enable self-verification and agentic operation
+- Phase 0 prevents duplicate skills before any creation work starts.
+- Evolution and timelessness scoring stays at the center. Score >=7 is required.
+- Every decision includes WHY.
+- Scripts are added when deterministic automation improves verification.
+- Panel approval is unanimous before finalization.
 
 ### Tool Escalation Policy
 
-Start with least privilege (`Read`, `Glob`, `Grep`, `Write`, `Edit`).
-
-Only add higher-risk tools when explicitly required:
-
-- `Bash` for deterministic local scripts that cannot be replaced with file edits
-- `WebFetch` / `WebSearch` only when external facts are required
-- `Task` only for true parallel sub-agent orchestration
+Start with least privilege: `Read`, `Glob`, `Grep`, `Write`, and `Edit`. Add
+`Bash`, `WebFetch`, `WebSearch`, or `Task` only when the current skill requires
+local scripts, external facts, or true parallel sub-agent orchestration.
 
 ---
 
@@ -149,113 +113,89 @@ Only add higher-risk tools when explicitly required:
 |---------|--------|
 | `SkillForge: {goal}` | Full autonomous execution |
 | `SkillForge --plan-only {goal}` | Generate specification only |
-| `SkillForge --quick {goal}` | Reduced depth (not recommended) |
+| `SkillForge --quick {goal}` | Reduced depth, not recommended |
 | `SkillForge --triage {input}` | Run Phase 0 triage only |
 | `SkillForge --improve {skill}` | Enter improvement mode for existing skill |
 
 ---
 
-## Phase 0: Skill Triage (NEW in v4.0)
+## Phase 0: Skill Triage
 
-Before creating anything, SkillForge intelligently analyzes your input to determine the best action.
+Classify the input, scan the skill ecosystem, score matches, then route to one
+of five actions. Use existing skills for matches >=80%, improve matches in the
+50-79% range, create below 50%, compose multi-domain requests, and clarify only
+when ambiguity or duplicate risk blocks a safe route.
 
-### How It Works
-
-```
-┌────────────────────────────────────────────────────────────────────┐
-│                        ANY USER INPUT                               │
-│  (prompt, error, code, URL, question, task request, anything)      │
-└────────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌────────────────────────────────────────────────────────────────────┐
-│  Step 1: INPUT CLASSIFICATION                                       │
-│  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐       │
-│  │ explicit_create │ │ explicit_improve│ │ skill_question  │       │
-│  │ "create skill"  │ │ "improve skill" │ │ "do I have..."  │       │
-│  └─────────────────┘ └─────────────────┘ └─────────────────┘       │
-│  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐       │
-│  │  task_request   │ │  error_message  │ │  code_snippet   │       │
-│  │ "help me with"  │ │ "TypeError..."  │ │ [pasted code]   │       │
-│  └─────────────────┘ └─────────────────┘ └─────────────────┘       │
-└────────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌────────────────────────────────────────────────────────────────────┐
-│  Step 2: SKILL ECOSYSTEM SCAN                                       │
-│  • Load index of 250+ skills (discover_skills.py)                  │
-│  • Match input against all skills with confidence scoring          │
-│  • Identify top matches with reasons                               │
-└────────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌────────────────────────────────────────────────────────────────────┐
-│  Step 3: DECISION MATRIX                                            │
-│                                                                     │
-│  Match ≥80%  + explicit create → CLARIFY (duplicate warning)       │
-│  Match ≥80%  + other input     → USE_EXISTING (recommend skill)    │
-│  Match 50-79%                  → IMPROVE_EXISTING (enhance match)  │
-│  Match <50%  + explicit create → CREATE_NEW (proceed to Phase 1)   │
-│  Multi-domain detected         → COMPOSE (suggest skill chain)     │
-│  Ambiguous input               → CLARIFY (ask for more info)       │
-└────────────────────────────────────────────────────────────────────┘
-```
-
-### Decision Actions
-
-| Action | When | Result |
-|--------|------|--------|
-| **USE_EXISTING** | Match ≥80% | Recommends existing skill(s) to invoke |
-| **IMPROVE_EXISTING** | Match 50-79% | Loads skill and enters enhancement mode |
-| **CREATE_NEW** | Match <50% | Proceeds to Phase 1 (Deep Analysis) |
-| **COMPOSE** | Multi-domain | Suggests skill chain via SkillComposer |
-| **CLARIFY** | Ambiguous or duplicate | Asks user to clarify intent |
-
-### Triage Script
-
-```bash
-# Run triage on any input
-python scripts/triage_skill_request.py "help me debug this error"
-
-# JSON output for automation
-python scripts/triage_skill_request.py "create a skill for payments" --json
-
-# Examples:
-python scripts/triage_skill_request.py "TypeError: Cannot read property 'map'"
-# → USE_EXISTING: Recommends ErrorExplainer (92%)
-
-python scripts/triage_skill_request.py "create a skill for code review"
-# → CLARIFY: CodeReview skill exists (85%), create anyway?
-
-python scripts/triage_skill_request.py "help me with API and auth and testing"
-# → COMPOSE: Multi-domain, suggests APIDesign + AuthSystem + TestGen chain
-```
-
-### Ecosystem Index
-
-Phase 0 uses a pre-built index of all skills:
-
-```bash
-# Rebuild skill index (run periodically or after installing new skills)
-python scripts/discover_skills.py
-
-# Index location: ~/.cache/skillrecommender/skill_index.json
-# Scans: ~/.claude/skills/, plugins/marketplaces/*, plugins/cache/*
-```
-
-### Integration with Phases 1-4
-
-- **USE_EXISTING**: Exits early, no creation needed
-- **IMPROVE_EXISTING**: Loads existing skill → Phase 1 analyzes gaps → Phase 2-4 enhance
-- **CREATE_NEW**: Full pipeline (Phase 1 → 2 → 3 → 4)
-- **COMPOSE**: Suggests using SkillComposer instead
-- **CLARIFY**: Pauses for user input before proceeding
+See [references/phase0-triage.md](references/phase0-triage.md) for the decision
+matrix, script examples, ecosystem index, and integration with later phases.
 
 ---
 
-## Validation & Packaging
+## Phase 1: Deep Analysis
 
-Before distribution, validate your skill:
+Expand explicit requirements, implicit requirements, unknown unknowns, and
+domain context. Apply all 11 thinking models, run regression questioning until
+three rounds add no new insight, and identify automation opportunities.
+
+See [references/phase1-analysis-deep-dive.md](references/phase1-analysis-deep-dive.md),
+[references/multi-lens-framework.md](references/multi-lens-framework.md), and
+[references/regression-questions.md](references/regression-questions.md).
+
+---
+
+## Phase 2: Specification
+
+Create the XML skill specification with metadata, context, requirements,
+architecture, scripts, evolution analysis, anti-patterns, and success criteria.
+Validate traceability, rationale, extension points, and timelessness before
+writing skill files.
+
+See [references/phase2-specification-deep-dive.md](references/phase2-specification-deep-dive.md)
+and [references/specification-template.md](references/specification-template.md).
+
+---
+
+## Phase 3: Generation
+
+Generate the skill directory in this order: structure, `SKILL.md`, references,
+assets, then scripts when scripts are needed. Keep `SKILL.md` concise and move
+deep detail into progressive-disclosure reference files.
+
+See [references/phase3-generation-deep-dive.md](references/phase3-generation-deep-dive.md),
+[references/output-structure.md](references/output-structure.md),
+[references/script-integration-framework.md](references/script-integration-framework.md),
+and [references/script-patterns-catalog.md](references/script-patterns-catalog.md).
+
+---
+
+## Phase 4: Synthesis Panel
+
+Run 3-4 independent evaluators: design and architecture, audience and usability,
+evolution and timelessness, plus script and automation when scripts exist. All
+agents must approve. Rejections loop back into targeted analysis and generation.
+
+See [references/phase4-synthesis-deep-dive.md](references/phase4-synthesis-deep-dive.md)
+and [references/synthesis-protocol.md](references/synthesis-protocol.md).
+
+---
+
+## Evolution and Architecture Selection
+
+Evaluate each skill across 6-month, 1-year, 2-year, and 5-year horizons. Reject
+transient designs, revise tool-bound designs, and approve principle-based skills
+with extension points. Select the architecture pattern that fits task complexity.
+
+See [references/evolution-scoring.md](references/evolution-scoring.md),
+[references/evolution-timelessness.md](references/evolution-timelessness.md), and
+[references/architecture-patterns.md](references/architecture-patterns.md).
+
+---
+
+## Validation and Packaging
+
+Before distribution, validate structure, frontmatter, scripts, documentation
+safety, and packaging. Keep command examples portable when a plugin-root path is
+needed.
 
 ```bash
 # Quick validation (required for packaging)
@@ -268,181 +208,9 @@ python scripts/validate-skill.py ~/.claude/skills/my-skill/
 python scripts/package_skill.py ~/.claude/skills/my-skill/ ./dist
 ```
 
-### Frontmatter Requirements
-
-Skills must use only these allowed frontmatter properties:
-
-| Property | Required | Description |
-|----------|----------|-------------|
-| `name` | Yes | Hyphen-case, max 64 chars |
-| `description` | Yes | Max 1024 chars, no angle brackets |
-| `license` | No | MIT, Apache-2.0, etc. |
-| `allowed-tools` | No | Restrict tool access (comma-separated or YAML list) |
-| `model` | No | Specific Claude model (e.g., `claude-sonnet-4-20250514`) |
-| `context` | No | Set to `fork` for isolated sub-agent context |
-| `agent` | No | Agent type when `context: fork` (`Explore`, `Plan`, `general-purpose`) |
-| `hooks` | No | Lifecycle hooks (`PreToolUse`, `PostToolUse`, `Stop`) |
-| `user-invocable` | No | Show in slash menu (default: `true`) |
-| `metadata` | No | Custom fields (version, author, domains, etc.) |
-
-**Basic Example:**
-
-```yaml
----
-name: my-skill
-description: What this skill does and when to use it
-license: MIT
-model: claude-opus-4-6
-user-invocable: true
-metadata:
-  version: 1.0.0
-  author: your-name
----
-```
-
-**Advanced Example (with forked context and hooks):**
-
-```yaml
----
-name: isolated-analyzer
-description: Runs analysis in isolated context with validation hooks
-license: MIT
-model: claude-opus-4-6
-context: fork
-agent: Explore
-user-invocable: true
-allowed-tools:
-  - Read
-  - Glob
-  - Grep
-hooks:
-  PreToolUse:
-    - matcher: "Bash"
-      hooks:
-        - type: command
-          command: "./scripts/validate.sh"
-metadata:
-  version: 1.0.0
----
-```
-
-**Field Details:**
-
-| Field | Values | Notes |
-|-------|--------|-------|
-| `context` | `fork` | Creates isolated sub-agent with separate conversation history |
-| `agent` | `Explore`, `Plan`, `general-purpose` | Only valid when `context: fork` |
-| `user-invocable` | `true`, `false` | `false` hides from slash menu but Claude can still auto-invoke |
-| `hooks` | Object | See [Hooks Integration](#hooks-integration) section |
-
----
-
-## Skill Output Structure
-
-```
-~/.claude/skills/{skill-name}/
-├── SKILL.md                    # Main entry point (required)
-├── references/                 # Deep documentation (optional)
-│   ├── patterns.md
-│   └── examples.md
-├── assets/                     # Templates (optional)
-│   └── templates/
-└── scripts/                    # Automation scripts (optional)
-    ├── validate.py             # Validation/verification
-    ├── generate.py             # Artifact generation
-    └── state.py                # State management
-```
-
-### Scripts Directory
-
-Scripts enable skills to be **agentic** - capable of autonomous operation with self-verification.
-
-| Category | Purpose | When to Include |
-|----------|---------|-----------------|
-| **Validation** | Verify outputs meet standards | Skill produces artifacts |
-| **Generation** | Create artifacts from templates | Repeatable artifact creation |
-| **State Management** | Track progress across sessions | Long-running operations |
-| **Transformation** | Convert/process data | Data processing tasks |
-| **Calculation** | Compute metrics/scores | Scoring or analysis |
-
-**Script Requirements:**
-
-- Python 3.x with standard library only (graceful fallbacks for extras)
-- `Result` dataclass pattern for structured returns
-- Exit codes: 0=success, 1=failure, 10=validation failure, 11=verification failure
-- Self-verification where applicable
-- Documented in SKILL.md with usage examples
-
-See: [references/script-integration-framework.md](references/script-integration-framework.md)
-
-### Hooks Integration
-
-Skills can define lifecycle hooks for validation, logging, and safety:
-
-```yaml
----
-name: secure-skill
-hooks:
-  PreToolUse:
-    - matcher: "Bash"
-      hooks:
-        - type: command
-          command: "./scripts/validate-input.sh"
-  PostToolUse:
-    - matcher: "Write"
-      hooks:
-        - type: command
-          command: "./scripts/log-output.sh"
-          once: true
-  Stop:
-    - hooks:
-        - type: command
-          command: "./scripts/cleanup.sh"
----
-```
-
-**Hook Types:**
-
-| Hook | When Triggered | Use Case |
-|------|----------------|----------|
-| `PreToolUse` | Before tool execution | Input validation, security checks |
-| `PostToolUse` | After tool execution | Output logging, verification |
-| `Stop` | When skill completes | Cleanup, state persistence |
-
-**Hook Configuration:**
-
-| Field | Description |
-|-------|-------------|
-| `matcher` | Tool name pattern to match (e.g., "Bash", "Write", "Bash(python:*)") |
-| `type` | Hook type: `command` (shell) or `prompt` (Claude evaluation) |
-| `command` | Shell command to execute (for `type: command`) |
-| `once` | If `true`, run only once per session (default: `false`) |
-
-Read `$TOOL_INPUT` / `$TOOL_OUTPUT` inside hook scripts from environment variables.
-Do not interpolate untrusted tool payloads directly into shell command strings.
-
-**When to Use Hooks:**
-
-| Scenario | Hook Type | Example |
-|----------|-----------|---------|
-| Validate script inputs | PreToolUse | Check parameters before `python scripts/*.py` |
-| Log generated artifacts | PostToolUse | Record files created by Write tool |
-| Security gate | PreToolUse | Block dangerous bash commands |
-| Cleanup temp files | Stop | Remove intermediate artifacts |
-
-**Example: Script Validation Hook**
-
-For skills with scripts, add input validation:
-
-```yaml
-hooks:
-  PreToolUse:
-    - matcher: "Bash(python:scripts/*)"
-      hooks:
-        - type: command
-          command: "python scripts/quick_validate.py . 2>/dev/null || true"
-          once: true
-```
+See [references/output-structure.md](references/output-structure.md) for allowed
+frontmatter fields, directory layout, script categories, hook configuration, and
+output requirements.
 
 ---
 
@@ -452,10 +220,10 @@ hooks:
 |-------|-----|---------|
 | Duplicate skills | Bloats registry | Check existing first |
 | Single trigger | Hard to discover | 3-5 varied phrases |
-| No verification | Can't confirm success | Measurable outcomes |
+| No verification | Cannot confirm success | Measurable outcomes |
 | Over-engineering | Complexity without value | Start simple |
-| Missing WHY | Can't evolve | Document rationale |
-| Invalid frontmatter | Can't package | Use allowed properties only |
+| Missing WHY | Cannot evolve | Document rationale |
+| Invalid frontmatter | Cannot package | Use allowed properties only |
 
 ---
 
@@ -463,491 +231,59 @@ hooks:
 
 After creation:
 
-- [ ] Frontmatter valid (only allowed properties)
-- [ ] Name is hyphen-case, ≤64 chars
-- [ ] Description ≤1024 chars, no `<` or `>`
+- [ ] Frontmatter valid with only allowed properties
+- [ ] Name is hyphen-case and <=64 chars
+- [ ] Description <=1024 chars, with no `<` or `>`
 - [ ] 3-5 trigger phrases defined
-- [ ] Timelessness score ≥ 7
+- [ ] Timelessness score >=7
 - [ ] `python scripts/quick_validate.py` passes
 - [ ] `python scripts/check_docs_safety.py` passes
+- [ ] Reference links resolve
+- [ ] Scripts self-verify when scripts are present
 
 ---
 
-<details>
-<summary><strong>Deep Dive: Phase 1 - Analysis</strong></summary>
-
-### 1A: Input Expansion
-
-Transform user's goal into comprehensive requirements:
-
-```
-USER INPUT: "Create a skill for X"
-                │
-                ▼
-┌─────────────────────────────────────────────────────────┐
-│ EXPLICIT REQUIREMENTS                                    │
-│ • What the user literally asked for                      │
-│ • Direct functionality stated                            │
-├─────────────────────────────────────────────────────────┤
-│ IMPLICIT REQUIREMENTS                                    │
-│ • What they probably expect but didn't say               │
-│ • Standard quality expectations                          │
-│ • Integration with existing patterns                     │
-├─────────────────────────────────────────────────────────┤
-│ UNKNOWN UNKNOWNS                                         │
-│ • What they don't know they need                         │
-│ • Expert-level considerations they'd miss                │
-│ • Future needs they haven't anticipated                  │
-├─────────────────────────────────────────────────────────┤
-│ DOMAIN CONTEXT                                           │
-│ • Related skills that exist                              │
-│ • Patterns from similar skills                           │
-│ • Lessons from skill failures                            │
-└─────────────────────────────────────────────────────────┘
-```
-
-**Check for overlap with existing skills:**
-
-```bash
-ls ~/.claude/skills/
-# Grep for similar triggers in existing SKILL.md files
-```
-
-| Match Score | Action |
-|-------------|--------|
-| >7/10 | Use existing skill instead |
-| 5-7/10 | Clarify distinction before proceeding |
-| <5/10 | Proceed with new skill |
-
-### 1B: Multi-Lens Analysis
-
-Apply all 11 thinking models systematically:
-
-| Lens | Core Question | Application |
-|------|---------------|-------------|
-| **First Principles** | What's fundamentally needed? | Strip convention, find core |
-| **Inversion** | What guarantees failure? | Build anti-patterns |
-| **Second-Order** | What happens after the obvious? | Map downstream effects |
-| **Pre-Mortem** | Why did this fail? | Proactive risk mitigation |
-| **Systems Thinking** | How do parts interact? | Integration mapping |
-| **Devil's Advocate** | Strongest counter-argument? | Challenge every decision |
-| **Constraints** | What's truly fixed? | Separate real from assumed |
-| **Pareto** | Which 20% delivers 80%? | Focus on high-value features |
-| **Root Cause** | Why is this needed? (5 Whys) | Address cause not symptom |
-| **Comparative** | How do options compare? | Weighted decision matrix |
-| **Opportunity Cost** | What are we giving up? | Explicit trade-offs |
-
-**Minimum requirement:** All 11 lenses scanned, at least 5 applied in depth.
-
-See: [references/multi-lens-framework.md](references/multi-lens-framework.md)
-
-### 1C: Regression Questioning
-
-Iterative self-questioning until no new insights emerge:
-
-```
-ROUND N:
-│
-├── "What am I missing?"
-├── "What would an expert in {domain} add?"
-├── "What would make this fail?"
-├── "What will this look like in 2 years?"
-├── "What's the weakest part of this design?"
-└── "Which thinking model haven't I applied?"
-    │
-    └── New insights > 0?
-        │
-        ├── YES → Incorporate and loop
-        └── NO → Check termination criteria
-```
-
-**Termination Criteria:**
-
-- Three consecutive rounds produce no new insights
-- All 11 thinking models have been applied
-- At least 3 simulated expert perspectives considered
-- Evolution/timelessness explicitly evaluated
-- Automation opportunities identified
-
-See: [references/regression-questions.md](references/regression-questions.md)
-
-### 1D: Automation Analysis
-
-Identify opportunities for scripts that enable agentic operation:
-
-```
-FOR EACH operation in the skill:
-│
-├── Is this operation repeatable?
-│   └── YES → Consider generation script
-│
-├── Does this produce verifiable output?
-│   └── YES → Consider validation script
-│
-├── Does this need state across sessions?
-│   └── YES → Consider state management script
-│
-├── Does this involve external tools?
-│   └── YES → Consider integration script
-│
-└── Can Claude verify success autonomously?
-    └── NO → Add self-verification script
-```
-
-**Automation Lens Questions:**
-
-| Question | Script Category if YES |
-|----------|----------------------|
-| What operations will be repeated identically? | Generation |
-| What outputs require validation? | Validation |
-| What state needs to persist? | State Management |
-| Can the skill run overnight autonomously? | All categories |
-| How will Claude verify correct execution? | Verification |
-
-**Decision: Script vs No Script**
-
-| Create Script When | Skip Script When |
-|-------------------|------------------|
-| Operation is deterministic | Requires human judgment |
-| Output can be validated | One-time setup |
-| Will be reused across invocations | Simple text output |
-| Enables autonomous operation | No verification needed |
-| External tool integration | Pure Claude reasoning |
-
-See: [references/script-integration-framework.md](references/script-integration-framework.md)
-
-</details>
-
-<details>
-<summary><strong>Deep Dive: Phase 2 - Specification</strong></summary>
-
-### Specification Structure
-
-The specification captures all analysis insights in XML format:
-
-```xml
-<skill_specification>
-  <metadata>
-    <name>skill-name</name>
-    <analysis_iterations>N</analysis_iterations>
-    <timelessness_score>X/10</timelessness_score>
-  </metadata>
-
-  <context>
-    <problem_statement>What + Why + Who</problem_statement>
-    <existing_landscape>Related skills, distinctiveness</existing_landscape>
-  </context>
-
-  <requirements>
-    <explicit>What user asked for</explicit>
-    <implicit>Expected but unstated</implicit>
-    <discovered>Found through analysis</discovered>
-  </requirements>
-
-  <architecture>
-    <pattern>Selected pattern with WHY</pattern>
-    <phases>Ordered phases with verification</phases>
-    <decision_points>Branches and defaults</decision_points>
-  </architecture>
-
-  <scripts>
-    <decision_summary>needs_scripts + rationale</decision_summary>
-    <script_inventory>name, category, purpose, patterns</script_inventory>
-    <agentic_capabilities>autonomous, self-verify, recovery</agentic_capabilities>
-  </scripts>
-
-  <evolution_analysis>
-    <timelessness_score>X/10</timelessness_score>
-    <extension_points>Where skill can grow</extension_points>
-    <obsolescence_triggers>What would break it</obsolescence_triggers>
-  </evolution_analysis>
-
-  <anti_patterns>
-    <pattern>What to avoid + WHY + alternative</pattern>
-  </anti_patterns>
-
-  <success_criteria>
-    <criterion>Measurable + verification method</criterion>
-  </success_criteria>
-</skill_specification>
-```
-
-See: [references/specification-template.md](references/specification-template.md)
-
-### Specification Validation
-
-Before proceeding to Phase 3:
-
-- [ ] All sections present with no placeholders
-- [ ] Every decision includes WHY
-- [ ] Timelessness score ≥ 7 with justification
-- [ ] At least 2 extension points documented
-- [ ] All requirements traceable to source
-- [ ] Scripts section complete (if applicable)
-- [ ] Agentic capabilities documented (if scripts present)
-
-</details>
-
-<details>
-<summary><strong>Deep Dive: Phase 3 - Generation</strong></summary>
-
-**Context:** Fresh, clean (no analysis artifacts polluting)
-**Standard:** Zero errors—every section verified before proceeding
-
-### Generation Order
-
-```
-1. Create directory structure
-   mkdir -p ~/.claude/skills/{skill-name}/references
-   mkdir -p ~/.claude/skills/{skill-name}/assets/templates
-   mkdir -p ~/.claude/skills/{skill-name}/scripts  # if scripts needed
-
-2. Write SKILL.md
-   • Frontmatter (YAML - allowed properties only)
-   • Title and brief intro
-   • Quick Start section
-   • Triggers (3-5 varied phrases)
-   • Quick Reference table
-   • How It Works overview
-   • Commands
-   • Scripts section (if applicable)
-   • Validation section
-   • Anti-Patterns
-   • Verification criteria
-   • Deep Dive sections (in <details> tags)
-
-3. Generate reference documents (if needed)
-   • Deep documentation for complex topics
-   • Templates for generated artifacts
-   • Checklists for validation
-
-4. Create assets (if needed)
-   • Templates for skill outputs
-
-5. Create scripts (if needed)
-   • Use script-template.py as base
-   • Include Result dataclass pattern
-   • Add self-verification
-   • Document exit codes
-   • Test before finalizing
-```
-
-### Quality Checks During Generation
-
-| Check | Requirement |
-|-------|-------------|
-| Frontmatter | Only allowed properties (name, description, license, allowed-tools, metadata) |
-| Name | Hyphen-case, ≤64 chars |
-| Description | ≤1024 chars, no angle brackets |
-| Triggers | 3-5 distinct, natural language |
-| Phases | 1-3 max, not over-engineered |
-| Verification | Concrete, measurable |
-| Tables over prose | Structured information in tables |
-| No placeholder text | Every section fully written |
-| Scripts (if present) | Shebang, docstring, argparse, exit codes, Result pattern |
-| Script docs | Scripts section in SKILL.md with usage examples |
-
-</details>
-
-<details>
-<summary><strong>Deep Dive: Phase 4 - Multi-Agent Synthesis</strong></summary>
-
-**Panel:** 3-4 Opus agents with distinct evaluative lenses
-**Requirement:** Unanimous approval (all agents)
-**Fallback:** Return to Phase 1 with feedback (max 5 iterations)
-
-### Panel Composition
-
-| Agent | Focus | Key Criteria | When Active |
-|-------|-------|--------------|-------------|
-| **Design/Architecture** | Structure, patterns, correctness | Pattern appropriate, phases logical, no circular deps | Always |
-| **Audience/Usability** | Clarity, discoverability, completeness | Triggers natural, steps unambiguous, no assumed knowledge | Always |
-| **Evolution/Timelessness** | Future-proofing, extension, ecosystem | Score ≥7, extension points clear, ecosystem fit | Always |
-| **Script/Automation** | Agentic capability, verification, quality | Scripts follow patterns, self-verify, documented | When scripts present |
-
-### Script Agent (Conditional)
-
-The Script Agent is activated when the skill includes a `scripts/` directory. Focus areas:
-
-| Criterion | Checks |
-|-----------|--------|
-| **Pattern Compliance** | Result dataclass, argparse, exit codes |
-| **Self-Verification** | Scripts can verify their own output |
-| **Error Handling** | Graceful failures, actionable messages |
-| **Documentation** | Usage examples in SKILL.md |
-| **Agentic Capability** | Scripts complete cleanly without interactive prompts during scoped, user-approved invocations |
-
-**Script Agent Scoring:**
-
-| Score | Meaning |
-|-------|---------|
-| 8-10 | Fully agentic, self-verifying, production-ready |
-| 6-7 | Functional but missing some agentic capabilities |
-| <6 | Requires revision - insufficient automation quality |
-
-### Agent Evaluation
-
-Each agent produces:
-
-```markdown
-## [Agent] Review
-
-### Verdict: APPROVED / CHANGES_REQUIRED
-
-### Scores
-| Criterion | Score (1-10) | Notes |
-|-----------|--------------|-------|
-
-### Strengths
-1. [Specific with evidence]
-
-### Issues (if CHANGES_REQUIRED)
-| Issue | Severity | Required Change |
-|-------|----------|-----------------|
-
-### Recommendations
-1. [Even if approved]
-```
-
-### Consensus Protocol
-
-```
-IF all agents APPROVED (3/3 or 4/4):
-    → Finalize skill
-    → Run validate-skill.py
-    → Update registry
-    → Complete
-
-ELSE:
-    → Collect all issues (including script issues)
-    → Return to Phase 1 with issues as input
-    → Re-apply targeted questioning
-    → Regenerate skill and scripts
-    → Re-submit to panel
-
-IF 5 iterations without consensus:
-    → Flag for human review
-    → Present all agent perspectives
-    → User makes final decision
-```
-
-See: [references/synthesis-protocol.md](references/synthesis-protocol.md)
-
-</details>
-
-<details>
-<summary><strong>Deep Dive: Evolution/Timelessness</strong></summary>
-
-Every skill is evaluated through the evolution lens:
-
-### Temporal Projection
-
-| Timeframe | Key Question |
-|-----------|--------------|
-| 6 months | How will usage patterns evolve? |
-| 1 year | What ecosystem changes are likely? |
-| 2 years | What new capabilities might obsolete this? |
-| 5 years | Is the core problem still relevant? |
-
-### Timelessness Scoring
-
-| Score | Description | Verdict |
-|-------|-------------|---------|
-| 1-3 | Transient, will be obsolete in months | Reject |
-| 4-6 | Moderate, depends on current tooling | Revise |
-| **7-8** | **Solid, principle-based, extensible** | **Approve** |
-| 9-10 | Timeless, addresses fundamental problem | Exemplary |
-
-**Requirement:** All skills must score ≥7.
-
-### Anti-Obsolescence Patterns
-
-| Do | Don't |
-|----|-------|
-| Design around principles | Hardcode implementations |
-| Document the WHY | Only document the WHAT |
-| Include extension points | Create closed systems |
-| Abstract volatile dependencies | Direct coupling |
-| Version-agnostic patterns | Pin specific versions |
-
-See: [references/evolution-scoring.md](references/evolution-scoring.md)
-
-</details>
-
-<details>
-<summary><strong>Architecture Pattern Selection</strong></summary>
-
-Select based on task complexity:
-
-| Pattern | Use When | Structure |
-|---------|----------|-----------|
-| **Single-Phase** | Simple linear tasks | Steps 1-2-3 |
-| **Checklist** | Quality/compliance audits | ☐ Item verification |
-| **Generator** | Creating artifacts | Input → Transform → Output |
-| **Multi-Phase** | Complex ordered workflows | Phase 1 → Phase 2 → Phase 3 |
-| **Multi-Agent Parallel** | Independent subtasks | Launch agents concurrently |
-| **Multi-Agent Sequential** | Dependent subtasks | Agent 1 → Agent 2 → Agent 3 |
-| **Orchestrator** | Coordinating multiple skills | Meta-skill chains |
-
-### Selection Decision Tree
-
-```
-Is it a simple procedure?
-├── Yes → Single-Phase
-└── No → Does it produce artifacts?
-    ├── Yes → Generator
-    └── No → Does it verify/audit?
-        ├── Yes → Checklist
-        └── No → Are subtasks independent?
-            ├── Yes → Multi-Agent Parallel
-            └── No → Multi-Agent Sequential or Multi-Phase
-```
-
-</details>
-
-<details>
-<summary><strong>Configuration</strong></summary>
-
-```yaml
-SKILLCREATOR_CONFIG:
-  mode: autonomous
-  depth: maximum  # always
-  core_lens: evolution_timelessness
-
-  analysis:
-    min_lens_depth: 5
-    max_questioning_rounds: 7
-    termination_empty_rounds: 3
-
-  synthesis:
-    panel_size: 3
-    require_unanimous: true
-    max_iterations: 5
-    escalate_to_human: true
-
-  evolution:
-    min_timelessness_score: 7
-    min_extension_points: 2
-    require_temporal_projection: true
-
-  model:
-    primary: claude-opus-4-6
-    subagents: claude-opus-4-6
-```
-
-</details>
+## Scripts
+
+The `scripts/` directory makes SkillForge agentic: it can scaffold, triage, validate, and package skills with self-verification. All scripts use Python 3 standard library, the `Result` dataclass pattern, and shared exit codes: `0`=success, `1`=failure, `10`=validation failure, `11`=verification failure.
+
+| Script | Purpose |
+|--------|---------|
+| `triage_skill_request.py` | Phase 0 triage: classify an input and route to build, improve, or reuse |
+| `discover_skills.py` | Ecosystem scan: enumerate existing skills before creating a new one |
+| `init_skill.py` | Scaffold a new skill directory from the standard structure |
+| `validate-skill.py` | Full validation of a generated skill against SkillForge standards |
+| `quick_validate.py` | Fast structural check of frontmatter and required sections |
+| `skill_modularity_audit.py` | Audit SKILL.md size and flag progressive-disclosure violations |
+| `package_skill.py` | Package a completed skill for distribution |
+| `check_docs_safety.py` | Safety scan of generated documentation |
+
+See [references/script-integration-framework.md](references/script-integration-framework.md) for when to add scripts and [references/script-patterns-catalog.md](references/script-patterns-catalog.md) for the standard patterns.
 
 ---
 
 ## References
 
-- [Regression Questions](references/regression-questions.md) - Complete question bank (7 categories)
-- [Multi-Lens Framework](references/multi-lens-framework.md) - 11 thinking models guide
-- [Specification Template](references/specification-template.md) - XML spec structure
-- [Evolution Scoring](references/evolution-scoring.md) - Timelessness evaluation
-- [Synthesis Protocol](references/synthesis-protocol.md) - Multi-agent panel details
-- [Script Integration Framework](references/script-integration-framework.md) - When and how to create scripts
-- [Script Patterns Catalog](references/script-patterns-catalog.md) - Standard Python patterns
+| Reference | Contents |
+|-----------|----------|
+| [Overview and Triggers](references/overview-and-triggers.md) | Original examples, trigger lists, routing diagram, commands |
+| [Phase 0 Triage](references/phase0-triage.md) | Input classification, ecosystem scan, decision matrix, triage scripts |
+| [Phase 1 Deep Dive](references/phase1-analysis-deep-dive.md) | Input expansion, lens scan, regression questioning, automation analysis |
+| [Multi-Lens Framework](references/multi-lens-framework.md) | 11 thinking models and application guidance |
+| [Regression Questions](references/regression-questions.md) | Complete question bank and termination criteria |
+| [Phase 2 Deep Dive](references/phase2-specification-deep-dive.md) | Specification structure and validation |
+| [Specification Template](references/specification-template.md) | Full XML specification template |
+| [Phase 3 Deep Dive](references/phase3-generation-deep-dive.md) | Generation order and quality checks |
+| [Output Structure](references/output-structure.md) | Frontmatter, directory structure, scripts, hooks |
+| [Script Integration Framework](references/script-integration-framework.md) | When and how to add scripts |
+| [Script Patterns Catalog](references/script-patterns-catalog.md) | Standard Python script patterns |
+| [Phase 4 Deep Dive](references/phase4-synthesis-deep-dive.md) | Panel composition, script agent, evaluation format, consensus loop |
+| [Synthesis Protocol](references/synthesis-protocol.md) | Multi-agent panel execution details |
+| [Evolution Scoring](references/evolution-scoring.md) | Timelessness scoring and evolution rubric |
+| [Evolution Timelessness](references/evolution-timelessness.md) | Temporal projection and anti-obsolescence patterns |
+| [Architecture Patterns](references/architecture-patterns.md) | Pattern selection guide and decision tree |
+| [Configuration](references/configuration.md) | SkillForge configuration defaults |
+| [Changelog](references/changelog.md) | Version history |
 
 ---
 
@@ -964,70 +300,15 @@ SKILLCREATOR_CONFIG:
 
 ## Extension Points
 
-1. **Additional Lenses:** Add new thinking models to `references/multi-lens-framework.md`
-2. **New Synthesis Agents:** Extend panel beyond 4 agents for specific domains
-3. **Custom Patterns:** Add architecture patterns to selection guide
-4. **Domain Templates:** Add domain-specific templates to `assets/templates/`
-5. **Script Patterns:** Add new patterns to `references/script-patterns-catalog.md`
-6. **Script Categories:** Extend the 7 script categories for new use cases
+1. Add thinking models in [references/multi-lens-framework.md](references/multi-lens-framework.md).
+2. Extend panel agents in [references/synthesis-protocol.md](references/synthesis-protocol.md).
+3. Add architecture patterns in [references/architecture-patterns.md](references/architecture-patterns.md).
+4. Add domain templates in `assets/templates/`.
+5. Add script patterns in [references/script-patterns-catalog.md](references/script-patterns-catalog.md).
+6. Extend script categories in [references/script-integration-framework.md](references/script-integration-framework.md).
 
 ---
 
 ## Changelog
 
-### v4.1.0 (Current)
-
-- **Extended frontmatter support** - Full support for `model`, `context`, `agent`, `hooks`, `user-invocable`
-- Created `scripts/_constants.py` for shared validation constants
-- Updated `scripts/quick_validate.py` with extended property validation
-- Updated `scripts/validate-skill.py` with hooks and agent validation
-- Fixed `scripts/discover_skills.py` to extract version from `metadata.version`
-- Added Hooks Integration section to SKILL.md and script-integration-framework.md
-- Added Forked Context documentation to synthesis-protocol.md
-- Updated skill template with modern best practices
-- Expanded frontmatter requirements table with 10 properties
-
-### v4.0.0
-
-- **Phase 0 Skill Triage** - Intelligent routing before creation
-- Universal input handling - any prompt works
-- Skill ecosystem scanning with 250+ skills indexed
-- Decision matrix: USE | IMPROVE | CREATE | COMPOSE
-- Renamed from SkillCreator to SkillForge
-
-### v3.2.0
-
-- Added Script Integration Framework for agentic skills
-- Added 4th Script Agent to synthesis panel (conditional)
-- Added Phase 1D: Automation Analysis
-- Added Automation Lens questions to regression questioning
-- Created `references/script-integration-framework.md`
-- Created `references/script-patterns-catalog.md`
-- Created `assets/templates/script-template.py`
-- Updated skill-spec-template.xml with `<scripts>` section
-- Updated validate-skill.py with script validation
-- Skills can now include self-verifying Python scripts
-
-### v3.1.0
-
-- Added progressive disclosure structure
-- Fixed frontmatter for packaging compatibility
-- Added validation & packaging section
-- Deep dive sections now collapsible
-
-### v3.0.0
-
-- Complete redesign as ultimate meta-skill
-- Added regression questioning loop
-- Added multi-lens analysis framework (11 models)
-- Added evolution/timelessness core lens
-- Added multi-agent synthesis panel
-
-### v2.0.0
-
-- Pattern selection guide
-- Quality standards checklist
-
-### v1.0.0
-
-- Basic skill structure
+See [references/changelog.md](references/changelog.md) for the full version history.

--- a/src/copilot-cli/skills/SkillForge/references/changelog.md
+++ b/src/copilot-cli/skills/SkillForge/references/changelog.md
@@ -1,0 +1,58 @@
+## Changelog
+
+### v4.1.0 (Current)
+
+- **Extended frontmatter support** - Full support for `model`, `context`, `agent`, `hooks`, `user-invocable`
+- Created `scripts/_constants.py` for shared validation constants
+- Updated `scripts/quick_validate.py` with extended property validation
+- Updated `scripts/validate-skill.py` with hooks and agent validation
+- Fixed `scripts/discover_skills.py` to extract version from `metadata.version`
+- Added Hooks Integration section to SKILL.md and script-integration-framework.md
+- Added Forked Context documentation to synthesis-protocol.md
+- Updated skill template with modern best practices
+- Expanded frontmatter requirements table with 10 properties
+
+### v4.0.0
+
+- **Phase 0 Skill Triage** - Intelligent routing before creation
+- Universal input handling - any prompt works
+- Skill ecosystem scanning with 250+ skills indexed
+- Decision matrix: USE | IMPROVE | CREATE | COMPOSE
+- Renamed from SkillCreator to SkillForge
+
+### v3.2.0
+
+- Added Script Integration Framework for agentic skills
+- Added 4th Script Agent to synthesis panel (conditional)
+- Added Phase 1D: Automation Analysis
+- Added Automation Lens questions to regression questioning
+- Created `references/script-integration-framework.md`
+- Created `references/script-patterns-catalog.md`
+- Created `assets/templates/script-template.py`
+- Updated skill-spec-template.xml with `<scripts>` section
+- Updated validate-skill.py with script validation
+- Skills can now include self-verifying Python scripts
+
+### v3.1.0
+
+- Added progressive disclosure structure
+- Fixed frontmatter for packaging compatibility
+- Added validation & packaging section
+- Deep dive sections now collapsible
+
+### v3.0.0
+
+- Complete redesign as ultimate meta-skill
+- Added regression questioning loop
+- Added multi-lens analysis framework (11 models)
+- Added evolution/timelessness core lens
+- Added multi-agent synthesis panel
+
+### v2.0.0
+
+- Pattern selection guide
+- Quality standards checklist
+
+### v1.0.0
+
+- Basic skill structure

--- a/src/copilot-cli/skills/SkillForge/references/evolution-timelessness.md
+++ b/src/copilot-cli/skills/SkillForge/references/evolution-timelessness.md
@@ -31,4 +31,4 @@ Every skill is evaluated through the evolution lens:
 | Abstract volatile dependencies | Direct coupling |
 | Version-agnostic patterns | Pin specific versions |
 
-See: [references/evolution-scoring.md](evolution-scoring.md)
+See: [evolution-scoring.md](evolution-scoring.md)

--- a/src/copilot-cli/skills/SkillForge/references/evolution-timelessness.md
+++ b/src/copilot-cli/skills/SkillForge/references/evolution-timelessness.md
@@ -31,4 +31,4 @@ Every skill is evaluated through the evolution lens:
 | Abstract volatile dependencies | Direct coupling |
 | Version-agnostic patterns | Pin specific versions |
 
-See: [references/evolution-scoring.md](references/evolution-scoring.md)
+See: [references/evolution-scoring.md](evolution-scoring.md)

--- a/src/copilot-cli/skills/SkillForge/references/output-structure.md
+++ b/src/copilot-cli/skills/SkillForge/references/output-structure.md
@@ -1,0 +1,179 @@
+# Skill Output Structure and Packaging
+
+### Frontmatter Requirements
+
+Skills must use only these allowed frontmatter properties:
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `name` | Yes | Hyphen-case, max 64 chars |
+| `description` | Yes | Max 1024 chars, no angle brackets |
+| `license` | No | MIT, Apache-2.0, etc. |
+| `allowed-tools` | No | Restrict tool access (comma-separated or YAML list) |
+| `model` | No | Specific Claude model (e.g., `claude-sonnet-4-20250514`) |
+| `context` | No | Set to `fork` for isolated sub-agent context |
+| `agent` | No | Agent type when `context: fork` (`Explore`, `Plan`, `general-purpose`) |
+| `hooks` | No | Lifecycle hooks (`PreToolUse`, `PostToolUse`, `Stop`) |
+| `user-invocable` | No | Show in slash menu (default: `true`) |
+| `metadata` | No | Custom fields (version, author, domains, etc.) |
+
+**Basic Example:**
+
+```yaml
+---
+name: my-skill
+description: What this skill does and when to use it
+license: MIT
+model: claude-opus-4-6
+user-invocable: true
+metadata:
+  version: 1.0.0
+  author: your-name
+---
+```
+
+**Advanced Example (with forked context and hooks):**
+
+```yaml
+---
+name: isolated-analyzer
+description: Runs analysis in isolated context with validation hooks
+license: MIT
+model: claude-opus-4-6
+context: fork
+agent: Explore
+user-invocable: true
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate.sh"
+metadata:
+  version: 1.0.0
+---
+```
+
+**Field Details:**
+
+| Field | Values | Notes |
+|-------|--------|-------|
+| `context` | `fork` | Creates isolated sub-agent with separate conversation history |
+| `agent` | `Explore`, `Plan`, `general-purpose` | Only valid when `context: fork` |
+| `user-invocable` | `true`, `false` | `false` hides from slash menu but Claude can still auto-invoke |
+| `hooks` | Object | See [Hooks Integration](#hooks-integration) section |
+
+---
+
+## Skill Output Structure
+
+```
+~/.claude/skills/{skill-name}/
+├── SKILL.md                    # Main entry point (required)
+├── references/                 # Deep documentation (optional)
+│   ├── patterns.md
+│   └── examples.md
+├── assets/                     # Templates (optional)
+│   └── templates/
+└── scripts/                    # Automation scripts (optional)
+    ├── validate.py             # Validation/verification
+    ├── generate.py             # Artifact generation
+    └── state.py                # State management
+```
+
+### Scripts Directory
+
+Scripts enable skills to be **agentic** - capable of autonomous operation with self-verification.
+
+| Category | Purpose | When to Include |
+|----------|---------|-----------------|
+| **Validation** | Verify outputs meet standards | Skill produces artifacts |
+| **Generation** | Create artifacts from templates | Repeatable artifact creation |
+| **State Management** | Track progress across sessions | Long-running operations |
+| **Transformation** | Convert/process data | Data processing tasks |
+| **Calculation** | Compute metrics/scores | Scoring or analysis |
+
+**Script Requirements:**
+
+- Python 3.x with standard library only (graceful fallbacks for extras)
+- `Result` dataclass pattern for structured returns
+- Exit codes: 0=success, 1=failure, 10=validation failure, 11=verification failure
+- Self-verification where applicable
+- Documented in SKILL.md with usage examples
+
+See: [references/script-integration-framework.md](script-integration-framework.md)
+
+### Hooks Integration
+
+Skills can define lifecycle hooks for validation, logging, and safety:
+
+```yaml
+---
+name: secure-skill
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "./scripts/validate-input.sh"
+  PostToolUse:
+    - matcher: "Write"
+      hooks:
+        - type: command
+          command: "./scripts/log-output.sh"
+          once: true
+  Stop:
+    - hooks:
+        - type: command
+          command: "./scripts/cleanup.sh"
+---
+```
+
+**Hook Types:**
+
+| Hook | When Triggered | Use Case |
+|------|----------------|----------|
+| `PreToolUse` | Before tool execution | Input validation, security checks |
+| `PostToolUse` | After tool execution | Output logging, verification |
+| `Stop` | When skill completes | Cleanup, state persistence |
+
+**Hook Configuration:**
+
+| Field | Description |
+|-------|-------------|
+| `matcher` | Tool name pattern to match (e.g., "Bash", "Write", "Bash(python:*)") |
+| `type` | Hook type: `command` (shell) or `prompt` (Claude evaluation) |
+| `command` | Shell command to execute (for `type: command`) |
+| `once` | If `true`, run only once per session (default: `false`) |
+
+Read `$TOOL_INPUT` / `$TOOL_OUTPUT` inside hook scripts from environment variables.
+Do not interpolate untrusted tool payloads directly into shell command strings.
+
+**When to Use Hooks:**
+
+| Scenario | Hook Type | Example |
+|----------|-----------|---------|
+| Validate script inputs | PreToolUse | Check parameters before `python scripts/*.py` |
+| Log generated artifacts | PostToolUse | Record files created by Write tool |
+| Security gate | PreToolUse | Block dangerous bash commands |
+| Cleanup temp files | Stop | Remove intermediate artifacts |
+
+**Example: Script Validation Hook**
+
+For skills with scripts, add input validation:
+
+```yaml
+hooks:
+  PreToolUse:
+    - matcher: "Bash(python:scripts/*)"
+      hooks:
+        - type: command
+          command: "python scripts/quick_validate.py . 2>/dev/null || true"
+          once: true
+```
+
+---

--- a/src/copilot-cli/skills/SkillForge/references/output-structure.md
+++ b/src/copilot-cli/skills/SkillForge/references/output-structure.md
@@ -105,7 +105,7 @@ Scripts enable skills to be **agentic** - capable of autonomous operation with s
 - Self-verification where applicable
 - Documented in SKILL.md with usage examples
 
-See: [references/script-integration-framework.md](script-integration-framework.md)
+See: [script-integration-framework.md](script-integration-framework.md)
 
 ### Hooks Integration
 

--- a/src/copilot-cli/skills/SkillForge/references/output-structure.md
+++ b/src/copilot-cli/skills/SkillForge/references/output-structure.md
@@ -100,8 +100,8 @@ Scripts enable skills to be **agentic** - capable of autonomous operation with s
 **Script Requirements:**
 
 - Python 3.x with standard library only (graceful fallbacks for extras)
-- `Result` dataclass pattern for structured returns
-- Exit codes: 0=success, 1=failure, 10=validation failure, 11=verification failure
+- `Result` dataclass pattern for structured returns, where a script produces structured output
+- Exit codes follow the repo convention: 0=success, 1=logic error, 2=config error, 3=external error (see AGENTS.md)
 - Self-verification where applicable
 - Documented in SKILL.md with usage examples
 

--- a/src/copilot-cli/skills/SkillForge/references/overview-and-triggers.md
+++ b/src/copilot-cli/skills/SkillForge/references/overview-and-triggers.md
@@ -47,7 +47,8 @@ TypeError: Cannot read property 'map' of undefined
 |-------|--------|--------------|
 | Any input | Triage → Route → Action | Phase 0 analysis |
 | Explicit create | New skill | Unanimous panel approval |
-| Task/question | Skill recommendation | Match confidence ≥60% |
+| Skill question | Skill recommendation | Match confidence ≥60% |
+| Task / code / URL | Recommend, improve, or compose | ≥80% recommend; 50-79% improve |
 
 ---
 

--- a/src/copilot-cli/skills/SkillForge/references/overview-and-triggers.md
+++ b/src/copilot-cli/skills/SkillForge/references/overview-and-triggers.md
@@ -33,7 +33,7 @@ TypeError: Cannot read property 'map' of undefined
 - `create skill` - Natural language activation
 - `design skill for {purpose}` - Purpose-first creation
 - `ultimate skill` - Emphasize maximum quality
-- `skillforge --plan-only` - Generate specification without execution
+- `SkillForge --plan-only` - Generate specification without execution
 
 ### Routing Triggers (NEW in v4.0)
 

--- a/src/copilot-cli/skills/SkillForge/references/overview-and-triggers.md
+++ b/src/copilot-cli/skills/SkillForge/references/overview-and-triggers.md
@@ -1,0 +1,131 @@
+# Overview and Triggers
+
+## Quick Start
+
+**Any input works.** SkillForge will intelligently route to the right action:
+
+```
+# These all work - SkillForge figures out what you need:
+
+SkillForge: create a skill for automated code review
+→ Creates new skill (after checking no duplicates exist)
+
+help me debug this TypeError
+→ Recommends ErrorExplainer skill (existing)
+
+improve the testgen skill to handle React components better
+→ Enters improvement mode for TestGen
+
+do I have a skill for database migrations?
+→ Recommends DBSchema, database-migration skills
+
+TypeError: Cannot read property 'map' of undefined
+→ Routes to debugging skills (error detected)
+```
+
+---
+
+## Triggers
+
+### Creation Triggers
+
+- `SkillForge: {goal}` - Full autonomous skill creation
+- `create skill` - Natural language activation
+- `design skill for {purpose}` - Purpose-first creation
+- `ultimate skill` - Emphasize maximum quality
+- `skillforge --plan-only` - Generate specification without execution
+
+### Routing Triggers (NEW in v4.0)
+
+- `{any input}` - Analyzes and routes automatically
+- `do I have a skill for` - Searches existing skills
+- `which skill` / `what skill` - Recommends matching skills
+- `improve {skill-name} skill` - Enters improvement mode
+- `help me with` / `I need to` - Detects task and routes
+
+| Input | Output | Quality Gate |
+|-------|--------|--------------|
+| Any input | Triage → Route → Action | Phase 0 analysis |
+| Explicit create | New skill | Unanimous panel approval |
+| Task/question | Skill recommendation | Match confidence ≥60% |
+
+---
+
+## Process Overview
+
+```
+ANY USER INPUT
+(prompt, error, code, URL, question, task request)
+    │
+    ▼
+┌─────────────────────────────────────────────────────┐
+│ Phase 0: SKILL TRIAGE (NEW)                         │
+│ • Classify input type (create/improve/question/task)│
+│ • Scan 250+ skills in ecosystem                     │
+│ • Match against existing skills with confidence %   │
+│ • Route to: USE | IMPROVE | CREATE | COMPOSE        │
+├─────────────────────────────────────────────────────┤
+│         ↓ USE_EXISTING    ↓ IMPROVE      ↓ CREATE   │
+│      [Recommend]      [Load & Enhance] [Continue]   │
+└─────────────────────────────────────────────────────┘
+    │ (if CREATE_NEW or IMPROVE_EXISTING)
+    ▼
+┌─────────────────────────────────────────────────────┐
+│ Phase 1: DEEP ANALYSIS                              │
+│ • Expand requirements (explicit, implicit, unknown) │
+│ • Apply 11 thinking models + Automation Lens        │
+│ • Question until no new insights (3 empty rounds)   │
+│ • Identify automation/script opportunities          │
+├─────────────────────────────────────────────────────┤
+│ Phase 2: SPECIFICATION                              │
+│ • Generate XML spec with all decisions + WHY        │
+│ • Include scripts section (if applicable)           │
+│ • Validate timelessness score ≥ 7                   │
+├─────────────────────────────────────────────────────┤
+│ Phase 3: GENERATION                                 │
+│ • Write SKILL.md with fresh context                 │
+│ • Generate references/, assets/, and scripts/       │
+├─────────────────────────────────────────────────────┤
+│ Phase 4: SYNTHESIS PANEL                            │
+│ • 3-4 Opus agents review independently              │
+│ • Script Agent added when scripts present           │
+│ • All agents must approve (unanimous)               │
+│ • If rejected → loop back with feedback             │
+└─────────────────────────────────────────────────────┘
+    │
+    ▼
+Production-Ready Agentic Skill
+```
+
+**Key principles:**
+
+- **Phase 0 prevents duplicates** - Always checks existing skills first
+- Evolution/timelessness is the core lens (score ≥ 7 required)
+- Every decision includes WHY
+- Zero tolerance for errors
+- Autonomous execution at maximum depth
+- Scripts enable self-verification and agentic operation
+
+### Tool Escalation Policy
+
+Start with least privilege (`Read`, `Glob`, `Grep`, `Write`, `Edit`).
+
+Only add higher-risk tools when explicitly required:
+
+- `Bash` for deterministic local scripts that cannot be replaced with file edits
+- `WebFetch` / `WebSearch` only when external facts are required
+- `Task` only for true parallel sub-agent orchestration
+
+---
+
+## Commands
+
+| Command | Action |
+|---------|--------|
+| `SkillForge: {goal}` | Full autonomous execution |
+| `SkillForge --plan-only {goal}` | Generate specification only |
+| `SkillForge --quick {goal}` | Reduced depth (not recommended) |
+| `SkillForge --triage {input}` | Run Phase 0 triage only |
+| `SkillForge --improve {skill}` | Enter improvement mode for existing skill |
+
+---

--- a/src/copilot-cli/skills/SkillForge/references/phase0-triage.md
+++ b/src/copilot-cli/skills/SkillForge/references/phase0-triage.md
@@ -38,6 +38,7 @@ Before creating anything, SkillForge intelligently analyzes your input to determ
 │  Step 3: DECISION MATRIX                                            │
 │                                                                     │
 │  Match ≥80%  + explicit create → CLARIFY (duplicate warning)       │
+│  Match ≥60%  + skill question  → USE_EXISTING (recommend skill)    │
 │  Match ≥80%  + other input     → USE_EXISTING (recommend skill)    │
 │  Match 50-79%                  → IMPROVE_EXISTING (enhance match)  │
 │  Match <50%  + explicit create → CREATE_NEW (proceed to Phase 1)   │
@@ -50,7 +51,7 @@ Before creating anything, SkillForge intelligently analyzes your input to determ
 
 | Action | When | Result |
 |--------|------|--------|
-| **USE_EXISTING** | Match ≥80% | Recommends existing skill(s) to invoke |
+| **USE_EXISTING** | Match ≥80% (task, code, URL) or ≥60% (skill question) | Recommends existing skill(s) to invoke |
 | **IMPROVE_EXISTING** | Match 50-79% | Loads skill and enters enhancement mode |
 | **CREATE_NEW** | Match <50% | Proceeds to Phase 1 (Deep Analysis) |
 | **COMPOSE** | Multi-domain | Suggests skill chain via SkillComposer |

--- a/src/copilot-cli/skills/SkillForge/references/phase0-triage.md
+++ b/src/copilot-cli/skills/SkillForge/references/phase0-triage.md
@@ -1,0 +1,99 @@
+# Phase 0 Skill Triage
+
+## Phase 0: Skill Triage (NEW in v4.0)
+
+Before creating anything, SkillForge intelligently analyzes your input to determine the best action.
+
+### How It Works
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│                        ANY USER INPUT                               │
+│  (prompt, error, code, URL, question, task request, anything)      │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  Step 1: INPUT CLASSIFICATION                                       │
+│  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐       │
+│  │ explicit_create │ │ explicit_improve│ │ skill_question  │       │
+│  │ "create skill"  │ │ "improve skill" │ │ "do I have..."  │       │
+│  └─────────────────┘ └─────────────────┘ └─────────────────┘       │
+│  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐       │
+│  │  task_request   │ │  error_message  │ │  code_snippet   │       │
+│  │ "help me with"  │ │ "TypeError..."  │ │ [pasted code]   │       │
+│  └─────────────────┘ └─────────────────┘ └─────────────────┘       │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  Step 2: SKILL ECOSYSTEM SCAN                                       │
+│  • Load index of 250+ skills (discover_skills.py)                  │
+│  • Match input against all skills with confidence scoring          │
+│  • Identify top matches with reasons                               │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌────────────────────────────────────────────────────────────────────┐
+│  Step 3: DECISION MATRIX                                            │
+│                                                                     │
+│  Match ≥80%  + explicit create → CLARIFY (duplicate warning)       │
+│  Match ≥80%  + other input     → USE_EXISTING (recommend skill)    │
+│  Match 50-79%                  → IMPROVE_EXISTING (enhance match)  │
+│  Match <50%  + explicit create → CREATE_NEW (proceed to Phase 1)   │
+│  Multi-domain detected         → COMPOSE (suggest skill chain)     │
+│  Ambiguous input               → CLARIFY (ask for more info)       │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### Decision Actions
+
+| Action | When | Result |
+|--------|------|--------|
+| **USE_EXISTING** | Match ≥80% | Recommends existing skill(s) to invoke |
+| **IMPROVE_EXISTING** | Match 50-79% | Loads skill and enters enhancement mode |
+| **CREATE_NEW** | Match <50% | Proceeds to Phase 1 (Deep Analysis) |
+| **COMPOSE** | Multi-domain | Suggests skill chain via SkillComposer |
+| **CLARIFY** | Ambiguous or duplicate | Asks user to clarify intent |
+
+### Triage Script
+
+```bash
+# Run triage on any input
+python scripts/triage_skill_request.py "help me debug this error"
+
+# JSON output for automation
+python scripts/triage_skill_request.py "create a skill for payments" --json
+
+# Examples:
+python scripts/triage_skill_request.py "TypeError: Cannot read property 'map'"
+# → USE_EXISTING: Recommends ErrorExplainer (92%)
+
+python scripts/triage_skill_request.py "create a skill for code review"
+# → CLARIFY: CodeReview skill exists (85%), create anyway?
+
+python scripts/triage_skill_request.py "help me with API and auth and testing"
+# → COMPOSE: Multi-domain, suggests APIDesign + AuthSystem + TestGen chain
+```
+
+### Ecosystem Index
+
+Phase 0 uses a pre-built index of all skills:
+
+```bash
+# Rebuild skill index (run periodically or after installing new skills)
+python scripts/discover_skills.py
+
+# Index location: ~/.cache/skillrecommender/skill_index.json
+# Scans: ~/.claude/skills/, plugins/marketplaces/*, plugins/cache/*
+```
+
+### Integration with Phases 1-4
+
+- **USE_EXISTING**: Exits early, no creation needed
+- **IMPROVE_EXISTING**: Loads existing skill → Phase 1 analyzes gaps → Phase 2-4 enhance
+- **CREATE_NEW**: Full pipeline (Phase 1 → 2 → 3 → 4)
+- **COMPOSE**: Suggests using SkillComposer instead
+- **CLARIFY**: Pauses for user input before proceeding
+
+---

--- a/src/copilot-cli/skills/SkillForge/references/phase1-analysis-deep-dive.md
+++ b/src/copilot-cli/skills/SkillForge/references/phase1-analysis-deep-dive.md
@@ -61,7 +61,7 @@ Apply all 11 thinking models systematically:
 
 **Minimum requirement:** All 11 lenses scanned, at least 5 applied in depth.
 
-See: [references/multi-lens-framework.md](references/multi-lens-framework.md)
+See: [references/multi-lens-framework.md](multi-lens-framework.md)
 
 ### 1C: Regression Questioning
 
@@ -91,7 +91,7 @@ ROUND N:
 - Evolution/timelessness explicitly evaluated
 - Automation opportunities identified
 
-See: [references/regression-questions.md](references/regression-questions.md)
+See: [references/regression-questions.md](regression-questions.md)
 
 ### 1D: Automation Analysis
 
@@ -136,4 +136,4 @@ FOR EACH operation in the skill:
 | Enables autonomous operation | No verification needed |
 | External tool integration | Pure Claude reasoning |
 
-See: [references/script-integration-framework.md](references/script-integration-framework.md)
+See: [references/script-integration-framework.md](script-integration-framework.md)

--- a/src/copilot-cli/skills/SkillForge/references/phase1-analysis-deep-dive.md
+++ b/src/copilot-cli/skills/SkillForge/references/phase1-analysis-deep-dive.md
@@ -61,7 +61,7 @@ Apply all 11 thinking models systematically:
 
 **Minimum requirement:** All 11 lenses scanned, at least 5 applied in depth.
 
-See: [references/multi-lens-framework.md](multi-lens-framework.md)
+See: [multi-lens-framework.md](multi-lens-framework.md)
 
 ### 1C: Regression Questioning
 
@@ -91,7 +91,7 @@ ROUND N:
 - Evolution/timelessness explicitly evaluated
 - Automation opportunities identified
 
-See: [references/regression-questions.md](regression-questions.md)
+See: [regression-questions.md](regression-questions.md)
 
 ### 1D: Automation Analysis
 
@@ -136,4 +136,4 @@ FOR EACH operation in the skill:
 | Enables autonomous operation | No verification needed |
 | External tool integration | Pure Claude reasoning |
 
-See: [references/script-integration-framework.md](script-integration-framework.md)
+See: [script-integration-framework.md](script-integration-framework.md)

--- a/src/copilot-cli/skills/SkillForge/references/phase2-specification-deep-dive.md
+++ b/src/copilot-cli/skills/SkillForge/references/phase2-specification-deep-dive.md
@@ -50,7 +50,7 @@ The specification captures all analysis insights in XML format:
 </skill_specification>
 ```
 
-See: [references/specification-template.md](references/specification-template.md)
+See: [references/specification-template.md](specification-template.md)
 
 ### Specification Validation
 

--- a/src/copilot-cli/skills/SkillForge/references/phase2-specification-deep-dive.md
+++ b/src/copilot-cli/skills/SkillForge/references/phase2-specification-deep-dive.md
@@ -50,7 +50,7 @@ The specification captures all analysis insights in XML format:
 </skill_specification>
 ```
 
-See: [references/specification-template.md](specification-template.md)
+See: [specification-template.md](specification-template.md)
 
 ### Specification Validation
 

--- a/src/copilot-cli/skills/SkillForge/references/phase3-generation-deep-dive.md
+++ b/src/copilot-cli/skills/SkillForge/references/phase3-generation-deep-dive.md
@@ -1,6 +1,6 @@
 
 **Context:** Fresh, clean (no analysis artifacts polluting)
-**Standard:** Zero errors—every section verified before proceeding
+**Standard:** Zero errors, every section verified before proceeding
 
 ### Generation Order
 

--- a/src/copilot-cli/skills/SkillForge/references/phase4-synthesis-deep-dive.md
+++ b/src/copilot-cli/skills/SkillForge/references/phase4-synthesis-deep-dive.md
@@ -22,7 +22,7 @@ The Script Agent is activated when the skill includes a `scripts/` directory. Fo
 | **Self-Verification** | Scripts can verify their own output |
 | **Error Handling** | Graceful failures, actionable messages |
 | **Documentation** | Usage examples in SKILL.md |
-| **Agentic Capability** | Can run autonomously without human intervention |
+| **Agentic Capability** | Scripts complete cleanly without interactive prompts during scoped, user-approved invocations |
 
 **Script Agent Scoring:**
 
@@ -78,4 +78,4 @@ IF 5 iterations without consensus:
     → User makes final decision
 ```
 
-See: [references/synthesis-protocol.md](references/synthesis-protocol.md)
+See: [references/synthesis-protocol.md](synthesis-protocol.md)

--- a/src/copilot-cli/skills/SkillForge/references/phase4-synthesis-deep-dive.md
+++ b/src/copilot-cli/skills/SkillForge/references/phase4-synthesis-deep-dive.md
@@ -78,4 +78,4 @@ IF 5 iterations without consensus:
     → User makes final decision
 ```
 
-See: [references/synthesis-protocol.md](synthesis-protocol.md)
+See: [synthesis-protocol.md](synthesis-protocol.md)


### PR DESCRIPTION
## Summary

Decomposes the SkillForge `SKILL.md` from 1033 lines to 298 using progressive
disclosure. Deep-dive content moves into demand-loaded reference files, with
explicit pointers plus a reference index table so agents load detail only when
a process step needs it.

## Changes

- Slim `SKILL.md` to 298 lines, under the 300-line ceiling (core workflow + pointers).
- Add four new references: overview-and-triggers, phase0-triage,
  output-structure, changelog.
- Restore a top-level `## Scripts` section (required by validate-skill.py)
  documenting the scripts directory with shared exit codes.
- Regenerate the Copilot CLI SkillForge twin via build_all.py.
- Bump both plugin manifests to 0.6.22 (parity gate).

## Verification

- validate-skill.py passes (67/77 checks, remainder pre-existing helper-module
  warnings unrelated to this change).
- build_all.py regenerates twins with no unexpected drift.
- No content lost: all removed sections are linked from the reference index.

Fixes #2934

## References

Primary source and generated twin:

- `.claude/skills/SkillForge/SKILL.md`
- `src/copilot-cli/skills/SkillForge/SKILL.md`
- `.claude/skills/SkillForge/scripts/validate-skill.py`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


