### PR TITLE
fix(skill-violation): prune .wt worktrees and scope scan to changed files (#3006)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/github/scripts/pr/new_pr.py
+++ b/.claude/skills/github/scripts/pr/new_pr.py
@@ -231,7 +231,15 @@ def run_validations(
         timeout=30,
         env=_git_env(),
     )
-    changed_files = result.stdout.strip().splitlines() if result.returncode == 0 else []
+    diff_failed = result.returncode != 0
+    if diff_failed:
+        print(
+            f"  WARNING: 'git diff {base}...{head}' failed (exit {result.returncode}); "
+            "changed-file set is unknown. Change-scoped checks are skipped, "
+            "not silently treated as 'no changes'.",
+            file=sys.stderr,
+        )
+    changed_files = result.stdout.strip().splitlines() if not diff_failed else []
     agents_changed = any(f.startswith(".agents/") for f in changed_files)
 
     if agents_changed:
@@ -289,7 +297,10 @@ def run_validations(
             timeout=30,
         )
     elif os.path.exists(skill_script):
-        print("  No changed files to check.")
+        if diff_failed:
+            print("  Skipped: git diff failed, changed files unknown (see warning above).")
+        else:
+            print("  No changed files to check.")
 
     # Validation 3: Test coverage detection (WARNING)
     print()

--- a/.claude/skills/github/scripts/pr/new_pr.py
+++ b/.claude/skills/github/scripts/pr/new_pr.py
@@ -297,6 +297,7 @@ def run_validations(
         subprocess.run(
             skill_args,
             timeout=30,
+            env=_git_env(),
         )
     elif os.path.exists(skill_script):
         if diff_failed:

--- a/.claude/skills/github/scripts/pr/new_pr.py
+++ b/.claude/skills/github/scripts/pr/new_pr.py
@@ -281,8 +281,11 @@ def run_validations(
     print("[2/5] Checking for skill violations...")
     skill_script = os.path.join(repo_root, "scripts/detect_skill_violation.py")
     if os.path.exists(skill_script):
+        skill_args = [sys.executable, skill_script]
+        for changed_file in changed_files:
+            skill_args.extend(["--file", changed_file])
         subprocess.run(
-            [sys.executable, skill_script],
+            skill_args,
             timeout=30,
         )
 

--- a/.claude/skills/github/scripts/pr/new_pr.py
+++ b/.claude/skills/github/scripts/pr/new_pr.py
@@ -235,8 +235,8 @@ def run_validations(
     if diff_failed:
         print(
             f"  WARNING: 'git diff {base}...{head}' failed (exit {result.returncode}); "
-            "changed-file set is unknown. Change-scoped checks are skipped, "
-            "not silently treated as 'no changes'.",
+            "the changed-file set is unknown. Validations that rely on it are "
+            "skipped, not treated as 'no changes'.",
             file=sys.stderr,
         )
     changed_files = result.stdout.strip().splitlines() if not diff_failed else []
@@ -281,6 +281,8 @@ def run_validations(
                             raise SystemExit(1)
         elif not has_legacy_md:
             print("  WARNING: No session log found but .agents/ files changed", file=sys.stderr)
+    elif diff_failed:
+        print("  Skipped: git diff failed, changed files unknown (see warning above).")
     else:
         print("  No .agents/ changes, skipping")
 

--- a/.claude/skills/github/scripts/pr/new_pr.py
+++ b/.claude/skills/github/scripts/pr/new_pr.py
@@ -280,7 +280,7 @@ def run_validations(
     print()
     print("[2/5] Checking for skill violations...")
     skill_script = os.path.join(repo_root, "scripts/detect_skill_violation.py")
-    if os.path.exists(skill_script):
+    if os.path.exists(skill_script) and changed_files:
         skill_args = [sys.executable, skill_script]
         for changed_file in changed_files:
             skill_args.extend(["--file", changed_file])
@@ -288,6 +288,8 @@ def run_validations(
             skill_args,
             timeout=30,
         )
+    elif os.path.exists(skill_script):
+        print("  No changed files to check.")
 
     # Validation 3: Test coverage detection (WARNING)
     print()

--- a/.claude/skills/github/scripts/pr/validate_pr_description.py
+++ b/.claude/skills/github/scripts/pr/validate_pr_description.py
@@ -19,6 +19,7 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # Validators
@@ -34,7 +35,7 @@ _ISSUE_KEYWORD_PATTERN = re.compile(
 )
 
 
-def validate_conventional_commit(title: str) -> dict:
+def validate_conventional_commit(title: str) -> dict[str, Any]:
     """Check title follows conventional commit format."""
     if _CONVENTIONAL_COMMIT_PATTERN.match(title):
         return {"Status": "PASS", "Message": "Title follows conventional commit format"}
@@ -47,7 +48,7 @@ def validate_conventional_commit(title: str) -> dict:
     }
 
 
-def validate_issue_keywords(text: str) -> dict:
+def validate_issue_keywords(text: str) -> dict[str, Any]:
     """Check for GitHub issue linking keywords."""
     keywords = [m.group() for m in _ISSUE_KEYWORD_PATTERN.finditer(text)]
     if keywords:
@@ -67,7 +68,7 @@ def validate_issue_keywords(text: str) -> dict:
     }
 
 
-def validate_template_compliance(body: str) -> dict:
+def validate_template_compliance(body: str) -> dict[str, Any]:
     """Check PR template section completion.
 
     Note: Patterns are coupled to .github/PULL_REQUEST_TEMPLATE.md format.

--- a/scripts/detect_skill_violation.py
+++ b/scripts/detect_skill_violation.py
@@ -68,6 +68,7 @@ VALID_EXTENSIONS = frozenset({".md", ".py", ".ps1", ".psm1"})
 SKIP_DIRS = frozenset(
     {
         ".git",
+        ".wt",
         ".worktrees",
         "node_modules",
         ".venv",
@@ -153,6 +154,29 @@ def get_staged_files(repo_root: Path) -> list[str]:
         return [f for f in files if Path(f).suffix in VALID_EXTENSIONS]
     except subprocess.TimeoutExpired:
         return []
+
+
+def get_requested_files(paths: Sequence[str]) -> list[str]:
+    """Return valid requested files, preserving order and removing duplicates.
+
+    Args:
+        paths: Requested file paths relative to the repository root.
+
+    Returns:
+        Relative file paths with extensions the scanner understands.
+    """
+    files: list[str] = []
+    seen: set[str] = set()
+    for raw_path in paths:
+        path = Path(raw_path)
+        if path.suffix not in VALID_EXTENSIONS:
+            continue
+        file_path = path.as_posix()
+        if file_path in seen:
+            continue
+        files.append(file_path)
+        seen.add(file_path)
+    return files
 
 
 def get_all_files(repo_root: Path) -> list[str]:
@@ -315,6 +339,13 @@ def parse_args() -> argparse.Namespace:
         help="Only check git-staged files",
     )
     parser.add_argument(
+        "--file",
+        dest="files",
+        action="append",
+        default=[],
+        help="Relative file to scan. May be repeated and overrides repository walk.",
+    )
+    parser.add_argument(
         "--quiet",
         action="store_true",
         help="Suppress output (exit code only)",
@@ -346,7 +377,9 @@ def main() -> int:
             return 0
 
         # Get files to check
-        if args.staged_only:
+        if args.files:
+            files = get_requested_files(args.files)
+        elif args.staged_only:
             files = get_staged_files(repo_root)
         else:
             files = get_all_files(repo_root)

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/github/scripts/pr/new_pr.py
+++ b/src/copilot-cli/skills/github/scripts/pr/new_pr.py
@@ -231,7 +231,15 @@ def run_validations(
         timeout=30,
         env=_git_env(),
     )
-    changed_files = result.stdout.strip().splitlines() if result.returncode == 0 else []
+    diff_failed = result.returncode != 0
+    if diff_failed:
+        print(
+            f"  WARNING: 'git diff {base}...{head}' failed (exit {result.returncode}); "
+            "changed-file set is unknown. Change-scoped checks are skipped, "
+            "not silently treated as 'no changes'.",
+            file=sys.stderr,
+        )
+    changed_files = result.stdout.strip().splitlines() if not diff_failed else []
     agents_changed = any(f.startswith(".agents/") for f in changed_files)
 
     if agents_changed:
@@ -289,7 +297,10 @@ def run_validations(
             timeout=30,
         )
     elif os.path.exists(skill_script):
-        print("  No changed files to check.")
+        if diff_failed:
+            print("  Skipped: git diff failed, changed files unknown (see warning above).")
+        else:
+            print("  No changed files to check.")
 
     # Validation 3: Test coverage detection (WARNING)
     print()

--- a/src/copilot-cli/skills/github/scripts/pr/new_pr.py
+++ b/src/copilot-cli/skills/github/scripts/pr/new_pr.py
@@ -297,6 +297,7 @@ def run_validations(
         subprocess.run(
             skill_args,
             timeout=30,
+            env=_git_env(),
         )
     elif os.path.exists(skill_script):
         if diff_failed:

--- a/src/copilot-cli/skills/github/scripts/pr/new_pr.py
+++ b/src/copilot-cli/skills/github/scripts/pr/new_pr.py
@@ -281,8 +281,11 @@ def run_validations(
     print("[2/5] Checking for skill violations...")
     skill_script = os.path.join(repo_root, "scripts/detect_skill_violation.py")
     if os.path.exists(skill_script):
+        skill_args = [sys.executable, skill_script]
+        for changed_file in changed_files:
+            skill_args.extend(["--file", changed_file])
         subprocess.run(
-            [sys.executable, skill_script],
+            skill_args,
             timeout=30,
         )
 

--- a/src/copilot-cli/skills/github/scripts/pr/new_pr.py
+++ b/src/copilot-cli/skills/github/scripts/pr/new_pr.py
@@ -235,8 +235,8 @@ def run_validations(
     if diff_failed:
         print(
             f"  WARNING: 'git diff {base}...{head}' failed (exit {result.returncode}); "
-            "changed-file set is unknown. Change-scoped checks are skipped, "
-            "not silently treated as 'no changes'.",
+            "the changed-file set is unknown. Validations that rely on it are "
+            "skipped, not treated as 'no changes'.",
             file=sys.stderr,
         )
     changed_files = result.stdout.strip().splitlines() if not diff_failed else []
@@ -281,6 +281,8 @@ def run_validations(
                             raise SystemExit(1)
         elif not has_legacy_md:
             print("  WARNING: No session log found but .agents/ files changed", file=sys.stderr)
+    elif diff_failed:
+        print("  Skipped: git diff failed, changed files unknown (see warning above).")
     else:
         print("  No .agents/ changes, skipping")
 

--- a/src/copilot-cli/skills/github/scripts/pr/new_pr.py
+++ b/src/copilot-cli/skills/github/scripts/pr/new_pr.py
@@ -280,7 +280,7 @@ def run_validations(
     print()
     print("[2/5] Checking for skill violations...")
     skill_script = os.path.join(repo_root, "scripts/detect_skill_violation.py")
-    if os.path.exists(skill_script):
+    if os.path.exists(skill_script) and changed_files:
         skill_args = [sys.executable, skill_script]
         for changed_file in changed_files:
             skill_args.extend(["--file", changed_file])
@@ -288,6 +288,8 @@ def run_validations(
             skill_args,
             timeout=30,
         )
+    elif os.path.exists(skill_script):
+        print("  No changed files to check.")
 
     # Validation 3: Test coverage detection (WARNING)
     print()

--- a/src/copilot-cli/skills/github/scripts/pr/validate_pr_description.py
+++ b/src/copilot-cli/skills/github/scripts/pr/validate_pr_description.py
@@ -19,6 +19,7 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # Validators
@@ -34,7 +35,7 @@ _ISSUE_KEYWORD_PATTERN = re.compile(
 )
 
 
-def validate_conventional_commit(title: str) -> dict:
+def validate_conventional_commit(title: str) -> dict[str, Any]:
     """Check title follows conventional commit format."""
     if _CONVENTIONAL_COMMIT_PATTERN.match(title):
         return {"Status": "PASS", "Message": "Title follows conventional commit format"}
@@ -47,7 +48,7 @@ def validate_conventional_commit(title: str) -> dict:
     }
 
 
-def validate_issue_keywords(text: str) -> dict:
+def validate_issue_keywords(text: str) -> dict[str, Any]:
     """Check for GitHub issue linking keywords."""
     keywords = [m.group() for m in _ISSUE_KEYWORD_PATTERN.finditer(text)]
     if keywords:
@@ -67,7 +68,7 @@ def validate_issue_keywords(text: str) -> dict:
     }
 
 
-def validate_template_compliance(body: str) -> dict:
+def validate_template_compliance(body: str) -> dict[str, Any]:
     """Check PR template section completion.
 
     Note: Patterns are coupled to .github/PULL_REQUEST_TEMPLATE.md format.

--- a/tests/test_detect_skill_violation.py
+++ b/tests/test_detect_skill_violation.py
@@ -187,7 +187,7 @@ class TestGetAllFiles:
 
     @pytest.mark.parametrize(
         "skip_dir",
-        ["worktrees", ".venv", ".pytest_cache", ".mypy_cache", "node_modules"],
+        ["worktrees", ".venv", ".pytest_cache", ".mypy_cache", "node_modules", ".wt"],
     )
     def test_prunes_high_cost_dirs(self, tmp_path: Path, skip_dir: str) -> None:
         """Each high-cost directory in SKIP_DIRS is pruned from the walk.

--- a/tests/test_detect_skill_violation.py
+++ b/tests/test_detect_skill_violation.py
@@ -25,6 +25,7 @@ from scripts.detect_skill_violation import (
     extract_capability_gaps,
     get_all_files,
     get_repo_root,
+    get_requested_files,
     get_skills_dir,
     get_staged_files,
     report_violations,
@@ -122,6 +123,18 @@ class TestGetStagedFiles:
         result = get_staged_files(project_root)
 
         assert isinstance(result, list)
+
+
+class TestGetRequestedFiles:
+    """Tests for explicit file selection."""
+
+    def test_filters_extensions_and_deduplicates(self) -> None:
+        """Only supported extensions are kept in original order."""
+        result = get_requested_files(
+            ["docs/readme.md", "image.png", "docs/readme.md", "scripts/tool.py"]
+        )
+
+        assert result == ["docs/readme.md", "scripts/tool.py"]
 
 
 class TestGetAllFiles:
@@ -512,6 +525,36 @@ class TestMainFunction:
         assert result == 0
         captured = capsys.readouterr()
         assert "No files to check" in captured.out
+
+    def test_main_file_argument_scans_only_requested_files(
+        self,
+        test_repo: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: CaptureFixture[str],
+    ) -> None:
+        """main() with --file scans only explicitly requested files."""
+        from scripts import detect_skill_violation
+
+        (test_repo / "violation.md").write_text("Run: gh pr create --title test")
+        (test_repo / "ignored.md").write_text("Run: gh issue list")
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "detect_skill_violation.py",
+                "--path",
+                str(test_repo),
+                "--file",
+                "violation.md",
+            ],
+        )
+
+        result = detect_skill_violation.main()
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "violation.md:1" in captured.out
+        assert "ignored.md" not in captured.out
 
     def test_main_invalid_repo(
         self,

--- a/tests/test_new_pr.py
+++ b/tests/test_new_pr.py
@@ -339,7 +339,7 @@ class TestRunValidations:
         """A failed git diff must NOT run detect_skill_violation.py with zero
         --file args (which would trigger a full-repo scan and 30s timeout), and
         must NOT silently masquerade as 'no changes'. Instead it warns visibly
-        and skips the change-scoped scan (Copilot review, PR #3007)."""
+        and skips the change-scoped scan (Copilot review, issue #3006)."""
         skill_script = tmp_path / "scripts" / "detect_skill_violation.py"
         skill_script.parent.mkdir(parents=True)
         skill_script.write_text("# mock")

--- a/tests/test_new_pr.py
+++ b/tests/test_new_pr.py
@@ -335,6 +335,31 @@ class TestRunValidations:
         ):
             run_validations(str(tmp_path), "main", "feat/branch")
 
+    def test_skill_violation_detection_scopes_to_changed_files(self, tmp_path):
+        skill_script = tmp_path / "scripts" / "detect_skill_violation.py"
+        skill_script.parent.mkdir(parents=True)
+        skill_script.write_text("# mock")
+        changed = "scripts/changed.py\ndocs/guide.md\n"
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:3] == ["git", "diff", "--name-only"]:
+                return _completed(stdout=changed, rc=0)
+            return _completed(rc=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            run_validations(str(tmp_path), "main", "feat/branch")
+
+        assert calls[1] == [
+            sys.executable,
+            str(skill_script),
+            "--file",
+            "scripts/changed.py",
+            "--file",
+            "docs/guide.md",
+        ]
+
     def test_agents_changed_with_session_log_runs_validator(self, tmp_path):
         changed = ".agents/sessions/2025-01-01-session-01.json\n"
         validate_script = tmp_path / "scripts" / "validate_session_json.py"

--- a/tests/test_new_pr.py
+++ b/tests/test_new_pr.py
@@ -358,8 +358,12 @@ class TestRunValidations:
         assert not any(
             len(cmd) >= 2 and cmd[1] == str(skill_script) for cmd in calls
         )
-        err = capsys.readouterr().err
-        assert "git diff" in err and "failed" in err
+        captured = capsys.readouterr()
+        assert "git diff" in captured.err and "failed" in captured.err
+        # Validation 1 (Session End) must also honor the failed diff: it must
+        # report the skip explicitly, not masquerade as "No .agents/ changes".
+        assert "Skipped: git diff failed" in captured.out
+        assert "No .agents/ changes, skipping" not in captured.out
 
     def test_skill_violation_detection_scopes_to_changed_files(self, tmp_path):
         skill_script = tmp_path / "scripts" / "detect_skill_violation.py"

--- a/tests/test_new_pr.py
+++ b/tests/test_new_pr.py
@@ -377,13 +377,16 @@ class TestRunValidations:
         with patch("subprocess.run", side_effect=fake_run):
             run_validations(str(tmp_path), "main", "feat/branch")
 
-        assert calls[1] == [
-            sys.executable,
-            str(skill_script),
-            "--file",
-            "scripts/changed.py",
-            "--file",
-            "docs/guide.md",
+        skill_calls = [c for c in calls if len(c) >= 2 and c[1] == str(skill_script)]
+        assert skill_calls == [
+            [
+                sys.executable,
+                str(skill_script),
+                "--file",
+                "scripts/changed.py",
+                "--file",
+                "docs/guide.md",
+            ]
         ]
 
     def test_agents_changed_with_session_log_runs_validator(self, tmp_path):

--- a/tests/test_new_pr.py
+++ b/tests/test_new_pr.py
@@ -335,6 +335,32 @@ class TestRunValidations:
         ):
             run_validations(str(tmp_path), "main", "feat/branch")
 
+    def test_skill_violation_scan_skipped_when_git_diff_fails(self, tmp_path, capsys):
+        """A failed git diff must NOT run detect_skill_violation.py with zero
+        --file args (which would trigger a full-repo scan and 30s timeout), and
+        must NOT silently masquerade as 'no changes'. Instead it warns visibly
+        and skips the change-scoped scan (Copilot review, PR #3007)."""
+        skill_script = tmp_path / "scripts" / "detect_skill_violation.py"
+        skill_script.parent.mkdir(parents=True)
+        skill_script.write_text("# mock")
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:3] == ["git", "diff", "--name-only"]:
+                return _completed(rc=128, stderr="fatal: bad revision")
+            return _completed(rc=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            run_validations(str(tmp_path), "main", "feat/branch")
+
+        # detect_skill_violation.py must never be invoked on a failed diff.
+        assert not any(
+            len(cmd) >= 2 and cmd[1] == str(skill_script) for cmd in calls
+        )
+        err = capsys.readouterr().err
+        assert "git diff" in err and "failed" in err
+
     def test_skill_violation_detection_scopes_to_changed_files(self, tmp_path):
         skill_script = tmp_path / "scripts" / "detect_skill_violation.py"
         skill_script.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Fixes the github skill's PR-creation flow wedging on checkouts that contain local `.wt/` worktrees. `scripts/detect_skill_violation.py` scanned the full checkout (~170k files here), took ~47s, and exceeded the 30s timeout in `new_pr.py`, aborting PR creation at the skill-violation check.

## Changes

- `scripts/detect_skill_violation.py`: prune `.wt` from the directory walk; add a repeatable `--file` argument and `get_requested_files()` so callers can scope the scan to changed files.
- `.claude/skills/github/scripts/pr/new_pr.py` (+ Copilot mirror): pass `git diff base...head` files to the validator via `--file`.
- `.claude/skills/github/scripts/pr/validate_pr_description.py` (+ mirror): typed return dicts (mypy).
- Tests for `.wt` pruning and `--file` scoping.
- Plugin version bump to 0.6.25 (both manifests, parity; rebased past #3009 which took 0.6.24).

## Verification

- Full scan 47.489s -> 6.727s; scoped scan 0.166s; violation fixture still detected.
- `pytest tests/test_detect_skill_violation.py tests/test_new_pr.py` = 89 passed.
- `ruff` and `mypy` clean; `validate_plugin_version_bump.py --base origin/main` OK.
- This PR was created using the fixed `new_pr.py` from this branch.

Fixes #3006

## References

- `scripts/detect_skill_violation.py`
- `.claude/skills/github/scripts/pr/new_pr.py`

