### PR TITLE
fix(github): filter changed files to scannable extensions before skill scan

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/github/scripts/pr/new_pr.py
+++ b/.claude/skills/github/scripts/pr/new_pr.py
@@ -55,6 +55,16 @@ from validate_pr_description import _CONVENTIONAL_COMMIT_PATTERN  # noqa: E402
 # entry 5 (Issue #1923).
 _DASH_RE = re.compile("[\u2013\u2014]")
 
+# Extensions the skill-violation scanner (scripts/detect_skill_violation.py)
+# actually inspects. Filtering changed files to this set before building the
+# scan argv keeps the command line short on large diffs and skips the
+# subprocess entirely when no changed file is scannable. This mirrors
+# detect_skill_violation.VALID_EXTENSIONS; the two are kept in sync by
+# test_new_pr.py, which imports both and asserts equality (same drift-guard
+# strategy as _DASH_RE above). A local constant avoids the cross-package
+# import path resolution the _DASH_RE comment documents rejecting.
+_SKILL_SCAN_EXTENSIONS = frozenset({".md", ".py", ".ps1", ".psm1"})
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -290,9 +300,10 @@ def run_validations(
     print()
     print("[2/5] Checking for skill violations...")
     skill_script = os.path.join(repo_root, "scripts/detect_skill_violation.py")
-    if os.path.exists(skill_script) and changed_files:
+    scannable_files = [f for f in changed_files if Path(f).suffix in _SKILL_SCAN_EXTENSIONS]
+    if os.path.exists(skill_script) and scannable_files:
         skill_args = [sys.executable, skill_script]
-        for changed_file in changed_files:
+        for changed_file in scannable_files:
             skill_args.extend(["--file", changed_file])
         subprocess.run(
             skill_args,
@@ -302,8 +313,10 @@ def run_validations(
     elif os.path.exists(skill_script):
         if diff_failed:
             print("  Skipped: git diff failed, changed files unknown (see warning above).")
-        else:
+        elif not changed_files:
             print("  No changed files to check.")
+        else:
+            print("  No changed files with a scannable extension (.md, .py, .ps1, .psm1).")
 
     # Validation 3: Test coverage detection (WARNING)
     print()

--- a/.claude/skills/github/scripts/pr/new_pr.py
+++ b/.claude/skills/github/scripts/pr/new_pr.py
@@ -316,7 +316,8 @@ def run_validations(
         elif not changed_files:
             print("  No changed files to check.")
         else:
-            print("  No changed files with a scannable extension (.md, .py, .ps1, .psm1).")
+            _exts = ", ".join(sorted(_SKILL_SCAN_EXTENSIONS))
+            print(f"  No changed files with a scannable extension ({_exts}).")
 
     # Validation 3: Test coverage detection (WARNING)
     print()

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/github/scripts/pr/new_pr.py
+++ b/src/copilot-cli/skills/github/scripts/pr/new_pr.py
@@ -55,6 +55,16 @@ from validate_pr_description import _CONVENTIONAL_COMMIT_PATTERN  # noqa: E402
 # entry 5 (Issue #1923).
 _DASH_RE = re.compile("[\u2013\u2014]")
 
+# Extensions the skill-violation scanner (scripts/detect_skill_violation.py)
+# actually inspects. Filtering changed files to this set before building the
+# scan argv keeps the command line short on large diffs and skips the
+# subprocess entirely when no changed file is scannable. This mirrors
+# detect_skill_violation.VALID_EXTENSIONS; the two are kept in sync by
+# test_new_pr.py, which imports both and asserts equality (same drift-guard
+# strategy as _DASH_RE above). A local constant avoids the cross-package
+# import path resolution the _DASH_RE comment documents rejecting.
+_SKILL_SCAN_EXTENSIONS = frozenset({".md", ".py", ".ps1", ".psm1"})
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -290,9 +300,10 @@ def run_validations(
     print()
     print("[2/5] Checking for skill violations...")
     skill_script = os.path.join(repo_root, "scripts/detect_skill_violation.py")
-    if os.path.exists(skill_script) and changed_files:
+    scannable_files = [f for f in changed_files if Path(f).suffix in _SKILL_SCAN_EXTENSIONS]
+    if os.path.exists(skill_script) and scannable_files:
         skill_args = [sys.executable, skill_script]
-        for changed_file in changed_files:
+        for changed_file in scannable_files:
             skill_args.extend(["--file", changed_file])
         subprocess.run(
             skill_args,
@@ -302,8 +313,10 @@ def run_validations(
     elif os.path.exists(skill_script):
         if diff_failed:
             print("  Skipped: git diff failed, changed files unknown (see warning above).")
-        else:
+        elif not changed_files:
             print("  No changed files to check.")
+        else:
+            print("  No changed files with a scannable extension (.md, .py, .ps1, .psm1).")
 
     # Validation 3: Test coverage detection (WARNING)
     print()

--- a/src/copilot-cli/skills/github/scripts/pr/new_pr.py
+++ b/src/copilot-cli/skills/github/scripts/pr/new_pr.py
@@ -316,7 +316,8 @@ def run_validations(
         elif not changed_files:
             print("  No changed files to check.")
         else:
-            print("  No changed files with a scannable extension (.md, .py, .ps1, .psm1).")
+            _exts = ", ".join(sorted(_SKILL_SCAN_EXTENSIONS))
+            print(f"  No changed files with a scannable extension ({_exts}).")
 
     # Validation 3: Test coverage detection (WARNING)
     print()

--- a/tests/test_new_pr.py
+++ b/tests/test_new_pr.py
@@ -469,6 +469,11 @@ class TestRunValidations:
         # tests (gemini-code-assist review, PR #3012).
         previous = sys.modules.get(mod_key)
         sys.modules[mod_key] = detector
+        # detect_skill_violation.py mutates global sys.path at import time
+        # (sys.path.insert(0, project_root)); snapshot and restore it in finally
+        # so the insertion cannot leak into later tests and create
+        # order-dependent failures (copilot review, PR #3012).
+        sys_path_snapshot = list(sys.path)
         try:
             spec.loader.exec_module(detector)
             assert _mod._SKILL_SCAN_EXTENSIONS == detector.VALID_EXTENSIONS
@@ -477,6 +482,7 @@ class TestRunValidations:
                 sys.modules[mod_key] = previous
             else:
                 sys.modules.pop(mod_key, None)
+            sys.path[:] = sys_path_snapshot
 
     def test_agents_changed_with_session_log_runs_validator(self, tmp_path):
         changed = ".agents/sessions/2025-01-01-session-01.json\n"

--- a/tests/test_new_pr.py
+++ b/tests/test_new_pr.py
@@ -393,6 +393,80 @@ class TestRunValidations:
             ]
         ]
 
+    def test_skill_violation_scan_skipped_when_no_scannable_extension(
+        self, tmp_path, capsys
+    ):
+        """When every changed file has an unscannable extension, the scanner
+        subprocess must be skipped entirely (issue #3010) and the skip reported."""
+        skill_script = tmp_path / "scripts" / "detect_skill_violation.py"
+        skill_script.parent.mkdir(parents=True)
+        skill_script.write_text("# mock")
+        changed = "assets/logo.png\ndata/table.json\nMakefile\n"
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:3] == ["git", "diff", "--name-only"]:
+                return _completed(stdout=changed, rc=0)
+            return _completed(rc=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            run_validations(str(tmp_path), "main", "feat/branch")
+
+        assert not any(len(cmd) >= 2 and cmd[1] == str(skill_script) for cmd in calls)
+        captured = capsys.readouterr()
+        assert "No changed files with a scannable extension" in captured.out
+
+    def test_skill_violation_scan_filters_unscannable_extensions(self, tmp_path):
+        """A mixed changed-file list must pass only scannable extensions to the
+        scanner argv, dropping the rest (issue #3010)."""
+        skill_script = tmp_path / "scripts" / "detect_skill_violation.py"
+        skill_script.parent.mkdir(parents=True)
+        skill_script.write_text("# mock")
+        changed = "scripts/mod.py\nassets/logo.png\ndocs/guide.md\nhooks/setup.ps1\ndata/x.json\n"
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:3] == ["git", "diff", "--name-only"]:
+                return _completed(stdout=changed, rc=0)
+            return _completed(rc=0)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            run_validations(str(tmp_path), "main", "feat/branch")
+
+        skill_calls = [c for c in calls if len(c) >= 2 and c[1] == str(skill_script)]
+        assert skill_calls == [
+            [
+                sys.executable,
+                str(skill_script),
+                "--file",
+                "scripts/mod.py",
+                "--file",
+                "docs/guide.md",
+                "--file",
+                "hooks/setup.ps1",
+            ]
+        ]
+
+    def test_skill_scan_extensions_match_detector(self):
+        """The local _SKILL_SCAN_EXTENSIONS constant must stay in sync with the
+        scanner's VALID_EXTENSIONS (drift guard, issue #3010). It is a local copy
+        by design: the two synced new_pr.py trees sit at different repo depths, so
+        cross-package importing scripts/detect_skill_violation.py is avoided (same
+        rationale documented for _DASH_RE)."""
+        detector_path = (
+            Path(__file__).resolve().parents[1] / "scripts" / "detect_skill_violation.py"
+        )
+        spec = importlib.util.spec_from_file_location(
+            "detect_skill_violation", detector_path
+        )
+        assert spec is not None and spec.loader is not None
+        detector = importlib.util.module_from_spec(spec)
+        sys.modules["detect_skill_violation"] = detector
+        spec.loader.exec_module(detector)
+        assert _mod._SKILL_SCAN_EXTENSIONS == detector.VALID_EXTENSIONS
+
     def test_agents_changed_with_session_log_runs_validator(self, tmp_path):
         changed = ".agents/sessions/2025-01-01-session-01.json\n"
         validate_script = tmp_path / "scripts" / "validate_session_json.py"

--- a/tests/test_new_pr.py
+++ b/tests/test_new_pr.py
@@ -458,14 +458,25 @@ class TestRunValidations:
         detector_path = (
             Path(__file__).resolve().parents[1] / "scripts" / "detect_skill_violation.py"
         )
-        spec = importlib.util.spec_from_file_location(
-            "detect_skill_violation", detector_path
-        )
+        mod_key = "detect_skill_violation_drift_guard"
+        spec = importlib.util.spec_from_file_location(mod_key, detector_path)
         assert spec is not None and spec.loader is not None
         detector = importlib.util.module_from_spec(spec)
-        sys.modules["detect_skill_violation"] = detector
-        spec.loader.exec_module(detector)
-        assert _mod._SKILL_SCAN_EXTENSIONS == detector.VALID_EXTENSIONS
+        # detect_skill_violation.py uses @dataclass, whose decorator resolves
+        # cls.__module__ via sys.modules, so the module must be registered
+        # before exec_module. Register under a unique key and restore prior
+        # state in finally to avoid leaking global sys.modules state into other
+        # tests (gemini-code-assist review, PR #3012).
+        previous = sys.modules.get(mod_key)
+        sys.modules[mod_key] = detector
+        try:
+            spec.loader.exec_module(detector)
+            assert _mod._SKILL_SCAN_EXTENSIONS == detector.VALID_EXTENSIONS
+        finally:
+            if previous is not None:
+                sys.modules[mod_key] = previous
+            else:
+                sys.modules.pop(mod_key, None)
 
     def test_agents_changed_with_session_log_runs_validator(self, tmp_path):
         changed = ".agents/sessions/2025-01-01-session-01.json\n"


### PR DESCRIPTION
## Summary

`new_pr.py` Validation 2 (skill-violation scan) built one `--file <path>` argv pair for **every** changed file and spawned the scanner even when no changed file had a supported extension. On large diffs the argv grew unboundedly (ARG_MAX risk) and the subprocess ran needlessly (30s timeout budget) despite the scanner internally filtering to `.md/.py/.ps1/.psm1`.

## Fix

- Filter `changed_files` to the scanner's extension set before building argv.
- Skip the subprocess entirely when the filtered list is empty, reporting the skip explicitly.
- `_SKILL_SCAN_EXTENSIONS` is a local mirror of the scanner's `VALID_EXTENSIONS`, drift-guarded by a new equality test, following the same inline-not-import precedent documented for `_DASH_RE` (the two synced `new_pr.py` trees sit at different repo depths, so cross-package importing is avoided).

## Tests

Added to `tests/test_new_pr.py`:
- negative: no scannable extension, scanner skipped plus skip message
- edge: mixed list, only scannable files in argv
- drift guard: local constant equals the scanner's `VALID_EXTENSIONS`

46 passed locally; full pre-push pytest suite green.

## Generated artifacts

Regenerated the `src/copilot-cli` mirror and bumped both project-toolkit plugin manifests 0.6.25 to 0.6.26 in lockstep.

Fixes #3010
Fixes #3013

## References

- `scripts/detect_skill_violation.py` (reference only, not changed): defines the canonical `VALID_EXTENSIONS` set this fix mirrors.
