### PR TITLE
test(e2e): treat Copilot CLI 1.0.70 plugin non-enumeration as benign

### DIFF
--- a/tests/e2e/test_plugin_load_smoke.py
+++ b/tests/e2e/test_plugin_load_smoke.py
@@ -161,13 +161,14 @@ def _plugin_enumeration_available(payload: object) -> bool:
 
     The smoke skips ONLY for the known-benign shape: a well-formed JSON array
     that carries zero ``source: plugin`` records. On Copilot CLI 1.0.69
-    (verified 2026-07-08 on this repo's shipped ``src/copilot-cli`` tree),
-    ``copilot --plugin-dir <dir> skill list --json`` run from a neutral cwd
-    surfaces ZERO ``source: plugin`` records: the output carries only
-    ``builtin`` and ``personal-copilot``. The ``source: project`` group that
-    does list the lifecycle skills is cwd-based (the repo you stand in), not
-    ``--plugin-dir`` based, so it is not a valid load signal for a neutral-cwd
-    smoke. See issue #2990.
+    (verified 2026-07-08 on this repo's shipped ``src/copilot-cli`` tree) and
+    1.0.70 (issue #3014), ``copilot --plugin-dir <dir> skill list --json`` run
+    from a neutral cwd surfaces ZERO ``source: plugin`` records: the output
+    carries only ``builtin`` and ``personal-copilot``. The ``source: project``
+    group that does list the lifecycle skills is cwd-based (the repo you stand
+    in), not ``--plugin-dir`` based, so it is not a valid load signal for a
+    neutral-cwd smoke. The full set of benign versions lives in
+    ``_COPILOT_BENIGN_NO_ENUM_VERSIONS`` below. See issues #2990 and #3014.
 
     The caller validates list-ness first:
     ``test_copilot_plugin_loads_expected_skills`` fails loud on a non-list
@@ -195,10 +196,13 @@ def _copilot_version_omits_plugin_enumeration(version_output: str) -> bool:
 
     Only the versions in ``_COPILOT_BENIGN_NO_ENUM_VERSIONS`` are allowed to skip
     the strict subset assertion when ``skill list --json`` surfaces zero
-    ``source: plugin`` records (issues #2990 and #3014). Any other version that
-    fails to enumerate the plugin is a real plugin-load regression and must fail
-    loud, so the smoke keeps its negative control instead of masking a broken
-    load on a CLI that DOES enumerate ``--plugin-dir`` skills.
+    ``source: plugin`` records (issues #2990 and #3014). This is an
+    output-surface quirk of those releases: the plugin loads and its hooks fire,
+    but ``skill list --json`` does not enumerate ``--plugin-dir`` skills under
+    ``source: plugin``. Any other version that surfaces zero ``source: plugin``
+    records is treated as a real plugin-load regression and must fail loud, so
+    the smoke keeps its negative control instead of masking a broken load on a
+    CLI that DOES enumerate ``--plugin-dir`` skills through this surface.
 
     The version token is the first ``MAJOR.MINOR.PATCH`` in the CLI's
     ``--version`` output; a ``-<suffix>`` build tag (for example ``1.0.69-3``) is

--- a/tests/e2e/test_plugin_load_smoke.py
+++ b/tests/e2e/test_plugin_load_smoke.py
@@ -187,7 +187,7 @@ def _plugin_enumeration_available(payload: object) -> bool:
     return _has_plugin_source_record(payload)
 
 
-_COPILOT_BENIGN_NO_ENUM_VERSIONS = frozenset({"1.0.69"})
+_COPILOT_BENIGN_NO_ENUM_VERSIONS = frozenset({"1.0.69", "1.0.70"})
 
 
 def _copilot_version_omits_plugin_enumeration(version_output: str) -> bool:
@@ -286,14 +286,15 @@ def test_copilot_plugin_loads_expected_skills(tmp_path: Path) -> None:
                 f"known-good --plugin-dir on CLI version {version_text!r}, which is "
                 "NOT a known plugin-enumeration-omitting version (issue #2990). "
                 "A version that enumerates --plugin-dir skills but returns none is a "
-                "real plugin-load regression, not the benign 1.0.69 shape. "
+                "real plugin-load regression, not the benign 1.0.69/1.0.70 shape. "
                 f"sources seen: {sources}"
             )
         pytest.skip(
             "copilot skill list --json surfaced no source:plugin records for a "
-            "known-good --plugin-dir. On CLI 1.0.69 the plugin-dir load is not "
-            "enumerated through this surface (issue #2990); the load itself is "
-            "unaffected. Skipping loud rather than false-failing. "
+            "known-good --plugin-dir. On CLI 1.0.69 and 1.0.70 the plugin-dir load "
+            "is not enumerated through this surface (issues #2990, #3014); the load "
+            "itself is unaffected (the plugin's hooks still load and fire). Skipping "
+            "loud rather than false-failing. "
             f"copilot --version: {version_text!r}; "
             f"sources seen: {sources}"
         )
@@ -526,13 +527,17 @@ def test_has_plugin_source_record() -> None:
 
 
 def test_copilot_version_omits_enumeration_true_for_benign_version() -> None:
-    """CLI 1.0.69 is the known plugin-enumeration-omitting release (issue #2990).
+    """CLI 1.0.69 and 1.0.70 are the known plugin-enumeration-omitting releases.
 
-    A build-tag suffix (``1.0.69-3``) tracks the same release, so it still
-    matches; extra surrounding text from ``--version`` is tolerated.
+    Both surface zero ``source: plugin`` records for a known-good ``--plugin-dir``
+    while the plugin still loads (issues #2990, #3014). A build-tag suffix
+    (``1.0.69-3``) tracks the same release, so it still matches; extra surrounding
+    text from ``--version`` is tolerated.
     """
     assert _copilot_version_omits_plugin_enumeration("1.0.69") is True
     assert _copilot_version_omits_plugin_enumeration("1.0.69-3") is True
+    assert _copilot_version_omits_plugin_enumeration("1.0.70") is True
+    assert _copilot_version_omits_plugin_enumeration("1.0.70-0") is True
     assert _copilot_version_omits_plugin_enumeration("copilot 1.0.69 (build 42)") is True
 
 
@@ -542,7 +547,8 @@ def test_copilot_version_omits_enumeration_false_for_other_versions() -> None:
     A CLI that enumerates ``--plugin-dir`` skills but returns none is a real
     plugin-load regression; the negative control depends on this returning False.
     """
-    assert _copilot_version_omits_plugin_enumeration("1.0.70") is False
+    assert _copilot_version_omits_plugin_enumeration("1.0.68") is False
+    assert _copilot_version_omits_plugin_enumeration("1.0.71") is False
     assert _copilot_version_omits_plugin_enumeration("1.1.0") is False
     assert _copilot_version_omits_plugin_enumeration("2.0.0") is False
 

--- a/tests/e2e/test_plugin_load_smoke.py
+++ b/tests/e2e/test_plugin_load_smoke.py
@@ -196,10 +196,9 @@ def _copilot_version_omits_plugin_enumeration(version_output: str) -> bool:
     Only the versions in ``_COPILOT_BENIGN_NO_ENUM_VERSIONS`` are allowed to skip
     the strict subset assertion when ``skill list --json`` surfaces zero
     ``source: plugin`` records (issues #2990 and #3014). Any other version that
-    fails to
-    enumerate the plugin is a real plugin-load regression and must fail loud, so
-    the smoke keeps its negative control instead of masking a broken load on a
-    CLI that DOES enumerate ``--plugin-dir`` skills.
+    fails to enumerate the plugin is a real plugin-load regression and must fail
+    loud, so the smoke keeps its negative control instead of masking a broken
+    load on a CLI that DOES enumerate ``--plugin-dir`` skills.
 
     The version token is the first ``MAJOR.MINOR.PATCH`` in the CLI's
     ``--version`` output; a ``-<suffix>`` build tag (for example ``1.0.69-3``) is
@@ -286,9 +285,9 @@ def test_copilot_plugin_loads_expected_skills(tmp_path: Path) -> None:
                 "copilot skill list --json surfaced no source:plugin records for a "
                 f"known-good --plugin-dir on CLI version {version_text!r}, which is "
                 "NOT a known plugin-enumeration-omitting version (issues #2990, "
-                "#3014). A version that enumerates --plugin-dir skills but returns "
-                "none is a real plugin-load regression, not the benign 1.0.69/1.0.70 "
-                "shape. "
+                "#3014). A version outside the benign 1.0.69/1.0.70 set that "
+                "surfaces no source:plugin records is treated as a real "
+                "plugin-load regression. "
                 f"sources seen: {sources}"
             )
         pytest.skip(

--- a/tests/e2e/test_plugin_load_smoke.py
+++ b/tests/e2e/test_plugin_load_smoke.py
@@ -281,11 +281,12 @@ def test_copilot_plugin_loads_expected_skills(tmp_path: Path) -> None:
             }
         )
         if not _copilot_version_omits_plugin_enumeration(version_text):
+            benign_versions = "/".join(sorted(_COPILOT_BENIGN_NO_ENUM_VERSIONS))
             pytest.fail(
                 "copilot skill list --json surfaced no source:plugin records for a "
                 f"known-good --plugin-dir on CLI version {version_text!r}, which is "
                 "NOT a known plugin-enumeration-omitting version (issues #2990, "
-                "#3014). A version outside the benign 1.0.69/1.0.70 set that "
+                f"#3014). A version outside the benign {benign_versions} set that "
                 "surfaces no source:plugin records is treated as a real "
                 "plugin-load regression. "
                 f"sources seen: {sources}"

--- a/tests/e2e/test_plugin_load_smoke.py
+++ b/tests/e2e/test_plugin_load_smoke.py
@@ -283,16 +283,16 @@ def test_copilot_plugin_loads_expected_skills(tmp_path: Path) -> None:
         if not _copilot_version_omits_plugin_enumeration(version_text):
             benign_versions = "/".join(sorted(_COPILOT_BENIGN_NO_ENUM_VERSIONS))
             pytest.fail(
-                "copilot skill list --json surfaced no source:plugin records for a "
+                "copilot skill list --json surfaced no source: plugin records for a "
                 f"known-good --plugin-dir on CLI version {version_text!r}, which is "
                 "NOT a known plugin-enumeration-omitting version (issues #2990, "
                 f"#3014). A version outside the benign {benign_versions} set that "
-                "surfaces no source:plugin records is treated as a real "
+                "surfaces no source: plugin records is treated as a real "
                 "plugin-load regression. "
                 f"sources seen: {sources}"
             )
         pytest.skip(
-            "copilot skill list --json surfaced no source:plugin records for a "
+            "copilot skill list --json surfaced no source: plugin records for a "
             "known-good --plugin-dir. On CLI 1.0.69 and 1.0.70 the plugin-dir load "
             "is not enumerated through this surface (issues #2990, #3014); the load "
             "itself is unaffected (the plugin's hooks still load and fire). Skipping "

--- a/tests/e2e/test_plugin_load_smoke.py
+++ b/tests/e2e/test_plugin_load_smoke.py
@@ -284,9 +284,10 @@ def test_copilot_plugin_loads_expected_skills(tmp_path: Path) -> None:
             pytest.fail(
                 "copilot skill list --json surfaced no source:plugin records for a "
                 f"known-good --plugin-dir on CLI version {version_text!r}, which is "
-                "NOT a known plugin-enumeration-omitting version (issue #2990). "
-                "A version that enumerates --plugin-dir skills but returns none is a "
-                "real plugin-load regression, not the benign 1.0.69/1.0.70 shape. "
+                "NOT a known plugin-enumeration-omitting version (issues #2990, "
+                "#3014). A version that enumerates --plugin-dir skills but returns "
+                "none is a real plugin-load regression, not the benign 1.0.69/1.0.70 "
+                "shape. "
                 f"sources seen: {sources}"
             )
         pytest.skip(
@@ -542,7 +543,7 @@ def test_copilot_version_omits_enumeration_true_for_benign_version() -> None:
 
 
 def test_copilot_version_omits_enumeration_false_for_other_versions() -> None:
-    """Any version not in the benign set must fail loud, not skip (issue #2990).
+    """Any version not in the benign set must fail loud, not skip (issues #2990, #3014).
 
     A CLI that enumerates ``--plugin-dir`` skills but returns none is a real
     plugin-load regression; the negative control depends on this returning False.

--- a/tests/e2e/test_plugin_load_smoke.py
+++ b/tests/e2e/test_plugin_load_smoke.py
@@ -195,7 +195,8 @@ def _copilot_version_omits_plugin_enumeration(version_output: str) -> bool:
 
     Only the versions in ``_COPILOT_BENIGN_NO_ENUM_VERSIONS`` are allowed to skip
     the strict subset assertion when ``skill list --json`` surfaces zero
-    ``source: plugin`` records (issue #2990). Any other version that fails to
+    ``source: plugin`` records (issues #2990 and #3014). Any other version that
+    fails to
     enumerate the plugin is a real plugin-load regression and must fail loud, so
     the smoke keeps its negative control instead of masking a broken load on a
     CLI that DOES enumerate ``--plugin-dir`` skills.


### PR DESCRIPTION
## Summary

Fixes #3014.

The e2e plugin-load smoke false-failed on Copilot CLI 1.0.70 because `skill list --json` surfaces zero `source:plugin` records for a known-good `--plugin-dir`, the same benign non-enumeration seen on 1.0.69 (#2990), not the distinct enumerate-but-empty regression the issue speculated.

## Evidence (empirical, runtime contract)

Print-mode boot with debug logging on the installed CLI 1.0.70-0:

```
copilot --plugin-dir src/copilot-cli --log-dir /tmp/cop-logs2 --log-level debug -p "..." --allow-all-tools
```

Debug log shows `Loaded 5 hook(s) from 1 plugin(s)` and the project-toolkit UserPromptSubmit hooks fire and self-skip via the consumer-repo guard. The plugin loads and its hooks execute; the `skill list --json` non-enumeration is a pure surfacing quirk, not a load regression.

## Change

- Add `1.0.70` to `_COPILOT_BENIGN_NO_ENUM_VERSIONS` so the smoke skips loud instead of false-failing.
- Update the skip/fail messages and the negative-control unit tests (a still-unknown version like `1.0.71` remains a loud fail).

Test-only change: no plugin-source edit, no mirror regen, no plugin bump.

## Verification

`uv run pytest tests/e2e/test_plugin_load_smoke.py`: 15 passed, 2 skipped.