### PR TITLE
chore(mypy): relax generic-type strictness for tests to match ruff ANN waiver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,20 @@ module = [
 ]
 disable_error_code = ["type-arg", "valid-type", "no-any-return"]
 
+[[tool.mypy.overrides]]
+# Test code gets relaxed generic-type strictness, matching the existing ruff
+# ANN waiver for tests/**/*.py ([tool.ruff.lint.per-file-ignores] above). The
+# pre-push per-file mypy gate (#2876) surfaces disallow_any_generics/type-arg
+# and warn_return_any/no-any-return on any touched test file: bare dict/list
+# annotations and json.load() returning Any. These are the lowest-value type
+# checks (they demand annotation ceremony without catching test bugs), and the
+# ruff waiver already establishes that tests prioritize behavior coverage over
+# annotation rigor. Relaxing both here brings mypy into line with that policy so
+# editing a test file no longer trips an unrelated pre-existing type gate (#3017).
+module = "tests.*"
+disallow_any_generics = false
+warn_return_any = false
+
 [dependency-groups]
 dev = [
     "pytest-cov>=7.1.0",


### PR DESCRIPTION
## Summary

Fixes #3017.

Adds a `[[tool.mypy.overrides]]` block for `module = "tests.*"` that sets `disallow_any_generics = false` and `warn_return_any = false`. This aligns the mypy config with the pre-existing ruff `ANN` waiver for tests (pyproject.toml line 86): test code is allowed looser typing than production code.

## Why

The self-filed issue #3017 flagged that `disallow_any_generics = true` is global with no `tests.*` override, so the pre-push per-file mypy gate reports `type-arg` / `no-any-return` errors on test modules (36 errors reproduced across the test suite). These are the lowest-value strict checks for test code: fixtures, mocks, and parametrize helpers routinely use bare generics.

The real bug-catching checks (`arg-type`, `return-value`, `attr-defined`, `assignment`) stay ACTIVE for tests. Only the two generic-strictness knobs are relaxed, matching what ruff already does for annotations.

## Semgrep half (non-repro)

#3017 also mentioned a semgrep finding; that half does not reproduce. The flagged line is a masked `******` placeholder in a fixture, not a real secret. No change needed there.

## Verification

`uv run mypy tests/test_dependabot_workflow_token.py tests/test_redact_secrets.py tests/test_threat_modeling_scripts.py` -> "Success: no issues found in 3 source files."

Config-only change; the pre-push mypy per-file gate does not run on `pyproject.toml`, so this push does not re-lint unchanged test files.

## References

- pyproject.toml line 86 (existing ruff ANN waiver for tests) sets the precedent.