### PR TITLE
style(tests): ruff cleanup burndown slice (9 test files)

### DIFF
--- a/tests/hooks/test_invoke_lsp_pre_delegation_guard.py
+++ b/tests/hooks/test_invoke_lsp_pre_delegation_guard.py
@@ -14,12 +14,8 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
-
-if TYPE_CHECKING:
-    pass
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_DIR = str(REPO_ROOT / ".claude" / "hooks" / "PreToolUse")

--- a/tests/hooks/test_invoke_lsp_pre_delegation_guard.py
+++ b/tests/hooks/test_invoke_lsp_pre_delegation_guard.py
@@ -15,12 +15,11 @@ import json
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
 
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    pass
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOOK_DIR = str(REPO_ROOT / ".claude" / "hooks" / "PreToolUse")

--- a/tests/hooks/test_pre_commit_slash_commands.py
+++ b/tests/hooks/test_pre_commit_slash_commands.py
@@ -8,7 +8,7 @@ git command failures, validation script failures.
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -16,7 +16,6 @@ HOOK_DIR = str(Path(__file__).resolve().parents[2] / ".claude" / "hooks")
 sys.path.insert(0, HOOK_DIR)
 
 import pre_commit_slash_commands  # noqa: E402
-
 
 # ---------------------------------------------------------------------------
 # Unit tests for get_staged_slash_commands

--- a/tests/hooks/test_qa_agent_validator.py
+++ b/tests/hooks/test_qa_agent_validator.py
@@ -161,28 +161,28 @@ class TestMain:
         assert result == 0
 
     def test_exits_0_on_empty_input(
-        self, mock_stdin: "Callable[[str], None]"
+        self, mock_stdin: Callable[[str], None]
     ):
         mock_stdin("")
         result = invoke_qa_agent_validator.main()
         assert result == 0
 
     def test_exits_0_for_non_qa_agent(
-        self, mock_stdin: "Callable[[str], None]"
+        self, mock_stdin: Callable[[str], None]
     ):
         mock_stdin(json.dumps({"subagent_type": "implementer"}))
         result = invoke_qa_agent_validator.main()
         assert result == 0
 
     def test_exits_0_for_missing_transcript(
-        self, mock_stdin: "Callable[[str], None]"
+        self, mock_stdin: Callable[[str], None]
     ):
         mock_stdin(json.dumps({"subagent_type": "qa"}))
         result = invoke_qa_agent_validator.main()
         assert result == 0
 
     def test_reports_passed_when_complete(
-        self, mock_stdin: "Callable[[str], None]", tmp_path, capsys
+        self, mock_stdin: Callable[[str], None], tmp_path, capsys
     ):
         transcript = tmp_path / "transcript.md"
         transcript.write_text(
@@ -205,7 +205,7 @@ class TestMain:
         assert data["missing_sections"] == []
 
     def test_reports_failure_when_incomplete(
-        self, mock_stdin: "Callable[[str], None]", tmp_path, capsys
+        self, mock_stdin: Callable[[str], None], tmp_path, capsys
     ):
         transcript = tmp_path / "transcript.md"
         transcript.write_text("# Some Other Section\n\nContent\n")
@@ -226,7 +226,7 @@ class TestMain:
         assert len(data["missing_sections"]) == 3
 
     def test_handles_file_read_error(
-        self, mock_stdin: "Callable[[str], None]", tmp_path, capsys
+        self, mock_stdin: Callable[[str], None], tmp_path, capsys
     ):
         """Handles OSError when reading transcript."""
         transcript_path = str(tmp_path / "unreadable.md")

--- a/tests/hooks/test_qa_agent_validator.py
+++ b/tests/hooks/test_qa_agent_validator.py
@@ -5,6 +5,8 @@ Covers: non-QA agent skip, missing transcript, valid transcript with
 all sections, missing sections, file errors, invalid JSON.
 """
 
+from __future__ import annotations
+
 import json
 import sys
 from pathlib import Path

--- a/tests/skills/github/conftest.py
+++ b/tests/skills/github/conftest.py
@@ -1,9 +1,8 @@
 """Shared fixtures for GitHub skill script tests."""
 
-import os
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/skills/github/test_extract_github_context.py
+++ b/tests/skills/github/test_extract_github_context.py
@@ -1,7 +1,5 @@
 """Tests for extract_github_context.py."""
 
-import json
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/skills/github/test_test_workflow_locally.py
+++ b/tests/skills/github/test_test_workflow_locally.py
@@ -1,13 +1,10 @@
 """Tests for test_workflow_locally.py."""
 
-import json
-import os
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
-
 from test_helpers import make_completed_process
 
 # Ensure importability

--- a/tests/skills/memory/test_invoke_memory_cross_reference.py
+++ b/tests/skills/memory/test_invoke_memory_cross_reference.py
@@ -3,9 +3,6 @@
 import json
 import sys
 from pathlib import Path
-from unittest.mock import patch
-
-import pytest
 
 SCRIPT_DIR = Path(__file__).resolve().parents[3] / ".claude" / "skills" / "memory" / "scripts"
 sys.path.insert(0, str(SCRIPT_DIR))

--- a/tests/skills/memory/test_measure_memory_performance.py
+++ b/tests/skills/memory/test_measure_memory_performance.py
@@ -2,9 +2,6 @@
 
 import sys
 from pathlib import Path
-from unittest.mock import patch
-
-import pytest
 
 SCRIPT_DIR = Path(__file__).resolve().parents[3] / ".claude" / "skills" / "memory" / "scripts"
 sys.path.insert(0, str(SCRIPT_DIR))

--- a/tests/skills/session/test_complete_session_log.py
+++ b/tests/skills/session/test_complete_session_log.py
@@ -1,11 +1,8 @@
 """Tests for complete_session_log.py session completion script."""
 
-import json
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 SCRIPT_DIR = Path(__file__).resolve().parents[3] / ".claude" / "skills" / "session-end" / "scripts"
 sys.path.insert(0, str(SCRIPT_DIR))


### PR DESCRIPTION
Burndown slice for the repo-wide ruff cleanup epic.

## Summary

Cleans 9 test files under \`tests/\` to zero ruff violations via safe autofix (I001 unsorted-imports, F401 unused-import, UP-series annotation modernization). No manual E501 rewrites, no logic changes: import reordering and unused-import removal only.

- 10 insertions, 27 deletions across 9 files.
- All touched test files pass (164 tests in the affected files, verified locally).
- Scoped to non-mirror paths so no plugin-version-bump or mirror regeneration is triggered.

## Why these files

The CI ruff ratchet (\`scripts/ci/ruff_ratchet.py\`) and pre-push per-file ruff gate check only changed files. Cleaning currently-dirty files to zero removes them from the backlog and unblocks future edits to them. This slice targets files that reach 100 percent clean with safe autofix alone.

## Scope note

\`tests/test_detect_scope_explosion.py\` was intentionally excluded. Touching it for a ruff autofix trips the pre-push per-file mypy gate: line 68 deliberately does \`result.file_count = 10\` inside \`pytest.raises(AttributeError)\` to assert the frozen \`ScopeResult\` dataclass rejects mutation, and mypy flags the deliberate assignment as \`[misc] read-only\`. Same two-gate interaction as #2876. Left for a separate mypy-targeted pass to keep this slice mechanical.

Refs #2993

## References

- scripts/ci/ruff_ratchet.py
- tests/test_detect_scope_explosion.py