### PR TITLE
chore(scripts): safe ruff auto-fixes on 2 standalone scripts (#2993)

### DIFF
--- a/scripts/detect_hook_bypass.py
+++ b/scripts/detect_hook_bypass.py
@@ -26,7 +26,7 @@ import re
 import subprocess
 import sys
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 # Matches squashed merge-resolution commits (single parent, merge-like subject)
@@ -209,7 +209,7 @@ def analyze_commits(
     commits = get_pr_commits(base_ref)
 
     report = AuditReport(
-        timestamp=datetime.now(timezone.utc).isoformat(),
+        timestamp=datetime.now(UTC).isoformat(),
         branch=branch,
         base_ref=base_ref,
         total_commits=len(commits),

--- a/scripts/external_signals/acceptance_criteria.py
+++ b/scripts/external_signals/acceptance_criteria.py
@@ -27,9 +27,9 @@ import argparse
 import json
 import re
 import sys
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable
 
 _ACCEPTANCE_HEADING = re.compile(
     r"^#{1,6}\s*acceptance(?:\s+criteria)?\s*$",
@@ -106,9 +106,9 @@ _STOP_WORDS: frozenset[str] = frozenset(
         "the", "and", "for", "are", "but", "not", "you", "all", "can", "her",
         "was", "one", "our", "out", "day", "get", "has", "him", "his", "how",
         "its", "let", "may", "new", "now", "old", "see", "two", "use", "way",
-        "who", "why", "yet", "did", "its", "per", "set", "via", "any", "had",
+        "who", "why", "yet", "did", "per", "set", "via", "any", "had",
         "top", "try", "put", "too", "off", "own", "big", "far", "few", "got",
-        "end", "due", "run", "nit", "nor", "nor", "isn", "was", "are",
+        "end", "due", "run", "nit", "nor", "isn",
     }
 )
 


### PR DESCRIPTION
## Summary

Chips away at the repo-wide ruff backlog by applying safe, behavior-preserving auto-fixes (import sort I001, unused-import F401) to two standalone, non-plugin-source scripts. No behavior change.

## Validation

- `ruff check` on both changed files: 0 remaining (of the safe-fix set)
- `mypy` on both changed files: `Success: no issues found in 2 source files`
- Full pre-push suite: PASS (pytest, security, governance, all 27 checks)

## Background

Why only two files: every ruff slice against this backlog hits three independent per-file gates that block on pre-existing debt in the touched file, not on the ruff change itself.

1. Per-file mypy (pre-push): follows imports and surfaces pre-existing type errors. Most candidates carry them.
2. taste-lints (pre-commit): blocks on pre-existing non-snake_case filenames, file-size, complexity. Hit on the two `eval-*.py` scripts.
3. Security-suppression gate (pre-push): blocks any `# type: ignore[...]` in the touched file, even pre-existing ones on lines the change never touched. Hit on `scripts/eval/_run_persistence.py`.

These two files are the intersection that passes all three. Structural options for bulk cleanup are captured in the issue thread.

## References

Refs #2993