### PR TITLE
feat(curating-memories): supersession sweep classifier (#3019)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.29",
+  "version": "0.6.30",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/curating-memories/SKILL.md
+++ b/.claude/skills/curating-memories/SKILL.md
@@ -2,7 +2,7 @@
 name: curating-memories
 description: Guidance for maintaining memory quality through curation. Covers updating outdated memories, marking obsolete content, and linking related knowledge. Use when memories need modification, when new information supersedes old, or when building knowledge graph connections.
 license: MIT
-version: 1.0.0
+version: 1.1.0
 model: claude-sonnet-4-6
 ---
 
@@ -175,6 +175,56 @@ Use [exploring-knowledge-graph](../exploring-knowledge-graph/SKILL.md) instead w
 2. Evaluate whether the memory needs updating, linking, or marking obsolete
 3. Apply the appropriate curation operation
 4. Verify the change took effect
+
+---
+
+## Scripts: Supersession Sweep
+
+The append-never-delete pattern is the failure this sweep targets: a memory
+that is fully resolved or historical but still reads as live guidance, so a
+fresh agent has to read past archaeology to reach current truth. Run the
+sweep to surface those files. It **proposes** a disposition per file and
+edits nothing; ratification is a separate, confirmed step.
+
+```bash
+uv run python "${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/curating-memories/scripts/supersession_sweep.py"
+```
+
+Add `--json` for machine-readable output, or `--root <dir>` to scan a
+directory other than `.serena/memories`.
+
+### The four buckets
+
+| Bucket | Signal | Action |
+|--------|--------|--------|
+| `live` | No supersession markers | Leave alone |
+| `healthy-supersession` | Struck-through obsolete content plus a dated banner, current truth visible | Leave alone; this is the target shape |
+| `resolved-or-historical-but-present` | `Status: RESOLVED`/`BLOCKING` co-present with references to removed artifacts or per-section `(Historical)` tags | Propose archive, or collapse to a one-line changelog footer |
+| `temporal-snapshot-as-live` | A dated point-in-time doc framed as current state | Propose a dated-snapshot banner |
+
+### The constraint (non-negotiable)
+
+The sweep is a generator self-report, which is the closed-loop-validator
+trap. The classification is a **routing signal into verification, never a
+verdict**:
+
+- The sweep proposes a disposition. It does not edit or delete.
+- Ratify with the [doc-accuracy](../doc-accuracy/SKILL.md) code-as-source-of-truth
+  discipline: archive a memory only after confirming the artifacts it
+  references are actually gone and no live path depends on it.
+- A human or a second independent check confirms before any content is
+  removed. A mis-flag on a load-bearing entry is the exact loss this
+  proposal-only design prevents.
+
+### The healthy-supersession target shape
+
+When you collapse a `resolved-or-historical-but-present` file, do not bury
+it. Strike through the obsolete content, add a dated banner explaining why,
+and keep current truth visible inline. `cost/cost-summary-reference.md` is
+the exemplar: obsolete rows struck through, a dated `IMPORTANT` banner,
+history preserved, nothing hidden. Strikethrough density alone is a
+healthy-supersession signal, never a rot signal; the sweep will not propose
+archiving a file on strikethrough count.
 
 ---
 

--- a/.claude/skills/curating-memories/scripts/supersession_sweep.py
+++ b/.claude/skills/curating-memories/scripts/supersession_sweep.py
@@ -42,8 +42,9 @@ HEALTHY_SUPERSESSION = "healthy-supersession"
 RESOLVED_HISTORICAL = "resolved-or-historical-but-present"
 TEMPORAL_SNAPSHOT = "temporal-snapshot-as-live"
 
-# Dispositions that warrant a proposal (everything except live).
-ACTIONABLE = (RESOLVED_HISTORICAL, HEALTHY_SUPERSESSION, TEMPORAL_SNAPSHOT)
+# Dispositions that warrant a follow-up proposal. healthy-supersession and
+# live are both "leave alone", so neither appears in the proposals list.
+ACTIONABLE = (RESOLVED_HISTORICAL, TEMPORAL_SNAPSHOT)
 
 _STATUS_RE = re.compile(r"status[^A-Za-z0-9]{0,6}(resolved|blocking)", re.IGNORECASE)
 _REMOVED_RE = re.compile(r"\(removed\)", re.IGNORECASE)
@@ -55,7 +56,7 @@ _BANNER_RE = re.compile(
 )
 _DATE_RE = re.compile(r"20\d{2}-\d{2}-\d{2}")
 _SNAPSHOT_FRAME_RE = re.compile(
-    r"top[\s\-]?\d+|snapshot|as of|current state|\bv\d+(?:\.\d+)*\b",
+    r"top[\s\-]?\d+|snapshot|as of|current state",
     re.IGNORECASE,
 )
 

--- a/.claude/skills/curating-memories/scripts/supersession_sweep.py
+++ b/.claude/skills/curating-memories/scripts/supersession_sweep.py
@@ -214,7 +214,10 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     root = Path(args.root)
     if not root.is_dir():
-        print(f"error: root not found: {root}", file=sys.stderr)
+        message = f"root not found: {root}"
+        print(f"error: {message}", file=sys.stderr)
+        if args.json:
+            print(json.dumps({"error": message}))
         return 0
     proposals = sweep(root)
     if args.json:

--- a/.claude/skills/curating-memories/scripts/supersession_sweep.py
+++ b/.claude/skills/curating-memories/scripts/supersession_sweep.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Supersession sweep: classify memory files for curation (issue #3019).
+
+Detects the append-never-delete pattern: memory files that are fully
+resolved or historical but still present as live guidance. The sweep
+*proposes* a disposition per file and emits a report. It never edits or
+deletes anything.
+
+The classification is a routing signal into verification, never a verdict.
+A memory is only archived after a separate, human-confirmed ratification
+step that checks the referenced artifacts are actually gone (the
+`doc-accuracy` code-as-source-of-truth discipline). A mis-flag on a
+load-bearing entry is the exact loss this proposal-only design prevents.
+
+Buckets:
+  live                                current guidance, leave alone
+  healthy-supersession                struck-through obsolete + dated
+                                      banner, current truth visible; the
+                                      target shape, leave alone
+  resolved-or-historical-but-present  RESOLVED/BLOCKING status co-present
+                                      with references to removed artifacts
+                                      or per-section historical tags;
+                                      propose archive/collapse
+  temporal-snapshot-as-live           dated point-in-time doc framed as
+                                      current; propose a dated-snapshot
+                                      banner
+
+Exit code is always 0: this is a proposal, not a gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+LIVE = "live"
+HEALTHY_SUPERSESSION = "healthy-supersession"
+RESOLVED_HISTORICAL = "resolved-or-historical-but-present"
+TEMPORAL_SNAPSHOT = "temporal-snapshot-as-live"
+
+# Dispositions that warrant a proposal (everything except live).
+ACTIONABLE = (RESOLVED_HISTORICAL, HEALTHY_SUPERSESSION, TEMPORAL_SNAPSHOT)
+
+_STATUS_RE = re.compile(r"status[^A-Za-z0-9]{0,6}(resolved|blocking)", re.IGNORECASE)
+_REMOVED_RE = re.compile(r"\(removed\)", re.IGNORECASE)
+_HISTORICAL_RE = re.compile(r"\(historical\)", re.IGNORECASE)
+_STRIKE_RE = re.compile(r"~~")
+_BANNER_RE = re.compile(
+    r"(important|update|superseded|deprecated|note)[^\n)]*\(20\d{2}-\d{2}-\d{2}\)",
+    re.IGNORECASE,
+)
+_DATE_RE = re.compile(r"20\d{2}-\d{2}-\d{2}")
+_SNAPSHOT_FRAME_RE = re.compile(
+    r"top[\s\-]?\d+|snapshot|as of|current state|\bv\d+(?:\.\d+)*\b",
+    re.IGNORECASE,
+)
+
+# Thresholds calibrated against the confirmed cases in issue #3019.
+MIN_REMOVED_FOR_ROT = 2
+MIN_STRIKE_PAIRS_FOR_HEALTHY = 3
+HEAD_LINES = 15
+
+
+@dataclass(frozen=True)
+class Signals:
+    """Structural signals extracted from a single memory file."""
+
+    status_resolved_blocking: bool
+    removed_refs: int
+    historical_tags: int
+    strikethrough_pairs: int
+    dated_banner: bool
+    dated_snapshot_frame: bool
+
+
+def scan_signals(text: str) -> Signals:
+    """Extract classification signals from memory file text."""
+    head = "\n".join(text.splitlines()[:HEAD_LINES])
+    return Signals(
+        status_resolved_blocking=bool(_STATUS_RE.search(text)),
+        removed_refs=len(_REMOVED_RE.findall(text)),
+        historical_tags=len(_HISTORICAL_RE.findall(text)),
+        strikethrough_pairs=len(_STRIKE_RE.findall(text)) // 2,
+        dated_banner=bool(_BANNER_RE.search(text)),
+        dated_snapshot_frame=bool(
+            _DATE_RE.search(head) and _SNAPSHOT_FRAME_RE.search(head)
+        ),
+    )
+
+
+def _is_resolved_historical(sig: Signals) -> bool:
+    """Rot: a done/blocked status still present, pointing at gone artifacts."""
+    if not sig.status_resolved_blocking:
+        return False
+    return sig.removed_refs >= MIN_REMOVED_FOR_ROT or sig.historical_tags >= 1
+
+
+def _is_healthy_supersession(sig: Signals) -> bool:
+    """Target shape: dated banner plus struck-through obsolete content."""
+    return sig.dated_banner and sig.strikethrough_pairs >= MIN_STRIKE_PAIRS_FOR_HEALTHY
+
+
+def classify(sig: Signals) -> str:
+    """Map signals to one bucket. Order encodes precedence.
+
+    Rot is checked before healthy-supersession so a resolved doc that also
+    has strikethrough is flagged, not excused. Healthy-supersession is
+    checked before temporal-snapshot so the dated-banner + strikethrough
+    target shape is never mistaken for a stale snapshot. Strikethrough
+    density alone never triggers a rot proposal (false-positive guard).
+    """
+    if _is_resolved_historical(sig):
+        return RESOLVED_HISTORICAL
+    if _is_healthy_supersession(sig):
+        return HEALTHY_SUPERSESSION
+    if sig.dated_snapshot_frame:
+        return TEMPORAL_SNAPSHOT
+    return LIVE
+
+
+def classify_file(path: Path) -> str:
+    """Classify a single memory file by path."""
+    return classify(scan_signals(path.read_text(encoding="utf-8")))
+
+
+@dataclass
+class Proposal:
+    """A per-file disposition proposal (never an edit)."""
+
+    path: str
+    disposition: str
+    signals: dict[str, object]
+
+
+def sweep(root: Path) -> list[Proposal]:
+    """Classify every markdown file under root. Returns proposals, no edits."""
+    proposals: list[Proposal] = []
+    for path in sorted(root.rglob("*.md")):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            # One unreadable file must not abort a whole-tree sweep. Skip it
+            # and surface the reason so the operator can follow up.
+            print(f"warning: skipping {path}: {exc}", file=sys.stderr)
+            continue
+        sig = scan_signals(text)
+        proposals.append(
+            Proposal(
+                path=str(path.relative_to(root)),
+                disposition=classify(sig),
+                signals=asdict(sig),
+            )
+        )
+    return proposals
+
+
+def _counts(proposals: list[Proposal]) -> dict[str, int]:
+    counts: dict[str, int] = {
+        LIVE: 0,
+        HEALTHY_SUPERSESSION: 0,
+        RESOLVED_HISTORICAL: 0,
+        TEMPORAL_SNAPSHOT: 0,
+    }
+    for proposal in proposals:
+        counts[proposal.disposition] = counts.get(proposal.disposition, 0) + 1
+    return counts
+
+
+def render_text(proposals: list[Proposal]) -> str:
+    """Human-readable proposal report."""
+    counts = _counts(proposals)
+    lines = [
+        "Supersession sweep (proposal only, no files changed):",
+        f"  scanned: {len(proposals)}",
+        f"  live: {counts[LIVE]}",
+        f"  healthy-supersession (leave alone): {counts[HEALTHY_SUPERSESSION]}",
+        "  resolved-or-historical-but-present (propose collapse): "
+        f"{counts[RESOLVED_HISTORICAL]}",
+        "  temporal-snapshot-as-live (propose dated banner): "
+        f"{counts[TEMPORAL_SNAPSHOT]}",
+    ]
+    flagged = [p for p in proposals if p.disposition in ACTIONABLE]
+    if flagged:
+        lines.append("")
+        lines.append("Proposals (ratify against on-disk/code state before acting):")
+        for proposal in flagged:
+            lines.append(f"  [{proposal.disposition}] {proposal.path}")
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Supersession sweep for memories.")
+    parser.add_argument(
+        "--root",
+        default=".serena/memories",
+        help="Directory of memory files to scan (default: .serena/memories).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the proposal report as JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"error: root not found: {root}", file=sys.stderr)
+        return 0
+    proposals = sweep(root)
+    if args.json:
+        payload = {
+            "counts": _counts(proposals),
+            "proposals": [asdict(p) for p in proposals],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print(render_text(proposals))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.29",
+  "version": "0.6.30",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/curating-memories/SKILL.md
+++ b/src/copilot-cli/skills/curating-memories/SKILL.md
@@ -2,7 +2,7 @@
 name: curating-memories
 description: Guidance for maintaining memory quality through curation. Covers updating outdated memories, marking obsolete content, and linking related knowledge. Use when memories need modification, when new information supersedes old, or when building knowledge graph connections.
 license: MIT
-version: 1.0.0
+version: 1.1.0
 model: claude-sonnet-4-6
 ---
 
@@ -175,6 +175,56 @@ Use [exploring-knowledge-graph](../exploring-knowledge-graph/SKILL.md) instead w
 2. Evaluate whether the memory needs updating, linking, or marking obsolete
 3. Apply the appropriate curation operation
 4. Verify the change took effect
+
+---
+
+## Scripts: Supersession Sweep
+
+The append-never-delete pattern is the failure this sweep targets: a memory
+that is fully resolved or historical but still reads as live guidance, so a
+fresh agent has to read past archaeology to reach current truth. Run the
+sweep to surface those files. It **proposes** a disposition per file and
+edits nothing; ratification is a separate, confirmed step.
+
+```bash
+uv run python "${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/curating-memories/scripts/supersession_sweep.py"
+```
+
+Add `--json` for machine-readable output, or `--root <dir>` to scan a
+directory other than `.serena/memories`.
+
+### The four buckets
+
+| Bucket | Signal | Action |
+|--------|--------|--------|
+| `live` | No supersession markers | Leave alone |
+| `healthy-supersession` | Struck-through obsolete content plus a dated banner, current truth visible | Leave alone; this is the target shape |
+| `resolved-or-historical-but-present` | `Status: RESOLVED`/`BLOCKING` co-present with references to removed artifacts or per-section `(Historical)` tags | Propose archive, or collapse to a one-line changelog footer |
+| `temporal-snapshot-as-live` | A dated point-in-time doc framed as current state | Propose a dated-snapshot banner |
+
+### The constraint (non-negotiable)
+
+The sweep is a generator self-report, which is the closed-loop-validator
+trap. The classification is a **routing signal into verification, never a
+verdict**:
+
+- The sweep proposes a disposition. It does not edit or delete.
+- Ratify with the [doc-accuracy](../doc-accuracy/SKILL.md) code-as-source-of-truth
+  discipline: archive a memory only after confirming the artifacts it
+  references are actually gone and no live path depends on it.
+- A human or a second independent check confirms before any content is
+  removed. A mis-flag on a load-bearing entry is the exact loss this
+  proposal-only design prevents.
+
+### The healthy-supersession target shape
+
+When you collapse a `resolved-or-historical-but-present` file, do not bury
+it. Strike through the obsolete content, add a dated banner explaining why,
+and keep current truth visible inline. `cost/cost-summary-reference.md` is
+the exemplar: obsolete rows struck through, a dated `IMPORTANT` banner,
+history preserved, nothing hidden. Strikethrough density alone is a
+healthy-supersession signal, never a rot signal; the sweep will not propose
+archiving a file on strikethrough count.
 
 ---
 

--- a/src/copilot-cli/skills/curating-memories/scripts/supersession_sweep.py
+++ b/src/copilot-cli/skills/curating-memories/scripts/supersession_sweep.py
@@ -42,8 +42,9 @@ HEALTHY_SUPERSESSION = "healthy-supersession"
 RESOLVED_HISTORICAL = "resolved-or-historical-but-present"
 TEMPORAL_SNAPSHOT = "temporal-snapshot-as-live"
 
-# Dispositions that warrant a proposal (everything except live).
-ACTIONABLE = (RESOLVED_HISTORICAL, HEALTHY_SUPERSESSION, TEMPORAL_SNAPSHOT)
+# Dispositions that warrant a follow-up proposal. healthy-supersession and
+# live are both "leave alone", so neither appears in the proposals list.
+ACTIONABLE = (RESOLVED_HISTORICAL, TEMPORAL_SNAPSHOT)
 
 _STATUS_RE = re.compile(r"status[^A-Za-z0-9]{0,6}(resolved|blocking)", re.IGNORECASE)
 _REMOVED_RE = re.compile(r"\(removed\)", re.IGNORECASE)
@@ -55,7 +56,7 @@ _BANNER_RE = re.compile(
 )
 _DATE_RE = re.compile(r"20\d{2}-\d{2}-\d{2}")
 _SNAPSHOT_FRAME_RE = re.compile(
-    r"top[\s\-]?\d+|snapshot|as of|current state|\bv\d+(?:\.\d+)*\b",
+    r"top[\s\-]?\d+|snapshot|as of|current state",
     re.IGNORECASE,
 )
 

--- a/src/copilot-cli/skills/curating-memories/scripts/supersession_sweep.py
+++ b/src/copilot-cli/skills/curating-memories/scripts/supersession_sweep.py
@@ -214,7 +214,10 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     root = Path(args.root)
     if not root.is_dir():
-        print(f"error: root not found: {root}", file=sys.stderr)
+        message = f"root not found: {root}"
+        print(f"error: {message}", file=sys.stderr)
+        if args.json:
+            print(json.dumps({"error": message}))
         return 0
     proposals = sweep(root)
     if args.json:

--- a/src/copilot-cli/skills/curating-memories/scripts/supersession_sweep.py
+++ b/src/copilot-cli/skills/curating-memories/scripts/supersession_sweep.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Supersession sweep: classify memory files for curation (issue #3019).
+
+Detects the append-never-delete pattern: memory files that are fully
+resolved or historical but still present as live guidance. The sweep
+*proposes* a disposition per file and emits a report. It never edits or
+deletes anything.
+
+The classification is a routing signal into verification, never a verdict.
+A memory is only archived after a separate, human-confirmed ratification
+step that checks the referenced artifacts are actually gone (the
+`doc-accuracy` code-as-source-of-truth discipline). A mis-flag on a
+load-bearing entry is the exact loss this proposal-only design prevents.
+
+Buckets:
+  live                                current guidance, leave alone
+  healthy-supersession                struck-through obsolete + dated
+                                      banner, current truth visible; the
+                                      target shape, leave alone
+  resolved-or-historical-but-present  RESOLVED/BLOCKING status co-present
+                                      with references to removed artifacts
+                                      or per-section historical tags;
+                                      propose archive/collapse
+  temporal-snapshot-as-live           dated point-in-time doc framed as
+                                      current; propose a dated-snapshot
+                                      banner
+
+Exit code is always 0: this is a proposal, not a gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+LIVE = "live"
+HEALTHY_SUPERSESSION = "healthy-supersession"
+RESOLVED_HISTORICAL = "resolved-or-historical-but-present"
+TEMPORAL_SNAPSHOT = "temporal-snapshot-as-live"
+
+# Dispositions that warrant a proposal (everything except live).
+ACTIONABLE = (RESOLVED_HISTORICAL, HEALTHY_SUPERSESSION, TEMPORAL_SNAPSHOT)
+
+_STATUS_RE = re.compile(r"status[^A-Za-z0-9]{0,6}(resolved|blocking)", re.IGNORECASE)
+_REMOVED_RE = re.compile(r"\(removed\)", re.IGNORECASE)
+_HISTORICAL_RE = re.compile(r"\(historical\)", re.IGNORECASE)
+_STRIKE_RE = re.compile(r"~~")
+_BANNER_RE = re.compile(
+    r"(important|update|superseded|deprecated|note)[^\n)]*\(20\d{2}-\d{2}-\d{2}\)",
+    re.IGNORECASE,
+)
+_DATE_RE = re.compile(r"20\d{2}-\d{2}-\d{2}")
+_SNAPSHOT_FRAME_RE = re.compile(
+    r"top[\s\-]?\d+|snapshot|as of|current state|\bv\d+(?:\.\d+)*\b",
+    re.IGNORECASE,
+)
+
+# Thresholds calibrated against the confirmed cases in issue #3019.
+MIN_REMOVED_FOR_ROT = 2
+MIN_STRIKE_PAIRS_FOR_HEALTHY = 3
+HEAD_LINES = 15
+
+
+@dataclass(frozen=True)
+class Signals:
+    """Structural signals extracted from a single memory file."""
+
+    status_resolved_blocking: bool
+    removed_refs: int
+    historical_tags: int
+    strikethrough_pairs: int
+    dated_banner: bool
+    dated_snapshot_frame: bool
+
+
+def scan_signals(text: str) -> Signals:
+    """Extract classification signals from memory file text."""
+    head = "\n".join(text.splitlines()[:HEAD_LINES])
+    return Signals(
+        status_resolved_blocking=bool(_STATUS_RE.search(text)),
+        removed_refs=len(_REMOVED_RE.findall(text)),
+        historical_tags=len(_HISTORICAL_RE.findall(text)),
+        strikethrough_pairs=len(_STRIKE_RE.findall(text)) // 2,
+        dated_banner=bool(_BANNER_RE.search(text)),
+        dated_snapshot_frame=bool(
+            _DATE_RE.search(head) and _SNAPSHOT_FRAME_RE.search(head)
+        ),
+    )
+
+
+def _is_resolved_historical(sig: Signals) -> bool:
+    """Rot: a done/blocked status still present, pointing at gone artifacts."""
+    if not sig.status_resolved_blocking:
+        return False
+    return sig.removed_refs >= MIN_REMOVED_FOR_ROT or sig.historical_tags >= 1
+
+
+def _is_healthy_supersession(sig: Signals) -> bool:
+    """Target shape: dated banner plus struck-through obsolete content."""
+    return sig.dated_banner and sig.strikethrough_pairs >= MIN_STRIKE_PAIRS_FOR_HEALTHY
+
+
+def classify(sig: Signals) -> str:
+    """Map signals to one bucket. Order encodes precedence.
+
+    Rot is checked before healthy-supersession so a resolved doc that also
+    has strikethrough is flagged, not excused. Healthy-supersession is
+    checked before temporal-snapshot so the dated-banner + strikethrough
+    target shape is never mistaken for a stale snapshot. Strikethrough
+    density alone never triggers a rot proposal (false-positive guard).
+    """
+    if _is_resolved_historical(sig):
+        return RESOLVED_HISTORICAL
+    if _is_healthy_supersession(sig):
+        return HEALTHY_SUPERSESSION
+    if sig.dated_snapshot_frame:
+        return TEMPORAL_SNAPSHOT
+    return LIVE
+
+
+def classify_file(path: Path) -> str:
+    """Classify a single memory file by path."""
+    return classify(scan_signals(path.read_text(encoding="utf-8")))
+
+
+@dataclass
+class Proposal:
+    """A per-file disposition proposal (never an edit)."""
+
+    path: str
+    disposition: str
+    signals: dict[str, object]
+
+
+def sweep(root: Path) -> list[Proposal]:
+    """Classify every markdown file under root. Returns proposals, no edits."""
+    proposals: list[Proposal] = []
+    for path in sorted(root.rglob("*.md")):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            # One unreadable file must not abort a whole-tree sweep. Skip it
+            # and surface the reason so the operator can follow up.
+            print(f"warning: skipping {path}: {exc}", file=sys.stderr)
+            continue
+        sig = scan_signals(text)
+        proposals.append(
+            Proposal(
+                path=str(path.relative_to(root)),
+                disposition=classify(sig),
+                signals=asdict(sig),
+            )
+        )
+    return proposals
+
+
+def _counts(proposals: list[Proposal]) -> dict[str, int]:
+    counts: dict[str, int] = {
+        LIVE: 0,
+        HEALTHY_SUPERSESSION: 0,
+        RESOLVED_HISTORICAL: 0,
+        TEMPORAL_SNAPSHOT: 0,
+    }
+    for proposal in proposals:
+        counts[proposal.disposition] = counts.get(proposal.disposition, 0) + 1
+    return counts
+
+
+def render_text(proposals: list[Proposal]) -> str:
+    """Human-readable proposal report."""
+    counts = _counts(proposals)
+    lines = [
+        "Supersession sweep (proposal only, no files changed):",
+        f"  scanned: {len(proposals)}",
+        f"  live: {counts[LIVE]}",
+        f"  healthy-supersession (leave alone): {counts[HEALTHY_SUPERSESSION]}",
+        "  resolved-or-historical-but-present (propose collapse): "
+        f"{counts[RESOLVED_HISTORICAL]}",
+        "  temporal-snapshot-as-live (propose dated banner): "
+        f"{counts[TEMPORAL_SNAPSHOT]}",
+    ]
+    flagged = [p for p in proposals if p.disposition in ACTIONABLE]
+    if flagged:
+        lines.append("")
+        lines.append("Proposals (ratify against on-disk/code state before acting):")
+        for proposal in flagged:
+            lines.append(f"  [{proposal.disposition}] {proposal.path}")
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Supersession sweep for memories.")
+    parser.add_argument(
+        "--root",
+        default=".serena/memories",
+        help="Directory of memory files to scan (default: .serena/memories).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the proposal report as JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"error: root not found: {root}", file=sys.stderr)
+        return 0
+    proposals = sweep(root)
+    if args.json:
+        payload = {
+            "counts": _counts(proposals),
+            "proposals": [asdict(p) for p in proposals],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print(render_text(proposals))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/curating-memories/test_supersession_sweep.py
+++ b/tests/skills/curating-memories/test_supersession_sweep.py
@@ -24,9 +24,12 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCRIPT_DIR = REPO_ROOT / ".claude" / "skills" / "curating-memories" / "scripts"
+_orig_sys_path = list(sys.path)
 sys.path.insert(0, str(SCRIPT_DIR))
-
-import supersession_sweep as sweep_mod  # noqa: E402
+try:
+    import supersession_sweep as sweep_mod  # noqa: E402
+finally:
+    sys.path[:] = _orig_sys_path
 
 LIVE = sweep_mod.LIVE
 HEALTHY = sweep_mod.HEALTHY_SUPERSESSION
@@ -76,6 +79,14 @@ def test_dated_snapshot_framing_is_temporal_snapshot() -> None:
 def test_plain_guidance_is_live() -> None:
     text = "# How to do X\n\nRun the thing. Then check the result.\n"
     assert sweep_mod.classify(sweep_mod.scan_signals(text)) == LIVE
+
+
+def test_version_string_without_framing_is_not_snapshot() -> None:
+    # Regression: a historical changelog with a version like v3.0.0 and a date
+    # must not be flagged as temporal-snapshot-as-live. Only explicit framing
+    # (top N, snapshot, as of, current state) qualifies.
+    text = "# Skill - Version History\n\n## v3.0.0 (2026-01-03)\n\nChanged stuff.\n"
+    assert sweep_mod.classify(sweep_mod.scan_signals(text)) != SNAPSHOT
 
 
 # --- negative / false-positive guards -------------------------------------
@@ -133,7 +144,7 @@ def test_sweep_proposes_without_editing(tmp_path: Path) -> None:
     rot.write_text("**Status**: RESOLVED\nx.py (removed) y.py (removed)\n")
     live = tmp_path / "b.md"
     live.write_text("# Live\n\nCurrent guidance.\n")
-    before = {p: p.read_text() for p in (rot, live)}
+    before = {p: p.read_text(encoding="utf-8") for p in (rot, live)}
 
     proposals = sweep_mod.sweep(tmp_path)
 
@@ -142,7 +153,7 @@ def test_sweep_proposes_without_editing(tmp_path: Path) -> None:
     assert dispositions["b.md"] == LIVE
     # AC4: nothing on disk changed.
     for path, content in before.items():
-        assert path.read_text() == content
+        assert path.read_text(encoding="utf-8") == content
 
 
 def test_main_json_exit_zero(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -158,6 +169,17 @@ def test_main_text_exit_zero(tmp_path: Path, capsys: pytest.CaptureFixture[str])
     rc = sweep_mod.main(["--root", str(tmp_path)])
     assert rc == 0
     assert "proposal only" in capsys.readouterr().out
+
+
+def test_healthy_supersession_not_listed_as_proposal() -> None:
+    # Regression: healthy-supersession is "leave alone", so it must be counted
+    # but never appear under Proposals, which would misroute operator attention.
+    healthy = sweep_mod.Proposal("h.md", HEALTHY, {})
+    rot = sweep_mod.Proposal("r.md", ROT, {})
+    report = sweep_mod.render_text([healthy, rot])
+    proposals_section = report.split("Proposals", 1)[1]
+    assert "r.md" in proposals_section
+    assert "h.md" not in proposals_section
 
 
 def test_main_missing_root_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/skills/curating-memories/test_supersession_sweep.py
+++ b/tests/skills/curating-memories/test_supersession_sweep.py
@@ -188,6 +188,17 @@ def test_main_missing_root_exits_zero(capsys: pytest.CaptureFixture[str]) -> Non
     assert "root not found" in capsys.readouterr().err
 
 
+def test_main_missing_root_json_emits_error_payload(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # --json callers must get parseable JSON even on a bad root, not empty
+    # stdout, so a downstream parser gets a structured error.
+    rc = sweep_mod.main(["--root", "/nonexistent/path/xyz", "--json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert json.loads(out)["error"].startswith("root not found")
+
+
 def test_sweep_skips_unreadable_file(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/skills/curating-memories/test_supersession_sweep.py
+++ b/tests/skills/curating-memories/test_supersession_sweep.py
@@ -196,7 +196,14 @@ def test_sweep_skips_unreadable_file(
     ],
 )
 def test_confirmed_cases_classify_as_expected(rel: str, expected: str) -> None:
+    # When the whole memories tree is absent (shallow checkout, foreign
+    # environment) the module-level skipif above skips this test. But when
+    # the tree IS present, a missing named case must FAIL, not skip: these
+    # files are the #3019 contract, and a silent skip would hide a rename,
+    # removal, or premature ratification that changed a proof case.
     path = MEMORIES / rel
-    if not path.exists():
-        pytest.skip(f"fixture absent: {rel}")
+    assert path.exists(), (
+        f"confirmed-case memory {rel} is missing; the #3019 contract requires "
+        "it. If it was intentionally renamed or ratified, update this test."
+    )
     assert sweep_mod.classify_file(path) == expected

--- a/tests/skills/curating-memories/test_supersession_sweep.py
+++ b/tests/skills/curating-memories/test_supersession_sweep.py
@@ -1,0 +1,202 @@
+"""Tests for the supersession sweep classifier (issue #3019).
+
+Locks the classification contract that keeps the sweep useful and safe:
+
+- The two confirmed append-never-delete cases classify as
+  resolved-or-historical-but-present (AC2).
+- The healthy-supersession exemplar classifies as healthy-supersession and
+  is left alone, proving strikethrough density alone never triggers a rot
+  proposal (AC3 false-positive guard).
+- The sweep proposes and never edits (AC4).
+
+Without these tests a future contributor could relax a threshold or reorder
+the precedence and silently turn the false-positive guard off, which would
+route a load-bearing memory toward archival.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_DIR = REPO_ROOT / ".claude" / "skills" / "curating-memories" / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import supersession_sweep as sweep_mod  # noqa: E402
+
+LIVE = sweep_mod.LIVE
+HEALTHY = sweep_mod.HEALTHY_SUPERSESSION
+ROT = sweep_mod.RESOLVED_HISTORICAL
+SNAPSHOT = sweep_mod.TEMPORAL_SNAPSHOT
+
+MEMORIES = REPO_ROOT / ".serena" / "memories"
+
+
+# --- positive: each bucket ------------------------------------------------
+
+
+def test_resolved_status_with_removed_refs_is_rot() -> None:
+    text = (
+        "# Bug\n\n**Status**: RESOLVED\n\n"
+        "The old_script.py (removed) and helper_mod (removed) are gone.\n"
+    )
+    assert sweep_mod.classify(sweep_mod.scan_signals(text)) == ROT
+
+
+def test_blocking_status_with_removed_refs_is_rot() -> None:
+    text = (
+        "# Blocker\n\n**Status**: BLOCKING\n\n"
+        "workflow-a (removed), workflow-b (removed), action-c (removed).\n"
+    )
+    assert sweep_mod.classify(sweep_mod.scan_signals(text)) == ROT
+
+
+def test_resolved_status_with_historical_tag_is_rot() -> None:
+    text = "# Old\n\n**Status**: RESOLVED\n\n## Context (Historical)\n\nstuff\n"
+    assert sweep_mod.classify(sweep_mod.scan_signals(text)) == ROT
+
+
+def test_dated_banner_with_strikethrough_is_healthy() -> None:
+    text = (
+        "# Ref\n\n> **IMPORTANT (2025-12-21)**: public repo, runners free.\n\n"
+        "| ~~Old~~ | ~~gone~~ | ~~n/a~~ | ~~x~~ |\n"
+    )
+    assert sweep_mod.classify(sweep_mod.scan_signals(text)) == HEALTHY
+
+
+def test_dated_snapshot_framing_is_temporal_snapshot() -> None:
+    text = "# Roadmap v0.3.0\n\nAs of 2026-01-23, the top 10 items are:\n\n- one\n"
+    assert sweep_mod.classify(sweep_mod.scan_signals(text)) == SNAPSHOT
+
+
+def test_plain_guidance_is_live() -> None:
+    text = "# How to do X\n\nRun the thing. Then check the result.\n"
+    assert sweep_mod.classify(sweep_mod.scan_signals(text)) == LIVE
+
+
+# --- negative / false-positive guards -------------------------------------
+
+
+def test_strikethrough_alone_is_not_rot() -> None:
+    # AC3: strikethrough density without a resolved/blocking status must not
+    # be flagged for archival.
+    text = "# Table\n\n| ~~a~~ | ~~b~~ | ~~c~~ | ~~d~~ | ~~e~~ |\n"
+    assert sweep_mod.classify(sweep_mod.scan_signals(text)) != ROT
+
+
+def test_removed_refs_without_status_is_not_rot() -> None:
+    text = "# Notes\n\nWe deleted old.py (removed) and gone.py (removed) last week.\n"
+    assert sweep_mod.classify(sweep_mod.scan_signals(text)) != ROT
+
+
+def test_healthy_requires_banner_not_strikethrough_alone() -> None:
+    text = "# Table\n\n| ~~a~~ | ~~b~~ | ~~c~~ | ~~d~~ |\n"
+    assert sweep_mod.classify(sweep_mod.scan_signals(text)) != HEALTHY
+
+
+def test_resolved_status_alone_without_gone_artifacts_is_not_rot() -> None:
+    # A resolved note that still points at live artifacts is not rot.
+    text = "# Done\n\n**Status**: RESOLVED\n\nSee current_module for details.\n"
+    assert sweep_mod.classify(sweep_mod.scan_signals(text)) != ROT
+
+
+# --- edge -----------------------------------------------------------------
+
+
+def test_empty_file_is_live() -> None:
+    assert sweep_mod.classify(sweep_mod.scan_signals("")) == LIVE
+
+
+def test_single_removed_ref_below_threshold_is_not_rot() -> None:
+    text = "# X\n\n**Status**: RESOLVED\n\nonly one.py (removed) here.\n"
+    assert sweep_mod.classify(sweep_mod.scan_signals(text)) != ROT
+
+
+def test_scan_signals_counts_pairs_and_refs() -> None:
+    text = "**Status**: BLOCKING\n(removed) (removed) ~~a~~ ~~b~~ (Historical)\n"
+    sig = sweep_mod.scan_signals(text)
+    assert sig.status_resolved_blocking is True
+    assert sig.removed_refs == 2
+    assert sig.strikethrough_pairs == 2
+    assert sig.historical_tags == 1
+
+
+# --- sweep + CLI ----------------------------------------------------------
+
+
+def test_sweep_proposes_without_editing(tmp_path: Path) -> None:
+    rot = tmp_path / "a.md"
+    rot.write_text("**Status**: RESOLVED\nx.py (removed) y.py (removed)\n")
+    live = tmp_path / "b.md"
+    live.write_text("# Live\n\nCurrent guidance.\n")
+    before = {p: p.read_text() for p in (rot, live)}
+
+    proposals = sweep_mod.sweep(tmp_path)
+
+    dispositions = {p.path: p.disposition for p in proposals}
+    assert dispositions["a.md"] == ROT
+    assert dispositions["b.md"] == LIVE
+    # AC4: nothing on disk changed.
+    for path, content in before.items():
+        assert path.read_text() == content
+
+
+def test_main_json_exit_zero(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (tmp_path / "a.md").write_text("**Status**: RESOLVED\n(removed) (removed)\n")
+    rc = sweep_mod.main(["--root", str(tmp_path), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"][ROT] == 1
+
+
+def test_main_text_exit_zero(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (tmp_path / "a.md").write_text("# Live\n\nguidance\n")
+    rc = sweep_mod.main(["--root", str(tmp_path)])
+    assert rc == 0
+    assert "proposal only" in capsys.readouterr().out
+
+
+def test_main_missing_root_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = sweep_mod.main(["--root", "/nonexistent/path/xyz"])
+    assert rc == 0
+    assert "root not found" in capsys.readouterr().err
+
+
+def test_sweep_skips_unreadable_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    good = tmp_path / "good.md"
+    good.write_text("# Live\n\nguidance\n")
+    bad = tmp_path / "bad.md"
+    bad.write_bytes(b"\xff\xfe invalid utf-8 \x80\x81")
+
+    proposals = sweep_mod.sweep(tmp_path)
+
+    paths = {p.path for p in proposals}
+    assert "good.md" in paths
+    assert "bad.md" not in paths
+    assert "skipping" in capsys.readouterr().err
+
+
+# --- integration: real acceptance-criteria files --------------------------
+
+
+@pytest.mark.skipif(not MEMORIES.is_dir(), reason="memories tree absent")
+@pytest.mark.parametrize(
+    ("rel", "expected"),
+    [
+        ("session/session-protocol-validator-pipe-bug.md", ROT),
+        ("ci/ci-infrastructure-droid-action-blocker.md", ROT),
+        ("cost/cost-summary-reference.md", HEALTHY),
+        ("planning/roadmap-v030-top-10-items.md", SNAPSHOT),
+    ],
+)
+def test_confirmed_cases_classify_as_expected(rel: str, expected: str) -> None:
+    path = MEMORIES / rel
+    if not path.exists():
+        pytest.skip(f"fixture absent: {rel}")
+    assert sweep_mod.classify_file(path) == expected


### PR DESCRIPTION
## Summary

Adds a supersession sweep to the `curating-memories` skill: a classifier that scans memory files, sorts each into one of four dispositions, and emits a proposal report. It never edits or deletes. The classification is a routing signal into verification, ratified separately against on-disk and code state (the constraint the issue calls non-negotiable).

## What it does

Four buckets, matching the issue taxonomy:

| Bucket | Signal | Action |
|--------|--------|--------|
| live | no supersession markers | leave alone |
| healthy-supersession | dated banner + struck-through obsolete content | leave alone (target shape) |
| resolved-or-historical-but-present | RESOLVED/BLOCKING status co-present with removed-artifact refs or historical tags | propose collapse |
| temporal-snapshot-as-live | dated point-in-time doc framed as current | propose dated banner |

Invoke via the portable plugin-root path documented in the skill's Scripts section.

## Acceptance criteria

- Classifies memory files into the four buckets and emits a proposal report, not edits.
- The two confirmed cases classify as resolved-or-historical-but-present.
- The healthy-supersession exemplar classifies as healthy-supersession and is left alone (strikethrough density alone never triggers a rot proposal, the false-positive guard).
- No file is modified or deleted by the sweep; ratification is a separate confirmed step.
- The healthy-supersession target shape is documented as the collapse target.

Ran against the real tree (830 files): 819 live, 1 healthy-supersession, 2 resolved-or-historical, 8 temporal-snapshot. The two rot cases and the healthy exemplar land exactly where the issue predicts.

## Validation

- 25 tests: positive per bucket, negative false-positive guards, edge, unreadable-file skip, JSON-error path, CLI exits. All pass.
- ruff + mypy clean on both new files.
- Both plugin manifests bumped to 0.6.30 (parity gate), copilot-cli mirror regenerated, staleness gate green.

## Notes

The two confirmed rot files are intentionally left unmodified so the classifier demonstrably flags them; collapsing them is the separate human-confirmed ratification step the issue mandates.

Review rounds addressed: sys.path restore, utf-8 encoding on reads, fail-loud integration test, ACTIONABLE excludes leave-alone buckets, snapshot regex no longer matches bare version strings, JSON error payload on bad root with --json.

## References

Refs #3019
