### PR TITLE
docs(adr): ADR-080 model pins require cited eval evidence (#2840)

### DIFF
--- a/.agents/analysis/ADR-080-model-pin-policy-debate.md
+++ b/.agents/analysis/ADR-080-model-pin-policy-debate.md
@@ -1,0 +1,154 @@
+# ADR-080 Debate Log: Model Pins Require Cited Eval Evidence
+
+Multi-agent adversarial review of the proposed model-pin policy, run
+2026-07-11 before the ADR was written. Three reviewers plus author
+grounding. This log satisfies the ADR-033 architect-review gate and records
+the findings that shaped the final ADR.
+
+## Participants
+
+| Reviewer | Model | Role |
+|----------|-------|------|
+| architect | Claude | Architectural coherence, mechanism correctness |
+| independent-thinker | GPT-5.5 | Adversarial: power, cost, simpler-policy |
+| critic | GPT-5.5 | Completeness, mirror obligations, test rigor |
+| author grounding | Claude | Fixture/generator/harness fact-finding |
+
+## Consensus verdict
+
+REVISE-then-accept. All three reviewers agree the overall shape
+(default-to-inherited, pin-only-with-evidence, warn-then-enforce ratchet) is
+sound. All three independently flagged that the shape is under-specified and
+that one premise is wrong: the sweep harness cannot evaluate skills or
+commands, only agents.
+
+## Decisive finding: the harness is agent-only
+
+The evidence mechanism the policy leans on (`scripts/eval/eval-model-sweep.py`)
+builds child args only for `--agent`/`--fixtures`/`--model`/`--n-runs`
+(`eval-model-sweep.py:158-184`) and the base evaluator reads
+`templates/agents/{agent}.shared.md` (`eval-agent-vs-baseline.py:104,394-406`).
+It has no skill or command path.
+
+Author grounding confirmed the consequence: of the current pins, only **1 of
+74 pinned skills** and **17 of 31 pinned agents** have an
+`evals/<name>-spike/fixtures` directory. About 90 of ~108 pinned units cannot
+produce a sweep at all.
+
+**Resolution adopted in the ADR:** the eval-evidence path applies to agents
+only. Skills and commands cannot carry a versioned pin (no way to justify
+one); their allowed states are no `model:` line or a rolling alias. This
+solves the three stated drift problems for ~83 skill/command pins without any
+sweep, and reserves the eval machinery for the ~17 agents where it works.
+
+## Findings and resolutions
+
+### High severity
+
+1. **KEEP_PIN bar was stated wrong (architect).** The verdict is
+   `qualifies = delta >= min_effect and ci_low > 0.0` with
+   `DEFAULT_MIN_EFFECT = 0.05` (`_model_sweep_core.py:277,62`), not "CI
+   excludes zero" alone. **Resolved:** ADR states both conditions.
+
+2. **`model-evidence:` frontmatter would pollute downstream mirrors
+   (architect, critic).** Generators preserve unknown frontmatter
+   (`copilot_body_translation.py:192-203`) and the agent generator injects
+   `model: "claude-opus-4.6"` as a default
+   (`templates/platforms/copilot-cli.yaml:95`;
+   `build/generate_agents_common.py:211-233`). Internal CI-artifact paths
+   would ship to Copilot/VS Code consumers, and removing a source pin would
+   not even propagate because the generator re-adds a default. **Resolved:**
+   evidence lives in a sidecar manifest `.agents/governance/model-pin-evidence.json`,
+   not frontmatter; and the migration must change the generator default to
+   inherit (no injected `model:`), or the policy is toothless for generated
+   agents.
+
+3. **DROP_PIN means underpowered, not "safe to remove" (independent-thinker).**
+   The paired bootstrap resamples fixture ids; with a 2-fixture floor
+   (`_model_sweep_core.py:321-335`) and 7-8 fixtures typical, the CI is
+   low-powered and a real winner can still get DROP_PIN
+   (`tests/eval/test_model_sweep_core.py:179-204`). **Resolved:** the ADR
+   requires at least 8 shared fixtures for a KEEP verdict to justify a pin,
+   treats an underpowered result as inconclusive (not evidence), and softens
+   the "always safe" claim: removing a pin returns the unit to the harness
+   default, the same baseline most units already run.
+
+4. **Identity binding unspecified (architect, critic).** The check must
+   verify `decision == KEEP_PIN` AND `artifact.agent == unit` AND
+   `artifact.winner == pinned model`, not merely that a field is present
+   (`_model_sweep_core.py:430-482`). **Resolved:** ADR specifies the full
+   predicate plus `fixtures_sha` and a max-age check.
+
+5. **Mirror obligations unspecified (critic).** Skills copy to
+   `src/copilot-cli`, agents generate from templates/platform config,
+   `.github/agents` is a hand-maintained install copy (`build/AGENTS.md:246`).
+   **Resolved:** ADR adds a source/mirror matrix and requires
+   `build_all.py --check` + install-parity + paired plugin-manifest bumps in
+   the same PR (ADR-079, plugin-version rule).
+
+### Medium severity
+
+6. **Bonferroni widening not disclosed (architect).** CI lower percentile is
+   divided by candidate count (`_model_sweep_core.py:340`). **Resolved:** ADR
+   pins the expected single-candidate-vs-default sweep protocol for evidence.
+
+7. **Ratchet baseline schema wrong shape (architect, independent-thinker).**
+   Exec-portability ratchet is `dict[str,int]`
+   (`check_skill_md_exec_portability.py:213-234`); model pins need
+   `dict[str,str]` (file to model-id) with new-pin and changed-value
+   detection, and the frozen baseline drains nothing on its own
+   (`check_vendor_portability.py:321-330,401-433`). **Resolved:** ADR
+   specifies the schema and adds a burn-down rule (baseline count must shrink
+   each release; entries carry a removal target).
+
+8. **Evidence staleness (architect, independent-thinker).** The sweep artifact
+   lacks the pinned file path/prompt hash; a citation can go stale.
+   **Resolved:** the check verifies `fixtures_sha` and a max artifact age and
+   re-validates when the default model changes.
+
+9. **Cost exception too loose (architect, independent-thinker).** `model: opus`
+   is a rolling alias but not cheaper than the default
+   (`.claude/agents/independent-thinker.md:4`, `.claude/commands/research.md:4`).
+   **Resolved:** the cost exception applies only to aliases that price below
+   the harness default (in practice `haiku`), validated against
+   `MODEL_PRICING_RATES_USD_PER_1K_TOKENS`.
+
+### Low severity
+
+10. **Counts are estimates; naive scans hit doc examples (critic, architect).**
+    `.claude/skills/CLAUDE.md:37` and `.claude/agents/AGENTS.md:187` carry
+    example `model:` lines. **Resolved:** the baseline is computed by a scanner
+    with explicit include/exclude rules (frontmatter only, unit files only, no
+    `AGENTS.md`/`CLAUDE.md` examples), not from a hand estimate.
+
+11. **Migration ordering (architect).** Ship generator/schema support before
+    the check can be satisfied. **Resolved:** ADR reorders so schema plus
+    generator support precedes enforce mode.
+
+12. **No bypass mechanism (critic).** **Resolved:** ADR specifies a
+    `--update-baseline` flow and a documented label/env escape hatch with an
+    audit trail, matching existing validators.
+
+## Strong alternative considered (independent-thinker)
+
+"Ban versioned model ids entirely; allow only no `model:` line or a rolling
+alias; require a rationale only for aliases; use sweeps only for rare version
+exceptions." This addresses format drift, version drift, and the retirement
+break directly, with no eval machinery, no stale artifacts, no underpowered
+CI, and no migration spend.
+
+**Disposition:** partially adopted. The final ADR bans versioned pins for
+skills and commands outright (they cannot be swept), which is exactly this
+alternative for ~83 of the pins. For agents, the owner's stated direction
+(#2840: keep a pin only with eval evidence) and the harness the owner built
+for it (#2901) are honored: a versioned agent pin is allowed only with a
+KEEP_PIN artifact. This is presented to the owner as the primary decision with
+the pure-simpler alternative recorded, per User Sovereignty; the owner reviews
+the PR and may choose the pure alternative instead.
+
+## Outcome
+
+The ADR was rewritten to incorporate all twelve findings and the agent-only
+scoping. High-severity gaps 1 through 5 are resolved in the decision text;
+medium and low findings are resolved in the implementation-notes and
+governance-check specification.

--- a/.agents/analysis/ADR-080-model-pin-policy-debate.md
+++ b/.agents/analysis/ADR-080-model-pin-policy-debate.md
@@ -2,7 +2,7 @@
 
 Multi-agent adversarial review of the proposed model-pin policy, run
 2026-07-11 before the ADR was written. Three reviewers plus author
-grounding. This log satisfies the ADR-033 architect-review gate and records
+grounding. This log satisfies the routing-level architect-review gate on ADR writes (the PreToolUse gate implemented per ADR-033, Routing-Level Enforcement Gates) and records
 the findings that shaped the final ADR.
 
 ## Participants
@@ -52,7 +52,7 @@ sweep, and reserves the eval machinery for the ~17 agents where it works.
 
 2. **`model-evidence:` frontmatter would pollute downstream mirrors
    (architect, critic).** Generators preserve unknown frontmatter
-   (`copilot_body_translation.py:192-203`) and the agent generator injects
+   (`build/scripts/copilot_body_translation.py:192-203`) and the agent generator injects
    `model: "claude-opus-4.6"` as a default
    (`templates/platforms/copilot-cli.yaml:95`;
    `build/generate_agents_common.py:211-233`). Internal CI-artifact paths

--- a/.agents/analysis/ADR-080-model-pin-policy-debate.md
+++ b/.agents/analysis/ADR-080-model-pin-policy-debate.md
@@ -26,8 +26,8 @@ commands, only agents.
 
 The evidence mechanism the policy leans on (`scripts/eval/eval-model-sweep.py`)
 builds child args only for `--agent`/`--fixtures`/`--model`/`--n-runs`
-(`eval-model-sweep.py:158-184`) and the base evaluator reads
-`templates/agents/{agent}.shared.md` (`eval-agent-vs-baseline.py:104,394-406`).
+(`scripts/eval/eval-model-sweep.py:158-184`) and the base evaluator reads
+`templates/agents/{agent}.shared.md` (`scripts/eval/eval-agent-vs-baseline.py:104,394-406`).
 It has no skill or command path.
 
 Author grounding confirmed the consequence: of the current pins, only **1 of
@@ -47,7 +47,7 @@ sweep, and reserves the eval machinery for the ~17 agents where it works.
 
 1. **KEEP_PIN bar was stated wrong (architect).** The verdict is
    `qualifies = delta >= min_effect and ci_low > 0.0` with
-   `DEFAULT_MIN_EFFECT = 0.05` (`_model_sweep_core.py:277,62`), not "CI
+   `DEFAULT_MIN_EFFECT = 0.05` (`scripts/eval/_model_sweep_core.py:277,62`), not "CI
    excludes zero" alone. **Resolved:** ADR states both conditions.
 
 2. **`model-evidence:` frontmatter would pollute downstream mirrors
@@ -65,7 +65,7 @@ sweep, and reserves the eval machinery for the ~17 agents where it works.
 
 3. **DROP_PIN means underpowered, not "safe to remove" (independent-thinker).**
    The paired bootstrap resamples fixture ids; with a 2-fixture floor
-   (`_model_sweep_core.py:321-335`) and 7-8 fixtures typical, the CI is
+   (`scripts/eval/_model_sweep_core.py:321-335`) and 7-8 fixtures typical, the CI is
    low-powered and a real winner can still get DROP_PIN
    (`tests/eval/test_model_sweep_core.py:179-204`). **Resolved:** the ADR
    requires at least 8 shared fixtures for a KEEP verdict to justify a pin,
@@ -76,7 +76,7 @@ sweep, and reserves the eval machinery for the ~17 agents where it works.
 4. **Identity binding unspecified (architect, critic).** The check must
    verify `decision == KEEP_PIN` AND `artifact.agent == unit` AND
    `artifact.winner == pinned model`, not merely that a field is present
-   (`_model_sweep_core.py:430-482`). **Resolved:** ADR specifies the full
+   (`scripts/eval/_model_sweep_core.py:430-482`). **Resolved:** ADR specifies the full
    predicate plus `fixtures_sha` and a max-age check.
 
 5. **Mirror obligations unspecified (critic).** Skills copy to
@@ -89,15 +89,15 @@ sweep, and reserves the eval machinery for the ~17 agents where it works.
 ### Medium severity
 
 6. **Bonferroni widening not disclosed (architect).** CI lower percentile is
-   divided by candidate count (`_model_sweep_core.py:340`). **Resolved:** ADR
+   divided by candidate count (`scripts/eval/_model_sweep_core.py:340`). **Resolved:** ADR
    pins the expected single-candidate-vs-default sweep protocol for evidence.
 
 7. **Ratchet baseline schema wrong shape (architect, independent-thinker).**
    Exec-portability ratchet is `dict[str,int]`
-   (`check_skill_md_exec_portability.py:213-234`); model pins need
+   (`scripts/validation/check_skill_md_exec_portability.py:213-234`); model pins need
    `dict[str,str]` (file to model-id) with new-pin and changed-value
    detection, and the frozen baseline drains nothing on its own
-   (`check_vendor_portability.py:321-330,401-433`). **Resolved:** ADR
+   (`scripts/validation/check_vendor_portability.py:321-330,401-433`). **Resolved:** ADR
    specifies the schema and adds a burn-down rule (baseline count must shrink
    each release; entries carry a removal target).
 

--- a/.agents/architecture/ADR-080-model-pin-justification-policy.md
+++ b/.agents/architecture/ADR-080-model-pin-justification-policy.md
@@ -91,9 +91,11 @@ the rule splits by unit kind, because only agents can be measured:
    exception is narrow.** Converting a bare alias to a versioned id (as #2891
    did for `haiku`) downgrades the unit and re-arms the #2839 retirement risk;
    do not do it for `sonnet` or `opus`. A `model-rationale:` cost exception is
-   valid only for an alias that prices strictly below the harness default in
-   `MODEL_PRICING_RATES_USD_PER_1K_TOKENS` (in practice `haiku`); it is not a
-   general escape hatch, and it never applies to a versioned pin.
+   valid only for an alias that resolves, via the platform `model_tiers`
+   mapping, to a versioned id priced strictly below the harness default in
+   `MODEL_PRICING_RATES_USD_PER_1K_TOKENS` (in practice `haiku`, which resolves
+   to `claude-haiku-4-5`); it is not a general escape hatch, and it never
+   applies to a versioned pin.
 
 4. **Evidence lives in a sidecar manifest, not in frontmatter.** A committed
    `.agents/governance/model-pin-evidence.json` maps each versioned agent pin

--- a/.agents/architecture/ADR-080-model-pin-justification-policy.md
+++ b/.agents/architecture/ADR-080-model-pin-justification-policy.md
@@ -46,11 +46,11 @@ The pins encode a guess, not a measurement. This ADR is criterion 1 of issue
 ### What measurement is actually possible
 
 Issue #2901 delivered the sweep harness (`scripts/eval/eval-model-sweep.py`
-plus `_model_sweep_core.py`) and #2902 completed the pricing table. But the
+plus `scripts/eval/_model_sweep_core.py`) and #2902 completed the pricing table. But the
 harness is **agent-shaped**: it builds child arguments only for `--agent`,
-`--fixtures`, `--model`, `--n-runs` (`eval-model-sweep.py:158-184`) and the
+`--fixtures`, `--model`, `--n-runs` (`scripts/eval/eval-model-sweep.py:158-184`) and the
 base evaluator reads `templates/agents/{agent}.shared.md`
-(`eval-agent-vs-baseline.py:104,394-406`). It cannot evaluate a skill or a
+(`scripts/eval/eval-agent-vs-baseline.py:104,394-406`). It cannot evaluate a skill or a
 command.
 
 Grounding the consequence: only **1 of 74 pinned skills** and **17 of 31
@@ -79,7 +79,7 @@ the rule splits by unit kind, because only agents can be measured:
    committed sweep artifact justifies it, recorded in a sidecar manifest (see
    point 4). The evidence bar is the harness verdict as it actually computes:
    `delta >= 0.05` mean recall **and** the paired bootstrap CI lower bound
-   `> 0` (`_model_sweep_core.py:277`, `DEFAULT_MIN_EFFECT = 0.05`), from a
+   `> 0` (`scripts/eval/_model_sweep_core.py:277`, `DEFAULT_MIN_EFFECT = 0.05`), from a
    single-candidate-versus-default sweep (so the CI is a plain 95 percent
    interval, not Bonferroni-widened) over **at least 8 shared fixtures**. A
    sweep with fewer shared fixtures, or one that returns DROP_PIN, is

--- a/.agents/architecture/ADR-080-model-pin-justification-policy.md
+++ b/.agents/architecture/ADR-080-model-pin-justification-policy.md
@@ -1,0 +1,270 @@
+---
+id: ADR-080
+status: proposed
+date: 2026-07-11
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
+# ADR-080: Model Pins Require Cited Eval Evidence
+
+## Status
+
+Proposed
+
+## Date
+
+2026-07-11
+
+## Context
+
+Skills, agents, and commands carry a `model:` frontmatter pin that forces a
+specific model and version for that unit of work. Scanning unit frontmatter on
+`main` (excluding the `AGENTS.md` and `CLAUDE.md` doc examples) finds roughly
+108 pins across `.claude/skills`, `.claude/agents`, and `.claude/commands`.
+None cites evidence that the pinned model beats the harness-inherited default
+for that unit.
+
+The pins cost us three concrete things, and all three trace to **versioned**
+ids, not to rolling aliases:
+
+- **Format drift.** The same intended model is spelled two ways: `claude-opus-4-6`
+  (hyphen) in skills, `claude-opus-4.6` (dot) in agents.
+- **Version drift.** One skill sits on `claude-opus-4-8` while others sit on
+  `claude-opus-4-6`. No decision produced the split.
+- **Retirement CI-break class.** A retired pinned id (`claude-opus-4.5`) broke
+  CI and motivated issue #2839. Every versioned pin is a latent break waiting
+  for the next model retirement. Rolling aliases (`sonnet`, `opus`, `haiku`)
+  do not retire and do not drift, so they carry none of these three costs.
+
+The pins encode a guess, not a measurement. This ADR is criterion 1 of issue
+#2840: the policy that says when a `model:` pin is allowed.
+
+### What measurement is actually possible
+
+Issue #2901 delivered the sweep harness (`scripts/eval/eval-model-sweep.py`
+plus `_model_sweep_core.py`) and #2902 completed the pricing table. But the
+harness is **agent-shaped**: it builds child arguments only for `--agent`,
+`--fixtures`, `--model`, `--n-runs` (`eval-model-sweep.py:158-184`) and the
+base evaluator reads `templates/agents/{agent}.shared.md`
+(`eval-agent-vs-baseline.py:104,394-406`). It cannot evaluate a skill or a
+command.
+
+Grounding the consequence: only **1 of 74 pinned skills** and **17 of 31
+pinned agents** have an `evals/<name>-spike/fixtures` directory. About 90 of
+the ~108 pinned units cannot produce a sweep at all. Any policy that says
+"pin only with a sweep" without acknowledging this would be unenforceable for
+83 percent of the pins. The adversarial review of this decision
+(`.agents/critique/ADR-080-model-pin-policy-debate.md`) treated this as the
+decisive finding.
+
+## Decision
+
+Default every skill, agent, and command to the harness-inherited model. The
+absence of a `model:` line is correct and needs no justification. Beyond that,
+the rule splits by unit kind, because only agents can be measured:
+
+1. **Skills and commands may not carry a versioned model id.** They cannot be
+   swept, so a version pin can never be justified. Their only allowed states
+   are: no `model:` line (inherit), or a bare rolling alias
+   (`sonnet` / `opus` / `haiku`) that carries a `model-rationale:` field. This
+   removes format drift, version drift, and the retirement break from all
+   skill and command pins with no eval spend.
+
+2. **Agents may carry a versioned pin only with a cited KEEP_PIN sweep.** A
+   versioned agent pin (for example `claude-opus-4-6`) is allowed only when a
+   committed sweep artifact justifies it, recorded in a sidecar manifest (see
+   point 4). The evidence bar is the harness verdict as it actually computes:
+   `delta >= 0.05` mean recall **and** the paired bootstrap CI lower bound
+   `> 0` (`_model_sweep_core.py:277`, `DEFAULT_MIN_EFFECT = 0.05`), from a
+   single-candidate-versus-default sweep (so the CI is a plain 95 percent
+   interval, not Bonferroni-widened) over **at least 8 shared fixtures**. A
+   sweep with fewer shared fixtures, or one that returns DROP_PIN, is
+   inconclusive and does not justify a pin: the pin is removed. Removing a pin
+   returns the unit to the harness default, the same baseline the majority of
+   units already run.
+
+3. **Rolling aliases are never minted from versioned ids, and the cost
+   exception is narrow.** Converting a bare alias to a versioned id (as #2891
+   did for `haiku`) downgrades the unit and re-arms the #2839 retirement risk;
+   do not do it for `sonnet` or `opus`. A `model-rationale:` cost exception is
+   valid only for an alias that prices strictly below the harness default in
+   `MODEL_PRICING_RATES_USD_PER_1K_TOKENS` (in practice `haiku`); it is not a
+   general escape hatch, and it never applies to a versioned pin.
+
+4. **Evidence lives in a sidecar manifest, not in frontmatter.** A committed
+   `.agents/governance/model-pin-evidence.json` maps each versioned agent pin
+   to its justifying artifact: unit name, pinned model id, artifact path,
+   `fixtures_sha`, harness/pricing date. Frontmatter is not used because the
+   generators copy unknown frontmatter keys straight into the customer-facing
+   mirrors (`copilot_body_translation.py:192-203`), which would ship internal
+   CI-artifact paths to Copilot and VS Code consumers.
+
+5. **The generator must stop injecting a default model.** The Copilot agent
+   generator currently injects `model: "claude-opus-4.6"` for every agent
+   (`templates/platforms/copilot-cli.yaml:95`,
+   `build/generate_agents_common.py:211-233`). While it does, removing a pin
+   from source does not remove it from the generated mirror. The migration
+   must change the generator to inherit (emit no `model:` unless the source
+   unit carries a justified one), or the policy is toothless for generated
+   agents.
+
+6. **A governance check enforces the rule as a draining ratchet.** A new
+   `scripts/validation/check_model_pins.py` scans unit frontmatter (excluding
+   `AGENTS.md` / `CLAUDE.md` examples) and fails: a skill or command with a
+   versioned id; a versioned agent pin without a valid manifest entry; a bare
+   alias without `model-rationale:`; a cost rationale on an alias that does not
+   price below the default. Because the pins predate the policy, the check
+   ships against a frozen baseline (`dict[str, str]` of unit-path to model-id),
+   grandfathering current pins and failing only on a new pin or a baselined pin
+   whose value changed without evidence. Unlike a pure freeze, the baseline
+   carries a burn-down obligation: its entry count must not grow and should
+   shrink each release until it is empty, at which point the check flips to
+   enforce. A `--update-baseline` flow plus a documented label escape hatch
+   handles legitimate exceptions with an audit trail.
+
+## Prior Art Investigation (Required when changing existing systems)
+
+### What Currently Exists
+
+- **Structure/pattern being changed**: `model:` frontmatter pins across
+  `.claude/skills/*/SKILL.md`, `.claude/agents/*.md`,
+  `.claude/commands/**/*.md`, mirrored into `src/copilot-cli` (copy) and
+  `.github/agents` (hand-maintained install copy, `build/AGENTS.md:246`).
+- **When introduced**: pins predate the eval harness; they accreted by hand.
+  The retirement break was #2839; the first cleanup was #2891 (merged); the
+  sweep harness was #2901 (merged).
+- **Original author and context**: various; the pins were hand-tuned guesses,
+  never measured.
+
+### Historical Rationale
+
+- **Why was it built this way?** No eval harness existed, so authors pinned
+  the model they believed best.
+- **What alternatives were considered?** None formally; incremental hand edits.
+- **What constraints drove the design?** Absence of a per-unit model
+  comparison, now lifted for agents by #2901.
+
+### Why Change Now
+
+- **Has the original problem changed?** Yes for agents (#2901 makes the
+  comparison runnable); no for skills and commands (still no evaluator).
+- **Is there a better solution now?** Yes: default-to-inherit plus a
+  kind-split evidence rule replaces 108 guesses with a measured, ratcheted
+  policy.
+- **What are the risks of change?** Broad blast radius. Mitigated by
+  defaulting to remove only where no evidence exists, sweeping only the ~17
+  fixture-backed agents, and shipping the check warn-then-enforce so no
+  existing pin breaks CI on landing.
+
+## Rationale
+
+### Alternatives Considered
+
+| Alternative | Pros | Cons | Why Not Chosen |
+|-------------|------|------|----------------|
+| Keep all pins, fix only spelling drift | Smallest change | Leaves 108 guesses and the retirement class in place | Does not solve pins that no evidence justifies |
+| Strip all pins now, re-pin later | Immediately uniform | Discards correct pins; re-pinning is the same churn reversed; pre-empts measurement | Owner rejected bulk-stripping without evidence |
+| Ban versioned ids entirely; allow only no-line or rolling alias; sweeps only for rare exceptions (the pure-simpler alternative) | No eval machinery, no stale artifacts, no migration spend; kills all three drift costs | Discards the owner's measured-keep goal and the harness built for it (#2901) | Partially adopted: this IS the rule for skills and commands; agents keep the evidence path per owner direction |
+| Require a sweep for every unit including skills and commands | Uniform rule | The harness cannot evaluate skills or commands; unenforceable for 83 percent of pins | Physically impossible with current tooling |
+| Default-to-inherit, kind-split evidence rule, draining ratchet (chosen) | Cheap where measurement is impossible, measured where it is possible; no flag day; drains over time | Two-kind rule is more complex than one; needs a manifest and a generator change | Matches the owner Definition of Done and what the tooling can actually do |
+
+### Trade-offs
+
+The rule is split by unit kind, which is more complex than a single sentence,
+but it is the split reality imposes: agents are measurable, skills and commands
+are not. The draining ratchet trades a clean immediate end state for a
+shippable one, and the sidecar manifest plus the generator change are one-time
+implementation costs that buy a policy that cannot be satisfied by a dangling
+frontmatter string.
+
+## Consequences
+
+### Positive
+
+- A new versioned pin cannot land without evidence (agents) or is banned
+  outright (skills, commands), so the backlog stops growing and drains.
+- Every kept agent pin cites a reproducible, identity-bound, freshness-checked
+  sweep, replacing a guess with a measurement.
+- The retirement-break class shrinks toward zero as versioned pins clear.
+- Enforcement is a gate, not prose, matching the repo's verify-over-trust
+  posture.
+
+### Negative
+
+- The migration is staged and costs API budget for the ~17 agent sweeps.
+- Two new surfaces appear: the sidecar manifest and the generator default
+  change.
+- The kind-split rule is harder to state than a single blanket rule.
+
+### Neutral
+
+- Rolling aliases remain legal (with a cost rationale where they undercut the
+  default), so intentional cheap-tier units are not forced onto the default.
+- The baseline file becomes a tracked artifact that only ratchets down.
+
+## Impact on Dependent Components
+
+| Component | Dependency Type | Required Update | Risk |
+|-----------|----------------|-----------------|------|
+| `scripts/validation/check_model_pins.py` (new) | Direct | Scanner, manifest and rationale validation, draining baseline | Medium |
+| `.agents/governance/model-pin-evidence.json` (new) | Direct | Manifest schema and initial (empty) content | Low |
+| Copilot agent generator config | Direct | Stop injecting `model: claude-opus-4.6`; inherit unless justified | Medium |
+| Skill / command copiers | Direct | Confirm no versioned `model:` survives into mirrors | Low |
+| CI workflow | Direct | Wire the check warn-then-enforce | Low |
+| Existing ~108 pinned units | Indirect | Grandfathered until swept (agents) or de-versioned (skills, commands) | Low at landing, Medium over migration |
+| Plugin manifests (`.claude`, `src/copilot-cli`) | Direct | Paired version bump in each migration PR | Low |
+
+## Implementation Notes
+
+Suggested sequence, each its own PR:
+
+1. **This ADR** (policy only).
+2. **Manifest schema plus the generator default change** so a justified pin
+   can be expressed and an unjustified one actually disappears from mirrors.
+3. **The governance check** `scripts/validation/check_model_pins.py` with a
+   scanner-derived frozen baseline, wired in warn mode, with tests.
+4. **Migration in batches**: de-version skill and command pins (remove or drop
+   to a cost-justified alias); sweep the ~17 fixture-backed agents and either
+   record a manifest entry (KEEP_PIN over >= 8 fixtures) or remove the pin.
+   Regenerate mirrors, run `build_all.py --check` and install parity, bump both
+   plugin manifests in the same PR. Flip the check to enforce once the baseline
+   drains.
+
+### Governance-check acceptance criteria (TESTING-RIGOR: positive, negative, edge)
+
+- Positive: versioned agent pin with a valid manifest entry (KEEP_PIN, unit
+  match, model match, `fixtures_sha` present, within max age) passes; bare
+  alias with a below-default cost rationale passes; unit with no `model:` line
+  passes.
+- Negative: versioned skill or command pin fails; versioned agent pin with no
+  manifest entry fails; manifest entry with `decision != KEEP_PIN`, wrong unit,
+  wrong model, or a missing artifact fails; bare alias without rationale fails;
+  cost rationale on a not-cheaper alias fails.
+- Edge: `model:` lines inside `AGENTS.md` / `CLAUDE.md` examples are ignored;
+  a stale manifest entry (past max age or default-model changed) fails; a
+  path-traversal artifact path is rejected; baseline known-pin passes, new pin
+  fails, baseline that grows fails the burn-down rule; warn mode reports but
+  exits zero, enforce mode exits nonzero.
+
+## Related Decisions
+
+- Issue #2840 (criterion 1 this ADR satisfies), #2839 (retirement break),
+  #2891 (bare-alias down-payment this ADR bounds), #2901 (sweep harness),
+  #2902 (pricing table).
+- ADR-034 (eval methodology), ADR-079 (plugin version bump ships with content).
+
+## References
+
+- `scripts/eval/eval-model-sweep.py`, `scripts/eval/_model_sweep_core.py`
+  (`qualifies = delta >= min_effect and ci_low > 0.0`, `DEFAULT_MIN_EFFECT`)
+- `scripts/eval/_eval_common.py` (`MODEL_PRICING_RATES_USD_PER_1K_TOKENS`)
+- `templates/platforms/copilot-cli.yaml`, `build/generate_agents_common.py`
+  (injected model default)
+- `scripts/validation/check_skill_md_exec_portability.py`,
+  `scripts/validation/check_vendor_portability.py` (ratchet patterns)
+- `.agents/critique/ADR-080-model-pin-policy-debate.md` (the review this ADR
+  incorporates)

--- a/.agents/architecture/ADR-080-model-pin-justification-policy.md
+++ b/.agents/architecture/ADR-080-model-pin-justification-policy.md
@@ -58,7 +58,7 @@ pinned agents** have an `evals/<name>-spike/fixtures` directory. About 90 of
 the ~108 pinned units cannot produce a sweep at all. Any policy that says
 "pin only with a sweep" without acknowledging this would be unenforceable for
 83 percent of the pins. The adversarial review of this decision
-(`.agents/critique/ADR-080-model-pin-policy-debate.md`) treated this as the
+(`.agents/analysis/ADR-080-model-pin-policy-debate.md`) treated this as the
 decisive finding.
 
 ## Decision
@@ -266,5 +266,5 @@ Suggested sequence, each its own PR:
   (injected model default)
 - `scripts/validation/check_skill_md_exec_portability.py`,
   `scripts/validation/check_vendor_portability.py` (ratchet patterns)
-- `.agents/critique/ADR-080-model-pin-policy-debate.md` (the review this ADR
+- `.agents/analysis/ADR-080-model-pin-policy-debate.md` (the review this ADR
   incorporates)

--- a/.agents/architecture/ADR-080-model-pin-justification-policy.md
+++ b/.agents/architecture/ADR-080-model-pin-justification-policy.md
@@ -102,7 +102,7 @@ the rule splits by unit kind, because only agents can be measured:
    to its justifying artifact: unit name, pinned model id, artifact path,
    `fixtures_sha`, harness/pricing date. Frontmatter is not used because the
    generators copy unknown frontmatter keys straight into the customer-facing
-   mirrors (`copilot_body_translation.py:192-203`), which would ship internal
+   mirrors (`build/scripts/copilot_body_translation.py:192-203`), which would ship internal
    CI-artifact paths to Copilot and VS Code consumers.
 
 5. **The generator must stop injecting a default model.** The Copilot agent

--- a/.agents/memory/episodes/episode-2026-07-11-session-2840-model-pin-adr.json
+++ b/.agents/memory/episodes/episode-2026-07-11-session-2840-model-pin-adr.json
@@ -1,0 +1,62 @@
+{
+  "id": "episode-2026-07-11-session-2840-model-pin-adr",
+  "session": "2026-07-11-session-2840-model-pin-adr",
+  "timestamp": "2026-07-11T00:00:00+00:00",
+  "outcome": "partial",
+  "task": "Author ADR-080, the model-pin justification policy that is criterion 1 of issue #2840. Ground the policy against the actual eval-sweep harness (#2901), run a multi-agent adversarial review (architect plus two GPT-5.5 reviewers), record the debate, incorporate all findings, and open a PR for owner review.",
+  "decisions": [
+    {
+      "id": "d001",
+      "timestamp": "2026-07-11T00:00:00+00:00",
+      "type": "implementation",
+      "context": "Re-listed open issues (3016, 2993, 2967, 2840). Per the owner's expanded mandate to write and review ADRs, selected #2840 as the keystone (its criterion 1 is an unwritten ADR).",
+      "chosen": "Re-listed open issues (3016, 2993, 2967, 2840). Per the owner's expanded mandate to write and review ADRs, selected #2840 as the keystone (its criterion 1 is an unwritten ADR).",
+      "rationale": "",
+      "outcome": "success",
+      "effects": []
+    }
+  ],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-11T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-listed open issues (3016, 2993, 2967, 2840). Per the owner's expanded mandate to write and review ADRs, selected #2840 as the keystone (its criterion 1 is an unwritten ADR).",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-11T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Grounded the policy against the real infra: eval-model-sweep.py is agent-only; only 1 of 74 pinned skills and 17 of 31 pinned agents have eval fixtures; KEEP_PIN needs delta>=0.05 AND ci_low>0; the Copilot generator injects model: claude-opus-4.6 as a default.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-11T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran the ADR Review Protocol: a multi-agent consensus debate on ADR-080 with the architect agent plus two GPT-5.5 adversarial reviewers (independent-thinker, critic). Recorded 12 findings and their resolutions in .agents/analysis/ADR-080-model-pin-policy-debate.md.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-11T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Wrote ADR-080 incorporating every finding: agent-only evidence scope, skills/commands banned from versioned pins, sidecar evidence manifest instead of frontmatter, generator default removal, draining ratchet with burn-down, freshness and identity binding, and the pure-simpler alternative recorded for the owner.",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 4
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-11-session-2840-model-pin-adr.json
+++ b/.agents/memory/episodes/episode-2026-07-11-session-2840-model-pin-adr.json
@@ -56,6 +56,14 @@
       "content": "Commit: 49e419146",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-11T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Addressed bot review on PR #3028: fixed the debate-log path references (analysis not critique), set endingCommit, and clarified that the rolling-alias cost exception resolves through the platform model_tiers mapping before the pricing lookup.",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-11-session-2840-model-pin-adr.json
+++ b/.agents/memory/episodes/episode-2026-07-11-session-2840-model-pin-adr.json
@@ -72,6 +72,14 @@
       "content": "Bot review round 3 on #3028: added the build/scripts/ path prefix to the copilot_body_translation citations and clarified the ADR-033 routing-gate reference.",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-11T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Bot review round 4: comprehensively prefixed every bare filename citation in ADR-080 and its debate log with full relative paths so all references are actionable.",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-11-session-2840-model-pin-adr.json
+++ b/.agents/memory/episodes/episode-2026-07-11-session-2840-model-pin-adr.json
@@ -64,6 +64,14 @@
       "content": "Addressed bot review on PR #3028: fixed the debate-log path references (analysis not critique), set endingCommit, and clarified that the rolling-alias cost exception resolves through the platform model_tiers mapping before the pricing lookup.",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-11T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Bot review round 3 on #3028: added the build/scripts/ path prefix to the copilot_body_translation citations and clarified the ADR-033 routing-gate reference.",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-11-session-2840-model-pin-adr.json
+++ b/.agents/memory/episodes/episode-2026-07-11-session-2840-model-pin-adr.json
@@ -48,6 +48,14 @@
       "content": "Wrote ADR-080 incorporating every finding: agent-only evidence scope, skills/commands banned from versioned pins, sidecar evidence manifest instead of frontmatter, generator default removal, draining ratchet with burn-down, freshness and identity binding, and the pure-simpler alternative recorded for the owner.",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-11T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 49e419146",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -55,7 +63,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/sessions/2026-07-11-session-2840-model-pin-adr.json
+++ b/.agents/sessions/2026-07-11-session-2840-model-pin-adr.json
@@ -129,6 +129,10 @@
     {
       "time": "T3",
       "entry": "Wrote ADR-080 incorporating every finding: agent-only evidence scope, skills/commands banned from versioned pins, sidecar evidence manifest instead of frontmatter, generator default removal, draining ratchet with burn-down, freshness and identity binding, and the pure-simpler alternative recorded for the owner."
+    },
+    {
+      "time": "T4",
+      "entry": "Addressed bot review on PR #3028: fixed the debate-log path references (analysis not critique), set endingCommit, and clarified that the rolling-alias cost exception resolves through the platform model_tiers mapping before the pricing lookup."
     }
   ],
   "endingCommit": "49e419146",

--- a/.agents/sessions/2026-07-11-session-2840-model-pin-adr.json
+++ b/.agents/sessions/2026-07-11-session-2840-model-pin-adr.json
@@ -131,7 +131,7 @@
       "entry": "Wrote ADR-080 incorporating every finding: agent-only evidence scope, skills/commands banned from versioned pins, sidecar evidence manifest instead of frontmatter, generator default removal, draining ratchet with burn-down, freshness and identity binding, and the pure-simpler alternative recorded for the owner."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "49e419146",
   "nextSteps": [
     "Owner reviews ADR-080; on acceptance, implement scripts/validation/check_model_pins.py with the frozen baseline and the sidecar manifest.",
     "Then migrate: de-version skill and command pins, sweep the ~17 fixture-backed agents, flip the check to enforce once the baseline drains."

--- a/.agents/sessions/2026-07-11-session-2840-model-pin-adr.json
+++ b/.agents/sessions/2026-07-11-session-2840-model-pin-adr.json
@@ -1,0 +1,139 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2840,
+    "date": "2026-07-11",
+    "branch": "feat/2840-model-pin-policy-adr",
+    "startingCommit": "4ece4776c",
+    "objective": "Author ADR-080, the model-pin justification policy that is criterion 1 of issue #2840. Ground the policy against the actual eval-sweep harness (#2901), run a multi-agent adversarial review (architect plus two GPT-5.5 reviewers), record the debate, incorporate all findings, and open a PR for owner review."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP is live on this local Copilot CLI (serena-* tools loaded via tool search); the project is auto-active and no separate activate_project verb is exposed on this harness."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Called serena-initial_instructions; the Serena manual loaded successfully."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md; observed the read-only rule (ADR-014) and did not modify it."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file created during the session under .agents/sessions/."
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Used the github skill scripts (new_pr, resolve threads) and ran validate scripts; read the ADR template and ADR-079 for conventions."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read the AGENTS.md skill-first rules and the surfaced usage-mandatory guidance."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/architecture/ADR-TEMPLATE.md, ADR-079, and the .agents/AGENTS.md artifact rules before authoring ADR-080."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded the repository and user memories surfaced this session (plugin versioning, push gates, eval harness, session-log rules)."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current returned feat/2840-model-pin-policy-adr."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Work is on feature branch feat/2840-model-pin-policy-adr, created off main at 4ece4776c."
+      },
+      "gitStatusVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git status inspected; only ADR-080, its debate log, and this session log are staged."
+      },
+      "startingCommitNoted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Starting commit recorded as 4ece4776c (main HEAD at branch creation)."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Session ongoing; ADR PR is being opened for owner review."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md was read only and never modified (read-only per ADR-014)."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "A policy ADR under owner review does not yet warrant a durable memory; will follow the outcome."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Ran markdownlint-cli2 on ADR-080 and the debate log; 0 errors. Byte-checked both for em/en dashes: 0."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ADR-080, the debate log, and this session log are committed together on feat/2840-model-pin-policy-adr."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "The pre-commit gates (adr-review evidence, session-log JSON, taste-lints, markdownlint) passed for this commit."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "No task-tracker changes in this ADR-authoring session."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Single-ADR session; a retrospective is not warranted."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "T0",
+      "entry": "Re-listed open issues (3016, 2993, 2967, 2840). Per the owner's expanded mandate to write and review ADRs, selected #2840 as the keystone (its criterion 1 is an unwritten ADR)."
+    },
+    {
+      "time": "T1",
+      "entry": "Grounded the policy against the real infra: eval-model-sweep.py is agent-only; only 1 of 74 pinned skills and 17 of 31 pinned agents have eval fixtures; KEEP_PIN needs delta>=0.05 AND ci_low>0; the Copilot generator injects model: claude-opus-4.6 as a default."
+    },
+    {
+      "time": "T2",
+      "entry": "Ran the ADR Review Protocol: a multi-agent consensus debate on ADR-080 with the architect agent plus two GPT-5.5 adversarial reviewers (independent-thinker, critic). Recorded 12 findings and their resolutions in .agents/analysis/ADR-080-model-pin-policy-debate.md."
+    },
+    {
+      "time": "T3",
+      "entry": "Wrote ADR-080 incorporating every finding: agent-only evidence scope, skills/commands banned from versioned pins, sidecar evidence manifest instead of frontmatter, generator default removal, draining ratchet with burn-down, freshness and identity binding, and the pure-simpler alternative recorded for the owner."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Owner reviews ADR-080; on acceptance, implement scripts/validation/check_model_pins.py with the frozen baseline and the sidecar manifest.",
+    "Then migrate: de-version skill and command pins, sweep the ~17 fixture-backed agents, flip the check to enforce once the baseline drains."
+  ]
+}

--- a/.agents/sessions/2026-07-11-session-2840-model-pin-adr.json
+++ b/.agents/sessions/2026-07-11-session-2840-model-pin-adr.json
@@ -137,6 +137,10 @@
     {
       "time": "T5",
       "entry": "Bot review round 3 on #3028: added the build/scripts/ path prefix to the copilot_body_translation citations and clarified the ADR-033 routing-gate reference."
+    },
+    {
+      "time": "T6",
+      "entry": "Bot review round 4: comprehensively prefixed every bare filename citation in ADR-080 and its debate log with full relative paths so all references are actionable."
     }
   ],
   "endingCommit": "49e419146",

--- a/.agents/sessions/2026-07-11-session-2840-model-pin-adr.json
+++ b/.agents/sessions/2026-07-11-session-2840-model-pin-adr.json
@@ -133,6 +133,10 @@
     {
       "time": "T4",
       "entry": "Addressed bot review on PR #3028: fixed the debate-log path references (analysis not critique), set endingCommit, and clarified that the rolling-alias cost exception resolves through the platform model_tiers mapping before the pricing lookup."
+    },
+    {
+      "time": "T5",
+      "entry": "Bot review round 3 on #3028: added the build/scripts/ path prefix to the copilot_body_translation citations and clarified the ADR-033 routing-gate reference."
     }
   ],
   "endingCommit": "49e419146",


### PR DESCRIPTION
## Summary

Authors **ADR-080**, criterion 1 of #2840: the policy that says when a `model:` pin is allowed. This is the keystone the other four acceptance criteria enforce. Policy only, no behavior change.

## The decision

Default every skill, agent, and command to the harness-inherited model. Beyond that the rule splits by unit kind, because only agents can be measured:

- **Skills and commands may not carry a versioned model id.** The sweep harness is agent-shaped and cannot evaluate them, so a version pin can never be justified. Allowed states: no `model:` line, or a rolling alias with a cost rationale. This removes format drift, version drift, and the retirement break from ~83 pins with zero eval spend.
- **Agents may keep a versioned pin only with a cited KEEP_PIN sweep** (`delta >= 0.05` mean recall AND the paired bootstrap CI excludes zero, over at least 8 shared fixtures). Evidence lives in a sidecar manifest, not frontmatter, because frontmatter mirrors to downstream Copilot and VS Code consumers.
- **Enforcement is a draining ratchet**: a governance check grandfathers the current pins against a frozen baseline that must shrink each release, then flips to enforce once drained.

## Why the kind split

Grounding the policy against the real infra surfaced the decisive fact: of the current pins, only **1 of 74 pinned skills** and **17 of 31 pinned agents** have eval fixtures. About 90 of ~108 pinned units cannot produce a sweep at all. A uniform "pin only with a sweep" rule would be unenforceable for 83 percent of pins. The kind split is what the tooling can actually deliver.

## adr-review

This ADR was hardened through a multi-agent adversarial debate before it was written, recorded in the debate log in this PR. Reviewers: the architect agent (Claude) plus two GPT-5.5 adversarial reviewers (independent-thinker and critic). Consensus verdict: revise-then-accept; the shape is sound, the specifics were under-specified. Twelve findings were incorporated, including three high-severity ones:

1. The KEEP_PIN bar also requires `delta >= min_effect`, not the CI condition alone.
2. `model-evidence:` in frontmatter would ship internal CI-artifact paths to consumers; evidence moved to a sidecar manifest, and the generator's injected model default must be removed or the policy is toothless for generated agents.
3. The governance check needs full identity binding (verdict AND unit AND model AND fixtures_sha AND max age), not a bare field-present check.

The GPT-5.5 independent-thinker also argued a simpler pure-alternative (ban versioned ids entirely, no eval machinery). It is partially adopted (it is exactly the rule for skills and commands) and recorded in the Alternatives table for you to choose instead if you prefer.

## Acceptance criteria (this PR)

- ADR-080 states the policy, the evidence bar, the governance-check design, and the migration sequence.
- The debate log records the multi-agent review and the resolution of every finding.
- No code behavior changes; implementation (the check, the manifest, the generator change, the migration) is sequenced as follow-up PRs.

## References

- see `scripts/eval/eval-model-sweep.py`, `scripts/eval/_model_sweep_core.py` (sweep verdict semantics)
- see `templates/platforms/copilot-cli.yaml`, `build/generate_agents_common.py` (injected model default)
- see `scripts/validation/check_skill_md_exec_portability.py` (ratchet pattern)

Refs #2840
