### PR TITLE
fix(hooks): scope pre-commit yamllint to staged files (#3031)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -658,7 +658,9 @@ elif [ -n "$STAGED_YAML_FILES" ]; then
         else
             # Respects .yamllint.yml config for the passed files.
             YAMLLINT_OUTPUT=$(mktemp)
-            if ! yamllint -f parsable "${YAML_FILES[@]}" > "$YAMLLINT_OUTPUT" 2>&1; then
+            # "--" ends option parsing so a staged path beginning with "-" is
+            # treated as a filename, not a yamllint flag (option injection).
+            if ! yamllint -f parsable -- "${YAML_FILES[@]}" > "$YAMLLINT_OUTPUT" 2>&1; then
                 echo_warning "yamllint found style issues (non-blocking):"
                 echo ""
                 # Show first 20 lines of warnings

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -635,27 +635,48 @@ elif [ -n "$STAGED_YAML_FILES" ]; then
 
     # Check if yamllint is installed
     if command -v yamllint &> /dev/null; then
-        # Run yamllint on repository root (respects .yamllint.yml config)
-        YAMLLINT_OUTPUT=$(mktemp)
-        
-        if ! yamllint -f parsable . > "$YAMLLINT_OUTPUT" 2>&1; then
-            echo_warning "yamllint found style issues (non-blocking):"
-            echo ""
-            # Show first 20 lines of warnings
-            head -20 "$YAMLLINT_OUTPUT"
-            echo ""
-            echo_info "Common style issues:"
-            echo_info "  - Line too long (exceeds 120 characters)"
-            echo_info "  - Trailing spaces"
-            echo_info "  - Inconsistent indentation"
-            echo_info "  - Missing space after comment"
-            echo ""
-            echo_info "Note: These are warnings, not errors. Fix when convenient."
-            # Non-blocking: don't set EXIT_STATUS
+        # Lint only the staged YAML files, not the whole working tree. Passing
+        # "." made yamllint walk every YAML on disk, including gitignored tool
+        # bundles (.codeql/cli alone vendors 5000+ YAMLs), which hung the commit
+        # for minutes (#3031). The staged set is already computed above.
+        # Bash 3 compatibility (macOS default): avoid mapfile/readarray.
+        YAML_FILES=()
+        while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            # Reject symlinks to prevent TOCTOU race conditions (MEDIUM-002).
+            if [ -L "$file" ]; then
+                echo_warning "Skipping symlink: $file"
+                continue
+            fi
+            # Skip anything no longer on disk (defensive; ACMR excludes deletes).
+            [ -f "$file" ] || continue
+            YAML_FILES+=("$file")
+        done <<< "$STAGED_YAML_FILES"
+
+        if [ ${#YAML_FILES[@]} -eq 0 ]; then
+            echo_info "No existing staged YAML files to lint."
         else
-            echo_success "YAML files conform to style guidelines."
+            # Respects .yamllint.yml config for the passed files.
+            YAMLLINT_OUTPUT=$(mktemp)
+            if ! yamllint -f parsable "${YAML_FILES[@]}" > "$YAMLLINT_OUTPUT" 2>&1; then
+                echo_warning "yamllint found style issues (non-blocking):"
+                echo ""
+                # Show first 20 lines of warnings
+                head -20 "$YAMLLINT_OUTPUT"
+                echo ""
+                echo_info "Common style issues:"
+                echo_info "  - Line too long (exceeds 120 characters)"
+                echo_info "  - Trailing spaces"
+                echo_info "  - Inconsistent indentation"
+                echo_info "  - Missing space after comment"
+                echo ""
+                echo_info "Note: These are warnings, not errors. Fix when convenient."
+                # Non-blocking: don't set EXIT_STATUS
+            else
+                echo_success "YAML files conform to style guidelines."
+            fi
+            rm -f "$YAMLLINT_OUTPUT"
         fi
-        rm -f "$YAMLLINT_OUTPUT"
     else
         echo_info "yamllint not installed. Skipping YAML style validation."
         echo_info ""

--- a/tests/hooks/test_pre_commit_yamllint_scope.py
+++ b/tests/hooks/test_pre_commit_yamllint_scope.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the pre-commit yamllint staged-file scoping.
+
+Regression guard for #3031. The yamllint step used to lint the entire working
+tree (``yamllint -f parsable .``), which walked thousands of files under
+gitignored tool bundles (``.codeql/cli`` alone vendors 5000+ YAMLs) and hung
+the commit for minutes whenever any YAML was staged. The fix scopes the lint to
+the staged YAML files via a bash-3-safe array build that also rejects symlinks
+(MEDIUM-002) and skips paths no longer on disk.
+
+To avoid duplicating the loop (which would drift from the hook), these tests
+extract the exact ``YAML_FILES`` array-build block from ``.githooks/pre-commit``
+and run it under bash against controlled inputs, plus a structural assertion
+that the whole-tree scan is gone.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRE_COMMIT = REPO_ROOT / ".githooks" / "pre-commit"
+
+
+def _hook_text() -> str:
+    return PRE_COMMIT.read_text(encoding="utf-8")
+
+
+def _extract_target_block() -> str:
+    """Return the YAML_FILES array-build loop from the hook.
+
+    Extracts from the ``YAML_FILES=()`` line through the terminating
+    ``done <<< "$STAGED_YAML_FILES"`` line, inclusive.
+    """
+    lines = _hook_text().splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == "YAML_FILES=()":
+            start = i
+            break
+    assert start is not None, "YAML_FILES=() array init not found in hook"
+    end = None
+    for j in range(start, len(lines)):
+        if 'done <<< "$STAGED_YAML_FILES"' in lines[j]:
+            end = j
+            break
+    assert end is not None, "array-build terminator not found in hook"
+    return "\n".join(lines[start : end + 1])
+
+
+def _run_block(paths: list[str], cwd: Path) -> list[str]:
+    """Run the extracted array-build block and return the selected targets.
+
+    ``paths`` becomes the newline-joined ``STAGED_YAML_FILES`` value. The hook
+    function ``echo_warning`` is stubbed. Returns the resulting ``YAML_FILES``
+    entries, one per line.
+    """
+    block = _extract_target_block()
+    value = "\n".join(paths)
+    script = (
+        "echo_warning() { :; }\n"
+        f'STAGED_YAML_FILES="{value}"\n'
+        f"{block}\n"
+        'if [ ${#YAML_FILES[@]} -gt 0 ]; then printf "%s\\n" "${YAML_FILES[@]}"; fi\n'
+    )
+    bash = shutil.which("bash")
+    assert bash is not None, "bash interpreter required for this test"
+    result = subprocess.run(
+        [bash, "-c", script],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [ln for ln in result.stdout.splitlines() if ln]
+
+
+# --- Positive: staged YAML files are selected ------------------------------
+
+
+def test_selects_staged_yaml_files(tmp_path: Path) -> None:
+    (tmp_path / "a.yml").write_text("k: v\n", encoding="utf-8")
+    (tmp_path / "b.yaml").write_text("k: v\n", encoding="utf-8")
+
+    selected = _run_block(["a.yml", "b.yaml"], cwd=tmp_path)
+
+    assert selected == ["a.yml", "b.yaml"]
+
+
+def test_preserves_nested_paths(tmp_path: Path) -> None:
+    nested = tmp_path / ".github" / "actions" / "x"
+    nested.mkdir(parents=True)
+    (nested / "action.yml").write_text("runs:\n", encoding="utf-8")
+
+    selected = _run_block([".github/actions/x/action.yml"], cwd=tmp_path)
+
+    assert selected == [".github/actions/x/action.yml"]
+
+
+# --- Negative / edge cases -------------------------------------------------
+
+
+def test_empty_input_selects_nothing(tmp_path: Path) -> None:
+    selected = _run_block([], cwd=tmp_path)
+
+    assert selected == []
+
+
+def test_skips_symlinks(tmp_path: Path) -> None:
+    real = tmp_path / "real.yml"
+    real.write_text("k: v\n", encoding="utf-8")
+    link = tmp_path / "link.yml"
+    link.symlink_to(real)
+
+    selected = _run_block(["link.yml", "real.yml"], cwd=tmp_path)
+
+    # Symlink rejected (MEDIUM-002); only the real path survives.
+    assert selected == ["real.yml"]
+
+
+def test_skips_paths_not_on_disk(tmp_path: Path) -> None:
+    (tmp_path / "present.yml").write_text("k: v\n", encoding="utf-8")
+
+    selected = _run_block(["present.yml", "ghost.yml"], cwd=tmp_path)
+
+    assert selected == ["present.yml"]
+
+
+# --- Structural: the whole-tree scan must not return -----------------------
+
+
+def test_hook_has_no_whole_tree_yamllint_scan() -> None:
+    text = _hook_text()
+    assert "yamllint -f parsable ." not in text, (
+        "whole-tree yamllint scan reintroduced (#3031); "
+        "scope to staged files instead"
+    )
+
+
+def test_hook_scopes_yamllint_to_array() -> None:
+    text = _hook_text()
+    assert 'yamllint -f parsable "${YAML_FILES[@]}"' in text, (
+        "yamllint must lint the staged-file array, not the whole tree"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/hooks/test_pre_commit_yamllint_scope.py
+++ b/tests/hooks/test_pre_commit_yamllint_scope.py
@@ -61,6 +61,9 @@ def _run_block(paths: list[str], cwd: Path) -> list[str]:
     """
     block = _extract_target_block()
     script = (
+        # Run under the same error mode as the hook (`.githooks/pre-commit`
+        # sets `set -e`) so the block's exit behavior matches production.
+        "set -e\n"
         "echo_warning() { :; }\n"
         f"{block}\n"
         'if [ ${#YAML_FILES[@]} -gt 0 ]; then printf "%s\\n" "${YAML_FILES[@]}"; fi\n'

--- a/tests/hooks/test_pre_commit_yamllint_scope.py
+++ b/tests/hooks/test_pre_commit_yamllint_scope.py
@@ -14,6 +14,7 @@ and run it under bash against controlled inputs, plus a structural assertion
 that the whole-tree scan is gone.
 """
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -53,26 +54,28 @@ def _extract_target_block() -> str:
 def _run_block(paths: list[str], cwd: Path) -> list[str]:
     """Run the extracted array-build block and return the selected targets.
 
-    ``paths`` becomes the newline-joined ``STAGED_YAML_FILES`` value. The hook
-    function ``echo_warning`` is stubbed. Returns the resulting ``YAML_FILES``
-    entries, one per line.
+    ``paths`` becomes the newline-joined ``STAGED_YAML_FILES`` value, passed via
+    the child environment so filenames stay literal (no bash expansion of ``$``,
+    backticks, or ``$(...)``). The hook function ``echo_warning`` is stubbed.
+    Returns the resulting ``YAML_FILES`` entries, one per line.
     """
     block = _extract_target_block()
-    value = "\n".join(paths)
     script = (
         "echo_warning() { :; }\n"
-        f'STAGED_YAML_FILES="{value}"\n'
         f"{block}\n"
         'if [ ${#YAML_FILES[@]} -gt 0 ]; then printf "%s\\n" "${YAML_FILES[@]}"; fi\n'
     )
     bash = shutil.which("bash")
     assert bash is not None, "bash interpreter required for this test"
+    env = {**os.environ, "STAGED_YAML_FILES": "\n".join(paths)}
     result = subprocess.run(
         [bash, "-c", script],
         cwd=cwd,
         capture_output=True,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         check=True,
+        env=env,
     )
     return [ln for ln in result.stdout.splitlines() if ln]
 
@@ -128,6 +131,16 @@ def test_skips_paths_not_on_disk(tmp_path: Path) -> None:
     assert selected == ["present.yml"]
 
 
+def test_selects_leading_dash_filename(tmp_path: Path) -> None:
+    # A filename starting with "-" must still be selected (and, at the yamllint
+    # call site, the "--" separator keeps it from being read as a flag).
+    (tmp_path / "-dash.yml").write_text("k: v\n", encoding="utf-8")
+
+    selected = _run_block(["-dash.yml"], cwd=tmp_path)
+
+    assert selected == ["-dash.yml"]
+
+
 # --- Structural: the whole-tree scan must not return -----------------------
 
 
@@ -141,8 +154,9 @@ def test_hook_has_no_whole_tree_yamllint_scan() -> None:
 
 def test_hook_scopes_yamllint_to_array() -> None:
     text = _hook_text()
-    assert 'yamllint -f parsable "${YAML_FILES[@]}"' in text, (
-        "yamllint must lint the staged-file array, not the whole tree"
+    assert 'yamllint -f parsable -- "${YAML_FILES[@]}"' in text, (
+        "yamllint must lint the staged-file array (with -- guard), "
+        "not the whole tree"
     )
 
 


### PR DESCRIPTION
## Summary

The pre-commit hook's yamllint step linted the entire working tree (`yamllint -f parsable .`) whenever any YAML file was staged, instead of the staged YAML files. On a real checkout that walks ~5,849 YAML files, ~5,608 of them under the gitignored `.codeql/cli` tool bundle, so the commit appeared to hang for minutes. Fixes #3031.

## Root cause

`.githooks/pre-commit` computed the staged YAML set (`STAGED_YAML_FILES`) but used it only as a gate, then ran `yamllint -f parsable .` against the whole tree. The yamllint ignore config did not cover the CodeQL CLI bundle, worktrees, or virtualenvs, so yamllint descended into all of them.

### Evidence

```
git ls-files '*.yml' '*.yaml' | wc -l   -> 97
find . -name '*.yml' -o -name '*.yaml' | wc -l   -> 5849   (5608 under .codeql/cli)
time yamllint -f parsable <one staged file>   -> 0.3s
```

## Fix

Build a bash-3-safe array of the staged YAML files (mirroring the actionlint block, including MEDIUM-002 symlink rejection and a defensive on-disk check) and pass it to yamllint instead of `.`. This scopes the check to what is being committed, drops the run to sub-second, and removes the dependency on the yamllint ignore list staying exhaustive as new tool bundles land.

## Tests

`test_pre_commit_yamllint_scope.py` (7 tests): extracts the array-build block from the hook and asserts staged-file selection, nested-path preservation, symlink skip, missing-path skip, and empty input, plus a structural guard that the whole-tree scan does not return and the scoped array form is present.

## Validation

- 7 pytest pass; full pre-push suite green (27 checks).
- ruff clean (incl. E501 ratchet), mypy clean.
- `bash -n .githooks/pre-commit` clean.
- No em/en dashes.

## Notes

The yamllint style config lives in `.yamllint.yml` (unchanged here); this PR only changes which files are handed to yamllint, not the rules.

Fixes #3031
