### PR TITLE
docs(adr): mark ADR-080 accepted (owner approved via #3028)

### DIFF
--- a/.agents/architecture/ADR-080-model-pin-justification-policy.md
+++ b/.agents/architecture/ADR-080-model-pin-justification-policy.md
@@ -1,6 +1,6 @@
 ---
 id: ADR-080
-status: proposed
+status: accepted
 date: 2026-07-11
 decision-makers: [rjmurillo]
 supersedes: []
@@ -13,7 +13,7 @@ implemented: false
 
 ## Status
 
-Proposed
+Accepted (approved by @rjmurillo on 2026-07-11, PR #3028).
 
 ## Date
 

--- a/.agents/memory/episodes/episode-2026-07-11-session-2840-model-pin-adr.json
+++ b/.agents/memory/episodes/episode-2026-07-11-session-2840-model-pin-adr.json
@@ -80,6 +80,14 @@
       "content": "Bot review round 4: comprehensively prefixed every bare filename citation in ADR-080 and its debate log with full relative paths so all references are actionable.",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-11T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Owner approved ADR-080 (PR #3028 merged). Flipped ADR-080 status proposed -> accepted in frontmatter and body.",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/sessions/2026-07-11-session-2840-model-pin-adr.json
+++ b/.agents/sessions/2026-07-11-session-2840-model-pin-adr.json
@@ -141,6 +141,10 @@
     {
       "time": "T6",
       "entry": "Bot review round 4: comprehensively prefixed every bare filename citation in ADR-080 and its debate log with full relative paths so all references are actionable."
+    },
+    {
+      "time": "T7",
+      "entry": "Owner approved ADR-080 (PR #3028 merged). Flipped ADR-080 status proposed -> accepted in frontmatter and body."
     }
   ],
   "endingCommit": "49e419146",


### PR DESCRIPTION
## Summary

Marks ADR-080 (model-pin justification policy) **accepted**, per owner approval on PR #3028.

## What changed

- `ADR-080` frontmatter `status: proposed` -> `status: accepted`, and the Status body section updated with the approval note (approved by @rjmurillo on 2026-07-11, PR #3028).
- Logged the acceptance in the session workLog for the 2840 ADR session.

## Context

The ADR itself merged in PR #3028; this flips its recorded status now that the owner has approved the decision. The multi-agent debate evidence is already on record under `## References`.

## Note on #2840

ADR-080 settles the policy for #2840 (model pins default to inherited; skills/commands cannot carry versioned pins; agents keep a pin only with cited eval evidence via a draining ratchet). The pin-removal implementation is separate ongoing work, so #2840 stays open to track it unless you want it closed.

## References

The decision record is `.agents/architecture/ADR-080-model-pin-justification-policy.md` and its debate log is `.agents/analysis/ADR-080-model-pin-policy-debate.md`.

Refs #2840
