### PR TITLE
fix(hooks): land causal-graph atomicity guard and pattern legacy note (#3034)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/memory/scripts/update_causal_graph.py
+++ b/.claude/skills/memory/scripts/update_causal_graph.py
@@ -153,7 +153,12 @@ def add_pattern(
     Returns the pattern when this episode contributes a new occurrence, or None
     when the episode already contributed (idempotent no-op). Reprocessing the
     same episode must not inflate ``occurrences`` or drift ``success_rate``
-    (#3034 follow-up); the ``episodes`` guard enforces at-most-once contribution.
+    (#3034 follow-up); the ``episodes`` guard enforces at-most-once contribution
+    for patterns created with provenance. Legacy patterns created before this
+    guard carry no ``episodes`` list, so the same heuristic as add_causal_edge
+    applies: the first reprocess bumps ``occurrences`` and ``success_rate`` once
+    (and may overcount if that episode had already contributed) before recording
+    the episode id; every later reprocess of the same episode is then a no-op.
     """
     # Check for existing pattern with same name
     for existing in graph["patterns"]:

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1507,40 +1507,52 @@ if [ -n "$STAGED_EPISODE_FILES" ]; then
                 # than a half-applied graph (#3034 review). The generator writes
                 # once per episode, so an early success followed by a later
                 # failure would otherwise persist an unstaged partial write.
+                #
+                # If a graph exists but cannot be snapshotted (mktemp or cp
+                # failure), we cannot guarantee a restore, so skip the update
+                # entirely rather than risk a half-applied graph (#3040 review).
+                # When no graph exists yet there is no prior state to protect, so
+                # the update may proceed.
                 _graph_backup=""
+                _can_update=1
                 if [ -f "$CAUSAL_GRAPH_FILE" ] && [ ! -L "$CAUSAL_GRAPH_FILE" ]; then
                     _graph_backup=$(mktemp 2>/dev/null) || _graph_backup=""
-                    if [ -n "$_graph_backup" ]; then
-                        cp -- "$CAUSAL_GRAPH_FILE" "$_graph_backup" || _graph_backup=""
+                    if [ -z "$_graph_backup" ] || ! cp -- "$CAUSAL_GRAPH_FILE" "$_graph_backup" 2>/dev/null; then
+                        _graph_backup=""
+                        _can_update=0
                     fi
                 fi
 
-                while IFS= read -r _episode; do
-                    [ -z "$_episode" ] && continue
-                    # Reject symlinks (MEDIUM-002).
-                    if [ -L "$REPO_ROOT/$_episode" ]; then
-                        echo_warning "Skipping symlink: $_episode"
-                        continue
-                    fi
-                    # Materialize the staged blob. A staged deletion has no
-                    # index blob, so "git show" fails and the episode is skipped.
-                    # Guard mktemp so its failure cannot abort this non-blocking
-                    # hook under set -e (#3034 review).
-                    _staged_tmp=$(mktemp 2>/dev/null) || {
-                        echo_warning "mktemp failed; skipping causal-graph update"
-                        UPDATE_EXIT=1
-                        break
-                    }
-                    if git show ":$_episode" > "$_staged_tmp" 2>/dev/null; then
-                        _episode_out=$("${PYTHON_CMD[@]}" "$UPDATE_CAUSAL_SCRIPT" --episode-path "$_staged_tmp" 2>&1) && _rc=0 || _rc=$?
-                        UPDATE_OUTPUT="${UPDATE_OUTPUT}${_episode_out}
-"
-                        if [ "$_rc" -ne 0 ]; then
-                            UPDATE_EXIT=$_rc
+                if [ "$_can_update" -eq 0 ]; then
+                    echo_warning "Could not snapshot the causal graph; skipping update (non-blocking)."
+                else
+                    while IFS= read -r _episode; do
+                        [ -z "$_episode" ] && continue
+                        # Reject symlinks (MEDIUM-002).
+                        if [ -L "$REPO_ROOT/$_episode" ]; then
+                            echo_warning "Skipping symlink: $_episode"
+                            continue
                         fi
-                    fi
-                    rm -f "$_staged_tmp"
-                done <<< "$STAGED_EPISODE_FILES"
+                        # Materialize the staged blob. A staged deletion has no
+                        # index blob, so "git show" fails and the episode is
+                        # skipped. Guard mktemp so its failure cannot abort this
+                        # non-blocking hook under set -e (#3034 review).
+                        _staged_tmp=$(mktemp 2>/dev/null) || {
+                            echo_warning "mktemp failed; skipping causal-graph update"
+                            UPDATE_EXIT=1
+                            break
+                        }
+                        if git show ":$_episode" > "$_staged_tmp" 2>/dev/null; then
+                            _episode_out=$("${PYTHON_CMD[@]}" "$UPDATE_CAUSAL_SCRIPT" --episode-path "$_staged_tmp" 2>&1) && _rc=0 || _rc=$?
+                            UPDATE_OUTPUT="${UPDATE_OUTPUT}${_episode_out}
+"
+                            if [ "$_rc" -ne 0 ]; then
+                                UPDATE_EXIT=$_rc
+                            fi
+                        fi
+                        rm -f "$_staged_tmp"
+                    done <<< "$STAGED_EPISODE_FILES"
+                fi
 
                 if [ $UPDATE_EXIT -eq 0 ]; then
                     # Check if causal graph was updated and stage it

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1518,6 +1518,9 @@ if [ -n "$STAGED_EPISODE_FILES" ]; then
                 if [ -f "$CAUSAL_GRAPH_FILE" ] && [ ! -L "$CAUSAL_GRAPH_FILE" ]; then
                     _graph_backup=$(mktemp 2>/dev/null) || _graph_backup=""
                     if [ -z "$_graph_backup" ] || ! cp -- "$CAUSAL_GRAPH_FILE" "$_graph_backup" 2>/dev/null; then
+                        # Remove a created-but-unusable temp file so it does not
+                        # leak when cp failed (#3043 review).
+                        [ -n "$_graph_backup" ] && rm -f "$_graph_backup"
                         _graph_backup=""
                         _can_update=0
                     fi
@@ -1554,7 +1557,12 @@ if [ -n "$STAGED_EPISODE_FILES" ]; then
                     done <<< "$STAGED_EPISODE_FILES"
                 fi
 
-                if [ $UPDATE_EXIT -eq 0 ]; then
+                if [ "$_can_update" -eq 0 ]; then
+                    # Snapshot failed; already warned above. Nothing was updated,
+                    # so do not stage or emit an "up to date" message (#3043
+                    # review).
+                    :
+                elif [ $UPDATE_EXIT -eq 0 ]; then
                     # Check if causal graph was updated and stage it
                     if [ -f "$CAUSAL_GRAPH_FILE" ]; then
                         # MEDIUM-002: Defense-in-depth symlink check before staging

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/memory/scripts/update_causal_graph.py
+++ b/src/copilot-cli/skills/memory/scripts/update_causal_graph.py
@@ -153,7 +153,12 @@ def add_pattern(
     Returns the pattern when this episode contributes a new occurrence, or None
     when the episode already contributed (idempotent no-op). Reprocessing the
     same episode must not inflate ``occurrences`` or drift ``success_rate``
-    (#3034 follow-up); the ``episodes`` guard enforces at-most-once contribution.
+    (#3034 follow-up); the ``episodes`` guard enforces at-most-once contribution
+    for patterns created with provenance. Legacy patterns created before this
+    guard carry no ``episodes`` list, so the same heuristic as add_causal_edge
+    applies: the first reprocess bumps ``occurrences`` and ``success_rate`` once
+    (and may overcount if that episode had already contributed) before recording
+    the episode id; every later reprocess of the same episode is then a no-op.
     """
     # Check for existing pattern with same name
     for existing in graph["patterns"]:

--- a/tests/hooks/test_pre_commit_causal_graph_scope.py
+++ b/tests/hooks/test_pre_commit_causal_graph_scope.py
@@ -120,6 +120,17 @@ def test_hook_snapshots_graph_for_atomicity() -> None:
     )
 
 
+def test_hook_skips_update_when_snapshot_fails() -> None:
+    text = _hook_text()
+    # If an existing graph cannot be snapshotted (mktemp or cp failure), the
+    # hook must not run the per-episode writes, because it could not restore a
+    # partial multi-episode failure (#3040 review).
+    assert "_can_update=0" in text, (
+        "pre-commit should skip the update when the graph snapshot cannot be "
+        "created, to preserve the atomicity guarantee"
+    )
+
+
 # --- behavioral guards on the generator ------------------------------------
 
 

--- a/tests/hooks/test_pre_commit_causal_graph_scope.py
+++ b/tests/hooks/test_pre_commit_causal_graph_scope.py
@@ -129,6 +129,16 @@ def test_hook_skips_update_when_snapshot_fails() -> None:
         "pre-commit should skip the update when the graph snapshot cannot be "
         "created, to preserve the atomicity guarantee"
     )
+    # A created-but-unusable temp file (mktemp ok, cp failed) must be removed,
+    # not leaked (#3043 review).
+    assert '[ -n "$_graph_backup" ] && rm -f "$_graph_backup"' in text, (
+        "pre-commit should remove the snapshot temp file when cp fails"
+    )
+    # A skipped update must not fall through to the staging/report block and
+    # print an 'up to date' success message (#3043 review).
+    assert 'if [ "$_can_update" -eq 0 ]; then' in text, (
+        "the staging block should no-op when the update was skipped"
+    )
 
 
 # --- behavioral guards on the generator ------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to PR #3040 (issue #3034). #3040 was squash-merged while I was landing
two commits that fixed Copilot review findings on that PR, so those fixes never
reached main. This PR lands them. The three review threads on #3040 were resolved
pointing at these changes, so main must carry them.

## What changed

- **Hook atomicity gap.** If the pre-commit cannot snapshot an existing causal
  graph (mktemp or cp failure), it now skips the per-episode update entirely via
  a `_can_update` guard, instead of mutating the graph with no way to restore a
  partial multi-episode failure. When no graph exists yet there is no prior state
  to protect, so the update proceeds. A structural guard covers the skip path.
- **add_pattern legacy docstring.** The docstring now carries the same legacy
  caveat as `add_causal_edge`: legacy patterns without episodes provenance get a
  one-time first-touch bump that may overcount, not a guaranteed at-most-once
  contract.

Lockstep plugin bump 0.6.33 -> 0.6.34 and regenerated the copilot-cli mirror.

## Testing

- `uv run pytest` on tests/hooks/test_pre_commit_causal_graph_scope.py: 11 passed.
- `uv run ruff check` and `uv run mypy` clean on the changed set.
- `bash -n` on the hook; `build_all.py --check` clean.

## Background

The merged #3040 covers the core #3034 fix (scope to staged episodes, episode-aware
idempotency, staged index blob, real exit-code handling, occurrence-weighted pattern
average, synced shipped tests). This PR only adds the two late review fixes. The
edit and deletion orphaning residual remains tracked in #3039.
