### PR TITLE
docs(governance): document the frontier-model operating assumption (#3041)

### DIFF
--- a/.agents/governance/agent-design-principles.md
+++ b/.agents/governance/agent-design-principles.md
@@ -6,6 +6,36 @@ These principles guide the design, implementation, and evolution of agents in th
 
 ---
 
+## Operating Assumption: Frontier-Model Execution
+
+**Statement**: This project's instructions assume a top-tier thinking frontier model runs them. Its dominant failure mode is over-thinking, not incapability.
+
+The guardrails in this repository are written to **constrain that capability down**, not to **scaffold a weaker model up**. Prescriptive and constraining instructions are calibrated for a capable model. Run this project on a materially less capable model than the current harness default and it falls outside the calibrated envelope; it may need scaffold-up instructions this project does not provide.
+
+### Why the direction matters
+
+The two costs are asymmetric. Constraining a frontier model down is a small edit: the capability is already present, so you prune over-thinking. Supporting a weaker model is not the inverse. It is not just loosening constraints; it means adding the decomposition, worked examples, and checks a weaker model needs, which costs more and may still hit the model's capability ceiling.
+
+A contributor who assumes symmetry will under-serve both tiers: the frontier model gets handcuffed, and the weaker model never gets the scaffolding it needed. Most guardrails in this repository constrain over-thinking, though a given instruction may serve another purpose.
+
+### Evidence
+
+External sources, not this project's own measurement:
+
+- Prompting Inversion (arXiv 2510.22251, Oct 2025) measured the same constrained prompt across model tiers on GSM8K. On gpt-4o it scored 97% versus 93% for chain-of-thought (n=100). On gpt-5 it scored 94.00% versus 96.36% for chain-of-thought (all 1,317 problems). The prompt that helped the mid-tier model hurt the frontier one. Read this as a prompt-preference reversal in one math benchmark, one model family (OpenAI), with the gpt-4o leg at n=100, not as a general law. The authors flag code generation as a domain where constraints might still help strong models, an open question for this repository.
+- Overthinking literature corroborates the frontier failure mode this project designs against: "Do NOT Think That Much for 2+3=?" (arXiv 2412.21187); LLMThinkBench (ACL 2026), where reasoning models emit far more output tokens than a basic task needs and GPT-5 and o-series models show near-zero accuracy gain from low to high reasoning effort; and Cuadron et al., "The Danger of Overthinking," where a higher overthinking score correlates with worse agentic-task performance.
+
+### Relationship to the model-pin policy
+
+ADR-080 (accepted, not yet implemented) sets the model-pin policy: an unpinned unit inherits the harness model, and that absence needs no justification. The policy still permits a bare rolling alias with a rationale on skills and commands, and an evidence-backed versioned pin on an agent when a cited sweep justifies it. For the inherited-model units, this project assumes the harness default stays inside the frontier-tier calibrated envelope, because the guardrails are constrain-down. If that stops being true, revisit the default-to-inherit policy and its exception rules. See [ADR-080](../architecture/ADR-080-model-pin-justification-policy.md).
+
+### How to Verify
+
+1. For a new prescriptive instruction, identify whether it constrains over-thinking or serves another documented project purpose. Both are valid.
+2. Do not merge an instruction as a default when its sole purpose is to compensate for a model below the calibrated envelope. That is scaffold-up this project does not provide, so flag it instead.
+
+---
+
 ## Principle 1: Non-Overlapping Specialization
 
 **Statement**: Each agent has a unique specialty that does not substantially overlap with other agents.
@@ -292,6 +322,7 @@ All ADRs must demonstrate compliance with all 6 principles:
 ## Related Documents
 
 - [ADR Template](../architecture/ADR-TEMPLATE.md)
+- [ADR-080: Model Pins Require Cited Eval Evidence](../architecture/ADR-080-model-pin-justification-policy.md)
 - [Steering Committee Charter](./steering-committee-charter.md)
 - [Agent Consolidation Process](./agent-consolidation-process.md)
 - [Agent Interview Protocol](./agent-interview-protocol.md)

--- a/.agents/governance/agent-design-principles.md
+++ b/.agents/governance/agent-design-principles.md
@@ -10,7 +10,7 @@ These principles guide the design, implementation, and evolution of agents in th
 
 **Statement**: This project's instructions assume a top-tier thinking frontier model runs them. Its dominant failure mode is over-thinking, not incapability.
 
-The guardrails in this repository are written to **constrain that capability down**, not to **scaffold a weaker model up**. Prescriptive and constraining instructions are calibrated for a capable model. Run this project on a materially less capable model than the current harness default and it falls outside the calibrated envelope; it may need scaffold-up instructions this project does not provide.
+The guardrails in this repository are written to **constrain that capability down**, not to **scaffold a weaker model up**. Prescriptive and constraining instructions are calibrated for a capable model. Run this project on a materially less capable model than the current harness default, and it falls outside the calibrated envelope. It may then need scaffold-up instructions this project does not provide.
 
 ### Why the direction matters
 

--- a/.agents/governance/agent-design-principles.md
+++ b/.agents/governance/agent-design-principles.md
@@ -23,7 +23,7 @@ A contributor who assumes symmetry will under-serve both tiers: the frontier mod
 External sources, not this project's own measurement:
 
 - Prompting Inversion (arXiv 2510.22251, Oct 2025) measured the same constrained prompt across model tiers on GSM8K. On gpt-4o it scored 97% versus 93% for chain-of-thought (n=100). On gpt-5 it scored 94.00% versus 96.36% for chain-of-thought (all 1,317 problems). The prompt that helped the mid-tier model hurt the frontier one. Read this as a prompt-preference reversal in one math benchmark, one model family (OpenAI), with the gpt-4o leg at n=100, not as a general law. The authors flag code generation as a domain where constraints might still help strong models, an open question for this repository.
-- Overthinking literature corroborates the frontier failure mode this project designs against: "Do NOT Think That Much for 2+3=?" (arXiv 2412.21187); LLMThinkBench (ACL 2026), where reasoning models emit far more output tokens than a basic task needs and GPT-5 and o-series models show near-zero accuracy gain from low to high reasoning effort; and Cuadron et al., "The Danger of Overthinking," where a higher overthinking score correlates with worse agentic-task performance.
+- Overthinking literature corroborates the frontier failure mode this project designs against: "Do NOT Think That Much for 2+3=?" (arXiv 2412.21187); LLMThinkBench (ACL 2026), where GPT-5 and o-series models show near-zero accuracy gain from low to high reasoning effort on basic tasks; and Cuadron et al., "The Danger of Overthinking," where a higher overthinking score correlates with worse agentic-task performance.
 
 ### Relationship to the model-pin policy
 

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -12521,6 +12521,114 @@
         "episode-2026-07-08-session-2814-adr006ci"
       ],
       "created": "2026-07-08T15:23:15.991925+00:00"
+    },
+    {
+      "id": "830078c3997a",
+      "type": "decision",
+      "label": "implementation: Selected #3041 (P1) as the next tractable issue: it documents the frontier-model operating assumption that #2840 and #3042 both depend on, and has concrete acceptance criteria with a provided draft.",
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ],
+      "created": "2026-07-14T04:09:24.917932+00:00"
+    },
+    {
+      "id": "34a94191c26b",
+      "type": "milestone",
+      "label": "milestone: Selected #3041 (P1) as the next tractable issue: it documents the frontier-model operating assumption that #2840 and #3042 both depend on, and has concrete acceptance criteria with a provided draft.",
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ],
+      "created": "2026-07-14T04:09:24.918184+00:00"
+    },
+    {
+      "id": "d8bde394ff80",
+      "type": "milestone",
+      "label": "milestone: Read ADR-080 (accepted, implemented:false; unpinned units inherit, rolling aliases and evidence-backed agent pins still permitted) and the agent-design-principles.md structure to place the assumption correctly and describe the pin policy accurately.",
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ],
+      "created": "2026-07-14T04:09:24.918414+00:00"
+    },
+    {
+      "id": "dd160906d141",
+      "type": "milestone",
+      "label": "milestone: Added an 'Operating Assumption: Frontier-Model Execution' section right after Purpose: the statement, the constrain-down vs scaffold-up asymmetry, the external evidence with the issue's caveats preserved, the relationship to ADR-080, and a How to Verify. Added an ADR-080 link to Related Documents.",
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ],
+      "created": "2026-07-14T04:09:24.918638+00:00"
+    },
+    {
+      "id": "58d93c0587ae",
+      "type": "milestone",
+      "label": "milestone: Satisfied AC2 by commenting on #2840 (the accepted ADR-080 is gated against direct edits) and AC4 by spinning out capability-floor detection as #3045; the assumption doc itself links to ADR-080.",
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ],
+      "created": "2026-07-14T04:09:24.918852+00:00"
+    },
+    {
+      "id": "6fdcd1ca973d",
+      "type": "milestone",
+      "label": "milestone: Ran a GPT-5.6 Sol adversarial review of the section. It flagged four issues: ADR-080 was misrepresented as a blanket pin removal (it is not, and it is not yet implemented); the evidence stated a two-model math result as a general law; the asymmetry used unsupported absolutes and the wrong 'loosening' framing; and one paper title dropped a character. Incorporated all four; re-review requested.",
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ],
+      "created": "2026-07-14T04:09:24.919063+00:00"
+    },
+    {
+      "id": "a6ee4c0689b7",
+      "type": "milestone",
+      "label": "milestone: Recursive re-review converged: findings 1 and 4 PASS; findings 2 and 3 refined (scoped the evidence to the GSM8K benchmark, removed an unverifiable 18x token figure and the later 'more tokens than a task needs' phrasing, and reframed How to Verify to preserve valid project-specific instructions while excluding scaffold-up-only defaults). Committed the documentation as 8964a355c; this follow-up drops the last token-budget phrasing.",
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ],
+      "created": "2026-07-14T04:09:24.919273+00:00"
+    },
+    {
+      "id": "dd1a6bc61747",
+      "type": "commit",
+      "label": "commit: Commit: 8964a355c",
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ],
+      "created": "2026-07-14T04:09:24.919494+00:00"
+    },
+    {
+      "id": "c6c194dc9f73",
+      "type": "milestone",
+      "label": "milestone: Addressed two Copilot PR review threads on #3046: split the long semicolon sentence in the assumption statement for readability, and regenerated this session's episode with --force so it carries only the real documentation commit event (8964a355c), dropping a stale starting-commit event left by an earlier endingCommit update.",
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ],
+      "created": "2026-07-14T04:09:24.919703+00:00"
+    },
+    {
+      "id": "25f2b7759e95",
+      "type": "outcome",
+      "label": "Outcome: success - Resolve issue #3041: document the project's implicit frontier-model operating assumption (guardrails are constrain-down, not scaffold-up) in .agents/governance/agent-design-principles.md, cross-reference the model-pin policy, and decide the capability-floor-detection scope. Ground the text against the real ADR-080 policy, run a GPT-5.6 Sol adversarial review of the content, and open a PR for owner review.",
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ],
+      "created": "2026-07-14T04:09:24.919916+00:00"
+    },
+    {
+      "id": "b051a7729312",
+      "type": "decision",
+      "label": "Selected #3041 (P1) as the next tractable issue: it documents the frontier-model operating assumption that #2840 and #3042 both depend on, and has concrete acceptance criteria with a provided draft.",
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ],
+      "created": "2026-07-14T04:09:24.920722+00:00"
+    },
+    {
+      "id": "4cf9da5bc698",
+      "type": "milestone",
+      "label": "Selected #3041 (P1) as the next tractable issue: it documents the frontier-model operating assumption that #2840 and #3042 both depend on, and has concrete acceptance criteria with a provided draft.",
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ],
+      "created": "2026-07-14T04:09:24.920948+00:00"
     }
   ],
   "patterns": [
@@ -12597,8 +12705,11 @@
       "trigger": "When implementation decision needed",
       "action": "Fail-closed (Option 2)",
       "success_rate": 1.0,
-      "occurrences": 396,
-      "created": "2026-06-02T04:20:23.790649+00:00"
+      "occurrences": 397,
+      "created": "2026-06-02T04:20:23.790649+00:00",
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ]
     },
     {
       "name": "recovery pattern",
@@ -13011,6 +13122,17 @@
       "weight": 0.6,
       "evidence_count": 12,
       "created": "2026-07-07T18:50:46.157581+00:00"
+    },
+    {
+      "source": "b051a7729312",
+      "target": "4cf9da5bc698",
+      "type": "causes",
+      "weight": 0.6,
+      "evidence_count": 1,
+      "episodes": [
+        "episode-2026-07-13-session-3041-frontier-model"
+      ],
+      "created": "2026-07-14T04:09:24.920971+00:00"
     }
   ]
 }

--- a/.agents/memory/episodes/episode-2026-07-13-session-3041-frontier-model.json
+++ b/.agents/memory/episodes/episode-2026-07-13-session-3041-frontier-model.json
@@ -64,6 +64,22 @@
       "content": "Commit: 49aa2ed4a",
       "caused_by": [],
       "leads_to": []
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Recursive re-review converged: findings 1 and 4 PASS; findings 2 and 3 refined (scoped the evidence to the GSM8K benchmark, removed an unverifiable 18x token figure and the later 'more tokens than a task needs' phrasing, and reframed How to Verify to preserve valid project-specific instructions while excluding scaffold-up-only defaults). Committed the documentation as 8964a355c; this follow-up drops the last token-budget phrasing.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-13T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 8964a355c",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-13-session-3041-frontier-model.json
+++ b/.agents/memory/episodes/episode-2026-07-13-session-3041-frontier-model.json
@@ -1,0 +1,78 @@
+{
+  "id": "episode-2026-07-13-session-3041-frontier-model",
+  "session": "2026-07-13-session-3041-frontier-model",
+  "timestamp": "2026-07-13T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Resolve issue #3041: document the project's implicit frontier-model operating assumption (guardrails are constrain-down, not scaffold-up) in .agents/governance/agent-design-principles.md, cross-reference the model-pin policy, and decide the capability-floor-detection scope. Ground the text against the real ADR-080 policy, run a GPT-5.6 Sol adversarial review of the content, and open a PR for owner review.",
+  "decisions": [
+    {
+      "id": "d001",
+      "timestamp": "2026-07-13T00:00:00+00:00",
+      "type": "implementation",
+      "context": "Selected #3041 (P1) as the next tractable issue: it documents the frontier-model operating assumption that #2840 and #3042 both depend on, and has concrete acceptance criteria with a provided draft.",
+      "chosen": "Selected #3041 (P1) as the next tractable issue: it documents the frontier-model operating assumption that #2840 and #3042 both depend on, and has concrete acceptance criteria with a provided draft.",
+      "rationale": "",
+      "outcome": "success",
+      "effects": []
+    }
+  ],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Selected #3041 (P1) as the next tractable issue: it documents the frontier-model operating assumption that #2840 and #3042 both depend on, and has concrete acceptance criteria with a provided draft.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read ADR-080 (accepted, implemented:false; unpinned units inherit, rolling aliases and evidence-backed agent pins still permitted) and the agent-design-principles.md structure to place the assumption correctly and describe the pin policy accurately.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added an 'Operating Assumption: Frontier-Model Execution' section right after Purpose: the statement, the constrain-down vs scaffold-up asymmetry, the external evidence with the issue's caveats preserved, the relationship to ADR-080, and a How to Verify. Added an ADR-080 link to Related Documents.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Satisfied AC2 by commenting on #2840 (the accepted ADR-080 is gated against direct edits) and AC4 by spinning out capability-floor detection as #3045; the assumption doc itself links to ADR-080.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran a GPT-5.6 Sol adversarial review of the section. It flagged four issues: ADR-080 was misrepresented as a blanket pin removal (it is not, and it is not yet implemented); the evidence stated a two-model math result as a general law; the asymmetry used unsupported absolutes and the wrong 'loosening' framing; and one paper title dropped a character. Incorporated all four; re-review requested.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-13T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 49aa2ed4a",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-13-session-3041-frontier-model.json
+++ b/.agents/memory/episodes/episode-2026-07-13-session-3041-frontier-model.json
@@ -60,24 +60,24 @@
     {
       "id": "e006",
       "timestamp": "2026-07-13T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 49aa2ed4a",
-      "caused_by": [],
-      "leads_to": []
-    },
-    {
-      "id": "e007",
-      "timestamp": "2026-07-13T00:00:00+00:00",
       "type": "milestone",
       "content": "Recursive re-review converged: findings 1 and 4 PASS; findings 2 and 3 refined (scoped the evidence to the GSM8K benchmark, removed an unverifiable 18x token figure and the later 'more tokens than a task needs' phrasing, and reframed How to Verify to preserve valid project-specific instructions while excluding scaffold-up-only defaults). Committed the documentation as 8964a355c; this follow-up drops the last token-budget phrasing.",
       "caused_by": [],
       "leads_to": []
     },
     {
-      "id": "e008",
+      "id": "e007",
       "timestamp": "2026-07-13T00:00:00+00:00",
       "type": "commit",
       "content": "Commit: 8964a355c",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-13T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Addressed two Copilot PR review threads on #3046: split the long semicolon sentence in the assumption statement for readability, and regenerated this session's episode with --force so it carries only the real documentation commit event (8964a355c), dropping a stale starting-commit event left by an earlier endingCommit update.",
       "caused_by": [],
       "leads_to": []
     }

--- a/.agents/sessions/2026-07-13-session-3041-frontier-model.json
+++ b/.agents/sessions/2026-07-13-session-3041-frontier-model.json
@@ -132,6 +132,10 @@
     {
       "time": "T5",
       "entry": "Recursive re-review converged: findings 1 and 4 PASS; findings 2 and 3 refined (scoped the evidence to the GSM8K benchmark, removed an unverifiable 18x token figure and the later 'more tokens than a task needs' phrasing, and reframed How to Verify to preserve valid project-specific instructions while excluding scaffold-up-only defaults). Committed the documentation as 8964a355c; this follow-up drops the last token-budget phrasing."
+    },
+    {
+      "time": "T6",
+      "entry": "Addressed two Copilot PR review threads on #3046: split the long semicolon sentence in the assumption statement for readability, and regenerated this session's episode with --force so it carries only the real documentation commit event (8964a355c), dropping a stale starting-commit event left by an earlier endingCommit update."
     }
   ],
   "endingCommit": "8964a355c",

--- a/.agents/sessions/2026-07-13-session-3041-frontier-model.json
+++ b/.agents/sessions/2026-07-13-session-3041-frontier-model.json
@@ -1,0 +1,138 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3041,
+    "date": "2026-07-13",
+    "branch": "feat/3041-frontier-model-assumption",
+    "startingCommit": "49aa2ed4a",
+    "objective": "Resolve issue #3041: document the project's implicit frontier-model operating assumption (guardrails are constrain-down, not scaffold-up) in .agents/governance/agent-design-principles.md, cross-reference the model-pin policy, and decide the capability-floor-detection scope. Ground the text against the real ADR-080 policy, run a GPT-5.6 Sol adversarial review of the content, and open a PR for owner review."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "No serena-* MCP tools are exposed in this Copilot CLI session's toolset, verified earlier by a tool_search_tool probe that returned no serena tools. Proceeded per the AGENTS.md Serena-unavailable fallback, reading .agents governance and architecture files directly."
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "serena-initial_instructions is not callable in this session (no serena-* tools available). Followed in-repo AGENTS.md and .claude/rules guidance instead."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md earlier this session; observed the read-only rule (ADR-014) and did not modify it."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file created for the 2026-07-13 portion of the continued session after the date rolled past the 2026-07-12 log."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current returned feat/3041-frontier-model-assumption."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Work is on the feature branch feat/3041-frontier-model-assumption, based off main at 49aa2ed4a."
+      },
+      "gitStatusVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git status inspected; only .agents/governance/agent-design-principles.md is the intended change. .serena/project.yml auto-refresh and 3 untracked auto-retro files were left unstaged."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Followed the skill-first usage-mandatory rule: used the github skill scripts for issue creation and comments (raw gh is blocked by the usage-mandatory guard)."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read ADR-080 (Decision and frontmatter, implemented:false) and the agent-design-principles.md structure before authoring; respected the adr-architect-gate by not editing the accepted ADR-080 and cross-referencing from #2840 instead."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded repository and user memories surfaced this session (session-log gate mechanics, false-completion gate two-token rule, adr-architect-gate on ADR edits, dash prohibition)."
+      },
+      "startingCommitNoted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Starting commit recorded as 49aa2ed4a (main HEAD after the #3034 fixes merged)."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "All four #3041 acceptance criteria addressed: assumption documented (AC1), asymmetry stated (AC3), cross-referenced from #2840 plus the doc links ADR-080 (AC2), capability-floor detection spun out to #3045 (AC4)."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md read only, never modified (read-only per ADR-014)."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena MCP is not callable in this session's toolset; durable context lives in the doc, the PR body, and this log."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 config excludes .agents/**, so the governance file is not linted by the repo config; byte-checked it for em/en dashes: 0."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "The #3041 documentation change is committed on feat/3041-frontier-model-assumption. endingCommit names the documentation commit (a commit cannot contain its own SHA, so the session-log commit follows it)."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Docs-only change: dash byte-check returned 0; markdownlint config excludes .agents; a GPT-5.6 Sol adversarial review of the content ran and its four findings (ADR-080 misrepresentation, evidence overclaim, asymmetry absolutes, one title typo) were incorporated. No code tests apply to a governance-doc change."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "No task-tracker changes; the work is tracked by issue #3041 and its PR."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Single-issue documentation session; a full retrospective is not warranted."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "T0",
+      "entry": "Selected #3041 (P1) as the next tractable issue: it documents the frontier-model operating assumption that #2840 and #3042 both depend on, and has concrete acceptance criteria with a provided draft."
+    },
+    {
+      "time": "T1",
+      "entry": "Read ADR-080 (accepted, implemented:false; unpinned units inherit, rolling aliases and evidence-backed agent pins still permitted) and the agent-design-principles.md structure to place the assumption correctly and describe the pin policy accurately."
+    },
+    {
+      "time": "T2",
+      "entry": "Added an 'Operating Assumption: Frontier-Model Execution' section right after Purpose: the statement, the constrain-down vs scaffold-up asymmetry, the external evidence with the issue's caveats preserved, the relationship to ADR-080, and a How to Verify. Added an ADR-080 link to Related Documents."
+    },
+    {
+      "time": "T3",
+      "entry": "Satisfied AC2 by commenting on #2840 (the accepted ADR-080 is gated against direct edits) and AC4 by spinning out capability-floor detection as #3045; the assumption doc itself links to ADR-080."
+    },
+    {
+      "time": "T4",
+      "entry": "Ran a GPT-5.6 Sol adversarial review of the section. It flagged four issues: ADR-080 was misrepresented as a blanket pin removal (it is not, and it is not yet implemented); the evidence stated a two-model math result as a general law; the asymmetry used unsupported absolutes and the wrong 'loosening' framing; and one paper title dropped a character. Incorporated all four; re-review requested."
+    }
+  ],
+  "endingCommit": "49aa2ed4a",
+  "nextSteps": [
+    "Open the PR (Fixes #3041) for owner review after the adversarial re-review confirms convergence.",
+    "Owner decides on #3045 (capability-floor detection) and #3042 (tiered eval sweep), which build on this documented assumption."
+  ]
+}

--- a/.agents/sessions/2026-07-13-session-3041-frontier-model.json
+++ b/.agents/sessions/2026-07-13-session-3041-frontier-model.json
@@ -128,9 +128,13 @@
     {
       "time": "T4",
       "entry": "Ran a GPT-5.6 Sol adversarial review of the section. It flagged four issues: ADR-080 was misrepresented as a blanket pin removal (it is not, and it is not yet implemented); the evidence stated a two-model math result as a general law; the asymmetry used unsupported absolutes and the wrong 'loosening' framing; and one paper title dropped a character. Incorporated all four; re-review requested."
+    },
+    {
+      "time": "T5",
+      "entry": "Recursive re-review converged: findings 1 and 4 PASS; findings 2 and 3 refined (scoped the evidence to the GSM8K benchmark, removed an unverifiable 18x token figure and the later 'more tokens than a task needs' phrasing, and reframed How to Verify to preserve valid project-specific instructions while excluding scaffold-up-only defaults). Committed the documentation as 8964a355c; this follow-up drops the last token-budget phrasing."
     }
   ],
-  "endingCommit": "49aa2ed4a",
+  "endingCommit": "8964a355c",
   "nextSteps": [
     "Open the PR (Fixes #3041) for owner review after the adversarial re-review confirms convergence.",
     "Owner decides on #3045 (capability-floor detection) and #3042 (tiered eval sweep), which build on this documented assumption."


### PR DESCRIPTION
## Summary

Fixes #3041.

Documents the project's implicit frontier-model operating assumption in
`agent-design-principles.md`. The project's guardrails are written for a
top-tier thinking frontier model whose failure mode is over-thinking, so they
constrain that capability down rather than scaffold a weaker model up. ADR-080
makes that assumption load-bearing (unpinned units inherit the harness model),
so stating it matters.

## Acceptance criteria

- [x] Frontier-model operating assumption documented in
  `agent-design-principles.md` (new "Operating Assumption: Frontier-Model
  Execution" section, placed right after Purpose so it frames every principle).
- [x] The pin policy cross-references the assumption: a comment on #2840 links
  it, and the section itself links to ADR-080. The accepted ADR-080 is gated
  against direct edits, so the reverse link lives on #2840 and in the section.
- [x] The constrain-down vs scaffold-up asymmetry is stated so a future
  contributor understands why supporting a weaker model is not the inverse-cost
  of the current design.
- [x] Capability-floor detection decision recorded: out of scope here, spun out
  to #3045.

## Review

Adversarially reviewed with GPT-5.6 Sol across three rounds. It corrected an
ADR-080 misstatement (a pin-evidence policy, accepted but not yet implemented,
not a blanket removal), an evidence overclaim (a two-model math-only result
presented as a general law), the asymmetry absolutes, and a paper-title typo.
Every finding is resolved, and the external citations now carry the sources'
own caveats.

## Notes

Docs-only, under `.agents/`, so no code tests apply. Byte-checked for em and en
dashes (0); the markdownlint config excludes `.agents/**`.

## Related

- #2840 (model-pin policy, the decision this assumption backs)
- #3042 (tiered eval sweep) and #3045 (capability-floor detection) build on the
  documented assumption.
