### PR TITLE
chore(lint): wrap over-long lines in three test files (#2993)

### DIFF
--- a/tests/eval/test_variance_control.py
+++ b/tests/eval/test_variance_control.py
@@ -161,17 +161,23 @@ class TestClassifyFinding:
     def test_bit_identical(self):
         text = vc.response_text_variance(["x", "x"])
         verdict = vc.verdict_distribution(["IDENTIFY", "IDENTIFY"])
-        assert vc.classify_finding(text, verdict, reps_answered=2, reps_total=2).startswith("responses-bit-identical")
+        assert vc.classify_finding(
+            text, verdict, reps_answered=2, reps_total=2
+        ).startswith("responses-bit-identical")
 
     def test_text_varies_verdict_stable(self):
         text = vc.response_text_variance(["a long answer", "a longer answer"])
         verdict = vc.verdict_distribution(["IDENTIFY", "IDENTIFY"])
-        assert vc.classify_finding(text, verdict, reps_answered=2, reps_total=2).startswith("text-varies-verdict-stable")
+        assert vc.classify_finding(
+            text, verdict, reps_answered=2, reps_total=2
+        ).startswith("text-varies-verdict-stable")
 
     def test_verdicts_vary(self):
         text = vc.response_text_variance(["a", "b"])
         verdict = vc.verdict_distribution(["IDENTIFY", "ESCALATE"])
-        assert vc.classify_finding(text, verdict, reps_answered=2, reps_total=2).startswith("verdicts-vary")
+        assert vc.classify_finding(
+            text, verdict, reps_answered=2, reps_total=2
+        ).startswith("verdicts-vary")
 
     def test_high_error_rate_odd_total(self):
         # 10 of 21 answered is fewer than half; must flag high-error-rate

--- a/tests/skills/golden-principles/test_scan_principles_diff_scope.py
+++ b/tests/skills/golden-principles/test_scan_principles_diff_scope.py
@@ -53,7 +53,9 @@ def _make_repo_with_diff(repo: Path) -> None:
 class TestGetDiffFiles:
     """Tests for diff-scoped file selection (--diff-scope)."""
 
-    def test_returns_only_changed_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_only_changed_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         _make_repo_with_diff(tmp_path)
         monkeypatch.chdir(tmp_path)
         result = get_diff_files("main")
@@ -63,7 +65,9 @@ class TestGetDiffFiles:
         assert result[0].endswith("/changed.py")
         assert os.path.isfile(result[0])
 
-    def test_returns_empty_when_no_changes(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_empty_when_no_changes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         _make_repo_with_diff(tmp_path)
         _run_git(tmp_path, "checkout", "main")
         monkeypatch.chdir(tmp_path)
@@ -106,7 +110,9 @@ class TestGetDiffFiles:
 class TestMainDiffScope:
     """Tests for the --diff-scope main entry path."""
 
-    def test_diff_scope_scans_only_changed_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_diff_scope_scans_only_changed_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         _make_repo_with_diff(tmp_path)
         # A pre-existing shell script on the base would trip GP-001 on a
         # whole-tree scan, but it is not in the diff so --diff-scope ignores it.
@@ -121,7 +127,9 @@ class TestMainDiffScope:
             result = main()
         assert result == EXIT_SUCCESS
 
-    def test_diff_scope_flags_violation_in_changed_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_diff_scope_flags_violation_in_changed_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         _make_repo_with_diff(tmp_path)
         # Add a new shell script in the diff: GP-001 (script-language) is an error.
         (tmp_path / "added.sh").write_text("echo added\n")
@@ -132,7 +140,9 @@ class TestMainDiffScope:
             result = main()
         assert result == EXIT_VIOLATIONS
 
-    def test_diff_scope_unknown_base_returns_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_diff_scope_unknown_base_returns_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # A git failure must surface as EXIT_ERROR, never a false EXIT_SUCCESS.
         _make_repo_with_diff(tmp_path)
         monkeypatch.chdir(tmp_path)
@@ -140,14 +150,18 @@ class TestMainDiffScope:
             result = main()
         assert result == EXIT_ERROR
 
-    def test_diff_scope_dash_base_returns_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_diff_scope_dash_base_returns_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         _make_repo_with_diff(tmp_path)
         monkeypatch.chdir(tmp_path)
         with patch("sys.argv", ["scan_principles.py", "--diff-scope=--bad"]):
             result = main()
         assert result == EXIT_ERROR
 
-    def test_diff_scope_empty_base_returns_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_diff_scope_empty_base_returns_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # An empty base (e.g. ship/review passing "$BASE_BRANCH" while unset) must
         # error, not silently fall through to a full-repository scan.
         _make_repo_with_diff(tmp_path)
@@ -156,7 +170,9 @@ class TestMainDiffScope:
             result = main()
         assert result == EXIT_ERROR
 
-    def test_diff_scope_catches_violation_from_subdirectory(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_diff_scope_catches_violation_from_subdirectory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # Diff paths are repo-root-relative; anchoring them to the git root means
         # the scan still finds them when cwd is a subdirectory. Without the
         # anchor the file would be skipped and the gate would pass falsely.

--- a/tests/skills/taste-lints/test_taste_lints.py
+++ b/tests/skills/taste-lints/test_taste_lints.py
@@ -397,7 +397,9 @@ def _make_repo_with_diff(repo: Path) -> None:
 class TestGetDiffFiles:
     """Tests for diff-scoped file selection (--diff-scope)."""
 
-    def test_returns_only_changed_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_only_changed_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         _make_repo_with_diff(tmp_path)
         monkeypatch.chdir(tmp_path)
         result = get_diff_files("main")
@@ -407,7 +409,9 @@ class TestGetDiffFiles:
         assert result[0].endswith("/changed.py")
         assert os.path.isfile(result[0])
 
-    def test_returns_empty_when_no_changes(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_empty_when_no_changes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         _make_repo_with_diff(tmp_path)
         _run_git(tmp_path, "checkout", "main")
         monkeypatch.chdir(tmp_path)
@@ -460,7 +464,9 @@ class TestGetDiffFiles:
 class TestMainDiffScope:
     """Tests for the --diff-scope main entry path."""
 
-    def test_diff_scope_scans_only_changed_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_diff_scope_scans_only_changed_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         _make_repo_with_diff(tmp_path)
         # Commit an oversized file on the base. A whole-tree scan would flag it,
         # but it is not in the feature diff so --diff-scope must ignore it. The
@@ -477,7 +483,9 @@ class TestMainDiffScope:
             result = main()
         assert result == EXIT_SUCCESS
 
-    def test_diff_scope_flags_violation_in_changed_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_diff_scope_flags_violation_in_changed_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         _make_repo_with_diff(tmp_path)
         oversized = tmp_path / "changed.py"
         oversized.write_text("y = 2\n" * 501)
@@ -488,7 +496,9 @@ class TestMainDiffScope:
             result = main()
         assert result == EXIT_VIOLATIONS
 
-    def test_diff_scope_unknown_base_returns_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_diff_scope_unknown_base_returns_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # A git failure must surface as EXIT_ERROR, never a false EXIT_SUCCESS.
         _make_repo_with_diff(tmp_path)
         monkeypatch.chdir(tmp_path)
@@ -496,14 +506,18 @@ class TestMainDiffScope:
             result = main()
         assert result == EXIT_ERROR
 
-    def test_diff_scope_dash_base_returns_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_diff_scope_dash_base_returns_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         _make_repo_with_diff(tmp_path)
         monkeypatch.chdir(tmp_path)
         with patch("sys.argv", ["taste_lints.py", "--diff-scope=--bad"]):
             result = main()
         assert result == EXIT_ERROR
 
-    def test_diff_scope_empty_base_returns_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_diff_scope_empty_base_returns_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # An empty base (e.g. ship/review passing "$BASE_BRANCH" while unset) must
         # error, not silently fall through to a full-repository scan.
         _make_repo_with_diff(tmp_path)
@@ -512,7 +526,9 @@ class TestMainDiffScope:
             result = main()
         assert result == EXIT_ERROR
 
-    def test_diff_scope_catches_violation_from_subdirectory(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_diff_scope_catches_violation_from_subdirectory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # Diff paths are repo-root-relative; anchoring them to the git root means
         # the lint still finds them when cwd is a subdirectory. Without the
         # anchor the file would be skipped and the gate would pass falsely.


### PR DESCRIPTION
## Summary

Refs #2993.

Down-payment on the repo-wide ruff burndown. Wraps 19 E501 (line-too-long)
violations across three test files by breaking long test-method signatures and
assert chains onto continuation lines.

## Files

- tests/skills/taste-lints/test_taste_lints.py (8)
- tests/skills/golden-principles/test_scan_principles_diff_scope.py (8)
- tests/eval/test_variance_control.py (3)

## Why these three

Chosen because they are tests-only (no plugin-mirror or .agents cascade) and
already mypy-clean, so the whole-file mypy, taste-lints, and
security-suppression gates that touching any file re-triggers all pass. That
keeps the batch a clean, low-risk landing.

## Approach

Line-wrapping only. No behavior change and no suppressions (repo policy treats
noqa as a last resort). E501 repo-wide drops from 457 to 438.

## Testing

- `uv run ruff check`: clean on all three files.
- `uv run mypy`: clean on all three files.
- `uv run pytest`: 118 passed across the three files.
