### PR TITLE
chore(lint): wrap long lines and sort imports in four test files (#2993)

### DIFF
--- a/tests/commands/test_spec_ontology.py
+++ b/tests/commands/test_spec_ontology.py
@@ -412,7 +412,10 @@ def test_completeness_check_treats_fragment_as_canonical_source(
     assert "cannot introduce an entity absent from the fragment" in normalized, (
         "REQ-local `## Ontology` sections must not mask fragment drift"
     )
-    assert "run entity coverage and decision-rule traceability only when an ontologyfragment exists" in normalized, (
+    assert (
+        "run entity coverage and decision-rule traceability only when an ontologyfragment exists"
+        in normalized
+    ), (
         "ontology checks must not fail degraded runs that lack a fragment"
     )
     assert "referenced anywhere in generated spec artifacts" in normalized, (
@@ -466,7 +469,10 @@ def test_empty_entity_vacuous_coverage_requires_no_requirement_entities(
 ) -> None:
     """Empty ontology coverage is vacuous only when REQs name no entities."""
     lowered = " ".join(completeness_text.lower().split())
-    assert "generated req, design, and task artifacts also reference no domain entities" in lowered, (
+    assert (
+        "generated req, design, and task artifacts also reference no domain entities"
+        in lowered
+    ), (
         "empty-entity ontology must require generated spec artifacts name no entities"
     )
     assert "critical entity-coverage gap" in lowered, (
@@ -500,7 +506,10 @@ def test_reference_fragment_exists_and_has_seven_sections() -> None:
 def test_reference_fragment_empty_entity_rule_matches_fail_closed_prompt() -> None:
     """The reference ontology records the same empty-entity guard as CI."""
     text = " ".join(REFERENCE_FRAGMENT.read_text(encoding="utf-8").lower().split())
-    assert "only when generated req, design, and task artifacts reference zero domain entities" in text, (
+    assert (
+        "only when generated req, design, and task artifacts reference zero domain entities"
+        in text
+    ), (
         "reference fragment must not allow O1=none to mask spec-artifact entities"
     )
     assert "ci completeness check" in text, (

--- a/tests/hooks/test_lsp_provider.py
+++ b/tests/hooks/test_lsp_provider.py
@@ -352,7 +352,10 @@ class TestYamlLanguageParsingFixes:
         serena_dir = tmp_path / ".serena"
         serena_dir.mkdir()
         (serena_dir / "project.yml").write_text(
-            "languages:\n- python  # primary language\n- typescript # frontend\n- bash#nospace_no_comment\n",
+            "languages:\n"
+            "- python  # primary language\n"
+            "- typescript # frontend\n"
+            "- bash#nospace_no_comment\n",
             encoding="utf-8",
         )
         # Inline comments stripped only when '#' has leading whitespace; the

--- a/tests/hooks/test_plugin_version_bump_guard.py
+++ b/tests/hooks/test_plugin_version_bump_guard.py
@@ -80,10 +80,15 @@ def _run(diff_stdout, find_violations_fake, tmp_path):
         # rev-parse @{push} -> rc 0 so the guard picks "@{push}" as the base.
         return _ok("")
 
-    with patch("subprocess.run", side_effect=_git_side_effect), \
-         patch("push_guard_base.get_project_directory", return_value=str(tmp_path)), \
-         patch("invoke_plugin_version_bump_guard.get_project_directory", return_value=str(tmp_path)), \
-         patch.dict(sys.modules, {"validate_plugin_version_bump": fake}):
+    with (
+        patch("subprocess.run", side_effect=_git_side_effect),
+        patch("push_guard_base.get_project_directory", return_value=str(tmp_path)),
+        patch(
+            "invoke_plugin_version_bump_guard.get_project_directory",
+            return_value=str(tmp_path),
+        ),
+        patch.dict(sys.modules, {"validate_plugin_version_bump": fake}),
+    ):
         return guard.main()
 
 

--- a/tests/skills/github/test_run_completion_gate.py
+++ b/tests/skills/github/test_run_completion_gate.py
@@ -23,7 +23,6 @@ from unittest.mock import patch
 
 import pytest
 
-
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _SCRIPT_PATH = (
     _REPO_ROOT


### PR DESCRIPTION
## Summary

Refs #2993. Second ruff down-payment.

Sorts imports and wraps long lines across four mypy-clean test files. No
behavior change; no suppressions.

## Changes

- `tests/skills/github/test_run_completion_gate.py`: I001 import sort (ruff auto-fix).
- `tests/commands/test_spec_ontology.py`: 3 E501 assert-with-message conditions
  parenthesized and split.
- `tests/hooks/test_plugin_version_bump_guard.py`: 1 E501 fixed by converting a
  backslash-continued `with` to parenthesized context managers.
- `tests/hooks/test_lsp_provider.py`: 1 E501 fixed by implicit string
  concatenation on a YAML fixture literal (byte-identical string).

## Why these four

All are tests-only (no plugin-mirror or `.agents` cascade) and already
mypy-clean, so the whole-file mypy, taste-lints, and security-suppression gates
that touching any file re-triggers all pass. Clean, low-risk landing.

## Testing

- `uv run ruff check`: clean on all four files.
- `uv run mypy`: clean on all four files.
- `uv run pytest`: 183 passed across the four files.

E501 repo-wide count drops from 438 to 432 (6 violations cleared: 1 I001 plus 5 E501).
