### PR TITLE
chore(lint): sort imports and wrap two long lines in three test files (#2993)

### DIFF
--- a/tests/commands/test_lifecycle_command_drift.py
+++ b/tests/commands/test_lifecycle_command_drift.py
@@ -92,7 +92,10 @@ def test_markdownlint_excludes_match_lifecycle_commands() -> None:
         # quotes; anchored on path-component boundary (start of line,
         # whitespace, list marker, or quote char).
         claude_re = rf"(?:^|[\s\-\"'])\.claude/commands/{re.escape(cmd)}\.md(?:[\s\"']|$)"
-        copilot_re = rf"(?:^|[\s\-\"'])src/copilot-cli/skills/{re.escape(cmd)}/SKILL\.md(?:[\s\"']|$)"
+        copilot_re = (
+            rf"(?:^|[\s\-\"'])src/copilot-cli/skills/{re.escape(cmd)}/"
+            rf"SKILL\.md(?:[\s\"']|$)"
+        )
         assert re.search(claude_re, config, re.MULTILINE), (
             f"markdownlint ignores missing entry for {cmd} (Claude Code): {claude_path}"
         )

--- a/tests/hooks/test_session_log_field_guard.py
+++ b/tests/hooks/test_session_log_field_guard.py
@@ -42,7 +42,8 @@ def _diff(stdout: str) -> subprocess.CompletedProcess[str]:
 
 
 def _valid_log() -> dict:
-    """Mirror the real session schema: markdownLintRun nested under protocolCompliance.sessionEnd."""
+    """Mirror the real session schema: markdownLintRun nested under
+    protocolCompliance.sessionEnd."""
     return {
         "session": {"id": 1234, "date": "2026-05-04"},
         "protocolCompliance": {

--- a/tests/skills/github/test_wait_for_unresolved_zero.py
+++ b/tests/skills/github/test_wait_for_unresolved_zero.py
@@ -339,8 +339,8 @@ class JsonContractStdoutTest(unittest.TestCase):
 
     def _capture(self, argv: list[str]) -> tuple[int, str, str]:
         """Run main(argv) and return (exit_code, stdout, stderr)."""
-        import io
         import contextlib
+        import io
 
         out_buf = io.StringIO()
         err_buf = io.StringIO()


### PR DESCRIPTION
## Summary

Refs #2993. Third ruff down-payment.

Sorts imports and wraps two long lines across three mypy-clean test files. No
behavior change; no suppressions.

## Changes

- `tests/skills/github/test_wait_for_unresolved_zero.py`: I001 import sort (ruff auto-fix).
- `tests/commands/test_lifecycle_command_drift.py`: 1 E501 fixed by splitting an
  rf-string regex via implicit concatenation (pattern byte-identical).
- `tests/hooks/test_session_log_field_guard.py`: 1 E501 fixed by wrapping a docstring.

## Why these three

All are tests-only (no plugin-mirror or `.agents` cascade) and already
mypy-clean, so the whole-file gates that touching any file re-triggers all pass.

## Testing

- `uv run ruff check`: clean on all three files.
- `uv run mypy`: clean on all three files.
- `uv run pytest`: 61 passed across the three files.

E501/import repo-wide count drops from 432 to 429.
