### PR TITLE
docs(memory): backfill four implementation-contract memories (#3054)

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-15-session-2602-backfill-four-implementation-contract-serena-memories.json
+++ b/.agents/memory/episodes/episode-2026-07-15-session-2602-backfill-four-implementation-contract-serena-memories.json
@@ -1,0 +1,27 @@
+{
+  "id": "episode-2026-07-15-session-2602-backfill-four-implementation-contract-serena-memories",
+  "session": "2026-07-15-session-2602-backfill-four-implementation-contract-serena-memories",
+  "timestamp": "2026-07-15T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Backfill four implementation-contract Serena memories (#3054) from completed work #2468 #2707 #2710 #2168",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-15T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: c48b74e6f5",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 5
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-15-session-2602-backfill-four-implementation-contract-serena-memories.json
+++ b/.agents/sessions/2026-07-15-session-2602-backfill-four-implementation-contract-serena-memories.json
@@ -1,0 +1,124 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2602,
+    "date": "2026-07-15",
+    "branch": "fix/backfill-serena-memories-3054",
+    "startingCommit": "c48b74e6f5",
+    "objective": "Backfill four implementation-contract Serena memories (#3054) from completed work #2468 #2707 #2710 #2168"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena active"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Manual read"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "auto-loaded"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "listed in context"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md+rules auto-loaded"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "constraints auto-loaded; #3054 scope respected"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "MEMORY.md + topical surfaced"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/backfill-serena-memories-3054"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/backfill-serena-memories-3054"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "branch off origin/main"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "c48b74e6f5"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "all MUSTs complete"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md untouched"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This change IS the memory update (4 memories + index)"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".serena/ is markdownlint-exempt; no other md changed"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "memories committed c48b74e; session log follow-up"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "validate_memory_tier.py PASS; pre-commit passed"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "item": "#3054 backfill 4 memories",
+      "evidence": "Added 4 evidence-backed memories (#2468 advisory-envelope, #2707 two-pipeline mirror recipe, #2710 eval multiprovider transport, #2168 LSP-first ADR-062) + memory-index.md row. validate_memory_tier.py PASS (344 warnings, my 4 referenced); em-dash prohibition clean; serena markdownlint-exempt. 5 files."
+    }
+  ],
+  "endingCommit": "c48b74e6f5",
+  "nextSteps": []
+}

--- a/.serena/memories/agents-two-pipeline-mirror-recipe.md
+++ b/.serena/memories/agents-two-pipeline-mirror-recipe.md
@@ -1,0 +1,22 @@
+# Two-Pipeline Agent Mirror Recipe (#2707)
+
+## Recipe
+
+To change shared agent behavior, edit BOTH of these in the same change, then regenerate:
+
+1. `src/claude/<agent>.md` , the hand-maintained Claude agent prompt (carries Claude-specific `name`/`model` frontmatter). NOT generated; edit directly.
+2. `templates/agents/<agent>.shared.md` , the shared body the Copilot CLI and VS Code copies are generated from.
+
+Then run `python3 build/generate_agents.py` to refresh the generated copies (`src/copilot-cli/agents/`, `src/vs-code-agents/`).
+
+`build/scripts/detect_agent_drift.py` FAILS if `src/claude/<agent>.md` diverges from the shared body in `templates/agents/<agent>.shared.md`. So the two must move in lockstep. Do NOT hand-edit the generated `src/copilot-cli/` or `src/vs-code-agents/` copies (canonical-source-mirror rule); add behavior to the template and regenerate.
+
+## Why (evidence)
+
+Issue #2707 shipped SkillOpt determinism fixes for `silent-failure-hunter` (an AGENT, alongside two skills). The agent fix required this two-pipeline edit; getting it wrong trips the drift gate. Contrasts with skills, which are single-source under `.claude/skills/` and mirrored to `src/copilot-cli/skills/` via `build/scripts/generate_skills.py` (directory-copy), and with slash commands (generate_commands.py).
+
+## Apply when
+
+Editing any agent's shared behavior. See `.claude/rules/claude-agents.md` MUST-1 for the binding rule.
+
+Source: issue/PR #2707 (MERGED); `.claude/rules/claude-agents.md`; `build/scripts/detect_agent_drift.py`.

--- a/.serena/memories/eval-multiprovider-transport.md
+++ b/.serena/memories/eval-multiprovider-transport.md
@@ -1,0 +1,16 @@
+# Eval Multi-Provider Transport (#2710)
+
+## Contract
+
+The eval harness can run against non-Anthropic providers when the `ANTHROPIC_API_KEY` budget is exhausted. Select via the `EVAL_PROVIDER` env var or a `--provider` flag. Anthropic stays the default on the existing dependency-free urllib path, so no existing baseline moves.
+
+- Strategy seam: `scripts/eval/_providers.py` defines `EvalProvider.complete(*, messages, system, model, max_tokens, temperature) -> str`. A new provider is a new class + one registry row; no edit to `call_api`, the retry/categorization adapter, or any eval script (Open/Closed).
+- **openai / github-models**: use the `openai` SDK. GitHub Models is OpenAI-compatible: same SDK, `base_url=https://models.github.ai/inference`, `GITHUB_TOKEN` as bearer, model names prefixed `openai/...`. The Anthropic-style separate `system` arg is folded into a leading system-role message.
+- **anthropic-sdk**: optional provider via the `anthropic` SDK. The default `anthropic` provider stays on the urllib path (no SDK dependency).
+- Providers normalize SDK errors to the exact message shapes `_anthropic_api.call_api` already emits (`<Provider> API returned HTTP <code>: ...`, `...timed out...`) so the existing `_eval_api_adapter` categorization keeps working.
+
+## Apply when
+
+Adding an eval provider, or when an eval defers with "ANTHROPIC_API_KEY budget exhausted" (the recurring blocker this fixed, e.g. on PR #2707). Do NOT `import anthropic` in a custom eval script expecting it to work by default; the SDK is only present for the optional providers.
+
+Source: issue/PR #2710 (MERGED); `scripts/eval/_providers.py`.

--- a/.serena/memories/hooks-pretooluse-advisory-envelope-contract.md
+++ b/.serena/memories/hooks-pretooluse-advisory-envelope-contract.md
@@ -1,0 +1,21 @@
+# PreToolUse Advisory-Envelope Contract (#2468)
+
+## Contract
+
+A PreToolUse hook that wants to surface advisory text to the model (not block/approve) MUST emit:
+
+```json
+{"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": "<advisory>"}}
+```
+
+It MUST NOT emit a top-level `{"decision": "allow", "reason": ...}`. The top-level `decision` field accepts only `approve` or `block`. The values `allow`/`deny`/`ask` are valid only under `hookSpecificOutput.permissionDecision`, not top-level `decision`.
+
+## Why (evidence)
+
+Issue #2468: two advisory PreToolUse hooks (`.claude/hooks/PreToolUse/invoke_correction_applier.py`, `invoke_topical_memory_injection.py`) emitted `{"decision": "allow", ...}`. The schema check rejected the output with `Hook JSON output validation failed: (root): Invalid input`, so the advisory was dropped before reaching the model. Correction memories (Self-Improving Agent) and topical memories silently never surfaced. The bad form was introduced by #1763 (2026-05-29) and #2005 (2026-05-31) and appeared twice per Bash run because the hook is registered in both `.claude/settings.json` and the `project-toolkit` plugin.
+
+## Apply when
+
+Writing or reviewing any advisory (non-blocking) PreToolUse hook. Blocking guards correctly use top-level `{"decision": "block", ...}`; only the advisory path uses the `hookSpecificOutput.additionalContext` envelope.
+
+Source: issue #2468 (CLOSED).

--- a/.serena/memories/lsp-first-enforcement-adr062.md
+++ b/.serena/memories/lsp-first-enforcement-adr062.md
@@ -1,0 +1,23 @@
+# LSP-First Navigation Enforcement (ADR-062, #2168)
+
+## What shipped
+
+A conditional, availability-gated enforcement layer that pushes agents to Serena/LSP symbol navigation over Grep/Glob/full-file Read for code files. Adapted from the MIT `nesaminua/claude-code-lsp-enforcement-kit` (JS), ported to Python.
+
+Components:
+- 7 Python hooks under `.claude/hooks/`: grep / glob / bash-grep / read / pre-delegation (agent) guards, a PostToolUse usage tracker, a SessionStart reset.
+- Shared lib: `lsp_provider`, `lsp_symbols`, `lsp_gate_state`.
+- Steering rule: `.claude/rules/lsp-first.md`.
+- Dual registration: `.claude/settings.json` + plugin `hooks.json`; generated Copilot CLI mirror.
+
+## Design invariants
+
+- **Conditional + fail-open**: the guards ALLOW the raw tool when no LSP is reachable, so they never deadlock. `detect_providers` is a config-only check, so a configured-but-down LSP needs `LSP_DOWN=true` to relax the gate (issue #2622); `SKIP_LSP_GATE=true` disables it entirely; `LSP_GATE_MODE=warn` downgrades to advisory.
+- Merge/rebase and dot-directory files bypass the read gate (issues #2454, #2622).
+- This is the ENFORCEMENT layer; the steering (AGENTS.md Serena-first) and the per-turn re-assertion hook (#1993) are the steering/nudge layers above it.
+
+## Apply when
+
+Touching LSP guards, adding a navigation tool that should route through Serena, or debugging a gate misfire (use the escape hatches above, not a hook edit). See ADR-062 (`.agents/architecture/ADR-062-conditional-lsp-first-enforcement.md`, ACCEPTED-WITH-DC) and `.claude/rules/lsp-first.md`.
+
+Source: issue #2165 / PR #2168 (MERGED); ADR-062.

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -77,6 +77,7 @@
 [Retrospective and Learning]
 |retrospective learning session failure skill persistence extract artifact: [skills-retrospective-index](skills-retrospective-index.md) (376), [retrospective/retrospective-artifact-efficiency-pattern](retrospective/retrospective-artifact-efficiency-pattern.md) (986)
 |skill sidecar observations learnings eval-harness fixtures build-model parity drift prompt-optimization ci-infrastructure: [agent-prompt-optimization-observations](agent-prompt-optimization-observations.md) (2449), [eval-harness-observations](eval-harness-observations.md) (935), [ci-infrastructure-observations](ci-infrastructure-observations.md) (890)
+|implementation contracts PreToolUse advisory envelope hookSpecificOutput two-pipeline agent mirror recipe generate_agents drift eval multiprovider transport EVAL_PROVIDER openai github-models LSP-first enforcement ADR-062 conditional fail-open: [hooks-pretooluse-advisory-envelope-contract](hooks-pretooluse-advisory-envelope-contract.md) (349), [agents-two-pipeline-mirror-recipe](agents-two-pipeline-mirror-recipe.md) (391), [eval-multiprovider-transport](eval-multiprovider-transport.md) (391), [lsp-first-enforcement-adr062](lsp-first-enforcement-adr062.md) (425)
 
 [Memory and Context]
 |context engineering token optimization progressive disclosure just-in-time: [memory/context-engineering-principles](memory/context-engineering-principles.md) (594), [memory/memory-token-efficiency](memory/memory-token-efficiency.md) (861)


### PR DESCRIPTION
## Summary

### What

Adds four evidence-backed Serena memories that record implementation contracts from completed work, so future agents can retrieve them:

- `hooks-pretooluse-advisory-envelope-contract` (#2468): advisory PreToolUse hooks must emit `hookSpecificOutput.additionalContext`, never top-level `decision:allow`.
- `agents-two-pipeline-mirror-recipe` (#2707): edit `src/claude/<agent>.md` and `templates/agents/<agent>.shared.md` in lockstep, then `generate_agents.py`; `detect_agent_drift.py` enforces it.
- `eval-multiprovider-transport` (#2710): `EVAL_PROVIDER`/`--provider` selects the `_providers.py` Strategy; anthropic stays the default urllib path.
- `lsp-first-enforcement-adr062` (#2168): 7 conditional fail-open hooks + escape hatches (`SKIP_LSP_GATE`, `LSP_DOWN`, `LSP_GATE_MODE`).

### Why

These four contracts were only in closed issues/PRs, untracked in the memory store, so an agent hitting the same surface could not recall them.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #3054 | Backfill four untracked Serena memories from completed work |

## Scope / acceptance

- Four memory files added on `main`, each preserving its source issue/PR/ADR evidence, and referenced from `memory-index.md` so the tier validator does not flag them (manual change = 5 files, within the AC cap).
- Excludes (per the issue) the three unfilled auto-retros, the superseded CVA draft, Serena config drift, and Graphify installer output.
- `validate_memory_tier.py` passes (my four are now referenced); em/en-dash prohibition clean; `.serena/**` is markdownlint-exempt.

Filed during an open-issue triage sweep (alongside PR #3058 for #3039).
