### PR TITLE
chore(lint): wrap six long lines across five test files (#2993)

### DIFF
--- a/tests/commands/test_spec_co_change_checklist.py
+++ b/tests/commands/test_spec_co_change_checklist.py
@@ -122,10 +122,12 @@ def test_co_change_checklist_concrete_example_present(step_6_region: str) -> Non
         # the section-name form of `{line_or_section}`, and the imperative
         # phrase shape. Points at the real verdict module so the worked
         # example does not push spec authors toward nonexistent paths.
-        'scripts/ai_review_common/verdict.py:"_KNOWN_VERDICT_TOKENS" -- add NEEDS_REVISION to the frozenset',
+        'scripts/ai_review_common/verdict.py:"_KNOWN_VERDICT_TOKENS" -- '
+        "add NEEDS_REVISION to the frozenset",
         # A second entry that exercises a second section-name variant of
         # `{line_or_section}` so both fragments pin distinct symbols.
-        'scripts/ai_review_common/verdict.py:"_EXTRACT_VERDICT_PATTERN" -- extend regex alternation',
+        'scripts/ai_review_common/verdict.py:"_EXTRACT_VERDICT_PATTERN" -- '
+        "extend regex alternation",
     ]
     for fragment in distinctive_fragments:
         assert fragment in step_6_region, (

--- a/tests/hooks/test_invoke_lsp_pre_delegation_guard_main.py
+++ b/tests/hooks/test_invoke_lsp_pre_delegation_guard_main.py
@@ -374,7 +374,9 @@ class TestEmitHelpers:
 # ---------------------------------------------------------------------------
 
 
-def _run_hook(stdin: str, env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+def _run_hook(
+    stdin: str, env_extra: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
     import os
 
     env = dict(os.environ)

--- a/tests/skills/security-review/test_skill_md.py
+++ b/tests/skills/security-review/test_skill_md.py
@@ -6,7 +6,13 @@ from pathlib import Path
 
 import pytest
 
-_SKILL_MD = Path(__file__).resolve().parents[3] / ".claude" / "skills" / "security-review" / "SKILL.md"
+_SKILL_MD = (
+    Path(__file__).resolve().parents[3]
+    / ".claude"
+    / "skills"
+    / "security-review"
+    / "SKILL.md"
+)
 
 
 def _read_skill() -> str:

--- a/tests/test_dependabot_workflow_token.py
+++ b/tests/test_dependabot_workflow_token.py
@@ -113,7 +113,9 @@ def test_approve_and_merge_steps_still_use_pat(workflow: dict) -> None:
     """
     job = workflow["jobs"]["dependabot"]
     write_steps = [
-        s for s in job["steps"] if s.get("name") in {"Approve PR", "Enable auto-merge for non-major updates"}
+        s
+        for s in job["steps"]
+        if s.get("name") in {"Approve PR", "Enable auto-merge for non-major updates"}
     ]
     assert len(write_steps) == 2, "expected Approve PR + Enable auto-merge steps"
     for step in write_steps:

--- a/tests/test_reconstruct_trace.py
+++ b/tests/test_reconstruct_trace.py
@@ -189,7 +189,9 @@ class TestMain:
         exit_code = main(["--sessions-dir", str(empty)])
         assert exit_code == 1
 
-    def test_specific_trace_id(self, sessions_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_specific_trace_id(
+        self, sessions_dir: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         exit_code = main(["--sessions-dir", str(sessions_dir), "--trace-id", TRACE_ID])
         assert exit_code == 0
         captured = capsys.readouterr()


### PR DESCRIPTION
## Summary

Refs #2993. Fourth ruff down-payment.

Wraps six E501 long lines across five mypy-clean test files: function and method
signatures, a list comprehension, two list-item strings (implicit
concatenation, byte-identical), and a path chain. No behavior change; no
suppressions.

## Files

- `tests/test_reconstruct_trace.py`
- `tests/hooks/test_invoke_lsp_pre_delegation_guard_main.py`
- `tests/test_dependabot_workflow_token.py`
- `tests/commands/test_spec_co_change_checklist.py`
- `tests/skills/security-review/test_skill_md.py`

## Testing

- `uv run ruff check`: clean on all five files.
- `uv run mypy`: clean on all five files.
- `uv run pytest`: 62 passed across the five files.

E501 repo-wide count drops from 429 to 423.

## Note

The easy clean-vein for #2993 (mypy-clean tests-only files) is thinning. Most
remaining candidates are coupled to #2876 mypy debt: touching them re-triggers
whole-file mypy, which fails on latent errors in imported source modules (for
example the dual-import `no-redef` pattern across the `scripts/quality_gate/`
modules). Further burndown of those files should ride on top of the #2876 fix.
