### PR TITLE
feat(eval): tiered model-panel sweep harness (#3042)

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-15-session-2604-build-tiered-model-panel-sweep-harness.json
+++ b/.agents/memory/episodes/episode-2026-07-15-session-2604-build-tiered-model-panel-sweep-harness.json
@@ -1,0 +1,35 @@
+{
+  "id": "episode-2026-07-15-session-2604-build-tiered-model-panel-sweep-harness",
+  "session": "2026-07-15-session-2604-build-tiered-model-panel-sweep-harness",
+  "timestamp": "2026-07-15T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Build tiered model-panel sweep harness (#3042): panel config, per-tier effect-size, degradation classification, dry-run, tests",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-15T00:00:00+00:00",
+      "type": "test",
+      "content": "scripts/eval/_model_panel_core.py + eval-model-panel.py + 24 tests. Reuses eval-agent-vs-baseline via #2710 --provider/--model; effect-size=recall_delta, degradation classification vs frontier band; --dry-run zero-spend; panel --panel-config-overridable. uv run pytest tests/eval/ -> 293 passed; ruff+mypy clean; no suppressions. Paid sweep owner-gated; unblocks #3045 #2840.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-15T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 79515f40df",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 2
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-15-session-2604-build-tiered-model-panel-sweep-harness.json
+++ b/.agents/sessions/2026-07-15-session-2604-build-tiered-model-panel-sweep-harness.json
@@ -1,0 +1,124 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2604,
+    "date": "2026-07-15",
+    "branch": "feat/tiered-model-panel-3042",
+    "startingCommit": "79515f40df",
+    "objective": "Build tiered model-panel sweep harness (#3042): panel config, per-tier effect-size, degradation classification, dry-run, tests"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "verified this session"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "verified this session"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "verified this session"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "verified this session"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "verified this session"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "verified this session"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "verified this session"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "feat/tiered-model-panel-3042"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On feat/tiered-model-panel-3042"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "79515f40df"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "verified this session"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "verified this session"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "verified this session"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "verified this session"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "verified this session"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "item": "#3042 tiered model-panel harness",
+      "evidence": "scripts/eval/_model_panel_core.py + eval-model-panel.py + 24 tests. Reuses eval-agent-vs-baseline via #2710 --provider/--model; effect-size=recall_delta, degradation classification vs frontier band; --dry-run zero-spend; panel --panel-config-overridable. uv run pytest tests/eval/ -> 293 passed; ruff+mypy clean; no suppressions. Paid sweep owner-gated; unblocks #3045 #2840."
+    }
+  ],
+  "endingCommit": "79515f40df",
+  "nextSteps": []
+}

--- a/scripts/eval/_model_panel_core.py
+++ b/scripts/eval/_model_panel_core.py
@@ -1,0 +1,292 @@
+"""Pure model and aggregation for the tiered model-panel sweep (issue #3042).
+
+The eval harness (`eval-agent-vs-baseline.py`) validates a unit (agent/skill)
+against ONE model. #3042 wants each unit swept across a tiered panel: two
+frontier tiers as the pass/fail reference band and lower tiers as degradation
+observation points, reporting effect size per tier per unit so a unit that
+degrades sharply below frontier is visible instead of assumed.
+
+This module is pure: the panel config, the per-tier effect-size matrix, the
+degradation classification, and the report shapes. All eval execution (running
+the harness through a provider) lives in `eval-model-panel.py` behind a single
+runner seam, so this logic is unit-testable with no API spend.
+
+Effect size per (unit, tier) is the harness's `recall_delta` (variant recall
+minus baseline recall): how much the unit's prompt helps at that tier. The
+reference band is the mean recall_delta over the frontier tiers; a probe tier
+"degrades" when its recall_delta falls more than `drop_threshold` below that
+band. The two frontier models (roles == "reference") set the band; the lower
+tiers (roles == "probe") are observed, never gating.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+# Roles a panel tier can play. A reference tier defines the pass/fail band; a
+# probe tier is observed for degradation and never gates.
+ROLE_REFERENCE = "reference"
+ROLE_PROBE = "probe"
+_ROLES = (ROLE_REFERENCE, ROLE_PROBE)
+
+# Default recall_delta drop (below the reference band) that flags a probe tier
+# as degraded for a unit. Overridable per run.
+DEFAULT_DROP_THRESHOLD = 0.15
+
+
+class PanelConfigError(ValueError):
+    """A panel config is malformed or names an unknown provider."""
+
+
+@dataclass(frozen=True)
+class PanelTier:
+    """One row of the model panel: a labelled (provider, model) at a role.
+
+    The GPT-5.6 tier model ids (Sol/Terra) are deployment-specific, so the panel
+    is data, not hardcoded: supply it via `--panel-config` (see `default_panel`
+    for the documented shape). `label` is the human tier name (opus/sol/...).
+    """
+
+    label: str
+    role: str
+    provider: str
+    model: str
+
+    @property
+    def is_reference(self) -> bool:
+        return self.role == ROLE_REFERENCE
+
+
+@dataclass(frozen=True)
+class Panel:
+    """The ordered tier list plus the degradation threshold."""
+
+    tiers: tuple[PanelTier, ...]
+    drop_threshold: float = DEFAULT_DROP_THRESHOLD
+
+    @property
+    def reference_tiers(self) -> tuple[PanelTier, ...]:
+        return tuple(t for t in self.tiers if t.is_reference)
+
+    @property
+    def probe_tiers(self) -> tuple[PanelTier, ...]:
+        return tuple(t for t in self.tiers if not t.is_reference)
+
+
+def default_panel() -> Panel:
+    """The documented default panel from #3042.
+
+    Two frontier reference tiers (Opus, Sol) plus two degradation probes
+    (Sonnet, Terra). The Anthropic model ids are concrete; the GPT-5.6 (Sol,
+    Terra) ids are placeholders the owner must confirm for their deployment,
+    which is exactly why the panel is `--panel-config`-overridable.
+    """
+    return Panel(
+        tiers=(
+            PanelTier("opus", ROLE_REFERENCE, "anthropic", "claude-opus-4-8"),
+            PanelTier("sol", ROLE_REFERENCE, "openai", "openai/gpt-5.6"),
+            PanelTier("sonnet", ROLE_PROBE, "anthropic", "claude-sonnet-4-6"),
+            PanelTier("terra", ROLE_PROBE, "openai", "openai/gpt-5.6-mini"),
+        ),
+    )
+
+
+def parse_panel(
+    payload: dict[str, Any], *, known_providers: set[str] | None = None,
+) -> Panel:
+    """Build a Panel from a config mapping. Raises PanelConfigError on any defect.
+
+    Shape: ``{"drop_threshold"?: float, "tiers": [{"label","role","provider",
+    "model"}, ...]}``. At least one reference tier is required (an empty
+    reference band cannot define pass/fail). ``known_providers``, when given,
+    rejects a tier naming a provider the transport cannot resolve.
+    """
+    raw_tiers = payload.get("tiers")
+    if not isinstance(raw_tiers, list) or not raw_tiers:
+        raise PanelConfigError("panel config must have a non-empty 'tiers' list")
+    tiers: list[PanelTier] = []
+    for index, row in enumerate(raw_tiers):
+        if not isinstance(row, dict):
+            raise PanelConfigError(f"tier {index} is not an object")
+        missing = [k for k in ("label", "role", "provider", "model") if not row.get(k)]
+        if missing:
+            raise PanelConfigError(
+                f"tier {index} missing field(s): {', '.join(missing)}"
+            )
+        role = str(row["role"])
+        if role not in _ROLES:
+            raise PanelConfigError(
+                f"tier {row['label']!r} has role {role!r}; expected one of {_ROLES}"
+            )
+        provider = str(row["provider"])
+        if known_providers is not None and provider not in known_providers:
+            raise PanelConfigError(
+                f"tier {row['label']!r} names unknown provider {provider!r}; "
+                f"known: {sorted(known_providers)}"
+            )
+        tiers.append(
+            PanelTier(str(row["label"]), role, provider, str(row["model"]))
+        )
+    if not any(t.is_reference for t in tiers):
+        raise PanelConfigError("panel needs at least one 'reference' tier")
+    threshold = payload.get("drop_threshold", DEFAULT_DROP_THRESHOLD)
+    try:
+        threshold = float(threshold)
+    except (TypeError, ValueError) as exc:
+        raise PanelConfigError("drop_threshold must be a number") from exc
+    return Panel(tiers=tuple(tiers), drop_threshold=threshold)
+
+
+@dataclass
+class CellResult:
+    """One (unit, tier) sweep outcome: the effect size or an error."""
+
+    unit: str
+    tier: str
+    recall_delta: float | None = None
+    ci_low: float | None = None
+    ci_high: float | None = None
+    error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None and self.recall_delta is not None
+
+
+@dataclass
+class UnitVerdict:
+    """Per-unit degradation summary across the panel."""
+
+    unit: str
+    reference_delta: float | None
+    probe_deltas: dict[str, float | None]
+    degraded_tiers: list[str] = field(default_factory=list)
+    robust: bool = False
+    incomplete: bool = False
+
+
+def cell_from_report(unit: str, tier: str, report: dict[str, Any]) -> CellResult:
+    """Extract the effect size from a harness report.json mapping."""
+    delta = report.get("recall_delta")
+    ci = report.get("bootstrap_ci_95") or [None, None]
+    if not isinstance(delta, (int, float)):
+        return CellResult(unit, tier, error="report has no numeric recall_delta")
+    low = ci[0] if isinstance(ci, list) and len(ci) == 2 else None
+    high = ci[1] if isinstance(ci, list) and len(ci) == 2 else None
+    return CellResult(
+        unit=unit,
+        tier=tier,
+        recall_delta=float(delta),
+        ci_low=float(low) if isinstance(low, (int, float)) else None,
+        ci_high=float(high) if isinstance(high, (int, float)) else None,
+    )
+
+
+def summarize_unit(
+    unit: str, panel: Panel, cells: dict[str, CellResult],
+) -> UnitVerdict:
+    """Classify one unit's degradation across the panel.
+
+    The reference band is the mean recall_delta over the reference tiers that
+    scored. A probe tier degrades when its recall_delta is more than
+    ``panel.drop_threshold`` below that band. A unit with no scored reference
+    tier is ``incomplete`` (no band to compare against). A unit with a complete
+    band and no degraded probe is ``robust`` (a good `auto`/cheap candidate).
+    """
+    ref_deltas: list[float] = []
+    for tier in panel.reference_tiers:
+        cell = cells.get(tier.label)
+        if cell is not None and cell.ok and cell.recall_delta is not None:
+            ref_deltas.append(cell.recall_delta)
+    reference = (sum(ref_deltas) / len(ref_deltas)) if ref_deltas else None
+
+    probe_deltas: dict[str, float | None] = {}
+    degraded: list[str] = []
+    for tier in panel.probe_tiers:
+        cell = cells.get(tier.label)
+        value = cell.recall_delta if cell and cell.ok else None
+        probe_deltas[tier.label] = value
+        if reference is not None and value is not None:
+            if reference - value > panel.drop_threshold:
+                degraded.append(tier.label)
+
+    incomplete = reference is None or any(v is None for v in probe_deltas.values())
+    robust = (not incomplete) and not degraded
+    return UnitVerdict(
+        unit=unit,
+        reference_delta=reference,
+        probe_deltas=probe_deltas,
+        degraded_tiers=degraded,
+        robust=robust,
+        incomplete=incomplete,
+    )
+
+
+def summarize(
+    panel: Panel, results: list[CellResult],
+) -> list[UnitVerdict]:
+    """Group cells by unit and classify each. Deterministic unit order."""
+    by_unit: dict[str, dict[str, CellResult]] = {}
+    for cell in results:
+        by_unit.setdefault(cell.unit, {})[cell.tier] = cell
+    return [summarize_unit(u, panel, by_unit[u]) for u in sorted(by_unit)]
+
+
+def to_json(panel: Panel, verdicts: list[UnitVerdict]) -> dict[str, object]:
+    return {
+        "drop_threshold": panel.drop_threshold,
+        "reference_tiers": [t.label for t in panel.reference_tiers],
+        "probe_tiers": [t.label for t in panel.probe_tiers],
+        "units": [
+            {
+                "unit": v.unit,
+                "reference_delta": (
+                    round(v.reference_delta, 4)
+                    if v.reference_delta is not None else None
+                ),
+                "probe_deltas": {
+                    k: (round(x, 4) if x is not None else None)
+                    for k, x in v.probe_deltas.items()
+                },
+                "degraded_tiers": v.degraded_tiers,
+                "robust": v.robust,
+                "incomplete": v.incomplete,
+            }
+            for v in verdicts
+        ],
+    }
+
+
+def to_human(panel: Panel, verdicts: list[UnitVerdict]) -> str:
+    lines = [
+        f"Model-panel sweep: {len(verdicts)} unit(s), reference band "
+        f"{[t.label for t in panel.reference_tiers]}, "
+        f"drop threshold {panel.drop_threshold:g}",
+    ]
+    for v in verdicts:
+        if v.incomplete:
+            tag = "INCOMPLETE"
+        elif v.robust:
+            tag = "robust across tiers"
+        else:
+            tag = f"DEGRADES at {', '.join(v.degraded_tiers)}"
+        ref = "n/a" if v.reference_delta is None else f"{v.reference_delta:+.3f}"
+        probes = ", ".join(
+            f"{k}={'n/a' if x is None else f'{x:+.3f}'}"
+            for k, x in v.probe_deltas.items()
+        )
+        lines.append(f"  {v.unit}: ref={ref} | {probes} | {tag}")
+    return "\n".join(lines)
+
+
+def load_panel_config(text: str, *, known_providers: set[str] | None = None) -> Panel:
+    """Parse a JSON panel-config string into a Panel."""
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise PanelConfigError(f"panel config is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise PanelConfigError("panel config must be a JSON object")
+    return parse_panel(payload, known_providers=known_providers)

--- a/scripts/eval/eval-model-panel.py
+++ b/scripts/eval/eval-model-panel.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Tiered model-panel sweep CLI (issue #3042).
+
+Sweeps each unit (agent/skill) across a tiered model panel by invoking the
+existing `eval-agent-vs-baseline.py` harness once per (unit, tier) with that
+tier's `--provider`/`--model`, then aggregates the per-tier `recall_delta` into
+a degradation report (see `_model_panel_core`). Two frontier tiers set the
+pass/fail reference band; lower tiers are observed for degradation, never gating.
+
+Spend boundary: `--dry-run` validates the panel and prints the planned harness
+invocations with ZERO API spend. A live run costs (units x tiers x n-runs x 2)
+model calls across two vendors, so the panel and run budget are an owner
+decision (#3042); the harness, dry-run, and report land first behind offline
+tests.
+
+Exit codes (AGENTS.md): 0 ok, 2 config (bad panel/args), 3 external (a harness
+invocation failed during a live run).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+_EVAL_DIR = Path(__file__).resolve().parent
+if str(_EVAL_DIR) not in sys.path:
+    sys.path.insert(0, str(_EVAL_DIR))
+
+from _model_panel_core import (  # noqa: E402
+    CellResult,
+    Panel,
+    PanelConfigError,
+    PanelTier,
+    cell_from_report,
+    default_panel,
+    load_panel_config,
+    summarize,
+    to_human,
+    to_json,
+)
+
+EXIT_OK = 0
+EXIT_CONFIG = 2
+EXIT_EXTERNAL = 3
+
+_HARNESS = _EVAL_DIR / "eval-agent-vs-baseline.py"
+
+# A runner turns a (unit, tier, n_runs, fixtures) request into the harness's
+# report.json mapping, or raises RuntimeError. The default runner shells out to
+# eval-agent-vs-baseline.py; tests inject a fake to exercise aggregation offline.
+Runner = Callable[[str, PanelTier, int, str], dict[str, object]]
+
+
+def _default_runner(unit: str, tier: PanelTier, n_runs: int, fixtures: str) -> dict[str, object]:
+    """Run the harness for one (unit, tier) and return its parsed report.json.
+
+    Reuses the whole existing pipeline (recall, bootstrap CI, cost) via the
+    documented `--provider`/`--model` flags added in #2710. Raises RuntimeError
+    on a non-zero exit or unreadable report so the caller records the cell as an
+    error instead of a silent zero.
+    """
+    argv = [
+        sys.executable, str(_HARNESS),
+        "--agent", unit,
+        "--fixtures", fixtures,
+        "--n-runs", str(n_runs),
+        "--provider", tier.provider,
+        "--model", tier.model,
+        "--output-format", "json",
+    ]
+    try:
+        completed = subprocess.run(
+            argv, capture_output=True, text=True, timeout=1800, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"harness invocation failed: {exc}") from exc
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"harness exited {completed.returncode}: "
+            f"{(completed.stderr or completed.stdout)[:200]}"
+        )
+    try:
+        report = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"harness stdout was not JSON: {exc}") from exc
+    if not isinstance(report, dict):
+        raise RuntimeError("harness report was not a JSON object")
+    return report
+
+
+def sweep(
+    panel: Panel,
+    units: list[str],
+    *,
+    fixtures_template: str,
+    n_runs: int,
+    runner: Runner,
+) -> list[CellResult]:
+    """Run every (unit, tier) cell through the runner and collect results.
+
+    `fixtures_template` is formatted with `{unit}` per unit. A cell whose runner
+    raises is recorded as an errored CellResult (the sweep continues), so one
+    provider outage does not lose the rest of the matrix.
+    """
+    results: list[CellResult] = []
+    for unit in units:
+        fixtures = fixtures_template.format(unit=unit)
+        for tier in panel.tiers:
+            try:
+                report = runner(unit, tier, n_runs, fixtures)
+            except RuntimeError as exc:
+                results.append(CellResult(unit, tier.label, error=str(exc)))
+                continue
+            results.append(cell_from_report(unit, tier.label, report))
+    return results
+
+
+def _resolve_panel(args: argparse.Namespace) -> Panel:
+    known = _known_providers()
+    if args.panel_config:
+        text = Path(args.panel_config).read_text(encoding="utf-8")
+        return load_panel_config(text, known_providers=known)
+    return default_panel()
+
+
+def _known_providers() -> set[str] | None:
+    """Provider names the transport can resolve, or None if unavailable."""
+    try:
+        from _providers import known_provider_names
+    except Exception:  # noqa: BLE001 - transport optional at config time
+        return None
+    try:
+        return set(known_provider_names())
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _dry_run_report(panel: Panel, units: list[str], n_runs: int) -> str:
+    planned = len(units) * len(panel.tiers)
+    lines = [
+        f"DRY RUN: {len(units)} unit(s) x {len(panel.tiers)} tier(s) = "
+        f"{planned} harness invocation(s), n-runs={n_runs}, ZERO spend.",
+        f"  reference band: {[t.label for t in panel.reference_tiers]}",
+    ]
+    for unit in units:
+        for tier in panel.tiers:
+            lines.append(
+                f"  - {unit} @ {tier.label} ({tier.role}): "
+                f"provider={tier.provider} model={tier.model}"
+            )
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Sweep each unit across a tiered model panel and report per-tier "
+            "effect size / degradation (issue #3042)."
+        )
+    )
+    parser.add_argument(
+        "--agents", nargs="+", required=True,
+        help="Units (agent names) to sweep.",
+    )
+    parser.add_argument(
+        "--fixtures-template",
+        default="evals/{unit}-spike/fixtures",
+        help="Fixtures path per unit; {unit} substitutes the unit name.",
+    )
+    parser.add_argument("--n-runs", type=int, default=3, help="Runs per cell (default: 3).")
+    parser.add_argument(
+        "--panel-config", default=None,
+        help="JSON panel config path; omit to use the documented default panel.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Validate the panel and print the plan with zero spend.",
+    )
+    parser.add_argument(
+        "--report", type=Path, default=None,
+        help="Write the JSON summary to this path (accretes a sample log).",
+    )
+    parser.add_argument(
+        "--output-format", choices=("human", "json"), default="human",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None, *, runner: Runner | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    if args.n_runs < 1:
+        print(f"error: --n-runs must be >= 1, got {args.n_runs}", file=sys.stderr)
+        return EXIT_CONFIG
+    try:
+        panel = _resolve_panel(args)
+    except (PanelConfigError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    if args.dry_run:
+        print(_dry_run_report(panel, args.agents, args.n_runs))
+        return EXIT_OK
+
+    results = sweep(
+        panel, args.agents,
+        fixtures_template=args.fixtures_template,
+        n_runs=args.n_runs,
+        runner=runner or _default_runner,
+    )
+    verdicts = summarize(panel, results)
+    if args.report is not None:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(
+            json.dumps(to_json(panel, verdicts), indent=2), encoding="utf-8",
+        )
+    if args.output_format == "json":
+        print(json.dumps(to_json(panel, verdicts), indent=2))
+    else:
+        print(to_human(panel, verdicts))
+    return EXIT_EXTERNAL if any(not c.ok for c in results) else EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval/eval-model-panel.py
+++ b/scripts/eval/eval-model-panel.py
@@ -23,6 +23,7 @@ import argparse
 import json
 import subprocess
 import sys
+import uuid
 from collections.abc import Callable
 from pathlib import Path
 
@@ -48,11 +49,30 @@ EXIT_CONFIG = 2
 EXIT_EXTERNAL = 3
 
 _HARNESS = _EVAL_DIR / "eval-agent-vs-baseline.py"
+_REPO_ROOT = _EVAL_DIR.parents[1]
+_REPORTS_DIR_TEMPLATE = "evals/{agent}-spike/reports"
 
 # A runner turns a (unit, tier, n_runs, fixtures) request into the harness's
 # report.json mapping, or raises RuntimeError. The default runner shells out to
 # eval-agent-vs-baseline.py; tests inject a fake to exercise aggregation offline.
 Runner = Callable[[str, PanelTier, int, str], dict[str, object]]
+
+
+def _make_run_id(unit: str, tier_label: str) -> str:
+    """Build a unique run id for one (unit, tier) cell: panel-<unit>-<tier>-<8hex>."""
+    suffix = uuid.uuid4().hex[:8]
+    slug = f"panel-{unit}-{tier_label}"[:55]
+    return f"{slug}-{suffix}"
+
+
+def _child_report_path(unit: str, run_id: str) -> Path:
+    """Path to the report.json the harness writes for a run."""
+    return (
+        _REPO_ROOT
+        / _REPORTS_DIR_TEMPLATE.format(agent=unit)
+        / run_id
+        / "report.json"
+    )
 
 
 def _default_runner(unit: str, tier: PanelTier, n_runs: int, fixtures: str) -> dict[str, object]:
@@ -63,6 +83,7 @@ def _default_runner(unit: str, tier: PanelTier, n_runs: int, fixtures: str) -> d
     on a non-zero exit or unreadable report so the caller records the cell as an
     error instead of a silent zero.
     """
+    run_id = _make_run_id(unit, tier.label)
     argv = [
         sys.executable, str(_HARNESS),
         "--agent", unit,
@@ -70,7 +91,7 @@ def _default_runner(unit: str, tier: PanelTier, n_runs: int, fixtures: str) -> d
         "--n-runs", str(n_runs),
         "--provider", tier.provider,
         "--model", tier.model,
-        "--output-format", "json",
+        "--run-id", run_id,
     ]
     try:
         completed = subprocess.run(
@@ -83,10 +104,13 @@ def _default_runner(unit: str, tier: PanelTier, n_runs: int, fixtures: str) -> d
             f"harness exited {completed.returncode}: "
             f"{(completed.stderr or completed.stdout)[:200]}"
         )
+    report_path = _child_report_path(unit, run_id)
     try:
-        report = json.loads(completed.stdout)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"harness stdout was not JSON: {exc}") from exc
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"harness exited 0 but report at {report_path} is unreadable: {exc}"
+        ) from exc
     if not isinstance(report, dict):
         raise RuntimeError("harness report was not a JSON object")
     return report

--- a/tests/eval/test_eval_model_panel.py
+++ b/tests/eval/test_eval_model_panel.py
@@ -1,0 +1,121 @@
+"""Tests for scripts/eval/eval-model-panel.py CLI (issue #3042).
+
+The hyphenated CLI module is loaded via importlib. The harness runner seam is
+injected so the sweep is exercised with zero API spend.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+EVAL_DIR = Path(__file__).resolve().parents[2] / "scripts" / "eval"
+if str(EVAL_DIR) not in sys.path:
+    sys.path.insert(0, str(EVAL_DIR))
+
+
+def _load_cli():
+    spec = importlib.util.spec_from_file_location(
+        "eval_model_panel", EVAL_DIR / "eval-model-panel.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+cli = _load_cli()
+
+
+def _fake_runner(deltas):
+    """Runner that returns a report.json with recall_delta from deltas[(unit,tier)]."""
+    def run(unit, tier, n_runs, fixtures):
+        key = (unit, tier.label)
+        if key not in deltas:
+            raise RuntimeError(f"no fake result for {key}")
+        return {"recall_delta": deltas[key], "bootstrap_ci_95": [0.0, 1.0]}
+    return run
+
+
+def test_dry_run_zero_spend(capsys):
+    code = cli.main(["--agents", "qa", "--dry-run"])
+    out = capsys.readouterr().out
+    assert code == cli.EXIT_OK
+    assert "DRY RUN" in out
+    assert "ZERO spend" in out
+    assert "qa @ opus" in out
+
+
+def test_bad_n_runs_exits_config(capsys):
+    code = cli.main(["--agents", "qa", "--n-runs", "0", "--dry-run"])
+    assert code == cli.EXIT_CONFIG
+    assert "n-runs" in capsys.readouterr().err
+
+
+def test_bad_panel_config_exits_config(tmp_path, capsys):
+    cfg = tmp_path / "panel.json"
+    cfg.write_text('{"tiers": []}', encoding="utf-8")
+    code = cli.main(["--agents", "qa", "--panel-config", str(cfg), "--dry-run"])
+    assert code == cli.EXIT_CONFIG
+
+
+def test_live_sweep_reports_degradation(capsys):
+    deltas = {
+        ("qa", "opus"): 0.5, ("qa", "sol"): 0.5,
+        ("qa", "sonnet"): 0.2, ("qa", "terra"): 0.45,
+    }
+    code = cli.main(
+        ["--agents", "qa", "--output-format", "json"],
+        runner=_fake_runner(deltas),
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert code == cli.EXIT_OK
+    unit = payload["units"][0]
+    assert unit["unit"] == "qa"
+    assert "sonnet" in unit["degraded_tiers"]
+    assert unit["robust"] is False
+
+
+def test_live_sweep_robust_unit(capsys):
+    deltas = {
+        ("qa", "opus"): 0.5, ("qa", "sol"): 0.5,
+        ("qa", "sonnet"): 0.48, ("qa", "terra"): 0.47,
+    }
+    code = cli.main(
+        ["--agents", "qa", "--output-format", "json"],
+        runner=_fake_runner(deltas),
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert code == cli.EXIT_OK
+    assert payload["units"][0]["robust"] is True
+
+
+def test_runner_error_records_cell_and_exits_external(capsys):
+    # Missing terra result -> that cell errors -> exit 3, but others still scored.
+    deltas = {
+        ("qa", "opus"): 0.5, ("qa", "sol"): 0.5, ("qa", "sonnet"): 0.5,
+    }
+    code = cli.main(
+        ["--agents", "qa", "--output-format", "json"],
+        runner=_fake_runner(deltas),
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert code == cli.EXIT_EXTERNAL
+    # terra missing -> unit incomplete
+    assert payload["units"][0]["incomplete"] is True
+
+
+def test_report_written(tmp_path):
+    deltas = {
+        ("qa", "opus"): 0.5, ("qa", "sol"): 0.5,
+        ("qa", "sonnet"): 0.5, ("qa", "terra"): 0.5,
+    }
+    report = tmp_path / "reports" / "panel.json"
+    code = cli.main(
+        ["--agents", "qa", "--report", str(report)],
+        runner=_fake_runner(deltas),
+    )
+    assert code == cli.EXIT_OK
+    assert json.loads(report.read_text())["units"][0]["robust"] is True

--- a/tests/eval/test_model_panel_core.py
+++ b/tests/eval/test_model_panel_core.py
@@ -1,0 +1,178 @@
+"""Tests for scripts/eval/_model_panel_core.py (issue #3042)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_EVAL_DIR = Path(__file__).resolve().parents[2] / "scripts" / "eval"
+if str(_EVAL_DIR) not in sys.path:
+    sys.path.insert(0, str(_EVAL_DIR))
+
+import _model_panel_core as core  # noqa: E402
+
+
+def _panel(threshold=0.15):
+    return core.Panel(
+        tiers=(
+            core.PanelTier("opus", core.ROLE_REFERENCE, "anthropic", "claude-opus-4-8"),
+            core.PanelTier("sol", core.ROLE_REFERENCE, "openai", "openai/gpt-5.6"),
+            core.PanelTier("sonnet", core.ROLE_PROBE, "anthropic", "claude-sonnet-4-6"),
+        ),
+        drop_threshold=threshold,
+    )
+
+
+# --- parse_panel -------------------------------------------------------------
+
+
+def test_parse_panel_ok():
+    payload = {
+        "drop_threshold": 0.2,
+        "tiers": [
+            {"label": "opus", "role": "reference", "provider": "anthropic", "model": "m1"},
+            {"label": "sonnet", "role": "probe", "provider": "anthropic", "model": "m2"},
+        ],
+    }
+    panel = core.parse_panel(payload)
+    assert panel.drop_threshold == 0.2
+    assert [t.label for t in panel.reference_tiers] == ["opus"]
+    assert [t.label for t in panel.probe_tiers] == ["sonnet"]
+
+
+def test_parse_panel_empty_tiers_raises():
+    with pytest.raises(core.PanelConfigError, match="non-empty"):
+        core.parse_panel({"tiers": []})
+
+
+def test_parse_panel_missing_field_raises():
+    with pytest.raises(core.PanelConfigError, match="missing"):
+        core.parse_panel({"tiers": [{"label": "x", "role": "probe", "provider": "a"}]})
+
+
+def test_parse_panel_bad_role_raises():
+    with pytest.raises(core.PanelConfigError, match="role"):
+        core.parse_panel({"tiers": [
+            {"label": "x", "role": "gate", "provider": "a", "model": "m"},
+        ]})
+
+
+def test_parse_panel_no_reference_raises():
+    with pytest.raises(core.PanelConfigError, match="reference"):
+        core.parse_panel({"tiers": [
+            {"label": "x", "role": "probe", "provider": "a", "model": "m"},
+        ]})
+
+
+def test_parse_panel_unknown_provider_raises():
+    with pytest.raises(core.PanelConfigError, match="unknown provider"):
+        core.parse_panel(
+            {"tiers": [
+                {"label": "x", "role": "reference", "provider": "nope", "model": "m"},
+            ]},
+            known_providers={"anthropic", "openai"},
+        )
+
+
+def test_load_panel_config_bad_json_raises():
+    with pytest.raises(core.PanelConfigError, match="not valid JSON"):
+        core.load_panel_config("{not json")
+
+
+def test_default_panel_shape():
+    panel = core.default_panel()
+    assert len(panel.reference_tiers) == 2
+    assert len(panel.probe_tiers) == 2
+
+
+# --- cell_from_report --------------------------------------------------------
+
+
+def test_cell_from_report_extracts_delta_and_ci():
+    cell = core.cell_from_report("qa", "opus", {
+        "recall_delta": 0.42, "bootstrap_ci_95": [0.3, 0.5],
+    })
+    assert cell.ok
+    assert cell.recall_delta == 0.42
+    assert cell.ci_low == 0.3 and cell.ci_high == 0.5
+
+
+def test_cell_from_report_missing_delta_is_error():
+    cell = core.cell_from_report("qa", "opus", {"foo": 1})
+    assert not cell.ok
+    assert "recall_delta" in cell.error
+
+
+# --- summarize ---------------------------------------------------------------
+
+
+def _cells(**deltas):
+    return [
+        core.CellResult(unit="qa", tier=t, recall_delta=d)
+        for t, d in deltas.items()
+    ]
+
+
+def test_robust_when_probe_matches_reference():
+    panel = _panel()
+    cells = {c.tier: c for c in _cells(opus=0.5, sol=0.5, sonnet=0.45)}
+    v = core.summarize_unit("qa", panel, cells)
+    assert v.reference_delta == pytest.approx(0.5)
+    assert v.robust is True
+    assert v.degraded_tiers == []
+
+
+def test_degrades_when_probe_drops_past_threshold():
+    panel = _panel(threshold=0.15)
+    cells = {c.tier: c for c in _cells(opus=0.5, sol=0.5, sonnet=0.2)}  # drop 0.3 > 0.15
+    v = core.summarize_unit("qa", panel, cells)
+    assert v.robust is False
+    assert v.degraded_tiers == ["sonnet"]
+
+
+def test_incomplete_when_reference_missing():
+    panel = _panel()
+    # only a probe scored; no reference band
+    cells = {c.tier: c for c in _cells(sonnet=0.3)}
+    v = core.summarize_unit("qa", panel, cells)
+    assert v.incomplete is True
+    assert v.robust is False
+
+
+def test_reference_band_is_mean_of_reference_tiers():
+    panel = _panel()
+    cells = {c.tier: c for c in _cells(opus=0.6, sol=0.4, sonnet=0.45)}
+    v = core.summarize_unit("qa", panel, cells)
+    assert v.reference_delta == pytest.approx(0.5)  # mean(0.6,0.4)
+    assert v.robust is True  # 0.5 - 0.45 = 0.05 < 0.15
+
+
+def test_summarize_groups_and_orders_units():
+    panel = _panel()
+    results = [
+        core.CellResult("b", "opus", recall_delta=0.5),
+        core.CellResult("a", "opus", recall_delta=0.5),
+    ]
+    verdicts = core.summarize(panel, results)
+    assert [v.unit for v in verdicts] == ["a", "b"]
+
+
+# --- renderers ---------------------------------------------------------------
+
+
+def test_to_json_shape():
+    panel = _panel()
+    cells = {c.tier: c for c in _cells(opus=0.5, sol=0.5, sonnet=0.2)}
+    verdicts = [core.summarize_unit("qa", panel, cells)]
+    payload = core.to_json(panel, verdicts)
+    assert payload["reference_tiers"] == ["opus", "sol"]
+    assert payload["units"][0]["degraded_tiers"] == ["sonnet"]
+
+
+def test_to_human_labels_degradation():
+    panel = _panel()
+    cells = {c.tier: c for c in _cells(opus=0.5, sol=0.5, sonnet=0.2)}
+    text = core.to_human(panel, [core.summarize_unit("qa", panel, cells)])
+    assert "DEGRADES at sonnet" in text


### PR DESCRIPTION
## Summary

### What

Adds the tiered model-panel sweep harness from #3042. Instead of validating a unit (agent/skill) against one model, it sweeps each unit across a tiered panel and reports effect size per tier so degradation below frontier is measured, not assumed.

- Two frontier tiers (Opus, Sol) form the pass/fail **reference band**; two lower tiers (Sonnet, Terra) are **degradation probes**, never gating.
- Per (unit, tier) it reuses the existing per-unit harness (see `eval-agent-vs-baseline.py`) via the `--provider`/`--model` transport from #2710, reads `recall_delta`, and classifies each unit **robust-across-tiers** or **degrades-at-\<tier\>** when a probe falls more than the drop threshold below the reference band.

### Why

The harness validated at the wrong ceiling (Sonnet) and had no reference frame to *see* the constrain-down-vs-scaffold-up degradation #3041 describes. This measures it.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #3042 | Eval harness must sweep a tiered model panel |

## Design

- `_model_panel_core.py` is pure: panel config, effect-size aggregation (reference band = mean `recall_delta` over frontier tiers), degradation classification, JSON/human report. Fully unit-testable, no spend.
- `eval-model-panel.py` orchestrates the sweep behind a single **runner seam** (`Runner`); the default runner shells out to the existing harness, tests inject a fake.
- `--dry-run` validates the panel and prints the plan with **zero spend**.
- The panel is `--panel-config`-overridable: the GPT-5.6 (Sol/Terra) model ids are deployment-specific, so they are data, not hardcoded. `parse_panel` rejects unknown providers, missing fields, and an empty reference band.

## What this unblocks

- The **paid sweep** (units x tiers x n-runs x 2 vendors) is the only owner-gated step: confirm the panel model ids + run budget, then run.
- **#3045** (capability-floor detection) consumes this panel's per-unit floor.
- **#2840** (strip model pins unless eval-justified) consumes the per-pin evidence this produces.

## Testing

- `uv run pytest tests/eval/` -> **293 pass** (24 new): panel parsing, band math, robust/degraded/incomplete classification, both renderers, and the CLI dry-run + exit-code contract with a mocked runner.
- ruff + mypy clean; no security-suppression comments; `--dry-run` verified against a real 2-unit x 4-tier plan.

Filed during an open-issue triage sweep.
