### PR TITLE
chore(lint): wrap long lines and sort imports in five test files (#2993)

### DIFF
--- a/tests/commands/test_spec_step0.py
+++ b/tests/commands/test_spec_step0.py
@@ -376,7 +376,9 @@ class TestHedgeMatch:
         """`eventually consistent` is a load-bearing technical term, not a hedge."""
         assert hedge_match("Storage is eventually consistent.", hedge_phrases) is None
 
-    def test_eventually_consistent_hyphenated_is_technical_term(self, hedge_phrases: list[str]) -> None:
+    def test_eventually_consistent_hyphenated_is_technical_term(
+        self, hedge_phrases: list[str]
+    ) -> None:
         """`eventually-consistent` (hyphenated form) must also be exempt.
         Per cursor PR #1931 comment 3213964377: hyphen is a non-word boundary
         for `\\b...\\b`, so the regex matches `eventually` inside
@@ -416,7 +418,8 @@ class TestQ1Aspirational:
         entities. The regex now matches `[A-Z][a-zA-Z]*` to accept any
         capitalized identifier. Three required to pass the >= 3 rule."""
         assert not q1_aspirational(
-            "KeyVault team escalated #1700; RPCEngine service filed #1820; the SRE rotation noted #1850."
+            "KeyVault team escalated #1700; RPCEngine service filed #1820; "
+            "the SRE rotation noted #1850."
         )
 
     def test_ticket_only_passes(self) -> None:
@@ -475,7 +478,9 @@ class TestQ3Specific:
         assert q3_specific("the auth service in prod-east times out.")
 
     def test_file_path_passes(self) -> None:
-        assert q3_specific("the GraphQL pagination in `get_pr_review_threads.py` is the bottleneck.")
+        assert q3_specific(
+            "the GraphQL pagination in `get_pr_review_threads.py` is the bottleneck."
+        )
 
     def test_generic_users_fails(self) -> None:
         assert not q3_specific("users")
@@ -513,7 +518,13 @@ class TestParseHedgePhrases:
 
     def test_required_phrases_present(self, spec_text: str) -> None:
         phrases = parse_hedge_phrases(spec_text)
-        for required in ["would be nice", "we believe", "stakeholders want", "probably", "eventually"]:
+        for required in [
+            "would be nice",
+            "we believe",
+            "stakeholders want",
+            "probably",
+            "eventually",
+        ]:
             assert required in phrases
 
     def test_no_standalone_words(self, spec_text: str) -> None:

--- a/tests/e2e/test_installed_plugin_hook_e2e.py
+++ b/tests/e2e/test_installed_plugin_hook_e2e.py
@@ -61,7 +61,9 @@ def _rel_script(command: str) -> str | None:
     return m.group(1) if m else None
 
 
-def _run_shim(script: Path, payload: dict, cwd: Path, debug: bool = True) -> subprocess.CompletedProcess:
+def _run_shim(
+    script: Path, payload: dict, cwd: Path, debug: bool = True
+) -> subprocess.CompletedProcess:
     env = dict(os.environ)
     env["CLAUDE_PLUGIN_ROOT"] = str(_SCOPED_ROOT)
     env["COPILOT_PLUGIN_ROOT"] = str(_SCOPED_ROOT)

--- a/tests/hooks/test_topical_memory_injection.py
+++ b/tests/hooks/test_topical_memory_injection.py
@@ -125,7 +125,10 @@ class TestFindTopicalMemories:
         # A memory file with YAML frontmatter must summarize to the heading,
         # not the first frontmatter key (e.g. "status: accepted").
         _seed_memories(tmp_path, {
-            "github/github-cli-notes.md": "---\nstatus: accepted\ntags: [a, b]\n---\n# Real Heading\nbody",
+            "github/github-cli-notes.md": (
+                "---\nstatus: accepted\ntags: [a, b]\n"
+                "---\n# Real Heading\nbody"
+            ),
         })
         out = find_topical_memories(str(tmp_path), "github", time.monotonic() + 10)
         assert len(out) == 1

--- a/tests/skills/github/test_get_issue_context.py
+++ b/tests/skills/github/test_get_issue_context.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
 from test_helpers import make_completed_process
 
 # Ensure importability
@@ -165,7 +164,10 @@ class TestGetIssueContext:
         }
         with (
             patch("get_issue_context.assert_gh_authenticated"),
-            patch("get_issue_context.resolve_repo_params", return_value=RepoInfo(owner="o", repo="r")),
+            patch(
+                "get_issue_context.resolve_repo_params",
+                return_value=RepoInfo(owner="o", repo="r"),
+            ),
             patch("subprocess.run", return_value=make_completed_process(
                 stdout=json.dumps(issue_data)
             )),

--- a/tests/test_security_scan_cli.py
+++ b/tests/test_security_scan_cli.py
@@ -83,7 +83,9 @@ def test_cwe78_detected_after_cwe22_delegation(cwe78_fixture: tuple[Path, str]) 
     """Removing the CWE-22 dispatch must not affect CWE-78 detection."""
     cwd, name = cwe78_fixture
     result = _scanner(name, cwd=cwd)
-    assert result.returncode == 10, f"Expected vulnerabilities exit code 10, got {result.returncode}"
+    assert result.returncode == 10, (
+        f"Expected vulnerabilities exit code 10, got {result.returncode}"
+    )
     assert "CWE-78" in result.stdout
     assert "Command Injection" in result.stdout
 


### PR DESCRIPTION
## Summary

Refs #2993. Fifth ruff down-payment.

Sorts imports and wraps eight E501 long lines across five mypy-clean test files:
patch calls in a `with` block, assert conditions and arguments, a dict-value
string (implicit concatenation, byte-identical), a for-loop list literal, and
two function/method signatures. No behavior change; no suppressions.

## Files

- `tests/skills/github/test_get_issue_context.py`
- `tests/test_security_scan_cli.py`
- `tests/hooks/test_topical_memory_injection.py`
- `tests/commands/test_spec_step0.py`
- `tests/e2e/test_installed_plugin_hook_e2e.py`

## Testing

- `uv run ruff check`: clean on all five files.
- `uv run mypy`: clean on all five files.
- `uv run pytest`: 105 passed on the four unit test files; the e2e file collects
  its 8 tests.

E501/import repo-wide count drops from 423 to 414.
