### PR TITLE
chore(lint): wrap five long lines across four test files (#2993)

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-15-session-2993-e501-wrap.json
+++ b/.agents/memory/episodes/episode-2026-07-15-session-2993-e501-wrap.json
@@ -1,0 +1,70 @@
+{
+  "id": "episode-2026-07-15-session-2993-e501-wrap",
+  "session": "2026-07-15-session-2993-e501-wrap",
+  "timestamp": "2026-07-15T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Resolve issue #2993 (ruff line-length cleanup) for a bounded set of top-level test files: wrap the long lines in four tests/ files whose only ruff violation is E501, so each file becomes fully ruff-clean without triggering the plugin-lib mirror cascade or a plugin version bump.",
+  "decisions": [
+    {
+      "id": "d001",
+      "timestamp": "2026-07-15T00:00:00+00:00",
+      "type": "test",
+      "context": "Selected a non-cascading subset of #2993: four top-level tests/ files (test_generate_agent_catalog.py, test_security_scan_cli.py, e2e/test_installed_plugin_hook_e2e.py, hooks/test_topical_memory_injection.py) whose ONLY ruff violation is E501. Deliberately excluded tests/test_redact_secrets.py to avoid the secret-shaped string literals interacting with the redaction guard.",
+      "chosen": "Selected a non-cascading subset of #2993: four top-level tests/ files (test_generate_agent_catalog.py, test_security_scan_cli.py, e2e/test_installed_plugin_hook_e2e.py, hooks/test_topical_memory_injection.py) whose ONLY ruff violation is E501. Deliberately excluded tests/test_redact_secrets.py to avoid the secret-shaped string literals interacting with the redaction guard.",
+      "rationale": "",
+      "outcome": "success",
+      "effects": []
+    }
+  ],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Selected a non-cascading subset of #2993: four top-level tests/ files (test_generate_agent_catalog.py, test_security_scan_cli.py, e2e/test_installed_plugin_hook_e2e.py, hooks/test_topical_memory_injection.py) whose ONLY ruff violation is E501. Deliberately excluded tests/test_redact_secrets.py to avoid the secret-shaped string literals interacting with the redaction guard.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Wrapped five long lines: two call/def sites in test_generate_agent_catalog.py, one assert message in test_security_scan_cli.py, one def signature in test_installed_plugin_hook_e2e.py, and one dict string value in test_topical_memory_injection.py. Used implicit string concatenation and parenthesized continuation so no value or signature changes.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-15T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verified ruff check on the four files: All checks passed. Ran pytest on the four files: 64 passed, 8 skipped.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-15T00:00:00+00:00",
+      "type": "test",
+      "content": "Verified ruff check on the four files: All checks passed. Ran pytest on the four files: 64 passed, 8 skipped.",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-15T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: a5aa5ef962",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 2
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-15-session-2993-e501-wrap.json
+++ b/.agents/sessions/2026-07-15-session-2993-e501-wrap.json
@@ -1,0 +1,105 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2993,
+    "date": "2026-07-15",
+    "branch": "chore/ruff-e501-wrap-2993",
+    "startingCommit": "d9b0dd087d",
+    "objective": "Resolve issue #2993 (ruff line-length cleanup) for a bounded set of top-level test files: wrap the long lines in four tests/ files whose only ruff violation is E501, so each file becomes fully ruff-clean without triggering the plugin-lib mirror cascade or a plugin version bump."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Session resumed post-compaction under caveman mode; serena-* tools are deferred and were not activated for this mechanical line-wrap task. Followed AGENTS.md and .claude/rules guidance read directly from the tree."
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not run; serena deferred. In-repo AGENTS.md and rules used instead."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-loaded by the SessionStart context loader and read; not modified (read-only per ADR-014)."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file created for the #2993 line-wrap work on 2026-07-15."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git rev-parse --abbrev-ref HEAD returned chore/ruff-e501-wrap-2993."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Work is on chore/ruff-e501-wrap-2993, based off origin/main at d9b0dd087d (git rev-list --count HEAD ^origin/main == 0 before commit)."
+      },
+      "gitStatusVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git status --short showed only the four intended test files modified; the untracked auto-retro skeleton was left unstaged."
+      },
+      "startingCommitNoted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Starting commit recorded as d9b0dd087d (branch head equal to origin/main)."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Five E501 lines wrapped across four files; ruff reports All checks passed for the four files; affected tests pass (64 passed, 8 skipped)."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md read only, never modified."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena deferred this session; durable context lives in this log and the PR body."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown files changed (Python test files only); markdownlint not applicable. Session log byte-checked for em/en dashes: 0."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "The four wrapped test files are committed on chore/ruff-e501-wrap-2993; endingCommit names that commit (the session-log commit follows it)."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ruff check on the four files: All checks passed. pytest on the four files: 64 passed, 8 skipped. No security-suppression comments introduced. No behavior change: line wraps only (implicit string concatenation and parenthesized continuation preserve values and signatures)."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "T0",
+      "entry": "Selected a non-cascading subset of #2993: four top-level tests/ files (test_generate_agent_catalog.py, test_security_scan_cli.py, e2e/test_installed_plugin_hook_e2e.py, hooks/test_topical_memory_injection.py) whose ONLY ruff violation is E501. Deliberately excluded tests/test_redact_secrets.py to avoid the secret-shaped string literals interacting with the redaction guard."
+    },
+    {
+      "time": "T1",
+      "entry": "Wrapped five long lines: two call/def sites in test_generate_agent_catalog.py, one assert message in test_security_scan_cli.py, one def signature in test_installed_plugin_hook_e2e.py, and one dict string value in test_topical_memory_injection.py. Used implicit string concatenation and parenthesized continuation so no value or signature changes."
+    },
+    {
+      "time": "T2",
+      "entry": "Verified ruff check on the four files: All checks passed. Ran pytest on the four files: 64 passed, 8 skipped."
+    }
+  ],
+  "endingCommit": "a5aa5ef962",
+  "nextSteps": [
+    "Push branch and open PR (Refs #2993) for the wrapped subset.",
+    "Remaining #2993 E501 sites in other files (including the secret-string file and any plugin-lib-cascading files) stay open under #2993 for a follow-up."
+  ]
+}

--- a/tests/build_scripts/test_generate_agent_catalog.py
+++ b/tests/build_scripts/test_generate_agent_catalog.py
@@ -255,7 +255,10 @@ def test_main_returns_external_error_on_unreadable_output_parent(tmp_path: Path)
     output_path.write_text("not a directory", encoding="utf-8")
 
     # Act
-    code = gac.main(["--templates-path", str(templates_dir), "--output", str(output_path / "out.md")])
+    code = gac.main([
+        "--templates-path", str(templates_dir),
+        "--output", str(output_path / "out.md"),
+    ])
 
     # Assert
     assert code == 3
@@ -288,7 +291,9 @@ def test_relative_templates_path_resolves_from_repo_root() -> None:
     assert output_path == REPO_ROOT / "docs" / "agent-catalog.md"
 
 
-def test_validator_returns_config_error_when_generator_import_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_validator_returns_config_error_when_generator_import_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     # Arrange
     import builtins
 

--- a/tests/e2e/test_installed_plugin_hook_e2e.py
+++ b/tests/e2e/test_installed_plugin_hook_e2e.py
@@ -61,7 +61,9 @@ def _rel_script(command: str) -> str | None:
     return m.group(1) if m else None
 
 
-def _run_shim(script: Path, payload: dict, cwd: Path, debug: bool = True) -> subprocess.CompletedProcess:
+def _run_shim(
+    script: Path, payload: dict, cwd: Path, debug: bool = True,
+) -> subprocess.CompletedProcess:
     env = dict(os.environ)
     env["CLAUDE_PLUGIN_ROOT"] = str(_SCOPED_ROOT)
     env["COPILOT_PLUGIN_ROOT"] = str(_SCOPED_ROOT)

--- a/tests/hooks/test_topical_memory_injection.py
+++ b/tests/hooks/test_topical_memory_injection.py
@@ -125,7 +125,9 @@ class TestFindTopicalMemories:
         # A memory file with YAML frontmatter must summarize to the heading,
         # not the first frontmatter key (e.g. "status: accepted").
         _seed_memories(tmp_path, {
-            "github/github-cli-notes.md": "---\nstatus: accepted\ntags: [a, b]\n---\n# Real Heading\nbody",
+            "github/github-cli-notes.md": (
+                "---\nstatus: accepted\ntags: [a, b]\n---\n# Real Heading\nbody"
+            ),
         })
         out = find_topical_memories(str(tmp_path), "github", time.monotonic() + 10)
         assert len(out) == 1

--- a/tests/test_security_scan_cli.py
+++ b/tests/test_security_scan_cli.py
@@ -83,7 +83,9 @@ def test_cwe78_detected_after_cwe22_delegation(cwe78_fixture: tuple[Path, str]) 
     """Removing the CWE-22 dispatch must not affect CWE-78 detection."""
     cwd, name = cwe78_fixture
     result = _scanner(name, cwd=cwd)
-    assert result.returncode == 10, f"Expected vulnerabilities exit code 10, got {result.returncode}"
+    assert result.returncode == 10, (
+        f"Expected vulnerabilities exit code 10, got {result.returncode}"
+    )
     assert "CWE-78" in result.stdout
     assert "Command Injection" in result.stdout
 


### PR DESCRIPTION
## Summary

Wraps 5 residual E501-only long lines across 4 top-level test files so each file is fully ruff-clean. These lines were missed by #3055 and #3060 (the ruff gate is per-changed-file, so untouched files keep their violations).

Line wraps only. No behavior change: implicit string concatenation and parenthesized continuation preserve every string value and every signature.

| File | Site |
|------|------|
| `tests/build_scripts/test_generate_agent_catalog.py` | `gac.main([...])` call, one long `def` |
| `tests/test_security_scan_cli.py` | assert message |
| `tests/e2e/test_installed_plugin_hook_e2e.py` | `_run_shim` signature |
| `tests/hooks/test_topical_memory_injection.py` | seeded-memory dict string value |

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #2993 | ruff line-length (E501) cleanup |

This is `Refs`, not `Fixes`: #2993 is a repo-wide burn-down (220 E501 across ~52 files, many in cascading source). See my comment on #2993 for the full count and the mass-sweep-vs-config decision that actually closes it. This PR is one honest incremental nibble matching the accepted #3055 / #3060 pattern.

## Testing

- `ruff check` on the 4 files: All checks passed.
- `pytest` on the 4 files: 64 passed, 8 skipped.

Filed during an open-issue triage sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
