### PR TITLE
fix(quality-gate): resolve mypy no-redef on dual-import idiom (#2876)

### DIFF
--- a/scripts/quality_gate/check_failed_agents.py
+++ b/scripts/quality_gate/check_failed_agents.py
@@ -34,11 +34,15 @@ import argparse
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-try:
+if TYPE_CHECKING:
     from .path_utils import REPOSITORY_ROOT
-except ImportError:  # pragma: no cover - script execution path
-    from path_utils import REPOSITORY_ROOT
+else:
+    try:
+        from .path_utils import REPOSITORY_ROOT
+    except ImportError:  # pragma: no cover - script execution path
+        from path_utils import REPOSITORY_ROOT
 
 _GITHUB_SCRIPTS = REPOSITORY_ROOT / ".github" / "scripts"
 sys.path.insert(0, str(_GITHUB_SCRIPTS))

--- a/scripts/quality_gate/external_signal_gate.py
+++ b/scripts/quality_gate/external_signal_gate.py
@@ -41,11 +41,15 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from typing import TYPE_CHECKING
 
-try:
+if TYPE_CHECKING:
     from .path_utils import REPOSITORY_ROOT
-except ImportError:  # pragma: no cover - script execution path
-    from path_utils import REPOSITORY_ROOT
+else:
+    try:
+        from .path_utils import REPOSITORY_ROOT
+    except ImportError:  # pragma: no cover - script execution path
+        from path_utils import REPOSITORY_ROOT
 
 _WORKSPACE = REPOSITORY_ROOT
 sys.path.insert(0, str(_WORKSPACE))
@@ -53,6 +57,7 @@ _GITHUB_SCRIPTS = _WORKSPACE / ".github" / "scripts"
 sys.path.insert(0, str(_GITHUB_SCRIPTS))
 
 from quality_gate_agents import QUALITY_GATE_AGENTS, agent_env_name  # noqa: E402
+
 from scripts.external_signals import gate_aggregator  # noqa: E402
 
 # pytest_status -> gate_aggregator verdict token.

--- a/scripts/quality_gate/post_pr_comment.py
+++ b/scripts/quality_gate/post_pr_comment.py
@@ -41,11 +41,15 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-try:
+if TYPE_CHECKING:
     from .path_utils import REPOSITORY_ROOT, resolve_workspace_path
-except ImportError:  # pragma: no cover - script execution path
-    from path_utils import REPOSITORY_ROOT, resolve_workspace_path
+else:
+    try:
+        from .path_utils import REPOSITORY_ROOT, resolve_workspace_path
+    except ImportError:  # pragma: no cover - script execution path
+        from path_utils import REPOSITORY_ROOT, resolve_workspace_path
 
 _GITHUB_SCRIPTS = REPOSITORY_ROOT / ".github" / "scripts"
 

--- a/scripts/quality_gate/run_pytest.py
+++ b/scripts/quality_gate/run_pytest.py
@@ -43,11 +43,15 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-try:
+if TYPE_CHECKING:
     from .path_utils import resolve_workspace_path
-except ImportError:  # pragma: no cover - script execution path
-    from path_utils import resolve_workspace_path
+else:
+    try:
+        from .path_utils import resolve_workspace_path
+    except ImportError:  # pragma: no cover - script execution path
+        from path_utils import resolve_workspace_path
 
 _SUMMARY_PATTERN = re.compile(r"passed|failed|error")
 _NO_SUMMARY = "No test summary available"

--- a/scripts/quality_gate/spec_external_signal_gate.py
+++ b/scripts/quality_gate/spec_external_signal_gate.py
@@ -52,11 +52,15 @@ import argparse
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-try:
+if TYPE_CHECKING:
     from .path_utils import REPOSITORY_ROOT
-except ImportError:  # pragma: no cover - script execution path
-    from path_utils import REPOSITORY_ROOT
+else:
+    try:
+        from .path_utils import REPOSITORY_ROOT
+    except ImportError:  # pragma: no cover - script execution path
+        from path_utils import REPOSITORY_ROOT
 
 _WORKSPACE = REPOSITORY_ROOT
 sys.path.insert(0, str(_WORKSPACE))

--- a/scripts/quality_gate/validate_artifact_download.py
+++ b/scripts/quality_gate/validate_artifact_download.py
@@ -26,11 +26,15 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-try:
+if TYPE_CHECKING:
     from .path_utils import REPOSITORY_ROOT, resolve_workspace_path
-except ImportError:  # pragma: no cover - script execution path
-    from path_utils import REPOSITORY_ROOT, resolve_workspace_path
+else:
+    try:
+        from .path_utils import REPOSITORY_ROOT, resolve_workspace_path
+    except ImportError:  # pragma: no cover - script execution path
+        from path_utils import REPOSITORY_ROOT, resolve_workspace_path
 
 _GITHUB_SCRIPTS = REPOSITORY_ROOT / ".github" / "scripts"
 sys.path.insert(0, str(_GITHUB_SCRIPTS))


### PR DESCRIPTION
## Summary

Refs #2876.

Resolves the mypy `no-redef` errors on the `path_utils` dual-import idiom across
six `scripts/quality_gate/` CI scripts. This also unblocks the #2993 ruff
burndown: several `tests/` files import these modules, and touching them
re-triggered whole-file mypy, which failed on the pre-existing `no-redef`.

## The pattern

mypy flags the fallback branch of the try / relative-except / absolute import as
a redefinition. Guarding the type-facing import under `TYPE_CHECKING` gives mypy
one import to analyze, while the runtime dual-import stays unchanged in the
`else` branch.

Before:

```python
try:
    from .path_utils import REPOSITORY_ROOT
except ImportError:  # pragma: no cover - script execution path
    from path_utils import REPOSITORY_ROOT
```

After:

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from .path_utils import REPOSITORY_ROOT
else:
    try:
        from .path_utils import REPOSITORY_ROOT
    except ImportError:  # pragma: no cover - script execution path
        from path_utils import REPOSITORY_ROOT
```

## Why it is behavior-preserving

- `TYPE_CHECKING` is False at runtime, so the `else` branch always runs. It is
  the original try/except, byte for byte, with the same `# pragma: no cover`.
- Package mode uses the relative import; script mode falls back to absolute.
  Both verified: all six modules import via `import scripts.quality_gate.<name>`,
  and running the scripts with `--help` exercises the script-mode fallback.
- coverage excludes `if TYPE_CHECKING:` blocks (pyproject `exclude_lines`), so no
  coverage regression; there is no coverage gate on these modules anyway.

## Testing

- `uv run mypy` on all six modules: clean (no `no-redef`).
- `uv run ruff check` on all six modules: clean.
- `uv run pytest tests/quality_gate/`: 194 passed.
- Adversarially reviewed with GPT-5.6 Sol.
