### PR TITLE
docs(memory): backfill four architecture contracts (#3054)

### DIFF
--- a/.serena/memories/architecture/architecture-agent-mirror-two-pipeline.md
+++ b/.serena/memories/architecture/architecture-agent-mirror-two-pipeline.md
@@ -1,0 +1,60 @@
+# Two-pipeline agent mirror: source, generate both trees, verify with drift + parity
+
+Agent definitions have ONE source and TWO generated destinations. Edit the
+source, regenerate, and let two independent checks prove the mirror is intact.
+Never hand-edit a generated agent file.
+
+## The pipeline
+
+- Source of truth: `templates/agents/<name>.shared.md` (29 shared bodies as of
+  #2707).
+- Generator: `build/generate_agents.py` (+ `build/generate_agents_common.py`),
+  invoked by `build/scripts/build_all.py::_build_agents` which calls
+  `generate_agents.main([...])` across all platform configs.
+- Destination 1 (Claude): `.claude/agents/<name>.md`.
+- Destination 2 (Copilot CLI mirror): `src/copilot-cli/agents/<name>.agent.md`.
+
+A single behavioral change (for example a severity rubric on
+silent-failure-hunter) is made ONCE in the `.shared.md` body and flows to both
+trees on regeneration.
+
+## The two verifications
+
+1. Source-to-generated drift: `build/scripts/detect_agent_drift.py`. Reports
+   the percentage match on every (source, generated) pair. The #2707 fix
+   required "detect_agent_drift 100% on all silent-failure-hunter pairs" before
+   it was mergeable.
+2. Installed-copy parity: `scripts/validation/run_install_parity_ci.py` (backed
+   by `build/scripts/validate_install_parity.py`). An agent ships in several
+   installed locations (the "install-parity members"); parity asserts every
+   member carries the identical body. The #2707 fix confirmed "all six
+   silent-failure-hunter install-parity members carry the identical rubric
+   body."
+
+## Why this matters
+
+The drift check catches "I edited the generated file, not the source" and "I
+edited the source but forgot to regenerate." The parity check catches "the two
+platform trees diverged." Together they make the single-source invariant
+enforceable in CI instead of a convention people forget.
+
+## Workflow when changing an agent
+
+1. Edit `templates/agents/<name>.shared.md`.
+2. Run `build/scripts/build_all.py --check` (must be clean after commit).
+3. Confirm `detect_agent_drift.py` reports 100% on the changed pairs.
+4. Confirm `run_install_parity_ci.py` is OK.
+5. The agent catalog line count regenerates (155 to 158 in #2707); commit the
+   regenerated catalog with the change. Generated artifacts ship WITH the
+   change, never in a follow-up PR.
+
+## Evidence
+
+- PR #2707 (merge a4af5d2f66aa): three SkillOpt fixes including
+  silent-failure-hunter, verified via `build_all.py --check`,
+  `detect_agent_drift` (100% on all pairs), and `run_install_parity_ci.py`.
+- Source tree: `templates/agents/*.shared.md`.
+- Generator: `build/generate_agents.py`, `build/scripts/build_all.py`.
+- Checks: `build/scripts/detect_agent_drift.py`,
+  `scripts/validation/run_install_parity_ci.py`,
+  `build/scripts/validate_install_parity.py`.

--- a/.serena/memories/architecture/architecture-eval-multiprovider-transport.md
+++ b/.serena/memories/architecture/architecture-eval-multiprovider-transport.md
@@ -1,0 +1,65 @@
+# Eval multi-provider transport (EVAL_PROVIDER Strategy)
+
+The eval harness can run through OpenAI or GitHub Models when the
+`ANTHROPIC_API_KEY` budget is exhausted. Provider selection is a Strategy behind
+`EVAL_PROVIDER` (env) or `--provider` (flag). Anthropic stays the default on the
+dependency-free urllib path, so no existing baseline moves.
+
+## Design (Open/Closed)
+
+- `scripts/eval/_providers.py` defines `EvalProvider` (a `Protocol`) with
+  `complete(*, messages, system, model, max_tokens, temperature) -> str`.
+- A new provider is a new class plus one row in `_REGISTRY`. No edit to
+  `call_api`, the retry/categorization adapter, or any eval script.
+- `call_api` (in `scripts/eval/_anthropic_api.py`) gains an optional `provider`
+  param, falling back to `EVAL_PROVIDER`. `None` or `anthropic` keeps the urllib
+  path byte-for-byte, so the zero-SDK default is preserved.
+
+## Providers
+
+- OpenAI and GitHub Models use the `openai` SDK. GitHub Models is
+  OpenAI-compatible: same SDK, `base_url` = `GITHUB_MODELS_BASE_URL`
+  (`https://models.github.ai/inference`), `GITHUB_TOKEN` as the bearer, model
+  names prefixed `openai/...`. The Anthropic-style separate `system` arg is
+  folded into a leading system-role message.
+- `anthropic-sdk` is an optional provider via the `anthropic` SDK; the default
+  `anthropic` provider stays on urllib.
+- Providers normalize SDK errors to the exact message shapes
+  `_anthropic_api.call_api` already emits (`<Provider> API returned HTTP
+  <code>: ...`, `...timed out...`), so `_eval_api_adapter._categorize_error`
+  classifies them unchanged.
+- release-it: every SDK client sets `timeout=120.0` and `max_retries=0`. The
+  adapter owns retries; an SDK retry layer would nest retries.
+
+## Correctness constraint (do not violate)
+
+A single eval invocation runs the baseline AND the variant through ONE provider.
+Scores from different providers are NOT comparable; re-baseline per provider
+(ADR-058 Experimental Design Symmetry). The help text and module docstring state
+this. Do not compare a Sonnet-baseline score against an OpenAI-variant score.
+
+## Credentials
+
+The adapter transport factory is provider-aware and skips `load_api_key()`
+(ANTHROPIC_API_KEY) for non-Anthropic providers, which self-load their own
+credential (`OPENAI_API_KEY` or `GITHUB_TOKEN`).
+
+## Dependencies
+
+`anthropic` is already core. Only `openai>=1.40` is added, as an opt-in `eval`
+extra (`pip install -e '.[eval]'`). The default eval needs no new dependency.
+
+## Wiring
+
+`--provider` is wired into `eval-agent-vs-baseline.py` and
+`eval-prompt-change.py`. Select with `EVAL_PROVIDER=github` or `--provider
+github` plus a GitHub Models model id.
+
+## Evidence
+
+- PR #2710 (merge 65d33d8b2980): multi-provider transport behind EVAL_PROVIDER.
+- `scripts/eval/_providers.py` (`EvalProvider` Protocol, `_REGISTRY`,
+  `GITHUB_MODELS_BASE_URL`), `scripts/eval/_anthropic_api.py` (`call_api`
+  provider param).
+- Tests: `tests/eval/test_providers.py` (26 offline tests, fake `openai` module
+  injected; no network, no real SDK).

--- a/.serena/memories/architecture/architecture-lsp-first-enforcement.md
+++ b/.serena/memories/architecture/architecture-lsp-first-enforcement.md
@@ -1,0 +1,64 @@
+# LSP-first navigation enforcement (ADR-062): conditional, fail-open hooks
+
+The repo mandates Serena-first / LSP-first navigation via steering, but steering
+drifts. ADR-062 adds the enforcement layer: hooks that nudge agents off
+grep/glob/full-file-read toward symbol tools, designed conditional and fail-open
+so they never deadlock.
+
+## Three-tier preference
+
+1. Serena MCP symbolic tools (find_symbol, find_referencing_symbols,
+   get_symbols_overview, find_implementations).
+2. Native LSP (Claude `LSP` tool; Copilot auto-LSP).
+3. grep / glob / sed as the last resort.
+
+## The load-bearing property: conditioning
+
+Each guard is a no-op (exit 0) UNLESS the target file's language has a reachable
+LSP that offers the relevant capability. This is what keeps the layer safe:
+
+- Symbol-grep guards (Grep / Bash-grep / Glob) key on
+  go-to-definition / find-references capability: programming languages only.
+  They never fire on markdown / json / yaml / toml.
+- The Read gate is graduated (warmup, 2 free reads, warn, block-until-nav,
+  surgical) and keys on `get_symbols_overview`, which Serena provides for all
+  configured languages.
+- Fail-open on EVERY uncertainty: no provider, tty / empty / malformed input, or
+  any exception all resolve to allow. The gate never blocks when it cannot
+  prove an LSP is available.
+
+## Components
+
+- Hooks (`.claude/hooks/`): `PreToolUse/invoke_lsp_grep_guard.py`,
+  `invoke_lsp_glob_guard.py`, `invoke_lsp_bash_grep_guard.py`,
+  `invoke_lsp_read_guard.py`, `invoke_lsp_pre_delegation_guard.py`; a PostToolUse
+  usage tracker (`invoke_lsp_usage_tracker.py` / `invoke_lsp_read_tracker.py`);
+  a SessionStart reset (`invoke_lsp_session_reset.py`).
+- Shared lib (`scripts/hook_utilities/`, mirrored to `.claude/lib/`):
+  `lsp_provider.py`, `lsp_symbols.py`, `lsp_gate_state.py`, `lsp_health.py`.
+- Steering rule: `.claude/rules/lsp-first.md`.
+- Dual registration: `settings.json` + plugin `hooks.json`, plus the generated
+  Copilot CLI mirror.
+
+## Escape hatches (know these when a guard misfires)
+
+- `SKIP_LSP_GATE=true`: disables the gate entirely (kill switch).
+- `LSP_GATE_MODE=warn`: downgrades block to advisory.
+- `LSP_DOWN=true`: LSP configured but runtime down; guards ALLOW native tools and
+  warn once instead of hard-blocking (graceful degradation, not a kill switch).
+- Merge / rebase in progress, or a conflict marker in the file window, bypasses
+  the read gate automatically.
+
+## Provenance
+
+Adapted from the MIT `nesaminua/claude-code-lsp-enforcement-kit` (JS), ported to
+Python. Sits ABOVE the per-turn Serena re-assertion hook (#1993) and BELOW the
+steering rule: rule states the preference, ADR-062 hooks enforce it.
+
+## Evidence
+
+- PR #2168 (merge 96aafb4fa707), closes #2165. Architect-reviewed
+  ACCEPTED-WITH-DC.
+- ADR: `.agents/architecture/ADR-062-conditional-lsp-first-enforcement.md`;
+  debate: `.agents/critique/ADR-062-debate-log.md` (6-agent review).
+- Steering: `.claude/rules/lsp-first.md`.

--- a/.serena/memories/architecture/architecture-pretooluse-advisory-envelope.md
+++ b/.serena/memories/architecture/architecture-pretooluse-advisory-envelope.md
@@ -1,0 +1,65 @@
+# PreToolUse advisory-hook output envelope contract
+
+A PreToolUse hook that wants to inject advisory context (not block) MUST emit the
+`hookSpecificOutput` / `additionalContext` envelope. Using the top-level
+`decision` field for advisories is invalid and the advisory is silently dropped.
+
+## The contract
+
+Advisory (non-blocking) output:
+
+```json
+{"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": "<advisory text>"}}
+```
+
+Blocking output uses the top-level `decision` field, which accepts only
+`approve` or `block`:
+
+```json
+{"decision": "block", "reason": "<why>"}
+```
+
+## The trap (do not repeat)
+
+`{"decision": "allow", "reason": ...}` is INVALID. `allow` / `deny` / `ask` are
+not valid top-level `decision` values; they belong under
+`hookSpecificOutput.permissionDecision`, a different field. When a hook emitted
+`decision: allow`, the runtime schema check rejected the whole output with
+`Hook JSON output validation failed: (root): Invalid input`, and the advisory
+never reached the model. The error surfaced twice because the hook was
+registered in both `.claude/settings.json` and the `project-toolkit` plugin, so
+both copies ran and both emitted the bad JSON.
+
+Two advisory hooks carried this defect and were fixed to the envelope above:
+
+- `.claude/hooks/PreToolUse/invoke_correction_applier.py` (Self-Improving Agent
+  correction memories)
+- `.claude/hooks/PreToolUse/invoke_topical_memory_injection.py` (topical memory
+  injection)
+
+Impact of the bug: correction memories and topical memories were dropped before
+reaching the model for roughly a week (regressions introduced 2026-05-29 in
+#1763 and 2026-05-31 in #2005).
+
+## Test the runtime contract, not a substring
+
+The prior tests only checked stderr or substring-matched stdout, so the invalid
+envelope passed green. This is the runtime-contract-not-tested anti-pattern. The
+fix added stdout-JSON regression guards that parse the emitted JSON and assert
+the envelope shape. When you touch an advisory hook, assert the parsed JSON
+object shape, not a fragment of the text.
+
+## Cross-harness note
+
+Both hooks have generated Copilot CLI shims under `src/copilot-cli/hooks/`. After
+editing the canonical `.claude/hooks/PreToolUse/*` copy, regenerate so the
+hook-drift guard exits 0, and bump `.claude/.claude-plugin/plugin.json`
+(0.5.134 to 0.5.135 in the original fix) in lockstep with the Copilot mirror.
+
+## Evidence
+
+- Issue #2468 (root cause and fix description), closed by PR #2473.
+- Fixed hooks: `.claude/hooks/PreToolUse/invoke_correction_applier.py`,
+  `.claude/hooks/PreToolUse/invoke_topical_memory_injection.py`.
+- Schema error observed: `PreToolUse:Bash hook error / Hook JSON output
+  validation failed: (root): Invalid input`.

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -26,7 +26,7 @@
 |security vulnerability TOCTOU secret injection: [skills-security-index](skills-security-index.md) (477)
 
 [Architecture and Design]
-|architecture ADR model composite tool allocation producer-consumer: [skills-architecture-index](skills-architecture-index.md) (363)
+|architecture ADR model composite tool allocation producer-consumer: [skills-architecture-index](skills-architecture-index.md) (546)
 |adr decision record active proposed superseded rationale artifact amendment: [adr-reference-index](adr-reference-index.md) (673), [adr/adr-artifact-count-verification](adr/adr-artifact-count-verification.md) (401), [adr/adr-retroactive-amendment-criteria](adr/adr-retroactive-amendment-criteria.md) (824), [adr/adr-review-observations](adr/adr-review-observations.md) (749)
 |cache invalidation TTL session-local cloudmcp stale refresh: [adr-reference-index](adr-reference-index.md) (673)
 |design agent specialization entry-criteria limitation composability: [skills-design-index](skills-design-index.md) (206)

--- a/.serena/memories/skills-architecture-index.md
+++ b/.serena/memories/skills-architecture-index.md
@@ -9,3 +9,7 @@
 | deployment path validation reference source tree resolve broken context | [architecture/architecture-015-deployment-path-validation](architecture/architecture-015-deployment-path-validation.md) |
 | template variant claude copilot generate maintain separate dual update | [architecture/architecture-template-variant-maintenance](architecture/architecture-template-variant-maintenance.md) |
 | ADR number check collision parallel branch sequential numbering | [architecture/architecture-016-adr-number-check](architecture/architecture-016-adr-number-check.md) |
+| hook advisory PreToolUse additionalContext hookSpecificOutput decision block permissionDecision envelope injection dropped | [architecture/architecture-pretooluse-advisory-envelope](architecture/architecture-pretooluse-advisory-envelope.md) |
+| agent shared-body source-of-truth two-destination drift install-parity regenerate silent-failure-hunter catalog | [architecture/architecture-agent-mirror-two-pipeline](architecture/architecture-agent-mirror-two-pipeline.md) |
+| eval provider EVAL_PROVIDER openai github-models strategy transport anthropic urllib budget re-baseline symmetry | [architecture/architecture-eval-multiprovider-transport](architecture/architecture-eval-multiprovider-transport.md) |
+| lsp serena navigation enforcement conditional fail-open grep glob read-gate SKIP_LSP_GATE ADR-062 symbol | [architecture/architecture-lsp-first-enforcement](architecture/architecture-lsp-first-enforcement.md) |


### PR DESCRIPTION
## Summary

Refs #3054.

Backfills four evidence-backed Serena memories from completed work so future
agents (without session-specific context) can retrieve the implementation
contracts they record.

## Memories added

All four live under `.serena/memories/architecture/` and are indexed in
`skills-architecture-index.md`. Each preserves its source issue, PR, ADR, and
merge-SHA evidence inline.

| Memory | Source | What it records |
| :-- | :-- | :-- |
| PreToolUse advisory-hook output envelope | #2468 / #2473 | The `hookSpecificOutput` / `additionalContext` envelope for non-blocking advisories, and why `decision: allow` silently drops the advisory. |
| Two-pipeline agent mirror recipe | #2707 | One shared agent-body source generates both platform trees; the drift and install-parity checks verify the mirror. |
| Eval multi-provider transport | #2710 | `EVAL_PROVIDER` Strategy (OpenAI, GitHub Models) behind an Open/Closed registry, with the per-provider re-baseline constraint. |
| LSP-first navigation enforcement | #2168 | ADR-062 conditional, fail-open hooks; the three-tier preference and the escape hatches. |

## Scope decisions

Per the issue, the following were deliberately excluded: the three unfilled
auto-retrospectives, the superseded CVA draft, Serena-generated config drift
(the Serena project config file), and local Graphify installer output.

## File budget

Five manually authored files: four memories plus the one index. The pre-commit
hook auto-updated the master memory index token counts and re-staged it; that
sixth file is generated maintenance, not authored content.

## Validation

- Memory index consistency check: PASSED (305 indexed, 0 missing, 0 keyword
  issues).
- Em/en-dash byte check on all changed files: clean.
- markdownlint: the Serena memories tree is excluded by repo config (design), so
  these files are not linted; each is well under the 10,000-character atomicity
  threshold.
