### PR TITLE
test(e2e): record Copilot CLI 1.0.71 plugin non-enumeration as benign

### DIFF
--- a/tests/e2e/test_plugin_load_smoke.py
+++ b/tests/e2e/test_plugin_load_smoke.py
@@ -197,7 +197,7 @@ def _copilot_version_omits_plugin_enumeration(version_output: str) -> bool:
 
     Only the versions in ``_COPILOT_BENIGN_NO_ENUM_VERSIONS`` are allowed to skip
     the strict subset assertion when ``skill list --json`` surfaces zero
-    ``source: plugin`` records (issues #2990 and #3014). This is an
+    ``source: plugin`` records (issues #2990, #3014, and #3090). This is an
     output-surface quirk of those releases: the plugin loads and its hooks fire,
     but ``skill list --json`` does not enumerate ``--plugin-dir`` skills under
     ``source: plugin``. Any other version that surfaces zero ``source: plugin``
@@ -290,8 +290,8 @@ def test_copilot_plugin_loads_expected_skills(tmp_path: Path) -> None:
             pytest.fail(
                 "copilot skill list --json surfaced no source: plugin records for a "
                 f"known-good --plugin-dir on CLI version {version_text!r}, which is "
-                "NOT a known plugin-enumeration-omitting version (issues #2990, "
-                f"#3014). A version outside the benign {benign_versions} set that "
+                "NOT a known plugin-enumeration-omitting version (issues #2990, #3014, "
+                f"#3090). A version outside the benign {benign_versions} set that "
                 "surfaces no source: plugin records is treated as a real "
                 "plugin-load regression. "
                 f"sources seen: {sources}"
@@ -299,7 +299,7 @@ def test_copilot_plugin_loads_expected_skills(tmp_path: Path) -> None:
         pytest.skip(
             "copilot skill list --json surfaced no source: plugin records for a "
             "known-good --plugin-dir. On CLI 1.0.69, 1.0.70, and 1.0.71 the plugin-dir load "
-            "is not enumerated through this surface (issues #2990, #3014); the load "
+            "is not enumerated through this surface (issues #2990, #3014, #3090); the load "
             "itself is unaffected (the plugin's hooks still load and fire). Skipping "
             "loud rather than false-failing. "
             f"copilot --version: {version_text!r}; "
@@ -537,7 +537,7 @@ def test_copilot_version_omits_enumeration_true_for_benign_version() -> None:
     """CLI 1.0.69, 1.0.70, and 1.0.71 are the known plugin-enumeration-omitting releases.
 
     Both surface zero ``source: plugin`` records for a known-good ``--plugin-dir``
-    while the plugin still loads (issues #2990, #3014). A build-tag suffix
+    while the plugin still loads (issues #2990, #3014, #3090). A build-tag suffix
     (``1.0.69-3``) tracks the same release, so it still matches; extra surrounding
     text from ``--version`` is tolerated.
     """
@@ -551,7 +551,7 @@ def test_copilot_version_omits_enumeration_true_for_benign_version() -> None:
 
 
 def test_copilot_version_omits_enumeration_false_for_other_versions() -> None:
-    """Any version not in the benign set must fail loud, not skip (issues #2990, #3014).
+    """Any version not in the benign set must fail loud, not skip (issues #2990, #3014, #3090).
 
     A CLI that enumerates ``--plugin-dir`` skills but returns none is a real
     plugin-load regression; the negative control depends on this returning False.

--- a/tests/e2e/test_plugin_load_smoke.py
+++ b/tests/e2e/test_plugin_load_smoke.py
@@ -161,14 +161,15 @@ def _plugin_enumeration_available(payload: object) -> bool:
 
     The smoke skips ONLY for the known-benign shape: a well-formed JSON array
     that carries zero ``source: plugin`` records. On Copilot CLI 1.0.69
-    (verified 2026-07-08 on this repo's shipped ``src/copilot-cli`` tree) and
-    1.0.70 (issue #3014), ``copilot --plugin-dir <dir> skill list --json`` run
+    (verified 2026-07-08 on this repo's shipped ``src/copilot-cli`` tree),
+    1.0.70 (issue #3014), and 1.0.71 (issue #3090; verified via
+    debug-boot hooks-fired proof on 1.0.71-3), ``copilot --plugin-dir <dir> skill list --json`` run
     from a neutral cwd surfaces ZERO ``source: plugin`` records: the output
     carries only ``builtin`` and ``personal-copilot``. The ``source: project``
     group that does list the lifecycle skills is cwd-based (the repo you stand
     in), not ``--plugin-dir`` based, so it is not a valid load signal for a
     neutral-cwd smoke. The full set of benign versions lives in
-    ``_COPILOT_BENIGN_NO_ENUM_VERSIONS`` below. See issues #2990 and #3014.
+    ``_COPILOT_BENIGN_NO_ENUM_VERSIONS`` below. See issues #2990, #3014, and #3090.
 
     The caller validates list-ness first:
     ``test_copilot_plugin_loads_expected_skills`` fails loud on a non-list
@@ -188,7 +189,7 @@ def _plugin_enumeration_available(payload: object) -> bool:
     return _has_plugin_source_record(payload)
 
 
-_COPILOT_BENIGN_NO_ENUM_VERSIONS = frozenset({"1.0.69", "1.0.70"})
+_COPILOT_BENIGN_NO_ENUM_VERSIONS = frozenset({"1.0.69", "1.0.70", "1.0.71"})
 
 
 def _copilot_version_omits_plugin_enumeration(version_output: str) -> bool:
@@ -297,7 +298,7 @@ def test_copilot_plugin_loads_expected_skills(tmp_path: Path) -> None:
             )
         pytest.skip(
             "copilot skill list --json surfaced no source: plugin records for a "
-            "known-good --plugin-dir. On CLI 1.0.69 and 1.0.70 the plugin-dir load "
+            "known-good --plugin-dir. On CLI 1.0.69, 1.0.70, and 1.0.71 the plugin-dir load "
             "is not enumerated through this surface (issues #2990, #3014); the load "
             "itself is unaffected (the plugin's hooks still load and fire). Skipping "
             "loud rather than false-failing. "
@@ -533,7 +534,7 @@ def test_has_plugin_source_record() -> None:
 
 
 def test_copilot_version_omits_enumeration_true_for_benign_version() -> None:
-    """CLI 1.0.69 and 1.0.70 are the known plugin-enumeration-omitting releases.
+    """CLI 1.0.69, 1.0.70, and 1.0.71 are the known plugin-enumeration-omitting releases.
 
     Both surface zero ``source: plugin`` records for a known-good ``--plugin-dir``
     while the plugin still loads (issues #2990, #3014). A build-tag suffix
@@ -544,6 +545,8 @@ def test_copilot_version_omits_enumeration_true_for_benign_version() -> None:
     assert _copilot_version_omits_plugin_enumeration("1.0.69-3") is True
     assert _copilot_version_omits_plugin_enumeration("1.0.70") is True
     assert _copilot_version_omits_plugin_enumeration("1.0.70-0") is True
+    assert _copilot_version_omits_plugin_enumeration("1.0.71") is True
+    assert _copilot_version_omits_plugin_enumeration("1.0.71-3") is True
     assert _copilot_version_omits_plugin_enumeration("copilot 1.0.69 (build 42)") is True
 
 
@@ -554,7 +557,6 @@ def test_copilot_version_omits_enumeration_false_for_other_versions() -> None:
     plugin-load regression; the negative control depends on this returning False.
     """
     assert _copilot_version_omits_plugin_enumeration("1.0.68") is False
-    assert _copilot_version_omits_plugin_enumeration("1.0.71") is False
     assert _copilot_version_omits_plugin_enumeration("1.1.0") is False
     assert _copilot_version_omits_plugin_enumeration("2.0.0") is False
 


### PR DESCRIPTION
## Summary

Record Copilot CLI `1.0.71` as a benign plugin-enumeration-omitting version in
the plugin-load smoke test, so the local pre-push `Plugin-load e2e` gate skips
loud instead of false-failing on `1.0.71-3`.

## Why

`copilot 1.0.71-3` surfaces zero `source: plugin` records for a known-good
`--plugin-dir` through `skill list --json` from a neutral cwd, continuing the
`1.0.69` (#2990) / `1.0.70` (#3014) surfacing quirk. The plugin still loads: a
print-mode debug boot logs the project-toolkit `serena-reassertion` and
`session-init-enforcer` hooks firing under `1.0.71-3`. This is a surfacing
quirk in the `skill list` enumeration surface, not a plugin-load regression.

## Changes

- Add `1.0.71` to `_COPILOT_BENIGN_NO_ENUM_VERSIONS`.
- Flip the negative-control unit assertion for `1.0.71` from `is False` to
  `is True`; add `1.0.71` / `1.0.71-3` to the benign-version unit test.
- Update the docstrings, the runtime skip message, and the issue references to
  include `1.0.71` (#3090).

Mirrors `df14b0ff9` (#3015), which did the same for `1.0.70`.

## Test evidence

- `pytest tests/e2e/test_plugin_load_smoke.py -k version_omits_enumeration` -> 3 passed.
- Real-CLI smoke under `1.0.71-3` (`RUN_CLI_E2E=1`) now SKIPs benignly:
  "On CLI 1.0.69, 1.0.70, and 1.0.71 the plugin-dir load is not enumerated
  through this surface ... Skipping loud rather than false-failing" instead of
  the prior fail-loud.

Fixes #3090
