### PR TITLE
docs(agents): document how to notice running below the calibrated model floor (#3045)

### DIFF
--- a/.agents/governance/agent-design-principles.md
+++ b/.agents/governance/agent-design-principles.md
@@ -34,6 +34,20 @@ ADR-080 (accepted, not yet implemented) sets the model-pin policy: an unpinned u
 1. For a new prescriptive instruction, identify whether it constrains over-thinking or serves another documented project purpose. Both are valid.
 2. Do not merge an instruction as a default when its sole purpose is to compensate for a model below the calibrated envelope. That is scaffold-up this project does not provide, so flag it instead.
 
+### Noticing You Are Below the Calibrated Floor
+
+This project's guardrails constrain a frontier model down. They do not scaffold a weaker model up (see issue #3041, and "Why the direction matters" above). The ADR-080 `auto` default inherits whatever model the harness resolves, and that default is safe only while the harness default stays inside the frontier-tier calibrated envelope. If the harness resolves a materially weaker model, the guardrails stop protecting output quality. They were written to prune over-thinking in a capable model, not to add the decomposition a less capable model needs.
+
+There is no automated signal for this today. Issue #3045 decided this stays docs-only for now: no harness hook or runtime check exists to detect it. Watch for these observable symptoms instead, and treat them as a reason to check which model actually ran the session:
+
+- **Instructions followed too literally.** The agent executes the letter of a guardrail without the judgment the guardrail assumed, producing brittle or redundant steps a frontier model would have skipped.
+- **Over-thinking on simple tasks.** A frontier model prunes unnecessary reasoning on trivial work because these guardrails tell it to. A weaker model can lack the judgment to recognize a task is trivial, so the same guardrails do not produce the same restraint.
+- **Degraded multi-step reasoning.** Plans lose coherence across steps, tool-call sequences drift from the stated objective, or the agent loses track of earlier constraints partway through a task.
+
+No single symptom proves the model is below the floor. Together, and especially when they appear on tasks that previously ran cleanly, they are worth investigating.
+
+**What comes after this decision.** An eval-derived floor (the lowest model tier at which this project's evals still pass) is a defensible number, not a guess. That number depends on issue #3042's tiered eval sweep, which has not run yet. Building a runtime check now, before that number exists, would mean scaffolding a decision with nothing to decide against. Revisit runtime detection after #3042 produces the floor.
+
 ---
 
 ## Principle 1: Non-Overlapping Specialization

--- a/.agents/memory/episodes/episode-2026-07-16-session-3045.json
+++ b/.agents/memory/episodes/episode-2026-07-16-session-3045.json
@@ -1,0 +1,83 @@
+{
+  "id": "episode-2026-07-16-session-3045",
+  "session": "2026-07-16-session-3045",
+  "timestamp": "2026-07-16T00:00:00+00:00",
+  "outcome": "success",
+  "task": "docs(agents): document how to notice running below the calibrated model floor (issue #3045)",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-16T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Located frontier-model operating-assumption doc via grep: .agents/governance/agent-design-principles.md (not templates/agents/ as initially assumed; corrected via search-first)",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-16T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Confirmed issue #3045 scope via get_issue_context.py: decision is docs-only, eval-derived floor deferred to #3042",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-16T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Checked ADR-080 for existing capability-floor open-item reference: none found, so ADR-080 left untouched per task's conditional instruction",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-16T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added 'Noticing You Are Below the Calibrated Floor' subsection to agent-design-principles.md under 'Operating Assumption: Frontier-Model Execution', citing #3041 and #3042",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-16T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verified zero em/en dashes in added lines via byte-level python check",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-16T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Committed docs change with Fixes #3045",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-16T00:00:00+00:00",
+      "type": "milestone",
+      "content": "uv run pytest tests/ -x -q: 14173 passed, 19 skipped, 45 xfailed, 3 warnings in 123.89s (full suite, unaffected by this docs-only change)",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-16T00:00:00+00:00",
+      "type": "test",
+      "content": "uv run pytest tests/ -x -q: 14173 passed, 19 skipped, 45 xfailed, 3 warnings in 123.89s (full suite, unaffected by this docs-only change)",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-16-session-3045.json
+++ b/.agents/memory/episodes/episode-2026-07-16-session-3045.json
@@ -76,7 +76,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 3
   },
   "lessons": []

--- a/.agents/sessions/2026-07-16-session-3045.json
+++ b/.agents/sessions/2026-07-16-session-3045.json
@@ -122,7 +122,7 @@
     "Committed docs change with Fixes #3045",
     "uv run pytest tests/ -x -q: 14173 passed, 19 skipped, 45 xfailed, 3 warnings in 123.89s (full suite, unaffected by this docs-only change)"
   ],
-  "endingCommit": "",
+  "endingCommit": "bb8ca086",
   "nextSteps": [
     "Open PR via .claude/skills/github/scripts/pr/new_pr.py",
     "Post decision comment on issue #3045 referencing the PR"

--- a/.agents/sessions/2026-07-16-session-3045.json
+++ b/.agents/sessions/2026-07-16-session-3045.json
@@ -1,0 +1,130 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3045,
+    "date": "2026-07-16",
+    "branch": "docs/3045-capability-floor-docs",
+    "startingCommit": "2435adcf",
+    "objective": "docs(agents): document how to notice running below the calibrated model floor (issue #3045)"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena already active in session context; list_memories and read_memory calls succeeded"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Called mcp__serena__initial_instructions"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read; file is read-only legacy per 2025-12-22 protocol change, superseded by session logs"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Listed .claude/skills/github/scripts/issue and .claude/skills/session-init/scripts, .claude/skills/session-end/scripts"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read mcp__serena__read_memory('usage-mandatory')"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/governance/PROJECT-CONSTRAINTS.md (Language, Skill Usage sections)"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "mcp__serena__list_memories(topic='governance') returned 10 memories; read usage-mandatory"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "docs/3045-capability-floor-docs"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On docs/3045-capability-floor-docs"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status --short run before and after branch checkout"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "2435adcf"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST sessionStart and sessionEnd items completed with evidence"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md not edited (read-only per 2025-12-22 protocol change)"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "mcp__serena__write_memory('governance/issue-3045-capability-floor-docs-decision')"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "npx markdownlint-cli2 run (file excluded by .agents/** glob); pre_pr.py Markdown Linting check: PASS"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Commit created on docs/3045-capability-floor-docs; SHA recorded in endingCommit below"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "pre_pr.py: 1 pre-existing failure (Skill Markdown Portability, ModuleNotFoundError in check_skill_md_portability.py) confirmed unrelated via git stash test against origin/main tip 2435adcf; all other 32 checks PASS/SKIP"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "No external task tracker for this docs-only task; tracked via this session log and issue #3045"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Single-file docs change with a pre-made decision; not warranted"
+      }
+    }
+  },
+  "workLog": [
+    "Located frontier-model operating-assumption doc via grep: .agents/governance/agent-design-principles.md (not templates/agents/ as initially assumed; corrected via search-first)",
+    "Confirmed issue #3045 scope via get_issue_context.py: decision is docs-only, eval-derived floor deferred to #3042",
+    "Checked ADR-080 for existing capability-floor open-item reference: none found, so ADR-080 left untouched per task's conditional instruction",
+    "Added 'Noticing You Are Below the Calibrated Floor' subsection to agent-design-principles.md under 'Operating Assumption: Frontier-Model Execution', citing #3041 and #3042",
+    "Verified zero em/en dashes in added lines via byte-level python check",
+    "Committed docs change with Fixes #3045",
+    "uv run pytest tests/ -x -q: 14173 passed, 19 skipped, 45 xfailed, 3 warnings in 123.89s (full suite, unaffected by this docs-only change)"
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Open PR via .claude/skills/github/scripts/pr/new_pr.py",
+    "Post decision comment on issue #3045 referencing the PR"
+  ]
+}


### PR DESCRIPTION
# Pull Request

## Summary

### What

Adds a "Noticing You Are Below the Calibrated Floor" subsection to
`.agents/governance/agent-design-principles.md`, listing the observable
symptoms of running below the frontier-tier model this project's guardrails
assume.

### Why

Issue #3045 asked whether the harness resolving a model below the calibrated
tier should be a detectable condition. The owner decided: docs-only for now.
Document the symptoms an operator or agent can watch for; defer an
eval-derived floor to issue #3042's tiered sweep, which has not run yet and
is the only source of a defensible number to detect against.

## Specification References

| Type | Reference | Description |
|------|-----------|--------------|
| **Issue** | Fixes #3045 | Capability-floor detection: make "auto resolved below the calibrated tier" observable, not silent |

## Changes

- Added a new subsection to `.agents/governance/agent-design-principles.md`
  under "Operating Assumption: Frontier-Model Execution" (after "How to
  Verify", before Principle 1), citing issue #3041 (the frontier-model
  assumption) and issue #3042 (the deferred eval-derived floor).
- Checked ADR-080 for an existing "capability-floor" open-item reference;
  none exists, so ADR-080 was left unchanged per the scoping decision.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: rubber stamp, standard scrutiny (governance file, human approval required per `.claude/rules/governance.md`), no rush.

**Focus areas**: whether the three listed symptoms (literal instruction-following, over-thinking on simple tasks, degraded multi-step reasoning) are the right observable signals, and whether the docs-only scope matches the #3045 decision.

## Testing

- [ ] Tests added/updated
- [ ] Manual testing completed
- [x] No testing required (documentation only)

Full suite run for verification anyway (docs change touched a session-log
JSON file alongside the markdown, so this was not a pure `.md`-only diff):
`uv run pytest tests/ -x -q` → 14173 passed, 19 skipped, 45 xfailed, 3
warnings in 123.89s. Unaffected by this change; run as pre-commit evidence.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [ ] Architect reviewed design changes
- [ ] Critic validated implementation plan
- [ ] QA verified test coverage

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed (`python3 scripts/validation/pre_pr.py`; one
      pre-existing, unrelated failure noted below)
- [x] Lint and formatting clean (scoped to changed files)
- [x] Code follows project style guidelines and code quality standards
- [x] Self-review completed (read the diff as if I did not write it)
- [x] Comments added only where the *why* is non-obvious
- [x] Documentation updated (if applicable)
- [x] No new warnings introduced

## Notes for Reviewers

This is a governance-file change. Per `.claude/rules/governance.md`,
governance changes require human review and auto-merge is prohibited; this
PR will not have auto-merge armed. It is additive documentation of an
already-made decision (#3045), not a new rule or policy reversal, so no new
ADR accompanies it.

**Unrelated pre-existing failure found during validation**: `pre_pr.py`'s
"Skill Markdown Portability" check fails with
`ModuleNotFoundError: No module named 'scripts'` inside
`scripts/validation/check_skill_md_portability.py` (line 60). Confirmed via
`git stash` that this reproduces on a clean `origin/main` tip (commit
`2435adcf`), independent of this PR's diff. Not fixed here to keep this PR
scoped to the docs-only decision; worth a separate issue if not already
tracked.

## Related Issues

Fixes #3045
