### PR TITLE
fix(validation): degrade workflow-gate tool gaps in remote containers (#3064)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -892,33 +892,48 @@ if [ -n "$CHANGED_WORKFLOWS" ]; then
                 > "$WF_LOCAL_OUTPUT" 2>&1
             WF_LOCAL_RC=$?
             if [ $WF_LOCAL_RC -eq 0 ]; then
-                WF_SECRET_SUMMARY=$("${PYTHON_CMD[@]}" - "$WF_LOCAL_OUTPUT" 2>/dev/null <<'PY'
+                # An exit 0 has three shapes: a clean pass, a secret-skip
+                # (secret_skipped=true), and an environment degrade
+                # (degraded=true) where a tool gap was downgraded inside a
+                # remote container (Issue #3064 extends #2548 item 3). Parse
+                # BOTH flags: without the degraded flag a container degrade
+                # surfaces as a silent record_pass, hiding that the local run
+                # did not actually execute.
+                WF_LOCAL_SUMMARY=$("${PYTHON_CMD[@]}" - "$WF_LOCAL_OUTPUT" 2>/dev/null <<'PY'
 import json
 import sys
 
 with open(sys.argv[1], encoding="utf-8") as handle:
     payload = json.load(handle)
-value = payload.get("secret_skipped")
-if not isinstance(value, bool):
+secret_skipped = payload.get("secret_skipped")
+degraded = payload.get("degraded")
+if not isinstance(secret_skipped, bool) or not isinstance(degraded, bool):
     raise SystemExit(2)
 note = payload.get("note")
-if value and not isinstance(note, str):
+if (secret_skipped or degraded) and not isinstance(note, str):
     raise SystemExit(2)
-print("true" if value else "false")
-if value and note:
+print("true" if secret_skipped else "false")
+print("true" if degraded else "false")
+if note and (secret_skipped or degraded):
     print(note)
 PY
 )
-                WF_SECRET_PARSE_RC=$?
-                WF_SECRET_SKIPPED=$(printf '%s\n' "$WF_SECRET_SUMMARY" | sed -n '1p')
-                WF_SECRET_NOTE=$(printf '%s\n' "$WF_SECRET_SUMMARY" | sed '1d')
-                if [ $WF_SECRET_PARSE_RC -ne 0 ]; then
+                WF_LOCAL_PARSE_RC=$?
+                WF_SECRET_SKIPPED=$(printf '%s\n' "$WF_LOCAL_SUMMARY" | sed -n '1p')
+                WF_DEGRADED=$(printf '%s\n' "$WF_LOCAL_SUMMARY" | sed -n '2p')
+                WF_LOCAL_NOTE=$(printf '%s\n' "$WF_LOCAL_SUMMARY" | sed '1,2d')
+                if [ $WF_LOCAL_PARSE_RC -ne 0 ]; then
                     cat "$WF_LOCAL_OUTPUT"
                     record_fail "Workflow local run returned malformed JSON"
                     echo_info "  Fix scripts/validation/run_workflow_local_test.py output before pushing."
+                elif [ "$WF_DEGRADED" = "true" ]; then
+                    if [ -n "$WF_LOCAL_NOTE" ]; then
+                        echo_info "  $WF_LOCAL_NOTE"
+                    fi
+                    record_warn "Workflow local run degraded: a required tool is unavailable in this environment; CI runs the full workflow check"
                 elif [ "$WF_SECRET_SKIPPED" = "true" ]; then
-                    if [ -n "$WF_SECRET_NOTE" ]; then
-                        echo_info "  $WF_SECRET_NOTE"
+                    if [ -n "$WF_LOCAL_NOTE" ]; then
+                        echo_info "  $WF_LOCAL_NOTE"
                     fi
                     record_warn "Workflow local run: some workflows skipped (secrets absent locally); CI runs them with real secrets"
                 else

--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -24,13 +24,18 @@ block with an actionable message. A documented bypass exists for workflows that
 genuinely cannot run under act (secrets, ARM-only runners): set
 ``SKIP_WORKFLOW_LOCAL_TEST=true``; the bypass is logged, not hidden.
 
-One gap degrades instead of blocking: when ``gh`` or the ``gh act`` extension is
-unavailable inside a managed remote container (Claude web containers or GitHub
-Codespaces, detected by env markers), the gate returns exit 0 with
-``degraded=True`` and a logged warning. Such an environment may not be able to
-provision ``gh act``, so blocking every workflow-touching push there is friction,
-not safety. A truthy ``CI`` marker overrides the managed-container signal, so CI,
-where ``gh act`` is provisioned, keeps the hard exit 3 (Issue #2548, item 3).
+Tool gaps degrade instead of blocking inside a managed remote container: when
+actionlint, ``gh``, the ``gh act`` extension, or the Docker daemon is
+unavailable inside a Claude web container or a GitHub Codespace (detected by env
+markers), the gate returns exit 0 with ``degraded=True`` and a logged warning.
+Such an environment may not be able to provision those tools, so blocking every
+workflow-touching push there is friction, not safety. A truthy ``CI`` marker
+overrides the managed-container signal, so CI, where the tools are provisioned,
+keeps the hard exit 3. On a dev laptop (no container marker) the gap also stays
+exit 3, so the local-run requirement is unchanged there. Issue #2548 item 3
+introduced this degrade for the ``gh``/``gh act`` gap; Issue #3064 extended it to
+the actionlint and Docker gaps so a container without those tools can still push
+a workflow edit.
 
 CLI
 ---
@@ -47,7 +52,10 @@ EXIT CODES (per ADR-035, exit-code contract in AGENTS.md)
 0 - all stages passed (or no workflow files, or bypassed)
 1 - a stage ran and failed (block the push)
 2 - configuration error (bad args, repo root absent)
-3 - a required tool is unavailable (actionlint, gh act, or Docker)
+3 - a required tool is unavailable (actionlint, gh act, or Docker). Inside a
+    managed remote container this gap degrades to exit 0 (degraded=True)
+    instead, because the tool cannot be provisioned there; CI and dev laptops
+    keep the hard exit 3 (Issue #3064)
 4 - unrunnable locally: actionlint passed but every changed workflow
     references a secret absent from this environment, so act has nothing to
     supply (auth per ADR-035). Skipped the act run audibly; CI runs it with the
@@ -565,26 +573,35 @@ def _act_full_stage(files: Sequence[str], repo_root: Path) -> StageResult:
 # --- Orchestration -------------------------------------------------------
 
 
-def _gh_act_gap_report(report: Report, tool_note: str) -> Report:
-    """Resolve a missing-``gh``/``gh act`` gap into a blocking or degraded Report.
+def _tool_gap_report(report: Report, note: str) -> Report:
+    """Resolve a missing-tool gap into a blocking or degraded Report.
 
-    In a remote container (see :func:`_is_remote_container`) the gap is an
-    environment limitation, not a code defect, so the gate degrades to a logged
-    warning (exit 0, ``degraded=True``) and the push proceeds. Everywhere else
-    the gap stays a blocking tool-unavailable failure (exit 3). The bypass hint
-    in ``tool_note`` is preserved either way (Issue #2548, item 3).
+    A tool gap is a missing actionlint, ``gh``, ``gh act`` extension, or Docker
+    daemon: the local run cannot proceed, but the workflow itself is not proven
+    broken. In a remote container (see :func:`_is_remote_container`) the gap is
+    an environment limitation, not a code defect, so the gate degrades to a
+    logged warning (exit 0, ``degraded=True``) and the push proceeds. Everywhere
+    else (a dev laptop, or CI where the tools are provisioned) the gap stays a
+    blocking tool-unavailable failure (exit 3). The install hint in ``note`` is
+    preserved either way.
+
+    Issue #2548 item 3 introduced this degrade for the ``gh``/``gh act`` gap;
+    Issue #3064 makes it the single DRY degrade path for every tool gap
+    (actionlint and Docker included), so a container that cannot provision
+    Docker or actionlint can still push a workflow edit while CI keeps the hard
+    exit 3.
     """
     if _is_remote_container():
         report.exit_code = 0
         report.degraded = True
         report.note = (
-            f"{tool_note} Remote container detected; gh act cannot be "
+            f"{note} Remote container detected; the missing tool cannot be "
             "provisioned here, so this gate is downgraded to a warning. CI "
             "still runs the full workflow check."
         )
         return report
     report.exit_code = 3
-    report.note = tool_note
+    report.note = note
     return report
 
 
@@ -654,13 +671,12 @@ def run_local_test(
     # with a real syntax error must still be caught here; linting only the
     # runnable subset would let that error bypass the gate (Issue #2841 review).
     if not _have("actionlint"):
-        report.exit_code = 3
-        report.note = (
+        return _tool_gap_report(
+            report,
             "actionlint not installed. Install it "
             "(https://github.com/rhysd/actionlint) or set "
-            f"{_BYPASS_ENV}=true to bypass for an unrunnable workflow."
+            f"{_BYPASS_ENV}=true to bypass for an unrunnable workflow.",
         )
-        return report
     s1 = _actionlint_stage(files, repo_root)
     report.stages.append(s1)
     if not s1.ok:
@@ -686,12 +702,12 @@ def run_local_test(
     # Stage 2 (dry-run) needs gh act but not a running Docker daemon: act -n
     # only plans the run.
     if not _have("gh"):
-        return _gh_act_gap_report(
+        return _tool_gap_report(
             report,
             f"gh CLI not installed. Install it or set {_BYPASS_ENV}=true.",
         )
     if not _gh_act_available():
-        return _gh_act_gap_report(
+        return _tool_gap_report(
             report,
             "gh act extension not installed. Install it via "
             f"'gh extension install nektos/gh-act' or set {_BYPASS_ENV}=true.",
@@ -712,17 +728,16 @@ def run_local_test(
     # Stage 3 (full run) executes in Docker, so it needs a live daemon.
     if full:
         if not _docker_ready():
-            report.exit_code = 3
             if not _have("docker"):
                 cause = "Docker is not installed"
             else:
                 cause = "the Docker daemon is not running"
-            report.note = (
+            note = (
                 f"{cause}; the full gh act run cannot execute. Install/start "
                 f"Docker or set {_BYPASS_ENV}=true to bypass an unrunnable "
                 "workflow (or pass --no-full for the lint+dry-run tier)."
             )
-            return report
+            return _tool_gap_report(report, note)
         s3 = _act_full_stage(runnable, repo_root)
         report.stages.append(s3)
         if not s3.ok:

--- a/tests/test_pre_push_tree_neutral.py
+++ b/tests/test_pre_push_tree_neutral.py
@@ -115,8 +115,9 @@ def test_workflow_local_mixed_secret_skip_uses_json_signal() -> None:
 
     assert "--format json --files" in workflow_section
     assert '.get("secret_skipped")' in workflow_section
-    assert "WF_SECRET_NOTE" in workflow_section
-    assert "WF_SECRET_PARSE_RC" in workflow_section
+    # #3064 degrade refactor renamed the note var (summary now carries secret+degrade)
+    assert "WF_LOCAL_NOTE" in workflow_section
+    assert "WF_LOCAL_PARSE_RC" in workflow_section
     assert "returned malformed JSON" in workflow_section
     assert 'grep -q "skipped (secrets absent locally)"' not in workflow_section
 

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -132,6 +132,39 @@ def test_actionlint_missing_is_exit_3(monkeypatch, tmp_path):
     assert "actionlint" in r.note
 
 
+def test_actionlint_missing_in_remote_container_downgrades_to_warning(
+    monkeypatch, tmp_path
+):
+    # actionlint unavailable inside a remote container (CLAUDECODE set, no CI)
+    # must not block the push: it degrades to a logged warning (exit 0), the same
+    # way the gh/gh act gap already does. Issue #3064 extends PR #2548's degrade
+    # to the actionlint gap.
+    monkeypatch.setattr(w, "_have", lambda tool: tool != "actionlint")
+    monkeypatch.delenv(w._BYPASS_ENV, raising=False)
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 0
+    assert r.degraded is True
+    assert "actionlint" in r.note
+
+
+def test_actionlint_missing_in_ci_still_blocks_even_with_container_signal(
+    monkeypatch, tmp_path
+):
+    # CI provisions actionlint, so a missing binary is a real failure. The CI
+    # marker overrides the container signal via the real _is_remote_container():
+    # hard exit 3, never degraded (Issue #3064).
+    monkeypatch.setattr(w, "_have", lambda tool: tool != "actionlint")
+    monkeypatch.delenv(w._BYPASS_ENV, raising=False)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("CI", "true")
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 3
+    assert r.degraded is False
+    assert "actionlint" in r.note
+
+
 def test_gh_missing_is_exit_3(monkeypatch, tmp_path):
     # On a normal (non-container) box, a missing gh CLI is a real tool gap and
     # blocks at exit 3. The container-downgrade seam is pinned off so the test
@@ -263,6 +296,40 @@ def test_docker_not_installed_is_exit_3_with_distinct_note(monkeypatch, tmp_path
     r = w.run_local_test([WF], tmp_path)
     assert r.exit_code == 3
     assert "Docker is not installed" in r.note
+
+
+def test_docker_missing_in_remote_container_downgrades_to_warning(
+    all_tools, monkeypatch, tmp_path
+):
+    # Docker unavailable inside a remote container (CLAUDECODE set, no CI) must
+    # not block the push: actionlint and the dry-run pass, and the full stage's
+    # Docker gap degrades to a logged warning (exit 0). Issue #3064.
+    monkeypatch.setattr(w, "_docker_ready", lambda: False)
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 0
+    assert r.degraded is True
+    assert "Docker" in r.note
+
+
+def test_docker_missing_in_ci_still_blocks_even_with_container_signal(
+    all_tools, monkeypatch, tmp_path
+):
+    # CI provisions Docker, so a down daemon is a real failure even with a
+    # container env marker present. The CI marker overrides the container signal
+    # via the real _is_remote_container(): hard exit 3, never degraded (#3064).
+    monkeypatch.setattr(w, "_docker_ready", lambda: False)
+    monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
+    monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("CI", "true")
+    r = w.run_local_test([WF], tmp_path)
+    assert r.exit_code == 3
+    assert r.degraded is False
+    assert "Docker" in r.note
 
 
 def test_no_full_does_not_require_docker(all_tools, monkeypatch, tmp_path):

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -121,7 +121,11 @@ def test_select_workflow_files_keeps_only_workflows(tmp_path):
 
 
 def test_actionlint_missing_is_exit_3(monkeypatch, tmp_path):
+    # On a normal (non-container) box a missing actionlint is a real tool gap and
+    # blocks at exit 3. The container-downgrade seam is pinned off so the test is
+    # deterministic regardless of the host env (Issue #3064).
     monkeypatch.setattr(w, "_have", lambda tool: tool != "actionlint")
+    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
     monkeypatch.delenv(w._BYPASS_ENV, raising=False)
     r = w.run_local_test([WF], tmp_path)
     assert r.exit_code == 3
@@ -234,8 +238,11 @@ def test_plain_docker_marker_does_not_downgrade(monkeypatch, tmp_path):
 
 def test_docker_down_is_exit_3_for_full(all_tools, monkeypatch, tmp_path):
     # Dry-run passes (no daemon needed); the full stage needs Docker -> exit 3.
-    # docker is installed but the daemon is down -> "not running" note.
+    # docker is installed but the daemon is down -> "not running" note. The
+    # container-downgrade seam is pinned off so the exit-3 assertion is
+    # deterministic regardless of the host env (Issue #3064).
     monkeypatch.setattr(w, "_docker_ready", lambda: False)
+    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
     monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
     monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
     r = w.run_local_test([WF], tmp_path)
@@ -245,9 +252,11 @@ def test_docker_down_is_exit_3_for_full(all_tools, monkeypatch, tmp_path):
 
 def test_docker_not_installed_is_exit_3_with_distinct_note(monkeypatch, tmp_path):
     # docker binary absent -> "not installed" note, distinct from daemon-down.
+    # The container-downgrade seam is pinned off (Issue #3064).
     monkeypatch.setattr(w, "_have", lambda tool: tool != "docker")
     monkeypatch.setattr(w, "_gh_act_available", lambda: True)
     monkeypatch.setattr(w, "_docker_ready", lambda: False)
+    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
     monkeypatch.setattr(w, "_actionlint_stage", lambda f, r: _ok("actionlint"))
     monkeypatch.setattr(w, "_act_dryrun_stage", lambda f, r: _ok("gh act -n"))
     monkeypatch.delenv(w._BYPASS_ENV, raising=False)
@@ -440,8 +449,11 @@ def test_all_secret_blocked_lints_before_skipping(monkeypatch, tmp_path):
 
 def test_all_secret_blocked_actionlint_missing_is_exit_3(monkeypatch, tmp_path):
     # actionlint is required for every changed workflow; its absence blocks
-    # (exit 3) even when every workflow is secret-blocked.
+    # (exit 3) even when every workflow is secret-blocked. Pin the
+    # container-downgrade seam off so the exit-3 assertion holds regardless of
+    # the host env (Issue #3064).
     monkeypatch.setattr(w, "_have", lambda tool: tool != "actionlint")
+    monkeypatch.setattr(w, "_is_remote_container", lambda: False)
     monkeypatch.delenv("BOT_PAT_2841", raising=False)
     _write_wf_secrets(tmp_path, WF, "BOT_PAT_2841")
     r = w.run_local_test([WF], tmp_path)


### PR DESCRIPTION
Refs #3064. Extends the pre-push workflow local-run gate's existing remote-container degrade (PR #2548) to also cover actionlint-absent and Docker-absent tool gaps via a shared _tool_gap_report path. Inside a remote container (CLAUDECODE/CODESPACES, CI unset) a tool gap degrades to a loud record_warn instead of a hard block; dev laptops and CI keep the hard exit-3 block. Issue stays OPEN (dev-laptop degrade needs a separate ADR). Security-agent PIV: PASS (supply-chain floor intact; validate_workflows.py section 8a stays BLOCKING; CI keeps hard exit 3). Full pre-push suite green (14176 tests).