### PR TITLE
feat(ci): ADR-006 run-block burn-down scanner (#3084)

### DIFF
--- a/scripts/ci/adr006_run_block_scanner.py
+++ b/scripts/ci/adr006_run_block_scanner.py
@@ -111,11 +111,16 @@ def scan_text(text: str) -> list[RunBlock]:
         key_indent = len(match.group("indent"))
         body, nxt = _body_lines(lines, i, key_indent)
         body_text = "\n".join(body)
+        # Filter out comments and blank lines before logic detection to avoid
+        # false positives from keywords appearing only in comment text.
+        code_only_text = "\n".join(
+            line for line in body if line.strip() and not line.strip().startswith("#")
+        )
         blocks.append(
             RunBlock(
                 line=i + 1,
                 code_lines=_count_code_lines(body),
-                has_logic=bool(_LOGIC.search(body_text)),
+                has_logic=bool(_LOGIC.search(code_only_text)),
                 body=body_text,
             )
         )

--- a/scripts/ci/adr006_run_block_scanner.py
+++ b/scripts/ci/adr006_run_block_scanner.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""ADR-006 run-block scanner: an objective, re-runnable burn-down metric (#3084).
+
+ADR-006 forbids business logic in workflow YAML ``run:`` blocks; the work is
+tracked by #2967. That burn-down count ("93 genuine violations") came from a
+one-off manual audit and could not be re-run or CI-tracked. This scanner makes
+it reproducible: it flags ``run:`` block scalars over a code-line threshold that
+also contain logic (conditionals, loops, parsing pipes, computed variables, or
+output assembly), the same high-signal heuristic the manual audit used.
+
+It is a METRIC by default (exit 0, prints the count + list). Pass ``--max N`` to
+turn it into a ratchet gate that exits 1 when the violation count exceeds N, so
+the burn-down cannot silently regress.
+
+Exit codes (AGENTS.md): 0 ok, 1 over --max, 2 config error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+EXIT_OK = 0
+EXIT_OVER_MAX = 1
+EXIT_CONFIG = 2
+
+_DEFAULT_THRESHOLD = 10
+_SCAN_GLOBS = (
+    ".github/workflows/*.yml",
+    ".github/workflows/*.yaml",
+    ".github/actions/*/action.yml",
+)
+
+# A run: key, optionally preceded by a YAML list dash, introducing a block
+# scalar (| or >). Inline one-line commands (no block scalar) are single
+# commands, not logic blocks, and are skipped.
+_RUN_KEY = re.compile(r"^(?P<indent>\s*)(?:-\s+)?run:\s*(?P<scalar>[|>][+-]?\d*)\s*$")
+
+# High-signal logic markers, matching the manual-audit criteria: conditionals,
+# loops, parsing pipes, computed variables, and output assembly.
+_LOGIC = re.compile(
+    r"""(?xm)
+    \bif\b | \belif\b | \bfor\b | \bwhile\b | \bcase\b |     # conditionals / loops
+    ^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*= |              # variable assignment
+    \$\( |                                                    # command substitution
+    \|\s*(?:jq|grep|sed|awk|python3?|cut|tr|head|tail|xargs)\b |  # parsing pipes
+    >>?\s*"?\$?\{?\s*GITHUB_(?:OUTPUT|ENV|STEP_SUMMARY)       # output assembly
+    """,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RunBlock:
+    """One ``run:`` block scalar found in a file."""
+
+    line: int  # 1-based line of the run: key
+    code_lines: int  # non-blank, non-comment body lines
+    has_logic: bool
+    body: str
+
+
+def _body_lines(lines: Sequence[str], start: int, key_indent: int) -> tuple[list[str], int]:
+    """Collect the block-scalar body after ``start`` (0-based key index).
+
+    A body line belongs to the block when it is blank or indented deeper than the
+    ``run:`` key. Returns (body_lines, next_index).
+    """
+    body: list[str] = []
+    j = start + 1
+    while j < len(lines):
+        raw = lines[j]
+        if raw.strip() == "":
+            body.append(raw)
+            j += 1
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        if indent > key_indent:
+            body.append(raw)
+            j += 1
+        else:
+            break
+    return body, j
+
+
+def _count_code_lines(body: Iterable[str]) -> int:
+    """Non-blank body lines that are not pure comments."""
+    count = 0
+    for raw in body:
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        count += 1
+    return count
+
+
+def scan_text(text: str) -> list[RunBlock]:
+    """Return every ``run:`` block scalar in ``text`` with its metrics."""
+    lines = text.splitlines()
+    blocks: list[RunBlock] = []
+    i = 0
+    while i < len(lines):
+        match = _RUN_KEY.match(lines[i])
+        if match is None:
+            i += 1
+            continue
+        key_indent = len(match.group("indent"))
+        body, nxt = _body_lines(lines, i, key_indent)
+        body_text = "\n".join(body)
+        blocks.append(
+            RunBlock(
+                line=i + 1,
+                code_lines=_count_code_lines(body),
+                has_logic=bool(_LOGIC.search(body_text)),
+                body=body_text,
+            )
+        )
+        i = nxt
+    return blocks
+
+
+def is_violation(block: RunBlock, threshold: int) -> bool:
+    """A block violates ADR-006 when it is large AND carries logic."""
+    return block.code_lines > threshold and block.has_logic
+
+
+def _iter_targets(root: Path) -> list[Path]:
+    targets: list[Path] = []
+    for pattern in _SCAN_GLOBS:
+        targets.extend(sorted(root.glob(pattern)))
+    return targets
+
+
+def scan_repo(root: Path, threshold: int) -> list[dict[str, object]]:
+    """Scan the repo's workflow/action files, returning violation records."""
+    found: list[tuple[str, RunBlock]] = []
+    for path in _iter_targets(root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        rel = path.relative_to(root).as_posix()
+        for block in scan_text(text):
+            if is_violation(block, threshold):
+                found.append((rel, block))
+    found.sort(key=lambda rb: (-rb[1].code_lines, rb[0], rb[1].line))
+    return [
+        {"file": rel, "line": block.line, "code_lines": block.code_lines}
+        for rel, block in found
+    ]
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="ADR-006 run-block burn-down scanner (#3084).")
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="Repo root.")
+    parser.add_argument(
+        "--threshold", type=int, default=_DEFAULT_THRESHOLD,
+        help=f"Min body code lines to count as a violation (default {_DEFAULT_THRESHOLD}).",
+    )
+    parser.add_argument(
+        "--max", type=int, default=None, dest="max_allowed",
+        help="Gate mode: exit 1 when the violation count exceeds MAX.",
+    )
+    parser.add_argument("--format", choices=("json", "human"), default="human")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    root = args.root.resolve()
+    if not root.is_dir():
+        print(f"error: root not found: {root}", file=sys.stderr)
+        return EXIT_CONFIG
+    if args.threshold < 0:
+        print("error: --threshold must be >= 0", file=sys.stderr)
+        return EXIT_CONFIG
+
+    violations = scan_repo(root, args.threshold)
+    count = len(violations)
+
+    if args.format == "json":
+        payload = {"threshold": args.threshold, "count": count, "violations": violations}
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"ADR-006 run-block violations (> {args.threshold} code lines + logic): {count}")
+        for v in violations:
+            print(f"  {v['file']}:{v['line']}  ({v['code_lines']} code lines)")
+
+    if args.max_allowed is not None and count > args.max_allowed:
+        print(
+            f"ADR-006 scanner: {count} violations exceeds --max {args.max_allowed}.",
+            file=sys.stderr,
+        )
+        return EXIT_OVER_MAX
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_adr006_run_block_scanner.py
+++ b/tests/ci/test_adr006_run_block_scanner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import textwrap
 from pathlib import Path
 
@@ -101,6 +102,71 @@ def test_gate_mode_exits_over_max(tmp_path: Path):
 
 def test_bad_root_is_config_error(tmp_path: Path):
     assert scanner.main(["--root", str(tmp_path / "absent")]) == scanner.EXIT_CONFIG
+
+
+def test_json_output_emits_threshold_count_and_violations(tmp_path: Path, capsys):
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "x.yml").write_text(_big_logic_run(), encoding="utf-8")
+
+    exit_code = scanner.main(["--root", str(tmp_path), "--format", "json"])
+
+    assert exit_code == scanner.EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["threshold"] == scanner._DEFAULT_THRESHOLD
+    assert payload["count"] == 1
+    violation = payload["violations"][0]
+    assert violation["file"].endswith("x.yml")
+    assert violation["code_lines"] > scanner._DEFAULT_THRESHOLD
+
+
+# Parse block modeled on .github/actions/ai-review/action.yml (verdict/labels/
+# milestone extraction, lines 680-769), a #2967-listed ADR-006 offender: sed
+# and python3 parsing pipes, computed variables, a case dispatch, and
+# GITHUB_OUTPUT assembly. sed patterns trimmed to fit the line-length limit;
+# the logic markers the scanner keys on are preserved.
+_AI_REVIEW_PARSE_BLOCK = textwrap.dedent(
+    r"""
+    steps:
+      - run: |
+          output=$(cat /tmp/ai-review-output.txt 2>/dev/null || echo "")
+          verdict=$(echo "$output" | sed -n 's/.*VERDICT: *\([A-Z_]*\).*/\1/p' | tail -n 1)
+          if [ -z "$verdict" ]; then
+            verdict=$(printf '%s' "$output" | python3 -c 'import sys; print(sys.stdin.read())')
+          fi
+          case "$verdict" in
+            PASS|WARN|CRITICAL_FAIL)
+              ;;
+            *)
+              verdict="NEEDS_REVIEW"
+              ;;
+          esac
+          labels_raw=$(echo "$output" | sed -n 's/.*LABEL: *\(.*\)/\1/p' | tr '\n' ',')
+          milestone=$(echo "$output" | sed -n 's/.*MILESTONE: *\(.*\)/\1/p' | head -1)
+          echo "verdict=$verdict" >> "$GITHUB_OUTPUT"
+          echo "labels=$labels_raw" >> "$GITHUB_OUTPUT"
+          echo "milestone=$milestone" >> "$GITHUB_OUTPUT"
+    """
+)
+
+
+def test_known_violating_parse_block_is_flagged():
+    block = scanner.scan_text(_AI_REVIEW_PARSE_BLOCK)[0]
+    assert block.has_logic is True
+    assert block.code_lines > scanner._DEFAULT_THRESHOLD
+    assert scanner.is_violation(block, scanner._DEFAULT_THRESHOLD) is True
+
+
+def test_large_pure_output_block_is_not_flagged():
+    body = "\n".join(f'          echo "line {i}"' for i in range(8))
+    body += "\n" + "\n".join(f'          printf "%s\\n" "value {i}"' for i in range(6))
+    text = "steps:\n  - run: |\n" + body + "\n"
+
+    block = scanner.scan_text(text)[0]
+
+    assert block.code_lines > scanner._DEFAULT_THRESHOLD
+    assert block.has_logic is False
+    assert scanner.is_violation(block, scanner._DEFAULT_THRESHOLD) is False
 
 
 if __name__ == "__main__":

--- a/tests/ci/test_adr006_run_block_scanner.py
+++ b/tests/ci/test_adr006_run_block_scanner.py
@@ -1,0 +1,109 @@
+"""Tests for the ADR-006 run-block scanner (#3084)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from scripts.ci import adr006_run_block_scanner as scanner
+
+
+def _big_logic_run() -> str:
+    body = "\n".join(f"          echo line {i}" for i in range(12))
+    return textwrap.dedent(
+        """\
+        jobs:
+          build:
+            steps:
+              - run: |
+                  if [ -n "$X" ]; then
+        """
+    ) + body + "\n"
+
+
+def test_detects_large_logic_block_as_violation():
+    blocks = scanner.scan_text(_big_logic_run())
+    assert len(blocks) == 1
+    block = blocks[0]
+    assert block.has_logic is True
+    assert block.code_lines > scanner._DEFAULT_THRESHOLD
+    assert scanner.is_violation(block, scanner._DEFAULT_THRESHOLD) is True
+
+
+def test_small_logic_block_is_not_a_violation():
+    text = textwrap.dedent(
+        """\
+        steps:
+          - run: |
+              if [ -n "$X" ]; then
+                echo hi
+              fi
+        """
+    )
+    block = scanner.scan_text(text)[0]
+    assert block.has_logic is True
+    assert scanner.is_violation(block, scanner._DEFAULT_THRESHOLD) is False
+
+
+def test_large_block_without_logic_is_not_a_violation():
+    body = "\n".join(f"      echo plain {i}" for i in range(15))
+    text = "steps:\n  - run: |\n" + body + "\n"
+    block = scanner.scan_text(text)[0]
+    assert block.code_lines > scanner._DEFAULT_THRESHOLD
+    assert block.has_logic is False
+    assert scanner.is_violation(block, scanner._DEFAULT_THRESHOLD) is False
+
+
+def test_inline_run_without_block_scalar_is_ignored():
+    text = "steps:\n  - run: echo hello world\n"
+    assert scanner.scan_text(text) == []
+
+
+def test_comments_and_blanks_are_not_counted():
+    text = textwrap.dedent(
+        """\
+        steps:
+          - run: |
+              # a comment
+              echo real
+
+              # another comment
+              echo real2
+        """
+    )
+    block = scanner.scan_text(text)[0]
+    assert block.code_lines == 2
+
+
+def test_line_number_points_at_run_key():
+    text = "steps:\n  - name: x\n  - run: |\n      echo hi\n"
+    block = scanner.scan_text(text)[0]
+    assert block.line == 3
+
+
+def test_output_assembly_counts_as_logic():
+    text = 'steps:\n  - run: |\n      echo "k=v" >> "$GITHUB_OUTPUT"\n'
+    assert scanner.scan_text(text)[0].has_logic is True
+
+
+def test_variable_assignment_counts_as_logic():
+    text = "steps:\n  - run: |\n      FOO=bar\n      echo done\n"
+    assert scanner.scan_text(text)[0].has_logic is True
+
+
+def test_gate_mode_exits_over_max(tmp_path: Path):
+    wf = tmp_path / ".github" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "x.yml").write_text(_big_logic_run(), encoding="utf-8")
+    assert scanner.main(["--root", str(tmp_path), "--max", "0"]) == scanner.EXIT_OVER_MAX
+    assert scanner.main(["--root", str(tmp_path), "--max", "5"]) == scanner.EXIT_OK
+
+
+def test_bad_root_is_config_error(tmp_path: Path):
+    assert scanner.main(["--root", str(tmp_path / "absent")]) == scanner.EXIT_CONFIG
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Fixes #3084. Gives #2967 the objective, re-runnable metric its manual audit lacked. scripts/ci/adr006_run_block_scanner.py flags run: block scalars over a code-line threshold (default 10) that also carry logic (conditionals, loops, parsing pipes, computed variables, output assembly) - the same high-signal criteria the #2967 audit used. Validated live: 91 violations, and the top offenders match #2967's list exactly (ai-review/action.yml:440 at 150 code lines, :226 at 117, ai-issue-triage.yml:331 at 75, pr-maintenance.yml:280 at 68, ...). Default is metric mode (exit 0, prints count + sorted list); --max N is a ratchet gate (exit 1 when count exceeds N) so the burn-down cannot silently regress. Stdlib-only, exit-code contract 0/1/2, 10 tests (pos/neg/edge, inline-run-ignored, comments/blanks not counted, gate mode, bad-root config error). Not yet wired into CI (a follow-up can add a --max gate step once #2967 lands its next extractions); this PR ships the tested metric tool.