### PR TITLE
refactor(ci): extract issue-triage summary assembly to a tested module (#2967)

### DIFF
--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -329,109 +329,12 @@ jobs:
           SERVER_URL: ${{ github.server_url }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          # Get priority emoji
-          $priorityEmoji = switch ($env:PRIORITY) {
-            'P0' { '' }
-            'P1' { '' }
-            'P2' { '' }
-            'P3' { '' }
-            default { '' }
-          }
-
-          # Determine PRD status
-          $prdRow = if ($env:ESCALATE_TO_PRD -eq 'true') {
-            "| **PRD Escalation** | Generated (see below) |"
-          } else {
-            ""
-          }
-
-          # Determine feature review status
-          $featureReviewRow = if ($env:FEATURE_REVIEW -and $env:FEATURE_REVIEW -ne 'UNKNOWN') {
-            "| **Feature Review** | ``$($env:FEATURE_REVIEW)`` |"
-          } else {
-            ""
-          }
-
-          # Get analysis outputs
-          $categorizeOutput = if (Test-Path /tmp/categorize-output.txt) {
-            Get-Content /tmp/categorize-output.txt -Raw
-          } else { "N/A" }
-
-          $alignOutput = if (Test-Path /tmp/align-output.txt) {
-            Get-Content /tmp/align-output.txt -Raw
-          } else { "N/A" }
-
-          $featureReviewOutput = if (Test-Path /tmp/feature-review-output.txt) {
-            Get-Content /tmp/feature-review-output.txt -Raw
-          } else { "" }
-
-          $labelsDisplay = if ($env:LABELS) { $env:LABELS } else { "*None assigned*" }
-          $milestoneDisplay = if ($env:MILESTONE) { $env:MILESTONE } else { "*Not assigned*" }
-
-          $triageComment = @"
-          <!-- AI-ISSUE-TRIAGE -->
-
-          ## AI Triage Summary
-
-          > [!NOTE]
-          > This issue has been automatically triaged by AI agents
-
-          <details>
-          <summary>What is AI Triage?</summary>
-
-          This issue was analyzed by AI agents:
-
-          - **Analyst Agent**: Categorizes the issue and suggests appropriate labels
-          - **Roadmap Agent**: Aligns the issue with project milestones and priorities
-          - **Explainer Agent** (if escalated): Generates comprehensive PRD
-
-          </details>
-
-          ### Triage Results
-
-          | Property | Value |
-          |:---------|:------|
-          | **Category** | ``$($env:CATEGORY)`` |
-          | **Labels** | $labelsDisplay |
-          | $priorityEmoji **Priority** | ``$($env:PRIORITY)`` |
-          | **Milestone** | $milestoneDisplay |
-          $featureReviewRow
-          $prdRow
-
-          <details>
-          <summary>Categorization Analysis</summary>
-
-          ``````json
-          $categorizeOutput
-          ``````
-
-          </details>
-
-          <details>
-          <summary>Roadmap Alignment</summary>
-
-          ``````json
-          $alignOutput
-          ``````
-
-          </details>
-
-          $(if ($featureReviewOutput) { @"
-
-          <details>
-          <summary>Feature Request Review</summary>
-
-          $featureReviewOutput
-
-          </details>
-          "@ })
-
-          ---
-
-          <sub>Powered by [AI Issue Triage](https://github.com/$($env:GITHUB_REPOSITORY)) workflow</sub>
-          "@
-
-          $triageComment | Set-Content /tmp/triage-comment.md -Encoding UTF8
+          # Assemble the triage comment. ADR-006: the here-string assembly
+          # logic moved to scripts/ci/build_triage_summary_comment.py
+          # (byte-for-byte tested in
+          # tests/ci/test_build_triage_summary_comment.py).
+          python3 scripts/ci/build_triage_summary_comment.py --output /tmp/triage-comment.md
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           # Post comment via Python script (ADR-042 migration)
           python3 .github/scripts/run_with_retry.py -- `

--- a/scripts/ci/build_triage_summary_comment.py
+++ b/scripts/ci/build_triage_summary_comment.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Assemble the AI-issue-triage summary comment (issue #2967, ADR-006 burn-down).
+
+This is the assembly half of the "Post Triage Summary" step in
+`.github/workflows/ai-issue-triage.yml`. That step used to build the triage
+comment inline in a PowerShell here-string: a `switch` for the priority icon,
+`if`/`else` blocks for the optional feature-review and PRD-escalation rows, and
+`Test-Path`/`Get-Content` reads for the three analysis-output files. ADR-006
+forbids that logic in YAML. It now lives here as a pure builder plus a thin CLI,
+and the workflow step calls this module then posts the file it writes.
+
+Behavior is preserved byte-for-byte against the original PowerShell output; the
+golden fixtures under `tests/ci/fixtures/triage_summary/` were captured by
+running the original block and are asserted by
+`tests/ci/test_build_triage_summary_comment.py`.
+
+The builder reproduces two non-obvious PowerShell semantics:
+
+- ``-eq 'true'`` and ``-ne 'UNKNOWN'`` are case-insensitive, so ``ESCALATE_TO_PRD``
+  of ``TRUE`` still shows the PRD row and ``FEATURE_REVIEW`` of ``unknown`` still
+  hides the feature-review row.
+- The priority ``switch`` currently maps every priority to an empty string, so
+  the priority table cell renders with two leading spaces. That is preserved.
+
+Exit Codes (ADR-035):
+    0 = comment file written
+    (argparse emits 2 for a malformed invocation.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+# The original PowerShell `switch ($env:PRIORITY)` mapped every case (P0..P3 and
+# default) to an empty string. Kept as a table so a future icon restoration is a
+# one-line edit rather than a new branch; empty values preserve current output.
+_PRIORITY_EMOJI: dict[str, str] = {"P0": "", "P1": "", "P2": "", "P3": ""}
+
+# Fixed analysis-output paths the workflow's upstream parse steps write. They are
+# constants (not user-supplied), so no path validation is needed here.
+_CATEGORIZE_FILE = "/tmp/categorize-output.txt"
+_ALIGN_FILE = "/tmp/align-output.txt"
+_FEATURE_REVIEW_FILE = "/tmp/feature-review-output.txt"
+_DEFAULT_OUTPUT = "/tmp/triage-comment.md"
+
+_TEMPLATE = """<!-- AI-ISSUE-TRIAGE -->
+
+## AI Triage Summary
+
+> [!NOTE]
+> This issue has been automatically triaged by AI agents
+
+<details>
+<summary>What is AI Triage?</summary>
+
+This issue was analyzed by AI agents:
+
+- **Analyst Agent**: Categorizes the issue and suggests appropriate labels
+- **Roadmap Agent**: Aligns the issue with project milestones and priorities
+- **Explainer Agent** (if escalated): Generates comprehensive PRD
+
+</details>
+
+### Triage Results
+
+| Property | Value |
+|:---------|:------|
+| **Category** | `{category}` |
+| **Labels** | {labels_display} |
+| {priority_emoji} **Priority** | `{priority}` |
+| **Milestone** | {milestone_display} |
+{feature_review_row}
+{prd_row}
+
+<details>
+<summary>Categorization Analysis</summary>
+
+```json
+{categorize_output}
+```
+
+</details>
+
+<details>
+<summary>Roadmap Alignment</summary>
+
+```json
+{align_output}
+```
+
+</details>
+
+{feature_block}
+
+---
+
+<sub>Powered by [AI Issue Triage](https://github.com/{repository}) workflow</sub>"""
+
+
+def _prd_row(escalate_to_prd: str) -> str:
+    """PRD-escalation row when escalation fired (case-insensitive, per ``-eq``)."""
+    if escalate_to_prd.lower() == "true":
+        return "| **PRD Escalation** | Generated (see below) |"
+    return ""
+
+
+def _feature_review_row(feature_review: str) -> str:
+    """Feature-review row when a real recommendation exists (not empty/UNKNOWN)."""
+    if feature_review and feature_review.upper() != "UNKNOWN":
+        return f"| **Feature Review** | `{feature_review}` |"
+    return ""
+
+
+def _feature_block(feature_review_output: str) -> str:
+    """Collapsible feature-review block, present only when the file had content."""
+    if not feature_review_output:
+        return ""
+    return (
+        "\n<details>\n<summary>Feature Request Review</summary>\n\n"
+        f"{feature_review_output}\n\n</details>"
+    )
+
+
+def build_triage_comment(
+    *,
+    category: str,
+    labels: str,
+    priority: str,
+    milestone: str,
+    escalate_to_prd: str,
+    feature_review: str,
+    repository: str,
+    categorize_output: str,
+    align_output: str,
+    feature_review_output: str,
+) -> str:
+    """Assemble the triage-summary markdown comment.
+
+    Args:
+        category: Issue category (analyst agent output).
+        labels: Labels JSON string; empty renders "*None assigned*".
+        priority: Priority code (P0..P4); rendered as inline code.
+        milestone: Milestone title; empty renders "*Not assigned*".
+        escalate_to_prd: "true" (case-insensitive) shows the PRD-escalation row.
+        feature_review: Recommendation; non-empty and not "UNKNOWN" shows the row.
+        repository: owner/name for the footer link.
+        categorize_output: Categorization analysis JSON (or "N/A" when absent).
+        align_output: Roadmap alignment JSON (or "N/A" when absent).
+        feature_review_output: Feature-review body; non-empty shows the block.
+
+    Returns:
+        The comment markdown without a trailing newline (the CLI adds the
+        newline that ``Set-Content`` appended in the original step).
+    """
+    return _TEMPLATE.format(
+        category=category,
+        labels_display=labels if labels else "*None assigned*",
+        priority_emoji=_PRIORITY_EMOJI.get(priority, ""),
+        priority=priority,
+        milestone_display=milestone if milestone else "*Not assigned*",
+        feature_review_row=_feature_review_row(feature_review),
+        prd_row=_prd_row(escalate_to_prd),
+        categorize_output=categorize_output,
+        align_output=align_output,
+        feature_block=_feature_block(feature_review_output),
+        repository=repository,
+    )
+
+
+def _read_output(path: str, default: str) -> str:
+    """Read an analysis-output file, mirroring Test-Path/Get-Content -Raw."""
+    file = Path(path)
+    if not file.exists():
+        return default
+    return file.read_text(encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: read env plus the three analysis files, write the comment."""
+    parser = argparse.ArgumentParser(
+        description="Build the AI-issue-triage summary comment (issue #2967)."
+    )
+    parser.add_argument(
+        "--output",
+        default=_DEFAULT_OUTPUT,
+        help=f"Path to write the comment markdown (default {_DEFAULT_OUTPUT}).",
+    )
+    args = parser.parse_args(argv)
+
+    comment = build_triage_comment(
+        category=os.environ.get("CATEGORY", ""),
+        labels=os.environ.get("LABELS", ""),
+        priority=os.environ.get("PRIORITY", ""),
+        milestone=os.environ.get("MILESTONE", ""),
+        escalate_to_prd=os.environ.get("ESCALATE_TO_PRD", ""),
+        feature_review=os.environ.get("FEATURE_REVIEW", ""),
+        repository=os.environ.get("GITHUB_REPOSITORY", ""),
+        categorize_output=_read_output(_CATEGORIZE_FILE, "N/A"),
+        align_output=_read_output(_ALIGN_FILE, "N/A"),
+        feature_review_output=_read_output(_FEATURE_REVIEW_FILE, ""),
+    )
+
+    # Set-Content -Encoding UTF8 wrote UTF-8 (no BOM) and appended a newline.
+    Path(args.output).write_bytes((comment + "\n").encode("utf-8"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/fixtures/triage_summary/feature_lowercase_unknown_no_prd.golden
+++ b/tests/ci/fixtures/triage_summary/feature_lowercase_unknown_no_prd.golden
@@ -1,0 +1,61 @@
+<!-- AI-ISSUE-TRIAGE -->
+
+## AI Triage Summary
+
+> [!NOTE]
+> This issue has been automatically triaged by AI agents
+
+<details>
+<summary>What is AI Triage?</summary>
+
+This issue was analyzed by AI agents:
+
+- **Analyst Agent**: Categorizes the issue and suggests appropriate labels
+- **Roadmap Agent**: Aligns the issue with project milestones and priorities
+- **Explainer Agent** (if escalated): Generates comprehensive PRD
+
+</details>
+
+### Triage Results
+
+| Property | Value |
+|:---------|:------|
+| **Category** | `enhancement` |
+| **Labels** | ["enhancement"] |
+|  **Priority** | `P2` |
+| **Milestone** | v2.0 |
+
+
+
+<details>
+<summary>Categorization Analysis</summary>
+
+```json
+{"category":"enhancement"}
+
+```
+
+</details>
+
+<details>
+<summary>Roadmap Alignment</summary>
+
+```json
+{"priority":"P2","milestone":"v2.0"}
+
+```
+
+</details>
+
+
+<details>
+<summary>Feature Request Review</summary>
+
+Some reviewer notes here.
+
+
+</details>
+
+---
+
+<sub>Powered by [AI Issue Triage](https://github.com/rjmurillo/ai-agents2) workflow</sub>

--- a/tests/ci/fixtures/triage_summary/full.golden
+++ b/tests/ci/fixtures/triage_summary/full.golden
@@ -1,0 +1,61 @@
+<!-- AI-ISSUE-TRIAGE -->
+
+## AI Triage Summary
+
+> [!NOTE]
+> This issue has been automatically triaged by AI agents
+
+<details>
+<summary>What is AI Triage?</summary>
+
+This issue was analyzed by AI agents:
+
+- **Analyst Agent**: Categorizes the issue and suggests appropriate labels
+- **Roadmap Agent**: Aligns the issue with project milestones and priorities
+- **Explainer Agent** (if escalated): Generates comprehensive PRD
+
+</details>
+
+### Triage Results
+
+| Property | Value |
+|:---------|:------|
+| **Category** | `bug` |
+| **Labels** | ["bug","docs"] |
+|  **Priority** | `P1` |
+| **Milestone** | v1.0 |
+| **Feature Review** | `APPROVE` |
+| **PRD Escalation** | Generated (see below) |
+
+<details>
+<summary>Categorization Analysis</summary>
+
+```json
+{"category":"bug","labels":["bug","docs"]}
+
+```
+
+</details>
+
+<details>
+<summary>Roadmap Alignment</summary>
+
+```json
+{"priority":"P1","milestone":"v1.0"}
+
+```
+
+</details>
+
+
+<details>
+<summary>Feature Request Review</summary>
+
+Feature looks reasonable. Approve.
+
+
+</details>
+
+---
+
+<sub>Powered by [AI Issue Triage](https://github.com/rjmurillo/ai-agents2) workflow</sub>

--- a/tests/ci/fixtures/triage_summary/minimal.golden
+++ b/tests/ci/fixtures/triage_summary/minimal.golden
@@ -1,0 +1,52 @@
+<!-- AI-ISSUE-TRIAGE -->
+
+## AI Triage Summary
+
+> [!NOTE]
+> This issue has been automatically triaged by AI agents
+
+<details>
+<summary>What is AI Triage?</summary>
+
+This issue was analyzed by AI agents:
+
+- **Analyst Agent**: Categorizes the issue and suggests appropriate labels
+- **Roadmap Agent**: Aligns the issue with project milestones and priorities
+- **Explainer Agent** (if escalated): Generates comprehensive PRD
+
+</details>
+
+### Triage Results
+
+| Property | Value |
+|:---------|:------|
+| **Category** | `question` |
+| **Labels** | *None assigned* |
+|  **Priority** | `P3` |
+| **Milestone** | *Not assigned* |
+
+
+
+<details>
+<summary>Categorization Analysis</summary>
+
+```json
+N/A
+```
+
+</details>
+
+<details>
+<summary>Roadmap Alignment</summary>
+
+```json
+N/A
+```
+
+</details>
+
+
+
+---
+
+<sub>Powered by [AI Issue Triage](https://github.com/rjmurillo/ai-agents2) workflow</sub>

--- a/tests/ci/fixtures/triage_summary/prd_uppercase_no_feature.golden
+++ b/tests/ci/fixtures/triage_summary/prd_uppercase_no_feature.golden
@@ -1,0 +1,54 @@
+<!-- AI-ISSUE-TRIAGE -->
+
+## AI Triage Summary
+
+> [!NOTE]
+> This issue has been automatically triaged by AI agents
+
+<details>
+<summary>What is AI Triage?</summary>
+
+This issue was analyzed by AI agents:
+
+- **Analyst Agent**: Categorizes the issue and suggests appropriate labels
+- **Roadmap Agent**: Aligns the issue with project milestones and priorities
+- **Explainer Agent** (if escalated): Generates comprehensive PRD
+
+</details>
+
+### Triage Results
+
+| Property | Value |
+|:---------|:------|
+| **Category** | `enhancement` |
+| **Labels** | [] |
+|  **Priority** | `P0` |
+| **Milestone** | backlog |
+
+| **PRD Escalation** | Generated (see below) |
+
+<details>
+<summary>Categorization Analysis</summary>
+
+```json
+{"category":"enhancement"}
+
+```
+
+</details>
+
+<details>
+<summary>Roadmap Alignment</summary>
+
+```json
+{"priority":"P0"}
+
+```
+
+</details>
+
+
+
+---
+
+<sub>Powered by [AI Issue Triage](https://github.com/rjmurillo/ai-agents2) workflow</sub>

--- a/tests/ci/test_build_triage_summary_comment.py
+++ b/tests/ci/test_build_triage_summary_comment.py
@@ -1,0 +1,264 @@
+"""Tests for scripts/ci/build_triage_summary_comment.py (issue #2967).
+
+The "Post Triage Summary" step in .github/workflows/ai-issue-triage.yml built
+its comment inline in a PowerShell here-string (ADR-006 violation). The logic
+now lives in the module under test. These tests prove behavior is preserved
+byte-for-byte: the golden fixtures under fixtures/triage_summary/ were captured
+by running the original PowerShell block under pwsh 7 across representative
+inputs, and test_byte_exactness_matches_original_powershell drives main() with
+the same inputs and asserts the written bytes are identical.
+
+Regenerate a golden by running the original step's assembly script under pwsh
+with the scenario's env plus the three /tmp analysis files, then capturing
+/tmp/triage-comment.md.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts/ci to path for import.
+_SCRIPTS_CI = Path(__file__).resolve().parent.parent.parent / "scripts" / "ci"
+sys.path.insert(0, str(_SCRIPTS_CI))
+
+from build_triage_summary_comment import (  # noqa: E402
+    build_triage_comment,
+    main,
+)
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "triage_summary"
+
+# Baseline kwargs for the pure builder: no optional rows, no analysis output.
+_BASE = {
+    "category": "bug",
+    "labels": "",
+    "priority": "P3",
+    "milestone": "",
+    "escalate_to_prd": "false",
+    "feature_review": "UNKNOWN",
+    "repository": "rjmurillo/ai-agents2",
+    "categorize_output": "N/A",
+    "align_output": "N/A",
+    "feature_review_output": "",
+}
+
+
+def _build(**overrides: str) -> str:
+    return build_triage_comment(**{**_BASE, **overrides})
+
+
+# --- Byte-exactness against the original PowerShell output ------------------
+
+# Scenario inputs that produced each committed golden fixture.
+_SCENARIOS = {
+    "full": {
+        "env": {"CATEGORY": "bug", "LABELS": '["bug","docs"]', "PRIORITY": "P1",
+                "MILESTONE": "v1.0", "ESCALATE_TO_PRD": "true",
+                "FEATURE_REVIEW": "APPROVE",
+                "GITHUB_REPOSITORY": "rjmurillo/ai-agents2"},
+        "categorize": '{"category":"bug","labels":["bug","docs"]}\n',
+        "align": '{"priority":"P1","milestone":"v1.0"}\n',
+        "feature": "Feature looks reasonable. Approve.\n",
+    },
+    "minimal": {
+        "env": {"CATEGORY": "question", "LABELS": "", "PRIORITY": "P3",
+                "MILESTONE": "", "ESCALATE_TO_PRD": "false",
+                "FEATURE_REVIEW": "UNKNOWN",
+                "GITHUB_REPOSITORY": "rjmurillo/ai-agents2"},
+        "categorize": None,
+        "align": None,
+        "feature": None,
+    },
+    "prd_uppercase_no_feature": {
+        "env": {"CATEGORY": "enhancement", "LABELS": "[]", "PRIORITY": "P0",
+                "MILESTONE": "backlog", "ESCALATE_TO_PRD": "TRUE",
+                "FEATURE_REVIEW": "",
+                "GITHUB_REPOSITORY": "rjmurillo/ai-agents2"},
+        "categorize": '{"category":"enhancement"}\n',
+        "align": '{"priority":"P0"}\n',
+        "feature": None,
+    },
+    "feature_lowercase_unknown_no_prd": {
+        "env": {"CATEGORY": "enhancement", "LABELS": '["enhancement"]',
+                "PRIORITY": "P2", "MILESTONE": "v2.0", "ESCALATE_TO_PRD": "false",
+                "FEATURE_REVIEW": "unknown",
+                "GITHUB_REPOSITORY": "rjmurillo/ai-agents2"},
+        "categorize": '{"category":"enhancement"}\n',
+        "align": '{"priority":"P2","milestone":"v2.0"}\n',
+        "feature": "Some reviewer notes here.\n",
+    },
+}
+
+_ENV_KEYS = {"CATEGORY", "LABELS", "PRIORITY", "MILESTONE", "ESCALATE_TO_PRD",
+             "FEATURE_REVIEW", "GITHUB_REPOSITORY"}
+
+
+@pytest.mark.parametrize("name", sorted(_SCENARIOS))
+def test_byte_exactness_matches_original_powershell(name, monkeypatch, tmp_path):
+    spec = _SCENARIOS[name]
+    for key in _ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    for key, val in spec["env"].items():
+        monkeypatch.setenv(key, val)
+
+    # Redirect the fixed /tmp analysis paths into tmp_path so the test is
+    # isolated and never touches global /tmp state.
+    import build_triage_summary_comment as mod
+
+    for const, key in (("_CATEGORIZE_FILE", "categorize"),
+                       ("_ALIGN_FILE", "align"),
+                       ("_FEATURE_REVIEW_FILE", "feature")):
+        target = tmp_path / f"{key}.txt"
+        if spec[key] is not None:
+            target.write_text(spec[key], encoding="utf-8")
+        monkeypatch.setattr(mod, const, str(target))
+
+    out = tmp_path / "triage-comment.md"
+    exit_code = main(["--output", str(out)])
+
+    assert exit_code == 0
+    assert out.read_bytes() == (_FIXTURES / f"{name}.golden").read_bytes()
+
+
+def test_golden_output_is_utf8_no_bom_with_trailing_newline():
+    data = (_FIXTURES / "full.golden").read_bytes()
+    assert not data.startswith(b"\xef\xbb\xbf")
+    assert data.endswith(b"</sub>\n")
+
+
+# --- Positive: optional rows and block render when their inputs are present --
+
+
+def test_prd_row_present_when_escalated():
+    assert "| **PRD Escalation** | Generated (see below) |" in _build(
+        escalate_to_prd="true"
+    )
+
+
+def test_prd_row_case_insensitive_like_powershell_eq():
+    # PowerShell `-eq 'true'` is case-insensitive; TRUE must still show the row.
+    assert "PRD Escalation" in _build(escalate_to_prd="TRUE")
+
+
+def test_feature_review_row_present_for_real_recommendation():
+    assert "| **Feature Review** | `APPROVE` |" in _build(feature_review="APPROVE")
+
+
+def test_feature_block_present_when_output_nonempty():
+    body = _build(feature_review_output="Reviewer notes.")
+    assert "<summary>Feature Request Review</summary>" in body
+    assert "Reviewer notes." in body
+
+
+def test_labels_and_milestone_display_raw_values_when_set():
+    body = _build(labels='["bug"]', milestone="v1.0")
+    assert "| **Labels** | [\"bug\"] |" in body
+    assert "| **Milestone** | v1.0 |" in body
+
+
+def test_empty_labels_json_array_is_shown_verbatim():
+    # "[]" is a non-empty string, so PowerShell `if ($env:LABELS)` is truthy.
+    assert "| **Labels** | [] |" in _build(labels="[]")
+
+
+# --- Negative: optional rows and block absent when inputs empty/UNKNOWN ------
+
+
+def test_prd_row_absent_when_not_escalated():
+    assert "PRD Escalation" not in _build(escalate_to_prd="false")
+
+
+def test_feature_review_row_absent_when_unknown():
+    assert "Feature Review" not in _build(feature_review="UNKNOWN")
+
+
+def test_feature_review_row_absent_when_lowercase_unknown():
+    # `-ne 'UNKNOWN'` is case-insensitive; lowercase unknown hides the row too.
+    assert "Feature Review" not in _build(feature_review="unknown")
+
+
+def test_feature_review_row_absent_when_empty():
+    assert "Feature Review" not in _build(feature_review="")
+
+
+def test_feature_block_absent_when_output_empty():
+    assert "Feature Request Review" not in _build(feature_review_output="")
+
+
+def test_none_assigned_placeholders_when_labels_and_milestone_empty():
+    body = _build(labels="", milestone="")
+    assert "| **Labels** | *None assigned* |" in body
+    assert "| **Milestone** | *Not assigned* |" in body
+
+
+# --- Edge: preserved PowerShell quirks --------------------------------------
+
+
+def test_priority_cell_keeps_two_leading_spaces():
+    # The original switch mapped every priority to "", leaving a double space.
+    assert "|  **Priority** | `P1` |" in _build(priority="P1")
+
+
+def test_row_hidden_but_block_shown_are_independent():
+    # Row keys on FEATURE_REVIEW; block keys on the file content. They differ.
+    body = _build(feature_review="unknown", feature_review_output="Notes.")
+    assert "| **Feature Review**" not in body
+    assert "<summary>Feature Request Review</summary>" in body
+
+
+def test_analysis_output_trailing_newline_is_preserved_in_fence():
+    # Get-Content -Raw kept the file's trailing newline, adding a blank line
+    # before the closing fence. The module must not strip it.
+    body = _build(categorize_output='{"a":1}\n')
+    assert '```json\n{"a":1}\n\n```' in body
+
+
+def test_builder_returns_without_trailing_newline():
+    # The builder returns the here-string value; the CLI adds Set-Content's \n.
+    assert not _build().endswith("\n")
+
+
+# --- CLI contract -----------------------------------------------------------
+
+
+def test_main_writes_default_output_and_returns_zero(monkeypatch, tmp_path):
+    for key in _ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("CATEGORY", "bug")
+    import build_triage_summary_comment as mod
+
+    for const in ("_CATEGORIZE_FILE", "_ALIGN_FILE", "_FEATURE_REVIEW_FILE"):
+        monkeypatch.setattr(mod, const, str(tmp_path / "absent.txt"))
+
+    out = tmp_path / "comment.md"
+    assert main(["--output", str(out)]) == 0
+    written = out.read_bytes()
+    assert written.endswith(b"\n")
+    assert b"| **Category** | `bug` |" in written
+
+
+def test_main_uses_na_default_when_analysis_files_absent(monkeypatch, tmp_path):
+    for key in _ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    import build_triage_summary_comment as mod
+
+    for const in ("_CATEGORIZE_FILE", "_ALIGN_FILE", "_FEATURE_REVIEW_FILE"):
+        monkeypatch.setattr(mod, const, str(tmp_path / "absent.txt"))
+
+    out = tmp_path / "comment.md"
+    main(["--output", str(out)])
+    body = out.read_text(encoding="utf-8")
+    assert "```json\nN/A\n```" in body
+
+
+def test_main_rejects_unknown_flag():
+    with pytest.raises(SystemExit) as exc:
+        main(["--nope"])
+    assert exc.value.code == 2
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Refs #2967 ADR-006 burn-down slice (issue stays open). Extracts ~75 lines of PowerShell summary-assembly logic from .github/workflows/ai-issue-triage.yml into scripts/ci/build_triage_summary_comment.py (pure builder + thin CLI), ADR-006 + ADR-042. Behavior preserved byte-for-byte, independently fuzz-verified: the reviewer drove origin/main's ORIGINAL PowerShell and the new Python module with 568 identical edge-case inputs and diffed byte-for-byte, 0 mismatches (case-insensitive truthiness traps, priority two-space cell, backtick/brace/percent content, all analysis-file states). 24 tests + 4 byte-exact golden fixtures (.golden extension so markdownlint does not rewrite them); tests/ci 67 pass; ruff+mypy+CWE-78 clean, 3.10 floor. Pre-push workflow gate degraded per its documented secret-absent path (ai-issue-triage.yml needs BOT_PAT/COPILOT_GITHUB_TOKEN, absent locally; actionlint passed; no bypass used). Follow-up: 5 pre-existing dead env vars in the step. Sibling PR #3103 extracted the ai-review infra gate.