### PR TITLE
test(validation): make workflow-gate tests hermetic against SKIP_WORKFLOW_LOCAL_TEST (#3115)

### DIFF
--- a/tests/validation/conftest.py
+++ b/tests/validation/conftest.py
@@ -1,0 +1,32 @@
+"""Hermetic env for the workflow-local-run gate tests (#3115).
+
+`scripts/validation/run_workflow_local_test.py` reads process env vars
+(`SKIP_WORKFLOW_LOCAL_TEST`, the remote-container markers, and `CI`) to decide
+whether to bypass or degrade. `tests/validation/test_run_workflow_local_test.py`
+asserts the non-bypassed behavior, so if a real push exports
+`SKIP_WORKFLOW_LOCAL_TEST=true` to get past an act-unrunnable workflow, that var
+leaks into the pre-push pytest subprocess and breaks these tests. That made the
+gate's own documented bypass unusable during any workflow-touching push.
+
+Clear those vars before every test in this directory so the suite pins the
+script's behavior from a known-empty environment. A test that wants a specific
+value sets it explicitly via monkeypatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+_GATE_ENV_VARS = (
+    "SKIP_WORKFLOW_LOCAL_TEST",
+    "CLAUDECODE",
+    "CODESPACES",
+    "CI",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_workflow_gate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove ambient workflow-gate env vars so tests run hermetically."""
+    for name in _GATE_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)


### PR DESCRIPTION
Fixes #3115. run_workflow_local_test.py reads SKIP_WORKFLOW_LOCAL_TEST plus the remote-container markers (CLAUDECODE, CODESPACES) and CI to decide bypass/degrade. Its tests assert the non-bypassed behavior, so exporting SKIP_WORKFLOW_LOCAL_TEST=true (the gate's own documented bypass for an act-unrunnable workflow) leaked into the pre-push pytest subprocess and broke 5 tests, a catch-22 that made any workflow-touching push to an act-unrunnable, secret-only-GITHUB_TOKEN workflow (e.g. pr-validation.yml) unpushable. Adds tests/validation/conftest.py with an autouse fixture that clears those vars via monkeypatch.delenv(raising=False) so the suite runs from a known-empty environment; tests that want a value set it explicitly. Verified: 92 pass with SKIP_WORKFLOW_LOCAL_TEST=true set (was 5 failing) and 92 pass without it, ruff clean. Unblocks the blocked #2967 workflow-file extraction slice (feat/adr006-extract-pr-validation-2967). Overlaps #3064 (same pre-push gate).