### PR TITLE
fix(github): implement --group-by-reviewer-priority in get_pr_review_comments (#3112)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.40",
+  "version": "0.6.45",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/github/scripts/pr/get_pr_review_comments.py
+++ b/.claude/skills/github/scripts/pr/get_pr_review_comments.py
@@ -89,6 +89,12 @@ def classify_reviewer_priority(author: str, author_type: str) -> str:
     return "Unknown"
 
 
+def _comment_user(comment: dict[str, Any]) -> dict[str, Any]:
+    """Return the GitHub user payload, or an empty payload for ghost accounts."""
+    user = comment.get("user")
+    return user if isinstance(user, dict) else {}
+
+
 def _group_comments_by_reviewer_priority(
     comments: list[dict[str, Any]],
     include_domain: bool,
@@ -363,7 +369,8 @@ def get_pr_review_comments(
 
     processed_review: list[dict[str, Any]] = []
     for comment in review_comments:
-        login = comment.get("user", {}).get("login", "")
+        user = _comment_user(comment)
+        login = user.get("login", "")
         if author and login != author:
             continue
 
@@ -386,7 +393,7 @@ def get_pr_review_comments(
             "Id": comment.get("id"),
             "CommentType": "Review",
             "Author": login,
-            "AuthorType": comment.get("user", {}).get("type", ""),
+            "AuthorType": user.get("type", ""),
             "Path": comment.get("path"),
             "Line": line,
             "Side": comment.get("side"),
@@ -420,7 +427,8 @@ def get_pr_review_comments(
             )
 
         for comment in issue_comments:
-            login = comment.get("user", {}).get("login", "")
+            user = _comment_user(comment)
+            login = user.get("login", "")
             if author and login != author:
                 continue
 
@@ -428,7 +436,7 @@ def get_pr_review_comments(
                 "Id": comment.get("id"),
                 "CommentType": "Issue",
                 "Author": login,
-                "AuthorType": comment.get("user", {}).get("type", ""),
+                "AuthorType": user.get("type", ""),
                 "Path": None,
                 "Line": None,
                 "Side": None,

--- a/.claude/skills/github/scripts/pr/get_pr_review_comments.py
+++ b/.claude/skills/github/scripts/pr/get_pr_review_comments.py
@@ -652,8 +652,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--group-by-reviewer-priority", action="store_true",
         help=(
             "Group comments by reviewer priority (P0 cursor[bot], P1 human, "
-            "P2 bot, then Unknown); composes with --group-by-domain as the "
-            "inner tiebreaker"
+            "P2 CodeRabbit/Copilot, then Unknown); composes with "
+            "--group-by-domain as the inner tiebreaker"
         ),
     )
     parser.add_argument(

--- a/.claude/skills/github/scripts/pr/get_pr_review_comments.py
+++ b/.claude/skills/github/scripts/pr/get_pr_review_comments.py
@@ -58,8 +58,8 @@ from github_core.comment_classification import classify_domain  # noqa: E402
 # ---------------------------------------------------------------------------
 # Reviewer-priority classification
 # ---------------------------------------------------------------------------
-# Source: pr-comment-responder SKILL.md "Reviewer Priority" table. The table
-# maps cursor[bot]=P0, human reviewers=P1, coderabbitai[bot]=P2, Copilot=P2.
+# Contract: .claude/skills/pr-comment-responder/SKILL.md, "Reviewer Priority".
+# The table maps cursor[bot]=P0, humans=P1, coderabbitai[bot]=P2, Copilot=P2.
 # A bot that is not one of those named reviewers falls to the deterministic
 # "Unknown" tier so no comment is dropped from triage.
 _REVIEWER_PRIORITY_BY_LOGIN: dict[str, str] = {

--- a/.claude/skills/github/scripts/pr/get_pr_review_comments.py
+++ b/.claude/skills/github/scripts/pr/get_pr_review_comments.py
@@ -52,7 +52,69 @@ from github_core.api import (  # noqa: E402
     gh_api_paginated,
     resolve_repo_params,
 )
+from github_core.bot_config import is_bot  # noqa: E402
 from github_core.comment_classification import classify_domain  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Reviewer-priority classification
+# ---------------------------------------------------------------------------
+# Source: pr-comment-responder SKILL.md "Reviewer Priority" table. The table
+# maps cursor[bot]=P0, human reviewers=P1, coderabbitai[bot]=P2, Copilot=P2.
+# A bot that is not one of those named reviewers falls to the deterministic
+# "Unknown" tier so no comment is dropped from triage.
+_REVIEWER_PRIORITY_BY_LOGIN: dict[str, str] = {
+    "cursor[bot]": "P0",
+    "coderabbitai[bot]": "P2",
+    "copilot": "P2",
+    "github-copilot[bot]": "P2",  # bot-login variant of the Copilot reviewer
+}
+
+_REVIEWER_TIERS: tuple[str, ...] = ("P0", "P1", "P2", "Unknown")
+_DOMAIN_GROUPS: tuple[str, ...] = ("Security", "Bug", "Style", "Summary", "General")
+
+
+def classify_reviewer_priority(author: str, author_type: str) -> str:
+    """Map a comment author to a reviewer-priority tier.
+
+    Order per the pr-comment-responder SKILL.md Reviewer Priority table:
+    P0 cursor[bot], P1 human reviewers, P2 named reviewer bots. An author that
+    is a bot but not one of the named reviewer bots falls to the deterministic
+    "Unknown" tier.
+    """
+    mapped = _REVIEWER_PRIORITY_BY_LOGIN.get((author or "").lower())
+    if mapped is not None:
+        return mapped
+    if not is_bot(author or "", author_type or None):
+        return "P1"
+    return "Unknown"
+
+
+def _group_comments_by_reviewer_priority(
+    comments: list[dict[str, Any]],
+    include_domain: bool,
+) -> dict[str, Any]:
+    """Bucket comments into reviewer-priority tiers, optionally nesting domains.
+
+    Tiers are inserted in P0, P1, P2, Unknown order. When include_domain is set,
+    each tier maps a domain group (Security, Bug, Style, Summary, General order)
+    to its comments; otherwise each tier maps to a flat list. Insertion order is
+    the processing order the skill consumes, so the output is deterministic.
+    """
+    grouped: dict[str, Any] = {
+        tier: ({d: [] for d in _DOMAIN_GROUPS} if include_domain else [])
+        for tier in _REVIEWER_TIERS
+    }
+    for comment in comments:
+        tier = classify_reviewer_priority(
+            comment.get("Author", ""), comment.get("AuthorType", "")
+        )
+        if include_domain:
+            domain = (comment.get("Domain") or "general").capitalize()
+            bucket = domain if domain in _DOMAIN_GROUPS else "General"
+            grouped[tier][bucket].append(comment)
+        else:
+            grouped[tier].append(comment)
+    return grouped
 
 # ---------------------------------------------------------------------------
 # Stale detection helpers
@@ -218,13 +280,13 @@ def test_diff_hunk_match(line: int, diff_hunk: str, content: str) -> bool:
 
 
 def get_staleness(
-    comment: dict,
+    comment: dict[str, Any],
     owner: str,
     repo: str,
     file_tree: list[str],
     content_cache: dict[str, str | None],
     head_sha: str | None,
-) -> dict:
+) -> dict[str, Any]:
     """Determine if a comment is stale."""
     comment_type = comment.get("CommentType", "")
     path = comment.get("Path")
@@ -267,9 +329,10 @@ def get_pr_review_comments(
     exclude_stale: bool = False,
     only_stale: bool = False,
     group_by_domain: bool = False,
+    group_by_reviewer_priority: bool = False,
     only_unaddressed: bool = False,
     bot_only: bool = False,
-) -> dict:
+) -> dict[str, Any]:
     """Get all comments for a PR with optional filtering and classification."""
     # Initialize stale detection caches
     file_tree: list[str] = []
@@ -298,7 +361,7 @@ def get_pr_review_comments(
             3,
         )
 
-    processed_review: list[dict] = []
+    processed_review: list[dict[str, Any]] = []
     for comment in review_comments:
         login = comment.get("user", {}).get("login", "")
         if author and login != author:
@@ -307,7 +370,7 @@ def get_pr_review_comments(
         line = comment.get("line") or comment.get("original_line")
         diff_hunk = comment.get("diff_hunk", "")
 
-        stale_info: dict = {"Stale": None, "StaleReason": None}
+        stale_info: dict[str, Any] = {"Stale": None, "StaleReason": None}
         if detect_stale:
             stale_info = get_staleness(
                 {
@@ -342,7 +405,7 @@ def get_pr_review_comments(
         })
 
     # Fetch issue comments if requested
-    processed_issue: list[dict] = []
+    processed_issue: list[dict[str, Any]] = []
     if include_issue_comments:
         try:
             issue_comments = gh_api_paginated(
@@ -402,7 +465,7 @@ def get_pr_review_comments(
             if nodes and nodes[0] and nodes[0].get("databaseId"):
                 unresolved_ids.add(nodes[0]["databaseId"])
 
-        filtered: list[dict] = []
+        filtered: list[dict[str, Any]] = []
         for c in all_comments:
             if bot_only and c.get("AuthorType") != "Bot":
                 continue
@@ -441,6 +504,34 @@ def get_pr_review_comments(
     author_summary = [
         {"Author": a, "Count": cnt} for a, cnt in author_counter.items()
     ]
+
+    # Handle GroupByReviewerPriority output mode (composes with domain: reviewer
+    # priority is the outer key, domain the inner tiebreaker).
+    if group_by_reviewer_priority:
+        reviewer_grouped = _group_comments_by_reviewer_priority(
+            all_comments, group_by_domain
+        )
+        reviewer_counts: dict[str, int] = {}
+        for tier in _REVIEWER_TIERS:
+            value = reviewer_grouped[tier]
+            reviewer_counts[tier] = (
+                sum(len(v) for v in value.values()) if group_by_domain else len(value)
+            )
+
+        reviewer_grouped["TotalComments"] = len(all_comments)
+        reviewer_grouped["ReviewerPriorityCounts"] = reviewer_counts
+        if group_by_domain:
+            reviewer_grouped["DomainCounts"] = {
+                k.capitalize(): v for k, v in domain_counts.items()
+            }
+        reviewer_grouped["StaleCount"] = stale_count
+
+        tiers_summary = ", ".join(f"{t}({reviewer_counts[t]})" for t in _REVIEWER_TIERS)
+        print(
+            f"PR #{pr_number}: Grouped by reviewer priority: {tiers_summary}",
+            file=sys.stderr,
+        )
+        return reviewer_grouped
 
     # Handle GroupByDomain output mode
     if group_by_domain:
@@ -558,6 +649,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Group comments by domain instead of flat array",
     )
     parser.add_argument(
+        "--group-by-reviewer-priority", action="store_true",
+        help=(
+            "Group comments by reviewer priority (P0 cursor[bot], P1 human, "
+            "P2 bot, then Unknown); composes with --group-by-domain as the "
+            "inner tiebreaker"
+        ),
+    )
+    parser.add_argument(
         "--only-unaddressed", action="store_true",
         help="Filter to comments needing attention",
     )
@@ -614,6 +713,7 @@ def main(argv: list[str] | None = None) -> int:
         exclude_stale=args.exclude_stale,
         only_stale=args.only_stale,
         group_by_domain=args.group_by_domain,
+        group_by_reviewer_priority=args.group_by_reviewer_priority,
         only_unaddressed=args.only_unaddressed,
         bot_only=args.bot_only,
     )

--- a/.claude/skills/github/scripts/pr/get_pr_review_comments.py
+++ b/.claude/skills/github/scripts/pr/get_pr_review_comments.py
@@ -67,6 +67,8 @@ _REVIEWER_PRIORITY_BY_LOGIN: dict[str, str] = {
     "coderabbitai[bot]": "P2",
     "copilot": "P2",
     "github-copilot[bot]": "P2",  # bot-login variant of the Copilot reviewer
+    "copilot-pull-request-reviewer[bot]": "P2",  # production Copilot PR reviewer
+    "copilot-pull-request-reviewer": "P2",  # User-type variant
 }
 
 _REVIEWER_TIERS: tuple[str, ...] = ("P0", "P1", "P2", "Unknown")
@@ -79,12 +81,14 @@ def classify_reviewer_priority(author: str, author_type: str) -> str:
     Order per the pr-comment-responder SKILL.md Reviewer Priority table:
     P0 cursor[bot], P1 human reviewers, P2 named reviewer bots. An author that
     is a bot but not one of the named reviewer bots falls to the deterministic
-    "Unknown" tier.
+    "Unknown" tier. Ghost/deleted accounts (empty author) also fall to Unknown.
     """
-    mapped = _REVIEWER_PRIORITY_BY_LOGIN.get((author or "").lower())
+    if not author:
+        return "Unknown"
+    mapped = _REVIEWER_PRIORITY_BY_LOGIN.get(author.lower())
     if mapped is not None:
         return mapped
-    if not is_bot(author or "", author_type or None):
+    if not is_bot(author, author_type or None):
         return "P1"
     return "Unknown"
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.40",
+  "version": "0.6.45",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_review_comments.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_review_comments.py
@@ -89,6 +89,12 @@ def classify_reviewer_priority(author: str, author_type: str) -> str:
     return "Unknown"
 
 
+def _comment_user(comment: dict[str, Any]) -> dict[str, Any]:
+    """Return the GitHub user payload, or an empty payload for ghost accounts."""
+    user = comment.get("user")
+    return user if isinstance(user, dict) else {}
+
+
 def _group_comments_by_reviewer_priority(
     comments: list[dict[str, Any]],
     include_domain: bool,
@@ -363,7 +369,8 @@ def get_pr_review_comments(
 
     processed_review: list[dict[str, Any]] = []
     for comment in review_comments:
-        login = comment.get("user", {}).get("login", "")
+        user = _comment_user(comment)
+        login = user.get("login", "")
         if author and login != author:
             continue
 
@@ -386,7 +393,7 @@ def get_pr_review_comments(
             "Id": comment.get("id"),
             "CommentType": "Review",
             "Author": login,
-            "AuthorType": comment.get("user", {}).get("type", ""),
+            "AuthorType": user.get("type", ""),
             "Path": comment.get("path"),
             "Line": line,
             "Side": comment.get("side"),
@@ -420,7 +427,8 @@ def get_pr_review_comments(
             )
 
         for comment in issue_comments:
-            login = comment.get("user", {}).get("login", "")
+            user = _comment_user(comment)
+            login = user.get("login", "")
             if author and login != author:
                 continue
 
@@ -428,7 +436,7 @@ def get_pr_review_comments(
                 "Id": comment.get("id"),
                 "CommentType": "Issue",
                 "Author": login,
-                "AuthorType": comment.get("user", {}).get("type", ""),
+                "AuthorType": user.get("type", ""),
                 "Path": None,
                 "Line": None,
                 "Side": None,

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_review_comments.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_review_comments.py
@@ -652,8 +652,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--group-by-reviewer-priority", action="store_true",
         help=(
             "Group comments by reviewer priority (P0 cursor[bot], P1 human, "
-            "P2 bot, then Unknown); composes with --group-by-domain as the "
-            "inner tiebreaker"
+            "P2 CodeRabbit/Copilot, then Unknown); composes with "
+            "--group-by-domain as the inner tiebreaker"
         ),
     )
     parser.add_argument(

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_review_comments.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_review_comments.py
@@ -58,8 +58,8 @@ from github_core.comment_classification import classify_domain  # noqa: E402
 # ---------------------------------------------------------------------------
 # Reviewer-priority classification
 # ---------------------------------------------------------------------------
-# Source: pr-comment-responder SKILL.md "Reviewer Priority" table. The table
-# maps cursor[bot]=P0, human reviewers=P1, coderabbitai[bot]=P2, Copilot=P2.
+# Contract: .claude/skills/pr-comment-responder/SKILL.md, "Reviewer Priority".
+# The table maps cursor[bot]=P0, humans=P1, coderabbitai[bot]=P2, Copilot=P2.
 # A bot that is not one of those named reviewers falls to the deterministic
 # "Unknown" tier so no comment is dropped from triage.
 _REVIEWER_PRIORITY_BY_LOGIN: dict[str, str] = {

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_review_comments.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_review_comments.py
@@ -52,7 +52,69 @@ from github_core.api import (  # noqa: E402
     gh_api_paginated,
     resolve_repo_params,
 )
+from github_core.bot_config import is_bot  # noqa: E402
 from github_core.comment_classification import classify_domain  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Reviewer-priority classification
+# ---------------------------------------------------------------------------
+# Source: pr-comment-responder SKILL.md "Reviewer Priority" table. The table
+# maps cursor[bot]=P0, human reviewers=P1, coderabbitai[bot]=P2, Copilot=P2.
+# A bot that is not one of those named reviewers falls to the deterministic
+# "Unknown" tier so no comment is dropped from triage.
+_REVIEWER_PRIORITY_BY_LOGIN: dict[str, str] = {
+    "cursor[bot]": "P0",
+    "coderabbitai[bot]": "P2",
+    "copilot": "P2",
+    "github-copilot[bot]": "P2",  # bot-login variant of the Copilot reviewer
+}
+
+_REVIEWER_TIERS: tuple[str, ...] = ("P0", "P1", "P2", "Unknown")
+_DOMAIN_GROUPS: tuple[str, ...] = ("Security", "Bug", "Style", "Summary", "General")
+
+
+def classify_reviewer_priority(author: str, author_type: str) -> str:
+    """Map a comment author to a reviewer-priority tier.
+
+    Order per the pr-comment-responder SKILL.md Reviewer Priority table:
+    P0 cursor[bot], P1 human reviewers, P2 named reviewer bots. An author that
+    is a bot but not one of the named reviewer bots falls to the deterministic
+    "Unknown" tier.
+    """
+    mapped = _REVIEWER_PRIORITY_BY_LOGIN.get((author or "").lower())
+    if mapped is not None:
+        return mapped
+    if not is_bot(author or "", author_type or None):
+        return "P1"
+    return "Unknown"
+
+
+def _group_comments_by_reviewer_priority(
+    comments: list[dict[str, Any]],
+    include_domain: bool,
+) -> dict[str, Any]:
+    """Bucket comments into reviewer-priority tiers, optionally nesting domains.
+
+    Tiers are inserted in P0, P1, P2, Unknown order. When include_domain is set,
+    each tier maps a domain group (Security, Bug, Style, Summary, General order)
+    to its comments; otherwise each tier maps to a flat list. Insertion order is
+    the processing order the skill consumes, so the output is deterministic.
+    """
+    grouped: dict[str, Any] = {
+        tier: ({d: [] for d in _DOMAIN_GROUPS} if include_domain else [])
+        for tier in _REVIEWER_TIERS
+    }
+    for comment in comments:
+        tier = classify_reviewer_priority(
+            comment.get("Author", ""), comment.get("AuthorType", "")
+        )
+        if include_domain:
+            domain = (comment.get("Domain") or "general").capitalize()
+            bucket = domain if domain in _DOMAIN_GROUPS else "General"
+            grouped[tier][bucket].append(comment)
+        else:
+            grouped[tier].append(comment)
+    return grouped
 
 # ---------------------------------------------------------------------------
 # Stale detection helpers
@@ -218,13 +280,13 @@ def test_diff_hunk_match(line: int, diff_hunk: str, content: str) -> bool:
 
 
 def get_staleness(
-    comment: dict,
+    comment: dict[str, Any],
     owner: str,
     repo: str,
     file_tree: list[str],
     content_cache: dict[str, str | None],
     head_sha: str | None,
-) -> dict:
+) -> dict[str, Any]:
     """Determine if a comment is stale."""
     comment_type = comment.get("CommentType", "")
     path = comment.get("Path")
@@ -267,9 +329,10 @@ def get_pr_review_comments(
     exclude_stale: bool = False,
     only_stale: bool = False,
     group_by_domain: bool = False,
+    group_by_reviewer_priority: bool = False,
     only_unaddressed: bool = False,
     bot_only: bool = False,
-) -> dict:
+) -> dict[str, Any]:
     """Get all comments for a PR with optional filtering and classification."""
     # Initialize stale detection caches
     file_tree: list[str] = []
@@ -298,7 +361,7 @@ def get_pr_review_comments(
             3,
         )
 
-    processed_review: list[dict] = []
+    processed_review: list[dict[str, Any]] = []
     for comment in review_comments:
         login = comment.get("user", {}).get("login", "")
         if author and login != author:
@@ -307,7 +370,7 @@ def get_pr_review_comments(
         line = comment.get("line") or comment.get("original_line")
         diff_hunk = comment.get("diff_hunk", "")
 
-        stale_info: dict = {"Stale": None, "StaleReason": None}
+        stale_info: dict[str, Any] = {"Stale": None, "StaleReason": None}
         if detect_stale:
             stale_info = get_staleness(
                 {
@@ -342,7 +405,7 @@ def get_pr_review_comments(
         })
 
     # Fetch issue comments if requested
-    processed_issue: list[dict] = []
+    processed_issue: list[dict[str, Any]] = []
     if include_issue_comments:
         try:
             issue_comments = gh_api_paginated(
@@ -402,7 +465,7 @@ def get_pr_review_comments(
             if nodes and nodes[0] and nodes[0].get("databaseId"):
                 unresolved_ids.add(nodes[0]["databaseId"])
 
-        filtered: list[dict] = []
+        filtered: list[dict[str, Any]] = []
         for c in all_comments:
             if bot_only and c.get("AuthorType") != "Bot":
                 continue
@@ -441,6 +504,34 @@ def get_pr_review_comments(
     author_summary = [
         {"Author": a, "Count": cnt} for a, cnt in author_counter.items()
     ]
+
+    # Handle GroupByReviewerPriority output mode (composes with domain: reviewer
+    # priority is the outer key, domain the inner tiebreaker).
+    if group_by_reviewer_priority:
+        reviewer_grouped = _group_comments_by_reviewer_priority(
+            all_comments, group_by_domain
+        )
+        reviewer_counts: dict[str, int] = {}
+        for tier in _REVIEWER_TIERS:
+            value = reviewer_grouped[tier]
+            reviewer_counts[tier] = (
+                sum(len(v) for v in value.values()) if group_by_domain else len(value)
+            )
+
+        reviewer_grouped["TotalComments"] = len(all_comments)
+        reviewer_grouped["ReviewerPriorityCounts"] = reviewer_counts
+        if group_by_domain:
+            reviewer_grouped["DomainCounts"] = {
+                k.capitalize(): v for k, v in domain_counts.items()
+            }
+        reviewer_grouped["StaleCount"] = stale_count
+
+        tiers_summary = ", ".join(f"{t}({reviewer_counts[t]})" for t in _REVIEWER_TIERS)
+        print(
+            f"PR #{pr_number}: Grouped by reviewer priority: {tiers_summary}",
+            file=sys.stderr,
+        )
+        return reviewer_grouped
 
     # Handle GroupByDomain output mode
     if group_by_domain:
@@ -558,6 +649,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Group comments by domain instead of flat array",
     )
     parser.add_argument(
+        "--group-by-reviewer-priority", action="store_true",
+        help=(
+            "Group comments by reviewer priority (P0 cursor[bot], P1 human, "
+            "P2 bot, then Unknown); composes with --group-by-domain as the "
+            "inner tiebreaker"
+        ),
+    )
+    parser.add_argument(
         "--only-unaddressed", action="store_true",
         help="Filter to comments needing attention",
     )
@@ -614,6 +713,7 @@ def main(argv: list[str] | None = None) -> int:
         exclude_stale=args.exclude_stale,
         only_stale=args.only_stale,
         group_by_domain=args.group_by_domain,
+        group_by_reviewer_priority=args.group_by_reviewer_priority,
         only_unaddressed=args.only_unaddressed,
         bot_only=args.bot_only,
     )

--- a/src/copilot-cli/skills/github/scripts/pr/get_pr_review_comments.py
+++ b/src/copilot-cli/skills/github/scripts/pr/get_pr_review_comments.py
@@ -67,6 +67,8 @@ _REVIEWER_PRIORITY_BY_LOGIN: dict[str, str] = {
     "coderabbitai[bot]": "P2",
     "copilot": "P2",
     "github-copilot[bot]": "P2",  # bot-login variant of the Copilot reviewer
+    "copilot-pull-request-reviewer[bot]": "P2",  # production Copilot PR reviewer
+    "copilot-pull-request-reviewer": "P2",  # User-type variant
 }
 
 _REVIEWER_TIERS: tuple[str, ...] = ("P0", "P1", "P2", "Unknown")
@@ -79,12 +81,14 @@ def classify_reviewer_priority(author: str, author_type: str) -> str:
     Order per the pr-comment-responder SKILL.md Reviewer Priority table:
     P0 cursor[bot], P1 human reviewers, P2 named reviewer bots. An author that
     is a bot but not one of the named reviewer bots falls to the deterministic
-    "Unknown" tier.
+    "Unknown" tier. Ghost/deleted accounts (empty author) also fall to Unknown.
     """
-    mapped = _REVIEWER_PRIORITY_BY_LOGIN.get((author or "").lower())
+    if not author:
+        return "Unknown"
+    mapped = _REVIEWER_PRIORITY_BY_LOGIN.get(author.lower())
     if mapped is not None:
         return mapped
-    if not is_bot(author or "", author_type or None):
+    if not is_bot(author, author_type or None):
         return "P1"
     return "Unknown"
 

--- a/tests/e2e/test_plugin_load_smoke.py
+++ b/tests/e2e/test_plugin_load_smoke.py
@@ -188,14 +188,16 @@ def _plugin_enumeration_available(
     The smoke skips ONLY for the known-benign shape: a well-formed JSON array
     that carries zero ``source: plugin`` records. On Copilot CLI 1.0.69
     (verified 2026-07-08 on this repo's shipped ``src/copilot-cli`` tree),
-    1.0.70 (issue #3014), and 1.0.71 (issue #3090; verified via
-    debug-boot hooks-fired proof on 1.0.71-3), ``copilot --plugin-dir <dir> skill list --json`` run
+    1.0.70 (issue #3014), 1.0.71 (issue #3090; verified via
+    debug-boot hooks-fired proof on 1.0.71-3), and 1.0.72 (issue #3135;
+    verified via debug-boot hook execution on 1.0.72-0),
+    ``copilot --plugin-dir <dir> skill list --json`` run
     from a neutral cwd surfaces ZERO ``source: plugin`` records: the output
     carries only ``builtin`` and ``personal-copilot``. The ``source: project``
     group that does list the lifecycle skills is cwd-based (the repo you stand
     in), not ``--plugin-dir`` based, so it is not a valid load signal for a
     neutral-cwd smoke. The full set of benign versions lives in
-    ``_COPILOT_BENIGN_NO_ENUM_VERSIONS`` below. See issues #2990, #3014, and #3090.
+    ``_COPILOT_BENIGN_NO_ENUM_VERSIONS`` below. See #2990, #3014, #3090, and #3135.
 
     The caller validates list-ness first:
     ``test_copilot_plugin_loads_expected_skills`` fails loud on a non-list
@@ -215,7 +217,7 @@ def _plugin_enumeration_available(
     return _has_plugin_source_record(payload, plugin_dir)
 
 
-_COPILOT_BENIGN_NO_ENUM_VERSIONS = frozenset({"1.0.69", "1.0.70", "1.0.71"})
+_COPILOT_BENIGN_NO_ENUM_VERSIONS = frozenset({"1.0.69", "1.0.70", "1.0.71", "1.0.72"})
 
 
 def _copilot_version_omits_plugin_enumeration(version_output: str) -> bool:
@@ -223,7 +225,7 @@ def _copilot_version_omits_plugin_enumeration(version_output: str) -> bool:
 
     Only the versions in ``_COPILOT_BENIGN_NO_ENUM_VERSIONS`` are allowed to skip
     the strict subset assertion when ``skill list --json`` surfaces zero
-    ``source: plugin`` records (issues #2990, #3014, and #3090). This is an
+    ``source: plugin`` records (issues #2990, #3014, #3090, and #3135). This is an
     output-surface quirk of those releases: the plugin loads and its hooks fire,
     but ``skill list --json`` does not enumerate ``--plugin-dir`` skills under
     ``source: plugin``. Any other version that surfaces zero ``source: plugin``
@@ -317,15 +319,16 @@ def test_copilot_plugin_loads_expected_skills(tmp_path: Path) -> None:
                 "copilot skill list --json surfaced no source: plugin records for a "
                 f"known-good --plugin-dir on CLI version {version_text!r}, which is "
                 "NOT a known plugin-enumeration-omitting version (issues #2990, #3014, "
-                f"#3090). A version outside the benign {benign_versions} set that "
+                f"#3090, #3135). A version outside the benign {benign_versions} set that "
                 "surfaces no source: plugin records is treated as a real "
                 "plugin-load regression. "
                 f"sources seen: {sources}"
             )
         pytest.skip(
             "copilot skill list --json surfaced no source: plugin records for a "
-            "known-good --plugin-dir. On CLI 1.0.69, 1.0.70, and 1.0.71 the plugin-dir load "
-            "is not enumerated through this surface (issues #2990, #3014, #3090); the load "
+            "known-good --plugin-dir. On CLI 1.0.69 through 1.0.72 the plugin-dir "
+            "load is not enumerated through this surface (issues #2990, #3014, "
+            "#3090, #3135); the load "
             "itself is unaffected (the plugin's hooks still load and fire). Skipping "
             "loud rather than false-failing. "
             f"copilot --version: {version_text!r}; "
@@ -586,12 +589,12 @@ def test_has_plugin_source_record() -> None:
 
 
 def test_copilot_version_omits_enumeration_true_for_benign_version() -> None:
-    """CLI 1.0.69 through 1.0.71 omit requested plugin-dir enumeration.
+    """CLI 1.0.69 through 1.0.72 omit requested plugin-dir enumeration.
 
-    Both surface zero ``source: plugin`` records for a known-good ``--plugin-dir``
-    while the plugin still loads (issues #2990, #3014, #3090). A build-tag suffix
-    (``1.0.69-3``) tracks the same release, so it still matches; extra surrounding
-    text from ``--version`` is tolerated.
+    These releases surface zero matching ``source: plugin`` records for a known-good
+    ``--plugin-dir`` while the plugin still loads (#2990, #3014, #3090, #3135).
+    A build-tag suffix such as ``1.0.69-3`` tracks the same release, so it
+    still matches; extra surrounding text from ``--version`` is tolerated.
     """
     assert _copilot_version_omits_plugin_enumeration("1.0.69") is True
     assert _copilot_version_omits_plugin_enumeration("1.0.69-3") is True
@@ -599,17 +602,19 @@ def test_copilot_version_omits_enumeration_true_for_benign_version() -> None:
     assert _copilot_version_omits_plugin_enumeration("1.0.70-0") is True
     assert _copilot_version_omits_plugin_enumeration("1.0.71") is True
     assert _copilot_version_omits_plugin_enumeration("1.0.71-3") is True
+    assert _copilot_version_omits_plugin_enumeration("1.0.72") is True
+    assert _copilot_version_omits_plugin_enumeration("1.0.72-0") is True
     assert _copilot_version_omits_plugin_enumeration("copilot 1.0.69 (build 42)") is True
 
 
 def test_copilot_version_omits_enumeration_false_for_other_versions() -> None:
-    """Any version not in the benign set must fail loud, not skip (issues #2990, #3014, #3090).
+    """Unknown versions must fail loud, not skip (#2990, #3014, #3090, #3135).
 
     A CLI that enumerates ``--plugin-dir`` skills but returns none is a real
     plugin-load regression; the negative control depends on this returning False.
     """
     assert _copilot_version_omits_plugin_enumeration("1.0.68") is False
-    assert _copilot_version_omits_plugin_enumeration("1.0.72") is False
+    assert _copilot_version_omits_plugin_enumeration("1.0.73") is False
     assert _copilot_version_omits_plugin_enumeration("1.1.0") is False
     assert _copilot_version_omits_plugin_enumeration("2.0.0") is False
 

--- a/tests/test_get_pr_review_comments.py
+++ b/tests/test_get_pr_review_comments.py
@@ -151,8 +151,11 @@ class TestBuildParser:
     def test_help_text_lists_reviewer_priority_flag(self, capsys):
         with pytest.raises(SystemExit) as exc:
             build_parser().parse_args(["--help"])
+
         assert exc.value.code == 0
-        assert "--group-by-reviewer-priority" in capsys.readouterr().out
+        help_text = capsys.readouterr().out
+        assert "--group-by-reviewer-priority" in help_text
+        assert "P2 CodeRabbit/Copilot, then Unknown" in help_text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_get_pr_review_comments.py
+++ b/tests/test_get_pr_review_comments.py
@@ -313,6 +313,18 @@ class TestClassifyReviewerPriority:
     def test_copilot_bot_login_variant_is_p2(self):
         assert classify_reviewer_priority("github-copilot[bot]", "Bot") == "P2"
 
+    def test_copilot_pr_reviewer_bot_is_p2(self):
+        assert classify_reviewer_priority("copilot-pull-request-reviewer[bot]", "Bot") == "P2"
+
+    def test_copilot_pr_reviewer_user_type_is_p2(self):
+        assert classify_reviewer_priority("copilot-pull-request-reviewer", "User") == "P2"
+
+    def test_ghost_author_empty_string_is_unknown(self):
+        assert classify_reviewer_priority("", "") == "Unknown"
+
+    def test_ghost_author_empty_with_user_type_is_unknown(self):
+        assert classify_reviewer_priority("", "User") == "Unknown"
+
     def test_unrecognized_bot_is_unknown(self):
         assert classify_reviewer_priority("randobot[bot]", "Bot") == "Unknown"
 

--- a/tests/test_get_pr_review_comments.py
+++ b/tests/test_get_pr_review_comments.py
@@ -22,8 +22,8 @@ _SCRIPTS_DIR = (
 )
 
 
-def _import_script(name: str):
-    spec = importlib.util.spec_from_file_location(name, _SCRIPTS_DIR / f"{name}.py")
+def _import_script(name: str, script_path: Path):
+    spec = importlib.util.spec_from_file_location(name, script_path)
     assert spec is not None
     assert spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
@@ -32,10 +32,25 @@ def _import_script(name: str):
     return mod
 
 
-_mod = _import_script("get_pr_review_comments")
+_mod = _import_script(
+    "get_pr_review_comments",
+    _SCRIPTS_DIR / "get_pr_review_comments.py",
+)
+_copilot_mod = _import_script(
+    "copilot_get_pr_review_comments",
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "copilot-cli"
+    / "skills"
+    / "github"
+    / "scripts"
+    / "pr"
+    / "get_pr_review_comments.py",
+)
 main = _mod.main
 build_parser = _mod.build_parser
 classify_reviewer_priority = _mod.classify_reviewer_priority
+copilot_classify_reviewer_priority = _copilot_mod.classify_reviewer_priority
 
 
 # ---------------------------------------------------------------------------
@@ -331,6 +346,18 @@ class TestClassifyReviewerPriority:
     def test_bot_by_type_only_is_unknown(self):
         assert classify_reviewer_priority("mystery", "Bot") == "Unknown"
 
+    @pytest.mark.parametrize(
+        ("author", "author_type", "expected"),
+        [
+            ("copilot-pull-request-reviewer[bot]", "Bot", "P2"),
+            ("copilot-pull-request-reviewer", "User", "P2"),
+            ("", "", "Unknown"),
+            ("", "User", "Unknown"),
+        ],
+    )
+    def test_copilot_mirror_reviewer_priorities(self, author, author_type, expected):
+        assert copilot_classify_reviewer_priority(author, author_type) == expected
+
 
 # ---------------------------------------------------------------------------
 # Tests: --group-by-reviewer-priority output mode
@@ -410,6 +437,19 @@ class TestGroupByReviewerPriority:
         assert out["Unknown"][0]["Author"] == "randobot[bot]"
         assert out["ReviewerPriorityCounts"]["Unknown"] == 1
         assert out["P0"] == []
+
+    def test_deleted_account_uses_unknown_bucket(self, capsys):
+        review = [_review_comment(1, "deleted-user", "Just a passing note")]
+        review[0]["user"] = None
+
+        rc = _run_main(
+            ["--pull-request", "1", "--group-by-reviewer-priority"], review=review
+        )
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["Unknown"][0]["Author"] == ""
+        assert out["ReviewerPriorityCounts"]["Unknown"] == 1
+        assert out["P1"] == []
 
     def test_pagination_places_every_comment(self, capsys):
         review = [

--- a/tests/test_get_pr_review_comments.py
+++ b/tests/test_get_pr_review_comments.py
@@ -35,6 +35,7 @@ def _import_script(name: str):
 _mod = _import_script("get_pr_review_comments")
 main = _mod.main
 build_parser = _mod.build_parser
+classify_reviewer_priority = _mod.classify_reviewer_priority
 
 
 # ---------------------------------------------------------------------------
@@ -44,6 +45,64 @@ build_parser = _mod.build_parser
 
 def _completed(stdout: str = "", stderr: str = "", rc: int = 0):
     return subprocess.CompletedProcess(args=[], returncode=rc, stdout=stdout, stderr=stderr)
+
+
+def _review_comment(
+    cid: int, login: str, body: str, ctype: str = "Bot", created: str = "2024-01-01"
+):
+    return {
+        "id": cid,
+        "user": {"login": login, "type": ctype},
+        "body": body,
+        "path": "src/main.py",
+        "line": 10,
+        "original_line": 10,
+        "reactions": {"eyes": 0},
+        "in_reply_to_id": None,
+        "created_at": created,
+        "updated_at": created,
+        "html_url": "https://example.com",
+    }
+
+
+def _issue_comment(
+    cid: int, login: str, body: str, ctype: str = "User", created: str = "2024-01-01"
+):
+    return {
+        "id": cid,
+        "user": {"login": login, "type": ctype},
+        "body": body,
+        "reactions": {"eyes": 0},
+        "created_at": created,
+        "updated_at": created,
+        "html_url": "https://example.com",
+    }
+
+
+def _run_main(argv, review=None, issue=None, unresolved=None):
+    """Run main() with GitHub I/O mocked at the boundary.
+
+    gh_api_paginated is called once (review comments) or, when the argv includes
+    --include-issue-comments, twice (review then issue). Pass issue=[...] to
+    exercise the second call. The real is_bot / classify_domain collaborators
+    run unmocked so classification stays faithful.
+    """
+    side = [review or []]
+    if issue is not None:
+        side.append(issue)
+    with patch(
+        "get_pr_review_comments.assert_gh_authenticated",
+    ), patch(
+        "get_pr_review_comments.resolve_repo_params",
+        return_value=RepoInfo(owner="o", repo="r"),
+    ), patch(
+        "get_pr_review_comments.gh_api_paginated",
+        side_effect=side,
+    ), patch(
+        "get_pr_review_comments.get_unresolved_review_threads",
+        return_value=unresolved or [],
+    ):
+        return main(argv)
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +137,22 @@ class TestBuildParser:
     def test_group_by_domain(self):
         args = build_parser().parse_args(["--pull-request", "1", "--group-by-domain"])
         assert args.group_by_domain is True
+
+    def test_group_by_reviewer_priority_defaults_false(self):
+        args = build_parser().parse_args(["--pull-request", "1"])
+        assert args.group_by_reviewer_priority is False
+
+    def test_group_by_reviewer_priority_parses(self):
+        args = build_parser().parse_args(
+            ["--pull-request", "1", "--group-by-reviewer-priority"]
+        )
+        assert args.group_by_reviewer_priority is True
+
+    def test_help_text_lists_reviewer_priority_flag(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            build_parser().parse_args(["--help"])
+        assert exc.value.code == 0
+        assert "--group-by-reviewer-priority" in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------
@@ -183,3 +258,149 @@ class TestMain:
         assert rc == 0
         output = json.loads(capsys.readouterr().out)
         assert output["TotalComments"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: classify_reviewer_priority (unit)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyReviewerPriority:
+    def test_cursor_bot_is_p0(self):
+        assert classify_reviewer_priority("cursor[bot]", "Bot") == "P0"
+
+    def test_cursor_bot_case_insensitive(self):
+        assert classify_reviewer_priority("Cursor[Bot]", "Bot") == "P0"
+
+    def test_human_reviewer_is_p1(self):
+        assert classify_reviewer_priority("alice", "User") == "P1"
+
+    def test_coderabbit_is_p2(self):
+        assert classify_reviewer_priority("coderabbitai[bot]", "Bot") == "P2"
+
+    def test_copilot_is_p2(self):
+        assert classify_reviewer_priority("Copilot", "Bot") == "P2"
+
+    def test_copilot_bot_login_variant_is_p2(self):
+        assert classify_reviewer_priority("github-copilot[bot]", "Bot") == "P2"
+
+    def test_unrecognized_bot_is_unknown(self):
+        assert classify_reviewer_priority("randobot[bot]", "Bot") == "Unknown"
+
+    def test_bot_by_type_only_is_unknown(self):
+        assert classify_reviewer_priority("mystery", "Bot") == "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Tests: --group-by-reviewer-priority output mode
+# ---------------------------------------------------------------------------
+
+
+class TestGroupByReviewerPriority:
+    def test_documented_command_groups_reviewer_then_domain(self, capsys):
+        """The exact command copied from pr-comment-responder SKILL.md runs and
+        nests reviewer priority outside, domain inside."""
+        review = [
+            _review_comment(1, "cursor[bot]", "Potential SQL injection vulnerability"),
+            _review_comment(2, "human-dev", "This will crash with an exception", ctype="User"),
+            _review_comment(3, "coderabbitai[bot]", "Fix the naming convention"),
+            _review_comment(4, "randobot[bot]", "Just a passing note"),
+        ]
+        issue = [
+            _issue_comment(5, "human-dev", "Please add authentication here", ctype="User"),
+        ]
+        rc = _run_main(
+            [
+                "--pull-request", "3076",
+                "--group-by-reviewer-priority",
+                "--group-by-domain",
+                "--include-issue-comments",
+            ],
+            review=review,
+            issue=issue,
+        )
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+
+        assert out["P0"]["Security"][0]["Author"] == "cursor[bot]"
+        assert out["P1"]["Bug"][0]["Author"] == "human-dev"
+        assert out["P2"]["Style"][0]["Author"] == "coderabbitai[bot]"
+        assert out["Unknown"]["General"][0]["Author"] == "randobot[bot]"
+        # Human security comment stays in the human tier; it never jumps to P0/P2.
+        assert out["P1"]["Security"][0]["Author"] == "human-dev"
+        assert out["TotalComments"] == 5
+        assert out["ReviewerPriorityCounts"] == {"P0": 1, "P1": 2, "P2": 1, "Unknown": 1}
+
+    def test_tier_key_order_is_p0_p1_p2_unknown(self, capsys):
+        review = [_review_comment(1, "cursor[bot]", "SQL injection")]
+        rc = _run_main(["--pull-request", "1", "--group-by-reviewer-priority"], review=review)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert list(out.keys())[:4] == ["P0", "P1", "P2", "Unknown"]
+
+    def test_domain_key_order_within_tier(self, capsys):
+        review = [_review_comment(1, "cursor[bot]", "SQL injection")]
+        rc = _run_main(
+            ["--pull-request", "1", "--group-by-reviewer-priority", "--group-by-domain"],
+            review=review,
+        )
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert list(out["P0"].keys()) == ["Security", "Bug", "Style", "Summary", "General"]
+
+    def test_flat_lists_without_domain(self, capsys):
+        review = [
+            _review_comment(1, "cursor[bot]", "note a"),
+            _review_comment(2, "human-dev", "note b", ctype="User"),
+        ]
+        rc = _run_main(["--pull-request", "1", "--group-by-reviewer-priority"], review=review)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert isinstance(out["P0"], list)
+        assert out["P0"][0]["Author"] == "cursor[bot]"
+        assert out["P1"][0]["Author"] == "human-dev"
+        assert out["P2"] == []
+
+    def test_unknown_reviewer_bucket(self, capsys):
+        review = [_review_comment(1, "randobot[bot]", "Just a passing note")]
+        rc = _run_main(["--pull-request", "1", "--group-by-reviewer-priority"], review=review)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["Unknown"][0]["Author"] == "randobot[bot]"
+        assert out["ReviewerPriorityCounts"]["Unknown"] == 1
+        assert out["P0"] == []
+
+    def test_pagination_places_every_comment(self, capsys):
+        review = [
+            _review_comment(1, "cursor[bot]", "SQL injection", created="2024-01-01"),
+            _review_comment(2, "human-dev", "crash", ctype="User", created="2024-01-02"),
+            _review_comment(3, "coderabbitai[bot]", "refactor naming", created="2024-01-03"),
+            _review_comment(4, "randobot[bot]", "note", created="2024-01-04"),
+            _review_comment(5, "human-two", "another crash", ctype="User", created="2024-01-05"),
+        ]
+        rc = _run_main(["--pull-request", "1", "--group-by-reviewer-priority"], review=review)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        counts = out["ReviewerPriorityCounts"]
+        assert counts["P0"] + counts["P1"] + counts["P2"] + counts["Unknown"] == 5
+        assert counts == {"P0": 1, "P1": 2, "P2": 1, "Unknown": 1}
+
+    def test_no_comments_yields_empty_tiers(self, capsys):
+        rc = _run_main(["--pull-request", "1", "--group-by-reviewer-priority"], review=[])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["TotalComments"] == 0
+        assert out["P0"] == [] and out["P1"] == [] and out["P2"] == [] and out["Unknown"] == []
+
+
+class TestGroupByDomainRegression:
+    def test_domain_alone_keeps_flat_domain_structure(self, capsys):
+        """--group-by-domain without the reviewer flag still returns the flat
+        Security/Bug/Style/Summary/General structure (no reviewer tiers)."""
+        review = [_review_comment(1, "cursor[bot]", "SQL injection")]
+        rc = _run_main(["--pull-request", "1", "--group-by-domain"], review=review)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert "P0" not in out
+        assert out["Security"][0]["Author"] == "cursor[bot]"
+        assert list(out.keys())[:5] == ["Security", "Bug", "Style", "Summary", "General"]

--- a/tests/test_get_pr_review_comments.py
+++ b/tests/test_get_pr_review_comments.py
@@ -192,6 +192,32 @@ class TestMain:
         assert output["Success"] is True
         assert output["TotalComments"] == 0
 
+    def test_review_comment_with_null_user_uses_empty_author(self, capsys):
+        review = _review_comment(100, "unused", "Deleted account comment")
+        review["user"] = None
+
+        rc = _run_main(["--pull-request", "42"], review=[review])
+
+        assert rc == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output["Comments"][0]["Author"] == ""
+        assert output["Comments"][0]["AuthorType"] == ""
+
+    def test_issue_comment_with_null_user_uses_empty_author(self, capsys):
+        issue = _issue_comment(200, "unused", "Deleted account comment")
+        issue["user"] = None
+
+        rc = _run_main(
+            ["--pull-request", "42", "--include-issue-comments"],
+            review=[],
+            issue=[issue],
+        )
+
+        assert rc == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output["Comments"][0]["Author"] == ""
+        assert output["Comments"][0]["AuthorType"] == ""
+
     def test_bot_comment_included(self, capsys):
         raw_comments = [
             {


### PR DESCRIPTION
Fixes #3112. The pr-comment-responder skill mandates a first-triage command using get_pr_review_comments.py --group-by-reviewer-priority, but the script never defined that flag, so argparse exited 2 before any comments loaded and the mandated workflow could not run. Adds the flag plus classify_reviewer_priority and a reviewer-priority output branch, reusing github_core.bot_config.is_bot and comment_classification.classify_domain (no reinvention). Tier mapping matches the SKILL.md table: cursor[bot]=P0, human=P1, coderabbitai/Copilot=P2, else Unknown. Composes with --group-by-domain (reviewer priority outer, domain inner); verified a human Security comment stays in P1 and does not jump tiers. Tests are fails-before/passes-after (pre-fix the parse test raised SystemExit(2)); the documented 4-flag repro command runs rc 0; 29 pass. Both plugin twins carry the fix byte-identical; parity manifests bumped to 0.6.45. Flag (pre-existing, not introduced here): Pyright reports review_comments/issue_comments possibly-unbound at get_pr_review_comments.py:365/:422 because it does not know error_and_exit is NoReturn; the pattern predates this change and mypy is clean. NOTE: PR #3121 (#3092) edits this same file from a different base; whichever lands first, the other rebases.

## Related Issues

Refs #3135. Copilot CLI 1.0.72 repeated the verified plugin enumeration gap and blocked pre-push. This PR adds that release to the fail-closed test allowlist.