### PR TITLE
fix(pre-push): key commit-limit-bypass lookup on the destination branch (#3110)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -324,6 +324,9 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         refs/heads/*)
             PUSH_REMOTE_BRANCH="${remote_ref#refs/heads/}"
             ;;
+        *)
+            PUSH_REMOTE_BRANCH=""
+            ;;
     esac
 
     # Store base and head for per-ref plugin version validation

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -249,6 +249,12 @@ ZERO="0000000000000000000000000000000000000000"
 CHANGED_FILES=""
 PUSH_RANGE=""
 PUSH_BRANCH=""
+# Destination (remote) branch of the push. For `git push origin HEAD:other` the
+# local and remote branch names differ, and PR policy (the commit-limit-bypass
+# label) lives on the PR whose head is the REMOTE branch, not the local one
+# (Issue #3110). Kept separate from PUSH_BRANCH so the bypass-label lookup can
+# prefer the destination branch while other checks keep using the local range.
+PUSH_REMOTE_BRANCH=""
 REFS_PROCESSED=0
 # Store each ref's base and head for per-ref validation (plugin version bump)
 PVB_BASES=()
@@ -312,6 +318,11 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     case "$local_ref" in
         refs/heads/*)
             PUSH_BRANCH="${local_ref#refs/heads/}"
+            ;;
+    esac
+    case "$remote_ref" in
+        refs/heads/*)
+            PUSH_REMOTE_BRANCH="${remote_ref#refs/heads/}"
             ;;
     esac
 
@@ -481,9 +492,15 @@ if [ -n "$PUSH_RANGE" ]; then
         # ("Enforce Blocking Issues"). The helper fails closed: any gh error
         # leaves the limit enforced.
         if set_python_cmd; then
+            # Prefer the destination (remote) branch: the commit-limit-bypass
+            # label lives on the PR whose head is the branch being pushed TO,
+            # which differs from the local branch on a `git push origin
+            # HEAD:other` repair push (Issue #3110). Fall back to the local
+            # branch, then the checked-out branch, for same-name pushes.
+            BYPASS_BRANCH="${PUSH_REMOTE_BRANCH:-${PUSH_BRANCH:-$current_branch}}"
             BYPASS_STATUS=$(env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR -u GIT_INDEX_FILE \
                 "${PYTHON_CMD[@]}" "$REPO_ROOT/scripts/validation/check_pr_bypass_label.py" \
-                --branch "${PUSH_BRANCH:-$current_branch}" 2>/dev/null)
+                --branch "$BYPASS_BRANCH" 2>/dev/null)
             BYPASS_EXIT=$?
         else
             BYPASS_STATUS="python unavailable; cannot check bypass label"

--- a/tests/test_pre_push_remote_branch_bypass.py
+++ b/tests/test_pre_push_remote_branch_bypass.py
@@ -1,0 +1,138 @@
+"""Pre-push commit-limit-bypass lookup uses the destination branch (#3110).
+
+Repairing an over-limit PR from an isolated local branch pushes with
+``git push origin HEAD:<pr-head>``, so the local and remote branch names differ.
+The ``commit-limit-bypass`` label lives on the PR whose head is the REMOTE
+branch, not the local one. Before the fix the hook derived the branch passed to
+``check_pr_bypass_label.py`` from the local ref, queried a branch with no PR, and
+blocked the repair push, forcing ``SKIP_SCOPE_CHECK=1``.
+
+These tests run the real ``.githooks/pre-push`` against a throwaway repo whose
+commit count exceeds the limit, with ``check_pr_bypass_label.py`` stubbed to echo
+the ``--branch`` value it received (mock at the process boundary). The assertion
+is which branch the hook actually queries.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+PRE_PUSH = Path(__file__).resolve().parents[1] / ".githooks" / "pre-push"
+
+_BYPASS_STUB = """#!/usr/bin/env python3
+import sys
+
+argv = sys.argv[1:]
+branch = ""
+for index, arg in enumerate(argv):
+    if arg == "--branch" and index + 1 < len(argv):
+        branch = argv[index + 1]
+print(f"QUERIED_BRANCH={branch}")
+raise SystemExit(1)
+"""
+
+
+def _run_git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        check=True,
+        text=True,
+        timeout=30,
+    )
+    return result.stdout.strip()
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _make_over_limit_repo(tmp_path: Path) -> tuple[Path, str, str, dict[str, str]]:
+    """Build a repo whose feature branch is 21 commits past origin/main."""
+    repo = tmp_path / "hook-repo"
+    repo.mkdir()
+    _run_git(repo, "init")
+    _run_git(repo, "checkout", "-b", "main")
+    _run_git(repo, "config", "user.name", "Pre Push Test")
+    _run_git(repo, "config", "user.email", "pre-push-test@example.invalid")
+
+    (repo / ".githooks").mkdir()
+    _write_executable(repo / ".githooks" / "pre-push", PRE_PUSH.read_text(encoding="utf-8"))
+
+    # Stub the bypass-label helper to echo the branch the hook queries.
+    validation_dir = repo / "scripts" / "validation"
+    validation_dir.mkdir(parents=True)
+    (validation_dir / "check_pr_bypass_label.py").write_text(_BYPASS_STUB, encoding="utf-8")
+
+    (repo / "README.md").write_text("# fixture\n", encoding="utf-8")
+    _run_git(repo, "add", ".")
+    _run_git(repo, "commit", "-m", "test: base")
+    base_sha = _run_git(repo, "rev-parse", "HEAD")
+    _run_git(repo, "update-ref", "refs/remotes/origin/main", base_sha)
+
+    # Isolated local repair branch, 21 commits past base (over the limit of 20).
+    # Non-.py files keep ruff/mypy/pytest phases empty so only the commit-count
+    # bypass path matters.
+    _run_git(repo, "checkout", "-b", "fix/local")
+    for index in range(21):
+        (repo / f"data_{index}.txt").write_text(f"{index}\n", encoding="utf-8")
+        _run_git(repo, "add", f"data_{index}.txt")
+        _run_git(repo, "commit", "-m", f"test: change {index}")
+    head_sha = _run_git(repo, "rev-parse", "HEAD")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for stub in ("ruff", "mypy"):
+        _write_executable(bin_dir / stub, "#!/usr/bin/env bash\nexit 0\n")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    env["TMPDIR"] = str(scratch)
+    return repo, base_sha, head_sha, env
+
+
+def _run_pre_push(repo: Path, stdin: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(repo / ".githooks" / "pre-push")],
+        cwd=repo,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=90,
+    )
+
+
+def test_bypass_lookup_uses_remote_branch_when_names_differ(tmp_path: Path) -> None:
+    """A HEAD:other repair push queries the destination branch, not the local one."""
+    repo, base_sha, head_sha, env = _make_over_limit_repo(tmp_path)
+
+    result = _run_pre_push(
+        repo,
+        f"refs/heads/fix/local {head_sha} refs/heads/perf/dest {base_sha}\n",
+        env,
+    )
+
+    output = result.stdout + result.stderr
+    assert "QUERIED_BRANCH=perf/dest" in output, output
+    assert "QUERIED_BRANCH=fix/local" not in output, output
+
+
+def test_bypass_lookup_uses_branch_for_same_name_push(tmp_path: Path) -> None:
+    """A normal same-name push still queries that branch (no regression)."""
+    repo, base_sha, head_sha, env = _make_over_limit_repo(tmp_path)
+
+    result = _run_pre_push(
+        repo,
+        f"refs/heads/fix/local {head_sha} refs/heads/fix/local {base_sha}\n",
+        env,
+    )
+
+    output = result.stdout + result.stderr
+    assert "QUERIED_BRANCH=fix/local" in output, output


### PR DESCRIPTION
Fixes #3110. Repairing an over-limit PR from an isolated local branch pushes with git push origin HEAD:<pr-head>, so the local and remote branch names differ. The commit-limit-bypass label lives on the PR whose head is the REMOTE branch, but the pre-push hook derived the branch passed to check_pr_bypass_label.py from the local ref (.githooks/pre-push:314), queried a branch with no PR, and blocked the repair push, forcing SKIP_SCOPE_CHECK=1.

Fix: capture the remote/destination branch (PUSH_REMOTE_BRANCH) in the ref loop and prefer it for the bypass-label lookup, falling back to the local branch then the checked-out branch for normal same-name pushes. The label must still genuinely exist on the destination PR and check_pr_bypass_label.py still fails closed on any gh error, so no new bypass is created; the query just targets the PR that actually receives the push.

SECURITY NOTE (push-gate change): this edits the pre-push commit/scope gate's bypass-label branch selection. It does not widen what the label permits; it points the existing label check at the correct PR. Your security review before merge is expected.

Regression test (tests/test_pre_push_remote_branch_bypass.py) runs the real hook against a 21-commit repo with check_pr_bypass_label.py stubbed to echo the branch it receives: a differing local/remote push queries the destination branch (fails-before/passes-after verified: on origin/main the query names the local branch), and a same-name push still queries that branch. No manifest bump (.githooks is not a plugin dir).