### PR TITLE
test(dispatch): preserve #3083 regression case for the small apply_patch host-vs-replay exit-code discrepancy

### DIFF
--- a/tests/build_scripts/test_dispatch_small_apply_patch_regression.py
+++ b/tests/build_scripts/test_dispatch_small_apply_patch_regression.py
@@ -3,7 +3,7 @@
 
 On Windows the Copilot CLI host reported ``Hook command failed with code 1`` on a
 small ``apply_patch`` PreToolUse payload, yet a direct replay of the same payload
-class through ``_dispatch.py`` returned exit 0. No PreToolUse shim matches
+through ``_dispatch.py`` returned exit 0. No PreToolUse shim matches
 ``apply_patch`` (the manifest carries Bash, Write/Edit, Grep, Glob, Read, Task,
 and Agent shims), so on this payload every shim skips and the dispatcher returns
 0. The dispatcher is not limited to {0, 2} in general: ``hook_dispatch.run_dispatch``
@@ -48,10 +48,9 @@ _MAX_STDIN_BYTES = 2 * 1024 * 1024
 # A small representative apply_patch payload, well under the 2 MiB stdin cap (the
 # #3074 recording was about 1,659 bytes; this fixture is smaller and not a
 # byte-exact copy, which does not matter: any sub-cap payload with no matching
-# shim returns 0). This
-# is the Copilot host event shape: sessionId, cwd, and a toolCalls entry whose
-# name is apply_patch. It carries no top-level tool_name, exactly as the recorded
-# data.input did, so every matcher shim skips it.
+# shim returns 0). This is the Copilot host event shape: sessionId, cwd, and a
+# toolCalls entry whose name is apply_patch. It carries no top-level tool_name,
+# exactly as the recorded data.input did, so every matcher shim skips it.
 _RECORDED_HOST_EVENT: dict[str, object] = {
     "sessionId": "regression-3083",
     "cwd": "consumer-repo",

--- a/tests/build_scripts/test_dispatch_small_apply_patch_regression.py
+++ b/tests/build_scripts/test_dispatch_small_apply_patch_regression.py
@@ -2,15 +2,20 @@
 """Regression guard for issue #3083 (Copilot host-versus-direct-replay code 1).
 
 On Windows the Copilot CLI host reported ``Hook command failed with code 1`` on a
-small (about 1,659 UTF-8 bytes) ``apply_patch`` PreToolUse payload, yet a direct
-replay of the exact payload through ``_dispatch.py`` returned exit 0. The
-generated dispatcher only ever returns 0 (allow) or 2 (deny, fail-closed), so the
-exit code 1 originates in the Windows ``py -3`` host or launcher, NOT in the
-dispatcher. That host bug is external and stays open on #3083; we cannot fix a
+small ``apply_patch`` PreToolUse payload, yet a direct replay of the same payload
+class through ``_dispatch.py`` returned exit 0. No PreToolUse shim matches
+``apply_patch`` (the manifest carries Bash, Write/Edit, Grep, Glob, Read, Task,
+and Agent shims), so on this payload every shim skips and the dispatcher returns
+0. The dispatcher is not limited to {0, 2} in general: ``hook_dispatch.run_dispatch``
+propagates a matching shim's first non-zero exit code, so a registered shim that
+exited 1 would surface 1. It is the ABSENCE of an ``apply_patch`` matcher, not a
+structural limit, that makes exit 1 impossible for THIS payload. The exit-1 the
+host reported therefore originates in the Windows ``py -3`` host or launcher, not
+the dispatcher. That host bug is external and stays open on #3083; we cannot fix a
 Windows launcher from this repo.
 
-What this preserves: the in-repo half of that discrepancy. It replays a faithful
-small ``apply_patch`` payload through the SHIPPED, committed
+What this preserves: the in-repo half of that discrepancy. It replays a small
+``apply_patch`` payload through the SHIPPED, committed
 ``src/copilot-cli/hooks/PreToolUse/_dispatch.py`` under the verified plugin-root
 contract and asserts exit 0. No registered PreToolUse shim matches
 ``apply_patch`` (the manifest carries Bash, Write/Edit, Grep, Glob, Read, Task,
@@ -40,8 +45,10 @@ _DISPATCH = _PLUGIN_ROOT / "hooks" / "PreToolUse" / "_dispatch.py"
 
 _MAX_STDIN_BYTES = 2 * 1024 * 1024
 
-# Faithful reconstruction of the small apply_patch payload issue #3074 recorded
-# (serialized data.input about 1,659 UTF-8 bytes, well under the 2 MiB cap). This
+# A small representative apply_patch payload, well under the 2 MiB stdin cap (the
+# #3074 recording was about 1,659 bytes; this fixture is smaller and not a
+# byte-exact copy, which does not matter: any sub-cap payload with no matching
+# shim returns 0). This
 # is the Copilot host event shape: sessionId, cwd, and a toolCalls entry whose
 # name is apply_patch. It carries no top-level tool_name, exactly as the recorded
 # data.input did, so every matcher shim skips it.

--- a/tests/build_scripts/test_dispatch_small_apply_patch_regression.py
+++ b/tests/build_scripts/test_dispatch_small_apply_patch_regression.py
@@ -82,9 +82,10 @@ def _run_dispatch(
 ) -> subprocess.CompletedProcess[bytes]:
     """Run the committed PreToolUse dispatcher under the plugin-root contract.
 
-    Copilot launches a plugin hook from the user's cwd (not the plugin dir) and
-    exports COPILOT_PLUGIN_ROOT plus a CLAUDE_PLUGIN_ROOT alias pointing at the
-    install dir. This reproduces that contract so the run matches production.
+    Copilot launches a plugin hook from the user's cwd, not the plugin dir.
+    The launcher chooses COPILOT_PLUGIN_ROOT with CLAUDE_PLUGIN_ROOT as its
+    fallback, while the Python bootstrap consumes CLAUDE_PLUGIN_ROOT. Set both
+    to the same install directory so this test covers either launcher input.
     """
     env = dict(os.environ)
     env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
@@ -113,7 +114,8 @@ def test_small_apply_patch_payload_allows(payload: dict[str, object], tmp_path: 
     assert proc.returncode == 0, (
         f"the committed dispatcher denied a benign small apply_patch payload "
         f"(rc={proc.returncode}). The dispatcher must allow; the Windows host's "
-        f"exit 1 is external (issue #3083).\n{proc.stderr.decode()[:600]}"
+        f"exit 1 is external (issue #3083).\n"
+        f"{proc.stderr.decode('utf-8', errors='replace')[:600]}"
     )
 
 

--- a/tests/build_scripts/test_dispatch_small_apply_patch_regression.py
+++ b/tests/build_scripts/test_dispatch_small_apply_patch_regression.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Regression guard for issue #3083 (Copilot host-versus-direct-replay code 1).
+
+On Windows the Copilot CLI host reported ``Hook command failed with code 1`` on a
+small (about 1,659 UTF-8 bytes) ``apply_patch`` PreToolUse payload, yet a direct
+replay of the exact payload through ``_dispatch.py`` returned exit 0. The
+generated dispatcher only ever returns 0 (allow) or 2 (deny, fail-closed), so the
+exit code 1 originates in the Windows ``py -3`` host or launcher, NOT in the
+dispatcher. That host bug is external and stays open on #3083; we cannot fix a
+Windows launcher from this repo.
+
+What this preserves: the in-repo half of that discrepancy. It replays a faithful
+small ``apply_patch`` payload through the SHIPPED, committed
+``src/copilot-cli/hooks/PreToolUse/_dispatch.py`` under the verified plugin-root
+contract and asserts exit 0. No registered PreToolUse shim matches
+``apply_patch`` (the manifest carries Bash, Write/Edit, Grep, Glob, Read, Task,
+and Agent shims), so every guard skips and the dispatcher allows. If a future
+dispatcher change ever made this benign payload return a non-zero code, this
+guard fails and localizes the regression to the dispatcher rather than the host.
+
+This gates the committed artifact, not the generator (see
+``.claude/rules/generated-artifacts.md``): it runs the real ``_dispatch.py`` as a
+subprocess, the same way issue #3074's repro invoked
+``py -3 -u "$root\\hooks\\PreToolUse\\_dispatch.py"``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_PLUGIN_ROOT = _REPO / "src" / "copilot-cli"
+_DISPATCH = _PLUGIN_ROOT / "hooks" / "PreToolUse" / "_dispatch.py"
+
+_MAX_STDIN_BYTES = 2 * 1024 * 1024
+
+# Faithful reconstruction of the small apply_patch payload issue #3074 recorded
+# (serialized data.input about 1,659 UTF-8 bytes, well under the 2 MiB cap). This
+# is the Copilot host event shape: sessionId, cwd, and a toolCalls entry whose
+# name is apply_patch. It carries no top-level tool_name, exactly as the recorded
+# data.input did, so every matcher shim skips it.
+_RECORDED_HOST_EVENT: dict[str, object] = {
+    "sessionId": "regression-3083",
+    "cwd": "consumer-repo",
+    "toolCalls": [
+        {
+            "id": "call_apply_patch_1",
+            "name": "apply_patch",
+            "args": (
+                "*** Begin Patch\n"
+                "*** Update File: README.md\n"
+                "@@\n"
+                "-old text\n"
+                "+new text\n"
+                "*** End Patch\n"
+            ),
+        }
+    ],
+}
+
+# Normalized hook shape: even when the dispatcher sees apply_patch as the tool
+# name directly, no registered guard matches it, so it still allows. This ties
+# the guard to apply_patch rather than to "any shape lacking tool_name".
+_NORMALIZED_EVENT: dict[str, object] = {"tool_name": "apply_patch", "tool_input": {}}
+
+
+def _run_dispatch(
+    payload: bytes, plugin_root: Path, cwd: Path
+) -> subprocess.CompletedProcess[bytes]:
+    """Run the committed PreToolUse dispatcher under the plugin-root contract.
+
+    Copilot launches a plugin hook from the user's cwd (not the plugin dir) and
+    exports COPILOT_PLUGIN_ROOT plus a CLAUDE_PLUGIN_ROOT alias pointing at the
+    install dir. This reproduces that contract so the run matches production.
+    """
+    env = dict(os.environ)
+    env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
+    env["COPILOT_PLUGIN_ROOT"] = str(plugin_root)
+    return subprocess.run(
+        [sys.executable, "-u", str(_DISPATCH)],
+        input=payload,
+        capture_output=True,
+        cwd=str(cwd),
+        env=env,
+        timeout=60,
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [_RECORDED_HOST_EVENT, _NORMALIZED_EVENT],
+    ids=["recorded-host-event", "normalized-tool-name"],
+)
+def test_small_apply_patch_payload_allows(payload: dict[str, object], tmp_path: Path) -> None:
+    raw = json.dumps(payload).encode("utf-8")
+    assert len(raw) < _MAX_STDIN_BYTES, "fixture must stay under the dispatcher cap"
+
+    proc = _run_dispatch(raw, _PLUGIN_ROOT, tmp_path)
+
+    assert proc.returncode == 0, (
+        f"the committed dispatcher denied a benign small apply_patch payload "
+        f"(rc={proc.returncode}). The dispatcher must allow; the Windows host's "
+        f"exit 1 is external (issue #3083).\n{proc.stderr.decode()[:600]}"
+    )
+
+
+def test_harness_observes_nonzero_exit(tmp_path: Path) -> None:
+    # Teeth for the positive assertion: point the plugin root at a directory that
+    # is not a plugin so the bootstrap fails closed (exit 2). This proves the same
+    # subprocess harness surfaces a non-zero exit, so ``assert rc == 0`` above is
+    # not vacuous. It deliberately avoids the 2 MiB cap path, which issue #3074 is
+    # changing, so this guard does not couple to that in-flight work.
+    raw = json.dumps(_RECORDED_HOST_EVENT).encode("utf-8")
+
+    proc = _run_dispatch(raw, tmp_path, tmp_path)
+
+    assert proc.returncode == 2, (
+        f"expected fail-closed exit 2 from a non-plugin root, got {proc.returncode}; "
+        f"the harness cannot observe non-zero exits, so the positive test lacks teeth"
+    )


### PR DESCRIPTION
Refs #3083. On Windows the Copilot CLI host reports Hook command failed with code 1 on a small apply_patch PreToolUse payload, yet a direct replay of the same payload through src/copilot-cli/hooks/PreToolUse/_dispatch.py returns exit 0. Root cause is EXTERNAL (the Windows py -3 host/launcher), so it cannot be fixed from this repo; #3083 stays open for the host telemetry (AC #1) and on-issue root-cause (AC #3).

What this preserves (AC #2, the in-repo half): tests/build_scripts/test_dispatch_small_apply_patch_regression.py runs the shipped, committed _dispatch.py as a subprocess on a small apply_patch payload and asserts exit 0. No PreToolUse shim matches apply_patch (the manifest carries Bash, Write/Edit, Grep, Glob, Read, Task, Agent), so every shim skips and the dispatcher allows. If a future dispatcher change ever made this benign payload return non-zero, the guard fails and localizes the regression to the dispatcher rather than the host. A teeth test (test_harness_observes_nonzero_exit) points the plugin root at a non-plugin dir so the fail-closed bootstrap returns exit 2, proving the subprocess harness observes non-zero exits, so the positive rc==0 assertion has teeth. 3 tests pass, ruff and mypy clean.

Scope: adds exactly one test file (tests/build_scripts/); no dispatcher, generator, guard, or manifest touched; no plugin manifest bump. Review flagged and I corrected two docstring claims: the dispatcher is NOT structurally limited to {0,2} (hook_dispatch.run_dispatch propagates a matching shim's non-zero exit, so a shim exiting 1 would surface 1); what makes exit 1 impossible here is the absence of an apply_patch matcher. The fixture is a small representative payload, not a byte-exact copy of the recorded ~1,659 bytes (size is irrelevant since any sub-cap payload with no matching shim returns 0).