### PR TITLE
test(validation): isolate workflow bypass environment

### DIFF
--- a/tests/validation/conftest.py
+++ b/tests/validation/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_workflow_local_test_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep validation tests independent of the pre-push bypass environment."""
+    monkeypatch.delenv("SKIP_WORKFLOW_LOCAL_TEST", raising=False)


### PR DESCRIPTION
# test(validation): isolate workflow bypass environment

## Summary

`tests/validation/test_run_workflow_local_test.py` inherited `SKIP_WORKFLOW_LOCAL_TEST` from the shell, so the pre-push workflow-gate bypass caused unrelated assertions to short-circuit. This adds a validation-scoped autouse fixture that removes that bypass before each test while allowing explicit test cases to set it themselves.

Fixes #3115

## Changes

- Add `tests/validation/conftest.py` to isolate `SKIP_WORKFLOW_LOCAL_TEST` for validation tests.

## Testing

Passed in the contained sandbox:

- `python3 -m pip install uv && uv run pytest tests/validation/test_run_workflow_local_test.py -q` (92 passed)
- `python3 -m pip install uv && SKIP_WORKFLOW_LOCAL_TEST=true uv run pytest tests/validation/test_run_workflow_local_test.py -q` (92 passed)

Attempted in the contained sandbox:

- `python3 -m pip install uv && uv run python3 scripts/validation/pre_pr.py`

The full pre-PR runner could not complete because the sandbox lacks `git` and `npx`, which caused six environment-related gate failures. The targeted test suite passed in both the normal and bypassed environments.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates, monitors, and is accountable for. @Dodothereal will address review feedback promptly and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
