### PR TITLE
fix(validation): exempt pytest numeric skipped counts from evidence contradiction (#3141)

### DIFF
--- a/.agents/sessions/2026-07-17-session-3056.json
+++ b/.agents/sessions/2026-07-17-session-3056.json
@@ -1,0 +1,135 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3056,
+    "date": "2026-07-17",
+    "branch": "fix/session-json-numeric-testcount-3141",
+    "startingCommit": "7a40f89e",
+    "objective": "Fleet triage of open issues: fix #3141 (validate_session_json numeric skipped false positive) and evaluate/close resolved issues"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena-initial_instructions returned the Serena manual; serena-list_memories returned the project memory index"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena-initial_instructions invoked at session start"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md (read-only dashboard, v1.4 notice)"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Reviewed .claude/skills catalog during fleet triage; used session-init new_session_log_json.py"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .serena/memories/usage-mandatory.md (skill-first incident log)"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/governance/PROJECT-CONSTRAINTS.md (canonical constraints index)"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena-list_memories + prompt-provided repository/user memories reviewed"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/session-json-numeric-testcount-3141"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/session-json-numeric-testcount-3141"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status clean on branch entry; verified before branch creation"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "7a40f89e"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All sessionStart MUST items complete; #3141 fix + pos/neg/edge tests + lint done"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified this session"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Recorded the #3141 numeric test-count guard fix to memory for future validator work"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown files in diff (only scripts/validate_session_json.py and tests/test_validate_session_json.py and session log JSON changed); markdownlint scoped run not applicable"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Committed to branch fix/session-json-numeric-testcount-3141; final SHA recorded in endingCommit at session end"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run pytest tests/test_validate_session_json.py: 89 passed; ruff check clean; mypy clean on scripts/validate_session_json.py"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Session todo tracking in autopilot fleet triage"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "timestamp": "2026-07-17T00:00:00Z",
+      "action": "Triaged 39 open issues; mapped 17 to existing open PRs (owner autopilot), identified no-PR set",
+      "outcome": "Focused work on genuine, in-repo, no-PR gaps to avoid duplicating in-flight PRs"
+    },
+    {
+      "timestamp": "2026-07-17T00:10:00Z",
+      "action": "Fixed #3141: validate_session_json flagged pytest numeric 'N skipped' counts as evidence contradictions",
+      "outcome": "Added _is_numeric_test_count guard; suppress 'skipped' only when preceded by a digit. Checklist 'skipped' still flags."
+    },
+    {
+      "timestamp": "2026-07-17T00:20:00Z",
+      "action": "Added pos+neg+edge tests; fixed 4 pre-existing ruff errors in the touched test file (I001 + 3 E501)",
+      "outcome": "89 tests pass; ruff check clean; mypy clean on scripts/validate_session_json.py"
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": []
+}

--- a/scripts/validate_session_json.py
+++ b/scripts/validate_session_json.py
@@ -73,7 +73,9 @@ CONTRADICTION_PATTERNS = re.compile(
 # in honest multi-scope evidence ("scorer deferred per PRD 11", "lint passed;
 # pending pre-commit final run") where a different piece of work, not the item, is
 # deferred. The other tokens (TODO, TBD, N/A, skipped, will run, will validate, not
-# available) signal the item itself is incomplete and always flag. See issue #2007.
+# available) signal the item itself is incomplete and always flag, EXCEPT that a
+# "skipped" token that is a numeric pytest outcome count is exempted separately
+# (see _NUMERIC_COUNT_TOKENS and issue #3141). See issue #2007.
 _SCOPE_QUALIFIED_TOKENS = frozenset({"deferred", "pending"})
 
 # Words that affirmatively report the item itself was done. When such a word
@@ -114,6 +116,15 @@ _NEGATION_BEFORE_AFFIRMATIVE = re.compile(
 # we deferred the deploy") rather than noting separate work, so it must NOT be
 # suppressed. See bug (gemini) on ordering/contrast false negatives.
 _CONTRAST_CONJUNCTION = re.compile(r"(?i)\b(but|however|except|though|although)\b")
+
+# pytest summarizes outcomes as counts like "21 skipped" or "45 xfailed". A
+# "skipped" token that is immediately preceded by a digit (ignoring whitespace)
+# is such a numeric test-outcome count, not a skipped validation step, so it must
+# not flag as a contradiction. Only "skipped" collides with pytest count output;
+# the other CONTRADICTION_PATTERNS tokens never appear as "<N> token" counts.
+# See issue #3141.
+_NUMERIC_COUNT_TOKENS = frozenset({"skipped"})
+_DIGIT_BEFORE_TOKEN = re.compile(r"\d\s*$")
 
 # Legacy field name for backward compatibility with existing session logs.
 # Issue #868: "handoffNotUpdated" with Complete=false was a confusing double negative.
@@ -263,11 +274,32 @@ def _is_scope_qualified(evidence: str, match: re.Match[str]) -> bool:
     return False
 
 
+def _is_numeric_test_count(evidence: str, match: re.Match[str]) -> bool:
+    """Return True if the token is a pytest numeric outcome count.
+
+    pytest reports outcomes as "<N> skipped" (for example
+    "14434 passed, 21 skipped, 45 xfailed"). A digit immediately before a
+    "skipped" token marks a test-outcome count, which is normal successful
+    evidence, not a skipped validation step. See issue #3141.
+
+    Args:
+        evidence: Full evidence string.
+        match: A single CONTRADICTION_PATTERNS match within the evidence.
+
+    Returns:
+        True if the matched token is a numeric test-outcome count.
+    """
+    if match.group(0).lower() not in _NUMERIC_COUNT_TOKENS:
+        return False
+    return bool(_DIGIT_BEFORE_TOKEN.search(evidence[: match.start()]))
+
+
 def _has_contradiction(evidence: str) -> bool:
     """Return True if evidence contradicts a "complete: true" claim.
 
     Flags any CONTRADICTION_PATTERNS token unless it is a scope-qualified
-    "deferred"/"pending" that points at a different subject. A genuine
+    "deferred"/"pending" that points at a different subject, or a "skipped"
+    token that is a numeric pytest outcome count ("21 skipped"). A genuine
     contradiction (an item-itself deferral, "TODO", a bare token) still flags
     even when scope-qualified tokens appear elsewhere in the same string.
 
@@ -278,7 +310,7 @@ def _has_contradiction(evidence: str) -> bool:
         True if at least one unqualified contradiction token is present.
     """
     return any(
-        not _is_scope_qualified(evidence, match)
+        not _is_scope_qualified(evidence, match) and not _is_numeric_test_count(evidence, match)
         for match in CONTRADICTION_PATTERNS.finditer(evidence)
     )
 

--- a/scripts/validate_session_json.py
+++ b/scripts/validate_session_json.py
@@ -123,8 +123,14 @@ _CONTRAST_CONJUNCTION = re.compile(r"(?i)\b(but|however|except|though|although)\
 # not flag as a contradiction. Only "skipped" collides with pytest count output;
 # the other CONTRADICTION_PATTERNS tokens never appear as "<N> token" counts.
 # See issue #3141.
+#
+# The count must be a standalone number: either at the start of the string or
+# immediately after a delimiter (comma, semicolon, colon). This prevents false
+# suppression when a numeric identifier precedes "skipped" (e.g. "step 21 skipped",
+# "PR #3141 skipped", "v2.1 skipped") where the number is part of an identifier,
+# not a pytest outcome count.
 _NUMERIC_COUNT_TOKENS = frozenset({"skipped"})
-_DIGIT_BEFORE_TOKEN = re.compile(r"\d\s*$")
+_DIGIT_BEFORE_TOKEN = re.compile(r"(?:^|[,;:]\s*)\d+\s*$")
 
 # Legacy field name for backward compatibility with existing session logs.
 # Issue #868: "handoffNotUpdated" with Complete=false was a confusing double negative.

--- a/tests/test_validate_session_json.py
+++ b/tests/test_validate_session_json.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from scripts.validate_session_json import (
+    _LEGACY_HANDOFF_FIELD,
     BRANCH_PATTERN,
     COMMIT_SHA_PATTERN,
     CONTRADICTION_PATTERNS,
@@ -23,7 +24,6 @@ from scripts.validate_session_json import (
     SESSION_END_REQUIRED_ITEMS,
     SESSION_START_REQUIRED_ITEMS,
     ValidationResult,
-    _LEGACY_HANDOFF_FIELD,
     get_case_insensitive,
     has_case_insensitive,
     load_session_file,
@@ -53,7 +53,11 @@ def _make_complete_end_section(**overrides: dict) -> dict:
         for name in SESSION_END_REQUIRED_ITEMS
     }
     # handoffPreserved is MUST: complete=True means HANDOFF.md was not modified
-    section["handoffPreserved"] = {"complete": True, "evidence": "HANDOFF.md not modified", "level": "MUST"}
+    section["handoffPreserved"] = {
+        "complete": True,
+        "evidence": "HANDOFF.md not modified",
+        "level": "MUST",
+    }
     section.update(overrides)
     return section
 
@@ -302,7 +306,11 @@ class TestValidateSessionEnd:
     def test_handoff_preserved_violated(self) -> None:
         """handoffPreserved with Complete=false fails (issue #868)."""
         session_end = _make_complete_end_section(
-            handoffPreserved={"complete": False, "evidence": "HANDOFF.md was modified", "level": "MUST"},
+            handoffPreserved={
+                "complete": False,
+                "evidence": "HANDOFF.md was modified",
+                "level": "MUST",
+            },
         )
         result = ValidationResult()
 
@@ -401,7 +409,9 @@ class TestChecklistSectionValidation:
         )
 
         assert not result.is_valid
-        assert any("Missing required item: sessionStart.requiredButMissing" in e for e in result.errors)
+        assert any(
+            "Missing required item: sessionStart.requiredButMissing" in e for e in result.errors
+        )
 
     def test_non_dict_items_ignored(self) -> None:
         """Non-dict values in section data are ignored."""
@@ -552,6 +562,45 @@ class TestEvidenceContradiction:
     def test_scope_qualified_deferral_not_flagged(self, evidence: str) -> None:
         """Deferred/pending pointing at a different scope must not warn (#2007)."""
         assert not self._warn(self._item(evidence)), f"false positive on {evidence!r}"
+
+    @pytest.mark.parametrize(
+        "evidence",
+        [
+            # Exact string from issue #3141: full pytest summary line.
+            "uv run pytest tests/ -q: 14434 passed, 21 skipped, 45 xfailed",
+            # Minimal numeric count.
+            "21 skipped",
+            # Zero is still a numeric count, not a skipped step.
+            "0 skipped",
+            # Thousands separator keeps the digit immediately before the token.
+            "1,234 skipped",
+            # Whitespace between digit and token (multiple spaces / tab).
+            "12   skipped",
+        ],
+    )
+    def test_numeric_skipped_count_not_flagged(self, evidence: str) -> None:
+        """A pytest numeric 'N skipped' count is not a contradiction (#3141)."""
+        assert not self._warn(self._item(evidence)), f"false positive on {evidence!r}"
+
+    @pytest.mark.parametrize(
+        "evidence",
+        [
+            # Bare status word: the item itself was skipped.
+            "Tests skipped.",
+            # A word (not a digit) immediately precedes the token, so it is a
+            # skipped step, not a numeric count.
+            "step skipped",
+            # The digit is not immediately before the token ("step" is), so this
+            # describes a skipped validation step and must still flag.
+            "1 step skipped",
+            # A numeric skipped count alongside a genuine incomplete token still
+            # flags on the genuine token (TODO).
+            "14434 passed, 21 skipped, 45 xfailed; TODO wire up remaining check",
+        ],
+    )
+    def test_skipped_step_still_flags(self, evidence: str) -> None:
+        """A skipped validation step (not a numeric count) must still warn (#3141)."""
+        assert self._warn(self._item(evidence)), f"expected warning for {evidence!r}"
 
 
 class TestValidateProtocolCompliance:

--- a/tests/test_validate_session_json.py
+++ b/tests/test_validate_session_json.py
@@ -596,6 +596,11 @@ class TestEvidenceContradiction:
             # A numeric skipped count alongside a genuine incomplete token still
             # flags on the genuine token (TODO).
             "14434 passed, 21 skipped, 45 xfailed; TODO wire up remaining check",
+            # Numeric identifier immediately before "skipped" where the number is
+            # part of an identifier phrase, not a pytest count. These must flag.
+            "step 21 skipped",
+            "PR #3141 skipped review",
+            "v2.1 skipped tests",
         ],
     )
     def test_skipped_step_still_flags(self, evidence: str) -> None:

--- a/tests/test_validate_session_json.py
+++ b/tests/test_validate_session_json.py
@@ -601,6 +601,12 @@ class TestEvidenceContradiction:
             "step 21 skipped",
             "PR #3141 skipped review",
             "v2.1 skipped tests",
+            # A numbered prose step sits after a word, not a delimiter, so it is
+            # not a pytest count and must still flag (#3141 review).
+            "Phase 2 skipped",
+            "check 5 skipped",
+            "test 3 skipped",
+            "phase3 skipped",
         ],
     )
     def test_skipped_step_still_flags(self, evidence: str) -> None:


### PR DESCRIPTION
## Summary

### What

`scripts/validate_session_json.py` no longer raises an "Evidence contradiction" warning when a completed item's evidence contains a pytest summary line such as `14434 passed, 21 skipped, 45 xfailed`.

### Why

The word "skipped" in `CONTRADICTION_PATTERNS` matched pytest's numeric outcome count. The command succeeded and thousands of tests passed, yet the validator implied the item was incomplete. That pressured authors to rewrite exact command output, which is dishonest evidence hygiene. Root cause and reproduction are in issue #3141.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #3141 | validate_session_json flags successful pytest skipped counts as contradictory evidence |

## Changes

- Add `_is_numeric_test_count`: a `skipped` token immediately preceded by a digit (ignoring whitespace) is a numeric pytest count, not a skipped validation step, so it is not a contradiction.
- Wire the guard into `_has_contradiction` alongside the existing scope qualified suppression.
- A checklist or status `skipped` with no leading digit still flags (unchanged behavior).
- Add pos, neg, and edge tests for the new behavior.
- Wrap four pre-existing ruff violations (one I001 import sort, three E501) in the touched test file so the pre-commit ruff gate stays green on the file I edited.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: the digit-prefix heuristic in `_is_numeric_test_count`. It suppresses only `skipped` preceded by a digit, so a genuine "step skipped" or "1 step skipped" contradiction still flags. I kept the fix narrow on purpose: broadening to any hyphen or word prefix would mask real skipped-step contradictions.

## Testing

Deliverables in this PR:

- [x] Tests added/updated

Evidence:

- `uv run --frozen --extra dev pytest tests/test_validate_session_json.py`: 89 passed.
- `uv run --frozen --extra dev ruff check` on both changed files: clean.
- `uv run --frozen --extra dev mypy scripts/validate_session_json.py`: clean.
- Issue reproduction from the body now returns no warning.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

## Author Pre-flight

- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed
- [x] No new warnings introduced

## Related Issues

Fixes #3141
