### PR TITLE
fix(hooks): resolve ruff/mypy via uv before PATH (#3136, #3132)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -453,7 +453,20 @@ STAGED_PY_FILES=$(echo "$STAGED_FILES" | grep -E '\.py$' || true)
 if [ -n "$STAGED_PY_FILES" ]; then
     echo_info "Checking Python files..."
 
-    if command -v ruff &> /dev/null; then
+    # Issue #3136: resolve ruff via uv first (the repository dev environment),
+    # then fall back to a PATH executable, matching the pre-push resolver. A
+    # uv-managed checkout without a global ruff must still lint at commit time
+    # rather than silently skip and defer the finding to push or CI.
+    RUFF_CMD=()
+    if command -v uv &> /dev/null \
+        && { [ -f "$REPO_ROOT/uv.lock" ] || [ -f "$REPO_ROOT/pyproject.toml" ]; } \
+        && uv run --frozen --extra dev ruff --version &> /dev/null; then
+        RUFF_CMD=(uv run --frozen --extra dev ruff)
+    elif command -v ruff &> /dev/null; then
+        RUFF_CMD=(ruff)
+    fi
+
+    if [ ${#RUFF_CMD[@]} -gt 0 ]; then
         # CRITICAL-001: Build array safely to prevent command injection
         PY_FILES=()
         while IFS= read -r file; do
@@ -465,7 +478,7 @@ if [ -n "$STAGED_PY_FILES" ]; then
             # Auto-fix if enabled
             if [ "$AUTOFIX" = "1" ]; then
                 echo_action "Auto-fixing Python files with ruff..."
-                ruff check --fix -- "${PY_FILES[@]}" 2>/dev/null || true
+                "${RUFF_CMD[@]}" check --fix -- "${PY_FILES[@]}" 2>/dev/null || true
 
                 # Re-stage fixed files even when unfixable advisory findings
                 # remain (Issue #2832). Re-staging only on a clean verify left
@@ -483,7 +496,7 @@ if [ -n "$STAGED_PY_FILES" ]; then
             fi
 
             # Verify (non-blocking)
-            if ! ruff check -- "${PY_FILES[@]}" 2>/dev/null; then
+            if ! "${RUFF_CMD[@]}" check -- "${PY_FILES[@]}" 2>/dev/null; then
                 echo_warning "Python linting found issues (non-blocking)."
                 echo_info "  Run: ruff check --fix <files>"
                 # Non-blocking: just warn, don't fail the commit
@@ -492,8 +505,8 @@ if [ -n "$STAGED_PY_FILES" ]; then
             fi
         fi
     else
-        echo_info "ruff not available. Skipping Python linting."
-        echo_info "  Install: pip install ruff"
+        echo_info "ruff not available via uv or PATH. Skipping Python linting."
+        echo_info "  Install: uv sync --extra dev (or pip install ruff)"
     fi
 else
     echo_info "No Python files staged. Skipping Python linting."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -740,7 +740,23 @@ fi
 # gets type-checked when its files change, and sync_plugin_lib.py guarantees
 # the synced copies are byte-identical.
 if [ -n "$CHANGED_PY_CANONICAL" ]; then
-    if command -v mypy &> /dev/null; then
+    # Issue #3132: resolve mypy via uv first (the repository dev environment),
+    # then fall back to a PATH executable, matching the RUFF_CMD selector above.
+    # A uv-managed checkout without a global mypy must still run this BLOCKING
+    # type check rather than silently skip it and defer type errors to CI.
+    MYPY_CMD=()
+    MYPY_SOURCE=""
+    if command -v uv &> /dev/null \
+        && { [ -f "$REPO_ROOT/uv.lock" ] || [ -f "$REPO_ROOT/pyproject.toml" ]; } \
+        && uv run --frozen --extra dev mypy --version &> /dev/null; then
+        MYPY_CMD=(uv run --frozen --extra dev mypy)
+        MYPY_SOURCE="uv"
+    elif command -v mypy &> /dev/null; then
+        MYPY_CMD=(mypy)
+        MYPY_SOURCE="path"
+    fi
+
+    if [ ${#MYPY_CMD[@]} -gt 0 ]; then
         PY_FILES=()
         while IFS= read -r file; do
             [ -z "$file" ] && continue
@@ -797,7 +813,7 @@ if [ -n "$CHANGED_PY_CANONICAL" ]; then
             if [ ${#PY_FILES_UNIQUE[@]} -gt 0 ]; then
                 MYPY_OUTPUT=$(mktemp)
                 TEMP_FILES+=("$MYPY_OUTPUT")
-                if mypy "${PY_FILES_UNIQUE[@]}" > "$MYPY_OUTPUT" 2>&1; then
+                if "${MYPY_CMD[@]}" "${PY_FILES_UNIQUE[@]}" > "$MYPY_OUTPUT" 2>&1; then
                     : # pass; aggregate recorded below
                 else
                     echo_info "  mypy issues (unique files):"
@@ -811,7 +827,7 @@ if [ -n "$CHANGED_PY_CANONICAL" ]; then
             for col_file in "${PY_FILES_COLLIDING[@]}"; do
                 MYPY_OUTPUT=$(mktemp)
                 TEMP_FILES+=("$MYPY_OUTPUT")
-                if mypy "$col_file" > "$MYPY_OUTPUT" 2>&1; then
+                if "${MYPY_CMD[@]}" "$col_file" > "$MYPY_OUTPUT" 2>&1; then
                     : # pass; aggregate recorded below
                 else
                     echo_info "  mypy issues in a colliding-basename file:"
@@ -829,7 +845,7 @@ if [ -n "$CHANGED_PY_CANONICAL" ]; then
                 MYPY_OUTPUT=$(mktemp)
                 TEMP_FILES+=("$MYPY_OUTPUT")
                 if MYPYPATH="$REPO_ROOT/scripts/validation${MYPYPATH:+:$MYPYPATH}" \
-                    mypy "$pm_file" > "$MYPY_OUTPUT" 2>&1; then
+                    "${MYPY_CMD[@]}" "$pm_file" > "$MYPY_OUTPUT" 2>&1; then
                     : # pass; aggregate recorded below
                 else
                     echo_info "  mypy issues in a scripts/validation module:"
@@ -840,7 +856,7 @@ if [ -n "$CHANGED_PY_CANONICAL" ]; then
             done
 
             if [ "$MYPY_OVERALL_PASS" = true ]; then
-                record_pass "Python type check/mypy (${#PY_FILES[@]} files)"
+                record_pass "Python type check/mypy (${#PY_FILES[@]} files via ${MYPY_SOURCE})"
             else
                 record_fail "Python type check/mypy"
                 echo_info "  Fix type errors before pushing."
@@ -849,7 +865,11 @@ if [ -n "$CHANGED_PY_CANONICAL" ]; then
             record_skip "Python type check (no accessible files)"
         fi
     else
-        record_skip "Python type check (mypy not installed)"
+        # Neither uv-managed mypy nor a PATH mypy is reachable. This is a
+        # BLOCKING phase (Issue #3132): a uv checkout that cannot resolve mypy
+        # is an environment bug, not a reason to silently drop the type check.
+        record_fail "Python type check (mypy unavailable via uv or PATH)"
+        echo_info "  Install: uv sync --extra dev (or pip install mypy)"
     fi
 else
     record_skip "Python type check (no .py files changed)"

--- a/tests/hooks/test_hooks_uv_tool_resolution.py
+++ b/tests/hooks/test_hooks_uv_tool_resolution.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Behavioral tests for uv-first tool resolution in the git hooks.
+
+Regression guards for #3136 (pre-commit ruff) and #3132 (pre-push mypy). Both
+hooks used to gate Python lint / type check on ``command -v <tool>`` alone, so a
+uv-managed checkout without the tool on the ambient ``PATH`` silently skipped a
+declared check and deferred the finding to push or CI.
+
+The fix builds a command array that prefers ``uv run --frozen --extra dev
+<tool>`` when uv and the project metadata resolve the tool, and falls back to a
+``PATH`` executable. To avoid duplicating the selector (which would drift from
+the hook), these tests extract the exact selection block from each hook and run
+it under bash against stubbed ``uv`` / tool executables and controlled project
+metadata, asserting which command is chosen.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRE_COMMIT = REPO_ROOT / ".githooks" / "pre-commit"
+PRE_PUSH = REPO_ROOT / ".githooks" / "pre-push"
+
+
+def _extract_block(hook: Path, init_line: str, end_prefix: str) -> str:
+    """Return the tool-selection block from a hook.
+
+    Extracts from the ``<TOOL>_CMD=()`` init line up to (but excluding) the
+    ``if [ ${#<TOOL>_CMD[@]} -gt 0 ]; then`` line that consumes the selection.
+    """
+    lines = hook.read_text(encoding="utf-8").splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == init_line:
+            start = i
+            break
+    assert start is not None, f"{init_line!r} not found in {hook.name}"
+    end = None
+    for j in range(start + 1, len(lines)):
+        if lines[j].strip().startswith(end_prefix):
+            end = j
+            break
+    assert end is not None, f"{end_prefix!r} terminator not found in {hook.name}"
+    return "\n".join(lines[start:end])
+
+
+def _make_stub(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_selector(
+    block: str,
+    *,
+    tool_var: str,
+    bin_dir: Path,
+    repo_root: Path,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[str, str]:
+    """Run an extracted selector block and return (CMD, SOURCE).
+
+    ``PATH`` is set to ``bin_dir`` only so stub presence fully controls
+    ``command -v`` lookups; the block otherwise uses bash builtins.
+    """
+    script = (
+        f'export PATH="{bin_dir}"\n'
+        f'REPO_ROOT="{repo_root}"\n'
+        f"{block}\n"
+        f'echo "CMD=${{{tool_var}_CMD[*]}}"\n'
+        f'echo "SOURCE=${{{tool_var}_SOURCE:-}}"\n'
+    )
+    env = {"PATH": os.environ.get("PATH", "")}
+    if extra_env:
+        env.update(extra_env)
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert proc.returncode == 0, f"selector block errored: {proc.stderr}"
+    cmd = source = ""
+    for out_line in proc.stdout.splitlines():
+        if out_line.startswith("CMD="):
+            cmd = out_line[len("CMD=") :]
+        elif out_line.startswith("SOURCE="):
+            source = out_line[len("SOURCE=") :]
+    return cmd, source
+
+
+def _setup_bins(tmp_path: Path, *, uv: bool, tool: str | None, uv_probe_exit: int) -> Path:
+    """Create a stub bin dir. ``uv`` and/or the named tool present as scripts."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    if uv:
+        # `uv run ... <tool> --version` exits uv_probe_exit; anything else 0.
+        # Use /bin/sh (absolute interpreter) so the stub runs even when PATH is
+        # narrowed to bin_dir only (no bash/env resolvable for a shebang lookup).
+        _make_stub(
+            bin_dir / "uv",
+            "#!/bin/sh\n"
+            'if [ "$1" = "run" ]; then exit ' + str(uv_probe_exit) + "; fi\nexit 0\n",
+        )
+    if tool:
+        _make_stub(bin_dir / tool, "#!/bin/sh\nexit 0\n")
+    return bin_dir
+
+
+def _repo_with_metadata(tmp_path: Path, *, metadata: bool) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    if metadata:
+        (root / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    return root
+
+
+# --- pre-commit ruff (#3136), no SOURCE var, assert on CMD ------------------
+
+RUFF_BLOCK = _extract_block(
+    PRE_COMMIT, "RUFF_CMD=()", "if [ ${#RUFF_CMD[@]} -gt 0 ]"
+)
+MYPY_BLOCK = _extract_block(
+    PRE_PUSH, "MYPY_CMD=()", "if [ ${#MYPY_CMD[@]} -gt 0 ]"
+)
+
+
+class TestRuffResolution:
+    """pre-commit RUFF_CMD selection (#3136)."""
+
+    def test_uv_preferred_when_available(self, tmp_path: Path) -> None:
+        bin_dir = _setup_bins(tmp_path, uv=True, tool="ruff", uv_probe_exit=0)
+        repo = _repo_with_metadata(tmp_path, metadata=True)
+        cmd, _ = _run_selector(
+            RUFF_BLOCK, tool_var="RUFF", bin_dir=bin_dir, repo_root=repo
+        )
+        assert cmd == "uv run --frozen --extra dev ruff"
+
+    def test_path_fallback_when_uv_absent(self, tmp_path: Path) -> None:
+        bin_dir = _setup_bins(tmp_path, uv=False, tool="ruff", uv_probe_exit=0)
+        repo = _repo_with_metadata(tmp_path, metadata=True)
+        cmd, _ = _run_selector(
+            RUFF_BLOCK, tool_var="RUFF", bin_dir=bin_dir, repo_root=repo
+        )
+        assert cmd == "ruff"
+
+    def test_empty_when_neither_available(self, tmp_path: Path) -> None:
+        bin_dir = _setup_bins(tmp_path, uv=False, tool=None, uv_probe_exit=0)
+        repo = _repo_with_metadata(tmp_path, metadata=True)
+        cmd, _ = _run_selector(
+            RUFF_BLOCK, tool_var="RUFF", bin_dir=bin_dir, repo_root=repo
+        )
+        assert cmd == ""
+
+    def test_path_fallback_on_uv_probe_failure(self, tmp_path: Path) -> None:
+        bin_dir = _setup_bins(tmp_path, uv=True, tool="ruff", uv_probe_exit=1)
+        repo = _repo_with_metadata(tmp_path, metadata=True)
+        cmd, _ = _run_selector(
+            RUFF_BLOCK, tool_var="RUFF", bin_dir=bin_dir, repo_root=repo
+        )
+        assert cmd == "ruff"
+
+    def test_path_fallback_when_no_project_metadata(self, tmp_path: Path) -> None:
+        bin_dir = _setup_bins(tmp_path, uv=True, tool="ruff", uv_probe_exit=0)
+        repo = _repo_with_metadata(tmp_path, metadata=False)
+        cmd, _ = _run_selector(
+            RUFF_BLOCK, tool_var="RUFF", bin_dir=bin_dir, repo_root=repo
+        )
+        assert cmd == "ruff"
+
+
+class TestMypyResolution:
+    """pre-push MYPY_CMD selection (#3132)."""
+
+    def test_uv_preferred_when_available(self, tmp_path: Path) -> None:
+        bin_dir = _setup_bins(tmp_path, uv=True, tool="mypy", uv_probe_exit=0)
+        repo = _repo_with_metadata(tmp_path, metadata=True)
+        cmd, source = _run_selector(
+            MYPY_BLOCK, tool_var="MYPY", bin_dir=bin_dir, repo_root=repo
+        )
+        assert cmd == "uv run --frozen --extra dev mypy"
+        assert source == "uv"
+
+    def test_path_fallback_when_uv_absent(self, tmp_path: Path) -> None:
+        bin_dir = _setup_bins(tmp_path, uv=False, tool="mypy", uv_probe_exit=0)
+        repo = _repo_with_metadata(tmp_path, metadata=True)
+        cmd, source = _run_selector(
+            MYPY_BLOCK, tool_var="MYPY", bin_dir=bin_dir, repo_root=repo
+        )
+        assert cmd == "mypy"
+        assert source == "path"
+
+    def test_empty_when_neither_available(self, tmp_path: Path) -> None:
+        bin_dir = _setup_bins(tmp_path, uv=False, tool=None, uv_probe_exit=0)
+        repo = _repo_with_metadata(tmp_path, metadata=True)
+        cmd, source = _run_selector(
+            MYPY_BLOCK, tool_var="MYPY", bin_dir=bin_dir, repo_root=repo
+        )
+        assert cmd == ""
+        assert source == ""
+
+    def test_path_fallback_on_uv_probe_failure(self, tmp_path: Path) -> None:
+        bin_dir = _setup_bins(tmp_path, uv=True, tool="mypy", uv_probe_exit=1)
+        repo = _repo_with_metadata(tmp_path, metadata=True)
+        cmd, source = _run_selector(
+            MYPY_BLOCK, tool_var="MYPY", bin_dir=bin_dir, repo_root=repo
+        )
+        assert cmd == "mypy"
+        assert source == "path"
+
+    def test_empty_on_uv_probe_failure_and_no_path_tool(self, tmp_path: Path) -> None:
+        bin_dir = _setup_bins(tmp_path, uv=True, tool=None, uv_probe_exit=1)
+        repo = _repo_with_metadata(tmp_path, metadata=True)
+        cmd, source = _run_selector(
+            MYPY_BLOCK, tool_var="MYPY", bin_dir=bin_dir, repo_root=repo
+        )
+        assert cmd == ""
+        assert source == ""
+
+
+class TestHookStructure:
+    """Structural guards that the silent-skip path is gone."""
+
+    def test_pre_commit_no_bare_ruff_gate(self) -> None:
+        text = PRE_COMMIT.read_text(encoding="utf-8")
+        assert "ruff not available via uv or PATH" in text
+        assert 'echo_info "  Install: pip install ruff"' not in text
+
+    def test_pre_push_mypy_missing_fails_not_skips(self) -> None:
+        text = PRE_PUSH.read_text(encoding="utf-8")
+        assert 'record_skip "Python type check (mypy not installed)"' not in text
+        assert "mypy unavailable via uv or PATH" in text
+
+    def test_pre_push_no_bare_mypy_invocation(self) -> None:
+        text = PRE_PUSH.read_text(encoding="utf-8")
+        for bare in ('\n                if mypy "', '\n                    mypy "'):
+            assert bare not in text, f"bare mypy invocation still present: {bare!r}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Pre-commit gated Python lint on `command -v ruff` and pre-push gated the
BLOCKING type check on `command -v mypy`. In a uv-managed checkout without
the tool on the ambient PATH, both hooks silently skipped their check and
deferred the finding to push time or CI, even though
`uv run --frozen --extra dev <tool>` resolves the tool in the same
checkout. Pre-push already resolved ruff through uv; mypy and pre-commit
ruff did not.

## Changes

Both hooks now build a command array that prefers
`uv run --frozen --extra dev <tool>` when uv plus project metadata
(uv.lock or pyproject.toml) resolve the tool, then fall back to a PATH
executable.

- **pre-commit ruff (#3136)**: skip only when neither uv nor PATH provides
  ruff, with a diagnostic that names both probes. Lint stays advisory
  (non-blocking), matching prior behavior.
- **pre-push mypy (#3132)**: run mypy through the selected command in all
  three partitions (unique basenames, colliding basenames, the
  `scripts/validation` MYPYPATH loop). When neither uv nor PATH provides
  mypy, fail the BLOCKING phase with setup guidance instead of skipping.
  The basename partition and MYPYPATH handling are preserved.

## Tests

Adds `tests/hooks/test_hooks_uv_tool_resolution.py`. It extracts the actual
selection blocks from both hooks and runs them under bash with stubbed
uv and tool executables, covering: uv success, PATH fallback,
missing-tool, uv-probe failure, and the no-metadata edge, plus structural
guards asserting the silent-skip paths are gone.

Result: 13 passed; ruff and mypy clean on the new test. Both hooks pass
`bash -n`. Selectors verified against this repo: both pick uv.

Fixes #3136
Fixes #3132
