### PR TITLE
fix(tooling): align ruff target-version with the 3.10 syntax floor (#3126)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,14 @@ exclude_dirs = [".venv", "tests", ".git"]
 skips = []
 
 [tool.ruff]
-target-version = "py314"
+# Match the hook-execution portability floor enforced by
+# scripts/validation/validate_python_syntax.py (_SUPPORT_FLOOR). target-version
+# governs the syntax ruff may EMIT (formatter) and push toward (pyupgrade), so
+# it must track the OLDEST interpreter tracked files must parse on (3.10), not
+# the higher requires-python dev/install contract. Setting this to py314 made
+# `ruff format` rewrite portable `except (A, B):` into PEP 758 `except A, B:`,
+# which the 3.10 floor gate rejects. See issue #3126.
+target-version = "py310"
 line-length = 100
 
 [tool.ruff.lint]

--- a/tests/validation/test_ruff_format_floor_compat.py
+++ b/tests/validation/test_ruff_format_floor_compat.py
@@ -1,0 +1,97 @@
+"""Ruff's formatter target must track the syntax support floor (issue #3126).
+
+Root cause: ``[tool.ruff] target-version`` was ``py314`` (the ``requires-python``
+dev/install contract) while ``scripts/validation/validate_python_syntax.py``
+enforces a 3.10 hook-portability floor. ``ruff format`` then rewrote portable
+``except (A, B):`` into PEP 758 ``except A, B:``, which the floor gate rejects,
+creating a repeatable edit, format, fail, repair loop.
+
+- pos: the repo ruff config formats an except tuple to floor-parseable output
+- neg: a ``py314`` formatter target re-emits the PEP 758 form the floor rejects,
+       proving the positive assertion has teeth (a real negative control)
+- guard: the configured ruff target equals the support floor, so the two cannot
+         silently drift back into opposition
+"""
+
+from __future__ import annotations
+
+import ast
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+_VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
+if str(_VALIDATION_DIR) not in sys.path:
+    sys.path.insert(0, str(_VALIDATION_DIR))
+
+from validate_python_syntax import support_floor  # noqa: E402
+
+# Portable on every Python 3: an exception tuple wrapped in parentheses.
+_EXCEPT_TUPLE = "try:\n    x = 1\nexcept (OSError, ValueError):\n    pass\n"
+# PEP 758 form ruff emits under a >=3.14 target; a SyntaxError below 3.14.
+_PEP758_MARKER = "except OSError, ValueError:"
+
+
+def _floor_ruff_tag() -> str:
+    """Render the support floor as ruff's ``pyXY`` target tag."""
+    major, minor = support_floor()
+    return f"py{major}{minor}"
+
+
+def _ruff_format(source: str, *, target: str | None = None) -> str:
+    """Format ``source`` via stdin using the repo ruff config.
+
+    Uses the ``ruff`` on PATH (present inside the uv dev venv that runs the
+    suite). Passing ``target`` overrides ``target-version`` to exercise the
+    negative control. Stdin avoids any per-path exclude in the repo config.
+    """
+    ruff = shutil.which("ruff")
+    if ruff is None:
+        pytest.skip("ruff is not on PATH; run under the uv dev environment")
+    cmd = [ruff, "format", "--config", str(PYPROJECT)]
+    if target is not None:
+        cmd += ["--target-version", target]
+    cmd.append("-")
+    result = subprocess.run(
+        cmd,
+        input=source,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    return result.stdout
+
+
+def test_configured_ruff_target_equals_support_floor() -> None:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    target = data["tool"]["ruff"]["target-version"]
+    assert target == _floor_ruff_tag(), (
+        "ruff target-version must match the validate_python_syntax support "
+        "floor so the formatter cannot emit syntax the floor gate rejects"
+    )
+
+
+def test_repo_config_format_preserves_floor_parseable_except() -> None:
+    formatted = _ruff_format(_EXCEPT_TUPLE)
+
+    assert _PEP758_MARKER not in formatted
+    assert "except (OSError, ValueError):" in formatted
+    # Must parse at the declared floor using the gate's own mechanism.
+    ast.parse(formatted, feature_version=support_floor())
+
+
+def test_py314_target_emits_floor_breaking_syntax_negative_control() -> None:
+    # A py314 formatter target reintroduces the exact regression; the literal
+    # 3.14 here is the PEP 758 boundary, not the (lower) support floor.
+    formatted = _ruff_format(_EXCEPT_TUPLE, target="py314")
+
+    assert _PEP758_MARKER in formatted
+    with pytest.raises(SyntaxError):
+        ast.parse(formatted, feature_version=support_floor())


### PR DESCRIPTION
## Summary

The repository formats Python as py314 (the `requires-python` dev/install
contract) but requires every tracked Python file to parse at a 3.10
hook-portability floor enforced by validate_python_syntax. With
`target-version = "py314"`, ruff format rewrites a portable exception tuple
into PEP 758 syntax that the floor gate rejects, so a normal format run
produces code that ruff check and mypy accept but the syntax-floor gate
fails. That is a repeatable edit, format, fail, repair loop.

## Root cause

ruff `target-version` declares the oldest interpreter the code must run on.
For tracked files that is the support floor (3.10), not the higher dev
contract. It was set to the dev floor, so the formatter and the pyupgrade
lint rules were free to emit and push toward 3.14-only syntax.

## Fix

Set `[tool.ruff] target-version = "py310"` to match the support floor. ruff
has no formatter-specific target override, so the global value is the correct
single knob, and it keeps local hooks, contributor commands, and CI on the
same setting.

Measured blast radius on the current tree:

- ruff check errors drop 406 to 397 (fewer pyupgrade suggestions; no new
  violations introduced).
- ruff format already-clean files rise 455 to 493 (the change reduces format
  churn, it does not add any).
- The exact reported repro (formatting an except tuple) no longer emits PEP
  758.

## Tests

Adds a regression module:

- guard: the configured ruff target equals `support_floor()`, so the two
  cannot silently drift back into opposition.
- pos: the repo config formats an except tuple to floor-parseable output.
- neg: a py314 formatter target re-emits the PEP 758 form and fails the floor
  parse, a real negative control proving the positive assertion has teeth.

Result: 3 passed; ruff and mypy clean; the whole-repo floor gate passes; the
sibling validate_python_syntax suite stays green (9 passed).

Fixes #3126
