### PR TITLE
fix(validation): detect uncommitted workflow changes in pre_pr (#3134)

### DIFF
--- a/scripts/validation/checks_plugin.py
+++ b/scripts/validation/checks_plugin.py
@@ -222,6 +222,53 @@ def _is_linked_worktree(repo_root: Path) -> bool:
     return git_dir_path.resolve() != git_common_dir_path.resolve()
 
 
+def _collect_changed_workflow_files(repo_root: Path, base_ref: str) -> list[str] | None:
+    """Deduplicated workflow files changed across every local git state.
+
+    Unions the committed branch range (``base_ref...HEAD``) with staged,
+    unstaged, and untracked files so ``pre_pr`` validates a workflow edit that
+    has not been committed yet (issue #3134). Deleted paths are dropped by the
+    final ``is_file`` check, which keeps a missing path from reaching the
+    runner (the runner rejects paths that escape or do not exist).
+
+    Returns ``None`` when the committed-range diff cannot run, preserving the
+    fail-open skip the caller documented. The three local-state sources are
+    additive: a non-zero exit in any one contributes nothing rather than
+    masking real changes from the others.
+    """
+    committed_code, committed_out, _ = _run_subprocess(
+        ["git", "-C", str(repo_root), "diff", "--name-only", f"{base_ref}...HEAD"]
+    )
+    if committed_code != 0:
+        return None
+
+    blocks = [committed_out]
+    for extra_args in (
+        ["diff", "--cached", "--name-only"],
+        ["diff", "--name-only"],
+        ["ls-files", "--others", "--exclude-standard"],
+    ):
+        code, out, _ = _run_subprocess(["git", "-C", str(repo_root), *extra_args])
+        if code == 0:
+            blocks.append(out)
+
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for block in blocks:
+        for line in block.splitlines():
+            path = line.strip()
+            if path and path not in seen:
+                seen.add(path)
+                ordered.append(path)
+    return [
+        path
+        for path in ordered
+        if path.startswith(".github/workflows/")
+        and path.endswith((".yml", ".yaml"))
+        and (repo_root / path).is_file()
+    ]
+
+
 def validate_workflow_local_run(repo_root: Path) -> bool:
     """Shift-left tier of the workflow local-run gate (actionlint + act -n).
 
@@ -238,10 +285,13 @@ def validate_workflow_local_run(repo_root: Path) -> bool:
     gate is the authoritative enforcer; pre_pr only warns so a contributor
     without local workflow dependencies is not stopped pre-PR.
 
-    Change detection uses :func:`_resolve_default_base_ref` to choose a default
-    branch ref for the diff. The branch's own upstream is deliberately not used:
-    once the branch is pushed it yields an empty diff, which is how pre_pr
-    previously missed changed workflows that pre-push detected (issue #2571).
+    Change detection unions the committed branch range with the staged,
+    unstaged, and untracked workflow files. The branch's own upstream is
+    deliberately not used for the committed range: once the branch is pushed it
+    yields an empty diff, which is how pre_pr previously missed changed
+    workflows that pre-push detected (issue #2571). The local-state sources are
+    added so a workflow edit that has not been committed yet is still validated
+    (issue #3134).
     """
     script = repo_root / "scripts" / "validation" / "run_workflow_local_test.py"
     if not script.exists():
@@ -252,19 +302,10 @@ def validate_workflow_local_run(repo_root: Path) -> bool:
         print("[WARN] workflow local-run: base ref unresolved; skipping.")
         return True
 
-    diff_code, diff_out, _ = _run_subprocess(
-        ["git", "-C", str(repo_root), "diff", "--name-only", f"{base_ref}...HEAD"]
-    )
-    if diff_code != 0:
+    changed = _collect_changed_workflow_files(repo_root, base_ref)
+    if changed is None:
         print("[WARN] workflow local-run: git diff failed; skipping.")
         return True
-    changed = [
-        line
-        for line in diff_out.splitlines()
-        if line.startswith(".github/workflows/")
-        and line.endswith((".yml", ".yaml"))
-        and (repo_root / line).is_file()
-    ]
     if not changed:
         print("No changed workflow files; nothing to run locally.")
         return True

--- a/tests/validation/test_checks_plugin.py
+++ b/tests/validation/test_checks_plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -35,3 +36,146 @@ def test_workflow_local_run_warns_on_missing_local_auth(
     output = capsys.readouterr().out
     assert "unrunnable-locally: actionlint passed" in output
     assert "workflow local-run auth material unavailable locally" in output
+
+
+def _git(root: Path, *args: str) -> str:
+    """Run a git command in ``root`` with a hermetic identity and return stdout."""
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=test",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _write(root: Path, rel: str, text: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+@pytest.fixture()
+def workflow_repo(tmp_path: Path) -> tuple[Path, str]:
+    """Isolated git repo with one committed workflow; returns (root, base_sha)."""
+    root = tmp_path
+    _git(root, "init", "-q")
+    _write(root, ".github/workflows/base.yml", "name: base\n")
+    _write(root, "README.md", "base\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "base")
+    base_sha = _git(root, "rev-parse", "HEAD").strip()
+    return root, base_sha
+
+
+def test_collect_detects_committed_workflow(workflow_repo: tuple[Path, str]) -> None:
+    root, base_sha = workflow_repo
+    _write(root, ".github/workflows/committed.yml", "name: committed\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "add committed workflow")
+
+    changed = checks_plugin._collect_changed_workflow_files(root, base_sha)
+
+    assert changed == [".github/workflows/committed.yml"]
+
+
+def test_collect_detects_staged_workflow(workflow_repo: tuple[Path, str]) -> None:
+    root, base_sha = workflow_repo
+    _write(root, ".github/workflows/staged.yml", "name: staged\n")
+    _git(root, "add", ".github/workflows/staged.yml")
+
+    changed = checks_plugin._collect_changed_workflow_files(root, base_sha)
+
+    assert changed is not None
+    assert ".github/workflows/staged.yml" in changed
+
+
+def test_collect_detects_unstaged_workflow(workflow_repo: tuple[Path, str]) -> None:
+    root, base_sha = workflow_repo
+    # Modify a tracked, committed workflow without staging it.
+    _write(root, ".github/workflows/base.yml", "name: base\n# edited\n")
+
+    changed = checks_plugin._collect_changed_workflow_files(root, base_sha)
+
+    assert changed is not None
+    assert ".github/workflows/base.yml" in changed
+
+
+def test_collect_detects_untracked_workflow(workflow_repo: tuple[Path, str]) -> None:
+    root, base_sha = workflow_repo
+    _write(root, ".github/workflows/untracked.yml", "name: untracked\n")
+
+    changed = checks_plugin._collect_changed_workflow_files(root, base_sha)
+
+    assert changed is not None
+    assert ".github/workflows/untracked.yml" in changed
+
+
+def test_collect_drops_deleted_workflow(workflow_repo: tuple[Path, str]) -> None:
+    root, base_sha = workflow_repo
+    _git(root, "rm", "-q", ".github/workflows/base.yml")
+
+    changed = checks_plugin._collect_changed_workflow_files(root, base_sha)
+
+    assert changed is not None
+    assert ".github/workflows/base.yml" not in changed
+
+
+def test_collect_dedupes_across_states(workflow_repo: tuple[Path, str]) -> None:
+    root, base_sha = workflow_repo
+    # Commit a change, then stage and further edit the same path so it appears
+    # in the committed range, the staged set, and the unstaged set at once.
+    _write(root, ".github/workflows/dupe.yml", "name: dupe\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "add dupe")
+    _write(root, ".github/workflows/dupe.yml", "name: dupe\n# staged\n")
+    _git(root, "add", ".github/workflows/dupe.yml")
+    _write(root, ".github/workflows/dupe.yml", "name: dupe\n# staged\n# unstaged\n")
+
+    changed = checks_plugin._collect_changed_workflow_files(root, base_sha)
+
+    assert changed is not None
+    assert changed.count(".github/workflows/dupe.yml") == 1
+
+
+def test_collect_ignores_non_workflow_paths(workflow_repo: tuple[Path, str]) -> None:
+    root, base_sha = workflow_repo
+    _write(root, "src/app.py", "print('x')\n")
+    _write(root, ".github/workflows/notes.txt", "not a workflow\n")
+
+    changed = checks_plugin._collect_changed_workflow_files(root, base_sha)
+
+    assert changed == []
+
+
+def test_collect_no_changes_returns_empty(workflow_repo: tuple[Path, str]) -> None:
+    root, base_sha = workflow_repo
+
+    changed = checks_plugin._collect_changed_workflow_files(root, base_sha)
+
+    assert changed == []
+
+
+def test_collect_returns_none_when_committed_diff_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_committed(args: list[str], *_: object, **__: object) -> tuple[int, str, str]:
+        if "diff" in args and "nope...HEAD" in args:
+            return 128, "", "bad revision"
+        return 0, "", ""
+
+    monkeypatch.setattr(checks_plugin, "_run_subprocess", fail_committed)
+
+    assert checks_plugin._collect_changed_workflow_files(tmp_path, "nope") is None


### PR DESCRIPTION
## Summary

`pre_pr`'s workflow local-run gate only diffed the committed range
(`base...HEAD`). A workflow change that was staged, unstaged, or untracked was
reported as "No changed workflow files" and skipped, so `pre-push` later flagged
it. That defeats the shift-left intent: the same edit should be caught at
`pre_pr` time, not at push time.

## Fix

Extract `_collect_changed_workflow_files(repo_root, base_ref)`, which unions:

1. the committed branch range (`base...HEAD`),
2. staged files (`git diff --cached`),
3. unstaged files (`git diff`), and
4. untracked files (`git ls-files --others --exclude-standard`).

It dedupes on first occurrence, then filters to existing
`.github/workflows/*.{yml,yaml}`. Deleted paths drop out via the `is_file`
check, so a removed workflow never reaches the runner.

Fail-open behavior is preserved: the committed-range diff still returns `None`
on failure (the caller warns and skips). The three local-state sources are
additive, so a non-zero exit in any one contributes nothing instead of masking
real changes from the others.

## Tests

Nine regression tests over a real isolated git repo (hermetic identity, no
signing) cover: committed, staged, unstaged, untracked, deleted-dropped,
dedup-across-states, non-workflow-ignored, no-change, and
committed-diff-failure fail-open. The pre-existing wrapper test still passes.

Verified locally: 10 passed, `ruff` clean, `mypy` clean.

Fixes #3134
