### PR TITLE
test(hooks): isolate LSP read-guard tests from outer merge state (#3137)

### DIFF
--- a/tests/hooks/test_invoke_lsp_read_guard.py
+++ b/tests/hooks/test_invoke_lsp_read_guard.py
@@ -29,6 +29,7 @@ HOOK_DIR = REPO_ROOT / ".claude" / "hooks" / "PreToolUse"
 sys.path.insert(0, str(HOOK_DIR))
 
 import invoke_lsp_read_guard as guard  # noqa: E402
+from hook_utilities import lsp_gate_state as _gate_state  # noqa: E402
 
 # A real in-repo file path whose extension is overview-capable (python). The
 # file need not exist; detect_providers keys on extension + config, and
@@ -66,6 +67,36 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LSP_GATE_MODE", raising=False)
     monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(REPO_ROOT))
     monkeypatch.delenv("TMPDIR", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_outer_merge_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate the suite from the live checkout's merge/rebase state (#3137).
+
+    ``is_gated_target`` consults ``_merge_in_progress`` against the caller's
+    ``project_dir``. Tests that pass the live ``REPO_ROOT`` inherit the outer
+    checkout's ``.git/MERGE_HEAD``/``rebase-merge``/``rebase-apply`` markers, so
+    running the suite mid-merge (exactly when merge-resolver asks for
+    validation) flips every gated target to bypass and false-fails ~15 tests.
+
+    Force the probe to report no merge only for the live ``REPO_ROOT``. Isolated
+    temporary repositories keep the real detection, so the explicit
+    merge/rebase/worktree/conflict bypass tests still exercise the production
+    signal. Production behavior is unchanged; only the test's dependency on
+    external git state is removed.
+    """
+    real_merge_in_progress = _gate_state._merge_in_progress
+    repo_root_resolved = REPO_ROOT.resolve()
+
+    def _scoped(project_dir: str) -> bool:
+        try:
+            if Path(project_dir).resolve() == repo_root_resolved:
+                return False
+        except (OSError, ValueError):
+            pass
+        return real_merge_in_progress(project_dir)
+
+    monkeypatch.setattr(_gate_state, "_merge_in_progress", _scoped)
 
 
 # ---------------------------------------------------------------------------
@@ -570,3 +601,48 @@ class TestLspRuntimeDownFailOpen:
 # ---------------------------------------------------------------------------
 # main: dispatch, kill switch, fail-open paths
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Outer-checkout merge-state isolation (issue #3137)
+# ---------------------------------------------------------------------------
+
+
+class TestOuterMergeStateIsolation:
+    """The suite must not observe the containing checkout's merge state.
+
+    Before #3137, ``is_gated_target`` consulted ``_merge_in_progress`` against
+    the live ``REPO_ROOT``, so running the suite while the checkout had
+    ``.git/MERGE_HEAD`` flipped every gated target to bypass and false-failed
+    the tier tests. The autouse neutralizer forces the live-root probe to report
+    no merge while leaving isolated repositories on the real detection.
+    """
+
+    def test_live_root_probe_is_neutralized(self):
+        # Under the neutralizer the live-root probe always reports no merge,
+        # regardless of the outer checkout's real .git/MERGE_HEAD state.
+        assert _gate_state._merge_in_progress(str(REPO_ROOT)) is False
+
+    def test_isolated_repo_merge_is_still_observed(self, tmp_path):
+        # The neutralizer is scoped to REPO_ROOT only: an isolated repo with a
+        # real MERGE_HEAD marker still reports a merge, so the explicit bypass
+        # tests keep exercising the production signal.
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        (repo / ".git" / "MERGE_HEAD").write_text("abc123\n", encoding="utf-8")
+        assert _gate_state._merge_in_progress(str(repo)) is True
+
+    def test_gated_target_holds_regardless_of_outer_merge(self):
+        # The observable effect: a live-root code target stays gated even when
+        # the outer checkout is mid-merge, because the probe is neutralized.
+        assert guard.is_gated_target(PY_TARGET, str(REPO_ROOT)) is True
+
+    def test_isolated_repo_bypass_still_holds(self, tmp_path):
+        # And an isolated mid-merge repo still bypasses, proving per-project_dir
+        # scoping rather than a global override.
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        (repo / ".git" / "MERGE_HEAD").write_text("abc123\n", encoding="utf-8")
+        target = repo / "sample.py"
+        target.write_text("def foo():\n    return 1\n", encoding="utf-8")
+        assert guard.is_gated_target(str(target), str(repo)) is False

--- a/tests/hooks/test_invoke_lsp_read_guard_entrypoints.py
+++ b/tests/hooks/test_invoke_lsp_read_guard_entrypoints.py
@@ -36,6 +36,7 @@ HOOK_DIR = REPO_ROOT / ".claude" / "hooks" / "PreToolUse"
 sys.path.insert(0, str(HOOK_DIR))
 
 import invoke_lsp_read_guard as guard  # noqa: E402
+from hook_utilities import lsp_gate_state as _gate_state  # noqa: E402
 
 # A real in-repo file path whose extension is overview-capable (python). The
 # file need not exist; detect_providers keys on extension + config, and
@@ -73,6 +74,32 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LSP_GATE_MODE", raising=False)
     monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(REPO_ROOT))
     monkeypatch.delenv("TMPDIR", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_outer_merge_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate in-process entrypoints from the live checkout merge state (#3137).
+
+    ``main`` -> ``evaluate`` -> ``is_gated_target`` consults ``_merge_in_progress``
+    against the live ``REPO_ROOT``, so running ``test_blocks_on_warmup_via_main``
+    while the checkout is mid-merge flips the target to bypass and returns 0
+    instead of the expected 2. Force the live-root probe to report no merge;
+    isolated repositories keep the real detection. Subprocess entrypoints run in
+    a separate interpreter that monkeypatch cannot reach, so those tests isolate
+    via an explicit project directory instead (see ``TestModuleAsScript``).
+    """
+    real_merge_in_progress = _gate_state._merge_in_progress
+    repo_root_resolved = REPO_ROOT.resolve()
+
+    def _scoped(project_dir: str) -> bool:
+        try:
+            if Path(project_dir).resolve() == repo_root_resolved:
+                return False
+        except (OSError, ValueError):
+            pass
+        return real_merge_in_progress(project_dir)
+
+    monkeypatch.setattr(_gate_state, "_merge_in_progress", _scoped)
 
 
 # ---------------------------------------------------------------------------
@@ -185,13 +212,25 @@ class TestModuleAsScript:
         assert result.returncode == 0
 
     def test_block_via_subprocess(self, tmp_path):
-        """In-repo python target with fresh (absent) state blocks: exit 2."""
+        """In-repo python target with fresh (absent) state blocks: exit 2.
+
+        The project directory is an isolated temp repo, not the live checkout,
+        so an in-progress merge in the containing ai-agents checkout cannot flip
+        the target to bypass (issue #3137). ``native_lsp`` availability keys on
+        the ``.py`` extension alone, so provider detection still fires outside
+        the real repo and the warmup tier blocks.
+        """
         hook_path = str(HOOK_DIR / "invoke_lsp_read_guard.py")
+        project = tmp_path / "repo"
+        project.mkdir()
+        target = project / "sample_module.py"
+        target.write_text("def foo():\n    return 1\n", encoding="utf-8")
         payload = json.dumps(
-            {"tool_name": "Read", "tool_input": {"file_path": PY_TARGET}}
+            {"tool_name": "Read", "tool_input": {"file_path": str(target)}}
         )
         env = dict(os.environ)
-        env["XDG_STATE_HOME"] = str(tmp_path)  # isolated, no warmup recorded
+        env["XDG_STATE_HOME"] = str(tmp_path / "state")  # isolated, no warmup
+        env["CLAUDE_PROJECT_DIR"] = str(project)  # isolate from live merge state
         env.pop("SKIP_LSP_GATE", None)
         env.pop("LSP_GATE_MODE", None)
         result = subprocess.run(
@@ -199,11 +238,43 @@ class TestModuleAsScript:
             input=payload,
             capture_output=True,
             text=True,
-            cwd=str(REPO_ROOT),
+            cwd=str(project),
             env=env,
         )
         assert result.returncode == 2
         assert "Warmup required" in result.stderr
+
+    def test_subprocess_bypasses_isolated_repo_merge(self, tmp_path):
+        """A subprocess honors per-project_dir merge detection (issue #3137).
+
+        Complements ``test_block_via_subprocess``: the same warmup state that
+        blocks a clean repo must allow when that repo has ``.git/MERGE_HEAD``,
+        proving the subprocess reads the merge signal from its own project
+        directory rather than the outer checkout.
+        """
+        hook_path = str(HOOK_DIR / "invoke_lsp_read_guard.py")
+        project = tmp_path / "repo"
+        (project / ".git").mkdir(parents=True)
+        (project / ".git" / "MERGE_HEAD").write_text("abc123\n", encoding="utf-8")
+        target = project / "sample_module.py"
+        target.write_text("def foo():\n    return 1\n", encoding="utf-8")
+        payload = json.dumps(
+            {"tool_name": "Read", "tool_input": {"file_path": str(target)}}
+        )
+        env = dict(os.environ)
+        env["XDG_STATE_HOME"] = str(tmp_path / "state")
+        env["CLAUDE_PROJECT_DIR"] = str(project)
+        env.pop("SKIP_LSP_GATE", None)
+        env.pop("LSP_GATE_MODE", None)
+        result = subprocess.run(
+            [sys.executable, hook_path],
+            input=payload,
+            capture_output=True,
+            text=True,
+            cwd=str(project),
+            env=env,
+        )
+        assert result.returncode == 0
 
     def test_main_guard_via_runpy(self, monkeypatch: pytest.MonkeyPatch):
         """Cover the ``sys.exit(main())`` guard line via runpy."""


### PR DESCRIPTION
## Summary

The LSP read-guard tests pass the live `REPO_ROOT` as `project_dir`. Production
`is_gated_target` consults `_merge_in_progress` against that directory, so when
the containing ai-agents checkout has `.git/MERGE_HEAD` (the normal
merge-resolver window, and exactly when full-suite validation runs) every gated
target flips to bypass and 15 tests false-fail. The production guard is correct
per #2454; only the tests leak an external git-state dependency.

## Fix

- Add a scoped autouse neutralizer to both read-guard test files. It forces the
  `_merge_in_progress` probe to report no merge for the live `REPO_ROOT` only,
  via `monkeypatch` on the shared gate-state module (late binding, so the
  running `is_gated_target` observes it). Isolated temp repositories keep the
  real detection, so the explicit merge, rebase, linked-worktree, and conflict
  bypass tests still exercise the production signal.
- Point the subprocess block test at an isolated project directory. A child
  interpreter cannot be monkeypatched, so isolation comes from `CLAUDE_PROJECT_DIR`
  plus `cwd`. `native_lsp` availability keys on the `.py` extension alone, so the
  warmup tier still blocks outside the real repo.

## Regression coverage

- Per-project_dir merge scoping in-process (neutralizer holds `REPO_ROOT`,
  isolated repo still detects its own `MERGE_HEAD`).
- A subprocess that bypasses its own isolated mid-merge repo, proving the child
  reads the merge signal from its project dir, not the outer checkout.
- Proof the live-root code target stays gated under the neutralizer.

## Verification

Simulated `.git/MERGE_HEAD` in the checkout, ran both files:

```text
before fix: 15 failed, 53 passed
after fix:  73 passed
```

Marker removed on cleanup. No production guard behavior changed.

Fixes #3137
