### PR TITLE
test(eval): isolate suite dry-run from live git state (Fixes #3138)

### DIFF
--- a/scripts/eval/eval-suite.py
+++ b/scripts/eval/eval-suite.py
@@ -84,6 +84,20 @@ def detect_changed_files(base_ref: str) -> list[str]:
     return sorted(set(committed + staged))
 
 
+def read_changed_files(source: str) -> list[str]:
+    """Read a newline-delimited changed-file list from ``source``.
+
+    Explicit alternative to :func:`detect_changed_files` for callers that must
+    not depend on the live checkout's git state (issue #3138). Blank lines are
+    dropped; an empty or whitespace-only file yields an empty list, which the
+    classifier treats as "nothing changed". Paths are returned deduplicated and
+    sorted to match :func:`detect_changed_files`.
+    """
+    text = Path(source).read_text(encoding="utf-8")
+    files = [line.strip() for line in text.splitlines()]
+    return sorted({path for path in files if path})
+
+
 # ---------------------------------------------------------------------------
 # Change classification
 # ---------------------------------------------------------------------------
@@ -359,13 +373,28 @@ def run_skill_knowledge(
 # Main orchestrator
 # ---------------------------------------------------------------------------
 
-def _detect_and_classify(base_ref: str) -> dict[str, list[str]]:
-    """Detect changed files and classify them by eval category."""
+def _detect_and_classify(
+    base_ref: str, changed_files_from: str | None = None
+) -> dict[str, list[str]]:
+    """Detect changed files and classify them by eval category.
+
+    When ``changed_files_from`` is set, the file list is read from that path
+    instead of running ``git diff`` against the live checkout (issue #3138).
+    """
     print(f"{'='*60}", file=sys.stderr)
-    print(f"  EVAL SUITE: Detecting changes vs {base_ref}", file=sys.stderr)
+    if changed_files_from is not None:
+        print(
+            f"  EVAL SUITE: Reading changes from {changed_files_from}",
+            file=sys.stderr,
+        )
+    else:
+        print(f"  EVAL SUITE: Detecting changes vs {base_ref}", file=sys.stderr)
     print(f"{'='*60}", file=sys.stderr)
 
-    changed_files = detect_changed_files(base_ref)
+    if changed_files_from is not None:
+        changed_files = read_changed_files(changed_files_from)
+    else:
+        changed_files = detect_changed_files(base_ref)
     if not changed_files:
         print("  No changes detected.", file=sys.stderr)
         sys.exit(0)
@@ -474,6 +503,10 @@ def main() -> None:
     )
     parser.add_argument("--base-ref", type=str, default="main",
                         help="Git ref to compare against (default: main)")
+    parser.add_argument("--changed-files-from", type=str, default=None,
+                        help="Read the changed-file list from this path (one "
+                             "path per line) instead of running git diff. An "
+                             "empty file means no changes.")
     parser.add_argument("--scope", type=str,
                         choices=["prompts", "agents", "skills", "all"],
                         default="all", help="Limit to specific scope")
@@ -485,7 +518,7 @@ def main() -> None:
     args = parser.parse_args()
 
     start_time = time.time()
-    classified = _detect_and_classify(args.base_ref)
+    classified = _detect_and_classify(args.base_ref, args.changed_files_from)
     results, any_failure = _run_evals(classified, args)
 
     elapsed = round(time.time() - start_time, 1)

--- a/tests/eval/test_eval_agents_dry_run.py
+++ b/tests/eval/test_eval_agents_dry_run.py
@@ -48,6 +48,12 @@ try:
     assert _spec and _spec.loader
     eval_agents = importlib.util.module_from_spec(_spec)
     _spec.loader.exec_module(eval_agents)
+    _suite_spec = importlib.util.spec_from_file_location(
+        "eval_suite", SUITE_SCRIPT
+    )
+    assert _suite_spec and _suite_spec.loader
+    eval_suite = importlib.util.module_from_spec(_suite_spec)
+    _suite_spec.loader.exec_module(eval_suite)
 finally:
     if _path_added and str(EVAL_DIR) in sys.path:
         sys.path.remove(str(EVAL_DIR))
@@ -193,19 +199,63 @@ class TestEvalAgentsCli:
 class TestEvalSuiteAgentsDryRun:
     """End-to-end test for the suite-level reproduction from the issue."""
 
-    def test_suite_agents_dry_run_does_not_fail_on_zero_scores(self):
+    def test_suite_agents_dry_run_does_not_fail_on_zero_scores(self, tmp_path):
         """`eval-suite.py --scope agents --dry-run` must not exit 1 just
         because dry-run produced zero scores (issue #2441 acceptance criterion 1).
         """
-        # Drive the suite against itself with no actual agent diff: the
-        # classifier returns no agents, so nothing to evaluate, dry-run is
-        # vacuously successful. Using base-ref=HEAD guarantees an empty diff
-        # regardless of repo state.
-        result = _run_suite("--scope", "agents", "--dry-run", "--base-ref", "HEAD")
+        # Drive the empty-diff case through the explicit --changed-files-from
+        # input (issue #3138). An empty file means "no changes", so the
+        # classifier returns no agents and the dry-run is vacuously successful.
+        # This reproduces the original empty-diff intent WITHOUT reading the
+        # live checkout: `--base-ref HEAD` does NOT guarantee an empty diff
+        # (staged/unstaged edits, e.g. during an in-progress merge, appear in
+        # `git diff HEAD`), which previously made this test false-fail.
+        empty_list = tmp_path / "changed_empty.txt"
+        empty_list.write_text("", encoding="utf-8")
+        result = _run_suite(
+            "--scope", "agents", "--dry-run",
+            "--changed-files-from", str(empty_list),
+        )
         assert result.returncode == 0, (
             f"Suite dry-run with empty diff must exit 0; got "
             f"{result.returncode}. stderr: {result.stderr[-500:]}"
         )
+
+    def test_read_changed_files_ignores_blank_and_dedups(self, tmp_path):
+        """The explicit changed-files input drops blanks and dedups (issue #3138)."""
+        listing = tmp_path / "changed.txt"
+        listing.write_text(
+            "\n".join(
+                [
+                    ".claude/agents/architect.md",
+                    "",
+                    "  ",
+                    ".claude/agents/architect.md",
+                    " src/claude/agents/analyst.md ",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        assert eval_suite.read_changed_files(str(listing)) == [
+            ".claude/agents/architect.md",
+            "src/claude/agents/analyst.md",
+        ]
+
+    def test_read_changed_files_empty_file_is_empty(self, tmp_path):
+        """A whitespace-only changed-files file classifies as no changes."""
+        listing = tmp_path / "blank.txt"
+        listing.write_text("\n  \n\t\n", encoding="utf-8")
+        assert eval_suite.read_changed_files(str(listing)) == []
+
+    def test_suite_classifier_includes_explicit_agent_change(self):
+        """Explicitly provided agent files ARE classified as agents.
+
+        The staged-change contract: when the input list names an agent file,
+        the classifier includes it. This proves the empty-diff test above is
+        empty because the list is empty, not because classification is broken.
+        """
+        classified = eval_suite.classify_changes([".claude/agents/architect.md"])
+        assert ".claude/agents/architect.md" in classified["agents"]
 
     # NOTE: A broader end-to-end test that drives the suite with real agent
     # files in the diff was prototyped (diffing against the git empty-tree


### PR DESCRIPTION
## Summary

`eval-suite.py --scope agents --dry-run --base-ref HEAD` did not guarantee an empty diff. `git diff --name-only HEAD` includes staged and unstaged edits, so during an in-progress merge live agent/skill files were classified as agent inputs and the dry-run false-failed with an all-zero weak-spot FAIL.

## Root cause

`detect_changed_files` runs `git diff` with `cwd=REPO_ROOT` derived from the script location, so a temp working directory cannot isolate it. The test comment claimed `--base-ref HEAD` yields an empty diff regardless of repo state; that is false whenever the index or working tree diverges from HEAD (staged merge resolutions, unstaged edits).

## Fix

- Add an explicit `--changed-files-from <path>` input that reads the changed-file list from a file instead of running git diff. Empty file means no changes.
- Drive the empty-diff acceptance case through an empty file, reproducing the original intent without reading the live checkout.
- Add a classifier test proving explicitly provided agent files are still included (the empty case is empty because the list is empty, not because classification broke).
- Replace the inaccurate comment.

## Verification

- 11 tests pass (was 7; +4 for the explicit-input path and classification).
- ruff and mypy clean on both files.
- Empirical: in an isolated temp repo with a simulated in-progress merge and a staged agent edit, the old `--base-ref HEAD` path sees the agent file (non-empty, would false-fail) while the new empty `--changed-files-from` file sees nothing (exit 0).

Fixes #3138
