### PR TITLE
fix(validation): detect staged, unstaged, untracked workflow changes (#3134)

### DIFF
--- a/scripts/validation/checks_plugin.py
+++ b/scripts/validation/checks_plugin.py
@@ -222,6 +222,55 @@ def _is_linked_worktree(repo_root: Path) -> bool:
     return git_dir_path.resolve() != git_common_dir_path.resolve()
 
 
+def _add_workflow_paths(repo_root: Path, diff_out: str, changed: list[str]) -> None:
+    """Append new ``.github/workflows`` YAML paths from ``diff_out`` to ``changed``.
+
+    Filters to workflow YAML files that still exist on disk (the ``is_file``
+    check drops deleted paths) and skips duplicates already collected.
+    """
+    for line in diff_out.splitlines():
+        if not line.startswith(".github/workflows/"):
+            continue
+        if not line.endswith((".yml", ".yaml")):
+            continue
+        if not (repo_root / line).is_file():
+            continue
+        if line not in changed:
+            changed.append(line)
+
+
+def _collect_changed_workflows(repo_root: Path, base_ref: str) -> list[str] | None:
+    """Union of changed workflow files across every local git state (issue #3134).
+
+    Combines four sources so a workflow edit is detected before it is committed:
+    committed range ``<base>...HEAD``, staged (``--cached``), unstaged, and
+    untracked (``ls-files --others --exclude-standard``). Deleted paths are
+    dropped by the ``is_file`` check in :func:`_add_workflow_paths`; duplicates
+    across sources collapse to the first occurrence.
+
+    Returns None when the committed-range diff itself fails (unresolved base
+    ref, git error), signalling the caller to warn and skip. The local sources
+    are best-effort: a non-zero exit contributes no paths but does not abort.
+    """
+    committed_code, committed_out, _ = _run_subprocess(
+        ["git", "-C", str(repo_root), "diff", "--name-only", f"{base_ref}...HEAD"]
+    )
+    if committed_code != 0:
+        return None
+    changed: list[str] = []
+    _add_workflow_paths(repo_root, committed_out, changed)
+    local_sources = [
+        ["git", "-C", str(repo_root), "diff", "--cached", "--name-only"],
+        ["git", "-C", str(repo_root), "diff", "--name-only"],
+        ["git", "-C", str(repo_root), "ls-files", "--others", "--exclude-standard"],
+    ]
+    for cmd in local_sources:
+        code, out, _ = _run_subprocess(cmd)
+        if code == 0:
+            _add_workflow_paths(repo_root, out, changed)
+    return changed
+
+
 def validate_workflow_local_run(repo_root: Path) -> bool:
     """Shift-left tier of the workflow local-run gate (actionlint + act -n).
 
@@ -242,6 +291,10 @@ def validate_workflow_local_run(repo_root: Path) -> bool:
     branch ref for the diff. The branch's own upstream is deliberately not used:
     once the branch is pushed it yields an empty diff, which is how pre_pr
     previously missed changed workflows that pre-push detected (issue #2571).
+
+    :func:`_collect_changed_workflows` unions the committed range with staged,
+    unstaged, and untracked git states (issue #3134) so a workflow edit is
+    validated before it is committed, not only after.
     """
     script = repo_root / "scripts" / "validation" / "run_workflow_local_test.py"
     if not script.exists():
@@ -252,19 +305,10 @@ def validate_workflow_local_run(repo_root: Path) -> bool:
         print("[WARN] workflow local-run: base ref unresolved; skipping.")
         return True
 
-    diff_code, diff_out, _ = _run_subprocess(
-        ["git", "-C", str(repo_root), "diff", "--name-only", f"{base_ref}...HEAD"]
-    )
-    if diff_code != 0:
+    changed = _collect_changed_workflows(repo_root, base_ref)
+    if changed is None:
         print("[WARN] workflow local-run: git diff failed; skipping.")
         return True
-    changed = [
-        line
-        for line in diff_out.splitlines()
-        if line.startswith(".github/workflows/")
-        and line.endswith((".yml", ".yaml"))
-        and (repo_root / line).is_file()
-    ]
     if not changed:
         print("No changed workflow files; nothing to run locally.")
         return True

--- a/tests/validation/test_checks_plugin.py
+++ b/tests/validation/test_checks_plugin.py
@@ -35,3 +35,142 @@ def test_workflow_local_run_warns_on_missing_local_auth(
     output = capsys.readouterr().out
     assert "unrunnable-locally: actionlint passed" in output
     assert "workflow local-run auth material unavailable locally" in output
+
+
+def _lines(paths: list[str]) -> str:
+    return "".join(f"{path}\n" for path in paths)
+
+
+def _install_workflow_gate(
+    repo_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    committed: list[str] | None = None,
+    staged: list[str] | None = None,
+    unstaged: list[str] | None = None,
+    untracked: list[str] | None = None,
+    on_disk: list[str] | None = None,
+) -> dict[str, list[str] | None]:
+    """Stub the runner script, git sources, and capture the runner's --files.
+
+    Files listed in ``on_disk`` are created so ``is_file`` keeps them; any path
+    named in a source but absent from ``on_disk`` acts as a deleted path.
+    """
+    script = repo_root / "scripts" / "validation" / "run_workflow_local_test.py"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("print('stub')\n", encoding="utf-8")
+
+    for rel in on_disk or []:
+        target = repo_root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("name: wf\n", encoding="utf-8")
+
+    monkeypatch.setattr(checks_plugin, "_resolve_default_base_ref", lambda _root: "origin/main")
+
+    captured: dict[str, list[str] | None] = {"files": None}
+
+    def fake_run_subprocess(args: list[str], *_: object, **__: object) -> tuple[int, str, str]:
+        if args and args[0] == "git":
+            if "ls-files" in args:
+                return 0, _lines(untracked or []), ""
+            if "--cached" in args:
+                return 0, _lines(staged or []), ""
+            if any(str(arg).endswith("...HEAD") for arg in args):
+                return 0, _lines(committed or []), ""
+            return 0, _lines(unstaged or []), ""
+        if "--files" in args:
+            captured["files"] = args[args.index("--files") + 1 :]
+        return 0, "", ""
+
+    monkeypatch.setattr(checks_plugin, "_run_subprocess", fake_run_subprocess)
+    return captured
+
+
+def test_workflow_local_run_detects_committed_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workflow = ".github/workflows/committed.yml"
+    captured = _install_workflow_gate(
+        tmp_path, monkeypatch, committed=[workflow], on_disk=[workflow]
+    )
+
+    assert checks_plugin.validate_workflow_local_run(tmp_path) is True
+    assert captured["files"] == [workflow]
+
+
+def test_workflow_local_run_detects_staged_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workflow = ".github/workflows/staged.yml"
+    captured = _install_workflow_gate(
+        tmp_path, monkeypatch, staged=[workflow], on_disk=[workflow]
+    )
+
+    assert checks_plugin.validate_workflow_local_run(tmp_path) is True
+    assert captured["files"] == [workflow]
+
+
+def test_workflow_local_run_detects_unstaged_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workflow = ".github/workflows/unstaged.yml"
+    captured = _install_workflow_gate(
+        tmp_path, monkeypatch, unstaged=[workflow], on_disk=[workflow]
+    )
+
+    assert checks_plugin.validate_workflow_local_run(tmp_path) is True
+    assert captured["files"] == [workflow]
+
+
+def test_workflow_local_run_detects_untracked_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workflow = ".github/workflows/untracked.yml"
+    captured = _install_workflow_gate(
+        tmp_path, monkeypatch, untracked=[workflow], on_disk=[workflow]
+    )
+
+    assert checks_plugin.validate_workflow_local_run(tmp_path) is True
+    assert captured["files"] == [workflow]
+
+
+def test_workflow_local_run_skips_deleted_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    live = ".github/workflows/live.yml"
+    gone = ".github/workflows/gone.yml"
+    captured = _install_workflow_gate(
+        tmp_path, monkeypatch, committed=[live, gone], on_disk=[live]
+    )
+
+    assert checks_plugin.validate_workflow_local_run(tmp_path) is True
+    assert captured["files"] == [live]
+
+
+def test_workflow_local_run_dedupes_across_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workflow = ".github/workflows/dup.yml"
+    captured = _install_workflow_gate(
+        tmp_path,
+        monkeypatch,
+        committed=[workflow],
+        staged=[workflow],
+        unstaged=[workflow],
+        on_disk=[workflow],
+    )
+
+    assert checks_plugin.validate_workflow_local_run(tmp_path) is True
+    assert captured["files"] == [workflow]
+
+
+def test_workflow_local_run_fast_skips_when_no_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    captured = _install_workflow_gate(tmp_path, monkeypatch)
+
+    assert checks_plugin.validate_workflow_local_run(tmp_path) is True
+    assert captured["files"] is None
+    assert "No changed workflow files" in capsys.readouterr().out


### PR DESCRIPTION
Fixes #3134.

pre_pr.py's workflow-change detection missed staged, unstaged, and untracked `.github/workflows` edits, so a modified-but-uncommitted workflow could skip validation. checks_plugin.py now collects changed workflows across all three git states. Built and adversarially verified (confirmed-correct) via the triage workflow; 8 tests pass, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fEJLmjckpeBeiDJRoKn3x