### PR TITLE
fix(pr-maintenance): treat empty/unparseable AI findings as no-op instead of exit 2

### DIFF
--- a/.agents/sessions/2026-07-17-session-3059.json
+++ b/.agents/sessions/2026-07-17-session-3059.json
@@ -102,7 +102,7 @@
     {
       "timestamp": "2026-07-17T20:30:00Z",
       "action": "Updated skill unit tests and bumped the plugin parity pair",
-      "result": "Rewrote TestParseFindings to assert no-op on empty/whitespace/prose/invalid/non-object plus regression cases for valid and fenced findings, and added three main-level tests including an empty-stdin reproduction of run 29603691792. Bumped .claude and src/copilot-cli plugin.json 0.6.62 -> 0.6.63. 55 tests passed; ruff, drift check, and version-bump gate all green."
+      "result": "Rewrote TestParseFindings to assert no-op on empty/whitespace/prose/invalid/non-object plus regression cases for valid and fenced findings, and added three main-level tests including an empty-stdin reproduction of run 29603691792. Bumped .claude and src/copilot-cli plugin.json to 0.6.64 (0.6.63 -> 0.6.64 after merging main, which had advanced to 0.6.63). 55 tests passed; ruff, drift check, and version-bump gate all green."
     }
   ],
   "endingCommit": "db98500e",

--- a/.agents/sessions/2026-07-17-session-3059.json
+++ b/.agents/sessions/2026-07-17-session-3059.json
@@ -1,0 +1,113 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3059,
+    "date": "2026-07-17",
+    "branch": "fix/pr-maintenance-empty-findings",
+    "startingCommit": "30ebace5",
+    "objective": "Fix hourly pr-maintenance.yml failure: parse_findings exits 2 on empty/prose AI findings (issue #3180, failing run 29603691792)"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Copilot CLI harness: no Serena MCP tools present in this environment. Skipped per AGENTS.md documented fallback (If unavailable: Skip Serena. Reference AGENTS.md for context)."
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not applicable without Serena MCP in the Copilot CLI harness; AGENTS.md governance was read directly from the repository instead."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md (read-only reference per ADR-014) at session start."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file: .agents/sessions/2026-07-17-session-3059.json"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current reported fix/pr-maintenance-empty-findings, branched from origin/main tip 30ebace5 with no prior commits ahead."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/pr-maintenance-empty-findings, not main or master."
+      },
+      "constraintsRead": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Read the canonical-source-mirror and plugin-version-bump instruction files plus AGENTS.md boundaries before editing generated trees."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All applicable MUST sessionEnd items are complete for this Copilot CLI session; Serena items are SHOULD and not applicable in this harness."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md was not modified (read-only per ADR-014)."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Copilot CLI harness has no Serena MCP; cross-session memory was not written this session. Issue #3180 and this session log carry the durable record instead."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Scoped markdownlint target set is empty: this PR changes only .py and .json files, no Markdown."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Fix committed as db98500e (5 files: canonical skill script, regenerated Copilot mirror, skill tests, and the two parity plugin.json manifests). Session log committed separately."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run pytest tests/test_invoke_pr_comment_processing_skill.py tests/test_invoke_pr_comment_processing.py reported 55 passed. Targeted ruff reported All checks passed. build/scripts/build_all.py --check exited 0 (no generation drift). build/scripts/validate_plugin_version_bump.py --base origin/main printed plugin-version-bump: OK."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Session todo list tracked seven items; each marked in_progress then done as completed."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "timestamp": "2026-07-17T20:05:00Z",
+      "action": "Diagnosed and mapped the three copies of invoke_pr_comment_processing.py",
+      "result": "Confirmed .claude/skills/.../invoke_pr_comment_processing.py is the copy invoked by pr-maintenance.yml:431; src/copilot-cli/skills/... is its byte-identical generated mirror (generate_skills.py from .claude/skills/); .github/scripts/... is an independent, dormant, test-only copy carrying an unrelated issue #2522 fix the skill copy lacks."
+    },
+    {
+      "timestamp": "2026-07-17T20:12:00Z",
+      "action": "Created tracking issue for the hourly failure",
+      "result": "Opened issue #3180 describing the WARN-verdict empty-JSON root cause and linking failing run 29603691792 (PR 3167). Assigned to self."
+    },
+    {
+      "timestamp": "2026-07-17T20:20:00Z",
+      "action": "Fixed parse_findings in the canonical skill script",
+      "result": "Empty, whitespace-only, unparseable, or non-object input now returns {\"comments\": []} (benign no-op, exit 0) instead of raise SystemExit(2). Markdown code-fence stripping preserved. Regenerated the Copilot CLI mirror via build/scripts/generate_skills.py; diff confirms byte parity with canonical."
+    },
+    {
+      "timestamp": "2026-07-17T20:30:00Z",
+      "action": "Updated skill unit tests and bumped the plugin parity pair",
+      "result": "Rewrote TestParseFindings to assert no-op on empty/whitespace/prose/invalid/non-object plus regression cases for valid and fenced findings, and added three main-level tests including an empty-stdin reproduction of run 29603691792. Bumped .claude and src/copilot-cli plugin.json 0.6.62 -> 0.6.63. 55 tests passed; ruff, drift check, and version-bump gate all green."
+    }
+  ],
+  "endingCommit": "db98500e",
+  "nextSteps": [
+    "Push branch fix/pr-maintenance-empty-findings and open PR against main with gh pr create (no auto-merge).",
+    "Flag in the PR body that .github/scripts/invoke_pr_comment_processing.py (dormant duplicate) shares the same parse_findings shape and the skill copy still lacks the issue #2522 reaction-failure fix; both are out of scope for this fix."
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.63",
+  "version": "0.6.64",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.62",
+  "version": "0.6.63",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/github/scripts/pr/invoke_pr_comment_processing.py
+++ b/.claude/skills/github/scripts/pr/invoke_pr_comment_processing.py
@@ -54,21 +54,54 @@ _CODE_FENCE_PATTERN = re.compile(r"```(?:json)?\s*([\s\S]*?)```")
 def parse_findings(json_str: str) -> dict:
     """Parse AI findings JSON, stripping markdown code fences if present.
 
-    Raises SystemExit(2) on parse failure.
+    Resilience contract (Issue #3180): this function runs inside the hourly
+    ``pr-maintenance`` workflow. When the AI Quality Gate returns a WARN or PASS
+    verdict, it routinely emits an empty body or prose instead of a findings
+    object, because there is nothing to report. That case means "no actionable
+    findings," which is success, not a config error.
+
+    So empty, whitespace-only, unparseable, or non-object input returns
+    ``{"comments": []}`` (a benign no-op) rather than raising. Failing here would
+    fail the whole scheduled run over one PR's benign non-JSON AI output. Prefer
+    resilience over strictness. A genuine config error (missing plugin lib) still
+    exits 2 at import time; parsing AI output does not.
     """
-    clean = json_str
     match = _CODE_FENCE_PATTERN.search(json_str)
-    if match:
-        clean = match.group(1).strip()
+    clean = match.group(1).strip() if match else json_str.strip()
+
+    # Empty or whitespace-only after fence stripping: the AI reported nothing.
+    if not clean:
+        print(
+            "No AI findings payload (empty/whitespace); treating as no "
+            "actionable findings (no-op).",
+            file=sys.stderr,
+        )
+        return {"comments": []}
 
     try:
-        parsed: dict = json.loads(clean)
-        return parsed
+        parsed = json.loads(clean)
     except json.JSONDecodeError as exc:
         preview = json_str[:500] if len(json_str) > 500 else json_str
-        print(f"Failed to parse AI findings JSON: {exc}", file=sys.stderr)
-        logger.debug("Raw JSON (first 500 chars): %s", preview)
-        raise SystemExit(2) from exc
+        print(
+            "WARNING: AI findings were not valid JSON; treating as no "
+            f"actionable findings (no-op). Detail: {exc}",
+            file=sys.stderr,
+        )
+        logger.debug("Raw AI findings (first 500 chars): %s", preview)
+        return {"comments": []}
+
+    # Well-formed JSON that is not a findings object (a list, string, number)
+    # cannot carry a "comments" array; treat it as a no-op instead of letting a
+    # downstream ``.get`` crash the run.
+    if not isinstance(parsed, dict):
+        print(
+            "WARNING: AI findings JSON was not an object; treating as no "
+            "actionable findings (no-op).",
+            file=sys.stderr,
+        )
+        return {"comments": []}
+
+    return parsed
 
 
 # ---------------------------------------------------------------------------

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.63",
+  "version": "0.6.64",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.62",
+  "version": "0.6.63",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/github/scripts/pr/invoke_pr_comment_processing.py
+++ b/src/copilot-cli/skills/github/scripts/pr/invoke_pr_comment_processing.py
@@ -54,21 +54,54 @@ _CODE_FENCE_PATTERN = re.compile(r"```(?:json)?\s*([\s\S]*?)```")
 def parse_findings(json_str: str) -> dict:
     """Parse AI findings JSON, stripping markdown code fences if present.
 
-    Raises SystemExit(2) on parse failure.
+    Resilience contract (Issue #3180): this function runs inside the hourly
+    ``pr-maintenance`` workflow. When the AI Quality Gate returns a WARN or PASS
+    verdict, it routinely emits an empty body or prose instead of a findings
+    object, because there is nothing to report. That case means "no actionable
+    findings," which is success, not a config error.
+
+    So empty, whitespace-only, unparseable, or non-object input returns
+    ``{"comments": []}`` (a benign no-op) rather than raising. Failing here would
+    fail the whole scheduled run over one PR's benign non-JSON AI output. Prefer
+    resilience over strictness. A genuine config error (missing plugin lib) still
+    exits 2 at import time; parsing AI output does not.
     """
-    clean = json_str
     match = _CODE_FENCE_PATTERN.search(json_str)
-    if match:
-        clean = match.group(1).strip()
+    clean = match.group(1).strip() if match else json_str.strip()
+
+    # Empty or whitespace-only after fence stripping: the AI reported nothing.
+    if not clean:
+        print(
+            "No AI findings payload (empty/whitespace); treating as no "
+            "actionable findings (no-op).",
+            file=sys.stderr,
+        )
+        return {"comments": []}
 
     try:
-        parsed: dict = json.loads(clean)
-        return parsed
+        parsed = json.loads(clean)
     except json.JSONDecodeError as exc:
         preview = json_str[:500] if len(json_str) > 500 else json_str
-        print(f"Failed to parse AI findings JSON: {exc}", file=sys.stderr)
-        logger.debug("Raw JSON (first 500 chars): %s", preview)
-        raise SystemExit(2) from exc
+        print(
+            "WARNING: AI findings were not valid JSON; treating as no "
+            f"actionable findings (no-op). Detail: {exc}",
+            file=sys.stderr,
+        )
+        logger.debug("Raw AI findings (first 500 chars): %s", preview)
+        return {"comments": []}
+
+    # Well-formed JSON that is not a findings object (a list, string, number)
+    # cannot carry a "comments" array; treat it as a no-op instead of letting a
+    # downstream ``.get`` crash the run.
+    if not isinstance(parsed, dict):
+        print(
+            "WARNING: AI findings JSON was not an object; treating as no "
+            "actionable findings (no-op).",
+            file=sys.stderr,
+        )
+        return {"comments": []}
+
+    return parsed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_invoke_pr_comment_processing_skill.py
+++ b/tests/test_invoke_pr_comment_processing_skill.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import subprocess
 import sys
@@ -86,13 +87,35 @@ class TestParseFindings:
         assert result == {"comments": []}
 
     def test_code_fence_json(self):
+        # Regression: valid findings wrapped in ```json fences still parse.
         result = parse_findings('```json\n{"comments": []}\n```')
         assert result == {"comments": []}
 
-    def test_invalid_json_exits_2(self):
-        with pytest.raises(SystemExit) as exc:
-            parse_findings("not json at all")
-        assert exc.value.code == 2
+    def test_valid_findings_with_comments_unchanged(self):
+        # Regression: a real findings object passes through untouched.
+        raw = '{"comments": [{"id": 7, "classification": "stale"}]}'
+        result = parse_findings(raw)
+        assert result == {"comments": [{"id": 7, "classification": "stale"}]}
+
+    def test_empty_string_is_noop(self):
+        # Issue #3180: WARN/PASS verdict emits an empty payload; that is "no
+        # findings" (success), not a fatal parse error.
+        assert parse_findings("") == {"comments": []}
+
+    def test_whitespace_only_is_noop(self):
+        assert parse_findings("   \n\t  ") == {"comments": []}
+
+    def test_prose_is_noop(self):
+        # The AI emitted prose instead of a findings object: benign no-op.
+        assert parse_findings("The review looks good.") == {"comments": []}
+
+    def test_invalid_json_is_noop(self):
+        # Issue #3180: malformed JSON must not fail the scheduled run.
+        assert parse_findings("{not valid json") == {"comments": []}
+
+    def test_non_object_json_is_noop(self):
+        # Well-formed JSON that is not an object cannot carry a comments array.
+        assert parse_findings("[1, 2, 3]") == {"comments": []}
 
 
 # ---------------------------------------------------------------------------
@@ -181,6 +204,30 @@ class TestMain:
             rc = main([
                 "--pr-number", "1", "--verdict", "PASS",
                 "--findings-json", '{"comments": []}',
+            ])
+        assert rc == 0
+
+    def test_warn_verdict_empty_findings_returns_0(self):
+        # Issue #3180: the exact hourly failure. A WARN verdict routinely emits
+        # an empty findings payload; the run must exit 0, not 2.
+        rc = main([
+            "--pr-number", "1", "--verdict", "WARN", "--findings-json", "",
+        ])
+        assert rc == 0
+
+    def test_pass_verdict_prose_findings_returns_0(self):
+        # AI emitted prose instead of a findings object: no-op, exit 0.
+        rc = main([
+            "--pr-number", "1", "--verdict", "PASS",
+            "--findings-json", "The review looks good.",
+        ])
+        assert rc == 0
+
+    def test_warn_verdict_empty_stdin_returns_0(self):
+        # Reproduces run 29603691792: findings piped via stdin ("-") are empty.
+        with patch.object(sys, "stdin", io.StringIO("")):
+            rc = main([
+                "--pr-number", "1", "--verdict", "WARN", "--findings-json", "-",
             ])
         assert rc == 0
 


### PR DESCRIPTION
## Summary

### What

`parse_findings()` in the PR comment processing skill now treats empty, whitespace-only, unparseable, or non-object AI findings as a no-op (returns `{"comments": []}`, exit 0) instead of `raise SystemExit(2)`. Markdown code-fence stripping is preserved.

### Why

The hourly PR maintenance workflow (see `.github/workflows/pr-maintenance.yml`) pipes AI Quality Gate output to `--findings-json -` on stdin. On a WARN or PASS verdict, the common case, the AI emits an empty body or prose because there is nothing to report. The old `parse_findings` did an unguarded `json.loads()` and raised `SystemExit(2)` on the resulting `JSONDecodeError`, so the whole scheduled run went red. It only passed on the rare run where the AI happened to emit well-formed JSON.

Failing run 29603691792 (PR 3167):

```text
Failed to parse AI findings JSON: Expecting value: line 1 column 1 (char 0)
##[error]Execute script failed with exit code 2
```

An AI verdict of WARN or PASS with no structured findings object means "nothing to process," which is success, not a config error. Resilience beats strictness here: the scheduled job must not fail over one PR's benign non-JSON AI output. A genuine config error (missing plugin lib) still exits 2 at import time.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #3180 | pr-maintenance parse_findings exits 2 on empty/prose AI findings; hourly run fails on WARN verdict |

## Changes

- `.claude/skills/github/scripts/pr/invoke_pr_comment_processing.py`: resilient `parse_findings` (canonical source, the copy the workflow invokes).
- `src/copilot-cli/skills/github/scripts/pr/invoke_pr_comment_processing.py`: regenerated Copilot CLI mirror, byte-identical to canonical.
- `tests/test_invoke_pr_comment_processing_skill.py`: rewrote the parse tests for the new no-op semantics and added three main-level tests, including an empty-stdin reproduction of the failing run.
- `.claude/.claude-plugin/plugin.json`, `src/copilot-cli/.claude-plugin/plugin.json`: plugin parity bump 0.6.63 to 0.6.64 (re-bumped after merging main, which had advanced to 0.6.63).
- `.agents/sessions/2026-07-17-session-3059.json`: session log.

## Test Plan

- `uv run pytest tests/test_invoke_pr_comment_processing_skill.py tests/test_invoke_pr_comment_processing.py`: 55 passed.
- New cases: empty, whitespace-only, prose ("The review looks good."), invalid JSON, and non-object JSON all return `{"comments": []}` with no exception; valid findings and fenced findings parse unchanged (regression guards); WARN verdict with empty stdin exits 0 (reproduces run 29603691792).
- `build/scripts/build_all.py --check` exit 0 (no generation drift). `build/scripts/validate_plugin_version_bump.py --base origin/main` printed OK. Targeted ruff clean.

## Security

The workflow's CWE-78 env-routing (issue #2520) is untouched. Untrusted AI output still flows through env and stdin, not expression interpolation. This change only relaxes parse strictness inside the Python consumer; it adds no new interpolation surface and reads the same stdin the workflow already routes.

## Out of Scope

- `.github/scripts/invoke_pr_comment_processing.py` is an independent, currently dormant (test-only) duplicate with the same `parse_findings` shape. No workflow invokes it, so it is not modified here.
- The running skill copy still lacks the issue #2522 reaction-failure fix that the dormant duplicate already carries. That is a separate pre-existing divergence and is not addressed by this PR.

Refs #3180

