### PR TITLE
test(hooks): fix 5 tests that broke main (PRs #3150/#3153 merged past failing required checks)

### DIFF
--- a/tests/hooks/test_claude_hook_dispatch.py
+++ b/tests/hooks/test_claude_hook_dispatch.py
@@ -463,11 +463,37 @@ def test_runtime_contract_force_push_to_main_blocks(tmp_path):
     # allows and the block comes from branch_protection_guard.
     on_main = tmp_path / "on-main"
     on_main.mkdir()
-    subprocess.run(["git", "init", str(on_main)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", str(on_main)], check=True, capture_output=True, timeout=30
+    )
     subprocess.run(
         ["git", "-C", str(on_main), "checkout", "-b", "main"],
         check=True,
         capture_output=True,
+        timeout=30,
+    )
+    # An unborn HEAD (branch created, no commit) makes `git branch
+    # --show-current` return an empty string on some git versions, which would
+    # let branch_protection_guard fail open and reintroduce the very
+    # non-determinism this negative control exists to remove. A single empty
+    # commit gives HEAD a born ref so the branch name resolves deterministically.
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(on_main),
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=Test",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ],
+        check=True,
+        capture_output=True,
+        timeout=30,
     )
     payload = json.dumps(
         {"tool_name": "Bash", "tool_input": {"command": "git push --force origin main"}}

--- a/tests/hooks/test_claude_hook_dispatch.py
+++ b/tests/hooks/test_claude_hook_dispatch.py
@@ -448,10 +448,27 @@ def test_runtime_contract_prompt_group_allows():
     assert result.returncode == 0, result.stderr.decode(errors="replace")
 
 
-def test_runtime_contract_force_push_to_main_blocks():
-    # Negative control: branch protection must still block a force-push
-    # to main through the push-chain group, proving group members really
-    # execute under the live manifest.
+def test_runtime_contract_force_push_to_main_blocks(tmp_path):
+    # Negative control: branch protection must still block a push made from a
+    # protected branch through the push-chain group, proving group members
+    # really execute under the live manifest.
+    #
+    # invoke_branch_protection_guard keys off the *current* branch of the
+    # resolved project directory, not the push target parsed from the command.
+    # A detached-HEAD checkout (CI's PR merge-commit checkout, or a --detach
+    # worktree) reports no current branch, so the guard fails open and the
+    # control becomes vacuous. Point CLAUDE_PROJECT_DIR at a scratch repo that
+    # is on `main` so the guard deterministically fires; the scratch repo has
+    # no .agents/sessions, so branch_context_guard (the group's first shim)
+    # allows and the block comes from branch_protection_guard.
+    on_main = tmp_path / "on-main"
+    on_main.mkdir()
+    subprocess.run(["git", "init", str(on_main)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(on_main), "checkout", "-b", "main"],
+        check=True,
+        capture_output=True,
+    )
     payload = json.dumps(
         {"tool_name": "Bash", "tool_input": {"command": "git push --force origin main"}}
     ).encode("utf-8")
@@ -464,10 +481,10 @@ def test_runtime_contract_force_push_to_main_blocks():
             "pretooluse-2-branch_context_guard",
         ],
         cwd=REPO_ROOT,
-        env=_entry_env(),
+        env=_entry_env({"CLAUDE_PROJECT_DIR": str(on_main)}),
         input=payload,
         capture_output=True,
         timeout=120,
         check=False,
     )
-    assert result.returncode == 2
+    assert result.returncode == 2, result.stderr.decode(errors="replace")

--- a/tests/test_pre_push_mypy_duplicate_modules.py
+++ b/tests/test_pre_push_mypy_duplicate_modules.py
@@ -215,9 +215,13 @@ def test_unique_files_still_bulk_checked() -> None:
 
     # Act -- content-level only
 
-    # Assert: mypy is called with the full PY_FILES_UNIQUE array
+    # Assert: mypy is called with the full PY_FILES_UNIQUE array in one bulk
+    # invocation. Issue #3132/#3150 resolves the type checker via uv first, so
+    # the command prefix is the "${MYPY_CMD[@]}" array rather than a bare
+    # ``mypy``; the fast-path contract is the single array-expanded call.
     assert (
-        'mypy "${PY_FILES_UNIQUE[@]}"' in text
+        '"${MYPY_CMD[@]}" "${PY_FILES_UNIQUE[@]}"' in text
+        or 'mypy "${PY_FILES_UNIQUE[@]}"' in text
         or "mypy ${PY_FILES_UNIQUE" in text
     ), (
         "Expected bulk mypy invocation on PY_FILES_UNIQUE array in pre-push; "
@@ -302,7 +306,10 @@ def test_pre_push_partitions_colliding_basenames_at_runtime(tmp_path: Path) -> N
 
     output = result.stdout + result.stderr
     assert result.returncode == 0, output
-    assert "PASS: Python type check/mypy (3 files)" in output
+    # Issue #3132/#3150: the pass label now records the resolution source
+    # ("via uv" or "via path"). The fixture repo has no uv.lock/pyproject.toml,
+    # so mypy always resolves to the PATH stub -> "via path".
+    assert "PASS: Python type check/mypy (3 files via path)" in output
 
     mypy_calls = (repo / "mypy.log").read_text(encoding="utf-8").splitlines()
     assert "pkg_c/bar.py" in mypy_calls

--- a/tests/test_pre_push_mypy_duplicate_modules.py
+++ b/tests/test_pre_push_mypy_duplicate_modules.py
@@ -217,15 +217,13 @@ def test_unique_files_still_bulk_checked() -> None:
 
     # Assert: mypy is called with the full PY_FILES_UNIQUE array in one bulk
     # invocation. Issue #3132/#3150 resolves the type checker via uv first, so
-    # the command prefix is the "${MYPY_CMD[@]}" array rather than a bare
-    # ``mypy``; the fast-path contract is the single array-expanded call.
-    assert (
-        '"${MYPY_CMD[@]}" "${PY_FILES_UNIQUE[@]}"' in text
-        or 'mypy "${PY_FILES_UNIQUE[@]}"' in text
-        or "mypy ${PY_FILES_UNIQUE" in text
-    ), (
-        "Expected bulk mypy invocation on PY_FILES_UNIQUE array in pre-push; "
-        "the non-colliding fast path appears to be missing"
+    # the command prefix is the "${MYPY_CMD[@]}" array. pre-push always uses
+    # the array for this fast-path call, so require it: a regression back to a
+    # bare PATH-only ``mypy`` must fail this mirror test.
+    assert '"${MYPY_CMD[@]}" "${PY_FILES_UNIQUE[@]}"' in text, (
+        "Expected bulk uv-first ${MYPY_CMD[@]} invocation on PY_FILES_UNIQUE "
+        "array in pre-push; the non-colliding fast path appears to be missing "
+        "or regressed to PATH-only mypy (Issue #3132/#3150)"
     )
 
 

--- a/tests/test_pre_push_mypy_validation_pathmodule.py
+++ b/tests/test_pre_push_mypy_validation_pathmodule.py
@@ -76,12 +76,12 @@ def test_pathmodule_loop_sets_mypypath_and_is_per_file() -> None:
     )
     # Single-file invocation inside the loop (never batched). Issue #3132/#3150
     # resolves mypy via uv first, so the invocation prefix is the
-    # "${MYPY_CMD[@]}" array rather than a bare ``mypy``.
-    assert (
-        '"${MYPY_CMD[@]}" "$pm_file"' in text
-        or 'mypy "$pm_file"' in text
-    ), (
-        "Expected the pathmodule loop to invoke mypy on one file at a time."
+    # "${MYPY_CMD[@]}" array rather than a bare ``mypy``. pre-push now
+    # unconditionally uses the array, so require it: a regression back to a
+    # bare PATH-only ``mypy`` must fail this mirror test.
+    assert '"${MYPY_CMD[@]}" "$pm_file"' in text, (
+        "Expected the pathmodule loop to invoke the uv-first ${MYPY_CMD[@]} "
+        "array on one file at a time (Issue #3132/#3150)."
     )
 
 
@@ -91,11 +91,11 @@ def test_unique_and_colliding_buckets_preserved() -> None:
     assert "PY_FILES_UNIQUE" in text
     assert "PY_FILES_COLLIDING" in text
     # Issue #3132/#3150: mypy resolved via uv first -> "${MYPY_CMD[@]}" prefix.
-    assert (
-        '"${MYPY_CMD[@]}" "${PY_FILES_UNIQUE[@]}"' in text
-        or 'mypy "${PY_FILES_UNIQUE[@]}"' in text
-    ), (
-        "Expected the bulk unique-basename mypy invocation to remain."
+    # pre-push always uses the array for the bulk unique-basename call, so
+    # require it; a regression to PATH-only ``mypy`` must fail this test.
+    assert '"${MYPY_CMD[@]}" "${PY_FILES_UNIQUE[@]}"' in text, (
+        "Expected the bulk unique-basename mypy invocation to use the "
+        "uv-first ${MYPY_CMD[@]} array (Issue #3132/#3150)."
     )
 
 

--- a/tests/test_pre_push_mypy_validation_pathmodule.py
+++ b/tests/test_pre_push_mypy_validation_pathmodule.py
@@ -74,8 +74,13 @@ def test_pathmodule_loop_sets_mypypath_and_is_per_file() -> None:
     assert 'MYPYPATH="$REPO_ROOT/scripts/validation' in text, (
         "Expected MYPYPATH to prepend scripts/validation for pathmodule files."
     )
-    # Single-file invocation inside the loop (never batched).
-    assert 'mypy "$pm_file"' in text, (
+    # Single-file invocation inside the loop (never batched). Issue #3132/#3150
+    # resolves mypy via uv first, so the invocation prefix is the
+    # "${MYPY_CMD[@]}" array rather than a bare ``mypy``.
+    assert (
+        '"${MYPY_CMD[@]}" "$pm_file"' in text
+        or 'mypy "$pm_file"' in text
+    ), (
         "Expected the pathmodule loop to invoke mypy on one file at a time."
     )
 
@@ -85,7 +90,11 @@ def test_unique_and_colliding_buckets_preserved() -> None:
     text = _text()
     assert "PY_FILES_UNIQUE" in text
     assert "PY_FILES_COLLIDING" in text
-    assert 'mypy "${PY_FILES_UNIQUE[@]}"' in text, (
+    # Issue #3132/#3150: mypy resolved via uv first -> "${MYPY_CMD[@]}" prefix.
+    assert (
+        '"${MYPY_CMD[@]}" "${PY_FILES_UNIQUE[@]}"' in text
+        or 'mypy "${PY_FILES_UNIQUE[@]}"' in text
+    ), (
         "Expected the bulk unique-basename mypy invocation to remain."
     )
 


### PR DESCRIPTION
## Summary

Restores `origin/main` to green. Five pytest tests failed on main because two PRs landed with their own required "Run Python Tests" check failing (admin-merged past the required-check wait during a PR drain). The "Run Python Tests" workflow runs on `pull_request`, not on pushes to main, so the red only surfaces when you branch off main and open a PR.

Full-suite scan confirms these five were the entire blast radius: 14788 passed, 0 other failures.

## What changed

Test files only, all in this diff:

1. Four pre-push mypy mirror assertions now accept the uv-first `"${MYPY_CMD[@]}"` invocation form and the new `via <source>` pass label, preserving each test's intent (bulk-unique invocation, per-file colliding loop, per-file pathmodule loop with MYPYPATH, aggregate pass output).
2. The force-push-to-main negative control is made deterministic by pointing CLAUDE_PROJECT_DIR at a scratch repo checked out on main, so the branch-protection block fires in any environment including CI's detached-HEAD checkout.

No plugin surfaces touched, so no plugin.json bump.

## Verification

- The five previously-failing tests now pass.
- Full suite: 14788 passed, 22 skipped, 45 xfailed, 0 failed.
- ruff clean on the changed files.

## Background

Root causes (in PRs not part of this diff, cited for context):

- PR #3150 (issue #3132) changed the pre-push mypy invocation from a bare `mypy` call to a `"${MYPY_CMD[@]}"` array and appended a `via ${MYPY_SOURCE}` suffix to the pass label, but did not update the mirror tests that grep for the old literal strings.
- PR #3153 added the negative control, which only passed when the checkout's current branch was literally main. The branch-protection guard keys off the current branch; CI's PR merge-commit checkout is detached HEAD, so the guard failed open and the control was vacuous.

## Lesson

Admin-merging past required checks (not just advisory threads) let #3150 and #3153 land red and broke main. Future drains must gate on the required "Run Python Tests" check before admin-merge.

Fixes #3198
