### PR TITLE
fix(scope): correct block boundary and staged-deletion count (#3171)

### DIFF
--- a/scripts/detect_scope_explosion.py
+++ b/scripts/detect_scope_explosion.py
@@ -7,13 +7,14 @@ Designed to run as a pre-commit check, delegated from .githooks/pre-commit.
 Thresholds:
   10 files: Warning (suggest reviewing scope)
   20 files: Strong warning (suggest splitting)
-  50 files: Block commit (hard limit)
+  50 files: Hard limit, still allowed (strong warning)
+  Over 50:  Block commit
 
 Bypass: Set SKIP_SCOPE_CHECK=1 environment variable for justified large PRs.
 
 EXIT CODES:
   0  - Success: File count within limits (or warnings issued)
-  1  - Block: File count exceeds hard limit (50 files)
+  1  - Block: File count exceeds hard limit (over 50 files)
   2  - Error: Could not determine branch state
 
 See: ADR-035 Exit Code Standardization
@@ -152,50 +153,6 @@ def get_merge_base(base_branch: str) -> str | None:
     return sha if result.returncode == 0 and sha else None
 
 
-def get_changed_files(merge_base: str) -> list[str]:
-    """Get files changed between merge base and HEAD.
-
-    Args:
-        merge_base: The commit to compare from.
-
-    Returns:
-        List of changed file paths.
-    """
-    result = subprocess.run(
-        ["git", "diff", "--name-only", "--diff-filter=ACMR", merge_base, "HEAD"],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        check=False,
-    )
-    if result.returncode != 0:
-        return []
-    return [f.strip() for f in result.stdout.splitlines() if f.strip()]
-
-
-def get_staged_new_files(merge_base: str) -> list[str]:
-    """Get staged files not yet committed that are new since merge base.
-
-    Includes currently staged changes to give accurate pre-commit count.
-
-    Args:
-        merge_base: The commit to compare from.
-
-    Returns:
-        List of staged file paths not already in the committed diff.
-    """
-    result = subprocess.run(
-        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
-        capture_output=True,
-        text=True,
-        timeout=10,
-        check=False,
-    )
-    if result.returncode != 0:
-        return []
-    return [f.strip() for f in result.stdout.splitlines() if f.strip()]
-
-
 def get_index_files_against_ref(base_ref: str) -> list[str]:
     """Get staged result files that differ from a base ref."""
     result = subprocess.run(
@@ -249,17 +206,21 @@ def detect_scope(base_branch: str = "main") -> ScopeResult | None:
     if not merge_base:
         return None
 
-    committed_files = get_changed_files(merge_base)
-    staged_files = get_staged_new_files(merge_base)
-
-    # Union of committed and staged files for total count
-    all_files = sorted(set(committed_files) | set(staged_files))
+    # Count the final staged tree against the merge base, matching the
+    # in-progress-merge path above. `git diff --cached --diff-filter=ACMR
+    # <base>` reflects the index as it will be committed, so a staged deletion
+    # of a branch-only file drops out of the count: the file is absent from the
+    # index and from the base, so it produces no diff entry. The former
+    # approach unioned the committed diff (merge_base..HEAD) with the staged
+    # ACMR set, which could not subtract such a deletion because the committed
+    # diff still listed it (Issue #3171).
+    files = sorted(set(get_index_files_against_ref(merge_base)))
 
     return ScopeResult(
-        file_count=len(all_files),
+        file_count=len(files),
         merge_base=merge_base[:12],
         current_branch=branch,
-        files=tuple(all_files),
+        files=tuple(files),
     )
 
 
@@ -303,7 +264,7 @@ def report(result: ScopeResult, quiet: bool = False) -> int:
         print("  Consider reviewing scope before the PR grows further.")
         return 0
 
-    if count < BLOCK_THRESHOLD:
+    if count <= BLOCK_THRESHOLD:
         print(f"WARNING: PR scope is large. {format_bar(count, STRONG_WARN_THRESHOLD)}")
         print(f"  Branch: {result.current_branch}")
         print(f"  {count} files changed since diverging from main.")
@@ -314,10 +275,10 @@ def report(result: ScopeResult, quiet: bool = False) -> int:
         print("    3. Start a new branch for remaining work")
         return 0
 
-    # Block threshold exceeded
+    # Block: count exceeds the hard limit (50 is allowed; 51+ blocks).
     print(f"BLOCKED: PR scope explosion detected. {format_bar(count, BLOCK_THRESHOLD)}")
     print(f"  Branch: {result.current_branch}")
-    print(f"  {count} files changed (hard limit: {BLOCK_THRESHOLD}).")
+    print(f"  {count} files changed (over the {BLOCK_THRESHOLD}-file hard limit).")
     print("  This PR is too large to review effectively.")
     print("")
     print("  Remediation:")

--- a/tests/test_detect_scope_explosion.py
+++ b/tests/test_detect_scope_explosion.py
@@ -21,13 +21,11 @@ from scripts.detect_scope_explosion import (
     ScopeResult,
     detect_scope,
     format_bar,
-    get_changed_files,
     get_current_branch,
     get_index_files_against_ref,
     get_merge_base,
     get_merge_head_commit,
     get_ref_commit,
-    get_staged_new_files,
     main,
     report,
     resolve_base_ref,
@@ -206,46 +204,6 @@ class TestGetMergeBase:
             assert cmd[3] == "origin/main"
 
 
-class TestGetChangedFiles:
-    """Tests for get_changed_files function."""
-
-    def test_returns_empty_on_failure(self) -> None:
-        with patch("scripts.detect_scope_explosion.subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[], returncode=1, stdout="", stderr=""
-            )
-            result = get_changed_files("abc123")
-            assert result == []
-
-    def test_parses_file_list(self) -> None:
-        with patch("scripts.detect_scope_explosion.subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[], returncode=0, stdout="a.py\nb.py\nc.md\n", stderr=""
-            )
-            result = get_changed_files("abc123")
-            assert result == ["a.py", "b.py", "c.md"]
-
-    def test_strips_empty_lines(self) -> None:
-        with patch("scripts.detect_scope_explosion.subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[], returncode=0, stdout="a.py\n\nb.py\n", stderr=""
-            )
-            result = get_changed_files("abc123")
-            assert result == ["a.py", "b.py"]
-
-
-class TestGetStagedNewFiles:
-    """Tests for get_staged_new_files function."""
-
-    def test_returns_empty_on_failure(self) -> None:
-        with patch("scripts.detect_scope_explosion.subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
-                args=[], returncode=1, stdout="", stderr=""
-            )
-            result = get_staged_new_files("abc123")
-            assert result == []
-
-
 class TestGetIndexFilesAgainstRef:
     """Tests for staged result diffing against a base ref."""
 
@@ -262,6 +220,25 @@ class TestGetIndexFilesAgainstRef:
                 args=[], returncode=1, stdout="", stderr=""
             )
             assert get_index_files_against_ref("origin/main") == []
+
+    def test_diffs_cached_index_against_base_ref(self) -> None:
+        # The --cached diff against the base ref reflects the final staged tree.
+        # A staged deletion of a branch-only file therefore drops out of the
+        # count (Issue #3171). Lock in the exact command shape that yields this.
+        with patch("scripts.detect_scope_explosion.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="kept.py\n", stderr=""
+            )
+            assert get_index_files_against_ref("origin/main") == ["kept.py"]
+            cmd = mock_run.call_args.args[0]
+            assert cmd[:5] == [
+                "git",
+                "diff",
+                "--cached",
+                "--name-only",
+                "--diff-filter=ACMR",
+            ]
+            assert cmd[5] == "origin/main"
 
 
 class TestDetectScope:
@@ -307,11 +284,8 @@ class TestDetectScope:
             "scripts.detect_scope_explosion.get_merge_base",
             return_value="abc123456789",
         ), patch(
-            "scripts.detect_scope_explosion.get_changed_files",
-            return_value=["a.py", "b.py"],
-        ), patch(
-            "scripts.detect_scope_explosion.get_staged_new_files",
-            return_value=["c.py"],
+            "scripts.detect_scope_explosion.get_index_files_against_ref",
+            return_value=["a.py", "b.py", "c.py"],
         ):
             result = detect_scope()
             assert result is not None
@@ -333,15 +307,45 @@ class TestDetectScope:
             "scripts.detect_scope_explosion.get_merge_base",
             return_value="abc123456789",
         ), patch(
-            "scripts.detect_scope_explosion.get_changed_files",
-            return_value=["a.py", "b.py"],
-        ), patch(
-            "scripts.detect_scope_explosion.get_staged_new_files",
-            return_value=["a.py", "c.py"],
+            "scripts.detect_scope_explosion.get_index_files_against_ref",
+            return_value=["a.py", "b.py", "a.py", "c.py"],
         ):
             result = detect_scope()
             assert result is not None
             assert result.file_count == 3
+
+    def test_staged_deletion_of_branch_only_file_subtracts(self) -> None:
+        # Regression for Issue #3171 Bug 2: staging the deletion of a
+        # branch-only file must lower the count. The non-merge path counts the
+        # final staged tree against the merge base via get_index_files_against_ref,
+        # so a deleted file simply never appears in that set.
+        captured_ref: list[str] = []
+
+        def fake_index_files(ref: str) -> list[str]:
+            captured_ref.append(ref)
+            # The staged deletion of "removed.py" leaves only these two.
+            return ["kept_a.py", "kept_b.py"]
+
+        with patch(
+            "scripts.detect_scope_explosion.get_current_branch",
+            return_value="feat/test",
+        ), patch(
+            "scripts.detect_scope_explosion.resolve_base_ref", return_value="origin/main"
+        ), patch(
+            "scripts.detect_scope_explosion.get_merge_head_commit", return_value=None
+        ), patch(
+            "scripts.detect_scope_explosion.get_merge_base",
+            return_value="base987654321",
+        ), patch(
+            "scripts.detect_scope_explosion.get_index_files_against_ref",
+            side_effect=fake_index_files,
+        ):
+            result = detect_scope()
+            assert result is not None
+            assert result.file_count == 2
+            assert "removed.py" not in result.files
+            # Counted against the merge base, not HEAD or the working tree.
+            assert captured_ref == ["base987654321"]
 
     def test_in_progress_base_merge_counts_index_against_base(self) -> None:
         with patch(
@@ -448,12 +452,46 @@ class TestReport:
         assert "WARNING" in captured.out
         assert "splitting" in captured.out.lower()
 
-    def test_at_block_threshold(self, capsys: CaptureFixture[str]) -> None:
+    def test_at_block_threshold_still_allowed(
+        self, capsys: CaptureFixture[str]
+    ) -> None:
+        # Issue #3171 Bug 1: 50 is the inclusive hard limit. It must pass with a
+        # strong warning, not block. Blocking begins at 51.
         result = ScopeResult(
-            file_count=50,
+            file_count=BLOCK_THRESHOLD,
             merge_base="abc123",
             current_branch="feat/test",
-            files=tuple(f"file{i}.py" for i in range(50)),
+            files=tuple(f"file{i}.py" for i in range(BLOCK_THRESHOLD)),
+        )
+        exit_code = report(result)
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+        assert "BLOCKED" not in captured.out
+
+    def test_just_below_block_threshold_allowed(
+        self, capsys: CaptureFixture[str]
+    ) -> None:
+        result = ScopeResult(
+            file_count=BLOCK_THRESHOLD - 1,
+            merge_base="abc123",
+            current_branch="feat/test",
+            files=tuple(f"file{i}.py" for i in range(BLOCK_THRESHOLD - 1)),
+        )
+        exit_code = report(result)
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "BLOCKED" not in captured.out
+
+    def test_just_over_block_threshold_blocks(
+        self, capsys: CaptureFixture[str]
+    ) -> None:
+        # 51 is the first blocking count.
+        result = ScopeResult(
+            file_count=BLOCK_THRESHOLD + 1,
+            merge_base="abc123",
+            current_branch="feat/test",
+            files=tuple(f"file{i}.py" for i in range(BLOCK_THRESHOLD + 1)),
         )
         exit_code = report(result)
         assert exit_code == 1


### PR DESCRIPTION
## Summary

Fixes two counting bugs in the scope-explosion pre-commit detector.

**Bug 1: off-by-one at the block boundary.** `report()` blocked at exactly
50 changed files. The exit-code contract documents 50 as an inclusive hard
limit, so 50 must pass with a strong warning and only 51+ should block. The
strong-warning branch used a strict `<` comparison; it now uses `<=`.

**Bug 2: staged deletions did not lower the count.** The non-merge path
unioned the committed diff (`merge_base..HEAD`) with the staged ACMR set. A
staged deletion of a branch-only file could not reduce the count because the
committed diff still listed that file. The path now counts the final staged
tree against the merge base with `git diff --cached --diff-filter=ACMR <base>`,
matching the in-progress-merge path. A staged deletion drops out of the set
because the file is absent from both the index and the base.

## Changes

- `report()`: strong-warning branch comparison `<` becomes `<=` so 50 passes
  and 51+ blocks.
- `detect_scope()` non-merge path: replaces the committed-plus-staged union
  with a single count of the staged index against the merge base.
- Removes the now-dead `get_changed_files` and `get_staged_new_files` helpers
  and their tests. The retained `get_index_files_against_ref` helper already
  produced the correct final-tree semantics and was covered by tests.

## Tests

- Boundary tests: 49 passes, 50 passes with a strong warning, 51 blocks.
- Staged-deletion regression test: a staged deletion lowers the count, and the
  count is taken against the merge base.
- Command-shape assertion on `get_index_files_against_ref`
  (`git diff --cached --name-only --diff-filter=ACMR <base>`).
- 42 tests pass; ruff and mypy clean.

## Verification

```
uv run pytest tests/test_detect_scope_explosion.py -q   # 42 passed
uv run ruff check   scripts/detect_scope_explosion.py tests/test_detect_scope_explosion.py
uv run mypy         scripts/detect_scope_explosion.py tests/test_detect_scope_explosion.py
```

Fixes #3171
