### PR TITLE
fix(hooks): trigger CLI smokes when shared hook probe changes (#3179)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -408,11 +408,14 @@ CHANGED_AGENT_DRIFT_INPUTS=$(echo "$CHANGED_FILES" | grep -E '^(src/claude/[^/]+
 # Hook-anchoring relevant paths (#2205): generator, both plugin hook files,
 # the project-mode settings source, the anchoring gate, and the e2e itself.
 # A change to any forces the real-CLI e2e (resolution under the live contract).
-CHANGED_HOOKS=$(echo "$CHANGED_FILES" | grep -E '^(build/scripts/generate_hooks\.py|src/copilot-cli/hooks/|\.claude/hooks/|\.claude/settings\.json|scripts/validation/validate_hook_anchoring\.py|tests/e2e/test_cli_hook_e2e\.py)' || true)
+# copilot_hook_probe.py is the shared fired-hook probe imported by the CLI hook
+# e2e and the plugin-load smoke (#3179); editing it alone must retrigger both.
+CHANGED_HOOKS=$(echo "$CHANGED_FILES" | grep -E '^(build/scripts/generate_hooks\.py|src/copilot-cli/hooks/|\.claude/hooks/|\.claude/settings\.json|scripts/validation/validate_hook_anchoring\.py|tests/e2e/test_cli_hook_e2e\.py|tests/e2e/copilot_hook_probe\.py)' || true)
 # Plugin-load relevant paths (#2736): sources, generated skill mirrors, plugin
 # manifests, generators, and the smoke itself. A change to any forces the real
-# CLI plugin-load smoke when a CLI is available.
-CHANGED_PLUGIN_LOAD=$(echo "$CHANGED_FILES" | grep -E '^(\.claude/(\.claude-plugin/plugin\.json|commands/|skills/)|src/copilot-cli/(\.claude-plugin/plugin\.json|skills/)|build/scripts/generate_(commands|skills)\.py|templates/platforms/copilot-cli\.yaml|tests/e2e/test_plugin_load_smoke\.py|\.github/workflows/nightly-cli-smoke\.yml)' || true)
+# CLI plugin-load smoke when a CLI is available. copilot_hook_probe.py is the
+# shared load-signal helper imported by the smoke (#3179).
+CHANGED_PLUGIN_LOAD=$(echo "$CHANGED_FILES" | grep -E '^(\.claude/(\.claude-plugin/plugin\.json|commands/|skills/)|src/copilot-cli/(\.claude-plugin/plugin\.json|skills/)|build/scripts/generate_(commands|skills)\.py|templates/platforms/copilot-cli\.yaml|tests/e2e/test_plugin_load_smoke\.py|tests/e2e/copilot_hook_probe\.py|\.github/workflows/nightly-cli-smoke\.yml)' || true)
 
 # ============================================================================
 # Phase 1: Fast Guards (< 5s)

--- a/tests/test_pre_push_hook_probe_glob_3179.py
+++ b/tests/test_pre_push_hook_probe_glob_3179.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Regression coverage for Issue #3179: pre-push glob gap on the shared probe.
+
+PR #3167 (fixes #3148) extracted the fired-hook probe into
+``tests/e2e/copilot_hook_probe.py``, imported by both ``test_cli_hook_e2e.py``
+and ``test_plugin_load_smoke.py``. The ``CHANGED_HOOKS`` and
+``CHANGED_PLUGIN_LOAD`` trigger globs in ``.githooks/pre-push`` did not match
+the helper, so editing it alone would ship without either smoke firing, a
+silent gap on a customer-facing push gate.
+
+These tests extract each glob's extended-regex from the hook and assert the
+helper path matches both, with negative and preservation controls so the fix
+cannot silently regress or over-broaden.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PRE_PUSH = REPO_ROOT / ".githooks" / "pre-push"
+HELPER = "tests/e2e/copilot_hook_probe.py"
+
+
+def _extract_glob(var_name: str) -> str:
+    """Return the extended-regex a pre-push glob assignment feeds to grep -E.
+
+    Parses the line ``VAR=$(echo "$CHANGED_FILES" | grep -E 'ERE' || true)`` and
+    returns the single-quoted ERE. The ERE is anchored, so it is usable directly
+    with ``re.match`` (ERE alternation, groups, and ``\\.`` are all valid
+    Python regex).
+    """
+    text = PRE_PUSH.read_text(encoding="utf-8")
+    pattern = re.compile(rf"^{re.escape(var_name)}=.*grep -E '([^']+)'", re.MULTILINE)
+    match = pattern.search(text)
+    if match is None:
+        raise AssertionError(f"{var_name} grep -E assignment not found in pre-push")
+    return match.group(1)
+
+
+def test_helper_matches_changed_hooks_glob() -> None:
+    ere = _extract_glob("CHANGED_HOOKS")
+    assert re.match(ere, HELPER), (
+        f"{HELPER} must match CHANGED_HOOKS so editing the shared probe "
+        f"retriggers the CLI hook e2e (#3179). ERE: {ere!r}"
+    )
+
+
+def test_helper_matches_changed_plugin_load_glob() -> None:
+    ere = _extract_glob("CHANGED_PLUGIN_LOAD")
+    assert re.match(ere, HELPER), (
+        f"{HELPER} must match CHANGED_PLUGIN_LOAD so editing the shared probe "
+        f"retriggers the plugin-load smoke (#3179). ERE: {ere!r}"
+    )
+
+
+def test_unrelated_path_does_not_match_either_glob() -> None:
+    # Negative control: a plain source file outside the trigger sets must not
+    # match, proving the globs stayed narrow after the fix.
+    unrelated = "scripts/detect_scope_explosion.py"
+    assert not re.match(_extract_glob("CHANGED_HOOKS"), unrelated)
+    assert not re.match(_extract_glob("CHANGED_PLUGIN_LOAD"), unrelated)
+
+
+def test_existing_smoke_triggers_are_preserved() -> None:
+    # Preservation control: the fix must not drop the smokes' own paths.
+    hooks_ere = _extract_glob("CHANGED_HOOKS")
+    plugin_ere = _extract_glob("CHANGED_PLUGIN_LOAD")
+    assert re.match(hooks_ere, "tests/e2e/test_cli_hook_e2e.py")
+    assert re.match(plugin_ere, "tests/e2e/test_plugin_load_smoke.py")


### PR DESCRIPTION
## Summary

Fixes #3179.

The pre-push plugin-load smoke and CLI hook e2e are gated by two path globs in
`.githooks/pre-push`. Neither glob matched the shared fired-hook probe helper
that PR 3167 extracted, so a change touching only that shared source could push
without either smoke firing. This adds the helper path to both globs plus a
static test that proves the match.

## Fix

- Add the shared probe path to both `CHANGED_HOOKS` and `CHANGED_PLUGIN_LOAD`
  trigger globs in `.githooks/pre-push` so editing the helper alone retriggers
  the CLI hook e2e and the plugin-load smoke.
- Add `tests/test_pre_push_hook_probe_glob_3179.py`: a static test that extracts
  each glob's extended-regex from the hook and asserts the helper path matches
  both, with a negative control (an unrelated source matches neither) and a
  preservation control (the smokes' own paths still match).

## Verification

```
uv run pytest tests/test_pre_push_hook_probe_glob_3179.py -q   # 4 passed
uv run ruff check tests/test_pre_push_hook_probe_glob_3179.py
uv run mypy tests/test_pre_push_hook_probe_glob_3179.py
```

Also byte-verified the live `grep -E` in both globs matches the helper path.

## Acceptance

Touching only the shared probe triggers both smokes on pre-push, confirmed by
the extracted-regex test.

## Background

The shared fired-hook probe helper `copilot_hook_probe.py` was extracted by PR
3167 and is imported by both `test_cli_hook_e2e.py` and `test_plugin_load_smoke.py`.
Before this change neither pre-push glob matched that helper, so a regression in
the helper alone would ship without the gate running.
