### PR TITLE
fix(hooks): fail closed on deeply nested JSON in standalone matcher shims (#3169)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.65",
+  "version": "0.6.66",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.66",
+  "version": "0.6.67",
   "author": {
     "name": "rjmurillo"
   }

--- a/build/scripts/generate_hooks_shim.py
+++ b/build/scripts/generate_hooks_shim.py
@@ -479,6 +479,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{{}}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{{}}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{{}}]: malformed JSON on stdin: {{}}".format(_MATCHER, exc),

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.65",
+  "version": "0.6.66",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.66",
+  "version": "0.6.67",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PostToolUse/invoke_lsp_usage_tracker__mcp_serena_find_symbol_find_referencing_symbols_34dc50.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_lsp_usage_tracker__mcp_serena_find_symbol_find_referencing_symbols_34dc50.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PostToolUse/invoke_markdown_auto_lint__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_markdown_auto_lint__Write_Edit_c39898.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PostToolUse/invoke_plan_state_sync__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_plan_state_sync__Write_Edit_c39898.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_push_0e93bf.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_push_0e93bf.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_1108b7.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_1108b7.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_hook_drift_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_hook_drift_guard__Bash_git_push_0e93bf.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_install_parity_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_install_parity_guard__Bash_git_push_0e93bf.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_bash_grep_guard__Bash_gG_rR_eE_pP_rR_gG_aA_gG_aA_cC_kK_gG_rR_eE_p_af1b8d.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_bash_grep_guard__Bash_gG_rR_eE_pP_rR_gG_aA_gG_aA_cC_kK_gG_rR_eE_p_af1b8d.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_glob_guard__Glob_181cd6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_glob_guard__Glob_181cd6.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_grep_guard__Grep_2589b1.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_grep_guard__Grep_2589b1.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_markdownlint_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_markdownlint_guard__Bash_git_push_0e93bf.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_plugin_version_bump_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_plugin_version_bump_guard__Bash_git_push_0e93bf.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_pr_description_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_pr_description_guard__Bash_git_push_0e93bf.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_retrospective_gate__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_retrospective_gate__Bash_git_push_0e93bf.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_routing_gates__Bash_gG_hH_pP_rR_cC_rR_eE_aA_tT_eE_gG_hH_pP_rR_m_61839c.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_routing_gates__Bash_gG_hH_pP_rR_cC_rR_eE_aA_tT_eE_gG_hH_pP_rR_m_61839c.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_security_commit_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_security_commit_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_security_gate__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_security_gate__Write_Edit_c39898.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_field_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_field_guard__Bash_git_push_0e93bf.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gG_hH_pP_rR_cC_rR_eE_aA_tT_eE_gG_hH_exe_pP_de420a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gG_hH_pP_rR_cC_rR_eE_aA_tT_eE_gG_hH_exe_pP_de420a.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/src/copilot-cli/hooks/PreToolUse/invoke_skill_first_guard__Bash_gG_hH_gG_hH_exe_gG_hH_gG_hH_gG_hH_gG_hH_eE_53dbd6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_skill_first_guard__Bash_gG_hH_gG_hH_exe_gG_hH_gG_hH_gG_hH_gG_hH_eE_53dbd6.py
@@ -313,6 +313,20 @@ def _shim_dispatch():
         _sys.exit(2)
     try:
         payload = _shim_load_json(_raw or b"{}")
+    except RecursionError:
+        # Deeply nested JSON exhausts the parser recursion budget and raises
+        # RecursionError, which is NOT a ValueError subclass, so it would
+        # otherwise escape the malformed-JSON handler below, print a traceback,
+        # and exit 1. A standalone shim (run directly, not under the dispatcher)
+        # must fail closed the same way the dispatcher does: bounded diagnostic
+        # (no traceback, no payload bytes) and exit 2 (issue #3169).
+        print(
+            "matcher-shim [{}]: stdin JSON nesting too deep; refusing".format(
+                _MATCHER
+            ),
+            file=_sys.stderr,
+        )
+        _sys.exit(2)
     except ValueError as exc:
         print(
             "matcher-shim [{}]: malformed JSON on stdin: {}".format(_MATCHER, exc),

--- a/tests/build_scripts/test_generate_hooks_schema_security.py
+++ b/tests/build_scripts/test_generate_hooks_schema_security.py
@@ -251,23 +251,59 @@ def test_committed_shim_rejects_duplicate_toolcalls_keys():
 def _nested_json_overflowing_stdin() -> bytes:
     """Return JSON bytes whose nesting overflows this interpreter's parser.
 
-    The exact depth that trips ``RecursionError`` in the stdlib JSON C
-    scanner depends on the C stack size, which varies by platform and Python
-    build. Probe upward until the local parser raises, then reuse those bytes:
-    the shim runs under the same interpreter, so the same depth overflows
-    there too. This keeps the test deterministic across environments instead
-    of hard-coding a depth that might parse cleanly on a larger stack.
-    Refs issue #3169.
+    The stdlib JSON C scanner raises ``RecursionError`` once nesting nears the
+    interpreter's C-stack recursion guard. That depth tracks the C stack size,
+    which varies by platform and Python build, so this probes for it at run
+    time instead of hard-coding a very deep constant. A fixed large depth would
+    build a needlessly deep payload on small-stack platforms (Windows, threaded
+    runners) where the guard trips far sooner. Refs issue #3169.
+
+    Two robustness details:
+
+    * ``MemoryError`` (a payload too large to allocate or parse) skips the test
+      rather than crashing the runner.
+    * The returned depth is twice the minimal depth that overflows this probe.
+      The probe runs deep inside pytest's call stack, so it hits the guard at a
+      shallower nesting than the shim does when it parses the same bytes near
+      the top of a fresh process. Doubling guarantees the shim overflows too,
+      and it scales with the platform's measured limit instead of a hand-tuned
+      constant.
     """
-    depth = 200_000
-    while depth <= 5_000_000:
-        payload = b"[" * depth + b"0" + b"]" * depth
+
+    def _overflows(candidate: int) -> bool:
+        payload = b"[" * candidate + b"0" + b"]" * candidate
         try:
             json.loads(payload)
+            return False
         except RecursionError:
-            return payload
+            return True
+
+    low = 0
+    high = 0
+    depth = 1_000
+    ceiling = 2_000_000
+    while depth <= ceiling:
+        try:
+            if _overflows(depth):
+                high = depth
+                break
+            low = depth
+        except MemoryError:
+            pytest.skip("insufficient memory to induce a JSON RecursionError")
         depth *= 2
-    pytest.skip("could not induce a JSON RecursionError in this interpreter")
+    if high == 0:
+        pytest.skip("could not induce a JSON RecursionError in this interpreter")
+    while high - low > 1:
+        mid = (low + high) // 2
+        try:
+            if _overflows(mid):
+                high = mid
+            else:
+                low = mid
+        except MemoryError:
+            pytest.skip("insufficient memory to induce a JSON RecursionError")
+    safe_depth = high * 2
+    return b"[" * safe_depth + b"0" + b"]" * safe_depth
 
 
 def _run_committed_pretooluse_dispatcher(

--- a/tests/build_scripts/test_generate_hooks_schema_security.py
+++ b/tests/build_scripts/test_generate_hooks_schema_security.py
@@ -10,6 +10,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "build" / "scripts"))
 sys.path.insert(0, str(REPO_ROOT / "build"))
@@ -244,3 +246,94 @@ def test_committed_shim_rejects_duplicate_toolcalls_keys():
 
     assert proc.returncode == 2
     assert b"duplicate JSON object key" in proc.stderr
+
+
+def _nested_json_overflowing_stdin() -> bytes:
+    """Return JSON bytes whose nesting overflows this interpreter's parser.
+
+    The exact depth that trips ``RecursionError`` in the stdlib JSON C
+    scanner depends on the C stack size, which varies by platform and Python
+    build. Probe upward until the local parser raises, then reuse those bytes:
+    the shim runs under the same interpreter, so the same depth overflows
+    there too. This keeps the test deterministic across environments instead
+    of hard-coding a depth that might parse cleanly on a larger stack.
+    Refs issue #3169.
+    """
+    depth = 200_000
+    while depth <= 5_000_000:
+        payload = b"[" * depth + b"0" + b"]" * depth
+        try:
+            json.loads(payload)
+        except RecursionError:
+            return payload
+        depth *= 2
+    pytest.skip("could not induce a JSON RecursionError in this interpreter")
+
+
+def _run_committed_pretooluse_dispatcher(
+    raw_input: bytes,
+) -> subprocess.CompletedProcess[bytes]:
+    dispatcher = (
+        REPO_ROOT / "src" / "copilot-cli" / "hooks" / "PreToolUse" / "_dispatch.py"
+    )
+    if not dispatcher.exists():
+        raise AssertionError(f"committed dispatcher missing: {dispatcher}")
+    env = dict(os.environ)
+    env["COPILOT_PLUGIN_ROOT"] = str(REPO_ROOT / "src" / "copilot-cli")
+    return subprocess.run(
+        [sys.executable, str(dispatcher)],
+        input=raw_input,
+        capture_output=True,
+        cwd=REPO_ROOT,
+        env=env,
+        timeout=30,
+    )
+
+
+def test_deeply_nested_json_fails_closed_direct_shim():
+    # Issue #3169: a standalone shim (run directly, not under the dispatcher)
+    # must fail closed on deeply nested JSON that raises RecursionError inside
+    # the parser, rather than leaking exit 1 and a full traceback. RecursionError
+    # is not a ValueError subclass, so it escaped the malformed-JSON handler.
+    transformed = inject_shim(_ECHO_SCRIPT, "Bash(git push*)")
+
+    proc = _run_shim_raw(transformed, _nested_json_overflowing_stdin())
+
+    assert proc.returncode == 2, proc.stderr.decode()
+    assert b"stdin JSON nesting too deep" in proc.stderr
+    assert b"Traceback" not in proc.stderr
+    assert b"RecursionError" not in proc.stderr
+    assert len(proc.stderr) < 512
+    assert proc.stdout == b""
+
+
+def test_shallow_json_still_parses_direct_shim():
+    # Negative control: nesting below the overflow threshold parses normally and
+    # does not trip the fail-closed path, so the RecursionError catch adds no
+    # false positives for well-formed input.
+    transformed = inject_shim(_ECHO_SCRIPT, "Bash(git push*)")
+    payload = {"tool_name": "Bash", "tool_input": {"command": "echo safe"}}
+
+    proc = _run_shim(transformed, payload)
+
+    assert proc.returncode == 0, proc.stderr.decode()
+    assert b"nesting too deep" not in proc.stderr
+
+
+def test_committed_shim_rejects_deeply_nested_json():
+    proc = _run_committed_git_push_shim(_nested_json_overflowing_stdin())
+
+    assert proc.returncode == 2, proc.stderr.decode()
+    assert b"stdin JSON nesting too deep" in proc.stderr
+    assert b"Traceback" not in proc.stderr
+    assert len(proc.stderr) < 4096
+
+
+def test_committed_dispatcher_rejects_deeply_nested_json():
+    # Dispatcher negative control: the production dispatcher already fails closed
+    # on RecursionError. This guards against regressing that path while fixing
+    # the standalone shim (issue #3169).
+    proc = _run_committed_pretooluse_dispatcher(_nested_json_overflowing_stdin())
+
+    assert proc.returncode == 2, proc.stderr.decode()
+    assert b"Traceback" not in proc.stderr


### PR DESCRIPTION
## Summary

Standalone matcher shims crashed instead of failing closed on deeply nested JSON. A payload deep enough to raise `RecursionError` inside the JSON parser escaped the shim's malformed-JSON handler, because `RecursionError` is not a `ValueError` subclass. The shim printed a full traceback and exited 1 instead of the documented fail-closed exit 2.

This adds a `RecursionError` catch at the standalone shim's stdin-parse site. The shim now fails closed with a bounded diagnostic (no traceback, no payload bytes) and exit 2, matching the dispatcher's existing behavior.

## Root cause

`json.loads` raises `RecursionError` (a `RuntimeError` subclass) on deeply nested input. The shim only caught `ValueError` at the top-level stdin parse, so the exception propagated out of `_shim_dispatch`, and the module-level dispatch call has no outer guard when a shim runs directly (not under the dispatcher).

## Fix

- Add `except RecursionError` before `except ValueError` in the shim template's `_shim_dispatch`, emitting a bounded message and exit 2.
- Regenerated all 33 matcher shims (no other drift).
- Bumped both plugin manifests to 0.6.67 (parity gate; raised from 0.6.66 after resolving a version-line conflict with main).

## Verification

Repro before fix (depth that overflows the parser): exit 1, 1110-byte stderr ending in a `RecursionError` traceback.
After fix: exit 2, 59-byte bounded message, no traceback, no payload bytes.

New tests:
- direct standalone shim: deep JSON exits 2, bounded stderr, no traceback
- shallow JSON negative control: parses normally, no false positive
- committed git-push shim: deep JSON exits 2
- committed PreToolUse dispatcher negative control: still exits 2

The overflow depth is probed at runtime (same interpreter as the shim subprocess) so the test is deterministic across platforms rather than hard-coding a stack-dependent depth.

15 tests pass in the schema-security file; 284 pass across the full shim and dispatcher suite; ruff and mypy clean; no artifact drift.

## References

- Generator: see `build/scripts/generate_hooks_shim.py`
- Tests: see `tests/build_scripts/test_generate_hooks_schema_security.py`

Fixes #3169
Refs #3097

