### PR TITLE
fix(hooks): fail open false-completion-gate for subagents without session logs (#3178)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.66",
+  "version": "0.6.68",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.65",
+  "version": "0.6.66",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PreToolUse/invoke_false_completion_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_false_completion_gate.py
@@ -372,10 +372,16 @@ def _is_completion_claim_in_message_file(command: str) -> tuple[bool, bool]:
     Returns a tuple ``(has_claim, body_unreadable)``.
 
     ``body_unreadable`` is True when ``-F`` was specified but the file
-    could not be read (outside trusted paths or I/O error). Callers use
-    that signal to keep the fail-closed contract end-to-end: when the
-    body cannot be inspected, the gate cannot fall through to the
-    "no session log => allow" branch.
+    could not be read (outside trusted paths or I/O error). In that case
+    ``has_claim`` is also True so the command is still routed through the
+    session-log evidence check instead of being skipped.
+
+    The production caller in ``main`` consumes only ``has_claim`` and
+    discards ``body_unreadable`` (issue #3178): an un-inspectable body no
+    longer forces a block on its own. When a session log exists the
+    evidence check still gates the commit; when none exists (subagents),
+    the gate fails open. ``body_unreadable`` stays in the return contract
+    for callers and tests that assert the read outcome directly.
     """
     message_file = _extract_commit_message_file(command)
     if message_file is None:
@@ -406,9 +412,12 @@ def _is_completion_claim_in_pr_body_file(command: str) -> tuple[bool, bool]:
     """Check if a gh pr create --body-file contains completion signals.
 
     Uses the same path containment as commit message files (CWE-22).
-    Returns a tuple ``(has_claim, body_unreadable)`` so callers can keep
-    the fail-closed contract end-to-end (see
-    ``_is_completion_claim_in_message_file``).
+    Returns a tuple ``(has_claim, body_unreadable)`` mirroring
+    ``_is_completion_claim_in_message_file``: an unreadable body yields
+    ``(True, True)`` so the command is routed to the evidence check, and
+    the production caller consumes only ``has_claim`` (issue #3178). The
+    ``body_unreadable`` element stays in the contract for tests and
+    callers that inspect the read outcome directly.
     """
     body_file = _extract_pr_body_file(command)
     if body_file is None:

--- a/.claude/hooks/PreToolUse/invoke_false_completion_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_false_completion_gate.py
@@ -726,15 +726,19 @@ def main() -> None:
     sessions_dir = str(Path(project_dir) / ".agents" / "sessions")
     session_logs = get_today_session_logs(sessions_dir)
 
-    # Fail-open when no session logs exist. Subagents legitimately have no
-    # session log, and with no evidence store to check against the gate
-    # cannot distinguish a true completion claim from a false one; blocking
-    # only taxes legitimate subagent commits whose -F / --body-file body is
-    # un-inspectable (heredoc, shell variable, temp file, or a path outside
-    # the trusted allowlist). The main-loop case is handled by the
-    # ``elif session_logs`` branch below, which still requires evidence, so
-    # an unreadable body cannot bypass the gate when a session exists
-    # (issue #3178).
+    # No today logs: fall through to the yesterday check below. The
+    # fail-open for subagents applies only when NO session log exists at
+    # all (neither today nor yesterday, or the sessions dir is unreadable).
+    # A subagent legitimately has no session log, and with no evidence
+    # store the gate cannot distinguish a true completion claim from a
+    # false one, so blocking only taxes legitimate subagent commits whose
+    # -F / --body-file body is un-inspectable (heredoc, shell variable,
+    # temp file, or a path outside the trusted allowlist). When yesterday's
+    # logs DO exist they are still evaluated: evidence there allows
+    # (cross-midnight continuation), its absence blocks. The main-loop case
+    # (today's logs present) is handled by the ``elif session_logs`` branch
+    # below, which still requires evidence, so an unreadable body cannot
+    # bypass the gate when a session exists (issue #3178).
     if not session_logs:
         # No today logs: check yesterday (cross-midnight continuation).
         sessions_path = Path(sessions_dir)

--- a/.claude/hooks/PreToolUse/invoke_false_completion_gate.py
+++ b/.claude/hooks/PreToolUse/invoke_false_completion_gate.py
@@ -20,8 +20,12 @@ Evidence requirements (any one satisfies):
 Bypass conditions:
 - SKIP_COMPLETION_GATE=true environment variable
 - Documentation-only changes (*.md files only)
-- No session log present (fail-open), unless the completion claim was
-  inferred from an unreadable -F / --body-file (fail-closed)
+- No session log present (fail-open). Subagents legitimately have no
+  session log, so with no evidence store to check against the gate cannot
+  distinguish a true completion claim from a false one and fails open even
+  when the -F / --body-file body is un-inspectable (issue #3178). The
+  main-loop case (session log present) still requires evidence, so an
+  unreadable body cannot bypass the gate when a session exists.
 - Non-commit/non-PR/non-merge commands
 
 Hook Type: PreToolUse (blocking on match)
@@ -46,6 +50,7 @@ import tempfile
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 # --- Standard hook boilerplate ---
 _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
@@ -150,12 +155,12 @@ def _probe_worktree_root() -> str:
             timeout=_GIT_TIMEOUT_SECONDS,
         )
     except (OSError, subprocess.TimeoutExpired):
-        return get_project_directory()
+        return str(get_project_directory())
     if result.returncode == 0:
         top = result.stdout.strip()
         if top:
             return str(Path(top).resolve())
-    return get_project_directory()
+    return str(get_project_directory())
 
 
 # Completion signal patterns in commit messages / PR titles
@@ -220,7 +225,7 @@ VERIFICATION_RESULT_PATTERNS = [
 ]
 
 
-def _read_stdin_json() -> dict | None:
+def _read_stdin_json() -> dict[str, Any] | None:
     """Read and parse JSON from stdin (Claude hook input)."""
     if sys.stdin.isatty():
         return None
@@ -228,12 +233,13 @@ def _read_stdin_json() -> dict | None:
         data = sys.stdin.read().strip()
         if not data:
             return None
-        return json.loads(data)
+        parsed = json.loads(data)
     except (json.JSONDecodeError, OSError):
         return None
+    return parsed if isinstance(parsed, dict) else None
 
 
-def _extract_command(hook_input: dict) -> str:
+def _extract_command(hook_input: dict[str, Any]) -> str:
     """Extract the command string from hook input.
 
     Defends against malformed input where ``hook_input``, ``tool_input``,
@@ -685,20 +691,13 @@ def main() -> None:
     # For `gh pr create --body-file <file>`, also check the body file contents.
     # `gh pr merge` is always treated as a completion claim since merging is
     # an inherent "done" action that requires verification evidence.
-    msg_claim, msg_unreadable = _is_completion_claim_in_message_file(command)
-    body_claim, body_unreadable = _is_completion_claim_in_pr_body_file(command)
+    msg_claim, _ = _is_completion_claim_in_message_file(command)
+    body_claim, _ = _is_completion_claim_in_pr_body_file(command)
     has_completion_claim = (
         _is_completion_claim(command) or msg_claim or body_claim or bool(is_pr_merge)
     )
     if not has_completion_claim:
         sys.exit(0)
-
-    # ``body_inferred`` is true when the completion claim was inferred from
-    # a body file that could not be read (commit -F / pr create --body-file
-    # pointing outside trusted paths). The fail-closed contract on those
-    # helpers must propagate: when we cannot read the body, we cannot fall
-    # through to the "no session log => allow" branch below.
-    body_inferred = msg_unreadable or body_unreadable
 
     # Resolve the CURRENT worktree, not the MAIN checkout. In a linked
     # worktree ``CLAUDE_PROJECT_DIR`` points at main, so the session dir and
@@ -718,11 +717,16 @@ def main() -> None:
     sessions_dir = str(Path(project_dir) / ".agents" / "sessions")
     session_logs = get_today_session_logs(sessions_dir)
 
-    # Fail-open when no session logs exist, EXCEPT when the completion
-    # claim was inferred from an unreadable body file. In that case we
-    # honor the fail-closed contract on the body-file helpers and require
-    # verification before allowing the command through.
-    if not session_logs and not body_inferred:
+    # Fail-open when no session logs exist. Subagents legitimately have no
+    # session log, and with no evidence store to check against the gate
+    # cannot distinguish a true completion claim from a false one; blocking
+    # only taxes legitimate subagent commits whose -F / --body-file body is
+    # un-inspectable (heredoc, shell variable, temp file, or a path outside
+    # the trusted allowlist). The main-loop case is handled by the
+    # ``elif session_logs`` branch below, which still requires evidence, so
+    # an unreadable body cannot bypass the gate when a session exists
+    # (issue #3178).
+    if not session_logs:
         # No today logs: check yesterday (cross-midnight continuation).
         sessions_path = Path(sessions_dir)
         if sessions_path.is_dir():

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.65",
+  "version": "0.6.66",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.66",
+  "version": "0.6.68",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_1108b7.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_1108b7.py
@@ -1075,15 +1075,19 @@ def _original_main(stdin_bytes):
         sessions_dir = str(Path(project_dir) / ".agents" / "sessions")
         session_logs = get_today_session_logs(sessions_dir)
 
-        # Fail-open when no session logs exist. Subagents legitimately have no
-        # session log, and with no evidence store to check against the gate
-        # cannot distinguish a true completion claim from a false one; blocking
-        # only taxes legitimate subagent commits whose -F / --body-file body is
-        # un-inspectable (heredoc, shell variable, temp file, or a path outside
-        # the trusted allowlist). The main-loop case is handled by the
-        # ``elif session_logs`` branch below, which still requires evidence, so
-        # an unreadable body cannot bypass the gate when a session exists
-        # (issue #3178).
+        # No today logs: fall through to the yesterday check below. The
+        # fail-open for subagents applies only when NO session log exists at
+        # all (neither today nor yesterday, or the sessions dir is unreadable).
+        # A subagent legitimately has no session log, and with no evidence
+        # store the gate cannot distinguish a true completion claim from a
+        # false one, so blocking only taxes legitimate subagent commits whose
+        # -F / --body-file body is un-inspectable (heredoc, shell variable,
+        # temp file, or a path outside the trusted allowlist). When yesterday's
+        # logs DO exist they are still evaluated: evidence there allows
+        # (cross-midnight continuation), its absence blocks. The main-loop case
+        # (today's logs present) is handled by the ``elif session_logs`` branch
+        # below, which still requires evidence, so an unreadable body cannot
+        # bypass the gate when a session exists (issue #3178).
         if not session_logs:
             # No today logs: check yesterday (cross-midnight continuation).
             sessions_path = Path(sessions_dir)

--- a/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_1108b7.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_1108b7.py
@@ -707,10 +707,16 @@ def _original_main(stdin_bytes):
         Returns a tuple ``(has_claim, body_unreadable)``.
 
         ``body_unreadable`` is True when ``-F`` was specified but the file
-        could not be read (outside trusted paths or I/O error). Callers use
-        that signal to keep the fail-closed contract end-to-end: when the
-        body cannot be inspected, the gate cannot fall through to the
-        "no session log => allow" branch.
+        could not be read (outside trusted paths or I/O error). In that case
+        ``has_claim`` is also True so the command is still routed through the
+        session-log evidence check instead of being skipped.
+
+        The production caller in ``main`` consumes only ``has_claim`` and
+        discards ``body_unreadable`` (issue #3178): an un-inspectable body no
+        longer forces a block on its own. When a session log exists the
+        evidence check still gates the commit; when none exists (subagents),
+        the gate fails open. ``body_unreadable`` stays in the return contract
+        for callers and tests that assert the read outcome directly.
         """
         message_file = _extract_commit_message_file(command)
         if message_file is None:
@@ -741,9 +747,12 @@ def _original_main(stdin_bytes):
         """Check if a gh pr create --body-file contains completion signals.
 
         Uses the same path containment as commit message files (CWE-22).
-        Returns a tuple ``(has_claim, body_unreadable)`` so callers can keep
-        the fail-closed contract end-to-end (see
-        ``_is_completion_claim_in_message_file``).
+        Returns a tuple ``(has_claim, body_unreadable)`` mirroring
+        ``_is_completion_claim_in_message_file``: an unreadable body yields
+        ``(True, True)`` so the command is routed to the evidence check, and
+        the production caller consumes only ``has_claim`` (issue #3178). The
+        ``body_unreadable`` element stays in the contract for tests and
+        callers that inspect the read outcome directly.
         """
         body_file = _extract_pr_body_file(command)
         if body_file is None:

--- a/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_1108b7.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_1108b7.py
@@ -356,8 +356,12 @@ def _original_main(stdin_bytes):
     Bypass conditions:
     - SKIP_COMPLETION_GATE=true environment variable
     - Documentation-only changes (*.md files only)
-    - No session log present (fail-open), unless the completion claim was
-      inferred from an unreadable -F / --body-file (fail-closed)
+    - No session log present (fail-open). Subagents legitimately have no
+      session log, so with no evidence store to check against the gate cannot
+      distinguish a true completion claim from a false one and fails open even
+      when the -F / --body-file body is un-inspectable (issue #3178). The
+      main-loop case (session log present) still requires evidence, so an
+      unreadable body cannot bypass the gate when a session exists.
     - Non-commit/non-PR/non-merge commands
 
     Hook Type: PreToolUse (blocking on match)
@@ -381,6 +385,7 @@ def _original_main(stdin_bytes):
     import time
     from datetime import UTC, datetime, timedelta
     from pathlib import Path
+    from typing import Any
 
     # --- Standard hook boilerplate ---
     _plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
@@ -485,12 +490,12 @@ def _original_main(stdin_bytes):
                 timeout=_GIT_TIMEOUT_SECONDS,
             )
         except (OSError, subprocess.TimeoutExpired):
-            return get_project_directory()
+            return str(get_project_directory())
         if result.returncode == 0:
             top = result.stdout.strip()
             if top:
                 return str(Path(top).resolve())
-        return get_project_directory()
+        return str(get_project_directory())
 
 
     # Completion signal patterns in commit messages / PR titles
@@ -555,7 +560,7 @@ def _original_main(stdin_bytes):
     ]
 
 
-    def _read_stdin_json() -> dict | None:
+    def _read_stdin_json() -> dict[str, Any] | None:
         """Read and parse JSON from stdin (Claude hook input)."""
         if sys.stdin.isatty():
             return None
@@ -563,12 +568,13 @@ def _original_main(stdin_bytes):
             data = sys.stdin.read().strip()
             if not data:
                 return None
-            return json.loads(data)
+            parsed = json.loads(data)
         except (json.JSONDecodeError, OSError):
             return None
+        return parsed if isinstance(parsed, dict) else None
 
 
-    def _extract_command(hook_input: dict) -> str:
+    def _extract_command(hook_input: dict[str, Any]) -> str:
         """Extract the command string from hook input.
 
         Defends against malformed input where ``hook_input``, ``tool_input``,
@@ -1020,20 +1026,13 @@ def _original_main(stdin_bytes):
         # For `gh pr create --body-file <file>`, also check the body file contents.
         # `gh pr merge` is always treated as a completion claim since merging is
         # an inherent "done" action that requires verification evidence.
-        msg_claim, msg_unreadable = _is_completion_claim_in_message_file(command)
-        body_claim, body_unreadable = _is_completion_claim_in_pr_body_file(command)
+        msg_claim, _ = _is_completion_claim_in_message_file(command)
+        body_claim, _ = _is_completion_claim_in_pr_body_file(command)
         has_completion_claim = (
             _is_completion_claim(command) or msg_claim or body_claim or bool(is_pr_merge)
         )
         if not has_completion_claim:
             sys.exit(0)
-
-        # ``body_inferred`` is true when the completion claim was inferred from
-        # a body file that could not be read (commit -F / pr create --body-file
-        # pointing outside trusted paths). The fail-closed contract on those
-        # helpers must propagate: when we cannot read the body, we cannot fall
-        # through to the "no session log => allow" branch below.
-        body_inferred = msg_unreadable or body_unreadable
 
         # Resolve the CURRENT worktree, not the MAIN checkout. In a linked
         # worktree ``CLAUDE_PROJECT_DIR`` points at main, so the session dir and
@@ -1053,11 +1052,16 @@ def _original_main(stdin_bytes):
         sessions_dir = str(Path(project_dir) / ".agents" / "sessions")
         session_logs = get_today_session_logs(sessions_dir)
 
-        # Fail-open when no session logs exist, EXCEPT when the completion
-        # claim was inferred from an unreadable body file. In that case we
-        # honor the fail-closed contract on the body-file helpers and require
-        # verification before allowing the command through.
-        if not session_logs and not body_inferred:
+        # Fail-open when no session logs exist. Subagents legitimately have no
+        # session log, and with no evidence store to check against the gate
+        # cannot distinguish a true completion claim from a false one; blocking
+        # only taxes legitimate subagent commits whose -F / --body-file body is
+        # un-inspectable (heredoc, shell variable, temp file, or a path outside
+        # the trusted allowlist). The main-loop case is handled by the
+        # ``elif session_logs`` branch below, which still requires evidence, so
+        # an unreadable body cannot bypass the gate when a session exists
+        # (issue #3178).
+        if not session_logs:
             # No today logs: check yesterday (cross-midnight continuation).
             sessions_path = Path(sessions_dir)
             if sessions_path.is_dir():

--- a/tests/test_false_completion_gate.py
+++ b/tests/test_false_completion_gate.py
@@ -412,16 +412,20 @@ class TestBodyFileFailClosed:
             'gh pr create --title "x"'
         ) == (False, False)
 
-    def test_unreadable_body_file_blocks_even_with_no_session_logs(
+    def test_unreadable_body_file_allows_when_no_session_logs(
         self, tmp_path: Path
     ) -> None:
-        """Regression for Cursor BugBot PRRT_kwDOQoWRls6EfZri.
+        """Subagent context (no session log) fails open (issue #3178).
 
-        When ``gh pr create --body-file`` points at a file outside the
-        trusted allowlist the helper returns the fail-closed claim. The
-        gate's caller MUST honor that signal even when there are no
-        session logs for today; otherwise the no-session fail-open path
-        silently bypasses the fail-closed contract.
+        Workflow subagents legitimately have no session log. When the
+        ``-F`` / ``--body-file`` body is un-inspectable (heredoc, shell
+        variable, temp file, or a path outside the trusted allowlist) the
+        helper infers a completion claim, but with no session log there is
+        no evidence store to check against, so the gate cannot distinguish
+        a true claim from a false one. Blocking only taxes legitimate
+        subagent commits, so the gate fails open. The main-loop case
+        (session log present) is covered by
+        ``test_unreadable_body_file_still_blocks_with_session_log``.
         """
         outside = tmp_path.parent / "definitely-outside" / "body.md"
         hook_input = {
@@ -439,6 +443,78 @@ class TestBodyFileFailClosed:
             invoke_false_completion_gate, "_is_documentation_only", return_value=False,
         ), patch.object(
             invoke_false_completion_gate, "get_today_session_logs", return_value=[],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                invoke_false_completion_gate.main()
+            assert exc_info.value.code == 0
+
+    def test_subagent_commit_dash_f_unreadable_no_session_log_allowed(
+        self, tmp_path: Path
+    ) -> None:
+        """Acceptance (issue #3178): subagent ``git commit -F`` fails open.
+
+        A subagent commit using ``git commit -F <file>`` where the path is
+        un-inspectable at scan time (here a missing temp file standing in
+        for a shell variable or heredoc) and NO session log exists is
+        allowed, not blocked.
+        """
+        missing = tmp_path / "does-not-exist-msg.txt"
+        hook_input = {
+            "tool_input": {"command": f"git commit -F {missing}"},
+        }
+        with patch.object(
+            invoke_false_completion_gate, "skip_if_consumer_repo", return_value=False
+        ), patch.object(
+            invoke_false_completion_gate, "_read_stdin_json", return_value=hook_input,
+        ), patch.object(
+            invoke_false_completion_gate,
+            "_resolve_worktree_root",
+            return_value=str(tmp_path),
+        ), patch.object(
+            invoke_false_completion_gate, "_is_documentation_only", return_value=False,
+        ), patch.object(
+            invoke_false_completion_gate, "get_today_session_logs", return_value=[],
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                invoke_false_completion_gate.main()
+            assert exc_info.value.code == 0
+
+    def test_unreadable_body_file_still_blocks_with_session_log(
+        self, tmp_path: Path
+    ) -> None:
+        """No bypass (issue #3178): a session log keeps the gate enforced.
+
+        When a session log exists (interactive main-loop context), an
+        unreadable ``-F`` body cannot bypass the gate: verification
+        evidence must still be present in the session log. Without it the
+        commit is blocked, proving the #3178 fail-open only applies to the
+        genuine no-session-log subagent case.
+        """
+        sessions_dir = tmp_path / ".agents" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        log = sessions_dir / "2026-01-01-session-001.json"
+        log.write_text(json.dumps({"work": []}), encoding="utf-8")
+
+        missing = tmp_path / "does-not-exist-msg.txt"
+        hook_input = {
+            "tool_input": {"command": f"git commit -F {missing}"},
+        }
+        with patch.object(
+            invoke_false_completion_gate, "skip_if_consumer_repo", return_value=False
+        ), patch.object(
+            invoke_false_completion_gate, "_read_stdin_json", return_value=hook_input,
+        ), patch.object(
+            invoke_false_completion_gate,
+            "_resolve_worktree_root",
+            return_value=str(tmp_path),
+        ), patch.object(
+            invoke_false_completion_gate, "_is_documentation_only", return_value=False,
+        ), patch.object(
+            invoke_false_completion_gate, "get_today_session_logs", return_value=[log],
+        ), patch.object(
+            invoke_false_completion_gate,
+            "_has_verification_evidence_across_logs",
+            return_value=False,
         ):
             with pytest.raises(SystemExit) as exc_info:
                 invoke_false_completion_gate.main()


### PR DESCRIPTION
## Summary

The false-completion-gate PreToolUse hook over-blocked commits made by workflow subagents, which legitimately have no session log. When a commit or PR used `-F` / `--body-file` with an un-inspectable body (heredoc, shell variable, temp file, or a path outside the trusted allowlist), the helper inferred a completion claim and `body_inferred` disabled the no-session-log fail-open branch, forcing a block. Subagents fixing #3102, #3148, and #3089 each hit this repeatedly on 2026-07-17.

## Fix

Fail open whenever no session log exists, regardless of body readability. With no session log there is no evidence store to check against, so the gate cannot distinguish a true completion claim from a false one; blocking only taxes legitimate subagent commits. The main-loop case is unchanged: when a session log is present the evidence branch still requires verification, so an unreadable body cannot bypass the gate when a session exists.

The `_is_completion_claim_in_*` helpers keep their fail-closed return signal (unchanged); only the gate's no-session-log decision changed. The now-dead `body_inferred` machinery is removed.

## Acceptance criteria (from #3178)

- A subagent commit `git commit -F <unreadable>` with a completion word and NO session log is allowed. Covered by `test_subagent_commit_dash_f_unreadable_no_session_log_allowed`.
- The main-loop case (session log present, claim without evidence) still blocks (no bypass). Covered by `test_unreadable_body_file_still_blocks_with_session_log`.
- Regression tests alongside the existing #3089 tests. The helper-level fail-closed tests are unchanged and still pass.

## Incidental fix

Editing the hook surfaced 5 pre-existing latent mypy errors (Python 3.14 `json.load` returns `Any`, bare `dict` generics, `Any`-typed imported `get_project_directory`). Fixed idiomatically: added `typing.Any`, coerced returns to `str`, annotated `dict[str, Any]`, and guarded `json.loads` with an `isinstance` check (also rejects non-dict JSON). No suppressions.

## Testing

- `uv run pytest tests/test_false_completion_gate.py` : 76 passed.
- `uv run ruff check` and `uv run --frozen --extra dev mypy` on the hook and tests: clean.
- Regenerated the Copilot shim via the build generator; drift check clean after commit. Both plugin manifests bumped to 0.6.68 (parity gate).
- Full pre-push suite: 29 checks, all passed.

## Security review

Inline threat model: the fail-open triggers only with zero session logs, where the gate has no evidence to enforce against and a trivial bypass (inline `-m "done"`) already existed. The main-loop enforcement (session log present) is unchanged. No new exploitable surface; verdict OK.

Fixes #3178
Refs #3089

## References

- Canonical hook: see `.claude/hooks/PreToolUse/invoke_false_completion_gate.py`
- Generated Copilot shim regenerated by `build/scripts/build_all.py`

