### PR TITLE
fix(hooks): port post-merge dispatcher hardening to current main (#3200)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.66",
+  "version": "0.6.67",
   "author": {
     "name": "rjmurillo"
   }

--- a/build/scripts/generate_dispatcher.py
+++ b/build/scripts/generate_dispatcher.py
@@ -87,12 +87,35 @@ from _bootstrap import ensure_plugin_paths  # noqa: E402
 # and observe events allow without dispatching a truncated payload.
 _MAX_STDIN_BYTES = __HOOK_STDIN_CEILING_MIB__ * 1024 * 1024
 _GATE_EVENTS = ("PreToolUse", "preToolUse")
+# The event this dispatcher was generated for, baked in at generation time.
+# The manifest 'event' must equal it exactly before any mode selection, so
+# editing the manifest cannot rebind a gate dispatcher to an observer event
+# and convert a fail-closed gate into fail-open behavior (#3200, #3074).
+_GENERATED_EVENT = __GENERATED_EVENT__
+# Bound manifest-controlled diagnostics. repr() escapes control characters
+# (no log injection, CWE-117) and the cap prevents an oversized manifest value
+# from emitting unbounded stderr (CWE-400). #3200.
+_MAX_DIAG_CHARS = 512
+
+
+def _diag(value):
+    text = repr(value)
+    if len(text) > _MAX_DIAG_CHARS:
+        return text[:_MAX_DIAG_CHARS] + "...(truncated)"
+    return text
 
 
 def _manifest_event(manifest):
     event = manifest.get("event")
     if not isinstance(event, str):
         raise TypeError("manifest field 'event' must be a string")
+    if event != _GENERATED_EVENT:
+        raise ValueError(
+            "manifest field 'event' must equal the generated event "
+            + _diag(_GENERATED_EVENT)
+            + ", got "
+            + _diag(event)
+        )
     return event
 
 
@@ -127,10 +150,20 @@ def _manifest_timeouts(manifest, shims):
             raise TypeError("manifest field 'shims' must contain strings")
         if shim not in timeouts:
             continue
-        timeout_sec = int(timeouts[shim])
-        if timeout_sec <= 0:
-            raise ValueError(f"manifest timeout for {shim} must be positive")
-        shim_timeouts[shim] = timeout_sec
+        timeout_value = timeouts[shim]
+        # Accept only a positive, non-boolean JSON integer. int(True) is 1 and
+        # int(3.9)/int("5") silently coerce, so a bool, float, or numeric string
+        # must be rejected rather than coerced (#3200).
+        if isinstance(timeout_value, bool) or not isinstance(timeout_value, int):
+            raise TypeError(
+                "manifest timeout for " + _diag(shim)
+                + " must be a non-boolean integer, got " + _diag(timeout_value)
+            )
+        if timeout_value <= 0:
+            raise ValueError(
+                "manifest timeout for " + _diag(shim) + " must be positive"
+            )
+        shim_timeouts[shim] = timeout_value
     return shim_timeouts
 
 
@@ -153,7 +186,7 @@ def _read_payload(event, shims, short_circuit):
     )
     print(
         f"hook-dispatch-entrypoint: stdin exceeds {_MAX_STDIN_BYTES} bytes "
-        f"for event {event} shims={shims}; {verdict}",
+        f"for event {_diag(event)} shims={_diag(shims)}; {verdict}",
         file=sys.stderr,
     )
     return raw, 2 if short_circuit else 0
@@ -172,7 +205,8 @@ def _main() -> int:
         return run_dispatch(event_dir, shims, raw, shim_timeouts, short_circuit=short_circuit)
     except Exception as exc:  # noqa: BLE001 - generated entrypoint must fail closed
         print(
-            f"hook-dispatch-entrypoint: {type(exc).__name__}: {exc}; denying (fail-closed)",
+            f"hook-dispatch-entrypoint: {type(exc).__name__}: "
+            f"{_diag(str(exc))}; denying (fail-closed)",
             file=sys.stderr,
         )
         return 2
@@ -333,10 +367,17 @@ def _copy_bootstrap(event_dir: Path) -> Path:
     return dest
 
 
-def write_entrypoint(event_dir: Path) -> Path:
-    """Write the dispatcher entrypoint next to the shims; return its path."""
+def write_entrypoint(event_dir: Path, event: str) -> Path:
+    """Write the dispatcher entrypoint next to the shims; return its path.
+
+    ``event`` is baked into the entrypoint as ``_GENERATED_EVENT`` (via a
+    ``repr`` so any event string is a safe Python literal), so the generated
+    dispatcher rejects any manifest whose ``event`` field differs from the
+    event it was generated for before any mode selection (#3200).
+    """
     entry_path = event_dir / "_dispatch.py"
-    entry_path.write_text(_ENTRYPOINT, encoding="utf-8")
+    source = _ENTRYPOINT.replace("__GENERATED_EVENT__", repr(event))
+    entry_path.write_text(source, encoding="utf-8")
     return entry_path
 
 
@@ -360,7 +401,7 @@ def emit_dispatcher(
     """
     _remove_stale_matcher_shims(event_dir, shim_names)
     write_manifest(event_dir, event, shim_names, shim_timeouts, mode=mode)
-    write_entrypoint(event_dir)
+    write_entrypoint(event_dir, event)
     _copy_bootstrap(event_dir)
     return dispatcher_entry(event, timeout_sec, matcher)
 

--- a/build/scripts/generate_hooks_shim.py
+++ b/build/scripts/generate_hooks_shim.py
@@ -346,11 +346,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.66",
+  "version": "0.6.67",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PostToolUse/_dispatch.py
+++ b/src/copilot-cli/hooks/PostToolUse/_dispatch.py
@@ -18,12 +18,35 @@ from _bootstrap import ensure_plugin_paths  # noqa: E402
 # and observe events allow without dispatching a truncated payload.
 _MAX_STDIN_BYTES = 64 * 1024 * 1024
 _GATE_EVENTS = ("PreToolUse", "preToolUse")
+# The event this dispatcher was generated for, baked in at generation time.
+# The manifest 'event' must equal it exactly before any mode selection, so
+# editing the manifest cannot rebind a gate dispatcher to an observer event
+# and convert a fail-closed gate into fail-open behavior (#3200, #3074).
+_GENERATED_EVENT = 'PostToolUse'
+# Bound manifest-controlled diagnostics. repr() escapes control characters
+# (no log injection, CWE-117) and the cap prevents an oversized manifest value
+# from emitting unbounded stderr (CWE-400). #3200.
+_MAX_DIAG_CHARS = 512
+
+
+def _diag(value):
+    text = repr(value)
+    if len(text) > _MAX_DIAG_CHARS:
+        return text[:_MAX_DIAG_CHARS] + "...(truncated)"
+    return text
 
 
 def _manifest_event(manifest):
     event = manifest.get("event")
     if not isinstance(event, str):
         raise TypeError("manifest field 'event' must be a string")
+    if event != _GENERATED_EVENT:
+        raise ValueError(
+            "manifest field 'event' must equal the generated event "
+            + _diag(_GENERATED_EVENT)
+            + ", got "
+            + _diag(event)
+        )
     return event
 
 
@@ -58,10 +81,20 @@ def _manifest_timeouts(manifest, shims):
             raise TypeError("manifest field 'shims' must contain strings")
         if shim not in timeouts:
             continue
-        timeout_sec = int(timeouts[shim])
-        if timeout_sec <= 0:
-            raise ValueError(f"manifest timeout for {shim} must be positive")
-        shim_timeouts[shim] = timeout_sec
+        timeout_value = timeouts[shim]
+        # Accept only a positive, non-boolean JSON integer. int(True) is 1 and
+        # int(3.9)/int("5") silently coerce, so a bool, float, or numeric string
+        # must be rejected rather than coerced (#3200).
+        if isinstance(timeout_value, bool) or not isinstance(timeout_value, int):
+            raise TypeError(
+                "manifest timeout for " + _diag(shim)
+                + " must be a non-boolean integer, got " + _diag(timeout_value)
+            )
+        if timeout_value <= 0:
+            raise ValueError(
+                "manifest timeout for " + _diag(shim) + " must be positive"
+            )
+        shim_timeouts[shim] = timeout_value
     return shim_timeouts
 
 
@@ -84,7 +117,7 @@ def _read_payload(event, shims, short_circuit):
     )
     print(
         f"hook-dispatch-entrypoint: stdin exceeds {_MAX_STDIN_BYTES} bytes "
-        f"for event {event} shims={shims}; {verdict}",
+        f"for event {_diag(event)} shims={_diag(shims)}; {verdict}",
         file=sys.stderr,
     )
     return raw, 2 if short_circuit else 0
@@ -103,7 +136,8 @@ def _main() -> int:
         return run_dispatch(event_dir, shims, raw, shim_timeouts, short_circuit=short_circuit)
     except Exception as exc:  # noqa: BLE001 - generated entrypoint must fail closed
         print(
-            f"hook-dispatch-entrypoint: {type(exc).__name__}: {exc}; denying (fail-closed)",
+            f"hook-dispatch-entrypoint: {type(exc).__name__}: "
+            f"{_diag(str(exc))}; denying (fail-closed)",
             file=sys.stderr,
         )
         return 2

--- a/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_adr_lifecycle_hook__Write_Edit_c39898.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_lsp_read_tracker__Read_852b43.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PostToolUse/invoke_lsp_usage_tracker__mcp_serena_find_symbol_find_referencing_symbols_34dc50.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_lsp_usage_tracker__mcp_serena_find_symbol_find_referencing_symbols_34dc50.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PostToolUse/invoke_markdown_auto_lint__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_markdown_auto_lint__Write_Edit_c39898.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_observation_sync__mcp_serena_write_memory_d88228.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PostToolUse/invoke_plan_state_sync__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PostToolUse/invoke_plan_state_sync__Write_Edit_c39898.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/_dispatch.py
+++ b/src/copilot-cli/hooks/PreToolUse/_dispatch.py
@@ -18,12 +18,35 @@ from _bootstrap import ensure_plugin_paths  # noqa: E402
 # and observe events allow without dispatching a truncated payload.
 _MAX_STDIN_BYTES = 64 * 1024 * 1024
 _GATE_EVENTS = ("PreToolUse", "preToolUse")
+# The event this dispatcher was generated for, baked in at generation time.
+# The manifest 'event' must equal it exactly before any mode selection, so
+# editing the manifest cannot rebind a gate dispatcher to an observer event
+# and convert a fail-closed gate into fail-open behavior (#3200, #3074).
+_GENERATED_EVENT = 'PreToolUse'
+# Bound manifest-controlled diagnostics. repr() escapes control characters
+# (no log injection, CWE-117) and the cap prevents an oversized manifest value
+# from emitting unbounded stderr (CWE-400). #3200.
+_MAX_DIAG_CHARS = 512
+
+
+def _diag(value):
+    text = repr(value)
+    if len(text) > _MAX_DIAG_CHARS:
+        return text[:_MAX_DIAG_CHARS] + "...(truncated)"
+    return text
 
 
 def _manifest_event(manifest):
     event = manifest.get("event")
     if not isinstance(event, str):
         raise TypeError("manifest field 'event' must be a string")
+    if event != _GENERATED_EVENT:
+        raise ValueError(
+            "manifest field 'event' must equal the generated event "
+            + _diag(_GENERATED_EVENT)
+            + ", got "
+            + _diag(event)
+        )
     return event
 
 
@@ -58,10 +81,20 @@ def _manifest_timeouts(manifest, shims):
             raise TypeError("manifest field 'shims' must contain strings")
         if shim not in timeouts:
             continue
-        timeout_sec = int(timeouts[shim])
-        if timeout_sec <= 0:
-            raise ValueError(f"manifest timeout for {shim} must be positive")
-        shim_timeouts[shim] = timeout_sec
+        timeout_value = timeouts[shim]
+        # Accept only a positive, non-boolean JSON integer. int(True) is 1 and
+        # int(3.9)/int("5") silently coerce, so a bool, float, or numeric string
+        # must be rejected rather than coerced (#3200).
+        if isinstance(timeout_value, bool) or not isinstance(timeout_value, int):
+            raise TypeError(
+                "manifest timeout for " + _diag(shim)
+                + " must be a non-boolean integer, got " + _diag(timeout_value)
+            )
+        if timeout_value <= 0:
+            raise ValueError(
+                "manifest timeout for " + _diag(shim) + " must be positive"
+            )
+        shim_timeouts[shim] = timeout_value
     return shim_timeouts
 
 
@@ -84,7 +117,7 @@ def _read_payload(event, shims, short_circuit):
     )
     print(
         f"hook-dispatch-entrypoint: stdin exceeds {_MAX_STDIN_BYTES} bytes "
-        f"for event {event} shims={shims}; {verdict}",
+        f"for event {_diag(event)} shims={_diag(shims)}; {verdict}",
         file=sys.stderr,
     )
     return raw, 2 if short_circuit else 0
@@ -103,7 +136,8 @@ def _main() -> int:
         return run_dispatch(event_dir, shims, raw, shim_timeouts, short_circuit=short_circuit)
     except Exception as exc:  # noqa: BLE001 - generated entrypoint must fail closed
         print(
-            f"hook-dispatch-entrypoint: {type(exc).__name__}: {exc}; denying (fail-closed)",
+            f"hook-dispatch-entrypoint: {type(exc).__name__}: "
+            f"{_diag(str(exc))}; denying (fail-closed)",
             file=sys.stderr,
         )
         return 2

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_architect_gate__Edit_Write_1da157.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_context_guard__Bash_git_push_0e93bf.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_branch_protection_guard__Bash_git_push_0e93bf.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_1108b7.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_false_completion_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_1108b7.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_hook_drift_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_hook_drift_guard__Bash_git_push_0e93bf.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_install_parity_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_install_parity_guard__Bash_git_push_0e93bf.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_bash_grep_guard__Bash_gG_rR_eE_pP_rR_gG_aA_gG_aA_cC_kK_gG_rR_eE_p_af1b8d.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_bash_grep_guard__Bash_gG_rR_eE_pP_rR_gG_aA_gG_aA_cC_kK_gG_rR_eE_p_af1b8d.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_glob_guard__Glob_181cd6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_glob_guard__Glob_181cd6.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_grep_guard__Grep_2589b1.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_grep_guard__Grep_2589b1.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Agent_5ce2e6.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_pre_delegation_guard__Task_7bb0dd.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_lsp_read_guard__Read_852b43.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_markdownlint_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_markdownlint_guard__Bash_git_push_0e93bf.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_plugin_version_bump_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_plugin_version_bump_guard__Bash_git_push_0e93bf.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_pr_description_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_pr_description_guard__Bash_git_push_0e93bf.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_prompt_eval_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_retrospective_gate__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_retrospective_gate__Bash_git_push_0e93bf.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_routing_gates__Bash_gG_hH_pP_rR_cC_rR_eE_aA_tT_eE_gG_hH_pP_rR_m_61839c.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_routing_gates__Bash_gG_hH_pP_rR_cC_rR_eE_aA_tT_eE_gG_hH_pP_rR_m_61839c.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_security_commit_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_security_commit_gate__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_security_gate__Write_Edit_c39898.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_security_gate__Write_Edit_c39898.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_field_guard__Bash_git_push_0e93bf.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_field_guard__Bash_git_push_0e93bf.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gG_hH_pP_rR_cC_rR_eE_aA_tT_eE_gG_hH_exe_pP_de420a.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gG_hH_pP_rR_cC_rR_eE_aA_tT_eE_gG_hH_exe_pP_de420a.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_session_log_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/PreToolUse/invoke_skill_first_guard__Bash_gG_hH_gG_hH_exe_gG_hH_gG_hH_gG_hH_gG_hH_eE_53dbd6.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_skill_first_guard__Bash_gG_hH_gG_hH_exe_gG_hH_gG_hH_gG_hH_gG_hH_eE_53dbd6.py
@@ -180,11 +180,27 @@ def _shim_candidate_payloads(payload):
                     len(tool_calls), _MAX_MATCHER_TOOL_CALLS
                 )
             )
-        if not tool_calls and (
-            "tool_name" in payload or "toolName" in payload
-        ):
+        # A payload may carry top-level action fields OR a `toolCalls` batch,
+        # never both: the host precedence contract between the two shapes is
+        # unverified, so a top-level Read alongside a Bash in `toolCalls` is
+        # ambiguous. Reject any mix (empty or non-empty batch) before a guard
+        # ever sees a candidate (#3200).
+        conflicting = [
+            field
+            for field in (
+                "tool_name",
+                "toolName",
+                "tool_input",
+                "toolArgs",
+                "tool_call_id",
+                "toolCallId",
+            )
+            if field in payload
+        ]
+        if conflicting:
             raise ValueError(
-                "empty toolCalls conflicts with top-level tool_name/toolName"
+                "toolCalls conflicts with top-level action fields: "
+                + ", ".join(conflicting)
             )
         for index, call in enumerate(tool_calls):
             if not isinstance(call, dict):

--- a/src/copilot-cli/hooks/SessionEnd/_dispatch.py
+++ b/src/copilot-cli/hooks/SessionEnd/_dispatch.py
@@ -18,12 +18,35 @@ from _bootstrap import ensure_plugin_paths  # noqa: E402
 # and observe events allow without dispatching a truncated payload.
 _MAX_STDIN_BYTES = 64 * 1024 * 1024
 _GATE_EVENTS = ("PreToolUse", "preToolUse")
+# The event this dispatcher was generated for, baked in at generation time.
+# The manifest 'event' must equal it exactly before any mode selection, so
+# editing the manifest cannot rebind a gate dispatcher to an observer event
+# and convert a fail-closed gate into fail-open behavior (#3200, #3074).
+_GENERATED_EVENT = 'SessionEnd'
+# Bound manifest-controlled diagnostics. repr() escapes control characters
+# (no log injection, CWE-117) and the cap prevents an oversized manifest value
+# from emitting unbounded stderr (CWE-400). #3200.
+_MAX_DIAG_CHARS = 512
+
+
+def _diag(value):
+    text = repr(value)
+    if len(text) > _MAX_DIAG_CHARS:
+        return text[:_MAX_DIAG_CHARS] + "...(truncated)"
+    return text
 
 
 def _manifest_event(manifest):
     event = manifest.get("event")
     if not isinstance(event, str):
         raise TypeError("manifest field 'event' must be a string")
+    if event != _GENERATED_EVENT:
+        raise ValueError(
+            "manifest field 'event' must equal the generated event "
+            + _diag(_GENERATED_EVENT)
+            + ", got "
+            + _diag(event)
+        )
     return event
 
 
@@ -58,10 +81,20 @@ def _manifest_timeouts(manifest, shims):
             raise TypeError("manifest field 'shims' must contain strings")
         if shim not in timeouts:
             continue
-        timeout_sec = int(timeouts[shim])
-        if timeout_sec <= 0:
-            raise ValueError(f"manifest timeout for {shim} must be positive")
-        shim_timeouts[shim] = timeout_sec
+        timeout_value = timeouts[shim]
+        # Accept only a positive, non-boolean JSON integer. int(True) is 1 and
+        # int(3.9)/int("5") silently coerce, so a bool, float, or numeric string
+        # must be rejected rather than coerced (#3200).
+        if isinstance(timeout_value, bool) or not isinstance(timeout_value, int):
+            raise TypeError(
+                "manifest timeout for " + _diag(shim)
+                + " must be a non-boolean integer, got " + _diag(timeout_value)
+            )
+        if timeout_value <= 0:
+            raise ValueError(
+                "manifest timeout for " + _diag(shim) + " must be positive"
+            )
+        shim_timeouts[shim] = timeout_value
     return shim_timeouts
 
 
@@ -84,7 +117,7 @@ def _read_payload(event, shims, short_circuit):
     )
     print(
         f"hook-dispatch-entrypoint: stdin exceeds {_MAX_STDIN_BYTES} bytes "
-        f"for event {event} shims={shims}; {verdict}",
+        f"for event {_diag(event)} shims={_diag(shims)}; {verdict}",
         file=sys.stderr,
     )
     return raw, 2 if short_circuit else 0
@@ -103,7 +136,8 @@ def _main() -> int:
         return run_dispatch(event_dir, shims, raw, shim_timeouts, short_circuit=short_circuit)
     except Exception as exc:  # noqa: BLE001 - generated entrypoint must fail closed
         print(
-            f"hook-dispatch-entrypoint: {type(exc).__name__}: {exc}; denying (fail-closed)",
+            f"hook-dispatch-entrypoint: {type(exc).__name__}: "
+            f"{_diag(str(exc))}; denying (fail-closed)",
             file=sys.stderr,
         )
         return 2

--- a/src/copilot-cli/hooks/SessionStart/_dispatch.py
+++ b/src/copilot-cli/hooks/SessionStart/_dispatch.py
@@ -18,12 +18,35 @@ from _bootstrap import ensure_plugin_paths  # noqa: E402
 # and observe events allow without dispatching a truncated payload.
 _MAX_STDIN_BYTES = 64 * 1024 * 1024
 _GATE_EVENTS = ("PreToolUse", "preToolUse")
+# The event this dispatcher was generated for, baked in at generation time.
+# The manifest 'event' must equal it exactly before any mode selection, so
+# editing the manifest cannot rebind a gate dispatcher to an observer event
+# and convert a fail-closed gate into fail-open behavior (#3200, #3074).
+_GENERATED_EVENT = 'SessionStart'
+# Bound manifest-controlled diagnostics. repr() escapes control characters
+# (no log injection, CWE-117) and the cap prevents an oversized manifest value
+# from emitting unbounded stderr (CWE-400). #3200.
+_MAX_DIAG_CHARS = 512
+
+
+def _diag(value):
+    text = repr(value)
+    if len(text) > _MAX_DIAG_CHARS:
+        return text[:_MAX_DIAG_CHARS] + "...(truncated)"
+    return text
 
 
 def _manifest_event(manifest):
     event = manifest.get("event")
     if not isinstance(event, str):
         raise TypeError("manifest field 'event' must be a string")
+    if event != _GENERATED_EVENT:
+        raise ValueError(
+            "manifest field 'event' must equal the generated event "
+            + _diag(_GENERATED_EVENT)
+            + ", got "
+            + _diag(event)
+        )
     return event
 
 
@@ -58,10 +81,20 @@ def _manifest_timeouts(manifest, shims):
             raise TypeError("manifest field 'shims' must contain strings")
         if shim not in timeouts:
             continue
-        timeout_sec = int(timeouts[shim])
-        if timeout_sec <= 0:
-            raise ValueError(f"manifest timeout for {shim} must be positive")
-        shim_timeouts[shim] = timeout_sec
+        timeout_value = timeouts[shim]
+        # Accept only a positive, non-boolean JSON integer. int(True) is 1 and
+        # int(3.9)/int("5") silently coerce, so a bool, float, or numeric string
+        # must be rejected rather than coerced (#3200).
+        if isinstance(timeout_value, bool) or not isinstance(timeout_value, int):
+            raise TypeError(
+                "manifest timeout for " + _diag(shim)
+                + " must be a non-boolean integer, got " + _diag(timeout_value)
+            )
+        if timeout_value <= 0:
+            raise ValueError(
+                "manifest timeout for " + _diag(shim) + " must be positive"
+            )
+        shim_timeouts[shim] = timeout_value
     return shim_timeouts
 
 
@@ -84,7 +117,7 @@ def _read_payload(event, shims, short_circuit):
     )
     print(
         f"hook-dispatch-entrypoint: stdin exceeds {_MAX_STDIN_BYTES} bytes "
-        f"for event {event} shims={shims}; {verdict}",
+        f"for event {_diag(event)} shims={_diag(shims)}; {verdict}",
         file=sys.stderr,
     )
     return raw, 2 if short_circuit else 0
@@ -103,7 +136,8 @@ def _main() -> int:
         return run_dispatch(event_dir, shims, raw, shim_timeouts, short_circuit=short_circuit)
     except Exception as exc:  # noqa: BLE001 - generated entrypoint must fail closed
         print(
-            f"hook-dispatch-entrypoint: {type(exc).__name__}: {exc}; denying (fail-closed)",
+            f"hook-dispatch-entrypoint: {type(exc).__name__}: "
+            f"{_diag(str(exc))}; denying (fail-closed)",
             file=sys.stderr,
         )
         return 2

--- a/src/copilot-cli/hooks/UserPromptSubmit/_dispatch.py
+++ b/src/copilot-cli/hooks/UserPromptSubmit/_dispatch.py
@@ -18,12 +18,35 @@ from _bootstrap import ensure_plugin_paths  # noqa: E402
 # and observe events allow without dispatching a truncated payload.
 _MAX_STDIN_BYTES = 64 * 1024 * 1024
 _GATE_EVENTS = ("PreToolUse", "preToolUse")
+# The event this dispatcher was generated for, baked in at generation time.
+# The manifest 'event' must equal it exactly before any mode selection, so
+# editing the manifest cannot rebind a gate dispatcher to an observer event
+# and convert a fail-closed gate into fail-open behavior (#3200, #3074).
+_GENERATED_EVENT = 'UserPromptSubmit'
+# Bound manifest-controlled diagnostics. repr() escapes control characters
+# (no log injection, CWE-117) and the cap prevents an oversized manifest value
+# from emitting unbounded stderr (CWE-400). #3200.
+_MAX_DIAG_CHARS = 512
+
+
+def _diag(value):
+    text = repr(value)
+    if len(text) > _MAX_DIAG_CHARS:
+        return text[:_MAX_DIAG_CHARS] + "...(truncated)"
+    return text
 
 
 def _manifest_event(manifest):
     event = manifest.get("event")
     if not isinstance(event, str):
         raise TypeError("manifest field 'event' must be a string")
+    if event != _GENERATED_EVENT:
+        raise ValueError(
+            "manifest field 'event' must equal the generated event "
+            + _diag(_GENERATED_EVENT)
+            + ", got "
+            + _diag(event)
+        )
     return event
 
 
@@ -58,10 +81,20 @@ def _manifest_timeouts(manifest, shims):
             raise TypeError("manifest field 'shims' must contain strings")
         if shim not in timeouts:
             continue
-        timeout_sec = int(timeouts[shim])
-        if timeout_sec <= 0:
-            raise ValueError(f"manifest timeout for {shim} must be positive")
-        shim_timeouts[shim] = timeout_sec
+        timeout_value = timeouts[shim]
+        # Accept only a positive, non-boolean JSON integer. int(True) is 1 and
+        # int(3.9)/int("5") silently coerce, so a bool, float, or numeric string
+        # must be rejected rather than coerced (#3200).
+        if isinstance(timeout_value, bool) or not isinstance(timeout_value, int):
+            raise TypeError(
+                "manifest timeout for " + _diag(shim)
+                + " must be a non-boolean integer, got " + _diag(timeout_value)
+            )
+        if timeout_value <= 0:
+            raise ValueError(
+                "manifest timeout for " + _diag(shim) + " must be positive"
+            )
+        shim_timeouts[shim] = timeout_value
     return shim_timeouts
 
 
@@ -84,7 +117,7 @@ def _read_payload(event, shims, short_circuit):
     )
     print(
         f"hook-dispatch-entrypoint: stdin exceeds {_MAX_STDIN_BYTES} bytes "
-        f"for event {event} shims={shims}; {verdict}",
+        f"for event {_diag(event)} shims={_diag(shims)}; {verdict}",
         file=sys.stderr,
     )
     return raw, 2 if short_circuit else 0
@@ -103,7 +136,8 @@ def _main() -> int:
         return run_dispatch(event_dir, shims, raw, shim_timeouts, short_circuit=short_circuit)
     except Exception as exc:  # noqa: BLE001 - generated entrypoint must fail closed
         print(
-            f"hook-dispatch-entrypoint: {type(exc).__name__}: {exc}; denying (fail-closed)",
+            f"hook-dispatch-entrypoint: {type(exc).__name__}: "
+            f"{_diag(str(exc))}; denying (fail-closed)",
             file=sys.stderr,
         )
         return 2

--- a/tests/build_scripts/test_generate_dispatcher.py
+++ b/tests/build_scripts/test_generate_dispatcher.py
@@ -170,7 +170,7 @@ class TestEmit:
             "    sys.path.insert(0, str(lib))\n",
             encoding="utf-8",
         )
-        gd.write_entrypoint(event_dir)
+        gd.write_entrypoint(event_dir, "preToolUse")
         (event_dir / "_manifest.json").write_text('{"event":"preToolUse"}\n', encoding="utf-8")
         env = dict(__import__("os").environ)
         env["CLAUDE_PLUGIN_ROOT"] = str(root)
@@ -224,7 +224,7 @@ class TestEmit:
             "    sys.path.insert(0, str(lib))\n",
             encoding="utf-8",
         )
-        gd.write_entrypoint(event_dir)
+        gd.write_entrypoint(event_dir, "preToolUse")
         gd.write_manifest(event_dir, "preToolUse", ["a.py"], {"a.py": 0})
         env = dict(__import__("os").environ)
         env["CLAUDE_PLUGIN_ROOT"] = str(root)
@@ -238,7 +238,7 @@ class TestEmit:
         )
 
         assert proc.returncode == 2
-        assert "manifest timeout for a.py must be positive" in proc.stderr.decode()
+        assert "manifest timeout for 'a.py' must be positive" in proc.stderr.decode()
 
     def test_generated_entrypoint_validates_mode_before_shim_entries(self, tmp_path):
         root, event_dir = _stage_plugin(tmp_path, "preToolUse")
@@ -817,3 +817,126 @@ class TestConsolidate:
     def test_consolidate_handles_empty_event(self, tmp_path):
         out = {"PreToolUse": []}
         assert gd.consolidate(out, tmp_path) == {"PreToolUse": []}
+
+
+class TestPostMergeHardening:
+    """Dispatcher hardening ported from PR #3097 (issue #3200).
+
+    Each test runs the GENERATED entrypoint as a subprocess under the verified
+    plugin-root contract, so it exercises the emitted ``_dispatch.py`` rather
+    than a string match against the generator template.
+    """
+
+    def _write_manifest(self, event_dir, manifest):
+        (event_dir / "_manifest.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+
+    def test_matching_event_dispatches(self, tmp_path):
+        # Positive: a manifest whose event equals the generated event runs.
+        root, event_dir = _stage_plugin(tmp_path, "preToolUse")
+        gd.emit_dispatcher(event_dir, "preToolUse", [], 5, mode="gate")
+
+        proc = _run_dispatch_entry(root, event_dir)
+
+        assert proc.returncode == 0, proc.stderr.decode()
+
+    def test_mismatched_event_fails_closed(self, tmp_path):
+        # Negative (#3200 defect 1): flipping the manifest event to another
+        # event with observe mode must be rejected before mode selection, so a
+        # gate dispatcher cannot be rebound into fail-open behavior.
+        root, event_dir = _stage_plugin(tmp_path, "preToolUse")
+        gd.emit_dispatcher(event_dir, "preToolUse", [], 5, mode="gate")
+        self._write_manifest(
+            event_dir,
+            {"event": "postToolUse", "mode": "observe", "shims": []},
+        )
+
+        proc = _run_dispatch_entry(root, event_dir)
+
+        stderr = proc.stderr.decode()
+        assert proc.returncode == 2, stderr
+        assert "must equal the generated event" in stderr
+        assert "'preToolUse'" in stderr
+
+    def test_boolean_timeout_rejected(self, tmp_path):
+        # Negative (#3200 defect 2): int(True) is 1; a boolean timeout must be
+        # rejected, not coerced.
+        root, event_dir = _stage_plugin(tmp_path, "preToolUse")
+        gd.emit_dispatcher(event_dir, "preToolUse", ["a.py"], 5, mode="gate")
+        self._write_manifest(
+            event_dir,
+            {
+                "event": "preToolUse",
+                "mode": "gate",
+                "shims": ["a.py"],
+                "timeouts": {"a.py": True},
+            },
+        )
+
+        proc = _run_dispatch_entry(root, event_dir)
+
+        stderr = proc.stderr.decode()
+        assert proc.returncode == 2, stderr
+        assert "non-boolean integer" in stderr
+
+    @pytest.mark.parametrize("bad_timeout", [1.5, "5", [5]])
+    def test_non_integer_timeout_rejected(self, tmp_path, bad_timeout):
+        # Negative (#3200 defect 2): float, numeric string, and list timeouts
+        # must all reject rather than coerce.
+        root, event_dir = _stage_plugin(tmp_path, "preToolUse")
+        gd.emit_dispatcher(event_dir, "preToolUse", ["a.py"], 5, mode="gate")
+        self._write_manifest(
+            event_dir,
+            {
+                "event": "preToolUse",
+                "mode": "gate",
+                "shims": ["a.py"],
+                "timeouts": {"a.py": bad_timeout},
+            },
+        )
+
+        proc = _run_dispatch_entry(root, event_dir)
+
+        stderr = proc.stderr.decode()
+        assert proc.returncode == 2, stderr
+        assert "non-boolean integer" in stderr
+
+    def test_valid_integer_timeout_accepted(self, tmp_path):
+        # Positive edge: a positive non-boolean integer timeout is accepted and
+        # the dispatcher proceeds (no registered shim => unmatched => allow).
+        root, event_dir = _stage_plugin(tmp_path, "preToolUse")
+        gd.emit_dispatcher(event_dir, "preToolUse", [], 5, mode="gate")
+        self._write_manifest(
+            event_dir,
+            {
+                "event": "preToolUse",
+                "mode": "gate",
+                "shims": [],
+                "timeouts": {},
+            },
+        )
+
+        proc = _run_dispatch_entry(root, event_dir)
+
+        assert proc.returncode == 0, proc.stderr.decode()
+
+    def test_oversized_manifest_value_stderr_is_bounded(self, tmp_path):
+        # Edge (#3200 defect 4): a huge manifest-controlled event value must not
+        # produce unbounded stderr. The diagnostic is repr-escaped and capped.
+        root, event_dir = _stage_plugin(tmp_path, "preToolUse")
+        gd.emit_dispatcher(event_dir, "preToolUse", [], 5, mode="gate")
+        self._write_manifest(
+            event_dir,
+            {"event": "Z" * 5000, "mode": "gate", "shims": []},
+        )
+
+        proc = _run_dispatch_entry(root, event_dir)
+
+        stderr = proc.stderr.decode()
+        assert proc.returncode == 2, stderr
+        assert "hook-dispatch-entrypoint" in stderr
+        assert "truncated" in stderr
+        # The 5000-char manifest value cannot flow verbatim into stderr.
+        assert len(stderr) < 2000
+        assert "Z" * 1000 not in stderr

--- a/tests/build_scripts/test_generate_hooks.py
+++ b/tests/build_scripts/test_generate_hooks.py
@@ -401,9 +401,12 @@ def test_inject_shim_replays_small_match_from_large_multi_call_event():
     assert proc.stdout.startswith(b"FIRED:Edit")
 
 
-def test_inject_shim_mixed_schema_top_level_fields_do_not_bypass_toolcalls_selection():
-    """A benign top-level tool_name/tool_input must not make the guard
-    evaluate the top level instead of the dangerous toolCalls entry."""
+def test_inject_shim_rejects_mixed_top_level_and_toolcalls_selection():
+    """A payload with both a top-level action and a toolCalls batch is
+    ambiguous: the host precedence is unverified, so a benign top-level
+    tool_name must not let a dangerous toolCalls entry slip through under a
+    guessed interpretation. The shim rejects the mix outright (#3200). This
+    replaces the former test that pinned silent toolCalls selection."""
     guard = (
         "import json\n"
         "import sys\n"
@@ -431,9 +434,9 @@ def test_inject_shim_mixed_schema_top_level_fields_do_not_bypass_toolcalls_selec
     proc = _run_shim(transformed, payload)
 
     assert proc.returncode == 2
-    assert proc.stdout.splitlines() == [
-        "EVALUATED:git push origin main --force",
-    ]
+    assert "toolCalls conflicts with top-level action fields" in proc.stderr
+    # The guard never ran: no candidate was ever evaluated.
+    assert "EVALUATED:" not in proc.stdout
 
 
 @pytest.mark.parametrize(
@@ -453,8 +456,6 @@ def test_inject_shim_denies_malformed_toolcalls_before_dispatch(
 ):
     transformed = inject_shim(_TRACE_SCRIPT, "^Edit$")
     payload = {
-        "tool_name": "Edit",
-        "tool_input": {"file_path": "README.md"},
         "toolCalls": [invalid_call],
     }
 
@@ -551,7 +552,13 @@ def test_inject_shim_allows_matching_top_level_name_aliases():
     assert proc.stdout.startswith("FIRED:Edit")
 
 
-def test_inject_shim_batch_replay_removes_conflicting_top_level_aliases():
+def test_inject_shim_rejects_mixed_top_level_and_nonempty_toolcalls():
+    # Hardening (#3200): a payload carrying BOTH top-level action fields and a
+    # non-empty toolCalls batch is ambiguous because the host precedence between
+    # the two shapes is unverified. The shim must reject it before any guard
+    # runs rather than silently drop the top-level aliases and dispatch the
+    # batch. This flips the former silent-drop behavior, which let an attacker
+    # hide a denied action behind a benign top-level alias (or vice versa).
     body = (
         "import json\n"
         "import sys\n"
@@ -578,14 +585,9 @@ def test_inject_shim_batch_replay_removes_conflicting_top_level_aliases():
 
     proc = _run_shim(transformed, payload)
 
-    replay = json.loads(proc.stdout)
-    assert proc.returncode == 0
-    assert replay == {
-        "sessionId": "canonical-batch",
-        "tool_call_id": "batch-call",
-        "tool_input": {"file_path": "README.md"},
-        "tool_name": "Edit",
-    }
+    assert proc.returncode == 2
+    assert "toolCalls conflicts with top-level action fields" in proc.stderr
+    assert proc.stdout == ""
 
 
 @pytest.mark.parametrize("top_level_name_field", ["tool_name", "toolName"])
@@ -603,7 +605,7 @@ def test_inject_shim_denies_empty_toolcalls_with_top_level_tool_name(
     proc = _run_shim(transformed, payload)
 
     assert proc.returncode == 2
-    assert "empty toolCalls" in proc.stderr
+    assert "toolCalls conflicts with top-level action fields" in proc.stderr
     assert "FIRED" not in proc.stdout
 
 
@@ -1733,7 +1735,7 @@ def test_generator_dispatcher_staging_failure_restores_earlier_owner(
     }
     source.write_text("print('new owner')\n", encoding="utf-8")
 
-    def fail_entrypoint(_event_dir: Path) -> Path:
+    def fail_entrypoint(_event_dir: Path, _event: str) -> Path:
         raise OSError("simulated dispatcher staging failure")
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Fixes #3200

Four dispatcher hardening defects were implemented in PR #3097 but lost in a merge race and never reached `main`. This re-applies them against the current generator sources and regenerates all Copilot CLI hook artifacts.

Refs #3074
Refs #3097

## The four defects

1. **Event binding (CWE-284).** Each generated `_dispatch.py` now bakes `_GENERATED_EVENT` via `repr(event)`. `_manifest_event` rejects any manifest whose `event` field differs from the baked value **before** mode selection. Without this, editing a generated manifest could rebind a fail-closed `PreToolUse` gate into a fail-open observer event.
2. **Strict timeout (CWE-20).** `_manifest_timeouts` accepts only a positive, non-boolean integer. A bool, float, or numeric string is rejected instead of silently `int()`-coerced (`int(True)` is `1`; `int("5")` is `5`).
3. **Mixed-schema reject (CWE-284).** `_shim_candidate_payloads` rejects a `toolCalls` batch that coexists with any top-level action field. The host precedence between the two shapes is unverified, so a top-level Read alongside a Bash in `toolCalls` was ambiguous; a guard could inspect one shape while dispatch acted on the other.
4. **Bounded diagnostics (CWE-117, CWE-400).** A new `_diag` helper wraps manifest-controlled values in `repr()` truncated to 512 chars. `repr()` escapes control characters (no stderr log injection); the cap prevents an oversized manifest value from emitting unbounded stderr.

## Tests

- New `TestPostMergeHardening` covers matching-event pass, mismatched-event reject, boolean-timeout reject, non-integer-timeout reject (parametrized `1.5`, `"5"`, `[5]`), valid-integer pass, and oversized-stderr bounding.
- Two tests that pinned the prior silent-drop / silent-select behavior are flipped to assert rejection. Both old and new paths exit 2; the new path is strictly safer (reject instead of guess).
- Targeted plus regression suites: 244 passed / 1 skipped (generators) and 126 passed (dispatcher regression). Pre-push green.

## Plugin version

Both manifests bumped to `0.6.69` (parity gate; resolved above main after intervening plugin PRs merged).

## Security review

Inline review verdict: OK. All four changes are defensive hardening that close gate-bypass and log-injection vectors. No new attack surface; the `repr()`-baked literal makes any event string a safe Python literal.

## References

See `build/scripts/generate_dispatcher.py` and `build/scripts/generate_hooks_shim.py` for the generator sources. Regenerated runtime artifacts live under `src/copilot-cli/hooks/`. Tests are in `tests/build_scripts/test_generate_dispatcher.py` and `tests/build_scripts/test_generate_hooks.py`.

