### PR TITLE
test(memory): lock #3143 causal-graph reconcile regression

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.68",
+  "version": "0.6.69",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.69",
+  "version": "0.6.70",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/memory/tests/test_update_causal_graph.py
+++ b/.claude/skills/memory/tests/test_update_causal_graph.py
@@ -318,3 +318,142 @@ class TestMainFunction:
         ])
         assert result == 0
         assert not graph_file.exists()
+
+
+class TestEpisodeReconcile:
+    """Reprocess-idempotency for an edited episode (regression for #3143).
+
+    #3143: a failed pre-commit retry reprocessed an episode whose milestone
+    label had been corrected. The old content-derived node was left behind, so
+    the committed graph held two nodes for the same episode. The reconcile path
+    (#3058) must retract the stale node while preserving nodes still supported
+    by other episodes.
+    """
+
+    @staticmethod
+    def _milestone_episode(chosen: str) -> dict[str, Any]:
+        return {
+            "id": "episode-2026-07-16-session-3056-record",
+            "timestamp": "2026-07-16T00:00:00",
+            "outcome": "success",
+            "task": "Milestone record",
+            "decisions": [{
+                "type": "milestone",
+                "chosen": chosen,
+                "outcome": "success",
+                "context": "record",
+            }],
+            "events": [],
+            "lessons": [],
+        }
+
+    def test_reprocess_changed_decision_retracts_stale_node(
+        self, tmp_path: Path,
+    ) -> None:
+        """A corrected milestone leaves exactly one milestone node (AC1, AC4)."""
+        ep_dir = tmp_path / "episodes"
+        ep_dir.mkdir()
+        graph_file = tmp_path / "graph.json"
+        ep_file = ep_dir / "episode-2026-07-16-session-3056-record.json"
+
+        ep_file.write_text(json.dumps(
+            self._milestone_episode("filed #3137, #3138, #3139, #3140, and #3141"),
+        ))
+        assert main([
+            "--episode-path", str(ep_file),
+            "--graph-path", str(graph_file),
+        ]) == 0
+
+        # Correct the milestone (same episode id, new content-derived node id).
+        ep_file.write_text(json.dumps(
+            self._milestone_episode(
+                "filed #3137, #3138, #3139, #3140, #3141, and #3142",
+            ),
+        ))
+        assert main([
+            "--episode-path", str(ep_file),
+            "--graph-path", str(graph_file),
+        ]) == 0
+
+        graph = json.loads(graph_file.read_text())
+        milestone_nodes = [
+            n for n in graph["nodes"] if n["label"].startswith("milestone:")
+        ]
+        assert len(milestone_nodes) == 1
+        assert "#3142" in milestone_nodes[0]["label"]
+        # The pre-correction node must be gone, not merely deduplicated.
+        assert not any(
+            n["label"].startswith("milestone:") and "#3142" not in n["label"]
+            for n in graph["nodes"]
+        )
+
+    def test_reprocess_preserves_node_shared_with_other_episode(
+        self, tmp_path: Path,
+    ) -> None:
+        """Retracting one episode keeps a node another episode still supports (AC6)."""
+        ep_dir = tmp_path / "episodes"
+        ep_dir.mkdir()
+        graph_file = tmp_path / "graph.json"
+
+        def design_episode(episode_id: str, chosen: list[str]) -> dict[str, Any]:
+            return {
+                "id": episode_id,
+                "timestamp": "2026-07-16T00:00:00",
+                "outcome": "success",
+                "task": "Design work",
+                "decisions": [
+                    {"type": "design", "chosen": c, "outcome": "success"}
+                    for c in chosen
+                ],
+                "events": [],
+                "lessons": [],
+            }
+
+        ep1 = ep_dir / "episode-one.json"
+        ep2 = ep_dir / "episode-two.json"
+        ep1.write_text(json.dumps(design_episode("episode-one", ["SHARED", "ONLY1"])))
+        ep2.write_text(json.dumps(design_episode("episode-two", ["SHARED"])))
+        assert main([
+            "--episode-path", str(ep_dir),
+            "--graph-path", str(graph_file),
+        ]) == 0
+
+        graph = json.loads(graph_file.read_text())
+        shared = next(n for n in graph["nodes"] if n["label"] == "design: SHARED")
+        assert set(shared["episodes"]) == {"episode-one", "episode-two"}
+
+        # Reprocess only episode-one, dropping both SHARED and ONLY1.
+        ep1.write_text(json.dumps(design_episode("episode-one", ["ONLY1-CHANGED"])))
+        assert main([
+            "--episode-path", str(ep1),
+            "--graph-path", str(graph_file),
+        ]) == 0
+
+        graph = json.loads(graph_file.read_text())
+        labels = {n["label"]: n for n in graph["nodes"]}
+        # Shared node survives, now supported only by episode-two.
+        assert "design: SHARED" in labels
+        assert labels["design: SHARED"]["episodes"] == ["episode-two"]
+        # Episode-one's dropped sole-supporter node is retracted.
+        assert "design: ONLY1" not in labels
+        assert "design: ONLY1-CHANGED" in labels
+
+    def test_unchanged_reprocess_is_byte_idempotent(
+        self, tmp_path: Path,
+    ) -> None:
+        """Reprocessing an unchanged episode changes no bytes (AC2)."""
+        ep_dir = tmp_path / "episodes"
+        ep_dir.mkdir()
+        graph_file = tmp_path / "graph.json"
+        ep_file = ep_dir / "episode-2026-07-16-session-3056-record.json"
+        ep_file.write_text(json.dumps(self._milestone_episode("filed #3141")))
+
+        assert main([
+            "--episode-path", str(ep_file), "--graph-path", str(graph_file),
+        ]) == 0
+        first = graph_file.read_text()
+
+        assert main([
+            "--episode-path", str(ep_file), "--graph-path", str(graph_file),
+        ]) == 0
+        assert graph_file.read_text() == first

--- a/.claude/skills/memory/tests/test_update_causal_graph.py
+++ b/.claude/skills/memory/tests/test_update_causal_graph.py
@@ -51,14 +51,14 @@ class TestLoadCausalGraph:
     def test_valid_file(self, tmp_path: Path) -> None:
         graph_file = tmp_path / "graph.json"
         data = {"nodes": [{"id": "abc"}], "edges": [], "patterns": []}
-        graph_file.write_text(json.dumps(data))
+        graph_file.write_text(json.dumps(data), encoding="utf-8")
 
         graph = load_causal_graph(graph_file)
         assert len(graph["nodes"]) == 1
 
     def test_invalid_json(self, tmp_path: Path) -> None:
         graph_file = tmp_path / "graph.json"
-        graph_file.write_text("not json")
+        graph_file.write_text("not json", encoding="utf-8")
 
         graph = load_causal_graph(graph_file)
         assert graph == {"nodes": [], "edges": [], "patterns": []}
@@ -77,7 +77,7 @@ class TestSaveCausalGraph:
         data = {"nodes": [{"id": "test"}], "edges": [], "patterns": []}
         save_causal_graph(graph_file, data)
 
-        loaded = json.loads(graph_file.read_text())
+        loaded = json.loads(graph_file.read_text(encoding="utf-8"))
         assert loaded["nodes"][0]["id"] == "test"
 
 
@@ -163,13 +163,16 @@ class TestGetEpisodeFiles:
 
     def test_single_file(self, tmp_path: Path) -> None:
         f = tmp_path / "episode-test.json"
-        f.write_text(json.dumps({"id": "test", "timestamp": "2026-01-01T00:00:00"}))
+        f.write_text(
+            json.dumps({"id": "test", "timestamp": "2026-01-01T00:00:00"}),
+            encoding="utf-8",
+        )
         assert get_episode_files(f) == [f]
 
     def test_directory(self, tmp_path: Path) -> None:
-        (tmp_path / "episode-001.json").write_text("{}")
-        (tmp_path / "episode-002.json").write_text("{}")
-        (tmp_path / "other.json").write_text("{}")
+        (tmp_path / "episode-001.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "episode-002.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "other.json").write_text("{}", encoding="utf-8")
         files = get_episode_files(tmp_path)
         assert len(files) == 2
 
@@ -274,7 +277,7 @@ class TestMainFunction:
             "events": [],
             "lessons": [],
         }
-        (ep_dir / "episode-test.json").write_text(json.dumps(episode))
+        (ep_dir / "episode-test.json").write_text(json.dumps(episode), encoding="utf-8")
 
         result = main([
             "--episode-path", str(ep_dir),
@@ -287,7 +290,7 @@ class TestMainFunction:
         assert stats["episodes_processed"] == 1
         assert stats["nodes_added"] > 0
 
-        graph = json.loads(graph_file.read_text())
+        graph = json.loads(graph_file.read_text(encoding="utf-8"))
         assert len(graph["nodes"]) > 0
 
     def test_dry_run(
@@ -309,7 +312,7 @@ class TestMainFunction:
             }],
             "events": [],
         }
-        (ep_dir / "episode-dry.json").write_text(json.dumps(episode))
+        (ep_dir / "episode-dry.json").write_text(json.dumps(episode), encoding="utf-8")
 
         result = main([
             "--episode-path", str(ep_dir),
@@ -358,7 +361,7 @@ class TestEpisodeReconcile:
 
         ep_file.write_text(json.dumps(
             self._milestone_episode("filed #3137, #3138, #3139, #3140, and #3141"),
-        ))
+        ), encoding="utf-8")
         assert main([
             "--episode-path", str(ep_file),
             "--graph-path", str(graph_file),
@@ -369,13 +372,13 @@ class TestEpisodeReconcile:
             self._milestone_episode(
                 "filed #3137, #3138, #3139, #3140, #3141, and #3142",
             ),
-        ))
+        ), encoding="utf-8")
         assert main([
             "--episode-path", str(ep_file),
             "--graph-path", str(graph_file),
         ]) == 0
 
-        graph = json.loads(graph_file.read_text())
+        graph = json.loads(graph_file.read_text(encoding="utf-8"))
         milestone_nodes = [
             n for n in graph["nodes"] if n["label"].startswith("milestone:")
         ]
@@ -411,25 +414,31 @@ class TestEpisodeReconcile:
 
         ep1 = ep_dir / "episode-one.json"
         ep2 = ep_dir / "episode-two.json"
-        ep1.write_text(json.dumps(design_episode("episode-one", ["SHARED", "ONLY1"])))
-        ep2.write_text(json.dumps(design_episode("episode-two", ["SHARED"])))
+        ep1.write_text(
+            json.dumps(design_episode("episode-one", ["SHARED", "ONLY1"])),
+            encoding="utf-8",
+        )
+        ep2.write_text(json.dumps(design_episode("episode-two", ["SHARED"])), encoding="utf-8")
         assert main([
             "--episode-path", str(ep_dir),
             "--graph-path", str(graph_file),
         ]) == 0
 
-        graph = json.loads(graph_file.read_text())
+        graph = json.loads(graph_file.read_text(encoding="utf-8"))
         shared = next(n for n in graph["nodes"] if n["label"] == "design: SHARED")
         assert set(shared["episodes"]) == {"episode-one", "episode-two"}
 
         # Reprocess only episode-one, dropping both SHARED and ONLY1.
-        ep1.write_text(json.dumps(design_episode("episode-one", ["ONLY1-CHANGED"])))
+        ep1.write_text(
+            json.dumps(design_episode("episode-one", ["ONLY1-CHANGED"])),
+            encoding="utf-8",
+        )
         assert main([
             "--episode-path", str(ep1),
             "--graph-path", str(graph_file),
         ]) == 0
 
-        graph = json.loads(graph_file.read_text())
+        graph = json.loads(graph_file.read_text(encoding="utf-8"))
         labels = {n["label"]: n for n in graph["nodes"]}
         # Shared node survives, now supported only by episode-two.
         assert "design: SHARED" in labels
@@ -446,14 +455,14 @@ class TestEpisodeReconcile:
         ep_dir.mkdir()
         graph_file = tmp_path / "graph.json"
         ep_file = ep_dir / "episode-2026-07-16-session-3056-record.json"
-        ep_file.write_text(json.dumps(self._milestone_episode("filed #3141")))
+        ep_file.write_text(json.dumps(self._milestone_episode("filed #3141")), encoding="utf-8")
 
         assert main([
             "--episode-path", str(ep_file), "--graph-path", str(graph_file),
         ]) == 0
-        first = graph_file.read_text()
+        first = graph_file.read_text(encoding="utf-8")
 
         assert main([
             "--episode-path", str(ep_file), "--graph-path", str(graph_file),
         ]) == 0
-        assert graph_file.read_text() == first
+        assert graph_file.read_text(encoding="utf-8") == first

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.68",
+  "version": "0.6.69",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.69",
+  "version": "0.6.70",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/memory/tests/test_update_causal_graph.py
+++ b/src/copilot-cli/skills/memory/tests/test_update_causal_graph.py
@@ -318,3 +318,142 @@ class TestMainFunction:
         ])
         assert result == 0
         assert not graph_file.exists()
+
+
+class TestEpisodeReconcile:
+    """Reprocess-idempotency for an edited episode (regression for #3143).
+
+    #3143: a failed pre-commit retry reprocessed an episode whose milestone
+    label had been corrected. The old content-derived node was left behind, so
+    the committed graph held two nodes for the same episode. The reconcile path
+    (#3058) must retract the stale node while preserving nodes still supported
+    by other episodes.
+    """
+
+    @staticmethod
+    def _milestone_episode(chosen: str) -> dict[str, Any]:
+        return {
+            "id": "episode-2026-07-16-session-3056-record",
+            "timestamp": "2026-07-16T00:00:00",
+            "outcome": "success",
+            "task": "Milestone record",
+            "decisions": [{
+                "type": "milestone",
+                "chosen": chosen,
+                "outcome": "success",
+                "context": "record",
+            }],
+            "events": [],
+            "lessons": [],
+        }
+
+    def test_reprocess_changed_decision_retracts_stale_node(
+        self, tmp_path: Path,
+    ) -> None:
+        """A corrected milestone leaves exactly one milestone node (AC1, AC4)."""
+        ep_dir = tmp_path / "episodes"
+        ep_dir.mkdir()
+        graph_file = tmp_path / "graph.json"
+        ep_file = ep_dir / "episode-2026-07-16-session-3056-record.json"
+
+        ep_file.write_text(json.dumps(
+            self._milestone_episode("filed #3137, #3138, #3139, #3140, and #3141"),
+        ))
+        assert main([
+            "--episode-path", str(ep_file),
+            "--graph-path", str(graph_file),
+        ]) == 0
+
+        # Correct the milestone (same episode id, new content-derived node id).
+        ep_file.write_text(json.dumps(
+            self._milestone_episode(
+                "filed #3137, #3138, #3139, #3140, #3141, and #3142",
+            ),
+        ))
+        assert main([
+            "--episode-path", str(ep_file),
+            "--graph-path", str(graph_file),
+        ]) == 0
+
+        graph = json.loads(graph_file.read_text())
+        milestone_nodes = [
+            n for n in graph["nodes"] if n["label"].startswith("milestone:")
+        ]
+        assert len(milestone_nodes) == 1
+        assert "#3142" in milestone_nodes[0]["label"]
+        # The pre-correction node must be gone, not merely deduplicated.
+        assert not any(
+            n["label"].startswith("milestone:") and "#3142" not in n["label"]
+            for n in graph["nodes"]
+        )
+
+    def test_reprocess_preserves_node_shared_with_other_episode(
+        self, tmp_path: Path,
+    ) -> None:
+        """Retracting one episode keeps a node another episode still supports (AC6)."""
+        ep_dir = tmp_path / "episodes"
+        ep_dir.mkdir()
+        graph_file = tmp_path / "graph.json"
+
+        def design_episode(episode_id: str, chosen: list[str]) -> dict[str, Any]:
+            return {
+                "id": episode_id,
+                "timestamp": "2026-07-16T00:00:00",
+                "outcome": "success",
+                "task": "Design work",
+                "decisions": [
+                    {"type": "design", "chosen": c, "outcome": "success"}
+                    for c in chosen
+                ],
+                "events": [],
+                "lessons": [],
+            }
+
+        ep1 = ep_dir / "episode-one.json"
+        ep2 = ep_dir / "episode-two.json"
+        ep1.write_text(json.dumps(design_episode("episode-one", ["SHARED", "ONLY1"])))
+        ep2.write_text(json.dumps(design_episode("episode-two", ["SHARED"])))
+        assert main([
+            "--episode-path", str(ep_dir),
+            "--graph-path", str(graph_file),
+        ]) == 0
+
+        graph = json.loads(graph_file.read_text())
+        shared = next(n for n in graph["nodes"] if n["label"] == "design: SHARED")
+        assert set(shared["episodes"]) == {"episode-one", "episode-two"}
+
+        # Reprocess only episode-one, dropping both SHARED and ONLY1.
+        ep1.write_text(json.dumps(design_episode("episode-one", ["ONLY1-CHANGED"])))
+        assert main([
+            "--episode-path", str(ep1),
+            "--graph-path", str(graph_file),
+        ]) == 0
+
+        graph = json.loads(graph_file.read_text())
+        labels = {n["label"]: n for n in graph["nodes"]}
+        # Shared node survives, now supported only by episode-two.
+        assert "design: SHARED" in labels
+        assert labels["design: SHARED"]["episodes"] == ["episode-two"]
+        # Episode-one's dropped sole-supporter node is retracted.
+        assert "design: ONLY1" not in labels
+        assert "design: ONLY1-CHANGED" in labels
+
+    def test_unchanged_reprocess_is_byte_idempotent(
+        self, tmp_path: Path,
+    ) -> None:
+        """Reprocessing an unchanged episode changes no bytes (AC2)."""
+        ep_dir = tmp_path / "episodes"
+        ep_dir.mkdir()
+        graph_file = tmp_path / "graph.json"
+        ep_file = ep_dir / "episode-2026-07-16-session-3056-record.json"
+        ep_file.write_text(json.dumps(self._milestone_episode("filed #3141")))
+
+        assert main([
+            "--episode-path", str(ep_file), "--graph-path", str(graph_file),
+        ]) == 0
+        first = graph_file.read_text()
+
+        assert main([
+            "--episode-path", str(ep_file), "--graph-path", str(graph_file),
+        ]) == 0
+        assert graph_file.read_text() == first

--- a/src/copilot-cli/skills/memory/tests/test_update_causal_graph.py
+++ b/src/copilot-cli/skills/memory/tests/test_update_causal_graph.py
@@ -51,14 +51,14 @@ class TestLoadCausalGraph:
     def test_valid_file(self, tmp_path: Path) -> None:
         graph_file = tmp_path / "graph.json"
         data = {"nodes": [{"id": "abc"}], "edges": [], "patterns": []}
-        graph_file.write_text(json.dumps(data))
+        graph_file.write_text(json.dumps(data), encoding="utf-8")
 
         graph = load_causal_graph(graph_file)
         assert len(graph["nodes"]) == 1
 
     def test_invalid_json(self, tmp_path: Path) -> None:
         graph_file = tmp_path / "graph.json"
-        graph_file.write_text("not json")
+        graph_file.write_text("not json", encoding="utf-8")
 
         graph = load_causal_graph(graph_file)
         assert graph == {"nodes": [], "edges": [], "patterns": []}
@@ -77,7 +77,7 @@ class TestSaveCausalGraph:
         data = {"nodes": [{"id": "test"}], "edges": [], "patterns": []}
         save_causal_graph(graph_file, data)
 
-        loaded = json.loads(graph_file.read_text())
+        loaded = json.loads(graph_file.read_text(encoding="utf-8"))
         assert loaded["nodes"][0]["id"] == "test"
 
 
@@ -163,13 +163,16 @@ class TestGetEpisodeFiles:
 
     def test_single_file(self, tmp_path: Path) -> None:
         f = tmp_path / "episode-test.json"
-        f.write_text(json.dumps({"id": "test", "timestamp": "2026-01-01T00:00:00"}))
+        f.write_text(
+            json.dumps({"id": "test", "timestamp": "2026-01-01T00:00:00"}),
+            encoding="utf-8",
+        )
         assert get_episode_files(f) == [f]
 
     def test_directory(self, tmp_path: Path) -> None:
-        (tmp_path / "episode-001.json").write_text("{}")
-        (tmp_path / "episode-002.json").write_text("{}")
-        (tmp_path / "other.json").write_text("{}")
+        (tmp_path / "episode-001.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "episode-002.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "other.json").write_text("{}", encoding="utf-8")
         files = get_episode_files(tmp_path)
         assert len(files) == 2
 
@@ -274,7 +277,7 @@ class TestMainFunction:
             "events": [],
             "lessons": [],
         }
-        (ep_dir / "episode-test.json").write_text(json.dumps(episode))
+        (ep_dir / "episode-test.json").write_text(json.dumps(episode), encoding="utf-8")
 
         result = main([
             "--episode-path", str(ep_dir),
@@ -287,7 +290,7 @@ class TestMainFunction:
         assert stats["episodes_processed"] == 1
         assert stats["nodes_added"] > 0
 
-        graph = json.loads(graph_file.read_text())
+        graph = json.loads(graph_file.read_text(encoding="utf-8"))
         assert len(graph["nodes"]) > 0
 
     def test_dry_run(
@@ -309,7 +312,7 @@ class TestMainFunction:
             }],
             "events": [],
         }
-        (ep_dir / "episode-dry.json").write_text(json.dumps(episode))
+        (ep_dir / "episode-dry.json").write_text(json.dumps(episode), encoding="utf-8")
 
         result = main([
             "--episode-path", str(ep_dir),
@@ -358,7 +361,7 @@ class TestEpisodeReconcile:
 
         ep_file.write_text(json.dumps(
             self._milestone_episode("filed #3137, #3138, #3139, #3140, and #3141"),
-        ))
+        ), encoding="utf-8")
         assert main([
             "--episode-path", str(ep_file),
             "--graph-path", str(graph_file),
@@ -369,13 +372,13 @@ class TestEpisodeReconcile:
             self._milestone_episode(
                 "filed #3137, #3138, #3139, #3140, #3141, and #3142",
             ),
-        ))
+        ), encoding="utf-8")
         assert main([
             "--episode-path", str(ep_file),
             "--graph-path", str(graph_file),
         ]) == 0
 
-        graph = json.loads(graph_file.read_text())
+        graph = json.loads(graph_file.read_text(encoding="utf-8"))
         milestone_nodes = [
             n for n in graph["nodes"] if n["label"].startswith("milestone:")
         ]
@@ -411,25 +414,31 @@ class TestEpisodeReconcile:
 
         ep1 = ep_dir / "episode-one.json"
         ep2 = ep_dir / "episode-two.json"
-        ep1.write_text(json.dumps(design_episode("episode-one", ["SHARED", "ONLY1"])))
-        ep2.write_text(json.dumps(design_episode("episode-two", ["SHARED"])))
+        ep1.write_text(
+            json.dumps(design_episode("episode-one", ["SHARED", "ONLY1"])),
+            encoding="utf-8",
+        )
+        ep2.write_text(json.dumps(design_episode("episode-two", ["SHARED"])), encoding="utf-8")
         assert main([
             "--episode-path", str(ep_dir),
             "--graph-path", str(graph_file),
         ]) == 0
 
-        graph = json.loads(graph_file.read_text())
+        graph = json.loads(graph_file.read_text(encoding="utf-8"))
         shared = next(n for n in graph["nodes"] if n["label"] == "design: SHARED")
         assert set(shared["episodes"]) == {"episode-one", "episode-two"}
 
         # Reprocess only episode-one, dropping both SHARED and ONLY1.
-        ep1.write_text(json.dumps(design_episode("episode-one", ["ONLY1-CHANGED"])))
+        ep1.write_text(
+            json.dumps(design_episode("episode-one", ["ONLY1-CHANGED"])),
+            encoding="utf-8",
+        )
         assert main([
             "--episode-path", str(ep1),
             "--graph-path", str(graph_file),
         ]) == 0
 
-        graph = json.loads(graph_file.read_text())
+        graph = json.loads(graph_file.read_text(encoding="utf-8"))
         labels = {n["label"]: n for n in graph["nodes"]}
         # Shared node survives, now supported only by episode-two.
         assert "design: SHARED" in labels
@@ -446,14 +455,14 @@ class TestEpisodeReconcile:
         ep_dir.mkdir()
         graph_file = tmp_path / "graph.json"
         ep_file = ep_dir / "episode-2026-07-16-session-3056-record.json"
-        ep_file.write_text(json.dumps(self._milestone_episode("filed #3141")))
+        ep_file.write_text(json.dumps(self._milestone_episode("filed #3141")), encoding="utf-8")
 
         assert main([
             "--episode-path", str(ep_file), "--graph-path", str(graph_file),
         ]) == 0
-        first = graph_file.read_text()
+        first = graph_file.read_text(encoding="utf-8")
 
         assert main([
             "--episode-path", str(ep_file), "--graph-path", str(graph_file),
         ]) == 0
-        assert graph_file.read_text() == first
+        assert graph_file.read_text(encoding="utf-8") == first


### PR DESCRIPTION
## Summary

Locks the causal-graph reconcile behavior with regression tests. The core defect
in #3143 (a failed pre-commit retry leaving stale duplicate nodes) was already
fixed by #3058, which landed with no test pinning the reprocess-with-changed-content
scenario. This adds that coverage to both maintained tree copies.

## Root cause and status

#3143 was filed 2026-07-17 01:13 UTC. The reconcile fix (#3058, commit 3601bb1b)
merged 2026-07-17 19:45 UTC, about 18 hours later. The observation predates the
fix. Empirically reproducing #3143's exact scenario against current main yields
one milestone node and zero stale duplicates: the bug is fixed. What was missing
is a regression test.

## Tests added (both trees)

- `test_reprocess_changed_decision_retracts_stale_node` (AC1, AC4): reprocess an
  episode whose milestone label was corrected; assert exactly one milestone node
  remains and the pre-correction node is retracted.
- `test_reprocess_preserves_node_shared_with_other_episode` (AC6): a node
  supported by two episodes survives when one episode drops it; the sole-supporter
  node is retracted.
- `test_unchanged_reprocess_is_byte_idempotent` (AC2): reprocessing unchanged
  content writes identical bytes.

## Non-vacuous proof

Mutation test: neutering the retract path makes the first test see two milestone
nodes (the exact #3143 symptom); the shipped reconcile yields one. The test fails
without the fix.

## Residual (why Refs, not Fixes)

AC3/AC5 (transactional pre-commit memory staging: restore state on a failed
commit, or run blocking gates before the auto-fix mutation) remain unmet. Those
are defense-in-depth against the same retry class, not the observable
duplicate-node symptom, which the reconcile path now self-heals on retry. The
issue stays open narrowed to that residual.

## Verification

- `.claude` tree: 29 passed. `src/copilot-cli` tree: 29 passed.
- mypy clean (per file, both trees), ruff clean, zero em/en dashes.
- Both plugin manifests bumped to 0.6.70 (parity verified). The bump target rose as intervening plugin PRs merged to main; the version-bump CI gate requires the branch to exceed main HEAD (0.6.69).

Refs #3143

## References

Prior art and canonical sources (not in this diff):

- The reconcile implementation lives in the memory skill causal-graph updater
  script; see `update_causal_graph.py` functions `_episode_membership` and
  `_retract_stale`.
- Fix provenance: PR #3058, commit 3601bb1b.

