### PR TITLE
fix(hooks): record verified Copilot SessionEnd subagent contract (#3160)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.69",
+  "version": "0.6.70",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/Stop/invoke_auto_retrospective.py
+++ b/.claude/hooks/Stop/invoke_auto_retrospective.py
@@ -605,16 +605,18 @@ def is_subagent_stop(payload: dict[str, Any]) -> bool:
     ``hook_input.get("subagent_type") == "qa"``). Any non-empty ``subagent_type``
     marks a subagent stop.
 
-    UNVERIFIED COPILOT MARKER (Issue #3140, follow-up Issue #3160): the reported
-    bug is on Copilot CLI, where Claude's Stop maps to Copilot's SessionEnd
-    (templates/platforms/copilot-cli.yaml eventRemap ``Stop: SessionEnd``, with
-    ``SubagentStop`` dropped) and a synchronous ``task`` subagent's return fires
-    SessionEnd against the parent worktree. Copilot's SessionEnd subagent payload
-    shape was NOT captured empirically in this environment, so the field it uses
-    to mark a subagent is unknown. If Copilot also sends ``subagent_type`` this
-    guard already covers it; if it uses a different key, the Copilot path stays
-    broken until #3160 captures the marker. Do NOT invent a key here: see
-    .claude/rules/generated-artifacts.md (verify the contract empirically).
+    VERIFIED COPILOT BEHAVIOR (Issue #3140, follow-up Issue #3160): on Copilot
+    CLI, Claude's Stop maps to Copilot's SessionEnd (templates/platforms/
+    copilot-cli.yaml eventRemap ``Stop: SessionEnd``, with ``SubagentStop``
+    dropped). Captured empirically on Copilot CLI 1.0.72 (2026-07-18): a
+    synchronous ``task`` subagent's return does NOT fire a SessionEnd hook. The
+    subagent lifecycle emits internal ``subagent_completed`` telemetry only; the
+    SessionEnd hook fires exactly once, on parent ``session_shutdown``, with
+    payload ``{hook_event_name, session_id, timestamp, cwd, reason}`` and no
+    ``subagent_type``. Copilot subagents therefore never reach this hook, so the
+    ``subagent_type`` check is correct for Claude and a harmless no-op on
+    Copilot. Method: dumped stdin from a --plugin-dir SessionEnd hook while
+    ``explore`` and ``code-review`` synchronous subagents ran to completion.
     """
     return bool(payload.get("subagent_type"))
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.69",
+  "version": "0.6.70",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/SessionEnd/invoke_auto_retrospective.py
+++ b/src/copilot-cli/hooks/SessionEnd/invoke_auto_retrospective.py
@@ -605,16 +605,18 @@ def is_subagent_stop(payload: dict[str, Any]) -> bool:
     ``hook_input.get("subagent_type") == "qa"``). Any non-empty ``subagent_type``
     marks a subagent stop.
 
-    UNVERIFIED COPILOT MARKER (Issue #3140, follow-up Issue #3160): the reported
-    bug is on Copilot CLI, where Claude's Stop maps to Copilot's SessionEnd
-    (templates/platforms/copilot-cli.yaml eventRemap ``Stop: SessionEnd``, with
-    ``SubagentStop`` dropped) and a synchronous ``task`` subagent's return fires
-    SessionEnd against the parent worktree. Copilot's SessionEnd subagent payload
-    shape was NOT captured empirically in this environment, so the field it uses
-    to mark a subagent is unknown. If Copilot also sends ``subagent_type`` this
-    guard already covers it; if it uses a different key, the Copilot path stays
-    broken until #3160 captures the marker. Do NOT invent a key here: see
-    .claude/rules/generated-artifacts.md (verify the contract empirically).
+    VERIFIED COPILOT BEHAVIOR (Issue #3140, follow-up Issue #3160): on Copilot
+    CLI, Claude's Stop maps to Copilot's SessionEnd (templates/platforms/
+    copilot-cli.yaml eventRemap ``Stop: SessionEnd``, with ``SubagentStop``
+    dropped). Captured empirically on Copilot CLI 1.0.72 (2026-07-18): a
+    synchronous ``task`` subagent's return does NOT fire a SessionEnd hook. The
+    subagent lifecycle emits internal ``subagent_completed`` telemetry only; the
+    SessionEnd hook fires exactly once, on parent ``session_shutdown``, with
+    payload ``{hook_event_name, session_id, timestamp, cwd, reason}`` and no
+    ``subagent_type``. Copilot subagents therefore never reach this hook, so the
+    ``subagent_type`` check is correct for Claude and a harmless no-op on
+    Copilot. Method: dumped stdin from a --plugin-dir SessionEnd hook while
+    ``explore`` and ``code-review`` synchronous subagents ran to completion.
     """
     return bool(payload.get("subagent_type"))
 

--- a/tests/test_auto_retrospective.py
+++ b/tests/test_auto_retrospective.py
@@ -898,6 +898,31 @@ class TestSubagentStopSkip(unittest.TestCase):
             invoke_auto_retrospective.is_subagent_stop({"hook_event_name": "Stop"})
         )
 
+    def test_captured_copilot_parent_sessionend_is_not_subagent(self):
+        """Copilot CLI 1.0.72 parent SessionEnd carries no subagent marker (#3160).
+
+        Empirically captured on 2026-07-18 by dumping stdin from a --plugin-dir
+        SessionEnd hook while a synchronous ``task`` subagent (``explore``, then
+        ``code-review``) ran to completion: the subagent return fired internal
+        ``subagent_completed`` telemetry, NOT a SessionEnd hook. The SessionEnd
+        hook fired exactly once, on parent ``session_shutdown``, with this exact
+        payload shape. There is therefore no Copilot subagent SessionEnd payload
+        to mark, and the real parent payload must classify as a parent stop so
+        the retro is still written. This locks that contract.
+        """
+        captured_copilot_parent_sessionend = {
+            "hook_event_name": "SessionEnd",
+            "session_id": "af826917-74ba-4525-889b-b5c431f9fb57",
+            "timestamp": "2026-07-18T01:01:15.489Z",
+            "cwd": "/tmp/iss3160_wt",
+            "reason": "complete",
+        }
+        self.assertFalse(
+            invoke_auto_retrospective.is_subagent_stop(
+                captured_copilot_parent_sessionend
+            )
+        )
+
 
 class TestDailyCreationClaim(unittest.TestCase):
     """Issue #3140: an atomic per-day claim serializes concurrent parent stops."""


### PR DESCRIPTION
## Summary

Resolves the open question in #3160: does a synchronous `task` subagent's return
fire a SessionEnd hook against the parent worktree on Copilot CLI, and which
payload field marks a subagent so `is_subagent_stop()` can guard it?

Answer, captured empirically on Copilot CLI 1.0.72 (2026-07-18): a subagent
return does NOT fire a SessionEnd hook at all. Subagent completion emits internal
`subagent_completed` telemetry only. The SessionEnd hook fires exactly once, on
the parent `session_shutdown`, with payload
`{hook_event_name, session_id, timestamp, cwd, reason}` and no `subagent_type`.
Copilot subagents therefore never reach this hook, so the existing
`subagent_type` check is correct for Claude and a harmless no-op on Copilot.

## Method

Built a non-destructive temp plugin whose SessionEnd hook dumps stdin, then ran
nested `copilot --plugin-dir <tmp> --allow-all-tools` twice: once driving an
`explore` subagent, once driving a synchronous `code-review` subagent from a
linked git worktree. Both runs captured exactly one SessionEnd payload (the
parent, `reason: complete`) with no subagent field. Debug-log telemetry confirmed
the subagent lifecycle is `subagent_started` then `subagent_completed`, distinct
from the parent SessionEnd hook dispatch.

## Changes

- Replace the stale "UNVERIFIED COPILOT MARKER" docstring in both byte-parity
  twins (`.claude/hooks/Stop/invoke_auto_retrospective.py` and
  `src/copilot-cli/hooks/SessionEnd/invoke_auto_retrospective.py`) with the
  verified contract.
- Add `test_captured_copilot_parent_sessionend_is_not_subagent` in
  `tests/test_auto_retrospective.py`, locking that the captured Copilot parent
  SessionEnd payload classifies as a parent stop (so the retro still writes).
- Bump project-toolkit manifests to 0.6.70.

## Testing

- `uv run pytest tests/test_auto_retrospective.py -x -q` -> 48 passed (was 47).
- ruff clean, mypy clean (per-file, both twins), 0 dashes, twins byte-identical.
- Full pre-push suite green.

## References

The Copilot event remap `Stop: SessionEnd` (with `SubagentStop` dropped) is
defined in `templates/platforms/copilot-cli.yaml`; this PR does not change it.

Refs #3160
