### PR TITLE
fix(skillforge): root quick_validate CWE-22 guard at cwd (#3224)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.70",
+  "version": "0.6.71",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/SkillForge/scripts/quick_validate.py
+++ b/.claude/skills/SkillForge/scripts/quick_validate.py
@@ -14,7 +14,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 try:
     import yaml
@@ -111,15 +111,45 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
     return frontmatter
 
 
-def _is_within(child: str, root: str) -> bool:
+class _PathModule(Protocol):
+    """Structural type for the ``os.path`` surface ``_is_within`` needs.
+
+    Lets tests substitute ``posixpath`` or ``ntpath`` for the host ``os.path``
+    while keeping a precise return type (``commonpath`` yields ``str``, so the
+    containment comparison stays ``bool`` instead of decaying to ``Any``).
+    """
+
+    def commonpath(self, paths: list[str], /) -> str: ...
+
+
+def _is_within(child: str, root: str, pathmod: _PathModule = os.path) -> bool:
     """Return True when case-normalized realpath ``child`` is ``root`` or nested inside it.
 
     Both arguments must already be ``os.path.normcase(os.path.realpath(...))``
-    results. ``os.path.join(root, "")`` appends exactly one trailing separator
-    whether or not ``root`` already ends with one, so a filesystem-root ``root``
-    (``/`` or ``C:\\``) does not double into ``//`` and reject valid descendants.
+    results. Containment is decided by ``os.path.commonpath`` rather than a
+    separator-appended prefix match, because ``os.path.join(root, "")`` does NOT
+    append a separator to a bare drive root (``C:\\``) or a bare UNC share root
+    (``\\\\server\\share``) on Windows. With the old prefix match a sibling that
+    merely shares a string prefix (``C:\\evil`` under ``C:\\``,
+    ``\\\\server\\shareevil`` under ``\\\\server\\share``) passed the guard and
+    escaped the CWD sandbox (CWE-22). ``commonpath`` compares whole path
+    components, so only true descendants match.
+
+    ``commonpath`` raises ``ValueError`` when the two paths cannot share a base
+    (different drives, drive-vs-UNC, or a bare UNC share root that ``ntpath``
+    treats as rootless). Those all mean "not contained", so the guard fails
+    closed and returns False.
+
+    ``pathmod`` is injected only so tests can pin ``posixpath`` or ``ntpath`` and
+    exercise both platforms' root semantics deterministically on any host;
+    production always uses the default ``os.path``.
     """
-    return child == root or child.startswith(os.path.join(root, ""))
+    if child == root:
+        return True
+    try:
+        return pathmod.commonpath([child, root]) == root
+    except ValueError:
+        return False
 
 
 def _contained_realpath(target: Path, root: str) -> str | None:

--- a/.claude/skills/SkillForge/scripts/quick_validate.py
+++ b/.claude/skills/SkillForge/scripts/quick_validate.py
@@ -18,6 +18,7 @@ from typing import Any
 
 try:
     import yaml
+
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False
@@ -34,14 +35,23 @@ try:
 except ImportError:
     # Fallback if _constants.py not available
     ALLOWED_PROPERTIES = {
-        'name', 'description', 'license', 'allowed-tools', 'metadata',
-        'model', 'context', 'agent', 'hooks', 'user-invocable', 'version',
-        'argument-hint'
+        "name",
+        "description",
+        "license",
+        "allowed-tools",
+        "metadata",
+        "model",
+        "context",
+        "agent",
+        "hooks",
+        "user-invocable",
+        "version",
+        "argument-hint",
     }
-    REQUIRED_PROPERTIES = {'name', 'description'}
+    REQUIRED_PROPERTIES = {"name", "description"}
     NAME_MAX_LENGTH = 64
     DESCRIPTION_MAX_LENGTH = 1024
-    NAME_REGEX = r'^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$'
+    NAME_REGEX = r"^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$"
 
 
 def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
@@ -50,7 +60,7 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
     Handles folded (>) and literal (|) scalars for multi-line descriptions.
     """
     frontmatter: dict[str, Any] = {}
-    lines = frontmatter_text.split('\n')
+    lines = frontmatter_text.split("\n")
     current_key = None
     current_value_lines: list[str] = []
     is_folded = False  # Track folded scalar (>)
@@ -58,21 +68,21 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
 
     for line in lines:
         # Check for top-level key
-        if ':' in line and not line.startswith(' ') and not line.startswith('\t'):
+        if ":" in line and not line.startswith(" ") and not line.startswith("\t"):
             # Save previous key if exists
             if current_key and (is_folded or is_literal):
-                frontmatter[current_key] = ' '.join(current_value_lines).strip()
+                frontmatter[current_key] = " ".join(current_value_lines).strip()
 
-            key, value = line.split(':', 1)
+            key, value = line.split(":", 1)
             current_key = key.strip()
             value = value.strip()
 
             # Check for folded (>) or literal (|) scalar
-            if value == '>' or value == '>-':
+            if value == ">" or value == ">-":
                 is_folded = True
                 is_literal = False
                 current_value_lines = []
-            elif value == '|' or value == '|-':
+            elif value == "|" or value == "|-":
                 is_literal = True
                 is_folded = False
                 current_value_lines = []
@@ -82,21 +92,21 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
                 frontmatter[current_key] = value
                 current_value_lines = []
 
-        elif (is_folded or is_literal) and (line.startswith('  ') or line.startswith('\t')):
+        elif (is_folded or is_literal) and (line.startswith("  ") or line.startswith("\t")):
             # Continuation of folded/literal scalar
             current_value_lines.append(line.strip())
 
-        elif line.startswith('  ') and current_key == 'metadata':
+        elif line.startswith("  ") and current_key == "metadata":
             # Basic nested parsing for metadata
-            if 'metadata' not in frontmatter or not isinstance(frontmatter['metadata'], dict):
-                frontmatter['metadata'] = {}
-            if ':' in line:
-                nested_key, nested_value = line.strip().split(':', 1)
-                frontmatter['metadata'][nested_key.strip()] = nested_value.strip()
+            if "metadata" not in frontmatter or not isinstance(frontmatter["metadata"], dict):
+                frontmatter["metadata"] = {}
+            if ":" in line:
+                nested_key, nested_value = line.strip().split(":", 1)
+                frontmatter["metadata"][nested_key.strip()] = nested_value.strip()
 
     # Save final key if it was a folded/literal scalar
     if current_key and (is_folded or is_literal) and current_value_lines:
-        frontmatter[current_key] = ' '.join(current_value_lines).strip()
+        frontmatter[current_key] = " ".join(current_value_lines).strip()
 
     return frontmatter
 
@@ -104,12 +114,18 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
 def _contained_realpath(target: Path, root: str) -> str | None:
     """Resolve ``target`` and return its real path only if it stays within ``root``.
 
-    ``root`` must already be an ``os.path.realpath`` result. Returns ``None`` when
-    the resolved target escapes ``root`` (via a symlink or ``..``), letting the
-    caller reject an out-of-root read (CWE-22).
+    ``root`` must already be an ``os.path.normcase(os.path.realpath(...))``
+    result. Returns ``None`` when the resolved target escapes ``root`` (via a
+    symlink or ``..``), letting the caller reject an out-of-root read (CWE-22).
+
+    The containment check compares case-normalized paths so a Windows path that
+    differs only by drive-letter or component casing (``C:\\`` vs ``c:\\``) is not
+    misclassified as an escape. The original real path is returned unchanged so
+    the caller reads the exact resolved target.
     """
     real = os.path.realpath(target)
-    if real == root or real.startswith(root + os.sep):
+    real_cmp = os.path.normcase(real)
+    if real_cmp == root or real_cmp.startswith(root + os.sep):
         return real
     return None
 
@@ -128,8 +144,9 @@ def validate_skill(skill_path, root: str | None = None):
 
     Args:
         skill_path: Path to the skill directory containing SKILL.md.
-        root: When set, the realpath-resolved trusted root. SKILL.md must
-            resolve within it or validation fails (CWE-22 containment).
+        root: When set, the ``os.path.normcase(os.path.realpath(...))`` trusted
+            root. SKILL.md must resolve within it or validation fails (CWE-22
+            containment).
 
     Returns:
         tuple: (is_valid: bool, message: str)
@@ -137,7 +154,7 @@ def validate_skill(skill_path, root: str | None = None):
     skill_path = Path(skill_path)
 
     # Check SKILL.md exists
-    skill_md = skill_path / 'SKILL.md'
+    skill_md = skill_path / "SKILL.md"
     if not skill_md.exists():
         return False, "SKILL.md not found"
 
@@ -153,12 +170,12 @@ def validate_skill(skill_path, root: str | None = None):
         read_target = Path(contained)
 
     # Read and validate frontmatter (explicit UTF-8 encoding)
-    content = read_target.read_text(encoding='utf-8')
-    if not content.startswith('---'):
+    content = read_target.read_text(encoding="utf-8")
+    if not content.startswith("---"):
         return False, "No YAML frontmatter found"
 
     # Extract frontmatter (handles both LF and CRLF line endings)
-    match = re.match(r'^---\r?\n(.*?)\r?\n---', content, re.DOTALL)
+    match = re.match(r"^---\r?\n(.*?)\r?\n---", content, re.DOTALL)
     if not match:
         return False, "Invalid frontmatter format"
 
@@ -192,7 +209,7 @@ def validate_skill(skill_path, root: str | None = None):
             return False, f"Missing '{field}' in frontmatter"
 
     # Validate name field
-    name = frontmatter.get('name', '')
+    name = frontmatter.get("name", "")
     if not isinstance(name, str):
         return False, f"Name must be a string, got {type(name).__name__}"
     name = name.strip()
@@ -203,7 +220,7 @@ def validate_skill(skill_path, root: str | None = None):
                 f"Name '{name}' should be hyphen-case "
                 "(start with letter, lowercase letters, digits, and hyphens only)"
             )
-        if '--' in name:
+        if "--" in name:
             return False, f"Name '{name}' cannot contain consecutive hyphens"
         # Check name length
         if len(name) > NAME_MAX_LENGTH:
@@ -213,13 +230,13 @@ def validate_skill(skill_path, root: str | None = None):
             )
 
     # Validate description field
-    description = frontmatter.get('description', '')
+    description = frontmatter.get("description", "")
     if not isinstance(description, str):
         return False, f"Description must be a string, got {type(description).__name__}"
     description = description.strip()
     if description:
         # Check for angle brackets
-        if '<' in description or '>' in description:
+        if "<" in description or ">" in description:
             return False, "Description cannot contain angle brackets (< or >)"
         # Check description length
         if len(description) > DESCRIPTION_MAX_LENGTH:
@@ -240,9 +257,11 @@ def main():
 
     skill_path = sys.argv[1]
 
-    # SECURITY: Validate path stays within the current working directory (CWE-22)
-    cwd_root = os.path.realpath(os.getcwd())
-    resolved = os.path.realpath(skill_path)
+    # SECURITY: Validate path stays within the current working directory (CWE-22).
+    # normcase() makes the containment check case-insensitive on Windows (C:\ vs
+    # c:\) while realpath() resolves symlinks so a descendant symlink cannot escape.
+    cwd_root = os.path.normcase(os.path.realpath(os.getcwd()))
+    resolved = os.path.normcase(os.path.realpath(skill_path))
     if not resolved.startswith(cwd_root + os.sep) and resolved != cwd_root:
         print(f"Error: Path traversal detected: {skill_path}")
         sys.exit(1)

--- a/.claude/skills/SkillForge/scripts/quick_validate.py
+++ b/.claude/skills/SkillForge/scripts/quick_validate.py
@@ -11,9 +11,10 @@ Usage:
 """
 
 import os
-import sys
 import re
+import sys
 from pathlib import Path
+from typing import Any
 
 try:
     import yaml
@@ -24,8 +25,11 @@ except ImportError:
 # Import shared constants
 try:
     from _constants import (
-        ALLOWED_PROPERTIES, REQUIRED_PROPERTIES,
-        NAME_MAX_LENGTH, DESCRIPTION_MAX_LENGTH, NAME_REGEX
+        ALLOWED_PROPERTIES,
+        DESCRIPTION_MAX_LENGTH,
+        NAME_MAX_LENGTH,
+        NAME_REGEX,
+        REQUIRED_PROPERTIES,
     )
 except ImportError:
     # Fallback if _constants.py not available
@@ -40,15 +44,15 @@ except ImportError:
     NAME_REGEX = r'^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$'
 
 
-def _parse_frontmatter_fallback(frontmatter_text: str) -> dict:
+def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
     """Fallback YAML parser for when PyYAML is not available.
 
     Handles folded (>) and literal (|) scalars for multi-line descriptions.
     """
-    frontmatter = {}
+    frontmatter: dict[str, Any] = {}
     lines = frontmatter_text.split('\n')
     current_key = None
-    current_value_lines = []
+    current_value_lines: list[str] = []
     is_folded = False  # Track folded scalar (>)
     is_literal = False  # Track literal scalar (|)
 
@@ -166,12 +170,18 @@ def validate_skill(skill_path):
     if name:
         # Check naming convention (hyphen-case: starts with letter, lowercase with hyphens)
         if not re.match(NAME_REGEX, name):
-            return False, f"Name '{name}' should be hyphen-case (start with letter, lowercase letters, digits, and hyphens only)"
+            return False, (
+                f"Name '{name}' should be hyphen-case "
+                "(start with letter, lowercase letters, digits, and hyphens only)"
+            )
         if '--' in name:
             return False, f"Name '{name}' cannot contain consecutive hyphens"
         # Check name length
         if len(name) > NAME_MAX_LENGTH:
-            return False, f"Name is too long ({len(name)} characters). Maximum is {NAME_MAX_LENGTH} characters."
+            return False, (
+                f"Name is too long ({len(name)} characters). "
+                f"Maximum is {NAME_MAX_LENGTH} characters."
+            )
 
     # Validate description field
     description = frontmatter.get('description', '')
@@ -184,7 +194,10 @@ def validate_skill(skill_path):
             return False, "Description cannot contain angle brackets (< or >)"
         # Check description length
         if len(description) > DESCRIPTION_MAX_LENGTH:
-            return False, f"Description is too long ({len(description)} characters). Maximum is {DESCRIPTION_MAX_LENGTH} characters."
+            return False, (
+                f"Description is too long ({len(description)} characters). "
+                f"Maximum is {DESCRIPTION_MAX_LENGTH} characters."
+            )
 
     return True, "Skill is valid!"
 
@@ -198,10 +211,10 @@ def main():
 
     skill_path = sys.argv[1]
 
-    # SECURITY: Validate path stays within allowed base directory (CWE-22)
-    skills_root = os.path.realpath(str(Path.home() / ".claude" / "skills"))
+    # SECURITY: Validate path stays within the current working directory (CWE-22)
+    cwd_root = os.path.realpath(os.getcwd())
     resolved = os.path.realpath(skill_path)
-    if not resolved.startswith(skills_root + os.sep) and resolved != skills_root:
+    if not resolved.startswith(cwd_root + os.sep) and resolved != cwd_root:
         print(f"Error: Path traversal detected: {skill_path}")
         sys.exit(1)
 

--- a/.claude/skills/SkillForge/scripts/quick_validate.py
+++ b/.claude/skills/SkillForge/scripts/quick_validate.py
@@ -101,7 +101,20 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
     return frontmatter
 
 
-def validate_skill(skill_path):
+def _contained_realpath(target: Path, root: str) -> str | None:
+    """Resolve ``target`` and return its real path only if it stays within ``root``.
+
+    ``root`` must already be an ``os.path.realpath`` result. Returns ``None`` when
+    the resolved target escapes ``root`` (via a symlink or ``..``), letting the
+    caller reject an out-of-root read (CWE-22).
+    """
+    real = os.path.realpath(target)
+    if real == root or real.startswith(root + os.sep):
+        return real
+    return None
+
+
+def validate_skill(skill_path, root: str | None = None):
     """
     Basic validation of a skill for packaging compatibility.
 
@@ -113,6 +126,11 @@ def validate_skill(skill_path):
     - Name format (hyphen-case, ≤64 chars)
     - Description format (≤1024 chars, no angle brackets)
 
+    Args:
+        skill_path: Path to the skill directory containing SKILL.md.
+        root: When set, the realpath-resolved trusted root. SKILL.md must
+            resolve within it or validation fails (CWE-22 containment).
+
     Returns:
         tuple: (is_valid: bool, message: str)
     """
@@ -123,8 +141,19 @@ def validate_skill(skill_path):
     if not skill_md.exists():
         return False, "SKILL.md not found"
 
+    # SECURITY (CWE-22): when a trusted root is supplied, ensure SKILL.md resolves
+    # inside it before reading. A descendant SKILL.md symlink can point outside the
+    # guarded root even when the skill directory itself is contained; read the
+    # resolved real path so the check and the read target cannot diverge.
+    read_target = skill_md
+    if root is not None:
+        contained = _contained_realpath(skill_md, root)
+        if contained is None:
+            return False, "SKILL.md resolves outside the permitted root"
+        read_target = Path(contained)
+
     # Read and validate frontmatter (explicit UTF-8 encoding)
-    content = skill_md.read_text(encoding='utf-8')
+    content = read_target.read_text(encoding='utf-8')
     if not content.startswith('---'):
         return False, "No YAML frontmatter found"
 
@@ -222,7 +251,7 @@ def main():
         print(f"Error: Path not found: {skill_path}")
         sys.exit(1)
 
-    valid, message = validate_skill(skill_path)
+    valid, message = validate_skill(skill_path, root=cwd_root)
 
     if valid:
         print(f"✅ {message}")

--- a/.claude/skills/SkillForge/scripts/quick_validate.py
+++ b/.claude/skills/SkillForge/scripts/quick_validate.py
@@ -111,6 +111,17 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
     return frontmatter
 
 
+def _is_within(child: str, root: str) -> bool:
+    """Return True when case-normalized realpath ``child`` is ``root`` or nested inside it.
+
+    Both arguments must already be ``os.path.normcase(os.path.realpath(...))``
+    results. ``os.path.join(root, "")`` appends exactly one trailing separator
+    whether or not ``root`` already ends with one, so a filesystem-root ``root``
+    (``/`` or ``C:\\``) does not double into ``//`` and reject valid descendants.
+    """
+    return child == root or child.startswith(os.path.join(root, ""))
+
+
 def _contained_realpath(target: Path, root: str) -> str | None:
     """Resolve ``target`` and return its real path only if it stays within ``root``.
 
@@ -125,7 +136,7 @@ def _contained_realpath(target: Path, root: str) -> str | None:
     """
     real = os.path.realpath(target)
     real_cmp = os.path.normcase(real)
-    if real_cmp == root or real_cmp.startswith(root + os.sep):
+    if _is_within(real_cmp, root):
         return real
     return None
 
@@ -262,7 +273,7 @@ def main():
     # c:\) while realpath() resolves symlinks so a descendant symlink cannot escape.
     cwd_root = os.path.normcase(os.path.realpath(os.getcwd()))
     resolved = os.path.normcase(os.path.realpath(skill_path))
-    if not resolved.startswith(cwd_root + os.sep) and resolved != cwd_root:
+    if not _is_within(resolved, cwd_root):
         print(f"Error: Path traversal detected: {skill_path}")
         sys.exit(1)
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.70",
+  "version": "0.6.71",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/SkillForge/scripts/quick_validate.py
+++ b/src/copilot-cli/skills/SkillForge/scripts/quick_validate.py
@@ -14,7 +14,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 try:
     import yaml
@@ -111,15 +111,45 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
     return frontmatter
 
 
-def _is_within(child: str, root: str) -> bool:
+class _PathModule(Protocol):
+    """Structural type for the ``os.path`` surface ``_is_within`` needs.
+
+    Lets tests substitute ``posixpath`` or ``ntpath`` for the host ``os.path``
+    while keeping a precise return type (``commonpath`` yields ``str``, so the
+    containment comparison stays ``bool`` instead of decaying to ``Any``).
+    """
+
+    def commonpath(self, paths: list[str], /) -> str: ...
+
+
+def _is_within(child: str, root: str, pathmod: _PathModule = os.path) -> bool:
     """Return True when case-normalized realpath ``child`` is ``root`` or nested inside it.
 
     Both arguments must already be ``os.path.normcase(os.path.realpath(...))``
-    results. ``os.path.join(root, "")`` appends exactly one trailing separator
-    whether or not ``root`` already ends with one, so a filesystem-root ``root``
-    (``/`` or ``C:\\``) does not double into ``//`` and reject valid descendants.
+    results. Containment is decided by ``os.path.commonpath`` rather than a
+    separator-appended prefix match, because ``os.path.join(root, "")`` does NOT
+    append a separator to a bare drive root (``C:\\``) or a bare UNC share root
+    (``\\\\server\\share``) on Windows. With the old prefix match a sibling that
+    merely shares a string prefix (``C:\\evil`` under ``C:\\``,
+    ``\\\\server\\shareevil`` under ``\\\\server\\share``) passed the guard and
+    escaped the CWD sandbox (CWE-22). ``commonpath`` compares whole path
+    components, so only true descendants match.
+
+    ``commonpath`` raises ``ValueError`` when the two paths cannot share a base
+    (different drives, drive-vs-UNC, or a bare UNC share root that ``ntpath``
+    treats as rootless). Those all mean "not contained", so the guard fails
+    closed and returns False.
+
+    ``pathmod`` is injected only so tests can pin ``posixpath`` or ``ntpath`` and
+    exercise both platforms' root semantics deterministically on any host;
+    production always uses the default ``os.path``.
     """
-    return child == root or child.startswith(os.path.join(root, ""))
+    if child == root:
+        return True
+    try:
+        return pathmod.commonpath([child, root]) == root
+    except ValueError:
+        return False
 
 
 def _contained_realpath(target: Path, root: str) -> str | None:

--- a/src/copilot-cli/skills/SkillForge/scripts/quick_validate.py
+++ b/src/copilot-cli/skills/SkillForge/scripts/quick_validate.py
@@ -18,6 +18,7 @@ from typing import Any
 
 try:
     import yaml
+
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False
@@ -34,14 +35,23 @@ try:
 except ImportError:
     # Fallback if _constants.py not available
     ALLOWED_PROPERTIES = {
-        'name', 'description', 'license', 'allowed-tools', 'metadata',
-        'model', 'context', 'agent', 'hooks', 'user-invocable', 'version',
-        'argument-hint'
+        "name",
+        "description",
+        "license",
+        "allowed-tools",
+        "metadata",
+        "model",
+        "context",
+        "agent",
+        "hooks",
+        "user-invocable",
+        "version",
+        "argument-hint",
     }
-    REQUIRED_PROPERTIES = {'name', 'description'}
+    REQUIRED_PROPERTIES = {"name", "description"}
     NAME_MAX_LENGTH = 64
     DESCRIPTION_MAX_LENGTH = 1024
-    NAME_REGEX = r'^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$'
+    NAME_REGEX = r"^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$"
 
 
 def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
@@ -50,7 +60,7 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
     Handles folded (>) and literal (|) scalars for multi-line descriptions.
     """
     frontmatter: dict[str, Any] = {}
-    lines = frontmatter_text.split('\n')
+    lines = frontmatter_text.split("\n")
     current_key = None
     current_value_lines: list[str] = []
     is_folded = False  # Track folded scalar (>)
@@ -58,21 +68,21 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
 
     for line in lines:
         # Check for top-level key
-        if ':' in line and not line.startswith(' ') and not line.startswith('\t'):
+        if ":" in line and not line.startswith(" ") and not line.startswith("\t"):
             # Save previous key if exists
             if current_key and (is_folded or is_literal):
-                frontmatter[current_key] = ' '.join(current_value_lines).strip()
+                frontmatter[current_key] = " ".join(current_value_lines).strip()
 
-            key, value = line.split(':', 1)
+            key, value = line.split(":", 1)
             current_key = key.strip()
             value = value.strip()
 
             # Check for folded (>) or literal (|) scalar
-            if value == '>' or value == '>-':
+            if value == ">" or value == ">-":
                 is_folded = True
                 is_literal = False
                 current_value_lines = []
-            elif value == '|' or value == '|-':
+            elif value == "|" or value == "|-":
                 is_literal = True
                 is_folded = False
                 current_value_lines = []
@@ -82,21 +92,21 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
                 frontmatter[current_key] = value
                 current_value_lines = []
 
-        elif (is_folded or is_literal) and (line.startswith('  ') or line.startswith('\t')):
+        elif (is_folded or is_literal) and (line.startswith("  ") or line.startswith("\t")):
             # Continuation of folded/literal scalar
             current_value_lines.append(line.strip())
 
-        elif line.startswith('  ') and current_key == 'metadata':
+        elif line.startswith("  ") and current_key == "metadata":
             # Basic nested parsing for metadata
-            if 'metadata' not in frontmatter or not isinstance(frontmatter['metadata'], dict):
-                frontmatter['metadata'] = {}
-            if ':' in line:
-                nested_key, nested_value = line.strip().split(':', 1)
-                frontmatter['metadata'][nested_key.strip()] = nested_value.strip()
+            if "metadata" not in frontmatter or not isinstance(frontmatter["metadata"], dict):
+                frontmatter["metadata"] = {}
+            if ":" in line:
+                nested_key, nested_value = line.strip().split(":", 1)
+                frontmatter["metadata"][nested_key.strip()] = nested_value.strip()
 
     # Save final key if it was a folded/literal scalar
     if current_key and (is_folded or is_literal) and current_value_lines:
-        frontmatter[current_key] = ' '.join(current_value_lines).strip()
+        frontmatter[current_key] = " ".join(current_value_lines).strip()
 
     return frontmatter
 
@@ -104,12 +114,18 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
 def _contained_realpath(target: Path, root: str) -> str | None:
     """Resolve ``target`` and return its real path only if it stays within ``root``.
 
-    ``root`` must already be an ``os.path.realpath`` result. Returns ``None`` when
-    the resolved target escapes ``root`` (via a symlink or ``..``), letting the
-    caller reject an out-of-root read (CWE-22).
+    ``root`` must already be an ``os.path.normcase(os.path.realpath(...))``
+    result. Returns ``None`` when the resolved target escapes ``root`` (via a
+    symlink or ``..``), letting the caller reject an out-of-root read (CWE-22).
+
+    The containment check compares case-normalized paths so a Windows path that
+    differs only by drive-letter or component casing (``C:\\`` vs ``c:\\``) is not
+    misclassified as an escape. The original real path is returned unchanged so
+    the caller reads the exact resolved target.
     """
     real = os.path.realpath(target)
-    if real == root or real.startswith(root + os.sep):
+    real_cmp = os.path.normcase(real)
+    if real_cmp == root or real_cmp.startswith(root + os.sep):
         return real
     return None
 
@@ -128,8 +144,9 @@ def validate_skill(skill_path, root: str | None = None):
 
     Args:
         skill_path: Path to the skill directory containing SKILL.md.
-        root: When set, the realpath-resolved trusted root. SKILL.md must
-            resolve within it or validation fails (CWE-22 containment).
+        root: When set, the ``os.path.normcase(os.path.realpath(...))`` trusted
+            root. SKILL.md must resolve within it or validation fails (CWE-22
+            containment).
 
     Returns:
         tuple: (is_valid: bool, message: str)
@@ -137,7 +154,7 @@ def validate_skill(skill_path, root: str | None = None):
     skill_path = Path(skill_path)
 
     # Check SKILL.md exists
-    skill_md = skill_path / 'SKILL.md'
+    skill_md = skill_path / "SKILL.md"
     if not skill_md.exists():
         return False, "SKILL.md not found"
 
@@ -153,12 +170,12 @@ def validate_skill(skill_path, root: str | None = None):
         read_target = Path(contained)
 
     # Read and validate frontmatter (explicit UTF-8 encoding)
-    content = read_target.read_text(encoding='utf-8')
-    if not content.startswith('---'):
+    content = read_target.read_text(encoding="utf-8")
+    if not content.startswith("---"):
         return False, "No YAML frontmatter found"
 
     # Extract frontmatter (handles both LF and CRLF line endings)
-    match = re.match(r'^---\r?\n(.*?)\r?\n---', content, re.DOTALL)
+    match = re.match(r"^---\r?\n(.*?)\r?\n---", content, re.DOTALL)
     if not match:
         return False, "Invalid frontmatter format"
 
@@ -192,7 +209,7 @@ def validate_skill(skill_path, root: str | None = None):
             return False, f"Missing '{field}' in frontmatter"
 
     # Validate name field
-    name = frontmatter.get('name', '')
+    name = frontmatter.get("name", "")
     if not isinstance(name, str):
         return False, f"Name must be a string, got {type(name).__name__}"
     name = name.strip()
@@ -203,7 +220,7 @@ def validate_skill(skill_path, root: str | None = None):
                 f"Name '{name}' should be hyphen-case "
                 "(start with letter, lowercase letters, digits, and hyphens only)"
             )
-        if '--' in name:
+        if "--" in name:
             return False, f"Name '{name}' cannot contain consecutive hyphens"
         # Check name length
         if len(name) > NAME_MAX_LENGTH:
@@ -213,13 +230,13 @@ def validate_skill(skill_path, root: str | None = None):
             )
 
     # Validate description field
-    description = frontmatter.get('description', '')
+    description = frontmatter.get("description", "")
     if not isinstance(description, str):
         return False, f"Description must be a string, got {type(description).__name__}"
     description = description.strip()
     if description:
         # Check for angle brackets
-        if '<' in description or '>' in description:
+        if "<" in description or ">" in description:
             return False, "Description cannot contain angle brackets (< or >)"
         # Check description length
         if len(description) > DESCRIPTION_MAX_LENGTH:
@@ -240,9 +257,11 @@ def main():
 
     skill_path = sys.argv[1]
 
-    # SECURITY: Validate path stays within the current working directory (CWE-22)
-    cwd_root = os.path.realpath(os.getcwd())
-    resolved = os.path.realpath(skill_path)
+    # SECURITY: Validate path stays within the current working directory (CWE-22).
+    # normcase() makes the containment check case-insensitive on Windows (C:\ vs
+    # c:\) while realpath() resolves symlinks so a descendant symlink cannot escape.
+    cwd_root = os.path.normcase(os.path.realpath(os.getcwd()))
+    resolved = os.path.normcase(os.path.realpath(skill_path))
     if not resolved.startswith(cwd_root + os.sep) and resolved != cwd_root:
         print(f"Error: Path traversal detected: {skill_path}")
         sys.exit(1)

--- a/src/copilot-cli/skills/SkillForge/scripts/quick_validate.py
+++ b/src/copilot-cli/skills/SkillForge/scripts/quick_validate.py
@@ -11,9 +11,10 @@ Usage:
 """
 
 import os
-import sys
 import re
+import sys
 from pathlib import Path
+from typing import Any
 
 try:
     import yaml
@@ -24,8 +25,11 @@ except ImportError:
 # Import shared constants
 try:
     from _constants import (
-        ALLOWED_PROPERTIES, REQUIRED_PROPERTIES,
-        NAME_MAX_LENGTH, DESCRIPTION_MAX_LENGTH, NAME_REGEX
+        ALLOWED_PROPERTIES,
+        DESCRIPTION_MAX_LENGTH,
+        NAME_MAX_LENGTH,
+        NAME_REGEX,
+        REQUIRED_PROPERTIES,
     )
 except ImportError:
     # Fallback if _constants.py not available
@@ -40,15 +44,15 @@ except ImportError:
     NAME_REGEX = r'^[a-z][a-z0-9-]*[a-z0-9]$|^[a-z]$'
 
 
-def _parse_frontmatter_fallback(frontmatter_text: str) -> dict:
+def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
     """Fallback YAML parser for when PyYAML is not available.
 
     Handles folded (>) and literal (|) scalars for multi-line descriptions.
     """
-    frontmatter = {}
+    frontmatter: dict[str, Any] = {}
     lines = frontmatter_text.split('\n')
     current_key = None
-    current_value_lines = []
+    current_value_lines: list[str] = []
     is_folded = False  # Track folded scalar (>)
     is_literal = False  # Track literal scalar (|)
 
@@ -166,12 +170,18 @@ def validate_skill(skill_path):
     if name:
         # Check naming convention (hyphen-case: starts with letter, lowercase with hyphens)
         if not re.match(NAME_REGEX, name):
-            return False, f"Name '{name}' should be hyphen-case (start with letter, lowercase letters, digits, and hyphens only)"
+            return False, (
+                f"Name '{name}' should be hyphen-case "
+                "(start with letter, lowercase letters, digits, and hyphens only)"
+            )
         if '--' in name:
             return False, f"Name '{name}' cannot contain consecutive hyphens"
         # Check name length
         if len(name) > NAME_MAX_LENGTH:
-            return False, f"Name is too long ({len(name)} characters). Maximum is {NAME_MAX_LENGTH} characters."
+            return False, (
+                f"Name is too long ({len(name)} characters). "
+                f"Maximum is {NAME_MAX_LENGTH} characters."
+            )
 
     # Validate description field
     description = frontmatter.get('description', '')
@@ -184,7 +194,10 @@ def validate_skill(skill_path):
             return False, "Description cannot contain angle brackets (< or >)"
         # Check description length
         if len(description) > DESCRIPTION_MAX_LENGTH:
-            return False, f"Description is too long ({len(description)} characters). Maximum is {DESCRIPTION_MAX_LENGTH} characters."
+            return False, (
+                f"Description is too long ({len(description)} characters). "
+                f"Maximum is {DESCRIPTION_MAX_LENGTH} characters."
+            )
 
     return True, "Skill is valid!"
 
@@ -198,10 +211,10 @@ def main():
 
     skill_path = sys.argv[1]
 
-    # SECURITY: Validate path stays within allowed base directory (CWE-22)
-    skills_root = os.path.realpath(str(Path.home() / ".claude" / "skills"))
+    # SECURITY: Validate path stays within the current working directory (CWE-22)
+    cwd_root = os.path.realpath(os.getcwd())
     resolved = os.path.realpath(skill_path)
-    if not resolved.startswith(skills_root + os.sep) and resolved != skills_root:
+    if not resolved.startswith(cwd_root + os.sep) and resolved != cwd_root:
         print(f"Error: Path traversal detected: {skill_path}")
         sys.exit(1)
 

--- a/src/copilot-cli/skills/SkillForge/scripts/quick_validate.py
+++ b/src/copilot-cli/skills/SkillForge/scripts/quick_validate.py
@@ -101,7 +101,20 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
     return frontmatter
 
 
-def validate_skill(skill_path):
+def _contained_realpath(target: Path, root: str) -> str | None:
+    """Resolve ``target`` and return its real path only if it stays within ``root``.
+
+    ``root`` must already be an ``os.path.realpath`` result. Returns ``None`` when
+    the resolved target escapes ``root`` (via a symlink or ``..``), letting the
+    caller reject an out-of-root read (CWE-22).
+    """
+    real = os.path.realpath(target)
+    if real == root or real.startswith(root + os.sep):
+        return real
+    return None
+
+
+def validate_skill(skill_path, root: str | None = None):
     """
     Basic validation of a skill for packaging compatibility.
 
@@ -113,6 +126,11 @@ def validate_skill(skill_path):
     - Name format (hyphen-case, ≤64 chars)
     - Description format (≤1024 chars, no angle brackets)
 
+    Args:
+        skill_path: Path to the skill directory containing SKILL.md.
+        root: When set, the realpath-resolved trusted root. SKILL.md must
+            resolve within it or validation fails (CWE-22 containment).
+
     Returns:
         tuple: (is_valid: bool, message: str)
     """
@@ -123,8 +141,19 @@ def validate_skill(skill_path):
     if not skill_md.exists():
         return False, "SKILL.md not found"
 
+    # SECURITY (CWE-22): when a trusted root is supplied, ensure SKILL.md resolves
+    # inside it before reading. A descendant SKILL.md symlink can point outside the
+    # guarded root even when the skill directory itself is contained; read the
+    # resolved real path so the check and the read target cannot diverge.
+    read_target = skill_md
+    if root is not None:
+        contained = _contained_realpath(skill_md, root)
+        if contained is None:
+            return False, "SKILL.md resolves outside the permitted root"
+        read_target = Path(contained)
+
     # Read and validate frontmatter (explicit UTF-8 encoding)
-    content = skill_md.read_text(encoding='utf-8')
+    content = read_target.read_text(encoding='utf-8')
     if not content.startswith('---'):
         return False, "No YAML frontmatter found"
 
@@ -222,7 +251,7 @@ def main():
         print(f"Error: Path not found: {skill_path}")
         sys.exit(1)
 
-    valid, message = validate_skill(skill_path)
+    valid, message = validate_skill(skill_path, root=cwd_root)
 
     if valid:
         print(f"✅ {message}")

--- a/src/copilot-cli/skills/SkillForge/scripts/quick_validate.py
+++ b/src/copilot-cli/skills/SkillForge/scripts/quick_validate.py
@@ -111,6 +111,17 @@ def _parse_frontmatter_fallback(frontmatter_text: str) -> dict[str, Any]:
     return frontmatter
 
 
+def _is_within(child: str, root: str) -> bool:
+    """Return True when case-normalized realpath ``child`` is ``root`` or nested inside it.
+
+    Both arguments must already be ``os.path.normcase(os.path.realpath(...))``
+    results. ``os.path.join(root, "")`` appends exactly one trailing separator
+    whether or not ``root`` already ends with one, so a filesystem-root ``root``
+    (``/`` or ``C:\\``) does not double into ``//`` and reject valid descendants.
+    """
+    return child == root or child.startswith(os.path.join(root, ""))
+
+
 def _contained_realpath(target: Path, root: str) -> str | None:
     """Resolve ``target`` and return its real path only if it stays within ``root``.
 
@@ -125,7 +136,7 @@ def _contained_realpath(target: Path, root: str) -> str | None:
     """
     real = os.path.realpath(target)
     real_cmp = os.path.normcase(real)
-    if real_cmp == root or real_cmp.startswith(root + os.sep):
+    if _is_within(real_cmp, root):
         return real
     return None
 
@@ -262,7 +273,7 @@ def main():
     # c:\) while realpath() resolves symlinks so a descendant symlink cannot escape.
     cwd_root = os.path.normcase(os.path.realpath(os.getcwd()))
     resolved = os.path.normcase(os.path.realpath(skill_path))
-    if not resolved.startswith(cwd_root + os.sep) and resolved != cwd_root:
+    if not _is_within(resolved, cwd_root):
         print(f"Error: Path traversal detected: {skill_path}")
         sys.exit(1)
 

--- a/tests/skills/test_skillforge_quick_validate_guard.py
+++ b/tests/skills/test_skillforge_quick_validate_guard.py
@@ -14,6 +14,8 @@ drift.
 from __future__ import annotations
 
 import importlib.util
+import ntpath
+import posixpath
 import subprocess
 import sys
 from pathlib import Path
@@ -166,12 +168,40 @@ def _load_module(script: Path):
 
 @pytest.mark.parametrize("script", _SCRIPTS, ids=_script_id)
 def test_is_within_handles_filesystem_root(script: Path) -> None:
-    # Regression for the doubled-separator bug: when the root is a filesystem
-    # root ("/" or a drive root), root + os.sep becomes "//", so a valid
-    # descendant was wrongly rejected. os.path.join(root, "") keeps one
-    # separator so containment holds at the root boundary.
+    # Cross-platform regression for the containment guard. ``_is_within`` runs on
+    # the host's ``os.path``, so a host-only assertion (POSIX literals on Linux CI)
+    # never exercises Windows drive/UNC root semantics where the CWE-22 sibling-
+    # share bypass lived. Inject ``posixpath`` and ``ntpath`` explicitly so both
+    # platforms are covered deterministically on any host. Inputs are normcased
+    # with the same module to mirror the production caller
+    # (``os.path.normcase(os.path.realpath(...))``).
     is_within = _load_module(script)._is_within
-    assert is_within("/foo", "/") is True  # descendant of filesystem root
-    assert is_within("/tmp/x", "/tmp") is True  # normal containment
-    assert is_within("/tmp", "/tmp") is True  # exact root
-    assert is_within("/tmpevil", "/tmp") is False  # sibling prefix, not nested
+    cases = [
+        # (pathmod, child, root, expected, label)
+        (posixpath, "/foo", "/", True, "posix descendant of root"),
+        (posixpath, "/tmp/x", "/tmp", True, "posix normal containment"),
+        (posixpath, "/tmp", "/tmp", True, "posix exact root"),
+        (posixpath, "/tmpevil", "/tmp", False, "posix sibling prefix"),
+        (ntpath, r"c:\repo\skill", r"c:\repo", True, "win normal containment"),
+        (ntpath, r"c:\repo", r"c:\repo", True, "win exact root"),
+        (ntpath, r"c:\repoevil", r"c:\repo", False, "win sibling prefix"),
+        (ntpath, r"c:\evil", "c:\\", True, "win descendant of bare drive root"),
+        (ntpath, r"d:\x", "c:\\", False, "win different drive fails closed"),
+        (ntpath, r"\\srv\share\repo\skill", r"\\srv\share\repo", True, "win UNC nested child"),
+        (ntpath, r"\\srv\share\repo", r"\\srv\share\repo", True, "win UNC exact root"),
+        (ntpath, r"\\srv\share\repoevil\x", r"\\srv\share\repo", False, "win UNC sibling prefix"),
+        (ntpath, r"\\srv\other\x", r"\\srv\share\repo", False, "win different UNC share"),
+        # The CWE-22 bypass the commonpath fix closes: a sibling share whose name
+        # string-prefixes the sandbox root. os.path.join(root, "") appends no
+        # separator to a bare UNC share, so the old startswith() let this escape.
+        (
+            ntpath,
+            r"\\srv\shareevil\skill",
+            r"\\srv\share",
+            False,
+            "win bare UNC sibling share (CWE-22)",
+        ),
+    ]
+    for pathmod, child, root, expected, label in cases:
+        got = is_within(pathmod.normcase(child), pathmod.normcase(root), pathmod)
+        assert got is expected, f"{label}: is_within({child!r}, {root!r}) = {got}, want {expected}"

--- a/tests/skills/test_skillforge_quick_validate_guard.py
+++ b/tests/skills/test_skillforge_quick_validate_guard.py
@@ -1,0 +1,95 @@
+"""Regression tests for the SkillForge quick_validate.py path-traversal guard.
+
+Issue #3224: the CLI guard hardcoded ``~/.claude/skills`` as the only allowed
+root, so any skill under the current working directory (a repo checkout, a
+Copilot CLI install) was rejected with "Path traversal detected" and could
+never be validated. The fix roots the CWE-22 guard at ``os.getcwd()`` to match
+the sibling ``validate-skill.py`` and the SKILL.md "current directory" guidance.
+
+These tests exercise the real CLI as the issue's repro does, and run against
+both the ``.claude`` copy and the ``src/copilot-cli`` mirror so the two cannot
+drift.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_SCRIPTS = [
+    _REPO_ROOT / ".claude" / "skills" / "SkillForge" / "scripts" / "quick_validate.py",
+    _REPO_ROOT
+    / "src"
+    / "copilot-cli"
+    / "skills"
+    / "SkillForge"
+    / "scripts"
+    / "quick_validate.py",
+]
+
+_TRAVERSAL_MARKER = "Path traversal detected"
+
+
+def _make_skill(dir_path: Path) -> None:
+    """Create a minimal skill directory so the guard has a real target."""
+    dir_path.mkdir(parents=True, exist_ok=True)
+    (dir_path / "SKILL.md").write_text(
+        "---\nname: sample\ndescription: sample skill\n---\n\n# Sample\n",
+        encoding="utf-8",
+    )
+
+
+def _run(script: Path, cwd: Path, arg: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(script), arg],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda p: p.parts[-4])
+def test_scripts_exist(script: Path) -> None:
+    assert script.is_file(), f"missing quick_validate copy: {script}"
+
+
+@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda p: p.parts[-4])
+def test_skill_under_cwd_passes_traversal_guard(script: Path, tmp_path: Path) -> None:
+    # A skill under the current working directory must clear the CWE-22 guard.
+    # The final validation verdict is irrelevant here; the guard must not fire.
+    _make_skill(tmp_path / "my-skill")
+    result = _run(script, cwd=tmp_path, arg="my-skill")
+    combined = result.stdout + result.stderr
+    assert _TRAVERSAL_MARKER not in combined, combined
+
+
+@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda p: p.parts[-4])
+def test_dotdot_escape_above_cwd_is_rejected(script: Path, tmp_path: Path) -> None:
+    # CWE-22 protection is preserved: a path resolving above cwd is rejected.
+    outside = tmp_path / "outside-skill"
+    _make_skill(outside)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    result = _run(script, cwd=workdir, arg="../outside-skill")
+    combined = result.stdout + result.stderr
+    assert _TRAVERSAL_MARKER in combined, combined
+    assert result.returncode == 1
+
+
+@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda p: p.parts[-4])
+def test_absolute_path_outside_cwd_is_rejected(script: Path, tmp_path: Path) -> None:
+    # An absolute path outside the working directory is also an escape.
+    outside = tmp_path / "elsewhere"
+    _make_skill(outside)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    result = _run(script, cwd=workdir, arg=str(outside))
+    combined = result.stdout + result.stderr
+    assert _TRAVERSAL_MARKER in combined, combined
+    assert result.returncode == 1

--- a/tests/skills/test_skillforge_quick_validate_guard.py
+++ b/tests/skills/test_skillforge_quick_validate_guard.py
@@ -23,16 +23,16 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 _SCRIPTS = [
     _REPO_ROOT / ".claude" / "skills" / "SkillForge" / "scripts" / "quick_validate.py",
-    _REPO_ROOT
-    / "src"
-    / "copilot-cli"
-    / "skills"
-    / "SkillForge"
-    / "scripts"
-    / "quick_validate.py",
+    _REPO_ROOT / "src" / "copilot-cli" / "skills" / "SkillForge" / "scripts" / "quick_validate.py",
 ]
 
 _TRAVERSAL_MARKER = "Path traversal detected"
+_OUTSIDE_ROOT_MARKER = "outside the permitted root"
+
+
+def _script_id(script: Path) -> str:
+    """Distinguish the .claude copy from the copilot-cli mirror in test IDs."""
+    return script.parts[-5]
 
 
 def _make_skill(dir_path: Path) -> None:
@@ -56,22 +56,26 @@ def _run(script: Path, cwd: Path, arg: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda p: p.parts[-4])
+@pytest.mark.parametrize("script", _SCRIPTS, ids=_script_id)
 def test_scripts_exist(script: Path) -> None:
     assert script.is_file(), f"missing quick_validate copy: {script}"
 
 
-@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda p: p.parts[-4])
+@pytest.mark.parametrize("script", _SCRIPTS, ids=_script_id)
 def test_skill_under_cwd_passes_traversal_guard(script: Path, tmp_path: Path) -> None:
     # A skill under the current working directory must clear the CWE-22 guard.
     # The final validation verdict is irrelevant here; the guard must not fire.
     _make_skill(tmp_path / "my-skill")
     result = _run(script, cwd=tmp_path, arg="my-skill")
     combined = result.stdout + result.stderr
+    # The script must reach a clean validation verdict, not crash before the
+    # guard: a traceback would also lack the traversal marker (a false pass).
+    assert result.returncode == 0, combined
     assert _TRAVERSAL_MARKER not in combined, combined
+    assert _OUTSIDE_ROOT_MARKER not in combined, combined
 
 
-@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda p: p.parts[-4])
+@pytest.mark.parametrize("script", _SCRIPTS, ids=_script_id)
 def test_dotdot_escape_above_cwd_is_rejected(script: Path, tmp_path: Path) -> None:
     # CWE-22 protection is preserved: a path resolving above cwd is rejected.
     outside = tmp_path / "outside-skill"
@@ -84,7 +88,7 @@ def test_dotdot_escape_above_cwd_is_rejected(script: Path, tmp_path: Path) -> No
     assert result.returncode == 1
 
 
-@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda p: p.parts[-4])
+@pytest.mark.parametrize("script", _SCRIPTS, ids=_script_id)
 def test_absolute_path_outside_cwd_is_rejected(script: Path, tmp_path: Path) -> None:
     # An absolute path outside the working directory is also an escape.
     outside = tmp_path / "elsewhere"
@@ -97,13 +101,8 @@ def test_absolute_path_outside_cwd_is_rejected(script: Path, tmp_path: Path) -> 
     assert result.returncode == 1
 
 
-_OUTSIDE_ROOT_MARKER = "outside the permitted root"
-
-
-@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda p: p.parts[-4])
-def test_descendant_symlink_skill_md_is_rejected(
-    script: Path, tmp_path: Path
-) -> None:
+@pytest.mark.parametrize("script", _SCRIPTS, ids=_script_id)
+def test_descendant_symlink_skill_md_is_rejected(script: Path, tmp_path: Path) -> None:
     # CWE-22: even when the skill directory is contained under cwd, a SKILL.md
     # symlink whose target is outside cwd must not be read or validated.
     outside = tmp_path / "outside"
@@ -127,7 +126,7 @@ def test_descendant_symlink_skill_md_is_rejected(
     assert "Skill is valid" not in combined, combined
 
 
-@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda p: p.parts[-4])
+@pytest.mark.parametrize("script", _SCRIPTS, ids=_script_id)
 def test_symlink_within_cwd_is_allowed(script: Path, tmp_path: Path) -> None:
     # A SKILL.md symlink whose target stays inside cwd resolves within the root,
     # so neither the traversal guard nor the containment check may fire.

--- a/tests/skills/test_skillforge_quick_validate_guard.py
+++ b/tests/skills/test_skillforge_quick_validate_guard.py
@@ -93,3 +93,56 @@ def test_absolute_path_outside_cwd_is_rejected(script: Path, tmp_path: Path) -> 
     combined = result.stdout + result.stderr
     assert _TRAVERSAL_MARKER in combined, combined
     assert result.returncode == 1
+
+
+_OUTSIDE_ROOT_MARKER = "outside the permitted root"
+
+
+@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda p: p.parts[-4])
+def test_descendant_symlink_skill_md_is_rejected(
+    script: Path, tmp_path: Path
+) -> None:
+    # CWE-22: even when the skill directory is contained under cwd, a SKILL.md
+    # symlink whose target is outside cwd must not be read or validated.
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.md"
+    secret.write_text(
+        "---\nname: leaked\ndescription: out-of-root content\n---\n",
+        encoding="utf-8",
+    )
+    workdir = tmp_path / "work"
+    contained = workdir / "evil"
+    contained.mkdir(parents=True)
+    try:
+        (contained / "SKILL.md").symlink_to(secret)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not permitted on this platform")
+    result = _run(script, cwd=workdir, arg="evil")
+    combined = result.stdout + result.stderr
+    assert _OUTSIDE_ROOT_MARKER in combined, combined
+    assert result.returncode == 1, combined
+    assert "Skill is valid" not in combined, combined
+
+
+@pytest.mark.parametrize("script", _SCRIPTS, ids=lambda p: p.parts[-4])
+def test_symlink_within_cwd_is_allowed(script: Path, tmp_path: Path) -> None:
+    # A SKILL.md symlink whose target stays inside cwd resolves within the root,
+    # so neither the traversal guard nor the containment check may fire.
+    workdir = tmp_path / "work"
+    real = workdir / "real"
+    real.mkdir(parents=True)
+    (real / "SKILL.md").write_text(
+        "---\nname: ok\ndescription: in-root content\n---\n",
+        encoding="utf-8",
+    )
+    skill = workdir / "skill"
+    skill.mkdir()
+    try:
+        (skill / "SKILL.md").symlink_to(real / "SKILL.md")
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not permitted on this platform")
+    result = _run(script, cwd=workdir, arg="skill")
+    combined = result.stdout + result.stderr
+    assert _OUTSIDE_ROOT_MARKER not in combined, combined
+    assert _TRAVERSAL_MARKER not in combined, combined

--- a/tests/skills/test_skillforge_quick_validate_guard.py
+++ b/tests/skills/test_skillforge_quick_validate_guard.py
@@ -13,6 +13,7 @@ drift.
 
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
@@ -145,5 +146,32 @@ def test_symlink_within_cwd_is_allowed(script: Path, tmp_path: Path) -> None:
         pytest.skip("symlink creation not permitted on this platform")
     result = _run(script, cwd=workdir, arg="skill")
     combined = result.stdout + result.stderr
+    # A clean exit proves the script validated the in-root target rather than
+    # crashing before the guard (a traceback would also lack both markers).
+    assert result.returncode == 0, combined
     assert _OUTSIDE_ROOT_MARKER not in combined, combined
     assert _TRAVERSAL_MARKER not in combined, combined
+
+
+def _load_module(script: Path):
+    """Import a quick_validate copy as a module to unit-test its helpers."""
+    spec = importlib.util.spec_from_file_location(
+        f"quick_validate_{script.parts[-5]}", script
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("script", _SCRIPTS, ids=_script_id)
+def test_is_within_handles_filesystem_root(script: Path) -> None:
+    # Regression for the doubled-separator bug: when the root is a filesystem
+    # root ("/" or a drive root), root + os.sep becomes "//", so a valid
+    # descendant was wrongly rejected. os.path.join(root, "") keeps one
+    # separator so containment holds at the root boundary.
+    is_within = _load_module(script)._is_within
+    assert is_within("/foo", "/") is True  # descendant of filesystem root
+    assert is_within("/tmp/x", "/tmp") is True  # normal containment
+    assert is_within("/tmp", "/tmp") is True  # exact root
+    assert is_within("/tmpevil", "/tmp") is False  # sibling prefix, not nested

--- a/tests/skills/test_skillforge_quick_validate_guard.py
+++ b/tests/skills/test_skillforge_quick_validate_guard.py
@@ -50,6 +50,8 @@ def _run(script: Path, cwd: Path, arg: str) -> subprocess.CompletedProcess[str]:
         cwd=str(cwd),
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
     )
 


### PR DESCRIPTION
## Summary

`quick_validate.py` hardcoded `~/.claude/skills` as the only allowed root for
its path-traversal guard. Any skill under the current working directory (a repo
checkout, a Copilot CLI install) was rejected with "Path traversal detected" and
could never be validated. The CWE-22 guard was too narrow, not too loose: it
produced false positives on legitimate targets.

## Fix

Root the guard at `os.path.realpath(os.getcwd())` so repo-local and Copilot CLI
skills validate, matching the sibling validator and the SKILL.md "current
directory" guidance. CWE-22 protection is preserved: a resolved path must start
with `cwd_root + os.sep` or equal `cwd_root`, so `../` and absolute paths above
cwd are still rejected.

## Scope note (touched-file lint debt)

Editing the file surfaced pre-existing lint/type debt that the changed-file
gates flag on any edit. Fixed idiomatically, no suppressions:

- Annotate `_parse_frontmatter_fallback` return and locals so mypy passes.
- Sort the import block (ruff I001) and reflow three over-length f-string error
  messages (ruff E501) with implicit concatenation.

Regenerated the Copilot-CLI mirror so both copies stay byte-identical (parity
gate) and bumped the project-toolkit plugin version 0.6.70 to 0.6.71 on both
parity manifests.

Pre-existing advisory taste-lints (function complexity in `validate_skill`, the
`SkillForge` directory name) are left as-is: decomposing or renaming is
unrelated churn outside this security fix.

## Testing

New suite runs the real CLI against both copies:

- Positive: a skill under cwd clears the guard.
- Negative: a `../` escape above cwd is rejected (exit 1).
- Negative: an absolute path outside cwd is rejected (exit 1).

8 passed. ruff clean, mypy clean, no build drift.

Fixes #3224

## References

- Sibling guard precedent: `.claude/skills/SkillForge/scripts/validate-skill.py`
