### PR TITLE
test(pre-pr): stop restoring sys.path so lazy version-pin import resolves

### DIFF
--- a/tests/validation/test_pre_pr_model_pin_wiring.py
+++ b/tests/validation/test_pre_pr_model_pin_wiring.py
@@ -33,20 +33,21 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # test scoped to the wiring it verifies.
 #
 # The three modules resolve their sibling imports at import time (cached in
-# ``sys.modules``); their only function-level imports are stdlib. Snapshot
-# ``sys.path`` and restore it in ``finally`` so the injected directory does not
-# leak into other test modules, while the already-imported modules keep working
-# at runtime from ``sys.modules``.
+# ``sys.modules``). Do NOT snapshot-and-restore ``sys.path`` after these imports.
+# Production ``pre_pr`` leaves ``scripts/validation`` on ``sys.path`` for the
+# whole run, and ``checks_tooling.validate_copilot_version_pin`` performs a
+# *function-local* ``from check_copilot_version_pin import EXIT_OK, check_action``
+# (checks_tooling.py, #3073) that resolves by bare name at call time. Restoring
+# ``sys.path`` here would remove that directory and make the lazy import fail
+# with ``ModuleNotFoundError`` when this test file runs in isolation (the full
+# suite masks it because test_check_copilot_version_pin.py imports the module
+# first). Mirror production: insert once, leave it.
 _VALIDATION_DIR = REPO_ROOT / "scripts" / "validation"
-_SYS_PATH_SNAPSHOT = list(sys.path)
 if str(_VALIDATION_DIR) not in sys.path:
     sys.path.insert(0, str(_VALIDATION_DIR))
-try:
-    import checks_spec  # noqa: E402
-    import pre_pr  # noqa: E402
-    import pre_pr_sequence  # noqa: E402
-finally:
-    sys.path[:] = _SYS_PATH_SNAPSHOT
+import checks_spec  # noqa: E402
+import pre_pr  # noqa: E402
+import pre_pr_sequence  # noqa: E402
 
 
 def test_validate_model_pins_passes_in_warn_mode() -> None:


### PR DESCRIPTION
## Summary

Follow-up regression fix for merged PR #3227. That PR added a `try/finally`
that snapshotted and restored `sys.path` around the pre-PR model-pin wiring
test. The restore reverts the `sys.path` insertion that lets the production
code path resolve its lazy import, so the test no longer exercises the real
import resolution it claims to protect.

## The bug

`validate_copilot_version_pin` (in the validation tooling module) does a lazy
`from check_copilot_version_pin import ...` at call time. Production resolves
that import because the validation dir is on `sys.path` (appended, not
removed). The merged test restored `sys.path` to a pre-test snapshot, which:

- pops the validation dir back off `sys.path`, and
- leaves `check_copilot_version_pin` out of `sys.modules`,

so a later call in the same process raises
`ModuleNotFoundError: No module named 'check_copilot_version_pin'`. The test's
restore made it diverge from production behavior. The full suite masks it
because another test imports the module first; running this file in isolation
fails.

## Fix

Drop the `try/finally` restore. Keep the `sys.path` insertion append-only, which
matches how production leaves the path after the validation runner executes. A
comment explains the production-faithfulness requirement so the restore is not
reintroduced.

## Verification

- `uv run pytest tests/validation/test_pre_pr_model_pin_wiring.py -q` -> 9 passed
  in isolation.
- Empirically reproduced the merged (restore) version raising `ModuleNotFoundError`
  in isolation; the append-only version resolves the import.

## References

- The lazy import under test lives in `scripts/validation/checks_tooling.py`
  (`validate_copilot_version_pin`), which is not modified by this PR.

Refs #3073
