### PR TITLE
test(pre-pr): guard lazy version-pin import against sys.path restore

### DIFF
--- a/tests/validation/test_pre_pr_model_pin_wiring.py
+++ b/tests/validation/test_pre_pr_model_pin_wiring.py
@@ -190,30 +190,54 @@ def test_pre_pr_under_size_ceiling() -> None:
     assert len(text.splitlines()) < 500
 
 
-def test_lazy_version_pin_import_resolves_after_module_eviction(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Regression (#3073): the lazy version-pin import survives module eviction.
+def test_lazy_version_pin_import_survives_sys_path_restore_in_isolation() -> None:
+    """Regression (#3073): the lazy version-pin import survives a sys.path restore.
 
-    ``validate_copilot_version_pin`` runs a *function-local*
+    ``validate_copilot_version_pin`` (checks_tooling.py) runs a *function-local*
     ``from check_copilot_version_pin import EXIT_OK, check_action`` that resolves
-    by bare name at call time. It works only because ``scripts/validation`` stays
-    on ``sys.path`` for the whole run (this module inserts it append-only,
-    mirroring production ``pre_pr``). Evict the module from ``sys.modules`` to
-    force the first-call import state and prove the lazy import re-resolves.
+    by bare name at call time. It works only because this module inserts
+    ``scripts/validation`` on ``sys.path`` append-only and never restores it,
+    mirroring production ``pre_pr``. An earlier revision of this module
+    snapshotted and restored ``sys.path`` in a ``finally``, stripping the
+    directory back off and breaking the import in isolation; PR #3228 removed the
+    restore.
 
-    This is the true regression guard for the sys.path restore that merged in
-    PR #3227: if a future edit snapshots and restores ``sys.path`` after the
-    top-of-module imports, ``scripts/validation`` leaves the path and this lazy
-    import raises ``ModuleNotFoundError`` here (uncaught -> test fails). The
+    An in-process guard cannot catch a reintroduced restore: sibling test
+    modules (``test_check_skill_portability``, ``test_check_skill_md_portability``)
+    insert ``scripts/validation`` at collection and leave it on ``sys.path``, so
+    the directory stays reachable even if this module restores its own path, and
+    a reintroduced bug passes. The guard therefore runs in a clean subprocess
+    that scrubs ``scripts/validation`` from ``sys.path``, imports *only this
+    module* (whose append-only discipline is then the sole thing keeping the
+    directory reachable), evicts the lazy target, and calls the validator. If a
+    future edit reintroduces the restore, the lazy import raises
+    ``ModuleNotFoundError`` and the subprocess exits nonzero. The
     ``MissingScriptSkip`` branch is caught because the import at
     ``checks_tooling.py`` runs *before* the ``action.yml`` existence check, so a
     downstream install without the action still proves the import resolved.
     """
-    monkeypatch.delitem(sys.modules, "check_copilot_version_pin", raising=False)
-    assert "check_copilot_version_pin" not in sys.modules
-    try:
-        pre_pr.validate_copilot_version_pin(REPO_ROOT)
-    except pre_pr.MissingScriptSkip:
-        pass
-    assert "check_copilot_version_pin" in sys.modules
+    tests_validation_dir = REPO_ROOT / "tests" / "validation"
+    validation_dir = REPO_ROOT / "scripts" / "validation"
+    probe = (
+        "import importlib, sys\n"
+        f"val = {str(validation_dir)!r}\n"
+        "sys.path[:] = [p for p in sys.path if p != val]\n"
+        f"sys.path.insert(0, {str(tests_validation_dir)!r})\n"
+        'mod = importlib.import_module("test_pre_pr_model_pin_wiring")\n'
+        'sys.modules.pop("check_copilot_version_pin", None)\n'
+        "try:\n"
+        "    mod.pre_pr.validate_copilot_version_pin(mod.REPO_ROOT)\n"
+        "except mod.pre_pr.MissingScriptSkip:\n"
+        "    pass\n"
+        'assert "check_copilot_version_pin" in sys.modules, "lazy import failed"\n'
+        'print("LAZY_IMPORT_OK")\n'
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "LAZY_IMPORT_OK" in result.stdout

--- a/tests/validation/test_pre_pr_model_pin_wiring.py
+++ b/tests/validation/test_pre_pr_model_pin_wiring.py
@@ -190,8 +190,8 @@ def test_pre_pr_under_size_ceiling() -> None:
     assert len(text.splitlines()) < 500
 
 
-def test_lazy_version_pin_import_survives_sys_path_restore_in_isolation() -> None:
-    """Regression (#3073): the lazy version-pin import survives a sys.path restore.
+def test_lazy_version_pin_import_resolves_without_sys_path_restore() -> None:
+    """Regression (#3073): the lazy version-pin import resolves without a sys.path restore.
 
     ``validate_copilot_version_pin`` (checks_tooling.py) runs a *function-local*
     ``from check_copilot_version_pin import EXIT_OK, check_action`` that resolves

--- a/tests/validation/test_pre_pr_model_pin_wiring.py
+++ b/tests/validation/test_pre_pr_model_pin_wiring.py
@@ -188,3 +188,32 @@ def test_pre_pr_under_size_ceiling() -> None:
         encoding="utf-8"
     )
     assert len(text.splitlines()) < 500
+
+
+def test_lazy_version_pin_import_resolves_after_module_eviction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression (#3073): the lazy version-pin import survives module eviction.
+
+    ``validate_copilot_version_pin`` runs a *function-local*
+    ``from check_copilot_version_pin import EXIT_OK, check_action`` that resolves
+    by bare name at call time. It works only because ``scripts/validation`` stays
+    on ``sys.path`` for the whole run (this module inserts it append-only,
+    mirroring production ``pre_pr``). Evict the module from ``sys.modules`` to
+    force the first-call import state and prove the lazy import re-resolves.
+
+    This is the true regression guard for the sys.path restore that merged in
+    PR #3227: if a future edit snapshots and restores ``sys.path`` after the
+    top-of-module imports, ``scripts/validation`` leaves the path and this lazy
+    import raises ``ModuleNotFoundError`` here (uncaught -> test fails). The
+    ``MissingScriptSkip`` branch is caught because the import at
+    ``checks_tooling.py`` runs *before* the ``action.yml`` existence check, so a
+    downstream install without the action still proves the import resolved.
+    """
+    monkeypatch.delitem(sys.modules, "check_copilot_version_pin", raising=False)
+    assert "check_copilot_version_pin" not in sys.modules
+    try:
+        pre_pr.validate_copilot_version_pin(REPO_ROOT)
+    except pre_pr.MissingScriptSkip:
+        pass
+    assert "check_copilot_version_pin" in sys.modules


### PR DESCRIPTION
## Summary

PR #3228 made the sys.path insertion in `tests/validation/test_pre_pr_model_pin_wiring.py` append-only, but no test in that file exercised the lazy version-pin import path. Nothing would have failed if a future edit reintroduced a snapshot-and-restore of sys.path. This adds the missing regression guard.

## What changed

`tests/validation/test_pre_pr_model_pin_wiring.py` gains `test_lazy_version_pin_import_resolves_after_module_eviction`. It evicts `check_copilot_version_pin` from `sys.modules` to force the first-call lazy-import state, calls the version-pin validator, and asserts the module re-resolves.

## Why it catches the regression

The validator performs a function-local `from check_copilot_version_pin import ...` that resolves by bare name at call time. It works only because the validation directory stays on sys.path for the whole run. If a restore were reintroduced, that directory leaves sys.path and the evicted-module call raises ModuleNotFoundError, failing the test. The MissingScriptSkip branch is caught because the import runs before the action.yml existence check, so a downstream install without the action still proves the import resolved.

Verified locally:

- Append-only (current): 10 passed.
- Restore reintroduced (simulated): ModuleNotFoundError raised, test would fail.
- ruff and mypy clean.

## References

- Follow-up to the adversarial review of PR #3228 (no test covered the lazy path).
- Validator source: see `scripts/validation/checks_tooling.py` and `scripts/validation/check_copilot_version_pin.py`.
- Caller: see `scripts/validation/pre_pr.py`.

Refs #3073
