### PR TITLE
fix(skillforge): accept valid child under a bare UNC share root (#3226 follow-up)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.71",
+  "version": "0.6.72",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/SkillForge/scripts/quick_validate.py
+++ b/.claude/skills/SkillForge/scripts/quick_validate.py
@@ -119,7 +119,12 @@ class _PathModule(Protocol):
     containment comparison stays ``bool`` instead of decaying to ``Any``).
     """
 
+    sep: str
+    altsep: str | None
+
     def commonpath(self, paths: list[str], /) -> str: ...
+
+    def splitdrive(self, p: str, /) -> tuple[str, str]: ...
 
 
 def _is_within(child: str, root: str, pathmod: _PathModule = os.path) -> bool:
@@ -135,10 +140,15 @@ def _is_within(child: str, root: str, pathmod: _PathModule = os.path) -> bool:
     escaped the CWD sandbox (CWE-22). ``commonpath`` compares whole path
     components, so only true descendants match.
 
-    ``commonpath`` raises ``ValueError`` when the two paths cannot share a base
-    (different drives, drive-vs-UNC, or a bare UNC share root that ``ntpath``
-    treats as rootless). Those all mean "not contained", so the guard fails
-    closed and returns False.
+    ``commonpath`` raises ``ValueError`` when the two paths cannot form a common
+    base. Different drives or drive-vs-UNC genuinely mean "not contained". But a
+    bare UNC share root (``\\\\server\\share``) has an empty root-relative part,
+    so ``ntpath`` treats it as rootless and refuses to mix it with a rooted
+    child, even though real descendants of that share ARE contained. On that
+    ``ValueError`` the guard decides by drive identity: contained only when child
+    and root share the same drive/share and root is that drive/share root itself.
+    This keeps the CWE-22 sibling-share rejection while no longer false-rejecting
+    a legitimate SKILL.md that lives directly under a bare share root.
 
     ``pathmod`` is injected only so tests can pin ``posixpath`` or ``ntpath`` and
     exercise both platforms' root semantics deterministically on any host;
@@ -149,7 +159,14 @@ def _is_within(child: str, root: str, pathmod: _PathModule = os.path) -> bool:
     try:
         return pathmod.commonpath([child, root]) == root
     except ValueError:
-        return False
+        # See the docstring: distinguish a genuine different-drive mismatch from
+        # a bare UNC share root that ``ntpath`` cannot mix with a rooted child.
+        child_drive, _ = pathmod.splitdrive(child)
+        root_drive, root_rel = pathmod.splitdrive(root)
+        if child_drive != root_drive:
+            return False
+        separators = {pathmod.sep, pathmod.altsep or pathmod.sep}
+        return root_rel == "" or root_rel in separators
 
 
 def _contained_realpath(target: Path, root: str) -> str | None:

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.71",
+  "version": "0.6.72",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/SkillForge/scripts/quick_validate.py
+++ b/src/copilot-cli/skills/SkillForge/scripts/quick_validate.py
@@ -119,7 +119,12 @@ class _PathModule(Protocol):
     containment comparison stays ``bool`` instead of decaying to ``Any``).
     """
 
+    sep: str
+    altsep: str | None
+
     def commonpath(self, paths: list[str], /) -> str: ...
+
+    def splitdrive(self, p: str, /) -> tuple[str, str]: ...
 
 
 def _is_within(child: str, root: str, pathmod: _PathModule = os.path) -> bool:
@@ -135,10 +140,15 @@ def _is_within(child: str, root: str, pathmod: _PathModule = os.path) -> bool:
     escaped the CWD sandbox (CWE-22). ``commonpath`` compares whole path
     components, so only true descendants match.
 
-    ``commonpath`` raises ``ValueError`` when the two paths cannot share a base
-    (different drives, drive-vs-UNC, or a bare UNC share root that ``ntpath``
-    treats as rootless). Those all mean "not contained", so the guard fails
-    closed and returns False.
+    ``commonpath`` raises ``ValueError`` when the two paths cannot form a common
+    base. Different drives or drive-vs-UNC genuinely mean "not contained". But a
+    bare UNC share root (``\\\\server\\share``) has an empty root-relative part,
+    so ``ntpath`` treats it as rootless and refuses to mix it with a rooted
+    child, even though real descendants of that share ARE contained. On that
+    ``ValueError`` the guard decides by drive identity: contained only when child
+    and root share the same drive/share and root is that drive/share root itself.
+    This keeps the CWE-22 sibling-share rejection while no longer false-rejecting
+    a legitimate SKILL.md that lives directly under a bare share root.
 
     ``pathmod`` is injected only so tests can pin ``posixpath`` or ``ntpath`` and
     exercise both platforms' root semantics deterministically on any host;
@@ -149,7 +159,14 @@ def _is_within(child: str, root: str, pathmod: _PathModule = os.path) -> bool:
     try:
         return pathmod.commonpath([child, root]) == root
     except ValueError:
-        return False
+        # See the docstring: distinguish a genuine different-drive mismatch from
+        # a bare UNC share root that ``ntpath`` cannot mix with a rooted child.
+        child_drive, _ = pathmod.splitdrive(child)
+        root_drive, root_rel = pathmod.splitdrive(root)
+        if child_drive != root_drive:
+            return False
+        separators = {pathmod.sep, pathmod.altsep or pathmod.sep}
+        return root_rel == "" or root_rel in separators
 
 
 def _contained_realpath(target: Path, root: str) -> str | None:

--- a/tests/skills/test_skillforge_quick_validate_guard.py
+++ b/tests/skills/test_skillforge_quick_validate_guard.py
@@ -201,6 +201,25 @@ def test_is_within_handles_filesystem_root(script: Path) -> None:
             False,
             "win bare UNC sibling share (CWE-22)",
         ),
+        # Regression (adv review of #3226): a legitimate descendant directly
+        # under a bare UNC share root must be accepted. ``ntpath.commonpath``
+        # raises "Can't mix absolute and relative paths" here because the bare
+        # share root's root-relative part is empty; the drive-aware fallback
+        # keeps this contained instead of false-rejecting a real SKILL.md read.
+        (
+            ntpath,
+            r"\\srv\share\skill",
+            r"\\srv\share",
+            True,
+            "win bare UNC share root, valid child",
+        ),
+        (
+            ntpath,
+            r"\\srv\share",
+            r"\\srv\share",
+            True,
+            "win bare UNC share root, exact equal",
+        ),
     ]
     for pathmod, child, root, expected, label in cases:
         got = is_within(pathmod.normcase(child), pathmod.normcase(root), pathmod)


### PR DESCRIPTION
## Summary

Follow-up to the adversarial review of PR #3226 (CWE-22 cwd containment guard). The review found a fail-closed false negative: when the trusted root is a bare UNC share root (`\\server\share`), the guard rejects a legitimate SKILL.md that resolves directly under it. This fixes the false negative while keeping the sibling-share rejection intact.

## Root cause

`_is_within` decides containment with `os.path.commonpath`. On Windows path semantics (`ntpath`), `splitdrive("\\server\share")` returns an empty root-relative part, so `ntpath` treats the bare share root as rootless and `commonpath` raises `ValueError: Can't mix absolute and relative paths` when compared against a rooted child. The prior code mapped every `ValueError` to "not contained" and returned False, which wrongly rejects a real descendant. A bare drive root (`C:\`) is unaffected because its root-relative part is a separator, not empty.

## What changed

- `_is_within`: on `ValueError`, decide by drive identity. Contained only when child and root share the same drive/share AND root is that drive/share root itself (root-relative part empty or a lone separator). Genuine different-drive and drive-vs-UNC mismatches still return False.
- `_PathModule` Protocol: add `splitdrive`, `sep`, `altsep` so the injected path module stays precisely typed.
- Regression tests: a valid child under a bare UNC share root is accepted; the exact-equal bare share root is accepted; the CWE-22 sibling-share case (`\\server\shareevil` under `\\server\share`) stays rejected.
- Regenerated the copilot-cli skill mirror; bumped both parity plugin manifests to 0.6.72.

## Verification

- `uv run pytest tests/skills/test_skillforge_quick_validate_guard.py` -> 14 passed (both claude and copilot-cli variants).
- ruff and mypy clean on canonical and mirror.
- Manifest parity holds (0.6.72 / 0.6.72).

## Out of Scope

The review also raised an Optional TOCTOU note (CWE-367): an attacker with write access inside the root could swap an ancestor directory for an escaping symlink between `realpath()` and `read_text()`. Deferred: an attacker who already has write access inside the guarded root can write a malicious SKILL.md directly, so the compensating control (`openat2(RESOLVE_BENEATH)` or descriptor-relative traversal) is a larger platform-specific change with no marginal risk reduction for this threat model. Tracked as a note for a dedicated follow-up if the threat model changes.

Refs #3226
