### PR TITLE
fix(taste-lints): exempt helper modules from hook invoke_ naming rule

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.77",
+  "version": "0.6.78",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/taste-lints/scripts/taste_lints.py
+++ b/.claude/skills/taste-lints/scripts/taste_lints.py
@@ -397,7 +397,12 @@ def _check_yaml_naming(filepath: str, name: str, suffix: str) -> Violation | Non
 
 
 def _check_hook_naming(filepath: str, name: str, suffix: str) -> Violation | None:
-    if name.startswith("invoke_") or name in ("__init__",):
+    # Entrypoint hooks require the invoke_ prefix so settings.json and the
+    # dispatcher can resolve them. Non-entrypoint modules that legitimately live
+    # in the hooks tree are exempt: private/dunder helpers (leading underscore,
+    # e.g. _bootstrap.py, __init__.py) and shared framework base classes
+    # (*_base.py, e.g. push_guard_base.py). See issue #3239.
+    if name.startswith("invoke_") or name.startswith("_") or name.endswith("_base"):
         return None
     return Violation(
         rule="naming",

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.77",
+  "version": "0.6.78",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/taste-lints/scripts/taste_lints.py
+++ b/src/copilot-cli/skills/taste-lints/scripts/taste_lints.py
@@ -397,7 +397,12 @@ def _check_yaml_naming(filepath: str, name: str, suffix: str) -> Violation | Non
 
 
 def _check_hook_naming(filepath: str, name: str, suffix: str) -> Violation | None:
-    if name.startswith("invoke_") or name in ("__init__",):
+    # Entrypoint hooks require the invoke_ prefix so settings.json and the
+    # dispatcher can resolve them. Non-entrypoint modules that legitimately live
+    # in the hooks tree are exempt: private/dunder helpers (leading underscore,
+    # e.g. _bootstrap.py, __init__.py) and shared framework base classes
+    # (*_base.py, e.g. push_guard_base.py). See issue #3239.
+    if name.startswith("invoke_") or name.startswith("_") or name.endswith("_base"):
         return None
     return Violation(
         rule="naming",

--- a/tests/skills/taste-lints/test_taste_lints.py
+++ b/tests/skills/taste-lints/test_taste_lints.py
@@ -172,6 +172,25 @@ class TestCheckNaming:
         hook_violations = [v for v in result if "invoke_" in v.message]
         assert hook_violations == []
 
+    def test_hook_leading_underscore_helper_exempt(self) -> None:
+        # Private helper module in the hooks tree; not an entrypoint. #3239.
+        result = check_naming(".claude/hooks/PreToolUse/_bootstrap.py", [])
+        assert [v for v in result if v.rule == "naming"] == []
+
+    def test_hook_base_module_exempt(self) -> None:
+        # Shared framework base class (*_base.py); not an entrypoint. #3239.
+        result = check_naming(".claude/hooks/PreToolUse/push_guard_base.py", [])
+        assert [v for v in result if v.rule == "naming"] == []
+
+    def test_hook_exemption_does_not_suppress_python_naming(self) -> None:
+        # The invoke_ exemption is scoped to the hook-naming rule. A leading
+        # underscore silences hook naming but must not mask a bad Python name:
+        # _BadName is not valid snake_case, so python naming still flags it. #3239.
+        result = check_naming(".claude/hooks/PreToolUse/_BadName.py", [])
+        naming_violations = [v for v in result if v.rule == "naming"]
+        assert len(naming_violations) == 1
+        assert "snake_case" in naming_violations[0].message
+
     def test_suppression_skips_naming(self) -> None:
         lines = ["# taste-lint: ignore naming\n"]
         result = check_naming("src/BadName.py", lines)


### PR DESCRIPTION
## Summary

**What:** Exempt non-entrypoint helper modules from the taste-lints hook `invoke_` naming rule.

**Why:** The hook-naming check enforced an `invoke_` prefix on every Python module under the hooks tree, exempting only `__init__`. Legitimate helper modules were flagged whenever a diff touched them and taste-lints ran.

## Specification References

| Issue | Title |
| ----- | ----- |
| #3239 | taste-lints hook-naming rule false-positives on helper modules |

## Changes

- `_check_hook_naming` now exempts private/dunder helpers (leading underscore, which subsumes the old `__init__` special-case) and framework base-class modules (a `_base` name suffix), in addition to `invoke_`-prefixed entrypoints.
- The exemption is scoped to the hook-naming rule only. Python `snake_case` naming still applies, so a badly named helper is not silently exempted.
- Applied to the canonical `taste_lints.py` and its byte-identical Copilot mirror (both listed under References below).
- Added positive, negative, and edge tests in the taste-lints test module.
- Bumped project-toolkit plugin manifests to 0.6.78 (parity).

The concrete modules and cases exercised:

```text
_bootstrap.py        -> exempt (private helper)
push_guard_base.py   -> exempt (framework base class)
invoke_my_guard.py   -> exempt (entrypoint, correct prefix)
my_guard.py          -> flagged (entrypoint, missing prefix)  [regression guard]
_BadName.py          -> flagged by Python snake_case rule     [edge: exemption not over-broad]
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Infrastructure/CI

## Scope boundary

The two real helper modules in the hooks tree today are the only non-entrypoint members. The pre-existing file-size advisory on the test module (already over the 500-line threshold on `main`) is non-blocking and out of scope for this false-positive fix.

## Verification

- Reproduced the false-positive at HEAD, confirmed both helpers now exempt while a bare entrypoint is still flagged.
- Ran the taste-lints test module: 76 passed.
- `uv run ruff check` on all three changed scripts: clean.
- `python3 build/scripts/check_plugin_manifest_parity.py`: 0.6.78 match.
- `python3 build/scripts/build_all.py --check`: exit 0 (no drift).
- Mirror byte-identity confirmed.

## References

- Canonical script: see `.claude/skills/taste-lints/scripts/taste_lints.py`
- Copilot mirror: see `src/copilot-cli/skills/taste-lints/scripts/taste_lints.py`
- Tests: see `tests/skills/taste-lints/test_taste_lints.py`
