### PR TITLE
test(skillforge): add repo-wide latent trigger-phrase guard (#3233)

### DIFF
--- a/tests/test_validate_skill_structural.py
+++ b/tests/test_validate_skill_structural.py
@@ -286,3 +286,105 @@ class TestSizeExceptionProperty:
         assert any("Unexpected frontmatter" in e for e in v.errors), (
             f"unknown key must still be rejected, got: {v.errors}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #3233: repo-wide latent trigger-phrase detection (decoupled from staging)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _trigger_safety_errors(errors: list[str]) -> list[str]:
+    """Filter validator errors down to the trigger-phrase safe-character check.
+
+    Isolating this one check keeps the repo-wide guard scoped to issue #3233 and
+    immune to unrelated latent failures (a missing Process section, a bad
+    frontmatter field) in other shipped skills.
+    """
+    return [e for e in errors if "unsafe characters" in e]
+
+
+def _iter_canonical_skill_dirs() -> list[Path]:
+    """Every shipped canonical skill directory (``.claude/skills/*/`` with SKILL.md)."""
+    base = _REPO_ROOT / ".claude" / "skills"
+    return sorted(p.parent for p in base.glob("*/SKILL.md"))
+
+
+class TestTriggerPhraseRepoWideGuard:
+    """Issue #3233: surface latent trigger-phrase violations repo-wide.
+
+    The pre-commit hook runs SkillForge validation only on *staged* SKILL.md
+    files, so a pre-existing unsafe trigger phrase stays latent until the file
+    is next staged for an unrelated reason, then blocks that unrelated commit
+    (the same class as the mypy latent-error pattern, #2949). This guard scans
+    every shipped skill on every test run, so a violation surfaces as its own
+    failure naming the offending file, decoupled from whoever next stages it.
+    """
+
+    def test_no_latent_trigger_phrase_violations_repo_wide(self) -> None:
+        """Positive: no shipped skill carries an unsafe trigger phrase today."""
+        skill_dirs = _iter_canonical_skill_dirs()
+        assert skill_dirs, "No canonical skills found; the glob or path is wrong"
+        orig = os.getcwd()
+        os.chdir(_REPO_ROOT)
+        try:
+            offenders: dict[str, list[str]] = {}
+            for skill_dir in skill_dirs:
+                validator: _ValidatorLike = SkillValidator(str(skill_dir))
+                validator.load_skill()
+                validator.validate_triggers()
+                errs = _trigger_safety_errors(validator.errors)
+                if errs:
+                    rel = skill_dir.relative_to(_REPO_ROOT).as_posix()
+                    offenders[rel] = errs
+        finally:
+            os.chdir(orig)
+        assert not offenders, (
+            "Latent SkillForge trigger-phrase violations found repo-wide "
+            "(issue #3233). Each file below has an unsafe trigger phrase that "
+            "would block the next unrelated commit that stages it:\n"
+            + "\n".join(
+                f"  {name}: {'; '.join(msgs)}" for name, msgs in offenders.items()
+            )
+        )
+
+    def test_guard_detects_injected_unsafe_trigger(self, tmp_path: Path) -> None:
+        """Negative: the guard's check flags a bracketed trigger phrase.
+
+        Proves the repo-wide assertion is not hollow: the same check it relies
+        on catches the exact defect from the #3233 reproduction (a ``[marker]``
+        trigger), which the safe_pattern allow-list rejects.
+        """
+        content = (
+            "---\nname: test-skill\ndescription: A valid skill for testing triggers\n---\n"
+            "# Title\n## Triggers\n`what does [skip-drift-check] do` `safe phrase`\n"
+            "## Process\nSteps.\n## Verification\n- [ ] a\n- [ ] b\n"
+        )
+        v = _make_skill(tmp_path, content)
+        v.load_skill()
+        v.validate_triggers()
+        assert _trigger_safety_errors(v.errors), (
+            f"Guard failed to flag a bracketed trigger; errors: {v.errors}"
+        )
+
+    def test_guard_ignores_other_latent_failures(self, tmp_path: Path) -> None:
+        """Edge: a skill invalid for unrelated reasons but with safe triggers is not flagged.
+
+        The guard isolates the trigger-safety concern, so a skill missing its
+        Process/Verification sections does not trip the repo-wide trigger-phrase
+        guard as long as its trigger phrases use allow-listed characters. This is
+        what lets the guard run across every shipped skill without coupling to
+        their other latent state.
+        """
+        content = (
+            "---\nname: test-skill\ndescription: A valid skill for testing triggers\n---\n"
+            "# Title\n## Triggers\n`run tests` `check {template}` `ref #123`\n"
+            # Deliberately no Process or Verification section.
+        )
+        v = _make_skill(tmp_path, content)
+        v.load_skill()
+        v.validate_triggers()
+        assert not _trigger_safety_errors(v.errors), (
+            f"Guard wrongly flagged safe triggers: {v.errors}"
+        )

--- a/tests/test_validate_skill_structural.py
+++ b/tests/test_validate_skill_structural.py
@@ -14,6 +14,8 @@ import sys
 from pathlib import Path
 from typing import Protocol
 
+import pytest
+
 # Add the SkillForge scripts directory to the import path
 _scripts_dir = os.path.join(
     os.path.dirname(__file__),
@@ -306,9 +308,37 @@ def _trigger_safety_errors(errors: list[str]) -> list[str]:
 
 
 def _iter_canonical_skill_dirs() -> list[Path]:
-    """Every shipped canonical skill directory (``.claude/skills/*/`` with SKILL.md)."""
+    """Every shipped canonical skill directory (``.claude/skills/*/``).
+
+    SkillValidator._find_skill_md accepts both ``SKILL.md`` and ``skill.md``, and
+    the glob is case-sensitive on Linux and macOS, so a lowercase-named skill
+    would be silently skipped by an uppercase-only glob. Match both names and
+    dedupe by parent directory so the repo-wide claim actually covers every
+    shipped skill.
+    """
     base = _REPO_ROOT / ".claude" / "skills"
-    return sorted(p.parent for p in base.glob("*/SKILL.md"))
+    dirs: set[Path] = set()
+    for name in ("SKILL.md", "skill.md"):
+        dirs.update(p.parent for p in base.glob(f"*/{name}"))
+    return sorted(dirs)
+
+
+def _scan_skill_dir(skill_dir: Path) -> list[str]:
+    """Return offender messages for one skill dir, empty when it is clean.
+
+    The caller must have chdir'd to an ancestor of ``skill_dir`` first, because
+    SkillValidator's CWE-22 guard rejects paths outside the current working
+    directory. A load failure (unreadable or missing SKILL.md) is reported as an
+    offender rather than filtered away, so a file that was never scanned cannot
+    let the repo-wide guarantee pass hollow.
+    """
+    validator: _ValidatorLike = SkillValidator(str(skill_dir))
+    if not validator.load_skill():
+        return [e for e in validator.errors if "read" in e.lower() or "not found" in e.lower()] or [
+            "load_skill() returned False"
+        ]
+    validator.validate_triggers()
+    return _trigger_safety_errors(validator.errors)
 
 
 class TestTriggerPhraseRepoWideGuard:
@@ -322,24 +352,22 @@ class TestTriggerPhraseRepoWideGuard:
     failure naming the offending file, decoupled from whoever next stages it.
     """
 
-    def test_no_latent_trigger_phrase_violations_repo_wide(self) -> None:
+    def test_no_latent_trigger_phrase_violations_repo_wide(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Positive: no shipped skill carries an unsafe trigger phrase today."""
         skill_dirs = _iter_canonical_skill_dirs()
         assert skill_dirs, "No canonical skills found; the glob or path is wrong"
-        orig = os.getcwd()
-        os.chdir(_REPO_ROOT)
-        try:
-            offenders: dict[str, list[str]] = {}
-            for skill_dir in skill_dirs:
-                validator: _ValidatorLike = SkillValidator(str(skill_dir))
-                validator.load_skill()
-                validator.validate_triggers()
-                errs = _trigger_safety_errors(validator.errors)
-                if errs:
-                    rel = skill_dir.relative_to(_REPO_ROOT).as_posix()
-                    offenders[rel] = errs
-        finally:
-            os.chdir(orig)
+        # monkeypatch.chdir auto-restores cwd on teardown, which is safer than a
+        # bare os.chdir under parallel runners (pytest-xdist). The chdir is
+        # required by SkillValidator's CWE-22 guard, which only accepts paths
+        # under the current working directory.
+        monkeypatch.chdir(_REPO_ROOT)
+        offenders: dict[str, list[str]] = {}
+        for skill_dir in skill_dirs:
+            msgs = _scan_skill_dir(skill_dir)
+            if msgs:
+                offenders[skill_dir.relative_to(_REPO_ROOT).as_posix()] = msgs
         assert not offenders, (
             "Latent SkillForge trigger-phrase violations found repo-wide "
             "(issue #3233). Each file below has an unsafe trigger phrase that "
@@ -387,4 +415,25 @@ class TestTriggerPhraseRepoWideGuard:
         v.validate_triggers()
         assert not _trigger_safety_errors(v.errors), (
             f"Guard wrongly flagged safe triggers: {v.errors}"
+        )
+
+    def test_scan_reports_unreadable_skill(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Edge: a skill dir whose SKILL.md cannot be loaded is reported, not skipped.
+
+        Without this, a file that ``load_skill()`` fails to read would have its
+        error filtered out by ``_trigger_safety_errors`` and the repo-wide guard
+        would pass while never scanning that skill. ``_scan_skill_dir`` treats the
+        load failure as an offender so the "repo-wide scanned" claim stays honest.
+        """
+        skill_dir = tmp_path / "broken-skill"
+        skill_dir.mkdir()
+        # No SKILL.md written: _find_skill_md defaults to <dir>/SKILL.md, which
+        # does not exist, so load_skill() returns False.
+        monkeypatch.chdir(tmp_path)
+        msgs = _scan_skill_dir(skill_dir)
+        assert msgs, "A skill dir with no readable SKILL.md must be reported as an offender"
+        assert any("not found" in m.lower() or "returned False" in m for m in msgs), (
+            f"Offender message should name the load failure, got: {msgs}"
         )


### PR DESCRIPTION
## Summary

SkillForge trigger-phrase validation runs only on staged skill definition files
via pre-commit. A pre-existing unsafe trigger phrase therefore stays latent until
the file is next staged for an unrelated reason, then blocks that unrelated
commit. Same class as the mypy latent-error pattern (#2949).

This adds a repo-wide pytest guard that scans every shipped skill on every test
run. A violation now surfaces as its own failure naming the offending file,
decoupled from whoever next stages it.

## What changed

Test-only. Appends `TestTriggerPhraseRepoWideGuard` plus two module-level
helpers to `tests/test_validate_skill_structural.py` (four tests):

- Positive: no shipped skill carries an unsafe trigger phrase today (repo is
  clean; every skill directory is scanned).
- Negative: the underlying check flags a bracketed trigger phrase, proving the
  repo-wide assertion is non-hollow.
- Edge (isolation): a skill invalid for unrelated reasons but with safe triggers
  is not flagged, proving the guard isolates the trigger-safety concern from
  other latent state.
- Edge (load failure): a skill directory with no readable SKILL.md is reported
  as an offender, proving the guard cannot pass hollow for a file it never read.

The dir glob matches both SKILL.md and skill.md filenames (the validator accepts
either name and the glob is case-sensitive on Linux and macOS), so no shipped
skill is silently skipped.

## Design decision

Kept the conservative `safe_pattern` reject (option 3 in the issue) rather than
widening the security allowlist. The rejected characters here are the square
brackets, which are rejected by not being allow-listed, not because they are
shell-dangerous. Widening the allowlist would touch two byte-identical validator
copies and require a plugin version bump; a test-only guard satisfies the
acceptance criteria without that blast radius.

## Verification

- `uv run pytest tests/test_validate_skill_structural.py` -> 18 passed
- `uv run ruff check tests/test_validate_skill_structural.py` -> clean
- `uv run mypy tests/test_validate_skill_structural.py` -> clean
- Pre-push: all checks passed

Fixes #3233
