### PR TITLE
test(memory): lock #3143 causal-graph changed-label retraction

### DIFF
--- a/tests/skills/memory/test_update_causal_graph.py
+++ b/tests/skills/memory/test_update_causal_graph.py
@@ -447,3 +447,83 @@ class TestPruneCli:
         ])
         assert rc == 0
         assert len(json.loads(graph_path.read_text())["edges"]) == 1
+
+
+class TestChangedLabelRetraction:
+    """Issue #3143: a failed commit's retry that corrects a milestone label
+    must not leave the stale node.
+
+    #3143 was filed 2026-07-17 01:13Z, about 18 hours before the #3039
+    reconcile fix (commit 3601bb1b, 2026-07-17 19:45Z) landed. The reported
+    symptom was two nodes for one episode after a pre-commit block, a milestone
+    correction, and a retry. The #3039 edit-shrink retraction covers this case:
+    the corrected label hashes to a new node id, so the prior node is present
+    in the episode's old membership but is not re-touched on reprocess, and so
+    it is retracted. These tests lock that behavior for the exact changed-label
+    scenario (acceptance criterion 4) and the unchanged reprocess (criterion 2).
+    """
+
+    def _write_episode(self, path: Path, milestone: str) -> None:
+        path.write_text(
+            json.dumps({
+                "id": "episode-2026-07-16-session-3056",
+                "task": "close 3097",
+                "outcome": "success",
+                "decisions": [],
+                "events": [{"type": "milestone", "content": milestone}],
+            }),
+            encoding="utf-8",
+        )
+
+    def _run(self, graph_path: Path, episode_path: Path) -> int:
+        return update_causal_graph.main([
+            "--episode-path", str(episode_path),
+            "--graph-path", str(graph_path),
+        ])
+
+    def _milestone_nodes(self, graph_path: Path) -> list[dict]:
+        graph = json.loads(graph_path.read_text(encoding="utf-8"))
+        return [n for n in graph["nodes"] if n["type"] == "milestone"]
+
+    def test_corrected_label_leaves_only_final_node(self, tmp_path):
+        graph_path = tmp_path / "graph.json"
+        episode_path = tmp_path / "episode-3056.json"
+
+        # First commit attempt: milestone ends in #3141. The graph is written
+        # and staged before a later gate blocks the commit.
+        self._write_episode(
+            episode_path, "filed #3137, #3138, #3139, #3140, and #3141",
+        )
+        assert self._run(graph_path, episode_path) == 0
+        first = self._milestone_nodes(graph_path)
+        assert len(first) == 1
+        assert "#3141" in first[0]["label"]
+
+        # Retry after correcting the milestone to include newly filed #3142.
+        # The corrected content hashes to a new node id.
+        self._write_episode(
+            episode_path, "filed #3137, #3138, #3139, #3140, #3141, and #3142",
+        )
+        assert self._run(graph_path, episode_path) == 0
+        final = self._milestone_nodes(graph_path)
+
+        # Exactly one milestone node survives, and it is the corrected version.
+        # Pre-#3039 the stale #3141 node lingered, giving two nodes for one
+        # episode.
+        assert len(final) == 1, final
+        assert "#3141, and #3142" in final[0]["label"]
+        assert first[0]["id"] != final[0]["id"]
+
+    def test_unchanged_reprocess_is_byte_idempotent(self, tmp_path):
+        graph_path = tmp_path / "graph.json"
+        episode_path = tmp_path / "episode-3056.json"
+        self._write_episode(
+            episode_path, "filed #3137, #3138, #3139, #3140, and #3141",
+        )
+        assert self._run(graph_path, episode_path) == 0
+        first_bytes = graph_path.read_text(encoding="utf-8")
+
+        # Reprocessing the identical episode must not add a node or churn the
+        # `created` timestamps: the committed graph stays byte-stable.
+        assert self._run(graph_path, episode_path) == 0
+        assert graph_path.read_text(encoding="utf-8") == first_bytes

--- a/tests/skills/memory/test_update_causal_graph.py
+++ b/tests/skills/memory/test_update_causal_graph.py
@@ -464,13 +464,20 @@ class TestChangedLabelRetraction:
     """
 
     def _write_episode(self, path: Path, milestone: str) -> None:
+        # Schema-complete mock: episode.schema.json also requires session,
+        # timestamp, and metrics. Populating them keeps the fixture valid if a
+        # future --since run parses timestamp (missing-key files are silently
+        # skipped by get_episode_files).
         path.write_text(
             json.dumps({
                 "id": "episode-2026-07-16-session-3056",
+                "session": "session-3056",
+                "timestamp": "2026-07-16T00:00:00Z",
                 "task": "close 3097",
                 "outcome": "success",
                 "decisions": [],
                 "events": [{"type": "milestone", "content": milestone}],
+                "metrics": {},
             }),
             encoding="utf-8",
         )
@@ -511,7 +518,11 @@ class TestChangedLabelRetraction:
         # Pre-#3039 the stale #3141 node lingered, giving two nodes for one
         # episode.
         assert len(final) == 1, final
-        assert "#3141, and #3142" in final[0]["label"]
+        # The surviving node is the corrected label: it carries the newly filed
+        # #3142 and still lists #3141. Assert the ids individually rather than
+        # the exact join punctuation, which is incidental to the behavior.
+        label = final[0]["label"]
+        assert "#3141" in label and "#3142" in label
         assert first[0]["id"] != final[0]["id"]
 
     def test_unchanged_reprocess_is_byte_idempotent(self, tmp_path):


### PR DESCRIPTION
## Summary

Adds a regression test that locks the causal-graph changed-label retraction
reported in #3143. Test-only change; no product code, no plugin bump.

## Evaluation (relevance vs what changed since filing)

#3143 was filed 2026-07-17 01:13Z. The #3039 reconcile fix (commit 3601bb1b)
landed 2026-07-17 19:45Z, about 18 hours later. #3143 was therefore observed on
pre-reconcile code. The reconcile logic now snapshots each episode's node/edge/
pattern membership, re-adds from current content, then retracts anything the
episode no longer supports. A corrected milestone label hashes to a new node
id, so the prior node is retracted on reprocess.

Empirical proof (run against current `tests/skills/memory/test_update_causal_graph.py` target):
the exact #3143 scenario (milestone "filed ... #3141" corrected to "... #3142"
across a save then retry) leaves exactly one node, the corrected one, and
reports `nodes_removed: 1`. Acceptance criteria 1, 2, 6, 7 are already
satisfied; criterion 7 (staged-episode-only scoping) was delivered in #3034.

## What this PR does

Adds `TestChangedLabelRetraction` to `tests/skills/memory/test_update_causal_graph.py`:

- `test_corrected_label_leaves_only_final_node` (acceptance criterion 4): proves
  a changed milestone label across a retry leaves only the final node.
- `test_unchanged_reprocess_is_byte_idempotent` (acceptance criterion 2): proves
  reprocessing an unchanged episode is byte-stable.

Both are non-hollow: neutering the retract path fails the changed-label test.

## Residual criteria 3 and 5 (rollback on a late gate block)

The reconcile fix makes the retry self-correcting, so the reported data-integrity
symptom (stale duplicate nodes in the committed graph) is gone. Criteria 3 and 5
ask the pre-commit to restore generated-file state when a later blocking gate
fails after a successful memory auto-fix. That residual has low harm (the retry
now produces a correct graph) and a risky fix (reordering a large shell hook,
where the scope gate counts the auto-fix output, creating a chicken-and-egg).
The pre-commit surface is being restructured under epic #3197, which owns the
internal-enforcement move. Recommend tracking criteria 3 and 5 there rather than
churning a standalone shell reorder now. Detailed evaluation posted on #3143.

## Verification

- `uv run pytest tests/skills/memory/test_update_causal_graph.py -q`: 32 passed.
- Non-hollow check: stubbing the retract path to a no-op fails the criterion-4 test.
- `uv run ruff check` clean; `uv run mypy` clean on the changed file.
- Pre-push: 14 passed, 13 skipped.

The test file is 529 lines (advisory taste-lint threshold is 500). Splitting a
single-module test suite into helper modules would scatter related tests, so the
file is kept whole; it is well under the 1000-line inspection signal.

Refs #3143

## References

Non-diff paths cited for context only:

- Reconcile fix: commit 3601bb1b, "fix(memory): retract stale causal-graph contributions on episode edit/delete (#3039)".
- Product code under evaluation: see `.claude/skills/memory/scripts/update_causal_graph.py` and `.githooks/pre-commit`.
