### PR TITLE
feat(dev): dogfood shipped Copilot plugin base on this repo (#3222)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,8 +70,9 @@ python3 scripts/dev/dogfood_copilot_plugin.py --uninstall
 
 Re-run `--install` after editing `src/copilot-cli` to refresh the copy; the new
 hooks load on your next Copilot session. The prior installed copy is backed up
-once and restored by `--uninstall`. This implements ADR-083 decision item 3.
-Refs #3222.
+once and restored by `--uninstall`. Set `COPILOT_HOME` to target a Copilot home
+other than `~/.copilot` (the install path follows it). This implements ADR-083
+decision item 3. Refs #3222.
 
 ## Git Configuration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,32 @@ Thank you for your interest in contributing to this project. This guide explains
 
 **After setup, quality gates are automated.** Pre-commit hooks run ruff (Python) and markdownlint on staged files. Pre-push hooks run full test suites, drift detection, and security scans before each push. CI runs the complete validation suite. No manual test commands needed for routine development.
 
+### Dogfood the shipped Copilot base
+
+Copilot CLI runs plugin hooks from an installed plugin directory, not from your
+checkout. By default that directory holds a published copy of `project-toolkit`,
+so a local checkout does not exercise the hooks it ships to customers. A broken
+hook can then reach customers before anyone here notices (see issue #3247).
+
+To run the exact hooks, skills, and agents you ship, copy your working tree over
+the installed plugin (the same way the marketplace install puts it there):
+
+```bash
+# Copy src/copilot-cli over ~/.copilot/installed-plugins/ai-agents/project-toolkit
+python3 scripts/dev/dogfood_copilot_plugin.py --install
+
+# Confirm the current state (flags a stale copy)
+python3 scripts/dev/dogfood_copilot_plugin.py --status
+
+# Restore the published copy
+python3 scripts/dev/dogfood_copilot_plugin.py --uninstall
+```
+
+Re-run `--install` after editing `src/copilot-cli` to refresh the copy; the new
+hooks load on your next Copilot session. The prior installed copy is backed up
+once and restored by `--uninstall`. This implements ADR-083 decision item 3.
+Refs #3222.
+
 ## Git Configuration
 
 This repository enforces LF line endings for all files via `.gitattributes` to prevent cross-platform issues. To ensure smooth collaboration, configure your Git client based on your operating system:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,9 @@ python3 scripts/dev/dogfood_copilot_plugin.py --uninstall
 Re-run `--install` after editing `src/copilot-cli` to refresh the copy; the new
 hooks load on your next Copilot session. The prior installed copy is backed up
 once and restored by `--uninstall`. Set `COPILOT_HOME` to target a Copilot home
-other than `~/.copilot` (the install path follows it). This implements ADR-083
-decision item 3. Refs #3222.
+other than `~/.copilot` (the install path follows it). This provides the dogfood
+install from ADR-083 decision item 3, copy-only on every platform; the ADR's
+platform-split wording is being reconciled in #3252. Refs #3222.
 
 ## Git Configuration
 

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -35,6 +35,17 @@ MARKETPLACE = "ai-agents"
 PLUGIN_NAME = "project-toolkit"
 _BACKUP_SUFFIX = ".marketplace-bak"
 
+# Match build_all.py's shipped-tree copy semantics (__pycache__, *.pyc, *.pyo)
+# and drop local tool caches so the dogfood copy mirrors what customers get.
+_COPY_IGNORE = shutil.ignore_patterns(
+    "__pycache__",
+    "*.pyc",
+    "*.pyo",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".mypy_cache",
+)
+
 
 def _repo_root() -> Path:
     """Return the git top-level for the directory holding this script."""
@@ -133,7 +144,7 @@ def dogfood_install(source: Path, target: Path) -> str:
         )
     note = _stash_existing(target)
     target.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(source, target)
+    shutil.copytree(source, target, ignore=_COPY_IGNORE)
     return f"copied {source} -> {target} ({note})"
 
 

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -57,20 +57,38 @@ def default_target() -> Path:
     return home / "installed-plugins" / MARKETPLACE / PLUGIN_NAME
 
 
-def _plugin_version(root: Path) -> str | None:
-    """Return the version string from a plugin root, or None if absent."""
+def _read_manifest(root: Path) -> dict[str, object] | None:
+    """Return a plugin root's parsed manifest, or None if absent or malformed.
+
+    Guards against a manifest that parses to a non-object JSON value (a list,
+    string, or null), which would otherwise crash callers that expect a dict.
+    """
     manifest = root / ".claude-plugin" / "plugin.json"
     if not manifest.is_file():
         return None
     try:
-        return str(json.loads(manifest.read_text(encoding="utf-8")).get("version"))
+        data = json.loads(manifest.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return None
+    return data if isinstance(data, dict) else None
+
+
+def _plugin_version(root: Path) -> str | None:
+    """Return the version string from a plugin root, or None if absent."""
+    manifest = _read_manifest(root)
+    if manifest is None:
+        return None
+    version = manifest.get("version")
+    return str(version) if version is not None else None
 
 
 def _is_plugin_root(root: Path) -> bool:
-    """Return True when root looks like a valid plugin (has a manifest)."""
-    return (root / ".claude-plugin" / "plugin.json").is_file()
+    """Return True when root has a well-formed manifest naming a plugin."""
+    manifest = _read_manifest(root)
+    if manifest is None:
+        return False
+    name = manifest.get("name")
+    return isinstance(name, str) and bool(name)
 
 
 def _backup_path(target: Path) -> Path:
@@ -118,6 +136,9 @@ def dogfood_uninstall(target: Path) -> str:
     elif target.is_dir():
         shutil.rmtree(target)
         removed = "removed copy"
+    elif target.exists():
+        target.unlink()
+        removed = "removed file"
     else:
         removed = "nothing installed"
 
@@ -168,18 +189,17 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
-    root = _repo_root()
-    source = default_source(root)
-    target = default_target()
-
     try:
+        root = _repo_root()
+        source = default_source(root)
+        target = default_target()
         if args.status:
             print(dogfood_status(source, target))
         elif args.uninstall:
             print(dogfood_uninstall(target))
         else:
             print(dogfood_install(source, target))
-    except (ValueError, OSError) as exc:
+    except (ValueError, OSError, subprocess.SubprocessError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
     return 0

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -107,6 +107,11 @@ def _stash_existing(target: Path) -> str:
         return "removed prior symlink"
     if target.is_dir():
         backup = _backup_path(target)
+        if backup.is_symlink():
+            # A symlink at the backup path is never one we created (we only ever
+            # rename a real directory there). Remove it so a dangling link does
+            # not make backup.exists() lie and crash the rename below on Windows.
+            backup.unlink()
         if backup.exists():
             shutil.rmtree(target)
             return "discarded copy (backup already present)"

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -120,12 +120,15 @@ def _stash_existing(target: Path) -> str:
         return "removed prior symlink"
     if target.is_dir():
         backup = _backup_path(target)
-        # A backup we created is always a real directory (we only ever rename a
-        # directory there). Anything else at that path (symlink, regular file,
-        # fifo) is not our backup: remove it so backup can never be mistaken for
-        # a valid prior copy and so the rename() below can create a real one.
+        # A backup we created is always a real plugin-root directory (we only
+        # ever rename the prior marketplace copy there). Anything else at that
+        # path (symlink, regular file, fifo, or a stray non-plugin directory)
+        # is not our backup: remove it so it cannot be mistaken for a valid
+        # prior copy and so the rename() below can create a real one.
         if backup.is_symlink() or (backup.exists() and not backup.is_dir()):
             backup.unlink()
+        elif backup.is_dir() and not _is_plugin_root(backup):
+            shutil.rmtree(backup)
         if backup.is_dir():
             shutil.rmtree(target)
             return "discarded copy (backup already present)"

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -14,7 +14,9 @@ sessions load the exact hooks, skills, and agents that ship. Re-run it after
 changing ``src/copilot-cli`` to refresh the install. The prior installed
 directory is backed up once before replacement, so ``--uninstall`` restores it.
 
-Implements ADR-083 decision item 3. Refs #3222.
+Provides the dogfood install called for by ADR-083 decision item 3, copy-only
+on every platform. ADR-083's symlink-on-Unix wording is being reconciled in
+#3252. Refs #3222.
 
 Exit codes: 0 success, 2 configuration error.
 """
@@ -53,7 +55,7 @@ def default_source(root: Path) -> Path:
 
 def default_target() -> Path:
     """Return the installed-plugin directory Copilot CLI loads from."""
-    home_env = os.environ.get("COPILOT_HOME")
+    home_env = os.environ.get("COPILOT_HOME", "").strip()
     home = Path(home_env) if home_env else Path.home() / ".copilot"
     return home / "installed-plugins" / MARKETPLACE / PLUGIN_NAME
 

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -120,12 +120,13 @@ def _stash_existing(target: Path) -> str:
         return "removed prior symlink"
     if target.is_dir():
         backup = _backup_path(target)
-        if backup.is_symlink():
-            # A symlink at the backup path is never one we created (we only ever
-            # rename a real directory there). Remove it so a dangling link does
-            # not make backup.exists() lie and crash the rename below on Windows.
+        # A backup we created is always a real directory (we only ever rename a
+        # directory there). Anything else at that path (symlink, regular file,
+        # fifo) is not our backup: remove it so backup can never be mistaken for
+        # a valid prior copy and so the rename() below can create a real one.
+        if backup.is_symlink() or (backup.exists() and not backup.is_dir()):
             backup.unlink()
-        if backup.exists():
+        if backup.is_dir():
             shutil.rmtree(target)
             return "discarded copy (backup already present)"
         target.rename(backup)

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -1,0 +1,189 @@
+"""Dogfood the shipped Copilot plugin base from the working tree.
+
+Copilot CLI runs plugin hooks from an installed plugin directory under
+``~/.copilot/installed-plugins/<marketplace>/<name>``. By default that
+directory is a *copy* of a published plugin version, so a local checkout of
+this repository does not exercise the hooks it ships to customers. That gap is
+how a broken hook (for example the stale LSP guards in issue #3247) can reach
+customers before anyone here notices.
+
+This script closes the gap the same way every other artifact reaches the
+machine here: by copying. It copies the working tree's ``src/copilot-cli``
+directory over the installed ``project-toolkit`` plugin, so local Copilot
+sessions load the exact hooks, skills, and agents that ship. Re-run it after
+changing ``src/copilot-cli`` to refresh the install. The prior installed
+directory is backed up once before replacement, so ``--uninstall`` restores it.
+
+Implements ADR-083 decision item 3. Refs #3222.
+
+Exit codes: 0 success, 2 configuration error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+MARKETPLACE = "ai-agents"
+PLUGIN_NAME = "project-toolkit"
+_BACKUP_SUFFIX = ".marketplace-bak"
+
+
+def _repo_root() -> Path:
+    """Return the git top-level for the directory holding this script."""
+    here = Path(__file__).resolve()
+    result = subprocess.run(
+        ["git", "-C", str(here.parent), "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def default_source(root: Path) -> Path:
+    """Return the shipped Copilot plugin root inside the repository."""
+    return root / "src" / "copilot-cli"
+
+
+def default_target() -> Path:
+    """Return the installed-plugin directory Copilot CLI loads from."""
+    home = Path(os.environ.get("COPILOT_HOME", Path.home() / ".copilot"))
+    return home / "installed-plugins" / MARKETPLACE / PLUGIN_NAME
+
+
+def _plugin_version(root: Path) -> str | None:
+    """Return the version string from a plugin root, or None if absent."""
+    manifest = root / ".claude-plugin" / "plugin.json"
+    if not manifest.is_file():
+        return None
+    try:
+        return str(json.loads(manifest.read_text(encoding="utf-8")).get("version"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _is_plugin_root(root: Path) -> bool:
+    """Return True when root looks like a valid plugin (has a manifest)."""
+    return (root / ".claude-plugin" / "plugin.json").is_file()
+
+
+def _backup_path(target: Path) -> Path:
+    return target.with_name(target.name + _BACKUP_SUFFIX)
+
+
+def _stash_existing(target: Path) -> str:
+    """Move an existing target aside so a fresh copy can replace it.
+
+    A real directory is preserved once as a backup (so uninstall can restore
+    it). A symlink or file is simply removed. Returns a human-readable note.
+    """
+    if target.is_symlink():
+        target.unlink()
+        return "removed prior symlink"
+    if target.is_dir():
+        backup = _backup_path(target)
+        if backup.exists():
+            shutil.rmtree(target)
+            return "discarded copy (backup already present)"
+        target.rename(backup)
+        return f"backed up copy to {backup.name}"
+    if target.exists():
+        target.unlink()
+        return "removed prior file"
+    return "no prior install"
+
+
+def dogfood_install(source: Path, target: Path) -> str:
+    """Copy the working-tree plugin over target. Returns an action summary."""
+    if not _is_plugin_root(source):
+        raise ValueError(f"not a plugin root (missing .claude-plugin/plugin.json): {source}")
+    note = _stash_existing(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, target)
+    return f"copied {source} -> {target} ({note})"
+
+
+def dogfood_uninstall(target: Path) -> str:
+    """Remove the dogfood copy and restore any backup. Returns a summary."""
+    backup = _backup_path(target)
+    if target.is_symlink():
+        target.unlink()
+        removed = "removed symlink"
+    elif target.is_dir():
+        shutil.rmtree(target)
+        removed = "removed copy"
+    else:
+        removed = "nothing installed"
+
+    if backup.exists():
+        backup.rename(target)
+        return f"{removed}; restored backup"
+    reinstall = f"copilot plugin update {PLUGIN_NAME}@{MARKETPLACE}"
+    return f"{removed}; no backup to restore (reinstall with: {reinstall})"
+
+
+def dogfood_status(source: Path, target: Path) -> str:
+    """Return a one-line description of the current install state."""
+    if target.is_symlink():
+        return f"symlinked -> {os.readlink(target)}"
+    if target.is_dir():
+        installed = _plugin_version(target)
+        shipped = _plugin_version(source)
+        marker = ""
+        if installed != shipped:
+            marker = f" (working tree ships v{shipped}; re-run --install to refresh)"
+        return f"installed copy at {target} [v{installed}]{marker}"
+    return f"not installed at {target}"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="dogfood_copilot_plugin",
+        description="Copy the working-tree project-toolkit over the installed Copilot plugin.",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--install",
+        action="store_true",
+        help="copy the working tree over the installed plugin (default)",
+    )
+    group.add_argument(
+        "--uninstall",
+        action="store_true",
+        help="remove the dogfood copy and restore any backup",
+    )
+    group.add_argument(
+        "--status",
+        action="store_true",
+        help="show the current install state and exit",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    root = _repo_root()
+    source = default_source(root)
+    target = default_target()
+
+    try:
+        if args.status:
+            print(dogfood_status(source, target))
+        elif args.uninstall:
+            print(dogfood_uninstall(target))
+        else:
+            print(dogfood_install(source, target))
+    except (ValueError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -53,7 +53,8 @@ def default_source(root: Path) -> Path:
 
 def default_target() -> Path:
     """Return the installed-plugin directory Copilot CLI loads from."""
-    home = Path(os.environ.get("COPILOT_HOME", Path.home() / ".copilot"))
+    home_env = os.environ.get("COPILOT_HOME")
+    home = Path(home_env) if home_env else Path.home() / ".copilot"
     return home / "installed-plugins" / MARKETPLACE / PLUGIN_NAME
 
 
@@ -120,7 +121,9 @@ def _stash_existing(target: Path) -> str:
 def dogfood_install(source: Path, target: Path) -> str:
     """Copy the working-tree plugin over target. Returns an action summary."""
     if not _is_plugin_root(source):
-        raise ValueError(f"not a plugin root (missing .claude-plugin/plugin.json): {source}")
+        raise ValueError(
+            f"not a plugin root (missing or invalid .claude-plugin/plugin.json): {source}"
+        )
     note = _stash_existing(target)
     target.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(source, target)

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -125,6 +125,19 @@ def test_install_survives_dangling_backup_symlink(
     assert not backup.is_symlink()
 
 
+def test_install_replaces_corrupt_file_backup(source: Path, target: Path) -> None:
+    _make_plugin_root(target, "0.0.1")  # a real copy to back up
+    backup = target.with_name(target.name + ".marketplace-bak")
+    backup.write_text("not a backup", encoding="utf-8")  # corrupt: a regular file
+
+    note = dogfood.dogfood_install(source, target)
+
+    assert dogfood._plugin_version(target) == "9.9.9"
+    assert "backed up copy" in note
+    assert backup.is_dir()  # corrupt file replaced by the real backup
+    assert dogfood._plugin_version(backup) == "0.0.1"  # prior copy preserved
+
+
 # --- install (negative) ---
 
 

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -1,4 +1,4 @@
-"""Tests for the Copilot dogfood-install helper (ADR-083 item 3, #3222)."""
+"""Tests for the Copilot dogfood-install helper (ADR-083 item 3 need, copy-only; #3222)."""
 
 from __future__ import annotations
 
@@ -264,6 +264,13 @@ def test_default_target_honors_copilot_home(monkeypatch, tmp_path: Path) -> None
 
 def test_default_target_ignores_empty_copilot_home(monkeypatch) -> None:
     monkeypatch.setenv("COPILOT_HOME", "")
+    resolved = dogfood.default_target()
+    expected = Path.home() / ".copilot" / "installed-plugins" / "ai-agents" / "project-toolkit"
+    assert resolved == expected
+
+
+def test_default_target_ignores_whitespace_copilot_home(monkeypatch) -> None:
+    monkeypatch.setenv("COPILOT_HOME", "   ")
     resolved = dogfood.default_target()
     expected = Path.home() / ".copilot" / "installed-plugins" / "ai-agents" / "project-toolkit"
     assert resolved == expected

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -93,6 +93,22 @@ def test_install_replaces_prior_symlink(source: Path, target: Path, tmp_path: Pa
     assert "removed prior symlink" in note
 
 
+def test_install_survives_dangling_backup_symlink(
+    source: Path, target: Path, tmp_path: Path
+) -> None:
+    _require_symlinks(tmp_path)
+    _make_plugin_root(target, "0.0.1")  # a real copy to back up
+    backup = target.with_name(target.name + ".marketplace-bak")
+    backup.symlink_to(tmp_path / "gone")  # dangling: points nowhere
+
+    note = dogfood.dogfood_install(source, target)
+
+    assert dogfood._plugin_version(target) == "9.9.9"
+    assert "backed up copy" in note
+    assert backup.is_dir()  # stray link replaced by the real backup
+    assert not backup.is_symlink()
+
+
 # --- install (negative) ---
 
 

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -61,6 +61,22 @@ def test_install_creates_copy(source: Path, target: Path) -> None:
     assert "copied" in note
 
 
+def test_install_excludes_local_caches(source: Path, target: Path) -> None:
+    cache_dir = source / "__pycache__"
+    cache_dir.mkdir()
+    (cache_dir / "mod.cpython-314.pyc").write_bytes(b"\x00")
+    (source / "skills" / ".ruff_cache").mkdir(parents=True)
+    (source / "skills" / ".ruff_cache" / "CACHEDIR.TAG").write_text("x", encoding="utf-8")
+    (source / "stale.pyc").write_bytes(b"\x00")
+
+    dogfood.dogfood_install(source, target)
+
+    assert not (target / "__pycache__").exists()
+    assert not (target / "skills" / ".ruff_cache").exists()
+    assert not (target / "stale.pyc").exists()
+    assert (target / ".claude-plugin" / "plugin.json").is_file()
+
+
 def test_install_refreshes_stale_copy(source: Path, target: Path) -> None:
     _make_plugin_root(target, "0.0.1")  # older install
     note = dogfood.dogfood_install(source, target)

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -1,0 +1,157 @@
+"""Tests for the Copilot dogfood-install helper (ADR-083 item 3, #3222)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "dev" / "dogfood_copilot_plugin.py"
+
+_spec = importlib.util.spec_from_file_location("dogfood_copilot_plugin", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+dogfood = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dogfood)
+
+
+def _make_plugin_root(path: Path, version: str) -> Path:
+    """Create a minimal plugin root with a manifest carrying version."""
+    (path / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (path / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "project-toolkit", "version": version}), encoding="utf-8"
+    )
+    (path / "hooks").mkdir(exist_ok=True)
+    return path
+
+
+@pytest.fixture
+def source(tmp_path: Path) -> Path:
+    return _make_plugin_root(tmp_path / "src" / "copilot-cli", "9.9.9")
+
+
+@pytest.fixture
+def target(tmp_path: Path) -> Path:
+    return tmp_path / "installed" / "ai-agents" / "project-toolkit"
+
+
+# --- install (positive) ---
+
+
+def test_install_creates_copy(source: Path, target: Path) -> None:
+    note = dogfood.dogfood_install(source, target)
+    assert target.is_dir()
+    assert not target.is_symlink()
+    assert (target / ".claude-plugin" / "plugin.json").is_file()
+    assert dogfood._plugin_version(target) == "9.9.9"
+    assert "copied" in note
+
+
+def test_install_refreshes_stale_copy(source: Path, target: Path) -> None:
+    _make_plugin_root(target, "0.0.1")  # older install
+    note = dogfood.dogfood_install(source, target)
+    assert dogfood._plugin_version(target) == "9.9.9"
+    assert "backed up copy" in note
+
+
+def test_install_backs_up_existing_copy_once(source: Path, target: Path) -> None:
+    _make_plugin_root(target, "0.0.1")
+    original = (target / ".claude-plugin" / "plugin.json").read_text()
+
+    dogfood.dogfood_install(source, target)  # first install backs up
+    dogfood.dogfood_install(source, target)  # second must not clobber the backup
+
+    backup = target.with_name(target.name + ".marketplace-bak")
+    assert backup.is_dir()
+    assert (backup / ".claude-plugin" / "plugin.json").read_text() == original
+
+
+def test_install_replaces_prior_symlink(source: Path, target: Path, tmp_path: Path) -> None:
+    other = _make_plugin_root(tmp_path / "other", "1.0.0")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.symlink_to(other, target_is_directory=True)
+
+    note = dogfood.dogfood_install(source, target)
+
+    assert target.is_dir()
+    assert not target.is_symlink()
+    assert "removed prior symlink" in note
+
+
+# --- install (negative) ---
+
+
+def test_install_rejects_non_plugin_source(tmp_path: Path, target: Path) -> None:
+    not_a_plugin = tmp_path / "empty"
+    not_a_plugin.mkdir()
+    with pytest.raises(ValueError, match="not a plugin root"):
+        dogfood.dogfood_install(not_a_plugin, target)
+
+
+def test_main_returns_config_error_on_bad_source(monkeypatch, tmp_path: Path, capsys) -> None:
+    empty = tmp_path / "src" / "copilot-cli"
+    empty.mkdir(parents=True)
+    monkeypatch.setattr(dogfood, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(dogfood, "default_target", lambda: tmp_path / "installed" / "x")
+    rc = dogfood.main([])
+    assert rc == 2
+    assert "error:" in capsys.readouterr().err
+
+
+# --- uninstall (positive + restore + no-backup edge) ---
+
+
+def test_uninstall_restores_backup(source: Path, target: Path) -> None:
+    _make_plugin_root(target, "0.0.1")
+    dogfood.dogfood_install(source, target)
+    note = dogfood.dogfood_uninstall(target)
+    assert "restored backup" in note
+    assert target.is_dir()
+    assert dogfood._plugin_version(target) == "0.0.1"
+
+
+def test_uninstall_without_backup_advises_reinstall(source: Path, target: Path) -> None:
+    dogfood.dogfood_install(source, target)  # no pre-existing copy to back up
+    note = dogfood.dogfood_uninstall(target)
+    assert "no backup" in note
+    assert not target.exists()
+
+
+def test_uninstall_when_nothing_installed(target: Path) -> None:
+    note = dogfood.dogfood_uninstall(target)
+    assert "nothing installed" in note
+
+
+# --- status (each state) ---
+
+
+def test_status_reports_current_copy(source: Path, target: Path) -> None:
+    dogfood.dogfood_install(source, target)
+    status = dogfood.dogfood_status(source, target)
+    assert "installed copy" in status
+    assert "9.9.9" in status
+    assert "re-run" not in status  # matches the shipped version
+
+
+def test_status_flags_stale_copy(source: Path, target: Path) -> None:
+    _make_plugin_root(target, "0.0.1")
+    status = dogfood.dogfood_status(source, target)
+    assert "re-run --install to refresh" in status
+
+
+def test_status_reports_not_installed(source: Path, target: Path) -> None:
+    assert "not installed" in dogfood.dogfood_status(source, target)
+
+
+# --- helpers ---
+
+
+def test_plugin_version_none_without_manifest(tmp_path: Path) -> None:
+    assert dogfood._plugin_version(tmp_path) is None
+
+
+def test_default_target_honors_copilot_home(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("COPILOT_HOME", str(tmp_path / "cop"))
+    resolved = dogfood.default_target()
+    assert resolved == tmp_path / "cop" / "installed-plugins" / "ai-agents" / "project-toolkit"

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -57,14 +58,14 @@ def test_install_refreshes_stale_copy(source: Path, target: Path) -> None:
 
 def test_install_backs_up_existing_copy_once(source: Path, target: Path) -> None:
     _make_plugin_root(target, "0.0.1")
-    original = (target / ".claude-plugin" / "plugin.json").read_text()
+    original = (target / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
 
     dogfood.dogfood_install(source, target)  # first install backs up
     dogfood.dogfood_install(source, target)  # second must not clobber the backup
 
     backup = target.with_name(target.name + ".marketplace-bak")
     assert backup.is_dir()
-    assert (backup / ".claude-plugin" / "plugin.json").read_text() == original
+    assert (backup / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8") == original
 
 
 def test_install_replaces_prior_symlink(source: Path, target: Path, tmp_path: Path) -> None:
@@ -89,12 +90,59 @@ def test_install_rejects_non_plugin_source(tmp_path: Path, target: Path) -> None
         dogfood.dogfood_install(not_a_plugin, target)
 
 
+def _write_manifest(root: Path, text: str) -> Path:
+    """Write a raw manifest body (possibly malformed) to a plugin root."""
+    (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(text, encoding="utf-8")
+    return root
+
+
+def test_install_rejects_malformed_manifest(tmp_path: Path, target: Path) -> None:
+    bad = _write_manifest(tmp_path / "bad", "{not valid json")
+    with pytest.raises(ValueError, match="not a plugin root"):
+        dogfood.dogfood_install(bad, target)
+
+
+def test_install_rejects_non_object_manifest(tmp_path: Path, target: Path) -> None:
+    bad = _write_manifest(tmp_path / "list", "[]")
+    with pytest.raises(ValueError, match="not a plugin root"):
+        dogfood.dogfood_install(bad, target)
+
+
+def test_install_rejects_manifest_without_name(tmp_path: Path, target: Path) -> None:
+    bad = _write_manifest(tmp_path / "noname", json.dumps({"version": "1.0.0"}))
+    with pytest.raises(ValueError, match="not a plugin root"):
+        dogfood.dogfood_install(bad, target)
+
+
+def test_install_rejects_malformed_source_before_touching_target(
+    source: Path, target: Path, tmp_path: Path
+) -> None:
+    _make_plugin_root(target, "0.0.1")  # a healthy prior install
+    bad = _write_manifest(tmp_path / "bad", "null")
+    with pytest.raises(ValueError, match="not a plugin root"):
+        dogfood.dogfood_install(bad, target)
+    # The bad source must not have disturbed the existing install or made a backup.
+    assert dogfood._plugin_version(target) == "0.0.1"
+    assert not target.with_name(target.name + ".marketplace-bak").exists()
+
+
 def test_main_returns_config_error_on_bad_source(monkeypatch, tmp_path: Path, capsys) -> None:
     empty = tmp_path / "src" / "copilot-cli"
     empty.mkdir(parents=True)
     monkeypatch.setattr(dogfood, "_repo_root", lambda: tmp_path)
     monkeypatch.setattr(dogfood, "default_target", lambda: tmp_path / "installed" / "x")
     rc = dogfood.main([])
+    assert rc == 2
+    assert "error:" in capsys.readouterr().err
+
+
+def test_main_returns_config_error_on_git_failure(monkeypatch, capsys) -> None:
+    def _boom() -> Path:
+        raise subprocess.CalledProcessError(128, ["git", "rev-parse"])
+
+    monkeypatch.setattr(dogfood, "_repo_root", _boom)
+    rc = dogfood.main(["--status"])
     assert rc == 2
     assert "error:" in capsys.readouterr().err
 
@@ -123,6 +171,19 @@ def test_uninstall_when_nothing_installed(target: Path) -> None:
     assert "nothing installed" in note
 
 
+def test_uninstall_removes_regular_file_and_restores_backup(target: Path) -> None:
+    backup = _make_plugin_root(target.with_name(target.name + ".marketplace-bak"), "0.0.1")
+    assert backup.is_dir()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("stray file", encoding="utf-8")  # target is a plain file
+
+    note = dogfood.dogfood_uninstall(target)
+
+    assert "removed file" in note
+    assert target.is_dir()  # backup restored over the removed file
+    assert dogfood._plugin_version(target) == "0.0.1"
+
+
 # --- status (each state) ---
 
 
@@ -149,6 +210,21 @@ def test_status_reports_not_installed(source: Path, target: Path) -> None:
 
 def test_plugin_version_none_without_manifest(tmp_path: Path) -> None:
     assert dogfood._plugin_version(tmp_path) is None
+
+
+def test_plugin_version_none_on_non_object_manifest(tmp_path: Path) -> None:
+    root = _write_manifest(tmp_path / "list", "[1, 2, 3]")
+    assert dogfood._plugin_version(root) is None
+
+
+def test_plugin_version_none_on_malformed_manifest(tmp_path: Path) -> None:
+    root = _write_manifest(tmp_path / "bad", "{oops")
+    assert dogfood._plugin_version(root) is None
+
+
+def test_plugin_version_none_when_version_missing(tmp_path: Path) -> None:
+    root = _write_manifest(tmp_path / "noversion", json.dumps({"name": "x"}))
+    assert dogfood._plugin_version(root) is None
 
 
 def test_default_target_honors_copilot_home(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -138,6 +138,20 @@ def test_install_replaces_corrupt_file_backup(source: Path, target: Path) -> Non
     assert dogfood._plugin_version(backup) == "0.0.1"  # prior copy preserved
 
 
+def test_install_replaces_stray_non_plugin_backup_dir(source: Path, target: Path) -> None:
+    _make_plugin_root(target, "0.0.1")  # a real copy to back up
+    backup = target.with_name(target.name + ".marketplace-bak")
+    backup.mkdir()  # stray directory, not a plugin root
+    (backup / "junk.txt").write_text("stray", encoding="utf-8")
+
+    note = dogfood.dogfood_install(source, target)
+
+    assert dogfood._plugin_version(target) == "9.9.9"
+    assert "backed up copy" in note
+    assert dogfood._plugin_version(backup) == "0.0.1"  # real prior copy backed up
+    assert not (backup / "junk.txt").exists()  # stray directory discarded
+
+
 # --- install (negative) ---
 
 

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -31,7 +31,7 @@ def _require_symlinks(tmp_path: Path) -> None:
     """Skip when the platform forbids symlink creation (Windows without privilege)."""
     probe = tmp_path / "_symlink_probe"
     try:
-        probe.symlink_to(tmp_path)
+        probe.symlink_to(tmp_path, target_is_directory=True)
     except OSError:
         pytest.skip("symlinks not permitted on this platform")
     finally:

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -27,6 +27,18 @@ def _make_plugin_root(path: Path, version: str) -> Path:
     return path
 
 
+def _require_symlinks(tmp_path: Path) -> None:
+    """Skip when the platform forbids symlink creation (Windows without privilege)."""
+    probe = tmp_path / "_symlink_probe"
+    try:
+        probe.symlink_to(tmp_path)
+    except OSError:
+        pytest.skip("symlinks not permitted on this platform")
+    finally:
+        if probe.is_symlink():
+            probe.unlink()
+
+
 @pytest.fixture
 def source(tmp_path: Path) -> Path:
     return _make_plugin_root(tmp_path / "src" / "copilot-cli", "9.9.9")
@@ -69,6 +81,7 @@ def test_install_backs_up_existing_copy_once(source: Path, target: Path) -> None
 
 
 def test_install_replaces_prior_symlink(source: Path, target: Path, tmp_path: Path) -> None:
+    _require_symlinks(tmp_path)
     other = _make_plugin_root(tmp_path / "other", "1.0.0")
     target.parent.mkdir(parents=True, exist_ok=True)
     target.symlink_to(other, target_is_directory=True)
@@ -231,3 +244,10 @@ def test_default_target_honors_copilot_home(monkeypatch, tmp_path: Path) -> None
     monkeypatch.setenv("COPILOT_HOME", str(tmp_path / "cop"))
     resolved = dogfood.default_target()
     assert resolved == tmp_path / "cop" / "installed-plugins" / "ai-agents" / "project-toolkit"
+
+
+def test_default_target_ignores_empty_copilot_home(monkeypatch) -> None:
+    monkeypatch.setenv("COPILOT_HOME", "")
+    resolved = dogfood.default_target()
+    expected = Path.home() / ".copilot" / "installed-plugins" / "ai-agents" / "project-toolkit"
+    assert resolved == expected


### PR DESCRIPTION
# Pull Request

## Summary

### What

Adds a copy-only dogfood installer so this repo runs the exact Copilot plugin base it ships to customers. `scripts/dev/dogfood_copilot_plugin.py --install` copies the working-tree `src/copilot-cli` over the installed `project-toolkit` plugin, so local Copilot CLI sessions load the hooks and skills from this checkout, not a stale published version.

### Why

Issue #3247 showed a stale installed plugin (v0.6.71) breaking the harness with exit-2 denies. We had no way to run the shipped hook base on this repo before publishing, so hook breakage reaches customers before we catch it. This closes that gap: edit the source, re-run `--install`, and the next session dogfoods the change. ADR-083 decision item 3 sanctioned a dogfood install for exactly this reason.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #3222 | Dogfood the shipped Copilot base on this repo |

This PR implements **phase 5 (dogfood install)** of the five-phase #3222. It references, not closes, that issue: phases 1 to 4 (ADR-083, base-artifact e2e CI, `surface` tag, two-plugin split) remain open.

## Changes

- Add `scripts/dev/dogfood_copilot_plugin.py`: copy-only installer with `--install`, `--uninstall`, `--status`. Backs up an existing marketplace copy once, honors `COPILOT_HOME`, exits 2 on config error.
- Add `tests/test_dogfood_copilot_plugin.py`: 14 positive, negative, and edge tests (install, refresh, backup-once, replace prior install, reject non-plugin source, uninstall restore, status states, env override).
- Add a Getting Started subsection to CONTRIBUTING.md documenting the copy-install and uninstall flow.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change
- [ ] Refactoring (no functional changes)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard, soft target

**Focus areas**: The copy-only mechanism choice (see Design note) and the ADR-083 reconciliation flagged below.

## Testing

Deliverables in this PR:

- [x] Tests added/updated
- [x] Manual testing completed
- [ ] No testing required (documentation only)

Manual: ran `--install` end to end. It replaced the prior installed copy, kept a one-time backup, and `copilot plugin list` enumerated `project-toolkit@ai-agents (v0.6.81)` from the dogfooded tree. ruff, mypy, and all 14 tests pass locally.

## Design note and ADR reconciliation

ADR-083 decision item 3 originally specified "symlink on Unix, copy on Windows." This PR ships copy-only on all platforms per owner directive: every other artifact in this repo is copied onto the machine (marketplace install, build pipeline), there is no existing symlink anywhere, and a symlink cannot be universal (Windows needs elevation). One consistent mechanism beats a platform split.

That makes the code diverge from the accepted ADR text, which is still marked not-implemented. Reconciling ADR-083 (amend item 3 and its downstream references from symlink to copy) fires the adr-review governance gate and needs a real multi-agent debate, which is not available on this harness. It is surfaced to the owner as a separate governance decision rather than silently amended here.

## Notes for Reviewers

Atomic: 3 files, one logical change. No plugin source touched, so no version bump gate applies.

## Related Issues

Refs #3222
