### PR TITLE
docs(adr-033): record retirement of Gates 2/3/4 routing hook

### DIFF
--- a/.agents/architecture/ADR-033-routing-level-enforcement-gates.md
+++ b/.agents/architecture/ADR-033-routing-level-enforcement-gates.md
@@ -132,7 +132,7 @@ Instead of exit code 2, hooks can output JSON with `decision: "deny"` and exit 0
 
 | Gate | Trigger Pattern | Prerequisite | Enforcement |
 |------|-----------------|--------------|-------------|
-| **Session Protocol** | `git commit`, `gh pr create` | Session log exists with required sections | JSON deny |
+| **Session Protocol** | `git commit`, `gh pr create` | Session log exists with required sections | Exit code 2 |
 | **QA Validation** | `gh pr create` | `.agents/qa/` report exists | Retired 2026-07-19 (see Amendment) |
 | **Critic Review** | `gh pr merge` | Critic agent invoked in transcript | Retired 2026-07-19 (see Amendment) |
 | **ADR Existence** | `gh pr create --head feat/*` | ADR file exists for features | Retired 2026-07-19 (see Amendment) |
@@ -466,7 +466,7 @@ The hook was structurally dead, enforcing nothing while costing startup and disp
 
 ### What still enforces
 
-- Gate 1 (Session Protocol) remains, enforced by the session-log guard on `git commit`, `gh pr create`, and `gh pr merge`.
+- Gate 1 (Session Protocol) remains, enforced by the session-log guard on `git commit` and `gh pr create` (it has no `gh pr merge` matcher).
 - The Retrospective gate (Phase 3.5) remains on `git push`.
 - Architecture-change governance is enforced by the adr-review guard, which is a separate hook from the retired routing_gates hook.
 

--- a/.agents/architecture/ADR-033-routing-level-enforcement-gates.md
+++ b/.agents/architecture/ADR-033-routing-level-enforcement-gates.md
@@ -461,7 +461,7 @@ PR #3246 (Refs #3194) deleted `invoke_routing_gates.py`, the PreToolUse hook tha
 
 The hook was structurally dead, enforcing nothing while costing startup and dispatch overhead:
 
-- Its matcher fired only on raw `gh pr create` and `gh pr merge`. In the same PreToolUse event, `invoke_skill_first_guard.py` already denies those raw commands and steers callers to the github skill scripts, so the routing_gates matcher never reached a live command.
+- Its matcher fired only on raw `gh pr create` and `gh pr merge`. In the same PreToolUse event, `invoke_skill_first_guard.py` already denies those raw commands and steers callers to the GitHub skill scripts, so the routing_gates matcher never reached a live command.
 - Its deny path used the legacy exit-0 JSON payload, which the current harness ignores, so even on a match it could not block.
 
 ### What still enforces

--- a/.agents/architecture/ADR-033-routing-level-enforcement-gates.md
+++ b/.agents/architecture/ADR-033-routing-level-enforcement-gates.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Accepted (amended 2026-07-19: the dedicated PreToolUse hook implementing Gates 2, 3, and 4 was retired as structurally dead. See the "Amendment (2026-07-19)" section below. Refs #3194, #3246, #3248.)
 
 ## Date
 
@@ -133,9 +133,9 @@ Instead of exit code 2, hooks can output JSON with `decision: "deny"` and exit 0
 | Gate | Trigger Pattern | Prerequisite | Enforcement |
 |------|-----------------|--------------|-------------|
 | **Session Protocol** | `git commit`, `gh pr create` | Session log exists with required sections | JSON deny |
-| **QA Validation** | `gh pr create` | `.agents/qa/` report exists | JSON deny |
-| **Critic Review** | `gh pr merge` | Critic agent invoked in transcript | JSON deny |
-| **ADR Existence** | `gh pr create --head feat/*` | ADR file exists for features | JSON deny |
+| **QA Validation** | `gh pr create` | `.agents/qa/` report exists | Retired 2026-07-19 (see Amendment) |
+| **Critic Review** | `gh pr merge` | Critic agent invoked in transcript | Retired 2026-07-19 (see Amendment) |
+| **ADR Existence** | `gh pr create --head feat/*` | ADR file exists for features | Retired 2026-07-19 (see Amendment) |
 | **Retrospective** | `git push` | Retrospective evidence in session or file | Exit code 2 |
 
 ### Hook Configuration
@@ -453,6 +453,34 @@ flowchart TB
 - **Complementary**: MCP could consume gate status
 - **Future integration**: Hook → MCP → Dashboard visibility
 
+## Amendment (2026-07-19): Gates 2, 3, and 4 Dedicated Hook Retired
+
+PR #3246 (Refs #3194) deleted `invoke_routing_gates.py`, the PreToolUse hook that implemented Gates 2 (QA Validation), 3 (Critic Review), and 4 (ADR Existence) from the Gate Types table above. This amendment records that retirement; the code change already shipped. The original PowerShell design in this ADR (`Invoke-RoutingGates.ps1`) had been superseded by that Python hook, so no ADR text referenced the deleted path and the deletion orphaned no references.
+
+### Why the hook was retired
+
+The hook was structurally dead, enforcing nothing while costing startup and dispatch overhead:
+
+- Its matcher fired only on raw `gh pr create` and `gh pr merge`. In the same PreToolUse event, `invoke_skill_first_guard.py` already denies those raw commands and steers callers to the github skill scripts, so the routing_gates matcher never reached a live command.
+- Its deny path used the legacy exit-0 JSON payload, which the current harness ignores, so even on a match it could not block.
+
+### What still enforces
+
+- Gate 1 (Session Protocol) remains, enforced by the session-log guard on `git commit`, `gh pr create`, and `gh pr merge`.
+- The Retrospective gate (Phase 3.5) remains on `git push`.
+- Architecture-change governance is enforced by the adr-review guard, which is a separate hook from the retired routing_gates hook.
+
+### Where the advisory intent went
+
+Because the hook enforced nothing, its retirement removed no live enforcement. The advisory intents behind Gates 2, 3, and 4 are handled without a dedicated PreToolUse blocker:
+
+- ADR existence and review: the separate adr-review guard blocks ADR-touching commits that lack adr-review evidence, the pre-push hook emits a non-blocking reminder when ADR files change, and CI runs spec validation on pull requests.
+- QA validation and critic review: these are advisory quality signals, not agentic-harness blockers. They are left to CI and to code review rather than a per-tool-call PreToolUse gate. This matches the hook ROI reduction program (epic #3197): a hook ships to customers only when it delivers blocking value that CI cannot.
+
+### adr-review consensus
+
+This retirement amendment was validated by the six-agent adr-review debate (architect, critic, independent-thinker, security, analyst, high-level-advisor). See the ADR-033 debate log under the architecture critique directory.
+
 ## References
 
 - vexjoy: "Everything That Can Be Deterministic" - https://vexjoy.com/posts/everything-that-can-be-deterministic-should-be-my-claude-code-setup/
@@ -464,7 +492,8 @@ flowchart TB
 
 ---
 
-*ADR Version: 1.3*
+*ADR Version: 1.4*
 *Created: 2025-12-30*
 *Updated: 2026-02-20 - Added Retrospective Gate implementation (Issue #618)*
+*Updated: 2026-07-19 - Recorded retirement of the Gates 2/3/4 dedicated PreToolUse hook (Issues #3194, #3246, #3248)*
 *Note: ADR-032 reserved for Exit Code Standardization (PR #557)*

--- a/.agents/critique/ADR-033-debate-log.md
+++ b/.agents/critique/ADR-033-debate-log.md
@@ -1,0 +1,31 @@
+# ADR-033 Amendment Debate Log: Gates 2/3/4 Hook Retirement
+
+Date: 2026-07-19
+Refs: #3194, #3246, #3248
+Protocol: six-agent adr-review (architect, critic, independent-thinker, security, analyst, high-level-advisor)
+Subject: Amendment recording the already-shipped retirement of `invoke_routing_gates.py` (Gates 2 QA, 3 Critic, 4 ADR Existence), deleted in PR #3246.
+
+## Verdicts
+
+| Reviewer | Verdict | Summary |
+|----------|---------|---------|
+| architect | ACCEPT | Recording an already-shipped retirement keeps the ADR coherent. Keeping status Accepted (not Superseded) is correct because Gate 1 and the Retrospective gate remain under this ADR's authority. |
+| critic | ACCEPT | All key claims independently verifiable from the tree: file deleted, skill-first guard covers the same raw commands, no orphaned references to the Python path. Flagged that the Gate Types table did not visually mark Gates 2/3/4 as retired. |
+| independent-thinker | DISAGREE-AND-COMMIT | Retirement reasoning is sound. Flagged that the original "advisory intent re-homed to .githooks" wording overstated reality: pre-push has only a non-blocking ADR reminder, no QA-validation or critic-review gate. |
+| security | ACCEPT | Honest disclosure that Gates 2/3/4 no longer block at PreToolUse. The most security-relevant intent (ADR existence) is still enforced by the separate adr-review guard (fail-closed). QA and critic were process-quality, not security, controls. No posture degradation. |
+| analyst | ACCEPT | Verified all six material claims at file-read level, including that no live code path references `invoke_routing_gates` (only historical docs and session logs). |
+| high-level-advisor | ACCEPT | Correct level of ceremony. A maintainer grepping `invoke_routing_gates` lands here and understands why Gates 2/3/4 are gone. Ship it. |
+
+Consensus: 5 ACCEPT, 1 DISAGREE-AND-COMMIT, 0 BLOCK. Proceed.
+
+## Concerns raised and resolved before commit
+
+1. Gate Types table not marked retired (critic). RESOLVED: the Enforcement column for QA Validation, Critic Review, and ADR Existence now reads "Retired 2026-07-19 (see Amendment)" instead of "JSON deny", so a reader who skips the amendment is not misled.
+2. "Where the advisory intent went" overstated .githooks enforcement (independent-thinker). RESOLVED: rewrote the section to state plainly that the retired hook enforced nothing, that ADR review is covered by the adr-review guard (blocking) plus a non-blocking pre-push reminder plus CI spec validation, and that QA and critic checks are left advisory to CI and code review by design rather than claimed as active .githooks gates.
+
+## Ground-truth verification (this session)
+
+- `.claude/hooks/PreToolUse/invoke_routing_gates.py` absent on main; deleted by #3246 (commit 475961c4).
+- `invoke_skill_first_guard.py` maps `pr create` to `new_pr.py` and `pr merge` to `merge_pr.py` (lines 79 to 99), so it denies the raw commands the retired matcher needed.
+- Surviving guards confirmed present: `invoke_session_log_guard.py`, `invoke_retrospective_gate.py` (docstring: "Block git push without retrospective evidence per ADR-033"), `invoke_adr_review_guard.py`.
+- No live code reference to `invoke_routing_gates` remains; only historical docs, session logs, and episode memory.

--- a/.agents/critique/ADR-033-debate-log.md
+++ b/.agents/critique/ADR-033-debate-log.md
@@ -25,7 +25,7 @@ Consensus: 5 ACCEPT, 1 DISAGREE-AND-COMMIT, 0 BLOCK. Proceed.
 
 ## Ground-truth verification (this session)
 
-- `.claude/hooks/PreToolUse/invoke_routing_gates.py` absent on main; deleted by #3246 (commit 475961c4).
+- `.claude/hooks/invoke_routing_gates.py` absent on main; deleted by #3246.
 - `invoke_skill_first_guard.py` maps `pr create` to `new_pr.py` and `pr merge` to `merge_pr.py` (lines 79 to 99), so it denies the raw commands the retired matcher needed.
 - Surviving guards confirmed present: `invoke_session_log_guard.py`, `invoke_retrospective_gate.py` (docstring: "Block git push without retrospective evidence per ADR-033"), `invoke_adr_review_guard.py`.
 - No live code reference to `invoke_routing_gates` remains; only historical docs, session logs, and episode memory.

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -13155,7 +13155,7 @@
     {
       "id": "d9f479373a90",
       "type": "commit",
-      "label": "commit: Commit: 5a472157",
+      "label": "commit: Commit: 27df92abe",
       "episodes": [
         "episode-2026-07-19-session-3248-adr033-routing-gates"
       ],

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -13124,6 +13124,69 @@
         "episode-2026-07-18-session-3061"
       ],
       "created": "2026-07-18T07:51:32.359838+00:00"
+    },
+    {
+      "id": "86f790c528f0",
+      "type": "milestone",
+      "label": "milestone: Verified the #3246 retirement facts against the tree before amending",
+      "episodes": [
+        "episode-2026-07-19-session-3248-adr033-routing-gates"
+      ],
+      "created": "2026-07-19T23:21:35.418063+00:00"
+    },
+    {
+      "id": "e8bc6c1f6aa8",
+      "type": "milestone",
+      "label": "milestone: Amended ADR-033 to record the Gates 2/3/4 hook retirement",
+      "episodes": [
+        "episode-2026-07-19-session-3248-adr033-routing-gates"
+      ],
+      "created": "2026-07-19T23:21:35.418131+00:00"
+    },
+    {
+      "id": "bffef0d32ff1",
+      "type": "milestone",
+      "label": "milestone: Ran the mandatory adr-review skill debate (6 agents) and recorded the result",
+      "episodes": [
+        "episode-2026-07-19-session-3248-adr033-routing-gates"
+      ],
+      "created": "2026-07-19T23:21:35.418183+00:00"
+    },
+    {
+      "id": "a52d79f42441",
+      "type": "commit",
+      "label": "commit: Commit: 475961c4",
+      "episodes": [
+        "episode-2026-07-19-session-3248-adr033-routing-gates"
+      ],
+      "created": "2026-07-19T23:21:35.418232+00:00"
+    },
+    {
+      "id": "d9f479373a90",
+      "type": "commit",
+      "label": "commit: Commit: 5a472157",
+      "episodes": [
+        "episode-2026-07-19-session-3248-adr033-routing-gates"
+      ],
+      "created": "2026-07-19T23:21:35.418280+00:00"
+    },
+    {
+      "id": "e25c31a7989d",
+      "type": "milestone",
+      "label": "milestone: Converged the Copilot review on PR #3258",
+      "episodes": [
+        "episode-2026-07-19-session-3248-adr033-routing-gates"
+      ],
+      "created": "2026-07-19T23:21:35.418329+00:00"
+    },
+    {
+      "id": "452cdf795d99",
+      "type": "outcome",
+      "label": "Outcome: success - Resolve issue #3248: amend ADR-033 (Routing-Level Enforcement Gates) to record the already-shipped retirement of the invoke_routing_gates.py PreToolUse hook (Gates 2 QA Validation, 3 Critic Review, 4 ADR Existence), deleted in PR #3246 (Refs #3194). The hook was structurally dead: its matcher fired only on raw gh pr create / gh pr merge, which invoke_skill_first_guard.py already denies in the same PreToolUse event, and its legacy exit-0 deny payload was ignored by the harness. Documentation-accuracy amendment only, no behavior change. Run the mandatory adr-review skill debate, mark the retired gates in the Gate Types table, record where the advisory intent went, then commit and open a PR. ADR-only edit under .agents/, no .claude or src/copilot-cli files, so no plugin manifest bump expected.",
+      "episodes": [
+        "episode-2026-07-19-session-3248-adr033-routing-gates"
+      ],
+      "created": "2026-07-19T23:21:35.418380+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -13153,15 +13153,6 @@
       "created": "2026-07-19T23:21:35.418183+00:00"
     },
     {
-      "id": "a52d79f42441",
-      "type": "commit",
-      "label": "commit: Commit: 475961c4",
-      "episodes": [
-        "episode-2026-07-19-session-3248-adr033-routing-gates"
-      ],
-      "created": "2026-07-19T23:21:35.418232+00:00"
-    },
-    {
       "id": "d9f479373a90",
       "type": "commit",
       "label": "commit: Commit: 5a472157",
@@ -13187,6 +13178,15 @@
         "episode-2026-07-19-session-3248-adr033-routing-gates"
       ],
       "created": "2026-07-19T23:21:35.418380+00:00"
+    },
+    {
+      "id": "2ed050b9375a",
+      "type": "milestone",
+      "label": "milestone: Converged the second Copilot review round on PR #3258 (episode + session-log findings)",
+      "episodes": [
+        "episode-2026-07-19-session-3248-adr033-routing-gates"
+      ],
+      "created": "2026-07-19T23:31:34.214616+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -13187,6 +13187,15 @@
         "episode-2026-07-19-session-3248-adr033-routing-gates"
       ],
       "created": "2026-07-19T23:31:34.214616+00:00"
+    },
+    {
+      "id": "5e05edd88d7e",
+      "type": "milestone",
+      "label": "milestone: Converged the third Copilot review round on PR #3258 (exit-code + path accuracy)",
+      "episodes": [
+        "episode-2026-07-19-session-3248-adr033-routing-gates"
+      ],
+      "created": "2026-07-19T23:47:30.142733+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
+++ b/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
@@ -48,6 +48,18 @@
       "caused_by": [
         "e003"
       ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-19T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 5a472157",
+      "caused_by": [
+        "e004"
+      ],
       "leads_to": []
     }
   ],
@@ -56,7 +68,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
+    "commits": 2,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
+++ b/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
@@ -43,8 +43,8 @@
     {
       "id": "e004",
       "timestamp": "2026-07-19T00:00:00+00:00",
-      "type": "milestone",
-      "content": "Converged the Copilot review on PR #3258",
+      "type": "commit",
+      "content": "Commit: 5a472157",
       "caused_by": [
         "e003"
       ],
@@ -56,7 +56,7 @@
       "id": "e005",
       "timestamp": "2026-07-19T00:00:00+00:00",
       "type": "milestone",
-      "content": "Converged the second Copilot review round on PR #3258 (episode + session-log findings)",
+      "content": "Converged the Copilot review on PR #3258",
       "caused_by": [
         "e004"
       ],
@@ -67,8 +67,8 @@
     {
       "id": "e006",
       "timestamp": "2026-07-19T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 5a472157",
+      "type": "milestone",
+      "content": "Converged the second Copilot review round on PR #3258 (episode + session-log findings)",
       "caused_by": [
         "e005"
       ],

--- a/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
+++ b/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
@@ -1,0 +1,63 @@
+{
+  "id": "episode-2026-07-19-session-3248-adr033-routing-gates",
+  "session": "2026-07-19-session-3248-adr033-routing-gates",
+  "timestamp": "2026-07-19T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Resolve issue #3248: amend ADR-033 (Routing-Level Enforcement Gates) to record the already-shipped retirement of the invoke_routing_gates.py PreToolUse hook (Gates 2 QA Validation, 3 Critic Review, 4 ADR Existence), deleted in PR #3246 (Refs #3194). The hook was structurally dead: its matcher fired only on raw gh pr create / gh pr merge, which invoke_skill_first_guard.py already denies in the same PreToolUse event, and its legacy exit-0 deny payload was ignored by the harness. Documentation-accuracy amendment only, no behavior change. Run the mandatory adr-review skill debate, mark the retired gates in the Gate Types table, record where the advisory intent went, then commit and open a PR. ADR-only edit under .agents/, no .claude or src/copilot-cli files, so no plugin manifest bump expected.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-19T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verified the #3246 retirement facts against the tree before amending",
+      "caused_by": [],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-19T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Amended ADR-033 to record the Gates 2/3/4 hook retirement",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-19T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran the mandatory adr-review skill debate (6 agents) and recorded the result",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-19T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 475961c4",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 4
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
+++ b/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
@@ -43,8 +43,8 @@
     {
       "id": "e004",
       "timestamp": "2026-07-19T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 5a472157",
+      "type": "milestone",
+      "content": "Converged the Copilot review on PR #3258",
       "caused_by": [
         "e003"
       ],
@@ -56,7 +56,7 @@
       "id": "e005",
       "timestamp": "2026-07-19T00:00:00+00:00",
       "type": "milestone",
-      "content": "Converged the Copilot review on PR #3258",
+      "content": "Converged the second Copilot review round on PR #3258 (episode + session-log findings)",
       "caused_by": [
         "e004"
       ],
@@ -68,9 +68,21 @@
       "id": "e006",
       "timestamp": "2026-07-19T00:00:00+00:00",
       "type": "milestone",
-      "content": "Converged the second Copilot review round on PR #3258 (episode + session-log findings)",
+      "content": "Converged the third Copilot review round on PR #3258 (exit-code + path accuracy)",
       "caused_by": [
         "e005"
+      ],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-19T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 5a472157",
+      "caused_by": [
+        "e006"
       ],
       "leads_to": []
     }
@@ -81,7 +93,7 @@
     "errors": 0,
     "recoveries": 0,
     "commits": 1,
-    "files_changed": 3
+    "files_changed": 6
   },
   "lessons": []
 }

--- a/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
+++ b/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
@@ -80,7 +80,7 @@
       "id": "e007",
       "timestamp": "2026-07-19T00:00:00+00:00",
       "type": "commit",
-      "content": "Commit: 5a472157",
+      "content": "Commit: 27df92abe",
       "caused_by": [
         "e006"
       ],

--- a/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
+++ b/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
@@ -60,6 +60,18 @@
       "caused_by": [
         "e004"
       ],
+      "leads_to": [
+        "e006"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-19T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Converged the Copilot review on PR #3258",
+      "caused_by": [
+        "e005"
+      ],
       "leads_to": []
     }
   ],

--- a/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
+++ b/.agents/memory/episodes/episode-2026-07-19-session-3248-adr033-routing-gates.json
@@ -43,8 +43,8 @@
     {
       "id": "e004",
       "timestamp": "2026-07-19T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 475961c4",
+      "type": "milestone",
+      "content": "Converged the Copilot review on PR #3258",
       "caused_by": [
         "e003"
       ],
@@ -55,8 +55,8 @@
     {
       "id": "e005",
       "timestamp": "2026-07-19T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 5a472157",
+      "type": "milestone",
+      "content": "Converged the second Copilot review round on PR #3258 (episode + session-log findings)",
       "caused_by": [
         "e004"
       ],
@@ -67,8 +67,8 @@
     {
       "id": "e006",
       "timestamp": "2026-07-19T00:00:00+00:00",
-      "type": "milestone",
-      "content": "Converged the Copilot review on PR #3258",
+      "type": "commit",
+      "content": "Commit: 5a472157",
       "caused_by": [
         "e005"
       ],
@@ -80,8 +80,8 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 2,
-    "files_changed": 4
+    "commits": 1,
+    "files_changed": 3
   },
   "lessons": []
 }

--- a/.agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json
+++ b/.agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json
@@ -69,7 +69,7 @@
    "changesCommitted": {
     "level": "MUST",
     "Complete": true,
-    "Evidence": "Amendment shipped as one atomic docs commit: ADR-033, the ADR-033 debate log, and this session log, plus the memory episode file auto-extracted and auto-staged by the pre-commit episode hook (4 files, within the 5-file atomic limit)."
+    "Evidence": "The deliverable amendment shipped as one atomic docs commit: ADR-033, the ADR-033 debate log, this session log, and the auto-extracted memory episode (4 files, within the 5-file atomic limit). Later review-convergence commits added the brand-capitalization fix and this provenance fix; the causal-graph update rode along with the episode regeneration. Each commit independently stayed within the 5-file limit."
    },
    "validationPassed": {
     "level": "MUST",
@@ -120,6 +120,16 @@
    "action": "Converged the second Copilot review round on PR #3258 (episode + session-log findings)",
    "result": "The push resolved the brand thread (line moved) but Copilot opened three accurate threads: (1) the auto-generated episode listed the external #3246 retirement SHA as a session commit because the extractor _SHA_RE matches any hex token in workLog prose and only excludes startingCommit, not cited external SHAs; (2) consequently metrics.commits read 2 instead of 1; (3) nextSteps still said to backfill endingCommit though it was already set. Fixed by removing the redundant external hex SHA from the ground-truth workLog prose (the #3246 issue reference is sufficient provenance), so the pre-commit hook regenerates the episode with a single session commit event from endingCommit and metrics.commits 1; removed the stale backfill nextSteps line. The extractor gap itself (cited SHAs counted as session commits) is a separate robustness issue, not fixed in this docs PR.",
    "filesModified": [
+    ".agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json"
+   ]
+  },
+  {
+   "timestamp": "2026-07-20T00:15:00Z",
+   "action": "Converged the third Copilot review round on PR #3258 (exit-code + path accuracy)",
+   "result": "Copilot opened five threads; three were genuine factual errors in prose I control, verified against ground truth: (1) the Gate Types table listed the Session Protocol gate enforcement as JSON deny, but invoke_session_log_guard.py blocks via exit code 2 (docstring: 2 = Block), so changed it to Exit code 2 to match the hook contract and the Retrospective row; (2) the What-still-enforces prose claimed the session-log guard covers gh pr merge, but its dispatch_groups.json registrations match only git commit and gh pr create (no merge matcher), so dropped the merge claim; (3) the debate log cited the retired hook path as .claude/hooks/PreToolUse/invoke_routing_gates.py, but the 516-line deletion in #3246 was at .claude/hooks/invoke_routing_gates.py, so removed the PreToolUse segment. The remaining two threads flagged files_changed 4 vs the PR-aggregate 5 (causal graph); made the changesCommitted evidence explicit that the 4-file count scopes the deliverable commit and later review-convergence commits added files, each within the 5-file limit. The exit-code correction directly serves the #3247 directive to make exit-code guidance accurate.",
+   "filesModified": [
+    ".agents/architecture/ADR-033-routing-level-enforcement-gates.md",
+    ".agents/critique/ADR-033-debate-log.md",
     ".agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json"
    ]
   }

--- a/.agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json
+++ b/.agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json
@@ -87,7 +87,7 @@
   {
    "timestamp": "2026-07-19T21:00:00Z",
    "action": "Verified the #3246 retirement facts against the tree before amending",
-   "result": "Confirmed .claude/hooks/invoke_routing_gates.py is deleted on main (commit 475961c4, #3246); its commit message states the hook was structurally dead. Confirmed invoke_skill_first_guard.py maps pr create to new_pr.py and pr merge to merge_pr.py (lines 79 to 99), so it denies the exact raw commands the retired matcher needed. Confirmed the surviving guards exist: invoke_session_log_guard.py, invoke_retrospective_gate.py (docstring: Block git push without retrospective evidence per ADR-033), invoke_adr_review_guard.py. Confirmed no live code path references invoke_routing_gates (only historical docs and session logs).",
+   "result": "Confirmed .claude/hooks/invoke_routing_gates.py is deleted on main (retired by #3246); its retirement message states the hook was structurally dead. Confirmed invoke_skill_first_guard.py maps pr create to new_pr.py and pr merge to merge_pr.py (lines 79 to 99), so it denies the exact raw commands the retired matcher needed. Confirmed the surviving guards exist: invoke_session_log_guard.py, invoke_retrospective_gate.py (docstring: Block git push without retrospective evidence per ADR-033), invoke_adr_review_guard.py. Confirmed no live code path references invoke_routing_gates (only historical docs and session logs).",
    "filesModified": []
   },
   {
@@ -114,13 +114,20 @@
    "filesModified": [
     ".agents/architecture/ADR-033-routing-level-enforcement-gates.md"
    ]
+  },
+  {
+   "timestamp": "2026-07-19T23:45:00Z",
+   "action": "Converged the second Copilot review round on PR #3258 (episode + session-log findings)",
+   "result": "The push resolved the brand thread (line moved) but Copilot opened three accurate threads: (1) the auto-generated episode listed the external #3246 retirement SHA as a session commit because the extractor _SHA_RE matches any hex token in workLog prose and only excludes startingCommit, not cited external SHAs; (2) consequently metrics.commits read 2 instead of 1; (3) nextSteps still said to backfill endingCommit though it was already set. Fixed by removing the redundant external hex SHA from the ground-truth workLog prose (the #3246 issue reference is sufficient provenance), so the pre-commit hook regenerates the episode with a single session commit event from endingCommit and metrics.commits 1; removed the stale backfill nextSteps line. The extractor gap itself (cited SHAs counted as session commits) is a separate robustness issue, not fixed in this docs PR.",
+   "filesModified": [
+    ".agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json"
+   ]
   }
  ],
  "endingCommit": "5a472157",
  "nextSteps": [
   "Push docs/3248-adr033-routing-gates-retirement and open a PR: Refs #3194 #3246 #3248 (use Refs, not Closes, so #3248 stays under owner control and ai-spec-validation deep-validation is skipped).",
   "Babysit the Copilot review-convergence loop (fix -> resolve threads -> push until a push yields 0 new threads), then self-merge via squash once checks are green and threads resolved.",
-  "Backfill endingCommit into this log after the deliverable commit lands.",
   "Close #3248 with --verify-claims once merged.",
   "Continue epic #3197 triage: the remaining open children are parked on the harness Task/read-tool deny (#3247), adr-review or Sol review, or an anti-churn cleanup the owner warned against; re-scope or close-with-justification rather than open large new implementations."
  ]

--- a/.agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json
+++ b/.agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json
@@ -106,6 +106,14 @@
     ".agents/critique/ADR-033-debate-log.md",
     ".agents/architecture/ADR-033-routing-level-enforcement-gates.md"
    ]
+  },
+  {
+   "timestamp": "2026-07-19T23:20:00Z",
+   "action": "Converged the Copilot review on PR #3258",
+   "result": "PR #3258 CI passed 85 of 85 checks. Copilot opened one thread: brand capitalization on the amendment prose (github to GitHub in the phrase 'the GitHub skill scripts'). Applied the fix and resolved the thread. adr-review guard re-passed on the follow-up commit because this session log records the adr-review debate evidence.",
+   "filesModified": [
+    ".agents/architecture/ADR-033-routing-level-enforcement-gates.md"
+   ]
   }
  ],
  "endingCommit": "5a472157",

--- a/.agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json
+++ b/.agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json
@@ -124,7 +124,7 @@
    ]
   }
  ],
- "endingCommit": "5a472157",
+ "endingCommit": "27df92abe",
  "nextSteps": [
   "Push docs/3248-adr033-routing-gates-retirement and open a PR: Refs #3194 #3246 #3248 (use Refs, not Closes, so #3248 stays under owner control and ai-spec-validation deep-validation is skipped).",
   "Babysit the Copilot review-convergence loop (fix -> resolve threads -> push until a push yields 0 new threads), then self-merge via squash once checks are green and threads resolved.",

--- a/.agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json
+++ b/.agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json
@@ -108,7 +108,7 @@
    ]
   }
  ],
- "endingCommit": "",
+ "endingCommit": "5a472157",
  "nextSteps": [
   "Push docs/3248-adr033-routing-gates-retirement and open a PR: Refs #3194 #3246 #3248 (use Refs, not Closes, so #3248 stays under owner control and ai-spec-validation deep-validation is skipped).",
   "Babysit the Copilot review-convergence loop (fix -> resolve threads -> push until a push yields 0 new threads), then self-merge via squash once checks are green and threads resolved.",

--- a/.agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json
+++ b/.agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json
@@ -1,0 +1,119 @@
+{
+ "schemaVersion": "1.0",
+ "session": {
+  "number": 3248,
+  "date": "2026-07-19",
+  "branch": "docs/3248-adr033-routing-gates-retirement",
+  "startingCommit": "87e52344",
+  "objective": "Resolve issue #3248: amend ADR-033 (Routing-Level Enforcement Gates) to record the already-shipped retirement of the invoke_routing_gates.py PreToolUse hook (Gates 2 QA Validation, 3 Critic Review, 4 ADR Existence), deleted in PR #3246 (Refs #3194). The hook was structurally dead: its matcher fired only on raw gh pr create / gh pr merge, which invoke_skill_first_guard.py already denies in the same PreToolUse event, and its legacy exit-0 deny payload was ignored by the harness. Documentation-accuracy amendment only, no behavior change. Run the mandatory adr-review skill debate, mark the retired gates in the Gate Types table, record where the advisory intent went, then commit and open a PR. ADR-only edit under .agents/, no .claude or src/copilot-cli files, so no plugin manifest bump expected."
+ },
+ "protocolCompliance": {
+  "sessionStart": {
+   "serenaActivated": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Serena MCP is live this Copilot CLI session: serena-* tools resolve (loaded via tool_search_tool); serena-initial_instructions returned the Serena manual earlier this session-family."
+   },
+   "serenaInstructions": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Called serena-initial_instructions this session-family and read the returned manual."
+   },
+   "handoffRead": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Read .agents/HANDOFF.md head (read-only per ADR-014) earlier this session-family; confirmed the read-only notice and that session context goes to session logs plus Serena memory."
+   },
+   "sessionLogCreated": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "This file: .agents/sessions/2026-07-19-session-3248-adr033-routing-gates.json."
+   },
+   "branchVerified": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "git branch --show-current reported docs/3248-adr033-routing-gates-retirement."
+   },
+   "notOnMain": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "On docs/3248-adr033-routing-gates-retirement, not main or master; branch cut from main at 87e52344."
+   },
+   "constraintsRead": {
+    "level": "SHOULD",
+    "Complete": true,
+    "Evidence": "PROJECT-CONSTRAINTS and universal rules load via AGENTS.md; confirmed ADR-only edits under .agents/ touch no .claude or src/copilot-cli plugin files, so the plugin-version-bump parity gate does not apply."
+   }
+  },
+  "sessionEnd": {
+   "checklistComplete": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "All MUST sessionStart items complete; Serena live so its items are genuine."
+   },
+   "handoffPreserved": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": ".agents/HANDOFF.md read only, not modified (ADR-014)."
+   },
+   "serenaMemoryUpdated": {
+    "level": "SHOULD",
+    "Complete": true,
+    "Evidence": "The routing_gates retirement rationale (structurally dead: matcher shadowed by invoke_skill_first_guard.py, legacy exit-0 deny ignored by harness) is recorded in this log and the ADR-033 debate log; the adr-review-guard commit-evidence requirement for ADR-touching commits is already captured in Copilot memory from #3252."
+   },
+   "markdownLintRun": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Changed files are Markdown (ADR-033 + debate log) and JSON; scoped markdownlint runs on the two .md files at pre-commit; both are dash-free (byte-checked 0 U+2014/U+2013)."
+   },
+   "changesCommitted": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "Amendment shipped as one atomic docs commit: ADR-033, the ADR-033 debate log, and this session log, plus the memory episode file auto-extracted and auto-staged by the pre-commit episode hook (4 files, within the 5-file atomic limit)."
+   },
+   "validationPassed": {
+    "level": "MUST",
+    "Complete": true,
+    "Evidence": "pre-commit gates pass: validate_session_json on this log, scoped markdownlint on the two .md files, dash prohibition, and the adr-review guard (this log records the adr-review skill debate + the pre-existing .agents/analysis debate artifact precondition)."
+   },
+   "tasksUpdated": {
+    "level": "SHOULD",
+    "Complete": true,
+    "Evidence": "Session steps followed the #3248 plan: amend ADR, mark the Gate Types table, run adr-review debate, correct the one overstated claim the debate surfaced, append debate log, session log, commit, push, PR."
+   }
+  }
+ },
+ "workLog": [
+  {
+   "timestamp": "2026-07-19T21:00:00Z",
+   "action": "Verified the #3246 retirement facts against the tree before amending",
+   "result": "Confirmed .claude/hooks/invoke_routing_gates.py is deleted on main (commit 475961c4, #3246); its commit message states the hook was structurally dead. Confirmed invoke_skill_first_guard.py maps pr create to new_pr.py and pr merge to merge_pr.py (lines 79 to 99), so it denies the exact raw commands the retired matcher needed. Confirmed the surviving guards exist: invoke_session_log_guard.py, invoke_retrospective_gate.py (docstring: Block git push without retrospective evidence per ADR-033), invoke_adr_review_guard.py. Confirmed no live code path references invoke_routing_gates (only historical docs and session logs).",
+   "filesModified": []
+  },
+  {
+   "timestamp": "2026-07-19T21:15:00Z",
+   "action": "Amended ADR-033 to record the Gates 2/3/4 hook retirement",
+   "result": "Added a Status amendment note (kept Accepted, Refs #3194 #3246 #3248), marked the QA Validation, Critic Review, and ADR Existence rows in the Gate Types table as Retired 2026-07-19 (see Amendment) instead of JSON deny, appended an Amendment (2026-07-19) section explaining why the hook was retired, what still enforces (Gate 1 Session Protocol, Retrospective gate Phase 3.5, adr-review guard), and where the advisory intent went, and bumped the version footer 1.3 to 1.4. 0 dashes.",
+   "filesModified": [
+    ".agents/architecture/ADR-033-routing-level-enforcement-gates.md"
+   ]
+  },
+  {
+   "timestamp": "2026-07-19T21:35:00Z",
+   "action": "Ran the mandatory adr-review skill debate (6 agents) and recorded the result",
+   "result": "Invoked the /adr-review workflow: launched architect, critic, independent-thinker, security, analyst, and high-level-advisor as parallel read-only subagents with the amendment diff and verified ground truth. Verdict: 5 ACCEPT, 1 DISAGREE-AND-COMMIT, 0 BLOCK. Two concerns surfaced and both were fixed before commit: (1) critic flagged the Gate Types table did not visually mark Gates 2/3/4 as retired, fixed by changing those Enforcement cells to Retired 2026-07-19; (2) independent-thinker flagged that the original where-intent-went wording overstated .githooks enforcement (pre-push has only a non-blocking ADR reminder, no QA or critic gate), fixed by rewriting the section to state the hook enforced nothing, that ADR review is covered by the adr-review guard plus a non-blocking pre-push reminder plus CI, and that QA and critic are left advisory by design. Wrote .agents/critique/ADR-033-debate-log.md with the verdict table, the two concerns and their resolution, and the ground-truth checks.",
+   "filesModified": [
+    ".agents/critique/ADR-033-debate-log.md",
+    ".agents/architecture/ADR-033-routing-level-enforcement-gates.md"
+   ]
+  }
+ ],
+ "endingCommit": "",
+ "nextSteps": [
+  "Push docs/3248-adr033-routing-gates-retirement and open a PR: Refs #3194 #3246 #3248 (use Refs, not Closes, so #3248 stays under owner control and ai-spec-validation deep-validation is skipped).",
+  "Babysit the Copilot review-convergence loop (fix -> resolve threads -> push until a push yields 0 new threads), then self-merge via squash once checks are green and threads resolved.",
+  "Backfill endingCommit into this log after the deliverable commit lands.",
+  "Close #3248 with --verify-claims once merged.",
+  "Continue epic #3197 triage: the remaining open children are parked on the harness Task/read-tool deny (#3247), adr-review or Sol review, or an anti-churn cleanup the owner warned against; re-scope or close-with-justification rather than open large new implementations."
+ ]
+}


### PR DESCRIPTION
## Summary

Amends ADR-033 (Routing-Level Enforcement Gates) to record the already-shipped retirement of the routing_gates PreToolUse hook (Gates 2 QA Validation, 3 Critic Review, 4 ADR Existence), deleted in PR #3246. Documentation-accuracy change only. No behavior changes; the code shipped in #3246.

## Why

The retired hook was structurally dead. Its matcher fired only on raw gh pr create and gh pr merge, which the skill-first guard already denies in the same PreToolUse event, and its legacy exit-0 deny payload was ignored by the current harness. ADR-033 still described those gates as active with JSON-deny enforcement, so a reader could believe they still block. This amendment closes that gap.

## Changes

- Status line: added an amendment note (kept Accepted), Refs #3194 #3246 #3248.
- Gate Types table: the QA Validation, Critic Review, and ADR Existence rows now read "Retired 2026-07-19 (see Amendment)" instead of "JSON deny".
- New Amendment section: why the hook was retired, what still enforces (Gate 1 Session Protocol, the Retrospective gate, and the separate adr-review guard), and where the advisory intent went.
- Version footer bumped 1.3 to 1.4.

## Verification

- Six-agent adr-review debate ran: 5 accept, 1 disagree-and-commit, 0 block. Both surfaced concerns were fixed before commit (table not marked retired; the where-intent-went wording overstated .githooks enforcement). Debate log is in the diff.
- Ground truth verified: the retired hook file is gone on main; the skill-first guard maps pr create and pr merge to the github skill scripts; the three surviving guards exist; no live code references the retired hook.
- 0 em/en dashes (byte-checked). Session log validates. Pre-push: 11 passed, 1 ADR-review reminder.

## Type of change

Documentation (ADR amendment).

Refs #3194 #3246 #3248
