### PR TITLE
fix(memory): order episode causal chain by lifecycle, not append order (#3260)

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.83",
+  "version": "0.6.84",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -1217,12 +1217,12 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-# Lifecycle precedence for the causal chain. A commit records work that was
-# already done, so it is a cause, not an effect; tests, errors, and review or CI
-# milestones follow the commit they validate or report on. Ranking events by
-# this lifecycle (within a shared timestamp) stops a commit that the extractor
-# appends last from being linked as ``caused_by`` a later PR-review milestone
-# (issue #3260). Types absent here sort at ``_CAUSAL_DEFAULT_RANK``.
+# Lifecycle precedence for the causal chain. Every extractor event shares one
+# session timestamp, so this rank, not the timestamp, is the real tie-breaker.
+# It enforces the invariant that a commit is never linked as ``caused_by`` a
+# later review milestone (issue #3260): a commit is created and pushed before
+# the tests, errors, and review or CI milestones that report on it, so it must
+# sort ahead of them. Types absent here sort at ``_CAUSAL_DEFAULT_RANK``.
 _CAUSAL_TYPE_RANK: dict[str, int] = {
     "implementation": 0,
     "commit": 1,

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -1217,16 +1217,39 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+# Lifecycle precedence for the causal chain. A commit records work that was
+# already done, so it is a cause, not an effect; tests, errors, and review or CI
+# milestones follow the commit they validate or report on. Ranking events by
+# this lifecycle (within a shared timestamp) stops a commit that the extractor
+# appends last from being linked as ``caused_by`` a later PR-review milestone
+# (issue #3260). Types absent here sort at ``_CAUSAL_DEFAULT_RANK``.
+_CAUSAL_TYPE_RANK: dict[str, int] = {
+    "implementation": 0,
+    "commit": 1,
+    "test": 2,
+    "error": 3,
+    "milestone": 4,
+}
+_CAUSAL_DEFAULT_RANK = 2
+
+
 def _link_sequential_events(events: list[dict[str, Any]]) -> None:
-    """Populate ``caused_by``/``leads_to`` as a linear chain over ordered events.
+    """Populate ``caused_by``/``leads_to`` as a lifecycle-ordered chain.
 
     ADR-038 defines ``caused_by``/``leads_to`` as first-class event fields so
     reflexion retrieval can walk a connected causal graph, but every
     event-construction site emits them empty, leaving the graph flat
-    (issue #3245). The extractor appends events in session-progression order, so
-    linking each event to its immediate predecessor and successor is the
-    cheapest defensible causal signal. Boundary events (the first, the last)
-    keep the empty side.
+    (issue #3245).
+
+    The chain follows the session lifecycle, not raw append order.
+    ``json_events`` appends every commit after the work-log milestones, so a
+    purely positional chain linked the commit as ``caused_by`` the final
+    PR-review milestone, inverting cause and effect: a commit is created and
+    pushed before any review happens (issue #3260). Events are ordered by
+    ``(timestamp, lifecycle rank, original position)`` so commits (causes)
+    precede the tests, errors, and review milestones (effects) that follow them,
+    while events of the same rank keep their original order. The physical
+    ``events`` list is left untouched; only the link fields change.
 
     Mutates in place. Must run on final ids, i.e. after any id reassignment by
     ``_dedupe_events``, so the references never dangle.
@@ -1234,13 +1257,22 @@ def _link_sequential_events(events: list[dict[str, Any]]) -> None:
     Overwrites ``caused_by``/``leads_to`` unconditionally. Under ``--preserve``,
     ids reassigned by ``merge_preserving`` make prior edges invalid, so any
     existing values (including curated edges on a loaded episode) are replaced
-    by the regenerated linear chain rather than retained.
+    by the regenerated chain rather than retained.
     """
-    ordered = [e for e in events if isinstance(e, dict) and e.get("id")]
-    last = len(ordered) - 1
-    for pos, evt in enumerate(ordered):
-        evt["caused_by"] = [ordered[pos - 1]["id"]] if pos > 0 else []
-        evt["leads_to"] = [ordered[pos + 1]["id"]] if pos < last else []
+    linkable = [e for e in events if isinstance(e, dict) and e.get("id")]
+    chain_order = sorted(
+        range(len(linkable)),
+        key=lambda i: (
+            linkable[i].get("timestamp") or "",
+            _CAUSAL_TYPE_RANK.get(linkable[i].get("type", ""), _CAUSAL_DEFAULT_RANK),
+            i,
+        ),
+    )
+    chain = [linkable[i] for i in chain_order]
+    last = len(chain) - 1
+    for pos, evt in enumerate(chain):
+        evt["caused_by"] = [chain[pos - 1]["id"]] if pos > 0 else []
+        evt["leads_to"] = [chain[pos + 1]["id"]] if pos < last else []
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.83",
+  "version": "0.6.84",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -1217,12 +1217,12 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-# Lifecycle precedence for the causal chain. A commit records work that was
-# already done, so it is a cause, not an effect; tests, errors, and review or CI
-# milestones follow the commit they validate or report on. Ranking events by
-# this lifecycle (within a shared timestamp) stops a commit that the extractor
-# appends last from being linked as ``caused_by`` a later PR-review milestone
-# (issue #3260). Types absent here sort at ``_CAUSAL_DEFAULT_RANK``.
+# Lifecycle precedence for the causal chain. Every extractor event shares one
+# session timestamp, so this rank, not the timestamp, is the real tie-breaker.
+# It enforces the invariant that a commit is never linked as ``caused_by`` a
+# later review milestone (issue #3260): a commit is created and pushed before
+# the tests, errors, and review or CI milestones that report on it, so it must
+# sort ahead of them. Types absent here sort at ``_CAUSAL_DEFAULT_RANK``.
 _CAUSAL_TYPE_RANK: dict[str, int] = {
     "implementation": 0,
     "commit": 1,

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -1217,16 +1217,39 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+# Lifecycle precedence for the causal chain. A commit records work that was
+# already done, so it is a cause, not an effect; tests, errors, and review or CI
+# milestones follow the commit they validate or report on. Ranking events by
+# this lifecycle (within a shared timestamp) stops a commit that the extractor
+# appends last from being linked as ``caused_by`` a later PR-review milestone
+# (issue #3260). Types absent here sort at ``_CAUSAL_DEFAULT_RANK``.
+_CAUSAL_TYPE_RANK: dict[str, int] = {
+    "implementation": 0,
+    "commit": 1,
+    "test": 2,
+    "error": 3,
+    "milestone": 4,
+}
+_CAUSAL_DEFAULT_RANK = 2
+
+
 def _link_sequential_events(events: list[dict[str, Any]]) -> None:
-    """Populate ``caused_by``/``leads_to`` as a linear chain over ordered events.
+    """Populate ``caused_by``/``leads_to`` as a lifecycle-ordered chain.
 
     ADR-038 defines ``caused_by``/``leads_to`` as first-class event fields so
     reflexion retrieval can walk a connected causal graph, but every
     event-construction site emits them empty, leaving the graph flat
-    (issue #3245). The extractor appends events in session-progression order, so
-    linking each event to its immediate predecessor and successor is the
-    cheapest defensible causal signal. Boundary events (the first, the last)
-    keep the empty side.
+    (issue #3245).
+
+    The chain follows the session lifecycle, not raw append order.
+    ``json_events`` appends every commit after the work-log milestones, so a
+    purely positional chain linked the commit as ``caused_by`` the final
+    PR-review milestone, inverting cause and effect: a commit is created and
+    pushed before any review happens (issue #3260). Events are ordered by
+    ``(timestamp, lifecycle rank, original position)`` so commits (causes)
+    precede the tests, errors, and review milestones (effects) that follow them,
+    while events of the same rank keep their original order. The physical
+    ``events`` list is left untouched; only the link fields change.
 
     Mutates in place. Must run on final ids, i.e. after any id reassignment by
     ``_dedupe_events``, so the references never dangle.
@@ -1234,13 +1257,22 @@ def _link_sequential_events(events: list[dict[str, Any]]) -> None:
     Overwrites ``caused_by``/``leads_to`` unconditionally. Under ``--preserve``,
     ids reassigned by ``merge_preserving`` make prior edges invalid, so any
     existing values (including curated edges on a loaded episode) are replaced
-    by the regenerated linear chain rather than retained.
+    by the regenerated chain rather than retained.
     """
-    ordered = [e for e in events if isinstance(e, dict) and e.get("id")]
-    last = len(ordered) - 1
-    for pos, evt in enumerate(ordered):
-        evt["caused_by"] = [ordered[pos - 1]["id"]] if pos > 0 else []
-        evt["leads_to"] = [ordered[pos + 1]["id"]] if pos < last else []
+    linkable = [e for e in events if isinstance(e, dict) and e.get("id")]
+    chain_order = sorted(
+        range(len(linkable)),
+        key=lambda i: (
+            linkable[i].get("timestamp") or "",
+            _CAUSAL_TYPE_RANK.get(linkable[i].get("type", ""), _CAUSAL_DEFAULT_RANK),
+            i,
+        ),
+    )
+    chain = [linkable[i] for i in chain_order]
+    last = len(chain) - 1
+    for pos, evt in enumerate(chain):
+        evt["caused_by"] = [chain[pos - 1]["id"]] if pos > 0 else []
+        evt["leads_to"] = [chain[pos + 1]["id"]] if pos < last else []
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/skills/memory/test_extract_session_episode.py
+++ b/tests/skills/memory/test_extract_session_episode.py
@@ -1231,12 +1231,17 @@ class TestStringDecisionPreservation:
 
 
 class TestSequentialEventLinks:
-    """Episode events form a connected causal chain, not a flat graph (#3245).
+    """Episode events form a lifecycle-ordered causal chain, not a flat graph.
 
-    ADR-038 defines ``caused_by``/``leads_to`` as first-class fields; the
-    extractor links each event to its immediate neighbors so reflexion retrieval
-    can walk the graph. Linking runs on final ids (after ``_dedupe_events``
-    reassignment) so references never dangle.
+    ADR-038 defines ``caused_by``/``leads_to`` as first-class fields (#3245); the
+    extractor links events so reflexion retrieval can walk the graph. The chain
+    follows the session lifecycle (a commit is a cause; tests, errors, and review
+    milestones are effects), not physical append order, so a commit that
+    ``json_events`` appends last is never ``caused_by`` a later milestone (#3260).
+    Linking runs on final ids (after ``_dedupe_events`` reassignment) so
+    references never dangle. Ordering keys on ``(timestamp, lifecycle rank,
+    original position)`` so genuine time order still dominates and rank only
+    breaks ties within a shared timestamp.
     """
 
     @staticmethod
@@ -1251,11 +1256,15 @@ class TestSequentialEventLinks:
         }
 
     def test_multi_event_chain(self):
+        # Physical order is milestone, test, commit; the causal chain reorders by
+        # lifecycle (commit first) without touching the physical list order.
         events = [self._evt("e001"), self._evt("e002", "test"), self._evt("e003", "commit")]
         extract_session_episode._link_sequential_events(events)
-        assert events[0]["caused_by"] == [] and events[0]["leads_to"] == ["e002"]
-        assert events[1]["caused_by"] == ["e001"] and events[1]["leads_to"] == ["e003"]
-        assert events[2]["caused_by"] == ["e002"] and events[2]["leads_to"] == []
+        assert [e["id"] for e in events] == ["e001", "e002", "e003"]
+        # commit (e003) is the root cause; test (e002) then milestone (e001) follow.
+        assert events[2]["caused_by"] == [] and events[2]["leads_to"] == ["e002"]
+        assert events[1]["caused_by"] == ["e003"] and events[1]["leads_to"] == ["e001"]
+        assert events[0]["caused_by"] == ["e002"] and events[0]["leads_to"] == []
 
     def test_single_event_has_no_links(self):
         events = [self._evt("e001")]
@@ -1273,9 +1282,58 @@ class TestSequentialEventLinks:
         malformed = {"type": "milestone", "content": "no id"}
         events = [self._evt("e001"), malformed, self._evt("e002", "commit")]
         extract_session_episode._link_sequential_events(events)
-        assert events[0]["leads_to"] == ["e002"]
-        assert events[2]["caused_by"] == ["e001"]
+        # commit (e002) is the cause of milestone (e001); malformed is untouched.
+        assert events[2]["caused_by"] == [] and events[2]["leads_to"] == ["e001"]
+        assert events[0]["caused_by"] == ["e002"] and events[0]["leads_to"] == []
         assert "caused_by" not in malformed
+
+    def test_commit_is_never_caused_by_a_milestone(self):
+        # #3260 regression: json_events appends commits last, so a positional
+        # chain linked the commit as caused_by the final milestone, inverting
+        # cause and effect. The commit must be a root cause, not a milestone's
+        # effect.
+        events = [
+            self._evt("e001", "milestone", "Did work"),
+            self._evt("e002", "milestone", "Reviewed"),
+            self._evt("e003", "commit", "Commit: abc1234"),
+        ]
+        extract_session_episode._link_sequential_events(events)
+        by_id = {e["id"]: e for e in events}
+        milestone_ids = {"e001", "e002"}
+        assert not (set(by_id["e003"]["caused_by"]) & milestone_ids)
+        assert by_id["e003"]["caused_by"] == []
+
+    def test_same_rank_events_keep_original_order(self):
+        # Same lifecycle rank and timestamp must preserve append order (stable sort).
+        events = [self._evt(f"e{n:03d}") for n in range(1, 4)]  # three milestones
+        extract_session_episode._link_sequential_events(events)
+        assert events[0]["caused_by"] == [] and events[0]["leads_to"] == ["e002"]
+        assert events[1]["caused_by"] == ["e001"] and events[1]["leads_to"] == ["e003"]
+        assert events[2]["caused_by"] == ["e002"] and events[2]["leads_to"] == []
+
+    def test_unknown_type_sorts_at_default_rank(self):
+        # An unknown type ranks with tests (default), between commit and error.
+        events = [
+            self._evt("e001", "error", "boom"),
+            self._evt("e002", "mystery", "?"),
+            self._evt("e003", "commit", "Commit: abc"),
+        ]
+        extract_session_episode._link_sequential_events(events)
+        by_id = {e["id"]: e for e in events}
+        assert by_id["e003"]["caused_by"] == [] and by_id["e003"]["leads_to"] == ["e002"]
+        assert by_id["e002"]["caused_by"] == ["e003"] and by_id["e002"]["leads_to"] == ["e001"]
+        assert by_id["e001"]["caused_by"] == ["e002"] and by_id["e001"]["leads_to"] == []
+
+    def test_timestamp_dominates_lifecycle_rank(self):
+        # A commit with a later timestamp must not be reordered before an earlier
+        # milestone; lifecycle rank only breaks ties within one timestamp.
+        early = self._evt("e001", "milestone", "early")
+        late = self._evt("e002", "commit", "late")
+        late["timestamp"] = "2026-07-19T09:00:00+00:00"  # after the milestone
+        events = [early, late]
+        extract_session_episode._link_sequential_events(events)
+        assert events[0]["caused_by"] == [] and events[0]["leads_to"] == ["e002"]
+        assert events[1]["caused_by"] == ["e001"] and events[1]["leads_to"] == []
 
     def test_relinking_is_idempotent(self):
         events = [self._evt("e001"), self._evt("e002", "commit")]
@@ -1300,8 +1358,8 @@ class TestSequentialEventLinks:
         return log
 
     def test_cli_generated_episode_is_linked(self, tmp_path):
-        # Acceptance (#3245): a newly generated multi-event episode populates
-        # caused_by/leads_to for non-boundary events.
+        # Acceptance (#3245 + #3260): a generated multi-event episode is a single
+        # connected chain whose root cause is the commit, not a milestone.
         out = tmp_path / "episodes"
         out.mkdir()
         log = self._write_json_log(tmp_path, ["First", "Second", "Third"])
@@ -1311,13 +1369,37 @@ class TestSequentialEventLinks:
             (out / "episode-2026-07-19-session-999.json").read_text(encoding="utf-8")
         )
         events = episode["events"]
-        assert len(events) >= 3
-        assert events[0]["caused_by"] == []
-        assert events[-1]["leads_to"] == []
-        for i in range(1, len(events)):
-            assert events[i]["caused_by"] == [events[i - 1]["id"]]
-        for i in range(len(events) - 1):
-            assert events[i]["leads_to"] == [events[i + 1]["id"]]
+        assert len(events) >= 4  # 3 milestones + 1 commit
+        by_id = {e["id"]: e for e in events}
+        ids = set(by_id)
+
+        # Exactly one root (no cause) and one tail (no effect); all links resolve.
+        roots = [e for e in events if not e["caused_by"]]
+        tails = [e for e in events if not e["leads_to"]]
+        assert len(roots) == 1 and len(tails) == 1
+        for e in events:
+            for ref in e["caused_by"] + e["leads_to"]:
+                assert ref in ids, f"dangling reference {ref}"
+
+        # #3260: the root cause is the commit and no commit is caused_by a milestone.
+        milestone_ids = {e["id"] for e in events if e["type"] == "milestone"}
+        commit_ids = {e["id"] for e in events if e["type"] == "commit"}
+        assert commit_ids, "expected at least one commit event"
+        assert roots[0]["type"] == "commit"
+        for cid in commit_ids:
+            assert not (set(by_id[cid]["caused_by"]) & milestone_ids)
+
+        # The chain is a single connected path visiting every event once.
+        walked: list[str] = []
+        seen: set[str] = set()
+        cur = roots[0]
+        while cur is not None:
+            assert cur["id"] not in seen, "cycle in causal chain"
+            seen.add(cur["id"])
+            walked.append(cur["id"])
+            nxt = cur["leads_to"]
+            cur = by_id[nxt[0]] if nxt else None
+        assert len(walked) == len(events)
 
     def test_links_reference_existing_ids_after_preserve(self, tmp_path):
         # Links must reference final ids: _dedupe_events reassigns ids on merge,


### PR DESCRIPTION
## Summary

Fixes a P1 causal-inversion bug in the episode extractor (flagged by Cursor Bugbot on #3245).

`json_events` appends every commit event **after** the work-log milestones, and the causal linker walked events by physical list position. The commit landed last and became `caused_by` the final PR-review milestone. That inverts cause and effect: a commit is created and pushed **before** any review happens, so a commit can never be an effect of a review milestone.

## Fix

Link the chain over a lifecycle-ordered view keyed on `(timestamp, lifecycle rank, original position)`:

| type | rank |
| --- | --- |
| implementation | 0 |
| commit | 1 |
| test | 2 |
| error | 3 |
| milestone | 4 |
| unknown | 2 (default) |

`timestamp` stays the primary key, so genuine time order still dominates and lifecycle rank only breaks ties within a shared timestamp (every extractor event shares one session timestamp today, so the tie-break is what does the work). The physical `events` list order is left untouched; only `caused_by` / `leads_to` change, so output event order stays backward-compatible. Stable sort keeps same-rank events in append order, so relinking is idempotent.

Result: a commit is now a root cause that `leads_to` the review milestones, and no event is ever `caused_by` a later milestone.

## Tests

- Rewrote the three assertions that encoded the buggy positional-chain contract (`test_multi_event_chain`, `test_events_without_id_are_skipped`, `test_cli_generated_episode_is_linked`).
- Added regression + edge coverage: commit-is-never-caused-by-a-milestone (the #3260 regression), same-rank stability, unknown-type default rank, and timestamp-dominates-rank.
- The CLI acceptance test now checks the graph structurally: a single connected path, exactly one root and one tail, no dangling references, and the commit as the root cause.
- Full file: 135 passed.

## Blast radius

Canonical script + regenerated `src/copilot-cli` mirror + repo-level test + both project-toolkit plugin manifests bumped to 0.6.84. Five files.

## Out of Scope

The taste-lint file-size and complexity warnings on the extractor are pre-existing (the flagged functions and the 1400-line file predate this change). This is a P1 bug fix, not a refactor, so decomposition is deferred.

Fixes #3260
