### PR TITLE
fix(ci): tolerate transient GitHub API 503 in PR validation gate

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -111,41 +111,6 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: python3 .github/scripts/parse_pr_standards.py
 
-      - name: Check Review Comment Status
-        if: steps.should-run.outputs.skip != 'true'
-        id: check-comments
-        shell: pwsh
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          Write-Host "Checking review comment status..."
-          
-          # Fetch PR review comments
-          $comments = gh api "/repos/$env:GITHUB_REPOSITORY/pulls/$env:PR_NUMBER/comments" | ConvertFrom-Json
-
-          # Count unresolved and security-related comments
-          $unresolvedCount = 0
-          $securityUnresolved = 0
-
-          foreach ($comment in $comments) {
-            # Count all unresolved comments (GitHub does not expose resolved status via API)
-            # For now, we count all comments as this is informational
-            $unresolvedCount++
-
-            # Check for security-related keywords that are not marked as "won't fix"
-            if ($comment.body -match '\b(security|vulnerability|CVE|injection|XSS)\b' -and
-                -not ($comment.body -match '\bwon''t fix\b|\bWONT_FIX\b')) {
-              $securityUnresolved++
-            }
-          }
-
-          "unresolved_count=$unresolvedCount" >> $env:GITHUB_OUTPUT
-          "security_unresolved=$securityUnresolved" >> $env:GITHUB_OUTPUT
-
-          Write-Host "Review comment status:"
-          Write-Host "  Total comments: $unresolvedCount"
-          Write-Host "  Security-related unresolved: $securityUnresolved"
-
       - name: Check QA Report Exists
         if: steps.should-run.outputs.skip != 'true'
         id: check-qa
@@ -199,8 +164,6 @@ jobs:
           BYPASS_USED: ${{ steps.validate-description.outputs.bypass_used }}
           BYPASS_LABEL: ${{ steps.validate-description.outputs.bypass_label }}
           BYPASS_COUNT: ${{ steps.validate-description.outputs.bypass_count }}
-          UNRESOLVED_COUNT: ${{ steps.check-comments.outputs.unresolved_count }}
-          SECURITY_UNRESOLVED: ${{ steps.check-comments.outputs.security_unresolved }}
           HAS_CODE_CHANGES: ${{ steps.check-qa.outputs.has_code_changes }}
           QA_EXISTS: ${{ steps.check-qa.outputs.qa_report_exists }}
           QA_REPORT: ${{ steps.check-qa.outputs.qa_report }}
@@ -341,45 +304,14 @@ jobs:
       - name: Check PR commit count
         if: steps.should-run.outputs.skip != 'true'
         id: commit-check
-        shell: pwsh
+        shell: bash
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          # Get commit count for this PR (see #362 for thresholds)
-          # NOTE: Pagination limited to 100 commits. PRs exceeding this are rare given 20-commit block threshold.
-          $commits = gh api "/repos/$env:GITHUB_REPOSITORY/pulls/$env:PR_NUMBER/commits?per_page=100" | ConvertFrom-Json
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "Failed to fetch commits for PR #$env:PR_NUMBER via 'gh api'. Exit code: $LASTEXITCODE"
-            exit $LASTEXITCODE
-          }
-
-          if (-not $commits) {
-            Write-Error "No commits were returned for PR #$env:PR_NUMBER. Aborting commit count check."
-            exit 1
-          }
-
-          $commitCount = $commits.Count
-
-          Write-Host "PR #$env:PR_NUMBER has $commitCount commits"
-          "commit_count=$commitCount" >> $env:GITHUB_OUTPUT
-
-          # Define thresholds per issue #362
-          $warningThreshold = 10
-          $alertThreshold = 15
-          $blockThreshold = 20
-
-          if ($commitCount -ge $blockThreshold) {
-            Write-Host "::error::PR exceeds commit limit ($commitCount >= $blockThreshold). Consider splitting this PR."
-            "status=BLOCKED" >> $env:GITHUB_OUTPUT
-          } elseif ($commitCount -ge $alertThreshold) {
-            Write-Host "::warning::PR approaching commit limit ($commitCount >= $alertThreshold). Consider shipping current changes."
-            "status=ALERT" >> $env:GITHUB_OUTPUT
-          } elseif ($commitCount -ge $warningThreshold) {
-            Write-Host "::notice::PR has many commits ($commitCount >= $warningThreshold). Consider squashing or splitting."
-            "status=WARNING" >> $env:GITHUB_OUTPUT
-          } else {
-            "status=OK" >> $env:GITHUB_OUTPUT
-          }
+        # Thin wrapper (ADR-006): classification and transient-failure handling
+        # live in the testable module. A transient GitHub API failure degrades
+        # to status=UNKNOWN and exit 0 (issue #3262); the downstream Enforce
+        # Blocking Issues step still enforces a real BLOCKED status.
+        run: python3 scripts/validation/pr_commit_count.py --pr-number "$PR_NUMBER"
 
       - name: Apply needs-split label
         # Fixes #2557: this step is ADVISORY and must never fail the job.

--- a/scripts/validation/pr_commit_count.py
+++ b/scripts/validation/pr_commit_count.py
@@ -18,10 +18,19 @@ Behavior:
 * On a *genuine* error (auth failure, PR not found, bad arguments), exit
   non-zero so the failure stays visible. Transient tolerance must never swallow
   a real policy or auth failure.
+* A missing ``gh`` binary is a *config* error (ADR-035 exit 2), not an external
+  or transient one: the environment is misconfigured, so the run cannot proceed.
+
+The commit count is fetched with ``per_page=100`` (the GitHub REST maximum for
+a single page) and is not paginated, so the reported count saturates at 100.
+Classification is unaffected: any PR at or above ``BLOCK_THRESHOLD`` (20) is
+``BLOCKED``, and 100 far exceeds 20, so a PR with more than 100 commits is
+always ``BLOCKED`` regardless of the exact count. For such PRs the emitted
+``commit_count`` is a floor.
 
 Exit codes follow ADR-035:
     0 - Success (a status was classified, including transient UNKNOWN)
-    2 - Config error (missing/invalid arguments, unresolvable repo)
+    2 - Config error (missing/invalid arguments, unresolvable repo, missing gh)
     3 - External error (non-transient gh/API failure)
 """
 
@@ -104,8 +113,11 @@ def is_transient_error(stderr: str) -> bool:
 def _run_gh(argv: list[str]) -> subprocess.CompletedProcess[str]:
     """Run a gh command, returning the completed process.
 
-    A timeout or a missing gh binary is surfaced as a transient-looking
-    CompletedProcess so the caller degrades rather than crashing the gate.
+    A timeout is surfaced as a transient CompletedProcess (returncode 124,
+    ``timeout was reached`` stderr) so the caller degrades rather than crashing.
+    A missing gh binary is a config error (ADR-035 exit 2), not transient: it is
+    signalled with returncode 127 and empty stderr so ``is_transient_error``
+    stays False and ``fetch_commit_count`` maps it to a config failure.
     """
     try:
         return subprocess.run(
@@ -130,10 +142,21 @@ def fetch_commit_count(pr_number: int, owner: str, repo: str) -> CountResult:
 
     Returns a CountResult. Transient transport failures yield
     ``CountResult(STATUS_UNKNOWN, None, transient=True)``; a non-transient gh
-    failure raises RuntimeError so the caller can exit 3.
+    failure raises RuntimeError so the caller can exit 3; a missing gh binary
+    raises FileNotFoundError so the caller can exit 2 (config error, ADR-035).
+
+    The count is fetched with ``per_page=100`` and is not paginated, so it
+    saturates at 100. This does not change classification: any count at or above
+    BLOCK_THRESHOLD (20) is BLOCKED, and 100 >> 20.
     """
     endpoint = f"repos/{owner}/{repo}/pulls/{pr_number}/commits?per_page=100"
     result = _run_gh(["gh", "api", endpoint])
+
+    if result.returncode == 127:
+        raise FileNotFoundError(
+            "GitHub CLI (gh) is not installed or not found on PATH; cannot fetch "
+            f"the commit count for PR #{pr_number}."
+        )
 
     if result.returncode != 0:
         if is_transient_error(result.stderr):
@@ -197,6 +220,9 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         outcome = fetch_commit_count(args.pr_number, repo_info.owner, repo_info.repo)
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
     except RuntimeError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 3

--- a/scripts/validation/pr_commit_count.py
+++ b/scripts/validation/pr_commit_count.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Classify a pull request's commit count for the PR validation gate.
+
+Extracted from the inline PowerShell of the ``Check PR commit count`` step in
+``.github/workflows/pr-validation.yml`` so the fetch-and-classify logic is
+testable (ADR-006) and tolerant of transient GitHub API failures (issue #3262).
+
+Behavior:
+
+* On a healthy API response, count commits and map the count to a status using
+  the issue #362 thresholds (warning 10, alert 15, block 20). The downstream
+  ``Enforce Blocking Issues`` step enforces the ``BLOCKED`` status; this script
+  only classifies.
+* On a *transient* transport error (HTTP 503, "no server is currently
+  available", connection reset, timeout), degrade to ``status=UNKNOWN`` and
+  exit 0. The commit cap is advisory for that run and re-fires on the next
+  healthy run, so a GitHub outage no longer red-blocks an otherwise clean PR.
+* On a *genuine* error (auth failure, PR not found, bad arguments), exit
+  non-zero so the failure stays visible. Transient tolerance must never swallow
+  a real policy or auth failure.
+
+Exit codes follow ADR-035:
+    0 - Success (a status was classified, including transient UNKNOWN)
+    2 - Config error (missing/invalid arguments, unresolvable repo)
+    3 - External error (non-transient gh/API failure)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.github_core.api import resolve_repo_params  # noqa: E402
+
+# Commit-count thresholds (issue #362). A PR at or above BLOCK_THRESHOLD is
+# blocked by the downstream Enforce Blocking Issues step unless it carries the
+# commit-limit-bypass label.
+WARNING_THRESHOLD = 10
+ALERT_THRESHOLD = 15
+BLOCK_THRESHOLD = 20
+
+# Sentinel status emitted when a transient API failure prevents a real count.
+STATUS_UNKNOWN = "UNKNOWN"
+
+# Substrings that mark a GitHub API failure as transient transport noise rather
+# than a real error. Matched case-insensitively against gh's stderr. Kept
+# deliberately narrow so auth (401/403) and not-found (404) stay fatal.
+_TRANSIENT_MARKERS: tuple[str, ...] = (
+    "no server is currently available",
+    "http 502",
+    "http 503",
+    "http 504",
+    "bad gateway",
+    "service unavailable",
+    "gateway timeout",
+    "connection reset",
+    "connection refused",
+    "timeout was reached",
+    "i/o timeout",
+    "eof",
+    "tls handshake timeout",
+)
+
+
+@dataclass(frozen=True)
+class CountResult:
+    """Outcome of a commit-count fetch.
+
+    Exactly one of ``count`` or ``transient`` is meaningful: when ``transient``
+    is True the count could not be determined and ``status`` is UNKNOWN.
+    """
+
+    status: str
+    count: int | None
+    transient: bool
+
+
+def classify_count(count: int) -> str:
+    """Map a commit count to a threshold status (issue #362)."""
+    if count >= BLOCK_THRESHOLD:
+        return "BLOCKED"
+    if count >= ALERT_THRESHOLD:
+        return "ALERT"
+    if count >= WARNING_THRESHOLD:
+        return "WARNING"
+    return "OK"
+
+
+def is_transient_error(stderr: str) -> bool:
+    """Return True when gh stderr indicates a transient transport failure."""
+    haystack = stderr.lower()
+    return any(marker in haystack for marker in _TRANSIENT_MARKERS)
+
+
+def _run_gh(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a gh command, returning the completed process.
+
+    A timeout or a missing gh binary is surfaced as a transient-looking
+    CompletedProcess so the caller degrades rather than crashing the gate.
+    """
+    try:
+        return subprocess.run(
+            argv,
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            argv, returncode=124, stdout="", stderr="timeout was reached"
+        )
+    except FileNotFoundError:
+        # gh missing is a config error, not transient. Signal with a distinct
+        # returncode and an empty stderr so is_transient_error stays False.
+        return subprocess.CompletedProcess(argv, returncode=127, stdout="", stderr="")
+
+
+def fetch_commit_count(pr_number: int, owner: str, repo: str) -> CountResult:
+    """Fetch and classify the commit count for a PR.
+
+    Returns a CountResult. Transient transport failures yield
+    ``CountResult(STATUS_UNKNOWN, None, transient=True)``; a non-transient gh
+    failure raises RuntimeError so the caller can exit 3.
+    """
+    endpoint = f"repos/{owner}/{repo}/pulls/{pr_number}/commits?per_page=100"
+    result = _run_gh(["gh", "api", endpoint])
+
+    if result.returncode != 0:
+        if is_transient_error(result.stderr):
+            return CountResult(STATUS_UNKNOWN, None, transient=True)
+        raise RuntimeError(
+            f"Failed to fetch commits for PR #{pr_number} "
+            f"(exit {result.returncode}): {result.stderr.strip()}"
+        )
+
+    try:
+        commits: Any = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        # A 200 with an unparseable body during a degraded window is treated as
+        # transient: skip the count rather than block on infra noise.
+        return CountResult(STATUS_UNKNOWN, None, transient=True)
+
+    if not isinstance(commits, list):
+        raise RuntimeError(
+            f"Unexpected commits payload for PR #{pr_number}: expected a list, "
+            f"got {type(commits).__name__}"
+        )
+
+    count = len(commits)
+    return CountResult(classify_count(count), count, transient=False)
+
+
+def _write_github_output(status: str, count: int | None) -> None:
+    """Append status/count key=value lines to $GITHUB_OUTPUT when set."""
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    count_value = "" if count is None else str(count)
+    with open(output_path, "a", encoding="utf-8") as handle:
+        handle.write(f"status={status}\n")
+        handle.write(f"commit_count={count_value}\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pr-number", type=int, required=True, help="Pull request number")
+    parser.add_argument(
+        "--owner", default="", help="Repository owner (inferred from git remote if omitted)"
+    )
+    parser.add_argument(
+        "--repo", default="", help="Repository name (inferred from git remote if omitted)"
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns an ADR-035 exit code."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.pr_number <= 0:
+        print(f"Error: --pr-number must be positive, got {args.pr_number}", file=sys.stderr)
+        return 2
+
+    # resolve_repo_params exits 2 on an unresolvable/invalid repo.
+    repo_info = resolve_repo_params(args.owner, args.repo)
+
+    try:
+        outcome = fetch_commit_count(args.pr_number, repo_info.owner, repo_info.repo)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 3
+
+    _write_github_output(outcome.status, outcome.count)
+
+    if outcome.transient:
+        print(
+            f"::warning::Commit count for PR #{args.pr_number} could not be "
+            "determined (transient GitHub API failure). Skipping the commit-count "
+            "check for this run; it re-fires on the next healthy run.",
+        )
+        return 0
+
+    count = outcome.count if outcome.count is not None else 0
+    print(f"PR #{args.pr_number} has {count} commits (status: {outcome.status})")
+    if outcome.status == "BLOCKED":
+        print(
+            f"::error::PR exceeds commit limit ({count} >= {BLOCK_THRESHOLD}). "
+            "Consider splitting this PR."
+        )
+    elif outcome.status == "ALERT":
+        print(
+            f"::warning::PR approaching commit limit ({count} >= {ALERT_THRESHOLD}). "
+            "Consider shipping current changes."
+        )
+    elif outcome.status == "WARNING":
+        print(
+            f"::notice::PR has many commits ({count} >= {WARNING_THRESHOLD}). "
+            "Consider squashing or splitting."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/pr_commit_count.py
+++ b/scripts/validation/pr_commit_count.py
@@ -215,8 +215,18 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: --pr-number must be positive, got {args.pr_number}", file=sys.stderr)
         return 2
 
-    # resolve_repo_params exits 2 on an unresolvable/invalid repo.
-    repo_info = resolve_repo_params(args.owner, args.repo)
+    # resolve_repo_params exits 2 on an unresolvable/invalid repo. Its shared
+    # remediation text names PowerShell-style -Owner/-Repo flags, so add a hint
+    # naming this script's actual --owner/--repo flags (PR #3264 review).
+    try:
+        repo_info = resolve_repo_params(args.owner, args.repo)
+    except SystemExit as exc:
+        print(
+            "Hint: pass --owner and --repo to this script when the repository "
+            "cannot be inferred from the git remote.",
+            file=sys.stderr,
+        )
+        return exc.code if isinstance(exc.code, int) else 2
 
     try:
         outcome = fetch_commit_count(args.pr_number, repo_info.owner, repo_info.repo)

--- a/tests/validation/test_pr_commit_count.py
+++ b/tests/validation/test_pr_commit_count.py
@@ -261,6 +261,17 @@ def test_main_missing_gh_returns_2(
     assert "not installed or not found on PATH" in capsys.readouterr().err
 
 
+def test_main_unresolvable_repo_emits_flag_hint_and_returns_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def _exit_2(owner: str, repo: str) -> object:
+        raise SystemExit(2)
+
+    monkeypatch.setattr(mod, "resolve_repo_params", _exit_2)
+    assert mod.main(["--pr-number", "42"]) == 2
+    assert "--owner and --repo" in capsys.readouterr().err
+
+
 def test_main_invalid_pr_number_returns_2(monkeypatch: pytest.MonkeyPatch) -> None:
     assert mod.main(["--pr-number", "0"]) == 2
 

--- a/tests/validation/test_pr_commit_count.py
+++ b/tests/validation/test_pr_commit_count.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Tests for scripts/validation/pr_commit_count.py (issue #3262).
+
+Covers positive (threshold classification), negative (genuine errors), and
+transient-error (503 / no-server / timeout / unparseable body) paths, plus
+GITHUB_OUTPUT emission and CLI exit codes, per TESTING-RIGOR.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.validation import pr_commit_count as mod  # noqa: E402
+
+
+def _completed(
+    returncode: int, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(["gh"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _commits_json(n: int) -> str:
+    return json.dumps([{"sha": f"{i:040x}"} for i in range(n)])
+
+
+# ---------------------------------------------------------------------------
+# classify_count: threshold boundaries (issue #362)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("count", "expected"),
+    [
+        (0, "OK"),
+        (9, "OK"),
+        (10, "WARNING"),
+        (14, "WARNING"),
+        (15, "ALERT"),
+        (19, "ALERT"),
+        (20, "BLOCKED"),
+        (99, "BLOCKED"),
+    ],
+)
+def test_classify_count_thresholds(count: int, expected: str) -> None:
+    assert mod.classify_count(count) == expected
+
+
+# ---------------------------------------------------------------------------
+# is_transient_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "gh: No server is currently available to service your request (HTTP 503)",
+        "HTTP 502 Bad Gateway",
+        "HTTP 504",
+        "Service Unavailable",
+        "connection reset by peer",
+        "connection refused",
+        "timeout was reached",
+        "net/http: TLS handshake timeout",
+        "unexpected EOF",
+    ],
+)
+def test_is_transient_error_true(stderr: str) -> None:
+    assert mod.is_transient_error(stderr) is True
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "",
+        "HTTP 404: Not Found",
+        "HTTP 401: Bad credentials",
+        "HTTP 403: Resource not accessible by integration",
+        "gh: Not Found (HTTP 404)",
+    ],
+)
+def test_is_transient_error_false(stderr: str) -> None:
+    assert mod.is_transient_error(stderr) is False
+
+
+# ---------------------------------------------------------------------------
+# fetch_commit_count: positive
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_healthy_below_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(0, _commits_json(3)))
+    result = mod.fetch_commit_count(42, "o", "r")
+    assert result == mod.CountResult("OK", 3, transient=False)
+
+
+def test_fetch_healthy_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(0, _commits_json(20)))
+    result = mod.fetch_commit_count(42, "o", "r")
+    assert result.status == "BLOCKED"
+    assert result.count == 20
+    assert result.transient is False
+
+
+def test_fetch_empty_list_is_ok_not_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A healthy 200 with an empty list means zero commits, which is not over
+    # the limit. The old inline step hard-failed here; the new contract is OK.
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(0, "[]"))
+    result = mod.fetch_commit_count(42, "o", "r")
+    assert result == mod.CountResult("OK", 0, transient=False)
+
+
+# ---------------------------------------------------------------------------
+# fetch_commit_count: transient degradation
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_transient_503_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_run_gh",
+        lambda argv: _completed(1, "", "No server is currently available (HTTP 503)"),
+    )
+    result = mod.fetch_commit_count(42, "o", "r")
+    assert result == mod.CountResult(mod.STATUS_UNKNOWN, None, transient=True)
+
+
+def test_fetch_unparseable_body_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(0, "<html>502</html>"))
+    result = mod.fetch_commit_count(42, "o", "r")
+    assert result.status == mod.STATUS_UNKNOWN
+    assert result.transient is True
+
+
+def test_fetch_timeout_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_timeout(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=30)
+
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    result = mod.fetch_commit_count(42, "o", "r")
+    assert result.transient is True
+    assert result.status == mod.STATUS_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# fetch_commit_count: genuine (non-transient) failures raise
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_auth_failure_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(1, "", "HTTP 401: Bad credentials"))
+    with pytest.raises(RuntimeError, match="Failed to fetch commits"):
+        mod.fetch_commit_count(42, "o", "r")
+
+
+def test_fetch_missing_gh_binary_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_missing(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(subprocess, "run", _raise_missing)
+    with pytest.raises(RuntimeError, match="Failed to fetch commits"):
+        mod.fetch_commit_count(42, "o", "r")
+
+
+def test_fetch_non_list_payload_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(0, '{"message":"x"}'))
+    with pytest.raises(RuntimeError, match="expected a list"):
+        mod.fetch_commit_count(42, "o", "r")
+
+
+# ---------------------------------------------------------------------------
+# _write_github_output
+# ---------------------------------------------------------------------------
+
+
+def test_write_github_output_writes_kv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    out = tmp_path / "gh_out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    mod._write_github_output("BLOCKED", 22)
+    content = out.read_text(encoding="utf-8")
+    assert "status=BLOCKED\n" in content
+    assert "commit_count=22\n" in content
+
+
+def test_write_github_output_unknown_count_is_blank(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = tmp_path / "gh_out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    mod._write_github_output(mod.STATUS_UNKNOWN, None)
+    content = out.read_text(encoding="utf-8")
+    assert "status=UNKNOWN\n" in content
+    assert "commit_count=\n" in content
+
+
+def test_write_github_output_noop_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    # Must not raise when GITHUB_OUTPUT is unset (local runs).
+    mod._write_github_output("OK", 1)
+
+
+# ---------------------------------------------------------------------------
+# main: exit codes + output emission
+# ---------------------------------------------------------------------------
+
+
+def _stub_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts.github_core.api import RepoInfo
+
+    monkeypatch.setattr(mod, "resolve_repo_params", lambda o, r: RepoInfo(owner="o", repo="r"))
+
+
+def test_main_healthy_returns_0_and_emits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _stub_repo(monkeypatch)
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(0, _commits_json(12)))
+    out = tmp_path / "gh_out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    rc = mod.main(["--pr-number", "42"])
+    assert rc == 0
+    content = out.read_text(encoding="utf-8")
+    assert "status=WARNING\n" in content
+    assert "commit_count=12\n" in content
+
+
+def test_main_transient_returns_0_with_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _stub_repo(monkeypatch)
+    monkeypatch.setattr(
+        mod, "_run_gh", lambda argv: _completed(1, "", "HTTP 503 service unavailable")
+    )
+    out = tmp_path / "gh_out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    rc = mod.main(["--pr-number", "42"])
+    assert rc == 0
+    assert "status=UNKNOWN\n" in out.read_text(encoding="utf-8")
+    assert "::warning::" in capsys.readouterr().out
+
+
+def test_main_genuine_failure_returns_3(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_repo(monkeypatch)
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(1, "", "HTTP 401: Bad credentials"))
+    assert mod.main(["--pr-number", "42"]) == 3
+
+
+def test_main_invalid_pr_number_returns_2(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert mod.main(["--pr-number", "0"]) == 2
+
+
+def test_main_blocked_emits_error_annotation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _stub_repo(monkeypatch)
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(0, _commits_json(25)))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "gh_out"))
+    rc = mod.main(["--pr-number", "42"])
+    assert rc == 0
+    assert "::error::PR exceeds commit limit" in capsys.readouterr().out

--- a/tests/validation/test_pr_commit_count.py
+++ b/tests/validation/test_pr_commit_count.py
@@ -165,7 +165,7 @@ def test_fetch_missing_gh_binary_raises(monkeypatch: pytest.MonkeyPatch) -> None
         raise FileNotFoundError("gh")
 
     monkeypatch.setattr(subprocess, "run", _raise_missing)
-    with pytest.raises(RuntimeError, match="Failed to fetch commits"):
+    with pytest.raises(FileNotFoundError, match="not installed or not found on PATH"):
         mod.fetch_commit_count(42, "o", "r")
 
 
@@ -250,6 +250,15 @@ def test_main_genuine_failure_returns_3(monkeypatch: pytest.MonkeyPatch) -> None
     _stub_repo(monkeypatch)
     monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(1, "", "HTTP 401: Bad credentials"))
     assert mod.main(["--pr-number", "42"]) == 3
+
+
+def test_main_missing_gh_returns_2(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _stub_repo(monkeypatch)
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(127, "", ""))
+    assert mod.main(["--pr-number", "42"]) == 2
+    assert "not installed or not found on PATH" in capsys.readouterr().err
 
 
 def test_main_invalid_pr_number_returns_2(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

The `Validate PR` required gate hard-failed merges during GitHub API degradation. Two informational `gh api` calls exited non-zero on a transient HTTP 503, turning an otherwise clean PR red with no way to merge until the outage cleared. Observed live on PR #3261 (run 29711005297) and PR #3258 (run 29708719280) during a "Minor Service Outage."

Fixes #3262

## What changed

**1. Commit-count check now tolerates transient failures (option 1 in the issue).**

The fetch/classify logic moved out of inline PowerShell into a testable module. On a transient transport error (HTTP 502/503/504, "no server is currently available," timeout, connection reset, unparseable 200 body) it degrades to `status=UNKNOWN` and exits 0, so a GitHub outage no longer red-blocks a clean PR. The commit cap re-fires on the next healthy run. A genuine failure (401/403/404) stays fatal (exit 3), so real auth or policy errors remain visible. The downstream `Enforce Blocking Issues` step still enforces a real `BLOCKED` status; the block thresholds (10/15/20) are unchanged.

**2. `Check Review Comment Status` step deleted (option 3 in the issue).**

Its `unresolved_count` / `security_unresolved` outputs were passed as env to the report step but never referenced in the report body: dead outputs that gated nothing while adding a second 503 failure surface. The security-keyword scan blocked nothing today, so removing it is not a security regression. A real security-comment gate is separate, on-demand work, not in scope here.

## Testing

Positive (threshold classification at every boundary), negative (401/404/non-list payload raise and stay fatal), and transient-error (503, no-server, timeout, unparseable body degrade to UNKNOWN) cases, plus GITHUB_OUTPUT emission and CLI exit codes. 39 tests, all passing. Also verified live: healthy PR classifies OK and exits 0; a nonexistent PR returns 404 and exits 3 without degrading.

- `python3 scripts/validation/pr_commit_count.py --pr-number 3263` -> `status=OK`, exit 0
- `python3 scripts/validation/pr_commit_count.py --pr-number 999999` -> `HTTP 404`, exit 3

## Design notes

The fix moves logic out of YAML into a testable module, which is the ADR-006 direction, and satisfies the issue's acceptance requirement for pos/neg/transient unit coverage that inline YAML cannot provide. This is a scoped bug fix on two steps, not the broader workflow burndown.

## References

- `.agents/architecture/ADR-006-thin-workflows-testable-modules.md` (thin-workflow pattern)
- `.agents/architecture/ADR-035` (exit-code contract)
