### PR TITLE
fix(ci): downgrade empty PR-context env vars under act

### DIFF
--- a/scripts/validation/run_workflow_local_test.py
+++ b/scripts/validation/run_workflow_local_test.py
@@ -494,15 +494,32 @@ _ACT_PR_CONTEXT_MISSING_PATTERN = re.compile(
     r"|assignee|assignees|requested_reviewers|milestone)'\)"
 )
 
+# The pull_request context is also consumed indirectly: workflows map
+# github.event.pull_request.* into step ``env:`` vars (PR_NUMBER, PR_TITLE) that
+# feed validation scripts. act leaves those vars empty on a local run, so the
+# scripts fail with their own signatures rather than the JS "Cannot read
+# properties of undefined" form above. These are the same act-only limitation,
+# event-scoped to pull_request:
+#   * PR_TITLE empty  -> parse_pr_standards.py prints "PR_TITLE environment
+#     variable is required".
+#   * PR_NUMBER empty -> pr_description.py's int("") raises "invalid literal for
+#     int() with base 10: ''".
+# Under a real pull_request run both env vars are populated, so neither signature
+# can arise in CI; downgrading them for pull_request events is safe. See #3265.
+_ACT_PR_CONTEXT_EMPTY_ENV_PATTERN = re.compile(
+    r"PR_TITLE environment variable is required"
+    r"|invalid literal for int\(\) with base 10: ''"
+)
+
 # Known act-only limitation signatures. A nonzero act exit whose combined output
 # matches one of these rules can be a local environment gap, not a workflow
-# defect. The pull_request context rule is event-scoped in _act_limitation_hint;
+# defect. The pull_request context rules are event-scoped in _act_limitation_hint;
 # every other nonzero exit still blocks.
 def _act_limitation_hint(combined: str, event: str | None = None) -> str | None:
     """Return the WARN hint when ``combined`` matches a known act limitation.
 
     Returns a hint for a known act-only limitation, or None when no known
-    limitation is present. The pull_request context TypeError is downgraded only
+    limitation is present. The pull_request context errors are downgraded only
     for pull_request runs. Under workflow_dispatch, the same error can be a real
     workflow defect and must remain blocking.
     """
@@ -515,6 +532,12 @@ def _act_limitation_hint(combined: str, event: str | None = None) -> str | None:
         return (
             "act does not populate the pull_request event context on a local run, so "
             "workflows reading github.event.pull_request properties fail only in local "
+            "act, not in CI."
+        )
+    if event == "pull_request" and _ACT_PR_CONTEXT_EMPTY_ENV_PATTERN.search(combined):
+        return (
+            "act leaves env vars mapped from github.event.pull_request (PR_NUMBER, "
+            "PR_TITLE) empty on a local run, so validation scripts fail only in local "
             "act, not in CI."
         )
     return None
@@ -530,12 +553,12 @@ def _run_act_stage(
     """Run an ``act`` invocation per workflow file, with act-limitation downgrade.
 
     A nonzero exit whose output carries a known act-only limitation signature
-    (a missing .git in the container, or an unpopulated ``pull_request`` event
-    context during a pull_request run) is a local environment gap, not a
-    workflow defect: actionlint and the act dry-run already validated the
-    workflow shape. Downgrade it to a passing stage with a ``[WARN]`` detail
-    instead of a hard FAIL so the act limitation does not block an otherwise
-    valid push. Every other nonzero exit still blocks.
+    (a missing .git in the container, an unpopulated ``pull_request`` event
+    context, or an empty PR-context env var during a pull_request run) is a
+    local environment gap, not a workflow defect: actionlint and the act dry-run
+    already validated the workflow shape. Downgrade it to a passing stage with a
+    ``[WARN]`` detail instead of a hard FAIL so the act limitation does not block
+    an otherwise valid push. Every other nonzero exit still blocks.
     """
     env = _act_env(repo_root)
     warnings: list[str] = []

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -1161,6 +1161,61 @@ def test_act_full_pr_context_real_failure_still_blocks(monkeypatch, tmp_path):
     assert "reading 'sha'" in res.detail
 
 
+def test_act_full_downgrades_empty_pr_title_env_to_warning(monkeypatch, tmp_path):
+    # PR_TITLE mapped from an empty github.event.pull_request.title under act
+    # makes parse_pr_standards.py exit non-zero; downgrade for pull_request. #3265
+    wf = _write_wf(tmp_path, "name: x\non: pull_request\njobs: {}\n")
+    monkeypatch.setattr(
+        w,
+        "_run",
+        lambda cmd, *, timeout, cwd=None, env=None: (
+            2,
+            "",
+            "PR_TITLE environment variable is required",
+        ),
+    )
+    res = w._act_full_stage([wf.name], tmp_path)
+    assert res.ok is True
+    assert "[WARN]" in res.detail
+    assert "PR_NUMBER, PR_TITLE" in res.detail
+
+
+def test_act_full_downgrades_empty_pr_number_env_to_warning(monkeypatch, tmp_path):
+    # PR_NUMBER mapped from an empty github.event.pull_request.number under act
+    # makes pr_description.py's int("") raise; downgrade for pull_request. #3265
+    wf = _write_wf(tmp_path, "name: x\non: pull_request\njobs: {}\n")
+    monkeypatch.setattr(
+        w,
+        "_run",
+        lambda cmd, *, timeout, cwd=None, env=None: (
+            1,
+            "",
+            "ValueError: invalid literal for int() with base 10: ''",
+        ),
+    )
+    res = w._act_full_stage([wf.name], tmp_path)
+    assert res.ok is True
+    assert "[WARN]" in res.detail
+
+
+def test_act_full_workflow_dispatch_empty_pr_env_still_blocks(monkeypatch, tmp_path):
+    # The empty PR-context env signatures downgrade only for pull_request runs.
+    # Under workflow_dispatch the same failure can be a real defect and blocks.
+    wf = _write_wf(tmp_path, "name: x\non: workflow_dispatch\njobs: {}\n")
+    monkeypatch.setattr(
+        w,
+        "_run",
+        lambda cmd, *, timeout, cwd=None, env=None: (
+            2,
+            "",
+            "PR_TITLE environment variable is required",
+        ),
+    )
+    res = w._act_full_stage([wf.name], tmp_path)
+    assert res.ok is False
+    assert "PR_TITLE environment variable is required" in res.detail
+
+
 def test_act_limitation_hint_matches_known_patterns() -> None:
     assert w._act_limitation_hint("fatal: not a git repository") is not None
     assert (
@@ -1192,6 +1247,42 @@ def test_act_limitation_hint_matches_known_patterns() -> None:
         is None
     )
     assert w._act_limitation_hint("Error: job 'build' exited 2") is None
+
+
+def test_act_limitation_hint_matches_empty_pr_env_patterns() -> None:
+    # Empty PR-context env-var manifestations (#3265), event-scoped to
+    # pull_request; workflow_dispatch keeps them blocking.
+    assert (
+        w._act_limitation_hint(
+            "PR_TITLE environment variable is required",
+            "pull_request",
+        )
+        is not None
+    )
+    assert (
+        w._act_limitation_hint(
+            "ValueError: invalid literal for int() with base 10: ''",
+            "pull_request",
+        )
+        is not None
+    )
+    assert (
+        w._act_limitation_hint(
+            "PR_TITLE environment variable is required",
+            "workflow_dispatch",
+        )
+        is None
+    )
+    # A non-empty int parse error is a real defect, not the empty-env signature.
+    assert (
+        w._act_limitation_hint(
+            "ValueError: invalid literal for int() with base 10: 'abc'",
+            "pull_request",
+        )
+        is None
+    )
+
+
 
 
 def test_format_text_surfaces_warning_detail_on_ok() -> None:

--- a/tests/validation/test_run_workflow_local_test.py
+++ b/tests/validation/test_run_workflow_local_test.py
@@ -1283,8 +1283,6 @@ def test_act_limitation_hint_matches_empty_pr_env_patterns() -> None:
     )
 
 
-
-
 def test_format_text_surfaces_warning_detail_on_ok() -> None:
     report = w.Report(
         exit_code=0,


### PR DESCRIPTION
## Summary

The pre-push `Workflow local run` gate runs the PR validation workflow under full `act`. Two of its steps read the `pull_request` event context that `act` does not populate locally, so every edit to that workflow false-blocks its own push and the author must reach for `SKIP_WORKFLOW_LOCAL_TEST=true`. The fix lives in `scripts/validation/run_workflow_local_test.py`.

Fixes #3265

## Root cause

`act` leaves the `pull_request` event context empty on a local run. The PR validation workflow maps those fields into step `env:` vars, so the validation scripts fail with script-specific signatures the harness did not recognize:

- Empty `PR_TITLE` makes the standards parser print "PR_TITLE environment variable is required" and exit 2.
- Empty `PR_NUMBER` makes the description validator raise "invalid literal for int() with base 10: ''".

The harness already downgrades the JS form of this same limitation ("Cannot read properties of undefined (reading 'title')"), but only that form, so the env-var manifestations slipped through and hard-failed.

## What changed

In `scripts/validation/run_workflow_local_test.py`, added an event-scoped pattern (`_ACT_PR_CONTEXT_EMPTY_ENV_PATTERN`) and a matching branch in `_act_limitation_hint`. On a `pull_request` run, the two empty PR-context env signatures degrade to a `[WARN]` instead of a hard `FAIL`. Under `workflow_dispatch` they still block, since the same failure can be a real defect there. A non-empty int parse error (base 10 with "abc") is untouched and stays a real failure. Under a real `pull_request` CI run both env vars are populated, so neither signature can arise in CI; the downgrade only fires under `act`.

## Testing

Positive (both empty-env signatures downgrade to WARN on a pull_request run), negative (workflow_dispatch keeps them blocking; a non-empty int parse error is not matched), and stage-level cases through the full act stage. 5 new tests in `tests/validation/test_run_workflow_local_test.py`; full module suite 96 passing.

- `uv run pytest tests/validation/test_run_workflow_local_test.py -q` produced 96 passed
- ruff clean, mypy clean

## References

- `.github/workflows/pr-validation.yml` (the workflow whose steps map the PR context into env vars)
- `.github/scripts/parse_pr_standards.py` (emits the PR_TITLE required signature)
- `scripts/validation/pr_description.py` (raises the empty PR_NUMBER int parse error)
