### PR TITLE
feat(dogfood): pre-push staleness advisory for local Copilot install (#3256)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -463,9 +463,9 @@ else
 fi
 
 # 1c. Dogfood staleness advisory (issue #3256): warn (never block) when a
-# local Copilot dogfood install trails the working tree. A stale copy can
-# silently produce a false "works on my machine" result for the hooks and
-# permissions we ship to customers, the same silent-staleness class that
+# local Copilot dogfood install is out of sync with the working tree. A stale
+# copy can silently produce a false "works on my machine" result for the hooks
+# and permissions we ship to customers, the same silent-staleness class that
 # caused the 0.5.248 rot. Fires only for developers who opted into
 # dogfooding (an installed copy is present); the drift logic lives in the
 # Python --check mode so this hook stays free of business logic.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -472,8 +472,13 @@ fi
 DOGFOOD_SCRIPT="$REPO_ROOT/scripts/dev/dogfood_copilot_plugin.py"
 if [ -f "$DOGFOOD_SCRIPT" ] && set_python_cmd; then
     DOGFOOD_ADVISORY=$("${PYTHON_CMD[@]}" "$DOGFOOD_SCRIPT" --check 2>/dev/null)
-    if [ $? -eq 1 ]; then
-        record_warn "Dogfood copy stale (non-blocking): $DOGFOOD_ADVISORY"
+    DOGFOOD_RC=$?
+    if [ "$DOGFOOD_RC" -eq 1 ]; then
+        # Double backslashes so echo -e in record_warn does not interpret
+        # Windows path segments (e.g. \temp, \name) as escape sequences.
+        record_warn "Dogfood copy stale (non-blocking): ${DOGFOOD_ADVISORY//\\/\\\\}"
+    elif [ "$DOGFOOD_RC" -eq 2 ]; then
+        record_warn "Dogfood staleness check could not run (non-blocking; config error)"
     fi
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -466,9 +466,11 @@ fi
 # local Copilot dogfood install is out of sync with the working tree. A stale
 # copy can silently produce a false "works on my machine" result for the hooks
 # and permissions we ship to customers, the same silent-staleness class that
-# caused the 0.5.248 rot. Fires only for developers who opted into
-# dogfooding (an installed copy is present); the drift logic lives in the
-# Python --check mode so this hook stays free of business logic.
+# caused the 0.5.248 rot. Warns only when an opted-in dogfood copy (one
+# carrying the .dogfood marker written by --install) differs from the working
+# tree in either direction; a stock marketplace install is left alone. The
+# drift logic lives in the Python --check mode so this hook stays free of
+# business logic.
 DOGFOOD_SCRIPT="$REPO_ROOT/scripts/dev/dogfood_copilot_plugin.py"
 if [ -f "$DOGFOOD_SCRIPT" ] && set_python_cmd; then
     DOGFOOD_ADVISORY=$("${PYTHON_CMD[@]}" "$DOGFOOD_SCRIPT" --check 2>/dev/null)

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -462,6 +462,21 @@ else
     record_skip "Placeholder identity check (no push range)"
 fi
 
+# 1c. Dogfood staleness advisory (issue #3256): warn (never block) when a
+# local Copilot dogfood install trails the working tree. A stale copy can
+# silently produce a false "works on my machine" result for the hooks and
+# permissions we ship to customers, the same silent-staleness class that
+# caused the 0.5.248 rot. Fires only for developers who opted into
+# dogfooding (an installed copy is present); the drift logic lives in the
+# Python --check mode so this hook stays free of business logic.
+DOGFOOD_SCRIPT="$REPO_ROOT/scripts/dev/dogfood_copilot_plugin.py"
+if [ -f "$DOGFOOD_SCRIPT" ] && set_python_cmd; then
+    DOGFOOD_ADVISORY=$("${PYTHON_CMD[@]}" "$DOGFOOD_SCRIPT" --check 2>/dev/null)
+    if [ $? -eq 1 ]; then
+        record_warn "Dogfood copy stale (non-blocking): $DOGFOOD_ADVISORY"
+    fi
+fi
+
 # Detect merge commits from main in the push range. Merges from upstream
 # naturally inflate commit/file counts with already-reviewed changes, so
 # limits are relaxed to avoid blocking legitimate merge-and-push workflows.

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -19,7 +19,7 @@ on every platform. ADR-083's symlink-on-Unix wording is being reconciled in
 #3252. Refs #3222.
 
 Exit codes: 0 success (or ``--check`` found no drift), 1 ``--check`` found the
-installed dogfood copy trailing the working tree, 2 configuration error.
+installed dogfood copy out of sync with the working tree, 2 configuration error.
 """
 
 from __future__ import annotations
@@ -176,10 +176,14 @@ def dogfood_uninstall(target: Path) -> str:
 
 
 def _is_stale(source: Path, target: Path) -> bool:
-    """Return True when an installed dogfood copy trails the working tree.
+    """Return True when an installed dogfood copy is out of sync with the tree.
 
-    Only a real installed directory can be stale. A live symlink always
-    tracks the working tree, and a missing target means nothing was
+    Any version mismatch counts, in either direction. Dogfooding demands the
+    installed copy exactly match the working tree, so a copy that is newer
+    than ``HEAD`` (a developer on an older branch) is just as wrong as one
+    that is older; both mislead local hook behavior. Ordering is deliberately
+    not used. Only a real installed directory can be stale: a live symlink
+    always tracks the working tree, and a missing target means nothing was
     dogfooded, so both are reported as not stale (no advisory warranted).
     """
     if target.is_symlink() or not target.is_dir():
@@ -207,18 +211,23 @@ def dogfood_check(source: Path, target: Path) -> tuple[bool, str]:
     Powers the ``--check`` mode used by the pre-push staleness advisory
     (issue #3256): the message is human-readable and the boolean drives the
     exit code so a git hook can warn (never block) when a local dogfood copy
-    trails ``HEAD``.
+    is out of sync with ``HEAD``. The message distinguishes stale, symlinked,
+    not-installed, and current states so manual ``--check`` output is honest.
     """
-    if not _is_stale(source, target):
-        return False, f"dogfood copy current at {target}"
-    installed = _plugin_version(target)
-    shipped = _plugin_version(source)
-    message = (
-        f"dogfood copy at {target} is v{installed}; working tree ships "
-        f"v{shipped}. Re-run 'python3 scripts/dev/dogfood_copilot_plugin.py "
-        f"--install' to refresh before trusting local hook behavior."
-    )
-    return True, message
+    if _is_stale(source, target):
+        installed = _plugin_version(target)
+        shipped = _plugin_version(source)
+        message = (
+            f"dogfood copy at {target} is v{installed}; working tree ships "
+            f"v{shipped}. Re-run 'python3 scripts/dev/dogfood_copilot_plugin.py "
+            f"--install' to refresh before trusting local hook behavior."
+        )
+        return True, message
+    if target.is_symlink():
+        return False, f"dogfood copy symlinked to the working tree at {target}"
+    if not target.is_dir():
+        return False, f"no dogfood copy installed at {target}"
+    return False, f"dogfood copy current at {target}"
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -189,14 +189,14 @@ def _is_stale(source: Path, target: Path) -> bool:
     dogfooded, so both are reported as not stale (no advisory warranted).
 
     Dogfooding is opt-in (ADR-083): a directory is only considered a dogfood
-    copy when the dogfood marker (``.dogfood``) or backup marker
-    (``.marketplace-bak``) exists, indicating the user explicitly ran
-    ``--install``. A stock marketplace install at the same path (no marker)
-    is not a dogfood copy and cannot be stale.
+    copy when the dogfood marker (``.dogfood``) exists inside the target,
+    indicating the user explicitly ran ``--install``. A stock marketplace
+    install at the same path (no marker) is not a dogfood copy and cannot be
+    stale, even if an orphan backup exists from a prior dogfood session.
     """
     if target.is_symlink() or not target.is_dir():
         return False
-    is_dogfood_copy = (target / _DOGFOOD_MARKER).exists() or _backup_path(target).exists()
+    is_dogfood_copy = (target / _DOGFOOD_MARKER).exists()
     if not is_dogfood_copy:
         return False
     return _plugin_version(target) != _plugin_version(source)

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -217,11 +217,15 @@ def dogfood_status(source: Path, target: Path) -> str:
         return f"symlinked -> {os.readlink(target)}"
     if target.is_dir():
         installed = _plugin_version(target)
-        marker = ""
+        if not _is_dogfood_copy(target):
+            return (
+                f"marketplace copy at {target} [v{installed}] (no .dogfood marker; not dogfooded)"
+            )
+        hint = ""
         if _is_stale(source, target):
             shipped = _plugin_version(source)
-            marker = f" (working tree ships v{shipped}; re-run --install to refresh)"
-        return f"installed copy at {target} [v{installed}]{marker}"
+            hint = f" (working tree ships v{shipped}; re-run --install to refresh)"
+        return f"dogfood copy at {target} [v{installed}]{hint}"
     return f"not installed at {target}"
 
 

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -18,7 +18,8 @@ Provides the dogfood install called for by ADR-083 decision item 3, copy-only
 on every platform. ADR-083's symlink-on-Unix wording is being reconciled in
 #3252. Refs #3222.
 
-Exit codes: 0 success, 2 configuration error.
+Exit codes: 0 success (or ``--check`` found no drift), 1 ``--check`` found the
+installed dogfood copy trailing the working tree, 2 configuration error.
 """
 
 from __future__ import annotations
@@ -174,18 +175,50 @@ def dogfood_uninstall(target: Path) -> str:
     return f"{removed}; no backup to restore (reinstall with: {reinstall})"
 
 
+def _is_stale(source: Path, target: Path) -> bool:
+    """Return True when an installed dogfood copy trails the working tree.
+
+    Only a real installed directory can be stale. A live symlink always
+    tracks the working tree, and a missing target means nothing was
+    dogfooded, so both are reported as not stale (no advisory warranted).
+    """
+    if target.is_symlink() or not target.is_dir():
+        return False
+    return _plugin_version(target) != _plugin_version(source)
+
+
 def dogfood_status(source: Path, target: Path) -> str:
     """Return a one-line description of the current install state."""
     if target.is_symlink():
         return f"symlinked -> {os.readlink(target)}"
     if target.is_dir():
         installed = _plugin_version(target)
-        shipped = _plugin_version(source)
         marker = ""
-        if installed != shipped:
+        if _is_stale(source, target):
+            shipped = _plugin_version(source)
             marker = f" (working tree ships v{shipped}; re-run --install to refresh)"
         return f"installed copy at {target} [v{installed}]{marker}"
     return f"not installed at {target}"
+
+
+def dogfood_check(source: Path, target: Path) -> tuple[bool, str]:
+    """Return whether the installed copy is stale and an advisory message.
+
+    Powers the ``--check`` mode used by the pre-push staleness advisory
+    (issue #3256): the message is human-readable and the boolean drives the
+    exit code so a git hook can warn (never block) when a local dogfood copy
+    trails ``HEAD``.
+    """
+    if not _is_stale(source, target):
+        return False, f"dogfood copy current at {target}"
+    installed = _plugin_version(target)
+    shipped = _plugin_version(source)
+    message = (
+        f"dogfood copy at {target} is v{installed}; working tree ships "
+        f"v{shipped}. Re-run 'python3 scripts/dev/dogfood_copilot_plugin.py "
+        f"--install' to refresh before trusting local hook behavior."
+    )
+    return True, message
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -209,6 +242,11 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="show the current install state and exit",
     )
+    group.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 (with an advisory) when the installed copy trails the working tree",
+    )
     return parser
 
 
@@ -220,6 +258,10 @@ def main(argv: list[str] | None = None) -> int:
         target = default_target()
         if args.status:
             print(dogfood_status(source, target))
+        elif args.check:
+            stale, message = dogfood_check(source, target)
+            print(message)
+            return 1 if stale else 0
         elif args.uninstall:
             print(dogfood_uninstall(target))
         else:

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -177,6 +177,16 @@ def dogfood_uninstall(target: Path) -> str:
     return f"{removed}; no backup to restore (reinstall with: {reinstall})"
 
 
+def _is_dogfood_copy(target: Path) -> bool:
+    """Return True when target carries the ``.dogfood`` opt-in marker.
+
+    ``dogfood_install`` writes the marker; a stock marketplace install at the
+    same path never has it. The marker is the sole discriminator between an
+    opted-in dogfood copy and a plain marketplace install (ADR-083).
+    """
+    return (target / _DOGFOOD_MARKER).is_file()
+
+
 def _is_stale(source: Path, target: Path) -> bool:
     """Return True when an installed dogfood copy is out of sync with the tree.
 
@@ -196,8 +206,7 @@ def _is_stale(source: Path, target: Path) -> bool:
     """
     if target.is_symlink() or not target.is_dir():
         return False
-    is_dogfood_copy = (target / _DOGFOOD_MARKER).exists()
-    if not is_dogfood_copy:
+    if not _is_dogfood_copy(target):
         return False
     return _plugin_version(target) != _plugin_version(source)
 
@@ -238,6 +247,12 @@ def dogfood_check(source: Path, target: Path) -> tuple[bool, str]:
         return False, f"dogfood copy symlinked to the working tree at {target}"
     if not target.is_dir():
         return False, f"no dogfood copy installed at {target}"
+    if not _is_dogfood_copy(target):
+        return (
+            False,
+            f"install at {target} is a marketplace copy, not a dogfood copy "
+            "(no .dogfood marker); staleness advisory skipped",
+        )
     return False, f"dogfood copy current at {target}"
 
 
@@ -265,7 +280,10 @@ def _build_parser() -> argparse.ArgumentParser:
     group.add_argument(
         "--check",
         action="store_true",
-        help="exit 1 (with an advisory) when the installed copy trails the working tree",
+        help=(
+            "exit 1 (with an advisory) when the dogfood copy differs from the "
+            "working tree (in either direction)"
+        ),
     )
     return parser
 

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -35,6 +35,7 @@ from pathlib import Path
 MARKETPLACE = "ai-agents"
 PLUGIN_NAME = "project-toolkit"
 _BACKUP_SUFFIX = ".marketplace-bak"
+_DOGFOOD_MARKER = ".dogfood"
 
 # Match build_all.py's shipped-tree copy semantics (__pycache__, *.pyc, *.pyo)
 # and drop local tool caches so the dogfood copy mirrors what customers get.
@@ -150,6 +151,7 @@ def dogfood_install(source: Path, target: Path) -> str:
     note = _stash_existing(target)
     target.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(source, target, ignore=_COPY_IGNORE)
+    (target / _DOGFOOD_MARKER).write_text("", encoding="utf-8")
     return f"copied {source} -> {target} ({note})"
 
 
@@ -187,13 +189,15 @@ def _is_stale(source: Path, target: Path) -> bool:
     dogfooded, so both are reported as not stale (no advisory warranted).
 
     Dogfooding is opt-in (ADR-083): a directory is only considered a dogfood
-    copy when the backup marker (``.marketplace-bak``) exists, indicating the
-    user explicitly ran ``--install``. A stock marketplace install at the same
-    path (no backup) is not a dogfood copy and cannot be stale.
+    copy when the dogfood marker (``.dogfood``) or backup marker
+    (``.marketplace-bak``) exists, indicating the user explicitly ran
+    ``--install``. A stock marketplace install at the same path (no marker)
+    is not a dogfood copy and cannot be stale.
     """
     if target.is_symlink() or not target.is_dir():
         return False
-    if not _backup_path(target).exists():
+    is_dogfood_copy = (target / _DOGFOOD_MARKER).exists() or _backup_path(target).exists()
+    if not is_dogfood_copy:
         return False
     return _plugin_version(target) != _plugin_version(source)
 

--- a/scripts/dev/dogfood_copilot_plugin.py
+++ b/scripts/dev/dogfood_copilot_plugin.py
@@ -185,8 +185,15 @@ def _is_stale(source: Path, target: Path) -> bool:
     not used. Only a real installed directory can be stale: a live symlink
     always tracks the working tree, and a missing target means nothing was
     dogfooded, so both are reported as not stale (no advisory warranted).
+
+    Dogfooding is opt-in (ADR-083): a directory is only considered a dogfood
+    copy when the backup marker (``.marketplace-bak``) exists, indicating the
+    user explicitly ran ``--install``. A stock marketplace install at the same
+    path (no backup) is not a dogfood copy and cannot be stale.
     """
     if target.is_symlink() or not target.is_dir():
+        return False
+    if not _backup_path(target).exists():
         return False
     return _plugin_version(target) != _plugin_version(source)
 

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -311,6 +311,37 @@ def test_is_stale_false_when_marketplace_install(source: Path, target: Path) -> 
     assert dogfood._is_stale(source, target) is False
 
 
+def test_is_stale_true_after_first_install_with_version_change(
+    source: Path, target: Path
+) -> None:
+    # First install (no prior copy) must still be detected as stale when the
+    # source version changes (issue #3256 regression: backup-only detection
+    # missed first installs because no backup was created).
+    dogfood.dogfood_install(source, target)
+    # Simulate a version bump in the working tree
+    (source / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "project-toolkit", "version": "10.0.0"}), encoding="utf-8"
+    )
+    assert dogfood._is_stale(source, target) is True
+
+
+def test_is_stale_true_after_symlink_replacement_with_version_change(
+    source: Path, target: Path, tmp_path: Path
+) -> None:
+    # Replacing a symlink must still be detected as stale when the source
+    # version changes (issue #3256 regression: no backup created for symlinks).
+    _require_symlinks(tmp_path)
+    other = _make_plugin_root(tmp_path / "other", "1.0.0")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.symlink_to(other, target_is_directory=True)
+    dogfood.dogfood_install(source, target)
+    # Simulate a version bump in the working tree
+    (source / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "project-toolkit", "version": "10.0.0"}), encoding="utf-8"
+    )
+    assert dogfood._is_stale(source, target) is True
+
+
 def test_is_stale_false_when_not_installed(source: Path, target: Path) -> None:
     assert dogfood._is_stale(source, target) is False
 

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -323,9 +323,7 @@ def test_is_stale_false_when_orphan_backup_exists(source: Path, target: Path) ->
     assert dogfood._is_stale(source, target) is False
 
 
-def test_is_stale_true_after_first_install_with_version_change(
-    source: Path, target: Path
-) -> None:
+def test_is_stale_true_after_first_install_with_version_change(source: Path, target: Path) -> None:
     # First install (no prior copy) must still be detected as stale when the
     # source version changes (issue #3256 regression: backup-only detection
     # missed first installs because no backup was created).
@@ -427,14 +425,24 @@ def test_main_check_returns_0_when_not_installed(monkeypatch, tmp_path: Path) ->
 
 
 def test_main_check_returns_0_when_marketplace_install(monkeypatch, tmp_path: Path) -> None:
-    # A marketplace install (no backup marker) with version mismatch is not
-    # considered a stale dogfood copy (issue #3256).
+    # A marketplace install (no .dogfood marker) with a version mismatch is
+    # not a stale dogfood copy (issue #3256).
     _make_plugin_root(tmp_path / "src" / "copilot-cli", "9.9.9")
     tgt = _make_plugin_root(tmp_path / "installed" / "project-toolkit", "0.0.1")
-    # No backup marker - this is a stock marketplace install
+    # No .dogfood marker: this is a stock marketplace install.
     monkeypatch.setattr(dogfood, "_repo_root", lambda: tmp_path)
     monkeypatch.setattr(dogfood, "default_target", lambda: tgt)
     assert dogfood.main(["--check"]) == 0
+
+
+def test_check_labels_marketplace_install(source: Path, target: Path) -> None:
+    # A markerless install at the target path is a marketplace copy, not a
+    # stale-or-current dogfood copy; the advisory names it as such and skips.
+    _make_plugin_root(target, "0.0.1")
+    stale, message = dogfood.dogfood_check(source, target)
+    assert stale is False
+    assert "marketplace copy" in message
+    assert "advisory skipped" in message
 
 
 # --- helpers ---

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -318,8 +318,18 @@ def test_check_flags_stale_copy(source: Path, target: Path) -> None:
 
 
 def test_check_reports_current_when_not_installed(source: Path, target: Path) -> None:
-    stale, _ = dogfood.dogfood_check(source, target)
+    stale, message = dogfood.dogfood_check(source, target)
     assert stale is False
+    assert "no dogfood copy installed" in message
+
+
+def test_check_reports_symlink_state(source: Path, target: Path, tmp_path: Path) -> None:
+    _require_symlinks(tmp_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.symlink_to(source, target_is_directory=True)
+    stale, message = dogfood.dogfood_check(source, target)
+    assert stale is False
+    assert "symlinked" in message
 
 
 def test_main_check_returns_1_on_stale(monkeypatch, tmp_path: Path, capsys) -> None:

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -285,8 +285,15 @@ def test_is_stale_false_when_versions_match(source: Path, target: Path) -> None:
     assert dogfood._is_stale(source, target) is False
 
 
-def test_is_stale_true_when_installed_trails(source: Path, target: Path) -> None:
+def test_is_stale_true_when_installed_older(source: Path, target: Path) -> None:
     _make_plugin_root(target, "0.0.1")
+    assert dogfood._is_stale(source, target) is True
+
+
+def test_is_stale_true_when_installed_newer(source: Path, target: Path) -> None:
+    # Any mismatch is stale, in either direction: a copy newer than the tree
+    # (older branch checked out) is just as wrong for dogfood fidelity.
+    _make_plugin_root(target, "99.0.0")
     assert dogfood._is_stale(source, target) is True
 
 

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -269,6 +269,8 @@ def test_status_reports_current_copy(source: Path, target: Path) -> None:
 
 def test_status_flags_stale_copy(source: Path, target: Path) -> None:
     _make_plugin_root(target, "0.0.1")
+    # Create backup marker to indicate this is a dogfood copy, not marketplace
+    _make_plugin_root(target.with_name(target.name + ".marketplace-bak"), "0.0.0")
     status = dogfood.dogfood_status(source, target)
     assert "re-run --install to refresh" in status
 
@@ -287,6 +289,8 @@ def test_is_stale_false_when_versions_match(source: Path, target: Path) -> None:
 
 def test_is_stale_true_when_installed_older(source: Path, target: Path) -> None:
     _make_plugin_root(target, "0.0.1")
+    # Create backup marker to indicate this is a dogfood copy, not marketplace
+    _make_plugin_root(target.with_name(target.name + ".marketplace-bak"), "0.0.0")
     assert dogfood._is_stale(source, target) is True
 
 
@@ -294,7 +298,17 @@ def test_is_stale_true_when_installed_newer(source: Path, target: Path) -> None:
     # Any mismatch is stale, in either direction: a copy newer than the tree
     # (older branch checked out) is just as wrong for dogfood fidelity.
     _make_plugin_root(target, "99.0.0")
+    # Create backup marker to indicate this is a dogfood copy, not marketplace
+    _make_plugin_root(target.with_name(target.name + ".marketplace-bak"), "0.0.0")
     assert dogfood._is_stale(source, target) is True
+
+
+def test_is_stale_false_when_marketplace_install(source: Path, target: Path) -> None:
+    # A marketplace install (no backup marker) is not a dogfood copy and cannot
+    # be stale, even if its version differs from the working tree (issue #3256).
+    _make_plugin_root(target, "0.0.1")
+    # No backup marker - this is a stock marketplace install
+    assert dogfood._is_stale(source, target) is False
 
 
 def test_is_stale_false_when_not_installed(source: Path, target: Path) -> None:
@@ -317,6 +331,8 @@ def test_check_reports_current_when_in_sync(source: Path, target: Path) -> None:
 
 def test_check_flags_stale_copy(source: Path, target: Path) -> None:
     _make_plugin_root(target, "0.0.1")
+    # Create backup marker to indicate this is a dogfood copy, not marketplace
+    _make_plugin_root(target.with_name(target.name + ".marketplace-bak"), "0.0.0")
     stale, message = dogfood.dogfood_check(source, target)
     assert stale is True
     assert "0.0.1" in message  # installed version
@@ -342,6 +358,8 @@ def test_check_reports_symlink_state(source: Path, target: Path, tmp_path: Path)
 def test_main_check_returns_1_on_stale(monkeypatch, tmp_path: Path, capsys) -> None:
     _make_plugin_root(tmp_path / "src" / "copilot-cli", "9.9.9")
     tgt = _make_plugin_root(tmp_path / "installed" / "project-toolkit", "0.0.1")
+    # Create backup marker to indicate this is a dogfood copy, not marketplace
+    _make_plugin_root(tgt.with_name(tgt.name + ".marketplace-bak"), "0.0.0")
     monkeypatch.setattr(dogfood, "_repo_root", lambda: tmp_path)
     monkeypatch.setattr(dogfood, "default_target", lambda: tgt)
     rc = dogfood.main(["--check"])
@@ -362,6 +380,17 @@ def test_main_check_returns_0_when_not_installed(monkeypatch, tmp_path: Path) ->
     _make_plugin_root(tmp_path / "src" / "copilot-cli", "9.9.9")
     monkeypatch.setattr(dogfood, "_repo_root", lambda: tmp_path)
     monkeypatch.setattr(dogfood, "default_target", lambda: tmp_path / "installed" / "nope")
+    assert dogfood.main(["--check"]) == 0
+
+
+def test_main_check_returns_0_when_marketplace_install(monkeypatch, tmp_path: Path) -> None:
+    # A marketplace install (no backup marker) with version mismatch is not
+    # considered a stale dogfood copy (issue #3256).
+    _make_plugin_root(tmp_path / "src" / "copilot-cli", "9.9.9")
+    tgt = _make_plugin_root(tmp_path / "installed" / "project-toolkit", "0.0.1")
+    # No backup marker - this is a stock marketplace install
+    monkeypatch.setattr(dogfood, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(dogfood, "default_target", lambda: tgt)
     assert dogfood.main(["--check"]) == 0
 
 

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -262,9 +262,19 @@ def test_uninstall_removes_regular_file_and_restores_backup(target: Path) -> Non
 def test_status_reports_current_copy(source: Path, target: Path) -> None:
     dogfood.dogfood_install(source, target)
     status = dogfood.dogfood_status(source, target)
-    assert "installed copy" in status
+    assert "dogfood copy" in status
     assert "9.9.9" in status
     assert "re-run" not in status  # matches the shipped version
+
+
+def test_status_labels_marketplace_copy(source: Path, target: Path) -> None:
+    # A markerless install is a marketplace copy; --status must not describe it
+    # as a dogfood copy (issue #3256).
+    _make_plugin_root(target, "0.0.1")
+    status = dogfood.dogfood_status(source, target)
+    assert "marketplace copy" in status
+    assert "not dogfooded" in status
+    assert "re-run" not in status
 
 
 def test_status_flags_stale_copy(source: Path, target: Path) -> None:

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -269,8 +269,8 @@ def test_status_reports_current_copy(source: Path, target: Path) -> None:
 
 def test_status_flags_stale_copy(source: Path, target: Path) -> None:
     _make_plugin_root(target, "0.0.1")
-    # Create backup marker to indicate this is a dogfood copy, not marketplace
-    _make_plugin_root(target.with_name(target.name + ".marketplace-bak"), "0.0.0")
+    # Create dogfood marker to indicate this is a dogfood copy, not marketplace
+    (target / ".dogfood").write_text("", encoding="utf-8")
     status = dogfood.dogfood_status(source, target)
     assert "re-run --install to refresh" in status
 
@@ -289,8 +289,8 @@ def test_is_stale_false_when_versions_match(source: Path, target: Path) -> None:
 
 def test_is_stale_true_when_installed_older(source: Path, target: Path) -> None:
     _make_plugin_root(target, "0.0.1")
-    # Create backup marker to indicate this is a dogfood copy, not marketplace
-    _make_plugin_root(target.with_name(target.name + ".marketplace-bak"), "0.0.0")
+    # Create dogfood marker to indicate this is a dogfood copy, not marketplace
+    (target / ".dogfood").write_text("", encoding="utf-8")
     assert dogfood._is_stale(source, target) is True
 
 
@@ -298,16 +298,28 @@ def test_is_stale_true_when_installed_newer(source: Path, target: Path) -> None:
     # Any mismatch is stale, in either direction: a copy newer than the tree
     # (older branch checked out) is just as wrong for dogfood fidelity.
     _make_plugin_root(target, "99.0.0")
-    # Create backup marker to indicate this is a dogfood copy, not marketplace
-    _make_plugin_root(target.with_name(target.name + ".marketplace-bak"), "0.0.0")
+    # Create dogfood marker to indicate this is a dogfood copy, not marketplace
+    (target / ".dogfood").write_text("", encoding="utf-8")
     assert dogfood._is_stale(source, target) is True
 
 
 def test_is_stale_false_when_marketplace_install(source: Path, target: Path) -> None:
-    # A marketplace install (no backup marker) is not a dogfood copy and cannot
+    # A marketplace install (no dogfood marker) is not a dogfood copy and cannot
     # be stale, even if its version differs from the working tree (issue #3256).
     _make_plugin_root(target, "0.0.1")
-    # No backup marker - this is a stock marketplace install
+    # No dogfood marker - this is a stock marketplace install
+    assert dogfood._is_stale(source, target) is False
+
+
+def test_is_stale_false_when_orphan_backup_exists(source: Path, target: Path) -> None:
+    # Issue #3256: An orphan backup from a prior dogfood session must not cause
+    # a marketplace install to be treated as stale. After dogfooding once, if
+    # Copilot overwrites the target with a marketplace copy (no .dogfood marker),
+    # the backup persists but the current install is NOT a dogfood copy.
+    _make_plugin_root(target, "0.0.1")
+    # Orphan backup exists from a prior dogfood session
+    _make_plugin_root(target.with_name(target.name + ".marketplace-bak"), "0.0.0")
+    # No .dogfood marker in target - this is a marketplace install
     assert dogfood._is_stale(source, target) is False
 
 
@@ -362,8 +374,8 @@ def test_check_reports_current_when_in_sync(source: Path, target: Path) -> None:
 
 def test_check_flags_stale_copy(source: Path, target: Path) -> None:
     _make_plugin_root(target, "0.0.1")
-    # Create backup marker to indicate this is a dogfood copy, not marketplace
-    _make_plugin_root(target.with_name(target.name + ".marketplace-bak"), "0.0.0")
+    # Create dogfood marker to indicate this is a dogfood copy, not marketplace
+    (target / ".dogfood").write_text("", encoding="utf-8")
     stale, message = dogfood.dogfood_check(source, target)
     assert stale is True
     assert "0.0.1" in message  # installed version
@@ -389,8 +401,8 @@ def test_check_reports_symlink_state(source: Path, target: Path, tmp_path: Path)
 def test_main_check_returns_1_on_stale(monkeypatch, tmp_path: Path, capsys) -> None:
     _make_plugin_root(tmp_path / "src" / "copilot-cli", "9.9.9")
     tgt = _make_plugin_root(tmp_path / "installed" / "project-toolkit", "0.0.1")
-    # Create backup marker to indicate this is a dogfood copy, not marketplace
-    _make_plugin_root(tgt.with_name(tgt.name + ".marketplace-bak"), "0.0.0")
+    # Create dogfood marker to indicate this is a dogfood copy, not marketplace
+    (tgt / ".dogfood").write_text("", encoding="utf-8")
     monkeypatch.setattr(dogfood, "_repo_root", lambda: tmp_path)
     monkeypatch.setattr(dogfood, "default_target", lambda: tgt)
     rc = dogfood.main(["--check"])

--- a/tests/test_dogfood_copilot_plugin.py
+++ b/tests/test_dogfood_copilot_plugin.py
@@ -277,6 +277,77 @@ def test_status_reports_not_installed(source: Path, target: Path) -> None:
     assert "not installed" in dogfood.dogfood_status(source, target)
 
 
+# --- check (--check drift signal, issue #3256) ---
+
+
+def test_is_stale_false_when_versions_match(source: Path, target: Path) -> None:
+    dogfood.dogfood_install(source, target)
+    assert dogfood._is_stale(source, target) is False
+
+
+def test_is_stale_true_when_installed_trails(source: Path, target: Path) -> None:
+    _make_plugin_root(target, "0.0.1")
+    assert dogfood._is_stale(source, target) is True
+
+
+def test_is_stale_false_when_not_installed(source: Path, target: Path) -> None:
+    assert dogfood._is_stale(source, target) is False
+
+
+def test_is_stale_false_when_symlinked(source: Path, target: Path, tmp_path: Path) -> None:
+    _require_symlinks(tmp_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.symlink_to(source, target_is_directory=True)
+    assert dogfood._is_stale(source, target) is False
+
+
+def test_check_reports_current_when_in_sync(source: Path, target: Path) -> None:
+    dogfood.dogfood_install(source, target)
+    stale, message = dogfood.dogfood_check(source, target)
+    assert stale is False
+    assert "current" in message
+
+
+def test_check_flags_stale_copy(source: Path, target: Path) -> None:
+    _make_plugin_root(target, "0.0.1")
+    stale, message = dogfood.dogfood_check(source, target)
+    assert stale is True
+    assert "0.0.1" in message  # installed version
+    assert "9.9.9" in message  # shipped version
+    assert "--install" in message
+
+
+def test_check_reports_current_when_not_installed(source: Path, target: Path) -> None:
+    stale, _ = dogfood.dogfood_check(source, target)
+    assert stale is False
+
+
+def test_main_check_returns_1_on_stale(monkeypatch, tmp_path: Path, capsys) -> None:
+    _make_plugin_root(tmp_path / "src" / "copilot-cli", "9.9.9")
+    tgt = _make_plugin_root(tmp_path / "installed" / "project-toolkit", "0.0.1")
+    monkeypatch.setattr(dogfood, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(dogfood, "default_target", lambda: tgt)
+    rc = dogfood.main(["--check"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "0.0.1" in out and "9.9.9" in out
+
+
+def test_main_check_returns_0_when_current(monkeypatch, tmp_path: Path) -> None:
+    _make_plugin_root(tmp_path / "src" / "copilot-cli", "9.9.9")
+    tgt = _make_plugin_root(tmp_path / "installed" / "project-toolkit", "9.9.9")
+    monkeypatch.setattr(dogfood, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(dogfood, "default_target", lambda: tgt)
+    assert dogfood.main(["--check"]) == 0
+
+
+def test_main_check_returns_0_when_not_installed(monkeypatch, tmp_path: Path) -> None:
+    _make_plugin_root(tmp_path / "src" / "copilot-cli", "9.9.9")
+    monkeypatch.setattr(dogfood, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(dogfood, "default_target", lambda: tmp_path / "installed" / "nope")
+    assert dogfood.main(["--check"]) == 0
+
+
 # --- helpers ---
 
 


### PR DESCRIPTION
## What

Add a pre-push staleness advisory for the local Copilot dogfood install. When a
developer has installed the working-tree plugin over their real Copilot plugin
(via the dogfood installer) and that install later trails `HEAD`, the pre-push
hook now emits a warning. It never blocks.

Two parts:

1. **`--check` mode** on the installer. Exits `1` with a human-readable advisory
   when the installed copy's plugin version trails the working tree; exits `0`
   when in sync, symlinked, or not installed. Refactors `dogfood_status` to reuse
   the new `_is_stale` helper (DRY).
2. **Warn-only pre-push block** (Phase 1c). Calls `--check`, records a warning on
   exit `1`, and is skipped entirely when no dogfood copy is present. The drift
   logic lives in Python; the hook only calls it and warns (ADR-006 / ADR-042).

## Why

A stale dogfood copy silently produces a false "works on my machine" result for
the exact hooks and permissions we ship to customers. That is the same
silent-staleness class that let the 0.5.248 rot go unnoticed. CI cannot catch it
(runners have no per-developer local install), so a local git-hook advisory at
the last gate before code leaves the machine is the only workable signal.

This surfaced live while implementing: the advisory fired on the author's machine
(installed v0.6.81 vs shipped v0.6.86), which is precisely the gap it is meant to
catch.

Warn, never block: per the ADR-083 six-agent debate, dogfooding is opt-in, so the
guard must not gate pushes for developers who never installed the plugin.

## Testing

- `uv run ruff format` + `uv run ruff check` + `uv run mypy`: clean.
- `uv run pytest tests/test_dogfood_copilot_plugin.py -q`: 39 passed (11 new,
  covering `_is_stale` match/trails/not-installed/symlinked, `dogfood_check`
  in-sync/stale/not-installed, and `main(["--check"])` exit 1/0/0).
- `bash -n .githooks/pre-push`: syntax OK.
- Full pre-push suite green on push (14 pass, 1 warn: the advisory firing on the
  author's own stale copy).

## Out of Scope

ADR-083 already tracks this follow-up; it stays accurate (it dropped the
installer-side auto re-copy, which this does not reintroduce). No ADR edit needed.

Refs #3256

## References

- `scripts/dev/dogfood_copilot_plugin.py`
- `tests/test_dogfood_copilot_plugin.py`
- `.githooks/pre-push`
