### PR TITLE
chore(hooks): trim unread pre-compact JSON writer from compact_checkpoint

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.87",
+  "version": "0.6.88",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PreCompact/invoke_compact_checkpoint.py
+++ b/.claude/hooks/PreCompact/invoke_compact_checkpoint.py
@@ -5,11 +5,10 @@ Claude Code PreCompact hook that snapshots the current work state before
 context is compacted, providing a resume context for the post-compaction
 session.
 
-Captures:
-1. Current session log path and last-modified timestamp
-2. Open TODO items from session log work field
-3. Current git branch
-4. Resume context string (printed to stdout for injection)
+Builds a resume-context string from the current session log (name, open
+TODO items, git branch) and prints it to stdout for injection into the
+post-compaction session. The stdout injection is the sole product; no
+on-disk checkpoint artifact is written (ADR-082, issue #3217).
 
 Hook Type: PreCompact (non-blocking, fail-open)
 Exit Codes:
@@ -157,37 +156,6 @@ def _extract_open_items(session_log: Path) -> list[str]:
     return items
 
 
-def _write_checkpoint(
-    project_dir: str,
-    session_log_name: str,
-    session_mtime: str,
-    branch: str,
-    open_items: list[str],
-    resume_context: str,
-) -> None:
-    """Write checkpoint file for compaction recovery."""
-    checkpoint_dir = Path(project_dir) / ".agents" / ".hook-state"
-    checkpoint_dir.mkdir(parents=True, exist_ok=True)
-
-    today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
-    timestamp = datetime.now(tz=UTC).strftime("%H%M%S-%f")
-
-    checkpoint_file = checkpoint_dir / f"pre-compact-{today}-{timestamp}-{os.getpid()}.json"
-    checkpoint_data = {
-        "session_log": session_log_name,
-        "session_mtime": session_mtime,
-        "branch": branch,
-        "open_items": open_items,
-        "resume_context": resume_context,
-        "created_at": datetime.now(tz=UTC).isoformat(),
-    }
-
-    checkpoint_file.write_text(
-        json.dumps(checkpoint_data, indent=2, ensure_ascii=False),
-        encoding="utf-8",
-    )
-
-
 def _drain_stdin() -> None:
     """Drain stdin to prevent pipe buffer blocking on the harness side.
 
@@ -217,13 +185,6 @@ def main() -> None:
     session_log = get_recent_session_log(sessions_dir)
 
     session_log_name = session_log.name if session_log else "(none)"
-    session_mtime = ""
-    if session_log and session_log.exists():
-        try:
-            mtime = session_log.stat().st_mtime
-            session_mtime = datetime.fromtimestamp(mtime, tz=UTC).isoformat()
-        except OSError:
-            session_mtime = "(unknown)"
 
     # Get open items
     open_items = _extract_open_items(session_log) if session_log else []
@@ -247,27 +208,11 @@ def main() -> None:
             items_preview += f" ... (+{len(open_items) - 5} more)"
         resume_context += f" Items: {items_preview}"
 
-    # Print the resume context to stdout first so the post-compaction
-    # session still receives it even when checkpoint persistence fails
-    # (full disk, read-only mount, permission error, etc.). The injected
-    # context is the primary product of this hook; the on-disk checkpoint
-    # is a best-effort audit artifact.
+    # The resume context printed to stdout is the sole product of this
+    # hook; it is injected into the post-compaction session. No on-disk
+    # artifact is written (ADR-082, issue #3217): the former
+    # pre-compact-*.json checkpoint had no reader and was removed.
     print(f"## ⚠️ Pre-Compaction Checkpoint\n\n{resume_context}")
-
-    try:
-        _write_checkpoint(
-            project_dir,
-            session_log_name,
-            session_mtime,
-            branch,
-            open_items,
-            resume_context,
-        )
-    except OSError as exc:
-        print(
-            f"[WARNING] {HOOK_NAME} checkpoint write failed: {exc}",
-            file=sys.stderr,
-        )
 
 
 if __name__ == "__main__":

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.87",
+  "version": "0.6.88",
   "author": {
     "name": "rjmurillo"
   }

--- a/tests/test_compact_checkpoint.py
+++ b/tests/test_compact_checkpoint.py
@@ -2,7 +2,6 @@
 """Tests for PreCompact/invoke_compact_checkpoint.py.
 
 Covers:
-- Checkpoint file creation with correct structure
 - Resume context stdout output
 - Open item extraction from session logs
 - Git branch detection
@@ -115,31 +114,6 @@ class TestGetCurrentBranch:
             assert result == "(unknown)"
 
 
-class TestWriteCheckpoint:
-    """Test _write_checkpoint function."""
-
-    def test_creates_checkpoint_file(self, tmp_path: Path) -> None:
-        (tmp_path / ".agents").mkdir()
-        invoke_compact_checkpoint._write_checkpoint(
-            str(tmp_path),
-            "2026-01-01-session-001.json",
-            "2026-01-01T10:00:00+00:00",
-            "feature/test",
-            ["Task A", "Task B"],
-            "Resume context here",
-        )
-
-        checkpoint_dir = tmp_path / ".agents" / ".hook-state"
-        assert checkpoint_dir.exists()
-        files = list(checkpoint_dir.glob("pre-compact-*.json"))
-        assert len(files) == 1
-
-        data = json.loads(files[0].read_text(encoding="utf-8"))
-        assert data["session_log"] == "2026-01-01-session-001.json"
-        assert data["branch"] == "feature/test"
-        assert len(data["open_items"]) == 2
-
-
 class TestMain:
     """Test main() function."""
 
@@ -178,6 +152,43 @@ class TestMain:
         captured = capsys.readouterr()
         assert "Pre-Compaction Checkpoint" in captured.out
         assert "feature/test" in captured.out
+
+    def test_writes_no_on_disk_checkpoint(
+        self, project_tree: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """main() must not create a pre-compact-*.json artifact (issue #3217).
+
+        The stdout injection is the sole product; the former on-disk
+        checkpoint had no reader and was removed. This guards against the
+        write path being reintroduced.
+        """
+        session_log = list(
+            (project_tree / ".agents" / "sessions").glob("*.json")
+        )[0]
+
+        with patch.object(
+            invoke_compact_checkpoint, "skip_if_consumer_repo", return_value=False
+        ), patch.object(
+            invoke_compact_checkpoint,
+            "get_project_directory",
+            return_value=str(project_tree),
+        ), patch.object(
+            invoke_compact_checkpoint,
+            "get_recent_session_log",
+            return_value=session_log,
+        ), patch.object(
+            invoke_compact_checkpoint,
+            "_get_current_branch",
+            return_value="feature/test",
+        ):
+            invoke_compact_checkpoint.main()
+
+        hook_state = project_tree / ".agents" / ".hook-state"
+        checkpoints = (
+            list(hook_state.glob("pre-compact-*.json")) if hook_state.exists() else []
+        )
+        assert checkpoints == []
+        assert not hasattr(invoke_compact_checkpoint, "_write_checkpoint")
 
     def test_handles_no_session_log(
         self, tmp_path: Path, capsys: pytest.CaptureFixture


### PR DESCRIPTION
## Summary

Trims the unread pre-compaction JSON writer from the PreCompact
`compact_checkpoint` hook. This is one bounded, solo-safe slice of epic
#3197's hook-ROI reduction (the `compact_checkpoint` KEEP-but-trim item
in #3217).

The hook's job is to inject a resume-context string into the
post-compaction session via stdout. It also wrote a per-compaction JSON
audit artifact under `.agents/.hook-state/`. That file had no production
reader: the only consumer was the hook's own unit test. ADR-082 already
established the stdout injection as the sole load-bearing product.

## Changes

- Remove `_write_checkpoint()` and its call site.
- Remove the now-orphaned `session_mtime` computation (only fed the
  writer).
- Keep the stdout resume-context injection and the fail-open contract
  (exit 0 always).
- Add a regression test asserting `main()` writes no on-disk checkpoint
  and that `_write_checkpoint` no longer exists.
- Bump both project-toolkit plugin manifests to 0.6.88 (parity gate).

## Why no generated mirror update

`compact_checkpoint` is a Claude-only PreCompact hook. Copilot CLI has
no PreCompact event, so the Copilot build drops it. A full build
regenerated nothing beyond the two edited source files.

## Verification

- `uv run pytest tests/test_compact_checkpoint.py` gives 12 passed.
- `uv run ruff check` clean on both files.
- Copilot build shows no generated drift.
- Plugin manifest parity and version-bump validators pass.

## Scope note

The remaining #3217 items (skill_first_guard and test_auto_approval to
host-native `permissions`, observation_sync direct-call) introduce a new
cross-CLI permission surface that needs adr-review and live dual-CLI
verification. They are intentionally left for a separate reviewed PR.

## Notes

Reference-only paths (not changed by this PR): the removed artifact
pattern and the build entry point that confirms no mirror drift.

```
.agents/.hook-state/pre-compact-*.json
build/scripts/build_all.py
```

Refs #3217
