### PR TITLE
fix(hooks): tie ADR review evidence to the staged ADR (#3196)

### DIFF
--- a/.agents/sessions/2026-07-21-session-3196-adr-review-staleness.json
+++ b/.agents/sessions/2026-07-21-session-3196-adr-review-staleness.json
@@ -1,0 +1,144 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3196,
+    "date": "2026-07-21",
+    "branch": "fix/3196-adr-review-staleness",
+    "startingCommit": "6052287c",
+    "objective": "Harden invoke_adr_review_guard.py line 326: tie debate-log evidence to the staged ADR by content so a stale or cross-branch *debate*.md no longer counts as review evidence (issue #3196 named weakness)."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "This Copilot CLI session exposes no serena-* MCP tools; Serena not activated. Loaded context from repository/user memories and read .agents files directly."
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "No serena-* tools available this session; initial_instructions not retrievable."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md earlier this session-family (read-only notice confirmed)."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file."
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Used github skill scripts under .claude/skills/github/scripts (merge_pr.py, test_pr_merge_ready.py, get_pr_checks.py)."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "usage-mandatory conventions surfaced in loaded memories; github scripts used over raw gh for PR mutations."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "PROJECT-CONSTRAINTS and .claude/rules applied (Python-first, atomic commits, no em-dashes, LSP-first)."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Repository and user memories loaded via harness prompt; hook-migration and plugin-versioning facts applied."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/3196-adr-review-staleness"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/3196-adr-review-staleness, branched from main 6052287c."
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status shows the guard, its test, and this log as the only intended changes; retro artifacts kept unstaged."
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "6052287c"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST items completed for this focused hardening fix."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified."
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Stored a repository memory recording that the #3196 guard-port half is largely done and only retirement remains; no Serena MCP available so memory persisted via Copilot memory."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown files changed; scoped lint not applicable."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Commit includes invoke_adr_review_guard.py, tests/test_invoke_adr_review_guard.py, and this session log."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run pytest tests/test_invoke_adr_review_guard.py: 39 passed; related guard suites 145 passed; ruff clean; mypy clean on the guard."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Fix tracked against #3196; PR references the issue."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "action": "Merged and babysat PR B #3290 (Windows lefthook integration): confirmed 84 checks green, 0 unresolved threads, squash-merged with branch delete, verified #3289 auto-closed and main Python Tests green on 6052287c.",
+      "files": []
+    },
+    {
+      "action": "Investigated the #3196 guard-port state: branch-protection and branch-context PreToolUse guards are already retired; branch/branch-context/session logic runs as lefthook git_hook_policy.py subcommands. Recorded the scope correction to memory.",
+      "files": []
+    },
+    {
+      "action": "Fixed the line-326 weakness in check_adr_review_evidence: added _extract_adr_ids and _debate_references_adr, threaded staged adr_changes through, and required at least one debate log to reference a staged ADR id by content (survives cross-branch checkout where mtime resets). Falls back to lenient behavior when no ADR id is extractable.",
+      "files": [
+        ".claude/hooks/PreToolUse/invoke_adr_review_guard.py"
+      ]
+    },
+    {
+      "action": "Added pos/neg/edge tests: debate log referencing the staged ADR passes; unrelated/stale debate log blocks with the ADR id in the reason; any-of-many matching passes; canonical-source-only staged change falls back to lenient.",
+      "files": [
+        "tests/test_invoke_adr_review_guard.py"
+      ]
+    }
+  ],
+  "endingCommit": "d73ce822",
+  "nextSteps": [
+    "Open PR referencing #3196 and babysit to green + self-merge once checks pass and threads resolve.",
+    "Post the corrected #3196 coverage matrix as an issue comment so the retirement increments target lefthook, not the stale .githooks path, and surface the gh-pr-create coverage gap for a decision.",
+    "Continue the remaining open issues per the autopilot mandate."
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.91",
+  "version": "0.6.92",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
@@ -308,15 +308,15 @@ def _debate_references_adr(debate_path: Path, adr_ids: set[str]) -> bool:
     gets a fresh mtime but keeps its text, so only content ties evidence to
     the ADR actually being committed.
 
-    Uses word-boundary regex to avoid prefix collisions (ADR-6 matching ADR-62).
+    Tokenizes ADR ids out of the text and compares by equality, so a shorter
+    id (ADR-6) never matches inside a longer one (ADR-62).
     """
     try:
-        text = debate_path.read_text(encoding="utf-8", errors="replace").upper()
+        text = debate_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return False
-    return any(
-        re.search(rf"\b{re.escape(adr_id)}\b", text) for adr_id in adr_ids
-    )
+    referenced = {match.group(0).upper() for match in _ADR_ID_PATTERN.finditer(text)}
+    return bool(referenced & adr_ids)
 
 
 def check_adr_review_evidence(

--- a/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
@@ -308,8 +308,8 @@ def _debate_references_adr(debate_path: Path, adr_ids: set[str]) -> bool:
     gets a fresh mtime but keeps its text, so only content ties evidence to
     the ADR actually being committed.
 
-    Tokenizes ADR ids out of the text and compares by equality, so a shorter
-    id (ADR-6) never matches inside a longer one (ADR-62).
+    Tokenizes whole ADR ids out of the text and compares them by equality, so
+    a shorter id never matches as a substring inside a longer one.
     """
     try:
         text = debate_path.read_text(encoding="utf-8", errors="replace")
@@ -327,8 +327,8 @@ def check_adr_review_evidence(
     """Check session log and artifacts for ADR review evidence.
 
     When ``adr_changes`` names one or more ADR files, at least one debate log
-    must reference one of those ADR identifiers; a stale or unrelated
-    ``*debate*.md`` no longer counts as evidence (issue #3196, line 326).
+    must reference one of those ADR identifiers; a stale or unrelated debate
+    artifact no longer counts as evidence (issue #3196).
 
     Returns dict with 'complete' (bool) and 'reason' or 'evidence' key.
     """

--- a/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
@@ -295,7 +295,7 @@ def _extract_adr_ids(paths: list[str]) -> set[str]:
     """Extract normalized ADR identifiers (e.g. ``ADR-062``) from staged paths."""
     ids: set[str] = set()
     for path in paths:
-        match = _ADR_ID_PATTERN.search(path)
+        match = _ADR_ID_PATTERN.search(Path(path).name)
         if match:
             ids.add(match.group(0).upper())
     return ids

--- a/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
@@ -62,6 +62,7 @@ from hook_utilities import (  # noqa: E402
 from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
 
 _ADR_PATTERN = re.compile(r"(?:^|[\\/])ADR-\d+(?:-\w+)*\.md$", re.IGNORECASE)
+_ADR_ID_PATTERN = re.compile(r"ADR-\d+", re.IGNORECASE)
 _CANONICAL_SOURCE_PATTERN = re.compile(r"SESSION-PROTOCOL\.md$", re.IGNORECASE)
 _FRONTMATTER_DELIM = "---"
 _NON_DECISION_FRONTMATTER_KEYS = frozenset({"implemented"})
@@ -290,11 +291,40 @@ def get_staged_adr_changes() -> list[str]:
 
 
 
+def _extract_adr_ids(paths: list[str]) -> set[str]:
+    """Extract normalized ADR identifiers (e.g. ``ADR-062``) from staged paths."""
+    ids: set[str] = set()
+    for path in paths:
+        match = _ADR_ID_PATTERN.search(path)
+        if match:
+            ids.add(match.group(0).upper())
+    return ids
+
+
+def _debate_references_adr(debate_path: Path, adr_ids: set[str]) -> bool:
+    """Return True when the debate artifact names at least one staged ADR id.
+
+    Content match, not mtime: a debate log checked out from another branch
+    gets a fresh mtime but keeps its text, so only content ties evidence to
+    the ADR actually being committed.
+    """
+    try:
+        text = debate_path.read_text(encoding="utf-8", errors="replace").upper()
+    except OSError:
+        return False
+    return any(adr_id in text for adr_id in adr_ids)
+
+
 def check_adr_review_evidence(
     session_log_path: Path,
     project_dir: str,
+    adr_changes: list[str] | None = None,
 ) -> dict[str, object]:
     """Check session log and artifacts for ADR review evidence.
+
+    When ``adr_changes`` names one or more ADR files, at least one debate log
+    must reference one of those ADR identifiers; a stale or unrelated
+    ``*debate*.md`` no longer counts as evidence (issue #3196, line 326).
 
     Returns dict with 'complete' (bool) and 'reason' or 'evidence' key.
     """
@@ -330,6 +360,20 @@ def check_adr_review_evidence(
                 "reason": (
                     "Session log mentions adr-review, but no debate "
                     f"log artifact found in {_AGENTS_DEBATE}"
+                ),
+            }
+
+        adr_ids = _extract_adr_ids(adr_changes or [])
+        if adr_ids and not any(
+            _debate_references_adr(log, adr_ids) for log in debate_logs
+        ):
+            return {
+                "complete": False,
+                "reason": (
+                    "Session log mentions adr-review and debate log(s) exist, "
+                    f"but none reference the staged ADR(s) {', '.join(sorted(adr_ids))}. "
+                    "Run /adr-review on the ADR(s) being committed; a stale or "
+                    "unrelated debate log is not evidence."
                 ),
             }
 
@@ -423,7 +467,7 @@ def _evaluate_adr_review(adr_changes: list[str], today: str) -> int:
         )
         return 2
 
-    evidence = check_adr_review_evidence(session_log, project_dir)
+    evidence = check_adr_review_evidence(session_log, project_dir, adr_changes)
 
     if not evidence["complete"]:
         print(

--- a/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
+++ b/.claude/hooks/PreToolUse/invoke_adr_review_guard.py
@@ -307,12 +307,16 @@ def _debate_references_adr(debate_path: Path, adr_ids: set[str]) -> bool:
     Content match, not mtime: a debate log checked out from another branch
     gets a fresh mtime but keeps its text, so only content ties evidence to
     the ADR actually being committed.
+
+    Uses word-boundary regex to avoid prefix collisions (ADR-6 matching ADR-62).
     """
     try:
         text = debate_path.read_text(encoding="utf-8", errors="replace").upper()
     except OSError:
         return False
-    return any(adr_id in text for adr_id in adr_ids)
+    return any(
+        re.search(rf"\b{re.escape(adr_id)}\b", text) for adr_id in adr_ids
+    )
 
 
 def check_adr_review_evidence(

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.91",
+  "version": "0.6.92",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -673,15 +673,15 @@ def _original_main(stdin_bytes):
         gets a fresh mtime but keeps its text, so only content ties evidence to
         the ADR actually being committed.
 
-        Uses word-boundary regex to avoid prefix collisions (ADR-6 matching ADR-62).
+        Tokenizes ADR ids out of the text and compares by equality, so a shorter
+        id (ADR-6) never matches inside a longer one (ADR-62).
         """
         try:
-            text = debate_path.read_text(encoding="utf-8", errors="replace").upper()
+            text = debate_path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             return False
-        return any(
-            re.search(rf"\b{re.escape(adr_id)}\b", text) for adr_id in adr_ids
-        )
+        referenced = {match.group(0).upper() for match in _ADR_ID_PATTERN.finditer(text)}
+        return bool(referenced & adr_ids)
 
 
     def check_adr_review_evidence(

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -427,6 +427,7 @@ def _original_main(stdin_bytes):
     from hook_utilities.guards import skip_if_consumer_repo  # noqa: E402
 
     _ADR_PATTERN = re.compile(r"(?:^|[\\/])ADR-\d+(?:-\w+)*\.md$", re.IGNORECASE)
+    _ADR_ID_PATTERN = re.compile(r"ADR-\d+", re.IGNORECASE)
     _CANONICAL_SOURCE_PATTERN = re.compile(r"SESSION-PROTOCOL\.md$", re.IGNORECASE)
     _FRONTMATTER_DELIM = "---"
     _NON_DECISION_FRONTMATTER_KEYS = frozenset({"implemented"})
@@ -655,11 +656,44 @@ def _original_main(stdin_bytes):
 
 
 
+    def _extract_adr_ids(paths: list[str]) -> set[str]:
+        """Extract normalized ADR identifiers (e.g. ``ADR-062``) from staged paths."""
+        ids: set[str] = set()
+        for path in paths:
+            match = _ADR_ID_PATTERN.search(Path(path).name)
+            if match:
+                ids.add(match.group(0).upper())
+        return ids
+
+
+    def _debate_references_adr(debate_path: Path, adr_ids: set[str]) -> bool:
+        """Return True when the debate artifact names at least one staged ADR id.
+
+        Content match, not mtime: a debate log checked out from another branch
+        gets a fresh mtime but keeps its text, so only content ties evidence to
+        the ADR actually being committed.
+
+        Uses word-boundary regex to avoid prefix collisions (ADR-6 matching ADR-62).
+        """
+        try:
+            text = debate_path.read_text(encoding="utf-8", errors="replace").upper()
+        except OSError:
+            return False
+        return any(
+            re.search(rf"\b{re.escape(adr_id)}\b", text) for adr_id in adr_ids
+        )
+
+
     def check_adr_review_evidence(
         session_log_path: Path,
         project_dir: str,
+        adr_changes: list[str] | None = None,
     ) -> dict[str, object]:
         """Check session log and artifacts for ADR review evidence.
+
+        When ``adr_changes`` names one or more ADR files, at least one debate log
+        must reference one of those ADR identifiers; a stale or unrelated
+        ``*debate*.md`` no longer counts as evidence (issue #3196, line 326).
 
         Returns dict with 'complete' (bool) and 'reason' or 'evidence' key.
         """
@@ -695,6 +729,20 @@ def _original_main(stdin_bytes):
                     "reason": (
                         "Session log mentions adr-review, but no debate "
                         f"log artifact found in {_AGENTS_DEBATE}"
+                    ),
+                }
+
+            adr_ids = _extract_adr_ids(adr_changes or [])
+            if adr_ids and not any(
+                _debate_references_adr(log, adr_ids) for log in debate_logs
+            ):
+                return {
+                    "complete": False,
+                    "reason": (
+                        "Session log mentions adr-review and debate log(s) exist, "
+                        f"but none reference the staged ADR(s) {', '.join(sorted(adr_ids))}. "
+                        "Run /adr-review on the ADR(s) being committed; a stale or "
+                        "unrelated debate log is not evidence."
                     ),
                 }
 
@@ -788,7 +836,7 @@ def _original_main(stdin_bytes):
             )
             return 2
 
-        evidence = check_adr_review_evidence(session_log, project_dir)
+        evidence = check_adr_review_evidence(session_log, project_dir, adr_changes)
 
         if not evidence["complete"]:
             print(

--- a/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
+++ b/src/copilot-cli/hooks/PreToolUse/invoke_adr_review_guard__Bash_gG_iI_tT_cC_oO_mM_mM_iI_tT_gG_iI_tT_cC_iI_g_ec29be.py
@@ -673,8 +673,8 @@ def _original_main(stdin_bytes):
         gets a fresh mtime but keeps its text, so only content ties evidence to
         the ADR actually being committed.
 
-        Tokenizes ADR ids out of the text and compares by equality, so a shorter
-        id (ADR-6) never matches inside a longer one (ADR-62).
+        Tokenizes whole ADR ids out of the text and compares them by equality, so
+        a shorter id never matches as a substring inside a longer one.
         """
         try:
             text = debate_path.read_text(encoding="utf-8", errors="replace")
@@ -692,8 +692,8 @@ def _original_main(stdin_bytes):
         """Check session log and artifacts for ADR review evidence.
 
         When ``adr_changes`` names one or more ADR files, at least one debate log
-        must reference one of those ADR identifiers; a stale or unrelated
-        ``*debate*.md`` no longer counts as evidence (issue #3196, line 326).
+        must reference one of those ADR identifiers; a stale or unrelated debate
+        artifact no longer counts as evidence (issue #3196).
 
         Returns dict with 'complete' (bool) and 'reason' or 'evidence' key.
         """

--- a/tests/test_invoke_adr_review_guard.py
+++ b/tests/test_invoke_adr_review_guard.py
@@ -311,6 +311,72 @@ class TestTestADRReviewEvidence:
         result = check_adr_review_evidence(log_file, str(tmp_path))
         assert result["complete"] is True
 
+    def test_incomplete_when_debate_log_unrelated_to_staged_adr(
+        self, tmp_path: Path
+    ) -> None:
+        log_file = tmp_path / "session.json"
+        log_file.write_text("/adr-review was run", encoding="utf-8")
+
+        analysis_dir = tmp_path / ".agents" / "analysis"
+        analysis_dir.mkdir(parents=True)
+        (analysis_dir / "adr-042-debate.md").write_text(
+            "Debate over ADR-042 retention policy", encoding="utf-8"
+        )
+
+        result = check_adr_review_evidence(
+            log_file, str(tmp_path), ["docs/architecture/ADR-062-navigation.md"]
+        )
+        assert result["complete"] is False
+        assert "ADR-062" in str(result["reason"])
+
+    def test_complete_when_debate_log_references_staged_adr(
+        self, tmp_path: Path
+    ) -> None:
+        log_file = tmp_path / "session.json"
+        log_file.write_text("/adr-review was run", encoding="utf-8")
+
+        analysis_dir = tmp_path / ".agents" / "analysis"
+        analysis_dir.mkdir(parents=True)
+        (analysis_dir / "adr-062-debate.md").write_text(
+            "6-agent debate on ADR-062 navigation", encoding="utf-8"
+        )
+
+        result = check_adr_review_evidence(
+            log_file, str(tmp_path), ["docs/architecture/ADR-062-navigation.md"]
+        )
+        assert result["complete"] is True
+
+    def test_complete_when_any_debate_log_references_staged_adr(
+        self, tmp_path: Path
+    ) -> None:
+        log_file = tmp_path / "session.json"
+        log_file.write_text("/adr-review was run", encoding="utf-8")
+
+        analysis_dir = tmp_path / ".agents" / "analysis"
+        analysis_dir.mkdir(parents=True)
+        (analysis_dir / "old-debate.md").write_text("ADR-001", encoding="utf-8")
+        (analysis_dir / "new-debate.md").write_text("ADR-062", encoding="utf-8")
+
+        result = check_adr_review_evidence(
+            log_file, str(tmp_path), ["docs/architecture/ADR-062-navigation.md"]
+        )
+        assert result["complete"] is True
+
+    def test_complete_lenient_when_staged_change_has_no_adr_id(
+        self, tmp_path: Path
+    ) -> None:
+        log_file = tmp_path / "session.json"
+        log_file.write_text("/adr-review was run", encoding="utf-8")
+
+        analysis_dir = tmp_path / ".agents" / "analysis"
+        analysis_dir.mkdir(parents=True)
+        (analysis_dir / "debate.md").write_text("some debate", encoding="utf-8")
+
+        result = check_adr_review_evidence(
+            log_file, str(tmp_path), [".agents/SESSION-PROTOCOL.md"]
+        )
+        assert result["complete"] is True
+
 
 class TestMainAllowPath:
     @patch("invoke_adr_review_guard.sys.stdin")


### PR DESCRIPTION
## Summary

`invoke_adr_review_guard.py` blocks commits that stage ADR changes unless the session shows adr-review evidence. The evidence check accepted any debate artifact in the analysis directory, so a stale debate log from another branch or months ago passed the gate. Issue #3196 names this as a known weakness.

## Change

`check_adr_review_evidence` now ties the evidence to the ADR actually being committed:

- Threads the staged ADR paths into the check.
- Requires at least one debate log to reference an ADR identifier (for example ADR-062) that is staged, matched by content so it survives a cross-branch checkout where mtime resets.
- Extracts the ADR id from the basename only, so a directory prefix like `docs/ADR-041-archive/` cannot shadow the real ADR filename.
- Falls back to the prior lenient behavior when the staged change carries no ADR-NNN id (canonical-source-only, such as the session protocol doc), to avoid over-blocking.

The vendored Copilot shim is regenerated in lockstep so the Validate Generated Files gate stays green.

## Why now

This guard runs on this repo's own ADR commits (dogfood). A weak guard is false confidence. The fix hardens the live gate and carries forward the correctness logic the eventual lefthook port will need.

## Tests

Added positive, negative, multi-log, and lenient-fallback cases. Full guard suites green (39 in the primary file, 145 across related suites), ruff and mypy clean.

Refs #3196
