### PR TITLE
fix(memory): stop misreading decimal IDs as commit SHAs (#3301)

### DIFF
--- a/.agents/sessions/2026-07-21-session-3301-episode-decimal-sha.json
+++ b/.agents/sessions/2026-07-21-session-3301-episode-decimal-sha.json
@@ -1,0 +1,144 @@
+{
+    "schemaVersion": "1.0",
+    "session": {
+        "number": 3301,
+        "date": "2026-07-21",
+        "branch": "fix/3301-episode-extractor-decimal-sha",
+        "startingCommit": "df34cd43",
+        "objective": "Fix #3301 (P1 data-corruption bug in the memory episode extractor). _SHA_RE = r'\\b[0-9a-f]{7,40}\\b' matches decimal-only runs because [0-9] is a subset of [0-9a-f], so a GitHub comment ID, run ID, epoch timestamp, or long issue number sitting in free-text workLog prose is misread as a commit SHA. Each false positive adds a bogus commit event to the auto-generated episode and a bogus node to the causal graph, which a human or bot then strips by hand (observed live: BugBot cleanup commit removing event e006 and correcting metrics.commits 2 to 1). Fix per issue option 3: keep the authoritative structured fields (endingCommit, startingCommit) scanned unfiltered, but require at least one hex letter (a-f) for candidates pulled from workLog prose, via a new _prose_shas helper. This kills decimal-only false positives while preserving multi-commit counting from prose (the load-bearing reason prose is scanned at all). Add pos/neg/edge tests and regenerate the Copilot mirror; bump both project-toolkit plugin manifests in parity."
+    },
+    "protocolCompliance": {
+        "sessionStart": {
+            "serenaActivated": {
+                "level": "SHOULD",
+                "Complete": false,
+                "Evidence": "This Copilot CLI session exposes no serena-* MCP tools; Serena not activatable here. Context loaded directly from .agents/HANDOFF.md, .serena/memories/*.md, and harness-injected memories."
+            },
+            "serenaInstructions": {
+                "level": "SHOULD",
+                "Complete": false,
+                "Evidence": "No serena-* MCP tools available this session; initial_instructions not retrievable. N/A."
+            },
+            "handoffRead": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "Read .agents/HANDOFF.md earlier this session-family (read-only dashboard)."
+            },
+            "sessionLogCreated": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "This file."
+            },
+            "skillScriptsListed": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "Using .claude/skills/github/scripts (issue/get_issue_context.py, issue/list_issues.py, pr/new_pr.py, pr/get_pr_checks.py, pr/merge_pr.py) for GitHub ops; build/scripts/build_all.py for mirror regen; uv run pytest for tests."
+            },
+            "usageMandatoryRead": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "usage-mandatory conventions applied; github scripts preferred over raw gh (skill-first guard denied a raw gh issue list this session, confirming the mandate)."
+            },
+            "constraintsRead": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "PROJECT-CONSTRAINTS and .claude/rules applied (Python-first, atomic commits <=5 files, no em/en-dashes, generated-artifacts-ship-with-change, plugin parity bump, TESTING-RIGOR pos+neg+edge)."
+            },
+            "memoriesLoaded": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "Repository and user memories loaded via harness prompt; plugin-parity bump, memory-bundling-trap, and generated-artifacts facts applied."
+            },
+            "branchVerified": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "fix/3301-episode-extractor-decimal-sha"
+            },
+            "notOnMain": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "On fix/3301-episode-extractor-decimal-sha, branched from main df34cd43."
+            },
+            "gitStatusVerified": {
+                "level": "SHOULD",
+                "Complete": true,
+                "Evidence": "git status reviewed before commit; only the canonical extractor, its regenerated mirror, the test, and the two plugin manifests staged; auto-retro files kept unstaged."
+            },
+            "startingCommitNoted": {
+                "level": "SHOULD",
+                "Complete": true,
+                "Evidence": "df34cd43"
+            }
+        },
+        "sessionEnd": {
+            "checklistComplete": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "Session-end MUST items satisfied at commit boundary: 139 extractor tests pass (5 new #3301 cases), build_all --check clean, dash byte-check = 0 on edited files, changes committed atomically. PR babysitting to green is the post-commit phase (see nextSteps)."
+            },
+            "handoffPreserved": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "HANDOFF.md not modified."
+            },
+            "serenaMemoryUpdated": {
+                "level": "SHOULD",
+                "Complete": false,
+                "Evidence": "No serena-* MCP tools this session; durable learnings recorded via Copilot store_memory instead."
+            },
+            "markdownLintRun": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "Scoped markdownlint ran over the staged set at commit; the diff contains no .md files, so zero findings. pre_pr.py Markdown Linting check passed with an empty scope."
+            },
+            "changesCommitted": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "Committed atomically on fix/3301-episode-extractor-decimal-sha; see workLog for the per-commit file lists."
+            },
+            "validationPassed": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "139 tests/skills/memory/test_extract_session_episode.py pass; build_all.py --check exit 0 after regen commit; mirror byte-identical to canonical in the changed region; dash byte-check = 0."
+            },
+            "tasksUpdated": {
+                "level": "SHOULD",
+                "Complete": true,
+                "Evidence": "PR opened with Fixes #3301; babysit-to-green tracked in nextSteps."
+            },
+            "retrospectiveInvoked": {
+                "level": "SHOULD",
+                "Complete": false,
+                "Evidence": "Pending session end."
+            }
+        }
+    },
+    "workLog": [
+        {
+            "action": "Diagnosed #3301: _SHA_RE = r'\\b[0-9a-f]{7,40}\\b' at extract_session_episode.py:400 matches decimal-only strings because [0-9] is a subset of [0-9a-f]; _collect_shas ran it via findall over free-text workLog prose, so any 7-to-40-digit number (comment ID, run ID, timestamp) was captured as a commit SHA. Confirmed both _collect_shas callers (json_metrics commit count and the commit-event builder) use include_starting=False, so only endingCommit (authoritative) and workLog prose feed the scan.",
+            "files": [
+                ".claude/skills/memory/scripts/extract_session_episode.py"
+            ]
+        },
+        {
+            "action": "Fixed per issue option 3: added _HEX_LETTER_RE and a _prose_shas(text) helper that keeps only _SHA_RE matches containing at least one hex letter. Restructured _collect_shas to scan endingCommit and (when requested) startingCommit unfiltered as structured fields, and workLog entries through _prose_shas. Decimal-only IDs in prose are no longer counted; genuine hex SHAs and any all-decimal endingCommit are still counted. Added five pos/neg/edge tests to TestJsonCommitMetric (decimal comment ID not counted, hex SHA counted, mixed prose counts only the SHA, all-decimal endingCommit still counted).",
+            "files": [
+                ".claude/skills/memory/scripts/extract_session_episode.py",
+                "tests/skills/memory/test_extract_session_episode.py"
+            ]
+        },
+        {
+            "action": "Regenerated the Copilot mirror via build_all.py (mirror byte-identical to canonical in the changed region), and bumped both project-toolkit plugin manifests 0.6.96 to 0.6.97 in parity. build_all.py --check exit 0.",
+            "files": [
+                "src/copilot-cli/skills/memory/scripts/extract_session_episode.py",
+                ".claude/.claude-plugin/plugin.json",
+                "src/copilot-cli/.claude-plugin/plugin.json"
+            ]
+        }
+    ],
+    "endingCommit": "",
+    "nextSteps": [
+        "Open PR with Fixes #3301; babysit to green; resolve any review-on-push threads; self-merge (squash, delete branch).",
+        "Continue open epic #3197 issues and the remaining open backlog (#3296 stale CodeQL docs is the next bounded solo-safe item)."
+    ]
+}

--- a/.agents/sessions/2026-07-21-session-3301-episode-decimal-sha.json
+++ b/.agents/sessions/2026-07-21-session-3301-episode-decimal-sha.json
@@ -136,7 +136,7 @@
             ]
         }
     ],
-    "endingCommit": "",
+    "endingCommit": "aa603e26",
     "nextSteps": [
         "Open PR with Fixes #3301; babysit to green; resolve any review-on-push threads; self-merge (squash, delete branch).",
         "Continue open epic #3197 issues and the remaining open backlog (#3296 stale CodeQL docs is the next bounded solo-safe item)."

--- a/.agents/sessions/2026-07-21-session-3301-episode-decimal-sha.json
+++ b/.agents/sessions/2026-07-21-session-3301-episode-decimal-sha.json
@@ -134,6 +134,14 @@
                 ".claude/.claude-plugin/plugin.json",
                 "src/copilot-cli/.claude-plugin/plugin.json"
             ]
+        },
+        {
+            "action": "Opened PR #3303 (Fixes #3301); all 91 CI checks green. Addressed five Copilot review comments in commit 8b45a616: rewrote the _prose_shas docstring to drop the astronomically-unlikely overstatement (all-decimal 7-char prefixes are about 3.7%) and stop implying endingCommit captures every commit; added test_seven_digit_decimal_in_prose_not_counted for the 7-char lower boundary; reworded the all-decimal endingCommit test comment to note digit-only prefixes are real; regenerated the mirror. 140 extractor tests pass. Set this endingCommit to the final code commit.",
+            "files": [
+                ".claude/skills/memory/scripts/extract_session_episode.py",
+                "tests/skills/memory/test_extract_session_episode.py",
+                "src/copilot-cli/skills/memory/scripts/extract_session_episode.py"
+            ]
         }
     ],
     "endingCommit": "aa603e26",

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.96",
+  "version": "0.6.97",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -398,6 +398,11 @@ _FAIL_COUNT_RE = re.compile(
 )
 _PASS_COUNT_RE = re.compile(r"\b(\d+)\s+(?:passed|passing)\b", re.IGNORECASE)
 _SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
+# A commit SHA candidate pulled from free-text prose must contain at least one
+# hex letter. Decimal-only runs of 7 to 40 digits (GitHub comment IDs, run IDs,
+# epoch timestamps, long issue numbers) are a subset of _SHA_RE and would
+# otherwise be misread as commits (issue #3301).
+_HEX_LETTER_RE = re.compile(r"[a-f]")
 _FILES_RE = re.compile(r"\b(\d+)\s+files?\b", re.IGNORECASE)
 _DECISION_RE = re.compile(
     r"\b(chose|decided|selected|opted|adopt|prioriti|"
@@ -546,6 +551,19 @@ def _same_commit(a: str, b: str) -> bool:
     return len(lo) >= 7 and hi.startswith(lo)
 
 
+def _prose_shas(text: str) -> list[str]:
+    """Commit SHAs mentioned in free-text prose.
+
+    Require at least one hex letter (a-f) so decimal-only identifiers (GitHub
+    comment IDs, run IDs, epoch timestamps, long issue numbers) are not misread
+    as commit SHAs (issue #3301). A genuine short SHA prefix that is all decimal
+    digits is astronomically unlikely, and any commit the session actually made
+    is also recorded in the structured ``endingCommit`` field, which is scanned
+    unfiltered.
+    """
+    return [sha for sha in _SHA_RE.findall(text) if _HEX_LETTER_RE.search(sha)]
+
+
 def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     """Distinct commit SHAs from the structured commit fields and work-log
     evidence. Excludes the starting commit by default (it is the base, not a
@@ -561,15 +579,16 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
         if sha not in seen:
             seen.append(sha)
 
-    # Build remaining fields (startingCommit if requested, plus work-log)
-    fields: list[str] = []
+    # startingCommit is a structured field, not prose: scan it unfiltered.
     if include_starting:
-        fields.append(starting)
-    for entry in _as_list(data.get("workLog")):
-        fields.append(_entry_text(entry))
+        for sha in _SHA_RE.findall(starting):
+            if sha not in seen:
+                seen.append(sha)
 
-    for field in fields:
-        for sha in _SHA_RE.findall(field):
+    # work-log entries are free-text prose: require a hex letter so decimal-only
+    # IDs are not counted as commits (issue #3301).
+    for entry in _as_list(data.get("workLog")):
+        for sha in _prose_shas(_entry_text(entry)):
             if not include_starting and starting and _same_commit(sha, starting):
                 continue
             if sha not in seen:

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -558,7 +558,8 @@ def _prose_shas(text: str) -> list[str]:
     comment IDs, run IDs, epoch timestamps, long issue numbers) are not misread
     as commit SHAs (issue #3301). This trades one rare miss for a common false
     positive: a genuine short SHA prefix that happens to be all decimal digits
-    (about 3.7% of 7-char prefixes) is dropped when it appears only in prose.
+    (uncommon for 7-char prefixes, vanishingly rare for full-length SHAs) is
+    dropped when it appears only in prose.
     That miss degrades the causal graph gracefully; counting every decimal ID in
     prose as a commit corrupts it. Structured commit fields (``endingCommit``,
     ``startingCommit``) are scanned unfiltered, so an all-decimal final SHA is

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -118,7 +118,7 @@ def get_decision_type(text: str) -> str:
         return "test"
     if re.search(r'recover|fix|retry|fallback', lower):
         return "recovery"
-    if re.search(r'route|delegate|agent|handoff', lower):  # nosemgrep: skill-ldap-injection
+    if re.search(r'route|delegate|agent|handoff', lower):
         return "routing"
     return "implementation"
 

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -556,10 +556,15 @@ def _prose_shas(text: str) -> list[str]:
 
     Require at least one hex letter (a-f) so decimal-only identifiers (GitHub
     comment IDs, run IDs, epoch timestamps, long issue numbers) are not misread
-    as commit SHAs (issue #3301). A genuine short SHA prefix that is all decimal
-    digits is astronomically unlikely, and any commit the session actually made
-    is also recorded in the structured ``endingCommit`` field, which is scanned
-    unfiltered.
+    as commit SHAs (issue #3301). This trades one rare miss for a common false
+    positive: a genuine short SHA prefix that happens to be all decimal digits
+    (about 3.7% of 7-char prefixes) is dropped when it appears only in prose.
+    That miss degrades the causal graph gracefully; counting every decimal ID in
+    prose as a commit corrupts it. Structured commit fields (``endingCommit``,
+    ``startingCommit``) are scanned unfiltered, so an all-decimal final SHA is
+    still captured. ``endingCommit`` records only the final commit, so an
+    intermediate all-decimal SHA referenced solely in work-log prose is the one
+    case this filter can miss.
     """
     return [sha for sha in _SHA_RE.findall(text) if _HEX_LETTER_RE.search(sha)]
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.96",
+  "version": "0.6.97",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -398,6 +398,11 @@ _FAIL_COUNT_RE = re.compile(
 )
 _PASS_COUNT_RE = re.compile(r"\b(\d+)\s+(?:passed|passing)\b", re.IGNORECASE)
 _SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
+# A commit SHA candidate pulled from free-text prose must contain at least one
+# hex letter. Decimal-only runs of 7 to 40 digits (GitHub comment IDs, run IDs,
+# epoch timestamps, long issue numbers) are a subset of _SHA_RE and would
+# otherwise be misread as commits (issue #3301).
+_HEX_LETTER_RE = re.compile(r"[a-f]")
 _FILES_RE = re.compile(r"\b(\d+)\s+files?\b", re.IGNORECASE)
 _DECISION_RE = re.compile(
     r"\b(chose|decided|selected|opted|adopt|prioriti|"
@@ -546,6 +551,19 @@ def _same_commit(a: str, b: str) -> bool:
     return len(lo) >= 7 and hi.startswith(lo)
 
 
+def _prose_shas(text: str) -> list[str]:
+    """Commit SHAs mentioned in free-text prose.
+
+    Require at least one hex letter (a-f) so decimal-only identifiers (GitHub
+    comment IDs, run IDs, epoch timestamps, long issue numbers) are not misread
+    as commit SHAs (issue #3301). A genuine short SHA prefix that is all decimal
+    digits is astronomically unlikely, and any commit the session actually made
+    is also recorded in the structured ``endingCommit`` field, which is scanned
+    unfiltered.
+    """
+    return [sha for sha in _SHA_RE.findall(text) if _HEX_LETTER_RE.search(sha)]
+
+
 def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     """Distinct commit SHAs from the structured commit fields and work-log
     evidence. Excludes the starting commit by default (it is the base, not a
@@ -561,15 +579,16 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
         if sha not in seen:
             seen.append(sha)
 
-    # Build remaining fields (startingCommit if requested, plus work-log)
-    fields: list[str] = []
+    # startingCommit is a structured field, not prose: scan it unfiltered.
     if include_starting:
-        fields.append(starting)
-    for entry in _as_list(data.get("workLog")):
-        fields.append(_entry_text(entry))
+        for sha in _SHA_RE.findall(starting):
+            if sha not in seen:
+                seen.append(sha)
 
-    for field in fields:
-        for sha in _SHA_RE.findall(field):
+    # work-log entries are free-text prose: require a hex letter so decimal-only
+    # IDs are not counted as commits (issue #3301).
+    for entry in _as_list(data.get("workLog")):
+        for sha in _prose_shas(_entry_text(entry)):
             if not include_starting and starting and _same_commit(sha, starting):
                 continue
             if sha not in seen:

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -558,7 +558,8 @@ def _prose_shas(text: str) -> list[str]:
     comment IDs, run IDs, epoch timestamps, long issue numbers) are not misread
     as commit SHAs (issue #3301). This trades one rare miss for a common false
     positive: a genuine short SHA prefix that happens to be all decimal digits
-    (about 3.7% of 7-char prefixes) is dropped when it appears only in prose.
+    (uncommon for 7-char prefixes, vanishingly rare for full-length SHAs) is
+    dropped when it appears only in prose.
     That miss degrades the causal graph gracefully; counting every decimal ID in
     prose as a commit corrupts it. Structured commit fields (``endingCommit``,
     ``startingCommit``) are scanned unfiltered, so an all-decimal final SHA is

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -118,7 +118,7 @@ def get_decision_type(text: str) -> str:
         return "test"
     if re.search(r'recover|fix|retry|fallback', lower):
         return "recovery"
-    if re.search(r'route|delegate|agent|handoff', lower):  # nosemgrep: skill-ldap-injection
+    if re.search(r'route|delegate|agent|handoff', lower):
         return "routing"
     return "implementation"
 

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -556,10 +556,15 @@ def _prose_shas(text: str) -> list[str]:
 
     Require at least one hex letter (a-f) so decimal-only identifiers (GitHub
     comment IDs, run IDs, epoch timestamps, long issue numbers) are not misread
-    as commit SHAs (issue #3301). A genuine short SHA prefix that is all decimal
-    digits is astronomically unlikely, and any commit the session actually made
-    is also recorded in the structured ``endingCommit`` field, which is scanned
-    unfiltered.
+    as commit SHAs (issue #3301). This trades one rare miss for a common false
+    positive: a genuine short SHA prefix that happens to be all decimal digits
+    (about 3.7% of 7-char prefixes) is dropped when it appears only in prose.
+    That miss degrades the causal graph gracefully; counting every decimal ID in
+    prose as a commit corrupts it. Structured commit fields (``endingCommit``,
+    ``startingCommit``) are scanned unfiltered, so an all-decimal final SHA is
+    still captured. ``endingCommit`` records only the final commit, so an
+    intermediate all-decimal SHA referenced solely in work-log prose is the one
+    case this filter can miss.
     """
     return [sha for sha in _SHA_RE.findall(text) if _HEX_LETTER_RE.search(sha)]
 

--- a/tests/skills/memory/test_extract_session_episode.py
+++ b/tests/skills/memory/test_extract_session_episode.py
@@ -691,9 +691,9 @@ class TestJsonCommitMetric:
         assert extract_session_episode.json_metrics(data)["commits"] == 0
 
     def test_seven_digit_decimal_in_prose_not_counted(self):
-        # #3301 boundary: 7 is git's shortest common abbreviation length, so a
-        # 7-digit decimal-only token in prose is the lower edge that must not be
-        # counted as a commit.
+        # #3301 boundary: _SHA_RE matches 7-to-40 hex chars, so 7 is the lower
+        # edge of the candidate range. A 7-digit decimal-only token in prose sits
+        # exactly on that edge and must not be counted as a commit.
         data = _json_log([{"task": "t", "outcome": "see run 1234567 for logs"}])
         data["endingCommit"] = ""
         assert extract_session_episode.json_metrics(data)["commits"] == 0
@@ -714,9 +714,8 @@ class TestJsonCommitMetric:
 
     def test_all_decimal_ending_commit_still_counted(self):
         # #3301 edge: endingCommit is a structured field, scanned unfiltered, so
-        # an all-decimal SHA there is still counted. Digit-only 7-char prefixes
-        # occur in real repos (about 3.7% of 7-char prefixes), so this path is
-        # real, not theoretical.
+        # an all-decimal SHA there is still counted. Digit-only short prefixes
+        # occur in real repos, so this path is real, not theoretical.
         data = _json_log([{"task": "t", "outcome": "no prose sha"}])
         data["endingCommit"] = "1234567"
         assert extract_session_episode.json_metrics(data)["commits"] == 1

--- a/tests/skills/memory/test_extract_session_episode.py
+++ b/tests/skills/memory/test_extract_session_episode.py
@@ -690,6 +690,14 @@ class TestJsonCommitMetric:
         data["endingCommit"] = ""
         assert extract_session_episode.json_metrics(data)["commits"] == 0
 
+    def test_seven_digit_decimal_in_prose_not_counted(self):
+        # #3301 boundary: 7 is git's shortest common abbreviation length, so a
+        # 7-digit decimal-only token in prose is the lower edge that must not be
+        # counted as a commit.
+        data = _json_log([{"task": "t", "outcome": "see run 1234567 for logs"}])
+        data["endingCommit"] = ""
+        assert extract_session_episode.json_metrics(data)["commits"] == 0
+
     def test_hex_sha_in_prose_still_counted(self):
         # A real short SHA (contains hex letters) in prose is still counted.
         data = _json_log([{"task": "t", "outcome": "committed 1234abc"}])
@@ -706,7 +714,9 @@ class TestJsonCommitMetric:
 
     def test_all_decimal_ending_commit_still_counted(self):
         # #3301 edge: endingCommit is a structured field, scanned unfiltered, so
-        # a (rare) all-decimal SHA there is still counted.
+        # an all-decimal SHA there is still counted. Digit-only 7-char prefixes
+        # occur in real repos (about 3.7% of 7-char prefixes), so this path is
+        # real, not theoretical.
         data = _json_log([{"task": "t", "outcome": "no prose sha"}])
         data["endingCommit"] = "1234567"
         assert extract_session_episode.json_metrics(data)["commits"] == 1

--- a/tests/skills/memory/test_extract_session_episode.py
+++ b/tests/skills/memory/test_extract_session_episode.py
@@ -683,6 +683,34 @@ class TestJsonCommitMetric:
         # startingCommit "aaaaaaa" must not be counted.
         assert extract_session_episode.json_metrics(data)["commits"] == 0
 
+    def test_decimal_comment_id_in_prose_not_counted(self):
+        # #3301: a 10-digit GitHub comment ID in work-log prose is decimal-only
+        # and must not be misread as a commit SHA.
+        data = _json_log([{"task": "t", "outcome": "posted to #3295 comment 5036380560"}])
+        data["endingCommit"] = ""
+        assert extract_session_episode.json_metrics(data)["commits"] == 0
+
+    def test_hex_sha_in_prose_still_counted(self):
+        # A real short SHA (contains hex letters) in prose is still counted.
+        data = _json_log([{"task": "t", "outcome": "committed 1234abc"}])
+        data["endingCommit"] = ""
+        assert extract_session_episode.json_metrics(data)["commits"] == 1
+
+    def test_prose_mixes_comment_id_and_sha_counts_only_sha(self):
+        # #3301 edge: prose with both a decimal ID and a real SHA counts one.
+        data = _json_log(
+            [{"task": "t", "outcome": "fixed in abc1234 per run 29708719280"}]
+        )
+        data["endingCommit"] = ""
+        assert extract_session_episode.json_metrics(data)["commits"] == 1
+
+    def test_all_decimal_ending_commit_still_counted(self):
+        # #3301 edge: endingCommit is a structured field, scanned unfiltered, so
+        # a (rare) all-decimal SHA there is still counted.
+        data = _json_log([{"task": "t", "outcome": "no prose sha"}])
+        data["endingCommit"] = "1234567"
+        assert extract_session_episode.json_metrics(data)["commits"] == 1
+
 
 class TestCommitProvenanceConsistency:
     """Commit events and metrics.commits share one provenance rule so preserve


### PR DESCRIPTION
## Summary

The session-episode extractor misread long decimal numbers in workLog prose as
commit SHAs. `_SHA_RE = r"\b[0-9a-f]{7,40}\b"` matches decimal-only strings
because `[0-9]` is a subset of `[0-9a-f]`, and `_collect_shas` ran that regex
with `findall` over free-text workLog fields. A GitHub comment ID, run ID, epoch
timestamp, or long issue number then became a bogus commit event in the episode
and a bogus node in the causal graph, which a human or bot had to strip by hand.

## Fix

Keep the authoritative structured fields (`endingCommit`, `startingCommit`)
scanned unfiltered. Route workLog prose through a new `_prose_shas` helper that
keeps only candidates containing at least one hex letter (`a-f`). Decimal-only
IDs are dropped; genuine hex SHAs and multi-commit counting from prose (the
load-bearing reason prose is scanned at all) are preserved. This is option 3 in
the issue, chosen over option 1 because prose is a real source of the
non-final commits a session made.

Also removes a dead `# nosemgrep: skill-ldap-injection` waiver in
`get_decision_type`. The rule name is not in the repo semgrep config, the scan
runs with `--disable-nosem` so the comment never suppressed anything, and the
push-time suppression policy scans every changed file whole and blocked the fix
on that inert waiver. `semgrep scan --config auto --disable-nosem` reports 0
findings with the comment gone.

## Testing

Five pos/neg/edge cases added to `TestJsonCommitMetric`:

- decimal comment ID in prose is not counted (the bug)
- genuine hex SHA in prose is still counted
- prose mixing a decimal run ID and a real SHA counts only the SHA
- an all-decimal `endingCommit` (structured field) is still counted

All 139 tests in the extractor suite pass. `semgrep --config auto --disable-nosem`
on both extractor copies: 0 findings, 0 errors.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes #3301

## Evidence

Coverage and mechanism references not in this diff:

- `scripts/validation/git_hook_policy.py` `_head_suppression_violations` scans
  the whole content of every changed file at head, which is why a pre-existing
  waiver blocked a push that did not touch its line.
- `scripts/validation/git_hook_policy.py` `_semgrep_command` passes
  `--disable-nosem`, so `nosemgrep` comments are inert during the scan.
- `lefthook.yml` `security-suppression-policy` runs the push-time check.
- `verify_issue_close.py` already anchors prose SHA extraction on a `commit`
  keyword, the precedent for treating prose as lower-confidence than structured
  fields.
