### PR TITLE
docs(codeql): rewrite reference docs for Python two-tier reality (#3296)

### DIFF
--- a/.agents/sessions/2026-07-21-session-3296-codeql-docs-python-two-tier.json
+++ b/.agents/sessions/2026-07-21-session-3296-codeql-docs-python-two-tier.json
@@ -135,7 +135,7 @@
             ]
         }
     ],
-    "endingCommit": "8cb988f6",
+    "endingCommit": "8e48ac37",
     "nextSteps": [
         "Open PR with Fixes #3296; babysit to green; resolve any review-on-push threads; self-merge (squash, delete branch).",
         "Continue the remaining open backlog; most survivors are design-heavy/governance (delegate ADR work to a Sol worktree) or anti-churn cleanups the user warned against. Do not auto-close epic #3197; #3219 is deferred build-on-demand."

--- a/.agents/sessions/2026-07-21-session-3296-codeql-docs-python-two-tier.json
+++ b/.agents/sessions/2026-07-21-session-3296-codeql-docs-python-two-tier.json
@@ -1,0 +1,143 @@
+{
+    "schemaVersion": "1.0",
+    "session": {
+        "number": 3296,
+        "date": "2026-07-21",
+        "branch": "docs/3296-codeql-python-two-tier",
+        "startingCommit": "1204b17c",
+        "objective": "Fix #3296 (P2 doc-only): overhaul the three CodeQL reference docs (docs/codeql-architecture.md, docs/codeql-integration.md, docs/codeql-rollout-checklist.md) so they match the shipping implementation. Two staleness axes: the implementation moved from PowerShell to Python (ADR-042 migration), and the CodeQL strategy dropped from three tiers to two after the ADR-041 amendment (2026-07-21) retired the unused automatic PostToolUse quick-scan hook. The docs still described the deleted hook, PowerShell script names, Pester tests, PSScriptAnalyzer, and a three-tier model. Rewrite all three to the Python two-tier reality: Tier 1 the codeql-analysis.yml CI gate (native CodeQL action, actions+python matrix, security-extended, Medium+), Tier 2 the on-demand codeql-scan skill. Document both invoke_codeql_scan.py wrappers with their real flags (the core .codeql/scripts one with --quick-scan, and the skill wrapper with --operation full/quick/validate), correct config paths to .github/codeql/, replace superseded ADR-005 with ADR-042, and remove the staleness banners. No em/en dashes."
+    },
+    "protocolCompliance": {
+        "sessionStart": {
+            "serenaActivated": {
+                "level": "SHOULD",
+                "Complete": false,
+                "Evidence": "This Copilot CLI session exposes no serena-* MCP tools; Serena not activatable here. Context loaded directly from .agents/HANDOFF.md, .serena/memories/*.md, and harness-injected memories."
+            },
+            "serenaInstructions": {
+                "level": "SHOULD",
+                "Complete": false,
+                "Evidence": "No serena-* MCP tools available this session; initial_instructions not retrievable. N/A."
+            },
+            "handoffRead": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "Read .agents/HANDOFF.md earlier this session-family (read-only dashboard)."
+            },
+            "sessionLogCreated": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "This file."
+            },
+            "skillScriptsListed": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "Using .claude/skills/github/scripts (issue/list_issues.py, issue/get_issue_context.py, pr/new_pr.py, pr/validate_pr_description.py, pr/get_pr_checks.py, pr/get_unresolved_review_threads.py, pr/add_pr_review_thread_reply.py, pr/wait_for_unresolved_zero.py, pr/test_pr_merge_ready.py, pr/merge_pr.py) for GitHub ops."
+            },
+            "usageMandatoryRead": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "usage-mandatory conventions applied; github scripts preferred over raw gh (list_issues.py used for backlog triage)."
+            },
+            "constraintsRead": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "PROJECT-CONSTRAINTS and .claude/rules applied (atomic commits <=5 files, no em/en-dashes, docs-only so no plugin parity bump needed, no fabricated flags: every documented CLI verified against the real script --help)."
+            },
+            "memoriesLoaded": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "Repository and user memories loaded via harness prompt; pr_description sheltering, dash byte-check, and Cursor-Agent concurrent-push facts applied."
+            },
+            "branchVerified": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "docs/3296-codeql-python-two-tier"
+            },
+            "notOnMain": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "On docs/3296-codeql-python-two-tier, branched from synced main 1204b17c."
+            },
+            "gitStatusVerified": {
+                "level": "SHOULD",
+                "Complete": true,
+                "Evidence": "git status reviewed before commit; only the three rewritten docs staged; auto-retro files kept unstaged."
+            },
+            "startingCommitNoted": {
+                "level": "SHOULD",
+                "Complete": true,
+                "Evidence": "1204b17c"
+            }
+        },
+        "sessionEnd": {
+            "checklistComplete": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "Session-end MUST items satisfied at commit boundary: scoped markdownlint 0 errors on the three docs, dash byte-check = 0, all relative links and referenced script/config/workflow paths resolve, both invoke_codeql_scan.py wrapper CLIs verified against --help, changes committed atomically. PR babysitting to green is the post-commit phase (see nextSteps)."
+            },
+            "handoffPreserved": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "HANDOFF.md not modified."
+            },
+            "serenaMemoryUpdated": {
+                "level": "SHOULD",
+                "Complete": false,
+                "Evidence": "No serena-* MCP tools this session; durable learnings recorded via Copilot store_memory instead."
+            },
+            "markdownLintRun": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "markdownlint-cli2 v0.21.0 ran over the three rewritten docs: Summary 0 error(s)."
+            },
+            "changesCommitted": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "Committed atomically on docs/3296-codeql-python-two-tier; docs rewrite in one commit (3 files), session log committed last."
+            },
+            "validationPassed": {
+                "level": "MUST",
+                "Complete": true,
+                "Evidence": "Independent verification: grep for PowerShell script names/.ps1/Pester/PSScriptAnalyzer/pwsh returns zero implementation refs; grep for Tier 3/three-tier/invoke_codeql_quick_scan/PostToolUse returns zero; dash byte-check = 0; markdownlint 0 errors; Tier 1 language matrix confirmed [actions, python]; both wrapper CLIs verified via --help; all relative links resolve."
+            },
+            "tasksUpdated": {
+                "level": "SHOULD",
+                "Complete": true,
+                "Evidence": "PR opened with Fixes #3296; babysit-to-green tracked in nextSteps."
+            },
+            "retrospectiveInvoked": {
+                "level": "SHOULD",
+                "Complete": false,
+                "Evidence": "Pending session end."
+            }
+        }
+    },
+    "workLog": [
+        {
+            "action": "Gathered authoritative ground truth before rewriting: captured --help for all six Python scripts in .codeql/scripts/ (install_codeql.py, install_codeql_integration.py, invoke_codeql_scan.py, test_codeql_config.py, get_codeql_diagnostics.py, test_codeql_rollout.py), read the ADR-041 two-tier amendment, the codeql-scan SKILL.md, and both workflows (codeql-analysis.yml Tier 1 native gate, test-codeql-integration.yml). Confirmed config files live at .github/codeql/codeql-config.yml and codeql-config-quick.yml, and the removed hook path .claude/hooks/PostToolUse/invoke_codeql_quick_scan.py is absent.",
+            "files": []
+        },
+        {
+            "action": "Delegated the bulk prose rewrite of the three docs to a general-purpose subagent with the full verified PS->Python script mapping, real CLI flags, the two-tier model verbatim from ADR-041, and hard rules (no fabricated flags, no em/en dashes, remove staleness banners, reframe three-tier to two-tier across mermaid diagrams/tables/timeouts, remove deleted-hook refs). Rewrite scale: 954 insertions, 1462 deletions across the three files.",
+            "files": [
+                "docs/codeql-architecture.md",
+                "docs/codeql-integration.md",
+                "docs/codeql-rollout-checklist.md"
+            ]
+        },
+        {
+            "action": "Reviewed the rewrite mechanically rather than trusting the subagent self-report: ran the three verification greps independently (all clean), confirmed the Tier 1 language matrix is [actions, python] against the real workflow, and traced the one suspicious flag (--operation) to a genuinely separate skill wrapper .claude/skills/codeql-scan/scripts/invoke_codeql_scan.py whose --help confirms --operation {full,quick,validate}; the agent correctly documented both wrappers. Verified all relative links and referenced script/config/workflow paths resolve, both ADR link filenames resolve, and markdownlint returns 0 errors.",
+            "files": [
+                "docs/codeql-architecture.md",
+                "docs/codeql-integration.md",
+                "docs/codeql-rollout-checklist.md"
+            ]
+        }
+    ],
+    "endingCommit": "8cb988f6",
+    "nextSteps": [
+        "Open PR with Fixes #3296; babysit to green; resolve any review-on-push threads; self-merge (squash, delete branch).",
+        "Continue the remaining open backlog; most survivors are design-heavy/governance (delegate ADR work to a Sol worktree) or anti-churn cleanups the user warned against. Do not auto-close epic #3197; #3219 is deferred build-on-demand."
+    ]
+}

--- a/docs/codeql-architecture.md
+++ b/docs/codeql-architecture.md
@@ -352,7 +352,7 @@ Current config facts:
 - Disables default query packs.
 - Runs selected command injection, SQL injection, cross-site scripting, path traversal, and hardcoded credential queries.
 - Filters out low severity findings and recommendations.
-- Uses the same scannable path family as the full config.
+- Scans the full config's path set minus `.claude/hooks/`, which the quick config does not include.
 
 Use it through the scan script rather than calling it directly:
 

--- a/docs/codeql-architecture.md
+++ b/docs/codeql-architecture.md
@@ -1,180 +1,163 @@
 # CodeQL Integration Architecture
 
-> [!WARNING]
-> **This document is partially out of date.** It describes the pre-Python-migration PowerShell implementation and a three-tier strategy whose Tier 3 (the automatic PostToolUse quick-scan hook) was removed as dead code on 2026-07-21. The current CodeQL strategy is two-tier: Tier 1 (CI/CD blocking gate) and Tier 2 (on-demand `codeql-scan` skill). See the ADR-041 amendment (2026-07-21) and issue #3296 for the full overhaul. Refs #3295, #3197.
-
 ## Purpose
 
-This document provides technical details of the CodeQL security analysis integration, including the multi-tier strategy, component architecture, performance optimizations, and extension points.
+This document explains the current CodeQL security analysis architecture. The implementation is Python-first per ADR-042, and the operational strategy is two-tier per ADR-041 as amended on 2026-07-21.
+
+The former automatic edit-time hook was retired on 2026-07-21. A portable rebuild for automatic edit-time scanning is deferred to issue #3219. Quick scans remain available on demand through `invoke_codeql_scan.py --quick-scan` and the `codeql-scan` skill.
 
 ---
 
 ## Architecture Overview
 
-### Multi-Tier Strategy
+### Two-Tier Strategy
 
-The CodeQL integration implements a three-tier architecture providing security analysis at different workflow stages:
+The CodeQL integration has two live tiers:
 
 ```mermaid
 flowchart TB
-    subgraph Tier1[Tier 1: CI/CD Pipeline]
-        CI[GitHub Actions Workflow] --> DB1[Database Creation]
-        DB1 --> Scan1[Full Scan]
-        Scan1 --> SARIF[SARIF Upload]
-        SARIF --> Security[Security Tab]
+    subgraph T1["Tier 1: CI/CD Pipeline"]
+        PR[Pull Request or Main Push] --> Paths[check-paths job]
+        Paths -->|Scannable files changed| Init[GitHub CodeQL Action Init]
+        Paths -->|No scannable files| Skip[Skip analysis with passing check]
+        Init --> Analyze[GitHub CodeQL Action Analyze]
+        Analyze --> Sarif[SARIF Upload]
+        Sarif --> Security[GitHub Security Tab]
+        Analyze --> Gate[Blocking PR Check]
     end
 
-    subgraph Tier2[Tier 2: Local Development]
-        Dev[Developer] --> VSCode[VSCode Tasks]
-        Dev --> Skill[Claude Code Skill]
-        VSCode --> DB2[Database Cache]
-        Skill --> DB2
-        DB2 --> Scan2[On-Demand Scan]
-        Scan2 --> Results[Local Results]
+    subgraph T2["Tier 2: Local On-Demand"]
+        Dev[Developer or Agent] --> Skill[codeql-scan skill]
+        Dev --> Script[invoke_codeql_scan.py]
+        Skill --> Script
+        Script --> ConfigChoice{Scan mode}
+        ConfigChoice -->|Full| FullConfig[.github/codeql/codeql-config.yml]
+        ConfigChoice -->|Quick| QuickConfig[.github/codeql/codeql-config-quick.yml]
+        Script --> DB[.codeql/db]
+        Script --> Results[.codeql/results]
     end
 
-    subgraph Tier3[Tier 3: Automatic Feedback]
-        Hook[PostToolUse Hook] --> Check{CLI Available?}
-        Check -->|Yes| QuickScan[Quick Scan]
-        Check -->|No| Degrade[Graceful Degradation]
-        QuickScan --> Feedback[Console Output]
-        Degrade --> Feedback
-    end
-
-    subgraph Config[Shared Configuration]
-        FullConfig[codeql-config.yml]
-        QuickConfig[codeql-config-quick.yml]
-    end
-
-    Tier1 --> Config
-    Tier2 --> Config
-    Tier3 --> Config
+    FullConfig --> Analyze
+    FullConfig --> Script
+    QuickConfig --> Script
 ```
 
 ### Component Relationships
 
 ```mermaid
 graph LR
-    A[Install-CodeQL.ps1] --> B[CodeQL CLI]
-    C[Install-CodeQLIntegration.ps1] --> A
-    C --> D[VSCode Integration]
-    C --> E[Claude Skill]
-    C --> F[PostToolUse Hook]
-    C --> G[Configurations]
+    Installer[install_codeql.py] --> CLI[CodeQL CLI]
+    Integration[install_codeql_integration.py] --> Installer
+    Integration --> VSCode[VS Code integration]
+    Integration --> Skill[codeql-scan skill]
+    Integration --> Configs[CodeQL configs]
 
-    B --> H[Invoke-CodeQLScan.ps1]
-    G --> H
-    H --> I[SARIF Results]
+    CLI --> Scan[invoke_codeql_scan.py]
+    Configs --> Scan
+    Scan --> DB[.codeql/db]
+    Scan --> SARIF[.codeql/results]
 
-    J[Test-CodeQLConfig.ps1] --> G
-    K[Get-CodeQLDiagnostics.ps1] --> B
-    K --> G
+    ConfigTest[test_codeql_config.py] --> Configs
+    Diagnostics[get_codeql_diagnostics.py] --> CLI
+    Diagnostics --> Configs
+    Rollout[test_codeql_rollout.py] --> Integration
 ```
 
 ---
 
-## Multi-Tier Strategy Rationale
+## Two-Tier Strategy Rationale
 
 ### Tier 1: CI/CD Integration
 
-**Purpose**: Enforce security standards across all contributions
+**Purpose**: enforce repository security checks before code merges.
 
 **Implementation**: `.github/workflows/codeql-analysis.yml`
 
 **Characteristics**:
 
-- **Blocking**: PR merge blocked if critical findings detected
-- **Comprehensive**: Full query packs for complete coverage
-- **Persistent**: Results uploaded to GitHub Security tab
-- **Automated**: Runs on every pull request
+- Runs on every pull request to `main`, every push to `main`, a weekly Monday 09:00 UTC schedule, and manual dispatch.
+- Uses GitHub's native CodeQL action.
+- Uploads SARIF to the GitHub Security tab.
+- Keeps a required check green on docs-only or non-scannable changes by running a skip path.
+- Blocks PRs when the blocking issue check fails.
 
-**Design Decisions**:
+**Scannable paths** come from the workflow's `check-paths` job. That job is the source of truth for paths that trigger analysis.
 
-1. **Full query packs**: Security-extended provides comprehensive coverage
-2. **SARIF upload**: Integrates with GitHub's native security features
-3. **Blocking behavior**: Prevents vulnerabilities from entering codebase
-4. **Matrix strategy**: Scans each language independently for faster results
+**Language matrix in the checked-in workflow**:
+
+- `actions`
+- `python`
+
+The workflow comments mention security coverage for repository automation. The actual matrix in `.github/workflows/codeql-analysis.yml` is the authority for what GitHub's CodeQL action runs today.
+
+**Timeout budget**: 300 seconds for analysis work, based on the ADR-041 operating budget. The workflow job has a higher GitHub Actions guardrail because setup, artifact upload, and reporting also run in that job.
+
+**Design decisions**:
+
+1. Use GitHub's native CodeQL action for SARIF upload and Security tab integration.
+2. Run the workflow on all PRs so required status checks are satisfied.
+3. Use path filtering to skip analysis work when no scannable files changed.
+4. Use security-extended query coverage with medium-or-higher filtering.
 
 **Trade-offs**:
 
-- **Latency**: Adds ~30-60 seconds to PR checks
-- **Resource usage**: Consumes GitHub Actions minutes
-- **False positives**: May require suppression comments
+| Factor | Choice | Builder impact |
+|--------|--------|----------------|
+| Feedback timing | PR-time | Findings arrive later than local scans, but enforcement is reliable. |
+| Runtime cost | GitHub Actions minutes | Path filtering cuts work on unrelated changes. |
+| Source of truth | Native workflow | GitHub Security tab becomes the shared review surface. |
 
-**Mitigation**:
+### Tier 2: Local On-Demand Scanning
 
-- Database caching reduces subsequent scan times
-- Parallel language scans minimize total duration
-- Clear documentation on suppression patterns
-
-### Tier 2: Local Development
-
-**Purpose**: Enable developers to find and fix issues before PR creation
+**Purpose**: let developers and agents find security issues before opening a PR.
 
 **Implementation**:
 
-- VSCode tasks (`.vscode/tasks.json`)
-- Claude Code skill (`.claude/skills/codeql-scan/`)
+- `.claude/skills/codeql-scan/`
+- `.codeql/scripts/invoke_codeql_scan.py`
+- Optional VS Code integration installed by `.codeql/scripts/install_codeql_integration.py`
 
 **Characteristics**:
 
-- **On-demand**: Developer-initiated when needed
-- **Fast**: Database caching for quick iterations
-- **Consistent**: Same query packs as CI for predictable results
-- **Flexible**: Can scan specific languages or full repository
+- Developer-initiated.
+- Uses the same full config as CI by default.
+- Supports quick targeted scans through `--quick-scan`.
+- Supports cached databases through `--use-cache`.
+- Writes local databases to `.codeql/db` by default.
+- Writes local results to `.codeql/results` by default.
 
-**Design Decisions**:
+**Timeout budget**: 60 seconds by default for on-demand local scans.
 
-1. **Database caching**: Store databases in `.codeql/db/` for reuse
-2. **Cache invalidation**: Rebuild on commit, config, or source changes
-3. **Shared configuration**: Use same config as CI for consistency
-4. **VSCode tasks**: Integrate into existing developer workflow
+**Quick scan replacement for the retired hook**:
 
-**Trade-offs**:
+Quick feedback is now explicit, not automatic. Use this command when you want targeted queries during active development:
 
-- **Disk space**: Cached databases ~100-300MB per language
-- **Optional**: Developers may skip local scanning
-- **Setup required**: Requires CodeQL CLI installation
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py --quick-scan --use-cache
+```
 
-**Mitigation**:
+With the default config path, `--quick-scan` auto-switches to `.github/codeql/codeql-config-quick.yml`.
 
-- Clear installation documentation
-- One-command setup script
-- Gitignore database directories
-- Encourage through documentation and examples
+**Design decisions**:
 
-### Tier 3: Automatic Scanning
-
-**Purpose**: Provide just-in-time security feedback during development
-
-**Implementation**: `.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py`
-
-**Characteristics**:
-
-- **Automatic**: Triggers after Edit/Write/NotebookEdit tools
-- **Targeted**: Limited to 5-10 critical security queries
-- **Non-blocking**: Errors don't halt workflow
-- **Graceful**: Degrades when CLI unavailable
-
-**Design Decisions**:
-
-1. **Quick configuration**: Separate config with targeted queries
-2. **File pattern matching**: Only scan Python and Actions files
-3. **Timeout budget**: 30 second maximum to avoid interrupting flow
-4. **Error suppression**: Continue on failure to avoid blocking development
+1. Keep local scanning optional so developers are not blocked by missing local setup.
+2. Use the Python script as the stable local entry point.
+3. Keep quick scan demand-driven until issue #3219 rebuilds portable edit-time scanning.
+4. Share config files under `.github/codeql/` so CI and local scans do not drift.
 
 **Trade-offs**:
 
-- **Limited coverage**: Fewer queries than full scan
-- **Skippable**: Non-blocking means developers may ignore warnings
-- **Performance impact**: Adds latency after file operations
+| Factor | Choice | Builder impact |
+|--------|--------|----------------|
+| Local setup | Required for local scans | CI still protects the repo if a developer skips setup. |
+| Scan mode | Full or quick | Builders pick coverage or speed per task. |
+| Cache | Optional with `--use-cache` | Faster iteration, with explicit cache use. |
 
-**Mitigation**:
+### Retired Automatic Edit-Time Scanning
 
-- CI/CD catches what hook misses
-- Clear console output highlights issues
-- Timeout prevents long delays
-- Graceful degradation maintains usability
+The automatic edit-time hook was retired on 2026-07-21 by the ADR-041 amendment. It was dead code because it was not registered in the active hook surfaces and only its own test imported it.
+
+Do not add documentation, setup steps, troubleshooting, or extension guidance for that retired hook. If automatic edit-time scanning is needed, use issue #3219 as the design target. Until then, use Tier 2 quick scans explicitly.
 
 ---
 
@@ -182,319 +165,272 @@ graph LR
 
 ### Installation Components
 
-#### Install-CodeQL.ps1
+#### install_codeql.py
 
-**Location**: `.codeql/scripts/Install-CodeQL.ps1`
+**Location**: `.codeql/scripts/install_codeql.py`
 
-**Purpose**: Download and install CodeQL CLI
+**Purpose**: download and install the CodeQL CLI.
 
-**Features**:
+**Command line**:
 
-- Cross-platform support (Windows, Linux, macOS)
-- Automatic version detection (latest stable)
-- PATH configuration with `-AddToPath` flag
-- Version verification
-- Idempotent installation (safe to re-run)
+```bash
+python3 .codeql/scripts/install_codeql.py --version VERSION --install-path INSTALL_PATH --force --add-to-path --ci
+```
+
+**Flags**:
+
+| Flag | Purpose |
+|------|---------|
+| `--version VERSION` | Install a specific CodeQL CLI version. |
+| `--install-path INSTALL_PATH` | Install under a specific directory. |
+| `--force` | Overwrite an existing installation. |
+| `--add-to-path` | Add the CodeQL CLI to PATH. |
+| `--ci` | Use non-interactive CI behavior. |
 
 **Architecture**:
 
 ```mermaid
 sequenceDiagram
     participant User
-    participant Script
+    participant Script as install_codeql.py
     participant GitHub
-    participant FileSystem
+    participant FS as File system
 
-    User->>Script: Install-CodeQL.ps1
-    Script->>GitHub: Get latest release
+    User->>Script: Run installer
+    Script->>GitHub: Resolve CodeQL release
     GitHub-->>Script: Release metadata
-    Script->>GitHub: Download CLI bundle
+    Script->>GitHub: Download CLI archive
     GitHub-->>Script: CLI archive
-    Script->>FileSystem: Extract to .codeql/cli/
-    Script->>FileSystem: Set executable permissions
-    Script->>User: Installation complete
+    Script->>FS: Extract under install path
+    Script->>FS: Set executable permissions
+    Script-->>User: Report installed CLI path
 ```
 
-**Exit Codes** (ADR-035):
+#### install_codeql_integration.py
 
-- `0`: Success
-- `1`: Download or extraction failed
-- `3`: Validation error (unable to verify installation)
+**Location**: `.codeql/scripts/install_codeql_integration.py`
 
-#### Install-CodeQLIntegration.ps1
+**Purpose**: install CodeQL integration components.
 
-**Location**: `.codeql/scripts/Install-CodeQLIntegration.ps1`
+**Command line**:
 
-**Purpose**: One-command setup orchestrating all integrations
+```bash
+python3 .codeql/scripts/install_codeql_integration.py --skip-cli --skip-vscode --skip-claude-skill --skip-pre-commit --ci
+```
 
-**Steps**:
+**Flags**:
 
-1. Install CodeQL CLI (calls `Install-CodeQL.ps1`)
-2. Create configuration directory
-3. Copy shared configurations
-4. Configure VSCode integration
-5. Set up Claude Code skill
-6. Install PostToolUse hook
-7. Validate installation
+| Flag | Purpose |
+|------|---------|
+| `--skip-cli` | Do not install the CodeQL CLI. |
+| `--skip-vscode` | Do not create VS Code configuration files. |
+| `--skip-claude-skill` | Do not install the Claude Code skill. |
+| `--skip-pre-commit` | Do not verify pre-commit integration. |
+| `--ci` | Use non-interactive CI behavior. |
 
-**Design Pattern**: Orchestrator script calling specialized components
+**Design pattern**: orchestrator script. It calls focused setup steps and validates the result.
 
-**Benefits**:
+### Scanning Component
 
-- Single entry point for users
-- Consistent setup across environments
-- Validation at each step
-- Clear error messages
+#### invoke_codeql_scan.py
 
-### Scanning Components
+**Location**: `.codeql/scripts/invoke_codeql_scan.py`
 
-#### Invoke-CodeQLScan.ps1
+**Purpose**: run CodeQL security scans on the repository.
 
-**Location**: `.codeql/scripts/Invoke-CodeQLScan.ps1`
+**Command line**:
 
-**Purpose**: Execute CodeQL security analysis
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py \
+  --repo-path REPO_PATH \
+  --config-path CONFIG_PATH \
+  --database-path DATABASE_PATH \
+  --results-path RESULTS_PATH \
+  --languages python actions \
+  --use-cache \
+  --ci \
+  --format console \
+  --quick-scan
+```
 
-**Parameters**:
+**Flags and defaults**:
 
-| Parameter | Type | Description | Default |
-|-----------|------|-------------|---------|
-| `Languages` | string[] | Languages to scan | Auto-detect |
-| `UseCache` | switch | Use cached databases | false |
-| `Force` | switch | Force database rebuild | false |
-| `ConfigPath` | string | Configuration file path | `.github/codeql/codeql-config.yml` |
-| `OutputPath` | string | SARIF output path | `.codeql/results/codeql-results.sarif` |
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--repo-path REPO_PATH` | `.` or `CODEQL_REPO_PATH` | Repository root. |
+| `--config-path CONFIG_PATH` | `.github/codeql/codeql-config.yml` or `CODEQL_CONFIG_PATH` | CodeQL config file. |
+| `--database-path DATABASE_PATH` | `.codeql/db` or `CODEQL_DATABASE_PATH` | Database cache directory. |
+| `--results-path RESULTS_PATH` | `.codeql/results` or `CODEQL_RESULTS_PATH` | SARIF and result output directory. |
+| `--languages [LANGUAGES ...]` | Auto-detected | Languages to scan. |
+| `--use-cache` | Off | Reuse cached databases when valid. |
+| `--ci` | Off | Exit 1 when findings are detected. |
+| `--format {console,sarif,json}` | `console` | Output format. |
+| `--quick-scan` | Off | Use targeted quick scan mode. |
+
+When `--quick-scan` is used with the default config path, the script switches to `.github/codeql/codeql-config-quick.yml`.
 
 **Workflow**:
 
 ```mermaid
 flowchart TD
-    A[Start] --> B{Languages Specified?}
-    B -->|No| C[Auto-detect Languages]
-    B -->|Yes| D[Use Specified]
-    C --> E[For Each Language]
-    D --> E
-
-    E --> F{Cache Exists?}
-    F -->|Yes| G{UseCache Flag?}
-    F -->|No| H[Create Database]
-    G -->|Yes| I{Cache Valid?}
-    G -->|No| H
-    I -->|Yes| J[Use Cached DB]
-    I -->|No| H
-
-    H --> K[Analyze Database]
-    J --> K
-    K --> L[Generate SARIF]
-    L --> M{More Languages?}
-    M -->|Yes| E
-    M -->|No| N[Combine Results]
-    N --> O[Output SARIF]
-    O --> P[End]
+    Start[Start] --> Langs{Languages supplied?}
+    Langs -->|No| Detect[Auto-detect languages]
+    Langs -->|Yes| UseLangs[Use supplied languages]
+    Detect --> Each[For each language]
+    UseLangs --> Each
+    Each --> Cache{Use cache?}
+    Cache -->|Yes| CheckCache[Check cached database]
+    Cache -->|No| BuildDB[Create database]
+    CheckCache -->|Valid| Analyze[Analyze database]
+    CheckCache -->|Invalid| BuildDB
+    BuildDB --> Analyze
+    Analyze --> Write[Write results]
+    Write --> More{More languages?}
+    More -->|Yes| Each
+    More -->|No| Done[Return exit code]
 ```
 
-**Language Detection**:
+**Common commands**:
 
-```powershell
-# Auto-detect based on file patterns
-if (Test-Path "*.py") { $languages += "python" }
-if (Test-Path ".github/workflows/*.yml") { $languages += "actions" }
+```bash
+# Full local scan
+python3 .codeql/scripts/invoke_codeql_scan.py
+
+# Fast targeted local scan
+python3 .codeql/scripts/invoke_codeql_scan.py --quick-scan --use-cache
+
+# Python only, JSON output
+python3 .codeql/scripts/invoke_codeql_scan.py --languages python --format json
+
+# CI behavior, exits 1 if findings are detected
+python3 .codeql/scripts/invoke_codeql_scan.py --ci
 ```
-
-**Database Caching**:
-
-- **Location**: `.codeql/db/{language}/`
-- **Invalidation**:
-  - Git HEAD changes
-  - Configuration updates
-  - Source file modifications
-  - `-Force` flag
-- **Benefits**: 3-5x faster scans
-
-**Error Handling**:
-
-- Language not supported → Skip with warning
-- Database creation failed → Exit with error (code 1)
-- Analysis timeout → Exit with error (code 1)
-- SARIF generation failed → Exit with error (code 1)
-
-**Exit Codes** (ADR-035):
-
-- `0`: Success (scan completed)
-- `1`: Failure (scan failed or findings above threshold)
-- `3`: Validation error (invalid configuration)
 
 ### Configuration Components
 
-#### Shared Configuration (codeql-config.yml)
+#### Shared Configuration
 
 **Location**: `.github/codeql/codeql-config.yml`
 
-**Purpose**: Single source of truth for CodeQL settings
+**Purpose**: full CodeQL configuration used by CI and default local scans.
 
-**Structure**:
+Current config facts:
+
+- Uses `security-extended`.
+- Includes explicit packs for `actions` and `python`.
+- Filters out low severity findings and recommendations.
+- Scans repository automation and script paths.
+- Ignores tests, `.agents/`, docs, and Markdown files.
 
 ```yaml
-name: "CodeQL Config"
+name: "CodeQL Configuration"
 
-# Query packs to run
+disable-default-queries: false
+
+packs:
+  - codeql/actions-queries:codeql-suites/actions-security-extended.qls
+  - codeql/python-queries:codeql-suites/python-security-extended.qls
+
 queries:
   - uses: security-extended
 
-# Severity filtering (in workflow)
-# error, warning, note
-
-# Paths to analyze
-paths:
-  - .github/workflows
-  - .claude/hooks
-  - .codeql/scripts
-  - scripts
-
-# Paths to exclude
-paths-ignore:
-  - tests
-  - "**/*.Tests.ps1"
-  - "**/*.md"
-  - node_modules
-  - .git
+query-filters:
+  - exclude:
+      problem.severity: low
+  - exclude:
+      tags contain: recommendation
 ```
 
-**Query Packs**:
-
-- `security-extended`: Security vulnerabilities + common coding errors
-- `security-and-quality`: Security + code quality
-- Custom packs via `uses:` directive
-
-**Benefits**:
-
-- Consistent results across tiers
-- Single file to update query packs
-- Version-controlled configuration
-- Easy to audit security standards
-
-#### Quick Configuration (codeql-config-quick.yml)
+#### Quick Configuration
 
 **Location**: `.github/codeql/codeql-config-quick.yml`
 
-**Purpose**: Targeted queries for PostToolUse hook
+**Purpose**: targeted query selection for explicit quick scans.
 
-**Structure**:
+Current config facts:
 
-```yaml
-name: "CodeQL Quick Config"
+- Disables default query packs.
+- Runs selected command injection, SQL injection, cross-site scripting, path traversal, and hardcoded credential queries.
+- Filters out low severity findings and recommendations.
+- Uses the same scannable path family as the full config.
 
-queries:
-  - uses: security-extended
-    tags:
-      - security
-      - cwe-078  # Command injection
-      - cwe-079  # XSS
-      - cwe-089  # SQL injection
-      - cwe-022  # Path traversal
-      - cwe-798  # Hard-coded credentials
+Use it through the scan script rather than calling it directly:
+
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py --quick-scan
 ```
 
-**Query Selection Rationale**:
+### Validation Component
 
-| CWE | Vulnerability | Severity | Frequency |
-|-----|---------------|----------|-----------|
-| CWE-078 | Command Injection | Critical | High |
-| CWE-079 | XSS | High | Medium |
-| CWE-089 | SQL Injection | Critical | Medium |
-| CWE-022 | Path Traversal | High | Medium |
-| CWE-798 | Hard-coded Credentials | High | Low |
+#### test_codeql_config.py
 
-**Performance**: ~5-15 seconds vs ~30-60 seconds for full scan
+**Location**: `.codeql/scripts/test_codeql_config.py`
 
-#### Test-CodeQLConfig.ps1
+**Purpose**: validate a CodeQL configuration file.
 
-**Location**: `.codeql/scripts/Test-CodeQLConfig.ps1`
+**Command line**:
 
-**Purpose**: Validate configuration syntax and query packs
-
-**Checks**:
-
-1. Configuration file exists
-2. Valid YAML syntax
-3. Query packs resolvable
-4. Paths exist
-5. No conflicting settings
-
-**Output**:
-
-```text
-[PASS] Configuration file exists
-[PASS] YAML syntax valid
-[PASS] Query packs resolvable
-[PASS] Paths valid
-[PASS] No conflicts detected
+```bash
+python3 .codeql/scripts/test_codeql_config.py --config-path CONFIG_PATH --ci --format console
 ```
 
-**Exit Codes**:
+**Flags**:
 
-- `0`: All checks passed
-- `1`: Validation failed
-- `3`: Configuration file not found
+| Flag | Purpose |
+|------|---------|
+| `--config-path CONFIG_PATH` | Validate a specific config file. |
+| `--ci` | Use CI behavior. |
+| `--format {console,json}` | Select output format. |
 
-### Diagnostic Components
+### Diagnostic Component
 
-#### Get-CodeQLDiagnostics.ps1
+#### get_codeql_diagnostics.py
 
-**Location**: `.codeql/scripts/Get-CodeQLDiagnostics.ps1`
+**Location**: `.codeql/scripts/get_codeql_diagnostics.py`
 
-**Purpose**: Troubleshooting and health checks
+**Purpose**: run CodeQL health checks and diagnostics.
 
-**Diagnostics**:
+**Command line**:
 
-1. **CLI Status**:
-   - Installation path
-   - Version
-   - Executable permissions
-2. **Configuration Status**:
-   - Files exist
-   - YAML validity
-   - Query pack resolution
-3. **Database Status**:
-   - Cached databases
-   - Disk usage
-   - Last update timestamp
-4. **Integration Status**:
-   - VSCode tasks configured
-   - Claude skill installed
-   - PostToolUse hook present
-5. **Performance Metrics**:
-   - Last scan duration
-   - Cache hit rate
-   - Database sizes
-
-**Output Format**:
-
-```text
-=== CodeQL Diagnostics ===
-
-[CLI Status]
-  Path: .codeql/cli/codeql
-  Version: v2.23.9
-  Executable: Yes
-
-[Configuration]
-  Full Config: Valid
-  Quick Config: Valid
-  Query Packs: Resolvable
-
-[Database Cache]
-  python: 156MB (last update: 2026-01-16 10:30:00)
-  actions: 42MB (last update: 2026-01-16 10:30:00)
-
-[Integration]
-  VSCode Tasks: Configured
-  Claude Skill: Installed
-  PostToolUse Hook: Installed
-
-[Performance]
-  Last Scan: 12.3s
-  Cache Hit Rate: 85%
+```bash
+python3 .codeql/scripts/get_codeql_diagnostics.py \
+  --repo-path REPO_PATH \
+  --config-path CONFIG_PATH \
+  --database-path DATABASE_PATH \
+  --results-path RESULTS_PATH \
+  --output-format console
 ```
+
+**Flags**:
+
+| Flag | Purpose |
+|------|---------|
+| `--repo-path REPO_PATH` | Repository root. |
+| `--config-path CONFIG_PATH` | Config file to inspect. |
+| `--database-path DATABASE_PATH` | Database cache directory. |
+| `--results-path RESULTS_PATH` | Results directory. |
+| `--output-format {console,json,markdown}` | Select output format. |
+
+### Rollout Validation Component
+
+#### test_codeql_rollout.py
+
+**Location**: `.codeql/scripts/test_codeql_rollout.py`
+
+**Purpose**: validate the deployed CodeQL integration.
+
+**Command line**:
+
+```bash
+python3 .codeql/scripts/test_codeql_rollout.py --format console --ci
+```
+
+**Flags**:
+
+| Flag | Purpose |
+|------|---------|
+| `--format {console,json}` | Select output format. |
+| `--ci` | Return a non-zero exit code on validation failures. |
 
 ---
 
@@ -502,55 +438,42 @@ queries:
 
 ### Shared Configuration Pattern
 
-**Problem**: Duplicate configuration across tiers leads to inconsistency
+**Problem**: duplicated CodeQL settings drift across CI and local tools.
 
-**Solution**: Single configuration file referenced by all tiers
-
-**Implementation**:
+**Solution**: keep the full and quick configs under `.github/codeql/`, and point all live tiers at those files.
 
 ```yaml
 # .github/workflows/codeql-analysis.yml
 - name: Initialize CodeQL
-  uses: github/codeql-action/init@v3
+  uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a
   with:
-    config-file: ./.github/codeql/codeql-config.yml
-
-# Invoke-CodeQLScan.ps1
-$ConfigPath = ".github/codeql/codeql-config.yml"
-& codeql database analyze $Database $ConfigPath
+    config-file: .github/codeql/codeql-config.yml
 ```
 
-**Benefits**:
+```bash
+# Local scan, default full config
+python3 .codeql/scripts/invoke_codeql_scan.py
 
-- CI and local scans use identical query packs
-- Single point of update
-- Version control tracks configuration changes
-- Easier to audit security coverage
+# Local scan, explicit quick config through scan mode
+python3 .codeql/scripts/invoke_codeql_scan.py --quick-scan
+```
 
-**Trade-offs**:
+### Validation Workflow
 
-- Configuration changes affect all tiers
-- Requires coordination for breaking changes
+```mermaid
+flowchart LR
+    Change[Config change] --> Local[test_codeql_config.py]
+    Local -->|Pass| Scan[invoke_codeql_scan.py --languages python]
+    Scan -->|Pass| PR[Open PR]
+    PR --> CI[codeql-analysis.yml]
+    CI --> Security[Security tab]
+```
 
-### Configuration Validation Workflow
+Run local config validation before a PR when editing `.github/codeql/`:
 
-**Workflow**: `.github/workflows/test-codeql-integration.yml`
-
-**Triggers**:
-
-- Configuration file changes
-- Pull requests
-- Manual dispatch
-
-**Steps**:
-
-1. Validate YAML syntax
-2. Resolve query packs
-3. Test database creation
-4. Run sample scans
-5. Verify SARIF output
-
-**Exit Criteria**: All steps pass with exit code 0
+```bash
+python3 .codeql/scripts/test_codeql_config.py --ci
+```
 
 ---
 
@@ -558,121 +481,53 @@ $ConfigPath = ".github/codeql/codeql-config.yml"
 
 ### Database Caching Strategy
 
-**Objective**: Reduce scan time from ~60s to ~15s
+Local scans can reuse databases when the caller passes `--use-cache`.
 
-**Implementation**:
-
-```powershell
-# Check cache validity
-$cacheValid = $false
-if (Test-Path $DatabasePath) {
-    $dbTimestamp = (Get-Item $DatabasePath).LastWriteTime
-    $headTimestamp = git log -1 --format=%cI
-    $configTimestamp = (Get-Item $ConfigPath).LastWriteTime
-
-    if ($dbTimestamp -gt $headTimestamp -and $dbTimestamp -gt $configTimestamp) {
-        $cacheValid = $true
-    }
-}
-
-if (-not $cacheValid -or $Force) {
-    # Rebuild database
-    & codeql database create $DatabasePath
-}
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py --use-cache
 ```
 
-**Cache Invalidation Triggers**:
+Default locations:
 
-1. **Git HEAD changes**: New commits modify source code
-2. **Configuration updates**: Query packs or paths changed
-3. **Source modifications**: Files in scanned paths updated
-4. **Force flag**: Manual cache invalidation
-
-**Performance Impact**:
-
-| Scenario | Without Cache | With Cache | Speedup |
-|----------|---------------|------------|---------|
-| First scan | 60s | 60s | 1x |
-| No changes | 60s | 12s | 5x |
-| Config change | 60s | 60s | 1x |
-| Code change | 60s | 20s | 3x |
+| Data | Location |
+|------|----------|
+| Databases | `.codeql/db` |
+| Results | `.codeql/results` |
+| Full config | `.github/codeql/codeql-config.yml` |
+| Quick config | `.github/codeql/codeql-config-quick.yml` |
 
 ### Targeted Query Selection
 
-**PostToolUse Hook Optimization**:
+Use quick scan mode when the task needs fast local feedback instead of full CI-equivalent coverage:
 
-**Problem**: Full query packs take 30-60 seconds, interrupting flow
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py --quick-scan --use-cache
+```
 
-**Solution**: Quick configuration with 5-10 critical queries
-
-**Query Selection Criteria**:
-
-1. **High severity**: Critical or high CVSS scores
-2. **Common vulnerabilities**: Frequently seen in codebases
-3. **Fast execution**: Low computational complexity
-4. **High value**: Catches real security issues
-
-**Selected CWEs**:
-
-- CWE-078: Command Injection (highest severity, common in automation)
-- CWE-079: Cross-Site Scripting (high severity, common in web)
-- CWE-089: SQL Injection (critical severity, medium frequency)
-- CWE-022: Path Traversal (high severity, common in file operations)
-- CWE-798: Hard-coded Credentials (high severity, easy to detect)
-
-**Performance Budget**:
-
-- Target: < 15 seconds
-- Timeout: 30 seconds
-- Average: 8-12 seconds
+Quick scan mode is useful during active development. Full scan mode is still the better pre-PR local check.
 
 ### Timeout Budgets
 
-**Tier 1 (CI/CD)**:
-
-- Timeout: 300 seconds (5 minutes)
-- Rationale: Comprehensive scan worth latency
-- Fallback: None (blocking)
-
-**Tier 2 (Local)**:
-
-- Timeout: 60 seconds (default)
-- Rationale: Developer-initiated, can wait
-- Fallback: Cancel and retry
-
-**Tier 3 (Automatic)**:
-
-- Timeout: 30 seconds
-- Rationale: Must not interrupt workflow
-- Fallback: Graceful degradation
+| Path | Budget | Behavior |
+|------|--------|----------|
+| Tier 1 CI/CD | 300 seconds | Blocking PR gate through GitHub's CodeQL action. |
+| Tier 2 local full scan | 60 seconds default | Developer-initiated local scan. |
+| Tier 2 local quick scan | 60 seconds default | Same local entry point, targeted query config. |
+| Automatic edit-time scan | Retired | Portable rebuild deferred to issue #3219. |
 
 ### Graceful Degradation
 
-**PostToolUse Hook Behavior**:
+CI is authoritative. Local scans are optional and can fail because the CLI is not installed, databases are missing, or the machine lacks required disk space.
 
-```powershell
-try {
-    # Attempt quick scan
-    $result = & codeql database analyze --timeout 30
-    Write-Output "Security scan: $result"
-}
-catch {
-    # CLI not available or scan failed
-    Write-Verbose "CodeQL scan skipped (CLI unavailable)"
-    # Continue without blocking
-}
+Expected local response:
+
+1. Run diagnostics.
+2. Fix the local setup issue.
+3. Use CI as the final gate.
+
+```bash
+python3 .codeql/scripts/get_codeql_diagnostics.py --output-format markdown
 ```
-
-**Benefits**:
-
-- Development continues even if CLI missing
-- No hard dependency on CodeQL for editing
-- Clear feedback when scan succeeds
-
-**Trade-offs**:
-
-- Developers may not notice scan failures
-- Requires CI/CD as safety net
 
 ---
 
@@ -680,127 +535,54 @@ catch {
 
 ### Adding New Languages
 
-**Steps**:
+Use the workflow matrix and config files as the source of truth. Do not document a language as scanned until `.github/workflows/codeql-analysis.yml` and `.github/codeql/codeql-config.yml` both support it.
 
-1. Update shared configuration:
+1. Update the matrix in `.github/workflows/codeql-analysis.yml`.
+2. Update packs and paths in `.github/codeql/codeql-config.yml`.
+3. Add quick scan queries to `.github/codeql/codeql-config-quick.yml` only if fast targeted coverage exists.
+4. Validate config.
+5. Run the integration workflow or the local scan for that language.
 
-   ```yaml
-   # .github/codeql/codeql-config.yml
-   languages:
-     - python
-     - actions
-     - javascript  # New language
-   ```
+```bash
+python3 .codeql/scripts/test_codeql_config.py --ci
+python3 .codeql/scripts/invoke_codeql_scan.py --languages python --ci
+```
 
-2. Update workflow matrix:
+### Adding Custom Query Packs
 
-   ```yaml
-   # .github/workflows/codeql-analysis.yml
-   strategy:
-     matrix:
-       language: [python, actions, javascript]
-   ```
-
-3. Update auto-detection:
-
-   ```powershell
-   # Invoke-CodeQLScan.ps1
-   if (Test-Path "*.js") { $languages += "javascript" }
-   ```
-
-4. Update PostToolUse hook file patterns:
-
-   ```python
-   # .claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
-   if re.search(r'\.(js|ts)$', file_path):
-       should_scan = True
-   ```
-
-### Custom Query Packs
-
-**Local Query Pack**:
-
-1. Create directory structure:
-
-   ```text
-   .codeql/
-   └── custom-queries/
-       ├── qlpack.yml
-       └── MyQuery.ql
-   ```
-
-2. Define pack metadata:
-
-   ```yaml
-   # .codeql/custom-queries/qlpack.yml
-   name: my-org/custom-queries
-   version: 1.0.0
-   dependencies:
-     codeql/python-all: "*"
-   ```
-
-3. Reference in configuration:
-
-   ```yaml
-   queries:
-     - uses: ./.codeql/custom-queries
-   ```
-
-**Remote Query Pack**:
+Add query packs to `.github/codeql/codeql-config.yml` after verifying the pack is trusted and versioned.
 
 ```yaml
-queries:
-  - uses: owner/repo/query-pack@v1.2.3
+packs:
+  - codeql/actions-queries:codeql-suites/actions-security-extended.qls
+  - codeql/python-queries:codeql-suites/python-security-extended.qls
 ```
 
-### Integration with Other Security Tools
+Security rule: do not add unpinned or untrusted query sources. Query packs execute during CI and local scans.
 
-**SARIF Format**: CodeQL outputs SARIF, enabling integration with:
+### Integrating Other Security Tools
 
-- GitHub Security tab
-- SARIF viewers (VSCode extension)
-- Other SAST tools (Checkmarx, SonarQube)
-- Security dashboards
+Keep CodeQL focused on semantic static analysis. If another tool is added, use a separate workflow or script unless it shares CodeQL databases or SARIF output.
 
-**Example**: Combine CodeQL with Semgrep:
-
-```yaml
-# .github/workflows/security.yml
-- name: CodeQL Analysis
-  uses: github/codeql-action/analyze@v3
-
-- name: Semgrep Analysis
-  uses: returntocorp/semgrep-action@v1
-
-- name: Merge SARIF Results
-  run: |
-    jq -s '.[0] * .[1]' codeql.sarif semgrep.sarif > combined.sarif
+```mermaid
+flowchart LR
+    Change[Code change] --> CodeQL[CodeQL semantic analysis]
+    Change --> Other[Other security tool]
+    CodeQL --> SARIF[SARIF output]
+    Other --> Report[Tool-specific report]
+    SARIF --> Review[Security review]
+    Report --> Review
 ```
 
-### Extending PostToolUse Hook
+### Automatic Edit-Time Rebuild
 
-**Add New File Types**:
+Do not extend the retired automatic hook. The replacement must be designed under issue #3219 with these constraints:
 
-```python
-# .claude/hooks/PostToolUse/invoke_codeql_quick_scan.py
-
-# Current: Python and Actions
-if re.search(r'\.(py|yml)$', file_path):
-    should_scan = True
-
-# Add JavaScript/TypeScript
-if ($FilePath -match '\.(py|yml|js|ts)$') { $shouldScan = $true }
-```
-
-**Add Custom Triggers**:
-
-```powershell
-# Scan on specific tool usage
-if ($ToolName -eq 'Edit' -and $FilePath -match 'security/*') {
-    # Always scan security-critical files
-    $shouldScan = $true
-}
-```
+- Demand-driven and visible to the user.
+- Cross-harness portable.
+- No hidden latency after every edit.
+- Uses the existing quick scan mode or a documented replacement.
+- Keeps CI as the blocking gate.
 
 ---
 
@@ -808,100 +590,41 @@ if ($ToolName -eq 'Edit' -and $FilePath -match 'security/*') {
 
 ### Unit Tests
 
-**Files**:
+The CodeQL Python scripts are tested with pytest.
 
-- `tests/Install-CodeQL.Tests.ps1`
-- `tests/Invoke-CodeQLScan.Tests.ps1`
-- `tests/Test-CodeQLConfig.Tests.ps1`
-- `tests/Get-CodeQLDiagnostics.Tests.ps1`
+Current test files include:
 
-**Coverage**:
+- `tests/test_install_codeql.py`
+- `tests/test_install_codeql_integration.py`
+- `tests/test_invoke_codeql_scan_py.py`
+- `tests/test_test_codeql_config.py`
+- `tests/test_get_codeql_diagnostics.py`
+- `tests/test_test_codeql_rollout.py`
+- `tests/skills/codeql-scan/test_invoke_codeql_scan_skill.py`
 
-- CLI installation and version verification
-- Database creation and caching
-- Configuration validation
-- SARIF output generation
-- Error handling and exit codes
+Run the targeted test set with:
 
-**Patterns**:
-
-```powershell
-Describe "Invoke-CodeQLScan" {
-    Context "When cache is valid" {
-        It "Should use cached database" {
-            # Arrange
-            Mock Test-Path { $true }
-            Mock Get-Item { @{ LastWriteTime = [datetime]::Now } }
-
-            # Act
-            & Invoke-CodeQLScan.ps1 -UseCache
-
-            # Assert
-            Assert-MockCalled Test-Path -ParameterFilter { $Path -like "*.codeql/db/*" }
-        }
-    }
-}
+```bash
+uv run pytest tests/test_install_codeql.py tests/test_install_codeql_integration.py tests/test_invoke_codeql_scan_py.py tests/test_test_codeql_config.py tests/test_get_codeql_diagnostics.py tests/test_test_codeql_rollout.py tests/skills/codeql-scan/test_invoke_codeql_scan_skill.py
 ```
 
 ### Integration Tests
 
-**File**: `tests/CodeQL-Integration.Tests.ps1`
+The workflow `.github/workflows/test-codeql-integration.yml` validates real usage patterns:
 
-**Scenarios**:
-
-1. **End-to-end scan**: Install CLI → Configure → Scan → Validate SARIF
-2. **Cache workflow**: First scan → Modify code → Second scan (cache hit)
-3. **Configuration changes**: Update config → Verify cache invalidation
-4. **Multi-language**: Scan Python + Actions → Verify both results
-
-**Example**:
-
-```powershell
-Describe "CodeQL Integration" {
-    It "Should perform end-to-end scan" {
-        # Install
-        & .codeql/scripts/Install-CodeQL.ps1
-
-        # Configure
-        & .codeql/scripts/Install-CodeQLIntegration.ps1
-
-        # Scan
-        & .codeql/scripts/Invoke-CodeQLScan.ps1
-
-        # Validate
-        $sarif = Get-Content .codeql/results/codeql-results.sarif | ConvertFrom-Json
-        $sarif.runs | Should -Not -BeNullOrEmpty
-    }
-}
-```
+1. Install the CodeQL CLI with `python3 .codeql/scripts/install_codeql.py --ci --force`.
+2. Validate config with `python3 .codeql/scripts/test_codeql_config.py --ci`.
+3. Scan the language matrix `[actions, python]` with `invoke_codeql_scan.py`.
+4. Verify SARIF output under `.codeql/results`.
 
 ### CI Validation
 
-**Workflow**: `.github/workflows/test-codeql-integration.yml`
+CI validation uses two workflows:
 
-**Jobs**:
-
-1. **Lint**: Validate PowerShell syntax with PSScriptAnalyzer
-2. **Unit Tests**: Run all Pester unit tests
-3. **Integration Tests**: Run end-to-end integration tests
-4. **Configuration Tests**: Validate YAML and query packs
-5. **Performance Tests**: Verify scan times within budgets
-
-**Matrix Testing**:
-
-```yaml
-strategy:
-  matrix:
-    os: [ubuntu-latest, windows-latest, macos-latest]
-    pwsh-version: ['7.4']
-```
-
-**Exit Criteria**:
-
-- All tests pass on all platforms
-- No PSScriptAnalyzer warnings
-- Configuration validation succeeds
-- Performance budgets met
+| Workflow | Purpose | Key commands |
+|----------|---------|--------------|
+| `.github/workflows/codeql-analysis.yml` | Blocking security gate with GitHub CodeQL action | Native CodeQL action init and analyze. |
+| `.github/workflows/test-codeql-integration.yml` | Proves local Python scripts work | `install_codeql.py`, `test_codeql_config.py`, `invoke_codeql_scan.py`. |
 
 ---
 
@@ -909,114 +632,76 @@ strategy:
 
 ### Query Pack Trust Model
 
-**Problem**: External query packs could contain malicious code
+CodeQL query packs execute code analysis logic in CI and on developer machines. Treat query pack changes as security-sensitive.
 
-**Mitigation**:
-
-1. **Pin versions**: Use `@version` to lock query packs
-2. **Review packs**: Audit before adding to configuration
-3. **Prefer official**: Use `security-extended` from GitHub
-4. **Local packs**: Keep custom queries in repository
-
-**Example**:
+Allowed pattern:
 
 ```yaml
-# GOOD: Pinned version
-queries:
-  - uses: github/codeql-action/security-extended@v3.24.0
-
-# BAD: Floating version
-queries:
-  - uses: untrusted/queries@latest
+packs:
+  - codeql/python-queries:codeql-suites/python-security-extended.qls
 ```
+
+Review requirements:
+
+- Source is trusted.
+- Versioning or suite name is explicit.
+- Query intent matches repository risk.
+- Local validation passes.
 
 ### SARIF Output Handling
 
-**Sensitive Information**: SARIF may contain:
+SARIF can include file paths, code snippets, and finding details. Keep local results out of commits.
 
-- File paths
-- Code snippets
-- Variable names
-- Configuration details
-
-**Protection**:
-
-```yaml
-# .gitignore
+```gitignore
+.codeql/db/
 .codeql/results/
-*.sarif
-
-# Only upload to private Security tab
-- name: Upload SARIF
-  uses: github/codeql-action/upload-sarif@v3
-  # Requires private repository or GitHub Advanced Security
+.codeql/logs/
+.codeql/cli/
 ```
+
+CI uploads SARIF to GitHub's Security tab through the CodeQL action. Do not publish SARIF to public artifacts unless the repository owner approves it.
 
 ### Database Storage Security
 
-**Sensitive Data**: Databases contain full codebase
+CodeQL databases can include indexed source content. Store them only in ignored local directories or ephemeral CI workspaces.
 
-**Protection**:
-
-```yaml
-# .gitignore
-.codeql/db/
-.codeql/cli/
-.codeql/logs/
-
-# Restrict permissions
-chmod 700 .codeql/db
+```bash
+# Local cleanup review, lists generated CodeQL paths only
+python3 - <<'PY'
+from pathlib import Path
+for path in (Path('.codeql/db'), Path('.codeql/results')):
+    if path.exists():
+        print(path)
+PY
 ```
 
-**Cleanup**:
-
-```powershell
-# Remove databases after CI run
-if ($env:CI) {
-    Remove-Item -Recurse -Force .codeql/db
-}
-```
+The cleanup example lists paths only. Delete with a safe file manager or a reviewed repository cleanup command.
 
 ### Workflow Permissions
 
-**Principle of Least Privilege**:
+The CodeQL workflow uses narrow permissions:
 
 ```yaml
-# .github/workflows/codeql-analysis.yml
 permissions:
-  contents: read        # Read repository contents
-  security-events: write  # Upload SARIF
-  pull-requests: read   # Check PR status
+  security-events: write
+  actions: read
+  contents: read
 ```
 
-**No write permissions** to:
-
-- Repository contents
-- Issues
-- Actions
-- Deployments
+Keep new permissions scoped to the job that needs them.
 
 ---
 
 ## Related Decisions
 
-- [ADR-005: PowerShell-Only Scripting](../.agents/architecture/ADR-005-powershell-only-scripting.md)
-- [ADR-006: Thin Workflows, Testable Modules](../.agents/architecture/ADR-006-thin-workflows-testable-modules.md)
-- [ADR-035: Exit Code Standardization](../.agents/architecture/ADR-035-exit-code-standardization.md)
-- [ADR-041: CodeQL Integration Multi-Tier Strategy](../.agents/architecture/ADR-041-codeql-integration.md)
-
----
+- [ADR-041: CodeQL Integration Multi-Tier Strategy](../.agents/architecture/ADR-041-codeql-integration.md), amended 2026-07-21 to the current two-tier strategy.
+- [ADR-042: Python Migration Strategy](../.agents/architecture/ADR-042-python-migration-strategy.md), supersedes the older scripting-language decision for new internal automation.
+- [ADR-006: Thin Workflows, Testable Modules](../.agents/architecture/ADR-006-thin-workflows-testable-modules.md), keeps workflow logic thin and scripts testable.
 
 ## References
 
-- [CodeQL Documentation](https://codeql.github.com/docs/)
-- [SARIF Specification](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html)
-- [GitHub Actions Security Best Practices](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
-- [CWE Top 25](https://cwe.mitre.org/top25/archive/2023/2023_top25_list.html)
-- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
-
----
-
-*Architecture Version: 1.0*
-*Created: 2026-01-16*
-*Related Issue: CodeQL Integration Implementation*
+- [CodeQL documentation](https://codeql.github.com/docs/)
+- [GitHub CodeQL action](https://github.com/github/codeql-action)
+- [SARIF specification](https://sarifweb.azurewebsites.net/)
+- [CodeQL integration guide](./codeql-integration.md)
+- [CodeQL rollout checklist](./codeql-rollout-checklist.md)

--- a/docs/codeql-integration.md
+++ b/docs/codeql-integration.md
@@ -1,29 +1,31 @@
 # CodeQL Integration Guide
 
-> [!WARNING]
-> **This document is partially out of date.** It describes the pre-Python-migration PowerShell implementation and a three-tier strategy whose Tier 3 (the automatic PostToolUse quick-scan hook) was removed as dead code on 2026-07-21. The current CodeQL strategy is two-tier: Tier 1 (CI/CD blocking gate) and Tier 2 (on-demand `codeql-scan` skill). See the ADR-041 amendment (2026-07-21) and issue #3296 for the full overhaul. Refs #3295, #3197.
+This guide explains how to install, run, and troubleshoot the current CodeQL integration. The implementation uses Python scripts in `.codeql/scripts/`, shared configs in `.github/codeql/`, and a two-tier strategy from ADR-041 as amended on 2026-07-21.
 
-This guide covers the complete CodeQL security analysis integration across CI/CD, local development, and automatic scanning workflows.
+The automatic edit-time hook was retired on 2026-07-21. Quick scans are still available on demand through `--quick-scan`. A portable automatic rebuild is deferred to issue #3219.
+
+---
 
 ## Overview
 
-CodeQL is a semantic code analysis engine that helps identify security vulnerabilities and coding errors. This repository implements a multi-tier CodeQL integration strategy providing:
+CodeQL is a semantic code analysis engine for security findings and code-quality defects. This repository uses it in two live tiers:
 
-- **Tier 1 (CI/CD)**: Automated security scanning on all pull requests with SARIF upload to GitHub Security tab
-- **Tier 2 (Local Development)**: Developer-initiated scans via VSCode tasks and Claude Code skills
-- **Tier 3 (Automatic)**: Non-blocking PostToolUse hook for targeted security feedback during development
+- **Tier 1 (CI/CD)**: GitHub's native CodeQL action runs as a blocking PR gate and uploads SARIF to the GitHub Security tab.
+- **Tier 2 (Local, on-demand)**: Developers and agents run the `codeql-scan` skill or `.codeql/scripts/invoke_codeql_scan.py` directly.
 
-**Supported Languages**:
+**Supported local script languages today**:
 
 - Python
 - GitHub Actions workflows
 
+The checked-in CI workflow matrix currently runs CodeQL for `actions` and `python`.
+
 **Benefits**:
 
-- Early vulnerability detection before code review
-- Consistent security standards across all contributions
-- Fast feedback during development with database caching
-- Graceful degradation when CLI unavailable
+- Security findings appear before merge.
+- Local scans let builders fix issues before opening a PR.
+- CI and local scans share `.github/codeql/codeql-config.yml` by default.
+- Quick local scans use `.github/codeql/codeql-config-quick.yml` through `--quick-scan`.
 
 ---
 
@@ -32,27 +34,43 @@ CodeQL is a semantic code analysis engine that helps identify security vulnerabi
 ### One-Command Setup
 
 ```bash
-# Install CodeQL CLI and configure all integrations
 python3 .codeql/scripts/install_codeql_integration.py
 ```
 
-This installs:
+This integration installer can install or configure:
 
-- CodeQL CLI (latest version)
-- Shared configuration
-- VSCode integration
-- Claude Code skill
-- PostToolUse hook
+- CodeQL CLI.
+- VS Code integration.
+- Claude Code `codeql-scan` skill.
+- Pre-commit verification.
+
+Use skip flags when you only want part of the setup:
+
+```bash
+python3 .codeql/scripts/install_codeql_integration.py --skip-vscode --skip-pre-commit
+```
+
+### Full Scan
+
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py
+```
+
+Defaults:
+
+- Repository path: `.` or `CODEQL_REPO_PATH`.
+- Config path: `.github/codeql/codeql-config.yml` or `CODEQL_CONFIG_PATH`.
+- Database path: `.codeql/db` or `CODEQL_DATABASE_PATH`.
+- Results path: `.codeql/results` or `CODEQL_RESULTS_PATH`.
+- Output format: `console`.
 
 ### Quick Scan
 
 ```bash
-# Full repository scan
-python3 .codeql/scripts/invoke_codeql_scan.py
-
-# Quick scan with caching
-python3 .codeql/scripts/invoke_codeql_scan.py --use-cache
+python3 .codeql/scripts/invoke_codeql_scan.py --quick-scan --use-cache
 ```
+
+With the default config path, `--quick-scan` switches to `.github/codeql/codeql-config-quick.yml`.
 
 ---
 
@@ -60,64 +78,57 @@ python3 .codeql/scripts/invoke_codeql_scan.py --use-cache
 
 ### Prerequisites
 
-- **PowerShell 7.5.4+**: Cross-platform PowerShell (`pwsh`)
-- **Internet connection**: For downloading CodeQL CLI
-- **Disk space**: ~500MB for CodeQL CLI and databases
+- Python 3.
+- Internet access for downloading the CodeQL CLI.
+- Disk space for the CLI, databases, and SARIF results.
+- `zstd` in CI or environments that need to extract the CodeQL bundle.
 
-### Installation Steps
-
-#### 1. Install CodeQL CLI
+### 1. Install CodeQL CLI
 
 ```bash
-# Download and install CodeQL CLI
-python3 .codeql/scripts/install_codeql.py
+python3 .codeql/scripts/install_codeql.py --ci --force
+```
 
-# Add to PATH (optional, for command-line access)
+Optional flags:
+
+```bash
+python3 .codeql/scripts/install_codeql.py --version VERSION
+python3 .codeql/scripts/install_codeql.py --install-path .codeql/cli
 python3 .codeql/scripts/install_codeql.py --add-to-path
 ```
 
-**Verification**:
+Verify the CLI:
 
 ```bash
-# Check CLI version
 .codeql/cli/codeql version
 ```
 
-Expected output:
-
-```text
-CodeQL command-line toolchain release 2.23.9.
-```
-
-#### 2. Configure Integration
+### 2. Configure Integration
 
 ```bash
-# Install all integration components
 python3 .codeql/scripts/install_codeql_integration.py
 ```
 
-This configures:
+Available flags:
 
-- Shared configuration at `.github/codeql/codeql-config.yml`
-- Quick scan configuration at `.github/codeql/codeql-config-quick.yml`
-- VSCode tasks and settings
-- Claude Code skill
-- PostToolUse hook
+| Flag | Use when |
+|------|----------|
+| `--skip-cli` | The CLI is already installed. |
+| `--skip-vscode` | You do not want editor configuration. |
+| `--skip-claude-skill` | You do not want the Claude Code skill installed. |
+| `--skip-pre-commit` | You do not want pre-commit verification. |
+| `--ci` | The command runs in automation. |
 
-#### 3. Verify Configuration
+### 3. Verify Configuration
 
 ```bash
-# Validate configuration files
-python3 .codeql/scripts/test_codeql_config.py
+python3 .codeql/scripts/test_codeql_config.py --ci
 ```
 
-**Expected output**:
+JSON output is available for automation:
 
-```text
-[PASS] Configuration file exists
-[PASS] YAML syntax valid
-[PASS] Query packs resolvable
-[PASS] Configuration ready
+```bash
+python3 .codeql/scripts/test_codeql_config.py --format json --ci
 ```
 
 ---
@@ -126,93 +137,95 @@ python3 .codeql/scripts/test_codeql_config.py
 
 ### Full Repository Scan
 
-Scans all supported languages with complete query packs:
-
 ```bash
 python3 .codeql/scripts/invoke_codeql_scan.py
 ```
 
-**Output**: SARIF results at `.codeql/results/codeql-results.sarif`
+Use this before opening a PR or after larger changes.
 
-**Duration**: ~30-60 seconds (first run), ~10-20 seconds (with cache)
+Expected local outputs:
 
-### Quick Scan with Cache
+- CodeQL databases under `.codeql/db`.
+- SARIF files under `.codeql/results`.
+- Console summary by default.
 
-Uses cached databases for faster feedback:
+### Quick Targeted Scan
 
 ```bash
-python3 .codeql/scripts/invoke_codeql_scan.py --use-cache
+python3 .codeql/scripts/invoke_codeql_scan.py --quick-scan --use-cache
 ```
 
-**Cache invalidation triggers**:
-
-- Git HEAD changes (new commits)
-- Configuration file updates
-- Forced rebuild with `-Force` flag
+Use this during active development when you want faster feedback from targeted queries.
 
 ### Language-Specific Scan
 
-Scan only specific language:
-
 ```bash
-# Python only
 python3 .codeql/scripts/invoke_codeql_scan.py --languages python
-
-# GitHub Actions only
 python3 .codeql/scripts/invoke_codeql_scan.py --languages actions
+python3 .codeql/scripts/invoke_codeql_scan.py --languages python actions
 ```
 
-### Configuration Validation
-
-Verify configuration before scanning:
+### Output Formats
 
 ```bash
-# Validate configuration
-python3 .codeql/scripts/test_codeql_config.py
+python3 .codeql/scripts/invoke_codeql_scan.py --format console
+python3 .codeql/scripts/invoke_codeql_scan.py --format sarif
+python3 .codeql/scripts/invoke_codeql_scan.py --format json
+```
 
-# Verbose diagnostics
-python3 .codeql/scripts/get_codeql_diagnostics.py
+### CI Behavior
+
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py --ci
+```
+
+In CI mode, the scan exits 1 when findings are detected.
+
+### Diagnostics
+
+```bash
+python3 .codeql/scripts/get_codeql_diagnostics.py --output-format console
+python3 .codeql/scripts/get_codeql_diagnostics.py --output-format json
+python3 .codeql/scripts/get_codeql_diagnostics.py --output-format markdown
 ```
 
 ### Claude Code Skill
 
 ```bash
-# Via skill system
 /codeql-scan
+```
 
-# Direct invocation
-python3 .claude/skills/codeql-scan/scripts/invoke_codeql_scan_skill.py --operation full
-python3 .claude/skills/codeql-scan/scripts/invoke_codeql_scan_skill.py --operation quick
+The skill wraps the same local scanning path. Its documented direct wrapper supports full, quick, and validate operations:
+
+```bash
+python3 .claude/skills/codeql-scan/scripts/invoke_codeql_scan.py --operation full
+python3 .claude/skills/codeql-scan/scripts/invoke_codeql_scan.py --operation quick
+python3 .claude/skills/codeql-scan/scripts/invoke_codeql_scan.py --operation validate
 ```
 
 ---
 
-## Multi-Tier Integration
+## Two-Tier Integration
 
 ```mermaid
 flowchart TD
-    A[Code Changes] --> B{Tier Selection}
-    B --> C[Tier 1: CI/CD]
-    B --> D[Tier 2: Local Dev]
-    B --> E[Tier 3: Automatic]
+    Change[Code changes] --> Choice{Where should scan run?}
+    Choice --> CI[Tier 1: CI/CD]
+    Choice --> Local[Tier 2: Local on-demand]
 
-    C --> C1[GitHub Actions Workflow]
-    C1 --> C2[Full Scan + SARIF Upload]
-    C2 --> C3[Blocking on Critical Findings]
+    CI --> Native[GitHub CodeQL action]
+    Native --> Full[Full security-extended analysis]
+    Full --> Upload[SARIF to GitHub Security tab]
+    Upload --> Gate[Required PR check]
 
-    D --> D1[Developer-Initiated]
-    D1 --> D2[VSCode Task]
-    D1 --> D3[Claude Code Skill]
-    D2 --> D4[On-Demand Scan]
-    D3 --> D4
-
-    E --> E1[PostToolUse Hook]
-    E1 --> E2[Targeted Queries]
-    E2 --> E3[Non-Blocking Feedback]
-
-    C3 --> F[Security Tab]
-    D4 --> G[Local Results]
-    E3 --> H[Console Output]
+    Local --> Skill[codeql-scan skill]
+    Local --> Script[invoke_codeql_scan.py]
+    Skill --> Script
+    Script --> Mode{Mode}
+    Mode --> FullLocal[Full scan]
+    Mode --> Quick[Quick targeted scan]
+    FullLocal --> Results[.codeql/results]
+    Quick --> Results
 ```
 
 ### Tier 1: CI/CD Integration
@@ -221,60 +234,49 @@ flowchart TD
 
 **Triggers**:
 
-- All pull requests
-- Pushes to main branch
-- Manual workflow dispatch
+- Push to `main`.
+- Pull request to `main`.
+- Weekly schedule, Monday 09:00 UTC, cron `0 9 * * 1`.
+- Manual dispatch.
 
 **Behavior**:
 
-- Scans all supported languages
-- Uploads SARIF to GitHub Security tab
-- Blocks merge if critical findings detected
-- Results visible in PR checks
+- Runs on all PRs to satisfy required status checks.
+- Uses `check-paths` to skip analysis when no scannable files changed.
+- Uses GitHub's native CodeQL action.
+- Uploads SARIF to the GitHub Security tab.
+- Uses `.github/codeql/codeql-config.yml`.
+- Filters out low severity findings and recommendations.
 
-**Configuration**: Shared config at `.github/codeql/codeql-config.yml`
+**Timeout budget**: 300 seconds for the CodeQL analysis path.
 
-**Timeout**: 300 seconds (5 minutes)
+### Tier 2: Local On-Demand Scanning
 
-### Tier 2: Local Development
+**Entry points**:
 
-**VSCode Tasks** (`.vscode/tasks.json`):
+- `/codeql-scan` skill.
+- `.codeql/scripts/invoke_codeql_scan.py`.
+- Optional editor tasks installed by the integration installer.
 
-- `CodeQL: Full Scan` - Complete repository analysis
-- `CodeQL: Quick Scan` - Fast scan with caching
-- `CodeQL: Validate Config` - Configuration check
-
-**Claude Code Skill** (`.claude/skills/codeql-scan/`):
+**Common commands**:
 
 ```bash
-/codeql-scan  # Interactive skill
+python3 .codeql/scripts/invoke_codeql_scan.py
+python3 .codeql/scripts/invoke_codeql_scan.py --quick-scan --use-cache
+python3 .codeql/scripts/invoke_codeql_scan.py --languages python --format json
 ```
 
-**Features**:
+**Timeout budget**: 60 seconds by default.
 
-- Database caching for fast iterations
-- Immediate feedback without waiting for CI
-- Same query packs as CI for consistency
+### Retired Automatic Edit-Time Scanning
 
-### Tier 3: Automatic Scanning
+The automatic edit-time hook was retired on 2026-07-21. Do not troubleshoot, reinstall, or extend it. Use explicit quick scans for fast feedback:
 
-**PostToolUse Hook** (`.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py`):
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py --quick-scan --use-cache
+```
 
-**Triggers**:
-
-- After Edit, Write, or NotebookEdit tool use
-- When files match Python or Actions patterns
-
-**Behavior**:
-
-- Runs targeted security queries (CWE-078, CWE-079, CWE-089, CWE-022, CWE-798)
-- Non-blocking (errors don't halt workflow)
-- Quick scan configuration (5-10 critical queries)
-- Graceful degradation when CLI unavailable
-
-**Timeout**: 30 seconds
-
-**Configuration**: Quick config at `.github/codeql/codeql-config-quick.yml`
+The portable rebuild is tracked by issue #3219.
 
 ---
 
@@ -284,93 +286,77 @@ flowchart TD
 
 **File**: `.github/codeql/codeql-config.yml`
 
-```yaml
-name: "CodeQL Config"
+This config is used by the CI workflow and local scans by default.
 
-queries:
-  - uses: security-extended
+Key settings:
 
-paths:
-  - .github/workflows
-  - .claude/hooks
-  - .codeql/scripts
-  - scripts
-
-paths-ignore:
-  - tests
-  - "**/*.Tests.ps1"
-  - "**/*.md"
-```
-
-**Query Packs**:
-
-- `security-extended`: Security vulnerabilities + common coding errors
-- Custom packs can be added via `uses:` directive
-
-**Severity Filtering**: Configured in workflow (error, warning, note)
+- `disable-default-queries: false`.
+- Packs for `actions` and `python` security-extended suites.
+- `queries: security-extended`.
+- Query filters exclude low severity and recommendation-tagged findings.
+- Paths include scripts, GitHub automation, Claude skills, hooks, and build code.
+- Paths ignore tests, `.agents/`, docs, and Markdown.
 
 ### Quick Scan Configuration
 
 **File**: `.github/codeql/codeql-config-quick.yml`
 
-```yaml
-name: "CodeQL Quick Config"
+This config is selected by `invoke_codeql_scan.py --quick-scan` when using the default config path.
 
-queries:
-  - uses: security-extended
-    tags:
-      - security
-      - cwe-078  # Command injection
-      - cwe-079  # XSS
-      - cwe-089  # SQL injection
-      - cwe-022  # Path traversal
-      - cwe-798  # Hard-coded credentials
-```
+It targets:
 
-**Purpose**: Fast targeted scans for PostToolUse hook
-
-**Queries**: 5-10 critical security patterns
-
-**Performance**: ~5-15 seconds vs ~30-60 seconds for full scan
+- Command injection.
+- SQL injection.
+- Cross-site scripting.
+- Path traversal.
+- Hardcoded credentials.
 
 ### Customization
 
 #### Adding New Languages
 
-1. Update `.github/codeql/codeql-config.yml`:
+Only document a language as supported after the workflow and config both support it.
 
-   ```yaml
-   languages:
-     - python
-     - actions
-     - javascript  # Add new language
-   ```
+1. Update `.github/workflows/codeql-analysis.yml`.
+2. Update `.github/codeql/codeql-config.yml`.
+3. Add targeted queries to `.github/codeql/codeql-config-quick.yml` if quick coverage is available.
+4. Validate config.
+5. Run a local scan for that language.
 
-2. Update workflow `.github/workflows/codeql-analysis.yml`:
-
-   ```yaml
-   strategy:
-     matrix:
-       language: [python, actions, javascript]
-   ```
+```bash
+python3 .codeql/scripts/test_codeql_config.py --ci
+python3 .codeql/scripts/invoke_codeql_scan.py --languages python --ci
+```
 
 #### Adding Custom Queries
 
+Add trusted query packs to `.github/codeql/codeql-config.yml`:
+
 ```yaml
-queries:
-  - uses: security-extended
-  - uses: ./custom-queries  # Local query pack
-  - uses: owner/repo/query-pack@version  # Remote pack
+packs:
+  - codeql/actions-queries:codeql-suites/actions-security-extended.qls
+  - codeql/python-queries:codeql-suites/python-security-extended.qls
+```
+
+Then validate:
+
+```bash
+python3 .codeql/scripts/test_codeql_config.py --ci
 ```
 
 #### Excluding Paths
 
+Add ignores under `paths-ignore` in `.github/codeql/codeql-config.yml`:
+
 ```yaml
 paths-ignore:
-  - vendor/**
-  - third-party/**
-  - "**/*.generated.*"
+  - tests/
+  - .agents/
+  - docs/
+  - '**/*.md'
 ```
+
+Keep exclusions narrow. Each exclusion removes security coverage.
 
 ---
 
@@ -378,120 +364,87 @@ paths-ignore:
 
 ### CLI Not Found
 
-**Error**:
+**Symptom**:
 
 ```text
-CodeQL CLI not found at .codeql/cli/codeql
+CodeQL CLI not found
 ```
 
-**Solution**:
+**Fix**:
 
 ```bash
-# Install CodeQL CLI
-python3 .codeql/scripts/install_codeql.py
-
-# Verify installation
+python3 .codeql/scripts/install_codeql.py --ci --force
 .codeql/cli/codeql version
 ```
 
 ### Configuration Validation Failed
 
-**Error**:
-
-```text
-[FAIL] YAML syntax invalid
-```
-
-**Solution**:
+**Fix**:
 
 ```bash
-# Validate YAML syntax
-python3 .codeql/scripts/test_codeql_config.py
-
-# Check for common issues:
-# - Incorrect indentation
-# - Missing quotes around paths with special characters
-# - Invalid query pack references
+python3 .codeql/scripts/test_codeql_config.py --ci --format console
 ```
+
+Check:
+
+- YAML syntax.
+- Query pack names.
+- Paths under `.github/codeql/`.
 
 ### Scan Timeout
 
-**Error**:
-
-```text
-Scan exceeded timeout of 300 seconds
-```
-
-**Solutions**:
+**Fix options**:
 
 ```bash
-# Option 1: Scan specific language
+# Scan one language
 python3 .codeql/scripts/invoke_codeql_scan.py --languages python
 
-# Option 2: Increase timeout (in workflow YAML)
-timeout-minutes: 10
-
-# Option 3: Use quick scan for faster feedback
+# Use cached databases
 python3 .codeql/scripts/invoke_codeql_scan.py --use-cache
+
+# Use targeted quick scan
+python3 .codeql/scripts/invoke_codeql_scan.py --quick-scan --use-cache
 ```
 
-### Cache Invalidation Issues
+### Cache Problems
 
-**Symptom**: Old results despite code changes
+**Symptom**: results do not reflect recent code changes.
 
-**Solutions**:
+**Fix options**:
 
 ```bash
-# Force database rebuild
+# Run without cache
 python3 .codeql/scripts/invoke_codeql_scan.py
 
-# Clear cache manually
-Remove-Item -Recurse -Force .codeql/db
+# Write databases to a fresh project-local path
+python3 .codeql/scripts/invoke_codeql_scan.py --database-path .codeql/db-fresh
 ```
 
-### Hook Not Triggering
+Do not commit local database directories.
 
-**Symptom**: PostToolUse hook not running
+### Retired Hook Questions
 
-**Verification**:
+The automatic edit-time hook no longer ships. If a guide or comment tells you to test it, that source is stale. Use the explicit quick scan command instead:
 
 ```bash
-# Check hook exists
-test -f ".claude/hooks/PostToolUse/invoke_codeql_quick_scan.py"
-
-# Check hook permissions
-ls -la ".claude/hooks/PostToolUse/invoke_codeql_quick_scan.py"
-
-# Manual test
-python3 .claude/hooks/PostToolUse/invoke_codeql_quick_scan.py --file-path "example.py" --tool-name "Edit"
+python3 .codeql/scripts/invoke_codeql_scan.py --quick-scan --use-cache
 ```
-
-**Common Issues**:
-
-- Hook not executable: Set executable permissions
-- CLI not installed: Run `Install-CodeQL.ps1`
-- Configuration invalid: Run `Test-CodeQLConfig.ps1`
 
 ### Database Creation Failed
 
-**Error**:
-
-```text
-Failed to create CodeQL database
-```
-
-**Solutions**:
+Run diagnostics:
 
 ```bash
-# Run diagnostics
-python3 .codeql/scripts/get_codeql_diagnostics.py
-
-# Check for:
-# - Unsupported language
-# - Syntax errors in source files
-# - Insufficient disk space
-# - Permission issues
+python3 .codeql/scripts/get_codeql_diagnostics.py --output-format markdown
 ```
+
+Check:
+
+- CLI installation.
+- Config file path.
+- Disk space.
+- File permissions.
+- Supported language value.
 
 ---
 
@@ -499,151 +452,65 @@ python3 .codeql/scripts/get_codeql_diagnostics.py
 
 ### When should I use full scan vs quick scan?
 
-**Full Scan** (`Invoke-CodeQLScan.ps1`):
+Use full scan before opening a PR, after broad changes, or when investigating a security-sensitive path:
 
-- Before creating PR
-- After major refactoring
-- When investigating security concerns
-- Weekly security audit
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py
+```
 
-**Quick Scan** (`Invoke-CodeQLScan.ps1 -UseCache`):
+Use quick scan during active development:
 
-- During active development
-- After small changes
-- For fast feedback loops
-- Via PostToolUse hook
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py --quick-scan --use-cache
+```
 
 ### How does database caching work?
 
-**Cache Location**: `.codeql/db/`
+Local databases live under `.codeql/db` by default. Pass `--use-cache` when you want the script to reuse valid cached databases:
 
-**Invalidation Triggers**:
-
-- Git HEAD changes (new commits)
-- Configuration file modifications
-- Source file changes in scanned paths
-- Manual force rebuild with `-Force`
-
-**Benefits**:
-
-- 3-5x faster scans
-- Reduces CI/CD time
-- Enables frequent local scanning
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py --use-cache
+```
 
 ### What languages are supported?
 
-**Current**:
+The checked-in CI workflow currently scans the `actions` and `python` matrix entries. Local scans accept languages through:
 
-- Python (`.py` files)
-- GitHub Actions (`.github/workflows/*.yml`)
-
-**Potential**:
-
-- JavaScript/TypeScript
-- C#
-- Java
-- Go
-- Ruby
-
-See [CodeQL language support](https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/) for complete list.
-
-### How do I add custom queries?
-
-**Local Query Pack**:
-
-1. Create `.codeql/custom-queries/` directory
-2. Add `qlpack.yml` defining pack
-3. Add `.ql` query files
-4. Reference in configuration:
-
-   ```yaml
-   queries:
-     - uses: ./custom-queries
-   ```
-
-**Remote Query Pack**:
-
-```yaml
-queries:
-  - uses: owner/repo/pack@version
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py --languages python actions
 ```
 
 ### What happens if scan finds vulnerabilities?
 
-**CI/CD (Tier 1)**:
-
-- SARIF uploaded to Security tab
-- PR check fails for critical findings
-- Results shown in PR diff view
-- Merge blocked until fixed
-
-**Local Development (Tier 2)**:
-
-- Results in `.codeql/results/codeql-results.sarif`
-- Summary shown in console
-- Developer reviews and fixes
-
-**Automatic (Tier 3)**:
-
-- Console warning with CWE reference
-- Non-blocking (development continues)
-- Suggestion to run full scan
+- Local default mode reports findings to the selected output format.
+- Local `--ci` mode exits 1 when findings are detected.
+- CI uploads SARIF and uses the workflow gate to block merge when configured blocking findings are present.
 
 ### How do I exclude false positives?
 
-**Option 1**: Suppress in code (language-specific)
+Prefer fixing the code. If a finding is a true false positive, document the reason in the code or CodeQL configuration and keep the suppression narrow.
 
-```python
-# Python example
-result = subprocess.run(command, shell=True)  # codeql[py/command-injection]
-```
+### Why is automatic edit-time scanning retired?
 
-**Option 2**: Exclude path in configuration
-
-```yaml
-paths-ignore:
-  - path/to/false-positive.py
-```
-
-**Option 3**: Custom query pack filtering specific patterns
-
-### Why is the hook non-blocking?
-
-**Design Decision**: PostToolUse hook provides feedback without interrupting workflow
-
-**Benefits**:
-
-- Developer remains in flow state
-- Graceful degradation when CLI unavailable
-- Fast feedback without blocking progress
-
-**Trade-off**: Developer may miss warnings if not paying attention
-
-**Mitigation**: CI/CD blocks merge for critical findings
+The retired hook was not registered in active hook surfaces and did not run. The ADR-041 amendment removed that dead path and kept the useful parts: CI enforcement and explicit local scans. Issue #3219 tracks a portable rebuild.
 
 ---
 
 ## Related Documentation
 
-- **Claude Code Skill**: [.claude/skills/codeql-scan/SKILL.md](../.claude/skills/codeql-scan/SKILL.md)
-- **CI/CD Workflow**: [.github/workflows/codeql-analysis.yml](../.github/workflows/codeql-analysis.yml)
-- **Test Workflow**: [.github/workflows/test-codeql-integration.yml](../.github/workflows/test-codeql-integration.yml)
-- **Architecture Details**: [codeql-architecture.md](./codeql-architecture.md)
-- **Installation Scripts**:
-  - [Install-CodeQL.ps1](../.codeql/scripts/Install-CodeQL.ps1)
-  - [Install-CodeQLIntegration.ps1](../.codeql/scripts/Install-CodeQLIntegration.ps1)
-- **Scanning Scripts**:
-  - [Invoke-CodeQLScan.ps1](../.codeql/scripts/Invoke-CodeQLScan.ps1)
-  - [Test-CodeQLConfig.ps1](../.codeql/scripts/Test-CodeQLConfig.ps1)
-  - [Get-CodeQLDiagnostics.ps1](../.codeql/scripts/Get-CodeQLDiagnostics.ps1)
-
----
+- [CodeQL architecture](./codeql-architecture.md)
+- [CodeQL rollout checklist](./codeql-rollout-checklist.md)
+- [ADR-041: CodeQL Integration Multi-Tier Strategy](../.agents/architecture/ADR-041-codeql-integration.md), amended 2026-07-21 to two tiers.
+- [ADR-042: Python Migration Strategy](../.agents/architecture/ADR-042-python-migration-strategy.md)
+- [CodeQL documentation](https://codeql.github.com/docs/)
+- [GitHub CodeQL action](https://github.com/github/codeql-action)
 
 ## Support
 
-For issues or questions:
+For local setup failures, run diagnostics first:
 
-1. **Diagnostics**: Run `python3 .codeql/scripts/get_codeql_diagnostics.py`
-2. **Validation**: Run `python3 .codeql/scripts/test_codeql_config.py`
-3. **Documentation**: See [CodeQL documentation](https://codeql.github.com/docs/)
-4. **Repository Issues**: [GitHub Issues](https://github.com/rjmurillo/ai-agents/issues)
+```bash
+python3 .codeql/scripts/get_codeql_diagnostics.py --output-format markdown
+```
+
+For CI failures, inspect `.github/workflows/codeql-analysis.yml`, the uploaded SARIF artifact, and the GitHub Security tab.

--- a/docs/codeql-integration.md
+++ b/docs/codeql-integration.md
@@ -81,7 +81,7 @@ With the default config path, `--quick-scan` switches to `.github/codeql/codeql-
 - Python 3.
 - Internet access for downloading the CodeQL CLI.
 - Disk space for the CLI, databases, and SARIF results.
-- `zstd` in CI or environments that need to extract the CodeQL bundle.
+- Standard `tar` with gzip support. The installer downloads a `.tar.gz` bundle and extracts it with `tar -xzf`, so it does not need `zstd`.
 
 ### 1. Install CodeQL CLI
 

--- a/docs/codeql-rollout-checklist.md
+++ b/docs/codeql-rollout-checklist.md
@@ -1,444 +1,383 @@
 # CodeQL Integration Rollout Checklist
 
-> [!WARNING]
-> **This document is partially out of date.** It describes the pre-Python-migration PowerShell implementation and a three-tier strategy whose Tier 3 (the automatic PostToolUse quick-scan hook) was removed as dead code on 2026-07-21. The current CodeQL strategy is two-tier: Tier 1 (CI/CD blocking gate) and Tier 2 (on-demand `codeql-scan` skill). See the ADR-041 amendment (2026-07-21) and issue #3296 for the full overhaul. Refs #3295, #3197.
+This checklist validates the current CodeQL integration. The implementation uses Python scripts in `.codeql/scripts/`, shared config files in `.github/codeql/`, and a two-tier strategy from ADR-041 as amended on 2026-07-21.
 
-This checklist provides a systematic approach to deploying and validating the CodeQL security analysis integration across all tiers.
+The automatic edit-time hook was retired on 2026-07-21. Do not include it in rollout, rollback, validation, or troubleshooting steps. Use explicit quick scans through `invoke_codeql_scan.py --quick-scan`.
+
+---
 
 ## Pre-Rollout
 
-Verify all prerequisites are met before beginning rollout:
+Verify all prerequisites before rollout:
 
-- [ ] **Implementation Complete**: All phases of CodeQL integration implemented
-  - [ ] CLI installation scripts (`Install-CodeQL.ps1`, `Install-CodeQLIntegration.ps1`)
-  - [ ] Scanning scripts (`Invoke-CodeQLScan.ps1`, `Test-CodeQLConfig.ps1`, `Get-CodeQLDiagnostics.ps1`)
-  - [ ] Shared configurations (`.github/codeql/codeql-config.yml`, `codeql-config-quick.yml`)
-  - [ ] CI/CD workflows (`.github/workflows/codeql-analysis.yml`, `test-codeql-integration.yml`)
-  - [ ] VSCode integration (`.vscode/tasks.json`, `.vscode/extensions.json`, `.vscode/settings.json`)
-  - [ ] Claude Code skill (`.claude/skills/codeql-scan/`)
-  - [ ] PostToolUse hook (`.claude/hooks/PostToolUse/invoke_codeql_quick_scan.py`)
+- [ ] **Implementation complete**
+  - [ ] CLI installer exists: `.codeql/scripts/install_codeql.py`
+  - [ ] Integration installer exists: `.codeql/scripts/install_codeql_integration.py`
+  - [ ] Scan script exists: `.codeql/scripts/invoke_codeql_scan.py`
+  - [ ] Config validator exists: `.codeql/scripts/test_codeql_config.py`
+  - [ ] Diagnostics script exists: `.codeql/scripts/get_codeql_diagnostics.py`
+  - [ ] Rollout validator exists: `.codeql/scripts/test_codeql_rollout.py`
+  - [ ] Shared config exists: `.github/codeql/codeql-config.yml`
+  - [ ] Quick config exists: `.github/codeql/codeql-config-quick.yml`
+  - [ ] CI workflow exists: `.github/workflows/codeql-analysis.yml`
+  - [ ] Integration test workflow exists: `.github/workflows/test-codeql-integration.yml`
+  - [ ] Claude Code skill exists: `.claude/skills/codeql-scan/`
 
-- [ ] **All Tests Passing**: Unit and integration tests verified
-  - [ ] `tests/test_install_codeql.py` passing
-  - [ ] `tests/test_invoke_codeql_scan_py.py` passing
-  - [ ] `tests/test_install_codeql_integration.py` passing
-  - [ ] `tests/test_test_codeql_rollout.py` passing
-  - [ ] Run: `uv run pytest tests/`
+- [ ] **Tests passing**
+  - [ ] CodeQL script unit tests pass.
+  - [ ] CodeQL skill tests pass.
+  - [ ] Rollout validator tests pass.
+  - [ ] Run targeted pytest command:
 
-- [ ] **Documentation Reviewed**: All documentation complete and accurate
+    ```bash
+    uv run pytest tests/test_install_codeql.py tests/test_install_codeql_integration.py tests/test_invoke_codeql_scan_py.py tests/test_test_codeql_config.py tests/test_get_codeql_diagnostics.py tests/test_test_codeql_rollout.py tests/skills/codeql-scan/test_invoke_codeql_scan_skill.py
+    ```
+
+- [ ] **Documentation reviewed**
   - [ ] User guide: `docs/codeql-integration.md`
-  - [ ] Architecture docs: `docs/codeql-architecture.md`
-  - [ ] ADR-041: `.agents/architecture/ADR-041-codeql-integration.md`
-  - [ ] AGENTS.md updated with CodeQL commands
+  - [ ] Architecture guide: `docs/codeql-architecture.md`
+  - [ ] Rollout checklist: `docs/codeql-rollout-checklist.md`
+  - [ ] ADR-041 amendment reflected: `.agents/architecture/ADR-041-codeql-integration.md`
+  - [ ] ADR-042 Python migration reference reflected: `.agents/architecture/ADR-042-python-migration-strategy.md`
 
-- [ ] **ADR Approved**: ADR-041 reviewed and accepted
-  - [ ] Multi-tier strategy rationale validated
-  - [ ] Alternatives considered documented
-  - [ ] Consequences understood and accepted
-  - [ ] Related decisions linked
+- [ ] **ADR status understood**
+  - [ ] ADR-041 remains the CodeQL strategy record.
+  - [ ] ADR-041 was amended on 2026-07-21 to two live tiers.
+  - [ ] ADR-042 supersedes the older scripting-language decision for new internal automation.
+  - [ ] Issue #3219 tracks the deferred portable automatic scanning rebuild.
 
 ---
 
 ## Rollout Steps
 
-### Step 1: Run Automated Validation
+### Step 1: Run Automated Deployment Validation
 
 ```bash
-python3 .codeql/scripts/test_codeql_rollout.py
+python3 .codeql/scripts/test_codeql_rollout.py --ci
 ```
 
-**Expected Result**: All checks pass (45/45)
+Optional JSON output:
 
-- [ ] **CLI Installation**:
-  - [ ] CodeQL CLI exists at `.codeql/cli/codeql`
-  - [ ] CLI version: v2.23.9 or later
-  - [ ] CLI executable (Unix systems)
+```bash
+python3 .codeql/scripts/test_codeql_rollout.py --format json --ci
+```
 
-- [ ] **Configuration**:
-  - [ ] Shared config exists (`.github/codeql/codeql-config.yml`)
-  - [ ] Quick config exists (`.github/codeql/codeql-config-quick.yml`)
-  - [ ] YAML syntax valid
-  - [ ] Query packs resolvable
+Expected result:
 
-- [ ] **Scripts**:
-  - [ ] All 5 required scripts exist
-  - [ ] Scripts executable (Unix systems)
-  - [ ] Pester tests exist (3 test files)
-
-- [ ] **CI/CD Integration**:
-  - [ ] CodeQL workflow exists (`.github/workflows/codeql-analysis.yml`)
-  - [ ] Test workflow exists (`.github/workflows/test-codeql-integration.yml`)
-  - [ ] SHA-pinned actions configured
-  - [ ] Shared config referenced in workflow
-
-- [ ] **Local Development**:
-  - [ ] VSCode extensions configured
-  - [ ] VSCode tasks configured
-  - [ ] VSCode settings configured
-  - [ ] Claude Code skill exists
-  - [ ] Skill script executable
-
-- [ ] **Automatic Scanning**:
-  - [ ] PostToolUse hook exists
-  - [ ] Hook script executable (Unix systems)
-  - [ ] Quick config referenced by hook
-
-- [ ] **Documentation**:
-  - [ ] User docs exist
-  - [ ] Developer docs exist
-  - [ ] ADR exists
-  - [ ] AGENTS.md updated
-
-- [ ] **Tests**:
-  - [ ] Unit tests discoverable
-  - [ ] Integration tests exist
-
-- [ ] **Gitignore**:
-  - [ ] CodeQL directories excluded (`.codeql/cli/`, `.codeql/db/`, `.codeql/results/`, `.codeql/logs/`)
+- [ ] Validator exits 0.
+- [ ] CLI installation checks pass.
+- [ ] Config file checks pass.
+- [ ] Script existence checks pass.
+- [ ] CI workflow checks pass.
+- [ ] Local development checks pass.
+- [ ] Documentation checks pass.
+- [ ] Gitignore checks pass for `.codeql/cli/`, `.codeql/db/`, `.codeql/results/`, and `.codeql/logs/`.
 
 ### Step 2: Verify CLI Installation
 
 ```bash
-python3 .codeql/scripts/install_codeql.py --add-to-path
+python3 .codeql/scripts/install_codeql.py --ci --force
 .codeql/cli/codeql version
 ```
 
-**Expected Output**:
+Expected result:
 
-```text
-CodeQL command-line toolchain release 2.23.9.
-```
+- [ ] CLI downloads successfully.
+- [ ] CLI executable exists at `.codeql/cli/codeql` on Linux.
+- [ ] `codeql version` prints a version.
 
-- [ ] CLI downloaded successfully
-- [ ] CLI version correct
-- [ ] CLI executable works
-
-### Step 3: Test Full Scan
-
-Run a full repository scan on a sample repository:
+### Step 3: Validate Full Configuration
 
 ```bash
-python3 .codeql/scripts/invoke_codeql_scan.py
+python3 .codeql/scripts/test_codeql_config.py --config-path .github/codeql/codeql-config.yml --ci
 ```
 
-**Expected Results**:
+Expected result:
 
-- [ ] Languages auto-detected (Python, GitHub Actions)
-- [ ] Databases created for each language
-- [ ] Analysis completed successfully
-- [ ] SARIF output generated at `.codeql/results/codeql-results.sarif`
-- [ ] Scan completed within 60 seconds
-- [ ] Exit code 0 (success)
+- [ ] Config file exists.
+- [ ] YAML is valid.
+- [ ] Query packs are resolvable.
+- [ ] Medium-or-higher filtering remains configured.
 
-**If Failures**:
-
-- Check diagnostics: `python3 .codeql/scripts/get_codeql_diagnostics.py`
-- Validate configuration: `python3 .codeql/scripts/test_codeql_config.py`
-- Review logs: `.codeql/logs/`
-
-### Step 4: Test Quick Scan with Caching
-
-Run a second scan to verify caching works:
+### Step 4: Validate Quick Configuration
 
 ```bash
-python3 .codeql/scripts/invoke_codeql_scan.py --use-cache
+python3 .codeql/scripts/test_codeql_config.py --config-path .github/codeql/codeql-config-quick.yml --ci
 ```
 
-**Expected Results**:
+Expected result:
 
-- [ ] Cached databases reused
-- [ ] Scan completed within 20 seconds (much faster than first scan)
-- [ ] Results consistent with full scan
-- [ ] Exit code 0 (success)
+- [ ] Quick config file exists.
+- [ ] YAML is valid.
+- [ ] Targeted query IDs are valid.
+- [ ] Low severity and recommendation filters remain configured.
 
-### Step 5: Verify VSCode Integration
+### Step 5: Test Full Local Scan
 
-Open the repository in VSCode:
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py --languages python actions --format console
+```
 
-- [ ] **Extensions Recommended**:
-  - [ ] VSCode prompts to install CodeQL extension
-  - [ ] Extension can be installed from recommendations
+Expected result:
 
-- [ ] **Tasks Available**:
-  - [ ] Run task: "CodeQL: Full Scan" (`Ctrl+Shift+P` -> "Tasks: Run Task")
-  - [ ] Task executes successfully
-  - [ ] Results appear in terminal
+- [ ] Databases are created under `.codeql/db`.
+- [ ] Results are written under `.codeql/results`.
+- [ ] Console output summarizes the scan.
+- [ ] Exit code is 0 when no scan failure occurs.
 
-- [ ] **Settings Applied**:
-  - [ ] CodeQL CLI path configured
-  - [ ] CodeQL extension recognizes CLI
+If the scan fails:
 
-### Step 6: Test Claude Code Skill
+```bash
+python3 .codeql/scripts/get_codeql_diagnostics.py --output-format markdown
+python3 .codeql/scripts/test_codeql_config.py --ci
+```
 
-In Claude Code session:
+### Step 6: Test Quick On-Demand Scan
+
+```bash
+python3 .codeql/scripts/invoke_codeql_scan.py --quick-scan --use-cache --format console
+```
+
+Expected result:
+
+- [ ] Script uses quick scan mode.
+- [ ] Default config switches to `.github/codeql/codeql-config-quick.yml`.
+- [ ] Cached databases are reused when valid.
+- [ ] Results are written under `.codeql/results`.
+- [ ] Scan finishes within the local 60 second default budget.
+
+### Step 7: Test Claude Code Skill
+
+In a Claude Code session:
 
 ```bash
 /codeql-scan
 ```
 
-**Or direct invocation**:
+Direct wrapper checks:
 
 ```bash
-python3 .claude/skills/codeql-scan/scripts/invoke_codeql_scan_skill.py --operation full
+python3 .claude/skills/codeql-scan/scripts/invoke_codeql_scan.py --operation validate
+python3 .claude/skills/codeql-scan/scripts/invoke_codeql_scan.py --operation full
+python3 .claude/skills/codeql-scan/scripts/invoke_codeql_scan.py --operation quick
 ```
 
-**Expected Results**:
+Expected result:
 
-- [ ] Skill loads without errors
-- [ ] Scan executes successfully
-- [ ] Results presented clearly
-- [ ] Exit code 0 (success)
-
-### Step 7: Verify PostToolUse Hook
-
-Trigger the hook by editing a Python or Actions file:
-
-1. Edit a `.py` or `.github/workflows/*.yml` file
-2. Observe console output after save
-
-**Expected Results**:
-
-- [ ] Hook triggers automatically after file edit
-- [ ] Quick scan executes (within 30 seconds)
-- [ ] Security warnings displayed (if any findings)
-- [ ] Non-blocking (can continue working immediately)
-- [ ] Graceful degradation if CLI unavailable
-
-**Test Graceful Degradation**:
-
-```bash
-# Temporarily rename CLI to test fallback
-mv .codeql/cli/codeql .codeql/cli/codeql.bak
-
-# Edit a Python file - hook should gracefully skip scan
-
-# Restore CLI
-mv .codeql/cli/codeql.bak .codeql/cli/codeql
-```
-
-- [ ] Hook does not crash when CLI unavailable
-- [ ] Workflow continues uninterrupted
+- [ ] Skill loads without errors.
+- [ ] Validate operation succeeds.
+- [ ] Full operation invokes the core scan path.
+- [ ] Quick operation invokes the targeted local scan path.
+- [ ] Results are clear enough for a developer to act.
 
 ### Step 8: Test CI/CD Workflow
 
-Create a test PR to validate CI integration:
+Use a normal PR that changes a scannable file. Do not create throwaway branches if a real rollout PR already exists.
+
+Expected workflow behavior:
+
+- [ ] `.github/workflows/codeql-analysis.yml` runs on the PR.
+- [ ] `check-paths` detects scannable file changes.
+- [ ] GitHub CodeQL action initializes with `.github/codeql/codeql-config.yml`.
+- [ ] CodeQL analysis runs for the workflow matrix.
+- [ ] SARIF is uploaded to `.codeql/results/<language>.sarif` in the workflow workspace.
+- [ ] SARIF artifact uploads with the `codeql-results-<language>` name.
+- [ ] GitHub Security tab receives uploaded results.
+- [ ] Required check reports pass or fails with actionable findings.
+
+For non-scannable changes:
+
+- [ ] `check-paths` reports no scannable files.
+- [ ] Skip job creates a passing check.
+- [ ] Required status checks are still satisfied.
+
+### Step 9: Test Integration Workflow
+
+The second workflow proves the local Python scripts work in CI.
+
+Expected workflow facts for `.github/workflows/test-codeql-integration.yml`:
+
+- [ ] Runs on `ubuntu-24.04` for CodeQL CLI jobs.
+- [ ] Installs the CLI with:
+
+  ```bash
+  python3 .codeql/scripts/install_codeql.py --ci --force
+  ```
+
+- [ ] Validates config with:
+
+  ```bash
+  python3 .codeql/scripts/test_codeql_config.py --ci
+  ```
+
+- [ ] Scans the language matrix `[actions, python]` with:
+
+  ```bash
+  python3 .codeql/scripts/invoke_codeql_scan.py --languages "$SCAN_LANGUAGE" --ci --format console
+  ```
+
+- [ ] Verifies SARIF files under `.codeql/results`.
+
+### Step 10: Review SARIF Output
+
+Inspect generated SARIF locally or from workflow artifacts:
 
 ```bash
-# Create test branch
-git checkout -b test/codeql-validation
-
-# Make a small change
-echo "# Test comment" >> README.md
-git add README.md
-git commit -m "test: verify CodeQL CI integration"
-
-# Push and create PR
-git push -u origin test/codeql-validation
-gh pr create --title "Test: CodeQL CI Integration" --body "Verify CodeQL workflow runs successfully"
+python3 - <<'PY'
+import json
+from pathlib import Path
+for path in Path('.codeql/results').glob('*.sarif'):
+    data = json.loads(path.read_text())
+    print(path, data.get('version'), len(data.get('runs', [])))
+PY
 ```
 
-**Expected Results**:
+Verify:
 
-- [ ] **Workflow Triggers**:
-  - [ ] CodeQL Analysis workflow runs automatically
-  - [ ] Workflow completes within 5 minutes
-
-- [ ] **Workflow Steps**:
-  - [ ] Checkout step succeeds
-  - [ ] Initialize CodeQL step succeeds
-  - [ ] Autobuild step succeeds (or manual build)
-  - [ ] Perform CodeQL Analysis step succeeds
-  - [ ] Upload SARIF step succeeds
-
-- [ ] **Results**:
-  - [ ] PR check shows green (or red if findings detected)
-  - [ ] SARIF uploaded to Security tab
-  - [ ] Results viewable in GitHub UI
-
-- [ ] **Blocking Behavior** (if critical findings):
-  - [ ] PR cannot be merged until resolved
-  - [ ] Clear error message shown
-
-### Step 9: Review SARIF Output
-
-Examine SARIF results:
-
-```bash
-cat .codeql/results/codeql-results.sarif | jq
-```
-
-**Verify**:
-
-- [ ] Valid SARIF 2.1.0 format
-- [ ] Contains runs for each scanned language
-- [ ] Results include rule ID, message, location
-- [ ] Severity levels populated (error, warning, note)
-- [ ] No sensitive information leaked (credentials, secrets)
+- [ ] SARIF version is present.
+- [ ] Each file has at least one run.
+- [ ] Results include rule ID, message, and location when findings exist.
+- [ ] No secrets are present in output.
+- [ ] Files are not staged for commit.
 
 ---
 
 ## Post-Rollout
 
-### Monitor First PR
+### Monitor First Production PR
 
-After rollout, monitor the next production PR:
-
-- [ ] **CodeQL Analysis Runs**:
-  - [ ] Workflow executes automatically
-  - [ ] Completes successfully (no timeouts)
-  - [ ] Results uploaded to Security tab
-
-- [ ] **Blocking Behavior Verified**:
-  - [ ] Critical findings block merge (if any found)
-  - [ ] Warning/note findings allow merge
-
-- [ ] **Developer Experience**:
-  - [ ] Results clear and actionable
-  - [ ] False positives minimal (< 10%)
-  - [ ] Performance acceptable (< 5 minute PR delay)
+- [ ] CodeQL Analysis workflow starts.
+- [ ] Path filtering behaves correctly.
+- [ ] Analysis completes without timeout.
+- [ ] SARIF uploads to the Security tab.
+- [ ] Required check behavior matches branch protection.
+- [ ] Findings are actionable.
 
 ### Verify SARIF Upload
 
 Check GitHub Security tab:
 
-- [ ] Navigate to repository -> Security -> Code scanning alerts
-- [ ] Verify CodeQL results appear
-- [ ] Check alert details are complete (location, recommendation, severity)
-- [ ] Verify alerts can be dismissed with reason
+- [ ] Navigate to repository -> Security -> Code scanning alerts.
+- [ ] Verify CodeQL results appear.
+- [ ] Check alert detail pages for file, line, rule, severity, and guidance.
+- [ ] Verify dismissal requires a reason.
 
 ### Validate Performance
 
-Check scan times across all tiers:
-
-| Tier | Target | Actual | Status |
+| Path | Target | Actual | Status |
 |------|--------|--------|--------|
-| **Full Scan (CI)** | < 60s | ______ | [ ] PASS |
-| **Quick Scan (Local)** | < 20s | ______ | [ ] PASS |
-| **Hook Scan (Auto)** | < 30s | ______ | [ ] PASS |
+| Tier 1 CI/CD analysis | 300 seconds or less | ______ | [ ] PASS |
+| Tier 2 local full scan | 60 seconds or less | ______ | [ ] PASS |
+| Tier 2 local quick scan | 60 seconds or less | ______ | [ ] PASS |
+| Cache reuse with `--use-cache` | Faster than rebuild | ______ | [ ] PASS |
 
-**If timeouts occur**:
+If timeouts occur:
 
-- [ ] Check database cache is working
-- [ ] Verify query pack selection (quick vs full)
-- [ ] Consider excluding large paths
-- [ ] Review `.codeql/logs/` for bottlenecks
+- [ ] Confirm the scan used the intended language list.
+- [ ] Confirm the config path is correct.
+- [ ] Run diagnostics.
+- [ ] Review `.codeql/results` and workflow logs.
+- [ ] Use quick scan for local iteration, not as a replacement for CI.
+
+```bash
+python3 .codeql/scripts/get_codeql_diagnostics.py --output-format markdown
+```
 
 ### Collect Developer Feedback
 
-Survey team members:
+Ask builders:
 
-- [ ] **Ease of Use**:
-  - [ ] Installation process clear?
-  - [ ] Documentation sufficient?
-  - [ ] VSCode integration helpful?
-
-- [ ] **Value**:
-  - [ ] Findings relevant?
-  - [ ] False positive rate acceptable?
-  - [ ] Caught real issues?
-
-- [ ] **Performance**:
-  - [ ] Scan times acceptable?
-  - [ ] Hook intrusive or helpful?
-  - [ ] CI delay tolerable?
+- [ ] Was CLI installation clear?
+- [ ] Did local scan output identify the next action?
+- [ ] Did quick scan feel fast enough for active development?
+- [ ] Did CI findings provide enough location and rule context?
+- [ ] Were false positives rare enough to keep trust?
 
 ---
 
 ## Success Criteria
 
-Mark rollout as successful when ALL criteria met:
+Mark rollout successful when all applicable criteria pass.
 
 ### Functional Criteria
 
-- [x] **All Validation Checks Pass**: `Test-CodeQLRollout.ps1` returns 45/45 checks passed
-- [ ] **CI/CD Workflow Completes**: First production PR shows green check for CodeQL
-- [ ] **SARIF Upload Successful**: Results visible in GitHub Security tab
-- [ ] **Local Development Works**: At least one developer successfully runs local scan
-- [ ] **Hook Functions**: PostToolUse hook executes without errors (or gracefully degrades)
+- [ ] `python3 .codeql/scripts/test_codeql_rollout.py --ci` exits 0.
+- [ ] `python3 .codeql/scripts/test_codeql_config.py --ci` exits 0.
+- [ ] `python3 .codeql/scripts/invoke_codeql_scan.py --languages python actions` completes without scan execution errors.
+- [ ] First production PR shows a CodeQL status check.
+- [ ] SARIF appears in the GitHub Security tab.
+- [ ] At least one developer or agent runs a local scan.
+- [ ] `/codeql-scan` skill loads and reaches the scan path.
 
 ### Performance Criteria
 
 | Metric | Target | Actual | Status |
 |--------|--------|--------|--------|
-| **Full Scan Duration** | < 60s | ______ | [ ] |
-| **Quick Scan Duration** | < 20s | ______ | [ ] |
-| **Hook Scan Duration** | < 30s | ______ | [ ] |
-| **Cache Hit Rate** | > 70% | ______ | [ ] |
-| **False Positive Rate** | < 20% | ______ | [ ] |
+| CI analysis budget | 300 seconds or less | ______ | [ ] |
+| Local full scan budget | 60 seconds or less | ______ | [ ] |
+| Local quick scan budget | 60 seconds or less | ______ | [ ] |
+| Cache reuse | Faster than rebuild | ______ | [ ] |
+| False positive rate | Below 20 percent | ______ | [ ] |
 
 ### Adoption Criteria
 
-- [ ] **Documentation Accessible**: At least 3 team members aware of CodeQL integration
-- [ ] **Local Usage**: At least 3 developers run local scan within first week
-- [ ] **Skill Adoption**: At least 1 developer uses `/codeql-scan` skill
-- [ ] **Zero Incidents**: No blocked PRs due to integration errors (findings are expected)
+- [ ] CodeQL docs are linked from the rollout PR.
+- [ ] At least one maintainer knows how to run the local scan.
+- [ ] At least one maintainer knows where SARIF appears in GitHub.
+- [ ] No rollout issue blocks unrelated PRs.
 
 ### Quality Criteria
 
-- [ ] **No False Positives in First 3 PRs**: Or < 10% of total findings are false positives
-- [ ] **Real Issues Found**: At least 1 legitimate security issue caught (validates value)
-- [ ] **Developer Satisfaction**: Feedback generally positive (no major complaints)
+- [ ] Docs mention the two live tiers only.
+- [ ] Docs point to Python scripts only.
+- [ ] Quick scan is documented as on-demand.
+- [ ] Automatic edit-time scanning is described only as retired.
+- [ ] ADR-041 and ADR-042 references are current.
 
 ---
 
 ## Rollback Plan
 
-If critical issues arise, follow this rollback procedure:
+Use the smallest rollback that restores developer flow.
 
-### Immediate Rollback (Emergency)
+### Immediate Rollback: CI Blocking Incorrectly
 
-**If CI/CD blocking all PRs incorrectly**:
+If CodeQL blocks PRs because of workflow failure or bad configuration:
 
 ```bash
-# Disable CodeQL workflow
 gh workflow disable codeql-analysis.yml
 ```
 
-**If PostToolUse hook causing crashes**:
+Then open a fix PR for the workflow or config. Keep local scanning available while CI is disabled.
 
-```bash
-# Temporarily disable hook
-mv ".claude/hooks/PostToolUse/invoke_codeql_quick_scan.py" ".claude/hooks/PostToolUse/invoke_codeql_quick_scan.py.disabled"
-```
+### Partial Rollback: Keep Local Scans Only
 
-### Partial Rollback
-
-**Keep Tier 2 (Local), disable Tier 1 (CI) and Tier 3 (Hook)**:
-
-- [ ] Disable CodeQL workflow: `gh workflow disable codeql-analysis.yml`
-- [ ] Disable PostToolUse hook: Rename or remove hook script
-- [ ] Keep local development tools (VSCode tasks, skill) for opt-in usage
+- [ ] Disable the CodeQL workflow with `gh workflow disable codeql-analysis.yml`.
+- [ ] Keep `.codeql/scripts/` for local scans.
+- [ ] Keep `.github/codeql/` for config validation and local scan consistency.
+- [ ] Keep `.claude/skills/codeql-scan/` for on-demand agent use.
+- [ ] Document the reason in the rollback PR.
 
 ### Full Rollback
 
-**Remove all CodeQL integration**:
+Only use full rollback if both CI and local scanning are broken and cannot be fixed quickly.
 
-```bash
-# Remove workflows
-rm .github/workflows/codeql-analysis.yml
-rm .github/workflows/test-codeql-integration.yml
+Move affected paths to a reviewed backup branch or restore them with git from the last known good commit. Do not delete local work with unsafe shell commands.
 
-# Remove configurations
-rm -r .github/codeql
+Paths involved:
 
-# Remove scripts
-rm -r .codeql/scripts
+- `.github/workflows/codeql-analysis.yml`
+- `.github/workflows/test-codeql-integration.yml`
+- `.github/codeql/`
+- `.codeql/scripts/`
+- `.claude/skills/codeql-scan/`
 
-# Remove CLI
-rm -r .codeql/cli
+Rollback PR checklist:
 
-# Remove VSCode integration
-# (Optional - doesn't hurt to keep)
-
-# Remove Claude integration
-rm -r .claude/skills/codeql-scan
-rm ".claude/hooks/PostToolUse/invoke_codeql_quick_scan.py"
-
-# Commit rollback
-git add .
-git commit -m "revert: remove CodeQL integration"
-git push
-```
+- [ ] Explain why rollback is needed.
+- [ ] Link the failing workflow run or local diagnostic output.
+- [ ] State which tier remains available, if any.
+- [ ] State the forward-fix plan.
 
 ---
 
@@ -446,8 +385,9 @@ git push
 
 - **User Guide**: [docs/codeql-integration.md](./codeql-integration.md)
 - **Architecture**: [docs/codeql-architecture.md](./codeql-architecture.md)
-- **ADR**: [.agents/architecture/ADR-041-codeql-integration.md](../.agents/architecture/ADR-041-codeql-integration.md)
-- **Validation Script**: [.codeql/scripts/Test-CodeQLRollout.ps1](../.codeql/scripts/Test-CodeQLRollout.ps1)
+- **ADR-041**: [.agents/architecture/ADR-041-codeql-integration.md](../.agents/architecture/ADR-041-codeql-integration.md)
+- **ADR-042**: [.agents/architecture/ADR-042-python-migration-strategy.md](../.agents/architecture/ADR-042-python-migration-strategy.md)
+- **Rollout Validator**: [.codeql/scripts/test_codeql_rollout.py](../.codeql/scripts/test_codeql_rollout.py)
 
 ---
 


### PR DESCRIPTION
## Summary

Overhauls the three CodeQL reference docs so they match the shipping implementation. Two changes drove the staleness: the implementation moved from PowerShell to Python (ADR-042), and the CodeQL strategy dropped from three tiers to two (ADR-041 amendment, 2026-07-21, which retired the unused automatic PostToolUse quick-scan hook). Only the three docs change in this PR.

## What changed

- Replaced every PowerShell script reference and sample with the Python scripts that actually ship, using their real command-line flags.
- Reframed the three-tier narrative to two-tier across prose, mermaid diagrams, comparison tables, and timeout budgets. Tier 1 is the CI/CD blocking gate (the native CodeQL workflow). Tier 2 is the on-demand codeql-scan skill, with quick scans preserved via the quick-scan flag.
- Documented both scan wrappers accurately: the core scan script (quick-scan flag) and the skill wrapper (operation full, quick, validate).
- Removed all references to the deleted hook and the retired automatic tier. Where useful, folded quick-scan content into the Tier 2 on-demand section. Portable rebuild of edit-time scanning stays deferred to #3219.
- Corrected the config-file locations, replaced the superseded ADR-005 (PowerShell-only) reference with ADR-042 (Python migration), and removed the staleness banners now that the docs are current.

## Verification

- grep for PowerShell script names, the PowerShell extension, Pester, PSScriptAnalyzer, and pwsh: zero implementation matches (the word PowerShell survives only where it names a scanned language).
- grep for the retired tier and the deleted hook path: zero matches except one dated historical note.
- Byte-check for U+2014 and U+2013: zero.
- Scoped markdownlint on the three docs: zero errors.
- Tier 1 language matrix, both wrapper CLIs, all relative links, and all referenced paths were verified against the real files before commit.

## References

Ground-truth sources reviewed but not edited (already correct); see for context, not changed in this PR:

- see `.github/codeql/codeql-config.yml` and `.github/codeql/codeql-config-quick.yml` (shared and quick configs)
- see `.codeql/scripts/invoke_codeql_scan.py` (core scan script) and `.claude/skills/codeql-scan/SKILL.md` (Tier 2 skill)
- see `.github/workflows/codeql-analysis.yml` (Tier 1 gate) and `.github/workflows/test-codeql-integration.yml` (integration test)
- see `.agents/architecture/ADR-041-codeql-integration.md` (amended two-tier) and `.agents/architecture/ADR-042-python-migration-strategy.md`

Fixes #3296
