### PR TITLE
test(hooks): guard retrospective gate cross-midnight yesterday-grace (#3305)

### DIFF
--- a/.agents/retrospective/2026-07-22-3305-retro-midnight-regression-guard.md
+++ b/.agents/retrospective/2026-07-22-3305-retro-midnight-regression-guard.md
@@ -1,0 +1,51 @@
+# Retrospective: #3305 retrospective-gate cross-midnight regression guard
+
+**Date**: 2026-07-22 (UTC)
+**Issue**: #3305
+**Branch**: fix/3305-retrospective-midnight-regression-tests
+
+## What I set out to do
+
+Fix the single-UTC-day false positive I filed as #3305: a session that
+does real work on day N and pushes just after 00:00 UTC on day N+1 was
+reported to be blocked by the re-homed `retrospective-policy` gate.
+
+## What actually happened (diagnosis reversal)
+
+The filed root cause was wrong. On current main, `check_retrospective_evidence`
+is already yesterday-aware. `_recent_date_prefixes` returns today and
+yesterday, and both `_today_retrospective_exists` and `_today_session_log`
+glob both dates. A frozen-clock reproduction of the exact issue scenario
+(yesterday-dated retro file, push at 00:30 UTC) returns rc=0 (pass). A
+negative control (two-days-old evidence) correctly blocks. The grace shipped
+with the #3295 re-home of the gate into `git_hook_policy.py`, but no
+regression test guarded it.
+
+## What I shipped instead
+
+Not a behavior fix (the behavior is correct), but the missing regression
+guard. Three tests in `tests/test_lefthook_integration.py`: two positive
+(yesterday retro file, yesterday session-log evidence) and one negative
+(two-days-old evidence still blocks). Mutation-verified: reverting
+`_recent_date_prefixes` to a today-only window flips both positive tests to
+BLOCK, proving they catch the regression.
+
+## Failure mode
+
+Primary: FM #9 Confident-Incorrectness Recurrence (`.agents/governance/FAILURE-MODES.md`). The shape matched exactly: partial
+signal (a push-time gate rejection), premature conclusion (a today-only
+window), confident delivery (I filed #3305 with that mechanism before
+reproducing it in isolation). The honest follow-up (reproduce, negate,
+mutate) disproved it. Lesson: a push-time gate rejection is a symptom, not a
+root cause. Reproduce on a clean tree before filing the mechanism.
+
+## Learnings
+
+1. The retrospective gate's cross-midnight tolerance is exactly one day
+   (today + yesterday), enforced on both the retro-file path and the
+   session-log path.
+2. When a filed bug does not reproduce, the correct deliverable is a
+   regression guard plus an accurate issue correction, not a fix for a
+   non-bug (which would be manufactured work).
+3. Harness note: Copilot CLI 1.0.74-0 denies the `Edit` tool at the harness
+   level (exit 2), same class as #3247. Fell back to bash file writes.

--- a/.agents/sessions/2026-07-22-session-3305-retro-midnight-tests.json
+++ b/.agents/sessions/2026-07-22-session-3305-retro-midnight-tests.json
@@ -1,0 +1,148 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3305,
+    "date": "2026-07-22",
+    "branch": "fix/3305-retrospective-midnight-regression-tests",
+    "startingCommit": "b1fd4f91842a88ac5603fce18297242c4c52feec",
+    "objective": "Regression-guard the retrospective gate cross-midnight yesterday-grace (issue #3305) and correct the issue's diagnosis."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena MCP activation tools are not exposed in this Copilot CLI session toolset (only lsp is present)."
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena initial_instructions tool is not exposed in this Copilot CLI session toolset."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md directly this session."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file created for branch fix/3305-retrospective-midnight-regression-tests."
+      },
+      "skillScriptsListed": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "github skill PR/CI scripts under .claude/skills/github/scripts used for the ship step."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .serena/memories/usage-mandatory.md directly this session."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/governance/PROJECT-CONSTRAINTS.md directly this session."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded repository and user memories from the session prompt and verified relevant ones against source files."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current returned fix/3305-retrospective-midnight-regression-tests."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Confirmed working in a dedicated worktree on a feature branch, not main."
+      },
+      "gitStatusVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git status inspected; only the intended test file and session artifacts are changed."
+      },
+      "startingCommitNoted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "startingCommit b1fd4f91842a88ac5603fce18297242c4c52feec recorded."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All session-start and session-end MUST items satisfied with honest evidence."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md was read only and left unmodified this session."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena memory write tools are not exposed; durable facts recorded via the Copilot memory surface instead."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 scoped run completed with 0 issues; the retro under .agents is config-excluded and no other markdown changed."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Test code and the regression guard committed at 645ec1b882663167e9bef22b43653ab4c937fffe, recorded as endingCommit for this session."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "validate_session_json.py exited 0; pytest retrospective tests pass; ruff check and mypy clean."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Progress tracked through session checkpoints across the ship sequence."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Wrote .agents/retrospective/2026-07-22-3305-retro-midnight-regression-guard.md documenting the diagnosis reversal."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "2026-07-22T00:20:00Z",
+      "action": "Re-diagnosed issue #3305 against current main",
+      "result": "Found the retrospective gate is already yesterday-aware: _today_retrospective_exists and _today_session_log both glob today and yesterday via _recent_date_prefixes. The originally filed root cause was wrong."
+    },
+    {
+      "time": "2026-07-22T00:45:00Z",
+      "action": "Ran frozen-clock reproduction (frozen 2026-07-22 00:15)",
+      "result": "Scenario A (yesterday retro file, cross-midnight) rc=0 pass; negative controls (no evidence) rc=1 block; edge (2-day-old evidence) rc=1 block. #3305 does not reproduce on main."
+    },
+    {
+      "time": "2026-07-22T01:00:00Z",
+      "action": "Added pos+neg+edge regression tests plus a freeze helper",
+      "result": "Three tests in tests/test_lefthook_integration.py lock in the yesterday-grace on both the retro-file and session-log paths, plus a negative control past the grace window. ruff check, ruff format, mypy, and pytest all green."
+    },
+    {
+      "time": "2026-07-22T01:10:00Z",
+      "action": "Mutation-tested the new guards",
+      "result": "Neutralizing _recent_date_prefixes (today twice) flipped both positive scenarios to rc=1, proving the tests catch a real regression rather than passing tautologically."
+    },
+    {
+      "time": "2026-07-22T01:20:00Z",
+      "action": "Wrote the #3305 retrospective and this session log",
+      "result": "Documented the confident-wrong-diagnosis failure mode and the corrected deliverable (regression guard, not a fix, to avoid manufactured work)."
+    }
+  ],
+  "endingCommit": "645ec1b882663167e9bef22b43653ab4c937fffe",
+  "nextSteps": [
+    "Push the branch and open a PR referencing issue #3305.",
+    "Correct issue #3305 with the accurate diagnosis and close it once the PR lands."
+  ]
+}

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -9,8 +9,9 @@ import subprocess
 import sys
 import time
 from collections.abc import Iterator, Mapping, Sequence
-from datetime import UTC, datetime
+from datetime import UTC, datetime, tzinfo
 from pathlib import Path
+from typing import Self
 
 import pytest
 import yaml
@@ -384,6 +385,105 @@ def test_retrospective_trivial_session_includes_ten_minute_boundary(
         session,
         [],
         now_epoch=boundary,
+    )
+
+
+def _freeze_policy_clock(monkeypatch: pytest.MonkeyPatch, instant: datetime) -> None:
+    """Freeze git_hook_policy's UTC clock to a fixed instant for date-window tests.
+
+    The retrospective and session-log helpers derive today/yesterday from
+    ``datetime.now(tz=UTC)``. Pinning it removes the once-per-day midnight-tick
+    race that would otherwise make the cross-midnight assertions flaky.
+    """
+
+    class _FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz: tzinfo | None = None) -> Self:
+            return cls.fromtimestamp(instant.timestamp(), tz)
+
+    monkeypatch.setattr(policy, "datetime", _FrozenDateTime)
+
+
+def test_retrospective_policy_accepts_yesterday_retro_across_midnight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retro dated yesterday UTC satisfies the gate today (cross-midnight grace).
+
+    Regression guard for #3305: a session that does real work on day N and
+    pushes just after 00:00 UTC on day N+1 must not be blocked when the day-N
+    retrospective exists. ``_today_retrospective_exists`` globs today AND
+    yesterday, so the yesterday-dated retro is honored.
+    """
+    _freeze_policy_clock(monkeypatch, datetime(2026, 3, 15, 0, 30, tzinfo=UTC))
+    retro = tmp_path / ".agents" / "retrospective" / "2026-03-14-session-finish.md"
+    retro.parent.mkdir(parents=True, exist_ok=True)
+    retro.write_text("# Retrospective\nreal work\n", encoding="utf-8")
+
+    # Two paths avoid the trivial-session bypass, isolating the yesterday grace.
+    assert (
+        policy.check_retrospective_evidence(
+            ["scripts/one.py", "tests/test_one.py"],
+            tmp_path,
+        )
+        == 0
+    )
+
+
+def test_retrospective_policy_accepts_yesterday_session_evidence_across_midnight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Evidence in a yesterday-dated session log satisfies the gate today.
+
+    Regression guard for #3305: ``_today_session_log`` globs today AND
+    yesterday, so evidence committed in the day-N session log is consulted on
+    day N+1 even with no retrospective file present.
+    """
+    _freeze_policy_clock(monkeypatch, datetime(2026, 3, 15, 0, 30, tzinfo=UTC))
+    sessions = tmp_path / ".agents" / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    (sessions / "2026-03-14-session-1.json").write_text(
+        '{"notes": "Learnings captured"}', encoding="utf-8"
+    )
+
+    # No retrospective file: the only passing path is the yesterday session log.
+    assert (
+        policy.check_retrospective_evidence(
+            ["scripts/one.py", "tests/test_one.py"],
+            tmp_path,
+        )
+        == 0
+    )
+
+
+def test_retrospective_policy_blocks_evidence_older_than_grace_window(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retro/session two days old is outside the 24h grace and still blocks.
+
+    Negative control for #3305: the cross-midnight tolerance is exactly one day
+    (today + yesterday). Evidence from two days ago must not satisfy the gate,
+    so the widened window cannot silently accept arbitrarily stale sessions.
+    """
+    _freeze_policy_clock(monkeypatch, datetime(2026, 3, 15, 0, 30, tzinfo=UTC))
+    retro = tmp_path / ".agents" / "retrospective" / "2026-03-13-x.md"
+    retro.parent.mkdir(parents=True, exist_ok=True)
+    retro.write_text("# Retrospective\nstale\n", encoding="utf-8")
+    sessions = tmp_path / ".agents" / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    (sessions / "2026-03-13-session-1.json").write_text(
+        '{"notes": "Learnings captured"}', encoding="utf-8"
+    )
+
+    # Two paths avoid the trivial-session bypass; two-days-old evidence is stale.
+    assert (
+        policy.check_retrospective_evidence(
+            ["scripts/one.py", "tests/test_one.py"],
+            tmp_path,
+        )
+        == 1
     )
 
 
@@ -776,12 +876,12 @@ def test_lefthook_skip_envs_preserve_check_only_execution(tmp_path: Path) -> Non
 
 def test_configuration_and_tree_have_no_payload_scripts() -> None:
     config_text = (PROJECT_ROOT / "lefthook.yml").read_text(encoding="utf-8")
-    policy_text = (
-        PROJECT_ROOT / "scripts/validation/git_hook_policy.py"
-    ).read_text(encoding="utf-8")
-    auto_retro_text = (
-        PROJECT_ROOT / ".claude/hooks/Stop/invoke_auto_retrospective.py"
-    ).read_text(encoding="utf-8")
+    policy_text = (PROJECT_ROOT / "scripts/validation/git_hook_policy.py").read_text(
+        encoding="utf-8"
+    )
+    auto_retro_text = (PROJECT_ROOT / ".claude/hooks/Stop/invoke_auto_retrospective.py").read_text(
+        encoding="utf-8"
+    )
 
     assert "scripts/hooks/pre-commit" not in config_text
     assert "scripts/hooks/pre-push" not in config_text
@@ -1508,9 +1608,7 @@ def test_branch_context_skips_unreadable_newest_log(
     _init_repo(repo, branch="feature/x")
     _commit_file(repo, "tracked", "value\n")
     _write_session_log(repo, branch="feature/other", name="session-1", mtime=1000.0)
-    unreadable = _write_session_log(
-        repo, branch="feature/x", name="session-2", mtime=2000.0
-    )
+    unreadable = _write_session_log(repo, branch="feature/x", name="session-2", mtime=2000.0)
 
     real_stat = Path.stat
 
@@ -1756,10 +1854,7 @@ def test_binary_command_boundary_maps_timeout_to_external_error(
 
     assert result.returncode == 3
     assert result.stdout == b"partial bytes\n"
-    assert result.stderr == (
-        b"binary child stalled\n"
-        b"ERROR: git diff timed out after 90 seconds\n"
-    )
+    assert result.stderr == (b"binary child stalled\nERROR: git diff timed out after 90 seconds\n")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds pos+neg+edge regression tests that lock in the retrospective push
gate's cross-midnight yesterday-grace. A session that does real work on
day N and pushes just after 00:00 UTC on day N+1 must not be blocked
when the day-N retrospective (or day-N session-log evidence) exists.

## Diagnosis correction

Issue #3305 was filed as a midnight-rollover false-positive with a
suspected root cause of a today-only date window. That diagnosis is
wrong. The gate is already yesterday-aware on both evidence paths: the
retro-file check and the session-log check each glob today AND yesterday
via a shared recent-date-prefix helper. A frozen-clock reproduction
(frozen 2026-07-22 00:15) confirms the exact #3305 scenario returns 0
(pass) on current main, while the negative controls (no evidence, and
evidence older than the grace window) return 1 (block).

Because there is no bug to fix, the correct deliverable is a regression
guard that prevents a silent revert to a today-only window, not a code
change. Fixing a non-bug would be manufactured work.

## What changed

- Three tests in the lefthook integration suite:
  - accepts a yesterday-dated retro file across midnight (rc 0)
  - accepts yesterday session-log evidence across midnight (rc 0)
  - blocks evidence older than the grace window (rc 1, negative control)
- A `_freeze_policy_clock` helper that pins the policy module's UTC clock
  to a fixed instant with a `datetime` subclass, removing the
  once-per-day midnight-tick flakiness.

## Testing

- 7 retrospective tests pass (4 existing plus 3 new).
- ruff check, ruff format, and mypy are clean on the changed file.
- The frozen instant is 2026-03-15 while the real clock is 2026-07-22,
  so a pass can only occur when the freeze is actually applied. That
  date gap is itself the proof the tests exercise the grace and are not
  tautologies.

Fixes #3305

## References

- Gate under test: see `scripts/validation/git_hook_policy.py`
  (`check_retrospective_evidence`, `_recent_date_prefixes`).
