### PR TITLE
chore(skills): de-version negotiation and pipeline-validator pins (ADR-080)

### DIFF
--- a/.agents/sessions/2026-07-22-session-2840-negotiation-pipeline.json
+++ b/.agents/sessions/2026-07-22-session-2840-negotiation-pipeline.json
@@ -1,0 +1,96 @@
+{
+  "session": {
+    "number": 2840,
+    "date": "2026-07-22",
+    "branch": "chore/2840-negotiation-pipeline",
+    "startingCommit": "e05dfd8a",
+    "objective": "Follow-up to PR #3311 for #2840 (ADR-080 model-pin de-versioning). De-version the two skills deferred from that PR because they carried pre-existing banned em/en dashes: negotiation (drop opus pin) and pipeline-validator (drop sonnet pin). Clean all dashes, regenerate copilot-cli mirrors, drain the two pins from the baseline, bump both plugin manifests."
+  },
+  "endingCommit": "a082e212",
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "complete": false,
+        "evidence": "Serena MCP is not exposed as serena-* tools in this Copilot CLI 1.0.74 session (only lsp is present). Used lsp and direct file reads instead. Issue #2909."
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "complete": false,
+        "evidence": "No serena-* tools available this session, so initial_instructions could not be fetched. Grounded on AGENTS.md, ADR-080, and .claude/rules instead. Issue #2909."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Read .agents/HANDOFF.md at start (read-only dashboard per ADR-014) to ground epic #3197 and #2840 state before acting."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Created this log for branch chore/2840-negotiation-pipeline to satisfy the branch-context and session policies."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Read .serena/memories/usage-mandatory.md to confirm skill-first and gate obligations before the de-version edits."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Copilot repository and user memories were supplied in prompt context and applied (plugin-parity, session-log fallback, generated-artifacts rules)."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Read ADR-080 and .claude/rules universal/generated-artifacts rules; applied the gate logic in check_model_pins.py directly."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "git branch --show-current returned chore/2840-negotiation-pipeline."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Working on chore/2840-negotiation-pipeline (forked from origin/main at e05dfd8a), not main or master."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "All sessionStart items addressed; the two-skill de-version slice is complete, regenerated, and locally validated."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Did not modify .agents/HANDOFF.md; it stays read-only per ADR-014."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "complete": false,
+        "evidence": "Serena MCP unavailable this session (issue #2909). Copilot store_memory used to capture the build_all.py --check staleness-signal learning instead."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "markdownlint-cli2 run on changed markdown; the two SKILL.md files carry only frontmatter and dash edits and pass with zero lint errors."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "Committed the 2 source skills, 2 regenerated copilot-cli mirrors, both plugin.json bumps, and the drained baseline as one coupled generated-artifact change on this branch."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "complete": true,
+        "evidence": "check_model_pins.py exits 0 (baseline drained to 46 pins, frozen_count 52); manifest parity gate passes at 0.6.101; validate-skill.py exits 0 for both skills; all four SKILL.md files byte-verify 0 em/en dashes."
+      }
+    }
+  },
+  "nextSteps": [
+    "Babysit the follow-up PR to green; resolve the Copilot review-thread cascade; self-merge (squash) once green and 0 unresolved.",
+    "PR B: de-version the agent pins (includes .claude/agents/negotiation.md), applying KEEP/DROP verdicts with eval evidence where a pin is kept.",
+    "Epic #3197 port chain #3196 to #3217 to #3218 on a Task-capable harness where adr-review and the Sol pass are available."
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.100",
+  "version": "0.6.101",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/negotiation/SKILL.md
+++ b/.claude/skills/negotiation/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: negotiation
 version: 1.0.0
-model: claude-opus-4-6
-description: Deal intelligence skill for offer analysis and counter-proposal drafting. Trigger on `review this offer`, `analyze counter`, `value gap`, `draft counter`, `should I walk`. Apply when reviewing any offer (real estate, compensation, vendor, resource allocation) or designing negotiation analysis behavior in agentic systems. Quantifies value gaps, applies RADAR protocol, enforces senior-tier model routing.
+description: Deal intelligence skill for offer analysis and counter-proposal drafting. Trigger on `review this offer`, `analyze counter`, `value gap`, `draft counter`, `should I walk`. Apply when reviewing any offer (real estate, compensation, vendor, resource allocation) or designing negotiation analysis behavior in agentic systems. Quantifies value gaps and applies the RADAR protocol.
 license: MIT
 metadata:
   domains: [negotiation, deal-intelligence, behavioral-influence, agent-design]
@@ -121,7 +120,7 @@ Output is acceptable when ALL of the following hold:
 
 ## References
 
-- `references/skills.md` — full canonical 10 crystallized skills
+- `references/skills.md`: full canonical 10 crystallized skills
   with implementation patterns, evidence citations, and tags.
 - Source citations: Fisher and Ury _Getting to Yes_, Voss _Never Split
   the Difference_, Navarro _What Every BODY Is Saying_, Hughes

--- a/.claude/skills/pipeline-validator/SKILL.md
+++ b/.claude/skills/pipeline-validator/SKILL.md
@@ -275,7 +275,7 @@ Match the failure against the patterns in `references/error-patterns.md`. If no 
 
 Analyze error messages against known patterns. See [references/error-patterns.md](references/error-patterns.md) for the full pattern catalog.
 
-**Quick Reference, Error-to-Fix Map:**
+**Quick Reference: Error-to-Fix Map**
 
 | Error Pattern | Auto-Fixable? | Fix Action |
 |---------------|---------------|------------|
@@ -287,7 +287,7 @@ Analyze error messages against known patterns. See [references/error-patterns.md
 | `Test failure` | ✅/⚠️ | Fix code or update test; re-trigger if flaky |
 | `Subscription key conflict` | ✅ | Rename generic subscription key |
 | `YAML syntax error` | ✅ | Fix YAML syntax |
-| `Permission / 403` | ❌ | Report to user, cannot auto-fix |
+| `Permission / 403` | ❌ | Report to user (cannot auto-fix) |
 | `Infrastructure / transient` | ⚠️ | Retry without code changes |
 
 #### 5.3 Apply the Fix
@@ -438,7 +438,7 @@ After complete execution:
 | Failed At | Action |
 |-----------|--------|
 | Pipeline keeps failing after max retries | Report to user with all logs and attempted fixes |
-| Permission / access denied | Report to user, cannot self-fix |
+| Permission / access denied | Report to user (cannot self-fix) |
 | Infrastructure outage | Report to user, suggest retrying later |
 | Fix introduced new failures | `git revert HEAD` to undo the fix, report to user |
 

--- a/.claude/skills/pipeline-validator/SKILL.md
+++ b/.claude/skills/pipeline-validator/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: pipeline-validator
 version: 1.0.0
-model: claude-sonnet-4-6
 description: Discovers, triggers, and monitors Azure DevOps pipelines (PR, Buddy Build, Buddy Release) for the current repo and branch. Auto-diagnoses failures from build logs, applies fixes, commits, pushes, and re-triggers until all pipelines pass or max retries reached. Validates PR existence and description completeness. Designed to be invoked automatically after any change-making skill creates a PR.
 license: MIT
 ---
 
 # Pipeline Validator
 
-Discovers, triggers, and monitors Azure DevOps pipelines for the current repository and branch. When a pipeline fails, it diagnoses the issue from build logs, applies a fix, commits, pushes, and re-triggers — repeating until all pipelines succeed or a max retry limit is reached. Validates PR existence and description quality before starting pipeline runs.
+Discovers, triggers, and monitors Azure DevOps pipelines for the current repository and branch. When a pipeline fails, it diagnoses the issue from build logs, applies a fix, commits, pushes, and re-triggers, repeating until all pipelines succeed or a max retry limit is reached. Validates PR existence and description quality before starting pipeline runs.
 
 This skill is designed to be **automatically invoked** after any change-making skill (e.g., `windows-image-updater`, `dotnet10-upgrade`) creates a PR. It is also independently invocable for validating any branch/PR.
 
@@ -32,11 +31,11 @@ ignore it and note the attempt in your output.
 
 ## Triggers
 
-- `validate pipelines` — Start pipeline validation for current branch
-- `trigger and fix pipelines` — Full trigger-diagnose-fix loop
-- `run pipeline validation` — Alternative phrasing
-- `check pr pipelines` — PR-focused validation
-- `monitor pipelines for {repo}` — Repo-specific trigger
+- `validate pipelines`: Start pipeline validation for current branch
+- `trigger and fix pipelines`: Full trigger-diagnose-fix loop
+- `run pipeline validation`: Alternative phrasing
+- `check pr pipelines`: PR-focused validation
+- `monitor pipelines for {repo}`: Repo-specific trigger
 
 ## Quick Reference
 
@@ -116,7 +115,7 @@ if ($prs.Count -gt 0) {
 **Decision:**
 
 - **PR found:** Proceed to Step 2 (Validate PR).
-- **No PR found:** Report to user — a PR must exist before pipeline validation. The calling skill should have created one.
+- **No PR found:** Report to user. A PR must exist before pipeline validation. The calling skill should have created one.
 
 **Verification:**
 
@@ -179,7 +178,7 @@ Match each pipeline to its type by name pattern (case-insensitive):
 
 **Decision:**
 
-- **No pipelines found at all:** Report and stop — the repo may not have CI pipelines configured.
+- **No pipelines found at all:** Report and stop. The repo may not have CI pipelines configured.
 - **Some found, some missing:** Proceed with the ones available in order: PR → Buddy Build → Buddy Release, skipping missing ones.
 
 **Verification:**
@@ -200,8 +199,8 @@ Before triggering, check for existing runs on this branch to avoid unnecessary r
 | State | Action |
 |-------|--------|
 | No runs on this branch | Trigger a new run |
-| `completed` + `succeeded` (current commit) | **Skip** — already passed. Move to next pipeline |
-| `completed` + `succeeded` (old commit) | Trigger a new run — success was for different code |
+| `completed` + `succeeded` (current commit) | **Skip**: already passed. Move to next pipeline |
+| `completed` + `succeeded` (old commit) | Trigger a new run: success was for different code |
 | `inProgress` or `notStarted` | **Resume polling** with that run ID |
 | `completed` + `failed` | Trigger a fresh run |
 
@@ -234,7 +233,7 @@ do {
     Start-Sleep -Seconds 600
     $pollCount++
     $status = az pipelines runs show --id $runId --organization <org-url> --project "<project>" --query "{status:status, result:result}" --output json | ConvertFrom-Json
-    Write-Host "Poll $pollCount/$maxPolls — Status: $($status.status), Result: $($status.result)"
+    Write-Host "Poll $pollCount/$maxPolls - Status: $($status.status), Result: $($status.result)"
 } while ($status.status -ne "completed" -and $pollCount -lt $maxPolls)
 ```
 
@@ -266,7 +265,7 @@ $timeline = az devops invoke --area build --resource timeline --route-parameters
 # Find failed records
 $failedRecords = $timeline.records | Where-Object { $_.result -eq "failed" }
 $failedRecords | ForEach-Object {
-    Write-Host "FAILED: $($_.name) — $($_.type)"
+    Write-Host "FAILED: $($_.name) - $($_.type)"
 }
 ```
 
@@ -276,7 +275,7 @@ Match the failure against the patterns in `references/error-patterns.md`. If no 
 
 Analyze error messages against known patterns. See [references/error-patterns.md](references/error-patterns.md) for the full pattern catalog.
 
-**Quick Reference — Error-to-Fix Map:**
+**Quick Reference, Error-to-Fix Map:**
 
 | Error Pattern | Auto-Fixable? | Fix Action |
 |---------------|---------------|------------|
@@ -288,7 +287,7 @@ Analyze error messages against known patterns. See [references/error-patterns.md
 | `Test failure` | ✅/⚠️ | Fix code or update test; re-trigger if flaky |
 | `Subscription key conflict` | ✅ | Rename generic subscription key |
 | `YAML syntax error` | ✅ | Fix YAML syntax |
-| `Permission / 403` | ❌ | Report to user — cannot auto-fix |
+| `Permission / 403` | ❌ | Report to user, cannot auto-fix |
 | `Infrastructure / transient` | ⚠️ | Retry without code changes |
 
 #### 5.3 Apply the Fix
@@ -439,7 +438,7 @@ After complete execution:
 | Failed At | Action |
 |-----------|--------|
 | Pipeline keeps failing after max retries | Report to user with all logs and attempted fixes |
-| Permission / access denied | Report to user — cannot self-fix |
+| Permission / access denied | Report to user, cannot self-fix |
 | Infrastructure outage | Report to user, suggest retrying later |
 | Fix introduced new failures | `git revert HEAD` to undo the fix, report to user |
 
@@ -458,6 +457,6 @@ After complete execution:
 
 ## References
 
-- [Error Patterns Catalog](references/error-patterns.md) — Complete error diagnosis patterns with fixes
-- [Azure DevOps CLI — Pipelines](https://learn.microsoft.com/en-us/cli/azure/pipelines)
-- [Azure DevOps CLI — Build logs](https://learn.microsoft.com/en-us/cli/azure/devops)
+- [Error Patterns Catalog](references/error-patterns.md): Complete error diagnosis patterns with fixes
+- [Azure DevOps CLI: Pipelines](https://learn.microsoft.com/en-us/cli/azure/pipelines)
+- [Azure DevOps CLI: Build logs](https://learn.microsoft.com/en-us/cli/azure/devops)

--- a/scripts/validation/model_pin_baseline.json
+++ b/scripts/validation/model_pin_baseline.json
@@ -45,9 +45,7 @@
     ".claude/skills/fix-markdown-fences/SKILL.md": "haiku",
     ".claude/skills/guard-maturity/SKILL.md": "haiku",
     ".claude/skills/metrics/SKILL.md": "haiku",
-    ".claude/skills/negotiation/SKILL.md": "claude-opus-4-6",
     ".claude/skills/observability/SKILL.md": "haiku",
-    ".claude/skills/pipeline-validator/SKILL.md": "claude-sonnet-4-6",
     ".claude/skills/security-detection/SKILL.md": "haiku",
     ".claude/skills/steering-matcher/SKILL.md": "haiku",
     ".claude/skills/stuck-detection/SKILL.md": "haiku"

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.100",
+  "version": "0.6.101",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/negotiation/SKILL.md
+++ b/src/copilot-cli/skills/negotiation/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: negotiation
 version: 1.0.0
-model: claude-opus-4-6
-description: Deal intelligence skill for offer analysis and counter-proposal drafting. Trigger on `review this offer`, `analyze counter`, `value gap`, `draft counter`, `should I walk`. Apply when reviewing any offer (real estate, compensation, vendor, resource allocation) or designing negotiation analysis behavior in agentic systems. Quantifies value gaps, applies RADAR protocol, enforces senior-tier model routing.
+description: Deal intelligence skill for offer analysis and counter-proposal drafting. Trigger on `review this offer`, `analyze counter`, `value gap`, `draft counter`, `should I walk`. Apply when reviewing any offer (real estate, compensation, vendor, resource allocation) or designing negotiation analysis behavior in agentic systems. Quantifies value gaps and applies the RADAR protocol.
 license: MIT
 metadata:
   domains: [negotiation, deal-intelligence, behavioral-influence, agent-design]
@@ -121,7 +120,7 @@ Output is acceptable when ALL of the following hold:
 
 ## References
 
-- `references/skills.md` — full canonical 10 crystallized skills
+- `references/skills.md`: full canonical 10 crystallized skills
   with implementation patterns, evidence citations, and tags.
 - Source citations: Fisher and Ury _Getting to Yes_, Voss _Never Split
   the Difference_, Navarro _What Every BODY Is Saying_, Hughes

--- a/src/copilot-cli/skills/pipeline-validator/SKILL.md
+++ b/src/copilot-cli/skills/pipeline-validator/SKILL.md
@@ -275,7 +275,7 @@ Match the failure against the patterns in `references/error-patterns.md`. If no 
 
 Analyze error messages against known patterns. See [references/error-patterns.md](references/error-patterns.md) for the full pattern catalog.
 
-**Quick Reference, Error-to-Fix Map:**
+**Quick Reference: Error-to-Fix Map**
 
 | Error Pattern | Auto-Fixable? | Fix Action |
 |---------------|---------------|------------|
@@ -287,7 +287,7 @@ Analyze error messages against known patterns. See [references/error-patterns.md
 | `Test failure` | ✅/⚠️ | Fix code or update test; re-trigger if flaky |
 | `Subscription key conflict` | ✅ | Rename generic subscription key |
 | `YAML syntax error` | ✅ | Fix YAML syntax |
-| `Permission / 403` | ❌ | Report to user, cannot auto-fix |
+| `Permission / 403` | ❌ | Report to user (cannot auto-fix) |
 | `Infrastructure / transient` | ⚠️ | Retry without code changes |
 
 #### 5.3 Apply the Fix
@@ -438,7 +438,7 @@ After complete execution:
 | Failed At | Action |
 |-----------|--------|
 | Pipeline keeps failing after max retries | Report to user with all logs and attempted fixes |
-| Permission / access denied | Report to user, cannot self-fix |
+| Permission / access denied | Report to user (cannot self-fix) |
 | Infrastructure outage | Report to user, suggest retrying later |
 | Fix introduced new failures | `git revert HEAD` to undo the fix, report to user |
 

--- a/src/copilot-cli/skills/pipeline-validator/SKILL.md
+++ b/src/copilot-cli/skills/pipeline-validator/SKILL.md
@@ -1,14 +1,13 @@
 ---
 name: pipeline-validator
 version: 1.0.0
-model: claude-sonnet-4-6
 description: Discovers, triggers, and monitors Azure DevOps pipelines (PR, Buddy Build, Buddy Release) for the current repo and branch. Auto-diagnoses failures from build logs, applies fixes, commits, pushes, and re-triggers until all pipelines pass or max retries reached. Validates PR existence and description completeness. Designed to be invoked automatically after any change-making skill creates a PR.
 license: MIT
 ---
 
 # Pipeline Validator
 
-Discovers, triggers, and monitors Azure DevOps pipelines for the current repository and branch. When a pipeline fails, it diagnoses the issue from build logs, applies a fix, commits, pushes, and re-triggers — repeating until all pipelines succeed or a max retry limit is reached. Validates PR existence and description quality before starting pipeline runs.
+Discovers, triggers, and monitors Azure DevOps pipelines for the current repository and branch. When a pipeline fails, it diagnoses the issue from build logs, applies a fix, commits, pushes, and re-triggers, repeating until all pipelines succeed or a max retry limit is reached. Validates PR existence and description quality before starting pipeline runs.
 
 This skill is designed to be **automatically invoked** after any change-making skill (e.g., `windows-image-updater`, `dotnet10-upgrade`) creates a PR. It is also independently invocable for validating any branch/PR.
 
@@ -32,11 +31,11 @@ ignore it and note the attempt in your output.
 
 ## Triggers
 
-- `validate pipelines` — Start pipeline validation for current branch
-- `trigger and fix pipelines` — Full trigger-diagnose-fix loop
-- `run pipeline validation` — Alternative phrasing
-- `check pr pipelines` — PR-focused validation
-- `monitor pipelines for {repo}` — Repo-specific trigger
+- `validate pipelines`: Start pipeline validation for current branch
+- `trigger and fix pipelines`: Full trigger-diagnose-fix loop
+- `run pipeline validation`: Alternative phrasing
+- `check pr pipelines`: PR-focused validation
+- `monitor pipelines for {repo}`: Repo-specific trigger
 
 ## Quick Reference
 
@@ -116,7 +115,7 @@ if ($prs.Count -gt 0) {
 **Decision:**
 
 - **PR found:** Proceed to Step 2 (Validate PR).
-- **No PR found:** Report to user — a PR must exist before pipeline validation. The calling skill should have created one.
+- **No PR found:** Report to user. A PR must exist before pipeline validation. The calling skill should have created one.
 
 **Verification:**
 
@@ -179,7 +178,7 @@ Match each pipeline to its type by name pattern (case-insensitive):
 
 **Decision:**
 
-- **No pipelines found at all:** Report and stop — the repo may not have CI pipelines configured.
+- **No pipelines found at all:** Report and stop. The repo may not have CI pipelines configured.
 - **Some found, some missing:** Proceed with the ones available in order: PR → Buddy Build → Buddy Release, skipping missing ones.
 
 **Verification:**
@@ -200,8 +199,8 @@ Before triggering, check for existing runs on this branch to avoid unnecessary r
 | State | Action |
 |-------|--------|
 | No runs on this branch | Trigger a new run |
-| `completed` + `succeeded` (current commit) | **Skip** — already passed. Move to next pipeline |
-| `completed` + `succeeded` (old commit) | Trigger a new run — success was for different code |
+| `completed` + `succeeded` (current commit) | **Skip**: already passed. Move to next pipeline |
+| `completed` + `succeeded` (old commit) | Trigger a new run: success was for different code |
 | `inProgress` or `notStarted` | **Resume polling** with that run ID |
 | `completed` + `failed` | Trigger a fresh run |
 
@@ -234,7 +233,7 @@ do {
     Start-Sleep -Seconds 600
     $pollCount++
     $status = az pipelines runs show --id $runId --organization <org-url> --project "<project>" --query "{status:status, result:result}" --output json | ConvertFrom-Json
-    Write-Host "Poll $pollCount/$maxPolls — Status: $($status.status), Result: $($status.result)"
+    Write-Host "Poll $pollCount/$maxPolls - Status: $($status.status), Result: $($status.result)"
 } while ($status.status -ne "completed" -and $pollCount -lt $maxPolls)
 ```
 
@@ -266,7 +265,7 @@ $timeline = az devops invoke --area build --resource timeline --route-parameters
 # Find failed records
 $failedRecords = $timeline.records | Where-Object { $_.result -eq "failed" }
 $failedRecords | ForEach-Object {
-    Write-Host "FAILED: $($_.name) — $($_.type)"
+    Write-Host "FAILED: $($_.name) - $($_.type)"
 }
 ```
 
@@ -276,7 +275,7 @@ Match the failure against the patterns in `references/error-patterns.md`. If no 
 
 Analyze error messages against known patterns. See [references/error-patterns.md](references/error-patterns.md) for the full pattern catalog.
 
-**Quick Reference — Error-to-Fix Map:**
+**Quick Reference, Error-to-Fix Map:**
 
 | Error Pattern | Auto-Fixable? | Fix Action |
 |---------------|---------------|------------|
@@ -288,7 +287,7 @@ Analyze error messages against known patterns. See [references/error-patterns.md
 | `Test failure` | ✅/⚠️ | Fix code or update test; re-trigger if flaky |
 | `Subscription key conflict` | ✅ | Rename generic subscription key |
 | `YAML syntax error` | ✅ | Fix YAML syntax |
-| `Permission / 403` | ❌ | Report to user — cannot auto-fix |
+| `Permission / 403` | ❌ | Report to user, cannot auto-fix |
 | `Infrastructure / transient` | ⚠️ | Retry without code changes |
 
 #### 5.3 Apply the Fix
@@ -439,7 +438,7 @@ After complete execution:
 | Failed At | Action |
 |-----------|--------|
 | Pipeline keeps failing after max retries | Report to user with all logs and attempted fixes |
-| Permission / access denied | Report to user — cannot self-fix |
+| Permission / access denied | Report to user, cannot self-fix |
 | Infrastructure outage | Report to user, suggest retrying later |
 | Fix introduced new failures | `git revert HEAD` to undo the fix, report to user |
 
@@ -458,6 +457,6 @@ After complete execution:
 
 ## References
 
-- [Error Patterns Catalog](references/error-patterns.md) — Complete error diagnosis patterns with fixes
-- [Azure DevOps CLI — Pipelines](https://learn.microsoft.com/en-us/cli/azure/pipelines)
-- [Azure DevOps CLI — Build logs](https://learn.microsoft.com/en-us/cli/azure/devops)
+- [Error Patterns Catalog](references/error-patterns.md): Complete error diagnosis patterns with fixes
+- [Azure DevOps CLI: Pipelines](https://learn.microsoft.com/en-us/cli/azure/pipelines)
+- [Azure DevOps CLI: Build logs](https://learn.microsoft.com/en-us/cli/azure/devops)


### PR DESCRIPTION
## Summary

Follow-up to #3311. De-versions the two skills deferred from that PR because they carried pre-existing banned em/en dashes that had to be cleaned in the same edit.

- **negotiation**: drops the `claude-opus-4-6` pin; removes the stale "senior-tier model routing" clause from the description; fixes 1 em dash.
- **pipeline-validator**: drops the `claude-sonnet-4-6` pin; fixes 18 em dashes.

Both now inherit the harness default model per ADR-080. No behavior change beyond model selection and prose punctuation.

## Changes

- Removed the two model pins from their source skills.
- Regenerated the copilot-cli mirrors.
- Drained the two pins from the model-pin baseline (46 pins; `frozen_count` 52 unchanged).
- Bumped both plugin manifests to 0.6.101 (parity held).

## Testing

```
uv run --frozen python scripts/validation/check_model_pins.py        # exit 0
uv run --frozen python build/scripts/check_plugin_manifest_parity.py # match 0.6.101
uv run --frozen python .claude/skills/SkillForge/scripts/validate-skill.py .claude/skills/negotiation        # exit 0
uv run --frozen python .claude/skills/SkillForge/scripts/validate-skill.py .claude/skills/pipeline-validator  # exit 0
# byte-check: 0 em/en dashes across all four SKILL.md files
```

Pre-push suite green: python-tests (194s), pre-pr-validation, plugin-load-e2e, build-all-check.

## Out of Scope

- Agent pins (`.claude/agents/negotiation.md`) are a separate follow-up (PR B).

Refs #2840
