### PR TITLE
test(hooks): guard freeform apply_patch strings through the shipped dispatcher (#3321)

### DIFF
--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -14447,6 +14447,78 @@
         "episode-2026-07-21-session-3290-mypy-diff-line-ratchet"
       ],
       "created": "2026-07-22T15:39:37.620865+00:00"
+    },
+    {
+      "id": "a370df207b3f",
+      "type": "milestone",
+      "label": "milestone: Read issue #3321 with its prior report #3203 and prior fix #3204. Established the current surface: #3295 (8318d1c350, version 0.6.98) retired invoke_security_gate__Write_Edit_c39898.py from the Copilot PreToolUse manifest and narrowed the host matcher in hooks.json from Bash|Write|Edit to Bash. Main is 0.6.101.",
+      "episodes": [
+        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
+      ],
+      "created": "2026-07-24T19:16:22.233994+00:00"
+    },
+    {
+      "id": "71b90211a8ea",
+      "type": "milestone",
+      "label": "milestone: Replayed six realistic payload shapes through the shipped src/copilot-cli/hooks/PreToolUse/_dispatch.py on main: top-level apply_patch with a raw patch string, the recorded toolCalls host event, Edit and Write with a raw patch string, a JSON-object args string, and a headerless string. All exit 0. Local Copilot CLI is 1.0.74, the same build the reporter names.",
+      "episodes": [
+        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
+      ],
+      "created": "2026-07-24T19:16:22.234057+00:00"
+    },
+    {
+      "id": "da23ae98496b",
+      "type": "milestone",
+      "label": "milestone: Ran a live probe with copilot 1.0.74 and --plugin-dir src/copilot-cli. This Linux build exposes no apply_patch tool (Unknown tool name in the tool allowlist), so the end-to-end reproduction the reporter describes is reachable only on their harness. Fell back to direct dispatcher replay, which is what the existing #3083 guard already uses.",
+      "episodes": [
+        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
+      ],
+      "created": "2026-07-24T19:16:22.234110+00:00"
+    },
+    {
+      "id": "33093c70775b",
+      "type": "milestone",
+      "label": "milestone: Extracted the pre-purge plugin tree (git archive 8318d1c350^ src/copilot-cli) and replayed the same shapes. Found the real mechanism: #3204's malformed_structural_lines fails closed on every column-0 *** line it cannot attribute to a path, and _PATCH_BEGIN_END recognizes only Begin Patch and End Patch. The standard V4A marker *** End of File therefore denies the whole patch (exit 2, tool_input carries malformed patch header(s)). The absolute Windows path in the report is not the trigger; _PATCH_FILE_HEADER parses drive-letter paths.",
+      "episodes": [
+        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
+      ],
+      "created": "2026-07-24T19:16:22.234162+00:00"
+    },
+    {
+      "id": "d5b0bb9da17a",
+      "type": "milestone",
+      "label": "milestone: Learnings captured in Serena memory decision-3321-freeform-apply-patch-gate. Added three fixtures to the existing #3083 guard rather than a new module: freeform-patch-string, freeform-patch-string-as-edit, and freeform-patch-end-of-file-marker, all replayed through the committed dispatcher with the file's existing non-plugin-root negative control supplying teeth. 8 tests green.",
+      "episodes": [
+        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
+      ],
+      "created": "2026-07-24T19:16:22.234213+00:00"
+    },
+    {
+      "id": "fec86ee3f3f4",
+      "type": "commit",
+      "label": "commit: Commit: 8385764d799b84a32c18d55a0bb3a8b1dd3162a5",
+      "episodes": [
+        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
+      ],
+      "created": "2026-07-24T19:16:22.234264+00:00"
+    },
+    {
+      "id": "1d53fea0023d",
+      "type": "commit",
+      "label": "commit: Commit: 8318d1c350",
+      "episodes": [
+        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
+      ],
+      "created": "2026-07-24T19:16:22.234315+00:00"
+    },
+    {
+      "id": "9cc0a372473b",
+      "type": "outcome",
+      "label": "Outcome: success - Triage issue #3321 (P0): project-toolkit denies a valid Copilot CLI freeform apply_patch on CLI 1.0.74. Determine whether main still reproduces, find the real denial mechanism, and lock the behavior with a regression guard on the shipped dispatcher.",
+      "episodes": [
+        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
+      ],
+      "created": "2026-07-24T19:16:22.234366+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -14503,15 +14503,6 @@
       "created": "2026-07-24T19:16:22.234264+00:00"
     },
     {
-      "id": "1d53fea0023d",
-      "type": "commit",
-      "label": "commit: Commit: 8318d1c350",
-      "episodes": [
-        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
-      ],
-      "created": "2026-07-24T19:16:22.234315+00:00"
-    },
-    {
       "id": "9cc0a372473b",
       "type": "outcome",
       "label": "Outcome: success - Triage issue #3321 (P0): project-toolkit denies a valid Copilot CLI freeform apply_patch on CLI 1.0.74. Determine whether main still reproduces, find the real denial mechanism, and lock the behavior with a regression guard on the shipped dispatcher.",
@@ -14519,6 +14510,24 @@
         "episode-2026-07-24-session-3321-apply-patch-regression-guard"
       ],
       "created": "2026-07-24T19:16:22.234366+00:00"
+    },
+    {
+      "id": "5c796af2eaf2",
+      "type": "milestone",
+      "label": "milestone: Read issue #3321 with its prior report #3203 and prior fix #3204. Established the current surface: PR #3295 (version 0.6.98) retired invoke_security_gate__Write_Edit_c39898.py from the Copilot PreToolUse manifest and narrowed the host matcher in hooks.json from Bash|Write|Edit to Bash. Main is 0.6.101. The merge SHA is cited in PR #3326 and in the Serena memory rather than here, because the episode extractor reads work-log prose SHAs as commits this session produced.",
+      "episodes": [
+        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
+      ],
+      "created": "2026-07-25T07:36:38.720762+00:00"
+    },
+    {
+      "id": "b4544b1913ac",
+      "type": "milestone",
+      "label": "milestone: Extracted the pre-purge plugin tree with git archive against the parent of the PR #3295 merge commit and replayed the same shapes. Found the real mechanism: #3204's malformed_structural_lines fails closed on every column-0 *** line it cannot attribute to a path, and _PATCH_BEGIN_END recognizes only Begin Patch and End Patch. The standard V4A marker *** End of File therefore denies the whole patch (exit 2, tool_input carries malformed patch header(s)). The absolute Windows path in the report is not the trigger; _PATCH_FILE_HEADER parses drive-letter paths.",
+      "episodes": [
+        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
+      ],
+      "created": "2026-07-25T07:36:38.720823+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -14449,15 +14449,6 @@
       "created": "2026-07-22T15:39:37.620865+00:00"
     },
     {
-      "id": "a370df207b3f",
-      "type": "milestone",
-      "label": "milestone: Read issue #3321 with its prior report #3203 and prior fix #3204. Established the current surface: #3295 (8318d1c350, version 0.6.98) retired invoke_security_gate__Write_Edit_c39898.py from the Copilot PreToolUse manifest and narrowed the host matcher in hooks.json from Bash|Write|Edit to Bash. Main is 0.6.101.",
-      "episodes": [
-        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
-      ],
-      "created": "2026-07-24T19:16:22.233994+00:00"
-    },
-    {
       "id": "71b90211a8ea",
       "type": "milestone",
       "label": "milestone: Replayed six realistic payload shapes through the shipped src/copilot-cli/hooks/PreToolUse/_dispatch.py on main: top-level apply_patch with a raw patch string, the recorded toolCalls host event, Edit and Write with a raw patch string, a JSON-object args string, and a headerless string. All exit 0. Local Copilot CLI is 1.0.74, the same build the reporter names.",
@@ -14474,15 +14465,6 @@
         "episode-2026-07-24-session-3321-apply-patch-regression-guard"
       ],
       "created": "2026-07-24T19:16:22.234110+00:00"
-    },
-    {
-      "id": "33093c70775b",
-      "type": "milestone",
-      "label": "milestone: Extracted the pre-purge plugin tree (git archive 8318d1c350^ src/copilot-cli) and replayed the same shapes. Found the real mechanism: #3204's malformed_structural_lines fails closed on every column-0 *** line it cannot attribute to a path, and _PATCH_BEGIN_END recognizes only Begin Patch and End Patch. The standard V4A marker *** End of File therefore denies the whole patch (exit 2, tool_input carries malformed patch header(s)). The absolute Windows path in the report is not the trigger; _PATCH_FILE_HEADER parses drive-letter paths.",
-      "episodes": [
-        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
-      ],
-      "created": "2026-07-24T19:16:22.234162+00:00"
     },
     {
       "id": "d5b0bb9da17a",
@@ -14528,6 +14510,15 @@
         "episode-2026-07-24-session-3321-apply-patch-regression-guard"
       ],
       "created": "2026-07-25T07:36:38.720823+00:00"
+    },
+    {
+      "id": "6f405e8c431e",
+      "type": "milestone",
+      "label": "milestone: Worked PR #3326 review threads. Corrected a stale shim list in the guard docstring, two undercounted changed-file claims in this log, and an episode that recorded PR #3295's merge SHA as a commit this session produced. Verified the root cause instead of hand-patching the metric: the pre-commit extractor re-derives metrics.commits from commit-typed events, so an earlier hand-edit was silently reverted. Fixed by citing #3295 by PR number in this log so a fresh extraction reproduces the committed episode exactly. Left the extractor's bare-SHA sweep unchanged; narrowing it breaks four tests that encode the #2170, #3123, and #3301 contract, which is a separate decision.",
+      "episodes": [
+        "episode-2026-07-24-session-3321-apply-patch-regression-guard"
+      ],
+      "created": "2026-07-25T07:38:28.278709+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/episodes/episode-2026-07-24-session-3321-apply-patch-regression-guard.json
+++ b/.agents/memory/episodes/episode-2026-07-24-session-3321-apply-patch-regression-guard.json
@@ -12,7 +12,7 @@
       "type": "milestone",
       "content": "Read issue #3321 with its prior report #3203 and prior fix #3204. Established the current surface: #3295 (8318d1c350, version 0.6.98) retired invoke_security_gate__Write_Edit_c39898.py from the Copilot PreToolUse manifest and narrowed the host matcher in hooks.json from Bash|Write|Edit to Bash. Main is 0.6.101.",
       "caused_by": [
-        "e007"
+        "e006"
       ],
       "leads_to": [
         "e002"
@@ -62,7 +62,9 @@
       "caused_by": [
         "e004"
       ],
-      "leads_to": []
+      "leads_to": [
+        "e007"
+      ]
     },
     {
       "id": "e006",
@@ -71,20 +73,30 @@
       "content": "Commit: 8385764d799b84a32c18d55a0bb3a8b1dd3162a5",
       "caused_by": [],
       "leads_to": [
-        "e007"
+        "e001"
       ]
     },
     {
       "id": "e007",
       "timestamp": "2026-07-24T00:00:00+00:00",
-      "type": "commit",
-      "content": "Commit: 8318d1c350",
+      "type": "milestone",
+      "content": "Read issue #3321 with its prior report #3203 and prior fix #3204. Established the current surface: PR #3295 (version 0.6.98) retired invoke_security_gate__Write_Edit_c39898.py from the Copilot PreToolUse manifest and narrowed the host matcher in hooks.json from Bash|Write|Edit to Bash. Main is 0.6.101. The merge SHA is cited in PR #3326 and in the Serena memory rather than here, because the episode extractor reads work-log prose SHAs as commits this session produced.",
       "caused_by": [
-        "e006"
+        "e005"
       ],
       "leads_to": [
-        "e001"
+        "e008"
       ]
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-24T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Extracted the pre-purge plugin tree with git archive against the parent of the PR #3295 merge commit and replayed the same shapes. Found the real mechanism: #3204's malformed_structural_lines fails closed on every column-0 *** line it cannot attribute to a path, and _PATCH_BEGIN_END recognizes only Begin Patch and End Patch. The standard V4A marker *** End of File therefore denies the whole patch (exit 2, tool_input carries malformed patch header(s)). The absolute Windows path in the report is not the trigger; _PATCH_FILE_HEADER parses drive-letter paths.",
+      "caused_by": [
+        "e007"
+      ],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -92,7 +104,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 2,
+    "commits": 1,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-24-session-3321-apply-patch-regression-guard.json
+++ b/.agents/memory/episodes/episode-2026-07-24-session-3321-apply-patch-regression-guard.json
@@ -10,7 +10,7 @@
       "id": "e001",
       "timestamp": "2026-07-24T00:00:00+00:00",
       "type": "milestone",
-      "content": "Read issue #3321 with its prior report #3203 and prior fix #3204. Established the current surface: #3295 (8318d1c350, version 0.6.98) retired invoke_security_gate__Write_Edit_c39898.py from the Copilot PreToolUse manifest and narrowed the host matcher in hooks.json from Bash|Write|Edit to Bash. Main is 0.6.101.",
+      "content": "Read issue #3321 with its prior report #3203 and prior fix #3204. Established the current surface: PR #3295 (version 0.6.98) retired invoke_security_gate__Write_Edit_c39898.py from the Copilot PreToolUse manifest and narrowed the host matcher in hooks.json from Bash|Write|Edit to Bash. Main is 0.6.101. The merge SHA is cited in PR #3326 and in the Serena memory rather than here, because the episode extractor reads work-log prose SHAs as commits this session produced.",
       "caused_by": [
         "e006"
       ],
@@ -46,7 +46,7 @@
       "id": "e004",
       "timestamp": "2026-07-24T00:00:00+00:00",
       "type": "milestone",
-      "content": "Extracted the pre-purge plugin tree (git archive 8318d1c350^ src/copilot-cli) and replayed the same shapes. Found the real mechanism: #3204's malformed_structural_lines fails closed on every column-0 *** line it cannot attribute to a path, and _PATCH_BEGIN_END recognizes only Begin Patch and End Patch. The standard V4A marker *** End of File therefore denies the whole patch (exit 2, tool_input carries malformed patch header(s)). The absolute Windows path in the report is not the trigger; _PATCH_FILE_HEADER parses drive-letter paths.",
+      "content": "Extracted the pre-purge plugin tree with git archive against the parent of the PR #3295 merge commit and replayed the same shapes. Found the real mechanism: #3204's malformed_structural_lines fails closed on every column-0 *** line it cannot attribute to a path, and _PATCH_BEGIN_END recognizes only Begin Patch and End Patch. The standard V4A marker *** End of File therefore denies the whole patch (exit 2, tool_input carries malformed patch header(s)). The absolute Windows path in the report is not the trigger; _PATCH_FILE_HEADER parses drive-letter paths.",
       "caused_by": [
         "e003"
       ],
@@ -80,21 +80,9 @@
       "id": "e007",
       "timestamp": "2026-07-24T00:00:00+00:00",
       "type": "milestone",
-      "content": "Read issue #3321 with its prior report #3203 and prior fix #3204. Established the current surface: PR #3295 (version 0.6.98) retired invoke_security_gate__Write_Edit_c39898.py from the Copilot PreToolUse manifest and narrowed the host matcher in hooks.json from Bash|Write|Edit to Bash. Main is 0.6.101. The merge SHA is cited in PR #3326 and in the Serena memory rather than here, because the episode extractor reads work-log prose SHAs as commits this session produced.",
+      "content": "Worked PR #3326 review threads. Corrected a stale shim list in the guard docstring, two undercounted changed-file claims in this log, and an episode that recorded PR #3295's merge SHA as a commit this session produced. Verified the root cause instead of hand-patching the metric: the pre-commit extractor re-derives metrics.commits from commit-typed events, so an earlier hand-edit was silently reverted. Fixed by citing #3295 by PR number in this log so a fresh extraction reproduces the committed episode exactly. Left the extractor's bare-SHA sweep unchanged; narrowing it breaks four tests that encode the #2170, #3123, and #3301 contract, which is a separate decision.",
       "caused_by": [
         "e005"
-      ],
-      "leads_to": [
-        "e008"
-      ]
-    },
-    {
-      "id": "e008",
-      "timestamp": "2026-07-24T00:00:00+00:00",
-      "type": "milestone",
-      "content": "Extracted the pre-purge plugin tree with git archive against the parent of the PR #3295 merge commit and replayed the same shapes. Found the real mechanism: #3204's malformed_structural_lines fails closed on every column-0 *** line it cannot attribute to a path, and _PATCH_BEGIN_END recognizes only Begin Patch and End Patch. The standard V4A marker *** End of File therefore denies the whole patch (exit 2, tool_input carries malformed patch header(s)). The absolute Windows path in the report is not the trigger; _PATCH_FILE_HEADER parses drive-letter paths.",
-      "caused_by": [
-        "e007"
       ],
       "leads_to": []
     }

--- a/.agents/memory/episodes/episode-2026-07-24-session-3321-apply-patch-regression-guard.json
+++ b/.agents/memory/episodes/episode-2026-07-24-session-3321-apply-patch-regression-guard.json
@@ -93,7 +93,7 @@
     "errors": 0,
     "recoveries": 0,
     "commits": 2,
-    "files_changed": 2
+    "files_changed": 4
   },
   "lessons": []
 }

--- a/.agents/memory/episodes/episode-2026-07-24-session-3321-apply-patch-regression-guard.json
+++ b/.agents/memory/episodes/episode-2026-07-24-session-3321-apply-patch-regression-guard.json
@@ -1,0 +1,99 @@
+{
+  "id": "episode-2026-07-24-session-3321-apply-patch-regression-guard",
+  "session": "2026-07-24-session-3321-apply-patch-regression-guard",
+  "timestamp": "2026-07-24T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Triage issue #3321 (P0): project-toolkit denies a valid Copilot CLI freeform apply_patch on CLI 1.0.74. Determine whether main still reproduces, find the real denial mechanism, and lock the behavior with a regression guard on the shipped dispatcher.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-24T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read issue #3321 with its prior report #3203 and prior fix #3204. Established the current surface: #3295 (8318d1c350, version 0.6.98) retired invoke_security_gate__Write_Edit_c39898.py from the Copilot PreToolUse manifest and narrowed the host matcher in hooks.json from Bash|Write|Edit to Bash. Main is 0.6.101.",
+      "caused_by": [
+        "e007"
+      ],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-24T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Replayed six realistic payload shapes through the shipped src/copilot-cli/hooks/PreToolUse/_dispatch.py on main: top-level apply_patch with a raw patch string, the recorded toolCalls host event, Edit and Write with a raw patch string, a JSON-object args string, and a headerless string. All exit 0. Local Copilot CLI is 1.0.74, the same build the reporter names.",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-24T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran a live probe with copilot 1.0.74 and --plugin-dir src/copilot-cli. This Linux build exposes no apply_patch tool (Unknown tool name in the tool allowlist), so the end-to-end reproduction the reporter describes is reachable only on their harness. Fell back to direct dispatcher replay, which is what the existing #3083 guard already uses.",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-24T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Extracted the pre-purge plugin tree (git archive 8318d1c350^ src/copilot-cli) and replayed the same shapes. Found the real mechanism: #3204's malformed_structural_lines fails closed on every column-0 *** line it cannot attribute to a path, and _PATCH_BEGIN_END recognizes only Begin Patch and End Patch. The standard V4A marker *** End of File therefore denies the whole patch (exit 2, tool_input carries malformed patch header(s)). The absolute Windows path in the report is not the trigger; _PATCH_FILE_HEADER parses drive-letter paths.",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-24T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Learnings captured in Serena memory decision-3321-freeform-apply-patch-gate. Added three fixtures to the existing #3083 guard rather than a new module: freeform-patch-string, freeform-patch-string-as-edit, and freeform-patch-end-of-file-marker, all replayed through the committed dispatcher with the file's existing non-plugin-root negative control supplying teeth. 8 tests green.",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-24T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 8385764d799b84a32c18d55a0bb3a8b1dd3162a5",
+      "caused_by": [],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-24T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 8318d1c350",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": [
+        "e001"
+      ]
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 2,
+    "files_changed": 2
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-24-session-3321-apply-patch-regression-guard.json
+++ b/.agents/sessions/2026-07-24-session-3321-apply-patch-regression-guard.json
@@ -47,7 +47,7 @@
       "gitStatusVerified": {
         "level": "SHOULD",
         "Complete": true,
-        "Evidence": "git status inspected before branching; pre-existing untracked retrospectives and worktrees left alone, and only the two intended files were staged."
+        "Evidence": "git status inspected before branching; pre-existing untracked retrospectives and worktrees left alone. Staged the regression test and this session log by hand; the commit hook then wrote the memory episode and causal-graph entries alongside them."
       }
     },
     "sessionEnd": {
@@ -69,7 +69,7 @@
       "markdownLintRun": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "The branch changes one Python test file and this JSON log; git diff --name-only lists zero markdown units, so the ADR-043 scoped markdownlint set is empty. Byte-checked both files for em and en dashes: zero found."
+        "Evidence": "The branch changes one Python test file, this JSON log, and the hook-written memory episode and causal-graph JSON; git diff --name-only lists zero markdown units, so the ADR-043 scoped markdownlint set is empty. Byte-checked the hand-authored files for em and en dashes: zero found."
       },
       "changesCommitted": {
         "level": "MUST",

--- a/.agents/sessions/2026-07-24-session-3321-apply-patch-regression-guard.json
+++ b/.agents/sessions/2026-07-24-session-3321-apply-patch-regression-guard.json
@@ -91,7 +91,7 @@
   "workLog": [
     {
       "time": "T0",
-      "entry": "Read issue #3321 with its prior report #3203 and prior fix #3204. Established the current surface: #3295 (8318d1c350, version 0.6.98) retired invoke_security_gate__Write_Edit_c39898.py from the Copilot PreToolUse manifest and narrowed the host matcher in hooks.json from Bash|Write|Edit to Bash. Main is 0.6.101."
+      "entry": "Read issue #3321 with its prior report #3203 and prior fix #3204. Established the current surface: PR #3295 (version 0.6.98) retired invoke_security_gate__Write_Edit_c39898.py from the Copilot PreToolUse manifest and narrowed the host matcher in hooks.json from Bash|Write|Edit to Bash. Main is 0.6.101. The merge SHA is cited in PR #3326 and in the Serena memory rather than here, because the episode extractor reads work-log prose SHAs as commits this session produced."
     },
     {
       "time": "T1",
@@ -103,7 +103,7 @@
     },
     {
       "time": "T3",
-      "entry": "Extracted the pre-purge plugin tree (git archive 8318d1c350^ src/copilot-cli) and replayed the same shapes. Found the real mechanism: #3204's malformed_structural_lines fails closed on every column-0 *** line it cannot attribute to a path, and _PATCH_BEGIN_END recognizes only Begin Patch and End Patch. The standard V4A marker *** End of File therefore denies the whole patch (exit 2, tool_input carries malformed patch header(s)). The absolute Windows path in the report is not the trigger; _PATCH_FILE_HEADER parses drive-letter paths."
+      "entry": "Extracted the pre-purge plugin tree with git archive against the parent of the PR #3295 merge commit and replayed the same shapes. Found the real mechanism: #3204's malformed_structural_lines fails closed on every column-0 *** line it cannot attribute to a path, and _PATCH_BEGIN_END recognizes only Begin Patch and End Patch. The standard V4A marker *** End of File therefore denies the whole patch (exit 2, tool_input carries malformed patch header(s)). The absolute Windows path in the report is not the trigger; _PATCH_FILE_HEADER parses drive-letter paths."
     },
     {
       "time": "T4",

--- a/.agents/sessions/2026-07-24-session-3321-apply-patch-regression-guard.json
+++ b/.agents/sessions/2026-07-24-session-3321-apply-patch-regression-guard.json
@@ -47,7 +47,7 @@
       "gitStatusVerified": {
         "level": "SHOULD",
         "Complete": true,
-        "Evidence": "git status inspected before branching; pre-existing untracked retrospectives and worktrees left alone. Staged the regression test and this session log by hand; the commit hook then wrote the memory episode and causal-graph entries alongside them."
+        "Evidence": "git status inspected before branching; pre-existing untracked retrospectives and worktrees left alone. Staged the regression test, this session log, and the memory episode by hand; the update-causal-graph commit hook then wrote and staged the causal-graph entry."
       }
     },
     "sessionEnd": {
@@ -69,7 +69,7 @@
       "markdownLintRun": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "The branch changes one Python test file, this JSON log, and the hook-written memory episode and causal-graph JSON; git diff --name-only lists zero markdown units, so the ADR-043 scoped markdownlint set is empty. Byte-checked the hand-authored files for em and en dashes: zero found."
+        "Evidence": "The branch changes one Python test file, this JSON log, the memory episode JSON, and the hook-written causal-graph JSON; git diff --name-only lists zero markdown units, so the ADR-043 scoped markdownlint set is empty. Byte-checked the hand-authored files for em and en dashes: zero found."
       },
       "changesCommitted": {
         "level": "MUST",

--- a/.agents/sessions/2026-07-24-session-3321-apply-patch-regression-guard.json
+++ b/.agents/sessions/2026-07-24-session-3321-apply-patch-regression-guard.json
@@ -108,6 +108,10 @@
     {
       "time": "T4",
       "entry": "Learnings captured in Serena memory decision-3321-freeform-apply-patch-gate. Added three fixtures to the existing #3083 guard rather than a new module: freeform-patch-string, freeform-patch-string-as-edit, and freeform-patch-end-of-file-marker, all replayed through the committed dispatcher with the file's existing non-plugin-root negative control supplying teeth. 8 tests green."
+    },
+    {
+      "time": "T5",
+      "entry": "Worked PR #3326 review threads. Corrected a stale shim list in the guard docstring, two undercounted changed-file claims in this log, and an episode that recorded PR #3295's merge SHA as a commit this session produced. Verified the root cause instead of hand-patching the metric: the pre-commit extractor re-derives metrics.commits from commit-typed events, so an earlier hand-edit was silently reverted. Fixed by citing #3295 by PR number in this log so a fresh extraction reproduces the committed episode exactly. Left the extractor's bare-SHA sweep unchanged; narrowing it breaks four tests that encode the #2170, #3123, and #3301 contract, which is a separate decision."
     }
   ],
   "endingCommit": "8385764d799b84a32c18d55a0bb3a8b1dd3162a5",

--- a/.agents/sessions/2026-07-24-session-3321-apply-patch-regression-guard.json
+++ b/.agents/sessions/2026-07-24-session-3321-apply-patch-regression-guard.json
@@ -1,0 +1,119 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3321,
+    "date": "2026-07-24",
+    "branch": "fix/3321-apply-patch-regression-guard",
+    "startingCommit": "bb69942d32d84f36059704af31ee9bf8aa16a403",
+    "objective": "Triage issue #3321 (P0): project-toolkit denies a valid Copilot CLI freeform apply_patch on CLI 1.0.74. Determine whether main still reproduces, find the real denial mechanism, and lock the behavior with a regression guard on the shipped dispatcher."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP active on this Copilot CLI harness; serena-initial_instructions returned the manual and serena-list_memories returned the project memory index. Activated after the first triage reads rather than before them."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Called serena-initial_instructions; the Serena Instructions Manual loaded (44.2 KB)."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md and honored the read-only rule (ADR-014); the file was never modified on this branch."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file created under .agents/sessions/ during the session."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current returned fix/3321-apply-patch-regression-guard, cut from main at bb69942d32."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All commits land on fix/3321-apply-patch-regression-guard; main was only read."
+      },
+      "memoriesLoaded": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Copilot repository and user memories loaded at session start; serena-list_memories queried for prior apply_patch, security-gate, #3203, and #3083 entries and returned none, so a new decision memory was written."
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status inspected before branching; pre-existing untracked retrospectives and worktrees left alone, and only the two intended files were staged."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Triage finished: main does not reproduce #3321, the real mechanism on plugin 0.6.66 through 0.6.97 is identified and reproduced, and three fixtures lock the behavior on the shipped dispatcher."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md read only, never modified (ADR-014)."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Wrote Serena memory decision-3321-freeform-apply-patch-gate recording the *** End of File denial mechanism, the 0.6.98 version boundary, and the reproduction commands."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "The branch changes one Python test file and this JSON log; git diff --name-only lists zero markdown units, so the ADR-043 scoped markdownlint set is empty. Byte-checked both files for em and en dashes: zero found."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Regression fixtures committed as 8385764d799b84a32c18d55a0bb3a8b1dd3162a5 on fix/3321-apply-patch-regression-guard; this session log commits alongside it."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "8 tests green in tests/build_scripts/test_dispatch_small_apply_patch_regression.py; ruff clean on the changed file; the full pre-push suite ran 13404 passed, 22 skipped, 45 xfailed, with build-all-check and pre-pr-validation green."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue #3321 stays open until the reporter confirms the installed plugin version; the PR carries that request."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "T0",
+      "entry": "Read issue #3321 with its prior report #3203 and prior fix #3204. Established the current surface: #3295 (8318d1c350, version 0.6.98) retired invoke_security_gate__Write_Edit_c39898.py from the Copilot PreToolUse manifest and narrowed the host matcher in hooks.json from Bash|Write|Edit to Bash. Main is 0.6.101."
+    },
+    {
+      "time": "T1",
+      "entry": "Replayed six realistic payload shapes through the shipped src/copilot-cli/hooks/PreToolUse/_dispatch.py on main: top-level apply_patch with a raw patch string, the recorded toolCalls host event, Edit and Write with a raw patch string, a JSON-object args string, and a headerless string. All exit 0. Local Copilot CLI is 1.0.74, the same build the reporter names."
+    },
+    {
+      "time": "T2",
+      "entry": "Ran a live probe with copilot 1.0.74 and --plugin-dir src/copilot-cli. This Linux build exposes no apply_patch tool (Unknown tool name in the tool allowlist), so the end-to-end reproduction the reporter describes is reachable only on their harness. Fell back to direct dispatcher replay, which is what the existing #3083 guard already uses."
+    },
+    {
+      "time": "T3",
+      "entry": "Extracted the pre-purge plugin tree (git archive 8318d1c350^ src/copilot-cli) and replayed the same shapes. Found the real mechanism: #3204's malformed_structural_lines fails closed on every column-0 *** line it cannot attribute to a path, and _PATCH_BEGIN_END recognizes only Begin Patch and End Patch. The standard V4A marker *** End of File therefore denies the whole patch (exit 2, tool_input carries malformed patch header(s)). The absolute Windows path in the report is not the trigger; _PATCH_FILE_HEADER parses drive-letter paths."
+    },
+    {
+      "time": "T4",
+      "entry": "Learnings captured in Serena memory decision-3321-freeform-apply-patch-gate. Added three fixtures to the existing #3083 guard rather than a new module: freeform-patch-string, freeform-patch-string-as-edit, and freeform-patch-end-of-file-marker, all replayed through the committed dispatcher with the file's existing non-plugin-root negative control supplying teeth. 8 tests green."
+    }
+  ],
+  "endingCommit": "8385764d799b84a32c18d55a0bb3a8b1dd3162a5",
+  "nextSteps": [
+    "Ask the reporter of #3321 for the installed project-toolkit version and a --log-dir hook stderr capture. Below 0.6.98 the upgrade closes it; at or above 0.6.98 a second mechanism exists that this session did not find.",
+    "If the reporter is below 0.6.98, close #3321 as fixed by #3295 and point at the regression fixtures added here.",
+    "Consider whether any future reinstatement of a patch-parsing gate must recognize the full V4A marker set (*** End of File, @@ hunk headers) instead of treating unknown column-0 *** lines as fatal."
+  ]
+}

--- a/tests/build_scripts/test_dispatch_small_apply_patch_regression.py
+++ b/tests/build_scripts/test_dispatch_small_apply_patch_regression.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """Regression guard for issue #3083 (Copilot host-versus-direct-replay code 1).
 
+Also guards issues #3203 and #3321 (freeform ``apply_patch`` denied by the
+plugin's PreToolUse gate) via the string-``tool_input`` fixtures below.
+
 On Windows the Copilot CLI host reported ``Hook command failed with code 1`` on a
 small ``apply_patch`` PreToolUse payload, yet a direct replay of the same payload
 through ``_dispatch.py`` returned exit 0. No PreToolUse shim matches
@@ -74,6 +77,46 @@ _RECORDED_HOST_EVENT: dict[str, object] = {
 # the guard to apply_patch rather than to "any shape lacking tool_name".
 _NORMALIZED_EVENT: dict[str, object] = {"tool_name": "apply_patch", "tool_input": {}}
 
+# Issues #3203 and #3321: the host delivers a freeform patch as a raw V4A STRING
+# in tool_input, not an object, and it reached the retired Write/Edit security
+# gate under both the apply_patch name and the Edit name. That gate required a
+# dict and denied (#3203); #3204 taught it to parse the string; #3295 retired the
+# gate and narrowed the host matcher to Bash. These fixtures carry the #3321
+# reproduction bytes (an *** Add File: header with an absolute Windows path to a
+# nested Markdown file) so a future guard that reintroduces a dict-only
+# tool_input assumption fails here instead of in a consumer's session.
+_WINDOWS_ADD_FILE_PATCH = (
+    "*** Begin Patch\n"
+    "*** Add File: C:\\Users\\op\\repo\\.agentlog\\feat-x\\copilot-cli\\workflow.md\n"
+    "+# Workflow\n"
+    "*** End Patch\n"
+)
+_FREEFORM_STRING_EVENT: dict[str, object] = {
+    "tool_name": "apply_patch",
+    "tool_input": _WINDOWS_ADD_FILE_PATCH,
+}
+_FREEFORM_EDIT_STRING_EVENT: dict[str, object] = {
+    "tool_name": "Edit",
+    "tool_input": _WINDOWS_ADD_FILE_PATCH,
+}
+# The concrete #3321 denial mechanism on plugin versions 0.6.66 through 0.6.97:
+# the retired gate treated EVERY column-0 ``***`` line it could not attribute to
+# a path as a malformed header and failed closed, so the standard V4A
+# ``*** End of File`` marker denied the whole patch. Replaying that exact byte
+# sequence against 8318d1c350^ reproduces
+# "tool_input carries malformed patch header(s)... : *** End of File" (exit 2);
+# the same bytes exit 0 here.
+_FREEFORM_END_OF_FILE_EVENT: dict[str, object] = {
+    "tool_name": "Edit",
+    "tool_input": (
+        "*** Begin Patch\n"
+        "*** Add File: C:\\Users\\op\\repo\\.agentlog\\feat-x\\copilot-cli\\workflow.md\n"
+        "+# Workflow\n"
+        "*** End of File\n"
+        "*** End Patch\n"
+    ),
+}
+
 
 def _run_dispatch(
     payload: bytes, plugin_root: Path, cwd: Path
@@ -100,8 +143,20 @@ def _run_dispatch(
 
 @pytest.mark.parametrize(
     "payload",
-    [_RECORDED_HOST_EVENT, _NORMALIZED_EVENT],
-    ids=["recorded-host-event", "normalized-tool-name"],
+    [
+        _RECORDED_HOST_EVENT,
+        _NORMALIZED_EVENT,
+        _FREEFORM_STRING_EVENT,
+        _FREEFORM_EDIT_STRING_EVENT,
+        _FREEFORM_END_OF_FILE_EVENT,
+    ],
+    ids=[
+        "recorded-host-event",
+        "normalized-tool-name",
+        "freeform-patch-string",
+        "freeform-patch-string-as-edit",
+        "freeform-patch-end-of-file-marker",
+    ],
 )
 def test_small_apply_patch_payload_allows(payload: dict[str, object], tmp_path: Path) -> None:
     raw = json.dumps(payload).encode("utf-8")

--- a/tests/build_scripts/test_dispatch_small_apply_patch_regression.py
+++ b/tests/build_scripts/test_dispatch_small_apply_patch_regression.py
@@ -7,8 +7,9 @@ plugin's PreToolUse gate) via the string-``tool_input`` fixtures below.
 On Windows the Copilot CLI host reported ``Hook command failed with code 1`` on a
 small ``apply_patch`` PreToolUse payload, yet a direct replay of the same payload
 through ``_dispatch.py`` returned exit 0. No PreToolUse shim matches
-``apply_patch`` (the manifest carries Bash, Write/Edit, Grep, Glob, Read, Task,
-and Agent shims), so on this payload every shim skips and the dispatcher returns
+``apply_patch``: the committed manifest registers a single ``Bash``-scoped
+markdownlint guard, and the broader shim set it replaced carried no
+``apply_patch`` matcher either. Every shim skips and the dispatcher returns
 0. The dispatcher is not limited to {0, 2} in general: ``hook_dispatch.run_dispatch``
 propagates a matching shim's first non-zero exit code, so a registered shim that
 exited 1 would surface 1. It is the ABSENCE of an ``apply_patch`` matcher, not a
@@ -21,8 +22,9 @@ What this preserves: the in-repo half of that discrepancy. It replays a small
 ``apply_patch`` payload through the SHIPPED, committed
 ``src/copilot-cli/hooks/PreToolUse/_dispatch.py`` under the verified plugin-root
 contract and asserts exit 0. No registered PreToolUse shim matches
-``apply_patch`` (the manifest carries Bash, Write/Edit, Grep, Glob, Read, Task,
-and Agent shims), so every guard skips and the dispatcher allows. If a future
+``apply_patch`` (see the shim list in
+``src/copilot-cli/hooks/PreToolUse/_manifest.json``), so every guard skips and
+the dispatcher allows. If a future
 dispatcher change ever made this benign payload return a non-zero code, this
 guard fails and localizes the regression to the dispatcher rather than the host.
 


### PR DESCRIPTION
## Summary

### What

Adds three fixtures to the existing dispatcher regression guard that replay the
issue #3321 reproduction bytes through the shipped Copilot CLI PreToolUse
dispatcher and assert exit 0. No production code changes.

### Why

Issue #3321 (P0) reports that project-toolkit still denies a valid freeform
`apply_patch` on Copilot CLI 1.0.74, after #3204 was supposed to close #3203.

Triage found two things.

**Main does not reproduce.** #3295 retired the Write/Edit security gate shim from
the Copilot PreToolUse manifest and narrowed the host matcher from
`Bash|Write|Edit` to `Bash`. Either change alone closes the report. Six payload
shapes replayed through the committed dispatcher on main all exit 0: top-level
`apply_patch` with a raw patch string, the recorded `toolCalls` host event,
`Edit` and `Write` with a raw patch string, a JSON-object args string, and a
headerless string.

**The real mechanism on 0.6.66 through 0.6.97 is not the parser.** #3204 taught
the gate to parse a raw V4A string, but its `malformed_structural_lines` check
fails closed on every column-0 `***` line it cannot attribute to a file path,
and the begin/end matcher recognizes only `*** Begin Patch` and `*** End Patch`.
The standard V4A marker `*** End of File` therefore denies the whole patch:

```text
tool_input carries malformed patch header(s) the gate cannot attribute to a
file path (fail-closed): *** End of File
```

Reproduced by extracting the pre-purge plugin tree with
`git archive 8318d1c350^ src/copilot-cli` and replaying that payload: exit 2.
The same bytes against main (0.6.101) exit 0.

The absolute Windows path and the nested Markdown target named in the report are
not the trigger. The file-header pattern captures the path as `\S.*?`, so a
drive-letter path parses fine.

### Version boundary

| Plugin version | PreToolUse host matcher | Gate shim | Freeform patch |
|---|---|---|---|
| 0.6.66 to 0.6.97 | `Bash\|Write\|Edit` | present | denied when the patch carries `*** End of File` |
| 0.6.98 and later (#3295) | `Bash` | retired | allowed |

## Question for the reporter

The report names Copilot CLI 1.0.74 but not the installed project-toolkit
version, and that fact decides the outcome:

1. **Below 0.6.98**: upgrading closes this. #3295 shipped 2026-07-22.
2. **0.6.98 or later**: there is a second mechanism this triage did not find, and
   the issue stays open.

@rjmurillo please ask the reporter for the installed project-toolkit version
plus a hook stderr capture from a failing run:

```text
copilot --log-dir <dir> --log-level debug ...
```

This PR is deliberately scoped to the regression guard. It does not claim to fix
the report, so it uses `Refs` rather than `Fixes`.

## Changes

- Three fixtures on the existing #3083 guard: `freeform-patch-string`
  (top-level `apply_patch` with a raw V4A string carrying an Add File header
  with an absolute Windows path to a nested Markdown file),
  `freeform-patch-string-as-edit` (the #3203 delivery path, same bytes under the
  `Edit` name), and `freeform-patch-end-of-file-marker` (the exact denial
  trigger).
- Session log for the triage.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush. The
diff is test-only; the substance is the triage conclusion in this description.

**Focus areas**: whether the version-boundary claim holds, and whether the
fixtures cover the shapes you would expect a future patch-parsing gate to break
on.

## Testing

- [x] Tests added/updated

8 tests green in the guard module. Full pre-push suite: 13404 passed, 22 skipped,
45 xfailed. Ruff clean on the changed file. The module's existing
`test_harness_observes_nonzero_exit` supplies the negative control, so the new
`assert rc == 0` cases are not vacuous.

Live end-to-end reproduction was attempted with Copilot CLI 1.0.74 and the plugin
loaded. This Linux build exposes no `apply_patch` tool ("Unknown tool name in the
tool allowlist"), so the end-to-end path is reachable only on the reporter's
harness. Direct dispatcher replay is the same technique the existing #3083 guard
uses.

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

Test-only change. It asserts the shipped dispatcher's current allow behavior; it
does not relax a gate. The retired gate's fail-closed posture is unchanged
because the gate no longer ships.

## Author Pre-flight

- [x] Builds locally (or N/A)
- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed
- [x] Comments added only where the why is non-obvious
- [x] No new warnings introduced

## Related Issues

Refs #3321
Refs #3203
Refs #3083

## References

Files named above that are not in this diff:

- src/copilot-cli/hooks/PreToolUse/_dispatch.py
- src/copilot-cli/hooks/PreToolUse/_manifest.json
- src/copilot-cli/hooks/hooks.json
- src/copilot-cli/hooks/PreToolUse/invoke_security_gate__Write_Edit_c39898.py (retired by #3295)
