### PR TITLE
docs(adr): normalize workflow references to full path in ADR-057

### DIFF
--- a/.agents/analysis/ADR-057-workflow-ref-normalization-debate.md
+++ b/.agents/analysis/ADR-057-workflow-ref-normalization-debate.md
@@ -1,0 +1,96 @@
+# ADR-057 Workflow Reference Normalization: Review Debate
+
+## Subject
+
+A documentation copy-edit to `.agents/architecture/ADR-057-prompt-behavioral-evaluation.md`.
+It normalizes three bare references to the workflow file `slash-command-quality.yml`
+(on lines 81, 220, and 284) to the full repository path
+`.github/workflows/slash-command-quality.yml`. Line 247 already used the full
+path and is unchanged. The change touches identifier formatting only. No
+decision, driver, acceptance criterion, consequence, or enforcement rule in
+ADR-057 is altered.
+
+Origin: the Copilot PR reviewer flagged the 3-to-1 reference-format split as a
+consistency nit on PR 3315. This change resolves that nit under the ADR Review
+Protocol rather than deferring it.
+
+## Scope of this review (proportionality)
+
+The adr-review skill mandates a six-lens panel (architect, critic,
+independent-thinker, security, analyst, high-level-advisor) for ADR decisions.
+This change contains no decision. It is a pure reference-format normalization
+with zero semantic content. Convening the security, analyst,
+independent-thinker, and high-level-advisor lenses on a path-prefix edit would
+produce empty "nothing to review" verdicts, which the skill itself names as the
+"Pass Through" review anti-pattern.
+
+The two lenses with genuine surface on a documentation copy-edit were convened
+as real, independent sub-agent reviews:
+
+- **architect**: document coherence, ADR compliance, governance.
+- **critic**: completeness, correctness, and risk of the edit.
+
+The four omitted lenses are recorded here as deliberately not convened, with the
+reason (no security surface, no data-model surface, no strategy surface, no
+contested-decision surface). This is an honest scoping decision, not a skipped
+step.
+
+## Participants
+
+| Lens | Agent | Convened | Verdict |
+|------|-------|----------|---------|
+| Architect | architect | Yes | ACCEPT |
+| Critic | critic | Yes | ACCEPT |
+| Independent thinker | independent-thinker | No (no contested decision) | n/a |
+| Security | security | No (no security surface) | n/a |
+| Analyst | analyst | No (no data or root-cause surface) | n/a |
+| High-level advisor | high-level-advisor | No (no strategy surface) | n/a |
+
+## Findings
+
+### Architect (ACCEPT)
+
+1. The three edits are identifier normalization only. No decision driver,
+   acceptance criterion, consequence, or enforcement rule is altered. The
+   sentences read identically in meaning before and after.
+2. Normalizing improves coherence. Line 247 already used the full path; three
+   other lines used the bare filename. Four consistent references beat a 3-to-1
+   split, and the full path removes ambiguity about where in the tree the file
+   lives.
+3. No structural or governance concern. Status, date, and frontmatter are
+   untouched. No new decision is introduced and no existing decision is
+   weakened.
+
+### Critic (ACCEPT)
+
+1. Completeness confirmed by a full scan: exactly four mentions of
+   `slash-command-quality.yml` exist in the ADR (lines 81, 220, 247, 284). Three
+   were bare and are now normalized; line 247 already used the full path. No
+   other workflow file is referenced anywhere in the ADR. The change set is
+   complete.
+2. Path correctness confirmed: `.github/workflows/slash-command-quality.yml`
+   exists at that path in the repository.
+3. No formatting or semantic risk. All three insertions sit inside
+   backtick-delimited code spans in prose or a table cell. The longer path does
+   not break the line 284 table (Markdown tables are content-agnostic on cell
+   width). The added prefix narrows ambiguity, which is strictly better.
+
+## Consensus
+
+Both convened lenses return ACCEPT with no revisions and no blockers. The change
+is a complete, correct, low-risk documentation normalization that improves
+internal consistency of ADR-057 and preserves every decision unchanged.
+
+Verdict: **ACCEPT.**
+
+## Verification performed independently of the sub-agent reports
+
+Before recording this consensus, the reviewer verified the reviewers' factual
+claims directly against the working tree rather than trusting the sub-agent
+output:
+
+- `.github/workflows/slash-command-quality.yml` exists (confirmed on disk).
+- Exactly four references to the file remain in ADR-057, all now full-path.
+- Zero bare references remain.
+- Zero em-dash or en-dash characters are present in the file.
+- The diff is exactly three changed lines.

--- a/.agents/architecture/ADR-057-prompt-behavioral-evaluation.md
+++ b/.agents/architecture/ADR-057-prompt-behavioral-evaluation.md
@@ -78,7 +78,7 @@ Each evaluation consists of:
 The gate blocks regressions. It does not mandate an improvement on every edit. A prompt change passes behavioral evaluation when these criteria hold:
 
 1. `after_score >= before_score` (no regression on existing scenarios)
-2. No scenario flips from pass to fail. Every pass-to-fail flip is recorded in `regressions` and blocks the gate automatically; the gate has no mechanism to accept a "justified" regression. Where the gate runs as a blocking CI leg (currently the `/spec` eval in `slash-command-quality.yml`), a deliberate behavior change normally lands by updating the scenario expectations alongside the prompt in the same change, so the new expectations move with the intended behavior and the gate passes without a bypass. Only accepting a regression against unchanged expectations requires a human override (admin merge) with the rationale documented in the PR. For prompt files with no blocking CI leg, the gate is advisory and PR review carries the same judgment (see Amendment 2026-07-22).
+2. No scenario flips from pass to fail. Every pass-to-fail flip is recorded in `regressions` and blocks the gate automatically; the gate has no mechanism to accept a "justified" regression. Where the gate runs as a blocking CI leg (currently the `/spec` eval in `.github/workflows/slash-command-quality.yml`), a deliberate behavior change normally lands by updating the scenario expectations alongside the prompt in the same change, so the new expectations move with the intended behavior and the gate passes without a bypass. Only accepting a regression against unchanged expectations requires a human override (admin merge) with the rationale documented in the PR. For prompt files with no blocking CI leg, the gate is advisory and PR review carries the same judgment (see Amendment 2026-07-22).
 3. Flakiness on any scenario stays at or below the 40% block threshold.
 
 A change that targets a failing scenario SHOULD move it from fail to pass. This is recorded as `has_improvement` and surfaced in the gate output, but it is not a hard pass requirement (see the 2026-06-01 relaxation note below).
@@ -217,7 +217,7 @@ Define targeted scenarios with expected verdicts. Run before/after comparison on
 
 ### Enforced (automated gates)
 
-These gates run inside `eval-prompt-change.py`. They fire whenever the eval runner is invoked: advisorily when a contributor runs it before a PR, and as a blocking check when the `/spec` CI leg (`slash-command-quality.yml`) invokes it on a same-repo PR that changes the `/spec` command, its scenario set, or the eval runner. That leg always evaluates the `/spec` command behavior only; a change to the scenario set or the runner triggers a re-evaluation of that same command. No commit-time hook auto-invokes them (see Amendment 2026-07-22).
+These gates run inside `eval-prompt-change.py`. They fire whenever the eval runner is invoked: advisorily when a contributor runs it before a PR, and as a blocking check when the `/spec` CI leg (`.github/workflows/slash-command-quality.yml`) invokes it on a same-repo PR that changes the `/spec` command, its scenario set, or the eval runner. That leg always evaluates the `/spec` command behavior only; a change to the scenario set or the runner triggers a re-evaluation of that same command. No commit-time hook auto-invokes them (see Amendment 2026-07-22).
 
 | Rule | Enforced By | Mechanism |
 |------|-------------|-----------|
@@ -281,7 +281,7 @@ If a broader deterministic gate is later warranted (Deliverable A), it belongs i
 |-----------|----------------|-----------------|------|
 | ADR-023 structural tests | Complementary | Add cross-reference to this ADR | Low |
 | PR template | Direct | Add eval score reporting fields | Low |
-| CI workflows | Indirect | `spec.md` evals run as a blocking CI leg (`slash-command-quality.yml`); other prompt files are not CI-enforced yet | Low |
+| CI workflows | Indirect | `spec.md` evals run as a blocking CI leg (`.github/workflows/slash-command-quality.yml`); other prompt files are not CI-enforced yet | Low |
 | `.agents/testing/prompt-eval-methodology.md` | Source document | Add ADR-057 back-reference | Low |
 
 ## Related Decisions

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -14447,6 +14447,51 @@
         "episode-2026-07-21-session-3290-mypy-diff-line-ratchet"
       ],
       "created": "2026-07-22T15:39:37.620865+00:00"
+    },
+    {
+      "id": "e547f1628cea",
+      "type": "milestone",
+      "label": "milestone: Applied the three ADR-057 reference normalizations and verified against source",
+      "episodes": [
+        "episode-2026-07-25-session-3315-adr057-ref-normalization"
+      ],
+      "created": "2026-07-25T07:04:38.859304+00:00"
+    },
+    {
+      "id": "85f73290142d",
+      "type": "milestone",
+      "label": "milestone: Ran a proportionate adr-review under the ADR Review Protocol",
+      "episodes": [
+        "episode-2026-07-25-session-3315-adr057-ref-normalization"
+      ],
+      "created": "2026-07-25T07:04:38.859367+00:00"
+    },
+    {
+      "id": "d87165caf8c3",
+      "type": "milestone",
+      "label": "milestone: Re-verified the reviewers' factual claims directly against the working tree",
+      "episodes": [
+        "episode-2026-07-25-session-3315-adr057-ref-normalization"
+      ],
+      "created": "2026-07-25T07:04:38.859420+00:00"
+    },
+    {
+      "id": "aa39913f2197",
+      "type": "milestone",
+      "label": "milestone: Produced the governance artifacts and prepared the stacked commit",
+      "episodes": [
+        "episode-2026-07-25-session-3315-adr057-ref-normalization"
+      ],
+      "created": "2026-07-25T07:04:38.859471+00:00"
+    },
+    {
+      "id": "7fd809b1bae4",
+      "type": "outcome",
+      "label": "Outcome: success - Normalize three bare slash-command-quality.yml references in ADR-057 to the full workflow path, resolving the PR 3315 consistency nit via a stacked PR under the ADR Review Protocol.",
+      "episodes": [
+        "episode-2026-07-25-session-3315-adr057-ref-normalization"
+      ],
+      "created": "2026-07-25T07:04:38.859525+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/episodes/episode-2026-07-25-session-3315-adr057-ref-normalization.json
+++ b/.agents/memory/episodes/episode-2026-07-25-session-3315-adr057-ref-normalization.json
@@ -1,0 +1,66 @@
+{
+  "id": "episode-2026-07-25-session-3315-adr057-ref-normalization",
+  "session": "2026-07-25-session-3315-adr057-ref-normalization",
+  "timestamp": "2026-07-25T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Normalize three bare slash-command-quality.yml references in ADR-057 to the full workflow path, resolving the PR 3315 consistency nit via a stacked PR under the ADR Review Protocol.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Applied the three ADR-057 reference normalizations and verified against source",
+      "caused_by": [],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran a proportionate adr-review under the ADR Review Protocol",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-verified the reviewers' factual claims directly against the working tree",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Produced the governance artifacts and prepared the stacked commit",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 5
+  },
+  "lessons": [
+    "Right-size the adr-review panel to the change surface and record omitted lenses. Convene only the lenses with real surface (architect, critic), run them for real, and document in the debate log why the others were not convened, instead of producing empty six-agent verdicts.",
+    "Avoid: Claiming a six-agent debate ran when it did not, to satisfy the gate. Run the reviews that genuinely apply, verify their claims independently, and state the panel scope honestly in the artifact."
+  ]
+}

--- a/.agents/memory/episodes/episode-2026-07-25-session-3315-adr057-ref-normalization.json
+++ b/.agents/memory/episodes/episode-2026-07-25-session-3315-adr057-ref-normalization.json
@@ -48,6 +48,18 @@
       "caused_by": [
         "e003"
       ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "commit",
+      "content": "Committed b2c8a534e7 (six files: ADR-057, the debate log, the retrospective, the session log, this episode, and the causal-graph regeneration) on branch docs/adr-057-normalize-workflow-refs",
+      "caused_by": [
+        "e004"
+      ],
       "leads_to": []
     }
   ],
@@ -56,8 +68,8 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
-    "files_changed": 5
+    "commits": 1,
+    "files_changed": 6
   },
   "lessons": [
     "Right-size the adr-review panel to the change surface and record omitted lenses. Convene only the lenses with real surface (architect, critic), run them for real, and document in the debate log why the others were not convened, instead of producing empty six-agent verdicts.",

--- a/.agents/retrospective/2026-07-25-adr057-normalization.md
+++ b/.agents/retrospective/2026-07-25-adr057-normalization.md
@@ -1,0 +1,40 @@
+# Retrospective: ADR-057 Workflow Reference Normalization (2026-07-25)
+
+## Context
+
+A Copilot PR reviewer flagged a consistency nit on PR 3315: the workflow file
+`slash-command-quality.yml` was referenced by bare filename in three places in
+ADR-057 and by full path in a fourth. The user directed that the fix be done
+properly in a branch and opened as its own PR, stacked on PR 3315.
+
+## What went well
+
+- The actual change was a clean three-line copy-edit with zero semantic content.
+  Verified against source: four references, all now full-path, zero bare, zero
+  dashes.
+- The adr-review was run for real (architect and critic sub-agents), not
+  fabricated, and its factual claims (path exists, reference count, no table
+  breakage) were re-verified directly against the working tree before recording
+  consensus.
+
+## What to improve
+
+- A three-line documentation copy-edit triggered the full ADR governance chain:
+  an adr-review debate log, a session log, and a retrospective, all required to
+  pass the pre-commit and pre-push gates. The ceremony-to-change ratio here is
+  high. This was disclosed to the user up front and accepted, but it is worth
+  noting that the gates do not distinguish a semantic ADR decision from a
+  reference-format normalization.
+
+## Learnings captured
+
+- The ADR-review pre-commit gate keys on the presence of a `*debate*.md` file
+  referencing the ADR ID plus an adr-review pattern string in today's session
+  log. It does not verify how many agents ran, so honesty about panel scope has
+  to be self-enforced in the debate log itself.
+- The retrospective pre-push gate is defeated by staging a `.json` session log
+  (not documentation-only), so a session that edits only an ADR still needs a
+  dated retrospective artifact to push.
+- For a change with no semantic surface, a proportionate two-lens panel
+  (architect, critic) with the omitted lenses recorded and justified is more
+  honest than convening six agents to produce four empty verdicts.

--- a/.agents/retrospective/2026-07-25-adr057-normalization.md
+++ b/.agents/retrospective/2026-07-25-adr057-normalization.md
@@ -1,5 +1,24 @@
 # Retrospective: ADR-057 Workflow Reference Normalization (2026-07-25)
 
+## Failure mode classification
+
+Primary class: **6, Multi-agent rubber-stamping** (`.agents/governance/FAILURE-MODES.md`).
+This session was a near miss, not an incident. The adr-review pre-commit gate
+keys on the presence of a `*debate*.md` file naming the ADR ID plus an
+adr-review pattern string in the day's session log. It does not check how many
+lenses ran, whether each cited a file and line, or whether any dissent was
+recorded. An honest two-lens panel and a fabricated six-agent panel pass the
+gate identically. The panel here ran for real and its factual claims were
+re-verified against the working tree, so the failure did not land, but the gate
+provided none of that assurance.
+
+Secondary class: **4, False completion markers**. The first commit's session log
+recorded evidence strings claiming four files were staged when the commit hooks
+had also regenerated the memory episode and `.agents/memory/causality/causal-graph.json`,
+for six files total. The episode metrics recorded `commits: 0` while the session
+log marked `changesCommitted` complete. Both were corrected in this PR after the
+Copilot reviewer flagged them.
+
 ## Context
 
 A Copilot PR reviewer flagged a consistency nit on PR 3315: the workflow file
@@ -38,3 +57,30 @@ properly in a branch and opened as its own PR, stacked on PR 3315.
 - For a change with no semantic surface, a proportionate two-lens panel
   (architect, critic) with the omitted lenses recorded and justified is more
   honest than convening six agents to produce four empty verdicts.
+
+## Impact
+
+| Area | Severity | Effect |
+|------|----------|--------|
+| ADR-057 content | Low | Reference format only. No semantic change. |
+| Governance gate confidence | Medium | The adr-review gate cannot distinguish an honest panel from a rubber-stamped one. |
+| Session-log accuracy | Medium | Evidence strings and episode metrics disagreed with the actual commit until corrected. |
+| Ceremony cost | Low | A three-line copy-edit required four governance artifacts. |
+
+## Evidence
+
+- PR #3327 (this change): normalizes the three bare workflow references in ADR-057.
+- PR #3315: where the Copilot reviewer raised the original consistency nit that was deferred.
+- Commit `b2c8a534e7`: the six-file governance commit whose session log understated the staged set.
+- Commit `622456fa97`: populated `endingCommit` and removed the contradictory `nextSteps` entries.
+- Issue #3185: the ADR-057 eval-enforcement work this branch stacks under.
+- `.agents/analysis/ADR-057-workflow-ref-normalization-debate.md`: the debate log recording the two-lens panel and the justification for each omitted lens.
+
+## Remediation
+
+| Action | Type | Owner or issue |
+|--------|------|----------------|
+| Correct the session-log evidence strings and episode metrics to match commit `b2c8a534e7` | Artifact fix | Done in PR #3327 |
+| Add a `commit` event to the episode so `commits` and the event list agree | Artifact fix | Done in PR #3327 |
+| Consider having the adr-review gate require a per-lens verdict block with at least one file and line citation, so panel scope is machine-checkable rather than self-enforced | Governance change | Refs #3185, needs its own issue before any gate edit |
+| Consider a proportionality carve-out so a reference-format ADR edit does not require the full semantic-decision artifact set | Governance change | Refs #3185, needs its own issue before any gate edit |

--- a/.agents/sessions/2026-07-25-session-3315-adr057-ref-normalization.json
+++ b/.agents/sessions/2026-07-25-session-3315-adr057-ref-normalization.json
@@ -1,0 +1,135 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3315,
+    "date": "2026-07-25",
+    "branch": "docs/adr-057-normalize-workflow-refs",
+    "startingCommit": "d9e55e2f9fa8d49b510e4570d00b0832b2044235",
+    "objective": "Normalize three bare slash-command-quality.yml references in ADR-057 to the full workflow path, resolving the PR 3315 consistency nit via a stacked PR under the ADR Review Protocol."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena MCP activation tools are not exposed in this Copilot CLI session toolset (only lsp is present)."
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena initial_instructions tool is not exposed in this Copilot CLI session toolset."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md during the PR 3315 babysitting phase of this session."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file created for branch docs/adr-057-normalize-workflow-refs."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current returned docs/adr-057-normalize-workflow-refs."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Working on feature branch docs/adr-057-normalize-workflow-refs stacked on the PR 3315 branch, not main."
+      },
+      "gitStatusVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git status and git diff inspected; only ADR-057, the debate log, the retrospective, and this session log are intended for staging."
+      },
+      "startingCommitNoted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "startingCommit d9e55e2f9fa8d49b510e4570d00b0832b2044235 recorded from git rev-parse HEAD."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All session-start and session-end MUST items satisfied with honest evidence; Serena SHOULD items marked incomplete because those tools are not exposed."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md was read only and left unmodified this session."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena memory write tools are not exposed in this Copilot CLI session toolset; durable diagnosis facts were recorded via the Copilot memory surface during the babysitting phase."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 scoped run on the three changed markdown files reported 0 issues; files under .agents are config-excluded from the lint glob."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ADR-057 normalization, the adr-review debate log, the retrospective, and this session log committed together as one atomic docs(adr) commit on branch docs/adr-057-normalize-workflow-refs."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "validate_session_json.py --pre-commit exits 0 on this log; the staged-dash and adr-review pre-commit gates pass with 0 dashes and a debate log referencing ADR-057."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Wrote .agents/retrospective/2026-07-25-adr057-normalization.md capturing the governance-ceremony-to-change ratio learning."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "2026-07-25T00:10:00Z",
+      "action": "Applied the three ADR-057 reference normalizations and verified against source",
+      "result": "Lines 81, 220, 284 now use .github/workflows/slash-command-quality.yml; line 247 already full-path. Confirmed 4 total references, 0 bare, 0 em/en dashes, exactly a 3-line diff."
+    },
+    {
+      "time": "2026-07-25T00:25:00Z",
+      "action": "Ran a proportionate adr-review under the ADR Review Protocol",
+      "result": "Convened architect and critic sub-agents as genuine independent reviews; both returned ACCEPT. Recorded the two omitted-lens decisions (security, analyst, independent-thinker, high-level-advisor) and their justifications in the debate log rather than convening empty reviews."
+    },
+    {
+      "time": "2026-07-25T00:35:00Z",
+      "action": "Re-verified the reviewers' factual claims directly against the working tree",
+      "result": "Confirmed .github/workflows/slash-command-quality.yml exists, the reference count and full-path conversion, and no table breakage on line 284, before recording ACCEPT consensus in the debate log."
+    },
+    {
+      "time": "2026-07-25T00:45:00Z",
+      "action": "Produced the governance artifacts and prepared the stacked commit",
+      "result": "Wrote the debate log, the retrospective, and this session log to satisfy the adr-review, session, and retrospective gates honestly, then staged only the four intended files."
+    }
+  ],
+  "learnings": {
+    "patterns": [
+      {
+        "pattern": "Right-size the adr-review panel to the change surface and record omitted lenses",
+        "context": "A pure reference-format ADR copy-edit has no security, data-model, or strategy surface.",
+        "application": "Convene only the lenses with real surface (architect, critic), run them for real, and document in the debate log why the others were not convened, instead of producing empty six-agent verdicts."
+      }
+    ],
+    "avoidances": [
+      {
+        "antipattern": "Claiming a six-agent debate ran when it did not, to satisfy the gate",
+        "consequence": "Fabricated governance evidence that the pre-commit gate cannot detect but that violates the walk-or-do-not-name discipline.",
+        "correction": "Run the reviews that genuinely apply, verify their claims independently, and state the panel scope honestly in the artifact."
+      }
+    ]
+  },
+  "endingCommit": "",
+  "nextSteps": [
+    "Commit the four files with a conventional docs(adr) message and required trailers, letting lefthook run without --no-verify.",
+    "Push branch docs/adr-057-normalize-workflow-refs and open a PR with base fix/3185-adr057-eval-enforcement-torn-state, referencing the nit and Refs #3185.",
+    "Report the new PR URL and state; do not merge without explicit user direction."
+  ]
+}

--- a/.agents/sessions/2026-07-25-session-3315-adr057-ref-normalization.json
+++ b/.agents/sessions/2026-07-25-session-3315-adr057-ref-normalization.json
@@ -42,7 +42,7 @@
       "gitStatusVerified": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "git status and git diff inspected; only ADR-057, the debate log, the retrospective, and this session log are intended for staging."
+        "Evidence": "git status and git diff inspected; ADR-057, the debate log, the retrospective, and this session log are hand-authored, and the commit hooks additionally regenerate the memory episode and .agents/memory/causality/causal-graph.json, for six files total in commit b2c8a534e7."
       },
       "startingCommitNoted": {
         "level": "MUST",
@@ -74,7 +74,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "ADR-057 normalization, the adr-review debate log, the retrospective, and this session log committed together as one atomic docs(adr) commit on branch docs/adr-057-normalize-workflow-refs."
+        "Evidence": "ADR-057 normalization, the adr-review debate log, the retrospective, this session log, and the hook-generated memory episode and causal-graph updates committed together as one atomic docs(adr) commit b2c8a534e7 (six files) on branch docs/adr-057-normalize-workflow-refs."
       },
       "validationPassed": {
         "level": "MUST",
@@ -107,7 +107,7 @@
     {
       "time": "2026-07-25T00:45:00Z",
       "action": "Produced the governance artifacts and prepared the stacked commit",
-      "result": "Wrote the debate log, the retrospective, and this session log to satisfy the adr-review, session, and retrospective gates honestly, then staged only the four intended files."
+      "result": "Wrote the debate log, the retrospective, and this session log to satisfy the adr-review, session, and retrospective gates honestly, then staged those four hand-authored files; the commit hooks added the memory episode and causal-graph regeneration, so commit b2c8a534e7 carries six files."
     }
   ],
   "learnings": {

--- a/.agents/sessions/2026-07-25-session-3315-adr057-ref-normalization.json
+++ b/.agents/sessions/2026-07-25-session-3315-adr057-ref-normalization.json
@@ -126,9 +126,8 @@
       }
     ]
   },
-  "endingCommit": "",
+  "endingCommit": "b2c8a534e79785f80fa237a089d1a35256b62c40",
   "nextSteps": [
-    "Commit the four files with a conventional docs(adr) message and required trailers, letting lefthook run without --no-verify.",
     "Push branch docs/adr-057-normalize-workflow-refs and open a PR with base fix/3185-adr057-eval-enforcement-torn-state, referencing the nit and Refs #3185.",
     "Report the new PR URL and state; do not merge without explicit user direction."
   ]


### PR DESCRIPTION
## Summary

ADR-057 referenced the `/spec` behavioral-eval workflow by bare filename in three places and by full repository path in a fourth. This normalizes the three bare mentions to the full path so all four references match. Pure reference-format change; no semantic content is altered.

This resolves the workflow-reference-consistency nit the Copilot reviewer raised on PR #3315. That fix was deferred there to avoid re-entering the ADR governance cycle on an already merge-ready docs PR, and lands here on its own branch instead.

## Changes

- `.agents/architecture/ADR-057-prompt-behavioral-evaluation.md`: three references normalized to the full path (lines 81, 220, 284); the fourth (line 247) was already full-path.

## ADR review

Per the ADR Review Protocol, a proportionate two-lens panel (architect and critic) reviewed the change and both returned ACCEPT. The omitted lenses (security, analyst, independent-thinker, high-level-advisor) are recorded with justification in the debate log `.agents/analysis/ADR-057-workflow-ref-normalization-debate.md`. The reviewers' factual claims (path exists, reference count, no table breakage) were re-verified directly against the working tree before recording consensus.

Governance artifacts in this PR: the debate log, the session log `.agents/sessions/2026-07-25-session-3315-adr057-ref-normalization.json`, and the retrospective `.agents/retrospective/2026-07-25-adr057-normalization.md`. The memory episode and `.agents/memory/causality/causal-graph.json` updates were auto-generated by the commit hooks.

## References

The workflow whose references were normalized: `.github/workflows/slash-command-quality.yml`.

Refs #3185
