### PR TITLE
fix(test): stop the Copilot install smoke test leaking into the real ~/.copilot on Windows

### DIFF
--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -14618,6 +14618,78 @@
         "episode-2026-07-25-session-2993-wire-orphaned-ratchets"
       ],
       "created": "2026-07-25T08:41:42.830933+00:00"
+    },
+    {
+      "id": "4c6fef2f54c1",
+      "type": "milestone",
+      "label": "milestone: The leak had two independent causes on the same platform, which is why nothing caught it. Isolation set HOME, but Copilot CLI resolves its home from USERPROFILE on Windows, so the install landed in the real user config. Teardown then read a module global the test had monkeypatched to the isolated directory, found no config file there, and returned. A guard that only fires when the thing it guards already worked is not a guard.",
+      "episodes": [
+        "episode-2026-07-25-session-3324-windows-home-isolation"
+      ],
+      "created": "2026-07-25T14:55:14.791120+00:00"
+    },
+    {
+      "id": "60bca8e61c9e",
+      "type": "milestone",
+      "label": "milestone: Set USERPROFILE beside HOME so the isolation reaches the variable the binary actually reads.",
+      "episodes": [
+        "episode-2026-07-25-session-3324-windows-home-isolation"
+      ],
+      "created": "2026-07-25T14:55:14.791182+00:00"
+    },
+    {
+      "id": "e3aecc923157",
+      "type": "milestone",
+      "label": "milestone: Made the leak loud. The test now asserts the isolated config file exists after install. A silent leak becomes a red test rather than corrupted global state, which is the property the previous fix lacked: it shipped on 2026-07-07 and the leak was still being written on 2026-07-16.",
+      "episodes": [
+        "episode-2026-07-25-session-3324-windows-home-isolation"
+      ],
+      "created": "2026-07-25T14:55:14.791235+00:00"
+    },
+    {
+      "id": "7d418028fa00",
+      "type": "milestone",
+      "label": "milestone: Gave the cleanup an explicit home parameter instead of reading the monkeypatched global, and swept both the isolated home and the real one. Teardown is the last line of defense, so it must not depend on the isolation working. This also removed the monkeypatch from five unit tests, which were only patching a global to reach a value they could pass directly.",
+      "episodes": [
+        "episode-2026-07-25-session-3324-windows-home-isolation"
+      ],
+      "created": "2026-07-25T14:55:14.791288+00:00"
+    },
+    {
+      "id": "c2a18db29349",
+      "type": "milestone",
+      "label": "milestone: Added a Windows CI leg for this file. The cleanup compares paths with as_posix and Path.parents, and the bug it guards was Windows-only. A POSIX-only leg is the reason a POSIX-only fix looked complete. The binary smoke test skips there without copilot on PATH; the cleanup coverage does not need it.",
+      "episodes": [
+        "episode-2026-07-25-session-3324-windows-home-isolation"
+      ],
+      "created": "2026-07-25T14:55:14.791340+00:00"
+    },
+    {
+      "id": "7c17167bb078",
+      "type": "milestone",
+      "label": "milestone: Pinned both subprocess captures to utf-8 with errors=replace while touching them. On Windows a bare text=True capture defaults to cp1252 and the reader thread raises on UTF-8 tool output, leaving stdout as None, which would turn the new assertion into a confusing NoneType failure on the exact platform this change targets.",
+      "episodes": [
+        "episode-2026-07-25-session-3324-windows-home-isolation"
+      ],
+      "created": "2026-07-25T14:55:14.791394+00:00"
+    },
+    {
+      "id": "4898184f1537",
+      "type": "commit",
+      "label": "commit: Commit: 62c24183fc",
+      "episodes": [
+        "episode-2026-07-25-session-3324-windows-home-isolation"
+      ],
+      "created": "2026-07-25T14:55:14.791445+00:00"
+    },
+    {
+      "id": "45328f5269e8",
+      "type": "outcome",
+      "label": "Outcome: success - Stop the Copilot install smoke test leaking a _direct project-toolkit shadow into the contributor's real ~/.copilot on Windows, and make a future leak loud instead of silent (issue #3324).",
+      "episodes": [
+        "episode-2026-07-25-session-3324-windows-home-isolation"
+      ],
+      "created": "2026-07-25T14:55:14.791499+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/episodes/episode-2026-07-25-session-3324-windows-home-isolation.json
+++ b/.agents/memory/episodes/episode-2026-07-25-session-3324-windows-home-isolation.json
@@ -74,17 +74,43 @@
       "caused_by": [
         "e005"
       ],
-      "leads_to": []
+      "leads_to": [
+        "e007"
+      ]
     },
     {
       "id": "e007",
       "timestamp": "2026-07-25T00:00:00+00:00",
       "type": "commit",
-      "content": "Commit: 62c24183fc",
-      "caused_by": [],
+      "content": "Commit: 632072417b",
+      "caused_by": [
+        "e006"
+      ],
       "leads_to": [
-        "e001"
+        "e008"
       ]
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: e53975cadf",
+      "caused_by": [
+        "e007"
+      ],
+      "leads_to": [
+        "e009"
+      ]
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 62c24183fc",
+      "caused_by": [
+        "e008"
+      ],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -92,8 +118,8 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
-    "files_changed": 4
+    "commits": 3,
+    "files_changed": 5
   },
   "lessons": []
 }

--- a/.agents/memory/episodes/episode-2026-07-25-session-3324-windows-home-isolation.json
+++ b/.agents/memory/episodes/episode-2026-07-25-session-3324-windows-home-isolation.json
@@ -1,0 +1,87 @@
+{
+  "id": "episode-2026-07-25-session-3324-windows-home-isolation",
+  "session": "2026-07-25-session-3324-windows-home-isolation",
+  "timestamp": "2026-07-25T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Stop the Copilot install smoke test leaking a _direct project-toolkit shadow into the contributor's real ~/.copilot on Windows, and make a future leak loud instead of silent (issue #3324).",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "The leak had two independent causes on the same platform, which is why nothing caught it. Isolation set HOME, but Copilot CLI resolves its home from USERPROFILE on Windows, so the install landed in the real user config. Teardown then read a module global the test had monkeypatched to the isolated directory, found no config file there, and returned. A guard that only fires when the thing it guards already worked is not a guard.",
+      "caused_by": [],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Set USERPROFILE beside HOME so the isolation reaches the variable the binary actually reads.",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Made the leak loud. The test now asserts the isolated config file exists after install. A silent leak becomes a red test rather than corrupted global state, which is the property the previous fix lacked: it shipped on 2026-07-07 and the leak was still being written on 2026-07-16.",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Gave the cleanup an explicit home parameter instead of reading the monkeypatched global, and swept both the isolated home and the real one. Teardown is the last line of defense, so it must not depend on the isolation working. This also removed the monkeypatch from five unit tests, which were only patching a global to reach a value they could pass directly.",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added a Windows CI leg for this file. The cleanup compares paths with as_posix and Path.parents, and the bug it guards was Windows-only. A POSIX-only leg is the reason a POSIX-only fix looked complete. The binary smoke test skips there without copilot on PATH; the cleanup coverage does not need it.",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": [
+        "e006"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Pinned both subprocess captures to utf-8 with errors=replace while touching them. On Windows a bare text=True capture defaults to cp1252 and the reader thread raises on UTF-8 tool output, leaving stdout as None, which would turn the new assertion into a confusing NoneType failure on the exact platform this change targets.",
+      "caused_by": [
+        "e005"
+      ],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 4
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-25-session-3324-windows-home-isolation.json
+++ b/.agents/memory/episodes/episode-2026-07-25-session-3324-windows-home-isolation.json
@@ -11,7 +11,9 @@
       "timestamp": "2026-07-25T00:00:00+00:00",
       "type": "milestone",
       "content": "The leak had two independent causes on the same platform, which is why nothing caught it. Isolation set HOME, but Copilot CLI resolves its home from USERPROFILE on Windows, so the install landed in the real user config. Teardown then read a module global the test had monkeypatched to the isolated directory, found no config file there, and returned. A guard that only fires when the thing it guards already worked is not a guard.",
-      "caused_by": [],
+      "caused_by": [
+        "e007"
+      ],
       "leads_to": [
         "e002"
       ]
@@ -73,6 +75,16 @@
         "e005"
       ],
       "leads_to": []
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 62c24183fc",
+      "caused_by": [],
+      "leads_to": [
+        "e001"
+      ]
     }
   ],
   "metrics": {
@@ -80,7 +92,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/sessions/2026-07-25-session-3324-windows-home-isolation.json
+++ b/.agents/sessions/2026-07-25-session-3324-windows-home-isolation.json
@@ -1,0 +1,122 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3324,
+    "date": "2026-07-25",
+    "branch": "fix/3324-windows-home-isolation",
+    "startingCommit": "c0e6d4c1ad506fd0a629b7988c8d21085a2eab15",
+    "objective": "Stop the Copilot install smoke test leaking a _direct project-toolkit shadow into the contributor's real ~/.copilot on Windows, and make a future leak loud instead of silent (issue #3324)."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP active on this Copilot CLI harness for the whole session."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena-initial_instructions called before any edit."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md; never modified it (ADR-014)."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file created under .agents/sessions/ during the session."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current returned fix/3324-windows-home-isolation, cut from origin/main at c0e6d4c1ad."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All work lands on fix/3324-windows-home-isolation."
+      },
+      "memoriesLoaded": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Copilot repository and user memories loaded, including the Windows subprocess encoding entry that turned out to apply to the two subprocess.run calls this change already touches."
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status inspected before branching; pre-existing untracked artifacts left alone."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Isolation now covers the env var Copilot actually reads on Windows, a leak fails the test instead of corrupting global state, teardown no longer depends on the isolation it backstops, and the whole file gets a Windows CI leg."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md read only (ADR-014)."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Recorded that Copilot CLI resolves its home from USERPROFILE on Windows, so HOME-only isolation is a no-op there."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git diff --name-only lists one Python test file, one workflow YAML, and this JSON log. Zero markdown units, so the ADR-043 scoped set is empty. Byte-checked the hand-authored files for em and en dashes: zero found."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "One atomic commit on fix/3324-windows-home-isolation."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "22 of 22 tests pass in tests/integration/test_e2e_install.py. The binary smoke test executed here, because copilot is on PATH, and it satisfied the new isolation assertion. Reverting the explicit-home parameter turns three cases red, so the coverage has teeth. ruff reports no findings. Both pytest.yml edits parse as YAML and clear actionlint."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "All four suggestions in issue #3324 are addressed in this change."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "T0",
+      "entry": "The leak had two independent causes on the same platform, which is why nothing caught it. Isolation set HOME, but Copilot CLI resolves its home from USERPROFILE on Windows, so the install landed in the real user config. Teardown then read a module global the test had monkeypatched to the isolated directory, found no config file there, and returned. A guard that only fires when the thing it guards already worked is not a guard."
+    },
+    {
+      "time": "T1",
+      "entry": "Set USERPROFILE beside HOME so the isolation reaches the variable the binary actually reads."
+    },
+    {
+      "time": "T2",
+      "entry": "Made the leak loud. The test now asserts the isolated config file exists after install. A silent leak becomes a red test rather than corrupted global state, which is the property the previous fix lacked: it shipped on 2026-07-07 and the leak was still being written on 2026-07-16."
+    },
+    {
+      "time": "T3",
+      "entry": "Gave the cleanup an explicit home parameter instead of reading the monkeypatched global, and swept both the isolated home and the real one. Teardown is the last line of defense, so it must not depend on the isolation working. This also removed the monkeypatch from five unit tests, which were only patching a global to reach a value they could pass directly."
+    },
+    {
+      "time": "T4",
+      "entry": "Added a Windows CI leg for this file. The cleanup compares paths with as_posix and Path.parents, and the bug it guards was Windows-only. A POSIX-only leg is the reason a POSIX-only fix looked complete. The binary smoke test skips there without copilot on PATH; the cleanup coverage does not need it."
+    },
+    {
+      "time": "T5",
+      "entry": "Pinned both subprocess captures to utf-8 with errors=replace while touching them. On Windows a bare text=True capture defaults to cp1252 and the reader thread raises on UTF-8 tool output, leaving stdout as None, which would turn the new assertion into a confusing NoneType failure on the exact platform this change targets."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "The binary smoke test still skips wherever copilot is absent, including the new Windows leg, so the USERPROFILE path is not yet proven by CI. Proving it needs the CLI installed on a Windows runner.",
+    "Contributors who already have the stale shadow must clear it by hand; this change stops new ones, it does not clean existing machines."
+  ]
+}

--- a/.agents/sessions/2026-07-25-session-3324-windows-home-isolation.json
+++ b/.agents/sessions/2026-07-25-session-3324-windows-home-isolation.json
@@ -74,7 +74,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Committed on fix/3324-windows-home-isolation across four commits: the isolation fix and its proof in the integration test, the credential-free smoke workflow change, and this log with its generated episode. Enumerating categories rather than a file count so the record does not drift as review commits land."
+        "Evidence": "Committed on fix/3324-windows-home-isolation across three commits: the isolation fix and its proof in the integration test, the credential-free smoke workflow change, and this log with its generated episode. Enumerating categories rather than a file count so the record does not drift as review commits land."
       },
       "validationPassed": {
         "level": "MUST",

--- a/.agents/sessions/2026-07-25-session-3324-windows-home-isolation.json
+++ b/.agents/sessions/2026-07-25-session-3324-windows-home-isolation.json
@@ -114,7 +114,7 @@
       "entry": "Pinned both subprocess captures to utf-8 with errors=replace while touching them. On Windows a bare text=True capture defaults to cp1252 and the reader thread raises on UTF-8 tool output, leaving stdout as None, which would turn the new assertion into a confusing NoneType failure on the exact platform this change targets."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "62c24183fcd34d5fc0fb855994d6d273a0803459",
   "nextSteps": [
     "The binary smoke test still skips wherever copilot is absent, including the new Windows leg, so the USERPROFILE path is not yet proven by CI. Proving it needs the CLI installed on a Windows runner.",
     "Contributors who already have the stale shadow must clear it by hand; this change stops new ones, it does not clean existing machines."

--- a/.agents/sessions/2026-07-25-session-3324-windows-home-isolation.json
+++ b/.agents/sessions/2026-07-25-session-3324-windows-home-isolation.json
@@ -69,7 +69,7 @@
       "markdownLintRun": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "git diff --name-only lists one Python test file, one workflow YAML, and this JSON log. Zero markdown units, so the ADR-043 scoped set is empty. Byte-checked the hand-authored files for em and en dashes: zero found."
+        "Evidence": "git diff --name-only lists five files: one Python test, two workflow YAML files, this session log, and its generated episode record. Zero markdown units, so the ADR-043 scoped set is empty. Byte-checked the hand-authored files for em and en dashes: zero found."
       },
       "changesCommitted": {
         "level": "MUST",

--- a/.agents/sessions/2026-07-25-session-3324-windows-home-isolation.json
+++ b/.agents/sessions/2026-07-25-session-3324-windows-home-isolation.json
@@ -69,17 +69,17 @@
       "markdownLintRun": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "git diff --name-only lists one Python test file, one workflow YAML, and this JSON log. Zero markdown units, so the ADR-043 scoped set is empty. Byte-checked the hand-authored files for em and en dashes: zero found."
+        "Evidence": "git diff --name-only origin/main...HEAD lists one Python test file, two workflow YAMLs, this JSON log, and its generated episode artifact. Zero markdown units, so the ADR-043 scoped set is empty. Byte-checked the hand-authored files for em and en dashes: zero found."
       },
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "One atomic commit on fix/3324-windows-home-isolation."
+        "Evidence": "Committed on fix/3324-windows-home-isolation across four commits: the isolation fix and its proof in the integration test, the credential-free smoke workflow change, and this log with its generated episode. Enumerating categories rather than a file count so the record does not drift as review commits land."
       },
       "validationPassed": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "22 of 22 tests pass in tests/integration/test_e2e_install.py. The binary smoke test executed here, because copilot is on PATH, and it satisfied the new isolation assertion. Reverting the explicit-home parameter turns three cases red, so the coverage has teeth. ruff reports no findings. Both pytest.yml edits parse as YAML and clear actionlint."
+        "Evidence": "37 of 37 tests pass in tests/integration/test_e2e_install.py. The binary smoke test executed here, because copilot is on PATH, and it satisfied the isolation assertion. Negative controls run and observed red: reverting the explicit-home parameter turns three cases red, and widening the decoding probe's predicate back to a disjunction turns two cases red."
       },
       "tasksUpdated": {
         "level": "SHOULD",
@@ -114,7 +114,7 @@
       "entry": "Pinned both subprocess captures to utf-8 with errors=replace while touching them. On Windows a bare text=True capture defaults to cp1252 and the reader thread raises on UTF-8 tool output, leaving stdout as None, which would turn the new assertion into a confusing NoneType failure on the exact platform this change targets."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "62c24183fc",
   "nextSteps": [
     "The binary smoke test still skips wherever copilot is absent, including the new Windows leg, so the USERPROFILE path is not yet proven by CI. Proving it needs the CLI installed on a Windows runner.",
     "Contributors who already have the stale shadow must clear it by hand; this change stops new ones, it does not clean existing machines."

--- a/.github/workflows/nightly-cli-smoke.yml
+++ b/.github/workflows/nightly-cli-smoke.yml
@@ -174,12 +174,14 @@ jobs:
       # every part of that test except the part that shells out. This job has a
       # pinned CLI on a windows-latest matrix leg, which makes it the only place
       # the real install path runs on the platform that leaked.
+      # No credentials: `plugin install <local-dir>` reads a path, not the API.
+      # Verified by running this test with no COPILOT_GITHUB_TOKEN and an
+      # isolated home that hides stored auth. Least privilege, and the
+      # non-CLI-steps credential policy test stays intact without an exemption.
       - name: Run Copilot install isolation smoke
         # always(): run even if an earlier smoke failed so all three report.
         if: always()
         shell: bash
-        env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
         run: >-
           uv run pytest
           tests/integration/test_e2e_install.py::TestCopilotBinaryInstall

--- a/.github/workflows/nightly-cli-smoke.yml
+++ b/.github/workflows/nightly-cli-smoke.yml
@@ -168,6 +168,33 @@ jobs:
           --smoke-substr test_plugin_load_smoke
           --expected-count 3
 
+      # Issue #3324: the isolation fix this covers is Windows-specific
+      # (Path.home() reads USERPROFILE first), and the test skips without the
+      # binary on PATH. The PR-time Windows leg has no CLI, so it exercised
+      # every part of that test except the part that shells out. This job has a
+      # pinned CLI on a windows-latest matrix leg, which makes it the only place
+      # the real install path runs on the platform that leaked.
+      - name: Run Copilot install isolation smoke
+        # always(): run even if an earlier smoke failed so all three report.
+        if: always()
+        shell: bash
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+        run: >-
+          uv run pytest
+          tests/integration/test_e2e_install.py::TestCopilotBinaryInstall
+          --junitxml=install-isolation-report.xml
+
+      - name: Assert the install isolation smoke actually ran
+        # always(): pytest exits 0 on a skip, so the skip needs its own gate.
+        if: always()
+        shell: bash
+        run: >-
+          uv run python scripts/validation/assert_smoke_ran.py
+          install-isolation-report.xml
+          --smoke-substr TestCopilotBinaryInstall
+          --expected-count 1
+
   smoke-result:
     name: Smoke Result
     needs: [authorize, smoke]

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -379,3 +379,14 @@ jobs:
         env:
           UV_PYTHON: '3.14'
         run: uv run pytest tests/test_check_ai_review_infra_gate.py -v
+
+      # Issue #3324: the _direct shadow cleanup compares paths with as_posix()
+      # and Path.parents, and the leak it guards was Windows-only. A POSIX-only
+      # leg is why a POSIX-only fix looked complete for nine days. The binary
+      # smoke test in this file skips without `copilot` on PATH; the cleanup
+      # coverage does not need it.
+      - name: Run install cleanup contract tests
+        shell: pwsh
+        env:
+          UV_PYTHON: '3.14'
+        run: uv run pytest tests/integration/test_e2e_install.py -q

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -69,8 +69,9 @@ def isolated_copilot_env(home: Path) -> dict[str, str]:
     }
     for name in _COPILOT_CACHE_VARS:
         env[name] = str(home / "cache" / name.lower())
-    for name in _COPILOT_CREDENTIAL_VARS:
-        env.pop(name, None)
+    for name in list(env):
+        if name.upper() in _COPILOT_CREDENTIAL_VARS:
+            env.pop(name)
     return env
 
 
@@ -610,7 +611,15 @@ class TestIsolatedCopilotEnv:
         """A background update writes outside the sandbox and adds network flake."""
         assert isolated_copilot_env(tmp_path)["COPILOT_AUTO_UPDATE"] == "false"
 
-    @pytest.mark.parametrize("name", _COPILOT_CREDENTIAL_VARS)
+    @pytest.mark.parametrize(
+        "name",
+        (
+            *_COPILOT_CREDENTIAL_VARS,
+            "copilot_github_token",
+            "Gh_Token",
+            "github_token",
+        ),
+    )
     def test_credentials_are_removed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, name: str
     ) -> None:

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -681,6 +681,11 @@ class TestSubprocessDecoding:
                 continue
             if not (isinstance(func.value, ast.Name) and func.value.id == "subprocess"):
                 continue
+            if any(keyword.arg is None for keyword in node.keywords):
+                raise AssertionError(
+                    f"subprocess.run at line {node.lineno} expands **kwargs; "
+                    "the decoding guard cannot inspect bundled arguments"
+                )
             kwargs = {kw.arg for kw in node.keywords}
             if kwargs & cls._CAPTURING and kwargs & cls._TEXT_MODE:
                 calls.append(node)
@@ -711,6 +716,10 @@ class TestSubprocessDecoding:
         """stdout=PIPE decodes exactly like capture_output=True does."""
         snippet = "subprocess.run(cmd, stdout=subprocess.PIPE, universal_newlines=True)"
         assert len(self._captured_runs(snippet)) == 1
+
+    def test_bundled_kwargs_cannot_bypass_the_guard(self) -> None:
+        with pytest.raises(AssertionError, match=r"expands \*\*kwargs"):
+            self._captured_runs("subprocess.run(cmd, **kwargs)")
 
     def test_every_captured_run_pins_encoding_and_errors(self) -> None:
         for call in self._captured_runs():

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -645,7 +645,14 @@ class TestSubprocessDecoding:
             if not (isinstance(func.value, ast.Name) and func.value.id == "subprocess"):
                 continue
             kwargs = {kw.arg for kw in node.keywords}
-            if "capture_output" in kwargs or "text" in kwargs:
+            captures_output = kwargs & {"capture_output", "stdout", "stderr"}
+            enables_text = kwargs & {
+                "text",
+                "universal_newlines",
+                "encoding",
+                "errors",
+            }
+            if captures_output and enables_text:
                 calls.append(node)
         return calls
 

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -254,7 +254,7 @@ def _strip_jsonc(text: str) -> str:
     )
 
 
-def _remove_direct_shadow(source_dir: Path) -> None:
+def _remove_direct_shadow(source_dir: Path, copilot_home: Path | None = None) -> None:
     """Undo the global side effect of ``copilot plugin install <source_dir>``.
 
     ``copilot plugin install <local-dir>`` registers a marketplace-less
@@ -269,8 +269,14 @@ def _remove_direct_shadow(source_dir: Path) -> None:
     is scoped to a ``project-toolkit`` entry with no marketplace whose
     ``source.path`` resolves to ``source_dir`` (or under its tmp parent), so an
     unrelated real install is never touched.
+
+    ``copilot_home`` is explicit rather than read from the module global so a
+    caller can sweep more than one home. Teardown used to read the global, which
+    the smoke test monkeypatched to the isolated dir; when isolation failed the
+    cleanup looked in an empty directory and the real shadow survived (#3324).
     """
-    config_path = COPILOT_HOME / "config.json"
+    home = COPILOT_HOME if copilot_home is None else copilot_home
+    config_path = home / "config.json"
     if not config_path.is_file():
         return
     try:
@@ -312,7 +318,7 @@ def _remove_direct_shadow(source_dir: Path) -> None:
     config["installedPlugins"] = remaining
     config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
 
-    cache_dir = COPILOT_HOME / "installed-plugins" / "_direct" / PLUGIN_NAME
+    cache_dir = home / "installed-plugins" / "_direct" / PLUGIN_NAME
     if cache_dir.is_dir():
         shutil.rmtree(cache_dir, ignore_errors=True)
 
@@ -338,31 +344,36 @@ class TestCopilotBinaryInstall:
         copilot_binary: str,
         installed_plugin: Path,
         tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """`copilot plugin install <local-dir>` exits 0 and registers the plugin.
 
-        Runs against an isolated ``HOME`` so the install writes to a throwaway
-        ``$HOME/.copilot/config.json`` under ``tmp_path`` instead of the real
-        user config. This removes the high-impact side effect of mutating the
-        contributor's global Copilot state: even if the process is killed before
-        the finally block, only the tmp config is affected. ``COPILOT_HOME`` is
-        redirected to the same isolated root so the cleanup targets it. Verified
-        the binary honors an isolated ``HOME`` for a local-dir install.
+        Runs against an isolated home so the install writes to a throwaway
+        config under ``tmp_path`` instead of the real user config. Copilot CLI
+        resolves its home from ``USERPROFILE`` on Windows and ``HOME`` on POSIX,
+        so both are set: a HOME-only env leaked a ``_direct`` shadow into the
+        contributor's real ~/.copilot on Windows for nine days (#3324).
+
+        Isolation is asserted rather than assumed. A silent leak used to be
+        invisible because teardown swept the isolated dir it was told to trust;
+        now a leak is a red test, and teardown sweeps the real home too so it
+        does not depend on the isolation it is meant to backstop.
         """
         isolated_home = tmp_path / "copilot-home"
         isolated_home.mkdir()
-        monkeypatch.setattr(f"{__name__}.COPILOT_HOME", isolated_home / ".copilot")
+        isolated_copilot = isolated_home / ".copilot"
         env = {
             **os.environ,
             "HOME": str(isolated_home),
-            "COPILOT_HOME": str(isolated_home / ".copilot"),
+            "USERPROFILE": str(isolated_home),
+            "COPILOT_HOME": str(isolated_copilot),
         }
         try:
             install_result = subprocess.run(
                 [copilot_binary, "plugin", "install", str(installed_plugin)],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=60,
                 env=env,
             )
@@ -372,10 +383,19 @@ class TestCopilotBinaryInstall:
                 f"stderr: {install_result.stderr}"
             )
 
+            assert (isolated_copilot / "config.json").is_file(), (
+                f"copilot did not write to the isolated home {isolated_copilot}. "
+                f"The install went somewhere else, most likely the real "
+                f"{Path.home() / '.copilot'}, which is the #3324 leak. Do not "
+                f"weaken this assertion; find which env var the binary honors."
+            )
+
             list_result = subprocess.run(
                 [copilot_binary, "plugin", "list"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=30,
                 env=env,
             )
@@ -385,7 +405,11 @@ class TestCopilotBinaryInstall:
                 f"{list_result.stdout}"
             )
         finally:
-            _remove_direct_shadow(installed_plugin)
+            # Sweep both homes. The isolated one is where the install belongs;
+            # the real one is the backstop for the case this test exists to
+            # catch, where isolation silently did not take.
+            for home in {isolated_copilot, COPILOT_HOME}:
+                _remove_direct_shadow(installed_plugin, home)
 
 
 @pytest.mark.integration
@@ -409,7 +433,7 @@ class TestDirectShadowCleanup:
         return config_path
 
     def test_removes_only_the_created_shadow(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path
     ) -> None:
         copilot_home = tmp_path / ".copilot"
         source_dir = tmp_path / "src" / PLUGIN_NAME
@@ -425,9 +449,7 @@ class TestDirectShadowCleanup:
         config_path = self._write_config(copilot_home, [real, shadow, other])
         cache_dir = copilot_home / "installed-plugins" / "_direct" / PLUGIN_NAME
         cache_dir.mkdir(parents=True)
-        monkeypatch.setattr(f"{__name__}.COPILOT_HOME", copilot_home)
-
-        _remove_direct_shadow(source_dir)
+        _remove_direct_shadow(source_dir, copilot_home)
 
         result = json.loads(_strip_jsonc(config_path.read_text(encoding="utf-8")))
         surviving = [
@@ -440,21 +462,19 @@ class TestDirectShadowCleanup:
         assert not cache_dir.exists()
 
     def test_preserves_config_without_a_shadow(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path
     ) -> None:
         copilot_home = tmp_path / ".copilot"
         source_dir = tmp_path / "src" / PLUGIN_NAME
         real = {"name": PLUGIN_NAME, "marketplace": "ai-agents", "enabled": True}
         config_path = self._write_config(copilot_home, [real])
         before = config_path.read_text(encoding="utf-8")
-        monkeypatch.setattr(f"{__name__}.COPILOT_HOME", copilot_home)
-
-        _remove_direct_shadow(source_dir)
+        _remove_direct_shadow(source_dir, copilot_home)
 
         assert config_path.read_text(encoding="utf-8") == before
 
     def test_leaves_unrelated_direct_install_untouched(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path
     ) -> None:
         copilot_home = tmp_path / ".copilot"
         source_dir = tmp_path / "src" / PLUGIN_NAME
@@ -465,32 +485,95 @@ class TestDirectShadowCleanup:
             "source": {"source": "local", "path": "/some/other/checkout"},
         }
         config_path = self._write_config(copilot_home, [unrelated])
-        monkeypatch.setattr(f"{__name__}.COPILOT_HOME", copilot_home)
-
-        _remove_direct_shadow(source_dir)
+        _remove_direct_shadow(source_dir, copilot_home)
 
         result = json.loads(_strip_jsonc(config_path.read_text(encoding="utf-8")))
         assert result["installedPlugins"] == [unrelated]
 
     def test_noop_when_config_absent(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path
     ) -> None:
         copilot_home = tmp_path / ".copilot"
-        monkeypatch.setattr(f"{__name__}.COPILOT_HOME", copilot_home)
-
-        _remove_direct_shadow(tmp_path / "src" / PLUGIN_NAME)  # must not raise
+        _remove_direct_shadow(tmp_path / "src" / PLUGIN_NAME, copilot_home)  # must not raise
 
         assert not (copilot_home / "config.json").exists()
 
     def test_survives_malformed_config(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path
     ) -> None:
         copilot_home = tmp_path / ".copilot"
         copilot_home.mkdir(parents=True)
         config_path = copilot_home / "config.json"
         config_path.write_text("{ not valid json", encoding="utf-8")
-        monkeypatch.setattr(f"{__name__}.COPILOT_HOME", copilot_home)
-
-        _remove_direct_shadow(tmp_path / "src" / PLUGIN_NAME)  # must not raise
+        _remove_direct_shadow(tmp_path / "src" / PLUGIN_NAME, copilot_home)  # must not raise
 
         assert config_path.read_text(encoding="utf-8") == "{ not valid json"
+
+    def test_sweeps_the_home_it_is_given_not_the_module_global(
+        self, tmp_path: Path
+    ) -> None:
+        # Teardown used to read the module global, which the smoke test
+        # monkeypatched to the isolated dir. When isolation silently failed on
+        # Windows, cleanup swept an empty directory and the real shadow
+        # survived for nine days (#3324). The home is now explicit so the smoke
+        # test can sweep the real one as a backstop.
+        leaked_home = tmp_path / "real" / ".copilot"
+        source_dir = tmp_path / "src" / PLUGIN_NAME
+        source_dir.mkdir(parents=True)
+        shadow = {
+            "name": PLUGIN_NAME,
+            "marketplace": "",
+            "enabled": True,
+            "source": {"source": "local", "path": str(source_dir)},
+        }
+        config_path = self._write_config(leaked_home, [shadow])
+
+        _remove_direct_shadow(source_dir, leaked_home)
+
+        result = json.loads(_strip_jsonc(config_path.read_text(encoding="utf-8")))
+        assert result["installedPlugins"] == []
+
+    def test_defaults_to_the_module_global_when_no_home_is_given(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The parameter is optional so existing callers keep working. Pin that
+        # the default still resolves through COPILOT_HOME.
+        copilot_home = tmp_path / ".copilot"
+        source_dir = tmp_path / "src" / PLUGIN_NAME
+        source_dir.mkdir(parents=True)
+        shadow = {
+            "name": PLUGIN_NAME,
+            "marketplace": "",
+            "enabled": True,
+            "source": {"source": "local", "path": str(source_dir)},
+        }
+        config_path = self._write_config(copilot_home, [shadow])
+        monkeypatch.setattr(f"{__name__}.COPILOT_HOME", copilot_home)
+
+        _remove_direct_shadow(source_dir)
+
+        result = json.loads(_strip_jsonc(config_path.read_text(encoding="utf-8")))
+        assert result["installedPlugins"] == []
+
+    def test_sweeping_two_homes_removes_both_shadows(self, tmp_path: Path) -> None:
+        # The smoke test sweeps the isolated home and the real one. A leak
+        # lands in exactly one of them and the caller does not know which, so
+        # both must be swept unconditionally without the sweep of an untouched
+        # home raising.
+        source_dir = tmp_path / "src" / PLUGIN_NAME
+        source_dir.mkdir(parents=True)
+        shadow = {
+            "name": PLUGIN_NAME,
+            "marketplace": "",
+            "enabled": True,
+            "source": {"source": "local", "path": str(source_dir)},
+        }
+        homes = [tmp_path / "isolated" / ".copilot", tmp_path / "real" / ".copilot"]
+        configs = [self._write_config(home, [shadow]) for home in homes]
+
+        for home in homes:
+            _remove_direct_shadow(source_dir, home)
+
+        for config_path in configs:
+            result = json.loads(_strip_jsonc(config_path.read_text(encoding="utf-8")))
+            assert result["installedPlugins"] == []

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -659,8 +659,8 @@ class TestSubprocessDecoding:
     guard this without a Windows runner and a real binary.
     """
 
-    #: Kwargs that route child output back into the parent process.
-    _CAPTURING = frozenset({"capture_output", "stdout", "stderr"})
+    #: Stream kwargs that route a subprocess pipe back into this process.
+    _PIPE_KWARGS = frozenset({"stdout", "stderr"})
     #: Kwargs that put the pipes into text mode, which is what forces a decode.
     _TEXT_MODE = frozenset({"text", "universal_newlines", "encoding", "errors"})
 
@@ -697,7 +697,21 @@ class TestSubprocessDecoding:
                     "the decoding guard cannot inspect bundled arguments"
                 )
             kwargs = {kw.arg for kw in node.keywords}
-            if kwargs & cls._CAPTURING and kwargs & cls._TEXT_MODE:
+            captures_output = any(
+                keyword.arg == "capture_output"
+                and isinstance(keyword.value, ast.Constant)
+                and keyword.value.value is True
+                for keyword in node.keywords
+            )
+            captures_pipe = any(
+                keyword.arg in cls._PIPE_KWARGS
+                and isinstance(keyword.value, ast.Attribute)
+                and keyword.value.attr == "PIPE"
+                and isinstance(keyword.value.value, ast.Name)
+                and keyword.value.value.id == "subprocess"
+                for keyword in node.keywords
+            )
+            if (captures_output or captures_pipe) and kwargs & cls._TEXT_MODE:
                 calls.append(node)
         return calls
 
@@ -726,6 +740,17 @@ class TestSubprocessDecoding:
         """stdout=PIPE decodes exactly like capture_output=True does."""
         snippet = "subprocess.run(cmd, stdout=subprocess.PIPE, universal_newlines=True)"
         assert len(self._captured_runs(snippet)) == 1
+
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            "subprocess.run(cmd, capture_output=False, text=True)",
+            "subprocess.run(cmd, stderr=subprocess.STDOUT, text=True)",
+            "subprocess.run(cmd, stdout=subprocess.DEVNULL, text=True)",
+        ],
+    )
+    def test_non_pipe_redirection_is_not_a_target(self, snippet: str) -> None:
+        assert self._captured_runs(snippet) == []
 
     def test_bundled_kwargs_cannot_bypass_the_guard(self) -> None:
         with pytest.raises(AssertionError, match=r"expands \*\*kwargs"):

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -19,6 +19,7 @@ Verification scope (per task M6-T5):
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import re
@@ -39,6 +40,36 @@ COPILOT_HOOKS_FILE = COPILOT_PLUGIN_SRC / "hooks" / "hooks.json"
 # restore it (see _remove_direct_shadow).
 COPILOT_HOME = Path.home() / ".copilot"
 PLUGIN_NAME = "project-toolkit"
+
+# Environment variables Copilot CLI reads to locate a package cache. Its
+# bootstrap scans these *before* COPILOT_HOME, so leaving them pointed at the
+# real user profile lets an isolated run load a cached package from outside the
+# sandbox, and lets it write there. HOME and USERPROFILE alone are not enough.
+_COPILOT_CACHE_VARS = ("LOCALAPPDATA", "XDG_CACHE_HOME", "COPILOT_CACHE_HOME")
+
+
+def isolated_copilot_env(home: Path) -> dict[str, str]:
+    """Environment that confines Copilot CLI to ``home``.
+
+    ``USERPROFILE`` is not optional. ``Path.home()`` consults it first on
+    Windows, so a HOME-only env leaked a ``_direct`` shadow into the
+    contributor's real ~/.copilot for nine days (#3324). The POSIX-only test
+    leg is why the POSIX-only fix looked complete.
+
+    Auto-update is disabled so a background version fetch cannot write outside
+    the sandbox or make the run depend on network state.
+    """
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "USERPROFILE": str(home),
+        "COPILOT_HOME": str(home / ".copilot"),
+        "COPILOT_AUTO_UPDATE": "false",
+    }
+    for name in _COPILOT_CACHE_VARS:
+        env[name] = str(home / "cache" / name.lower())
+    return env
+
 
 # Copilot CLI hook event names. PascalCase event keys make Copilot CLI emit the
 # VS Code-compatible snake_case payload (tool_name, tool_input) the shims expect;
@@ -121,16 +152,12 @@ class TestInstalledManifest:
         data = json.loads(manifest.read_text(encoding="utf-8"))
         assert isinstance(data, dict)
 
-    def test_manifest_name_is_project_toolkit(
-        self, installed_plugin: Path
-    ) -> None:
+    def test_manifest_name_is_project_toolkit(self, installed_plugin: Path) -> None:
         manifest = installed_plugin / ".claude-plugin" / "plugin.json"
         data = json.loads(manifest.read_text(encoding="utf-8"))
         assert data.get("name") == "project-toolkit"
 
-    def test_manifest_omits_runtime_rejected_discovery_keys(
-        self, installed_plugin: Path
-    ) -> None:
+    def test_manifest_omits_runtime_rejected_discovery_keys(self, installed_plugin: Path) -> None:
         """Claude marketplace manifests rely on auto-discovery, not explicit keys."""
         manifest = installed_plugin / ".claude-plugin" / "plugin.json"
         data = json.loads(manifest.read_text(encoding="utf-8"))
@@ -149,39 +176,30 @@ class TestInstalledHooks:
 
     def test_hooks_has_version_1_wrapper(self, installed_plugin: Path) -> None:
         """REQ-003-007: top-level {"version": 1, "hooks": {...}}."""
-        data = json.loads(
-            (installed_plugin / "hooks" / "hooks.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((installed_plugin / "hooks" / "hooks.json").read_text(encoding="utf-8"))
         assert data.get("version") == 1, (
             f"hooks.json must have version: 1 (got {data.get('version')!r})"
         )
 
     def test_hooks_event_keys_are_valid(self, installed_plugin: Path) -> None:
-        data = json.loads(
-            (installed_plugin / "hooks" / "hooks.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((installed_plugin / "hooks" / "hooks.json").read_text(encoding="utf-8"))
         events = data.get("hooks", {})
         assert isinstance(events, dict), "hooks.hooks must be an object"
         unknown = set(events.keys()) - VALID_COPILOT_EVENTS
         assert not unknown, (
-            f"Unknown Copilot CLI hook events: {unknown}. "
-            f"Valid: {sorted(VALID_COPILOT_EVENTS)}"
+            f"Unknown Copilot CLI hook events: {unknown}. Valid: {sorted(VALID_COPILOT_EVENTS)}"
         )
 
     def test_hooks_event_entries_are_lists(self, installed_plugin: Path) -> None:
         """Each event maps to a list of hook entry objects."""
-        data = json.loads(
-            (installed_plugin / "hooks" / "hooks.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((installed_plugin / "hooks" / "hooks.json").read_text(encoding="utf-8"))
         for event, entries in data.get("hooks", {}).items():
             assert isinstance(entries, list), (
                 f"hooks.{event} must be a list, got {type(entries).__name__}"
             )
             assert entries, f"hooks.{event} must not be empty"
 
-    def test_hook_command_paths_resolve_case_sensitively(
-        self, installed_plugin: Path
-    ) -> None:
+    def test_hook_command_paths_resolve_case_sensitively(self, installed_plugin: Path) -> None:
         """Every /hooks/<dir>/<script>.py path in hooks.json must resolve to a
         committed file matching by exact case (regression guard for #2290).
 
@@ -191,9 +209,7 @@ class TestInstalledHooks:
         fails. A case-insensitive Path.exists() would not catch this; this walks
         real directory entries so it fails on any host before reaching Linux CI.
         """
-        data = json.loads(
-            (installed_plugin / "hooks" / "hooks.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((installed_plugin / "hooks" / "hooks.json").read_text(encoding="utf-8"))
         script_paths = _iter_hook_script_paths(data)
         assert script_paths, "expected at least one hook script command path"
         unresolved = [
@@ -249,9 +265,7 @@ def _strip_jsonc(text: str) -> str:
     automatically."). No string value in this file begins a line with ``//``,
     so a line-oriented strip is sufficient and avoids a JSONC dependency.
     """
-    return "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("//")
-    )
+    return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("//"))
 
 
 def _remove_direct_shadow(source_dir: Path, copilot_home: Path | None = None) -> None:
@@ -323,8 +337,6 @@ def _remove_direct_shadow(source_dir: Path, copilot_home: Path | None = None) ->
         shutil.rmtree(cache_dir, ignore_errors=True)
 
 
-
-
 class TestCopilotBinaryInstall:
     """Smoke test: invoke `copilot` to install the plugin and list it.
 
@@ -361,12 +373,7 @@ class TestCopilotBinaryInstall:
         isolated_home = tmp_path / "copilot-home"
         isolated_home.mkdir()
         isolated_copilot = isolated_home / ".copilot"
-        env = {
-            **os.environ,
-            "HOME": str(isolated_home),
-            "USERPROFILE": str(isolated_home),
-            "COPILOT_HOME": str(isolated_copilot),
-        }
+        env = isolated_copilot_env(isolated_home)
         try:
             install_result = subprocess.run(
                 [copilot_binary, "plugin", "install", str(installed_plugin)],
@@ -401,8 +408,7 @@ class TestCopilotBinaryInstall:
             )
             assert list_result.returncode == 0
             assert "project-toolkit" in list_result.stdout, (
-                f"project-toolkit not registered after install:\n"
-                f"{list_result.stdout}"
+                f"project-toolkit not registered after install:\n{list_result.stdout}"
             )
         finally:
             # Sweep both homes. The isolated one is where the install belongs;
@@ -426,15 +432,12 @@ class TestDirectShadowCleanup:
         copilot_home.mkdir(parents=True, exist_ok=True)
         config_path = copilot_home / "config.json"
         config_path.write_text(
-            "// This file is managed automatically.\n"
-            + json.dumps({"installedPlugins": plugins}),
+            "// This file is managed automatically.\n" + json.dumps({"installedPlugins": plugins}),
             encoding="utf-8",
         )
         return config_path
 
-    def test_removes_only_the_created_shadow(
-        self, tmp_path: Path
-    ) -> None:
+    def test_removes_only_the_created_shadow(self, tmp_path: Path) -> None:
         copilot_home = tmp_path / ".copilot"
         source_dir = tmp_path / "src" / PLUGIN_NAME
         source_dir.mkdir(parents=True)
@@ -453,17 +456,14 @@ class TestDirectShadowCleanup:
 
         result = json.loads(_strip_jsonc(config_path.read_text(encoding="utf-8")))
         surviving = [
-            (entry["name"], entry.get("marketplace"))
-            for entry in result["installedPlugins"]
+            (entry["name"], entry.get("marketplace")) for entry in result["installedPlugins"]
         ]
         assert (PLUGIN_NAME, "") not in surviving
         assert (PLUGIN_NAME, "ai-agents") in surviving
         assert ("caveman", "caveman") in surviving
         assert not cache_dir.exists()
 
-    def test_preserves_config_without_a_shadow(
-        self, tmp_path: Path
-    ) -> None:
+    def test_preserves_config_without_a_shadow(self, tmp_path: Path) -> None:
         copilot_home = tmp_path / ".copilot"
         source_dir = tmp_path / "src" / PLUGIN_NAME
         real = {"name": PLUGIN_NAME, "marketplace": "ai-agents", "enabled": True}
@@ -473,9 +473,7 @@ class TestDirectShadowCleanup:
 
         assert config_path.read_text(encoding="utf-8") == before
 
-    def test_leaves_unrelated_direct_install_untouched(
-        self, tmp_path: Path
-    ) -> None:
+    def test_leaves_unrelated_direct_install_untouched(self, tmp_path: Path) -> None:
         copilot_home = tmp_path / ".copilot"
         source_dir = tmp_path / "src" / PLUGIN_NAME
         unrelated = {
@@ -490,17 +488,13 @@ class TestDirectShadowCleanup:
         result = json.loads(_strip_jsonc(config_path.read_text(encoding="utf-8")))
         assert result["installedPlugins"] == [unrelated]
 
-    def test_noop_when_config_absent(
-        self, tmp_path: Path
-    ) -> None:
+    def test_noop_when_config_absent(self, tmp_path: Path) -> None:
         copilot_home = tmp_path / ".copilot"
         _remove_direct_shadow(tmp_path / "src" / PLUGIN_NAME, copilot_home)  # must not raise
 
         assert not (copilot_home / "config.json").exists()
 
-    def test_survives_malformed_config(
-        self, tmp_path: Path
-    ) -> None:
+    def test_survives_malformed_config(self, tmp_path: Path) -> None:
         copilot_home = tmp_path / ".copilot"
         copilot_home.mkdir(parents=True)
         config_path = copilot_home / "config.json"
@@ -509,9 +503,7 @@ class TestDirectShadowCleanup:
 
         assert config_path.read_text(encoding="utf-8") == "{ not valid json"
 
-    def test_sweeps_the_home_it_is_given_not_the_module_global(
-        self, tmp_path: Path
-    ) -> None:
+    def test_sweeps_the_home_it_is_given_not_the_module_global(self, tmp_path: Path) -> None:
         # Teardown used to read the module global, which the smoke test
         # monkeypatched to the isolated dir. When isolation silently failed on
         # Windows, cleanup swept an empty directory and the real shadow
@@ -577,3 +569,97 @@ class TestDirectShadowCleanup:
         for config_path in configs:
             result = json.loads(_strip_jsonc(config_path.read_text(encoding="utf-8")))
             assert result["installedPlugins"] == []
+
+
+class TestIsolatedCopilotEnv:
+    """The env that confines the binary smoke test to a throwaway home.
+
+    These run everywhere, including the Windows CI leg, without needing the
+    `copilot` binary. That matters: the binary smoke test skips when the CLI is
+    absent, so before this class the Windows leg proved nothing about the #3324
+    fix. Deleting the USERPROFILE line left CI green.
+    """
+
+    def test_userprofile_points_at_the_isolated_home(self, tmp_path: Path) -> None:
+        """Path.home() reads USERPROFILE first on Windows. This is the #3324 fix."""
+        env = isolated_copilot_env(tmp_path)
+        assert env["USERPROFILE"] == str(tmp_path)
+
+    def test_home_points_at_the_isolated_home(self, tmp_path: Path) -> None:
+        """POSIX reads HOME. Both must move together or one platform leaks."""
+        env = isolated_copilot_env(tmp_path)
+        assert env["HOME"] == str(tmp_path)
+
+    def test_copilot_home_is_under_the_isolated_home(self, tmp_path: Path) -> None:
+        env = isolated_copilot_env(tmp_path)
+        assert Path(env["COPILOT_HOME"]) == tmp_path / ".copilot"
+
+    @pytest.mark.parametrize("name", _COPILOT_CACHE_VARS)
+    def test_package_cache_vars_are_redirected(self, tmp_path: Path, name: str) -> None:
+        """Copilot scans these before COPILOT_HOME, so an unset one escapes."""
+        env = isolated_copilot_env(tmp_path)
+        assert Path(env[name]).is_relative_to(tmp_path), (
+            f"{name} still points outside the sandbox, so a cached package "
+            f"from the real user profile can be read or written"
+        )
+
+    def test_auto_update_is_disabled(self, tmp_path: Path) -> None:
+        """A background update writes outside the sandbox and adds network flake."""
+        assert isolated_copilot_env(tmp_path)["COPILOT_AUTO_UPDATE"] == "false"
+
+    def test_no_isolated_var_leaks_the_real_home(self, tmp_path: Path) -> None:
+        """Guard the guard: catches a typo that silently reuses os.environ."""
+        env = isolated_copilot_env(tmp_path)
+        real_home = str(Path.home())
+        for name in ("HOME", "USERPROFILE", "COPILOT_HOME", *_COPILOT_CACHE_VARS):
+            assert real_home not in env[name], f"{name} still references the real home"
+
+    def test_unrelated_environment_is_preserved(self, tmp_path: Path) -> None:
+        """PATH must survive, or the binary under test is not findable."""
+        env = isolated_copilot_env(tmp_path)
+        assert env.get("PATH") == os.environ.get("PATH")
+
+
+class TestSubprocessDecoding:
+    """Every captured subprocess in this module must pin its decoding.
+
+    On Windows `subprocess.run(text=True, capture_output=True)` with no
+    encoding defaults to cp1252, whose reader thread raises UnicodeDecodeError
+    on the UTF-8 glyphs the CLI prints. The exception is swallowed and
+    `result.stdout` comes back None, so assertions fail with a NoneType
+    cascade that names nothing useful. Source inspection is the only way to
+    guard this without a Windows runner and a real binary.
+    """
+
+    @staticmethod
+    def _captured_runs() -> list[ast.Call]:
+        tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+        calls = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and func.attr == "run"):
+                continue
+            if not (isinstance(func.value, ast.Name) and func.value.id == "subprocess"):
+                continue
+            kwargs = {kw.arg for kw in node.keywords}
+            if "capture_output" in kwargs or "text" in kwargs:
+                calls.append(node)
+        return calls
+
+    def test_the_probe_finds_the_calls_it_claims_to_check(self) -> None:
+        """Guard the guard: a rename would make the checks below vacuous."""
+        assert len(self._captured_runs()) >= 2
+
+    def test_every_captured_run_pins_encoding_and_errors(self) -> None:
+        for call in self._captured_runs():
+            kwargs = {kw.arg for kw in call.keywords}
+            assert "encoding" in kwargs, (
+                f"subprocess.run at line {call.lineno} captures output without "
+                f"encoding=; on Windows this decodes as cp1252 and returns None"
+            )
+            assert "errors" in kwargs, (
+                f"subprocess.run at line {call.lineno} sets encoding but not "
+                f"errors=; a stray byte then raises instead of degrading"
+            )

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -631,9 +631,29 @@ class TestSubprocessDecoding:
     guard this without a Windows runner and a real binary.
     """
 
-    @staticmethod
-    def _captured_runs() -> list[ast.Call]:
-        tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    #: Kwargs that route child output back into the parent process.
+    _CAPTURING = frozenset({"capture_output", "stdout", "stderr"})
+    #: Kwargs that put the pipes into text mode, which is what forces a decode.
+    _TEXT_MODE = frozenset({"text", "universal_newlines", "encoding", "errors"})
+
+    @classmethod
+    def _captured_runs(cls, source: str | None = None) -> list[ast.Call]:
+        """Return the ``subprocess.run`` calls that actually decode child output.
+
+        Both halves of the predicate are load-bearing. A capture with no text
+        mode returns bytes, never decodes, and must not be asked for an
+        ``encoding``: adding one would silently flip it into text mode and
+        change the value the caller gets back. Text mode with nothing captured
+        writes straight to the terminal and decodes nothing in this process.
+        Only the intersection can hit the Windows cp1252 reader-thread failure,
+        so only the intersection is checked.
+
+        ``source`` defaults to this module so the guard polices itself; tests
+        pass a snippet to pin the predicate against shapes this file does not
+        contain.
+        """
+        text = source if source is not None else Path(__file__).read_text(encoding="utf-8")
+        tree = ast.parse(text)
         calls = []
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
@@ -644,13 +664,35 @@ class TestSubprocessDecoding:
             if not (isinstance(func.value, ast.Name) and func.value.id == "subprocess"):
                 continue
             kwargs = {kw.arg for kw in node.keywords}
-            if "capture_output" in kwargs or "text" in kwargs:
+            if kwargs & cls._CAPTURING and kwargs & cls._TEXT_MODE:
                 calls.append(node)
         return calls
 
     def test_the_probe_finds_the_calls_it_claims_to_check(self) -> None:
         """Guard the guard: a rename would make the checks below vacuous."""
         assert len(self._captured_runs()) >= 2
+
+    def test_byte_mode_capture_is_not_a_target(self) -> None:
+        """A capture with no text mode returns bytes and must not be flagged.
+
+        Demanding ``encoding=`` here would be worse than a false positive: the
+        only way to satisfy it is to add the kwarg, which flips the call into
+        text mode and changes what the caller receives.
+        """
+        assert self._captured_runs("subprocess.run(cmd, capture_output=True)") == []
+
+    def test_text_mode_without_capture_is_not_a_target(self) -> None:
+        """Nothing is piped back, so this process decodes nothing."""
+        assert self._captured_runs("subprocess.run(cmd, text=True)") == []
+
+    def test_captured_text_mode_is_a_target(self) -> None:
+        """The intersection is the cp1252 failure mode, so it must be caught."""
+        assert len(self._captured_runs("subprocess.run(cmd, capture_output=True, text=True)")) == 1
+
+    def test_redirected_pipe_counts_as_capture(self) -> None:
+        """stdout=PIPE decodes exactly like capture_output=True does."""
+        snippet = "subprocess.run(cmd, stdout=subprocess.PIPE, universal_newlines=True)"
+        assert len(self._captured_runs(snippet)) == 1
 
     def test_every_captured_run_pins_encoding_and_errors(self) -> None:
         for call in self._captured_runs():

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -661,8 +661,10 @@ class TestSubprocessDecoding:
 
     #: Stream kwargs that route a subprocess pipe back into this process.
     _PIPE_KWARGS = frozenset({"stdout", "stderr"})
-    #: Kwargs that put the pipes into text mode, which is what forces a decode.
-    _TEXT_MODE = frozenset({"text", "universal_newlines", "encoding", "errors"})
+    #: Boolean kwargs that put captured pipes into text mode when true.
+    _TEXT_FLAGS = frozenset({"text", "universal_newlines"})
+    #: Codec kwargs whose presence enables text-mode decoding.
+    _TEXT_OPTIONS = frozenset({"encoding", "errors"})
 
     @classmethod
     def _captured_runs(cls, source: str | None = None) -> list[ast.Call]:
@@ -711,7 +713,13 @@ class TestSubprocessDecoding:
                 and keyword.value.value.id == "subprocess"
                 for keyword in node.keywords
             )
-            if (captures_output or captures_pipe) and kwargs & cls._TEXT_MODE:
+            text_mode = bool(kwargs & cls._TEXT_OPTIONS) or any(
+                keyword.arg in cls._TEXT_FLAGS
+                and isinstance(keyword.value, ast.Constant)
+                and keyword.value.value is True
+                for keyword in node.keywords
+            )
+            if (captures_output or captures_pipe) and text_mode:
                 calls.append(node)
         return calls
 
@@ -735,6 +743,14 @@ class TestSubprocessDecoding:
     def test_captured_text_mode_is_a_target(self) -> None:
         """The intersection is the cp1252 failure mode, so it must be caught."""
         assert len(self._captured_runs("subprocess.run(cmd, capture_output=True, text=True)")) == 1
+
+    @pytest.mark.parametrize("flag", ["text", "universal_newlines"])
+    def test_explicit_false_text_flag_is_not_a_target(self, flag: str) -> None:
+        assert self._captured_runs(f"subprocess.run(cmd, capture_output=True, {flag}=False)") == []
+
+    def test_one_true_text_flag_overrides_the_other_false_flag(self) -> None:
+        snippet = "subprocess.run(cmd, capture_output=True, text=False, universal_newlines=True)"
+        assert len(self._captured_runs(snippet)) == 1
 
     def test_redirected_pipe_counts_as_capture(self) -> None:
         """stdout=PIPE decodes exactly like capture_output=True does."""

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -46,6 +46,7 @@ PLUGIN_NAME = "project-toolkit"
 # real user profile lets an isolated run load a cached package from outside the
 # sandbox, and lets it write there. HOME and USERPROFILE alone are not enough.
 _COPILOT_CACHE_VARS = ("LOCALAPPDATA", "XDG_CACHE_HOME", "COPILOT_CACHE_HOME")
+_COPILOT_CREDENTIAL_VARS = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
 
 
 def isolated_copilot_env(home: Path) -> dict[str, str]:
@@ -68,6 +69,8 @@ def isolated_copilot_env(home: Path) -> dict[str, str]:
     }
     for name in _COPILOT_CACHE_VARS:
         env[name] = str(home / "cache" / name.lower())
+    for name in _COPILOT_CREDENTIAL_VARS:
+        env.pop(name, None)
     return env
 
 
@@ -606,6 +609,13 @@ class TestIsolatedCopilotEnv:
     def test_auto_update_is_disabled(self, tmp_path: Path) -> None:
         """A background update writes outside the sandbox and adds network flake."""
         assert isolated_copilot_env(tmp_path)["COPILOT_AUTO_UPDATE"] == "false"
+
+    @pytest.mark.parametrize("name", _COPILOT_CREDENTIAL_VARS)
+    def test_credentials_are_removed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, name: str
+    ) -> None:
+        monkeypatch.setenv(name, "ambient-secret")
+        assert name not in isolated_copilot_env(tmp_path)
 
     def test_no_isolated_var_is_passed_through_from_the_ambient_environment(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -607,12 +607,29 @@ class TestIsolatedCopilotEnv:
         """A background update writes outside the sandbox and adds network flake."""
         assert isolated_copilot_env(tmp_path)["COPILOT_AUTO_UPDATE"] == "false"
 
-    def test_no_isolated_var_leaks_the_real_home(self, tmp_path: Path) -> None:
-        """Guard the guard: catches a typo that silently reuses os.environ."""
+    def test_no_isolated_var_is_passed_through_from_the_ambient_environment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guard the guard: catches a typo that silently reuses os.environ.
+
+        Asserting the values sit under ``tmp_path`` cannot catch this, and
+        every such assertion is already made above, one test per variable. The
+        distinct question here is where the value came from, not what shape it
+        has, so each variable gets a sentinel in the ambient environment first.
+        A helper that reads ``os.environ[name]`` returns the sentinel; one that
+        derives from ``tmp_path`` cannot.
+        """
+        names = ("HOME", "USERPROFILE", "COPILOT_HOME", *_COPILOT_CACHE_VARS)
+        sentinels = {name: f"/sentinel/ambient/{name}" for name in names}
+        for name, value in sentinels.items():
+            monkeypatch.setenv(name, value)
+
         env = isolated_copilot_env(tmp_path)
-        for name in ("HOME", "USERPROFILE", "COPILOT_HOME", *_COPILOT_CACHE_VARS):
-            assert Path(env[name]).is_relative_to(tmp_path), (
-                f"{name} still references the real home"
+
+        for name, value in sentinels.items():
+            assert env[name] != value, (
+                f"{name} was copied out of the ambient environment instead of "
+                f"being derived from the sandbox root"
             )
 
     def test_unrelated_environment_is_preserved(self, tmp_path: Path) -> None:

--- a/tests/integration/test_e2e_install.py
+++ b/tests/integration/test_e2e_install.py
@@ -610,9 +610,10 @@ class TestIsolatedCopilotEnv:
     def test_no_isolated_var_leaks_the_real_home(self, tmp_path: Path) -> None:
         """Guard the guard: catches a typo that silently reuses os.environ."""
         env = isolated_copilot_env(tmp_path)
-        real_home = str(Path.home())
         for name in ("HOME", "USERPROFILE", "COPILOT_HOME", *_COPILOT_CACHE_VARS):
-            assert real_home not in env[name], f"{name} still references the real home"
+            assert Path(env[name]).is_relative_to(tmp_path), (
+                f"{name} still references the real home"
+            )
 
     def test_unrelated_environment_is_preserved(self, tmp_path: Path) -> None:
         """PATH must survive, or the binary under test is not findable."""


### PR DESCRIPTION
## Summary

`test_copilot_plugin_install_succeeds` leaked a `_direct` plugin shadow into the contributor's real `~/.copilot` on Windows. Two independent causes, both Windows-only, which is why a POSIX-only fix looked complete for nine days.

Fixes #3324

## Cause 1: the isolation env var was wrong for the platform

The test set `HOME` and `COPILOT_HOME`. Copilot CLI resolves its home from `USERPROFILE` on Windows. On POSIX the isolation worked; on Windows the install wrote to the real user profile. `USERPROFILE` is now set alongside `HOME`.

## Cause 2: teardown trusted the isolation it exists to backstop

`_remove_direct_shadow` read the module-level `COPILOT_HOME`, which the test monkeypatched to the isolated directory. So when isolation failed, cleanup swept an empty temp directory and reported success while the real shadow survived. The two failures were perfectly correlated: the only case where cleanup matters is the case where it was pointed at the wrong place.

`copilot_home` is now an explicit parameter and teardown sweeps both the isolated home and the real one. A backstop that depends on the thing it backstops is not a backstop.

## The leak was silent, so it is now a red test

The install is asserted to have written into the isolated home. Previously a leak produced no signal at all: the test passed, cleanup passed, and the contributor found a stray `_direct` entry later with nothing tying it to a test run. The assertion message names the failure mode and tells the next reader not to weaken it.

## Cause 3: the suite had no Windows leg

The cleanup logic compares paths with `as_posix()` and walks `Path.parents`, and the bug it guards is Windows-only, yet this file only ran on POSIX. A `pwsh` leg is added to `.github/workflows/pytest.yml`. The binary smoke test skips without `copilot` on PATH, so the leg costs nothing when the CLI is absent while still exercising the path-comparison code.

## Cause 4: `subprocess.run(text=True)` with no encoding

On Windows this defaults to cp1252 and its reader thread raises `UnicodeDecodeError` on UTF-8 tool output, leaving `result.stdout` as `None` and cascading into confusing `NoneType` failures rather than the real error. Both calls now pass `encoding="utf-8", errors="replace"`.

## Cause 5: the Windows leg did not exercise the fix

Found in adversarial review of this PR. The `pwsh` leg above ran, but every test that touches `USERPROFILE` lived inside the binary smoke class, which skips when `copilot` is not on PATH. The PR-time Windows runner has no CLI. So the leg reported `21 passed, 1 skipped`, and deleting the `USERPROFILE` line or the encoding arguments left CI green. A Windows leg that cannot fail on the Windows bug is a costume.

Three changes close it:

1. The isolation environment is now built by `isolated_copilot_env()`, covered by tests that need no binary. Those run on the Windows leg and go red when the fix is removed.
2. An AST probe asserts every captured `subprocess.run` in the module pins `encoding` and `errors`. That is the only way to guard the cp1252 failure without both a Windows runner and a real binary.
3. The binary smoke now also runs on the nightly job, whose `windows-latest` matrix leg installs a pinned CLI, gated by the existing smoke-ran assertion so a silent skip fails the job. That step lives in `.github/workflows/nightly-cli-smoke.yml`. It runs with no credentials: `plugin install <local-dir>` reads a path, not the API, verified with no token and an isolated home that hides stored auth.

## Cause 6: the isolation env was incomplete

Also from review. Copilot CLI's bootstrap reads `LOCALAPPDATA`, `XDG_CACHE_HOME`, and `COPILOT_CACHE_HOME`, and scans those package caches *before* `COPILOT_HOME`. Overriding only `HOME`, `USERPROFILE`, and `COPILOT_HOME` left an isolated run able to read and write the real user profile's cache. All three are now redirected, and `COPILOT_AUTO_UPDATE=false` stops a background fetch from writing outside the sandbox or making the run depend on network state.

## Verification

```
uv run pytest tests/integration/test_e2e_install.py -q        33 passed
actionlint + validate_workflows on both changed workflows      clean
uv run python scripts/validation/run_workflow_local_test.py --files .github/workflows/pytest.yml
  workflow-local-test: OK (actionlint, gh act -n, gh act (full))
```

Negative controls run individually, each failing only its own case:

| Mutation | Result |
| --- | --- |
| Drop `USERPROFILE` from the isolation env | 2 fail (was green on the Windows leg) |
| Drop the `encoding` and `errors` arguments | 1 fails (was green everywhere) |
| Drop the package-cache redirection | 4 fail |
| Drop `COPILOT_AUTO_UPDATE=false` | 1 fails |
| Revert `_remove_direct_shadow` to read the module global | real-home sweep unreachable |

Rebased onto main so it carries the act paths-filter downgrade from #3333; without it the local workflow gate fails on an act limitation rather than a real defect.

## Notes

The nine-day gap between the original fix and the observed leak is the useful part of this issue. The first fix was correct on the platform it was tested on, and nothing in CI could have contradicted it, because the only leg that could reproduce the bug did not exist.

