### PR TITLE
fix(memory): merge causal-graph.json by content instead of by line

### DIFF
--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -14663,6 +14663,42 @@
         "episode-2026-07-25-session-3343-branch-context-merge"
       ],
       "created": "2026-07-25T14:05:27.596517+00:00"
+    },
+    {
+      "id": "5c02899361f5",
+      "type": "milestone",
+      "label": "milestone: Measured the conflict rather than assuming its shape. update_causal_graph processes only staged episode paths and returns immediately when none are staged, so it is incremental, never a rebuild, and the update-causal-graph hook job is skipped on merge anyway. That makes the issue's recommended workaround (check out one side then rerun the generator) the drift cause: 41 of 242 episodes on disk had no node in the committed graph. A from-scratch rebuild does not reproduce the committed graph and stamps per-node wall-clock timestamps, so the issue's byte-identical acceptance criterion is unachievable.",
+      "episodes": [
+        "episode-2026-07-25-session-3345-causal-graph-merge-driver"
+      ],
+      "created": "2026-07-25T16:57:41.485799+00:00"
+    },
+    {
+      "id": "6c6cfb1a5fcc",
+      "type": "milestone",
+      "label": "milestone: Added a content-union merge driver for the causal graph and registered it. Records key on stable identities, counters reconcile three-way against the ancestor instead of summing, episode lists union, created takes the earliest and last_used the latest. A side that will not parse exits nonzero so git leaves the conflict for a human rather than silently taking one side. Registration runs from pre-commit because merge=<name> in .gitattributes is a no-op without per-clone git config.",
+      "episodes": [
+        "episode-2026-07-25-session-3345-causal-graph-merge-driver"
+      ],
+      "created": "2026-07-25T16:57:41.485863+00:00"
+    },
+    {
+      "id": "75d6d20c974a",
+      "type": "milestone",
+      "label": "milestone: 32 tests covering union semantics, counter reconciliation, field policies, malformed-record tolerance, load-time refusal, the driver exit contract, and two end-to-end git merges in a scratch repo. The end-to-end set includes a control that omits git config and asserts the merge still conflicts, proving the .gitattributes entry alone does nothing. Three negative controls fired: taking ours instead of the union turned 7 tests red, summing counters instead of three-way reconciliation turned 3 red, and swallowing parse errors turned 4 red.",
+      "episodes": [
+        "episode-2026-07-25-session-3345-causal-graph-merge-driver"
+      ],
+      "created": "2026-07-25T16:57:41.485917+00:00"
+    },
+    {
+      "id": "e92d08491d2e",
+      "type": "outcome",
+      "label": "Outcome: success - Stop .agents/memory/causality/causal-graph.json conflicting on every merge (issue #3345) without the data loss the issue's own workaround causes. Resolve by content union through a git merge driver instead of by line.",
+      "episodes": [
+        "episode-2026-07-25-session-3345-causal-graph-merge-driver"
+      ],
+      "created": "2026-07-25T16:57:41.485970+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -5361,8 +5361,8 @@
       "episodes": [
         "episode-2026-06-07-session-2368-agentsmd-optimization-study-apply-open",
         "episode-2026-06-07-session-2375-add-paths-frontmatter-clauderules-claude",
-        "episode-2026-06-09-session-2377-drive-2513-ready-to-merge-squash-merge",
         "episode-2026-06-09-session-2376-gate-se-book-rules-code-globs-paths",
+        "episode-2026-06-09-session-2377-drive-2513-ready-to-merge-squash-merge",
         "episode-2026-06-11-session-2377-auto-retro-hook-block-and-fill-continuation-relocate"
       ],
       "created": "2026-06-07T20:00:30.167694+00:00"
@@ -8411,9 +8411,9 @@
       "type": "commit",
       "label": "commit: Commit: f13f73f",
       "episodes": [
+        "episode-2026-07-02-session-2603-issue-2810-subprocess-timeout-staging-verification-hardening",
         "episode-2026-07-02-session-2603-issues-2812-atomic-writes-2813",
         "episode-2026-07-03-session-2603-issue-2811-pr-b-subprocess-timeouts",
-        "episode-2026-07-02-session-2603-issue-2810-subprocess-timeout-staging-verification-hardening",
         "episode-2026-07-03-session-2603-issue-2828-add-auto-router"
       ],
       "created": "2026-07-02T15:29:52.544813+00:00"
@@ -14735,6 +14735,24 @@
         "episode-2026-07-25-session-3345-causal-graph-merge-driver"
       ],
       "created": "2026-07-26T01:11:32.565886+00:00"
+    },
+    {
+      "id": "594ed9921409",
+      "type": "milestone",
+      "label": "milestone: Used the driver to resolve a real causal-graph conflict on the sibling branch and it lost data. Six of the ten patterns in the committed graph carry no id, so _key gave all six the same empty key and the union kept one: ten patterns in, five out. A record carrying none of its identity fields now falls back to its content, which still matches an untouched record across sides and at worst carries an edited one through twice. Partially keyed records are unaffected. Re-verified against the three real stages: ten patterns in and ten out, nodes 1635 base, 1641 ours, 1657 theirs, merging to 1663. Negative control fired.",
+      "episodes": [
+        "episode-2026-07-25-session-3345-causal-graph-merge-driver"
+      ],
+      "created": "2026-07-26T01:31:52.189486+00:00"
+    },
+    {
+      "id": "0b90b99668bf",
+      "type": "commit",
+      "label": "commit: Commit: 0d3d41d58c6a8968fcc90108cfd6b408c07a7775",
+      "episodes": [
+        "episode-2026-07-25-session-3345-causal-graph-merge-driver"
+      ],
+      "created": "2026-07-26T01:31:52.189550+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -14737,22 +14737,31 @@
       "created": "2026-07-26T01:11:32.565886+00:00"
     },
     {
-      "id": "594ed9921409",
+      "id": "d73e9bf018a5",
       "type": "milestone",
-      "label": "milestone: Used the driver to resolve a real causal-graph conflict on the sibling branch and it lost data. Six of the ten patterns in the committed graph carry no id, so _key gave all six the same empty key and the union kept one: ten patterns in, five out. A record carrying none of its identity fields now falls back to its content, which still matches an untouched record across sides and at worst carries an edited one through twice. Partially keyed records are unaffected. Re-verified against the three real stages: ten patterns in and ten out, nodes 1635 base, 1641 ours, 1657 theirs, merging to 1663. Negative control fired.",
+      "label": "milestone: Used the driver to resolve a real causal-graph conflict on the sibling branch and it lost data. Six of the ten patterns in the committed graph carry no id, so _key gave all six the same empty key and the union kept one: ten patterns in, five out. A record carrying none of its identity fields now falls back to its content, which still matches an untouched record across sides and at worst carries an edited one through twice. Partially keyed records are unaffected. Re-verified against the three real stages: ten patterns in and ten out, nodes 1635 base, 1641 ours, 1657 theirs, merging to 1663. Negative control fired. Filed the upstream defect as issue #3353.",
       "episodes": [
         "episode-2026-07-25-session-3345-causal-graph-merge-driver"
       ],
-      "created": "2026-07-26T01:31:52.189486+00:00"
+      "created": "2026-07-26T02:05:18.496316+00:00"
     },
     {
-      "id": "0b90b99668bf",
-      "type": "commit",
-      "label": "commit: Commit: 0d3d41d58c6a8968fcc90108cfd6b408c07a7775",
+      "id": "2334291fd648",
+      "type": "milestone",
+      "label": "milestone: Replaced the uv-routed merge driver registration with the installer's own interpreter path after a probe showed a missing uv makes git fall back to the text merge",
       "episodes": [
         "episode-2026-07-25-session-3345-causal-graph-merge-driver"
       ],
-      "created": "2026-07-26T01:31:52.189550+00:00"
+      "created": "2026-07-26T02:05:18.496383+00:00"
+    },
+    {
+      "id": "e560e4474465",
+      "type": "commit",
+      "label": "commit: Commit: 9ba22151f30121b311e1fc8cb3fdedd8c401856d",
+      "episodes": [
+        "episode-2026-07-25-session-3345-causal-graph-merge-driver"
+      ],
+      "created": "2026-07-26T02:05:18.496436+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -14699,6 +14699,24 @@
         "episode-2026-07-25-session-3345-causal-graph-merge-driver"
       ],
       "created": "2026-07-25T16:57:41.485970+00:00"
+    },
+    {
+      "id": "b1c4497668ca",
+      "type": "milestone",
+      "label": "milestone: Addressed the PR #3348 review. Two flagged claims were false and were rejected with probe evidence rather than patched around: git runs a merge driver from the top of the working tree even when git merge is invoked in a subdirectory, so the relative script path resolves, and %O %A %B substitute to bare temp names like .merge_file_yvRBP2 that cannot carry a space. The arguments are quoted anyway as shell hygiene. Four findings were real. Top-level version and updated were special-cased ahead of the field loop, which is how a key only one side carried came to be dropped; the field dispatch is now shared by records and the document. version joins the policy table under a prefer-present rule because the generator drops it on a fresh write (issue #3351) and that omission is not a deletion. _merge_counter discarded a valid number when the other side was malformed. _load read an empty ours or theirs as an empty graph, which would let a truncated file delete the other side. Four negative controls fired.",
+      "episodes": [
+        "episode-2026-07-25-session-3345-causal-graph-merge-driver"
+      ],
+      "created": "2026-07-26T00:55:19.531741+00:00"
+    },
+    {
+      "id": "c3ab73ec0e5f",
+      "type": "commit",
+      "label": "commit: Commit: 03044f4b1cd402c0088c6d429b1515d3d5421952",
+      "episodes": [
+        "episode-2026-07-25-session-3345-causal-graph-merge-driver"
+      ],
+      "created": "2026-07-26T00:55:19.531803+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -14717,6 +14717,24 @@
         "episode-2026-07-25-session-3345-causal-graph-merge-driver"
       ],
       "created": "2026-07-26T00:55:19.531803+00:00"
+    },
+    {
+      "id": "c8abaa28b8e8",
+      "type": "milestone",
+      "label": "milestone: Addressed the second PR #3348 review round. One finding remained from the first pass, and one new finding arrived: merge_graphs still drops a top-level key that survives only in the ancestor when both sides have stopped emitting it, which is accepted as intentional (an agreed deletion should stay deleted; the only known case where an omission is a defect rather than a deletion is `version`, already fixed via issue #3351's prefer-present rule) and closed with a rebuttal rather than a further code change. The genuinely new finding was real: _COLLECTIONS was ordered nodes, edges, patterns, so a no-op merge reordered the top-level JSON relative to the generator's nodes, patterns, edges schema and produced a noisy diff. Reordered _COLLECTIONS to match; one negative control (reverting the order) turned the new ordering test red.",
+      "episodes": [
+        "episode-2026-07-25-session-3345-causal-graph-merge-driver"
+      ],
+      "created": "2026-07-26T01:11:32.565825+00:00"
+    },
+    {
+      "id": "b332bb47aeab",
+      "type": "commit",
+      "label": "commit: Commit: d96e557bdea82d455e0b7f9102abf59d82d5ec31",
+      "episodes": [
+        "episode-2026-07-25-session-3345-causal-graph-merge-driver"
+      ],
+      "created": "2026-07-26T01:11:32.565886+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/episodes/episode-2026-07-25-session-3345-causal-graph-merge-driver.json
+++ b/.agents/memory/episodes/episode-2026-07-25-session-3345-causal-graph-merge-driver.json
@@ -12,7 +12,7 @@
       "type": "milestone",
       "content": "Measured the conflict rather than assuming its shape. update_causal_graph processes only staged episode paths and returns immediately when none are staged, so it is incremental, never a rebuild, and the update-causal-graph hook job is skipped on merge anyway. That makes the issue's recommended workaround (check out one side then rerun the generator) the drift cause: 41 of 242 episodes on disk had no node in the committed graph. A from-scratch rebuild does not reproduce the committed graph and stamps per-node wall-clock timestamps, so the issue's byte-identical acceptance criterion is unachievable.",
       "caused_by": [
-        "e005"
+        "e007"
       ],
       "leads_to": [
         "e002"
@@ -50,7 +50,9 @@
       "caused_by": [
         "e003"
       ],
-      "leads_to": []
+      "leads_to": [
+        "e006"
+      ]
     },
     {
       "id": "e005",
@@ -58,6 +60,28 @@
       "type": "commit",
       "content": "Commit: 03044f4b1cd402c0088c6d429b1515d3d5421952",
       "caused_by": [],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Addressed the second PR #3348 review round. One finding remained from the first pass, and one new finding arrived: merge_graphs still drops a top-level key that survives only in the ancestor when both sides have stopped emitting it, which is accepted as intentional (an agreed deletion should stay deleted; the only known case where an omission is a defect rather than a deletion is `version`, already fixed via issue #3351's prefer-present rule) and closed with a rebuttal rather than a further code change. The genuinely new finding was real: _COLLECTIONS was ordered nodes, edges, patterns, so a no-op merge reordered the top-level JSON relative to the generator's nodes, patterns, edges schema and produced a noisy diff. Reordered _COLLECTIONS to match; one negative control (reverting the order) turned the new ordering test red.",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: d96e557bdea82d455e0b7f9102abf59d82d5ec31",
+      "caused_by": [
+        "e005"
+      ],
       "leads_to": [
         "e001"
       ]
@@ -68,7 +92,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
+    "commits": 2,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-25-session-3345-causal-graph-merge-driver.json
+++ b/.agents/memory/episodes/episode-2026-07-25-session-3345-causal-graph-merge-driver.json
@@ -11,7 +11,9 @@
       "timestamp": "2026-07-25T00:00:00+00:00",
       "type": "milestone",
       "content": "Measured the conflict rather than assuming its shape. update_causal_graph processes only staged episode paths and returns immediately when none are staged, so it is incremental, never a rebuild, and the update-causal-graph hook job is skipped on merge anyway. That makes the issue's recommended workaround (check out one side then rerun the generator) the drift cause: 41 of 242 episodes on disk had no node in the committed graph. A from-scratch rebuild does not reproduce the committed graph and stamps per-node wall-clock timestamps, so the issue's byte-identical acceptance criterion is unachievable.",
-      "caused_by": [],
+      "caused_by": [
+        "e005"
+      ],
       "leads_to": [
         "e002"
       ]
@@ -36,7 +38,29 @@
       "caused_by": [
         "e002"
       ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Addressed the PR #3348 review. Two flagged claims were false and were rejected with probe evidence rather than patched around: git runs a merge driver from the top of the working tree even when git merge is invoked in a subdirectory, so the relative script path resolves, and %O %A %B substitute to bare temp names like .merge_file_yvRBP2 that cannot carry a space. The arguments are quoted anyway as shell hygiene. Four findings were real. Top-level version and updated were special-cased ahead of the field loop, which is how a key only one side carried came to be dropped; the field dispatch is now shared by records and the document. version joins the policy table under a prefer-present rule because the generator drops it on a fresh write (issue #3351) and that omission is not a deletion. _merge_counter discarded a valid number when the other side was malformed. _load read an empty ours or theirs as an empty graph, which would let a truncated file delete the other side. Four negative controls fired.",
+      "caused_by": [
+        "e003"
+      ],
       "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 03044f4b1cd402c0088c6d429b1515d3d5421952",
+      "caused_by": [],
+      "leads_to": [
+        "e001"
+      ]
     }
   ],
   "metrics": {
@@ -44,7 +68,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-25-session-3345-causal-graph-merge-driver.json
+++ b/.agents/memory/episodes/episode-2026-07-25-session-3345-causal-graph-merge-driver.json
@@ -12,7 +12,7 @@
       "type": "milestone",
       "content": "Measured the conflict rather than assuming its shape. update_causal_graph processes only staged episode paths and returns immediately when none are staged, so it is incremental, never a rebuild, and the update-causal-graph hook job is skipped on merge anyway. That makes the issue's recommended workaround (check out one side then rerun the generator) the drift cause: 41 of 242 episodes on disk had no node in the committed graph. A from-scratch rebuild does not reproduce the committed graph and stamps per-node wall-clock timestamps, so the issue's byte-identical acceptance criterion is unachievable.",
       "caused_by": [
-        "e007"
+        "e010"
       ],
       "leads_to": [
         "e002"
@@ -72,7 +72,9 @@
       "caused_by": [
         "e004"
       ],
-      "leads_to": []
+      "leads_to": [
+        "e008"
+      ]
     },
     {
       "id": "e007",
@@ -81,6 +83,40 @@
       "content": "Commit: d96e557bdea82d455e0b7f9102abf59d82d5ec31",
       "caused_by": [
         "e005"
+      ],
+      "leads_to": [
+        "e010"
+      ]
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Used the driver to resolve a real causal-graph conflict on the sibling branch and it lost data. Six of the ten patterns in the committed graph carry no id, so _key gave all six the same empty key and the union kept one: ten patterns in, five out. A record carrying none of its identity fields now falls back to its content, which still matches an untouched record across sides and at worst carries an edited one through twice. Partially keyed records are unaffected. Re-verified against the three real stages: ten patterns in and ten out, nodes 1635 base, 1641 ours, 1657 theirs, merging to 1663. Negative control fired. Filed the upstream defect as issue #3353.",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": [
+        "e009"
+      ]
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Replaced the uv-routed merge driver registration with the installer's own interpreter path after a probe showed a missing uv makes git fall back to the text merge",
+      "caused_by": [
+        "e008"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 9ba22151f30121b311e1fc8cb3fdedd8c401856d",
+      "caused_by": [
+        "e007"
       ],
       "leads_to": [
         "e001"
@@ -92,7 +128,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 2,
+    "commits": 3,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-25-session-3345-causal-graph-merge-driver.json
+++ b/.agents/memory/episodes/episode-2026-07-25-session-3345-causal-graph-merge-driver.json
@@ -1,0 +1,51 @@
+{
+  "id": "episode-2026-07-25-session-3345-causal-graph-merge-driver",
+  "session": "2026-07-25-session-3345-causal-graph-merge-driver",
+  "timestamp": "2026-07-25T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Stop .agents/memory/causality/causal-graph.json conflicting on every merge (issue #3345) without the data loss the issue's own workaround causes. Resolve by content union through a git merge driver instead of by line.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Measured the conflict rather than assuming its shape. update_causal_graph processes only staged episode paths and returns immediately when none are staged, so it is incremental, never a rebuild, and the update-causal-graph hook job is skipped on merge anyway. That makes the issue's recommended workaround (check out one side then rerun the generator) the drift cause: 41 of 242 episodes on disk had no node in the committed graph. A from-scratch rebuild does not reproduce the committed graph and stamps per-node wall-clock timestamps, so the issue's byte-identical acceptance criterion is unachievable.",
+      "caused_by": [],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added a content-union merge driver for the causal graph and registered it. Records key on stable identities, counters reconcile three-way against the ancestor instead of summing, episode lists union, created takes the earliest and last_used the latest. A side that will not parse exits nonzero so git leaves the conflict for a human rather than silently taking one side. Registration runs from pre-commit because merge=<name> in .gitattributes is a no-op without per-clone git config.",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-25T00:00:00+00:00",
+      "type": "milestone",
+      "content": "32 tests covering union semantics, counter reconciliation, field policies, malformed-record tolerance, load-time refusal, the driver exit contract, and two end-to-end git merges in a scratch repo. The end-to-end set includes a control that omits git config and asserts the merge still conflicts, proving the .gitattributes entry alone does nothing. Three negative controls fired: taking ours instead of the union turned 7 tests red, summing counters instead of three-way reconciliation turned 3 red, and swallowing parse errors turned 4 red.",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 4
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-25-session-3345-causal-graph-merge-driver.json
+++ b/.agents/sessions/2026-07-25-session-3345-causal-graph-merge-driver.json
@@ -54,7 +54,7 @@
       "checklistComplete": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "The merge exemption in check_branch_context now keys on upstream presence rather than on MERGE_HEAD, and the change was measured against the real wedged branch before it was committed."
+        "Evidence": "Causal-graph merge driver implemented, registered from pre-commit, and tested with 32 tests covering union semantics, counter reconciliation, field policies, and end-to-end git merges."
       },
       "handoffPreserved": {
         "level": "MUST",
@@ -115,7 +115,7 @@
       ]
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "e2c860e1c",
   "nextSteps": [
     "File the causal-graph drift finding: 41 of 242 episodes have no node in the committed graph and no hook path backfills them.",
     "File that the generator drops the version and updated keys when it writes a graph from scratch.",

--- a/.agents/sessions/2026-07-25-session-3345-causal-graph-merge-driver.json
+++ b/.agents/sessions/2026-07-25-session-3345-causal-graph-merge-driver.json
@@ -122,9 +122,17 @@
         "scripts/maintenance/install_merge_drivers.py",
         "tests/validation/test_merge_causal_graph.py"
       ]
+    },
+    {
+      "phase": "review",
+      "summary": "Addressed the second PR #3348 review round. One finding remained from the first pass, and one new finding arrived: merge_graphs still drops a top-level key that survives only in the ancestor when both sides have stopped emitting it, which is accepted as intentional (an agreed deletion should stay deleted; the only known case where an omission is a defect rather than a deletion is `version`, already fixed via issue #3351's prefer-present rule) and closed with a rebuttal rather than a further code change. The genuinely new finding was real: _COLLECTIONS was ordered nodes, edges, patterns, so a no-op merge reordered the top-level JSON relative to the generator's nodes, patterns, edges schema and produced a noisy diff. Reordered _COLLECTIONS to match; one negative control (reverting the order) turned the new ordering test red.",
+      "files": [
+        "scripts/validation/merge_causal_graph.py",
+        "tests/validation/test_merge_causal_graph.py"
+      ]
     }
   ],
-  "endingCommit": "03044f4b1cd402c0088c6d429b1515d3d5421952",
+  "endingCommit": "d96e557bdea82d455e0b7f9102abf59d82d5ec31",
   "nextSteps": [
     "File the causal-graph drift finding: 41 of 242 episodes have no node in the committed graph and no hook path backfills them.",
     "File that the generator drops the version and updated keys when it writes a graph from scratch.",

--- a/.agents/sessions/2026-07-25-session-3345-causal-graph-merge-driver.json
+++ b/.agents/sessions/2026-07-25-session-3345-causal-graph-merge-driver.json
@@ -1,0 +1,125 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3345,
+    "date": "2026-07-25",
+    "branch": "fix/3345-causal-graph-merge-driver",
+    "startingCommit": "c798e0df7df28ae194ea966f7f1801b3a5c219a1",
+    "objective": "Stop .agents/memory/causality/causal-graph.json conflicting on every merge (issue #3345) without the data loss the issue's own workaround causes. Resolve by content union through a git merge driver instead of by line."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP is live on this Copilot CLI harness; serena-initial_instructions returned the manual and serena-write_memory recorded the finding."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena-initial_instructions read; Serena symbolic tools used for lookup in this repo."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md and honored the read-only rule (ADR-014); never modified on this branch."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file created under .agents/sessions/ during the session."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current returned fix/3345-causal-graph-merge-driver, cut from origin/main at c798e0df7d."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Work performed on fix/3345-causal-graph-merge-driver; no commit touched main."
+      },
+      "memoriesLoaded": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Copilot repository and user memories loaded at session start, including the plugin-parity bump rule and the branch-protection ruleset entry."
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status --short inspected before and after moving the work onto this branch; the embedded pr3097-worktree checkout was left untracked and never staged."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "The merge exemption in check_branch_context now keys on upstream presence rather than on MERGE_HEAD, and the change was measured against the real wedged branch before it was committed."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md read only, never modified (ADR-014)."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Recorded that update_causal_graph is incremental over staged episodes, so the issue's checkout-and-regenerate workaround permanently drops the other side's nodes."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown files changed on this branch, so the scoped markdownlint pass had no in-scope input."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All work committed on this branch; nothing left uncommitted except pre-existing untracked paths that predate the session."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "uv run --frozen pytest tests/validation/ tests/ci/ -q reported 844 passed with the new merge-driver tests included; ruff check, ruff format and mypy clean on both new scripts and the new test module; scripts/validate_workflows.py passed."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue #3345 tracked in the session todo list and moved to done once the driver, its registration and its tests were green."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "phase": "investigation",
+      "summary": "Measured the conflict rather than assuming its shape. update_causal_graph processes only staged episode paths and returns immediately when none are staged, so it is incremental, never a rebuild, and the update-causal-graph hook job is skipped on merge anyway. That makes the issue's recommended workaround (check out one side then rerun the generator) the drift cause: 41 of 242 episodes on disk had no node in the committed graph. A from-scratch rebuild does not reproduce the committed graph and stamps per-node wall-clock timestamps, so the issue's byte-identical acceptance criterion is unachievable.",
+      "files": [
+        "scripts/validation/git_hook_policy.py",
+        "lefthook.yml"
+      ]
+    },
+    {
+      "phase": "implementation",
+      "summary": "Added a content-union merge driver for the causal graph and registered it. Records key on stable identities, counters reconcile three-way against the ancestor instead of summing, episode lists union, created takes the earliest and last_used the latest. A side that will not parse exits nonzero so git leaves the conflict for a human rather than silently taking one side. Registration runs from pre-commit because merge=<name> in .gitattributes is a no-op without per-clone git config.",
+      "files": [
+        "scripts/validation/merge_causal_graph.py",
+        "scripts/maintenance/install_merge_drivers.py",
+        ".gitattributes",
+        "lefthook.yml"
+      ]
+    },
+    {
+      "phase": "testing",
+      "summary": "32 tests covering union semantics, counter reconciliation, field policies, malformed-record tolerance, load-time refusal, the driver exit contract, and two end-to-end git merges in a scratch repo. The end-to-end set includes a control that omits git config and asserts the merge still conflicts, proving the .gitattributes entry alone does nothing. Three negative controls fired: taking ours instead of the union turned 7 tests red, summing counters instead of three-way reconciliation turned 3 red, and swallowing parse errors turned 4 red.",
+      "files": [
+        "tests/validation/test_merge_causal_graph.py"
+      ]
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "File the causal-graph drift finding: 41 of 242 episodes have no node in the committed graph and no hook path backfills them.",
+    "File that the generator drops the version and updated keys when it writes a graph from scratch.",
+    "File that fixture-shaped records n001 'Status test node' and p001 'Good pattern' are committed in the production graph.",
+    "Post the measurement to issue #3345 disproving its byte-identical acceptance criterion."
+  ]
+}

--- a/.agents/sessions/2026-07-25-session-3345-causal-graph-merge-driver.json
+++ b/.agents/sessions/2026-07-25-session-3345-causal-graph-merge-driver.json
@@ -113,9 +113,18 @@
       "files": [
         "tests/validation/test_merge_causal_graph.py"
       ]
+    },
+    {
+      "phase": "review",
+      "summary": "Addressed the PR #3348 review. Two flagged claims were false and were rejected with probe evidence rather than patched around: git runs a merge driver from the top of the working tree even when git merge is invoked in a subdirectory, so the relative script path resolves, and %O %A %B substitute to bare temp names like .merge_file_yvRBP2 that cannot carry a space. The arguments are quoted anyway as shell hygiene. Four findings were real. Top-level version and updated were special-cased ahead of the field loop, which is how a key only one side carried came to be dropped; the field dispatch is now shared by records and the document. version joins the policy table under a prefer-present rule because the generator drops it on a fresh write (issue #3351) and that omission is not a deletion. _merge_counter discarded a valid number when the other side was malformed. _load read an empty ours or theirs as an empty graph, which would let a truncated file delete the other side. Four negative controls fired.",
+      "files": [
+        "scripts/validation/merge_causal_graph.py",
+        "scripts/maintenance/install_merge_drivers.py",
+        "tests/validation/test_merge_causal_graph.py"
+      ]
     }
   ],
-  "endingCommit": "e2c860e1c",
+  "endingCommit": "03044f4b1cd402c0088c6d429b1515d3d5421952",
   "nextSteps": [
     "File the causal-graph drift finding: 41 of 242 episodes have no node in the committed graph and no hook path backfills them.",
     "File that the generator drops the version and updated keys when it writes a graph from scratch.",

--- a/.agents/sessions/2026-07-25-session-3345-causal-graph-merge-driver.json
+++ b/.agents/sessions/2026-07-25-session-3345-causal-graph-merge-driver.json
@@ -130,9 +130,17 @@
         "scripts/validation/merge_causal_graph.py",
         "tests/validation/test_merge_causal_graph.py"
       ]
+    },
+    {
+      "phase": "correction",
+      "summary": "Used the driver to resolve a real causal-graph conflict on the sibling branch and it lost data. Six of the ten patterns in the committed graph carry no id, so _key gave all six the same empty key and the union kept one: ten patterns in, five out. A record carrying none of its identity fields now falls back to its content, which still matches an untouched record across sides and at worst carries an edited one through twice. Partially keyed records are unaffected. Re-verified against the three real stages: ten patterns in and ten out, nodes 1635 base, 1641 ours, 1657 theirs, merging to 1663. Negative control fired. Filed the upstream defect as issue #3353.",
+      "files": [
+        "scripts/validation/merge_causal_graph.py",
+        "tests/validation/test_merge_causal_graph.py"
+      ]
     }
   ],
-  "endingCommit": "d96e557bdea82d455e0b7f9102abf59d82d5ec31",
+  "endingCommit": "0ab20c06c900d3e1eb177bfebb31bfd5b1a543d4",
   "nextSteps": [
     "File the causal-graph drift finding: 41 of 242 episodes have no node in the committed graph and no hook path backfills them.",
     "File that the generator drops the version and updated keys when it writes a graph from scratch.",

--- a/.agents/sessions/2026-07-25-session-3345-causal-graph-merge-driver.json
+++ b/.agents/sessions/2026-07-25-session-3345-causal-graph-merge-driver.json
@@ -138,9 +138,17 @@
         "scripts/validation/merge_causal_graph.py",
         "tests/validation/test_merge_causal_graph.py"
       ]
+    },
+    {
+      "action": "Replaced the uv-routed merge driver registration with the installer's own interpreter path after a probe showed a missing uv makes git fall back to the text merge",
+      "outcome": "50 tests pass; two negative controls fired; probe: uv-routed driver with uv off PATH produced CONFLICT, interpreter-routed driver merged 3 nodes cleanly",
+      "files": [
+        "scripts/maintenance/install_merge_drivers.py",
+        "tests/validation/test_merge_causal_graph.py"
+      ]
     }
   ],
-  "endingCommit": "0ab20c06c900d3e1eb177bfebb31bfd5b1a543d4",
+  "endingCommit": "9ba22151f30121b311e1fc8cb3fdedd8c401856d",
   "nextSteps": [
     "File the causal-graph drift finding: 41 of 242 episodes have no node in the committed graph and no hook path backfills them.",
     "File that the generator drops the version and updated keys when it writes a graph from scratch.",

--- a/.gitattributes
+++ b/.gitattributes
@@ -505,3 +505,37 @@
 #
 *.md diff=markdown
 *.skill diff=markdown
+
+# ============================================================================
+# Merge Driver: Generated Causal Graph
+# ============================================================================
+#
+# WHY DO WE NEED THIS?
+#
+# .agents/memory/causality/causal-graph.json is generated state committed as one
+# blob, and the pre-commit generator rewrites it on essentially every commit. Both
+# sides of any merge have therefore touched it, and git cannot reconcile two
+# rewrites of one JSON document, so every merge of the default branch into a
+# feature branch conflicted on a file no human authored (issue #3345).
+#
+# The workaround made it worse. Taking one side wholesale discards every node the
+# other side contributed, and rerunning the generator does not restore them: it is
+# incremental and only processes episodes staged in the current commit, of which a
+# merge has none. Measured on main when this was added, 41 of 242 episodes on disk
+# had no node in the committed graph.
+#
+# WHAT THIS DOES
+#
+# Merges the two graphs by content instead of by line. Records carry stable
+# identities, so the merge is their union; counters reconcile three-way against
+# the ancestor rather than summing. If either side will not parse, the driver
+# exits nonzero and git leaves the conflict for a human.
+#
+# The driver name resolves through local git config, which is not committed.
+# scripts/maintenance/install_merge_drivers.py registers it from the pre-commit
+# hook so a clone self-heals. Before that first commit the name resolves to
+# nothing and git runs its default text merge, which is the conflict this repo
+# already produces today: the unregistered state degrades to the status quo, it
+# does not corrupt the graph.
+#
+.agents/memory/causality/causal-graph.json merge=causal-graph

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,6 +15,10 @@ pre-commit:
       timeout: 1m
       run: uv run --frozen python scripts/maintenance/repair_packed_refs.py
 
+    - name: install-merge-drivers
+      timeout: 1m
+      run: uv run --frozen python scripts/maintenance/install_merge_drivers.py
+
     - name: branch-policy
       timeout: 2m
       run: uv run --frozen python scripts/validation/git_hook_policy.py branch

--- a/scripts/maintenance/install_merge_drivers.py
+++ b/scripts/maintenance/install_merge_drivers.py
@@ -1,0 +1,68 @@
+"""Register this repository's git merge drivers in the local clone.
+
+A ``.gitattributes`` entry naming a merge driver does nothing on its own. Git
+looks the name up in config, and config is per clone and never committed, so a
+clone without the matching ``git config`` silently falls back to the default
+text merge. For the causal graph that means the conflict this repository is
+trying to eliminate comes back, and the developer resolving it by hand deletes
+graph state without knowing (issue #3345).
+
+Running this from the pre-commit hook makes a clone self-heal on its first
+commit instead of depending on a setup step someone can skip. It is idempotent:
+if the driver is already registered with the value we want, nothing is written.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+# driver name -> (config key suffix, value)
+_DRIVERS: dict[str, dict[str, str]] = {
+    "causal-graph": {
+        "name": "Union merge for the generated causal graph",
+        "driver": ("uv run --frozen python scripts/validation/merge_causal_graph.py %O %A %B"),
+    },
+}
+
+
+def _git(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=_PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def _current(key: str) -> str | None:
+    result = _git(["config", "--local", "--get", key])
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def install() -> int:
+    """Return 0 when every driver is registered, 1 when git rejected a write."""
+    for driver, settings in _DRIVERS.items():
+        for setting, value in settings.items():
+            key = f"merge.{driver}.{setting}"
+            if _current(key) == value:
+                continue
+            result = _git(["config", "--local", key, value])
+            if result.returncode != 0:
+                print(
+                    f"ERROR: could not set {key}: {result.stderr.strip()}",
+                    file=sys.stderr,
+                )
+                return 1
+            print(f"Registered merge driver setting {key}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(install())

--- a/scripts/maintenance/install_merge_drivers.py
+++ b/scripts/maintenance/install_merge_drivers.py
@@ -20,6 +20,24 @@ from pathlib import Path
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
+
+def _interpreter() -> str:
+    """Return the interpreter to bake into the registered driver command.
+
+    The merge driver is stdlib-only, so any Python that can start will run it.
+    Registering this process's own interpreter is therefore both sufficient and
+    the one path proven to work: it is running right now.
+
+    ``as_posix`` matters because git hands the driver string to ``sh`` even on
+    Windows, and ``sh`` eats the backslashes in a native ``D:\\...\\python.exe``.
+
+    ``sys.executable`` is documented as possibly empty when the interpreter
+    cannot determine its own path (embedded hosts). ``python3`` is the only
+    fallback left at that point.
+    """
+    return Path(sys.executable).as_posix() if sys.executable else "python3"
+
+
 # driver name -> (config key suffix, value)
 _DRIVERS: dict[str, dict[str, str]] = {
     "causal-graph": {
@@ -31,9 +49,21 @@ _DRIVERS: dict[str, dict[str, str]] = {
         # %O %A %B are quoted as a matter of shell hygiene. Git substitutes them
         # into this string before sh parses it, and today it substitutes bare
         # temp names like .merge_file_yvRBP2 that cannot contain a space.
-        "driver": (
-            'uv run --frozen python scripts/validation/merge_causal_graph.py "%O" "%A" "%B"'
-        ),
+        #
+        # An absolute interpreter path rather than `uv run --frozen python`.
+        # The driver imports only argparse, json, sys, pathlib and typing, so it
+        # needs no project environment, and routing it through uv would let a
+        # merge fail wherever uv cannot run: offline, before the first sync, or
+        # in a clone that never installed it. A failed driver is not a loud
+        # error, it is a silent fall back to the text merge and the conflict
+        # this driver exists to eliminate.
+        #
+        # The path is machine-local, which is the right scope: it is written to
+        # `git config --local`, which is never committed. It self-heals because
+        # the installer runs from pre-commit and rewrites the key whenever the
+        # computed value differs from what is registered, so a recreated or
+        # relocated venv is repaired on the next commit.
+        "driver": (f'"{_interpreter()}" scripts/validation/merge_causal_graph.py "%O" "%A" "%B"'),
     },
 }
 

--- a/scripts/maintenance/install_merge_drivers.py
+++ b/scripts/maintenance/install_merge_drivers.py
@@ -98,7 +98,9 @@ def install() -> int:
                     f"ERROR: could not set {key}: {result.stderr.strip()}",
                     file=sys.stderr,
                 )
-                return 1
+                # ADR-035: a failed `git config` write is a configuration
+                # failure (2), not a logic error (1).
+                return 2
             print(f"Registered merge driver setting {key}")
     return 0
 

--- a/scripts/maintenance/install_merge_drivers.py
+++ b/scripts/maintenance/install_merge_drivers.py
@@ -24,7 +24,16 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _DRIVERS: dict[str, dict[str, str]] = {
     "causal-graph": {
         "name": "Union merge for the generated causal graph",
-        "driver": ("uv run --frozen python scripts/validation/merge_causal_graph.py %O %A %B"),
+        # Git runs a merge driver from the top of the working tree even when
+        # `git merge` was invoked in a subdirectory, so the relative script path
+        # resolves. Verified by probe; see PR #3348.
+        #
+        # %O %A %B are quoted as a matter of shell hygiene. Git substitutes them
+        # into this string before sh parses it, and today it substitutes bare
+        # temp names like .merge_file_yvRBP2 that cannot contain a space.
+        "driver": (
+            'uv run --frozen python scripts/validation/merge_causal_graph.py "%O" "%A" "%B"'
+        ),
     },
 }
 

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -114,7 +114,19 @@ def _records(graph: dict[str, Any], collection: str) -> list[dict[str, Any]]:
 
 
 def _key(record: dict[str, Any], fields: tuple[str, ...]) -> tuple[str, ...]:
-    return tuple(str(record.get(field, "")) for field in fields)
+    """Identify a record for matching across the three sides.
+
+    A record that carries none of its identity fields has no identity, and
+    keying it on the absent fields would collapse every such record onto one
+    empty key and keep exactly one. Measured on the committed graph: 6 of 10
+    patterns carry no ``id``, so union merging dropped 5 of them. Those records
+    fall back to their content, which matches an untouched record across sides
+    and, at worst, carries an edited one through twice. A duplicate is
+    recoverable; a dropped record is not.
+    """
+    if any(field in record for field in fields):
+        return tuple(str(record.get(field, "")) for field in fields)
+    return ("", json.dumps(record, sort_keys=True, default=str))
 
 
 def _index(

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -25,10 +25,11 @@ Failure is loud. If any input will not parse, the driver exits nonzero and git
 leaves the conflict markers in place for a human. Silently taking a side is the
 behavior that caused the drift this driver exists to stop.
 
-Registered by ``git_hook_policy.py install-merge-drivers``, which runs from the
-pre-commit hook so a clone self-heals on first commit rather than depending on a
-setup step someone can skip. A ``.gitattributes`` entry without the matching
-``git config`` is a silent no-op, which is why registration is automatic.
+Registered by the pre-commit hook through
+``scripts/maintenance/install_merge_drivers.py``, so a clone self-heals on its
+first commit rather than depending on a setup step someone can skip. A
+``.gitattributes`` entry without the matching ``git config`` is a silent no-op,
+which is why registration is automatic.
 """
 
 from __future__ import annotations
@@ -229,7 +230,13 @@ def _merge_fields(
         elif field in _LATEST:
             merged[field] = _extreme(base_value, ours_value, theirs_value, latest=True)
         elif field in _PREFER_PRESENT:
-            merged[field] = ours_value if ours_value is not None else theirs_value
+            merged[field] = (
+                ours_value
+                if ours_value is not None
+                else theirs_value
+                if theirs_value is not None
+                else base_value
+            )
         else:
             merged[field] = _prefer_diverged(base_value, ours_value, theirs_value)
     return merged
@@ -275,6 +282,9 @@ def merge_graphs(
     # Every top-level key either side carries, including ones the schema grows
     # later. Collections have their own union rule and are merged below.
     scalars = [key for key in _ordered_keys(ours, theirs) if key not in _COLLECTIONS]
+    scalars.extend(
+        sorted(field for field in _PREFER_PRESENT if field in base and field not in scalars)
+    )
     merged = _merge_fields(base, ours, theirs, scalars)
 
     for collection, fields in _COLLECTIONS.items():

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -153,10 +153,13 @@ def _merge_counter(base: JsonValue, ours: JsonValue, theirs: JsonValue) -> JsonV
         if theirs_number:
             return theirs
         return ours if ours is not None else theirs
-    start = base if isinstance(base, (int, float)) else 0
-    ours_value = ours if isinstance(ours, (int, float)) else start
-    theirs_value = theirs if isinstance(theirs, (int, float)) else start
-    merged = start + (ours_value - start) + (theirs_value - start)
+    # When there is no ancestor value, both branches independently added this
+    # record. Take the maximum rather than summing deltas, which would
+    # double-count when both sides added the same content with the same count.
+    if not isinstance(base, (int, float)):
+        return max(ours, theirs)
+    # Three-way merge: apply both sides' deltas to the ancestor.
+    merged = base + (ours - base) + (theirs - base)
     return max(merged, 0)
 
 

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -47,15 +47,16 @@ JsonValue: TypeAlias = str | int | float | bool | None | list["JsonValue"] | dic
 
 # Which record collections we merge, and the field that identifies a record
 # within each. Node ids are content hashes, patterns are keyed by name because
-# committed patterns may omit ids, and an edge is identified by the triple it
-# connects. Ordered nodes, patterns, edges to match the schema
+# committed patterns may omit ids, and an edge is identified by the pair it
+# connects (matching the generator's deduplication in update_causal_graph.py).
+# Ordered nodes, patterns, edges to match the schema
 # order the generator writes (see .agents/memory/causality/causal-graph.json),
 # so a merge that changes no content does not also reorder the top-level JSON
 # and produce a noisy diff.
 _COLLECTIONS: dict[str, tuple[str, ...]] = {
     "nodes": ("id",),
     "patterns": ("name",),
-    "edges": ("source", "target", "type"),
+    "edges": ("source", "target"),
 }
 
 # Field-merge policy. Anything not named here falls through to _prefer_diverged.

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -119,16 +119,20 @@ def _records(graph: dict[str, Any], collection: str) -> list[dict[str, Any]]:
 def _key(record: dict[str, Any], fields: tuple[str, ...]) -> tuple[str, ...]:
     """Identify a record for matching across the three sides.
 
-    A record that carries none of its identity fields has no identity, and
-    keying it on the absent fields would collapse every such record onto one
-    empty key and keep exactly one. Measured on the committed graph: 6 of 10
-    patterns carry no ``id``, so union merging dropped 5 of them. Those records
-    fall back to their content, which matches an untouched record across sides
-    and, at worst, carries an edited one through twice. A duplicate is
-    recoverable; a dropped record is not.
+    A record missing any identity field has no usable identity, and keying it on
+    the absent ones collapses every such record onto the same key, keeping
+    exactly one. Measured on the committed graph: 6 of 10 patterns carry no
+    ``id``, so union merging dropped 5 of them. Partial identities collapse the
+    same way and were the second half of the bug: three malformed edges carrying
+    only ``source`` all key to ``("a", "")``, so two are dropped.
+
+    Requiring every field, rather than any, is what makes the fallback fire in
+    both cases. Those records fall back to their content, which matches an
+    untouched record across sides and, at worst, carries an edited one through
+    twice. A duplicate is recoverable; a dropped record is not.
     """
-    if any(field in record for field in fields):
-        return tuple(str(record.get(field, "")) for field in fields)
+    if all(field in record for field in fields):
+        return tuple(str(record[field]) for field in fields)
     return ("", json.dumps(record, sort_keys=True, default=str))
 
 
@@ -349,7 +353,12 @@ def main(argv: list[str] | None = None) -> int:
             f"ERROR: causal graph merge driver could not write {args.ours}: {exc}",
             file=sys.stderr,
         )
-        return 1
+        # ADR-035: filesystem failure is external (3), not a logic error (1).
+        # Git reads any nonzero the same way, as "leave the conflict in place",
+        # so this only distinguishes the two when a human runs the driver by
+        # hand to resolve a conflict, which is exactly when it is worth knowing
+        # whether the input was malformed or the disk refused the write.
+        return 3
     return 0
 
 

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -45,8 +45,9 @@ from typing import Any, TypeAlias
 JsonValue: TypeAlias = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
 
 # Which record collections we merge, and the field that identifies a record
-# within each. Node and pattern ids are content hashes; an edge is identified by
-# the triple it connects. Ordered nodes, patterns, edges to match the schema
+# within each. Node ids are content hashes, patterns are keyed by name because
+# committed patterns may omit ids, and an edge is identified by the triple it
+# connects. Ordered nodes, patterns, edges to match the schema
 # order the generator writes (see .agents/memory/causality/causal-graph.json),
 # so a merge that changes no content does not also reorder the top-level JSON
 # and produce a noisy diff.

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -52,7 +52,7 @@ JsonValue: TypeAlias = str | int | float | bool | None | list["JsonValue"] | dic
 # and produce a noisy diff.
 _COLLECTIONS: dict[str, tuple[str, ...]] = {
     "nodes": ("id",),
-    "patterns": ("id",),
+    "patterns": ("name",),
     "edges": ("source", "target", "type"),
 }
 

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -154,6 +154,8 @@ def _merge_counter(base: JsonValue, ours: JsonValue, theirs: JsonValue) -> JsonV
         if theirs_number:
             return theirs
         return ours if ours is not None else theirs
+    assert isinstance(ours, (int, float))
+    assert isinstance(theirs, (int, float))
     # When there is no ancestor value, both branches independently added this
     # record. Take the maximum rather than summing deltas, which would
     # double-count when both sides added the same content with the same count.

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -143,26 +143,24 @@ def _merge_counter(base: JsonValue, ours: JsonValue, theirs: JsonValue) -> JsonV
     Summing ours and theirs would count everything they inherited twice. Three
     way keeps a counter that neither side touched unchanged.
     """
-    ours_number = isinstance(ours, (int, float))
-    theirs_number = isinstance(theirs, (int, float))
-    if not ours_number or not theirs_number:
+    ours_count = ours if isinstance(ours, (int, float)) else None
+    theirs_count = theirs if isinstance(theirs, (int, float)) else None
+    if ours_count is None or theirs_count is None:
         # Only one side holds a number, so there are no two deltas to reconcile.
         # Keep whichever side has one: dropping it because the other side is
         # malformed would lose the count the good side actually recorded.
-        if ours_number:
-            return ours
-        if theirs_number:
-            return theirs
+        if ours_count is not None:
+            return ours_count
+        if theirs_count is not None:
+            return theirs_count
         return ours if ours is not None else theirs
-    assert isinstance(ours, (int, float))
-    assert isinstance(theirs, (int, float))
     # When there is no ancestor value, both branches independently added this
     # record. Take the maximum rather than summing deltas, which would
     # double-count when both sides added the same content with the same count.
     if not isinstance(base, (int, float)):
-        return max(ours, theirs)
+        return max(ours_count, theirs_count)
     # Three-way merge: apply both sides' deltas to the ancestor.
-    merged = base + (ours - base) + (theirs - base)
+    merged = base + (ours_count - base) + (theirs_count - base)
     return max(merged, 0)
 
 
@@ -208,6 +206,33 @@ def _ordered_keys(ours: dict[str, Any], theirs: dict[str, Any]) -> list[str]:
     return list(ours) + [field for field in theirs if field not in ours]
 
 
+def _fields_to_merge(
+    base: dict[str, Any],
+    ours: dict[str, Any],
+    theirs: dict[str, Any],
+    exclude: frozenset[str] = frozenset(),
+) -> list[str]:
+    """Fields to merge: everything either side carries, plus recoverable ones.
+
+    A key neither side carries is normally an agreed deletion, and iterating
+    only what the sides carry is what keeps it deleted. _PREFER_PRESENT names
+    the exception. Those fields go missing because the generator drops them on
+    a fresh write, so once both sides have regenerated, neither carries the
+    field and the ancestor holds the only surviving copy.
+
+    Records and the top-level document share this for the same reason they
+    share _merge_fields. Extending only the top-level key list is how version
+    and updated became one-off special cases the first time.
+    """
+    keys = [field for field in _ordered_keys(ours, theirs) if field not in exclude]
+    recoverable = [
+        field
+        for field in base
+        if field in _PREFER_PRESENT and field not in keys and field not in exclude
+    ]
+    return recoverable + keys
+
+
 def _merge_fields(
     base: dict[str, Any],
     ours: dict[str, Any],
@@ -232,12 +257,15 @@ def _merge_fields(
         elif field in _LATEST:
             merged[field] = _extreme(base_value, ours_value, theirs_value, latest=True)
         elif field in _PREFER_PRESENT:
-            merged[field] = (
-                ours_value
-                if ours_value is not None
-                else theirs_value
-                if theirs_value is not None
-                else base_value
+            # Falling back to the ancestor matters. These fields go missing
+            # because the generator drops them on a fresh write, not because
+            # anyone deleted them. Without the base fallback, two sides that
+            # both regenerated would agree on the omission and merge_graphs
+            # would strip the field, turning a generator defect into a
+            # permanent loss the next merge cannot recover.
+            merged[field] = next(
+                (value for value in (ours_value, theirs_value, base_value) if value is not None),
+                None,
             )
         else:
             merged[field] = _prefer_diverged(base_value, ours_value, theirs_value)
@@ -255,7 +283,8 @@ def _merge_record(
     if theirs is None:
         return dict(ours)
 
-    return _merge_fields(base or {}, ours, theirs, _ordered_keys(ours, theirs))
+    ancestor = base or {}
+    return _merge_fields(ancestor, ours, theirs, _fields_to_merge(ancestor, ours, theirs))
 
 
 def _merge_collection(
@@ -283,10 +312,7 @@ def merge_graphs(
     """Merge two causal graphs against their common ancestor."""
     # Every top-level key either side carries, including ones the schema grows
     # later. Collections have their own union rule and are merged below.
-    scalars = [key for key in _ordered_keys(ours, theirs) if key not in _COLLECTIONS]
-    scalars.extend(
-        sorted(field for field in _PREFER_PRESENT if field in base and field not in scalars)
-    )
+    scalars = _fields_to_merge(base, ours, theirs, exclude=frozenset(_COLLECTIONS))
     merged = _merge_fields(base, ours, theirs, scalars)
 
     for collection, fields in _COLLECTIONS.items():

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -174,9 +174,9 @@ def _merge_set(ours: JsonValue, theirs: JsonValue) -> JsonValue:
     return [seen[rendering] for rendering in sorted(seen)]
 
 
-def _extreme(ours: JsonValue, theirs: JsonValue, *, latest: bool) -> JsonValue:
-    """Pick the earliest or latest of two comparable values, tolerating None."""
-    candidates = [value for value in (ours, theirs) if isinstance(value, str) and value]
+def _extreme(base: JsonValue, ours: JsonValue, theirs: JsonValue, *, latest: bool) -> JsonValue:
+    """Pick the earliest or latest of three comparable values, tolerating None."""
+    candidates = [value for value in (base, ours, theirs) if isinstance(value, str) and value]
     if not candidates:
         return ours if ours is not None else theirs
     return max(candidates) if latest else min(candidates)
@@ -221,9 +221,9 @@ def _merge_fields(
         elif field in _SET_VALUED:
             merged[field] = _merge_set(ours_value, theirs_value)
         elif field in _EARLIEST:
-            merged[field] = _extreme(ours_value, theirs_value, latest=False)
+            merged[field] = _extreme(base_value, ours_value, theirs_value, latest=False)
         elif field in _LATEST:
-            merged[field] = _extreme(ours_value, theirs_value, latest=True)
+            merged[field] = _extreme(base_value, ours_value, theirs_value, latest=True)
         elif field in _PREFER_PRESENT:
             merged[field] = ours_value if ours_value is not None else theirs_value
         else:

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -222,8 +222,15 @@ def merge_graphs(
     merged: dict[str, Any] = {}
 
     for field in ("version",):
-        merged[field] = _prefer_diverged(base.get(field), ours.get(field), theirs.get(field))
-    merged["updated"] = _extreme(ours.get("updated"), theirs.get("updated"), latest=True)
+        result = _prefer_diverged(base.get(field), ours.get(field), theirs.get(field))
+        if result is None:
+            result = base.get(field)
+        merged[field] = result
+
+    updated_result = _extreme(ours.get("updated"), theirs.get("updated"), latest=True)
+    if updated_result is None:
+        updated_result = base.get("updated")
+    merged["updated"] = updated_result
 
     for collection, fields in _COLLECTIONS.items():
         merged[collection] = _merge_collection(base, ours, theirs, collection, fields)

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -1,0 +1,272 @@
+"""Git merge driver for the generated causal graph.
+
+Every merge of the default branch into a feature branch conflicts on
+``.agents/memory/causality/causal-graph.json``. The file is generated state
+committed as one blob, and the pre-commit generator rewrites it on essentially
+every commit, so both sides of any merge have touched it. Git cannot reconcile
+two rewrites of one JSON document, so it hands the developer a conflict in a
+file no human authored (issue #3345).
+
+The documented workaround made it worse. ``git checkout origin/main -- <graph>``
+takes one side wholesale and discards every node the branch contributed, and
+rerunning the generator does not restore them: the generator is incremental and
+only processes episodes staged in the current commit, of which a merge has none.
+Measured on main at the time of writing, 41 of 242 episodes on disk had no node
+in the committed graph, and the most recent absences were episodes that had
+arrived through exactly this path.
+
+This driver resolves the conflict by content instead. Nodes, edges, and patterns
+are append-mostly and carry stable identities, so the merge of two graphs is the
+union of their records. Counters reconcile three-way against the ancestor
+(``base + (ours - base) + (theirs - base)``) rather than summing, which would
+double-count everything the two sides already shared.
+
+Failure is loud. If any input will not parse, the driver exits nonzero and git
+leaves the conflict markers in place for a human. Silently taking a side is the
+behavior that caused the drift this driver exists to stop.
+
+Registered by ``git_hook_policy.py install-merge-drivers``, which runs from the
+pre-commit hook so a clone self-heals on first commit rather than depending on a
+setup step someone can skip. A ``.gitattributes`` entry without the matching
+``git config`` is a silent no-op, which is why registration is automatic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, TypeAlias
+
+# A value as it comes out of json.load. Naming it beats `Any`: these helpers
+# genuinely accept whatever the generated graph holds, and the alias says so
+# without disabling the ban on untyped signatures.
+JsonValue: TypeAlias = "str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]"
+
+# Which record collections we merge, and the field that identifies a record
+# within each. Node and pattern ids are content hashes; an edge is identified by
+# the triple it connects.
+_COLLECTIONS: dict[str, tuple[str, ...]] = {
+    "nodes": ("id",),
+    "edges": ("source", "target", "type"),
+    "patterns": ("id",),
+}
+
+# Field-merge policy. Anything not named here falls through to _prefer_diverged.
+_COUNTERS = frozenset({"evidence_count", "occurrences", "frequency"})
+_SET_VALUED = frozenset({"episodes"})
+_EARLIEST = frozenset({"created"})
+_LATEST = frozenset({"last_used", "updated"})
+
+
+class GraphMergeError(Exception):
+    """An input could not be read or was not a causal graph."""
+
+
+def _load(path: Path, label: str) -> dict[str, Any]:
+    """Read one side of the merge.
+
+    A missing ancestor is normal: git passes an empty file for an add/add
+    conflict. A malformed one is not, and must not be treated as empty.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise GraphMergeError(f"cannot read {label} ({path}): {exc}") from exc
+
+    if not text.strip():
+        return {}
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise GraphMergeError(f"{label} ({path}) is not valid JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise GraphMergeError(f"{label} ({path}) is {type(data).__name__}, expected an object")
+    return data
+
+
+def _records(graph: dict[str, Any], collection: str) -> list[dict[str, Any]]:
+    """Return the records in one collection, ignoring anything malformed.
+
+    A non-list collection or a non-object record is dropped rather than raised
+    on: the graph is generated, and one bad record should not block a merge that
+    can still carry every good one.
+    """
+    value = graph.get(collection)
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _key(record: dict[str, Any], fields: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(str(record.get(field, "")) for field in fields)
+
+
+def _index(
+    records: list[dict[str, Any]], fields: tuple[str, ...]
+) -> dict[tuple[str, ...], dict[str, Any]]:
+    return {_key(record, fields): record for record in records}
+
+
+def _merge_counter(base: JsonValue, ours: JsonValue, theirs: JsonValue) -> JsonValue:
+    """Apply both sides' deltas to the ancestor.
+
+    Summing ours and theirs would count everything they inherited twice. Three
+    way keeps a counter that neither side touched unchanged.
+    """
+    numbers = [value for value in (base, ours, theirs) if isinstance(value, (int, float))]
+    if len(numbers) < 2:
+        return ours if ours is not None else theirs
+    start = base if isinstance(base, (int, float)) else 0
+    ours_value = ours if isinstance(ours, (int, float)) else start
+    theirs_value = theirs if isinstance(theirs, (int, float)) else start
+    merged = start + (ours_value - start) + (theirs_value - start)
+    return max(merged, 0)
+
+
+def _merge_set(ours: JsonValue, theirs: JsonValue) -> JsonValue:
+    """Union two list-valued fields.
+
+    Sorted on a canonical rendering so the result does not depend on which side
+    git called ours, and deduplicated so a record merged twice does not grow its
+    episode list.
+    """
+    if not isinstance(ours, list) or not isinstance(theirs, list):
+        return ours if isinstance(ours, list) else theirs
+    seen: dict[str, Any] = {}
+    for item in ours + theirs:
+        seen.setdefault(json.dumps(item, sort_keys=True), item)
+    return [seen[rendering] for rendering in sorted(seen)]
+
+
+def _extreme(ours: JsonValue, theirs: JsonValue, *, latest: bool) -> JsonValue:
+    """Pick the earliest or latest of two comparable values, tolerating None."""
+    candidates = [value for value in (ours, theirs) if isinstance(value, str) and value]
+    if not candidates:
+        return ours if ours is not None else theirs
+    return max(candidates) if latest else min(candidates)
+
+
+def _prefer_diverged(base: JsonValue, ours: JsonValue, theirs: JsonValue) -> JsonValue:
+    """Take whichever side moved away from the ancestor.
+
+    When both moved, take ours. A merge driver is called with a defined ours and
+    theirs, so this is deterministic for the caller even though it is not
+    symmetric, and it matches what `git merge -X ours` would do for the field.
+    """
+    if ours == theirs:
+        return ours
+    if ours == base:
+        return theirs
+    return ours
+
+
+def _merge_record(
+    base: dict[str, Any] | None,
+    ours: dict[str, Any] | None,
+    theirs: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Merge one record present on at least one side."""
+    if ours is None:
+        return dict(theirs or {})
+    if theirs is None:
+        return dict(ours)
+
+    base = base or {}
+    merged: dict[str, Any] = {}
+    for field in list(ours) + [f for f in theirs if f not in ours]:
+        base_value, ours_value, theirs_value = (
+            base.get(field),
+            ours.get(field),
+            theirs.get(field),
+        )
+        if field in _COUNTERS:
+            merged[field] = _merge_counter(base_value, ours_value, theirs_value)
+        elif field in _SET_VALUED:
+            merged[field] = _merge_set(ours_value, theirs_value)
+        elif field in _EARLIEST:
+            merged[field] = _extreme(ours_value, theirs_value, latest=False)
+        elif field in _LATEST:
+            merged[field] = _extreme(ours_value, theirs_value, latest=True)
+        else:
+            merged[field] = _prefer_diverged(base_value, ours_value, theirs_value)
+    return merged
+
+
+def _merge_collection(
+    base: dict[str, Any],
+    ours: dict[str, Any],
+    theirs: dict[str, Any],
+    collection: str,
+    fields: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    """Union one collection, preserving ours-first order so diffs stay readable."""
+    base_index = _index(_records(base, collection), fields)
+    ours_index = _index(_records(ours, collection), fields)
+    theirs_index = _index(_records(theirs, collection), fields)
+
+    ordered = list(ours_index) + [key for key in theirs_index if key not in ours_index]
+    return [
+        _merge_record(base_index.get(key), ours_index.get(key), theirs_index.get(key))
+        for key in ordered
+    ]
+
+
+def merge_graphs(
+    base: dict[str, Any], ours: dict[str, Any], theirs: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge two causal graphs against their common ancestor."""
+    merged: dict[str, Any] = {}
+
+    for field in ("version",):
+        merged[field] = _prefer_diverged(base.get(field), ours.get(field), theirs.get(field))
+    merged["updated"] = _extreme(ours.get("updated"), theirs.get("updated"), latest=True)
+
+    for collection, fields in _COLLECTIONS.items():
+        merged[collection] = _merge_collection(base, ours, theirs, collection, fields)
+
+    # Carry any top-level key the schema grows later rather than dropping it.
+    for side in (ours, theirs):
+        for field, value in side.items():
+            if field not in merged:
+                merged[field] = value
+
+    return {field: value for field, value in merged.items() if value is not None}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("base", type=Path, help="common ancestor (git %%O)")
+    parser.add_argument("ours", type=Path, help="our version, also the output path (git %%A)")
+    parser.add_argument("theirs", type=Path, help="their version (git %%B)")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Return 0 on a written merge, 1 when git must leave the conflict alone."""
+    args = parse_args(argv)
+    try:
+        merged = merge_graphs(
+            _load(args.base, "ancestor"),
+            _load(args.ours, "ours"),
+            _load(args.theirs, "theirs"),
+        )
+        args.ours.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
+    except GraphMergeError as exc:
+        print(f"ERROR: causal graph merge driver: {exc}", file=sys.stderr)
+        print("Leaving the conflict in place; resolve it by hand.", file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(
+            f"ERROR: causal graph merge driver could not write {args.ours}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -42,7 +42,7 @@ from typing import Any, TypeAlias
 # A value as it comes out of json.load. Naming it beats `Any`: these helpers
 # genuinely accept whatever the generated graph holds, and the alias says so
 # without disabling the ban on untyped signatures.
-JsonValue: TypeAlias = "str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]"
+JsonValue: TypeAlias = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
 
 # Which record collections we merge, and the field that identifies a record
 # within each. Node and pattern ids are content hashes; an edge is identified by
@@ -58,17 +58,24 @@ _COUNTERS = frozenset({"evidence_count", "occurrences", "frequency"})
 _SET_VALUED = frozenset({"episodes"})
 _EARLIEST = frozenset({"created"})
 _LATEST = frozenset({"last_used", "updated"})
+# Metadata the generator is known to drop on a fresh write (issue #3351).
+# _prefer_diverged would read that omission as a deletion and propagate the
+# loss into the merge even when the other side still has the value.
+_PREFER_PRESENT = frozenset({"version"})
 
 
 class GraphMergeError(Exception):
     """An input could not be read or was not a causal graph."""
 
 
-def _load(path: Path, label: str) -> dict[str, Any]:
+def _load(path: Path, label: str, *, may_be_empty: bool = False) -> dict[str, Any]:
     """Read one side of the merge.
 
-    A missing ancestor is normal: git passes an empty file for an add/add
-    conflict. A malformed one is not, and must not be treated as empty.
+    An empty ancestor is normal: git passes an empty file for an add/add
+    conflict, where the two sides have no common history for this path. An empty
+    ours or theirs is not. Reading it as an empty graph would let a truncated
+    file merge cleanly and delete everything the other side has, which is the
+    silent data loss this driver exists to prevent.
     """
     try:
         text = path.read_text(encoding="utf-8")
@@ -76,7 +83,9 @@ def _load(path: Path, label: str) -> dict[str, Any]:
         raise GraphMergeError(f"cannot read {label} ({path}): {exc}") from exc
 
     if not text.strip():
-        return {}
+        if may_be_empty:
+            return {}
+        raise GraphMergeError(f"{label} ({path}) is empty, expected a graph")
 
     try:
         data = json.loads(text)
@@ -117,8 +126,16 @@ def _merge_counter(base: JsonValue, ours: JsonValue, theirs: JsonValue) -> JsonV
     Summing ours and theirs would count everything they inherited twice. Three
     way keeps a counter that neither side touched unchanged.
     """
-    numbers = [value for value in (base, ours, theirs) if isinstance(value, (int, float))]
-    if len(numbers) < 2:
+    ours_number = isinstance(ours, (int, float))
+    theirs_number = isinstance(theirs, (int, float))
+    if not ours_number or not theirs_number:
+        # Only one side holds a number, so there are no two deltas to reconcile.
+        # Keep whichever side has one: dropping it because the other side is
+        # malformed would lose the count the good side actually recorded.
+        if ours_number:
+            return ours
+        if theirs_number:
+            return theirs
         return ours if ours is not None else theirs
     start = base if isinstance(base, (int, float)) else 0
     ours_value = ours if isinstance(ours, (int, float)) else start
@@ -164,6 +181,41 @@ def _prefer_diverged(base: JsonValue, ours: JsonValue, theirs: JsonValue) -> Jso
     return ours
 
 
+def _ordered_keys(ours: dict[str, Any], theirs: dict[str, Any]) -> list[str]:
+    """Ours first, then anything only theirs has, so diffs stay readable."""
+    return list(ours) + [field for field in theirs if field not in ours]
+
+
+def _merge_fields(
+    base: dict[str, Any],
+    ours: dict[str, Any],
+    theirs: dict[str, Any],
+    keys: list[str],
+) -> dict[str, Any]:
+    """Apply the field-merge policy table to one level of the document.
+
+    Records and the top-level document merge their fields the same way, so this
+    is shared rather than restated. Restating it is how the top level came to
+    handle version and updated as one-off special cases.
+    """
+    merged: dict[str, Any] = {}
+    for field in keys:
+        base_value, ours_value, theirs_value = base.get(field), ours.get(field), theirs.get(field)
+        if field in _COUNTERS:
+            merged[field] = _merge_counter(base_value, ours_value, theirs_value)
+        elif field in _SET_VALUED:
+            merged[field] = _merge_set(ours_value, theirs_value)
+        elif field in _EARLIEST:
+            merged[field] = _extreme(ours_value, theirs_value, latest=False)
+        elif field in _LATEST:
+            merged[field] = _extreme(ours_value, theirs_value, latest=True)
+        elif field in _PREFER_PRESENT:
+            merged[field] = ours_value if ours_value is not None else theirs_value
+        else:
+            merged[field] = _prefer_diverged(base_value, ours_value, theirs_value)
+    return merged
+
+
 def _merge_record(
     base: dict[str, Any] | None,
     ours: dict[str, Any] | None,
@@ -175,25 +227,7 @@ def _merge_record(
     if theirs is None:
         return dict(ours)
 
-    base = base or {}
-    merged: dict[str, Any] = {}
-    for field in list(ours) + [f for f in theirs if f not in ours]:
-        base_value, ours_value, theirs_value = (
-            base.get(field),
-            ours.get(field),
-            theirs.get(field),
-        )
-        if field in _COUNTERS:
-            merged[field] = _merge_counter(base_value, ours_value, theirs_value)
-        elif field in _SET_VALUED:
-            merged[field] = _merge_set(ours_value, theirs_value)
-        elif field in _EARLIEST:
-            merged[field] = _extreme(ours_value, theirs_value, latest=False)
-        elif field in _LATEST:
-            merged[field] = _extreme(ours_value, theirs_value, latest=True)
-        else:
-            merged[field] = _prefer_diverged(base_value, ours_value, theirs_value)
-    return merged
+    return _merge_fields(base or {}, ours, theirs, _ordered_keys(ours, theirs))
 
 
 def _merge_collection(
@@ -219,27 +253,13 @@ def merge_graphs(
     base: dict[str, Any], ours: dict[str, Any], theirs: dict[str, Any]
 ) -> dict[str, Any]:
     """Merge two causal graphs against their common ancestor."""
-    merged: dict[str, Any] = {}
-
-    for field in ("version",):
-        result = _prefer_diverged(base.get(field), ours.get(field), theirs.get(field))
-        if result is None:
-            result = base.get(field)
-        merged[field] = result
-
-    updated_result = _extreme(ours.get("updated"), theirs.get("updated"), latest=True)
-    if updated_result is None:
-        updated_result = base.get("updated")
-    merged["updated"] = updated_result
+    # Every top-level key either side carries, including ones the schema grows
+    # later. Collections have their own union rule and are merged below.
+    scalars = [key for key in _ordered_keys(ours, theirs) if key not in _COLLECTIONS]
+    merged = _merge_fields(base, ours, theirs, scalars)
 
     for collection, fields in _COLLECTIONS.items():
         merged[collection] = _merge_collection(base, ours, theirs, collection, fields)
-
-    # Carry any top-level key the schema grows later rather than dropping it.
-    for side in (ours, theirs):
-        for field, value in side.items():
-            if field not in merged:
-                merged[field] = value
 
     return {field: value for field, value in merged.items() if value is not None}
 
@@ -257,7 +277,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
         merged = merge_graphs(
-            _load(args.base, "ancestor"),
+            _load(args.base, "ancestor", may_be_empty=True),
             _load(args.ours, "ours"),
             _load(args.theirs, "theirs"),
         )

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -46,11 +46,14 @@ JsonValue: TypeAlias = str | int | float | bool | None | list["JsonValue"] | dic
 
 # Which record collections we merge, and the field that identifies a record
 # within each. Node and pattern ids are content hashes; an edge is identified by
-# the triple it connects.
+# the triple it connects. Ordered nodes, patterns, edges to match the schema
+# order the generator writes (see .agents/memory/causality/causal-graph.json),
+# so a merge that changes no content does not also reorder the top-level JSON
+# and produce a noisy diff.
 _COLLECTIONS: dict[str, tuple[str, ...]] = {
     "nodes": ("id",),
-    "edges": ("source", "target", "type"),
     "patterns": ("id",),
+    "edges": ("source", "target", "type"),
 }
 
 # Field-merge policy. Anything not named here falls through to _prefer_diverged.

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import pytest
 
+from scripts.maintenance import install_merge_drivers
 from scripts.validation import merge_causal_graph
 from scripts.validation.merge_causal_graph import (
     GraphMergeError,
@@ -105,6 +106,33 @@ class TestRecordsWithoutIdentityFieldsAreNotCollapsed:
 
         assert len(merged["edges"]) == 1
         assert merged["edges"][0]["evidence_count"] == 6
+
+    def test_malformed_edges_sharing_one_identity_field_all_survive(self) -> None:
+        """PR #3348 review: a partial identity keyed on a half-empty tuple.
+
+        Three edges carrying only ``source`` all keyed to ``("a", "")`` under
+        the old any-field rule, so the union kept one and dropped two. That is
+        the same collapse the id-less patterns hit, in the one shape the driver
+        promises to tolerate: malformed records must not cost good ones.
+        """
+        malformed = [
+            {"source": "a", "evidence_count": 1},
+            {"source": "a", "evidence_count": 2},
+            {"source": "a", "evidence_count": 3},
+        ]
+
+        merged = merge_graphs(_graph(), _graph(edges=malformed), _graph())
+
+        assert sorted(e["evidence_count"] for e in merged["edges"]) == [1, 2, 3]
+
+    def test_a_partial_identity_does_not_match_a_complete_one(self) -> None:
+        """An edge missing ``target`` is a different record, not the same one."""
+        complete = {"source": "a", "target": "b", "evidence_count": 1}
+        partial = {"source": "a", "evidence_count": 9}
+
+        merged = merge_graphs(_graph(), _graph(edges=[complete]), _graph(edges=[partial]))
+
+        assert len(merged["edges"]) == 2
 
     def test_patterns_key_on_name_and_merge_counters(self) -> None:
         """Patterns are keyed by name, not id, aligning with the generator."""
@@ -349,6 +377,33 @@ class TestDriverExitContract:
         theirs = self._write(tmp_path, "theirs.json", _graph())
         assert main([str(tmp_path / "absent.json"), str(ours), str(theirs)]) == 1
 
+    def test_an_unwritable_destination_exits_three(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PR #3348 review: ADR-035 separates logic (1) from external (3).
+
+        Git reads every nonzero the same way, so this distinction only pays off
+        when a human runs the driver by hand to resolve a conflict, which is
+        exactly when "your JSON is malformed" and "the disk refused the write"
+        need to be told apart. Fails the write itself rather than staging an
+        unwritable path: ``ours`` is also an input, so a directory or a stripped
+        mode bit fails during load and never reaches the branch under test, and
+        root and Windows both ignore mode bits anyway.
+        """
+        base = self._write(tmp_path, "base.json", _graph())
+        ours = self._write(tmp_path, "ours.json", _graph())
+        theirs = self._write(tmp_path, "theirs.json", _graph())
+        original = Path.write_text
+
+        def refuse(self: Path, *args: Any, **kwargs: Any) -> int:
+            if self == ours:
+                raise OSError(28, "No space left on device")
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", refuse)
+
+        assert main([str(base), str(ours), str(theirs)]) == 3
+
 
 class TestGitActuallyUsesTheDriver:
     """An end-to-end merge, because the unit tests cannot prove git invokes it."""
@@ -418,6 +473,40 @@ class TestGitActuallyUsesTheDriver:
             _DRIVER_COMMAND,
         )
         result = self._git(repo, "merge", "feature")
+        assert result.returncode == 0, result.stdout + result.stderr
+        graph = json.loads(
+            (repo / ".agents/memory/causality/causal-graph.json").read_text(encoding="utf-8")
+        )
+        assert {n["id"] for n in graph["nodes"]} == {"shared", "feature", "trunk"}
+
+    def test_the_command_git_is_actually_given_resolves_from_a_subdirectory(
+        self, repo: Path
+    ) -> None:
+        """PR #3348 review: every other e2e test registered an absolute path.
+
+        The command the installer really writes carries a repo-relative script
+        path, so those tests passed while proving nothing about the assumption
+        the relative form rests on: that git runs a merge driver from the top of
+        the working tree even when the merge was invoked from a subdirectory.
+        A fresh clone would have been the first place that assumption was tried.
+
+        Registers the exact strings from ``_DRIVERS`` and merges from
+        ``.agents/memory/causality`` so a regression to a cwd-relative lookup
+        shows up here instead of on somebody's machine.
+        """
+        driver = install_merge_drivers._DRIVERS["causal-graph"]
+        assert "scripts/validation/merge_causal_graph.py" in driver["driver"]
+        assert str(_ROOT) not in driver["driver"].split('" ', 1)[-1], (
+            "the script path must stay repo-relative for a fresh clone to work"
+        )
+
+        self._diverge(repo)
+        for setting, value in driver.items():
+            self._git(repo, "config", f"merge.causal-graph.{setting}", value)
+
+        subdirectory = repo / ".agents" / "memory" / "causality"
+        result = self._git(subdirectory, "merge", "feature")
+
         assert result.returncode == 0, result.stdout + result.stderr
         graph = json.loads(
             (repo / ".agents/memory/causality/causal-graph.json").read_text(encoding="utf-8")
@@ -563,6 +652,27 @@ class TestRegistrationIsWiredAndIdempotent:
         monkeypatch.setattr(sys, "executable", "")
 
         assert install_merge_drivers._interpreter() == "python3"
+
+    def test_a_rejected_config_write_exits_two(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """PR #3348 review: ADR-035 makes 2 the configuration-failure code.
+
+        A rejected `git config` write is a configuration failure, not a logic
+        error. This runs from a lefthook hook, where the exit code is the only
+        signal a maintainer gets about which half broke.
+        """
+        from scripts.maintenance import install_merge_drivers
+
+        def reject(args: list[str]) -> subprocess.CompletedProcess[str]:
+            if args[:2] == ["config", "--local"] and "--get" not in args:
+                return subprocess.CompletedProcess(args, 1, "", "permission denied")
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        monkeypatch.setattr(install_merge_drivers, "_git", reject)
+
+        assert install_merge_drivers.install() == 2
+        assert "could not set" in capsys.readouterr().err
 
     def test_installing_twice_writes_once(self, capsys: pytest.CaptureFixture[str]) -> None:
         from scripts.maintenance import install_merge_drivers

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -105,6 +105,18 @@ class TestRecordsWithoutIdentityFieldsAreNotCollapsed:
         assert len(merged["edges"]) == 1
         assert merged["edges"][0]["evidence_count"] == 6
 
+    def test_patterns_key_on_name_and_merge_counters(self) -> None:
+        """Patterns are keyed by name, not id, aligning with the generator."""
+        base = _graph(patterns=[{"name": "shared", "occurrences": 1}])
+        ours = _graph(patterns=[{"name": "shared", "occurrences": 3}])
+        theirs = _graph(patterns=[{"name": "shared", "occurrences": 4}])
+
+        merged = merge_graphs(base, ours, theirs)
+
+        assert len(merged["patterns"]) == 1
+        assert merged["patterns"][0]["name"] == "shared"
+        assert merged["patterns"][0]["occurrences"] == 6
+
 
 class TestUnionSemantics:
     """Both sides survive. Taking one side is what caused the drift."""

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -1,0 +1,359 @@
+"""Tests for the causal graph merge driver and its registration.
+
+Issue #3345: every merge of the default branch conflicted on the generated
+causal graph, and the documented workaround silently deleted graph state. These
+cover the union semantics, the loud-failure contract, and the wiring that keeps
+a `.gitattributes` entry from becoming a no-op.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.validation.merge_causal_graph import (
+    GraphMergeError,
+    _load,
+    main,
+    merge_graphs,
+)
+
+_ROOT = Path(__file__).resolve().parents[2]
+_DRIVER = "scripts/validation/merge_causal_graph.py"
+
+
+def _node(node_id: str, **overrides: Any) -> dict[str, Any]:
+    node = {
+        "id": node_id,
+        "type": "decision",
+        "label": f"node {node_id}",
+        "episodes": [f"episode-{node_id}"],
+        "created": "2026-01-01T00:00:00+00:00",
+    }
+    node.update(overrides)
+    return node
+
+
+def _graph(**overrides: Any) -> dict[str, Any]:
+    graph: dict[str, Any] = {
+        "version": "3",
+        "updated": "2026-01-01T00:00:00+00:00",
+        "nodes": [],
+        "patterns": [],
+        "edges": [],
+    }
+    graph.update(overrides)
+    return graph
+
+
+class TestUnionSemantics:
+    """Both sides survive. Taking one side is what caused the drift."""
+
+    def test_disjoint_nodes_from_both_sides_survive(self) -> None:
+        base = _graph(nodes=[_node("shared")])
+        ours = _graph(nodes=[_node("shared"), _node("ours")])
+        theirs = _graph(nodes=[_node("shared"), _node("theirs")])
+        merged = merge_graphs(base, ours, theirs)
+        assert {n["id"] for n in merged["nodes"]} == {"shared", "ours", "theirs"}
+
+    def test_a_record_present_on_both_sides_appears_once(self) -> None:
+        graph = _graph(nodes=[_node("shared")])
+        merged = merge_graphs(graph, graph, graph)
+        assert [n["id"] for n in merged["nodes"]] == ["shared"]
+
+    def test_edges_key_on_the_triple_they_connect(self) -> None:
+        edge = {"source": "a", "target": "b", "type": "causes", "evidence_count": 1}
+        other = {"source": "a", "target": "b", "type": "enables", "evidence_count": 1}
+        merged = merge_graphs(_graph(), _graph(edges=[edge]), _graph(edges=[other]))
+        assert len(merged["edges"]) == 2
+
+    def test_union_is_independent_of_which_side_git_calls_ours(self) -> None:
+        base = _graph(nodes=[_node("shared")])
+        a = _graph(nodes=[_node("shared"), _node("a")])
+        b = _graph(nodes=[_node("shared"), _node("b")])
+        forward = {n["id"] for n in merge_graphs(base, a, b)["nodes"]}
+        reverse = {n["id"] for n in merge_graphs(base, b, a)["nodes"]}
+        assert forward == reverse
+
+    def test_an_unknown_top_level_key_is_carried_not_dropped(self) -> None:
+        """The schema may grow; a merge must not silently truncate it."""
+        merged = merge_graphs(_graph(), _graph(cohorts=[1]), _graph())
+        assert merged["cohorts"] == [1]
+
+
+class TestCounterReconciliation:
+    """Counters merge three-way. Summing would double-count the shared ancestor."""
+
+    def _counted(self, base: int, ours: int, theirs: int) -> int:
+        edge = {"source": "a", "target": "b", "type": "causes"}
+        merged = merge_graphs(
+            _graph(edges=[{**edge, "evidence_count": base}]),
+            _graph(edges=[{**edge, "evidence_count": ours}]),
+            _graph(edges=[{**edge, "evidence_count": theirs}]),
+        )
+        count = merged["edges"][0]["evidence_count"]
+        assert isinstance(count, int)
+        return count
+
+    def test_both_sides_deltas_apply(self) -> None:
+        assert self._counted(68, 71, 73) == 76
+
+    def test_a_counter_neither_side_touched_is_unchanged(self) -> None:
+        assert self._counted(68, 68, 68) == 68
+
+    def test_one_sided_change_is_not_doubled(self) -> None:
+        assert self._counted(10, 15, 10) == 15
+
+    def test_a_decrease_cannot_drive_the_counter_negative(self) -> None:
+        assert self._counted(4, 0, 0) == 0
+
+
+class TestFieldPolicies:
+    def test_episode_lists_union_and_deduplicate(self) -> None:
+        merged = merge_graphs(
+            _graph(nodes=[_node("n", episodes=["a"])]),
+            _graph(nodes=[_node("n", episodes=["a", "b"])]),
+            _graph(nodes=[_node("n", episodes=["a", "c"])]),
+        )
+        assert merged["nodes"][0]["episodes"] == ["a", "b", "c"]
+
+    def test_created_takes_the_earliest(self) -> None:
+        merged = merge_graphs(
+            _graph(),
+            _graph(nodes=[_node("n", created="2026-05-01T00:00:00+00:00")]),
+            _graph(nodes=[_node("n", created="2026-02-01T00:00:00+00:00")]),
+        )
+        assert merged["nodes"][0]["created"] == "2026-02-01T00:00:00+00:00"
+
+    def test_last_used_takes_the_latest(self) -> None:
+        pattern = {"id": "p", "name": "p"}
+        merged = merge_graphs(
+            _graph(),
+            _graph(patterns=[{**pattern, "last_used": "2026-02-01"}]),
+            _graph(patterns=[{**pattern, "last_used": "2026-05-01"}]),
+        )
+        assert merged["patterns"][0]["last_used"] == "2026-05-01"
+
+    def test_updated_takes_the_latest(self) -> None:
+        merged = merge_graphs(
+            _graph(),
+            _graph(updated="2026-02-01"),
+            _graph(updated="2026-05-01"),
+        )
+        assert merged["updated"] == "2026-05-01"
+
+    def test_a_field_only_one_side_changed_takes_that_side(self) -> None:
+        merged = merge_graphs(
+            _graph(nodes=[_node("n", label="original")]),
+            _graph(nodes=[_node("n", label="original")]),
+            _graph(nodes=[_node("n", label="changed")]),
+        )
+        assert merged["nodes"][0]["label"] == "changed"
+
+
+class TestMalformedInputIsToleratedNotFatal:
+    """A generated file with one bad record should still merge the good ones."""
+
+    def test_a_non_list_collection_is_ignored(self) -> None:
+        merged = merge_graphs(_graph(), _graph(nodes="oops"), _graph(nodes=[_node("n")]))
+        assert [n["id"] for n in merged["nodes"]] == ["n"]
+
+    def test_a_non_object_record_is_dropped(self) -> None:
+        merged = merge_graphs(_graph(), _graph(nodes=["oops", _node("n")]), _graph())
+        assert [n["id"] for n in merged["nodes"]] == ["n"]
+
+    def test_an_empty_ancestor_is_an_add_add_not_an_error(self) -> None:
+        """Git passes an empty ancestor when both sides created the file."""
+        merged = merge_graphs({}, _graph(nodes=[_node("a")]), _graph(nodes=[_node("b")]))
+        assert {n["id"] for n in merged["nodes"]} == {"a", "b"}
+
+
+class TestLoadRefusesWhatItCannotTrust:
+    def test_empty_file_is_an_empty_graph(self, tmp_path: Path) -> None:
+        path = tmp_path / "base.json"
+        path.write_text("", encoding="utf-8")
+        assert _load(path, "ancestor") == {}
+
+    def test_unparseable_file_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "ours.json"
+        path.write_text("{not json", encoding="utf-8")
+        with pytest.raises(GraphMergeError, match="not valid JSON"):
+            _load(path, "ours")
+
+    def test_json_that_is_not_an_object_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "ours.json"
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+        with pytest.raises(GraphMergeError, match="expected an object"):
+            _load(path, "ours")
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(GraphMergeError, match="cannot read"):
+            _load(tmp_path / "absent.json", "theirs")
+
+
+class TestDriverExitContract:
+    """git keys off the exit code: nonzero means leave the conflict alone."""
+
+    def _write(self, tmp_path: Path, name: str, payload: object) -> Path:
+        path = tmp_path / name
+        path.write_text(
+            payload if isinstance(payload, str) else json.dumps(payload),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_successful_merge_exits_zero_and_writes_ours(self, tmp_path: Path) -> None:
+        base = self._write(tmp_path, "base.json", _graph())
+        ours = self._write(tmp_path, "ours.json", _graph(nodes=[_node("a")]))
+        theirs = self._write(tmp_path, "theirs.json", _graph(nodes=[_node("b")]))
+        assert main([str(base), str(ours), str(theirs)]) == 0
+        written = json.loads(ours.read_text(encoding="utf-8"))
+        assert {n["id"] for n in written["nodes"]} == {"a", "b"}
+
+    def test_corrupt_side_exits_one_and_leaves_ours_untouched(self, tmp_path: Path) -> None:
+        """The behavior that stops a silent side-take from deleting graph state."""
+        base = self._write(tmp_path, "base.json", _graph())
+        ours = self._write(tmp_path, "ours.json", _graph(nodes=[_node("a")]))
+        theirs = self._write(tmp_path, "theirs.json", "{corrupt")
+        before = ours.read_text(encoding="utf-8")
+        assert main([str(base), str(ours), str(theirs)]) == 1
+        assert ours.read_text(encoding="utf-8") == before
+
+    def test_corrupt_ours_exits_one(self, tmp_path: Path) -> None:
+        base = self._write(tmp_path, "base.json", _graph())
+        ours = self._write(tmp_path, "ours.json", "{corrupt")
+        theirs = self._write(tmp_path, "theirs.json", _graph())
+        assert main([str(base), str(ours), str(theirs)]) == 1
+
+    def test_missing_input_exits_one(self, tmp_path: Path) -> None:
+        ours = self._write(tmp_path, "ours.json", _graph())
+        theirs = self._write(tmp_path, "theirs.json", _graph())
+        assert main([str(tmp_path / "absent.json"), str(ours), str(theirs)]) == 1
+
+
+class TestGitActuallyUsesTheDriver:
+    """An end-to-end merge, because the unit tests cannot prove git invokes it."""
+
+    def _git(self, repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+
+    @pytest.fixture
+    def repo(self, tmp_path: Path) -> Path:
+        repo = tmp_path / "repo"
+        (repo / ".agents/memory/causality").mkdir(parents=True)
+        (repo / "scripts/validation").mkdir(parents=True)
+        (repo / "scripts/validation/merge_causal_graph.py").write_text(
+            (_ROOT / _DRIVER).read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        (repo / ".gitattributes").write_text(
+            ".agents/memory/causality/causal-graph.json merge=causal-graph\n",
+            encoding="utf-8",
+        )
+        graph = repo / ".agents/memory/causality/causal-graph.json"
+        graph.write_text(json.dumps(_graph(nodes=[_node("shared")])), encoding="utf-8")
+
+        self._git(repo, "init", "-q", ".")
+        self._git(repo, "config", "user.email", "test@example.com")
+        self._git(repo, "config", "user.name", "test")
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-qm", "base")
+        # `checkout -` is unreliable in a fresh repo; pin the trunk name.
+        self._trunk = self._git(repo, "branch", "--show-current").stdout.strip()
+        return repo
+
+    def _diverge(self, repo: Path) -> None:
+        graph = repo / ".agents/memory/causality/causal-graph.json"
+        self._git(repo, "checkout", "-qb", "feature")
+        graph.write_text(
+            json.dumps(_graph(nodes=[_node("shared"), _node("feature")])), encoding="utf-8"
+        )
+        self._git(repo, "commit", "-qam", "feature side")
+        self._git(repo, "checkout", "-q", self._trunk)
+        graph.write_text(
+            json.dumps(_graph(nodes=[_node("shared"), _node("trunk")])), encoding="utf-8"
+        )
+        self._git(repo, "commit", "-qam", "trunk side")
+
+    def test_without_registration_the_merge_conflicts(self, repo: Path) -> None:
+        """The negative control: `.gitattributes` alone is a no-op."""
+        self._diverge(repo)
+        result = self._git(repo, "merge", "feature")
+        assert result.returncode != 0
+        assert "CONFLICT" in result.stdout + result.stderr
+
+    def test_with_registration_the_merge_succeeds_and_keeps_both_sides(self, repo: Path) -> None:
+        self._diverge(repo)
+        self._git(repo, "config", "merge.causal-graph.name", "union")
+        self._git(
+            repo,
+            "config",
+            "merge.causal-graph.driver",
+            f"{sys.executable} scripts/validation/merge_causal_graph.py %O %A %B",
+        )
+        result = self._git(repo, "merge", "feature")
+        assert result.returncode == 0, result.stdout + result.stderr
+        graph = json.loads(
+            (repo / ".agents/memory/causality/causal-graph.json").read_text(encoding="utf-8")
+        )
+        assert {n["id"] for n in graph["nodes"]} == {"shared", "feature", "trunk"}
+
+    def test_a_corrupt_side_still_conflicts_rather_than_taking_ours(self, repo: Path) -> None:
+        graph = repo / ".agents/memory/causality/causal-graph.json"
+        self._git(repo, "checkout", "-qb", "feature")
+        graph.write_text("{corrupt", encoding="utf-8")
+        self._git(repo, "commit", "-qam", "corrupt side")
+        self._git(repo, "checkout", "-q", self._trunk)
+        graph.write_text(
+            json.dumps(_graph(nodes=[_node("shared"), _node("trunk")])), encoding="utf-8"
+        )
+        self._git(repo, "commit", "-qam", "trunk side")
+        self._git(repo, "config", "merge.causal-graph.name", "union")
+        self._git(
+            repo,
+            "config",
+            "merge.causal-graph.driver",
+            f"{sys.executable} scripts/validation/merge_causal_graph.py %O %A %B",
+        )
+        result = self._git(repo, "merge", "feature")
+        assert result.returncode != 0
+        assert "CONFLICT" in result.stdout + result.stderr
+
+
+class TestRegistrationIsWiredAndIdempotent:
+    """A driver nobody registers is a driver that never runs."""
+
+    def test_gitattributes_routes_the_graph_to_the_driver(self) -> None:
+        attributes = (_ROOT / ".gitattributes").read_text(encoding="utf-8")
+        assert ".agents/memory/causality/causal-graph.json merge=causal-graph" in attributes
+
+    def test_the_installer_runs_from_a_hook(self) -> None:
+        """Registration must not depend on a setup step someone can skip."""
+        lefthook = (_ROOT / "lefthook.yml").read_text(encoding="utf-8")
+        assert "scripts/maintenance/install_merge_drivers.py" in lefthook
+
+    def test_the_registered_command_points_at_the_driver(self) -> None:
+        from scripts.maintenance.install_merge_drivers import _DRIVERS
+
+        assert _DRIVER in _DRIVERS["causal-graph"]["driver"]
+        assert _DRIVERS["causal-graph"]["driver"].endswith("%O %A %B")
+
+    def test_installing_twice_writes_once(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from scripts.maintenance import install_merge_drivers
+
+        assert install_merge_drivers.install() == 0
+        capsys.readouterr()
+        assert install_merge_drivers.install() == 0
+        assert capsys.readouterr().out == ""

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -417,6 +417,84 @@ class TestRegistrationIsWiredAndIdempotent:
         assert _DRIVER in _DRIVERS["causal-graph"]["driver"]
         assert _DRIVERS["causal-graph"]["driver"].endswith('"%O" "%A" "%B"')
 
+    def test_the_driver_is_stdlib_only(self) -> None:
+        """The premise of registering a bare interpreter instead of `uv run`.
+
+        If this driver ever imports a third-party package, the registered
+        command stops being sufficient and every clone that has not synced its
+        environment falls back to the text merge.
+        """
+        import ast
+
+        tree = ast.parse((_ROOT / _DRIVER).read_text(encoding="utf-8"))
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                imported.add(node.module.split(".")[0])
+
+        assert imported <= set(sys.stdlib_module_names), imported - set(sys.stdlib_module_names)
+
+    def test_the_registered_command_does_not_route_through_a_package_manager(self) -> None:
+        """A merge must not need uv, a network, or a synced environment.
+
+        Routing the driver through `uv run` fails wherever uv cannot run, and a
+        failed merge driver is not a loud error. Git falls back to the text
+        merge, which is exactly the conflict issue #3345 exists to remove.
+        """
+        from scripts.maintenance.install_merge_drivers import _DRIVERS
+
+        command = _DRIVERS["causal-graph"]["driver"]
+
+        assert not command.startswith("uv ")
+        assert "uv run" not in command
+        assert command.startswith('"')
+
+    def test_the_registered_interpreter_exists_and_runs_the_driver(self, tmp_path: Path) -> None:
+        """The baked path must be a working interpreter, not just a string."""
+        from scripts.maintenance.install_merge_drivers import _DRIVERS
+
+        interpreter = _DRIVERS["causal-graph"]["driver"].split('"')[1]
+
+        assert Path(interpreter).is_file()
+
+        base = tmp_path / "b.json"
+        ours = tmp_path / "o.json"
+        theirs = tmp_path / "t.json"
+        base.write_text(json.dumps({"nodes": [{"id": "a"}]}), encoding="utf-8")
+        ours.write_text(json.dumps({"nodes": [{"id": "a"}, {"id": "b"}]}), encoding="utf-8")
+        theirs.write_text(json.dumps({"nodes": [{"id": "a"}, {"id": "c"}]}), encoding="utf-8")
+
+        result = subprocess.run(
+            [interpreter, str(_ROOT / _DRIVER), *map(str, (base, ours, theirs))],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert len(json.loads(ours.read_text(encoding="utf-8"))["nodes"]) == 3
+
+    def test_the_interpreter_is_posix_separated_for_sh(self) -> None:
+        r"""Git hands the driver string to sh even on Windows, and sh eats
+        backslashes, so a native D:\...\python.exe would arrive mangled."""
+        from scripts.maintenance.install_merge_drivers import _DRIVERS
+
+        assert "\\" not in _DRIVERS["causal-graph"]["driver"]
+
+    def test_an_interpreter_that_cannot_name_itself_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """sys.executable is documented as possibly empty in embedded hosts."""
+        from scripts.maintenance import install_merge_drivers
+
+        monkeypatch.setattr(sys, "executable", "")
+
+        assert install_merge_drivers._interpreter() == "python3"
+
     def test_installing_twice_writes_once(self, capsys: pytest.CaptureFixture[str]) -> None:
         from scripts.maintenance import install_merge_drivers
 

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -134,11 +134,20 @@ class TestUnionSemantics:
         merged = merge_graphs(graph, graph, graph)
         assert [n["id"] for n in merged["nodes"]] == ["shared"]
 
-    def test_edges_key_on_the_triple_they_connect(self) -> None:
+    def test_edges_key_on_the_pair_they_connect(self) -> None:
+        """Edges with the same source/target but different types merge as one.
+
+        The generator (update_causal_graph.py) enforces at most one edge per
+        (source, target) pair, so the merge driver must do the same. When two
+        branches change the type field differently, the merge keeps one record
+        rather than emitting two edges for the same pair.
+        """
         edge = {"source": "a", "target": "b", "type": "causes", "evidence_count": 1}
         other = {"source": "a", "target": "b", "type": "enables", "evidence_count": 1}
         merged = merge_graphs(_graph(), _graph(edges=[edge]), _graph(edges=[other]))
-        assert len(merged["edges"]) == 2
+        assert len(merged["edges"]) == 1
+        assert merged["edges"][0]["source"] == "a"
+        assert merged["edges"][0]["target"] == "b"
 
     def test_union_is_independent_of_which_side_git_calls_ours(self) -> None:
         base = _graph(nodes=[_node("shared")])

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -567,6 +567,11 @@ class TestTopLevelFieldsGoThroughTheSamePolicyTable:
         merged = merge_graphs(base, {"nodes": []}, {"version": "1.0", "nodes": []})
         assert merged["version"] == "1.0"
 
+    def test_version_survives_when_both_sides_omit_it(self) -> None:
+        base = {"version": "1.0", "nodes": []}
+        merged = merge_graphs(base, {"nodes": []}, {"nodes": []})
+        assert merged["version"] == "1.0"
+
     def test_updated_takes_the_later_timestamp(self) -> None:
         merged = merge_graphs(
             {"updated": "2026-01-01T00:00:00Z", "nodes": []},

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -179,6 +179,31 @@ class TestCounterReconciliation:
     def test_a_decrease_cannot_drive_the_counter_negative(self) -> None:
         assert self._counted(4, 0, 0) == 0
 
+    def test_new_shared_record_does_not_double_count(self) -> None:
+        """Both branches independently adding the same record takes max, not sum.
+
+        Regression test for a bug where a record absent from the ancestor but
+        present on both sides with the same counter value would double that
+        value (e.g., 5 and 5 became 10) instead of keeping a single copy.
+        """
+        edge = {"source": "a", "target": "b", "type": "causes", "evidence_count": 5}
+        merged = merge_graphs(
+            _graph(edges=[]),
+            _graph(edges=[edge]),
+            _graph(edges=[edge]),
+        )
+        assert merged["edges"][0]["evidence_count"] == 5
+
+    def test_new_shared_record_with_differing_counts_takes_max(self) -> None:
+        """When no ancestor exists, take the higher count, not the sum."""
+        edge = {"source": "a", "target": "b", "type": "causes"}
+        merged = merge_graphs(
+            _graph(edges=[]),
+            _graph(edges=[{**edge, "evidence_count": 3}]),
+            _graph(edges=[{**edge, "evidence_count": 7}]),
+        )
+        assert merged["edges"][0]["evidence_count"] == 7
+
 
 class TestFieldPolicies:
     def test_episode_lists_union_and_deduplicate(self) -> None:

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -51,6 +51,17 @@ def _graph(**overrides: Any) -> dict[str, Any]:
     return graph
 
 
+# Git invokes merge drivers through sh even on Windows, so a native interpreter
+# path like D:\\hostedtoolcache\\python.exe loses its backslashes to shell
+# escaping. Render it POSIX-style and quote it, matching how this repository
+# feeds interpreter paths to lefthook run strings.
+_PYTHON_POSIX = Path(sys.executable).as_posix()
+_DRIVER_SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "validation" / "merge_causal_graph.py"
+).as_posix()
+_DRIVER_COMMAND = f'"{_PYTHON_POSIX}" "{_DRIVER_SCRIPT}" "%O" "%A" "%B"'
+
+
 class TestUnionSemantics:
     """Both sides survive. Taking one side is what caused the drift."""
 
@@ -174,10 +185,22 @@ class TestMalformedInputIsToleratedNotFatal:
 
 
 class TestLoadRefusesWhatItCannotTrust:
-    def test_empty_file_is_an_empty_graph(self, tmp_path: Path) -> None:
+    def test_an_empty_ancestor_is_an_empty_graph(self, tmp_path: Path) -> None:
+        """Git passes an empty ancestor for an add/add conflict. That is normal."""
         path = tmp_path / "base.json"
         path.write_text("", encoding="utf-8")
-        assert _load(path, "ancestor") == {}
+        assert _load(path, "ancestor", may_be_empty=True) == {}
+
+    def test_an_empty_side_is_refused(self, tmp_path: Path) -> None:
+        """A truncated ours or theirs must not merge cleanly as an empty graph.
+
+        Reading it as {} would delete everything the other side has, which is
+        the silent data loss the driver exists to prevent.
+        """
+        path = tmp_path / "ours.json"
+        path.write_text("   \n", encoding="utf-8")
+        with pytest.raises(GraphMergeError, match="empty"):
+            _load(path, "ours")
 
     def test_unparseable_file_raises(self, tmp_path: Path) -> None:
         path = tmp_path / "ours.json"
@@ -301,7 +324,7 @@ class TestGitActuallyUsesTheDriver:
             repo,
             "config",
             "merge.causal-graph.driver",
-            f"{sys.executable} scripts/validation/merge_causal_graph.py %O %A %B",
+            _DRIVER_COMMAND,
         )
         result = self._git(repo, "merge", "feature")
         assert result.returncode == 0, result.stdout + result.stderr
@@ -325,7 +348,7 @@ class TestGitActuallyUsesTheDriver:
             repo,
             "config",
             "merge.causal-graph.driver",
-            f"{sys.executable} scripts/validation/merge_causal_graph.py %O %A %B",
+            _DRIVER_COMMAND,
         )
         result = self._git(repo, "merge", "feature")
         assert result.returncode != 0
@@ -348,7 +371,7 @@ class TestRegistrationIsWiredAndIdempotent:
         from scripts.maintenance.install_merge_drivers import _DRIVERS
 
         assert _DRIVER in _DRIVERS["causal-graph"]["driver"]
-        assert _DRIVERS["causal-graph"]["driver"].endswith("%O %A %B")
+        assert _DRIVERS["causal-graph"]["driver"].endswith('"%O" "%A" "%B"')
 
     def test_installing_twice_writes_once(self, capsys: pytest.CaptureFixture[str]) -> None:
         from scripts.maintenance import install_merge_drivers
@@ -357,3 +380,65 @@ class TestRegistrationIsWiredAndIdempotent:
         capsys.readouterr()
         assert install_merge_drivers.install() == 0
         assert capsys.readouterr().out == ""
+
+
+class TestTopLevelFieldsGoThroughTheSamePolicyTable:
+    """PR #3348 review: version and updated were one-off special cases.
+
+    Handling them separately from every other field is how a key only one side
+    carried came to be dropped. They now run through the shared field pass.
+    """
+
+    def test_a_key_only_theirs_carries_survives(self) -> None:
+        merged = merge_graphs({}, {"nodes": []}, {"nodes": [], "schema_note": "added upstream"})
+        assert merged["schema_note"] == "added upstream"
+
+    def test_version_survives_when_one_side_omits_it(self) -> None:
+        """Issue #3351: the generator drops version on a fresh write.
+
+        That omission is a generator defect, not a deletion, so it must not
+        propagate into the merge when the other side still has the value.
+        """
+        base = {"version": "1.0", "nodes": []}
+        merged = merge_graphs(base, {"version": "1.0", "nodes": []}, {"nodes": []})
+        assert merged["version"] == "1.0"
+
+    def test_version_survives_when_the_other_side_omits_it(self) -> None:
+        base = {"version": "1.0", "nodes": []}
+        merged = merge_graphs(base, {"nodes": []}, {"version": "1.0", "nodes": []})
+        assert merged["version"] == "1.0"
+
+    def test_updated_takes_the_later_timestamp(self) -> None:
+        merged = merge_graphs(
+            {"updated": "2026-01-01T00:00:00Z", "nodes": []},
+            {"updated": "2026-02-01T00:00:00Z", "nodes": []},
+            {"updated": "2026-03-01T00:00:00Z", "nodes": []},
+        )
+        assert merged["updated"] == "2026-03-01T00:00:00Z"
+
+    def test_a_field_both_sides_removed_stays_removed(self) -> None:
+        """Not every absence is a generator defect. An agreed deletion is a deletion."""
+        merged = merge_graphs({"retired": "old", "nodes": []}, {"nodes": []}, {"nodes": []})
+        assert "retired" not in merged
+
+
+class TestCounterKeepsTheSideThatHasANumber:
+    """PR #3348 review: a malformed counter on one side discarded a good one."""
+
+    @staticmethod
+    def _counted(base: object, ours: object, theirs: object) -> object:
+        merged = merge_graphs(
+            {"nodes": [{"id": "n1", "frequency": base}]} if base is not None else {"nodes": []},
+            {"nodes": [{"id": "n1", "frequency": ours}]},
+            {"nodes": [{"id": "n1", "frequency": theirs}]},
+        )
+        return merged["nodes"][0]["frequency"]
+
+    def test_a_string_on_ours_does_not_discard_a_number_on_theirs(self) -> None:
+        assert self._counted(2, "corrupt", 7) == 7
+
+    def test_a_string_on_theirs_does_not_discard_a_number_on_ours(self) -> None:
+        assert self._counted(2, 7, "corrupt") == 7
+
+    def test_two_malformed_sides_keep_ours(self) -> None:
+        assert self._counted(2, "a", "b") == "a"

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import pytest
 
+from scripts.validation import merge_causal_graph
 from scripts.validation.merge_causal_graph import (
     GraphMergeError,
     _load,
@@ -439,6 +440,28 @@ class TestGitActuallyUsesTheDriver:
 class TestRegistrationIsWiredAndIdempotent:
     """A driver nobody registers is a driver that never runs."""
 
+    def test_the_docstring_names_the_script_lefthook_actually_runs(self) -> None:
+        """PR #3348 review: the docstring credited a script that never runs it.
+
+        A wrong pointer here costs a maintainer the whole debugging session,
+        because the file they are told to inspect has nothing to do with the
+        driver being missing. Read the runner out of lefthook.yml so the claim
+        cannot drift from the wiring again.
+        """
+        lefthook = (_ROOT / "lefthook.yml").read_text(encoding="utf-8")
+        runners = [
+            line.split("python", 1)[1].strip()
+            for line in lefthook.splitlines()
+            if "install_merge_drivers.py" in line and "run:" in line
+        ]
+        assert runners, "lefthook.yml no longer runs install_merge_drivers.py"
+
+        docstring = merge_causal_graph.__doc__ or ""
+        assert runners[0] in docstring, (
+            f"module docstring must name {runners[0]}, the script lefthook runs"
+        )
+        assert "git_hook_policy.py install-merge-drivers" not in docstring
+
     def test_gitattributes_routes_the_graph_to_the_driver(self) -> None:
         attributes = (_ROOT / ".gitattributes").read_text(encoding="utf-8")
         assert ".agents/memory/causality/causal-graph.json merge=causal-graph" in attributes
@@ -568,9 +591,55 @@ class TestTopLevelFieldsGoThroughTheSamePolicyTable:
         assert merged["version"] == "1.0"
 
     def test_version_survives_when_both_sides_omit_it(self) -> None:
+        """The case that actually happens once the defect has run twice.
+
+        Two branches that each regenerated the graph both drop version, so
+        they agree on the omission and neither side can supply it. Without a
+        fallback to the ancestor, merge_graphs strips the field and the value
+        is gone for good: the next merge has no ancestor copy left to recover.
+        """
         base = {"version": "1.0", "nodes": []}
         merged = merge_graphs(base, {"nodes": []}, {"nodes": []})
         assert merged["version"] == "1.0"
+
+    def test_records_recover_the_same_fields_the_document_does(self) -> None:
+        """Recovery is a field policy, so it cannot live at one level only.
+
+        Extending just the top-level key list is how version and updated became
+        one-off special cases the first time. A record that both sides
+        regenerated has to recover the same way the document does.
+        """
+        base = {"nodes": [{"id": "n1", "version": "1.0", "label": "a"}]}
+        regenerated = {"nodes": [{"id": "n1", "label": "a"}]}
+        merged = merge_graphs(base, regenerated, regenerated)
+
+        assert merged["nodes"][0]["version"] == "1.0"
+
+    def test_a_present_side_still_outranks_the_ancestor(self) -> None:
+        """The base fallback is a floor, not a preference. A real bump wins."""
+        base = {"version": "1.0", "nodes": []}
+        bumped = {"version": "2.0", "nodes": []}
+        stripped: dict[str, Any] = {"nodes": []}
+
+        assert merge_graphs(base, bumped, stripped)["version"] == "2.0"
+        assert merge_graphs(base, stripped, bumped)["version"] == "2.0"
+
+    def test_only_prefer_present_fields_are_recovered_from_the_ancestor(self) -> None:
+        """The ancestor reach is deliberately narrow, and this pins the edge.
+
+        Widening it to every ancestor key would resurrect more than version.
+        `updated` is a _LATEST field, and _extreme returns the ancestor value
+        when neither side has one, so an unrestricted recovery would republish
+        a stale timestamp and claim the graph was touched then. Losing the
+        field is honest; backdating it is not. If dropping `updated` on a fresh
+        write turns out to need recovery too, fix the generator (issue #3351),
+        do not backdate here.
+        """
+        base = {"version": "1.0", "updated": "2026-01-01T00:00:00Z", "nodes": []}
+        merged = merge_graphs(base, {"nodes": []}, {"nodes": []})
+
+        assert merged["version"] == "1.0"
+        assert "updated" not in merged
 
     def test_updated_takes_the_later_timestamp(self) -> None:
         merged = merge_graphs(

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -62,6 +62,50 @@ _DRIVER_SCRIPT = (
 _DRIVER_COMMAND = f'"{_PYTHON_POSIX}" "{_DRIVER_SCRIPT}" "%O" "%A" "%B"'
 
 
+class TestRecordsWithoutIdentityFieldsAreNotCollapsed:
+    """Six of the ten patterns in the committed graph carry no ``id``.
+
+    Keying those on the absent field gave every one of them the same empty key,
+    so a union merge kept one and silently dropped five. Caught on real data
+    while merging this branch, not in a fixture.
+    """
+
+    @staticmethod
+    def _pattern(name: str) -> dict[str, object]:
+        return {"name": name, "description": f"Pattern from {name}", "occurrences": 1}
+
+    def test_distinct_id_less_records_all_survive(self) -> None:
+        shared = self._pattern("shared")
+        base = _graph(patterns=[shared])
+        ours = _graph(patterns=[shared, self._pattern("ours-a"), self._pattern("ours-b")])
+        theirs = _graph(patterns=[shared, self._pattern("theirs-a")])
+
+        merged = merge_graphs(base, ours, theirs)
+
+        names = sorted(p["name"] for p in merged["patterns"])
+        assert names == ["ours-a", "ours-b", "shared", "theirs-a"]
+
+    def test_an_identical_id_less_record_is_not_duplicated(self) -> None:
+        """Content keying still matches an untouched record across both sides."""
+        shared = self._pattern("shared")
+        merged = merge_graphs(
+            _graph(patterns=[shared]), _graph(patterns=[shared]), _graph(patterns=[shared])
+        )
+
+        assert len(merged["patterns"]) == 1
+
+    def test_a_partially_keyed_record_still_uses_its_identity_fields(self) -> None:
+        """An edge missing only ``type`` keeps matching on source and target."""
+        base = _graph(edges=[{"source": "a", "target": "b", "evidence_count": 1}])
+        ours = _graph(edges=[{"source": "a", "target": "b", "evidence_count": 3}])
+        theirs = _graph(edges=[{"source": "a", "target": "b", "evidence_count": 4}])
+
+        merged = merge_graphs(base, ours, theirs)
+
+        assert len(merged["edges"]) == 1
+        assert merged["edges"][0]["evidence_count"] == 6
+
+
 class TestUnionSemantics:
     """Both sides survive. Taking one side is what caused the drift."""
 

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -442,3 +442,17 @@ class TestCounterKeepsTheSideThatHasANumber:
 
     def test_two_malformed_sides_keep_ours(self) -> None:
         assert self._counted(2, "a", "b") == "a"
+
+
+class TestTopLevelKeyOrderMatchesTheGeneratedSchema:
+    """PR #3348 review: a merge must not reorder unchanged content.
+
+    The generator always writes nodes, then patterns, then edges. If
+    ``merge_graphs`` emitted a different order, a merge that changed no
+    content would still rewrite the whole file and produce a noisy diff.
+    """
+
+    def test_collections_are_emitted_nodes_then_patterns_then_edges(self) -> None:
+        merged = merge_graphs(_graph(), _graph(), _graph())
+        collection_keys = [key for key in merged if key in {"nodes", "patterns", "edges"}]
+        assert collection_keys == ["nodes", "patterns", "edges"]


### PR DESCRIPTION
## Summary

Every branch that touches the causal graph conflicts on merge, because both sides append machine-written records to one JSON file and git compares it line by line. This resolves the file by content instead.

Fixes #3345

## Why not the workaround the issue recommends

The issue suggests checking out one side and rerunning the generator. That is the drift cause, not the fix.

`update_causal_graph` processes only episode paths staged in the current commit and returns immediately when none are staged. It is incremental, never a rebuild. A merge stages no episodes, and the hook job carries `skip: merge` anyway. So taking one side wholesale discards every node the other side contributed, and the regeneration step restores nothing.

Measured on main before this change: **41 of 242 episodes on disk had no node in the committed graph.** The most recent gaps are from PRs merged this week.

## Why acceptance criterion 2 cannot be met as written

The issue asks for output byte-identical to a fresh generator run. That is unachievable:

- A from-scratch rebuild does not reproduce the committed graph (1991 nodes vs 1634, 6 patterns vs 10, 62 edges vs 53).
- The generator stamps per-node wall-clock `created` timestamps, so two developers rebuilding produce different bytes. Byte-identity would be a second conflict generator, not a fix.

## What this does

Merges the two graphs by content. Records carry stable identities, so the merge is their union:

| Field class | Policy |
|---|---|
| `evidence_count`, `occurrences`, `frequency` | Three-way against the ancestor: `base + (ours - base) + (theirs - base)`, floored at 0. Summing would double-count the shared ancestor. |
| `episodes` | Deduplicated union, sorted. |
| `created` | Earliest. |
| `last_used`, `updated` | Latest. |
| Everything else | Take the side that diverged from base; ours on a true conflict. |

Verified against real data: a base edge at `evidence_count` 68, ours +3, theirs +5, merges to 76, not 68+71+73.

If either side will not parse, the driver exits nonzero and git leaves the conflict for a human. It never silently picks a side.

## Registration is the load-bearing part

A `merge=<name>` attribute is inert on its own. Git resolves the name through `merge.<name>.driver` in local config, which lives in `.git/config` and is never committed. Proven in a scratch repo: the merge conflicted with the attribute alone and succeeded only after `git config`.

So registration runs from pre-commit and a clone self-heals on its first commit. Before that first commit the name resolves to nothing and git runs its default text merge, which is exactly the conflict this repo produces today. The unregistered state degrades to the status quo; it does not corrupt the graph.

## Verification

- 32 new tests: union semantics, counter reconciliation, field policies, malformed-record tolerance, load-time refusal, the driver exit contract, and two end-to-end `git merge` runs in a scratch repo.
- One of those end-to-end tests omits the `git config` step and asserts the merge still conflicts, proving the attribute alone does nothing.
- 844 tests green across the validation and CI suites.
- Three negative controls fired: taking ours instead of the union turned 7 tests red; summing counters instead of three-way reconciliation turned 3 red; swallowing parse errors turned 4 red.
- The installer was run twice against this clone: it registered on the first run and was silent on the second.

## Follow-ups, filed separately

The drift itself (41 orphaned episodes), the generator dropping `version` and `updated` on a fresh write, and two fixture-shaped records committed in the production graph are separate defects. This PR stops new drift; it does not backfill the existing gap.


## Review round four

Four threads, all merited, all fixed in `f8b5f9a35f`.

**Live data loss in `_key`.** It trusted an identity tuple when *any* field was
present, so an edge carrying only `source` keyed to `("a", "")`. Measured: three
such edges all key to the same tuple, the index keeps one, two are dropped.
That is the same collapse the id-less patterns hit, in the one shape this driver
promises to tolerate. Requiring every field routes partial records to the
content fallback, where the worst case is a duplicate. Single-field identities
are unaffected, since `any` and `all` agree on one field.

**Every end-to-end test proved less than it looked.** They registered an
absolute path to the driver in this checkout. The command the installer really
writes carries a repo-relative script path, so neither that form nor the
assumption under it (git runs a merge driver from the top of the working tree)
was covered. A fresh clone would have been the first place either was tried.
The new test registers the real strings and merges from a subdirectory.

**ADR-035 exit codes.** A filesystem write failure is external (3), not logic
(1); a rejected `git config` write is configuration (2). Git reads every nonzero
as "leave the conflict", so this only pays off when a human runs the driver by
hand, which is exactly how the conflict on PR #3354 got resolved this week.

Negative controls, all four fired. The installer exit code was genuinely
unpinned: reverting `2` to `1` left all 62 tests green until the new test landed.

Test count 58 to 63.
