### PR TITLE
fix(validation): write causal graph merges atomically

### DIFF
--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -15365,6 +15365,60 @@
         "episode-2026-07-26-session-3347-resolve-remaining-3347-review-threads"
       ],
       "created": "2026-07-26T02:02:26.671569+00:00"
+    },
+    {
+      "id": "2e95507629ad",
+      "type": "milestone",
+      "label": "milestone: Created and claimed issue #3357 after confirming no existing PR.",
+      "episodes": [
+        "episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge"
+      ],
+      "created": "2026-07-26T03:54:38.685227+00:00"
+    },
+    {
+      "id": "54bff604b702",
+      "type": "milestone",
+      "label": "milestone: Added sibling temporary writes, destination mode preservation, atomic replacement, and primary-plus-secondary error reporting.",
+      "episodes": [
+        "episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge"
+      ],
+      "created": "2026-07-26T03:54:38.685295+00:00"
+    },
+    {
+      "id": "74edafa55d32",
+      "type": "milestone",
+      "label": "milestone: 67 targeted tests pass; Ruff, formatting, and mypy pass for both changed files.",
+      "episodes": [
+        "episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge"
+      ],
+      "created": "2026-07-26T03:54:38.685352+00:00"
+    },
+    {
+      "id": "f00f85ef66f1",
+      "type": "milestone",
+      "label": "milestone: Filled the 2026-07-26 auto-retrospective and persisted three reusable memories.",
+      "episodes": [
+        "episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge"
+      ],
+      "created": "2026-07-26T03:54:38.685407+00:00"
+    },
+    {
+      "id": "a7e66cd22291",
+      "type": "commit",
+      "label": "commit: Commit: 4033554b78",
+      "episodes": [
+        "episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge"
+      ],
+      "created": "2026-07-26T03:54:38.685461+00:00"
+    },
+    {
+      "id": "2a4e05fded44",
+      "type": "outcome",
+      "label": "Outcome: success - Fix atomic causal graph merge writes for issue 3357",
+      "episodes": [
+        "episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge"
+      ],
+      "created": "2026-07-26T03:54:38.685517+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -15419,6 +15419,33 @@
         "episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge"
       ],
       "created": "2026-07-26T03:54:38.685517+00:00"
+    },
+    {
+      "id": "b8dbaa12a4a0",
+      "type": "milestone",
+      "label": "milestone: 68 targeted tests pass; Ruff, formatting, and mypy pass for both changed files.",
+      "episodes": [
+        "episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge"
+      ],
+      "created": "2026-07-26T04:13:25.358473+00:00"
+    },
+    {
+      "id": "1e45190c0837",
+      "type": "milestone",
+      "label": "milestone: Fixed PR #3359 review finding by closing the raw mkstemp descriptor when os.fdopen fails.",
+      "episodes": [
+        "episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge"
+      ],
+      "created": "2026-07-26T04:13:25.358537+00:00"
+    },
+    {
+      "id": "0013cdc2ffb2",
+      "type": "commit",
+      "label": "commit: Commit: c195050067",
+      "episodes": [
+        "episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge"
+      ],
+      "created": "2026-07-26T04:13:25.358593+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/episodes/episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge.json
@@ -1,0 +1,75 @@
+{
+  "id": "episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge",
+  "session": "2026-07-26-session-3357-fix-atomic-causal-graph-merge",
+  "timestamp": "2026-07-26T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Fix atomic causal graph merge writes for issue 3357",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Created and claimed issue #3357 after confirming no existing PR.",
+      "caused_by": [
+        "e005"
+      ],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added sibling temporary writes, destination mode preservation, atomic replacement, and primary-plus-secondary error reporting.",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "67 targeted tests pass; Ruff, formatting, and mypy pass for both changed files.",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Filled the 2026-07-26 auto-retrospective and persisted three reusable memories.",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 4033554b78",
+      "caused_by": [],
+      "leads_to": [
+        "e001"
+      ]
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 8
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3357-fix-atomic-causal-graph-merge.json
@@ -12,7 +12,7 @@
       "type": "milestone",
       "content": "Created and claimed issue #3357 after confirming no existing PR.",
       "caused_by": [
-        "e005"
+        "e008"
       ],
       "leads_to": [
         "e002"
@@ -50,7 +50,9 @@
       "caused_by": [
         "e003"
       ],
-      "leads_to": []
+      "leads_to": [
+        "e006"
+      ]
     },
     {
       "id": "e005",
@@ -58,6 +60,40 @@
       "type": "commit",
       "content": "Commit: 4033554b78",
       "caused_by": [],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "68 targeted tests pass; Ruff, formatting, and mypy pass for both changed files.",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fixed PR #3359 review finding by closing the raw mkstemp descriptor when os.fdopen fails.",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: c195050067",
+      "caused_by": [
+        "e005"
+      ],
       "leads_to": [
         "e001"
       ]
@@ -68,7 +104,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
+    "commits": 2,
     "files_changed": 8
   },
   "lessons": []

--- a/.agents/retrospective/2026-07-26-auto-retro.md
+++ b/.agents/retrospective/2026-07-26-auto-retro.md
@@ -44,7 +44,7 @@
    then reran the failed PR validation job.
 10. Merged #3348 at `f8b5f9a35f` after required CI and thread gates passed.
 11. Probed an atomic-write follow-up, found and corrected mode loss, and reached
-    67 focused tests with clean Ruff and mypy results.
+    68 focused tests with clean Ruff and mypy results.
 12. Deleted the accidentally recreated #3348 branch and opened issue #3357 for
     the focused follow-up.
 
@@ -151,7 +151,8 @@ Content-only verification was incomplete.
 - Remote SHA comparisons preserved concurrent commits `a20e67fa3c`,
   `bf60eab071`, `434721b64d`, and `f8b5f9a35f`.
 - The atomic-write follow-up now covers replace failure, partial writes, close
-  failure, cleanup failure, and mode preservation across 67 focused tests.
+  failure, cleanup failure, descriptor ownership, and mode preservation across
+  68 focused tests.
 
 ### What Could Improve
 

--- a/.agents/retrospective/2026-07-26-auto-retro.md
+++ b/.agents/retrospective/2026-07-26-auto-retro.md
@@ -1,0 +1,364 @@
+# Retrospective: PR autofix queue, 2026-07-26
+
+## Session Info
+- **Date**: 2026-07-26
+- **Agents**: Copilot CLI, pr-comment-responder, merge-resolver, retrospective
+- **Task Type**: Bug
+- **Outcome**: Complete. Eleven queued PRs merged. Issue #3357 tracks the
+  atomic-write defect found in the merged causal-graph driver.
+
+## Phase 0: Data Gathering
+
+### 4-Step Debrief
+
+- **Observe**: The queue merged PRs #3326, #3327, #3334, #3336, #3337,
+  #3338, #3339, #3340, #3344, #3347, and #3348. PR #3348 required five
+  review rounds, a documented commit-limit bypass, and concurrent-commit
+  reconciliation through `f8b5f9a35f`.
+- **Respond**: The session resolved every review thread, reran the failed PR
+  validation job after adding `commit-limit-bypass`, and merged #3348 after
+  required CI passed. It then deleted an accidentally recreated remote branch
+  and opened issue #3357 for the unmerged atomic-write correction.
+- **Analyze**: Live-state gates, completion gates, and remote-head checks
+  preserved concurrent commits. A failed fetch followed by a push recreated a
+  branch GitHub had deleted after merge. Content-only atomic-write tests also
+  missed a mode change from `0644` to `0600`.
+- **Apply**: Treat failed fetches and missing expected refs as push blockers.
+  Audit delegated files and outcomes. Test atomic replacement for content,
+  cleanup, close failures, and destination metadata.
+
+### Execution Trace
+
+1. Triaged the open queue and processed land-ready PRs before thread work.
+2. Merged ten PRs after fresh live-state and four-condition completion gates.
+3. Isolated PR #3347 in a worktree after the shared checkout changed.
+4. Found that a #3348 responder changed retrospective and Serena artifacts
+   instead of resolving the assigned final thread.
+5. Removed the unrelated artifacts and preserved `.serena/project.yml`.
+6. Corrected the inaccurate causal-graph key comment and resolved all 16
+   review threads.
+7. Merged current `main` into #3348 after PR #3347 landed.
+8. Incorporated four later review fixes for ancestor recovery, counter
+   semantics, edge identity, malformed records, and exit-code behavior.
+9. Used `commit-limit-bypass` after review churn pushed #3348 past 20 commits,
+   then reran the failed PR validation job.
+10. Merged #3348 at `f8b5f9a35f` after required CI and thread gates passed.
+11. Probed an atomic-write follow-up, found and corrected mode loss, and reached
+    67 focused tests with clean Ruff and mypy results.
+12. Deleted the accidentally recreated #3348 branch and opened issue #3357 for
+    the focused follow-up.
+
+### Outcome Classification
+
+- **Glad**: Eleven PRs merged without overwriting concurrent branch work.
+- **Sad**: A stale push recreated a deleted branch, and the atomic-write fix
+  missed #3348's merge by one race.
+- **Mad**: None. The defect was preserved as tested code and issue #3357.
+
+## Phase 1: Insights Generated
+
+### Five Whys: Delegated work left the assigned PR path
+
+1. Why did the responder fail to finish #3348? It created unrelated
+   retrospective and Serena artifacts.
+2. Why did that output survive until review? Its return value was inspected
+   after execution, not constrained by a changed-file scope check.
+3. Why was a return value insufficient? A plausible narrative does not prove
+   that the assigned thread changed state.
+4. Why was thread state the better verifier? The task's acceptance condition
+   was a zero unresolved-thread count, not artifact creation.
+5. Why did recovery succeed? The branch diff exposed the unrelated files
+   before they were pushed.
+
+**Root cause**: Delegated PR work lacked an artifact-level scope and outcome
+audit. This maps to FM-7, Self-Contained Agent Delegation Failure.
+
+### Five Whys: The merge-resolver helper failed to create its worktree
+
+1. Why did the helper fail? The PR branch was already checked out.
+2. Why was the branch already checked out? The primary checkout owned #3348.
+3. Why did the helper need another worktree? Its default workflow isolates
+   conflict resolution by checking out the same branch elsewhere.
+4. Why was isolation unnecessary here? A trial merge completed cleanly with
+   no unmerged files.
+5. Why was recovery safe? The existing `.serena/project.yml` edit stayed
+   unstaged, and validation covered the merged result.
+
+**Root cause**: The helper's isolated-worktree path did not fit a branch
+already owned by the current checkout. This was an efficiency failure, not a
+correctness failure.
+
+### Five Whys: A deleted remote branch was recreated
+
+1. Why did the #3348 branch reappear after merge? A later push recreated it.
+2. Why did the push run after GitHub deleted the branch? The local workflow
+   continued from a stale branch snapshot.
+3. Why was the snapshot stale? A fetch failed before the push.
+4. Why did work continue after the failed fetch? The command chain did not
+   make fetch success a blocking precondition.
+5. Why was deletion recovery needed? Push safety checked commit identity but
+   not the existence and freshness of the remote ref.
+
+**Root cause**: Push authorization depended on stale local state after a failed
+fetch. This maps to FM-5, Premature Merge and Deploy, as a destructive
+shared-branch near miss.
+
+### Five Whys: The first atomic-write fix changed file mode
+
+1. Why did mode change from `0644` to `0600`? `mkstemp()` created the temporary
+   file with owner-only permissions.
+2. Why did replacement keep that mode? `os.replace()` moves the temporary
+   inode and its metadata.
+3. Why did tests miss the change? They asserted merged content and failure
+   cleanup only.
+4. Why was content treated as the full contract? The design considered
+   atomicity but not destination metadata.
+5. Why was the issue found before commit? An empirical probe inspected mode
+   bits after replacement.
+
+**Root cause**: The atomic-write contract omitted destination metadata.
+Content-only verification was incomplete.
+
+### Patterns and Shifts
+
+- Remote-head checks repeatedly caught or guarded concurrent branch movement.
+- New review rounds arrived after earlier threads were resolved. Thread count
+  had to be re-read after every push.
+- Comment accuracy mattered. `_COLLECTIONS` used node `id`, pattern `name`,
+  and the edge triple, not a single hash rule.
+- Generated causal-graph conflicts became clean merges once the registered
+  content merge driver was active.
+- A failed prerequisite must stop the mutation chain. Continuing after a
+  failed fetch converted a cleanup action into branch recreation.
+- Atomic replacement changes inode metadata unless the implementation copies
+  the required destination properties.
+
+### Learning Matrix
+
+| Category | Learning |
+|----------|----------|
+| Continue | Run live-state and completion gates immediately before actions. |
+| Change | Audit delegate file changes and the real PR outcome before acceptance. |
+| Stop | Pushing after any failed fetch or missing expected remote ref. |
+| Start | Probe atomic replacement for metadata, partial writes, and close errors. |
+
+### What Went Well
+
+- PR #3347 merged only after 18 threads resolved and its completion gate
+  passed.
+- PR #3348 merged after all later review rounds, required CI, and a documented
+  commit-limit bypass.
+- Remote SHA comparisons preserved concurrent commits `a20e67fa3c`,
+  `bf60eab071`, `434721b64d`, and `f8b5f9a35f`.
+- The atomic-write follow-up now covers replace failure, partial writes, close
+  failure, cleanup failure, and mode preservation across 67 focused tests.
+
+### What Could Improve
+
+- The delegated #3348 responder should have been checked against its assigned
+  files and unresolved-thread count before its output was accepted.
+- The push that recreated the deleted branch should have stopped when its
+  preceding fetch failed.
+- The first atomic-write test should have asserted file mode, not content
+  alone. The missing assertion allowed a `0644` to `0600` regression.
+- The assistant sent a stopping response while a required CI watcher still
+  ran. Autofix was not complete at that point.
+
+## Phase 2: Diagnosis
+
+### Successes (Tag: helpful)
+| Strategy | Evidence | Impact | Atomicity |
+|----------|----------|--------|-----------|
+| Fresh live-state gate before PR action | #3348 returned `Data.action=ACT` before the thread reply | 10 | 98% |
+| Remote-head comparison before push | #3348 remote `403adeb3f5` matched merge commit parent | 10 | 98% |
+| Four-condition completion gate | Eleven PRs merged only after branch, CI, threads, and merge state passed | 10 | 96% |
+| Empirical metadata probe | Detected mode change from `0644` to `0600` before commit | 9 | 97% |
+
+### Failures (Tag: harmful)
+| Strategy | Error Type | Root Cause | Prevention | Atomicity |
+|----------|------------|------------|------------|-----------|
+| Accept delegated output before scope audit | FM-7 delegation failure | Narrative output did not prove thread completion | Compare changed files and unresolved-thread count | 96% |
+| Stop while CI watcher remained active | Process control near miss | Long-running check was treated as a stopping point | Finalize only after completion gate or blocker | 95% |
+| Invoke isolated resolver on checked-out branch | Tool-fit error | Helper needed a second checkout of an owned branch | Use a clean in-place trial merge first | 90% |
+| Push after failed fetch | FM-5 shared-branch near miss | Stale local state authorized a remote mutation | Require successful fetch and expected ref existence | 98% |
+| Test atomic content without metadata | Contract omission | Replacement inode metadata was not part of assertions | Assert required metadata after replacement | 97% |
+
+### Near Misses
+| What Almost Failed | Recovery | Learning |
+|--------------------|----------|----------|
+| Merge before required CI completed, FM-5 | Completion gate blocked merge | Never merge from `CanMerge` or thread count alone. |
+| Concurrent agents overwrote branch work | Remote SHA matched before each push | A push needs a live branch ownership check. |
+| Unrelated `.serena/project.yml` was staged | Explicit path staging left it unstaged | Stage only task files in shared checkouts. |
+| Delegate artifacts entered PR #3348 | Scope audit removed them before push | Agent output is evidence to inspect, not authority. |
+| Deleted #3348 branch was left recreated | Live remote inspection exposed it and deletion restored state | Failed fetches block later pushes. |
+| Atomic replacement weakened permissions | Mode probe exposed `0644` to `0600` before commit | Metadata belongs in the write contract. |
+
+## Phase 3: Decisions
+
+### Action Classification
+
+| Action | Decision | Evidence |
+|--------|----------|----------|
+| Keep | Live-state gate and completion gate | Ten safe merges and no premature merge |
+| Keep | Remote-head SHA checks | Concurrent work survived on #3340, #3347, and #3348 |
+| Drop | Accepting delegated work from narrative alone | #3348 responder missed the assigned thread |
+| Add | Changed-file and outcome audit after delegation | The audit isolated unrelated artifacts |
+| Add | Failed-fetch stop before any push | A stale push recreated the deleted #3348 branch |
+| Add | Metadata checks for atomic replacement | First probe found mode loss |
+| Modify | Try a clean in-place base merge before a second worktree | #3348 merged `main` without conflicts |
+
+### SMART Validation
+
+- **Delegation scope audit**: After each delegated PR task, inspect changed
+  files and re-query the assigned acceptance condition before using its
+  output. The check is specific, takes one command pair, and runs immediately.
+- **Push ownership check**: Before each push, compare live `headRefOid` with
+  the expected local parent. A failed fetch, missing ref, or mismatch blocks
+  the push.
+- **Autofix stop rule**: Do not send a final response while a required CI
+  watcher is active. Resume after notification and run the completion gate.
+- **Atomic-write contract**: Verify unchanged destination content on write,
+  close, and replace failures. Verify cleanup and destination mode on success.
+
+### Action Sequence
+
+1. Query the PR's live state.
+2. Assign or perform one bounded action.
+3. Audit changed files and the action's acceptance condition.
+4. Validate the smallest relevant test set and system-boundary metadata.
+5. Fetch successfully and compare the remote head with the expected commit.
+6. Push, re-read threads and CI, then run the completion gate.
+7. Merge only after all four conditions pass.
+
+## Phase 4: Extracted Learnings
+
+### Learning 1
+- **Statement**: Audit delegated file changes against the assigned PR outcome.
+- **Atomicity Score**: 96%
+- **Evidence**: PR #3348 responder created unrelated artifacts and left its thread open.
+- **Skill Operation**: ADD
+- **Target Skill ID**: pr-review-delegated-work-scope-audit
+
+### Learning 2
+- **Statement**: Compare the live remote head before every PR push.
+- **Atomicity Score**: 98%
+- **Evidence**: Concurrent updates occurred on PRs #3340, #3347, and #3348.
+- **Skill Operation**: UPDATE
+- **Target Skill ID**: pr-comment-005-branch-state-verification
+
+### Learning 3
+- **Statement**: End autofix only after its completion gate returns.
+- **Atomicity Score**: 95%
+- **Evidence**: A final response was sent while #3348 CI still ran.
+- **Skill Operation**: TAG
+- **Target Skill ID**: pr-autofix
+
+### Learning 4
+- **Statement**: Stop a push chain when fetch fails or the expected ref is missing.
+- **Atomicity Score**: 98%
+- **Evidence**: A stale push recreated #3348's branch after GitHub deleted it.
+- **Skill Operation**: UPDATE
+- **Target Skill ID**: pr-comment-005-branch-state-verification
+
+### Learning 5
+- **Statement**: Preserve destination metadata during atomic file replacement.
+- **Atomicity Score**: 97%
+- **Evidence**: The first #3357 probe changed mode from `0644` to `0600`.
+- **Skill Operation**: ADD
+- **Target Skill ID**: atomic-replace-preserve-metadata
+
+## Skillbook Updates
+
+### ADD
+```json
+{
+  "skill_id": "pr-review-delegated-work-scope-audit",
+  "statement": "Audit delegated file changes against the assigned PR outcome.",
+  "context": "After delegated PR review, CI fix, or thread response work.",
+  "evidence": "PR #3348 scope diversion on 2026-07-26.",
+  "atomicity": 96
+}
+```
+
+```json
+{
+  "skill_id": "atomic-replace-preserve-metadata",
+  "statement": "Preserve destination metadata during atomic file replacement.",
+  "context": "When changing an in-place write to temporary-file plus os.replace.",
+  "evidence": "Issue #3357 mode regression probe on 2026-07-26.",
+  "atomicity": 97
+}
+```
+
+### UPDATE
+
+| Skill ID | Current | Proposed | Why |
+|----------|---------|----------|-----|
+| pr-comment-005-branch-state-verification | Compare live remote head before pushes | Also stop on failed fetch or missing expected ref | A stale push recreated the deleted #3348 branch |
+
+### TAG
+
+| Skill ID | Tag | Evidence | Impact |
+|----------|-----|----------|--------|
+| pr-autofix | completion-gate-before-final | #3348 CI watcher remained active | Prevents premature stopping and merge |
+
+### REMOVE
+
+| Skill ID | Reason | Evidence |
+|----------|--------|----------|
+| None | No stored skill was disproven | Session evidence supported current gates |
+
+## Deduplication Check
+
+| New Skill | Most Similar | Similarity | Decision |
+|-----------|--------------|------------|----------|
+| pr-review-delegated-work-scope-audit | FM-7 Self-Contained Agent Delegation Failure | 65% | Add PR-specific outcome audit |
+| remote-head-before-push | pr-comment-005-branch-state-verification | 85% | Update existing memory |
+| completion-gate-before-final | pr-autofix completion gate | 100% | Tag existing skill, no duplicate |
+| atomic-replace-preserve-metadata | atomic write implementation guidance | 55% | Add tested metadata rule |
+
+## Failure Patterns
+
+- **FM-5 Premature Merge and Deploy, near miss**: A push continued after a
+  failed fetch and recreated the deleted #3348 branch. Live inspection and
+  explicit deletion restored the merged state.
+- **FM-7 Self-Contained Agent Delegation Failure, occurred**: Delegated agents
+  created retrospective and Serena artifacts outside their assigned code
+  review scope. Changed-file audits quarantined those artifacts.
+- **FM-4 False Completion Markers, avoided after correction**: An earlier
+  response treated an active CI waiter as a stopping point. The workflow
+  resumed, ran the completion gate, and merged #3348.
+- **FM-9 Confident-Incorrectness Recurrence, near miss**: The first atomic
+  replacement looked correct under content-only tests but changed destination
+  mode. A direct metadata probe disproved the assumption before commit.
+
+## Phase 5: Persist and Close
+
+### Memory Persistence
+
+- Updated `pr-comment-005-branch-state-verification` with failed-fetch and
+  missing-ref stop conditions.
+- Added `delegated-pr-work-scope-audit` for post-delegation file and outcome
+  checks.
+- Added `atomic-replace-preserve-metadata` with the `0644` to `0600` evidence.
+
+### + / Delta
+
+- **+** Live-state gates and remote SHA checks preserved concurrent commits
+  across eleven merged PRs.
+- **Delta** Prerequisite failure handling must be mechanical. A failed fetch
+  cannot be followed by a push.
+
+### ROTI
+
+- **8/10**. The queue reached zero open PRs and exposed two reusable safety
+  rules. Branch recreation and delegated scope drift added recovery work.
+
+### Helped, Hindered, Hypothesis
+
+- **Helped**: Fresh PR state, remote SHA comparison, targeted tests, and direct
+  filesystem probes.
+- **Hindered**: Asynchronous reviewer rounds, delegated scope drift, and stale
+  local state after a failed fetch.
+- **Hypothesis**: Making fetch success, expected-ref existence, and metadata
+  assertions blocking gates will remove both recovery classes in future runs.

--- a/.agents/retrospective/INDEX.md
+++ b/.agents/retrospective/INDEX.md
@@ -13,3 +13,4 @@
 | 2026-07-03 | [2026-07-03-auto-retro.md](2026-07-03-auto-retro.md) | Auto-generated session retro |
 | 2026-07-19 | [2026-07-19-auto-retro.md](2026-07-19-auto-retro.md) | Auto-generated session retro |
 | 2026-07-25 | [2026-07-25-adr057-normalization.md](2026-07-25-adr057-normalization.md) | Auto-generated session retro |
+| 2026-07-26 | [2026-07-26-auto-retro.md](2026-07-26-auto-retro.md) | Auto-generated session retro |

--- a/.agents/sessions/2026-07-26-session-3357-fix-atomic-causal-graph-merge.json
+++ b/.agents/sessions/2026-07-26-session-3357-fix-atomic-causal-graph-merge.json
@@ -1,0 +1,139 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3357,
+    "date": "2026-07-26",
+    "branch": "fix/3357-atomic-causal-graph-write",
+    "startingCommit": "aaaf9081f5",
+    "objective": "Fix atomic causal graph merge writes for issue 3357"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP active; initial_instructions returned successfully"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena initial_instructions read after session initialization"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read; confirmed read-only status"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "session-init and github skill script catalogs loaded"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory usage-mandatory read"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded PR branch-state and delegated-work scope audit memories"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/3357-atomic-causal-graph-write"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/3357-atomic-causal-graph-write"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status inspected before branch creation and commit"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "aaaf9081f5"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST session-start and session-end fields completed"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md remained unchanged"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Updated branch-state memory and added atomic replacement memory"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 checked 5 retrospective and memory files with 0 issues"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Code committed as 4033554b78; session artifacts staged for closing commit"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "67 focused tests pass; Ruff, format check, and mypy pass"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue #3357 created and claimed"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": ".agents/retrospective/2026-07-26-auto-retro.md filled"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "phase": "issue",
+      "summary": "Created and claimed issue #3357 after confirming no existing PR."
+    },
+    {
+      "phase": "implementation",
+      "summary": "Added sibling temporary writes, destination mode preservation, atomic replacement, and primary-plus-secondary error reporting."
+    },
+    {
+      "phase": "validation",
+      "summary": "67 targeted tests pass; Ruff, formatting, and mypy pass for both changed files."
+    },
+    {
+      "phase": "retrospective",
+      "summary": "Filled the 2026-07-26 auto-retrospective and persisted three reusable memories."
+    }
+  ],
+  "endingCommit": "4033554b78",
+  "nextSteps": [
+    "Push fix/3357-atomic-causal-graph-write and open a PR that fixes #3357.",
+    "Merge only after required CI and review-thread gates pass."
+  ]
+}

--- a/.agents/sessions/2026-07-26-session-3357-fix-atomic-causal-graph-merge.json
+++ b/.agents/sessions/2026-07-26-session-3357-fix-atomic-causal-graph-merge.json
@@ -94,7 +94,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Code committed as 4033554b78; session artifacts staged for closing commit"
+        "Evidence": "Code committed as 4033554b78"
       },
       "validationPassed": {
         "level": "MUST",

--- a/.agents/sessions/2026-07-26-session-3357-fix-atomic-causal-graph-merge.json
+++ b/.agents/sessions/2026-07-26-session-3357-fix-atomic-causal-graph-merge.json
@@ -94,12 +94,12 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Code committed as 4033554b78; session artifacts staged for closing commit"
+        "Evidence": "Atomic-write fixes committed as 4033554b78 and c195050067"
       },
       "validationPassed": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "67 focused tests pass; Ruff, format check, and mypy pass"
+        "Evidence": "68 focused tests pass; Ruff, format check, and mypy pass"
       },
       "tasksUpdated": {
         "level": "SHOULD",
@@ -124,14 +124,18 @@
     },
     {
       "phase": "validation",
-      "summary": "67 targeted tests pass; Ruff, formatting, and mypy pass for both changed files."
+      "summary": "68 targeted tests pass; Ruff, formatting, and mypy pass for both changed files."
     },
     {
       "phase": "retrospective",
       "summary": "Filled the 2026-07-26 auto-retrospective and persisted three reusable memories."
+    },
+    {
+      "phase": "review",
+      "summary": "Fixed PR #3359 review finding by closing the raw mkstemp descriptor when os.fdopen fails."
     }
   ],
-  "endingCommit": "4033554b78",
+  "endingCommit": "c195050067",
   "nextSteps": [
     "Push fix/3357-atomic-causal-graph-write and open a PR that fixes #3357.",
     "Merge only after required CI and review-thread gates pass."

--- a/.serena/memories/memory-index.md
+++ b/.serena/memories/memory-index.md
@@ -19,7 +19,7 @@
 [Scripting and Testing]
 |powershell ps1 psm1 module pester test discovery isolation variable scope script: [skills-powershell-index](skills-powershell-index.md) (443), [skills-pester-testing-index](skills-pester-testing-index.md) (181), [powershell/pester-variable-scoping](powershell/pester-variable-scoping.md) (497), [powershell/powershell-variable-shadowing-detection](powershell/powershell-variable-shadowing-detection.md) (665), [patterns/pattern-thin-workflows](patterns/pattern-thin-workflows.md) (1373)
 |bash exit code cross-language contract AUTOFIX pre-commit hook: [skills-bash-integration-index](skills-bash-integration-index.md) (110)
-|copilot hook generation matcher shim stale cleanup NO-REGEN windows transaction fail closed root: [copilot-hook-generation-invariants](copilot-hook-generation-invariants.md) (1809)
+|copilot hook generation matcher shim stale cleanup NO-REGEN windows transaction fail closed root: [copilot-hook-generation-invariants](copilot-hook-generation-invariants.md) (1837)
 |test exit code pytest pester error failed passed block commit: [testing/testing-exit-code-interpretation](testing/testing-exit-code-interpretation.md) (628)
 |regex pattern match escape lookahead anchor quantifier: [utilities/utilities-regex](utilities/utilities-regex.md) (548)
 

--- a/.serena/memories/pr-review/delegated-pr-work-scope-audit.md
+++ b/.serena/memories/pr-review/delegated-pr-work-scope-audit.md
@@ -1,0 +1,32 @@
+# Skill: Audit Delegated PR Work Before Acceptance
+
+## Statement
+
+Compare a delegated agent's changed files and completed actions with its assigned PR scope before accepting the result.
+
+## Trigger
+
+After any delegated PR review, CI fix, or thread-response task returns.
+
+## Action
+
+1. Inspect the agent result and `git status --short` or the branch diff.
+2. Confirm every changed file supports the assigned PR action.
+3. Isolate or discard unrelated artifacts before continuing.
+4. Re-check the original completion condition, such as unresolved thread count.
+
+## Evidence
+
+PR #3348's responder was assigned the final review thread but created retrospective and Serena artifacts instead. The scope audit caught the diversion, preserved the existing `.serena/project.yml` change, and returned work to the remaining thread.
+
+## Failure Mode
+
+Maps to FM-7, Self-Contained Agent Delegation Failure. A delegate can return plausible output without completing the assigned action.
+
+## Atomicity
+
+**Score**: 96%
+
+## Category
+
+pr-comment-responder

--- a/.serena/memories/pr-review/pr-comment-005-branch-state-verification.md
+++ b/.serena/memories/pr-review/pr-comment-005-branch-state-verification.md
@@ -14,6 +14,12 @@ Before any file modification during PR comment response.
 2. Confirm output matches expected PR branch
 3. If mismatch, checkout correct branch before proceeding
 
+## Concurrent Push Extension
+
+Before every push, compare the PR's live `headRefOid` with the local commit that was last fetched or extended. Stop when they differ. A failed fetch or a missing expected remote ref also blocks the push. Pushing from a stale snapshot can recreate a branch that GitHub deleted after merge.
+
+**Evidence**: PRs #3340, #3347, and #3348 had concurrent branch updates. SHA checks preserved those commits and prevented overwrite.
+
 ## Benefit
 
 Prevents edits to wrong branch when branch checkouts fail silently with uncommitted changes.

--- a/.serena/memories/validation/atomic-replace-preserve-metadata.md
+++ b/.serena/memories/validation/atomic-replace-preserve-metadata.md
@@ -1,0 +1,32 @@
+# Skill: Preserve Destination Metadata During Atomic Replacement
+
+## Statement
+
+When replacing an existing file through a sibling temporary file, copy required destination metadata before `os.replace()`.
+
+## Trigger
+
+Any fix that changes an in-place write to temporary-file plus atomic replacement.
+
+## Action
+
+1. Write the complete payload to a sibling temporary file.
+2. Preserve required metadata, including POSIX mode bits, from the destination.
+3. Replace the destination only after the temporary write and close succeed.
+4. Test content safety on write and replace failures, temporary cleanup, and metadata preservation.
+
+## Evidence
+
+Issue #3357 changed the causal-graph merge driver from direct `Path.write_text()` to atomic replacement. An empirical probe found the first implementation changed mode `0644` to `0600`; copying `stat.S_IMODE(path.stat().st_mode)` before replacement fixed it.
+
+## Failure Mode
+
+Content-only tests can approve an atomic replacement that silently changes permissions or other required metadata.
+
+## Atomicity
+
+**Score**: 97%
+
+## Category
+
+validation

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -36,7 +36,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import stat
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any, TypeAlias
 
@@ -72,6 +75,38 @@ _PREFER_PRESENT = frozenset({"version"})
 
 class GraphMergeError(Exception):
     """An input could not be read or was not a causal graph."""
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Replace ``path`` only after its full content reaches a sibling file."""
+    fd, temporary = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        handle = os.fdopen(fd, "w", encoding="utf-8")
+        try:
+            handle.write(text)
+        except OSError as write_error:
+            try:
+                handle.close()
+            except OSError as close_error:
+                message = (
+                    f"{write_error.strerror or write_error}; failed to close temporary "
+                    f"file {temporary}: {close_error}"
+                )
+                raise OSError(write_error.errno, message) from write_error
+            raise
+        handle.close()
+        os.chmod(temporary, stat.S_IMODE(path.stat().st_mode))
+        os.replace(temporary, path)
+    except OSError as primary:
+        try:
+            Path(temporary).unlink(missing_ok=True)
+        except OSError as cleanup:
+            message = (
+                f"{primary.strerror or primary}; failed to remove temporary file "
+                f"{temporary}: {cleanup}"
+            )
+            raise OSError(primary.errno, message) from primary
+        raise
 
 
 def _load(path: Path, label: str, *, may_be_empty: bool = False) -> dict[str, Any]:
@@ -335,7 +370,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Return 0 on a written merge, 1 when git must leave the conflict alone."""
+    """Return 0 on success, 1 for invalid input, or 3 for a write failure."""
     args = parse_args(argv)
     try:
         merged = merge_graphs(
@@ -343,7 +378,7 @@ def main(argv: list[str] | None = None) -> int:
             _load(args.ours, "ours"),
             _load(args.theirs, "theirs"),
         )
-        args.ours.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
+        _atomic_write_text(args.ours, json.dumps(merged, indent=2) + "\n")
     except GraphMergeError as exc:
         print(f"ERROR: causal graph merge driver: {exc}", file=sys.stderr)
         print("Leaving the conflict in place; resolve it by hand.", file=sys.stderr)

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -81,7 +81,18 @@ def _atomic_write_text(path: Path, text: str) -> None:
     """Replace ``path`` only after its full content reaches a sibling file."""
     fd, temporary = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
     try:
-        handle = os.fdopen(fd, "w", encoding="utf-8")
+        try:
+            handle = os.fdopen(fd, "w", encoding="utf-8")
+        except OSError as fdopen_error:
+            try:
+                os.close(fd)
+            except OSError as close_error:
+                message = (
+                    f"{fdopen_error.strerror or fdopen_error}; failed to close "
+                    f"temporary file descriptor {fd}: {close_error}"
+                )
+                raise OSError(fdopen_error.errno, message) from fdopen_error
+            raise
         try:
             handle.write(text)
         except OSError as write_error:

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -9,10 +9,12 @@ a `.gitattributes` entry from becoming a no-op.
 from __future__ import annotations
 
 import json
+import os
+import stat
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 import pytest
 
@@ -357,6 +359,16 @@ class TestDriverExitContract:
         written = json.loads(ours.read_text(encoding="utf-8"))
         assert {n["id"] for n in written["nodes"]} == {"a", "b"}
 
+    @pytest.mark.skipif(os.name == "nt", reason="Windows does not expose POSIX mode bits")
+    def test_successful_merge_preserves_destination_mode(self, tmp_path: Path) -> None:
+        base = self._write(tmp_path, "base.json", _graph())
+        ours = self._write(tmp_path, "ours.json", _graph(nodes=[_node("ours")]))
+        theirs = self._write(tmp_path, "theirs.json", _graph(nodes=[_node("theirs")]))
+        ours.chmod(0o640)
+
+        assert main([str(base), str(ours), str(theirs)]) == 0
+        assert stat.S_IMODE(ours.stat().st_mode) == 0o640
+
     def test_corrupt_side_exits_one_and_leaves_ours_untouched(self, tmp_path: Path) -> None:
         """The behavior that stops a silent side-take from deleting graph state."""
         base = self._write(tmp_path, "base.json", _graph())
@@ -377,32 +389,119 @@ class TestDriverExitContract:
         theirs = self._write(tmp_path, "theirs.json", _graph())
         assert main([str(tmp_path / "absent.json"), str(ours), str(theirs)]) == 1
 
-    def test_an_unwritable_destination_exits_three(
+    def test_an_unwritable_destination_exits_three_without_truncating_ours(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """PR #3348 review: ADR-035 separates logic (1) from external (3).
-
-        Git reads every nonzero the same way, so this distinction only pays off
-        when a human runs the driver by hand to resolve a conflict, which is
-        exactly when "your JSON is malformed" and "the disk refused the write"
-        need to be told apart. Fails the write itself rather than staging an
-        unwritable path: ``ours`` is also an input, so a directory or a stripped
-        mode bit fails during load and never reaches the branch under test, and
-        root and Windows both ignore mode bits anyway.
-        """
+        """A failed final replace leaves Git's merge-result input untouched."""
         base = self._write(tmp_path, "base.json", _graph())
-        ours = self._write(tmp_path, "ours.json", _graph())
-        theirs = self._write(tmp_path, "theirs.json", _graph())
-        original = Path.write_text
+        ours = self._write(tmp_path, "ours.json", _graph(nodes=[_node("ours")]))
+        theirs = self._write(tmp_path, "theirs.json", _graph(nodes=[_node("theirs")]))
+        before = ours.read_text(encoding="utf-8")
 
-        def refuse(self: Path, *args: Any, **kwargs: Any) -> int:
-            if self == ours:
-                raise OSError(28, "No space left on device")
-            return original(self, *args, **kwargs)
+        def refuse(_source: object, _target: object) -> None:
+            raise OSError(28, "No space left on device")
 
-        monkeypatch.setattr(Path, "write_text", refuse)
+        monkeypatch.setattr(merge_causal_graph.os, "replace", refuse)
 
         assert main([str(base), str(ours), str(theirs)]) == 3
+        assert ours.read_text(encoding="utf-8") == before
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    def test_a_partial_temporary_write_leaves_ours_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        base = self._write(tmp_path, "base.json", _graph())
+        ours = self._write(tmp_path, "ours.json", _graph(nodes=[_node("ours")]))
+        theirs = self._write(tmp_path, "theirs.json", _graph(nodes=[_node("theirs")]))
+        before = ours.read_text(encoding="utf-8")
+        original_fdopen = merge_causal_graph.os.fdopen
+
+        class PartialWriter:
+            def __init__(self, fd: int) -> None:
+                self._handle: TextIO = original_fdopen(fd, "w", encoding="utf-8")
+
+            def write(self, text: str) -> None:
+                self._handle.write(text[:1])
+                self._handle.flush()
+                raise OSError(28, "No space left on device")
+
+            def close(self) -> None:
+                self._handle.close()
+
+        def fail_after_partial_write(fd: int, _mode: str, *, encoding: str) -> PartialWriter:
+            assert encoding == "utf-8"
+            return PartialWriter(fd)
+
+        monkeypatch.setattr(merge_causal_graph.os, "fdopen", fail_after_partial_write)
+
+        assert main([str(base), str(ours), str(theirs)]) == 3
+        assert ours.read_text(encoding="utf-8") == before
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    def test_close_failure_does_not_mask_a_partial_write_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        base = self._write(tmp_path, "base.json", _graph())
+        ours = self._write(tmp_path, "ours.json", _graph(nodes=[_node("ours")]))
+        theirs = self._write(tmp_path, "theirs.json", _graph(nodes=[_node("theirs")]))
+        before = ours.read_text(encoding="utf-8")
+        original_fdopen = merge_causal_graph.os.fdopen
+
+        class WriteAndCloseFailure:
+            def __init__(self, fd: int) -> None:
+                self._handle: TextIO = original_fdopen(fd, "w", encoding="utf-8")
+
+            def write(self, text: str) -> None:
+                self._handle.write(text[:1])
+                self._handle.flush()
+                raise OSError(28, "No space left on device")
+
+            def close(self) -> None:
+                self._handle.close()
+                raise OSError(5, "Input/output error")
+
+        def fail_write_and_close(fd: int, _mode: str, *, encoding: str) -> WriteAndCloseFailure:
+            assert encoding == "utf-8"
+            return WriteAndCloseFailure(fd)
+
+        monkeypatch.setattr(merge_causal_graph.os, "fdopen", fail_write_and_close)
+
+        assert main([str(base), str(ours), str(theirs)]) == 3
+        error = capsys.readouterr().err
+        assert "No space left on device" in error
+        assert "failed to close temporary file" in error
+        assert "Input/output error" in error
+        assert ours.read_text(encoding="utf-8") == before
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    def test_cleanup_failure_reports_primary_and_cleanup_errors(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        base = self._write(tmp_path, "base.json", _graph())
+        ours = self._write(tmp_path, "ours.json", _graph(nodes=[_node("ours")]))
+        theirs = self._write(tmp_path, "theirs.json", _graph(nodes=[_node("theirs")]))
+
+        def refuse_replace(_source: object, _target: object) -> None:
+            raise OSError(28, "No space left on device")
+
+        def refuse_cleanup(_path: Path, missing_ok: bool = False) -> None:
+            assert missing_ok
+            raise OSError(13, "Permission denied")
+
+        monkeypatch.setattr(merge_causal_graph.os, "replace", refuse_replace)
+        monkeypatch.setattr(Path, "unlink", refuse_cleanup)
+
+        assert main([str(base), str(ours), str(theirs)]) == 3
+        error = capsys.readouterr().err
+        assert "No space left on device" in error
+        assert "failed to remove temporary file" in error
+        assert "Permission denied" in error
 
 
 class TestGitActuallyUsesTheDriver:

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -8,6 +8,7 @@ a `.gitattributes` entry from becoming a no-op.
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import stat
@@ -435,6 +436,30 @@ class TestDriverExitContract:
         monkeypatch.setattr(merge_causal_graph.os, "fdopen", fail_after_partial_write)
 
         assert main([str(base), str(ours), str(theirs)]) == 3
+        assert ours.read_text(encoding="utf-8") == before
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    def test_fdopen_failure_closes_descriptor_and_leaves_ours_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        base = self._write(tmp_path, "base.json", _graph())
+        ours = self._write(tmp_path, "ours.json", _graph(nodes=[_node("ours")]))
+        theirs = self._write(tmp_path, "theirs.json", _graph(nodes=[_node("theirs")]))
+        before = ours.read_text(encoding="utf-8")
+        captured_fd: list[int] = []
+
+        def refuse_fdopen(fd: int, _mode: str, *, encoding: str) -> TextIO:
+            assert encoding == "utf-8"
+            captured_fd.append(fd)
+            raise OSError(24, "Too many open files")
+
+        monkeypatch.setattr(merge_causal_graph.os, "fdopen", refuse_fdopen)
+
+        assert main([str(base), str(ours), str(theirs)]) == 3
+        assert len(captured_fd) == 1
+        with pytest.raises(OSError) as closed:
+            os.fstat(captured_fd[0])
+        assert closed.value.errno == errno.EBADF
         assert ours.read_text(encoding="utf-8") == before
         assert list(tmp_path.glob("*.tmp")) == []
 


### PR DESCRIPTION
## Summary

- Write merged causal graphs to a sibling temporary file before replacement.
- Preserve destination mode bits and the original file on write, close, or replace failure.
- Report primary and cleanup failures without masking either cause.
- Record the completed PR autofix retrospective and reusable safety memories.

## Validation

- 67 focused merge-driver tests passed.
- 13,869 repository tests passed, with 23 skipped and 45 expected failures.
- Ruff, formatting, mypy, security scan, and pre-PR validation passed.
- Formal `/review` returned WARN only for pre-existing file-size debt. The implementation axes passed.

Fixes #3357