### PR TITLE
fix(memory): replace the merged causal graph atomically

### DIFF
--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -14525,7 +14525,8 @@
       "type": "milestone",
       "label": "milestone: Applied the three ADR-057 reference normalizations and verified against source",
       "episodes": [
-        "episode-2026-07-25-session-3315-adr057-ref-normalization"
+        "episode-2026-07-25-session-3315-adr057-ref-normalization",
+        "episode-2026-07-26-session-3357-atomic-merge-write"
       ],
       "created": "2026-07-25T07:04:38.859304+00:00"
     },
@@ -14534,7 +14535,8 @@
       "type": "milestone",
       "label": "milestone: Ran a proportionate adr-review under the ADR Review Protocol",
       "episodes": [
-        "episode-2026-07-25-session-3315-adr057-ref-normalization"
+        "episode-2026-07-25-session-3315-adr057-ref-normalization",
+        "episode-2026-07-26-session-3357-atomic-merge-write"
       ],
       "created": "2026-07-25T07:04:38.859367+00:00"
     },
@@ -14543,7 +14545,8 @@
       "type": "milestone",
       "label": "milestone: Re-verified the reviewers' factual claims directly against the working tree",
       "episodes": [
-        "episode-2026-07-25-session-3315-adr057-ref-normalization"
+        "episode-2026-07-25-session-3315-adr057-ref-normalization",
+        "episode-2026-07-26-session-3357-atomic-merge-write"
       ],
       "created": "2026-07-25T07:04:38.859420+00:00"
     },
@@ -14552,7 +14555,8 @@
       "type": "milestone",
       "label": "milestone: Produced the governance artifacts and prepared the stacked commit",
       "episodes": [
-        "episode-2026-07-25-session-3315-adr057-ref-normalization"
+        "episode-2026-07-25-session-3315-adr057-ref-normalization",
+        "episode-2026-07-26-session-3357-atomic-merge-write"
       ],
       "created": "2026-07-25T07:04:38.859471+00:00"
     },
@@ -15365,6 +15369,33 @@
         "episode-2026-07-26-session-3347-resolve-remaining-3347-review-threads"
       ],
       "created": "2026-07-26T02:02:26.671569+00:00"
+    },
+    {
+      "id": "5b1f3ecd25c4",
+      "type": "commit",
+      "label": "commit: Commit: b2c8a534e79785f80fa237a089d1a35256b62c40",
+      "episodes": [
+        "episode-2026-07-26-session-3357-atomic-merge-write"
+      ],
+      "created": "2026-07-26T04:20:25.446361+00:00"
+    },
+    {
+      "id": "86ba34f6f06c",
+      "type": "commit",
+      "label": "commit: Commit: b2c8a534e7",
+      "episodes": [
+        "episode-2026-07-26-session-3357-atomic-merge-write"
+      ],
+      "created": "2026-07-26T04:20:25.446425+00:00"
+    },
+    {
+      "id": "897339e3c991",
+      "type": "outcome",
+      "label": "Outcome: success - Make the causal graph merge driver write atomically so a failed write leaves ours intact (#3357)",
+      "episodes": [
+        "episode-2026-07-26-session-3357-atomic-merge-write"
+      ],
+      "created": "2026-07-26T04:20:25.446481+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/episodes/episode-2026-07-26-session-3357-atomic-merge-write.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3357-atomic-merge-write.json
@@ -1,0 +1,90 @@
+{
+  "id": "episode-2026-07-26-session-3357-atomic-merge-write",
+  "session": "2026-07-26-session-3357-atomic-merge-write",
+  "timestamp": "2026-07-26T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Make the causal graph merge driver write atomically so a failed write leaves ours intact (#3357)",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Applied the three ADR-057 reference normalizations and verified against source",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran a proportionate adr-review under the ADR Review Protocol",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-verified the reviewers' factual claims directly against the working tree",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Produced the governance artifacts and prepared the stacked commit",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: b2c8a534e79785f80fa237a089d1a35256b62c40",
+      "caused_by": [],
+      "leads_to": [
+        "e006"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: b2c8a534e7",
+      "caused_by": [
+        "e005"
+      ],
+      "leads_to": [
+        "e001"
+      ]
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 2,
+    "files_changed": 4
+  },
+  "lessons": [
+    "Right-size the adr-review panel to the change surface and record omitted lenses. Convene only the lenses with real surface (architect, critic), run them for real, and document in the debate log why the others were not convened, instead of producing empty six-agent verdicts.",
+    "Avoid: Claiming a six-agent debate ran when it did not, to satisfy the gate. Run the reviews that genuinely apply, verify their claims independently, and state the panel scope honestly in the artifact."
+  ]
+}

--- a/.agents/sessions/2026-07-26-session-3357-atomic-merge-write.json
+++ b/.agents/sessions/2026-07-26-session-3357-atomic-merge-write.json
@@ -1,0 +1,132 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3357,
+    "date": "2026-07-26",
+    "branch": "fix/3357-atomic-merge-write",
+    "startingCommit": "aaaf9081f568db83665f79ba89261a5cd746fb01",
+    "objective": "Make the causal graph merge driver write atomically so a failed write leaves ours intact (#3357)",
+    "endingCommit": ""
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena MCP activation tools are not exposed in this Copilot CLI session toolset (only lsp is present)."
+      },
+      "serenaInstructions": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena initial_instructions tool is not exposed in this Copilot CLI session toolset."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md during the PR 3315 babysitting phase of this session."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file created for branch docs/adr-057-normalize-workflow-refs."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current returned docs/adr-057-normalize-workflow-refs."
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Working on feature branch docs/adr-057-normalize-workflow-refs stacked on the PR 3315 branch, not main."
+      },
+      "gitStatusVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git status and git diff inspected; ADR-057, the debate log, the retrospective, and this session log are hand-authored, and the commit hooks additionally regenerate the memory episode and .agents/memory/causality/causal-graph.json, for six files total in commit b2c8a534e7."
+      },
+      "startingCommitNoted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "startingCommit d9e55e2f9fa8d49b510e4570d00b0832b2044235 recorded from git rev-parse HEAD."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All session-start and session-end MUST items satisfied with honest evidence; Serena SHOULD items marked incomplete because those tools are not exposed."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md was read only and left unmodified this session."
+      },
+      "serenaMemoryUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Serena memory write tools are not exposed in this Copilot CLI session toolset; durable diagnosis facts were recorded via the Copilot memory surface during the babysitting phase."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 scoped run on the three changed markdown files reported 0 issues; files under .agents are config-excluded from the lint glob."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "ADR-057 normalization, the adr-review debate log, the retrospective, this session log, and the hook-generated memory episode and causal-graph updates committed together as one atomic docs(adr) commit b2c8a534e7 (six files) on branch docs/adr-057-normalize-workflow-refs."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "validate_session_json.py --pre-commit exits 0 on this log; the staged-dash and adr-review pre-commit gates pass with 0 dashes and a debate log referencing ADR-057."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Wrote .agents/retrospective/2026-07-25-adr057-normalization.md capturing the governance-ceremony-to-change ratio learning."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "time": "2026-07-25T00:10:00Z",
+      "action": "Applied the three ADR-057 reference normalizations and verified against source",
+      "result": "Lines 81, 220, 284 now use .github/workflows/slash-command-quality.yml; line 247 already full-path. Confirmed 4 total references, 0 bare, 0 em/en dashes, exactly a 3-line diff."
+    },
+    {
+      "time": "2026-07-25T00:25:00Z",
+      "action": "Ran a proportionate adr-review under the ADR Review Protocol",
+      "result": "Convened architect and critic sub-agents as genuine independent reviews; both returned ACCEPT. Recorded the two omitted-lens decisions (security, analyst, independent-thinker, high-level-advisor) and their justifications in the debate log rather than convening empty reviews."
+    },
+    {
+      "time": "2026-07-25T00:35:00Z",
+      "action": "Re-verified the reviewers' factual claims directly against the working tree",
+      "result": "Confirmed .github/workflows/slash-command-quality.yml exists, the reference count and full-path conversion, and no table breakage on line 284, before recording ACCEPT consensus in the debate log."
+    },
+    {
+      "time": "2026-07-25T00:45:00Z",
+      "action": "Produced the governance artifacts and prepared the stacked commit",
+      "result": "Wrote the debate log, the retrospective, and this session log to satisfy the adr-review, session, and retrospective gates honestly, then staged those four hand-authored files; the commit hooks added the memory episode and causal-graph regeneration, so commit b2c8a534e7 carries six files."
+    }
+  ],
+  "learnings": {
+    "patterns": [
+      {
+        "pattern": "Right-size the adr-review panel to the change surface and record omitted lenses",
+        "context": "A pure reference-format ADR copy-edit has no security, data-model, or strategy surface.",
+        "application": "Convene only the lenses with real surface (architect, critic), run them for real, and document in the debate log why the others were not convened, instead of producing empty six-agent verdicts."
+      }
+    ],
+    "avoidances": [
+      {
+        "antipattern": "Claiming a six-agent debate ran when it did not, to satisfy the gate",
+        "consequence": "Fabricated governance evidence that the pre-commit gate cannot detect but that violates the walk-or-do-not-name discipline.",
+        "correction": "Run the reviews that genuinely apply, verify their claims independently, and state the panel scope honestly in the artifact."
+      }
+    ]
+  },
+  "endingCommit": "b2c8a534e79785f80fa237a089d1a35256b62c40",
+  "nextSteps": []
+}

--- a/.agents/sessions/2026-07-26-session-3357-atomic-merge-write.json
+++ b/.agents/sessions/2026-07-26-session-3357-atomic-merge-write.json
@@ -28,27 +28,27 @@
       "sessionLogCreated": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "This file created for branch docs/adr-057-normalize-workflow-refs."
+        "Evidence": "This file created for branch fix/3357-atomic-merge-write."
       },
       "branchVerified": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "git branch --show-current returned docs/adr-057-normalize-workflow-refs."
+        "Evidence": "git branch --show-current returned fix/3357-atomic-merge-write."
       },
       "notOnMain": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Working on feature branch docs/adr-057-normalize-workflow-refs stacked on the PR 3315 branch, not main."
+        "Evidence": "Working on feature branch fix/3357-atomic-merge-write, not main."
       },
       "gitStatusVerified": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "git status and git diff inspected; ADR-057, the debate log, the retrospective, and this session log are hand-authored, and the commit hooks additionally regenerate the memory episode and .agents/memory/causality/causal-graph.json, for six files total in commit b2c8a534e7."
+        "Evidence": "git status and git diff inspected; merge_causal_graph.py, test_merge_causal_graph.py, this session log, and the causal-graph.json updated in commit 25d482155."
       },
       "startingCommitNoted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "startingCommit d9e55e2f9fa8d49b510e4570d00b0832b2044235 recorded from git rev-parse HEAD."
+        "Evidence": "startingCommit aaaf9081f568db83665f79ba89261a5cd746fb01 recorded from git rev-parse HEAD."
       }
     },
     "sessionEnd": {
@@ -75,58 +75,53 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "ADR-057 normalization, the adr-review debate log, the retrospective, this session log, and the hook-generated memory episode and causal-graph updates committed together as one atomic docs(adr) commit b2c8a534e7 (six files) on branch docs/adr-057-normalize-workflow-refs."
+        "Evidence": "Atomic merge write fix committed as 25d482155 on branch fix/3357-atomic-merge-write, updating merge_causal_graph.py and tests."
       },
       "validationPassed": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "validate_session_json.py --pre-commit exits 0 on this log; the staged-dash and adr-review pre-commit gates pass with 0 dashes and a debate log referencing ADR-057."
+        "Evidence": "validate_session_json.py --pre-commit exits 0 on this log."
       },
       "retrospectiveInvoked": {
         "level": "SHOULD",
-        "Complete": true,
-        "Evidence": "Wrote .agents/retrospective/2026-07-25-adr057-normalization.md capturing the governance-ceremony-to-change ratio learning."
+        "Complete": false,
+        "Evidence": "No retrospective written for this bugfix session."
       }
     }
   },
   "workLog": [
     {
-      "time": "2026-07-25T00:10:00Z",
-      "action": "Applied the three ADR-057 reference normalizations and verified against source",
-      "result": "Lines 81, 220, 284 now use .github/workflows/slash-command-quality.yml; line 247 already full-path. Confirmed 4 total references, 0 bare, 0 em/en dashes, exactly a 3-line diff."
+      "time": "2026-07-26T04:00:00Z",
+      "action": "Implemented atomic write for causal graph merge driver",
+      "result": "Updated merge_causal_graph.py to write to a temporary file and rename over the destination, preserving the original file on failure."
     },
     {
-      "time": "2026-07-25T00:25:00Z",
-      "action": "Ran a proportionate adr-review under the ADR Review Protocol",
-      "result": "Convened architect and critic sub-agents as genuine independent reviews; both returned ACCEPT. Recorded the two omitted-lens decisions (security, analyst, independent-thinker, high-level-advisor) and their justifications in the debate log rather than convening empty reviews."
+      "time": "2026-07-26T04:15:00Z",
+      "action": "Added tests for atomic write behavior",
+      "result": "Five tests added: byte-identical destination after refused rename and mid-payload write, no temporary left behind, and preserved mode on success."
     },
     {
-      "time": "2026-07-25T00:35:00Z",
-      "action": "Re-verified the reviewers' factual claims directly against the working tree",
-      "result": "Confirmed .github/workflows/slash-command-quality.yml exists, the reference count and full-path conversion, and no table breakage on line 284, before recording ACCEPT consensus in the debate log."
-    },
-    {
-      "time": "2026-07-25T00:45:00Z",
-      "action": "Produced the governance artifacts and prepared the stacked commit",
-      "result": "Wrote the debate log, the retrospective, and this session log to satisfy the adr-review, session, and retrospective gates honestly, then staged those four hand-authored files; the commit hooks added the memory episode and causal-graph regeneration, so commit b2c8a534e7 carries six files."
+      "time": "2026-07-26T04:20:00Z",
+      "action": "Committed the fix",
+      "result": "Commit 25d482155 on branch fix/3357-atomic-merge-write fixes #3357."
     }
   ],
   "learnings": {
     "patterns": [
       {
-        "pattern": "Right-size the adr-review panel to the change surface and record omitted lenses",
-        "context": "A pure reference-format ADR copy-edit has no security, data-model, or strategy surface.",
-        "application": "Convene only the lenses with real surface (architect, critic), run them for real, and document in the debate log why the others were not convened, instead of producing empty six-agent verdicts."
+        "pattern": "Write to temporary then rename for atomic file updates",
+        "context": "A truncating write that fails mid-stream leaves partial data; rename is atomic on POSIX.",
+        "application": "Use mkstemp to create the temporary, write the payload, preserve the original mode, then os.replace over the destination."
       }
     ],
     "avoidances": [
       {
-        "antipattern": "Claiming a six-agent debate ran when it did not, to satisfy the gate",
-        "consequence": "Fabricated governance evidence that the pre-commit gate cannot detect but that violates the walk-or-do-not-name discipline.",
-        "correction": "Run the reviews that genuinely apply, verify their claims independently, and state the panel scope honestly in the artifact."
+        "antipattern": "Writing directly to the destination file in a merge driver",
+        "consequence": "Disk-full or interrupted write leaves a half-written file; git's fallback cannot help because the damage is already in the destination.",
+        "correction": "Write to a sibling temporary and rename, so every failure before the rename leaves the original byte-identical."
       }
     ]
   },
-  "endingCommit": "b2c8a534e79785f80fa237a089d1a35256b62c40",
+  "endingCommit": "25d482155bbfc6d01fc0af8fd6a88d135da09d29",
   "nextSteps": []
 }

--- a/scripts/validation/merge_causal_graph.py
+++ b/scripts/validation/merge_causal_graph.py
@@ -36,7 +36,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import stat
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any, TypeAlias
 
@@ -334,6 +337,40 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _atomic_write(path: Path, text: str) -> None:
+    """Replace path with text, or leave path exactly as it was.
+
+    Git hands the driver the working-tree file as %A and reads the exit code to
+    decide whether to trust it. A plain write truncates first, so a disk-full or
+    interrupted write leaves a half-written graph on disk. The nonzero exit that
+    follows tells git to keep the conflict, and what git then keeps is the
+    damaged file rather than the original ours side.
+
+    Writing a sibling temporary and renaming it over the destination removes
+    that window: the rename either happens or it does not, and every failure
+    before it leaves the destination byte-identical.
+    """
+    mode = stat.S_IMODE(path.stat().st_mode)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    tmp = Path(tmp_name)
+    try:
+        handle = os.fdopen(fd, "w", encoding="utf-8")
+    except BaseException:
+        os.close(fd)
+        tmp.unlink(missing_ok=True)
+        raise
+    try:
+        with handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
 def main(argv: list[str] | None = None) -> int:
     """Return 0 on a written merge, 1 when git must leave the conflict alone."""
     args = parse_args(argv)
@@ -343,7 +380,7 @@ def main(argv: list[str] | None = None) -> int:
             _load(args.ours, "ours"),
             _load(args.theirs, "theirs"),
         )
-        args.ours.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
+        _atomic_write(args.ours, json.dumps(merged, indent=2) + "\n")
     except GraphMergeError as exc:
         print(f"ERROR: causal graph merge driver: {exc}", file=sys.stderr)
         print("Leaving the conflict in place; resolve it by hand.", file=sys.stderr)

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -9,6 +9,7 @@ a `.gitattributes` entry from becoming a no-op.
 from __future__ import annotations
 
 import json
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -393,16 +394,115 @@ class TestDriverExitContract:
         base = self._write(tmp_path, "base.json", _graph())
         ours = self._write(tmp_path, "ours.json", _graph())
         theirs = self._write(tmp_path, "theirs.json", _graph())
-        original = Path.write_text
 
-        def refuse(self: Path, *args: Any, **kwargs: Any) -> int:
-            if self == ours:
-                raise OSError(28, "No space left on device")
-            return original(self, *args, **kwargs)
+        def refuse(*args: Any, **kwargs: Any) -> None:
+            raise OSError(28, "No space left on device")
 
-        monkeypatch.setattr(Path, "write_text", refuse)
+        monkeypatch.setattr(merge_causal_graph.os, "replace", refuse)
 
         assert main([str(base), str(ours), str(theirs)]) == 3
+
+
+class TestAFailedWriteLeavesOursIntact:
+    """Issue #3357: git keeps whatever is in %A when the driver exits nonzero.
+
+    ``Path.write_text`` truncates before it writes, so a disk-full or
+    interrupted write left a half-written graph on disk and the nonzero exit
+    told git to preserve exactly that. These tests pin the replacement:
+    the destination is either fully updated or untouched.
+    """
+
+    def _case(self, tmp_path: Path) -> tuple[Path, Path, Path]:
+        for name, graph in (
+            ("base.json", _graph()),
+            ("ours.json", _graph(nodes=[_node("a")])),
+            ("theirs.json", _graph(nodes=[_node("b")])),
+        ):
+            body = graph if isinstance(graph, str) else json.dumps(graph, indent=2)
+            (tmp_path / name).write_text(body + "\n", encoding="utf-8")
+        return tmp_path / "base.json", tmp_path / "ours.json", tmp_path / "theirs.json"
+
+    def _strays(self, tmp_path: Path) -> list[str]:
+        known = {"base.json", "ours.json", "theirs.json"}
+        return sorted(p.name for p in tmp_path.iterdir() if p.name not in known)
+
+    def test_a_refused_rename_leaves_ours_byte_identical(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        base, ours, theirs = self._case(tmp_path)
+        before = ours.read_bytes()
+
+        def refuse(*args: Any, **kwargs: Any) -> None:
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(merge_causal_graph.os, "replace", refuse)
+
+        assert main([str(base), str(ours), str(theirs)]) == 3
+        assert ours.read_bytes() == before
+
+    def test_a_refused_rename_leaves_no_temporary_behind(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        base, ours, theirs = self._case(tmp_path)
+
+        def refuse(*args: Any, **kwargs: Any) -> None:
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(merge_causal_graph.os, "replace", refuse)
+
+        main([str(base), str(ours), str(theirs)])
+        assert self._strays(tmp_path) == []
+
+    def test_a_refused_body_write_leaves_ours_byte_identical(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The failure the old code could not survive: mid-payload, post-truncate."""
+        base, ours, theirs = self._case(tmp_path)
+        before = ours.read_bytes()
+        real_fdopen = merge_causal_graph.os.fdopen
+
+        class Stingy:
+            def __init__(self, handle: Any) -> None:
+                self._handle = handle
+
+            def write(self, _text: str) -> int:
+                raise OSError(28, "No space left on device")
+
+            def __enter__(self) -> Stingy:
+                return self
+
+            def __exit__(self, *exc: Any) -> None:
+                self._handle.close()
+
+        monkeypatch.setattr(
+            merge_causal_graph.os, "fdopen", lambda *a, **k: Stingy(real_fdopen(*a, **k))
+        )
+
+        assert main([str(base), str(ours), str(theirs)]) == 3
+        assert ours.read_bytes() == before
+        assert self._strays(tmp_path) == []
+
+    def test_a_successful_merge_preserves_the_destination_mode(self, tmp_path: Path) -> None:
+        """os.replace carries the temporary's mode, not the destination's.
+
+        mkstemp creates at 0600, so without an explicit chmod a merged graph
+        would come back private to the user who ran the merge.
+        """
+        base, ours, theirs = self._case(tmp_path)
+        ours.chmod(0o640)
+
+        assert main([str(base), str(ours), str(theirs)]) == 0
+        assert stat.S_IMODE(ours.stat().st_mode) == 0o640
+
+    def test_a_successful_merge_writes_the_union_and_leaves_no_temporary(
+        self, tmp_path: Path
+    ) -> None:
+        base, ours, theirs = self._case(tmp_path)
+
+        assert main([str(base), str(ours), str(theirs)]) == 0
+        written = json.loads(ours.read_text(encoding="utf-8"))
+        assert {n["id"] for n in written["nodes"]} == {"a", "b"}
+        assert self._strays(tmp_path) == []
 
 
 class TestGitActuallyUsesTheDriver:


### PR DESCRIPTION
## Summary

Fixes #3357.

The driver wrote the merge result straight into git's `%A` with `Path.write_text`. That call truncates the destination before it writes. A disk-full or interrupted write therefore leaves a half-written graph on disk, and the nonzero exit that follows tells git to leave the conflict alone. What git then leaves in the working tree is the damaged file, not the ours side it was supposed to fall back to.

The one code path that exists to stop silent graph loss could cause it.

## The fix

The result goes to a sibling temporary and is renamed over the destination. `os.replace` either happens or it does not, so every failure before it leaves the destination byte-identical, and the temporary is unlinked on the way out.

Mode needed explicit handling. `mkstemp` creates at `0600` and `os.replace` carries the temporary's mode rather than the destination's, so a merged graph would have come back private to whoever ran the merge. The destination mode is read first and reapplied before the rename.

## Tests

The existing exit-3 test drove the failure through `Path.write_text`, which the driver no longer calls. That it failed is the point: the change is real. It now fails `os.replace`.

Five tests cover the acceptance criteria:

| Criterion | Test |
| --- | --- |
| Failed final write leaves `%A` byte-identical | refused rename, and refused mid-payload write |
| Temporary files removed on failure | both failure tests assert the directory is clean |
| Successful write preserves destination mode | destination set to `0640`, asserted after |
| Existing tests remain green | 68 pass |

The mid-payload test is the one that matters most: it is the exact shape the old code could not survive, since the truncation had already happened by then.

## Negative controls

| Control | Result |
| --- | --- |
| Restore the plain `write_text` | 3 red |
| Drop the `chmod` | 1 red |
| Drop the temporary cleanup | 2 red |

## Verification

- 68 pass, up from 63
- `ruff check`, `ruff format --check`, `mypy`: clean
- no mirror of this script exists, so no plugin manifest bump
