### PR TITLE
fix(ci): make the session-protocol gate report what it found

### DIFF
--- a/.agents/sessions/2026-07-26-session-3364-session-protocol-gate.json
+++ b/.agents/sessions/2026-07-26-session-3364-session-protocol-gate.json
@@ -1,0 +1,135 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3364,
+    "date": "2026-07-26",
+    "branch": "fix/3364-3365-session-protocol-gate",
+    "startingCommit": "23054169f8",
+    "objective": "Fix two defects in the session-protocol CI gate: a MUST-failure counter that could never reach a nonzero value (#3365), and validator findings that were computed then discarded instead of echoed to the job log (#3364)."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP active; serena-list_memories returned the project memory index."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena-initial_instructions returned the project manual."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md before starting."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file."
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Reviewed .claude/skills/ for an owning skill; none covers CI gate repair."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .serena/memories/usage-mandatory.md."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/governance/PROJECT-CONSTRAINTS.md."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded .serena/memories/*.md including adr-reference-index."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "git branch --show-current -> fix/3364-3365-session-protocol-gate"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Branch is fix/3364-3365-session-protocol-gate, not main."
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status --short clean apart from the intended edits."
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "23054169f8 (merge-base with main)."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All session-start and session-end items reviewed."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified."
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Recorded the phantom-regex failure shape for future gate audits."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown files changed in this branch."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "54548416a0 fix(ci): make the session-protocol gate report what it found"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "181 passed across tests/test_validate_session_json.py, tests/test_ai_session_protocol_workflow.py, tests/test_aggregate_session_verdicts.py, tests/test_generate_session_report.py. Three negative controls each turn the matching tests red."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issues #3364 and #3365 closed by this PR."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Findings folded into the commit body and PR description."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "phase": "Investigate",
+      "summary": "Confirmed both defects against the shipped workflow. The MUST regex targets markdown table rows; grep -c '\"|\"' scripts/validate_session_json.py returns 0, so the pattern can never match. Found a third defect while reading: validation-result.md is written twice in a row, so the markdown-wrapped first write is dead."
+    },
+    {
+      "phase": "Implement",
+      "summary": "Added --json-output to validate_session_json.py emitting verdict, must_failures, error_count, errors and warnings. Routed the three MUST error shapes through module constants shared by the emit sites and count_must_failures so the count cannot drift from the messages. Rewired the workflow counter to read the summary, echoed findings into a collapsible group on the failure path, and dropped the dead write."
+    },
+    {
+      "phase": "Verify",
+      "summary": "181 passed. Four pwsh tests execute the counter block sliced out of the shipped workflow, including the four-failure case the old regex could never reach. Negative controls: restoring the phantom regex turns 4 tests red, dropping the echo turns 1 red, restoring the double write turns 1 red. Confirmed --pre-commit and the no-flag callers are unaffected."
+    }
+  ],
+  "endingCommit": "54548416a0",
+  "nextSteps": [
+    "Watch the first CI run that fails session validation and confirm the findings appear in the job log.",
+    "Issue #3363 (episode extractor counts any SHA as a session commit) is the next item in this cluster."
+  ]
+}

--- a/.github/workflows/ai-session-protocol.yml
+++ b/.github/workflows/ai-session-protocol.yml
@@ -205,7 +205,9 @@ jobs:
           # Use appropriate validator based on file type
           if ($extension -eq '.json') {
             # JSON format - simple schema validation
-            $result = & python3 ./scripts/validate_session_json.py $sessionFile 2>&1
+            # --json-output leaves stdout human-readable and writes a
+            # machine-readable summary the MUST counter below can trust.
+            $result = & python3 ./scripts/validate_session_json.py $sessionFile --json-output validation-summary.json 2>&1
             $exitCode = $LASTEXITCODE
             $format = 'JSON'
           } else {
@@ -222,13 +224,19 @@ jobs:
             $format = 'Markdown (unsupported)'
           }
           
-          # Build markdown output
           $fileName = Split-Path $sessionFile -Leaf
           $status = if ($exitCode -eq 0) { 'PASS' } else { 'FAIL' }
-          $mdResult = "# Session Validation: $fileName`n`nFormat: $format`nResult: $status`n`n" + '```' + "`n$($result -join "`n")`n" + '```'
-          $mdResult | Out-File -FilePath "validation-result.md" -Encoding UTF8
 
-          # Save markdown output for artifact
+          # Echo the findings into the job log. This is a blocking gate, so a
+          # contributor opening a red check has to be able to read why it failed
+          # without downloading an artifact (issue #3364).
+          if ($exitCode -ne 0) {
+            Write-Host "::group::Session validation findings for $fileName"
+            $result | ForEach-Object { Write-Host $_ }
+            Write-Host "::endgroup::"
+          }
+
+          # Save output for the artifact
           $result | Out-File -FilePath "validation-result.md" -Encoding UTF8
           
           # Create simplified results directory
@@ -250,11 +258,21 @@ jobs:
           # Save markdown output
           $result | Out-File -FilePath "validation-results/${fileName}-findings.txt" -Encoding UTF8
           
-          # Count MUST failures (look for FAIL in MUST level checks)
-          # Pattern matches markdown table rows: | CheckName | MUST | FAIL |
+          # Read the MUST failure count from the validator's own summary.
+          # The previous regex looked for a markdown table this validator has
+          # never emitted, so the count was structurally pinned at 0 and the
+          # "Enforce MUST Requirements" step below was decorative (issue #3365).
           $mustFailCount = 0
-          if ($result -match '(?m)^\|\s*\w+\s*\|\s*MUST\s*\|\s*FAIL\s*\|') {
-            $mustFailCount = ([regex]::Matches($result, '(?m)^\|\s*\w+\s*\|\s*MUST\s*\|\s*FAIL\s*\|')).Count
+          if (Test-Path "validation-summary.json") {
+            $summary = Get-Content "validation-summary.json" -Raw | ConvertFrom-Json
+            $mustFailCount = [int]$summary.must_failures
+          } elseif ($exitCode -ne 0) {
+            # No summary means the validator died before writing one (unsupported
+            # format, crash). Fail closed with 1 rather than report a confident 0:
+            # the "Enforce MUST Requirements" step tests `-gt 0`, so any sentinel
+            # at or below zero would read as "nothing to enforce".
+            Write-Host "::warning::No validation summary produced; assuming a MUST failure"
+            $mustFailCount = 1
           }
           $mustFailCount | Out-File -FilePath "validation-results/${fileName}-must-failures.txt" -Encoding UTF8
           

--- a/scripts/validate_session_json.py
+++ b/scripts/validate_session_json.py
@@ -223,6 +223,34 @@ def has_case_insensitive(data: dict[str, Any], key: str) -> bool:
     return False
 
 
+# Error prefixes that mark a MUST-level protocol failure. Used at both the
+# emit sites below and by count_must_failures, so the counter cannot drift from
+# the messages. Issue #3365: the CI workflow previously counted these with a
+# regex for a markdown table this validator has never emitted, so the count was
+# structurally pinned at zero.
+_INCOMPLETE_MUST_PREFIX = "Incomplete MUST: "
+_MISSING_REQUIRED_PREFIX = "Missing required item: "
+_MUST_NOT_VIOLATED_PREFIX = "MUST NOT violated: "
+_MUST_FAILURE_PREFIXES: tuple[str, ...] = (
+    _INCOMPLETE_MUST_PREFIX,
+    _MISSING_REQUIRED_PREFIX,
+    _MUST_NOT_VIOLATED_PREFIX,
+)
+
+
+def count_must_failures(result: ValidationResult) -> int:
+    """Count MUST-level failures among a result's errors.
+
+    Args:
+        result: A completed validation result.
+
+    Returns:
+        The number of errors that represent a MUST or MUST NOT violation.
+        Schema and format errors are real failures but are not MUST-level.
+    """
+    return sum(1 for error in result.errors if error.startswith(_MUST_FAILURE_PREFIXES))
+
+
 def validate_session_section(session: dict[str, Any], result: ValidationResult) -> None:
     """Validate the session section of the log.
 
@@ -391,7 +419,7 @@ def validate_must_item(
     level = get_case_insensitive(check_data, "level")
 
     if level == "MUST" and not is_complete:
-        result.errors.append(f"Incomplete MUST: {section_name}.{item_name}")
+        result.errors.append(f"{_INCOMPLETE_MUST_PREFIX}{section_name}.{item_name}")
 
     if level == "MUST" and is_complete and not evidence:
         result.warnings.append(f"Missing evidence: {section_name}.{item_name}")
@@ -433,7 +461,7 @@ def validate_checklist_section(
         if item_name in section_data:
             validate_must_item(section_data[item_name], item_name, section_name, result)
         else:
-            result.errors.append(f"Missing required item: {section_name}.{item_name}")
+            result.errors.append(f"{_MISSING_REQUIRED_PREFIX}{section_name}.{item_name}")
 
 
 def validate_session_start(session_start: dict[str, Any], result: ValidationResult) -> None:
@@ -467,7 +495,7 @@ def validate_session_end(session_end: dict[str, Any], result: ValidationResult) 
         is_complete = get_case_insensitive(check_data, "complete")
         level = get_case_insensitive(check_data, "level")
         if level == "MUST NOT" and is_complete:
-            result.errors.append("MUST NOT violated: HANDOFF.md was modified (read-only)")
+            result.errors.append(f"{_MUST_NOT_VIOLATED_PREFIX}HANDOFF.md was modified (read-only)")
 
 
 def validate_protocol_compliance(
@@ -694,7 +722,40 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Suppress verbose output when called from pre-commit hook",
     )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        metavar="PATH",
+        help=(
+            "Also write a machine-readable summary to PATH. Human-readable "
+            "output on stdout is unchanged, so this is safe to add to any "
+            "existing caller."
+        ),
+    )
     return parser.parse_args()
+
+
+def build_summary(session_path: Path, result: ValidationResult) -> dict[str, Any]:
+    """Build the machine-readable summary emitted by --json-output.
+
+    Args:
+        session_path: Path to the validated session log.
+        result: The completed validation result.
+
+    Returns:
+        A JSON-serialisable summary. `must_failures` counts only MUST-level
+        violations; `errors` holds every error including schema failures, so
+        `must_failures` can legitimately be 0 on a NON_COMPLIANT verdict.
+    """
+    return {
+        "file": str(session_path),
+        "verdict": "COMPLIANT" if result.is_valid else "NON_COMPLIANT",
+        "exit_code": 0 if result.is_valid else 1,
+        "must_failures": count_must_failures(result),
+        "error_count": len(result.errors),
+        "errors": list(result.errors),
+        "warnings": list(result.warnings),
+    }
 
 
 def main() -> int:
@@ -728,6 +789,10 @@ def main() -> int:
 
         # Report results
         report_results(validated_path, result, args.pre_commit)
+
+        if args.json_output is not None:
+            summary = build_summary(validated_path, result)
+            args.json_output.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
 
         return 0 if result.is_valid else 1
 

--- a/tests/test_ai_session_protocol_workflow.py
+++ b/tests/test_ai_session_protocol_workflow.py
@@ -8,15 +8,16 @@ branch failed with "Migration failed". These tests pin the fix in place.
 
 from __future__ import annotations
 
+import json
+import shutil
+import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 WORKFLOW = (
-    Path(__file__).resolve().parent.parent
-    / ".github"
-    / "workflows"
-    / "ai-session-protocol.yml"
+    Path(__file__).resolve().parent.parent / ".github" / "workflows" / "ai-session-protocol.yml"
 )
 
 
@@ -59,3 +60,125 @@ def test_json_branch_still_calls_python_validator() -> None:
     """JSON path is the supported branch; keep its validator wired up."""
     run = _validate_step_run()
     assert "python3 ./scripts/validate_session_json.py $sessionFile" in run
+
+
+def _counter_block() -> str:
+    """Extract the MUST-counting PowerShell from the validate step.
+
+    Slicing the real workflow text keeps the test honest: it exercises the
+    shipped code rather than a copy that can drift.
+    """
+    run = _validate_step_run()
+    start = run.index("$mustFailCount = 0")
+    end = run.index("$mustFailCount | Out-File")
+    return run[start:end]
+
+
+def _run_counter(tmp_path: Path, summary: str | None, exit_code: int) -> int:
+    """Run the extracted counter block under pwsh and return its verdict."""
+    if summary is not None:
+        (tmp_path / "validation-summary.json").write_text(summary, encoding="utf-8")
+    script = tmp_path / "counter.ps1"
+    script.write_text(
+        f"$exitCode = {exit_code}\n{_counter_block()}\nWrite-Output $mustFailCount\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        ["pwsh", "-NoProfile", "-File", str(script)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=tmp_path,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return int(proc.stdout.strip().splitlines()[-1])
+
+
+pwsh_required = pytest.mark.skipif(shutil.which("pwsh") is None, reason="pwsh not installed")
+
+
+class TestMustFailureCounter:
+    """Issue #3365: the counter must be able to reach a nonzero value.
+
+    The previous implementation regexed for markdown table rows
+    (`| Check | MUST | FAIL |`) that scripts/validate_session_json.py has never
+    emitted, so the count was structurally pinned at 0 and the downstream
+    "Enforce MUST Requirements" step was decorative.
+    """
+
+    def test_the_phantom_markdown_table_regex_is_gone(self) -> None:
+        """The old pattern matched output no validator produces."""
+        run = _validate_step_run()
+        assert "MUST\\s*\\|\\s*FAIL" not in run, (
+            "ai-session-protocol.yml still counts MUST failures with a regex "
+            "for a markdown table validate_session_json.py never emits (#3365)."
+        )
+
+    def test_the_counter_reads_the_validator_summary(self) -> None:
+        run = _validate_step_run()
+        assert "--json-output validation-summary.json" in run
+        assert "$summary.must_failures" in run
+
+    @pwsh_required
+    def test_a_summary_with_must_failures_counts_them(self, tmp_path: Path) -> None:
+        """The regression the phantom regex could never catch."""
+        summary = json.dumps({"verdict": "NON_COMPLIANT", "must_failures": 4})
+        assert _run_counter(tmp_path, summary, exit_code=1) == 4
+
+    @pwsh_required
+    def test_a_clean_summary_counts_zero(self, tmp_path: Path) -> None:
+        summary = json.dumps({"verdict": "COMPLIANT", "must_failures": 0})
+        assert _run_counter(tmp_path, summary, exit_code=0) == 0
+
+    @pwsh_required
+    def test_a_missing_summary_on_failure_fails_closed(self, tmp_path: Path) -> None:
+        """No summary means the validator died; do not report a confident zero.
+
+        The enforcement step tests `-gt 0`, so 0 or a negative sentinel would
+        read as "nothing to enforce" and let the failure through that path.
+        """
+        assert _run_counter(tmp_path, None, exit_code=1) == 1
+
+    @pwsh_required
+    def test_a_missing_summary_on_success_counts_zero(self, tmp_path: Path) -> None:
+        """A skipped or deleted file exits 0 and legitimately has no summary."""
+        assert _run_counter(tmp_path, None, exit_code=0) == 0
+
+
+class TestValidationFindingsReachTheJobLog:
+    """Issue #3364: a blocking gate must say why it failed in the job log.
+
+    The findings were computed, written to an artifact, and never echoed, so a
+    red required check showed only "Exit code: 1".
+    """
+
+    def test_the_failure_path_echoes_the_findings(self) -> None:
+        run = _validate_step_run()
+        failure_echo = run[run.index("if ($exitCode -ne 0) {") :]
+        assert "$result | ForEach-Object { Write-Host $_ }" in failure_echo, (
+            "The validate step no longer echoes validator findings to the job "
+            "log; contributors would have to download an artifact (#3364)."
+        )
+
+    def test_the_artifact_upload_is_preserved(self) -> None:
+        """The echo is additive: tooling still gets the artifact."""
+        run = _validate_step_run()
+        assert '$result | Out-File -FilePath "validation-result.md"' in run
+        assert "validation-results/${fileName}-findings.txt" in run
+
+    def test_the_dead_double_write_is_gone(self) -> None:
+        """validation-result.md was written twice on the post-validation path.
+
+        The first write wrapped the findings in markdown, the second
+        immediately overwrote it with the raw findings, so the wrapper was
+        dead. The early-exit branch for a deleted file has its own legitimate
+        write and is deliberately outside this slice.
+        """
+        run = _validate_step_run()
+        post_validation = run[run.index("$fileName = Split-Path") :]
+        assert post_validation.count('Out-File -FilePath "validation-result.md"') == 1, (
+            "validation-result.md is written more than once after validation; "
+            "the earlier write is immediately overwritten."
+        )

--- a/tests/test_validate_session_json.py
+++ b/tests/test_validate_session_json.py
@@ -18,13 +18,18 @@ from unittest import mock
 import pytest
 
 from scripts.validate_session_json import (
+    _INCOMPLETE_MUST_PREFIX,
     _LEGACY_HANDOFF_FIELD,
+    _MISSING_REQUIRED_PREFIX,
+    _MUST_NOT_VIOLATED_PREFIX,
     BRANCH_PATTERN,
     COMMIT_SHA_PATTERN,
     CONTRADICTION_PATTERNS,
     SESSION_END_REQUIRED_ITEMS,
     SESSION_START_REQUIRED_ITEMS,
     ValidationResult,
+    build_summary,
+    count_must_failures,
     get_case_insensitive,
     has_case_insensitive,
     load_session_file,
@@ -1474,3 +1479,93 @@ class TestSectionAbsenceIsReportedOnce:
         assert any(
             "sessionStart" in error and error.startswith("Schema:") for error in result.errors
         )
+
+
+class TestCountMustFailures:
+    """Issue #3365: the CI MUST counter must be able to reach a nonzero value.
+
+    The workflow previously counted MUST failures with a regex for markdown
+    table rows this validator has never emitted, so the count was pinned at 0
+    and the "Enforce MUST Requirements" step could not fire on its own terms.
+    """
+
+    def test_no_errors_counts_zero(self) -> None:
+        assert count_must_failures(ValidationResult()) == 0
+
+    @pytest.mark.parametrize(
+        "prefix",
+        [_INCOMPLETE_MUST_PREFIX, _MISSING_REQUIRED_PREFIX, _MUST_NOT_VIOLATED_PREFIX],
+        ids=["incomplete-must", "missing-required", "must-not-violated"],
+    )
+    def test_every_must_prefix_is_counted(self, prefix: str) -> None:
+        """Each MUST-level error shape the validator emits must be countable."""
+        result = ValidationResult(errors=[f"{prefix}sessionStart.handoffRead"])
+        assert count_must_failures(result) == 1
+
+    def test_non_must_errors_are_not_counted(self) -> None:
+        """Schema and format errors are real failures but not MUST-level."""
+        result = ValidationResult(
+            errors=[
+                "Invalid commit SHA format: zzz",
+                "Schema: cannot load session-log.schema.json, schema layer skipped: boom",
+            ]
+        )
+        assert count_must_failures(result) == 0
+
+    def test_must_and_non_must_errors_are_separated(self) -> None:
+        result = ValidationResult(
+            errors=[
+                f"{_INCOMPLETE_MUST_PREFIX}sessionStart.handoffRead",
+                f"{_INCOMPLETE_MUST_PREFIX}sessionStart.serenaActivated",
+                "Invalid commit SHA format: zzz",
+            ]
+        )
+        assert count_must_failures(result) == 2
+        assert len(result.errors) == 3
+
+    def test_an_incomplete_must_item_reaches_the_counter_end_to_end(self) -> None:
+        """The prefix constants must match what the validators actually emit.
+
+        A test that only feeds hand-written strings to the counter would stay
+        green if the emit sites drifted. This one runs a real validation.
+        """
+        start = _make_complete_start_section()
+        start["handoffRead"]["complete"] = False
+        result = ValidationResult()
+        validate_session_start(start, result)
+        assert count_must_failures(result) >= 1
+
+
+class TestBuildSummary:
+    """The --json-output summary is the workflow's machine-readable contract."""
+
+    def test_a_clean_result_reports_compliant(self, tmp_path: Path) -> None:
+        summary = build_summary(tmp_path / "s.json", ValidationResult())
+        assert summary["verdict"] == "COMPLIANT"
+        assert summary["exit_code"] == 0
+        assert summary["must_failures"] == 0
+        assert summary["error_count"] == 0
+
+    def test_a_failing_result_reports_non_compliant(self, tmp_path: Path) -> None:
+        result = ValidationResult(
+            errors=[f"{_INCOMPLETE_MUST_PREFIX}sessionStart.handoffRead"],
+            warnings=["Missing evidence: sessionEnd.changesCommitted"],
+        )
+        summary = build_summary(tmp_path / "s.json", result)
+        assert summary["verdict"] == "NON_COMPLIANT"
+        assert summary["exit_code"] == 1
+        assert summary["must_failures"] == 1
+        assert summary["error_count"] == 1
+        assert summary["warnings"] == ["Missing evidence: sessionEnd.changesCommitted"]
+
+    def test_non_must_errors_leave_must_failures_at_zero(self, tmp_path: Path) -> None:
+        """A NON_COMPLIANT verdict with 0 MUST failures is legitimate."""
+        result = ValidationResult(errors=["Invalid commit SHA format: zzz"])
+        summary = build_summary(tmp_path / "s.json", result)
+        assert summary["verdict"] == "NON_COMPLIANT"
+        assert summary["must_failures"] == 0
+        assert summary["error_count"] == 1
+
+    def test_the_summary_is_json_serialisable(self, tmp_path: Path) -> None:
+        summary = build_summary(tmp_path / "s.json", ValidationResult(errors=["boom"]))
+        assert json.loads(json.dumps(summary)) == summary


### PR DESCRIPTION
## Summary

Three defects in the same step of `.github/workflows/ai-session-protocol.yml`. Two were filed; the third turned up while reading the code.

## The MUST counter could never be nonzero (#3365)

The step counted MUST failures with a regex for markdown table rows:

```
'(?m)^\|\s*\w+\s*\|\s*MUST\s*\|\s*FAIL\s*\|'
```

The validator has never emitted a table. It prints plain lines. The count was structurally pinned at 0, which made the downstream "Enforce MUST Requirements" step decorative. The gate still blocked, because the job also fails on the validator exit code, so nothing surfaced the blindness. Observed on #3361: `MUST failures: 0` against a `NON_COMPLIANT` verdict with four incomplete MUST items.

Fix: a new `--json-output PATH` flag on the validator writes a machine-readable summary (`verdict`, `must_failures`, `error_count`, `errors`, `warnings`). Stdout is unchanged, so every existing caller keeps working. The workflow reads `must_failures` from that summary.

A missing summary on a nonzero exit now counts **1**, not 0. The enforcement step tests `-gt 0`, so a zero or negative sentinel would read as "nothing to enforce".

The three MUST error prefixes are now module constants used at both the emit sites and the counter, so the count cannot drift from the messages.

Before and after on a log with three flipped MUST items:

```
old regex -> 0
new counter -> must_failures = 3 | verdict NON_COMPLIANT | errors 3
```

## Findings never reached the job log (#3364)

The findings were captured, written to an artifact, and discarded. A contributor opening a red required check saw only `Exit code: 1` and had to guess an artifact name to learn why. They are now echoed inside a collapsible group on the failure path. The artifact upload is unchanged.

## Third defect, found while reading

The result file was written twice in a row on the post-validation path. The first write wrapped the findings in markdown and the second immediately overwrote it with the raw findings, so the wrapper was dead. Dropped it. The early-exit branch for a deleted file has its own legitimate write and is untouched.

## Verification

181 passed across the session-protocol test surface.

Four of the new tests slice the counter block out of the shipped workflow and execute it under `pwsh`, so they test the code that runs rather than a copy. That includes the four-failure case the old regex could never reach.

Negative controls, each run against the real tree:

| Reverted | Tests red |
|---|---|
| Phantom table regex restored | 4 |
| Failure-path echo removed | 1 |
| Dead double write restored | 1 |

Confirmed `--pre-commit` and the no-flag callers are unaffected.

Fixes #3364
Fixes #3365
