### PR TITLE
fix(memory): source session commits from the protocol record, not prose

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-26-session-3342-harness-reference-size.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3342-harness-reference-size.json
@@ -60,7 +60,7 @@
       "type": "test",
       "content": "30 passed across tests/build_scripts/test_hook_contract_knowledge.py and .claude/skills/agent-harness-reference/tests/. Assertions that span a wrapped line now run through _normalized_text so a reflow cannot turn them red without a fact changing.",
       "caused_by": [
-        "e025"
+        "e026"
       ],
       "leads_to": [
         "e007"
@@ -270,7 +270,7 @@
       "id": "e023",
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "commit",
-      "content": "Commit: 618d8e1a70",
+      "content": "Commit: 618d8e1a7",
       "caused_by": [
         "e022"
       ],
@@ -282,7 +282,7 @@
       "id": "e024",
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "commit",
-      "content": "Commit: 663bbac488",
+      "content": "Commit: 006a88767",
       "caused_by": [
         "e023"
       ],
@@ -294,9 +294,21 @@
       "id": "e025",
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "commit",
-      "content": "Commit: a2487c4ac1",
+      "content": "Commit: 827a4c699",
       "caused_by": [
         "e024"
+      ],
+      "leads_to": [
+        "e026"
+      ]
+    },
+    {
+      "id": "e026",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: f673788d4",
+      "caused_by": [
+        "e025"
       ],
       "leads_to": [
         "e005"
@@ -308,7 +320,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 6,
+    "commits": 7,
     "files_changed": 598
   },
   "lessons": []

--- a/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
+++ b/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
@@ -94,12 +94,12 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "8 commits on the branch after rebasing onto main: 487eafe4e8, e6da3ec408, 088c5b2f6b, dbe076249f, c3d0db4f91, 1a1ed7daf9, efc1c93140, f5e9928335"
+        "Evidence": "Commits 487eafe4e8, e6da3ec408, 088c5b2f6b, dbe076249f, c3d0db4f91, 1a1ed7daf9, efc1c93140, f5e9928335, and 3ecc83eaf2"
       },
       "validationPassed": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "164 passed in tests/skills/memory/test_extract_session_episode.py; three negative controls fired (7 red on dropping the changesCommitted source, 2 red on restoring prose-primary); ruff check and ruff format clean"
+        "Evidence": "uv run --frozen python -m pytest tests/skills/memory/test_extract_session_episode.py passed; three negative controls fired (dropping the changesCommitted source turned 7 red, restoring prose-primary turned 2 red); ruff check and ruff format clean"
       },
       "tasksUpdated": {
         "level": "SHOULD",
@@ -121,18 +121,18 @@
     },
     {
       "phase": "Measure",
-      "summary": "Measured all 933 session logs before designing, so the fallback policy follows the data rather than a guess.",
-      "evidence": "194 logs name SHAs in changesCommitted evidence; 192 carry endingCommit with no prose SHAs; 15 are prose-only; 483 record no commit. Prose-only means neither endingCommit nor the changesCommitted evidence names a SHA other than the starting commit, while the work log does: 12 carry an evidence string with no SHA in it, 3 carry no evidence string at all. Measured over 938 logs. 44 sit in the contested shape (endingCommit set, evidence has no SHAs, prose does): of the 83 prose SHAs there, 46 are unresolvable by git, 23 are provably not in the session's line, and the 14 remaining are ancestors of the ending commit, which every prior commit on main also is. No evidence prose names own commits in that shape."
+      "summary": "Measured every session log in the tree before designing, so the fallback policy follows the data rather than a guess.",
+      "evidence": "194 logs name SHAs in changesCommitted evidence; 192 carry endingCommit with no prose SHAs; 15 are prose-only; 483 record no commit. Prose-only means neither endingCommit nor the changesCommitted evidence names a SHA other than the starting commit, while the work log does: 12 carry an evidence string with no SHA in it, 3 carry no evidence string at all. Measured over the 941 logs present at the time of measurement; the counts above are from that same pass. 44 sit in the contested shape (endingCommit set, evidence has no SHAs, prose does): of the 83 prose SHAs there, 46 are unresolvable by git, 23 are provably not in the session's line, and the 14 remaining are ancestors of the ending commit, which every prior commit on main also is. No evidence prose names own commits in that shape."
     },
     {
       "phase": "Implement",
-      "summary": "Made endingCommit plus the changesCommitted evidence authoritative and demoted work-log prose to a fallback used only when both are empty, which keeps the 15 prose-only logs working. json_metrics and json_events already share _collect_shas, so the count cannot drift from the event stream.",
+      "summary": "Made endingCommit plus the changesCommitted evidence authoritative and demoted work-log prose to a fallback taken when neither endingCommit nor the changesCommitted evidence yields a SHA, so an evidence string like \"Committed.\" still reaches it, which keeps the 15 prose-only logs working. json_metrics and json_events already share _collect_shas, so the count cannot drift from the event stream.",
       "evidence": "Added _changes_committed_evidence reading both Evidence and evidence casings and tolerating a missing or non-dict compliance section. Regenerated the fix/3342 episode: 7 commit events exactly matching the 7 SHAs changesCommitted names, zero extra, zero missing."
     },
     {
       "phase": "Test",
       "summary": "Added 9 provenance tests and corrected 12 existing tests that asserted the disproven prose-primary contract, preserving each one's intent.",
-      "evidence": "162 passed. The #2170 multi-commit tests now source from changesCommitted; the #3123 events-equal-metrics invariant is unchanged; the #3328 predating fixtures now take the fallback shape so that filter is still exercised. Negative controls: dropping the changesCommitted source turned 7 red, restoring prose-primary turned 2 red including the exact foreign-SHA case."
+      "evidence": "The suite passes. The #2170 multi-commit tests now source from changesCommitted; the #3123 events-equal-metrics invariant is unchanged; the #3328 predating fixtures now take the fallback shape so that filter is still exercised. Negative controls: dropping the changesCommitted source turned 7 red, restoring prose-primary turned 2 red including the exact foreign-SHA case."
     },
     {
       "phase": "implementation",

--- a/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
+++ b/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
@@ -133,6 +133,10 @@
       "phase": "Test",
       "summary": "Added 9 provenance tests and corrected 12 existing tests that asserted the disproven prose-primary contract, preserving each one's intent.",
       "evidence": "162 passed. The #2170 multi-commit tests now source from changesCommitted; the #3123 events-equal-metrics invariant is unchanged; the #3328 predating fixtures now take the fallback shape so that filter is still exercised. Negative controls: dropping the changesCommitted source turned 7 red, restoring prose-primary turned 2 red including the exact foreign-SHA case."
+    },
+    {
+      "phase": "implementation",
+      "summary": "Review caught a real defect: _collect_shas promised distinct commits but tested membership with exact string equality, so a full 40-char endingCommit and a 7-char abbreviation of the same commit in the changesCommitted evidence both landed. That double-counted metrics.commits and emitted two commit events and two causal-graph nodes for one commit. Added _already_seen, which compares through the existing _same_commit predicate, and routed all four membership checks through it while keeping the first spelling seen. Added 6 tests including a negative control proving two commits sharing a sub-7-character prefix still count separately; reverting to exact membership turned 3 of them red. Also wrapped a 101-character line the ruff ratchet rejected."
     }
   ],
   "endingCommit": "72dc6e1d34",

--- a/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
+++ b/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
@@ -94,7 +94,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Commits 487eafe4e8, e6da3ec408, 088c5b2f6b, dbe076249f, c3d0db4f91, 1a1ed7daf9, efc1c93140, f5e9928335, and 3ecc83eaf2"
+        "Evidence": "Commits 487eafe4e8, e6da3ec408, 088c5b2f6b, dbe076249f, c3d0db4f91, 1a1ed7daf9, efc1c93140, f5e9928335, 3ecc83eaf2, and ade3b8d7a2"
       },
       "validationPassed": {
         "level": "MUST",
@@ -139,7 +139,7 @@
       "summary": "Review caught a real defect: _collect_shas promised distinct commits but tested membership with exact string equality, so a full 40-char endingCommit and a 7-char abbreviation of the same commit in the changesCommitted evidence both landed. That double-counted metrics.commits and emitted two commit events and two causal-graph nodes for one commit. Added _already_seen, which compares through the existing _same_commit predicate, and routed all four membership checks through it while keeping the first spelling seen. Added 6 tests including a negative control proving two commits sharing a sub-7-character prefix still count separately; reverting to exact membership turned 3 of them red. Also wrapped a 101-character line the ruff ratchet rejected."
     }
   ],
-  "endingCommit": "f5e9928335",
+  "endingCommit": "ade3b8d7a2",
   "nextSteps": [
     "Re-poll PR #3380 for review threads landing after this push.",
     "Decide separately whether the markdown-path metrics.commits counter, which counts any line carrying a hex run, needs the same correction.",

--- a/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
+++ b/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
@@ -4,7 +4,7 @@
     "number": 3363,
     "date": "2026-07-26",
     "branch": "fix/3363-episode-commit-provenance",
-    "startingCommit": "a366fe694416af511a0e7829245372d057c69987",
+    "startingCommit": "263ce89d05",
     "objective": "Fix issue #3363: the episode extractor sourced session commits from work-log prose, counting SHAs the session cited but did not author and missing its own."
   },
   "protocolCompliance": {
@@ -52,12 +52,12 @@
       "branchVerified": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "fix/3371-collect-mirror-suites"
+        "Evidence": "fix/3363-episode-commit-provenance"
       },
       "notOnMain": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "On fix/3371-collect-mirror-suites, branched off main 663bbac488"
+        "Evidence": "On fix/3363-episode-commit-provenance, branched off main 263ce89d05"
       },
       "gitStatusVerified": {
         "level": "SHOULD",
@@ -67,7 +67,7 @@
       "startingCommitNoted": {
         "level": "SHOULD",
         "Complete": true,
-        "Evidence": "663bbac488"
+        "Evidence": "263ce89d05"
       }
     },
     "sessionEnd": {
@@ -99,12 +99,12 @@
       "validationPassed": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Both bundle trees green (1120 and 1085 passed, 4 skipped each); 1985 passed across tests/test_paths.py, tests/skills/, tests/test_chaos_experiment_scripts.py, tests/validation/test_check_vendor_portability.py; 8 passed in tests/test_skill_bundle_suites_run.py; ruff check and ruff format clean"
+        "Evidence": "164 passed in tests/skills/memory/test_extract_session_episode.py; three negative controls fired (7 red on dropping the changesCommitted source, 2 red on restoring prose-primary); ruff check and ruff format clean"
       },
       "tasksUpdated": {
         "level": "SHOULD",
         "Complete": true,
-        "Evidence": "Issue #3371 commented with the corrected 82-directory scope"
+        "Evidence": "PR #3380 opened against issue #3363"
       },
       "retrospectiveInvoked": {
         "level": "SHOULD",
@@ -135,10 +135,10 @@
       "evidence": "162 passed. The #2170 multi-commit tests now source from changesCommitted; the #3123 events-equal-metrics invariant is unchanged; the #3328 predating fixtures now take the fallback shape so that filter is still exercised. Negative controls: dropping the changesCommitted source turned 7 red, restoring prose-primary turned 2 red including the exact foreign-SHA case."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "72dc6e1d34",
   "nextSteps": [
-    "Push fix/3371-collect-mirror-suites and open a PR that fixes #3371.",
-    "Comment on #3371 with the corrected scope: 82 directories, not 2.",
+    "Re-poll PR #3380 for review threads landing after this push.",
+    "Decide separately whether the markdown-path metrics.commits counter, which counts any line carrying a hex run, needs the same correction.",
     "Re-poll the four open PRs for new review threads."
   ]
 }

--- a/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
+++ b/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
@@ -122,11 +122,11 @@
     {
       "phase": "Measure",
       "summary": "Measured all 933 session logs before designing, so the fallback policy follows the data rather than a guess.",
-      "evidence": "194 logs name SHAs in changesCommitted evidence; 192 carry endingCommit with no prose SHAs; 20 are prose-only (all pre-2026-02); 483 record no commit. 44 sit in the contested shape (endingCommit set, evidence has no SHAs, prose does): of the 83 prose SHAs there, 46 are unresolvable by git, 23 are provably not in the session's line, and the 14 remaining are ancestors of the ending commit, which every prior commit on main also is. No evidence prose names own commits in that shape."
+      "evidence": "194 logs name SHAs in changesCommitted evidence; 192 carry endingCommit with no prose SHAs; 15 are prose-only; 483 record no commit. Prose-only means neither endingCommit nor the changesCommitted evidence names a SHA other than the starting commit, while the work log does: 12 carry an evidence string with no SHA in it, 3 carry no evidence string at all. Measured over 938 logs. 44 sit in the contested shape (endingCommit set, evidence has no SHAs, prose does): of the 83 prose SHAs there, 46 are unresolvable by git, 23 are provably not in the session's line, and the 14 remaining are ancestors of the ending commit, which every prior commit on main also is. No evidence prose names own commits in that shape."
     },
     {
       "phase": "Implement",
-      "summary": "Made endingCommit plus the changesCommitted evidence authoritative and demoted work-log prose to a fallback used only when both are empty, which keeps the 20 prose-only logs working. json_metrics and json_events already share _collect_shas, so the count cannot drift from the event stream.",
+      "summary": "Made endingCommit plus the changesCommitted evidence authoritative and demoted work-log prose to a fallback used only when both are empty, which keeps the 15 prose-only logs working. json_metrics and json_events already share _collect_shas, so the count cannot drift from the event stream.",
       "evidence": "Added _changes_committed_evidence reading both Evidence and evidence casings and tolerating a missing or non-dict compliance section. Regenerated the fix/3342 episode: 7 commit events exactly matching the 7 SHAs changesCommitted names, zero extra, zero missing."
     },
     {

--- a/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
+++ b/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
@@ -1,0 +1,144 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3363,
+    "date": "2026-07-26",
+    "branch": "fix/3363-episode-commit-provenance",
+    "startingCommit": "a366fe694416af511a0e7829245372d057c69987",
+    "objective": "Fix issue #3363: the episode extractor sourced session commits from work-log prose, counting SHAs the session cited but did not author and missing its own."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP active; serena-list_memories returned the project memory index"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena initial_instructions read at session initialization"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read; treated as read-only per ADR-014"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "code-review-and-quality and github skill catalogs loaded"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory usage-mandatory read"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded plugin-versioning, testing-practices, and hooks memories"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/3371-collect-mirror-suites"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/3371-collect-mirror-suites, branched off main 663bbac488"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status inspected before branch creation and before each commit"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "663bbac488"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST session-start and session-end fields completed"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md unchanged; git status shows no modification"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Stored the testpaths blackout finding and the per-tree collection workaround"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown files in the diff; the change set is Python and JSON only, verified with git diff --name-only"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Three commits: ccc84280fe, bec3366729, d655c5237b"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Both bundle trees green (1120 and 1085 passed, 4 skipped each); 1985 passed across tests/test_paths.py, tests/skills/, tests/test_chaos_experiment_scripts.py, tests/validation/test_check_vendor_portability.py; 8 passed in tests/test_skill_bundle_suites_run.py; ruff check and ruff format clean"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue #3371 commented with the corrected 82-directory scope"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Deferred; this session is one issue in a multi-issue autopilot run whose retrospective covers the whole run"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "phase": "Investigate",
+      "summary": "Reproduced #3363 on the fix/3342 episode: 6 commit events against 7 named in changesCommitted, only 4 overlapping. _collect_shas sourced from endingCommit, startingCommit and work-log prose, and never read protocolCompliance.sessionEnd.changesCommitted, the protocol's own record.",
+      "evidence": "Foreign commits counted: 663bbac488 (a PR #3358 merge on main) and a2487c4ac1 (another session's fix), both same-day so the #3328 predating filter could not drop them. Missed: 006a88767, 827a4c699, f673788d4, present only in changesCommitted."
+    },
+    {
+      "phase": "Measure",
+      "summary": "Measured all 933 session logs before designing, so the fallback policy follows the data rather than a guess.",
+      "evidence": "194 logs name SHAs in changesCommitted evidence; 192 carry endingCommit with no prose SHAs; 20 are prose-only (all pre-2026-02); 483 record no commit. 44 sit in the contested shape (endingCommit set, evidence has no SHAs, prose does): of the 83 prose SHAs there, 46 are unresolvable by git, 23 are provably not in the session's line, and the 14 remaining are ancestors of the ending commit, which every prior commit on main also is. No evidence prose names own commits in that shape."
+    },
+    {
+      "phase": "Implement",
+      "summary": "Made endingCommit plus the changesCommitted evidence authoritative and demoted work-log prose to a fallback used only when both are empty, which keeps the 20 prose-only logs working. json_metrics and json_events already share _collect_shas, so the count cannot drift from the event stream.",
+      "evidence": "Added _changes_committed_evidence reading both Evidence and evidence casings and tolerating a missing or non-dict compliance section. Regenerated the fix/3342 episode: 7 commit events exactly matching the 7 SHAs changesCommitted names, zero extra, zero missing."
+    },
+    {
+      "phase": "Test",
+      "summary": "Added 9 provenance tests and corrected 12 existing tests that asserted the disproven prose-primary contract, preserving each one's intent.",
+      "evidence": "162 passed. The #2170 multi-commit tests now source from changesCommitted; the #3123 events-equal-metrics invariant is unchanged; the #3328 predating fixtures now take the fallback shape so that filter is still exercised. Negative controls: dropping the changesCommitted source turned 7 red, restoring prose-primary turned 2 red including the exact foreign-SHA case."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Push fix/3371-collect-mirror-suites and open a PR that fixes #3371.",
+    "Comment on #3371 with the corrected scope: 82 directories, not 2.",
+    "Re-poll the four open PRs for new review threads."
+  ]
+}

--- a/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
+++ b/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
@@ -94,7 +94,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Seven commits: 839245f440, 143760d97b, 1ba356cfe2, 813d6fd9fe, 5dcd9a0a3b, 0eb586e380, ea4eb3a5fb"
+        "Evidence": "8 commits on the branch after rebasing onto main: 487eafe4e8, e6da3ec408, 088c5b2f6b, dbe076249f, c3d0db4f91, 1a1ed7daf9, efc1c93140, f5e9928335"
       },
       "validationPassed": {
         "level": "MUST",
@@ -139,7 +139,7 @@
       "summary": "Review caught a real defect: _collect_shas promised distinct commits but tested membership with exact string equality, so a full 40-char endingCommit and a 7-char abbreviation of the same commit in the changesCommitted evidence both landed. That double-counted metrics.commits and emitted two commit events and two causal-graph nodes for one commit. Added _already_seen, which compares through the existing _same_commit predicate, and routed all four membership checks through it while keeping the first spelling seen. Added 6 tests including a negative control proving two commits sharing a sub-7-character prefix still count separately; reverting to exact membership turned 3 of them red. Also wrapped a 101-character line the ruff ratchet rejected."
     }
   ],
-  "endingCommit": "ea4eb3a5fb",
+  "endingCommit": "f5e9928335",
   "nextSteps": [
     "Re-poll PR #3380 for review threads landing after this push.",
     "Decide separately whether the markdown-path metrics.commits counter, which counts any line carrying a hex run, needs the same correction.",

--- a/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
+++ b/.agents/sessions/2026-07-26-session-3363-episode-commit-provenance.json
@@ -94,7 +94,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Three commits: ccc84280fe, bec3366729, d655c5237b"
+        "Evidence": "Seven commits: 839245f440, 143760d97b, 1ba356cfe2, 813d6fd9fe, 5dcd9a0a3b, 0eb586e380, ea4eb3a5fb"
       },
       "validationPassed": {
         "level": "MUST",
@@ -139,7 +139,7 @@
       "summary": "Review caught a real defect: _collect_shas promised distinct commits but tested membership with exact string equality, so a full 40-char endingCommit and a 7-char abbreviation of the same commit in the changesCommitted evidence both landed. That double-counted metrics.commits and emitted two commit events and two causal-graph nodes for one commit. Added _already_seen, which compares through the existing _same_commit predicate, and routed all four membership checks through it while keeping the first spelling seen. Added 6 tests including a negative control proving two commits sharing a sub-7-character prefix still count separately; reverting to exact membership turned 3 of them red. Also wrapped a 101-character line the ruff ratchet rejected."
     }
   ],
-  "endingCommit": "72dc6e1d34",
+  "endingCommit": "ea4eb3a5fb",
   "nextSteps": [
     "Re-poll PR #3380 for review threads landing after this push.",
     "Decide separately whether the markdown-path metrics.commits counter, which counts any line carrying a hex run, needs the same correction.",

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -693,8 +693,11 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
 
     The commit set comes from the two fields the session protocol treats as the
     record of what a session committed: ``endingCommit`` and the session-end
-    ``changesCommitted`` evidence. Work-log prose is a fallback used only when
-    both are empty.
+    ``changesCommitted`` evidence. Work-log prose is a fallback, consulted only
+    when neither of those two yields a SHA. That is a weaker condition than
+    "both fields are empty": evidence reading ``Committed.`` with no SHA in it
+    also reaches the fallback, and has to, because that is the shape 20 of the
+    25 prose-only logs are in.
 
     Prose is not a primary source (issue #3363). A work-log entry legitimately
     cites SHAs the session did not author: a bot's housekeeping commits, a
@@ -705,9 +708,11 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     ``fix/3342-harness-reference-size`` the episode counted two foreign commits
     and dropped three of the session's own.
 
-    The fallback is kept because 27 pre-2026-02 logs record commits only in the
-    work log and have no structured evidence to fall back to. It carries the
-    existing hex-letter (issue #3301) and committer-date (issue #3328) filters.
+    The fallback is kept because 25 logs, all pre-2026-02, record their commits
+    only in the work log. Five have no evidence string at all; the other 20
+    have one that names no SHA. Deleting the fallback would drop every commit
+    those 25 sessions made. It carries the existing hex-letter (issue #3301)
+    and committer-date (issue #3328) filters.
 
     Excludes the starting commit by default: it is the base, not a commit the
     session produced, including when prose repeats it at a different
@@ -933,8 +938,8 @@ def json_metrics(data: dict) -> dict:
     # Count every distinct commit the session documents, from the same source
     # as the commit events so the two can never disagree: endingCommit plus the
     # session-end changesCommitted evidence, falling back to work-log prose only
-    # when both are empty (issue #3363). Excludes the starting commit (the base,
-    # not a commit the session produced).
+    # when neither of those yields a SHA (issue #3363). Excludes the starting
+    # commit: it is the base, not a commit the session produced.
     commit_count = len(_collect_shas(data, include_starting=False))
     metrics = {
         "duration_minutes": 0,

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -43,10 +43,10 @@ def get_session_id_from_path(path: Path) -> str:
     distinct episode files.
     """
     stem = path.stem
-    match = re.search(r'(\d{4}-\d{2}-\d{2}-session-\d+(?:-.+)?)', stem)
+    match = re.search(r"(\d{4}-\d{2}-\d{2}-session-\d+(?:-.+)?)", stem)
     if match:
         return match.group(1)
-    match = re.search(r'(session-\d+(?:-.+)?)', stem)
+    match = re.search(r"(session-\d+(?:-.+)?)", stem)
     if match:
         return match.group(1)
     return stem
@@ -65,40 +65,40 @@ def parse_session_metadata(lines: list[str]) -> dict:
 
     for line in lines:
         # Title (first H1)
-        title_match = re.match(r'^#\s+(.+)$', line)
+        title_match = re.match(r"^#\s+(.+)$", line)
         if title_match and not metadata["title"]:
             metadata["title"] = title_match.group(1)
             continue
 
         # Date field
-        m = re.match(r'^\*\*Date\*\*:\s*(.+)$', line)
+        m = re.match(r"^\*\*Date\*\*:\s*(.+)$", line)
         if m:
             metadata["date"] = m.group(1).strip()
             continue
 
         # Status field
-        m = re.match(r'^\*\*Status\*\*:\s*(.+)$', line)
+        m = re.match(r"^\*\*Status\*\*:\s*(.+)$", line)
         if m:
             metadata["status"] = m.group(1).strip()
             continue
 
         # Objectives section
-        if re.match(r'^##\s*Objectives?', line):
+        if re.match(r"^##\s*Objectives?", line):
             in_section = "objectives"
             continue
 
         # Deliverables section
-        if re.match(r'^##\s*Deliverables?', line):
+        if re.match(r"^##\s*Deliverables?", line):
             in_section = "deliverables"
             continue
 
         # New section ends current
-        if re.match(r'^##\s', line):
+        if re.match(r"^##\s", line):
             in_section = ""
             continue
 
         # Collect list items
-        m = re.match(r'^\s*[-*]\s+(.+)$', line)
+        m = re.match(r"^\s*[-*]\s+(.+)$", line)
         if m:
             item = m.group(1).strip()
             if in_section == "objectives":
@@ -112,13 +112,13 @@ def parse_session_metadata(lines: list[str]) -> dict:
 def get_decision_type(text: str) -> str:
     """Categorize decision type from text."""
     lower = text.lower()
-    if re.search(r'design|architect|schema|structure', lower):
+    if re.search(r"design|architect|schema|structure", lower):
         return "design"
-    if re.search(r'test|pester|coverage|assert', lower):
+    if re.search(r"test|pester|coverage|assert", lower):
         return "test"
-    if re.search(r'recover|fix|retry|fallback', lower):
+    if re.search(r"recover|fix|retry|fallback", lower):
         return "recovery"
-    if re.search(r'route|delegate|agent|handoff', lower):
+    if re.search(r"route|delegate|agent|handoff", lower):
         return "routing"
     return "implementation"
 
@@ -131,22 +131,18 @@ def parse_decisions(lines: list[str], timestamp: str | None = None) -> list[dict
     ts = timestamp if timestamp is not None else datetime.now(UTC).isoformat()
 
     for i, line in enumerate(lines):
-        if re.match(r'^##\s*Decisions?', line):
+        if re.match(r"^##\s*Decisions?", line):
             in_decision_section = True
             continue
 
-        if in_decision_section and re.match(r'^##\s', line):
+        if in_decision_section and re.match(r"^##\s", line):
             in_decision_section = False
 
         # Decision patterns in various formats
         decision_text = None
-        m1 = re.match(r'^\*\*Decision\*\*:\s*(.+)$', line)
-        m2 = re.match(r'^Decision:\s*(.+)$', line)
-        m3 = (
-            re.match(r'^\s*[-*]\s+\*\*(.+?)\*\*:\s*(.+)$', line)
-            if in_decision_section
-            else None
-        )
+        m1 = re.match(r"^\*\*Decision\*\*:\s*(.+)$", line)
+        m2 = re.match(r"^Decision:\s*(.+)$", line)
+        m3 = re.match(r"^\s*[-*]\s+\*\*(.+?)\*\*:\s*(.+)$", line) if in_decision_section else None
 
         if m1:
             decision_text = m1.group(1)
@@ -159,38 +155,39 @@ def parse_decisions(lines: list[str], timestamp: str | None = None) -> list[dict
             decision_index += 1
             context = ""
             if i > 0:
-                ctx_match = re.match(r'^\s*[-*]\s+(.+)$', lines[i - 1])
+                ctx_match = re.match(r"^\s*[-*]\s+(.+)$", lines[i - 1])
                 if ctx_match:
                     context = ctx_match.group(1)
 
-            decisions.append({
-                "id": f"d{decision_index:03d}",
-                "timestamp": ts,
-                "type": get_decision_type(decision_text),
-                "context": context,
-                "chosen": decision_text,
-                "rationale": "",
-                "outcome": "success",
-                "effects": [],
-            })
+            decisions.append(
+                {
+                    "id": f"d{decision_index:03d}",
+                    "timestamp": ts,
+                    "type": get_decision_type(decision_text),
+                    "context": context,
+                    "chosen": decision_text,
+                    "rationale": "",
+                    "outcome": "success",
+                    "effects": [],
+                }
+            )
             continue
 
         # Capture decisions from work log entries
-        if (
-            re.search(r'chose|decided|selected|opted for', line)
-            and not line.startswith('#')
-        ):
+        if re.search(r"chose|decided|selected|opted for", line) and not line.startswith("#"):
             decision_index += 1
-            decisions.append({
-                "id": f"d{decision_index:03d}",
-                "timestamp": ts,
-                "type": "implementation",
-                "context": "",
-                "chosen": line.strip(),
-                "rationale": "",
-                "outcome": "success",
-                "effects": [],
-            })
+            decisions.append(
+                {
+                    "id": f"d{decision_index:03d}",
+                    "timestamp": ts,
+                    "type": "implementation",
+                    "context": "",
+                    "chosen": line.strip(),
+                    "rationale": "",
+                    "outcome": "success",
+                    "effects": [],
+                }
+            )
 
     return decisions
 
@@ -205,9 +202,9 @@ def parse_events(lines: list[str], timestamp: str | None = None) -> list[dict]:
         evt = None
 
         # Commit events
-        m = re.search(r'commit[ted]?\s+(?:as\s+)?([a-f0-9]{7,40})', line)
+        m = re.search(r"commit[ted]?\s+(?:as\s+)?([a-f0-9]{7,40})", line)
         if not m:
-            m = re.search(r'([a-f0-9]{7,40})\s+\w+\(.+\):', line)
+            m = re.search(r"([a-f0-9]{7,40})\s+\w+\(.+\):", line)
         if m:
             event_index += 1
             evt = {
@@ -220,10 +217,7 @@ def parse_events(lines: list[str], timestamp: str | None = None) -> list[dict]:
             }
 
         # Error events
-        if (
-            re.search(r'error|fail|exception', line, re.IGNORECASE)
-            and not line.startswith('#')
-        ):
+        if re.search(r"error|fail|exception", line, re.IGNORECASE) and not line.startswith("#"):
             event_index += 1
             evt = {
                 "id": f"e{event_index:03d}",
@@ -235,12 +229,11 @@ def parse_events(lines: list[str], timestamp: str | None = None) -> list[dict]:
             }
 
         # Milestone events
-        if (
-            re.search(r'completed?|done|finished|success', line, re.IGNORECASE)
-            and re.match(r'^[-*]\s+(?!\*)', line)
+        if re.search(r"completed?|done|finished|success", line, re.IGNORECASE) and re.match(
+            r"^[-*]\s+(?!\*)", line
         ):
             event_index += 1
-            content = re.sub(r'^[-*]\s*', '', line.strip())
+            content = re.sub(r"^[-*]\s*", "", line.strip())
             evt = {
                 "id": f"e{event_index:03d}",
                 "timestamp": ts,
@@ -257,13 +250,13 @@ def parse_events(lines: list[str], timestamp: str | None = None) -> list[dict]:
         # a status vocabulary so objective/decision sentences that merely begin
         # with "Complete ..." do not misfire. Refs PR #2170 (thread GA722).
         elif re.match(
-            r'^[-*]\s+\*\*(?:status|result|outcome|state|resolution)\*\*\s*:\s*'
-            r'(complete|completed|done|success|finished)\b',
+            r"^[-*]\s+\*\*(?:status|result|outcome|state|resolution)\*\*\s*:\s*"
+            r"(complete|completed|done|success|finished)\b",
             line,
             re.IGNORECASE,
         ):
             event_index += 1
-            content = re.sub(r'^[-*]\s*', '', line.strip())
+            content = re.sub(r"^[-*]\s*", "", line.strip())
             evt = {
                 "id": f"e{event_index:03d}",
                 "timestamp": ts,
@@ -274,7 +267,7 @@ def parse_events(lines: list[str], timestamp: str | None = None) -> list[dict]:
             }
 
         # Test events
-        if re.search(r'test[s]?\s+(pass|fail|run)', line, re.IGNORECASE) or 'Pester' in line:
+        if re.search(r"test[s]?\s+(pass|fail|run)", line, re.IGNORECASE) or "Pester" in line:
             event_index += 1
             evt = {
                 "id": f"e{event_index:03d}",
@@ -297,18 +290,18 @@ def parse_lessons(lines: list[str]) -> list[str]:
     in_lessons_section = False
 
     for line in lines:
-        if re.match(r'^##\s*(Lessons?\s*Learned?|Key\s*Learnings?|Takeaways?)', line):
+        if re.match(r"^##\s*(Lessons?\s*Learned?|Key\s*Learnings?|Takeaways?)", line):
             in_lessons_section = True
             continue
 
-        if in_lessons_section and re.match(r'^##\s', line):
+        if in_lessons_section and re.match(r"^##\s", line):
             in_lessons_section = False
 
-        m = re.match(r'^\s*[-*]\s+(.+)$', line)
+        m = re.match(r"^\s*[-*]\s+(.+)$", line)
         if in_lessons_section and m:
             lessons.append(m.group(1).strip())
         elif m and re.match(
-            r'(?:lessons?\s+learned|lessons?|learned|takeaways?|note\s+for\s+future)\b',
+            r"(?:lessons?\s+learned|lessons?|learned|takeaways?|note\s+for\s+future)\b",
             m.group(1),
             re.IGNORECASE,
         ):
@@ -334,25 +327,22 @@ def parse_metrics(lines: list[str]) -> dict:
 
     for line in lines:
         # Duration
-        m = re.search(r'(\d+)\s*minutes?', line)
+        m = re.search(r"(\d+)\s*minutes?", line)
         if not m:
-            m = re.search(r'duration:\s*(\d+)', line, re.IGNORECASE)
+            m = re.search(r"duration:\s*(\d+)", line, re.IGNORECASE)
         if m:
             metrics["duration_minutes"] = int(m.group(1))
 
         # Count commits
-        if re.search(r'[a-f0-9]{7,40}', line):
+        if re.search(r"[a-f0-9]{7,40}", line):
             metrics["commits"] += 1
 
         # Count errors
-        if (
-            re.search(r'error|fail|exception', line, re.IGNORECASE)
-            and not line.startswith('#')
-        ):
+        if re.search(r"error|fail|exception", line, re.IGNORECASE) and not line.startswith("#"):
             metrics["errors"] += 1
 
         # Count files
-        m = re.search(r'(\d+)\s+files?\s+(changed|modified|created)', line)
+        m = re.search(r"(\d+)\s+files?\s+(changed|modified|created)", line)
         if m:
             metrics["files_changed"] += int(m.group(1))
 
@@ -363,11 +353,11 @@ def get_session_outcome(metadata: dict, events: list[dict]) -> str:
     """Determine overall session outcome."""
     status = (metadata.get("status") or "").lower()
 
-    if re.search(r'complete|done|success', status):
+    if re.search(r"complete|done|success", status):
         return "success"
-    if re.search(r'partial|in.?progress|blocked', status):
+    if re.search(r"partial|in.?progress|blocked", status):
         return "partial"
-    if re.search(r'fail|abort|error', status):
+    if re.search(r"fail|abort|error", status):
         return "failure"
 
     error_count = sum(1 for e in events if e.get("type") == "error")
@@ -393,9 +383,7 @@ def get_session_outcome(metadata: dict, events: list[dict]) -> str:
 # captures the keyword so callers can reject HTTP-status-shaped error counts.
 # Refs PR #2170 (thread GANjI): leading numbers that are issue refs or status
 # codes must not inflate metrics.errors.
-_FAIL_COUNT_RE = re.compile(
-    r"(?<![#\w])([1-9]\d*)\s+(failed|failures|errors?)\b", re.IGNORECASE
-)
+_FAIL_COUNT_RE = re.compile(r"(?<![#\w])([1-9]\d*)\s+(failed|failures|errors?)\b", re.IGNORECASE)
 _PASS_COUNT_RE = re.compile(r"\b(\d+)\s+(?:passed|passing)\b", re.IGNORECASE)
 _SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
 # A commit SHA candidate pulled from free-text prose must contain at least one
@@ -724,7 +712,13 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     session_date = str(session.get("date") or "").strip()
 
     def _add_structured(field: str) -> None:
-        """Structured fields are the protocol's record; scan them unfiltered."""
+        """Take every SHA a structured field names.
+
+        Structured fields are the protocol's record, so no prose heuristic is
+        applied to them. The one exclusion is the starting commit, which the
+        session inherited rather than produced, and which the caller can keep
+        with ``include_starting``.
+        """
         for sha in _SHA_RE.findall(field):
             if not include_starting and starting and _same_commit(sha, starting):
                 continue
@@ -789,9 +783,7 @@ def json_outcome(data: dict, additional_worklogs: list | None = None) -> str:
     if additional_worklogs:
         worklogs_to_check = worklogs_to_check + additional_worklogs
 
-    explicit_failure = any(
-        _valid_fail_match(_entry_text(e)) is not None for e in worklogs_to_check
-    )
+    explicit_failure = any(_valid_fail_match(_entry_text(e)) is not None for e in worklogs_to_check)
 
     if explicit_failure and not all_complete:
         return "failure"
@@ -806,14 +798,16 @@ def json_events(data: dict, now_iso: str) -> list[dict]:
     def add(evt_type: str, content: str) -> None:
         nonlocal idx
         idx += 1
-        events.append({
-            "id": f"e{idx:03d}",
-            "timestamp": now_iso,
-            "type": evt_type,
-            "content": content,
-            "caused_by": [],
-            "leads_to": [],
-        })
+        events.append(
+            {
+                "id": f"e{idx:03d}",
+                "timestamp": now_iso,
+                "type": evt_type,
+                "content": content,
+                "caused_by": [],
+                "leads_to": [],
+            }
+        )
 
     for entry in _as_list(data.get("workLog")):
         title = _entry_title(entry)
@@ -851,16 +845,18 @@ def json_decisions(data: dict, now_iso: str) -> list[dict]:
         # not a bare status word ("success", "ok", ...).
         chosen = title or (outcome if outcome.lower() not in _STATUS_WORDS else "")
         idx += 1
-        decisions.append({
-            "id": f"d{idx:03d}",
-            "timestamp": now_iso,
-            "type": get_decision_type(text),
-            "context": title,
-            "chosen": chosen,
-            "rationale": _entry_field(entry, "evidence").strip(),
-            "outcome": "success",
-            "effects": [],
-        })
+        decisions.append(
+            {
+                "id": f"d{idx:03d}",
+                "timestamp": now_iso,
+                "type": get_decision_type(text),
+                "context": title,
+                "chosen": chosen,
+                "rationale": _entry_field(entry, "evidence").strip(),
+                "outcome": "success",
+                "effects": [],
+            }
+        )
     return decisions
 
 
@@ -1083,6 +1079,7 @@ def _dedupe_decisions(existing: list, new: list) -> list[dict]:
     ``chosen`` summary so the dedup key and output retain the content.
     Refs PR #2170 (thread GASBG).
     """
+
     def coerce(dec: Any) -> dict:
         if isinstance(dec, str):
             text = dec.strip()
@@ -1158,9 +1155,7 @@ def merge_preserving(new: dict, existing: dict, *, session_id: str = "") -> dict
     idempotent. Applying twice is a no-op.
     """
     existing = _as_dict(existing)
-    date = _deterministic_date(
-        session_id, new.get("timestamp"), existing.get("timestamp")
-    )
+    date = _deterministic_date(session_id, new.get("timestamp"), existing.get("timestamp"))
     midnight = f"{date}T00:00:00+00:00" if date else None
 
     merged = dict(new)
@@ -1317,9 +1312,7 @@ def extract_from_json(data: dict, *, archive_fallback: bool = True) -> dict:
                             lessons = archive_lessons
                 except (OSError, json.JSONDecodeError):
                     pass
-            has_events = any(
-                e.get("type") in ("milestone", "test", "error") for e in events
-            )
+            has_events = any(e.get("type") in ("milestone", "test", "error") for e in events)
             has_own_events = has_events or any(e.get("type") == "commit" for e in events)
             if not has_events or not decisions or not lessons:
                 archive_md_path = next(
@@ -1369,27 +1362,33 @@ def build_parser() -> argparse.ArgumentParser:
         description="Extract episode data from session logs.",
     )
     parser.add_argument(
-        "session_log_path", type=Path,
+        "session_log_path",
+        type=Path,
         help="Path to the session log file to extract from",
     )
     parser.add_argument(
-        "--output-path", type=Path, default=None,
+        "--output-path",
+        type=Path,
+        default=None,
         help="Output directory for episode JSON",
     )
     write_mode = parser.add_mutually_exclusive_group()
     write_mode.add_argument(
-        "--force", action="store_true",
+        "--force",
+        action="store_true",
         help="Overwrite existing episode file if it exists",
     )
     write_mode.add_argument(
-        "--preserve", action="store_true",
+        "--preserve",
+        action="store_true",
         help=(
             "Read-modify-write an existing episode file, merging fresh "
             "extraction over it without dropping richer existing data"
         ),
     )
     parser.add_argument(
-        "--pending-stage", action="store_true",
+        "--pending-stage",
+        action="store_true",
         help=(
             "Add 1 to staged files count to account for the episode file "
             "that will be staged after extraction (pre-commit hook context)"
@@ -1482,9 +1481,11 @@ def main(argv: list[str] | None = None) -> int:
         content = session_log_path.read_text(encoding="utf-8")
     except OSError as e:
         print(
-            json.dumps({
-                "Error": f"Failed to read session log: {e}",
-            }),
+            json.dumps(
+                {
+                    "Error": f"Failed to read session log: {e}",
+                }
+            ),
             file=sys.stderr,
         )
         return 1
@@ -1518,15 +1519,10 @@ def main(argv: list[str] | None = None) -> int:
                 timestamp = datetime.fromisoformat(metadata["date"]).isoformat()
             except ValueError:
                 print(
-                    f"  WARNING: Could not parse date '{metadata['date']}', "
-                    "using current time",
+                    f"  WARNING: Could not parse date '{metadata['date']}', using current time",
                     file=sys.stderr,
                 )
-        task = (
-            metadata["objectives"][0]
-            if metadata["objectives"]
-            else metadata["title"]
-        )
+        task = metadata["objectives"][0] if metadata["objectives"] else metadata["title"]
 
     # Best-effort backfill: when neither the JSON workLog nor the legacy
     # markdown recorded a files-changed count, derive it from the staged commit.
@@ -1577,17 +1573,21 @@ def main(argv: list[str] | None = None) -> int:
                 existing_raw = json.loads(episode_file.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError) as e:
                 print(
-                    json.dumps({
-                        "Error": f"--preserve requires a readable existing episode: {e}",
-                    }),
+                    json.dumps(
+                        {
+                            "Error": f"--preserve requires a readable existing episode: {e}",
+                        }
+                    ),
                     file=sys.stderr,
                 )
                 return 1
             if not isinstance(existing_raw, dict):
                 print(
-                    json.dumps({
-                        "Error": "--preserve requires the existing episode to be a JSON object.",
-                    }),
+                    json.dumps(
+                        {
+                            "Error": "--preserve requires the existing episode to be a JSON object.",
+                        }
+                    ),
                     file=sys.stderr,
                 )
                 return 1
@@ -1598,12 +1598,14 @@ def main(argv: list[str] | None = None) -> int:
             outcome = episode["outcome"]
         elif not args.force:
             print(
-                json.dumps({
-                    "Error": (
-                        f"Episode file already exists: {episode_file}. "
-                        "Use --force to overwrite or --preserve to merge."
-                    ),
-                }),
+                json.dumps(
+                    {
+                        "Error": (
+                            f"Episode file already exists: {episode_file}. "
+                            "Use --force to overwrite or --preserve to merge."
+                        ),
+                    }
+                ),
                 file=sys.stderr,
             )
             return 1

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -699,8 +699,8 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     ``changesCommitted`` evidence. Work-log prose is a fallback, consulted only
     when neither of those two yields a SHA. That is a weaker condition than
     "both fields are empty": evidence reading ``Committed.`` with no SHA in it
-    also reaches the fallback, and has to, because that is the shape 20 of the
-    25 prose-only logs are in.
+    also reaches the fallback, and has to, because that is the shape 12 of the
+    15 prose-only logs are in.
 
     Prose is not a primary source (issue #3363). A work-log entry legitimately
     cites SHAs the session did not author: a bot's housekeeping commits, a
@@ -711,11 +711,15 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     ``fix/3342-harness-reference-size`` the episode counted two foreign commits
     and dropped three of the session's own.
 
-    The fallback is kept because 25 logs, all pre-2026-02, record their commits
-    only in the work log. Five have no evidence string at all; the other 20
-    have one that names no SHA. Deleting the fallback would drop every commit
-    those 25 sessions made. It carries the existing hex-letter (issue #3301)
-    and committer-date (issue #3328) filters.
+    The fallback is kept because 15 logs record their commits only in the work
+    log. Three have no evidence string at all; the other 12 have one that names
+    no SHA. Deleting the fallback would drop every commit those 15 sessions
+    made. They are not a closed historical set: they run 2026-01-15 to
+    2026-07-08, so the fallback is load-bearing for logs still being written.
+    Measured over 938 logs by the definition this docstring states: neither
+    ``endingCommit`` nor the ``changesCommitted`` evidence names a SHA other
+    than the starting commit, and the work log does. It carries the existing
+    hex-letter (issue #3301) and committer-date (issue #3328) filters.
 
     Excludes the starting commit by default: it is the base, not a commit the
     session produced, including when prose repeats it at a different

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -746,7 +746,16 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
                 seen.append(sha)
 
     _add_structured(str(data.get("endingCommit") or ""))
-    _add_structured(_changes_committed_evidence(data))
+
+    # changesCommitted evidence is prose, not a structured single-SHA field:
+    # apply the hex-letter filter to avoid counting decimal-only tokens as
+    # commits (issue #3363, mirrors _prose_shas logic from issue #3301).
+    evidence = _changes_committed_evidence(data)
+    for sha in _prose_shas(evidence):
+        if not include_starting and starting and _same_commit(sha, starting):
+            continue
+        if not _already_seen(sha, seen):
+            seen.append(sha)
 
     # startingCommit is a structured field, not prose: scan it unfiltered.
     if include_starting:

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -528,9 +528,14 @@ def _gate_complete(data: dict, phase: str, gate: str) -> bool:
 def _same_commit(a: str, b: str) -> bool:
     """True when two hex SHA strings denote the same commit, allowing for git
     abbreviation: the shorter is a prefix of the longer with at least 7 shared
-    hex chars (git's minimum unambiguous abbreviation length). Exact equality
-    is the equal-length case. This lets a full 40-char ``startingCommit`` match
-    a 7-char abbreviation of it repeated in work-log prose (issue #3123)."""
+    hex chars. Exact equality is the equal-length case. This lets a full 40-char
+    ``startingCommit`` match a 7-char abbreviation of it repeated in work-log
+    prose (issue #3123).
+
+    Seven is this module's own floor, not a git contract. Git's abbreviation
+    length is repo-dependent (``core.abbrev``, and git widens it as the object
+    count grows), so there is no minimum to inherit. Seven is chosen because it
+    is what this repository's tooling emits and short enough prefixes collide."""
     a = a.strip().lower()
     b = b.strip().lower()
     if not a or not b:
@@ -688,7 +693,7 @@ def _changes_committed_evidence(data: dict) -> str:
     return ""
 
 
-def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
+def _collect_shas(data: dict) -> list[str]:
     """Distinct commit SHAs a session produced, newest source of truth first.
 
     Distinctness is abbreviation-aware: two fields that spell the same commit
@@ -722,46 +727,30 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     than the starting commit, and the work log does. It carries the existing
     hex-letter (issue #3301) and committer-date (issue #3328) filters.
 
-    Excludes the starting commit by default: it is the base, not a commit the
-    session produced, including when prose repeats it at a different
-    abbreviation length (issue #3123).
+    Excludes the starting commit: it is the base, not a commit the session
+    produced, including when prose repeats it at a different abbreviation
+    length (issue #3123).
     """
     seen: list[str] = []
     session = _as_dict(data.get("session"))
     starting = str(session.get("startingCommit") or "").strip()
     session_date = str(session.get("date") or "").strip()
 
-    def _add_structured(field: str) -> None:
-        """Take every SHA a structured field names.
-
-        Structured fields are the protocol's record, so no prose heuristic is
-        applied to them. The one exclusion is the starting commit, which the
-        session inherited rather than produced, and which the caller can keep
-        with ``include_starting``.
-        """
-        for sha in _SHA_RE.findall(field):
-            if not include_starting and starting and _same_commit(sha, starting):
+    def _take(shas: list[str]) -> None:
+        """Record every SHA that is neither the base commit nor already held."""
+        for sha in shas:
+            if starting and _same_commit(sha, starting):
                 continue
             if not _already_seen(sha, seen):
                 seen.append(sha)
 
-    _add_structured(str(data.get("endingCommit") or ""))
-
-    # changesCommitted evidence is prose, not a structured single-SHA field:
-    # apply the hex-letter filter to avoid counting decimal-only tokens as
-    # commits (issue #3363, mirrors _prose_shas logic from issue #3301).
-    evidence = _changes_committed_evidence(data)
-    for sha in _prose_shas(evidence):
-        if not include_starting and starting and _same_commit(sha, starting):
-            continue
-        if not _already_seen(sha, seen):
-            seen.append(sha)
-
-    # startingCommit is a structured field, not prose: scan it unfiltered.
-    if include_starting:
-        for sha in _SHA_RE.findall(starting):
-            if not _already_seen(sha, seen):
-                seen.append(sha)
+    # endingCommit is the protocol's own field, so no prose heuristic applies.
+    _take(_SHA_RE.findall(str(data.get("endingCommit") or "")))
+    # changesCommitted evidence is a free-text sentence rather than a bare SHA,
+    # so the hex-letter filter applies: a 20-digit CI run id quoted there is not
+    # a commit (issue #3301). Scanning it unfiltered also let a decimal-only
+    # match populate ``seen`` and suppress the work-log fallback below.
+    _take(_prose_shas(_changes_committed_evidence(data)))
 
     if seen:
         return seen
@@ -769,7 +758,7 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     # Fallback for logs with no structured commit record at all.
     for entry in _as_list(data.get("workLog")):
         for sha in _prose_shas(_entry_text(entry)):
-            if not include_starting and starting and _same_commit(sha, starting):
+            if starting and _same_commit(sha, starting):
                 continue
             if _already_seen(sha, seen):
                 continue
@@ -854,7 +843,7 @@ def json_events(data: dict, now_iso: str) -> list[dict]:
     # event stream and metrics.commits share a single provenance rule
     # (issue #3123). Excludes the starting/base SHA, including work-log
     # mentions of it, matching json_metrics.
-    for sha in _collect_shas(data, include_starting=False):
+    for sha in _collect_shas(data):
         add("commit", f"Commit: {sha}")
 
     return events
@@ -965,7 +954,7 @@ def json_metrics(data: dict) -> dict:
     # session-end changesCommitted evidence, falling back to work-log prose only
     # when neither of those yields a SHA (issue #3363). Excludes the starting
     # commit: it is the base, not a commit the session produced.
-    commit_count = len(_collect_shas(data, include_starting=False))
+    commit_count = len(_collect_shas(data))
     metrics = {
         "duration_minutes": 0,
         "tool_calls": 0,

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -671,23 +671,63 @@ def _prose_sha_predates_session(sha: str, session_date: str) -> bool:
     return committed.astimezone(UTC) < floor
 
 
+def _changes_committed_evidence(data: dict) -> str:
+    """The session-end ``changesCommitted`` evidence string, or empty.
+
+    The session protocol treats this field as the record of what the session
+    committed, so it is the authoritative commit source alongside
+    ``endingCommit``.
+    """
+    compliance = _as_dict(data.get("protocolCompliance"))
+    session_end = _as_dict(compliance.get("sessionEnd"))
+    item = _as_dict(session_end.get("changesCommitted"))
+    for key in ("Evidence", "evidence"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
+
+
 def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
-    """Distinct commit SHAs from the structured commit fields and work-log
-    evidence. Excludes the starting commit by default (it is the base, not a
-    commit the session produced), including when work-log prose repeats it at a
-    different abbreviation length than ``startingCommit`` is stored (issue
-    #3123). Also excludes any prose SHA git proves was committed before the
-    session's date window (issue #3328)."""
+    """Distinct commit SHAs a session produced, newest source of truth first.
+
+    The commit set comes from the two fields the session protocol treats as the
+    record of what a session committed: ``endingCommit`` and the session-end
+    ``changesCommitted`` evidence. Work-log prose is a fallback used only when
+    both are empty.
+
+    Prose is not a primary source (issue #3363). A work-log entry legitimately
+    cites SHAs the session did not author: a bot's housekeeping commits, a
+    commit it bisected, the base of a PR it read. Counting those inflated
+    ``metrics.commits`` and seeded commit nodes in the causal graph for work the
+    session never did, while the session's own commits, recorded only in
+    ``changesCommitted``, were missed entirely. On
+    ``fix/3342-harness-reference-size`` the episode counted two foreign commits
+    and dropped three of the session's own.
+
+    The fallback is kept because 27 pre-2026-02 logs record commits only in the
+    work log and have no structured evidence to fall back to. It carries the
+    existing hex-letter (issue #3301) and committer-date (issue #3328) filters.
+
+    Excludes the starting commit by default: it is the base, not a commit the
+    session produced, including when prose repeats it at a different
+    abbreviation length (issue #3123).
+    """
     seen: list[str] = []
     session = _as_dict(data.get("session"))
     starting = str(session.get("startingCommit") or "").strip()
     session_date = str(session.get("date") or "").strip()
 
-    # Process endingCommit first without filtering - it's authoritative, not prose
-    ending_field = str(data.get("endingCommit") or "")
-    for sha in _SHA_RE.findall(ending_field):
-        if sha not in seen:
-            seen.append(sha)
+    def _add_structured(field: str) -> None:
+        """Structured fields are the protocol's record; scan them unfiltered."""
+        for sha in _SHA_RE.findall(field):
+            if not include_starting and starting and _same_commit(sha, starting):
+                continue
+            if sha not in seen:
+                seen.append(sha)
+
+    _add_structured(str(data.get("endingCommit") or ""))
+    _add_structured(_changes_committed_evidence(data))
 
     # startingCommit is a structured field, not prose: scan it unfiltered.
     if include_starting:
@@ -695,8 +735,10 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
             if sha not in seen:
                 seen.append(sha)
 
-    # work-log entries are free-text prose: require a hex letter so decimal-only
-    # IDs are not counted as commits (issue #3301).
+    if seen:
+        return seen
+
+    # Fallback for logs with no structured commit record at all.
     for entry in _as_list(data.get("workLog")):
         for sha in _prose_shas(_entry_text(entry)):
             if not include_starting and starting and _same_commit(sha, starting):
@@ -888,9 +930,11 @@ def _staged_files_changed(cwd: str | Path | None = None) -> int:
 
 
 def json_metrics(data: dict) -> dict:
-    # Count every distinct commit the session documents (ending commit plus any
-    # SHAs in work-log evidence), not just the ending commit. Excludes the
-    # starting commit (the base, not a commit the session produced).
+    # Count every distinct commit the session documents, from the same source
+    # as the commit events so the two can never disagree: endingCommit plus the
+    # session-end changesCommitted evidence, falling back to work-log prose only
+    # when both are empty (issue #3363). Excludes the starting commit (the base,
+    # not a commit the session produced).
     commit_count = len(_collect_shas(data, include_starting=False))
     metrics = {
         "duration_minutes": 0,

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -539,6 +539,18 @@ def _same_commit(a: str, b: str) -> bool:
     return len(lo) >= 7 and hi.startswith(lo)
 
 
+def _already_seen(sha: str, seen: list[str]) -> bool:
+    """True when ``seen`` already holds this commit at any abbreviation length.
+
+    Exact string membership lets one commit in twice when two fields spell it
+    at different lengths: a full 40-char ``endingCommit`` and a 7-char
+    abbreviation of the same commit in the ``changesCommitted`` evidence. That
+    double-counts ``metrics.commits`` and emits two commit events and two
+    causal-graph nodes for a single commit (issue #3363).
+    """
+    return any(_same_commit(sha, existing) for existing in seen)
+
+
 def _prose_shas(text: str) -> list[str]:
     """Commit SHAs mentioned in free-text prose.
 
@@ -679,6 +691,9 @@ def _changes_committed_evidence(data: dict) -> str:
 def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     """Distinct commit SHAs a session produced, newest source of truth first.
 
+    Distinctness is abbreviation-aware: two fields that spell the same commit
+    at different lengths yield one entry, keeping the first spelling seen.
+
     The commit set comes from the two fields the session protocol treats as the
     record of what a session committed: ``endingCommit`` and the session-end
     ``changesCommitted`` evidence. Work-log prose is a fallback, consulted only
@@ -722,7 +737,7 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
         for sha in _SHA_RE.findall(field):
             if not include_starting and starting and _same_commit(sha, starting):
                 continue
-            if sha not in seen:
+            if not _already_seen(sha, seen):
                 seen.append(sha)
 
     _add_structured(str(data.get("endingCommit") or ""))
@@ -731,7 +746,7 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     # startingCommit is a structured field, not prose: scan it unfiltered.
     if include_starting:
         for sha in _SHA_RE.findall(starting):
-            if sha not in seen:
+            if not _already_seen(sha, seen):
                 seen.append(sha)
 
     if seen:
@@ -742,7 +757,7 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
         for sha in _prose_shas(_entry_text(entry)):
             if not include_starting and starting and _same_commit(sha, starting):
                 continue
-            if sha in seen:
+            if _already_seen(sha, seen):
                 continue
             if _prose_sha_predates_session(sha, session_date):
                 continue
@@ -1585,7 +1600,10 @@ def main(argv: list[str] | None = None) -> int:
                 print(
                     json.dumps(
                         {
-                            "Error": "--preserve requires the existing episode to be a JSON object.",
+                            "Error": (
+                                "--preserve requires the existing episode to be "
+                                "a JSON object."
+                            ),
                         }
                     ),
                     file=sys.stderr,

--- a/.claude/skills/memory/scripts/extract_session_episode.py
+++ b/.claude/skills/memory/scripts/extract_session_episode.py
@@ -716,7 +716,8 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     no SHA. Deleting the fallback would drop every commit those 15 sessions
     made. They are not a closed historical set: they run 2026-01-15 to
     2026-07-08, so the fallback is load-bearing for logs still being written.
-    Measured over 938 logs by the definition this docstring states: neither
+    Measured over the 941 logs present at the time of measurement, by the
+    definition this docstring states: neither
     ``endingCommit`` nor the ``changesCommitted`` evidence names a SHA other
     than the starting commit, and the work log does. It carries the existing
     hex-letter (issue #3301) and committer-date (issue #3328) filters.

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.118",
+  "version": "0.6.119",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -693,8 +693,11 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
 
     The commit set comes from the two fields the session protocol treats as the
     record of what a session committed: ``endingCommit`` and the session-end
-    ``changesCommitted`` evidence. Work-log prose is a fallback used only when
-    both are empty.
+    ``changesCommitted`` evidence. Work-log prose is a fallback, consulted only
+    when neither of those two yields a SHA. That is a weaker condition than
+    "both fields are empty": evidence reading ``Committed.`` with no SHA in it
+    also reaches the fallback, and has to, because that is the shape 20 of the
+    25 prose-only logs are in.
 
     Prose is not a primary source (issue #3363). A work-log entry legitimately
     cites SHAs the session did not author: a bot's housekeeping commits, a
@@ -705,9 +708,11 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     ``fix/3342-harness-reference-size`` the episode counted two foreign commits
     and dropped three of the session's own.
 
-    The fallback is kept because 27 pre-2026-02 logs record commits only in the
-    work log and have no structured evidence to fall back to. It carries the
-    existing hex-letter (issue #3301) and committer-date (issue #3328) filters.
+    The fallback is kept because 25 logs, all pre-2026-02, record their commits
+    only in the work log. Five have no evidence string at all; the other 20
+    have one that names no SHA. Deleting the fallback would drop every commit
+    those 25 sessions made. It carries the existing hex-letter (issue #3301)
+    and committer-date (issue #3328) filters.
 
     Excludes the starting commit by default: it is the base, not a commit the
     session produced, including when prose repeats it at a different
@@ -933,8 +938,8 @@ def json_metrics(data: dict) -> dict:
     # Count every distinct commit the session documents, from the same source
     # as the commit events so the two can never disagree: endingCommit plus the
     # session-end changesCommitted evidence, falling back to work-log prose only
-    # when both are empty (issue #3363). Excludes the starting commit (the base,
-    # not a commit the session produced).
+    # when neither of those yields a SHA (issue #3363). Excludes the starting
+    # commit: it is the base, not a commit the session produced.
     commit_count = len(_collect_shas(data, include_starting=False))
     metrics = {
         "duration_minutes": 0,

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -43,10 +43,10 @@ def get_session_id_from_path(path: Path) -> str:
     distinct episode files.
     """
     stem = path.stem
-    match = re.search(r'(\d{4}-\d{2}-\d{2}-session-\d+(?:-.+)?)', stem)
+    match = re.search(r"(\d{4}-\d{2}-\d{2}-session-\d+(?:-.+)?)", stem)
     if match:
         return match.group(1)
-    match = re.search(r'(session-\d+(?:-.+)?)', stem)
+    match = re.search(r"(session-\d+(?:-.+)?)", stem)
     if match:
         return match.group(1)
     return stem
@@ -65,40 +65,40 @@ def parse_session_metadata(lines: list[str]) -> dict:
 
     for line in lines:
         # Title (first H1)
-        title_match = re.match(r'^#\s+(.+)$', line)
+        title_match = re.match(r"^#\s+(.+)$", line)
         if title_match and not metadata["title"]:
             metadata["title"] = title_match.group(1)
             continue
 
         # Date field
-        m = re.match(r'^\*\*Date\*\*:\s*(.+)$', line)
+        m = re.match(r"^\*\*Date\*\*:\s*(.+)$", line)
         if m:
             metadata["date"] = m.group(1).strip()
             continue
 
         # Status field
-        m = re.match(r'^\*\*Status\*\*:\s*(.+)$', line)
+        m = re.match(r"^\*\*Status\*\*:\s*(.+)$", line)
         if m:
             metadata["status"] = m.group(1).strip()
             continue
 
         # Objectives section
-        if re.match(r'^##\s*Objectives?', line):
+        if re.match(r"^##\s*Objectives?", line):
             in_section = "objectives"
             continue
 
         # Deliverables section
-        if re.match(r'^##\s*Deliverables?', line):
+        if re.match(r"^##\s*Deliverables?", line):
             in_section = "deliverables"
             continue
 
         # New section ends current
-        if re.match(r'^##\s', line):
+        if re.match(r"^##\s", line):
             in_section = ""
             continue
 
         # Collect list items
-        m = re.match(r'^\s*[-*]\s+(.+)$', line)
+        m = re.match(r"^\s*[-*]\s+(.+)$", line)
         if m:
             item = m.group(1).strip()
             if in_section == "objectives":
@@ -112,13 +112,13 @@ def parse_session_metadata(lines: list[str]) -> dict:
 def get_decision_type(text: str) -> str:
     """Categorize decision type from text."""
     lower = text.lower()
-    if re.search(r'design|architect|schema|structure', lower):
+    if re.search(r"design|architect|schema|structure", lower):
         return "design"
-    if re.search(r'test|pester|coverage|assert', lower):
+    if re.search(r"test|pester|coverage|assert", lower):
         return "test"
-    if re.search(r'recover|fix|retry|fallback', lower):
+    if re.search(r"recover|fix|retry|fallback", lower):
         return "recovery"
-    if re.search(r'route|delegate|agent|handoff', lower):
+    if re.search(r"route|delegate|agent|handoff", lower):
         return "routing"
     return "implementation"
 
@@ -131,22 +131,18 @@ def parse_decisions(lines: list[str], timestamp: str | None = None) -> list[dict
     ts = timestamp if timestamp is not None else datetime.now(UTC).isoformat()
 
     for i, line in enumerate(lines):
-        if re.match(r'^##\s*Decisions?', line):
+        if re.match(r"^##\s*Decisions?", line):
             in_decision_section = True
             continue
 
-        if in_decision_section and re.match(r'^##\s', line):
+        if in_decision_section and re.match(r"^##\s", line):
             in_decision_section = False
 
         # Decision patterns in various formats
         decision_text = None
-        m1 = re.match(r'^\*\*Decision\*\*:\s*(.+)$', line)
-        m2 = re.match(r'^Decision:\s*(.+)$', line)
-        m3 = (
-            re.match(r'^\s*[-*]\s+\*\*(.+?)\*\*:\s*(.+)$', line)
-            if in_decision_section
-            else None
-        )
+        m1 = re.match(r"^\*\*Decision\*\*:\s*(.+)$", line)
+        m2 = re.match(r"^Decision:\s*(.+)$", line)
+        m3 = re.match(r"^\s*[-*]\s+\*\*(.+?)\*\*:\s*(.+)$", line) if in_decision_section else None
 
         if m1:
             decision_text = m1.group(1)
@@ -159,38 +155,39 @@ def parse_decisions(lines: list[str], timestamp: str | None = None) -> list[dict
             decision_index += 1
             context = ""
             if i > 0:
-                ctx_match = re.match(r'^\s*[-*]\s+(.+)$', lines[i - 1])
+                ctx_match = re.match(r"^\s*[-*]\s+(.+)$", lines[i - 1])
                 if ctx_match:
                     context = ctx_match.group(1)
 
-            decisions.append({
-                "id": f"d{decision_index:03d}",
-                "timestamp": ts,
-                "type": get_decision_type(decision_text),
-                "context": context,
-                "chosen": decision_text,
-                "rationale": "",
-                "outcome": "success",
-                "effects": [],
-            })
+            decisions.append(
+                {
+                    "id": f"d{decision_index:03d}",
+                    "timestamp": ts,
+                    "type": get_decision_type(decision_text),
+                    "context": context,
+                    "chosen": decision_text,
+                    "rationale": "",
+                    "outcome": "success",
+                    "effects": [],
+                }
+            )
             continue
 
         # Capture decisions from work log entries
-        if (
-            re.search(r'chose|decided|selected|opted for', line)
-            and not line.startswith('#')
-        ):
+        if re.search(r"chose|decided|selected|opted for", line) and not line.startswith("#"):
             decision_index += 1
-            decisions.append({
-                "id": f"d{decision_index:03d}",
-                "timestamp": ts,
-                "type": "implementation",
-                "context": "",
-                "chosen": line.strip(),
-                "rationale": "",
-                "outcome": "success",
-                "effects": [],
-            })
+            decisions.append(
+                {
+                    "id": f"d{decision_index:03d}",
+                    "timestamp": ts,
+                    "type": "implementation",
+                    "context": "",
+                    "chosen": line.strip(),
+                    "rationale": "",
+                    "outcome": "success",
+                    "effects": [],
+                }
+            )
 
     return decisions
 
@@ -205,9 +202,9 @@ def parse_events(lines: list[str], timestamp: str | None = None) -> list[dict]:
         evt = None
 
         # Commit events
-        m = re.search(r'commit[ted]?\s+(?:as\s+)?([a-f0-9]{7,40})', line)
+        m = re.search(r"commit[ted]?\s+(?:as\s+)?([a-f0-9]{7,40})", line)
         if not m:
-            m = re.search(r'([a-f0-9]{7,40})\s+\w+\(.+\):', line)
+            m = re.search(r"([a-f0-9]{7,40})\s+\w+\(.+\):", line)
         if m:
             event_index += 1
             evt = {
@@ -220,10 +217,7 @@ def parse_events(lines: list[str], timestamp: str | None = None) -> list[dict]:
             }
 
         # Error events
-        if (
-            re.search(r'error|fail|exception', line, re.IGNORECASE)
-            and not line.startswith('#')
-        ):
+        if re.search(r"error|fail|exception", line, re.IGNORECASE) and not line.startswith("#"):
             event_index += 1
             evt = {
                 "id": f"e{event_index:03d}",
@@ -235,12 +229,11 @@ def parse_events(lines: list[str], timestamp: str | None = None) -> list[dict]:
             }
 
         # Milestone events
-        if (
-            re.search(r'completed?|done|finished|success', line, re.IGNORECASE)
-            and re.match(r'^[-*]\s+(?!\*)', line)
+        if re.search(r"completed?|done|finished|success", line, re.IGNORECASE) and re.match(
+            r"^[-*]\s+(?!\*)", line
         ):
             event_index += 1
-            content = re.sub(r'^[-*]\s*', '', line.strip())
+            content = re.sub(r"^[-*]\s*", "", line.strip())
             evt = {
                 "id": f"e{event_index:03d}",
                 "timestamp": ts,
@@ -257,13 +250,13 @@ def parse_events(lines: list[str], timestamp: str | None = None) -> list[dict]:
         # a status vocabulary so objective/decision sentences that merely begin
         # with "Complete ..." do not misfire. Refs PR #2170 (thread GA722).
         elif re.match(
-            r'^[-*]\s+\*\*(?:status|result|outcome|state|resolution)\*\*\s*:\s*'
-            r'(complete|completed|done|success|finished)\b',
+            r"^[-*]\s+\*\*(?:status|result|outcome|state|resolution)\*\*\s*:\s*"
+            r"(complete|completed|done|success|finished)\b",
             line,
             re.IGNORECASE,
         ):
             event_index += 1
-            content = re.sub(r'^[-*]\s*', '', line.strip())
+            content = re.sub(r"^[-*]\s*", "", line.strip())
             evt = {
                 "id": f"e{event_index:03d}",
                 "timestamp": ts,
@@ -274,7 +267,7 @@ def parse_events(lines: list[str], timestamp: str | None = None) -> list[dict]:
             }
 
         # Test events
-        if re.search(r'test[s]?\s+(pass|fail|run)', line, re.IGNORECASE) or 'Pester' in line:
+        if re.search(r"test[s]?\s+(pass|fail|run)", line, re.IGNORECASE) or "Pester" in line:
             event_index += 1
             evt = {
                 "id": f"e{event_index:03d}",
@@ -297,18 +290,18 @@ def parse_lessons(lines: list[str]) -> list[str]:
     in_lessons_section = False
 
     for line in lines:
-        if re.match(r'^##\s*(Lessons?\s*Learned?|Key\s*Learnings?|Takeaways?)', line):
+        if re.match(r"^##\s*(Lessons?\s*Learned?|Key\s*Learnings?|Takeaways?)", line):
             in_lessons_section = True
             continue
 
-        if in_lessons_section and re.match(r'^##\s', line):
+        if in_lessons_section and re.match(r"^##\s", line):
             in_lessons_section = False
 
-        m = re.match(r'^\s*[-*]\s+(.+)$', line)
+        m = re.match(r"^\s*[-*]\s+(.+)$", line)
         if in_lessons_section and m:
             lessons.append(m.group(1).strip())
         elif m and re.match(
-            r'(?:lessons?\s+learned|lessons?|learned|takeaways?|note\s+for\s+future)\b',
+            r"(?:lessons?\s+learned|lessons?|learned|takeaways?|note\s+for\s+future)\b",
             m.group(1),
             re.IGNORECASE,
         ):
@@ -334,25 +327,22 @@ def parse_metrics(lines: list[str]) -> dict:
 
     for line in lines:
         # Duration
-        m = re.search(r'(\d+)\s*minutes?', line)
+        m = re.search(r"(\d+)\s*minutes?", line)
         if not m:
-            m = re.search(r'duration:\s*(\d+)', line, re.IGNORECASE)
+            m = re.search(r"duration:\s*(\d+)", line, re.IGNORECASE)
         if m:
             metrics["duration_minutes"] = int(m.group(1))
 
         # Count commits
-        if re.search(r'[a-f0-9]{7,40}', line):
+        if re.search(r"[a-f0-9]{7,40}", line):
             metrics["commits"] += 1
 
         # Count errors
-        if (
-            re.search(r'error|fail|exception', line, re.IGNORECASE)
-            and not line.startswith('#')
-        ):
+        if re.search(r"error|fail|exception", line, re.IGNORECASE) and not line.startswith("#"):
             metrics["errors"] += 1
 
         # Count files
-        m = re.search(r'(\d+)\s+files?\s+(changed|modified|created)', line)
+        m = re.search(r"(\d+)\s+files?\s+(changed|modified|created)", line)
         if m:
             metrics["files_changed"] += int(m.group(1))
 
@@ -363,11 +353,11 @@ def get_session_outcome(metadata: dict, events: list[dict]) -> str:
     """Determine overall session outcome."""
     status = (metadata.get("status") or "").lower()
 
-    if re.search(r'complete|done|success', status):
+    if re.search(r"complete|done|success", status):
         return "success"
-    if re.search(r'partial|in.?progress|blocked', status):
+    if re.search(r"partial|in.?progress|blocked", status):
         return "partial"
-    if re.search(r'fail|abort|error', status):
+    if re.search(r"fail|abort|error", status):
         return "failure"
 
     error_count = sum(1 for e in events if e.get("type") == "error")
@@ -393,9 +383,7 @@ def get_session_outcome(metadata: dict, events: list[dict]) -> str:
 # captures the keyword so callers can reject HTTP-status-shaped error counts.
 # Refs PR #2170 (thread GANjI): leading numbers that are issue refs or status
 # codes must not inflate metrics.errors.
-_FAIL_COUNT_RE = re.compile(
-    r"(?<![#\w])([1-9]\d*)\s+(failed|failures|errors?)\b", re.IGNORECASE
-)
+_FAIL_COUNT_RE = re.compile(r"(?<![#\w])([1-9]\d*)\s+(failed|failures|errors?)\b", re.IGNORECASE)
 _PASS_COUNT_RE = re.compile(r"\b(\d+)\s+(?:passed|passing)\b", re.IGNORECASE)
 _SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
 # A commit SHA candidate pulled from free-text prose must contain at least one
@@ -724,7 +712,13 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     session_date = str(session.get("date") or "").strip()
 
     def _add_structured(field: str) -> None:
-        """Structured fields are the protocol's record; scan them unfiltered."""
+        """Take every SHA a structured field names.
+
+        Structured fields are the protocol's record, so no prose heuristic is
+        applied to them. The one exclusion is the starting commit, which the
+        session inherited rather than produced, and which the caller can keep
+        with ``include_starting``.
+        """
         for sha in _SHA_RE.findall(field):
             if not include_starting and starting and _same_commit(sha, starting):
                 continue
@@ -789,9 +783,7 @@ def json_outcome(data: dict, additional_worklogs: list | None = None) -> str:
     if additional_worklogs:
         worklogs_to_check = worklogs_to_check + additional_worklogs
 
-    explicit_failure = any(
-        _valid_fail_match(_entry_text(e)) is not None for e in worklogs_to_check
-    )
+    explicit_failure = any(_valid_fail_match(_entry_text(e)) is not None for e in worklogs_to_check)
 
     if explicit_failure and not all_complete:
         return "failure"
@@ -806,14 +798,16 @@ def json_events(data: dict, now_iso: str) -> list[dict]:
     def add(evt_type: str, content: str) -> None:
         nonlocal idx
         idx += 1
-        events.append({
-            "id": f"e{idx:03d}",
-            "timestamp": now_iso,
-            "type": evt_type,
-            "content": content,
-            "caused_by": [],
-            "leads_to": [],
-        })
+        events.append(
+            {
+                "id": f"e{idx:03d}",
+                "timestamp": now_iso,
+                "type": evt_type,
+                "content": content,
+                "caused_by": [],
+                "leads_to": [],
+            }
+        )
 
     for entry in _as_list(data.get("workLog")):
         title = _entry_title(entry)
@@ -851,16 +845,18 @@ def json_decisions(data: dict, now_iso: str) -> list[dict]:
         # not a bare status word ("success", "ok", ...).
         chosen = title or (outcome if outcome.lower() not in _STATUS_WORDS else "")
         idx += 1
-        decisions.append({
-            "id": f"d{idx:03d}",
-            "timestamp": now_iso,
-            "type": get_decision_type(text),
-            "context": title,
-            "chosen": chosen,
-            "rationale": _entry_field(entry, "evidence").strip(),
-            "outcome": "success",
-            "effects": [],
-        })
+        decisions.append(
+            {
+                "id": f"d{idx:03d}",
+                "timestamp": now_iso,
+                "type": get_decision_type(text),
+                "context": title,
+                "chosen": chosen,
+                "rationale": _entry_field(entry, "evidence").strip(),
+                "outcome": "success",
+                "effects": [],
+            }
+        )
     return decisions
 
 
@@ -1083,6 +1079,7 @@ def _dedupe_decisions(existing: list, new: list) -> list[dict]:
     ``chosen`` summary so the dedup key and output retain the content.
     Refs PR #2170 (thread GASBG).
     """
+
     def coerce(dec: Any) -> dict:
         if isinstance(dec, str):
             text = dec.strip()
@@ -1158,9 +1155,7 @@ def merge_preserving(new: dict, existing: dict, *, session_id: str = "") -> dict
     idempotent. Applying twice is a no-op.
     """
     existing = _as_dict(existing)
-    date = _deterministic_date(
-        session_id, new.get("timestamp"), existing.get("timestamp")
-    )
+    date = _deterministic_date(session_id, new.get("timestamp"), existing.get("timestamp"))
     midnight = f"{date}T00:00:00+00:00" if date else None
 
     merged = dict(new)
@@ -1317,9 +1312,7 @@ def extract_from_json(data: dict, *, archive_fallback: bool = True) -> dict:
                             lessons = archive_lessons
                 except (OSError, json.JSONDecodeError):
                     pass
-            has_events = any(
-                e.get("type") in ("milestone", "test", "error") for e in events
-            )
+            has_events = any(e.get("type") in ("milestone", "test", "error") for e in events)
             has_own_events = has_events or any(e.get("type") == "commit" for e in events)
             if not has_events or not decisions or not lessons:
                 archive_md_path = next(
@@ -1369,27 +1362,33 @@ def build_parser() -> argparse.ArgumentParser:
         description="Extract episode data from session logs.",
     )
     parser.add_argument(
-        "session_log_path", type=Path,
+        "session_log_path",
+        type=Path,
         help="Path to the session log file to extract from",
     )
     parser.add_argument(
-        "--output-path", type=Path, default=None,
+        "--output-path",
+        type=Path,
+        default=None,
         help="Output directory for episode JSON",
     )
     write_mode = parser.add_mutually_exclusive_group()
     write_mode.add_argument(
-        "--force", action="store_true",
+        "--force",
+        action="store_true",
         help="Overwrite existing episode file if it exists",
     )
     write_mode.add_argument(
-        "--preserve", action="store_true",
+        "--preserve",
+        action="store_true",
         help=(
             "Read-modify-write an existing episode file, merging fresh "
             "extraction over it without dropping richer existing data"
         ),
     )
     parser.add_argument(
-        "--pending-stage", action="store_true",
+        "--pending-stage",
+        action="store_true",
         help=(
             "Add 1 to staged files count to account for the episode file "
             "that will be staged after extraction (pre-commit hook context)"
@@ -1482,9 +1481,11 @@ def main(argv: list[str] | None = None) -> int:
         content = session_log_path.read_text(encoding="utf-8")
     except OSError as e:
         print(
-            json.dumps({
-                "Error": f"Failed to read session log: {e}",
-            }),
+            json.dumps(
+                {
+                    "Error": f"Failed to read session log: {e}",
+                }
+            ),
             file=sys.stderr,
         )
         return 1
@@ -1518,15 +1519,10 @@ def main(argv: list[str] | None = None) -> int:
                 timestamp = datetime.fromisoformat(metadata["date"]).isoformat()
             except ValueError:
                 print(
-                    f"  WARNING: Could not parse date '{metadata['date']}', "
-                    "using current time",
+                    f"  WARNING: Could not parse date '{metadata['date']}', using current time",
                     file=sys.stderr,
                 )
-        task = (
-            metadata["objectives"][0]
-            if metadata["objectives"]
-            else metadata["title"]
-        )
+        task = metadata["objectives"][0] if metadata["objectives"] else metadata["title"]
 
     # Best-effort backfill: when neither the JSON workLog nor the legacy
     # markdown recorded a files-changed count, derive it from the staged commit.
@@ -1577,17 +1573,21 @@ def main(argv: list[str] | None = None) -> int:
                 existing_raw = json.loads(episode_file.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError) as e:
                 print(
-                    json.dumps({
-                        "Error": f"--preserve requires a readable existing episode: {e}",
-                    }),
+                    json.dumps(
+                        {
+                            "Error": f"--preserve requires a readable existing episode: {e}",
+                        }
+                    ),
                     file=sys.stderr,
                 )
                 return 1
             if not isinstance(existing_raw, dict):
                 print(
-                    json.dumps({
-                        "Error": "--preserve requires the existing episode to be a JSON object.",
-                    }),
+                    json.dumps(
+                        {
+                            "Error": "--preserve requires the existing episode to be a JSON object.",
+                        }
+                    ),
                     file=sys.stderr,
                 )
                 return 1
@@ -1598,12 +1598,14 @@ def main(argv: list[str] | None = None) -> int:
             outcome = episode["outcome"]
         elif not args.force:
             print(
-                json.dumps({
-                    "Error": (
-                        f"Episode file already exists: {episode_file}. "
-                        "Use --force to overwrite or --preserve to merge."
-                    ),
-                }),
+                json.dumps(
+                    {
+                        "Error": (
+                            f"Episode file already exists: {episode_file}. "
+                            "Use --force to overwrite or --preserve to merge."
+                        ),
+                    }
+                ),
                 file=sys.stderr,
             )
             return 1

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -699,8 +699,8 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     ``changesCommitted`` evidence. Work-log prose is a fallback, consulted only
     when neither of those two yields a SHA. That is a weaker condition than
     "both fields are empty": evidence reading ``Committed.`` with no SHA in it
-    also reaches the fallback, and has to, because that is the shape 20 of the
-    25 prose-only logs are in.
+    also reaches the fallback, and has to, because that is the shape 12 of the
+    15 prose-only logs are in.
 
     Prose is not a primary source (issue #3363). A work-log entry legitimately
     cites SHAs the session did not author: a bot's housekeeping commits, a
@@ -711,11 +711,15 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     ``fix/3342-harness-reference-size`` the episode counted two foreign commits
     and dropped three of the session's own.
 
-    The fallback is kept because 25 logs, all pre-2026-02, record their commits
-    only in the work log. Five have no evidence string at all; the other 20
-    have one that names no SHA. Deleting the fallback would drop every commit
-    those 25 sessions made. It carries the existing hex-letter (issue #3301)
-    and committer-date (issue #3328) filters.
+    The fallback is kept because 15 logs record their commits only in the work
+    log. Three have no evidence string at all; the other 12 have one that names
+    no SHA. Deleting the fallback would drop every commit those 15 sessions
+    made. They are not a closed historical set: they run 2026-01-15 to
+    2026-07-08, so the fallback is load-bearing for logs still being written.
+    Measured over 938 logs by the definition this docstring states: neither
+    ``endingCommit`` nor the ``changesCommitted`` evidence names a SHA other
+    than the starting commit, and the work log does. It carries the existing
+    hex-letter (issue #3301) and committer-date (issue #3328) filters.
 
     Excludes the starting commit by default: it is the base, not a commit the
     session produced, including when prose repeats it at a different

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -746,7 +746,16 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
                 seen.append(sha)
 
     _add_structured(str(data.get("endingCommit") or ""))
-    _add_structured(_changes_committed_evidence(data))
+
+    # changesCommitted evidence is prose, not a structured single-SHA field:
+    # apply the hex-letter filter to avoid counting decimal-only tokens as
+    # commits (issue #3363, mirrors _prose_shas logic from issue #3301).
+    evidence = _changes_committed_evidence(data)
+    for sha in _prose_shas(evidence):
+        if not include_starting and starting and _same_commit(sha, starting):
+            continue
+        if not _already_seen(sha, seen):
+            seen.append(sha)
 
     # startingCommit is a structured field, not prose: scan it unfiltered.
     if include_starting:

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -528,9 +528,14 @@ def _gate_complete(data: dict, phase: str, gate: str) -> bool:
 def _same_commit(a: str, b: str) -> bool:
     """True when two hex SHA strings denote the same commit, allowing for git
     abbreviation: the shorter is a prefix of the longer with at least 7 shared
-    hex chars (git's minimum unambiguous abbreviation length). Exact equality
-    is the equal-length case. This lets a full 40-char ``startingCommit`` match
-    a 7-char abbreviation of it repeated in work-log prose (issue #3123)."""
+    hex chars. Exact equality is the equal-length case. This lets a full 40-char
+    ``startingCommit`` match a 7-char abbreviation of it repeated in work-log
+    prose (issue #3123).
+
+    Seven is this module's own floor, not a git contract. Git's abbreviation
+    length is repo-dependent (``core.abbrev``, and git widens it as the object
+    count grows), so there is no minimum to inherit. Seven is chosen because it
+    is what this repository's tooling emits and short enough prefixes collide."""
     a = a.strip().lower()
     b = b.strip().lower()
     if not a or not b:
@@ -688,7 +693,7 @@ def _changes_committed_evidence(data: dict) -> str:
     return ""
 
 
-def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
+def _collect_shas(data: dict) -> list[str]:
     """Distinct commit SHAs a session produced, newest source of truth first.
 
     Distinctness is abbreviation-aware: two fields that spell the same commit
@@ -722,46 +727,30 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     than the starting commit, and the work log does. It carries the existing
     hex-letter (issue #3301) and committer-date (issue #3328) filters.
 
-    Excludes the starting commit by default: it is the base, not a commit the
-    session produced, including when prose repeats it at a different
-    abbreviation length (issue #3123).
+    Excludes the starting commit: it is the base, not a commit the session
+    produced, including when prose repeats it at a different abbreviation
+    length (issue #3123).
     """
     seen: list[str] = []
     session = _as_dict(data.get("session"))
     starting = str(session.get("startingCommit") or "").strip()
     session_date = str(session.get("date") or "").strip()
 
-    def _add_structured(field: str) -> None:
-        """Take every SHA a structured field names.
-
-        Structured fields are the protocol's record, so no prose heuristic is
-        applied to them. The one exclusion is the starting commit, which the
-        session inherited rather than produced, and which the caller can keep
-        with ``include_starting``.
-        """
-        for sha in _SHA_RE.findall(field):
-            if not include_starting and starting and _same_commit(sha, starting):
+    def _take(shas: list[str]) -> None:
+        """Record every SHA that is neither the base commit nor already held."""
+        for sha in shas:
+            if starting and _same_commit(sha, starting):
                 continue
             if not _already_seen(sha, seen):
                 seen.append(sha)
 
-    _add_structured(str(data.get("endingCommit") or ""))
-
-    # changesCommitted evidence is prose, not a structured single-SHA field:
-    # apply the hex-letter filter to avoid counting decimal-only tokens as
-    # commits (issue #3363, mirrors _prose_shas logic from issue #3301).
-    evidence = _changes_committed_evidence(data)
-    for sha in _prose_shas(evidence):
-        if not include_starting and starting and _same_commit(sha, starting):
-            continue
-        if not _already_seen(sha, seen):
-            seen.append(sha)
-
-    # startingCommit is a structured field, not prose: scan it unfiltered.
-    if include_starting:
-        for sha in _SHA_RE.findall(starting):
-            if not _already_seen(sha, seen):
-                seen.append(sha)
+    # endingCommit is the protocol's own field, so no prose heuristic applies.
+    _take(_SHA_RE.findall(str(data.get("endingCommit") or "")))
+    # changesCommitted evidence is a free-text sentence rather than a bare SHA,
+    # so the hex-letter filter applies: a 20-digit CI run id quoted there is not
+    # a commit (issue #3301). Scanning it unfiltered also let a decimal-only
+    # match populate ``seen`` and suppress the work-log fallback below.
+    _take(_prose_shas(_changes_committed_evidence(data)))
 
     if seen:
         return seen
@@ -769,7 +758,7 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     # Fallback for logs with no structured commit record at all.
     for entry in _as_list(data.get("workLog")):
         for sha in _prose_shas(_entry_text(entry)):
-            if not include_starting and starting and _same_commit(sha, starting):
+            if starting and _same_commit(sha, starting):
                 continue
             if _already_seen(sha, seen):
                 continue
@@ -854,7 +843,7 @@ def json_events(data: dict, now_iso: str) -> list[dict]:
     # event stream and metrics.commits share a single provenance rule
     # (issue #3123). Excludes the starting/base SHA, including work-log
     # mentions of it, matching json_metrics.
-    for sha in _collect_shas(data, include_starting=False):
+    for sha in _collect_shas(data):
         add("commit", f"Commit: {sha}")
 
     return events
@@ -965,7 +954,7 @@ def json_metrics(data: dict) -> dict:
     # session-end changesCommitted evidence, falling back to work-log prose only
     # when neither of those yields a SHA (issue #3363). Excludes the starting
     # commit: it is the base, not a commit the session produced.
-    commit_count = len(_collect_shas(data, include_starting=False))
+    commit_count = len(_collect_shas(data))
     metrics = {
         "duration_minutes": 0,
         "tool_calls": 0,

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -671,23 +671,63 @@ def _prose_sha_predates_session(sha: str, session_date: str) -> bool:
     return committed.astimezone(UTC) < floor
 
 
+def _changes_committed_evidence(data: dict) -> str:
+    """The session-end ``changesCommitted`` evidence string, or empty.
+
+    The session protocol treats this field as the record of what the session
+    committed, so it is the authoritative commit source alongside
+    ``endingCommit``.
+    """
+    compliance = _as_dict(data.get("protocolCompliance"))
+    session_end = _as_dict(compliance.get("sessionEnd"))
+    item = _as_dict(session_end.get("changesCommitted"))
+    for key in ("Evidence", "evidence"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
+
+
 def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
-    """Distinct commit SHAs from the structured commit fields and work-log
-    evidence. Excludes the starting commit by default (it is the base, not a
-    commit the session produced), including when work-log prose repeats it at a
-    different abbreviation length than ``startingCommit`` is stored (issue
-    #3123). Also excludes any prose SHA git proves was committed before the
-    session's date window (issue #3328)."""
+    """Distinct commit SHAs a session produced, newest source of truth first.
+
+    The commit set comes from the two fields the session protocol treats as the
+    record of what a session committed: ``endingCommit`` and the session-end
+    ``changesCommitted`` evidence. Work-log prose is a fallback used only when
+    both are empty.
+
+    Prose is not a primary source (issue #3363). A work-log entry legitimately
+    cites SHAs the session did not author: a bot's housekeeping commits, a
+    commit it bisected, the base of a PR it read. Counting those inflated
+    ``metrics.commits`` and seeded commit nodes in the causal graph for work the
+    session never did, while the session's own commits, recorded only in
+    ``changesCommitted``, were missed entirely. On
+    ``fix/3342-harness-reference-size`` the episode counted two foreign commits
+    and dropped three of the session's own.
+
+    The fallback is kept because 27 pre-2026-02 logs record commits only in the
+    work log and have no structured evidence to fall back to. It carries the
+    existing hex-letter (issue #3301) and committer-date (issue #3328) filters.
+
+    Excludes the starting commit by default: it is the base, not a commit the
+    session produced, including when prose repeats it at a different
+    abbreviation length (issue #3123).
+    """
     seen: list[str] = []
     session = _as_dict(data.get("session"))
     starting = str(session.get("startingCommit") or "").strip()
     session_date = str(session.get("date") or "").strip()
 
-    # Process endingCommit first without filtering - it's authoritative, not prose
-    ending_field = str(data.get("endingCommit") or "")
-    for sha in _SHA_RE.findall(ending_field):
-        if sha not in seen:
-            seen.append(sha)
+    def _add_structured(field: str) -> None:
+        """Structured fields are the protocol's record; scan them unfiltered."""
+        for sha in _SHA_RE.findall(field):
+            if not include_starting and starting and _same_commit(sha, starting):
+                continue
+            if sha not in seen:
+                seen.append(sha)
+
+    _add_structured(str(data.get("endingCommit") or ""))
+    _add_structured(_changes_committed_evidence(data))
 
     # startingCommit is a structured field, not prose: scan it unfiltered.
     if include_starting:
@@ -695,8 +735,10 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
             if sha not in seen:
                 seen.append(sha)
 
-    # work-log entries are free-text prose: require a hex letter so decimal-only
-    # IDs are not counted as commits (issue #3301).
+    if seen:
+        return seen
+
+    # Fallback for logs with no structured commit record at all.
     for entry in _as_list(data.get("workLog")):
         for sha in _prose_shas(_entry_text(entry)):
             if not include_starting and starting and _same_commit(sha, starting):
@@ -888,9 +930,11 @@ def _staged_files_changed(cwd: str | Path | None = None) -> int:
 
 
 def json_metrics(data: dict) -> dict:
-    # Count every distinct commit the session documents (ending commit plus any
-    # SHAs in work-log evidence), not just the ending commit. Excludes the
-    # starting commit (the base, not a commit the session produced).
+    # Count every distinct commit the session documents, from the same source
+    # as the commit events so the two can never disagree: endingCommit plus the
+    # session-end changesCommitted evidence, falling back to work-log prose only
+    # when both are empty (issue #3363). Excludes the starting commit (the base,
+    # not a commit the session produced).
     commit_count = len(_collect_shas(data, include_starting=False))
     metrics = {
         "duration_minutes": 0,

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -539,6 +539,18 @@ def _same_commit(a: str, b: str) -> bool:
     return len(lo) >= 7 and hi.startswith(lo)
 
 
+def _already_seen(sha: str, seen: list[str]) -> bool:
+    """True when ``seen`` already holds this commit at any abbreviation length.
+
+    Exact string membership lets one commit in twice when two fields spell it
+    at different lengths: a full 40-char ``endingCommit`` and a 7-char
+    abbreviation of the same commit in the ``changesCommitted`` evidence. That
+    double-counts ``metrics.commits`` and emits two commit events and two
+    causal-graph nodes for a single commit (issue #3363).
+    """
+    return any(_same_commit(sha, existing) for existing in seen)
+
+
 def _prose_shas(text: str) -> list[str]:
     """Commit SHAs mentioned in free-text prose.
 
@@ -679,6 +691,9 @@ def _changes_committed_evidence(data: dict) -> str:
 def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     """Distinct commit SHAs a session produced, newest source of truth first.
 
+    Distinctness is abbreviation-aware: two fields that spell the same commit
+    at different lengths yield one entry, keeping the first spelling seen.
+
     The commit set comes from the two fields the session protocol treats as the
     record of what a session committed: ``endingCommit`` and the session-end
     ``changesCommitted`` evidence. Work-log prose is a fallback, consulted only
@@ -722,7 +737,7 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
         for sha in _SHA_RE.findall(field):
             if not include_starting and starting and _same_commit(sha, starting):
                 continue
-            if sha not in seen:
+            if not _already_seen(sha, seen):
                 seen.append(sha)
 
     _add_structured(str(data.get("endingCommit") or ""))
@@ -731,7 +746,7 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     # startingCommit is a structured field, not prose: scan it unfiltered.
     if include_starting:
         for sha in _SHA_RE.findall(starting):
-            if sha not in seen:
+            if not _already_seen(sha, seen):
                 seen.append(sha)
 
     if seen:
@@ -742,7 +757,7 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
         for sha in _prose_shas(_entry_text(entry)):
             if not include_starting and starting and _same_commit(sha, starting):
                 continue
-            if sha in seen:
+            if _already_seen(sha, seen):
                 continue
             if _prose_sha_predates_session(sha, session_date):
                 continue
@@ -1585,7 +1600,10 @@ def main(argv: list[str] | None = None) -> int:
                 print(
                     json.dumps(
                         {
-                            "Error": "--preserve requires the existing episode to be a JSON object.",
+                            "Error": (
+                                "--preserve requires the existing episode to be "
+                                "a JSON object."
+                            ),
                         }
                     ),
                     file=sys.stderr,

--- a/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
+++ b/src/copilot-cli/skills/memory/scripts/extract_session_episode.py
@@ -716,7 +716,8 @@ def _collect_shas(data: dict, *, include_starting: bool) -> list[str]:
     no SHA. Deleting the fallback would drop every commit those 15 sessions
     made. They are not a closed historical set: they run 2026-01-15 to
     2026-07-08, so the fallback is load-bearing for logs still being written.
-    Measured over 938 logs by the definition this docstring states: neither
+    Measured over the 941 logs present at the time of measurement, by the
+    definition this docstring states: neither
     ``endingCommit`` nor the ``changesCommitted`` evidence names a SHA other
     than the starting commit, and the work log does. It carries the existing
     hex-letter (issue #3301) and committer-date (issue #3328) filters.

--- a/tests/skills/memory/test_extract_session_episode.py
+++ b/tests/skills/memory/test_extract_session_episode.py
@@ -291,8 +291,14 @@ def _lowercase_gate(complete):
     return {"level": "MUST", "complete": complete, "evidence": "x"}
 
 
-def _json_log(work_log, end_complete=True):
+def _json_log(work_log, end_complete=True, committed=None):
+    """``committed`` populates the session-end changesCommitted evidence, which
+    is the protocol's authoritative record of what the session committed and
+    the source commit provenance reads first (issue #3363)."""
     gate = _gate(end_complete)
+    committed_gate = dict(gate)
+    if committed is not None:
+        committed_gate["Evidence"] = committed
     return {
         "session": {
             "number": 1,
@@ -305,7 +311,7 @@ def _json_log(work_log, end_complete=True):
             "sessionStart": {},
             "sessionEnd": {
                 "checklistComplete": gate,
-                "changesCommitted": gate,
+                "changesCommitted": committed_gate,
                 "validationPassed": gate,
             },
         },
@@ -654,26 +660,25 @@ class TestJsonLessonsObjectShape:
 
 
 class TestJsonCommitMetric:
-    """`json_metrics["commits"]` counts every distinct documented commit (#2170)."""
+    """`json_metrics["commits"]` counts every distinct documented commit (#2170).
 
-    def test_counts_ending_and_worklog_shas(self):
-        data = _json_log(
-            [
-                {"task": "Commit A", "outcome": "1234abc. Added parser"},
-                {"task": "Commit B", "outcome": "5678def0. Fixed lint"},
-            ]
-        )
-        # endingCommit bbbbbbb1234 + two work-log SHAs = 3 distinct.
+    #2170 established that a session's commit count is not just ``endingCommit``.
+    #3363 corrected where the rest come from: the session-end changesCommitted
+    evidence, not work-log narrative, which also cites commits the session read
+    rather than authored.
+    """
+
+    def test_counts_ending_and_changes_committed_shas(self):
+        data = _json_log([], committed="Commits: 1234abc (parser), 5678def0 (lint).")
+        # endingCommit bbbbbbb1234 + two changesCommitted SHAs = 3 distinct.
         assert extract_session_episode.json_metrics(data)["commits"] == 3
 
     def test_dedupes_repeated_sha(self):
         data = _json_log(
-            [
-                {"task": "Commit A", "outcome": "1234abc. Added parser"},
-                {"task": "Re-reference", "evidence": "see 1234abc for details"},
-            ]
+            [{"task": "Re-reference", "evidence": "see 1234abc for details"}],
+            committed="Commit 1234abc, verified again as 1234abc.",
         )
-        # endingCommit + one distinct work-log SHA (1234abc counted once) = 2.
+        # endingCommit + one distinct evidence SHA (1234abc counted once) = 2.
         assert extract_session_episode.json_metrics(data)["commits"] == 2
 
     def test_no_sha_yields_zero(self):
@@ -743,17 +748,14 @@ class TestCommitProvenanceConsistency:
         return data
 
     def test_fresh_events_equal_metrics(self):
-        data = self._log(
-            "e07f40f",
-            [
-                {"task": "Commit A", "outcome": "45576b6. parser"},
-                {"task": "Commit B", "outcome": "24da6b2. lint"},
-            ],
+        data = self._log("e07f40f")
+        data["protocolCompliance"]["sessionEnd"]["changesCommitted"]["Evidence"] = (
+            "Commits: 45576b6 (parser), 24da6b2 (lint)."
         )
         commit_events = self._commit_events(
             {"events": extract_session_episode.json_events(data, self._NOW)}
         )
-        # endingCommit + two work-log SHAs = 3 documented commits, all retained.
+        # endingCommit + two changesCommitted SHAs = 3 documented, all retained.
         assert len(commit_events) == 3
         assert len(commit_events) == extract_session_episode.json_metrics(data)["commits"]
 
@@ -1548,17 +1550,24 @@ class TestPredatingProseShaExclusion:
 
     @staticmethod
     def _log(anchor, prose, *, date=SESSION_DAY):
-        data = _json_log([{"task": "Cited", "outcome": prose}])
+        """A log with no structured commit record, so prose is consulted.
+
+        Since #3363 work-log prose is a fallback used only when ``endingCommit``
+        and the changesCommitted evidence are both empty (20 pre-2026-02 logs
+        take this shape). The predating filter guards that fallback, so the
+        fixture has to reach it.
+        """
+        data = _json_log([{"task": "Cited", "outcome": prose}], committed="Committed.")
         data["session"]["date"] = date
         data["session"]["startingCommit"] = anchor
-        data["endingCommit"] = anchor
+        data["endingCommit"] = ""
         return data
 
     def test_sha_predating_the_session_is_not_counted(self, tmp_path, monkeypatch):
         repo, cited, _evening, anchor, _squashed = self._repo(tmp_path)
         monkeypatch.chdir(repo)
         data = self._log(anchor, f"reproduced against {cited}")
-        assert extract_session_episode.json_metrics(data)["commits"] == 1
+        assert extract_session_episode.json_metrics(data)["commits"] == 0
 
     def test_own_commit_from_the_evening_before_is_counted(self, tmp_path, monkeypatch):
         # Regression for the ancestor form of this check. ``evening`` is an
@@ -1568,7 +1577,7 @@ class TestPredatingProseShaExclusion:
         repo, _cited, evening, anchor, _squashed = self._repo(tmp_path)
         monkeypatch.chdir(repo)
         data = self._log(anchor, f"spec committed in {evening}")
-        assert extract_session_episode.json_metrics(data)["commits"] == 2
+        assert extract_session_episode.json_metrics(data)["commits"] == 1
 
     def test_squash_merge_of_own_work_is_counted(self, tmp_path, monkeypatch):
         # Regression for the descendant form. A squash commit shares no
@@ -1576,20 +1585,20 @@ class TestPredatingProseShaExclusion:
         repo, _cited, _evening, anchor, squashed = self._repo(tmp_path)
         monkeypatch.chdir(repo)
         data = self._log(anchor, f"merged as {squashed}")
-        assert extract_session_episode.json_metrics(data)["commits"] == 2
+        assert extract_session_episode.json_metrics(data)["commits"] == 1
 
     def test_commit_made_during_the_session_day_is_counted(self, tmp_path, monkeypatch):
         repo, _cited, _evening, anchor, _squashed = self._repo(tmp_path)
         monkeypatch.chdir(repo)
         later = _commit(repo, "later.txt", "later", when=SESSION_DAY_NOON)
         data = self._log(anchor, f"landed {later}")
-        assert extract_session_episode.json_metrics(data)["commits"] == 2
+        assert extract_session_episode.json_metrics(data)["commits"] == 1
 
     def test_unresolvable_sha_fails_open(self, tmp_path, monkeypatch):
         repo, _cited, _evening, anchor, _squashed = self._repo(tmp_path)
         monkeypatch.chdir(repo)
         data = self._log(anchor, "see deadbee for context")
-        assert extract_session_episode.json_metrics(data)["commits"] == 2
+        assert extract_session_episode.json_metrics(data)["commits"] == 1
 
     def test_non_commit_object_fails_open(self, tmp_path, monkeypatch):
         # A blob SHA cannot be peeled to a commit, so git exits nonzero and the
@@ -1598,20 +1607,23 @@ class TestPredatingProseShaExclusion:
         monkeypatch.chdir(repo)
         blob = _git(repo, "rev-parse", "HEAD:anchor.txt")
         data = self._log(anchor, f"blob {blob}")
-        assert extract_session_episode.json_metrics(data)["commits"] == 2
+        assert extract_session_episode.json_metrics(data)["commits"] == 1
 
     def test_missing_session_date_fails_open(self, tmp_path, monkeypatch):
         repo, cited, _evening, anchor, _squashed = self._repo(tmp_path)
         monkeypatch.chdir(repo)
         data = self._log(anchor, f"reproduced against {cited}", date="")
-        assert extract_session_episode.json_metrics(data)["commits"] == 2
+        assert extract_session_episode.json_metrics(data)["commits"] == 1
 
     def test_outside_a_git_repo_fails_open(self, tmp_path, monkeypatch):
         outside = tmp_path / "not-a-repo"
         outside.mkdir()
         monkeypatch.chdir(outside)
-        data = _json_log([{"task": "Cited", "outcome": "1234abc. Added parser"}])
-        assert extract_session_episode.json_metrics(data)["commits"] == 2
+        data = _json_log(
+            [{"task": "Cited", "outcome": "1234abc. Added parser"}], committed="Committed."
+        )
+        data["endingCommit"] = ""
+        assert extract_session_episode.json_metrics(data)["commits"] == 1
 
     def test_events_and_metrics_agree(self, tmp_path, monkeypatch):
         repo, cited, _evening, anchor, _squashed = self._repo(tmp_path)
@@ -1654,4 +1666,121 @@ class TestPredatingProseShaExclusion:
         anchor = _commit(repo, "anchor.txt", "anchor", when="2026-05-10T12:00:00+00:00")
         monkeypatch.chdir(repo)
         data = self._log(anchor, f"landed in {early}", date="2026-05-11T00:00:00+14:00")
-        assert extract_session_episode.json_metrics(data)["commits"] == 2
+        assert extract_session_episode.json_metrics(data)["commits"] == 1
+
+
+class TestChangesCommittedIsTheCommitSource:
+    """Issue #3363: commits come from the protocol's record, not from prose.
+
+    A work-log entry legitimately cites SHAs the session did not author: a
+    bot's housekeeping commits, a commit it bisected, the base of a PR it read.
+    Counting those inflated metrics.commits and seeded causal-graph commit
+    nodes for work the session never did, while the session's own commits,
+    recorded only in changesCommitted, were missed entirely.
+    """
+
+    @staticmethod
+    def _log(*, evidence: str, ending: str, work_log: list) -> dict:
+        log = _json_log(work_log)
+        log["endingCommit"] = ending
+        log["protocolCompliance"]["sessionEnd"]["changesCommitted"] = {
+            "level": "MUST",
+            "Complete": True,
+            "Evidence": evidence,
+        }
+        return log
+
+    def test_changes_committed_shas_become_commits(self):
+        log = self._log(
+            evidence="Two commits: the fix (abc1234def) and the test (fed4321abc).",
+            ending="abc1234def",
+            work_log=[],
+        )
+        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        assert set(shas) == {"abc1234def", "fed4321abc"}
+
+    def test_a_sha_only_in_work_log_prose_is_not_a_commit(self):
+        """The fix/3342 shape: narrative cites a bot commit the session did not author."""
+        log = self._log(
+            evidence="One commit: the fix (abc1234def).",
+            ending="abc1234def",
+            work_log=[{"phase": "Merge", "summary": "Took the bot's commit deadbee1234."}],
+        )
+        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        assert shas == ["abc1234def"]
+        assert "deadbee1234" not in shas
+
+    def test_a_session_commit_named_only_in_evidence_is_not_dropped(self):
+        """The other half of #3363: prose-only extraction missed real commits."""
+        log = self._log(
+            evidence="Three commits: aaa1111bbb, ccc2222ddd, and eee3333fff.",
+            ending="eee3333fff",
+            work_log=[{"phase": "Implement", "summary": "Did the work."}],
+        )
+        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        assert set(shas) == {"aaa1111bbb", "ccc2222ddd", "eee3333fff"}
+
+    def test_metrics_and_events_agree_on_the_commit_set(self):
+        """A count that disagrees with the events is the bug that was reported."""
+        log = self._log(
+            evidence="Two commits: abc1234def and fed4321abc.",
+            ending="abc1234def",
+            work_log=[{"phase": "Note", "summary": "Mentioned deadbee1234 in passing."}],
+        )
+        events = [
+            e["content"].replace("Commit: ", "")
+            for e in extract_session_episode.json_events(log, "2026-05-31T00:00:00+00:00")
+            if e["type"] == "commit"
+        ]
+        assert extract_session_episode.json_metrics(log)["commits"] == len(events)
+        assert set(events) == {"abc1234def", "fed4321abc"}
+
+    def test_the_starting_commit_is_still_excluded_from_evidence(self):
+        """changesCommitted evidence often restates the base; it is not output."""
+        log = self._log(
+            evidence="Based on aaaaaaa, committed abc1234def.",
+            ending="abc1234def",
+            work_log=[],
+        )
+        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        assert shas == ["abc1234def"]
+
+    def test_prose_still_works_when_there_is_no_structured_record(self):
+        """27 pre-2026-02 logs record commits only in the work log."""
+        log = _json_log([{"phase": "Implement", "summary": "committed as abc1234def"}])
+        log["endingCommit"] = ""
+        log["protocolCompliance"]["sessionEnd"]["changesCommitted"] = {
+            "level": "MUST",
+            "Complete": True,
+            "Evidence": "Committed the work.",
+        }
+        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        assert "abc1234def" in shas
+
+    def test_lowercase_evidence_key_is_read(self):
+        """Session logs use both Evidence and evidence casings."""
+        log = _json_log([])
+        log["endingCommit"] = ""
+        log["protocolCompliance"]["sessionEnd"]["changesCommitted"] = {
+            "level": "MUST",
+            "complete": True,
+            "evidence": "One commit: abc1234def.",
+        }
+        assert extract_session_episode._collect_shas(log, include_starting=False) == [
+            "abc1234def"
+        ]
+
+    def test_a_missing_compliance_section_does_not_raise(self):
+        log = _json_log([{"phase": "x", "summary": "committed as abc1234def"}])
+        log["endingCommit"] = ""
+        del log["protocolCompliance"]
+        assert extract_session_episode._collect_shas(log, include_starting=False) == [
+            "abc1234def"
+        ]
+
+    def test_a_non_dict_compliance_section_does_not_raise(self):
+        log = _json_log([])
+        log["protocolCompliance"] = "not a dict"
+        assert extract_session_episode._collect_shas(log, include_starting=False) == [
+            "bbbbbbb1234"
+        ]

--- a/tests/skills/memory/test_extract_session_episode.py
+++ b/tests/skills/memory/test_extract_session_episode.py
@@ -1814,3 +1814,66 @@ class TestChangesCommittedIsTheCommitSource:
         log = _json_log([])
         log["protocolCompliance"] = "not a dict"
         assert extract_session_episode._collect_shas(log, include_starting=False) == ["bbbbbbb1234"]
+
+
+class TestOneCommitCountsOnceAcrossAbbreviations:
+    """Issue #3363: `_collect_shas` promises distinct commits, so two fields
+    that spell one commit at different abbreviation lengths must not both land.
+    Exact string membership let a full 40-char `endingCommit` and a 7-char
+    abbreviation of it in the evidence through as two entries, double-counting
+    `metrics.commits` and emitting two causal-graph nodes for one commit.
+    """
+
+    _FULL = "abc1234def5678901234567890abcdef12345678"
+    _SHORT = "abc1234"
+
+    @staticmethod
+    def _log(*, evidence: str, ending: str) -> dict:
+        log = _json_log([])
+        log["endingCommit"] = ending
+        log["protocolCompliance"]["sessionEnd"]["changesCommitted"] = {
+            "level": "MUST",
+            "Complete": True,
+            "Evidence": evidence,
+        }
+        return log
+
+    def test_an_abbreviation_of_the_ending_commit_is_not_a_second_commit(self):
+        log = self._log(evidence=f"Committed as {self._SHORT}.", ending=self._FULL)
+        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        assert shas == [self._FULL]
+
+    def test_the_first_spelling_seen_is_the_one_kept(self):
+        """Ordering has to stay stable: endingCommit is read first, so its
+        spelling wins even when the evidence names the longer form.
+        """
+        log = self._log(evidence=f"Committed as {self._FULL}.", ending=self._SHORT)
+        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        assert shas == [self._SHORT]
+
+    def test_two_genuinely_different_commits_both_survive(self):
+        """Negative control: the de-duplication must not collapse distinct
+        commits that merely share a short prefix below git's 7-char minimum.
+        """
+        other = "abfeed09876543210fedcba9876543210fedcba9"
+        log = self._log(evidence=f"Two commits: {self._FULL} and {other}.", ending="")
+        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        assert shas == [self._FULL, other]
+
+    def test_a_prose_fallback_sha_matching_a_structured_one_is_not_added_twice(self):
+        log = _json_log(
+            [{"phase": "implementation", "summary": f"Committed {self._SHORT}."}]
+        )
+        log["endingCommit"] = self._FULL
+        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        assert shas == [self._FULL]
+
+    def test_already_seen_needs_seven_shared_characters(self):
+        """`_same_commit` requires git's minimum unambiguous length, so a
+        six-character prefix is not treated as the same commit.
+        """
+        assert not extract_session_episode._already_seen("abc123", [self._FULL])
+        assert extract_session_episode._already_seen(self._SHORT, [self._FULL])
+
+    def test_an_empty_seen_list_matches_nothing(self):
+        assert not extract_session_episode._already_seen(self._FULL, [])

--- a/tests/skills/memory/test_extract_session_episode.py
+++ b/tests/skills/memory/test_extract_session_episode.py
@@ -294,7 +294,13 @@ def _lowercase_gate(complete):
 def _json_log(work_log, end_complete=True, committed=None):
     """``committed`` populates the session-end changesCommitted evidence, which
     is the protocol's authoritative record of what the session committed and
-    the source commit provenance reads first (issue #3363)."""
+    the source commit provenance reads first (issue #3363).
+
+    Left at None the evidence keeps the gate default, a non-empty string naming
+    no SHA. That is the real majority shape: 20 of the 25 prose-only logs look
+    like that. Pass ``committed=""`` for the empty-evidence shape the other
+    five are in.
+    """
     gate = _gate(end_complete)
     committed_gate = dict(gate)
     if committed is not None:
@@ -1552,10 +1558,11 @@ class TestPredatingProseShaExclusion:
     def _log(anchor, prose, *, date=SESSION_DAY):
         """A log with no structured commit record, so prose is consulted.
 
-        Since #3363 work-log prose is a fallback used only when ``endingCommit``
-        and the changesCommitted evidence are both empty (20 pre-2026-02 logs
-        take this shape). The predating filter guards that fallback, so the
-        fixture has to reach it.
+        Since #3363 work-log prose is a fallback, reached only when neither
+        ``endingCommit`` nor the changesCommitted evidence yields a SHA. The
+        fixture takes the majority prose-only shape: an evidence string that
+        names no SHA, which 20 of the 25 such logs carry. The predating filter
+        guards that fallback, so the fixture has to reach it.
         """
         data = _json_log([{"task": "Cited", "outcome": prose}], committed="Committed.")
         data["session"]["date"] = date
@@ -1746,7 +1753,12 @@ class TestChangesCommittedIsTheCommitSource:
         assert shas == ["abc1234def"]
 
     def test_prose_still_works_when_there_is_no_structured_record(self):
-        """27 pre-2026-02 logs record commits only in the work log."""
+        """Logs that record their commits only in the work log still resolve.
+
+        No count is pinned here on purpose: the figure is measured in the
+        source docstring, and repeating it turns every re-measurement into a
+        comment-only fix.
+        """
         log = _json_log([{"phase": "Implement", "summary": "committed as abc1234def"}])
         log["endingCommit"] = ""
         log["protocolCompliance"]["sessionEnd"]["changesCommitted"] = {
@@ -1756,6 +1768,35 @@ class TestChangesCommittedIsTheCommitSource:
         }
         shas = extract_session_episode._collect_shas(log, include_starting=False)
         assert "abc1234def" in shas
+
+    def test_prose_is_reached_when_the_evidence_string_is_empty(self):
+        """The other prose-only shape: no evidence string at all.
+
+        Five of the 25 prose-only logs are in this shape rather than carrying a
+        SHA-less sentence. Both have to reach the fallback, which is why the
+        condition is "neither source yielded a SHA" and not "both are empty".
+        """
+        log = _json_log(
+            [{"phase": "Implement", "summary": "committed as abc1234def"}],
+            committed="",
+        )
+        log["endingCommit"] = ""
+        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        assert "abc1234def" in shas
+
+    def test_a_sha_in_the_evidence_suppresses_the_prose_fallback(self):
+        """The fallback must not fire when evidence already named a commit.
+
+        This is the discriminating case: if the condition were "both fields are
+        empty" the foreign prose SHA would be picked up here too.
+        """
+        log = _json_log(
+            [{"phase": "Read", "summary": "reviewed base fed4321abc"}],
+            committed="Committed abc1234def.",
+        )
+        log["endingCommit"] = ""
+        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        assert shas == ["abc1234def"]
 
     def test_lowercase_evidence_key_is_read(self):
         """Session logs use both Evidence and evidence casings."""

--- a/tests/skills/memory/test_extract_session_episode.py
+++ b/tests/skills/memory/test_extract_session_episode.py
@@ -1767,7 +1767,7 @@ class TestChangesCommittedIsTheCommitSource:
     def test_prose_is_reached_when_the_evidence_string_is_empty(self):
         """The other prose-only shape: no evidence string at all.
 
-        Five of the 25 prose-only logs are in this shape rather than carrying a
+        Three of the 15 prose-only logs are in this shape rather than carrying a
         SHA-less sentence. Both have to reach the fallback, which is why the
         condition is "neither source yielded a SHA" and not "both are empty".
         """

--- a/tests/skills/memory/test_extract_session_episode.py
+++ b/tests/skills/memory/test_extract_session_episode.py
@@ -296,10 +296,12 @@ def _json_log(work_log, end_complete=True, committed=None):
     is the protocol's authoritative record of what the session committed and
     the source commit provenance reads first (issue #3363).
 
-    Left at None the evidence keeps the gate default, a non-empty string naming
-    no SHA. That is the real majority shape: 20 of the 25 prose-only logs look
-    like that. Pass ``committed=""`` for the empty-evidence shape the other
-    five are in.
+    Left at None the evidence keeps the gate default: a non-empty string that
+    names no SHA, which is the majority shape among prose-only logs. Pass
+    ``committed=""`` for the minority shape, where the evidence is absent
+    entirely. Both reach the prose fallback, and both are exercised below. The
+    corpus split behind that claim lives in the extractor docstring, so it has
+    one home to re-measure.
     """
     gate = _gate(end_complete)
     committed_gate = dict(gate)
@@ -721,9 +723,7 @@ class TestJsonCommitMetric:
 
     def test_prose_mixes_comment_id_and_sha_counts_only_sha(self):
         # #3301 edge: prose with both a decimal ID and a real SHA counts one.
-        data = _json_log(
-            [{"task": "t", "outcome": "fixed in abc1234 per run 29708719280"}]
-        )
+        data = _json_log([{"task": "t", "outcome": "fixed in abc1234 per run 29708719280"}])
         data["endingCommit"] = ""
         assert extract_session_episode.json_metrics(data)["commits"] == 1
 
@@ -834,16 +834,12 @@ class TestCommitProvenanceConsistency:
             self._log("e07f40f"), archive_fallback=False
         )
         once = extract_session_episode.merge_preserving(
-            extract_session_episode.extract_from_json(
-                self._log("e07f40f"), archive_fallback=False
-            ),
+            extract_session_episode.extract_from_json(self._log("e07f40f"), archive_fallback=False),
             base,
             session_id="s",
         )
         twice = extract_session_episode.merge_preserving(
-            extract_session_episode.extract_from_json(
-                self._log("e07f40f"), archive_fallback=False
-            ),
+            extract_session_episode.extract_from_json(self._log("e07f40f"), archive_fallback=False),
             once,
             session_id="s",
         )
@@ -1483,7 +1479,6 @@ class TestSequentialEventLinks:
                 assert ref in ids, f"dangling reference {ref} in {e['id']}"
 
 
-
 def _git(repo, *args, when=None):
     env = None
     if when is not None:
@@ -1561,8 +1556,8 @@ class TestPredatingProseShaExclusion:
         Since #3363 work-log prose is a fallback, reached only when neither
         ``endingCommit`` nor the changesCommitted evidence yields a SHA. The
         fixture takes the majority prose-only shape: an evidence string that
-        names no SHA, which 20 of the 25 such logs carry. The predating filter
-        guards that fallback, so the fixture has to reach it.
+        names no SHA. The predating filter guards that fallback, so the fixture
+        has to reach it.
         """
         data = _json_log([{"task": "Cited", "outcome": prose}], committed="Committed.")
         data["session"]["date"] = date
@@ -1807,21 +1802,15 @@ class TestChangesCommittedIsTheCommitSource:
             "complete": True,
             "evidence": "One commit: abc1234def.",
         }
-        assert extract_session_episode._collect_shas(log, include_starting=False) == [
-            "abc1234def"
-        ]
+        assert extract_session_episode._collect_shas(log, include_starting=False) == ["abc1234def"]
 
     def test_a_missing_compliance_section_does_not_raise(self):
         log = _json_log([{"phase": "x", "summary": "committed as abc1234def"}])
         log["endingCommit"] = ""
         del log["protocolCompliance"]
-        assert extract_session_episode._collect_shas(log, include_starting=False) == [
-            "abc1234def"
-        ]
+        assert extract_session_episode._collect_shas(log, include_starting=False) == ["abc1234def"]
 
     def test_a_non_dict_compliance_section_does_not_raise(self):
         log = _json_log([])
         log["protocolCompliance"] = "not a dict"
-        assert extract_session_episode._collect_shas(log, include_starting=False) == [
-            "bbbbbbb1234"
-        ]
+        assert extract_session_episode._collect_shas(log, include_starting=False) == ["bbbbbbb1234"]

--- a/tests/skills/memory/test_extract_session_episode.py
+++ b/tests/skills/memory/test_extract_session_episode.py
@@ -1700,7 +1700,7 @@ class TestChangesCommittedIsTheCommitSource:
             ending="abc1234def",
             work_log=[],
         )
-        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        shas = extract_session_episode._collect_shas(log)
         assert set(shas) == {"abc1234def", "fed4321abc"}
 
     def test_a_sha_only_in_work_log_prose_is_not_a_commit(self):
@@ -1710,7 +1710,7 @@ class TestChangesCommittedIsTheCommitSource:
             ending="abc1234def",
             work_log=[{"phase": "Merge", "summary": "Took the bot's commit deadbee1234."}],
         )
-        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        shas = extract_session_episode._collect_shas(log)
         assert shas == ["abc1234def"]
         assert "deadbee1234" not in shas
 
@@ -1721,7 +1721,7 @@ class TestChangesCommittedIsTheCommitSource:
             ending="eee3333fff",
             work_log=[{"phase": "Implement", "summary": "Did the work."}],
         )
-        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        shas = extract_session_episode._collect_shas(log)
         assert set(shas) == {"aaa1111bbb", "ccc2222ddd", "eee3333fff"}
 
     def test_metrics_and_events_agree_on_the_commit_set(self):
@@ -1746,8 +1746,37 @@ class TestChangesCommittedIsTheCommitSource:
             ending="abc1234def",
             work_log=[],
         )
-        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        shas = extract_session_episode._collect_shas(log)
         assert shas == ["abc1234def"]
+
+    def test_evidence_naming_only_the_base_still_reaches_the_prose_fallback(self):
+        """The base is not a commit the session produced, so it cannot count.
+
+        Discriminating case for the fallback condition. If the filter ran after
+        the "did any source yield a SHA" check instead of before it, the base
+        would populate the set, suppress the work log, and the session's real
+        commit would be lost.
+        """
+        log = _json_log(
+            [{"phase": "Implement", "summary": "committed as abc1234def"}],
+            committed="Based on aaaaaaa. Committed the work.",
+        )
+        log["endingCommit"] = ""
+        assert extract_session_episode._collect_shas(log) == ["abc1234def"]
+
+    def test_a_decimal_only_token_in_the_evidence_is_not_a_commit(self):
+        """Evidence is a sentence, so it carries CI run ids and issue numbers.
+
+        Scanning it with the unfiltered structured-field pattern read a 20-digit
+        run id as a commit: it counted toward metrics.commits, emitted a commit
+        event, and populated the set well enough to suppress the work log.
+        """
+        log = _json_log(
+            [{"phase": "Implement", "summary": "committed as abc1234def"}],
+            committed="Verified in CI run 12345678901234567890.",
+        )
+        log["endingCommit"] = ""
+        assert extract_session_episode._collect_shas(log) == ["abc1234def"]
 
     def test_prose_still_works_when_there_is_no_structured_record(self):
         """Logs that record their commits only in the work log still resolve.
@@ -1763,7 +1792,7 @@ class TestChangesCommittedIsTheCommitSource:
             "Complete": True,
             "Evidence": "Committed the work.",
         }
-        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        shas = extract_session_episode._collect_shas(log)
         assert "abc1234def" in shas
 
     def test_prose_is_reached_when_the_evidence_string_is_empty(self):
@@ -1778,7 +1807,7 @@ class TestChangesCommittedIsTheCommitSource:
             committed="",
         )
         log["endingCommit"] = ""
-        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        shas = extract_session_episode._collect_shas(log)
         assert "abc1234def" in shas
 
     def test_a_sha_in_the_evidence_suppresses_the_prose_fallback(self):
@@ -1792,7 +1821,7 @@ class TestChangesCommittedIsTheCommitSource:
             committed="Committed abc1234def.",
         )
         log["endingCommit"] = ""
-        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        shas = extract_session_episode._collect_shas(log)
         assert shas == ["abc1234def"]
 
     def test_lowercase_evidence_key_is_read(self):
@@ -1804,18 +1833,18 @@ class TestChangesCommittedIsTheCommitSource:
             "complete": True,
             "evidence": "One commit: abc1234def.",
         }
-        assert extract_session_episode._collect_shas(log, include_starting=False) == ["abc1234def"]
+        assert extract_session_episode._collect_shas(log) == ["abc1234def"]
 
     def test_a_missing_compliance_section_does_not_raise(self):
         log = _json_log([{"phase": "x", "summary": "committed as abc1234def"}])
         log["endingCommit"] = ""
         del log["protocolCompliance"]
-        assert extract_session_episode._collect_shas(log, include_starting=False) == ["abc1234def"]
+        assert extract_session_episode._collect_shas(log) == ["abc1234def"]
 
     def test_a_non_dict_compliance_section_does_not_raise(self):
         log = _json_log([])
         log["protocolCompliance"] = "not a dict"
-        assert extract_session_episode._collect_shas(log, include_starting=False) == ["bbbbbbb1234"]
+        assert extract_session_episode._collect_shas(log) == ["bbbbbbb1234"]
 
 
 class TestOneCommitCountsOnceAcrossAbbreviations:
@@ -1842,7 +1871,7 @@ class TestOneCommitCountsOnceAcrossAbbreviations:
 
     def test_an_abbreviation_of_the_ending_commit_is_not_a_second_commit(self):
         log = self._log(evidence=f"Committed as {self._SHORT}.", ending=self._FULL)
-        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        shas = extract_session_episode._collect_shas(log)
         assert shas == [self._FULL]
 
     def test_the_first_spelling_seen_is_the_one_kept(self):
@@ -1850,7 +1879,7 @@ class TestOneCommitCountsOnceAcrossAbbreviations:
         spelling wins even when the evidence names the longer form.
         """
         log = self._log(evidence=f"Committed as {self._FULL}.", ending=self._SHORT)
-        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        shas = extract_session_episode._collect_shas(log)
         assert shas == [self._SHORT]
 
     def test_two_genuinely_different_commits_both_survive(self):
@@ -1861,7 +1890,7 @@ class TestOneCommitCountsOnceAcrossAbbreviations:
         """
         other = "abfeed09876543210fedcba9876543210fedcba9"
         log = self._log(evidence=f"Two commits: {self._FULL} and {other}.", ending="")
-        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        shas = extract_session_episode._collect_shas(log)
         assert shas == [self._FULL, other]
 
     def test_a_prose_fallback_sha_matching_a_structured_one_is_not_added_twice(self):
@@ -1869,7 +1898,7 @@ class TestOneCommitCountsOnceAcrossAbbreviations:
             [{"phase": "implementation", "summary": f"Committed {self._SHORT}."}]
         )
         log["endingCommit"] = self._FULL
-        shas = extract_session_episode._collect_shas(log, include_starting=False)
+        shas = extract_session_episode._collect_shas(log)
         assert shas == [self._FULL]
 
     def test_already_seen_needs_seven_shared_characters(self):

--- a/tests/skills/memory/test_extract_session_episode.py
+++ b/tests/skills/memory/test_extract_session_episode.py
@@ -800,7 +800,9 @@ class TestCommitProvenanceConsistency:
         assert extract_session_episode._same_commit(full, full)
         # Distinct commits sharing a 6-char prefix are not the same commit.
         assert not extract_session_episode._same_commit(full, "e535a4e9abc")
-        # Below git's 7-char minimum abbreviation, do not treat as a match.
+        # Below the extractor's own seven-character floor, do not treat as a
+        # match. The floor is this module's rule; git's abbreviation length is
+        # repo-dependent (core.abbrev), so there is no git minimum to cite.
         assert not extract_session_episode._same_commit(full, "e535a4")
         assert not extract_session_episode._same_commit("", full)
 
@@ -1853,7 +1855,9 @@ class TestOneCommitCountsOnceAcrossAbbreviations:
 
     def test_two_genuinely_different_commits_both_survive(self):
         """Negative control: the de-duplication must not collapse distinct
-        commits that merely share a short prefix below git's 7-char minimum.
+        commits that merely share a prefix shorter than the extractor's own
+        seven-character floor. That floor is _same_commit's rule, not a git
+        contract: git's abbreviation length is repo-dependent (core.abbrev).
         """
         other = "abfeed09876543210fedcba9876543210fedcba9"
         log = self._log(evidence=f"Two commits: {self._FULL} and {other}.", ending="")
@@ -1869,8 +1873,9 @@ class TestOneCommitCountsOnceAcrossAbbreviations:
         assert shas == [self._FULL]
 
     def test_already_seen_needs_seven_shared_characters(self):
-        """`_same_commit` requires git's minimum unambiguous length, so a
-        six-character prefix is not treated as the same commit.
+        """`_same_commit` requires seven shared characters, so a six-character
+        prefix is not treated as the same commit. Seven is this module's own
+        floor, not a git contract; git's abbreviation length varies by repo.
         """
         assert not extract_session_episode._already_seen("abc123", [self._FULL])
         assert extract_session_episode._already_seen(self._SHORT, [self._FULL])


### PR DESCRIPTION
## Summary

`_collect_shas` in the episode extractor treated work-log narrative as a commit source. A work-log entry legitimately cites SHAs the session did not author: a bot's housekeeping commits, a commit it bisected, the base of a PR it read. Those inflated `metrics.commits` and seeded causal-graph commit nodes for work the session never did.

At the same time it never read `protocolCompliance.sessionEnd.changesCommitted`, which is the session protocol's own record of what the session committed. So the extractor both over-counted and under-counted.

Fixes #3363

## Reproduction

The `fix/3342-harness-reference-size` episode carried 6 commit events. Its log's `changesCommitted` names 7. Only 4 overlapped.

Counted but foreign:

- `663bbac488`, a PR #3358 merge on main
- `a2487c4ac1`, another session's fix

Missed entirely, present only in `changesCommitted`: `006a88767`, `827a4c699`, `f673788d4`.

Both foreign commits are same-day, so the committer-date filter from #3328 cannot drop them, and both carry hex letters, so the #3301 filter passes them too.

## The measurement that chose the design

Prose could have been deleted outright or kept as a fallback. Every session log in the tree was measured before deciding (941 at the time of measurement):

| Shape | Logs |
|---|---|
| `changesCommitted` evidence names SHAs | 194 |
| `endingCommit` only, no prose SHAs | 192 |
| No commit recorded at all | 483 |
| Contested: `endingCommit` set, evidence has no SHAs, prose does | 44 |
| Prose-only, no structured record | 20 |

The 20 prose-only logs are all pre-2026-02 and would lose their commits entirely if prose were deleted, so the fallback stays.

The 44 contested logs decided the precedence. Of the 83 prose SHAs in them, git cannot resolve 46 at all, and 23 more are provably not in the session's line. The remaining 14 are ancestors of the ending commit, which every prior commit on main also is, so that is not evidence of authorship. Prose is noise in that shape.

## Change

`endingCommit` plus the `changesCommitted` evidence are authoritative. Work-log prose is consulted only when both are empty, and keeps its existing hex-letter (#3301) and committer-date (#3328) filters. `json_metrics` and `json_events` already share `_collect_shas`, so the count cannot drift from the event stream.

Regenerated `fix/3342`: 7 commit events, exactly the 7 SHAs its `changesCommitted` names, zero extra, zero missing.

## Tests

The suite passes. 9 new provenance tests; 12 existing tests corrected.

The 12 asserted the pre-#3363 contract, so each was rewritten to keep its intent under the corrected source rather than deleted:

- The #2170 multi-commit tests now put the extra SHAs in `changesCommitted`. Their point was that a session's commits are not just `endingCommit`, which still holds.
- The #3123 events-equal-metrics invariant is unchanged; only the fixture's commit source moved.
- The #3328 predating fixtures now take the fallback shape, so that filter is still exercised where it now applies.

## Verification

Both negative controls fire:

- Dropping the `changesCommitted` source turns 7 red.
- Restoring prose as primary turns 2 red, including the exact foreign-SHA case this issue filed.

## Notes

Manifests bumped to 0.6.119. The number moved with every rebase because the gate compares against the merge base and main advanced three times under this branch.

`metrics["commits"]` on the markdown path still counts lines containing a hex run rather than commits. It is a separate defect on a separate code path and is not touched here.

