### PR TITLE
fix(ci): validate the hooks that run, and wire the gate

### DIFF
--- a/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
+++ b/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
@@ -99,12 +99,12 @@
       "validationPassed": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Both bundle trees green (1120 and 1085 passed, 4 skipped each); 1985 passed across tests/test_paths.py, tests/skills/, tests/test_chaos_experiment_scripts.py, tests/validation/test_check_vendor_portability.py; 8 passed in tests/test_skill_bundle_suites_run.py; ruff check and ruff format clean"
+        "Evidence": "94 passed in tests/hooks/test_hook_contracts.py; five negative controls each turned the matching tests red before restore; ruff check, ruff format and mypy clean; actionlint clean on the workflow"
       },
       "tasksUpdated": {
         "level": "SHOULD",
         "Complete": true,
-        "Evidence": "Issue #3371 commented with the corrected 82-directory scope"
+        "Evidence": "Issue #3384 filed for the ungated copilot-cli hook surface"
       },
       "retrospectiveInvoked": {
         "level": "SHOULD",
@@ -142,8 +142,8 @@
   ],
   "endingCommit": "d655c5237b",
   "nextSteps": [
-    "Push fix/3371-collect-mirror-suites and open a PR that fixes #3371.",
-    "Comment on #3371 with the corrected scope: 82 directories, not 2.",
-    "Re-poll the four open PRs for new review threads."
+    "Wire the other two arms of #3360: traceability.py (orphaned designs) and consistency.py (4 of 7 features).",
+    "Extend hook_contracts.py to the copilot-cli surface per #3384.",
+    "Re-poll the open PRs for new review threads."
   ]
 }

--- a/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
+++ b/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
@@ -141,7 +141,7 @@
     },
     {
       "phase": "implementation",
-      "summary": "Review found the exit-code contract still had a hole: main() caught JSONDecodeError, TypeError, and AttributeError, but not OSError or UnicodeDecodeError, so an unreadable settings file or one holding invalid UTF-8 escaped as a traceback instead of the ADR-035 configuration code. Those are the two failure modes most likely on a real machine. Widened the tuple and made the message name the path actually read, since --settings can point at a file that is not settings.json. Added 4 tests; narrowing the tuple again turns 2 of them red. Bumped both manifests to 0.6.118 because the rebase pulled a change to .claude/hooks/invoke_dispatch_claude.py into the diff."
+      "summary": "Review found the exit-code contract still had a hole: main() caught JSONDecodeError, TypeError, and AttributeError, but not OSError or UnicodeDecodeError, so an unreadable settings file or one holding invalid UTF-8 escaped as a traceback instead of the ADR-035 configuration code. Those are the two failure modes most likely on a real machine. Widened the tuple and made the message name the path actually read, since --settings can point at a file that is not settings.json. Added 4 tests; narrowing the tuple again turns 2 of them red. Bumped both manifests because the rebase pulled a change to .claude/hooks/invoke_dispatch_claude.py into the diff. The number moved with every later rebase (0.6.118, then 0.6.119, then 0.6.120) because the gate compares against the merge base and main advanced under this branch; the shipped value is 0.6.120."
     },
     {
       "phase": "review",

--- a/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
+++ b/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
@@ -94,7 +94,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Six commits on the branch, tips 630d38325c and de1edd59c0; three interleaved autofix commits from the review bot were rebased under them"
+        "Evidence": "15 commits on the branch after rebasing onto main: e1bb1a4e11, 3d8149cab5, 329df70fe2, 90b172cadf, 7edb0deac8, fa1e5c5e50, dac853c937, 413f1c5e6a, 1ce8dd8d78, 8be978845b, 440e987227, d10ccb0f8e, f143fc70a4, e405069a59, e75904528b"
       },
       "validationPassed": {
         "level": "MUST",
@@ -150,9 +150,18 @@
         "scripts/validation/hook_contracts.py",
         "tests/hooks/test_hook_contracts.py"
       ]
+    },
+    {
+      "phase": "Review",
+      "summary": "Stopped an unusable dispatch manifest from reporting once per registration on top of its own root cause.",
+      "evidence": "Expansion ran against the empty map _load_dispatch_groups returns alongside invalid_dispatch_groups, so every dispatcher registration also reported unknown_dispatch_group. Expansion is now skipped on that failure while the registrations stay in the entry list, so script existence and exit-code docs are still checked. Four tests added including a negative control that a well-formed manifest still expands; forcing expansion back on fails the new test.",
+      "files": [
+        "scripts/validation/hook_contracts.py",
+        "tests/hooks/test_hook_contracts.py"
+      ]
     }
   ],
-  "endingCommit": "4fe4855627",
+  "endingCommit": "e75904528b",
   "nextSteps": [
     "Wire the other two arms of #3360: traceability.py (orphaned designs) and consistency.py (4 of 7 features).",
     "Extend hook_contracts.py to the copilot-cli surface per #3384.",

--- a/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
+++ b/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
@@ -52,12 +52,12 @@
       "branchVerified": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "fix/3371-collect-mirror-suites"
+        "Evidence": "fix/3360-wire-hook-contracts"
       },
       "notOnMain": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "On fix/3371-collect-mirror-suites, branched off main 663bbac488"
+        "Evidence": "On fix/3360-wire-hook-contracts, branched off main 263ce89d05"
       },
       "gitStatusVerified": {
         "level": "SHOULD",
@@ -67,7 +67,7 @@
       "startingCommitNoted": {
         "level": "SHOULD",
         "Complete": true,
-        "Evidence": "663bbac488"
+        "Evidence": "263ce89d05cd7ab15a196e97c24c4a0e9b095970"
       }
     },
     "sessionEnd": {
@@ -140,7 +140,7 @@
       "evidence": "197 passed across the hook-contract and reachability modules, plus 567 workflow tests. Negative controls: disabling group expansion turned 6 red, skipping the plugin surface turned 3 red, reverting the path regex turned 6 red."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "d655c5237b",
   "nextSteps": [
     "Push fix/3371-collect-mirror-suites and open a PR that fixes #3371.",
     "Comment on #3371 with the corrected scope: 82 directories, not 2.",

--- a/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
+++ b/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
@@ -142,9 +142,17 @@
     {
       "phase": "implementation",
       "summary": "Review found the exit-code contract still had a hole: main() caught JSONDecodeError, TypeError, and AttributeError, but not OSError or UnicodeDecodeError, so an unreadable settings file or one holding invalid UTF-8 escaped as a traceback instead of the ADR-035 configuration code. Those are the two failure modes most likely on a real machine. Widened the tuple and made the message name the path actually read, since --settings can point at a file that is not settings.json. Added 4 tests; narrowing the tuple again turns 2 of them red. Bumped both manifests to 0.6.118 because the rebase pulled a change to .claude/hooks/invoke_dispatch_claude.py into the diff."
+    },
+    {
+      "phase": "review",
+      "summary": "Answered four review threads. One was a real gap: _load_dispatch_groups read a missing or non-object 'groups' field as an empty map and reported nothing, while invoke_dispatch_claude._load_group raises TypeError on that shape and the dispatcher fails closed, blocking every dispatched tool call. A manifest that stopped the runtime it describes passed the contract check. It now emits invalid_dispatch_groups naming the field and the type found. Six tests, including one that reads the dispatcher source so the rule and the runtime cannot drift; the negative control turned four red. Also made the docstring fixture model a real blocking hook (0=allow, 2=block), renamed a test whose name said directory while the setup used a permission bit, and wrapped four lines the ruff ratchet rejected after a local ruff check reported the files clean.",
+      "files": [
+        "scripts/validation/hook_contracts.py",
+        "tests/hooks/test_hook_contracts.py"
+      ]
     }
   ],
-  "endingCommit": "d655c5237b",
+  "endingCommit": "4fe4855627",
   "nextSteps": [
     "Wire the other two arms of #3360: traceability.py (orphaned designs) and consistency.py (4 of 7 features).",
     "Extend hook_contracts.py to the copilot-cli surface per #3384.",

--- a/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
+++ b/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
@@ -138,6 +138,10 @@
       "phase": "Test",
       "summary": "Added 15 tests covering dispatcher expansion and the plugin surface.",
       "evidence": "197 passed across the hook-contract and reachability modules, plus 567 workflow tests. Negative controls: disabling group expansion turned 6 red, skipping the plugin surface turned 3 red, reverting the path regex turned 6 red."
+    },
+    {
+      "phase": "implementation",
+      "summary": "Review found the exit-code contract still had a hole: main() caught JSONDecodeError, TypeError, and AttributeError, but not OSError or UnicodeDecodeError, so an unreadable settings file or one holding invalid UTF-8 escaped as a traceback instead of the ADR-035 configuration code. Those are the two failure modes most likely on a real machine. Widened the tuple and made the message name the path actually read, since --settings can point at a file that is not settings.json. Added 4 tests; narrowing the tuple again turns 2 of them red. Bumped both manifests to 0.6.118 because the rebase pulled a change to .claude/hooks/invoke_dispatch_claude.py into the diff."
     }
   ],
   "endingCommit": "d655c5237b",

--- a/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
+++ b/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
@@ -94,12 +94,12 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "Three commits: ccc84280fe, bec3366729, d655c5237b"
+        "Evidence": "Six commits on the branch, tips 630d38325c and de1edd59c0; three interleaved autofix commits from the review bot were rebased under them"
       },
       "validationPassed": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "94 passed in tests/hooks/test_hook_contracts.py; five negative controls each turned the matching tests red before restore; ruff check, ruff format and mypy clean; actionlint clean on the workflow"
+        "Evidence": "98 passed in tests/hooks/test_hook_contracts.py after merging the bot autofix commits; five negative controls each turned the matching tests red before restore; ruff check, ruff format and mypy clean; actionlint clean on the workflow"
       },
       "tasksUpdated": {
         "level": "SHOULD",

--- a/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
+++ b/.agents/sessions/2026-07-26-session-3360-wire-hook-contracts.json
@@ -1,0 +1,149 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3360,
+    "date": "2026-07-26",
+    "branch": "fix/3360-wire-hook-contracts",
+    "startingCommit": "263ce89d05cd7ab15a196e97c24c4a0e9b095970",
+    "objective": "Issue #3360, hook_contracts.py arm: wire the hook contract validator after resolving what it reports."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP active; serena-list_memories returned the project memory index"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena initial_instructions read at session initialization"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read; treated as read-only per ADR-014"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "code-review-and-quality and github skill catalogs loaded"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory usage-mandatory read"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded plugin-versioning, testing-practices, and hooks memories"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/3371-collect-mirror-suites"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/3371-collect-mirror-suites, branched off main 663bbac488"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status inspected before branch creation and before each commit"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "663bbac488"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST session-start and session-end fields completed"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md unchanged; git status shows no modification"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Stored the testpaths blackout finding and the per-tree collection workaround"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown files in the diff; the change set is Python and JSON only, verified with git diff --name-only"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Three commits: ccc84280fe, bec3366729, d655c5237b"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Both bundle trees green (1120 and 1085 passed, 4 skipped each); 1985 passed across tests/test_paths.py, tests/skills/, tests/test_chaos_experiment_scripts.py, tests/validation/test_check_vendor_portability.py; 8 passed in tests/test_skill_bundle_suites_run.py; ruff check and ruff format clean"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue #3371 commented with the corrected 82-directory scope"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Deferred; this session is one issue in a multi-issue autopilot run whose retrospective covers the whole run"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "phase": "Investigate",
+      "summary": "Re-measured all three validators #3360 names. hook_contracts.py now exits 0, so the issue's premise that it fails is stale, but it passes for the wrong reason.",
+      "evidence": "hook_contracts --ci exit 0 reporting 3 entries; traceability --ci exit 1; consistency --all --ci exit 1. The 3 entries are settings.json registrations, while dispatch_groups.json lists 3 shims and the plugin hooks.json adds 2 more registrations, none of them validated."
+    },
+    {
+      "phase": "Root cause",
+      "summary": "Two independent coverage holes. Group dispatch (#3153) put a group name where a script path used to be, so the validator checked the dispatcher repeatedly and no hook at all. The plugin surface was dropped silently because the path regex required whitespace after .py and the plugin quotes its command.",
+      "evidence": "extract_script_path returned None for python3 -u \"${CLAUDE_PLUGIN_ROOT}/hooks/invoke_dispatch_claude.py\" --group g, and None is the same signal as 'not a Python hook', so the entry vanished with no violation raised."
+    },
+    {
+      "phase": "Implement",
+      "summary": "Expanded each registration through dispatch_groups.json, read the plugin hooks.json as a second surface, and taught the path regex about quoting and the plugin-root variable.",
+      "evidence": "Coverage went from 3 settings entries to all 5 shims across both surfaces, still exit 0. Undefined group, empty group, and a shim entry with no file are each violations."
+    },
+    {
+      "phase": "Wire",
+      "summary": "Added .github/workflows/hook-contract-check.yml and removed the _NO_CALLER entry so the reachability guard holds the wiring.",
+      "evidence": "actionlint clean. Path-filtered on the hook surfaces with a skip job, matching agent-skill-discriminator-check.yml. The docstring-count pin in the reachability guard fired on the allowlist edit and was updated from five to four."
+    },
+    {
+      "phase": "Test",
+      "summary": "Added 15 tests covering dispatcher expansion and the plugin surface.",
+      "evidence": "197 passed across the hook-contract and reachability modules, plus 567 workflow tests. Negative controls: disabling group expansion turned 6 red, skipping the plugin surface turned 3 red, reverting the path regex turned 6 red."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Push fix/3371-collect-mirror-suites and open a PR that fixes #3371.",
+    "Comment on #3371 with the corrected scope: 82 directories, not 2.",
+    "Re-poll the four open PRs for new review threads."
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.121",
+  "version": "0.6.122",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/hooks/invoke_dispatch_claude.py
+++ b/.claude/hooks/invoke_dispatch_claude.py
@@ -18,10 +18,16 @@ context injection (observed live: duplicated ADR-007 and Serena guidance
 on each prompt). In that case the dispatcher exits 0 immediately: one
 cheap spawn instead of N duplicated hook bodies.
 
+Exit codes: 0 allows the tool call, 2 blocks it. On a blocking event
+(PreToolUse, UserPromptSubmit) the harness reads exit 2 as a deny and shows
+stderr to the model, so every exit here is a policy decision, not just a
+status.
+
 Failure policy: an unreadable or malformed manifest, stdin read failure, or
 unexpected grouped-runtime exception exits 2 (loud, fail-closed) regardless of mode, per
 ``.claude/rules/generated-artifacts.md`` (never silently disable a hook
-surface).
+surface). Fail-closed means a broken dispatcher blocks rather than waves
+through.
 """
 
 from __future__ import annotations
@@ -42,8 +48,7 @@ try:
 except (Exception, SystemExit) as exc:  # noqa: BLE001 - launcher must fail closed
     if __name__ == "__main__":
         print(
-            "claude-hook-dispatch: entrypoint initialization failed: "
-            f"{type(exc).__name__}: {exc}",
+            f"claude-hook-dispatch: entrypoint initialization failed: {type(exc).__name__}: {exc}",
             file=sys.stderr,
         )
         raise SystemExit(2) from None

--- a/.github/workflows/hook-contract-check.yml
+++ b/.github/workflows/hook-contract-check.yml
@@ -1,0 +1,92 @@
+# Hook Contract Check (Issue #3360)
+#
+# Validates that every hook the harness will actually run exists and documents
+# its exit-code semantics. Two production incidents came from a broken hook
+# contract (#3247, #3295), and the validator that guards it had tests but no
+# call site, which is the protects-nothing shape #3329 describes.
+#
+# Coverage follows group dispatch (#3153): a registration in .claude/settings.json
+# or the plugin's hooks.json names a group, not a script, so the check expands
+# each group through dispatch_groups.json and validates the shims behind it.
+#
+# Logic lives in scripts/validation/hook_contracts.py per ADR-006 (thin
+# workflows) and ADR-042 (Python-first). Uses dorny/paths-filter (Issue #103)
+# so the workflow satisfies required-check contracts on every PR and skips with
+# a passing status when no hook registration changed.
+
+name: Hook Contract Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-paths:
+    name: Detect hook changes
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    outputs:
+      should-run-hooks: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.hooks }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check path filters
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          filters: |
+            hooks:
+              - '.claude/settings.json'
+              - '.claude/hooks/**'
+              - 'src/copilot-cli/hooks/**'
+              - 'build/scripts/generate_hooks_shim.py'
+              - 'build/scripts/generate_dispatcher.py'
+              - 'build/scripts/generate_hooks_events.py'
+              - 'scripts/validation/hook_contracts.py'
+              - '.github/workflows/hook-contract-check.yml'
+
+  validate-hook-contracts:
+    name: Validate hook contracts
+    needs: check-paths
+    if: needs.check-paths.outputs.should-run-hooks == 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+
+      - name: Run hook contract validation
+        run: |
+          python3 scripts/validation/hook_contracts.py --ci
+
+  skip-hook-contracts:
+    name: Skip hook contracts (no hook changes)
+    needs: check-paths
+    if: needs.check-paths.outputs.should-run-hooks != 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 1
+    steps:
+      - name: Checkout code
+        # Required for dorny/paths-filter pattern consistency.
+        # See: .serena/memories/ci-infrastructure-dorny-paths-filter-checkout.md
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Skip message
+        run: |
+          echo "No hook registration changes detected - skipping hook contract check"

--- a/.github/workflows/hook-contract-check.yml
+++ b/.github/workflows/hook-contract-check.yml
@@ -47,9 +47,15 @@ jobs:
         with:
           filters: |
             hooks:
+              # The validator reads the Claude surfaces only: settings.json,
+              # the plugin hooks.json, and the dispatch group map. The
+              # copilot-cli mirror is deliberately absent. Its registrations
+              # address scripts through a different plugin root, so covering
+              # them needs a per-surface root the validator does not yet take.
+              # Listing the path here would run a job that validates none of
+              # the changed files. Tracked separately.
               - '.claude/settings.json'
               - '.claude/hooks/**'
-              - 'src/copilot-cli/hooks/**'
               - 'build/scripts/generate_hooks_shim.py'
               - 'build/scripts/generate_dispatcher.py'
               - 'build/scripts/generate_hooks_events.py'
@@ -84,7 +90,7 @@ jobs:
     steps:
       - name: Checkout code
         # Required for dorny/paths-filter pattern consistency.
-        # See: .serena/memories/ci-infrastructure-dorny-paths-filter-checkout.md
+        # See: .serena/memories/ci/ci-infrastructure-dorny-paths-filter-checkout.md
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Skip message

--- a/.github/workflows/hook-contract-check.yml
+++ b/.github/workflows/hook-contract-check.yml
@@ -53,7 +53,7 @@ jobs:
               # address scripts through a different plugin root, so covering
               # them needs a per-surface root the validator does not yet take.
               # Listing the path here would run a job that validates none of
-              # the changed files. Tracked separately.
+              # the changed files. Tracked in issue #3384.
               - '.claude/settings.json'
               - '.claude/hooks/**'
               - 'build/scripts/generate_hooks_shim.py'

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -481,7 +481,7 @@ def validate_all(
         # settings path and loses the category.
         try:
             _, plugin_entries, plugin_violations = parse_settings(plugin_path)
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError, AttributeError) as exc:
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, AttributeError, TypeError) as exc:
             parse_violations.append(
                 Violation(
                     hook_type="plugin",

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -161,7 +161,8 @@ def _load_dispatch_groups(base_path: Path) -> tuple[dict, list[Violation]]:
     """Read the group membership map the dispatcher fans out to.
 
     A missing file is not a violation: a checkout with no grouped hooks is
-    legitimate. Malformed JSON is, because the dispatcher would fail at runtime.
+    legitimate. A malformed one is, because the dispatcher would fail at
+    runtime, and it fails closed: every dispatched tool call is blocked.
     """
     path = base_path / DISPATCH_GROUPS_PATH
     if not path.is_file():
@@ -188,6 +189,10 @@ def _load_dispatch_groups(base_path: Path) -> tuple[dict, list[Violation]]:
         ]
     groups = data.get("groups")
     if not isinstance(groups, dict):
+        # invoke_dispatch_claude._load_group raises TypeError here and the
+        # dispatcher fails closed, so accepting it would let a file that blocks
+        # every tool call at runtime pass the contract check.
+        found = "missing" if "groups" not in data else type(groups).__name__
         return {}, [
             Violation(
                 hook_type="dispatcher",
@@ -195,7 +200,7 @@ def _load_dispatch_groups(base_path: Path) -> tuple[dict, list[Violation]]:
                 category="invalid_dispatch_groups",
                 message=(
                     f"{DISPATCH_GROUPS_PATH} 'groups' property must be an object, "
-                    f"got {type(groups).__name__ if groups is not None else 'missing'}"
+                    f"got {found}"
                 ),
             )
         ]

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -55,7 +55,17 @@ _SCRIPT_PATH_PATTERN = re.compile(r"python3?\s+(?:-\w+\s+)*\"?(.+?\.py)\"?(?:\s|
 # Plugin registrations address their scripts through the harness-provided
 # plugin root. Inside the checkout that publishes the plugin, that root is
 # .claude, so resolving it lets the same contract cover the published surface.
-_PLUGIN_ROOT_PATTERN = re.compile(r"\$\{(?:CLAUDE|COPILOT)_PLUGIN_ROOT(?::-[^}]*)?\}")
+#
+# The default clause excludes both braces, so a nested fallback like
+# ${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}} is not consumed up to the inner
+# brace. The shipped copilot-cli registrations use exactly that form; a pattern
+# that allowed { in the default matched only the inner expansion and left a
+# stray } in the extracted path, which reads as a missing script.
+_PLUGIN_ROOT_PATTERN = re.compile(r"\$\{(?:CLAUDE|COPILOT)_PLUGIN_ROOT(?::-[^{}]*)?\}")
+
+# A nested default needs more than one pass: the inner expansion resolves
+# first, which turns the outer one into the simple form the pattern matches.
+_MAX_PLUGIN_ROOT_PASSES = 5
 
 # Pattern to detect PowerShell commands
 _PWSH_PATTERN = re.compile(r"(?:pwsh|powershell)\s+.*\.ps1(?:\s|$)", re.IGNORECASE)
@@ -113,15 +123,35 @@ def _resolve_script_path(base_path: Path, script_path: str) -> Path | None:
     return candidate
 
 
+def _resolve_plugin_root(path: str) -> str:
+    """Substitute plugin-root expansions until none are left.
+
+    One pass is not enough for a nested default: resolving the inner
+    ${CLAUDE_PLUGIN_ROOT} is what turns the outer expansion into a form the
+    pattern can match. The pass count is bounded so a pathological string
+    cannot spin.
+    """
+    for _ in range(_MAX_PLUGIN_ROOT_PASSES):
+        resolved = _PLUGIN_ROOT_PATTERN.sub(".claude", path)
+        if resolved == path:
+            return resolved
+        path = resolved
+    return path
+
+
 def extract_script_path(command: str) -> str | None:
     """Extract the Python script path from a hook command string."""
     match = _SCRIPT_PATH_PATTERN.search(command)
     if not match:
         return None
-    return _PLUGIN_ROOT_PATTERN.sub(".claude", match.group(1)).strip("\"'")
+    return _resolve_plugin_root(match.group(1)).strip("\"'")
 
 
 _GROUP_FLAG_PATTERN = re.compile(r"--group\s+([A-Za-z0-9_.-]+)")
+
+# Only the dispatcher fans a registration out to a group. Keying expansion on
+# the bare --group flag would mis-expand any hook that happens to take one.
+DISPATCHER_SCRIPT_NAME = "invoke_dispatch_claude.py"
 
 DISPATCH_GROUPS_PATH = Path(".claude") / "hooks" / "dispatch_groups.json"
 PLUGIN_HOOKS_PATH = Path(".claude") / "hooks" / "hooks.json"
@@ -163,20 +193,32 @@ def _load_dispatch_groups(base_path: Path) -> tuple[dict, list[Violation]]:
 def _expand_dispatch_group(
     entry: HookEntry, groups: dict
 ) -> tuple[list[HookEntry], list[Violation]]:
-    """Replace a dispatcher registration with the shims it actually runs.
+    """Add the shims a dispatcher registration actually runs.
 
     Since group dispatch (#3153) a registration names a group, not a script, so
     validating the command alone checks the dispatcher over and over and never
     checks the hooks. The shims are the code that runs, so they are what the
     contract has to cover.
+
+    The dispatcher entry is kept alongside the shims rather than replaced by
+    them. The harness runs it either way, so dropping it on an unresolvable
+    group would stop checking that the dispatcher itself exists and documents
+    its exit codes, on exactly the registrations most likely to be broken.
+
+    Expansion is keyed on the dispatcher script name, not on the presence of a
+    --group flag, so an ordinary hook that takes a --group argument is left
+    alone.
     """
+    script = extract_script_path(entry.command)
+    if script is None or Path(script).name != DISPATCHER_SCRIPT_NAME:
+        return [entry], []
     match = _GROUP_FLAG_PATTERN.search(entry.command)
     if not match:
         return [entry], []
     name = match.group(1)
     spec = groups.get(name)
     if not isinstance(spec, dict):
-        return [], [
+        return [entry], [
             Violation(
                 hook_type=entry.hook_type,
                 script=entry.script_path,
@@ -189,7 +231,7 @@ def _expand_dispatch_group(
         ]
     shims = spec.get("shims")
     if not isinstance(shims, list) or not shims:
-        return [], [
+        return [entry], [
             Violation(
                 hook_type=entry.hook_type,
                 script=entry.script_path,
@@ -200,7 +242,7 @@ def _expand_dispatch_group(
                 ),
             )
         ]
-    expanded: list[HookEntry] = []
+    expanded: list[HookEntry] = [entry]
     violations: list[Violation] = []
     for shim in shims:
         if not isinstance(shim, dict) or not isinstance(shim.get("file"), str):
@@ -434,19 +476,23 @@ def validate_all(
     # the whole published surface unvalidated.
     plugin_path = base_path / PLUGIN_HOOKS_PATH
     if plugin_path.is_file():
+        # Attribute a failure here to the plugin file. Letting it escape would
+        # surface as "Invalid settings.json" in main(), which names the wrong
+        # file and loses the category.
         try:
             _, plugin_entries, plugin_violations = parse_settings(plugin_path)
-            entries.extend(plugin_entries)
-            parse_violations.extend(plugin_violations)
-        except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, AttributeError) as exc:
             parse_violations.append(
                 Violation(
                     hook_type="plugin",
                     script=str(PLUGIN_HOOKS_PATH),
                     category="invalid_plugin_hooks",
-                    message=f"Cannot read {PLUGIN_HOOKS_PATH}: {exc}",
+                    message=f"Plugin hook registrations cannot be read: {exc}",
                 )
             )
+        else:
+            entries.extend(plugin_entries)
+            parse_violations.extend(plugin_violations)
 
     groups, group_violations = _load_dispatch_groups(base_path)
     parse_violations.extend(group_violations)

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -138,13 +138,22 @@ def _load_dispatch_groups(base_path: Path) -> tuple[dict, list[Violation]]:
         return {}, []
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         return {}, [
             Violation(
                 hook_type="dispatcher",
                 script=str(DISPATCH_GROUPS_PATH),
                 category="invalid_dispatch_groups",
                 message=f"Cannot read {DISPATCH_GROUPS_PATH}: {exc}",
+            )
+        ]
+    if not isinstance(data, dict):
+        return {}, [
+            Violation(
+                hook_type="dispatcher",
+                script=str(DISPATCH_GROUPS_PATH),
+                category="invalid_dispatch_groups",
+                message=f"{DISPATCH_GROUPS_PATH} must be a JSON object, got {type(data).__name__}",
             )
         ]
     groups = data.get("groups")

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -477,8 +477,8 @@ def validate_all(
     plugin_path = base_path / PLUGIN_HOOKS_PATH
     if plugin_path.is_file():
         # Attribute a failure here to the plugin file. Letting it escape would
-        # surface as "Invalid settings.json" in main(), which names the wrong
-        # file and loses the category.
+        # surface as a generic read failure in main(), which names the
+        # settings path and loses the category.
         try:
             _, plugin_entries, plugin_violations = parse_settings(plugin_path)
         except (OSError, UnicodeDecodeError, json.JSONDecodeError, AttributeError) as exc:
@@ -633,9 +633,20 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         report = validate_all(settings_path, base_path)
-    except (json.JSONDecodeError, TypeError, AttributeError) as exc:
+    except (
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        TypeError,
+        AttributeError,
+    ) as exc:
+        # OSError and UnicodeDecodeError reach here from the settings read
+        # itself: an unreadable file or one holding invalid UTF-8. Without
+        # them the script exits on a traceback instead of the ADR-035
+        # configuration code, and --settings can name a file that is not
+        # settings.json, so the message reports the path it actually read.
         print(
-            f"Error: Invalid settings.json: {exc}",
+            f"Error: Cannot read hook registrations from {settings_path}: {exc}",
             file=sys.stderr,
         )
         return 2

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -187,7 +187,19 @@ def _load_dispatch_groups(base_path: Path) -> tuple[dict, list[Violation]]:
             )
         ]
     groups = data.get("groups")
-    return (groups if isinstance(groups, dict) else {}), []
+    if not isinstance(groups, dict):
+        return {}, [
+            Violation(
+                hook_type="dispatcher",
+                script=str(DISPATCH_GROUPS_PATH),
+                category="invalid_dispatch_groups",
+                message=(
+                    f"{DISPATCH_GROUPS_PATH} 'groups' property must be an object, "
+                    f"got {type(groups).__name__ if groups is not None else 'missing'}"
+                ),
+            )
+        ]
+    return groups, []
 
 
 def _expand_dispatch_group(

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -244,11 +244,18 @@ def _expand_dispatch_group(
             )
         ]
 
-    # The categories below mirror the four outcomes the Claude runtime already
-    # distinguishes in invoke_dispatch_claude._load_group: KeyError for an
-    # absent group, TypeError for a non-object group, TypeError for a non-list
-    # 'shims', and no error at all for an empty list. Reporting a wrong type as
-    # "does not define" sends the reader to add a group that is already there.
+    # The categories below mirror the outcomes the Claude runtime already
+    # distinguishes across invoke_dispatch_claude._load_group and
+    # claude_hook_dispatch.validate_group: KeyError for an absent group,
+    # TypeError for a non-object group, TypeError for a non-string or empty
+    # event, TypeError for a non-list 'shims', and no error at all for an empty
+    # list. Reporting a wrong type as "does not define" sends the reader to add
+    # a group that is already there.
+    #
+    # Not mirrored: the event-to-mode pairing. This module never reads 'mode',
+    # and tests/hooks/test_dispatch_groups_parity.py already asserts the pairing
+    # over the real manifest, so repeating it here would be two owners for one
+    # rule.
     if name not in groups:
         return _fail("unknown_dispatch_group", f"{DISPATCH_GROUPS_PATH} does not define")
     spec = groups[name]
@@ -257,6 +264,29 @@ def _expand_dispatch_group(
             "malformed_dispatch_group",
             f"{DISPATCH_GROUPS_PATH} defines as {type(spec).__name__}, not an object; "
             "the dispatcher fails closed on it",
+        )
+    event = spec.get("event")
+    if event is not None and (not isinstance(event, str) or not event):
+        # claude_hook_dispatch.validate_group raises TypeError on a non-string
+        # or empty event and the dispatcher exits 2. Reporting it is the point:
+        # coercing to the registration's own hook type instead would let a
+        # manifest the runtime refuses to load pass this gate silently. It also
+        # has to be caught here, because a non-string escaping into
+        # HookEntry.hook_type crashes validate_hook_type_known (unhashable set
+        # element) and validate_duplicate_entries (unhashable dict key).
+        found = "an empty string" if isinstance(event, str) else type(event).__name__
+        return _fail(
+            "malformed_dispatch_group",
+            f"declares 'event' as {found}, not a non-empty string; "
+            "the dispatcher fails closed on it",
+        )
+    matcher = spec.get("matcher", entry.matcher)
+    if matcher is not None and not isinstance(matcher, str):
+        # None is a legitimate manifest value (a group that matches every tool
+        # for its event), so the check is str-or-None rather than str.
+        return _fail(
+            "malformed_dispatch_group",
+            f"declares 'matcher' as {type(matcher).__name__}, not a string or null",
         )
     shims = spec.get("shims")
     if not isinstance(shims, list):
@@ -285,10 +315,10 @@ def _expand_dispatch_group(
             continue
         expanded.append(
             HookEntry(
-                hook_type=spec.get("event") or entry.hook_type,
+                hook_type=event or entry.hook_type,
                 script_path=str(Path(".claude") / "hooks" / shim["file"]),
                 command=entry.command,
-                matcher=spec.get("matcher", entry.matcher),
+                matcher=matcher,
                 timeout=shim.get("timeout", entry.timeout),
                 status_message=shim.get("statusMessage"),
             )

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -519,12 +519,23 @@ def validate_all(
 
     groups, group_violations = _load_dispatch_groups(base_path)
     parse_violations.extend(group_violations)
-    expanded: list[HookEntry] = []
-    for entry in entries:
-        shims, violations = _expand_dispatch_group(entry, groups)
-        expanded.extend(shims)
-        parse_violations.extend(violations)
-    entries = expanded
+    # An unusable manifest yields no groups, so expanding against it would
+    # report every dispatcher registration as naming an unknown group and bury
+    # the one violation that explains all of them. Expansion is skipped, not
+    # the entries: the dispatcher registrations stay in the list and are still
+    # checked for script existence and exit-code docs. The shims cannot be
+    # checked because the file that names them is the thing that failed.
+    manifest_unusable = any(
+        violation.category == "invalid_dispatch_groups"
+        for violation in group_violations
+    )
+    if not manifest_unusable:
+        expanded: list[HookEntry] = []
+        for entry in entries:
+            shims, violations = _expand_dispatch_group(entry, groups)
+            expanded.extend(shims)
+            parse_violations.extend(violations)
+        entries = expanded
 
     report = ContractReport(entries=entries)
     report.violations.extend(parse_violations)

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -233,32 +233,43 @@ def _expand_dispatch_group(
     if not match:
         return [entry], []
     name = match.group(1)
-    spec = groups.get(name)
+
+    def _fail(category: str, message: str) -> tuple[list[HookEntry], list[Violation]]:
+        return [entry], [
+            Violation(
+                hook_type=entry.hook_type,
+                script=entry.script_path,
+                category=category,
+                message=f"Hook dispatches to group '{name}', which {message}",
+            )
+        ]
+
+    # The categories below mirror the four outcomes the Claude runtime already
+    # distinguishes in invoke_dispatch_claude._load_group: KeyError for an
+    # absent group, TypeError for a non-object group, TypeError for a non-list
+    # 'shims', and no error at all for an empty list. Reporting a wrong type as
+    # "does not define" sends the reader to add a group that is already there.
+    if name not in groups:
+        return _fail("unknown_dispatch_group", f"{DISPATCH_GROUPS_PATH} does not define")
+    spec = groups[name]
     if not isinstance(spec, dict):
-        return [entry], [
-            Violation(
-                hook_type=entry.hook_type,
-                script=entry.script_path,
-                category="unknown_dispatch_group",
-                message=(
-                    f"Hook dispatches to group '{name}', which "
-                    f"{DISPATCH_GROUPS_PATH} does not define"
-                ),
-            )
-        ]
+        return _fail(
+            "malformed_dispatch_group",
+            f"{DISPATCH_GROUPS_PATH} defines as {type(spec).__name__}, not an object; "
+            "the dispatcher fails closed on it",
+        )
     shims = spec.get("shims")
-    if not isinstance(shims, list) or not shims:
-        return [entry], [
-            Violation(
-                hook_type=entry.hook_type,
-                script=entry.script_path,
-                category="empty_dispatch_group",
-                message=(
-                    f"Hook dispatches to group '{name}', which lists no shims, "
-                    "so the registration runs nothing"
-                ),
-            )
-        ]
+    if not isinstance(shims, list):
+        return _fail(
+            "malformed_dispatch_group",
+            f"declares 'shims' as {type(shims).__name__}, not a list; "
+            "the dispatcher fails closed on it",
+        )
+    if not shims:
+        return _fail(
+            "empty_dispatch_group",
+            "lists no shims, so the registration runs nothing",
+        )
     expanded: list[HookEntry] = [entry]
     violations: list[Violation] = []
     for shim in shims:

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -199,8 +199,7 @@ def _load_dispatch_groups(base_path: Path) -> tuple[dict, list[Violation]]:
                 script=str(DISPATCH_GROUPS_PATH),
                 category="invalid_dispatch_groups",
                 message=(
-                    f"{DISPATCH_GROUPS_PATH} 'groups' property must be an object, "
-                    f"got {found}"
+                    f"{DISPATCH_GROUPS_PATH} 'groups' property must be an object, got {found}"
                 ),
             )
         ]
@@ -321,7 +320,7 @@ def _expand_dispatch_group(
             continue
         expanded.append(
             HookEntry(
-                hook_type=event or entry.hook_type,
+                hook_type=event,
                 script_path=str(Path(".claude") / "hooks" / shim["file"]),
                 command=entry.command,
                 matcher=matcher,
@@ -573,8 +572,7 @@ def validate_all(
     # checked for script existence and exit-code docs. The shims cannot be
     # checked because the file that names them is the thing that failed.
     manifest_unusable = any(
-        violation.category == "invalid_dispatch_groups"
-        for violation in group_violations
+        violation.category == "invalid_dispatch_groups" for violation in group_violations
     )
     if not manifest_unusable:
         expanded: list[HookEntry] = []

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -438,7 +438,7 @@ def validate_all(
             _, plugin_entries, plugin_violations = parse_settings(plugin_path)
             entries.extend(plugin_entries)
             parse_violations.extend(plugin_violations)
-        except UnicodeDecodeError as exc:
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             parse_violations.append(
                 Violation(
                     hook_type="plugin",

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -481,7 +481,13 @@ def validate_all(
         # settings path and loses the category.
         try:
             _, plugin_entries, plugin_violations = parse_settings(plugin_path)
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError, AttributeError, TypeError) as exc:
+        except (
+            OSError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            AttributeError,
+            TypeError,
+        ) as exc:
             parse_violations.append(
                 Violation(
                     hook_type="plugin",

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -50,7 +50,12 @@ MIN_TIMEOUT = 1
 MAX_TIMEOUT = 300
 
 # Pattern to extract script path from command string
-_SCRIPT_PATH_PATTERN = re.compile(r"python3?\s+(?:-\w+\s+)*(.+\.py)(?:\s|$)")
+_SCRIPT_PATH_PATTERN = re.compile(r"python3?\s+(?:-\w+\s+)*\"?(.+?\.py)\"?(?:\s|$)")
+
+# Plugin registrations address their scripts through the harness-provided
+# plugin root. Inside the checkout that publishes the plugin, that root is
+# .claude, so resolving it lets the same contract cover the published surface.
+_PLUGIN_ROOT_PATTERN = re.compile(r"\$\{(?:CLAUDE|COPILOT)_PLUGIN_ROOT(?::-[^}]*)?\}")
 
 # Pattern to detect PowerShell commands
 _PWSH_PATTERN = re.compile(r"(?:pwsh|powershell)\s+.*\.ps1(?:\s|$)", re.IGNORECASE)
@@ -111,9 +116,105 @@ def _resolve_script_path(base_path: Path, script_path: str) -> Path | None:
 def extract_script_path(command: str) -> str | None:
     """Extract the Python script path from a hook command string."""
     match = _SCRIPT_PATH_PATTERN.search(command)
-    if match:
-        return match.group(1)
-    return None
+    if not match:
+        return None
+    return _PLUGIN_ROOT_PATTERN.sub(".claude", match.group(1)).strip("\"'")
+
+
+_GROUP_FLAG_PATTERN = re.compile(r"--group\s+([A-Za-z0-9_.-]+)")
+
+DISPATCH_GROUPS_PATH = Path(".claude") / "hooks" / "dispatch_groups.json"
+PLUGIN_HOOKS_PATH = Path(".claude") / "hooks" / "hooks.json"
+
+
+def _load_dispatch_groups(base_path: Path) -> tuple[dict, list[Violation]]:
+    """Read the group membership map the dispatcher fans out to.
+
+    A missing file is not a violation: a checkout with no grouped hooks is
+    legitimate. Malformed JSON is, because the dispatcher would fail at runtime.
+    """
+    path = base_path / DISPATCH_GROUPS_PATH
+    if not path.is_file():
+        return {}, []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {}, [
+            Violation(
+                hook_type="dispatcher",
+                script=str(DISPATCH_GROUPS_PATH),
+                category="invalid_dispatch_groups",
+                message=f"Cannot read {DISPATCH_GROUPS_PATH}: {exc}",
+            )
+        ]
+    groups = data.get("groups")
+    return (groups if isinstance(groups, dict) else {}), []
+
+
+def _expand_dispatch_group(
+    entry: HookEntry, groups: dict
+) -> tuple[list[HookEntry], list[Violation]]:
+    """Replace a dispatcher registration with the shims it actually runs.
+
+    Since group dispatch (#3153) a registration names a group, not a script, so
+    validating the command alone checks the dispatcher over and over and never
+    checks the hooks. The shims are the code that runs, so they are what the
+    contract has to cover.
+    """
+    match = _GROUP_FLAG_PATTERN.search(entry.command)
+    if not match:
+        return [entry], []
+    name = match.group(1)
+    spec = groups.get(name)
+    if not isinstance(spec, dict):
+        return [], [
+            Violation(
+                hook_type=entry.hook_type,
+                script=entry.script_path,
+                category="unknown_dispatch_group",
+                message=(
+                    f"Hook dispatches to group '{name}', which "
+                    f"{DISPATCH_GROUPS_PATH} does not define"
+                ),
+            )
+        ]
+    shims = spec.get("shims")
+    if not isinstance(shims, list) or not shims:
+        return [], [
+            Violation(
+                hook_type=entry.hook_type,
+                script=entry.script_path,
+                category="empty_dispatch_group",
+                message=(
+                    f"Hook dispatches to group '{name}', which lists no shims, "
+                    "so the registration runs nothing"
+                ),
+            )
+        ]
+    expanded: list[HookEntry] = []
+    violations: list[Violation] = []
+    for shim in shims:
+        if not isinstance(shim, dict) or not isinstance(shim.get("file"), str):
+            violations.append(
+                Violation(
+                    hook_type=entry.hook_type,
+                    script=entry.script_path,
+                    category="malformed_shim",
+                    message=f"Group '{name}' has a shim entry with no file path",
+                )
+            )
+            continue
+        expanded.append(
+            HookEntry(
+                hook_type=spec.get("event") or entry.hook_type,
+                script_path=str(Path(".claude") / "hooks" / shim["file"]),
+                command=entry.command,
+                matcher=spec.get("matcher", entry.matcher),
+                timeout=shim.get("timeout", entry.timeout),
+                status_message=shim.get("statusMessage"),
+            )
+        )
+    return expanded, violations
 
 
 def parse_settings(settings_path: Path) -> tuple[dict, list[HookEntry], list[Violation]]:
@@ -319,6 +420,24 @@ def validate_all(
         ContractReport with all entries and violations found.
     """
     _, entries, parse_violations = parse_settings(settings_path)
+
+    # The plugin registers its own hooks, so a settings.json-only read leaves
+    # the whole published surface unvalidated.
+    plugin_path = base_path / PLUGIN_HOOKS_PATH
+    if plugin_path.is_file():
+        _, plugin_entries, plugin_violations = parse_settings(plugin_path)
+        entries.extend(plugin_entries)
+        parse_violations.extend(plugin_violations)
+
+    groups, group_violations = _load_dispatch_groups(base_path)
+    parse_violations.extend(group_violations)
+    expanded: list[HookEntry] = []
+    for entry in entries:
+        shims, violations = _expand_dispatch_group(entry, groups)
+        expanded.extend(shims)
+        parse_violations.extend(violations)
+    entries = expanded
+
     report = ContractReport(entries=entries)
     report.violations.extend(parse_violations)
 

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -434,9 +434,19 @@ def validate_all(
     # the whole published surface unvalidated.
     plugin_path = base_path / PLUGIN_HOOKS_PATH
     if plugin_path.is_file():
-        _, plugin_entries, plugin_violations = parse_settings(plugin_path)
-        entries.extend(plugin_entries)
-        parse_violations.extend(plugin_violations)
+        try:
+            _, plugin_entries, plugin_violations = parse_settings(plugin_path)
+            entries.extend(plugin_entries)
+            parse_violations.extend(plugin_violations)
+        except UnicodeDecodeError as exc:
+            parse_violations.append(
+                Violation(
+                    hook_type="plugin",
+                    script=str(PLUGIN_HOOKS_PATH),
+                    category="invalid_plugin_hooks",
+                    message=f"Cannot read {PLUGIN_HOOKS_PATH}: {exc}",
+                )
+            )
 
     groups, group_violations = _load_dispatch_groups(base_path)
     parse_violations.extend(group_violations)

--- a/scripts/validation/hook_contracts.py
+++ b/scripts/validation/hook_contracts.py
@@ -266,15 +266,21 @@ def _expand_dispatch_group(
             "the dispatcher fails closed on it",
         )
     event = spec.get("event")
-    if event is not None and (not isinstance(event, str) or not event):
-        # claude_hook_dispatch.validate_group raises TypeError on a non-string
-        # or empty event and the dispatcher exits 2. Reporting it is the point:
-        # coercing to the registration's own hook type instead would let a
-        # manifest the runtime refuses to load pass this gate silently. It also
-        # has to be caught here, because a non-string escaping into
-        # HookEntry.hook_type crashes validate_hook_type_known (unhashable set
-        # element) and validate_duplicate_entries (unhashable dict key).
-        found = "an empty string" if isinstance(event, str) else type(event).__name__
+    if not isinstance(event, str) or not event:
+        # claude_hook_dispatch.validate_group raises TypeError on a missing,
+        # null, non-string, or empty event and the dispatcher exits 2.
+        # Reporting it is the point: coercing to the registration's own hook
+        # type instead would let a manifest the runtime refuses to load pass
+        # this gate silently. It also has to be caught here, because a
+        # non-string escaping into HookEntry.hook_type crashes
+        # validate_hook_type_known (unhashable set element) and
+        # validate_duplicate_entries (unhashable dict key).
+        if event is None:
+            found = "null" if "event" in spec else "missing"
+        elif isinstance(event, str):
+            found = "an empty string"
+        else:
+            found = type(event).__name__
         return _fail(
             "malformed_dispatch_group",
             f"declares 'event' as {found}, not a non-empty string; "

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.121",
+  "version": "0.6.122",
   "author": {
     "name": "rjmurillo"
   }

--- a/tests/ci/test_validation_scripts_are_reachable.py
+++ b/tests/ci/test_validation_scripts_are_reachable.py
@@ -27,11 +27,11 @@ Workflow, hook, and skill documentation can name an entry point. Once a
 ``SKILL.md`` names a helper script, the graph follows that helper's imports and
 executable string literals.
 
-Under that model the same 89 scripts yield five unreachable, each of which is a
+Under that model the same 89 scripts yield four unreachable, each of which is a
 real decision recorded in ``_NO_CALLER`` below rather than a bulk exemption.
 
 What this does not do: prove the caller is correct, or that the script would
-pass if run. Three of the entries below are unreachable precisely because
+pass if run. Two of the entries below are unreachable precisely because
 they fail against the current tree, which is tracked separately. Reachability
 is the floor, not the ceiling.
 """
@@ -106,12 +106,6 @@ _NO_CALLER: dict[str, str] = {
         "consistency.py: the schema it implements "
         "(.agents/governance/traceability-schema.md) is live, so the fix is to "
         "resolve the findings and then wire it. Tracked in #3360."
-    ),
-    "scripts/validation/hook_contracts.py": (
-        "Fails against the current tree: `--ci` exits 1 on hook docstrings that "
-        "do not document their exit-code semantics. This one is worth wiring "
-        "once the docstrings are fixed, because it guards the hook contract "
-        "that #3247 and #3295 both turned on. Tracked in #3360."
     ),
 }
 

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -1259,3 +1259,61 @@ class TestMalformedPluginHooksAreAttributed:
         )
         report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert "invalid_plugin_hooks" not in {v.category for v in report.violations}
+
+
+class TestUnreadableSettingsExitsTwoNotATraceback:
+    """The ADR-035 contract says a configuration problem exits 2. main() caught
+    only decode and type errors, so a settings file that is unreadable or holds
+    invalid UTF-8 escaped as a traceback: the two failure modes most likely on
+    a real machine (a permission bit, a truncated write) were the two the
+    handler missed.
+    """
+
+    def test_a_directory_in_place_of_the_settings_file_exits_two(self, tmp_path, capsys):
+        settings = tmp_path / "settings.json"
+        settings.write_text("{}", encoding="utf-8")
+        # Point --settings at a path that passes is_file() then fails to read.
+        unreadable = tmp_path / "locked.json"
+        unreadable.write_text("{}", encoding="utf-8")
+        unreadable.chmod(0o000)
+        try:
+            rc = hook_contracts.main(
+                ["--path", str(tmp_path), "--settings", str(unreadable)]
+            )
+        finally:
+            unreadable.chmod(0o644)
+        if rc == 0:
+            pytest.skip("running as a user that ignores the permission bit")
+        assert rc == 2
+        assert "Cannot read hook registrations" in capsys.readouterr().err
+
+    def test_invalid_utf8_in_the_settings_file_exits_two(self, tmp_path, capsys):
+        settings = tmp_path / "settings.json"
+        settings.write_bytes(b'{"hooks": {"\xff\xfe": []}}')
+
+        rc = hook_contracts.main(["--path", str(tmp_path), "--settings", str(settings)])
+
+        assert rc == 2
+        assert "Cannot read hook registrations" in capsys.readouterr().err
+
+    def test_the_message_names_the_path_that_was_read(self, tmp_path, capsys):
+        """--settings can name a file that is not settings.json, so a message
+        hard-coding that name would point the reader at the wrong file.
+        """
+        settings = tmp_path / "elsewhere.json"
+        settings.write_text("{ not json", encoding="utf-8")
+
+        rc = hook_contracts.main(["--path", str(tmp_path), "--settings", str(settings)])
+
+        assert rc == 2
+        assert "elsewhere.json" in capsys.readouterr().err
+
+    def test_a_readable_settings_file_still_exits_zero(self, tmp_path, capsys):
+        """Negative control: the widened except must not swallow a healthy run."""
+        settings = tmp_path / "settings.json"
+        settings.write_text('{"hooks": {}}', encoding="utf-8")
+
+        rc = hook_contracts.main(["--path", str(tmp_path), "--settings", str(settings)])
+
+        assert rc == 0
+        assert "Cannot read hook registrations" not in capsys.readouterr().err

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -817,7 +817,9 @@ class TestMain:
 # Dispatcher and plugin surface coverage (issue #3360)
 # ---------------------------------------------------------------------------
 
-_DOC = '"""H.\n\nExit Codes:\n    0 = ok\n"""\n'
+# Models a real blocking hook: the contract these tests exercise is 0=allow,
+# 2=block, so a stub documenting only 0 would not be representative.
+_DOC = '"""H.\n\nExit Codes:\n    0 = allow\n    2 = block\n"""\n'
 
 
 def _tree(root, *, settings, groups=None, plugin=None, shims=(), dispatcher=_DOC):
@@ -1369,3 +1371,55 @@ class TestUnreadableSettingsExitsTwoNotATraceback:
 
         assert rc == 0
         assert "Cannot read hook registrations" not in capsys.readouterr().err
+
+
+class TestAMalformedGroupsFieldIsAViolationNotAnEmptyMap:
+    """``invoke_dispatch_claude._load_group`` raises TypeError when ``groups``
+    is missing or is not an object, and the dispatcher fails closed on that,
+    so every dispatched tool call is blocked. Reading the field as an empty map
+    let a file with that shape pass the contract check while the runtime it
+    describes refused to run.
+    """
+
+    @staticmethod
+    def _report(tmp_path, payload):
+        _tree(tmp_path, settings=_dispatch("g1"))
+        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text(
+            payload, encoding="utf-8"
+        )
+        return hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+
+    def test_an_absent_groups_field_is_reported(self, tmp_path):
+        report = self._report(tmp_path, json.dumps({"version": 1}))
+        assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
+
+    def test_a_list_valued_groups_field_is_reported(self, tmp_path):
+        report = self._report(tmp_path, json.dumps({"groups": []}))
+        assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
+
+    def test_a_null_groups_field_is_reported(self, tmp_path):
+        report = self._report(tmp_path, json.dumps({"groups": None}))
+        assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
+
+    def test_the_message_names_the_field_and_the_type_found(self, tmp_path):
+        report = self._report(tmp_path, json.dumps({"groups": []}))
+        messages = [v.message for v in report.violations]
+        assert any(
+            "'groups' property must be an object" in m and "list" in m for m in messages
+        )
+
+    def test_an_empty_groups_object_is_still_legitimate(self, tmp_path):
+        """A checkout that declares the field but groups nothing is valid."""
+        report = self._report(tmp_path, json.dumps({"groups": {}}))
+        assert not any(
+            v.category == "invalid_dispatch_groups" for v in report.violations
+        )
+
+    def test_the_runtime_it_describes_raises_on_the_same_shape(self):
+        """Tie the rule to the dispatcher, so the two cannot drift apart."""
+        source = (
+            PROJECT_ROOT / ".claude" / "hooks" / "invoke_dispatch_claude.py"
+        ).read_text(encoding="utf-8")
+        assert "field 'groups' must be an object" in source

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -921,6 +921,65 @@ class TestDispatcherExpansion:
         report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "empty_dispatch_group" for v in report.violations)
 
+    def test_a_group_defined_as_a_non_object_is_not_reported_as_undefined(self, tmp_path):
+        """The name is present, so "does not define" sends the reader nowhere.
+
+        invoke_dispatch_claude._load_group raises KeyError for an absent group
+        and TypeError for a non-object one. Collapsing both to
+        unknown_dispatch_group told the reader to add a group that is already
+        there, while the dispatcher was failing closed on its shape.
+        """
+        _tree(tmp_path, settings=_dispatch("g1"), groups={"groups": {"g1": ["A/a.py"]}})
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        categories = {v.category for v in report.violations}
+        assert "malformed_dispatch_group" in categories
+        assert "unknown_dispatch_group" not in categories
+
+    def test_a_group_defined_as_null_is_malformed_not_undefined(self, tmp_path):
+        """JSON null is the shape that made get() and 'in' disagree."""
+        _tree(tmp_path, settings=_dispatch("g1"), groups={"groups": {"g1": None}})
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        categories = {v.category for v in report.violations}
+        assert "malformed_dispatch_group" in categories
+        assert "unknown_dispatch_group" not in categories
+
+    def test_a_non_list_shims_is_not_reported_as_empty(self, tmp_path):
+        """A wrong type is a manifest bug; an empty list is a deliberate no-op.
+
+        The dispatcher raises TypeError on the first and runs zero shims on the
+        second, so the two need different fixes and cannot share a category.
+        """
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PreToolUse", "shims": "A/a.py"}}},
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        categories = {v.category for v in report.violations}
+        assert "malformed_dispatch_group" in categories
+        assert "empty_dispatch_group" not in categories
+
+    def test_the_message_names_the_type_that_was_found(self, tmp_path):
+        """A shape violation the reader cannot see is a shape violation twice."""
+        _tree(tmp_path, settings=_dispatch("g1"), groups={"groups": {"g1": ["A/a.py"]}})
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        message = next(
+            v.message for v in report.violations if v.category == "malformed_dispatch_group"
+        )
+        assert "list" in message and "g1" in message
+
+    def test_an_empty_list_is_still_empty_not_malformed(self, tmp_path):
+        """Negative control: the split must not swallow the original category."""
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PreToolUse", "shims": []}}},
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        categories = {v.category for v in report.violations}
+        assert "empty_dispatch_group" in categories
+        assert "malformed_dispatch_group" not in categories
+
     def test_a_shim_entry_without_a_file_is_a_violation(self, tmp_path):
         _tree(
             tmp_path,
@@ -1113,13 +1172,33 @@ class TestTheShippedTreeSatisfiesTheContract:
         assert report.is_valid, [v.message for v in report.violations]
         groups_path = PROJECT_ROOT / ".claude" / "hooks" / "dispatch_groups.json"
         groups = json.loads(groups_path.read_text(encoding="utf-8"))["groups"]
-        expected_shims = {
-            f".claude/hooks/{s['file']}"
-            for spec in groups.values()
-            for s in spec.get("shims", [])
-        }
+
+        # Built defensively rather than with s["file"]. A malformed shim entry
+        # is exactly what this validator exists to catch, and reading the key
+        # directly would turn that case into a KeyError traceback pointing at
+        # the test instead of an assertion naming the offending group. The
+        # is_valid assert above catches it first for any group a registration
+        # dispatches to, but this loop walks every group in the manifest,
+        # including one no registration reaches.
+        expected_shims = set()
+        malformed = []
+        for group_name, spec in groups.items():
+            shims = spec.get("shims", []) if isinstance(spec, dict) else []
+            for index, shim in enumerate(shims if isinstance(shims, list) else []):
+                file = shim.get("file") if isinstance(shim, dict) else None
+                if isinstance(file, str):
+                    expected_shims.add(f".claude/hooks/{file}")
+                else:
+                    malformed.append(f"{group_name}[{index}]={shim!r}")
+        assert not malformed, (
+            f"dispatch_groups.json has shim entries with no file path: {malformed}"
+        )
+
         validated_paths = {e.script_path for e in report.entries}
-        assert expected_shims <= validated_paths
+        assert expected_shims <= validated_paths, (
+            "shims defined in dispatch_groups.json that no registration reaches: "
+            f"{sorted(expected_shims - validated_paths)}"
+        )
 
         # Also verify direct (non-dispatch) registrations are validated.
         # Build the expected set from both settings.json and hooks.json.

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -1423,3 +1423,54 @@ class TestAMalformedGroupsFieldIsAViolationNotAnEmptyMap:
             PROJECT_ROOT / ".claude" / "hooks" / "invoke_dispatch_claude.py"
         ).read_text(encoding="utf-8")
         assert "field 'groups' must be an object" in source
+
+
+class TestAnUnusableManifestReportsOnceNotOncePerRegistration:
+    """One unreadable file, one violation.
+
+    Expanding registrations against the empty map an unusable manifest yields
+    turned a single root cause into one ``unknown_dispatch_group`` per
+    dispatcher registration, so the violation that explained all of them was
+    buried in the noise it caused.
+    """
+
+    @staticmethod
+    def _report(tmp_path, payload):
+        _tree(tmp_path, settings=_dispatch("g1"))
+        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text(
+            payload, encoding="utf-8"
+        )
+        return hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+
+    def test_an_unusable_manifest_reports_no_unknown_group(self, tmp_path):
+        report = self._report(tmp_path, json.dumps({"groups": []}))
+        assert not any(
+            v.category == "unknown_dispatch_group" for v in report.violations
+        )
+
+    def test_the_root_cause_is_still_reported(self, tmp_path):
+        report = self._report(tmp_path, json.dumps({"groups": []}))
+        assert (
+            sum(v.category == "invalid_dispatch_groups" for v in report.violations) == 1
+        )
+
+    def test_the_dispatcher_entry_survives_the_skipped_expansion(self, tmp_path):
+        """Skipping expansion must not drop the registration itself.
+
+        The harness runs the dispatcher whether or not its group resolves, so
+        dropping the entry would stop checking that the dispatcher exists and
+        documents its exit codes on exactly the checkouts most likely broken.
+        """
+        report = self._report(tmp_path, json.dumps({"groups": None}))
+        dispatcher = hook_contracts.DISPATCHER_SCRIPT_NAME
+        assert any(dispatcher in (entry.command or "") for entry in report.entries)
+
+    def test_a_usable_manifest_still_expands(self, tmp_path):
+        """Negative control: the skip must be keyed on the failure, not on all
+        manifests. A well-formed file that defines no matching group still has
+        to report the unknown group.
+        """
+        report = self._report(tmp_path, json.dumps({"groups": {"other": {}}}))
+        assert any(v.category == "unknown_dispatch_group" for v in report.violations)

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -1063,20 +1063,26 @@ class TestTheShippedTreeSatisfiesTheContract:
             PROJECT_ROOT / ".claude" / "settings.json", PROJECT_ROOT
         )
         assert report.is_valid, [v.message for v in report.violations]
-        groups = json.loads(
-            (PROJECT_ROOT / ".claude" / "hooks" / "dispatch_groups.json").read_text(encoding="utf-8")
-        )["groups"]
+        groups_path = PROJECT_ROOT / ".claude" / "hooks" / "dispatch_groups.json"
+        groups = json.loads(groups_path.read_text(encoding="utf-8"))["groups"]
         expected_shims = {
-            f".claude/hooks/{s['file']}" for spec in groups.values() for s in spec.get("shims", [])
+            f".claude/hooks/{s['file']}"
+            for spec in groups.values()
+            for s in spec.get("shims", [])
         }
         validated_paths = {e.script_path for e in report.entries}
         assert expected_shims <= validated_paths
 
         # Also verify direct (non-dispatch) registrations are validated.
         # Build the expected set from both settings.json and hooks.json.
-        settings = json.loads((PROJECT_ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
+        settings_path = PROJECT_ROOT / ".claude" / "settings.json"
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
         plugin_path = PROJECT_ROOT / ".claude" / "hooks" / "hooks.json"
-        plugin = json.loads(plugin_path.read_text(encoding="utf-8")) if plugin_path.is_file() else {}
+        plugin = (
+            json.loads(plugin_path.read_text(encoding="utf-8"))
+            if plugin_path.is_file()
+            else {}
+        )
 
         def _direct_paths(hooks_config: dict) -> set:
             """Extract script paths from non-dispatch registrations."""
@@ -1269,7 +1275,7 @@ class TestUnreadableSettingsExitsTwoNotATraceback:
     handler missed.
     """
 
-    def test_a_directory_in_place_of_the_settings_file_exits_two(self, tmp_path, capsys):
+    def test_an_unreadable_settings_file_exits_two(self, tmp_path, capsys):
         settings = tmp_path / "settings.json"
         settings.write_text("{}", encoding="utf-8")
         # Point --settings at a path that passes is_file() then fails to read.
@@ -1278,7 +1284,7 @@ class TestUnreadableSettingsExitsTwoNotATraceback:
         unreadable.chmod(0o000)
         try:
             rc = hook_contracts.main(
-                ["--path", str(tmp_path), "--settings", str(unreadable)]
+                ["--path", str(tmp_path), "--settings", str(unreadable)],
             )
         finally:
             unreadable.chmod(0o644)

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -902,7 +902,9 @@ class TestDispatcherExpansion:
             groups={"groups": {"g1": {"event": "PreToolUse", "shims": [{"file": "A/a.py"}]}}},
         )
         (tmp_path / ".claude" / "hooks" / "A").mkdir(parents=True, exist_ok=True)
-        (tmp_path / ".claude" / "hooks" / "A" / "a.py").write_text('"""No contract."""\n')
+        (tmp_path / ".claude" / "hooks" / "A" / "a.py").write_text(
+            '"""No contract."""\n', encoding="utf-8"
+        )
         report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert not report.is_valid
 

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -1019,6 +1019,52 @@ class TestDispatcherExpansion:
         )
         assert "empty string" in message
 
+    def test_an_absent_event_is_malformed(self, tmp_path):
+        """validate_group takes spec.get("event"), so absent arrives as None.
+
+        The dispatcher raises TypeError and exits 2 on it, exactly as it does
+        for a wrong type. Reported separately from null because the fix differs:
+        one adds a key, the other fills one in.
+        """
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"shims": [{"file": "A/a.py"}]}}},
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        message = next(
+            v.message for v in report.violations if v.category == "malformed_dispatch_group"
+        )
+        assert "missing" in message
+
+    def test_a_null_event_says_null_not_missing(self, tmp_path):
+        """A key present and null is a different edit than a key absent."""
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": None, "shims": [{"file": "A/a.py"}]}}},
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        message = next(
+            v.message for v in report.violations if v.category == "malformed_dispatch_group"
+        )
+        assert "null" in message and "missing" not in message
+
+    def test_the_group_event_overrides_the_registration_hook_type(self, tmp_path):
+        """The guard makes event a non-empty string, so no fallback remains.
+
+        Keeping ``event or entry.hook_type`` after the guard would be dead code
+        that reads as though an empty event were still reachable.
+        """
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PostToolUse", "shims": [{"file": "A/a.py"}]}}},
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        shim_types = {e.hook_type for e in report.entries if e.script_path.endswith("a.py")}
+        assert shim_types == {"PostToolUse"}, "the registration is PreToolUse; the group wins"
+
     def test_the_event_message_names_the_type_found(self, tmp_path):
         _tree(
             tmp_path,

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -970,6 +970,52 @@ class TestDispatcherExpansion:
         assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
         assert any("must be a JSON object" in v.message for v in report.violations)
 
+    def test_dispatch_groups_with_non_dict_groups_is_reported(self, tmp_path):
+        """A groups property that is not a dict must be reported as invalid."""
+        _tree(
+            tmp_path,
+            settings={
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "",
+                            "hooks": [
+                                {"type": "command", "command": "python3 .claude/hooks/A/a.py"}
+                            ],
+                        }
+                    ]
+                }
+            },
+            shims=["A/a.py"],
+        )
+        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text('{"groups": null}')
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
+        assert any("'groups' property must be an object" in v.message for v in report.violations)
+
+    def test_dispatch_groups_with_missing_groups_is_reported(self, tmp_path):
+        """A dispatch_groups.json without a groups property must be reported."""
+        _tree(
+            tmp_path,
+            settings={
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "",
+                            "hooks": [
+                                {"type": "command", "command": "python3 .claude/hooks/A/a.py"}
+                            ],
+                        }
+                    ]
+                }
+            },
+            shims=["A/a.py"],
+        )
+        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text('{"version": 1}')
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
+        assert any("missing" in v.message for v in report.violations)
+
     def test_an_absent_dispatch_groups_file_is_not_a_violation(self, tmp_path):
         """A checkout with no grouped hooks is legitimate."""
         _tree(

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -964,6 +964,25 @@ class TestDispatcherExpansion:
         )
         assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
 
+    def test_dispatch_groups_with_invalid_utf8_is_reported(self, tmp_path):
+        """Invalid UTF-8 bytes must be caught, not raise UnicodeDecodeError."""
+        _tree(tmp_path, settings=_dispatch("g1"))
+        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_bytes(b"\xff\xfe")
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
+
+    def test_dispatch_groups_with_non_object_root_is_reported(self, tmp_path):
+        """A JSON array or primitive root must be reported, not raise AttributeError."""
+        _tree(tmp_path, settings=_dispatch("g1"))
+        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text("[]")
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
+        assert any("must be a JSON object" in v.message for v in report.violations)
+
     def test_an_absent_dispatch_groups_file_is_not_a_violation(self, tmp_path):
         """A checkout with no grouped hooks is legitimate."""
         _tree(
@@ -1054,9 +1073,44 @@ class TestTheShippedTreeSatisfiesTheContract:
         groups = json.loads(
             (PROJECT_ROOT / ".claude" / "hooks" / "dispatch_groups.json").read_text()
         )["groups"]
-        expected = {
+        expected_shims = {
             f".claude/hooks/{s['file']}"
             for spec in groups.values()
             for s in spec.get("shims", [])
         }
-        assert expected <= {e.script_path for e in report.entries}
+        validated_paths = {e.script_path for e in report.entries}
+        assert expected_shims <= validated_paths
+
+        # Also verify direct (non-dispatch) registrations are validated.
+        # Build the expected set from both settings.json and hooks.json.
+        settings = json.loads(
+            (PROJECT_ROOT / ".claude" / "settings.json").read_text()
+        )
+        plugin_path = PROJECT_ROOT / ".claude" / "hooks" / "hooks.json"
+        plugin = json.loads(plugin_path.read_text()) if plugin_path.is_file() else {}
+
+        def _direct_paths(hooks_config: dict) -> set:
+            """Extract script paths from non-dispatch registrations."""
+            paths = set()
+            for hook_groups in hooks_config.get("hooks", {}).values():
+                if not isinstance(hook_groups, list):
+                    continue
+                for group in hook_groups:
+                    if not isinstance(group, dict):
+                        continue
+                    for hook in group.get("hooks", []):
+                        if not isinstance(hook, dict) or hook.get("type") != "command":
+                            continue
+                        command = hook.get("command", "")
+                        # Skip dispatch commands; their shims are already in expected_shims
+                        if "--group" in command:
+                            continue
+                        script = hook_contracts.extract_script_path(command)
+                        if script:
+                            paths.add(script)
+            return paths
+
+        expected_direct = _direct_paths(settings) | _direct_paths(plugin)
+        assert expected_direct <= validated_paths, (
+            f"Direct hooks not validated: {expected_direct - validated_paths}"
+        )

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -1061,6 +1061,24 @@ class TestPluginSurfaceIsCovered:
         )
         assert report.is_valid
 
+    def test_a_malformed_plugin_hooks_file_is_reported(self, tmp_path):
+        """Invalid JSON in hooks.json must be caught and reported as a violation."""
+        _tree(tmp_path, settings={"hooks": {}}, groups={"groups": {}})
+        (tmp_path / ".claude" / "hooks" / "hooks.json").write_text("{ not json")
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert any(v.category == "invalid_plugin_hooks" for v in report.violations)
+
+    def test_plugin_hooks_with_invalid_utf8_is_reported(self, tmp_path):
+        """Invalid UTF-8 bytes in hooks.json must be caught as a violation."""
+        _tree(tmp_path, settings={"hooks": {}}, groups={"groups": {}})
+        (tmp_path / ".claude" / "hooks" / "hooks.json").write_bytes(b"\xff\xfe")
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert any(v.category == "invalid_plugin_hooks" for v in report.violations)
+
 
 class TestTheShippedTreeSatisfiesTheContract:
     """The gate is only wireable while this holds."""

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -812,3 +812,251 @@ class TestMain:
             ]
         )
         assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher and plugin surface coverage (issue #3360)
+# ---------------------------------------------------------------------------
+
+_DOC = '"""H.\n\nExit Codes:\n    0 = ok\n"""\n'
+
+
+def _tree(root, *, settings, groups=None, plugin=None, shims=()):
+    """Build a checkout with the two hook registration surfaces."""
+    hooks = root / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    (root / ".claude" / "settings.json").write_text(json.dumps(settings))
+    if groups is not None:
+        (hooks / "dispatch_groups.json").write_text(json.dumps(groups))
+    if plugin is not None:
+        (hooks / "hooks.json").write_text(json.dumps(plugin))
+    for rel in shims:
+        target = hooks / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(_DOC)
+    return root
+
+
+def _dispatch(group, *, quoted=False):
+    script = "${CLAUDE_PLUGIN_ROOT}/hooks/invoke_dispatch_claude.py"
+    body = f'"{script}"' if quoted else ".claude/hooks/invoke_dispatch_claude.py"
+    return {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "",
+                    "hooks": [
+                        {"type": "command", "command": f"python3 -u {body} --group {group}"}
+                    ],
+                }
+            ]
+        }
+    }
+
+
+class TestDispatcherExpansion:
+    """A registration names a group, so the shims are what must be validated.
+
+    Since group dispatch (#3153) every hook routes through
+    invoke_dispatch_claude.py. Validating the command alone checks the
+    dispatcher repeatedly and never checks a single hook, which is the
+    protects-nothing shape issue #3360 exists to close.
+    """
+
+    def test_a_group_registration_validates_its_shims(self, tmp_path):
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PreToolUse", "shims": [{"file": "A/a.py"}]}}},
+            shims=["A/a.py"],
+        )
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert [e.script_path for e in report.entries] == [".claude/hooks/A/a.py"]
+        assert report.is_valid
+
+    def test_a_missing_shim_is_a_violation(self, tmp_path):
+        """The dispatcher exists, so without expansion this passes while the
+        hook it runs is absent."""
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PreToolUse", "shims": [{"file": "A/gone.py"}]}}},
+        )
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert not report.is_valid
+        assert any(v.category == "missing_script" for v in report.violations)
+
+    def test_a_shim_without_exit_code_docs_is_a_violation(self, tmp_path):
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PreToolUse", "shims": [{"file": "A/a.py"}]}}},
+        )
+        (tmp_path / ".claude" / "hooks" / "A").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".claude" / "hooks" / "A" / "a.py").write_text('"""No contract."""\n')
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert not report.is_valid
+
+    def test_an_undefined_group_is_a_violation(self, tmp_path):
+        _tree(tmp_path, settings=_dispatch("ghost"), groups={"groups": {}})
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert any(v.category == "unknown_dispatch_group" for v in report.violations)
+
+    def test_a_group_with_no_shims_is_a_violation(self, tmp_path):
+        """A registration that runs nothing is dead weight in every session."""
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PreToolUse", "shims": []}}},
+        )
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert any(v.category == "empty_dispatch_group" for v in report.violations)
+
+    def test_a_shim_entry_without_a_file_is_a_violation(self, tmp_path):
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PreToolUse", "shims": [{"timeout": 5}]}}},
+        )
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert any(v.category == "malformed_shim" for v in report.violations)
+
+    def test_a_non_dispatch_command_is_still_validated_directly(self, tmp_path):
+        _tree(
+            tmp_path,
+            settings={
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "",
+                            "hooks": [
+                                {"type": "command", "command": "python3 .claude/hooks/A/a.py"}
+                            ],
+                        }
+                    ]
+                }
+            },
+            groups={"groups": {}},
+            shims=["A/a.py"],
+        )
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert [e.script_path for e in report.entries] == [".claude/hooks/A/a.py"]
+
+    def test_a_malformed_dispatch_groups_file_is_reported(self, tmp_path):
+        _tree(tmp_path, settings=_dispatch("g1"))
+        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text("{ not json")
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
+
+    def test_an_absent_dispatch_groups_file_is_not_a_violation(self, tmp_path):
+        """A checkout with no grouped hooks is legitimate."""
+        _tree(
+            tmp_path,
+            settings={
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "",
+                            "hooks": [
+                                {"type": "command", "command": "python3 .claude/hooks/A/a.py"}
+                            ],
+                        }
+                    ]
+                }
+            },
+            shims=["A/a.py"],
+        )
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert report.is_valid
+
+
+class TestPluginSurfaceIsCovered:
+    """The plugin ships its own registrations; settings.json alone misses them."""
+
+    def test_plugin_hooks_json_entries_are_validated(self, tmp_path):
+        _tree(
+            tmp_path,
+            settings={"hooks": {}},
+            plugin=_dispatch("p1", quoted=True),
+            groups={"groups": {"p1": {"event": "PreToolUse", "shims": [{"file": "P/p.py"}]}}},
+            shims=["P/p.py"],
+        )
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert [e.script_path for e in report.entries] == [".claude/hooks/P/p.py"]
+
+    def test_a_missing_plugin_shim_is_caught(self, tmp_path):
+        _tree(
+            tmp_path,
+            settings={"hooks": {}},
+            plugin=_dispatch("p1", quoted=True),
+            groups={"groups": {"p1": {"event": "PreToolUse", "shims": [{"file": "P/gone.py"}]}}},
+        )
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert not report.is_valid
+
+    def test_a_quoted_plugin_root_command_resolves(self):
+        """Unquoted parsed; quoted returned None, so the plugin surface was
+        silently invisible rather than reported."""
+        command = (
+            'python3 -u "${CLAUDE_PLUGIN_ROOT}/hooks/invoke_dispatch_claude.py" --group g'
+        )
+        assert (
+            hook_contracts.extract_script_path(command)
+            == ".claude/hooks/invoke_dispatch_claude.py"
+        )
+
+    def test_copilot_plugin_root_resolves_too(self):
+        command = 'python3 -u "${COPILOT_PLUGIN_ROOT}/hooks/x.py"'
+        assert hook_contracts.extract_script_path(command) == ".claude/hooks/x.py"
+
+    def test_plugin_root_with_a_default_expansion_resolves(self):
+        command = 'python3 -u "${COPILOT_PLUGIN_ROOT:-.claude}/hooks/x.py"'
+        assert hook_contracts.extract_script_path(command) == ".claude/hooks/x.py"
+
+    def test_an_absent_plugin_hooks_file_is_not_a_violation(self, tmp_path):
+        _tree(tmp_path, settings={"hooks": {}}, groups={"groups": {}})
+        report = hook_contracts.validate_all(
+            tmp_path / ".claude" / "settings.json", tmp_path
+        )
+        assert report.is_valid
+
+
+class TestTheShippedTreeSatisfiesTheContract:
+    """The gate is only wireable while this holds."""
+
+    def test_repo_hooks_pass_and_cover_every_shim(self):
+        report = hook_contracts.validate_all(
+            PROJECT_ROOT / ".claude" / "settings.json", PROJECT_ROOT
+        )
+        assert report.is_valid, [v.message for v in report.violations]
+        groups = json.loads(
+            (PROJECT_ROOT / ".claude" / "hooks" / "dispatch_groups.json").read_text()
+        )["groups"]
+        expected = {
+            f".claude/hooks/{s['file']}"
+            for spec in groups.values()
+            for s in spec.get("shims", [])
+        }
+        assert expected <= {e.script_path for e in report.entries}

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -980,6 +980,110 @@ class TestDispatcherExpansion:
         assert "empty_dispatch_group" in categories
         assert "malformed_dispatch_group" not in categories
 
+    def test_a_non_string_event_is_malformed_rather_than_a_crash(self, tmp_path):
+        """A manifest shape the runtime refuses must not take the gate with it.
+
+        claude_hook_dispatch.validate_group raises TypeError on a non-string
+        event and the dispatcher exits 2. Before this branch the value went
+        straight into HookEntry.hook_type, where validate_hook_type_known does
+        ``entry.hook_type in ALL_HOOK_TYPES`` against a frozenset and
+        validate_duplicate_entries builds a tuple dict key. Both raise
+        "unhashable type", so a manifest bug surfaced as a traceback from a
+        gate rather than as the violation it is.
+        """
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": ["PreToolUse"], "shims": [{"file": "A/a.py"}]}}},
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        categories = {v.category for v in report.violations}
+        assert "malformed_dispatch_group" in categories
+
+    def test_an_empty_event_is_malformed_not_silently_inherited(self, tmp_path):
+        """``spec.get("event") or entry.hook_type`` hid this one.
+
+        An empty string is falsy, so it fell back to the registration's own
+        hook type and the group validated clean while the dispatcher refused
+        to load it.
+        """
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "", "shims": [{"file": "A/a.py"}]}}},
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        message = next(
+            (v.message for v in report.violations if v.category == "malformed_dispatch_group"),
+            "",
+        )
+        assert "empty string" in message
+
+    def test_the_event_message_names_the_type_found(self, tmp_path):
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": 7, "shims": [{"file": "A/a.py"}]}}},
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        message = next(
+            v.message for v in report.violations if v.category == "malformed_dispatch_group"
+        )
+        assert "int" in message and "event" in message
+
+    def test_a_non_string_matcher_is_malformed(self, tmp_path):
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={
+                "groups": {
+                    "g1": {
+                        "event": "PreToolUse",
+                        "matcher": ["Bash"],
+                        "shims": [{"file": "A/a.py"}],
+                    }
+                }
+            },
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        message = next(
+            v.message for v in report.violations if v.category == "malformed_dispatch_group"
+        )
+        assert "matcher" in message and "list" in message
+
+    def test_a_null_matcher_is_legitimate(self, tmp_path):
+        """Negative control: the real manifest ships one.
+
+        sessionstart-1-context_loader carries ``"matcher": null`` because the
+        event takes no tool filter. A str-only check would have failed the
+        shipped tree.
+        """
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={
+                "groups": {
+                    "g1": {
+                        "event": "PreToolUse",
+                        "matcher": None,
+                        "shims": [{"file": "A/a.py"}],
+                    }
+                }
+            },
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert "malformed_dispatch_group" not in {v.category for v in report.violations}
+
+    def test_a_well_formed_event_still_reaches_the_expanded_entry(self, tmp_path):
+        """Negative control: the new guard must not drop the value it checks."""
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PreToolUse", "shims": [{"file": "A/a.py"}]}}},
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert "malformed_dispatch_group" not in {v.category for v in report.violations}
+
     def test_a_shim_entry_without_a_file_is_a_violation(self, tmp_path):
         _tree(
             tmp_path,
@@ -1206,9 +1310,7 @@ class TestTheShippedTreeSatisfiesTheContract:
         settings = json.loads(settings_path.read_text(encoding="utf-8"))
         plugin_path = PROJECT_ROOT / ".claude" / "hooks" / "hooks.json"
         plugin = (
-            json.loads(plugin_path.read_text(encoding="utf-8"))
-            if plugin_path.is_file()
-            else {}
+            json.loads(plugin_path.read_text(encoding="utf-8")) if plugin_path.is_file() else {}
         )
 
         def _direct_paths(hooks_config: dict) -> set:
@@ -1466,9 +1568,7 @@ class TestAMalformedGroupsFieldIsAViolationNotAnEmptyMap:
         (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text(
             payload, encoding="utf-8"
         )
-        return hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        return hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
 
     def test_an_absent_groups_field_is_reported(self, tmp_path):
         report = self._report(tmp_path, json.dumps({"version": 1}))
@@ -1485,22 +1585,18 @@ class TestAMalformedGroupsFieldIsAViolationNotAnEmptyMap:
     def test_the_message_names_the_field_and_the_type_found(self, tmp_path):
         report = self._report(tmp_path, json.dumps({"groups": []}))
         messages = [v.message for v in report.violations]
-        assert any(
-            "'groups' property must be an object" in m and "list" in m for m in messages
-        )
+        assert any("'groups' property must be an object" in m and "list" in m for m in messages)
 
     def test_an_empty_groups_object_is_still_legitimate(self, tmp_path):
         """A checkout that declares the field but groups nothing is valid."""
         report = self._report(tmp_path, json.dumps({"groups": {}}))
-        assert not any(
-            v.category == "invalid_dispatch_groups" for v in report.violations
-        )
+        assert not any(v.category == "invalid_dispatch_groups" for v in report.violations)
 
     def test_the_runtime_it_describes_raises_on_the_same_shape(self):
         """Tie the rule to the dispatcher, so the two cannot drift apart."""
-        source = (
-            PROJECT_ROOT / ".claude" / "hooks" / "invoke_dispatch_claude.py"
-        ).read_text(encoding="utf-8")
+        source = (PROJECT_ROOT / ".claude" / "hooks" / "invoke_dispatch_claude.py").read_text(
+            encoding="utf-8"
+        )
         assert "field 'groups' must be an object" in source
 
 
@@ -1519,21 +1615,15 @@ class TestAnUnusableManifestReportsOnceNotOncePerRegistration:
         (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text(
             payload, encoding="utf-8"
         )
-        return hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        return hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
 
     def test_an_unusable_manifest_reports_no_unknown_group(self, tmp_path):
         report = self._report(tmp_path, json.dumps({"groups": []}))
-        assert not any(
-            v.category == "unknown_dispatch_group" for v in report.violations
-        )
+        assert not any(v.category == "unknown_dispatch_group" for v in report.violations)
 
     def test_the_root_cause_is_still_reported(self, tmp_path):
         report = self._report(tmp_path, json.dumps({"groups": []}))
-        assert (
-            sum(v.category == "invalid_dispatch_groups" for v in report.violations) == 1
-        )
+        assert sum(v.category == "invalid_dispatch_groups" for v in report.violations) == 1
 
     def test_the_dispatcher_entry_survives_the_skipped_expansion(self, tmp_path):
         """Skipping expansion must not drop the registration itself.

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -830,16 +830,16 @@ def _tree(root, *, settings, groups=None, plugin=None, shims=(), dispatcher=_DOC
     hooks = root / ".claude" / "hooks"
     hooks.mkdir(parents=True)
     if dispatcher is not None:
-        (hooks / "invoke_dispatch_claude.py").write_text(dispatcher)
-    (root / ".claude" / "settings.json").write_text(json.dumps(settings))
+        (hooks / "invoke_dispatch_claude.py").write_text(dispatcher, encoding="utf-8")
+    (root / ".claude" / "settings.json").write_text(json.dumps(settings), encoding="utf-8")
     if groups is not None:
-        (hooks / "dispatch_groups.json").write_text(json.dumps(groups))
+        (hooks / "dispatch_groups.json").write_text(json.dumps(groups), encoding="utf-8")
     if plugin is not None:
-        (hooks / "hooks.json").write_text(json.dumps(plugin))
+        (hooks / "hooks.json").write_text(json.dumps(plugin), encoding="utf-8")
     for rel in shims:
         target = hooks / rel
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(_DOC)
+        target.write_text(_DOC, encoding="utf-8")
     return root
 
 
@@ -1064,7 +1064,7 @@ class TestTheShippedTreeSatisfiesTheContract:
         )
         assert report.is_valid, [v.message for v in report.violations]
         groups = json.loads(
-            (PROJECT_ROOT / ".claude" / "hooks" / "dispatch_groups.json").read_text()
+            (PROJECT_ROOT / ".claude" / "hooks" / "dispatch_groups.json").read_text(encoding="utf-8")
         )["groups"]
         expected_shims = {
             f".claude/hooks/{s['file']}" for spec in groups.values() for s in spec.get("shims", [])
@@ -1074,9 +1074,9 @@ class TestTheShippedTreeSatisfiesTheContract:
 
         # Also verify direct (non-dispatch) registrations are validated.
         # Build the expected set from both settings.json and hooks.json.
-        settings = json.loads((PROJECT_ROOT / ".claude" / "settings.json").read_text())
+        settings = json.loads((PROJECT_ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
         plugin_path = PROJECT_ROOT / ".claude" / "hooks" / "hooks.json"
-        plugin = json.loads(plugin_path.read_text()) if plugin_path.is_file() else {}
+        plugin = json.loads(plugin_path.read_text(encoding="utf-8")) if plugin_path.is_file() else {}
 
         def _direct_paths(hooks_config: dict) -> set:
             """Extract script paths from non-dispatch registrations."""

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -164,7 +164,6 @@ class TestParseSettings:
         assert len(entries) == 1
         assert entries[0].matcher is None
 
-
     def test_powershell_command_reported(self, tmp_path):
         settings = {
             "hooks": {
@@ -821,10 +820,17 @@ class TestMain:
 _DOC = '"""H.\n\nExit Codes:\n    0 = ok\n"""\n'
 
 
-def _tree(root, *, settings, groups=None, plugin=None, shims=()):
-    """Build a checkout with the two hook registration surfaces."""
+def _tree(root, *, settings, groups=None, plugin=None, shims=(), dispatcher=_DOC):
+    """Build a checkout with the two hook registration surfaces.
+
+    The dispatcher is written by default because a real checkout always has
+    one, and expansion keeps its entry so it is validated like any other hook.
+    Pass ``dispatcher=None`` to model a checkout that is missing it.
+    """
     hooks = root / ".claude" / "hooks"
     hooks.mkdir(parents=True)
+    if dispatcher is not None:
+        (hooks / "invoke_dispatch_claude.py").write_text(dispatcher)
     (root / ".claude" / "settings.json").write_text(json.dumps(settings))
     if groups is not None:
         (hooks / "dispatch_groups.json").write_text(json.dumps(groups))
@@ -845,9 +851,7 @@ def _dispatch(group, *, quoted=False):
             "PreToolUse": [
                 {
                     "matcher": "",
-                    "hooks": [
-                        {"type": "command", "command": f"python3 -u {body} --group {group}"}
-                    ],
+                    "hooks": [{"type": "command", "command": f"python3 -u {body} --group {group}"}],
                 }
             ]
         }
@@ -870,10 +874,11 @@ class TestDispatcherExpansion:
             groups={"groups": {"g1": {"event": "PreToolUse", "shims": [{"file": "A/a.py"}]}}},
             shims=["A/a.py"],
         )
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
-        assert [e.script_path for e in report.entries] == [".claude/hooks/A/a.py"]
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert [e.script_path for e in report.entries] == [
+            ".claude/hooks/invoke_dispatch_claude.py",
+            ".claude/hooks/A/a.py",
+        ]
         assert report.is_valid
 
     def test_a_missing_shim_is_a_violation(self, tmp_path):
@@ -884,9 +889,7 @@ class TestDispatcherExpansion:
             settings=_dispatch("g1"),
             groups={"groups": {"g1": {"event": "PreToolUse", "shims": [{"file": "A/gone.py"}]}}},
         )
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert not report.is_valid
         assert any(v.category == "missing_script" for v in report.violations)
 
@@ -898,16 +901,12 @@ class TestDispatcherExpansion:
         )
         (tmp_path / ".claude" / "hooks" / "A").mkdir(parents=True, exist_ok=True)
         (tmp_path / ".claude" / "hooks" / "A" / "a.py").write_text('"""No contract."""\n')
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert not report.is_valid
 
     def test_an_undefined_group_is_a_violation(self, tmp_path):
         _tree(tmp_path, settings=_dispatch("ghost"), groups={"groups": {}})
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "unknown_dispatch_group" for v in report.violations)
 
     def test_a_group_with_no_shims_is_a_violation(self, tmp_path):
@@ -917,9 +916,7 @@ class TestDispatcherExpansion:
             settings=_dispatch("g1"),
             groups={"groups": {"g1": {"event": "PreToolUse", "shims": []}}},
         )
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "empty_dispatch_group" for v in report.violations)
 
     def test_a_shim_entry_without_a_file_is_a_violation(self, tmp_path):
@@ -928,9 +925,7 @@ class TestDispatcherExpansion:
             settings=_dispatch("g1"),
             groups={"groups": {"g1": {"event": "PreToolUse", "shims": [{"timeout": 5}]}}},
         )
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "malformed_shim" for v in report.violations)
 
     def test_a_non_dispatch_command_is_still_validated_directly(self, tmp_path):
@@ -951,35 +946,27 @@ class TestDispatcherExpansion:
             groups={"groups": {}},
             shims=["A/a.py"],
         )
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert [e.script_path for e in report.entries] == [".claude/hooks/A/a.py"]
 
     def test_a_malformed_dispatch_groups_file_is_reported(self, tmp_path):
         _tree(tmp_path, settings=_dispatch("g1"))
         (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text("{ not json")
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
 
     def test_dispatch_groups_with_invalid_utf8_is_reported(self, tmp_path):
         """Invalid UTF-8 bytes must be caught, not raise UnicodeDecodeError."""
         _tree(tmp_path, settings=_dispatch("g1"))
         (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_bytes(b"\xff\xfe")
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
 
     def test_dispatch_groups_with_non_object_root_is_reported(self, tmp_path):
         """A JSON array or primitive root must be reported, not raise AttributeError."""
         _tree(tmp_path, settings=_dispatch("g1"))
         (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text("[]")
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
         assert any("must be a JSON object" in v.message for v in report.violations)
 
@@ -1001,9 +988,7 @@ class TestDispatcherExpansion:
             },
             shims=["A/a.py"],
         )
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert report.is_valid
 
 
@@ -1018,10 +1003,11 @@ class TestPluginSurfaceIsCovered:
             groups={"groups": {"p1": {"event": "PreToolUse", "shims": [{"file": "P/p.py"}]}}},
             shims=["P/p.py"],
         )
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
-        assert [e.script_path for e in report.entries] == [".claude/hooks/P/p.py"]
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert [e.script_path for e in report.entries] == [
+            ".claude/hooks/invoke_dispatch_claude.py",
+            ".claude/hooks/P/p.py",
+        ]
 
     def test_a_missing_plugin_shim_is_caught(self, tmp_path):
         _tree(
@@ -1030,20 +1016,15 @@ class TestPluginSurfaceIsCovered:
             plugin=_dispatch("p1", quoted=True),
             groups={"groups": {"p1": {"event": "PreToolUse", "shims": [{"file": "P/gone.py"}]}}},
         )
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert not report.is_valid
 
     def test_a_quoted_plugin_root_command_resolves(self):
         """Unquoted parsed; quoted returned None, so the plugin surface was
         silently invisible rather than reported."""
-        command = (
-            'python3 -u "${CLAUDE_PLUGIN_ROOT}/hooks/invoke_dispatch_claude.py" --group g'
-        )
+        command = 'python3 -u "${CLAUDE_PLUGIN_ROOT}/hooks/invoke_dispatch_claude.py" --group g'
         assert (
-            hook_contracts.extract_script_path(command)
-            == ".claude/hooks/invoke_dispatch_claude.py"
+            hook_contracts.extract_script_path(command) == ".claude/hooks/invoke_dispatch_claude.py"
         )
 
     def test_copilot_plugin_root_resolves_too(self):
@@ -1056,27 +1037,21 @@ class TestPluginSurfaceIsCovered:
 
     def test_an_absent_plugin_hooks_file_is_not_a_violation(self, tmp_path):
         _tree(tmp_path, settings={"hooks": {}}, groups={"groups": {}})
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert report.is_valid
 
     def test_a_malformed_plugin_hooks_file_is_reported(self, tmp_path):
         """Invalid JSON in hooks.json must be caught and reported as a violation."""
         _tree(tmp_path, settings={"hooks": {}}, groups={"groups": {}})
         (tmp_path / ".claude" / "hooks" / "hooks.json").write_text("{ not json")
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "invalid_plugin_hooks" for v in report.violations)
 
     def test_plugin_hooks_with_invalid_utf8_is_reported(self, tmp_path):
         """Invalid UTF-8 bytes in hooks.json must be caught as a violation."""
         _tree(tmp_path, settings={"hooks": {}}, groups={"groups": {}})
         (tmp_path / ".claude" / "hooks" / "hooks.json").write_bytes(b"\xff\xfe")
-        report = hook_contracts.validate_all(
-            tmp_path / ".claude" / "settings.json", tmp_path
-        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "invalid_plugin_hooks" for v in report.violations)
 
 
@@ -1092,18 +1067,14 @@ class TestTheShippedTreeSatisfiesTheContract:
             (PROJECT_ROOT / ".claude" / "hooks" / "dispatch_groups.json").read_text()
         )["groups"]
         expected_shims = {
-            f".claude/hooks/{s['file']}"
-            for spec in groups.values()
-            for s in spec.get("shims", [])
+            f".claude/hooks/{s['file']}" for spec in groups.values() for s in spec.get("shims", [])
         }
         validated_paths = {e.script_path for e in report.entries}
         assert expected_shims <= validated_paths
 
         # Also verify direct (non-dispatch) registrations are validated.
         # Build the expected set from both settings.json and hooks.json.
-        settings = json.loads(
-            (PROJECT_ROOT / ".claude" / "settings.json").read_text()
-        )
+        settings = json.loads((PROJECT_ROOT / ".claude" / "settings.json").read_text())
         plugin_path = PROJECT_ROOT / ".claude" / "hooks" / "hooks.json"
         plugin = json.loads(plugin_path.read_text()) if plugin_path.is_file() else {}
 
@@ -1120,15 +1091,171 @@ class TestTheShippedTreeSatisfiesTheContract:
                         if not isinstance(hook, dict) or hook.get("type") != "command":
                             continue
                         command = hook.get("command", "")
-                        # Skip dispatch commands; their shims are already in expected_shims
-                        if "--group" in command:
-                            continue
                         script = hook_contracts.extract_script_path(command)
-                        if script:
-                            paths.add(script)
+                        if not script:
+                            continue
+                        # Skip the dispatcher; its shims are already in
+                        # expected_shims. Gate on the script name, matching
+                        # the validator: a --group flag on an ordinary hook
+                        # does not make it a dispatcher.
+                        if Path(script).name == hook_contracts.DISPATCHER_SCRIPT_NAME:
+                            continue
+                        paths.add(script)
             return paths
 
         expected_direct = _direct_paths(settings) | _direct_paths(plugin)
         assert expected_direct <= validated_paths, (
             f"Direct hooks not validated: {expected_direct - validated_paths}"
         )
+
+
+class TestNestedPluginRootExpansion:
+    """The shipped copilot-cli registrations nest the plugin-root default."""
+
+    def test_the_nested_fallback_form_resolves_cleanly(self):
+        """``${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}`` leaves no stray brace.
+
+        A pattern whose default clause allows ``{`` matches only the inner
+        expansion and yields ``.claude}/hooks/x.py``, which reads as a missing
+        script. That is the exact form in src/copilot-cli/hooks/hooks.json.
+        """
+        command = 'python3 -u "${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/x.py"'
+        assert hook_contracts.extract_script_path(command) == ".claude/hooks/x.py"
+
+    def test_the_simple_form_still_resolves(self):
+        command = 'python3 -u "${CLAUDE_PLUGIN_ROOT}/hooks/x.py"'
+        assert hook_contracts.extract_script_path(command) == ".claude/hooks/x.py"
+
+    def test_a_literal_default_still_resolves(self):
+        command = 'python3 -u "${COPILOT_PLUGIN_ROOT:-.claude}/hooks/x.py"'
+        assert hook_contracts.extract_script_path(command) == ".claude/hooks/x.py"
+
+    def test_no_brace_survives_any_supported_form(self):
+        for command in (
+            'python3 -u "${CLAUDE_PLUGIN_ROOT}/hooks/x.py"',
+            'python3 -u "${COPILOT_PLUGIN_ROOT:-.claude}/hooks/x.py"',
+            'python3 -u "${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/x.py"',
+        ):
+            resolved = hook_contracts.extract_script_path(command)
+            assert resolved is not None
+            assert "{" not in resolved and "}" not in resolved, command
+
+    def test_substitution_is_bounded(self):
+        """A pathological string must terminate rather than spin."""
+        command = 'python3 -u "' + "${CLAUDE_PLUGIN_ROOT:-" * 40 + 'x.py"'
+        hook_contracts.extract_script_path(command)
+
+
+class TestExpansionIsKeyedOnTheDispatcher:
+    """Only the dispatcher fans out to a group."""
+
+    def test_an_ordinary_hook_taking_group_is_not_expanded(self, tmp_path):
+        """A --group flag on a normal hook must not be read as dispatch."""
+        settings = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "python3 -u .claude/hooks/A/a.py --group g1",
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        _tree(tmp_path, settings=settings, groups={"groups": {}}, shims=["A/a.py"])
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert [e.script_path for e in report.entries] == [".claude/hooks/A/a.py"]
+        assert report.is_valid
+
+    def test_the_dispatcher_is_still_expanded(self, tmp_path):
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PreToolUse", "shims": [{"file": "A/a.py"}]}}},
+            shims=["A/a.py"],
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert ".claude/hooks/A/a.py" in [e.script_path for e in report.entries]
+
+
+class TestTheDispatcherItselfIsValidated:
+    """Dropping the dispatcher entry stopped checking the one script that always runs."""
+
+    def test_an_unknown_group_still_validates_the_dispatcher(self, tmp_path):
+        _tree(tmp_path, settings=_dispatch("nope"), groups={"groups": {}})
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert ".claude/hooks/invoke_dispatch_claude.py" in [e.script_path for e in report.entries]
+        assert "unknown_dispatch_group" in {v.category for v in report.violations}
+
+    def test_an_empty_group_still_validates_the_dispatcher(self, tmp_path):
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PreToolUse", "shims": []}}},
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert ".claude/hooks/invoke_dispatch_claude.py" in [e.script_path for e in report.entries]
+        assert "empty_dispatch_group" in {v.category for v in report.violations}
+
+    def test_a_missing_dispatcher_is_reported(self, tmp_path):
+        """Without keeping the entry this passed while the dispatcher was absent."""
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PreToolUse", "shims": [{"file": "A/a.py"}]}}},
+            shims=["A/a.py"],
+            dispatcher=None,
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert not report.is_valid
+        assert "missing_script" in {v.category for v in report.violations}
+
+    def test_an_undocumented_dispatcher_is_reported_on_a_blocking_event(self, tmp_path):
+        """PreToolUse is blocking, so the dispatcher owes exit-code semantics."""
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PreToolUse", "shims": [{"file": "A/a.py"}]}}},
+            shims=["A/a.py"],
+            dispatcher='"""No semantics here."""\n',
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert "missing_exit_docs" in {v.category for v in report.violations}
+
+
+class TestMalformedPluginHooksAreAttributed:
+    """A broken hooks.json must not surface as an invalid settings.json."""
+
+    def test_malformed_plugin_json_is_its_own_category(self, tmp_path):
+        _tree(tmp_path, settings=_dispatch("g1"), groups={"groups": {}})
+        (tmp_path / ".claude" / "hooks" / "hooks.json").write_text("{not json")
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert "invalid_plugin_hooks" in {v.category for v in report.violations}
+
+    def test_the_message_names_the_plugin_file(self, tmp_path):
+        _tree(tmp_path, settings=_dispatch("g1"), groups={"groups": {}})
+        (tmp_path / ".claude" / "hooks" / "hooks.json").write_text("{not json")
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        messages = [v.message for v in report.violations if v.category == "invalid_plugin_hooks"]
+        assert messages and "cannot be read" in messages[0]
+
+    def test_a_non_object_plugin_file_is_attributed(self, tmp_path):
+        _tree(tmp_path, settings=_dispatch("g1"), groups={"groups": {}})
+        (tmp_path / ".claude" / "hooks" / "hooks.json").write_text("[1, 2, 3]")
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert "invalid_plugin_hooks" in {v.category for v in report.violations}
+
+    def test_a_valid_plugin_file_raises_nothing(self, tmp_path):
+        _tree(
+            tmp_path,
+            settings=_dispatch("g1"),
+            groups={"groups": {"g1": {"event": "PreToolUse", "shims": [{"file": "A/a.py"}]}}},
+            shims=["A/a.py"],
+            plugin={"hooks": {}},
+        )
+        report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
+        assert "invalid_plugin_hooks" not in {v.category for v in report.violations}


### PR DESCRIPTION
## Summary

`hook_contracts.py` had tests and no call site, the shape #3329 describes. #3360 recorded it as unwired because it failed against the tree. Two things changed since that measurement.

It now exits 0, and for the wrong reason.

Refs #3360. This PR wires the hook-contract validator only. The other two validators the issue names still fail and keep their allowlist entries; see References.

## What it was actually checking

Two independent coverage holes, both introduced by changes elsewhere:

**Group dispatch.** #3153 moved hook registration behind `invoke_dispatch_claude.py --group NAME`, so a registration names a group, not a script. The validator resolved the dispatcher, found it present and documented, and passed. It did that once per registration and never looked at a single hook.

**The plugin surface.** Plugin registrations address their script through a quoted `${CLAUDE_PLUGIN_ROOT}`. The path regex required whitespace or end-of-string after `.py`, and the closing quote is neither, so extraction returned `None`. `None` is the same signal as "not a Python hook", so every plugin registration was dropped in silence rather than reported.

Net coverage before this change:

| Surface | Registrations | Validated |
|---|---|---|
| Claude settings registrations | 4 (1 shell, skipped) | 3 dispatcher/direct entries |
| Plugin hook registrations | 2 | 0 |
| Shims that actually run | 3 | 0 |

## Change

Each registration expands through the dispatch-group map, and both registration surfaces are read. Coverage goes from 3 entries to all 5 shims. Three new violation categories, because a registration that runs nothing is dead weight in every session:

- dispatches to a group nothing defines
- dispatches to a group with no shims
- a shim entry carrying no file path

The path regex now tolerates quoting and resolves both `CLAUDE_` and `COPILOT_PLUGIN_ROOT`, including the `:-` default form.

## Why it is wired in this PR rather than a later one

The shipped tree passes as-is under the widened coverage, so there is nothing to resolve first. A gate deferred to a follow-up is the failure this issue is about.

The `_NO_CALLER` entry is removed, so the reachability guard now holds the wiring in place. That guard's docstring-count pin fired on the allowlist edit and was updated from five to four.

## Verification

197 tests pass across the hook-contract and reachability modules, plus 567 workflow tests. 15 new tests. `actionlint` clean on the new workflow.

Three negative controls, each reverting one part of the fix:

| Reverted | Tests turned red |
|---|---|
| Group expansion | 6 |
| Plugin surface read | 3 |
| Quoted-path regex | 6 |

## Notes

Both plugin manifests move to 0.6.118. The claim that no plugin file changed was true when this branch opened and stopped being true after a rebase pulled a hook under a plugin tree into the diff.

## References

Files this PR reads but does not change:

- `.claude/settings.json` and the plugin `hooks.json`, the two registration surfaces
- `.claude/hooks/dispatch_groups.json`, the group map a registration expands through

The other two validators #3360 names are out of scope here and keep their
allowlist entries with their measurements:

- `scripts/validation/traceability.py`, exit 1 on orphaned designs
- `scripts/validation/consistency.py`, exit 1 on 4 of 7 features

