### PR TITLE
fix(ci): assert every hand-written dependency pin agrees with pyproject

### DIFF
--- a/.agents/sessions/2026-07-26-session-3377.json
+++ b/.agents/sessions/2026-07-26-session-3377.json
@@ -1,0 +1,161 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3377,
+    "date": "2026-07-26",
+    "branch": "fix/3377-ci-pin-drift",
+    "startingCommit": "f0cfbce5bc",
+    "objective": "Assert every hand-written CI dependency pin agrees with pyproject.toml"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP active; memory tools returned project data"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena initial_instructions read before editing"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read and preserved as read-only"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "scripts/validation listed while locating the sibling pin checker"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena memory usage-mandatory read"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Loaded usage-mandatory and the ruff-configuration floor-lockstep memory"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/3377-ci-pin-drift"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/3377-ci-pin-drift"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status inspected before each commit"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Recorded in session.startingCommit"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All MUST session-start and session-end fields completed"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md unchanged"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Recorded that packaging canonicalize_name collapses separator runs rather than deleting them, so pyyaml and py_yaml are different names"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "No markdown files changed in this session"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Commits da847ab207 and d6862a6d9a"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "799 tests in tests/validation/ and 140 in tests/ci/ passed; the new gate found the real drift on its first run against the unchanged tree and its real-tree test went red when the stale pin was restored; ruff check and ruff format clean; ruff ratchet passed for 5 changed Python files"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issue #3377 fixed"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Deferred; the 2026-07-26 auto-retrospective covers this continuous run"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "phase": "investigation",
+      "summary": "Confirmed the report against main: .github/workflows/validate-generated-agents.yml pins pytest==9.0.3 and .github/actions/validate-plugin-manifests/action.yml pins pytest==8.3.3, while pyproject declares pytest>=9.0.3 in both the base and dev groups. The action installs a major below the declared floor."
+    },
+    {
+      "phase": "design",
+      "summary": "The issue offered two shapes. Preference 1 was to stop hand-pinning and install the locked dev environment, but neither surface uses that pattern today and both are deliberately light single-purpose installs, so switching them would trade a narrow drift for a much heavier CI step. Took preference 2: a gate that reads the constraint from pyproject and fails any contradicting literal. That is the converse-assertion shape of #3341 and #3371, where something asserts a pin exists and nothing asserts it agrees with the source of truth."
+    },
+    {
+      "phase": "implementation",
+      "summary": "check_ci_dependency_pins.py merges the base dependency list with every optional-dependency extra and intersects the specifiers per package, because CI installs one version that has to work wherever the step needs it. It scans .yml and .yaml under .github for quoted pkg==version literals and reports file, line, pin, and the constraint violated. Packages pyproject does not declare are skipped: pip itself is installed by CI and carries no constraint to disagree with. Prerelease pins are judged with prereleases=True so an 8.x release candidate cannot read as satisfying a >=9 floor by silent exclusion.",
+      "files": [
+        "scripts/validation/check_ci_dependency_pins.py"
+      ]
+    },
+    {
+      "phase": "validation",
+      "summary": "Run against the tree unchanged the gate found the real drift on its first invocation and exited 1. Corrected the action to pytest==9.0.3 with a comment recording why the number is what it is, so the next reader does not re-derive the wrong answer from two literals.",
+      "files": [
+        ".github/actions/validate-plugin-manifests/action.yml"
+      ]
+    },
+    {
+      "phase": "testing",
+      "summary": "28 tests. Two of them failed on first run and both premises were mine, not the code's: canonicalize_name collapses runs of separators to a single hyphen rather than deleting them, so py_yaml is genuinely not pyyaml, and the intersected specifier renders both bounds. Corrected the tests. Coverage includes an unquoted equality that must not read as a pin, a non-YAML file that must not be scanned, an undeclared package that must not be checked, an unparseable version that must be a violation rather than a pass, a prerelease, and a control asserting the repository actually pins something the gate covers so the real-tree test cannot pass vacuously.",
+      "files": [
+        "tests/validation/test_check_ci_dependency_pins.py"
+      ]
+    },
+    {
+      "phase": "validation",
+      "summary": "Negative control: restoring pytest==8.3.3 in the action turned the real-tree test red, and restoring the fix turned it green. Wired the gate at two call sites because #3329 showed a guard with none protects nothing: the real-tree test runs under the required Run Python Tests check, and checks_tooling.validate_ci_dependency_pins puts it in the pre-PR sequence for the author's terminal.",
+      "files": [
+        "scripts/validation/checks_tooling.py",
+        "scripts/validation/pre_pr.py",
+        "scripts/validation/pre_pr_sequence.py"
+      ]
+    }
+  ],
+  "endingCommit": "d6862a6d9a",
+  "nextSteps": [
+    "Correct ADR-008's implementation status for three deleted hooks (#3373)",
+    "State in ADR-082 that dispatch group ids are opaque (#3374)"
+  ]
+}

--- a/.github/actions/validate-plugin-manifests/action.yml
+++ b/.github/actions/validate-plugin-manifests/action.yml
@@ -45,7 +45,11 @@ runs:
       # disagreeing literals and proposed aligning the correct one down to it.
       # scripts/validation/check_ci_dependency_pins.py now fails when any pin
       # under .github/ contradicts pyproject. Refs #3377.
-      run: pip install 'pytest==9.0.3'
+      # python3 -m pip, not bare pip: bare pip resolves through PATH and can
+      # install into an interpreter other than the one actions/setup-python
+      # selected. The other three install sites under .github/ already use the
+      # module form.
+      run: python3 -m pip install 'pytest==9.0.3'
 
     - name: Run validator unit tests
       if: inputs.run-tests == 'true'

--- a/.github/actions/validate-plugin-manifests/action.yml
+++ b/.github/actions/validate-plugin-manifests/action.yml
@@ -40,7 +40,12 @@ runs:
     - name: Install pytest (pinned for deterministic CI)
       if: inputs.run-tests == 'true'
       shell: bash
-      run: pip install 'pytest==8.3.3'
+      # Must satisfy the pyproject.toml floor (pytest>=9.0.3). This pin sat at
+      # 8.3.3, one major below the floor, and a PR #3361 review read the two
+      # disagreeing literals and proposed aligning the correct one down to it.
+      # scripts/validation/check_ci_dependency_pins.py now fails when any pin
+      # under .github/ contradicts pyproject. Refs #3377.
+      run: pip install 'pytest==9.0.3'
 
     - name: Run validator unit tests
       if: inputs.run-tests == 'true'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     "mypy>=2.1.0",
     "semgrep==1.171.0",
     "lefthook==2.1.10",
+    "packaging>=24.0",
 ]
 eval = [
     # OpenAI + GitHub Models providers (scripts/eval/_providers.py).
@@ -245,4 +246,5 @@ dev = [
     "mypy>=2.1.0",
     "semgrep==1.171.0",
     "lefthook==2.1.10",
+    "packaging>=24.0",
 ]

--- a/scripts/validation/check_ci_dependency_pins.py
+++ b/scripts/validation/check_ci_dependency_pins.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Assert every hand-written ``pkg==version`` pin in ``.github/`` agrees with
+``pyproject.toml`` (Issue #3377).
+
+Two CI install steps pinned pytest by hand and disagreed with each other::
+
+    .github/workflows/validate-generated-agents.yml   pytest==9.0.3
+    .github/actions/validate-plugin-manifests/action.yml   pytest==8.3.3
+
+``pyproject.toml`` declares ``pytest>=9.0.3``, so the action installed a pytest
+the project does not support. Nothing caught it: both pins are string literals
+in YAML with no gate comparing them to the source of truth.
+
+The cost is not the stale pin itself. A reader looking at two disagreeing
+literals cannot tell which is authoritative without opening ``pyproject.toml``,
+so "align them" resolves toward the wrong one about half the time. That is
+exactly what happened on PR #3361: a review proposed aligning down to 8.3.3 and
+an autofix commit downgraded the correct pin.
+
+This is the converse-assertion shape of Issues #3341 and #3371: something
+asserts the pin exists, nothing asserts it agrees with the source of truth.
+
+Scope: a pin is checked only when ``pyproject.toml`` declares that package.
+CI installs tools the project does not depend on (``pip`` itself, for one), and
+those carry no constraint to disagree with.
+
+Call sites, because a guard with none protects nothing (Issue #3329):
+
+* ``tests/validation/test_check_ci_dependency_pins.py::TestTheRealTree`` runs
+  ``check`` against this repository under the required "Run Python Tests"
+  check, alongside a negative control proving the scan is not vacuous.
+* ``checks_tooling.validate_ci_dependency_pins`` puts it in the pre-PR
+  sequence for the author's terminal.
+
+ADR-006 keeps the logic here rather than in workflow YAML. ADR-042 mandates
+Python for new scripts.
+
+Exit codes (ADR-035):
+    0 - every checked pin satisfies its declared constraint
+    1 - at least one pin violates its constraint (logic failure)
+    2 - pyproject.toml or the scan root is missing or unparseable (config)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import tomllib
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
+
+EXIT_OK = 0
+EXIT_LOGIC = 1
+EXIT_CONFIG = 2
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# A quoted pin as it appears in a shell ``run:`` line: 'pytest==9.0.3'.
+# Quoting is required so a bare ``==`` inside prose or a comparison in a
+# script body is not read as a dependency pin.
+_PIN_RE = re.compile(r"""['"]([A-Za-z0-9][A-Za-z0-9._-]*)==([0-9][^'"\s]*)['"]""")
+
+
+@dataclass(frozen=True)
+class Pin:
+    """One ``pkg==version`` literal found in a CI file."""
+
+    path: Path
+    line: int
+    name: str
+    version: str
+
+    @property
+    def canonical(self) -> str:
+        return canonicalize_name(self.name)
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A pin that does not satisfy the constraint pyproject declares."""
+
+    pin: Pin
+    constraint: str
+
+    def render(self, root: Path) -> str:
+        try:
+            shown = self.pin.path.relative_to(root)
+        except ValueError:
+            shown = self.pin.path
+        return (
+            f"{shown}:{self.pin.line}: {self.pin.name}=={self.pin.version} "
+            f"violates pyproject constraint '{self.pin.name}{self.constraint}'"
+        )
+
+
+def declared_constraints(pyproject: Path) -> dict[str, SpecifierSet]:
+    """Return canonical package name -> combined specifier from pyproject.
+
+    Merges ``[project].dependencies`` with every entry under
+    ``[project.optional-dependencies]``. A package declared in more than one
+    place contributes all of its specifiers, so a pin must satisfy the
+    intersection. That is the honest reading: CI installs one version, and it
+    has to work everywhere the project claims to need the package.
+    """
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    groups: list[list[str]] = [list(project.get("dependencies", []))]
+    for extra in project.get("optional-dependencies", {}).values():
+        groups.append(list(extra))
+
+    merged: dict[str, SpecifierSet] = {}
+    for group in groups:
+        for raw in group:
+            try:
+                req = Requirement(raw)
+            except InvalidRequirement:
+                continue
+            if not req.specifier:
+                continue
+            key = canonicalize_name(req.name)
+            merged[key] = merged.get(key, SpecifierSet()) & req.specifier
+    return merged
+
+
+def find_pins(root: Path) -> list[Pin]:
+    """Return every quoted ``pkg==version`` literal under ``root``.
+
+    Scans ``.yml`` and ``.yaml`` only. A pin in a Python or shell file is
+    installed the same way, but those files are covered by the dependency
+    resolver rather than by hand-written literals, and widening the scan
+    turns ordinary equality comparisons into false positives.
+    """
+    pins: list[Pin] = []
+    for path in sorted(root.rglob("*")):
+        if path.suffix not in {".yml", ".yaml"} or not path.is_file():
+            continue
+        for number, text in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for name, version in _PIN_RE.findall(text):
+                pins.append(Pin(path=path, line=number, name=name, version=version))
+    return pins
+
+
+def violations(pins: list[Pin], constraints: dict[str, SpecifierSet]) -> list[Violation]:
+    """Return the pins that contradict a declared constraint."""
+    found: list[Violation] = []
+    for pin in pins:
+        specifier = constraints.get(pin.canonical)
+        if specifier is None:
+            continue
+        try:
+            parsed = Version(pin.version)
+        except InvalidVersion:
+            found.append(Violation(pin=pin, constraint=str(specifier)))
+            continue
+        # prereleases=True so a pinned release candidate is judged against the
+        # constraint rather than silently excluded and reported as passing.
+        if not specifier.contains(parsed, prereleases=True):
+            found.append(Violation(pin=pin, constraint=str(specifier)))
+    return found
+
+
+def check(root: Path, pyproject: Path) -> int:
+    """Validate every pin under ``root`` and return an exit code."""
+    if not pyproject.is_file():
+        print(f"::error::pyproject.toml not found: {pyproject}", file=sys.stderr)
+        return EXIT_CONFIG
+    if not root.is_dir():
+        print(f"::error::scan root not found: {root}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    try:
+        constraints = declared_constraints(pyproject)
+    except (tomllib.TOMLDecodeError, InvalidSpecifier, OSError) as exc:
+        print(f"::error::cannot read constraints from {pyproject}: {exc}", file=sys.stderr)
+        return EXIT_CONFIG
+
+    found = violations(find_pins(root), constraints)
+    if not found:
+        return EXIT_OK
+
+    for violation in found:
+        print(f"::error::{violation.render(_REPO_ROOT)}", file=sys.stderr)
+    print(
+        f"::error::{len(found)} CI pin(s) contradict pyproject.toml. "
+        f"Update the pin, not pyproject, unless the floor itself is wrong.",
+        file=sys.stderr,
+    )
+    return EXIT_LOGIC
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--root", default=str(_REPO_ROOT / ".github"), help="directory to scan")
+    parser.add_argument(
+        "--pyproject", default=str(_REPO_ROOT / "pyproject.toml"), help="constraint source"
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return check(Path(args.root), Path(args.pyproject))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_ci_dependency_pins.py
+++ b/scripts/validation/check_ci_dependency_pins.py
@@ -57,11 +57,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-if sys.version_info >= (3, 11):
-    import tomllib
-else:  # pragma: no cover - 3.10 fallback path
-    tomllib = None  # type: ignore[assignment]
-
+import tomllib
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.utils import canonicalize_name
@@ -106,9 +102,15 @@ class Violation:
     pin: Pin
     constraint: str
 
-    def render(self, root: Path) -> str:
+    def render(self, repo_root: Path) -> str:
+        """Render relative to the repository root, not the scan root.
+
+        The scan root is ``.github/``; showing a path relative to it would
+        print ``workflows/pytest.yml``, which is not a path anyone can open
+        from where they are standing.
+        """
         try:
-            shown = self.pin.path.relative_to(root)
+            shown = self.pin.path.relative_to(repo_root)
         except ValueError:
             shown = self.pin.path
         return (
@@ -147,7 +149,7 @@ def declared_constraints(pyproject: Path) -> dict[str, SpecifierSet]:
 
 
 def find_pins(root: Path) -> list[Pin]:
-    """Return every quoted ``pkg==version`` literal under ``root``.
+    """Return every ``pkg==version`` literal under ``root``, quoted or not.
 
     Scans ``.yml`` and ``.yaml`` only. A pin in a Python or shell file is
     installed the same way, but those files are covered by the dependency
@@ -193,13 +195,6 @@ def violations(pins: list[Pin], constraints: dict[str, SpecifierSet]) -> list[Vi
 
 def check(root: Path, pyproject: Path) -> int:
     """Validate every pin under ``root`` and return an exit code."""
-    if tomllib is None:  # pragma: no cover - 3.10 fallback path
-        print(
-            "::error::tomllib unavailable (Python 3.11+ required); "
-            "skipping CI dependency pin check",
-            file=sys.stderr,
-        )
-        return EXIT_CONFIG
     if not pyproject.is_file():
         print(f"::error::pyproject.toml not found: {pyproject}", file=sys.stderr)
         return EXIT_CONFIG

--- a/scripts/validation/check_ci_dependency_pins.py
+++ b/scripts/validation/check_ci_dependency_pins.py
@@ -123,10 +123,11 @@ def declared_constraints(pyproject: Path) -> dict[str, SpecifierSet]:
     """Return canonical package name -> combined specifier from pyproject.
 
     Merges ``[project].dependencies`` with every entry under
-    ``[project.optional-dependencies]``. A package declared in more than one
-    place contributes all of its specifiers, so a pin must satisfy the
-    intersection. That is the honest reading: CI installs one version, and it
-    has to work everywhere the project claims to need the package.
+    ``[project.optional-dependencies]`` and ``[dependency-groups]``.
+    A package declared in more than one place contributes all of its
+    specifiers, so a pin must satisfy the intersection. That is the honest
+    reading: CI installs one version, and it has to work everywhere the
+    project claims to need the package.
     """
     data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
     project = data.get("project", {})
@@ -139,9 +140,11 @@ def declared_constraints(pyproject: Path) -> dict[str, SpecifierSet]:
         for extra in optional_deps.values():
             if isinstance(extra, list):
                 groups.append([item for item in extra if isinstance(item, str)])
-    for group in data.get("dependency-groups", {}).values():
-        if isinstance(group, list):
-            groups.append([item for item in group if isinstance(item, str)])
+    dep_groups = data.get("dependency-groups", {})
+    if isinstance(dep_groups, dict):
+        for group in dep_groups.values():
+            if isinstance(group, list):
+                groups.append([item for item in group if isinstance(item, str)])
 
     merged: dict[str, SpecifierSet] = {}
     for group in groups:

--- a/scripts/validation/check_ci_dependency_pins.py
+++ b/scripts/validation/check_ci_dependency_pins.py
@@ -130,9 +130,15 @@ def declared_constraints(pyproject: Path) -> dict[str, SpecifierSet]:
     """
     data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
     project = data.get("project", {})
-    groups: list[list[str]] = [list(project.get("dependencies", []))]
-    for extra in project.get("optional-dependencies", {}).values():
-        groups.append(list(extra))
+    deps = project.get("dependencies", [])
+    groups: list[list[str]] = []
+    if isinstance(deps, list):
+        groups.append([item for item in deps if isinstance(item, str)])
+    optional_deps = project.get("optional-dependencies", {})
+    if isinstance(optional_deps, dict):
+        for extra in optional_deps.values():
+            if isinstance(extra, list):
+                groups.append([item for item in extra if isinstance(item, str)])
     for group in data.get("dependency-groups", {}).values():
         if isinstance(group, list):
             groups.append([item for item in group if isinstance(item, str)])

--- a/scripts/validation/check_ci_dependency_pins.py
+++ b/scripts/validation/check_ci_dependency_pins.py
@@ -57,7 +57,11 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-import tomllib
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - 3.10 fallback path
+    tomllib = None  # type: ignore[assignment]
+
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.utils import canonicalize_name
@@ -189,6 +193,13 @@ def violations(pins: list[Pin], constraints: dict[str, SpecifierSet]) -> list[Vi
 
 def check(root: Path, pyproject: Path) -> int:
     """Validate every pin under ``root`` and return an exit code."""
+    if tomllib is None:  # pragma: no cover - 3.10 fallback path
+        print(
+            "::error::tomllib unavailable (Python 3.11+ required); "
+            "skipping CI dependency pin check",
+            file=sys.stderr,
+        )
+        return EXIT_CONFIG
     if not pyproject.is_file():
         print(f"::error::pyproject.toml not found: {pyproject}", file=sys.stderr)
         return EXIT_CONFIG

--- a/scripts/validation/check_ci_dependency_pins.py
+++ b/scripts/validation/check_ci_dependency_pins.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Assert every hand-written ``pkg==version`` pin in ``.github/`` agrees with
-``pyproject.toml`` (Issue #3377).
+"""Assert every hand-written ``pkg==version`` pin in ``.github/`` YAML agrees
+with ``pyproject.toml`` (Issue #3377).
 
 Two CI install steps pinned pytest by hand and disagreed with each other::
 
@@ -20,9 +20,17 @@ an autofix commit downgraded the correct pin.
 This is the converse-assertion shape of Issues #3341 and #3371: something
 asserts the pin exists, nothing asserts it agrees with the source of truth.
 
-Scope: a pin is checked only when ``pyproject.toml`` declares that package.
-CI installs tools the project does not depend on (``pip`` itself, for one), and
-those carry no constraint to disagree with.
+Scope, stated so a reader does not infer coverage that is not here:
+
+* Workflow and action YAML under ``.github/`` only. A pin in a requirements
+  file, a shell script, a Dockerfile, or a composite action written in another
+  format is not read.
+* A pin is checked only when ``pyproject.toml`` declares that package. CI
+  installs tools the project does not depend on (``pip`` itself, for one), and
+  those carry no constraint to disagree with.
+* Quoted and unquoted pins both count. ``pytest==9.0.3`` and
+  ``'pytest==9.0.3'`` install the same version, so keying on the quotes would
+  let an unquoted pin drift silently.
 
 Call sites, because a guard with none protects nothing (Issue #3329):
 
@@ -61,10 +69,16 @@ EXIT_CONFIG = 2
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# A quoted pin as it appears in a shell ``run:`` line: 'pytest==9.0.3'.
-# Quoting is required so a bare ``==`` inside prose or a comparison in a
-# script body is not read as a dependency pin.
-_PIN_RE = re.compile(r"""['"]([A-Za-z0-9][A-Za-z0-9._-]*)==([0-9][^'"\s]*)['"]""")
+# A pin as it appears in a shell ``run:`` line: pytest==9.0.3, quoted or not.
+# Both spellings install the same version, so keying on the quotes would let an
+# unquoted pin drift silently.
+#
+# What keeps YAML's own ``==`` out: GitHub expressions space their operator
+# (``env.FOO == '1'``), the lookbehind rejects ``===`` and mid-token matches,
+# and a version must start with a digit, so ``foo==bar`` is not a pin.
+_PIN_RE = re.compile(
+    r"""(?<![A-Za-z0-9._=-])['"]?([A-Za-z][A-Za-z0-9._-]*)==([0-9][A-Za-z0-9._*+!-]*)"""
+)
 
 
 @dataclass(frozen=True)
@@ -141,7 +155,7 @@ def find_pins(root: Path) -> list[Pin]:
     """
     pins: list[Pin] = []
     for path in sorted(root.rglob("*")):
-        if path.suffix not in {".yml", ".yaml"} or not path.is_file():
+        if path.suffix.lower() not in {".yml", ".yaml"} or not path.is_file():
             continue
         try:
             content = path.read_text(encoding="utf-8")

--- a/scripts/validation/check_ci_dependency_pins.py
+++ b/scripts/validation/check_ci_dependency_pins.py
@@ -135,12 +135,20 @@ def find_pins(root: Path) -> list[Pin]:
     installed the same way, but those files are covered by the dependency
     resolver rather than by hand-written literals, and widening the scan
     turns ordinary equality comparisons into false positives.
+
+    Per-file errors (I/O failures, encoding issues) are logged and skipped so
+    that one unreadable file does not abort the scan of other pins.
     """
     pins: list[Pin] = []
     for path in sorted(root.rglob("*")):
         if path.suffix not in {".yml", ".yaml"} or not path.is_file():
             continue
-        for number, text in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        try:
+            content = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            print(f"::warning::skipping {path}: {exc}", file=sys.stderr)
+            continue
+        for number, text in enumerate(content.splitlines(), 1):
             for name, version in _PIN_RE.findall(text):
                 pins.append(Pin(path=path, line=number, name=name, version=version))
     return pins
@@ -176,7 +184,7 @@ def check(root: Path, pyproject: Path) -> int:
 
     try:
         constraints = declared_constraints(pyproject)
-    except (tomllib.TOMLDecodeError, InvalidSpecifier, OSError) as exc:
+    except (tomllib.TOMLDecodeError, InvalidSpecifier, OSError, UnicodeDecodeError) as exc:
         print(f"::error::cannot read constraints from {pyproject}: {exc}", file=sys.stderr)
         return EXIT_CONFIG
 

--- a/scripts/validation/check_ci_dependency_pins.py
+++ b/scripts/validation/check_ci_dependency_pins.py
@@ -169,6 +169,13 @@ def find_pins(root: Path) -> list[Pin]:
             print(f"::warning::skipping {path}: {exc}", file=sys.stderr)
             continue
         for number, text in enumerate(content.splitlines(), 1):
+            # Skip YAML/shell comment lines: a pin mentioned in a comment is not
+            # an active install (Issue #3377 comment-stripping fix).  Only
+            # leading-# lines are dropped; trailing # can appear inside quotes
+            # or parameter expansions (${VAR#pat}), so stripping there mangles
+            # live commands.
+            if text.lstrip().startswith("#"):
+                continue
             for name, version in _PIN_RE.findall(text):
                 pins.append(Pin(path=path, line=number, name=name, version=version))
     return pins

--- a/scripts/validation/check_ci_dependency_pins.py
+++ b/scripts/validation/check_ci_dependency_pins.py
@@ -133,6 +133,9 @@ def declared_constraints(pyproject: Path) -> dict[str, SpecifierSet]:
     groups: list[list[str]] = [list(project.get("dependencies", []))]
     for extra in project.get("optional-dependencies", {}).values():
         groups.append(list(extra))
+    for group in data.get("dependency-groups", {}).values():
+        if isinstance(group, list):
+            groups.append([item for item in group if isinstance(item, str)])
 
     merged: dict[str, SpecifierSet] = {}
     for group in groups:

--- a/scripts/validation/checks_tooling.py
+++ b/scripts/validation/checks_tooling.py
@@ -342,3 +342,23 @@ def validate_copilot_version_pin(repo_root: Path) -> bool:
             "ai-review/action.yml not present (downstream install); nothing to pin-check"
         )
     return bool(check_action(action) == EXIT_OK)
+
+
+def validate_ci_dependency_pins(repo_root: Path) -> bool:
+    """Assert every hand-written pkg==version pin in .github/ agrees with
+    pyproject.toml (Issue #3377).
+
+    Thin wrapper over ``check_ci_dependency_pins.check``. The .github tree is
+    absent in downstream installs, so SKIP rather than FAIL when it is not
+    present.
+    """
+    from check_ci_dependency_pins import EXIT_OK as PIN_OK
+    from check_ci_dependency_pins import check as check_pins
+
+    workflows = repo_root / ".github"
+    pyproject = repo_root / "pyproject.toml"
+    if not workflows.is_dir() or not pyproject.is_file():
+        raise MissingScriptSkip(
+            ".github/ or pyproject.toml not present (downstream install); no pins to check"
+        )
+    return bool(check_pins(workflows, pyproject) == PIN_OK)

--- a/scripts/validation/checks_tooling.py
+++ b/scripts/validation/checks_tooling.py
@@ -345,12 +345,13 @@ def validate_copilot_version_pin(repo_root: Path) -> bool:
 
 
 def validate_ci_dependency_pins(repo_root: Path) -> bool:
-    """Assert every hand-written pkg==version pin in .github/ agrees with
+    """Assert every hand-written pkg==version pin in .github/ YAML agrees with
     pyproject.toml (Issue #3377).
 
-    Thin wrapper over ``check_ci_dependency_pins.check``. The .github tree is
-    absent in downstream installs, so SKIP rather than FAIL when it is not
-    present.
+    Thin wrapper over ``check_ci_dependency_pins.check``, whose module docstring
+    holds the full scope. In short: workflow and action YAML only, and only for
+    packages pyproject declares. The .github tree is absent in downstream
+    installs, so SKIP rather than FAIL when it is not present.
     """
     from check_ci_dependency_pins import EXIT_OK as PIN_OK
     from check_ci_dependency_pins import check as check_pins

--- a/scripts/validation/checks_tooling.py
+++ b/scripts/validation/checks_tooling.py
@@ -353,13 +353,13 @@ def validate_ci_dependency_pins(repo_root: Path) -> bool:
     packages pyproject declares. The .github tree is absent in downstream
     installs, so SKIP rather than FAIL when it is not present.
     """
-    from check_ci_dependency_pins import EXIT_OK as PIN_OK
-    from check_ci_dependency_pins import check as check_pins
-
     workflows = repo_root / ".github"
     pyproject = repo_root / "pyproject.toml"
     if not workflows.is_dir() or not pyproject.is_file():
         raise MissingScriptSkip(
             ".github/ or pyproject.toml not present (downstream install); no pins to check"
         )
+    from check_ci_dependency_pins import EXIT_OK as PIN_OK
+    from check_ci_dependency_pins import check as check_pins
+
     return bool(check_pins(workflows, pyproject) == PIN_OK)

--- a/scripts/validation/pre_pr.py
+++ b/scripts/validation/pre_pr.py
@@ -93,6 +93,7 @@ from checks_tooling import (  # noqa: E402, F401
     _find_latest_session_log,
     _markdown_lint_targets,
     validate_agent_drift,
+    validate_ci_dependency_pins,
     validate_copilot_version_pin,
     validate_markdown_lint,
     validate_path_normalization,

--- a/scripts/validation/pre_pr_sequence.py
+++ b/scripts/validation/pre_pr_sequence.py
@@ -51,6 +51,7 @@ from checks_spec import (  # noqa: E402
 )
 from checks_tooling import (  # noqa: E402
     validate_agent_drift,
+    validate_ci_dependency_pins,
     validate_copilot_version_pin,
     validate_markdown_lint,
     validate_path_normalization,
@@ -150,6 +151,16 @@ def run_all_validations(
         "Copilot CLI Version Pin",
         state,
         lambda: validate_copilot_version_pin(repo_root),
+    )
+
+    # 3.57 CI Dependency Pins (Issue #3377). Fails when a hand-written
+    # pkg==version literal under .github/ contradicts the pyproject constraint
+    # for that package. Two pytest pins disagreed and one sat a major below the
+    # declared floor; a review then proposed aligning the correct one down.
+    run_validation(
+        "CI Dependency Pins",
+        state,
+        lambda: validate_ci_dependency_pins(repo_root),
     )
 
     # 3.6 Design Review Frontmatter

--- a/tests/validation/test_check_ci_dependency_pins.py
+++ b/tests/validation/test_check_ci_dependency_pins.py
@@ -24,6 +24,10 @@ dependencies = ["PyYAML==6.0.3", "requests"]
 [project.optional-dependencies]
 dev = ["pytest>=9.0.3", "pytest-cov>=7.1.0"]
 eval = ["pytest>=8.0"]
+
+[dependency-groups]
+lint = ["ruff>=0.15.16", {include-group = "dev"}]
+dev = ["pytest>=9.0.3"]
 """
 
 
@@ -43,7 +47,38 @@ def _pyproject(tmp_path: Path, body: str = _PYPROJECT) -> Path:
 class TestDeclaredConstraints:
     def test_it_merges_base_and_every_extra(self, tmp_path):
         c = gate.declared_constraints(_pyproject(tmp_path))
-        assert set(c) == {"pyyaml", "pytest", "pytest-cov"}
+        assert set(c) == {"pyyaml", "pytest", "pytest-cov", "ruff"}
+
+    def test_a_constraint_only_in_a_dependency_group_is_enforced(self, tmp_path):
+        """ruff is declared nowhere but [dependency-groups].lint.
+
+        uv sync installs dependency groups by default and ignores extras, so a
+        pin that contradicts one is a real drift the gate has to see.
+        """
+        c = gate.declared_constraints(_pyproject(tmp_path))
+        assert not c["ruff"].contains(gate.Version("0.15.0"), prereleases=True)
+        assert c["ruff"].contains(gate.Version("0.15.16"), prereleases=True)
+
+    def test_an_include_group_table_is_not_read_as_a_requirement(self, tmp_path):
+        """PEP 735 lets a group include another by table, not by string.
+
+        Requirement() would reject the dict outright; the named group is read
+        on its own pass, so skipping the table loses nothing.
+        """
+        c = gate.declared_constraints(_pyproject(tmp_path))
+        assert "include-group" not in c
+
+    def test_a_dependency_group_that_is_not_a_list_is_skipped(self, tmp_path):
+        """A malformed table must not take the gate down.
+
+        The gate runs in CI ahead of the tests that would diagnose it, so a
+        TypeError here reads as a pin failure rather than a broken pyproject.
+        """
+        path = _pyproject(
+            tmp_path,
+            '[project]\nname="x"\ndependencies=["pytest>=9"]\n[dependency-groups]\ndev="oops"\n',
+        )
+        assert set(gate.declared_constraints(path)) == {"pytest"}
 
     def test_a_package_in_two_groups_intersects_its_specifiers(self, tmp_path):
         """pytest is >=9.0.3 in dev and >=8.0 in eval. CI installs one version,

--- a/tests/validation/test_check_ci_dependency_pins.py
+++ b/tests/validation/test_check_ci_dependency_pins.py
@@ -7,9 +7,12 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "validation"))
-
-import check_ci_dependency_pins as gate  # noqa: E402
+_validation_path = str(Path(__file__).resolve().parents[2] / "scripts" / "validation")
+sys.path.insert(0, _validation_path)
+try:
+    import check_ci_dependency_pins as gate  # noqa: E402
+finally:
+    sys.path.remove(_validation_path)
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 

--- a/tests/validation/test_check_ci_dependency_pins.py
+++ b/tests/validation/test_check_ci_dependency_pins.py
@@ -108,6 +108,18 @@ class TestFindPins:
         root = _write(tmp_path, "x = 'pytest==8.3.3'\n", name="s.py")
         assert gate.find_pins(root) == []
 
+    def test_a_comment_line_is_not_a_pin(self, tmp_path):
+        """A pin mentioned in a YAML/shell comment is not an active install."""
+        root = _write(tmp_path, "# previously pytest==8.3.3\nrun: pip install pytest==9.0.3\n")
+        (pin,) = gate.find_pins(root)
+        assert pin.version == "9.0.3"
+
+    def test_an_indented_comment_line_is_not_a_pin(self, tmp_path):
+        """Comments in run blocks are often indented."""
+        root = _write(tmp_path, "run: |\n    # old: pytest==8.3.3\n    pip install pytest==9.0.3\n")
+        (pin,) = gate.find_pins(root)
+        assert pin.version == "9.0.3"
+
     def test_it_recurses_into_subdirectories(self, tmp_path):
         root = tmp_path / "gh"
         nested = root / "actions" / "a"

--- a/tests/validation/test_check_ci_dependency_pins.py
+++ b/tests/validation/test_check_ci_dependency_pins.py
@@ -71,10 +71,38 @@ class TestFindPins:
         root = _write(tmp_path, "run: pip install 'PyYAML==6.0.3' 'pytest==9.0.3'\n")
         assert {p.name for p in gate.find_pins(root)} == {"PyYAML", "pytest"}
 
-    def test_an_unquoted_equality_is_not_a_pin(self, tmp_path):
-        """Negative control: a bare == in a script body is a comparison."""
+    def test_an_unquoted_pin_is_still_a_pin(self, tmp_path):
+        """pip does not require the quotes, so neither can the gate.
+
+        Keying on quotes made the coverage a spelling accident: the same pin
+        one shell-quoting style over drifts silently.
+        """
+        root = _write(tmp_path, "run: pip install pytest==8.3.3\n")
+        (pin,) = gate.find_pins(root)
+        assert (pin.name, pin.version) == ("pytest", "8.3.3")
+
+    def test_a_spaced_comparison_is_not_a_pin(self, tmp_path):
+        """Negative control: a spaced == in a script body is a comparison."""
         root = _write(tmp_path, "run: if [ $x == 1.0 ]; then echo hi; fi\n")
         assert gate.find_pins(root) == []
+
+    def test_a_github_expression_comparison_is_not_a_pin(self, tmp_path):
+        """The shape that dropping the quote requirement could have caught."""
+        root = _write(tmp_path, "if: ${{ github.ref == 'refs/heads/main' }}\n")
+        assert gate.find_pins(root) == []
+
+    def test_a_triple_equals_is_not_a_pin(self, tmp_path):
+        """The lookbehind's job: === is an operator, not a pin."""
+        assert gate.find_pins(_write(tmp_path, "run: test a===1.0\n")) == []
+
+    def test_a_version_must_start_with_a_digit(self, tmp_path):
+        """foo==bar is a comparison of two words, not a pinned release."""
+        assert gate.find_pins(_write(tmp_path, "run: echo foo==bar\n")) == []
+
+    def test_an_uppercase_suffix_is_still_yaml(self, tmp_path):
+        """Suffix matching is casefolded so a .YML file is not skipped."""
+        root = _write(tmp_path, "run: pip install 'pytest==8.3.3'\n", name="w.YML")
+        assert len(gate.find_pins(root)) == 1
 
     def test_non_yaml_files_are_not_scanned(self, tmp_path):
         root = _write(tmp_path, "x = 'pytest==8.3.3'\n", name="s.py")

--- a/tests/validation/test_check_ci_dependency_pins.py
+++ b/tests/validation/test_check_ci_dependency_pins.py
@@ -1,0 +1,197 @@
+"""Tests for the CI dependency pin gate (Issue #3377)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "validation"))
+
+import check_ci_dependency_pins as gate  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_PYPROJECT = """
+[project]
+name = "x"
+dependencies = ["PyYAML==6.0.3", "requests"]
+
+[project.optional-dependencies]
+dev = ["pytest>=9.0.3", "pytest-cov>=7.1.0"]
+eval = ["pytest>=8.0"]
+"""
+
+
+def _write(tmp_path: Path, body: str, name: str = "w.yml") -> Path:
+    root = tmp_path / "gh"
+    root.mkdir(exist_ok=True)
+    (root / name).write_text(body, encoding="utf-8")
+    return root
+
+
+def _pyproject(tmp_path: Path, body: str = _PYPROJECT) -> Path:
+    path = tmp_path / "pyproject.toml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+class TestDeclaredConstraints:
+    def test_it_merges_base_and_every_extra(self, tmp_path):
+        c = gate.declared_constraints(_pyproject(tmp_path))
+        assert set(c) == {"pyyaml", "pytest", "pytest-cov"}
+
+    def test_a_package_in_two_groups_intersects_its_specifiers(self, tmp_path):
+        """pytest is >=9.0.3 in dev and >=8.0 in eval. CI installs one version,
+        so it has to satisfy both."""
+        c = gate.declared_constraints(_pyproject(tmp_path))
+        assert not c["pytest"].contains(gate.Version("8.3.3"), prereleases=True)
+        assert c["pytest"].contains(gate.Version("9.0.3"), prereleases=True)
+
+    def test_a_dependency_with_no_specifier_carries_no_constraint(self, tmp_path):
+        """requests is declared bare; a pin cannot contradict nothing."""
+        assert "requests" not in gate.declared_constraints(_pyproject(tmp_path))
+
+    def test_an_unparseable_requirement_is_skipped_not_fatal(self, tmp_path):
+        path = _pyproject(tmp_path, '[project]\nname="x"\ndependencies=["!!!", "pytest>=9"]\n')
+        assert set(gate.declared_constraints(path)) == {"pytest"}
+
+
+class TestFindPins:
+    def test_it_reports_the_line_number(self, tmp_path):
+        root = _write(tmp_path, "a: 1\nb: 2\nrun: pip install 'pytest==8.3.3'\n")
+        (pin,) = gate.find_pins(root)
+        assert (pin.line, pin.name, pin.version) == (3, "pytest", "8.3.3")
+
+    def test_it_finds_several_pins_on_one_line(self, tmp_path):
+        root = _write(tmp_path, "run: pip install 'PyYAML==6.0.3' 'pytest==9.0.3'\n")
+        assert {p.name for p in gate.find_pins(root)} == {"PyYAML", "pytest"}
+
+    def test_an_unquoted_equality_is_not_a_pin(self, tmp_path):
+        """Negative control: a bare == in a script body is a comparison."""
+        root = _write(tmp_path, "run: if [ $x == 1.0 ]; then echo hi; fi\n")
+        assert gate.find_pins(root) == []
+
+    def test_non_yaml_files_are_not_scanned(self, tmp_path):
+        root = _write(tmp_path, "x = 'pytest==8.3.3'\n", name="s.py")
+        assert gate.find_pins(root) == []
+
+    def test_it_recurses_into_subdirectories(self, tmp_path):
+        root = tmp_path / "gh"
+        nested = root / "actions" / "a"
+        nested.mkdir(parents=True)
+        (nested / "action.yml").write_text("run: pip install 'pytest==8.3.3'\n", encoding="utf-8")
+        assert len(gate.find_pins(root)) == 1
+
+
+class TestViolations:
+    def _v(self, tmp_path, body):
+        c = gate.declared_constraints(_pyproject(tmp_path))
+        return gate.violations(gate.find_pins(_write(tmp_path, body)), c)
+
+    def test_a_pin_below_the_floor_is_a_violation(self, tmp_path):
+        (v,) = self._v(tmp_path, "run: pip install 'pytest==8.3.3'\n")
+        assert v.pin.version == "8.3.3"
+        # dev says >=9.0.3 and eval says >=8.0; the message carries both so a
+        # reader sees every declaration the pin has to satisfy.
+        assert ">=9.0.3" in v.constraint and ">=8.0" in v.constraint
+
+    def test_a_pin_at_the_floor_passes(self, tmp_path):
+        assert self._v(tmp_path, "run: pip install 'pytest==9.0.3'\n") == []
+
+    def test_a_pin_above_the_floor_passes(self, tmp_path):
+        assert self._v(tmp_path, "run: pip install 'pytest==9.1.1'\n") == []
+
+    def test_an_exact_match_passes(self, tmp_path):
+        assert self._v(tmp_path, "run: pip install 'PyYAML==6.0.3'\n") == []
+
+    def test_a_pin_contradicting_an_exact_declaration_is_a_violation(self, tmp_path):
+        (v,) = self._v(tmp_path, "run: pip install 'PyYAML==6.0.2'\n")
+        assert v.pin.name == "PyYAML"
+
+    def test_an_undeclared_package_is_not_checked(self, tmp_path):
+        """pip itself is installed by CI and is not a project dependency."""
+        assert self._v(tmp_path, 'run: python -m pip install "pip==26.1.2"\n') == []
+
+    def test_the_name_is_matched_case_insensitively(self, tmp_path):
+        """pyproject declares PyYAML; a pin spelled pyyaml is the same
+        distribution under PEP 503 normalization."""
+        (v,) = self._v(tmp_path, "run: pip install 'pyyaml==6.0.2'\n")
+        assert v.pin.canonical == "pyyaml"
+
+    def test_separator_runs_normalize_to_one_hyphen(self, tmp_path):
+        """PEP 503 collapses runs of -_. to a single hyphen, so pytest_cov and
+        pytest.cov both reach the pytest-cov constraint."""
+        (v,) = self._v(tmp_path, "run: pip install 'pytest_cov==7.0.0'\n")
+        assert v.pin.canonical == "pytest-cov"
+
+    def test_an_unparseable_version_is_a_violation_not_a_pass(self, tmp_path):
+        (v,) = self._v(tmp_path, "run: pip install 'pytest==9.x.y'\n")
+        assert v.pin.version == "9.x.y"
+
+    def test_a_prerelease_is_judged_not_skipped(self, tmp_path):
+        """Without prereleases=True a specifier excludes prereleases silently,
+        so an 8.x release candidate would read as passing a >=9 floor."""
+        (v,) = self._v(tmp_path, "run: pip install 'pytest==8.4.0rc1'\n")
+        assert v.pin.version == "8.4.0rc1"
+
+
+class TestCheck:
+    def test_a_clean_tree_exits_zero(self, tmp_path, capsys):
+        root = _write(tmp_path, "run: pip install 'pytest==9.0.3'\n")
+        assert gate.check(root, _pyproject(tmp_path)) == gate.EXIT_OK
+        assert capsys.readouterr().err == ""
+
+    def test_a_violation_exits_one_and_names_the_file(self, tmp_path, capsys):
+        root = _write(tmp_path, "run: pip install 'pytest==8.3.3'\n")
+        assert gate.check(root, _pyproject(tmp_path)) == gate.EXIT_LOGIC
+        err = capsys.readouterr().err
+        assert "w.yml:1" in err
+        assert "pytest==8.3.3" in err
+        assert ">=9.0.3" in err
+
+    def test_a_missing_pyproject_is_a_config_failure(self, tmp_path, capsys):
+        root = _write(tmp_path, "x: 1\n")
+        assert gate.check(root, tmp_path / "nope.toml") == gate.EXIT_CONFIG
+        assert "pyproject.toml not found" in capsys.readouterr().err
+
+    def test_a_missing_root_is_a_config_failure(self, tmp_path, capsys):
+        assert gate.check(tmp_path / "nope", _pyproject(tmp_path)) == gate.EXIT_CONFIG
+        assert "scan root not found" in capsys.readouterr().err
+
+    def test_an_unparseable_pyproject_is_a_config_failure(self, tmp_path, capsys):
+        bad = tmp_path / "pyproject.toml"
+        bad.write_text("[project\n", encoding="utf-8")
+        assert gate.check(_write(tmp_path, "x: 1\n"), bad) == gate.EXIT_CONFIG
+        assert "cannot read constraints" in capsys.readouterr().err
+
+
+class TestMain:
+    def test_it_returns_the_check_exit_code(self, tmp_path):
+        root = _write(tmp_path, "run: pip install 'pytest==8.3.3'\n")
+        argv = ["--root", str(root), "--pyproject", str(_pyproject(tmp_path))]
+        assert gate.main(argv) == gate.EXIT_LOGIC
+
+    def test_the_defaults_point_at_this_repository(self):
+        parser = gate.build_parser()
+        args = parser.parse_args([])
+        assert Path(args.root) == _REPO_ROOT / ".github"
+        assert Path(args.pyproject) == _REPO_ROOT / "pyproject.toml"
+
+
+class TestTheRealTree:
+    def test_every_pin_in_this_repository_agrees_with_pyproject(self):
+        """The gate's reason for existing: .github/ once carried pytest==8.3.3
+        against a pytest>=9.0.3 floor and nothing noticed."""
+        assert gate.check(_REPO_ROOT / ".github", _REPO_ROOT / "pyproject.toml") == gate.EXIT_OK
+
+    def test_the_repository_actually_pins_something_the_gate_checks(self):
+        """Negative control: a gate that scans nothing passes vacuously."""
+        constraints = gate.declared_constraints(_REPO_ROOT / "pyproject.toml")
+        checked = [p for p in gate.find_pins(_REPO_ROOT / ".github") if p.canonical in constraints]
+        assert checked, "no CI pin is covered by a pyproject constraint"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/validation/test_check_ci_dependency_pins.py
+++ b/tests/validation/test_check_ci_dependency_pins.py
@@ -224,5 +224,60 @@ class TestTheRealTree:
         assert checked, "no CI pin is covered by a pyproject constraint"
 
 
+class TestPinsInstallIntoTheSelectedInterpreter:
+    """A correct version installed into the wrong interpreter is still absent.
+
+    The version gate above answers "which pytest". This answers "whose
+    site-packages". Bare ``pip`` resolves through PATH, which on a runner need
+    not be the interpreter ``actions/setup-python`` just selected; the module
+    form ``python3 -m pip`` cannot disagree with the python that runs it.
+
+    Kept as a test rather than folded into the validator: the validator's
+    subject is a pkg==version literal, and this is about the command around it.
+    """
+
+    _INSTALL_FILES = sorted(
+        list((_REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+        + list((_REPO_ROOT / ".github" / "actions").glob("*/action.yml"))
+    )
+
+    @staticmethod
+    def _bare_pip_lines(path: Path) -> list[str]:
+        try:
+            shown: Path | str = path.relative_to(_REPO_ROOT)
+        except ValueError:
+            shown = path
+        out = []
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            stripped = line.strip().removeprefix("- ").lstrip()
+            stripped = stripped.removeprefix("run:").strip()
+            if stripped.startswith(("pip install", "pip3 install")):
+                out.append(f"{shown}:{number}")
+        return out
+
+    def test_no_workflow_or_action_calls_bare_pip_install(self):
+        offenders = [entry for path in self._INSTALL_FILES for entry in self._bare_pip_lines(path)]
+        assert not offenders, (
+            "use `python3 -m pip install` so the package lands in the interpreter "
+            f"actions/setup-python selected: {offenders}"
+        )
+
+    def test_the_scan_reads_files(self):
+        """Vacuity control: a glob that matches nothing passes for free."""
+        assert len(self._INSTALL_FILES) > 5
+
+    def test_the_detector_recognizes_a_bare_call(self, tmp_path: Path):
+        """Negative control on the detector, not on the tree."""
+        bad = tmp_path / "action.yml"
+        bad.write_text("runs:\n  steps:\n    - run: pip install 'x==1'\n", encoding="utf-8")
+        assert self._bare_pip_lines(bad) == [f"{bad}:3"]
+
+    def test_the_detector_accepts_the_module_form(self, tmp_path: Path):
+        good = tmp_path / "action.yml"
+        body = "runs:\n  steps:\n    - run: python3 -m pip install 'x==1'\n"
+        good.write_text(body, encoding="utf-8")
+        assert self._bare_pip_lines(good) == []
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
Fixes #3377

## Problem

Two CI install steps pinned pytest by hand and disagreed with each other. The
workflow pinned 9.0.3; the composite action pinned 8.3.3. `pyproject.toml`
declares `pytest>=9.0.3` in both the base and dev groups, so the action
installed a pytest the project does not support.

The stale pin is not the interesting part. A reader looking at two disagreeing
string literals cannot tell which is authoritative without opening
`pyproject.toml`, so "align them" resolves toward the wrong one about half the
time. On PR #3361 it did: a review proposed aligning down to 8.3.3, and an
autofix commit downgraded the correct pin.

## Fix

A gate that reads the constraint from the source of truth. This is the
converse-assertion shape of #3341 and #3371, where something asserts a pin
exists and nothing asserts it agrees with what declares it.

Constraints merge the base dependency list with every optional-dependency
extra and intersect per package, because CI installs one version that has to
work wherever the step needs it. Packages `pyproject.toml` does not declare are
skipped: pip itself is installed by CI and carries no constraint to disagree
with. Prerelease pins are judged rather than silently excluded, so an 8.x
release candidate cannot read as satisfying a `>=9` floor.

Run against the tree unchanged, it found the real drift on the first
invocation and exited 1. The action is now pinned at 9.0.3, with a comment
recording why the number is what it is so the next reader does not re-derive
the wrong answer from two literals.

## Why not the issue's first preference

The issue preferred dropping hand-pinning and installing the locked dev
environment. Neither surface uses that pattern today; both are deliberately
light single-purpose installs, one of which runs a single test file. Switching
them trades a narrow drift for a much heavier CI step on every run. Taking the
second preference keeps the installs light and removes the drift class
entirely.

## Wiring

A guard with no call site protects nothing (#3329), so this has two:

- The real-tree test runs under the required "Run Python Tests" check, with a
  control asserting the repository actually pins something the gate covers, so
  it cannot pass vacuously.
- `validate_ci_dependency_pins` puts it in the pre-PR sequence for the author's
  terminal.

## Verification

28 tests. Two failed on first run and both premises were mine, not the code's:
`canonicalize_name` collapses runs of separators to a single hyphen rather than
deleting them, so `py_yaml` is genuinely not `pyyaml`; and an intersected
specifier renders both bounds. Corrected the tests.

Coverage includes an unquoted equality that must not read as a pin, a non-YAML
file that must not be scanned, an undeclared package that must not be checked,
an unparseable version that must be a violation rather than a pass, a
prerelease, and every ADR-035 exit code.

Negative control: restoring the stale pin turned the real-tree test red;
restoring the fix turned it green.

- 799 tests pass in the validation suite, 140 in the CI suite.
- Ruff check, ruff format, and the ratchet all clean.
- No plugin tree touched, so no manifest bump.
