### PR TITLE
fix(hooks): fail closed when the causal graph snapshot cannot be restored

### DIFF
--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1276,7 +1276,24 @@ def update_causal_graph(repo_root: Path) -> int:
     result = _apply_causal_graph_updates(staged, deleted, graph_path, repo_root)
     if result == 0:
         return _stage_causal_graph(graph_path, repo_root)
-    _restore_file(graph_path, snapshot)
+    try:
+        _restore_file(graph_path, snapshot)
+    except OSError as exc:
+        # The updater already failed, so the graph on disk is mid-write. Letting
+        # the OSError propagate ends the hook with a traceback that says nothing
+        # about which of the two failures the operator is looking at, and the
+        # "original graph restored" line below would be a lie if it ran. Name
+        # both failures and block, because a partially mutated graph must not be
+        # committed. Issue #3389.
+        print(f"ERROR: causal graph update failed (exit {result})", file=sys.stderr)
+        print(
+            f"ERROR: restoring the original causal graph also failed: {exc}\n"
+            f"       {graph_path} may be partially written. Rebuild it before"
+            " committing:\n"
+            f"           {_causal_repair_command(graph_path, repo_root)}",
+            file=sys.stderr,
+        )
+        return 2
     print("WARNING: causal graph update failed; original graph restored", file=sys.stderr)
     # The restore preserves the file as found, so a corrupt graph stays corrupt
     # and this warning repeats on every commit. Name the repair (issue #3370).
@@ -1349,7 +1366,6 @@ def _prune_deleted_episodes(
     if result.returncode != 0:
         _print_process_output(result)
     return result.returncode
-
 
 
 def _deleted_episode_id(relative_path: str, repo_root: Path) -> str:

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1285,7 +1285,7 @@ def update_causal_graph(repo_root: Path) -> int:
         # "original graph restored" line below would be a lie if it ran. Name
         # both failures and block, because a partially mutated graph must not be
         # committed. Issue #3389.
-        print(f"ERROR: causal graph update failed (exit {result})", file=sys.stderr)
+        print(f"ERROR: causal graph update failed (updater exit {result})", file=sys.stderr)
         print(
             f"ERROR: restoring the original causal graph also failed: {exc}\n"
             f"       {graph_path} may be partially written. Rebuild it before"

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -1,0 +1,164 @@
+"""Snapshot restoration must fail closed, not traceback (Issue #3389).
+
+``update_causal_graph`` snapshots the generated causal graph, runs the updater,
+and restores the snapshot when the updater fails. The restore itself was
+unguarded: an ``OSError`` from ``Path.write_bytes`` or ``Path.unlink`` escaped
+the function, so the operator got a traceback naming neither failure, and the
+graph could be left partially written.
+
+Two failures are in play whenever this path runs, and the operator needs both:
+the updater failed, and the attempt to undo it also failed. A message naming
+only one of them sends the reader to the wrong repair.
+
+The success-shaped line matters as much as the exit code. ``original graph
+restored`` printed after a failed restore is worse than silence, because it
+tells the reader the thing they most need to doubt.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.validation import git_hook_policy as policy  # noqa: E402
+
+_GRAPH = ".agents/memory/causality/causal-graph.json"
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A repo whose staged set is nonempty and whose updater always fails."""
+    monkeypatch.setattr(
+        policy, "_staged_episode_paths", lambda root, flt: ["ep.md"] if flt == "ACMR" else []
+    )
+    monkeypatch.setattr(policy, "_apply_causal_graph_updates", lambda *a, **k: 1)
+    return tmp_path
+
+
+def _write_graph(repo_root: Path, text: str = '{"nodes": []}') -> Path:
+    path = repo_root / _GRAPH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class TestARestoreFailureBlocks:
+    def test_a_write_failure_returns_two(self, repo, monkeypatch, capsys):
+        """The graph existed, so restoration writes the snapshot back."""
+        _write_graph(repo)
+        monkeypatch.setattr(
+            Path, "write_bytes", lambda self, data: (_ for _ in ()).throw(OSError("disk full"))
+        )
+        assert policy.update_causal_graph(repo) == 2
+        assert "disk full" in capsys.readouterr().err
+
+    def test_an_unlink_failure_returns_two(self, repo, monkeypatch, capsys):
+        """The graph did not exist, so restoration removes what the updater made.
+
+        The snapshot is None on this path, which is the branch that reaches
+        Path.unlink rather than Path.write_bytes.
+        """
+        monkeypatch.setattr(
+            Path, "unlink", lambda self, missing_ok=False: (_ for _ in ()).throw(OSError("EPERM"))
+        )
+        assert policy.update_causal_graph(repo) == 2
+        assert "EPERM" in capsys.readouterr().err
+
+    def test_it_never_claims_the_graph_was_restored(self, repo, monkeypatch, capsys):
+        """The line that must not print. It is the one the reader trusts."""
+        _write_graph(repo)
+        monkeypatch.setattr(
+            Path, "write_bytes", lambda self, data: (_ for _ in ()).throw(OSError("nope"))
+        )
+        policy.update_causal_graph(repo)
+        assert "original graph restored" not in capsys.readouterr().err
+
+    def test_it_names_both_failures(self, repo, monkeypatch, capsys):
+        """One failure caused the other; a message naming one misdirects."""
+        _write_graph(repo)
+        monkeypatch.setattr(
+            Path, "write_bytes", lambda self, data: (_ for _ in ()).throw(OSError("nope"))
+        )
+        policy.update_causal_graph(repo)
+        err = capsys.readouterr().err
+        assert "causal graph update failed" in err
+        assert "restoring the original causal graph also failed" in err
+
+    def test_it_names_the_graph_and_the_repair(self, repo, monkeypatch, capsys):
+        """A blocked commit with no next step is a blocked commit twice."""
+        _write_graph(repo)
+        monkeypatch.setattr(
+            Path, "write_bytes", lambda self, data: (_ for _ in ()).throw(OSError("nope"))
+        )
+        policy.update_causal_graph(repo)
+        err = capsys.readouterr().err
+        assert _GRAPH in err.replace("\\", "/")
+        assert "update_causal_graph" in err or "rebuild" in err.lower()
+
+    def test_it_does_not_raise(self, repo, monkeypatch):
+        """The point of the change: an exit code, not a traceback."""
+        _write_graph(repo)
+        monkeypatch.setattr(
+            Path, "write_bytes", lambda self, data: (_ for _ in ()).throw(OSError("nope"))
+        )
+        policy.update_causal_graph(repo)
+
+
+class TestTheOrdinaryPathsAreUnchanged:
+    """Negative controls. A guard that swallows the success path is not a guard."""
+
+    def test_a_successful_restore_still_warns_and_passes(self, repo, capsys):
+        _write_graph(repo, '{"nodes": ["original"]}')
+        assert policy.update_causal_graph(repo) == 0
+        err = capsys.readouterr().err
+        assert "original graph restored" in err
+
+    def test_a_successful_restore_puts_the_bytes_back(self, repo):
+        graph = _write_graph(repo, '{"nodes": ["original"]}')
+        graph.write_text('{"nodes": ["mutated"]}', encoding="utf-8")
+        # Re-snapshot by re-reading: update_causal_graph snapshots at entry, so
+        # write the mutation first and let the failing updater trigger restore.
+        assert policy.update_causal_graph(repo) == 0
+        assert json.loads(graph.read_text(encoding="utf-8"))["nodes"] == ["mutated"]
+
+    def test_no_staged_episodes_is_a_no_op(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(policy, "_staged_episode_paths", lambda root, flt: [])
+        assert policy.update_causal_graph(tmp_path) == 0
+
+    def test_a_successful_update_never_reaches_the_restore(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            policy, "_staged_episode_paths", lambda root, flt: ["ep.md"] if flt == "ACMR" else []
+        )
+        monkeypatch.setattr(policy, "_apply_causal_graph_updates", lambda *a, **k: 0)
+        monkeypatch.setattr(policy, "_stage_causal_graph", lambda *a, **k: 0)
+
+        def _boom(*_a, **_k):
+            raise AssertionError("restore ran on the success path")
+
+        monkeypatch.setattr(policy, "_restore_file", _boom)
+        assert policy.update_causal_graph(tmp_path) == 0
+
+
+class TestTheHarnessActuallyExercisesRestore:
+    """Vacuity control: these tests are worthless if restore never runs."""
+
+    def test_the_failing_updater_reaches_restore(self, repo, monkeypatch):
+        seen: list[bytes | None] = []
+
+        def _record(path: Path, snapshot: bytes | None) -> None:
+            seen.append(snapshot)
+
+        monkeypatch.setattr(policy, "_restore_file", _record)
+        policy.update_causal_graph(repo)
+        assert len(seen) == 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -120,13 +120,23 @@ class TestTheOrdinaryPathsAreUnchanged:
         err = capsys.readouterr().err
         assert "original graph restored" in err
 
-    def test_a_successful_restore_puts_the_bytes_back(self, repo):
+    def test_a_successful_restore_puts_the_bytes_back(self, repo, monkeypatch):
+        """The mutation has to happen after the snapshot, or the test is vacuous.
+
+        ``update_causal_graph`` snapshots at entry. Mutating the file before the
+        call puts the mutation *into* the snapshot, so the end state matches
+        whether restore ran or not. Writing it from inside the failing updater
+        is the only ordering that makes the assertion discriminate.
+        """
         graph = _write_graph(repo, '{"nodes": ["original"]}')
-        graph.write_text('{"nodes": ["mutated"]}', encoding="utf-8")
-        # Re-snapshot by re-reading: update_causal_graph snapshots at entry, so
-        # write the mutation first and let the failing updater trigger restore.
+
+        def _mutate_then_fail(*_a, **_k) -> int:
+            graph.write_text('{"nodes": ["mutated"]}', encoding="utf-8")
+            return 1
+
+        monkeypatch.setattr(policy, "_apply_causal_graph_updates", _mutate_then_fail)
         assert policy.update_causal_graph(repo) == 0
-        assert json.loads(graph.read_text(encoding="utf-8"))["nodes"] == ["mutated"]
+        assert json.loads(graph.read_text(encoding="utf-8"))["nodes"] == ["original"]
 
     def test_no_staged_episodes_is_a_no_op(self, tmp_path, monkeypatch):
         monkeypatch.setattr(policy, "_staged_episode_paths", lambda root, flt: [])

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -100,7 +100,7 @@ class TestARestoreFailureBlocks:
         policy.update_causal_graph(repo)
         err = capsys.readouterr().err
         assert _GRAPH in err.replace("\\", "/")
-        assert "update_causal_graph" in err or "rebuild" in err.lower()
+        assert "--reset-graph" in err
 
     def test_it_does_not_raise(self, repo, monkeypatch):
         """The point of the change: an exit code, not a traceback."""


### PR DESCRIPTION
## Summary

`update_causal_graph` snapshots the generated causal graph, runs the updater, and restores the snapshot when the updater fails. The restore was unguarded, so an `OSError` escaped the function.

Fixes #3389

## The failure

Two things can fail on that path. The updater failed, which is why restore is running at all. Then restore failed too. Before this change the operator got a traceback that named neither, and could not tell whether the graph on disk was the original or a partial write. Because the exception escaped rather than returning a code, the hook died on the traceback instead of on a decision.

Now it returns exit 2 and prints both failures.

The message ordering matters more than the code. `original graph restored` printed after a failed restore is worse than silence: it tells the reader the one thing they most need to doubt. That line is now unreachable when restoration fails.

## Coverage

Eleven tests. Both restore branches run against the real implementation rather than a stub, because the branch is selected by whether the graph existed at entry:

- An existing graph reaches `Path.write_bytes`.
- An absent graph reaches `Path.unlink` with a `None` snapshot.

Five controls hold the ordinary paths: a successful restore still warns and returns 0, still puts the original bytes back, an empty staged set is a no-op, and a successful update never reaches restore at all. One vacuity control proves the failing-updater fixture actually reaches restore, since every test above it would pass for free otherwise.

## Verification

- 11 tests pass; 782 pass across the validation suite.
- Negative control: removing the try/except turns all six positive tests red and leaves the five controls green.
- ruff check, ruff format, and mypy clean.

## Notes

No plugin tree touched, so no manifest bump.
