### PR TITLE
docs(governance): add worktree identity, path resolution, and skill contract rules

### DIFF
--- a/.claude/rules/harness-path-resolution.md
+++ b/.claude/rules/harness-path-resolution.md
@@ -1,0 +1,47 @@
+---
+paths: ".claude/skills/**,src/copilot-cli/skills/**,.claude/commands/**"
+priority: high
+---
+
+# Harness Path Resolution Rule
+
+A skill that shells out to a helper script must resolve that script's directory before invoking it. The resolver walks a candidate ladder: harness environment variables first, then a repo-relative path, then installed-plugin copies under `$HOME`. Every rung after the repo-relative one points at a *different copy of the code* — usually an older one.
+
+This rule exists because `src/copilot-cli/skills/pr-autofix/SKILL.md` contains a `resolve_pr_scripts_dir()` whose repo-relative rung is the bare string `.claude`. A bare relative path only resolves when the process cwd is the repository root. Executed from `repo/src/`, the `.claude` probe misses and the resolver silently returns `$HOME/.copilot/installed-plugins/_direct/project-toolkit/skills/github/scripts/pr`.
+
+The consequence measured on `9768d541`: that installed copy was dated one month earlier than the repo, and its `check_pr_live_state.py` was 495 lines against the repo's 560 — 215 lines different. `check_pr_live_state.py` is the blocking per-PR live-state gate (issue #2455) that `pr-autofix` runs before every tier action. From a subdirectory, the skill enforced its primary safety gate using a month-old implementation, with no warning and no version check. The resolver fails open and fails silent.
+
+## What a resolver MUST do
+
+1. **Anchor the repo-relative rung absolutely.** Derive the repository root rather than assuming cwd is it:
+
+   ```sh
+   repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+   ```
+
+   Probe `"$repo_root/.claude/skills/..."`, never bare `.claude/skills/...`. A resolver whose correctness depends on cwd is correct only by accident.
+
+2. **Order in-repo copies ahead of installed-plugin copies.** The working tree is the source of truth during development. An installed plugin is a snapshot of some earlier commit. Falling through from the former to the latter is a silent downgrade, not a fallback.
+
+3. **Not fail open on a set-but-wrong harness variable.** If `COPILOT_PLUGIN_ROOT` or `CLAUDE_PLUGIN_ROOT` is set and the path it names does not contain the expected script, that is a misconfiguration. Continuing down the ladder converts an explicit configuration error into a silent use of a different codebase.
+
+4. **Emit the resolved path when it is not the in-repo copy.** One line on stderr naming which rung matched. Silence is what turns a stale-copy execution into an undiagnosable behavioral difference.
+
+## What the reviewer MUST verify
+
+When a diff adds or edits a resolver function in a `SKILL.md`, a command file, or a helper script:
+
+- Extract the resolver and execute it from at least three working directories: the repo root, a subdirectory of the repo, and a path outside the repo. Reading the ladder is not sufficient — the bare-`.claude` defect is invisible on inspection and obvious on execution.
+- Confirm the repo-relative rung is anchored to `git rev-parse --show-toplevel` or an equivalent absolute derivation.
+- If an installed-plugin rung exists, confirm it is ordered last and that selecting it is announced.
+
+## Verifying a stale copy is in play
+
+When a skill behaves differently than its scripts read, compare the copies directly before theorizing:
+
+```sh
+diff <(wc -l < "$repo_root/.claude/skills/github/scripts/pr/check_pr_live_state.py") \
+     <(wc -l < "$HOME/.copilot/installed-plugins/_direct/project-toolkit/skills/github/scripts/pr/check_pr_live_state.py")
+```
+
+A line-count difference between the two copies means the resolver's choice is load-bearing and the ladder must be audited.

--- a/.claude/rules/skill-contract-tests.md
+++ b/.claude/rules/skill-contract-tests.md
@@ -1,0 +1,36 @@
+---
+paths: ".claude/skills/**,src/copilot-cli/skills/**,.claude/commands/**"
+priority: high
+---
+
+# Skill Contract Test Rule
+
+When a `SKILL.md` documents a script's exit codes, output fields, or flag semantics, that documentation is executable behavior written in prose. Nothing recompiles it when the script changes. The script's own unit tests assert the script against itself; they never open the `SKILL.md` and never notice when the two disagree.
+
+This rule exists because `pr-autofix` documents several load-bearing contracts that no test binds:
+
+- `check_pr_live_state.py` exits `0` with `action=ACT` for an actionable PR and exits `1` with `action=SKIP` for one already merged. The skill branches on both.
+- `test_pr_merged.py` exits `0` unconditionally (issue #2308), with `--exit-100-on-merged` restoring the legacy `100` sentinel and `--exit-zero-on-merged` retained as a parsed no-op.
+
+All of these were verified correct on `9768d541` by execution. None of them are covered by a test that reads the `SKILL.md`. `tests/test_pr_autofix_worktree_identity.py` and `tests/test_pr_autofix_lease.py` exercise scripts, not documented contracts. The exit-code semantics in #2308 already drifted once and were re-documented in prose; prose does not go red the next time.
+
+## What a skill that documents a contract MUST have
+
+A test that reads the `SKILL.md`, extracts the documented contract, and asserts the script actually honors it. The established in-repo pattern is `tests/validation/test_check_skill_md_exec_portability.py`, which parses `SKILL.md` files as test input — content-testing a `SKILL.md` is a solved problem here, not a new capability.
+
+The test asserts the pairing, not either side alone:
+
+- Exit codes: invoke the script against a fixture in each documented state and assert the exit code the `SKILL.md` names.
+- Output fields: assert the documented key exists in the emitted envelope with the documented value.
+- Flags: assert the flag parses. A flag registered indirectly through a shared helper such as `add_output_format_arg(parser)` will not appear in a literal grep of the script; verify with `--help` or an actual invocation, never with a string search.
+
+## Why grep is insufficient for these checks
+
+Auditing `pr-autofix` produced a false alarm: `grep -c -- "--output-format"` returned `0` in the script, suggesting the `SKILL.md` invoked an unsupported flag. Executing the script disproved it — the flag is registered by an imported helper and is fully supported. A contract test must invoke, not scan.
+
+The negative control matters equally: confirm `argparse` rejects a bogus flag (`--bogus-flag` → exit `2`, usage line) before concluding that a real flag was accepted. An acceptance that cannot fail proves nothing.
+
+## What the reviewer MUST verify
+
+- If a diff changes a script's exit codes, output schema, or flag surface, confirm a test binds the new behavior to the `SKILL.md` text — or that the `SKILL.md` stops making the claim.
+- If a diff adds a contract statement to a `SKILL.md` (an exit-code table, a documented field, a tier table mirrored from a protocol doc), confirm a test asserts it. An unbound contract is a comment.

--- a/.claude/rules/worktree-identity.md
+++ b/.claude/rules/worktree-identity.md
@@ -1,0 +1,41 @@
+---
+paths: "**"
+priority: high
+---
+
+# Worktree Identity Rule
+
+Before writing any file into a repository, confirm the directory you are writing to is the directory git is tracking. These are not the same thing, and when they diverge git reports success while your changes go nowhere.
+
+This rule exists because `~/repos/ai-agents/.git/config` carried `core.worktree` pointing at a Kanban workspace under `~/.hermes/kanban/boards/ai-agents/workspaces/<id>/work`. Files written into `~/repos/ai-agents` were real on disk, correct in content, and permanently invisible to git. `git status` reported a clean tree throughout, because it was faithfully reporting on the *other* directory. Two rule files and 22 generated outputs landed before the mismatch surfaced, and only then via an unrelated observation.
+
+## The check
+
+Run before the first write, from the directory you intend to edit:
+
+```bash
+[ "$(git rev-parse --show-toplevel)" = "$(pwd -P)" ] || echo "MISMATCH"
+git config --local core.worktree     # must be empty, or equal to pwd
+```
+
+A mismatch means every write from here is invisible to version control. `cd` to the reported toplevel and write there.
+
+## Why `git status` cannot be the confirmation
+
+A clean `git status` is consistent with two states: nothing changed, or git is not observing this directory at all. It cannot distinguish them, so it cannot serve as evidence that a write landed. When a write is expected to produce a diff and `git status` shows none, treat that as a failed probe and investigate the tree identity before re-writing or concluding the write succeeded.
+
+The positive control is a throwaway file:
+
+```bash
+: > .probe-$$ && git status --porcelain --untracked-files=all -- .probe-$$ ; rm -f .probe-$$
+```
+
+Empty output means git does not see writes in this directory.
+
+## Positive control on the target artifacts
+
+Confirm the files you intend to modify already exist in the tree before editing. A skill, rule, or script that is absent usually means a stale branch or the wrong worktree, not a greenfield. Creating it fresh in that state produces a duplicate that diverges from the real one on `main`.
+
+## Relationship to path resolution
+
+This is the same defect class as a script resolver probing a bare relative path such as `.claude/skills/...`: both assume the current working directory is the repository root, both silently operate on a different tree when that assumption breaks, and both fail open with no diagnostic. See `harness-path-resolution.md`. Anchor on `git rev-parse --show-toplevel` in both cases.

--- a/.github/instructions/harness-path-resolution.instructions.md
+++ b/.github/instructions/harness-path-resolution.instructions.md
@@ -1,0 +1,46 @@
+---
+applyTo: .claude/skills/**,src/copilot-cli/skills/**,.claude/commands/**
+---
+
+# Harness Path Resolution Rule
+
+A skill that shells out to a helper script must resolve that script's directory before invoking it. The resolver walks a candidate ladder: harness environment variables first, then a repo-relative path, then installed-plugin copies under `$HOME`. Every rung after the repo-relative one points at a *different copy of the code* — usually an older one.
+
+This rule exists because `src/copilot-cli/skills/pr-autofix/SKILL.md` contains a `resolve_pr_scripts_dir()` whose repo-relative rung is the bare string `.claude`. A bare relative path only resolves when the process cwd is the repository root. Executed from `repo/src/`, the `.claude` probe misses and the resolver silently returns `$HOME/.copilot/installed-plugins/_direct/project-toolkit/skills/github/scripts/pr`.
+
+The consequence measured on `9768d541`: that installed copy was dated one month earlier than the repo, and its `check_pr_live_state.py` was 495 lines against the repo's 560 — 215 lines different. `check_pr_live_state.py` is the blocking per-PR live-state gate (issue #2455) that `pr-autofix` runs before every tier action. From a subdirectory, the skill enforced its primary safety gate using a month-old implementation, with no warning and no version check. The resolver fails open and fails silent.
+
+## What a resolver MUST do
+
+1. **Anchor the repo-relative rung absolutely.** Derive the repository root rather than assuming cwd is it:
+
+   ```sh
+   repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+   ```
+
+   Probe `"$repo_root/.claude/skills/..."`, never bare `.claude/skills/...`. A resolver whose correctness depends on cwd is correct only by accident.
+
+2. **Order in-repo copies ahead of installed-plugin copies.** The working tree is the source of truth during development. An installed plugin is a snapshot of some earlier commit. Falling through from the former to the latter is a silent downgrade, not a fallback.
+
+3. **Not fail open on a set-but-wrong harness variable.** If `COPILOT_PLUGIN_ROOT` or `CLAUDE_PLUGIN_ROOT` is set and the path it names does not contain the expected script, that is a misconfiguration. Continuing down the ladder converts an explicit configuration error into a silent use of a different codebase.
+
+4. **Emit the resolved path when it is not the in-repo copy.** One line on stderr naming which rung matched. Silence is what turns a stale-copy execution into an undiagnosable behavioral difference.
+
+## What the reviewer MUST verify
+
+When a diff adds or edits a resolver function in a `SKILL.md`, a command file, or a helper script:
+
+- Extract the resolver and execute it from at least three working directories: the repo root, a subdirectory of the repo, and a path outside the repo. Reading the ladder is not sufficient — the bare-`.claude` defect is invisible on inspection and obvious on execution.
+- Confirm the repo-relative rung is anchored to `git rev-parse --show-toplevel` or an equivalent absolute derivation.
+- If an installed-plugin rung exists, confirm it is ordered last and that selecting it is announced.
+
+## Verifying a stale copy is in play
+
+When a skill behaves differently than its scripts read, compare the copies directly before theorizing:
+
+```sh
+diff <(wc -l < "$repo_root/.claude/skills/github/scripts/pr/check_pr_live_state.py") \
+     <(wc -l < "$HOME/.copilot/installed-plugins/_direct/project-toolkit/skills/github/scripts/pr/check_pr_live_state.py")
+```
+
+A line-count difference between the two copies means the resolver's choice is load-bearing and the ladder must be audited.

--- a/.github/instructions/skill-contract-tests.instructions.md
+++ b/.github/instructions/skill-contract-tests.instructions.md
@@ -1,0 +1,35 @@
+---
+applyTo: .claude/skills/**,src/copilot-cli/skills/**,.claude/commands/**
+---
+
+# Skill Contract Test Rule
+
+When a `SKILL.md` documents a script's exit codes, output fields, or flag semantics, that documentation is executable behavior written in prose. Nothing recompiles it when the script changes. The script's own unit tests assert the script against itself; they never open the `SKILL.md` and never notice when the two disagree.
+
+This rule exists because `pr-autofix` documents several load-bearing contracts that no test binds:
+
+- `check_pr_live_state.py` exits `0` with `action=ACT` for an actionable PR and exits `1` with `action=SKIP` for one already merged. The skill branches on both.
+- `test_pr_merged.py` exits `0` unconditionally (issue #2308), with `--exit-100-on-merged` restoring the legacy `100` sentinel and `--exit-zero-on-merged` retained as a parsed no-op.
+
+All of these were verified correct on `9768d541` by execution. None of them are covered by a test that reads the `SKILL.md`. `tests/test_pr_autofix_worktree_identity.py` and `tests/test_pr_autofix_lease.py` exercise scripts, not documented contracts. The exit-code semantics in #2308 already drifted once and were re-documented in prose; prose does not go red the next time.
+
+## What a skill that documents a contract MUST have
+
+A test that reads the `SKILL.md`, extracts the documented contract, and asserts the script actually honors it. The established in-repo pattern is `tests/validation/test_check_skill_md_exec_portability.py`, which parses `SKILL.md` files as test input — content-testing a `SKILL.md` is a solved problem here, not a new capability.
+
+The test asserts the pairing, not either side alone:
+
+- Exit codes: invoke the script against a fixture in each documented state and assert the exit code the `SKILL.md` names.
+- Output fields: assert the documented key exists in the emitted envelope with the documented value.
+- Flags: assert the flag parses. A flag registered indirectly through a shared helper such as `add_output_format_arg(parser)` will not appear in a literal grep of the script; verify with `--help` or an actual invocation, never with a string search.
+
+## Why grep is insufficient for these checks
+
+Auditing `pr-autofix` produced a false alarm: `grep -c -- "--output-format"` returned `0` in the script, suggesting the `SKILL.md` invoked an unsupported flag. Executing the script disproved it — the flag is registered by an imported helper and is fully supported. A contract test must invoke, not scan.
+
+The negative control matters equally: confirm `argparse` rejects a bogus flag (`--bogus-flag` → exit `2`, usage line) before concluding that a real flag was accepted. An acceptance that cannot fail proves nothing.
+
+## What the reviewer MUST verify
+
+- If a diff changes a script's exit codes, output schema, or flag surface, confirm a test binds the new behavior to the `SKILL.md` text — or that the `SKILL.md` stops making the claim.
+- If a diff adds a contract statement to a `SKILL.md` (an exit-code table, a documented field, a tier table mirrored from a protocol doc), confirm a test asserts it. An unbound contract is a comment.

--- a/.github/instructions/worktree-identity.instructions.md
+++ b/.github/instructions/worktree-identity.instructions.md
@@ -1,0 +1,40 @@
+---
+applyTo: '**'
+---
+
+# Worktree Identity Rule
+
+Before writing any file into a repository, confirm the directory you are writing to is the directory git is tracking. These are not the same thing, and when they diverge git reports success while your changes go nowhere.
+
+This rule exists because `~/repos/ai-agents/.git/config` carried `core.worktree` pointing at a Kanban workspace under `~/.hermes/kanban/boards/ai-agents/workspaces/<id>/work`. Files written into `~/repos/ai-agents` were real on disk, correct in content, and permanently invisible to git. `git status` reported a clean tree throughout, because it was faithfully reporting on the *other* directory. Two rule files and 22 generated outputs landed before the mismatch surfaced, and only then via an unrelated observation.
+
+## The check
+
+Run before the first write, from the directory you intend to edit:
+
+```bash
+[ "$(git rev-parse --show-toplevel)" = "$(pwd -P)" ] || echo "MISMATCH"
+git config --local core.worktree     # must be empty, or equal to pwd
+```
+
+A mismatch means every write from here is invisible to version control. `cd` to the reported toplevel and write there.
+
+## Why `git status` cannot be the confirmation
+
+A clean `git status` is consistent with two states: nothing changed, or git is not observing this directory at all. It cannot distinguish them, so it cannot serve as evidence that a write landed. When a write is expected to produce a diff and `git status` shows none, treat that as a failed probe and investigate the tree identity before re-writing or concluding the write succeeded.
+
+The positive control is a throwaway file:
+
+```bash
+: > .probe-$$ && git status --porcelain --untracked-files=all -- .probe-$$ ; rm -f .probe-$$
+```
+
+Empty output means git does not see writes in this directory.
+
+## Positive control on the target artifacts
+
+Confirm the files you intend to modify already exist in the tree before editing. A skill, rule, or script that is absent usually means a stale branch or the wrong worktree, not a greenfield. Creating it fresh in that state produces a duplicate that diverges from the real one on `main`.
+
+## Relationship to path resolution
+
+This is the same defect class as a script resolver probing a bare relative path such as `.claude/skills/...`: both assume the current working directory is the repository root, both silently operate on a different tree when that assumption breaks, and both fail open with no diagnostic. See `harness-path-resolution.md`. Anchor on `git rev-parse --show-toplevel` in both cases.

--- a/.serena/memories/analysis/analysis-pr-autofix-audit-findings.md
+++ b/.serena/memories/analysis/analysis-pr-autofix-audit-findings.md
@@ -1,0 +1,53 @@
+# pr-autofix Audit Findings (2026-07-26)
+
+Audited `src/copilot-cli/skills/pr-autofix/SKILL.md` (282 lines) at `origin/main` @ `17b89457`. Every claim below is execution-verified, not read-verified.
+
+## What is correct (do not re-file these)
+
+Verified by running the scripts, not by reading them:
+
+| Documented contract | Test | Result |
+|---|---|---|
+| live-state gate: exit 0 + `action=ACT` | open PR #3382 | exit 0, `ACT` |
+| live-state gate: exit 1 + `action=SKIP` | merged PR #3390 | exit 1, `SKIP`, "PR is already merged" |
+| `test_pr_merged.py` exits 0 always (#2308) | merged PR #3390 | exit 0 |
+| `--exit-100-on-merged` legacy sentinel | same | exit 100 |
+| `--exit-zero-on-merged` parsed no-op | same | exit 0 |
+| all 10 referenced pr scripts exist | both trees | 10/10 |
+| tier tables match `docs/autonomous-pr-monitor.md` | T1..T5 | identical |
+
+## Two false alarms that cost time
+
+1. **`--output-format` appeared absent.** `grep -c -- "--output-format"` returned 0 in `check_pr_live_state.py`. The flag is registered indirectly via an imported `add_output_format_arg(parser)` helper. Executing the script proved it fully supported. **Never conclude a flag is unsupported from a literal grep; invoke it or read `--help`.** Negative control: `--bogus-flag` yields exit 2 with a usage line, so argparse is genuinely strict.
+
+2. **`src/` vs `.claude/` duplication looked like drift.** `pr-autofix` lives in `src/copilot-cli/skills/` and as `.claude/commands/pr-autofix.md`. Bodies are byte-identical apart from one blank line, because `.claude/commands/` is **generated** by `build/scripts/generate_commands.py`. Not a finding. 14 skills follow this pattern (build, ship, spec, plan, test, pr-review, push-pr, ...).
+
+## Finding 1: resolver picks a stale copy from any subdirectory
+
+`resolve_pr_scripts_dir()` appears **5 times verbatim** in the file. Its ladder probes the bare relative string `".claude"` (lines 44, 135 at `17b89457`), which only resolves when cwd is the repo root.
+
+Executed from three directories:
+
+| cwd | resolves to |
+|---|---|
+| repo root | `.claude/skills/github/scripts/pr` (correct) |
+| `repo/src/` | `~/.copilot/installed-plugins/_direct/project-toolkit/...` (wrong) |
+| outside repo | same installed-plugin path |
+
+Consequence measured: that installed copy was dated 2026-06-26, one month stale. Its `check_pr_live_state.py` was **495 lines vs the repo's 560, 215 lines different**. That script is the blocking per-PR live-state gate (#2455) run before every tier action. From a subdirectory the skill enforces its primary safety gate using a month-old implementation, silently.
+
+Fix: anchor the repo-relative rung on `git rev-parse --show-toplevel`, order in-repo copies ahead of installed-plugin copies, and announce on stderr when a non-repo rung matches.
+
+Corroboration already in the file: line 93 (#2443) documents the same stale-helper hazard for `test_pr_merge_ready.py` and adds a `ScriptCommit` field to detect it. The resolver has no equivalent guard.
+
+## Finding 2: no test binds SKILL.md contracts to script behavior
+
+`grep -rln "pr-autofix/SKILL.md" tests/` returns nothing. `tests/test_pr_autofix_worktree_identity.py` and `tests/test_pr_autofix_lease.py` exercise scripts, never the documented contracts.
+
+Positive control proving this is a solved pattern in-repo: `tests/validation/test_check_skill_md_exec_portability.py` parses `SKILL.md` files as test input. Content-testing a SKILL.md is established here, not a new capability.
+
+The #2308 exit-code semantics already drifted once and were re-documented in prose. Prose does not go red on the next drift.
+
+## Rules written from this audit
+
+`.claude/rules/harness-path-resolution.md`, `.claude/rules/skill-contract-tests.md`, `.claude/rules/worktree-identity.md`. See memory `worktree-identity-before-writes`.

--- a/.serena/memories/analysis/analysis-worktree-identity-before-writes.md
+++ b/.serena/memories/analysis/analysis-worktree-identity-before-writes.md
@@ -1,0 +1,37 @@
+# Worktree Identity Verification Before Writes
+
+Verified 2026-07-26 against `origin/main` @ `17b89457`.
+
+## The failure
+
+`~/repos/ai-agents/.git/config` sets `core.worktree` to a Kanban workspace under `~/.hermes/kanban/boards/ai-agents/workspaces/<id>/work`. That `.git` directory therefore manages a *different* tree than the one you are standing in.
+
+Files written into `~/repos/ai-agents` were real on disk, correct in content, and permanently invisible to git. `git status` reported a clean tree the entire time, because it was faithfully reporting on the other directory. Two rule files plus 22 generated outputs landed before the mismatch surfaced, and only via an unrelated observation.
+
+`git rev-parse --show-toplevel` from `~/repos/ai-agents` returns the Kanban path, not `~/repos/ai-agents`.
+
+## The check (run before the first write)
+
+```bash
+[ "$(git rev-parse --show-toplevel)" = "$(pwd -P)" ] || echo MISMATCH
+git config --local core.worktree      # must be empty or equal to pwd
+```
+
+Full four-condition gate: `~/.hermes/skills/software-development/negative-probe-positive-control/scripts/preflight-worktree.sh`
+
+1. toplevel equals `pwd -P`
+2. the worktree's **own local** `core.worktree` does not redirect. Read `--local` only when `git rev-parse --git-dir` equals `--git-common-dir`; plain `git config` reports inherited values and false-positives on legitimate linked worktrees
+3. a throwaway probe file actually appears in `git status --untracked-files=all`
+4. every file you intend to edit already exists (absence means wrong branch, not greenfield)
+
+## Why `git status` is not the confirmation
+
+A clean status is equally consistent with "nothing changed" and "git is not observing this directory." It cannot distinguish them. When a write should have produced a diff and status shows none, treat it as a failed probe and check tree identity before rewriting or concluding success.
+
+## Same defect class as bare relative path resolution
+
+`src/copilot-cli/skills/pr-autofix/SKILL.md` `resolve_pr_scripts_dir()` probes the bare relative string `".claude"` (lines 44, 135 at `17b89457`). Both bugs assume cwd is the repo root, both silently operate on a different tree, both fail open with no diagnostic. Anchor on `git rev-parse --show-toplevel` in both cases. See `.claude/rules/worktree-identity.md` and `.claude/rules/harness-path-resolution.md`.
+
+## Generated-mirror note
+
+`.github/instructions/` and `src/copilot-cli/instructions/` are **generated** from `.claude/rules/` by `build/scripts/generate_rules.py` (35 rules to 70 outputs at `17b89457`). Author the `.claude/rules/` file only, then run the generator. Never hand-write the mirrors. Frontmatter uses `paths:`/`priority:` on the source; the generator rewrites to `applyTo:` and drops `priority:`.

--- a/.serena/memories/skills-analysis-index.md
+++ b/.serena/memories/skills-analysis-index.md
@@ -1,5 +1,7 @@
 | Keywords | File |
 |----------|------|
+| worktree identity core.worktree git status clean invisible writes before editing | [analysis/analysis-worktree-identity-before-writes](analysis/analysis-worktree-identity-before-writes.md) |
+| pr-autofix audit resolver stale plugin copy skill contract test exit codes | [analysis/analysis-pr-autofix-audit-findings](analysis/analysis-pr-autofix-audit-findings.md) |
 | gap analysis template severity root cause remediation affected | [analysis/analysis-001-capability-gap-template-88](analysis/analysis-001-capability-gap-template-88.md) |
 | outline recommendation specs analyst section structure template | [analysis/analysis-002-comprehensive-analysis-standard-95](analysis/analysis-002-comprehensive-analysis-standard-95.md) |
 | git blame author commit PR investigation history context annotate | [analysis/analysis-git-blame](analysis/analysis-git-blame.md) |

--- a/src/copilot-cli/instructions/harness-path-resolution.instructions.md
+++ b/src/copilot-cli/instructions/harness-path-resolution.instructions.md
@@ -1,0 +1,46 @@
+---
+applyTo: src/copilot-cli/skills/**
+---
+
+# Harness Path Resolution Rule
+
+A skill that shells out to a helper script must resolve that script's directory before invoking it. The resolver walks a candidate ladder: harness environment variables first, then a repo-relative path, then installed-plugin copies under `$HOME`. Every rung after the repo-relative one points at a *different copy of the code* — usually an older one.
+
+This rule exists because `src/copilot-cli/skills/pr-autofix/SKILL.md` contains a `resolve_pr_scripts_dir()` whose repo-relative rung is the bare string `.claude`. A bare relative path only resolves when the process cwd is the repository root. Executed from `repo/src/`, the `.claude` probe misses and the resolver silently returns `$HOME/.copilot/installed-plugins/_direct/project-toolkit/skills/github/scripts/pr`.
+
+The consequence measured on `9768d541`: that installed copy was dated one month earlier than the repo, and its `check_pr_live_state.py` was 495 lines against the repo's 560 — 215 lines different. `check_pr_live_state.py` is the blocking per-PR live-state gate (issue #2455) that `pr-autofix` runs before every tier action. From a subdirectory, the skill enforced its primary safety gate using a month-old implementation, with no warning and no version check. The resolver fails open and fails silent.
+
+## What a resolver MUST do
+
+1. **Anchor the repo-relative rung absolutely.** Derive the repository root rather than assuming cwd is it:
+
+   ```sh
+   repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+   ```
+
+   Probe `"$repo_root/.claude/skills/..."`, never bare `.claude/skills/...`. A resolver whose correctness depends on cwd is correct only by accident.
+
+2. **Order in-repo copies ahead of installed-plugin copies.** The working tree is the source of truth during development. An installed plugin is a snapshot of some earlier commit. Falling through from the former to the latter is a silent downgrade, not a fallback.
+
+3. **Not fail open on a set-but-wrong harness variable.** If `COPILOT_PLUGIN_ROOT` or `CLAUDE_PLUGIN_ROOT` is set and the path it names does not contain the expected script, that is a misconfiguration. Continuing down the ladder converts an explicit configuration error into a silent use of a different codebase.
+
+4. **Emit the resolved path when it is not the in-repo copy.** One line on stderr naming which rung matched. Silence is what turns a stale-copy execution into an undiagnosable behavioral difference.
+
+## What the reviewer MUST verify
+
+When a diff adds or edits a resolver function in a `SKILL.md`, a command file, or a helper script:
+
+- Extract the resolver and execute it from at least three working directories: the repo root, a subdirectory of the repo, and a path outside the repo. Reading the ladder is not sufficient — the bare-`.claude` defect is invisible on inspection and obvious on execution.
+- Confirm the repo-relative rung is anchored to `git rev-parse --show-toplevel` or an equivalent absolute derivation.
+- If an installed-plugin rung exists, confirm it is ordered last and that selecting it is announced.
+
+## Verifying a stale copy is in play
+
+When a skill behaves differently than its scripts read, compare the copies directly before theorizing:
+
+```sh
+diff <(wc -l < "$repo_root/.claude/skills/github/scripts/pr/check_pr_live_state.py") \
+     <(wc -l < "$HOME/.copilot/installed-plugins/_direct/project-toolkit/skills/github/scripts/pr/check_pr_live_state.py")
+```
+
+A line-count difference between the two copies means the resolver's choice is load-bearing and the ladder must be audited.

--- a/src/copilot-cli/instructions/skill-contract-tests.instructions.md
+++ b/src/copilot-cli/instructions/skill-contract-tests.instructions.md
@@ -1,0 +1,35 @@
+---
+applyTo: src/copilot-cli/skills/**
+---
+
+# Skill Contract Test Rule
+
+When a `SKILL.md` documents a script's exit codes, output fields, or flag semantics, that documentation is executable behavior written in prose. Nothing recompiles it when the script changes. The script's own unit tests assert the script against itself; they never open the `SKILL.md` and never notice when the two disagree.
+
+This rule exists because `pr-autofix` documents several load-bearing contracts that no test binds:
+
+- `check_pr_live_state.py` exits `0` with `action=ACT` for an actionable PR and exits `1` with `action=SKIP` for one already merged. The skill branches on both.
+- `test_pr_merged.py` exits `0` unconditionally (issue #2308), with `--exit-100-on-merged` restoring the legacy `100` sentinel and `--exit-zero-on-merged` retained as a parsed no-op.
+
+All of these were verified correct on `9768d541` by execution. None of them are covered by a test that reads the `SKILL.md`. `tests/test_pr_autofix_worktree_identity.py` and `tests/test_pr_autofix_lease.py` exercise scripts, not documented contracts. The exit-code semantics in #2308 already drifted once and were re-documented in prose; prose does not go red the next time.
+
+## What a skill that documents a contract MUST have
+
+A test that reads the `SKILL.md`, extracts the documented contract, and asserts the script actually honors it. The established in-repo pattern is `tests/validation/test_check_skill_md_exec_portability.py`, which parses `SKILL.md` files as test input — content-testing a `SKILL.md` is a solved problem here, not a new capability.
+
+The test asserts the pairing, not either side alone:
+
+- Exit codes: invoke the script against a fixture in each documented state and assert the exit code the `SKILL.md` names.
+- Output fields: assert the documented key exists in the emitted envelope with the documented value.
+- Flags: assert the flag parses. A flag registered indirectly through a shared helper such as `add_output_format_arg(parser)` will not appear in a literal grep of the script; verify with `--help` or an actual invocation, never with a string search.
+
+## Why grep is insufficient for these checks
+
+Auditing `pr-autofix` produced a false alarm: `grep -c -- "--output-format"` returned `0` in the script, suggesting the `SKILL.md` invoked an unsupported flag. Executing the script disproved it — the flag is registered by an imported helper and is fully supported. A contract test must invoke, not scan.
+
+The negative control matters equally: confirm `argparse` rejects a bogus flag (`--bogus-flag` → exit `2`, usage line) before concluding that a real flag was accepted. An acceptance that cannot fail proves nothing.
+
+## What the reviewer MUST verify
+
+- If a diff changes a script's exit codes, output schema, or flag surface, confirm a test binds the new behavior to the `SKILL.md` text — or that the `SKILL.md` stops making the claim.
+- If a diff adds a contract statement to a `SKILL.md` (an exit-code table, a documented field, a tier table mirrored from a protocol doc), confirm a test asserts it. An unbound contract is a comment.

--- a/src/copilot-cli/instructions/worktree-identity.instructions.md
+++ b/src/copilot-cli/instructions/worktree-identity.instructions.md
@@ -1,0 +1,40 @@
+---
+applyTo: '**'
+---
+
+# Worktree Identity Rule
+
+Before writing any file into a repository, confirm the directory you are writing to is the directory git is tracking. These are not the same thing, and when they diverge git reports success while your changes go nowhere.
+
+This rule exists because `~/repos/ai-agents/.git/config` carried `core.worktree` pointing at a Kanban workspace under `~/.hermes/kanban/boards/ai-agents/workspaces/<id>/work`. Files written into `~/repos/ai-agents` were real on disk, correct in content, and permanently invisible to git. `git status` reported a clean tree throughout, because it was faithfully reporting on the *other* directory. Two rule files and 22 generated outputs landed before the mismatch surfaced, and only then via an unrelated observation.
+
+## The check
+
+Run before the first write, from the directory you intend to edit:
+
+```bash
+[ "$(git rev-parse --show-toplevel)" = "$(pwd -P)" ] || echo "MISMATCH"
+git config --local core.worktree     # must be empty, or equal to pwd
+```
+
+A mismatch means every write from here is invisible to version control. `cd` to the reported toplevel and write there.
+
+## Why `git status` cannot be the confirmation
+
+A clean `git status` is consistent with two states: nothing changed, or git is not observing this directory at all. It cannot distinguish them, so it cannot serve as evidence that a write landed. When a write is expected to produce a diff and `git status` shows none, treat that as a failed probe and investigate the tree identity before re-writing or concluding the write succeeded.
+
+The positive control is a throwaway file:
+
+```bash
+: > .probe-$$ && git status --porcelain --untracked-files=all -- .probe-$$ ; rm -f .probe-$$
+```
+
+Empty output means git does not see writes in this directory.
+
+## Positive control on the target artifacts
+
+Confirm the files you intend to modify already exist in the tree before editing. A skill, rule, or script that is absent usually means a stale branch or the wrong worktree, not a greenfield. Creating it fresh in that state produces a duplicate that diverges from the real one on `main`.
+
+## Relationship to path resolution
+
+This is the same defect class as a script resolver probing a bare relative path such as `.claude/skills/...`: both assume the current working directory is the repository root, both silently operate on a different tree when that assumption breaks, and both fail open with no diagnostic. See `harness-path-resolution.md`. Anchor on `git rev-parse --show-toplevel` in both cases.


### PR DESCRIPTION
## Summary

- Add rules that verify worktree identity before writes.
- Require repository helpers to resolve from the active checkout.
- Require tests when skill prose defines executable contracts.
- Generate both Copilot instruction mirrors and record the audit evidence.

## Validation

- Rule mirrors regenerate without drift.
- Both project-toolkit manifests use the same version.
- Markdown and repository validation gates pass.

Fixes #3402
