### PR TITLE
test: reland two hardening changes orphaned by mid-push merges

### DIFF
--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-07-26T15:54:29.827462+00:00",
+  "updated": "2026-07-26T21:44:36.629341+00:00",
   "nodes": [
     {
       "id": "b1cc1534da48",
@@ -16634,6 +16634,42 @@
         "episode-2026-07-26-session-3388"
       ],
       "created": "2026-07-26T15:54:29.823811+00:00"
+    },
+    {
+      "id": "9cd858b422a8",
+      "type": "milestone",
+      "label": "milestone: Both improvements are on a branch off main rather than lost with their deleted source branches",
+      "episodes": [
+        "episode-2026-07-26-session-3400-orphaned-test-hardening"
+      ],
+      "created": "2026-07-26T21:44:36.625392+00:00"
+    },
+    {
+      "id": "9e2436c31114",
+      "type": "commit",
+      "label": "commit: Commit: af7c0a453b",
+      "episodes": [
+        "episode-2026-07-26-session-3400-orphaned-test-hardening"
+      ],
+      "created": "2026-07-26T21:44:36.625463+00:00"
+    },
+    {
+      "id": "850b77e74be4",
+      "type": "commit",
+      "label": "commit: Commit: 5b69d082cb",
+      "episodes": [
+        "episode-2026-07-26-session-3400-orphaned-test-hardening"
+      ],
+      "created": "2026-07-26T21:44:36.625524+00:00"
+    },
+    {
+      "id": "31da4797f42b",
+      "type": "outcome",
+      "label": "Outcome: success - Reland two test-hardening changes orphaned when PRs #3381 and #3398 merged mid-push",
+      "episodes": [
+        "episode-2026-07-26-session-3400-orphaned-test-hardening"
+      ],
+      "created": "2026-07-26T21:44:36.625585+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/episodes/episode-2026-07-26-session-3400-orphaned-test-hardening.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3400-orphaned-test-hardening.json
@@ -1,0 +1,51 @@
+{
+  "id": "episode-2026-07-26-session-3400-orphaned-test-hardening",
+  "session": "2026-07-26-session-3400-orphaned-test-hardening",
+  "timestamp": "2026-07-26T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Reland two test-hardening changes orphaned when PRs #3381 and #3398 merged mid-push",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Both improvements are on a branch off main rather than lost with their deleted source branches",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: af7c0a453b",
+      "caused_by": [],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 5b69d082cb",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e001"
+      ]
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 2,
+    "files_changed": 2
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-26-session-3400-orphaned-test-hardening.json
+++ b/.agents/sessions/2026-07-26-session-3400-orphaned-test-hardening.json
@@ -79,7 +79,7 @@
       "markdownLintRun": {
         "complete": true,
         "level": "MUST",
-        "evidence": "No markdown authored this session"
+        "evidence": "markdownlint-cli2 \".serena/memories/decision-session-protocol-workflow-stdlib-only.md\" \u2014 0 files linted (path excluded by .markdownlint-cli2.jsonc ignore glob .serena/**)"
       },
       "changesCommitted": {
         "complete": true,

--- a/.agents/sessions/2026-07-26-session-3400-orphaned-test-hardening.json
+++ b/.agents/sessions/2026-07-26-session-3400-orphaned-test-hardening.json
@@ -1,0 +1,123 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3400,
+    "date": "2026-07-26",
+    "branch": "test/3398-3381-orphaned-hardening",
+    "startingCommit": "71dade78e3",
+    "objective": "Reland two test-hardening changes orphaned when PRs #3381 and #3398 merged mid-push"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "branchVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "git branch --show-current returned test/3398-3381-orphaned-hardening before any edit"
+      },
+      "constraintsRead": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read this session; Python-first honored"
+      },
+      "gitStateVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Branched from origin/main at 71dade78e3 after git pull --ff-only"
+      },
+      "handoffRead": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": ".agents/HANDOFF.md read this session and left unmodified per ADR-014"
+      },
+      "notOnMain": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "git branch --show-current = test/3398-3381-orphaned-hardening"
+      },
+      "serenaActivated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "serena-read_memory returned usage-mandatory; serena-* tools are live in this session"
+      },
+      "serenaInstructions": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "serena-initial_instructions called and read this session"
+      },
+      "sessionLogCreated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Not needed; this session edited two test files"
+      },
+      "usageMandatoryRead": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Serena memory usage-mandatory read via serena-read_memory"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "This section"
+      },
+      "handoffPreserved": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": ".agents/HANDOFF.md untouched; not in git status"
+      },
+      "serenaMemoryUpdated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "serena-write_memory wrote decision-session-protocol-workflow-stdlib-only this session"
+      },
+      "markdownLintRun": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "No markdown authored this session"
+      },
+      "changesCommitted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Commits 5b69d082cb and af7c0a453b on test/3398-3381-orphaned-hardening"
+      },
+      "validationPassed": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "uv run pytest on both files: 139 passed. Negative control (drop --episode-path from the emitted repair command) turned exactly 1 test red"
+      },
+      "tasksUpdated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Both changes were review-thread responses on PRs that merged before the push landed; relanded here"
+      },
+      "retrospectiveInvoked": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Deferred to the objective-level retrospective"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "phase": "Reland",
+      "actions": [
+        "PR #3381 merged and deleted its branch while a push carrying the utf-8 encoding sweep was still running the pre-push suite",
+        "PR #3398 merged with the review bot's weaker single-flag assertion while a push carrying the stronger version was in flight",
+        "Recovered both from the orphaned local commits and rebased onto main at 71dade78e3",
+        "Re-ran the negative control against the merged baseline to confirm the strengthening still bites"
+      ],
+      "outcome": "Both improvements are on a branch off main rather than lost with their deleted source branches"
+    }
+  ],
+  "endingCommit": "af7c0a453b",
+  "nextSteps": [
+    "Resolve the two remaining threads on PR #3396 and the one on PR #3397",
+    "Report the open-issue count discrepancy: the objective assumed 31, the repository had 12"
+  ]
+}

--- a/.agents/sessions/2026-07-26-session-3400-orphaned-test-hardening.json
+++ b/.agents/sessions/2026-07-26-session-3400-orphaned-test-hardening.json
@@ -79,7 +79,7 @@
       "markdownLintRun": {
         "complete": true,
         "level": "MUST",
-        "evidence": "markdownlint-cli2 \".serena/memories/decision-session-protocol-workflow-stdlib-only.md\" \u2014 0 files linted (path excluded by .markdownlint-cli2.jsonc ignore glob .serena/**)"
+        "evidence": "markdownlint-cli2 \".serena/memories/decision-session-protocol-workflow-stdlib-only.md\" - 0 files linted (path excluded by .markdownlint-cli2.jsonc ignore glob .serena/**)"
       },
       "changesCommitted": {
         "complete": true,

--- a/.serena/memories/decision-session-protocol-workflow-stdlib-only.md
+++ b/.serena/memories/decision-session-protocol-workflow-stdlib-only.md
@@ -1,0 +1,43 @@
+# Decision: the `validate` job of ai-session-protocol.yml is stdlib-only
+
+## Question
+
+Can a validation script invoked by `.github/workflows/ai-session-protocol.yml`
+import a third-party package?
+
+## Conventional answer
+
+Everywhere else in this repo, Python scripts run under `uv run --frozen`, so
+the project venv resolves `yaml`, `jsonschema`, `packaging`, and the rest.
+The obvious move when adding a rule to the session-protocol workflow is to
+call an existing module such as `scripts/validation/git_hook_policy.py`.
+
+## First-principles position
+
+Read the job, do not assume it matches its siblings. The `validate` job's
+steps are: checkout, `git fetch origin main --unshallow || git fetch origin
+main`, a pwsh validate step, and upload-artifact. There is **no**
+`actions/setup-python`, **no** `astral-sh/setup-uv`, and **no** dependency
+install. It calls bare `python3` and inherits whatever the runner image
+carries.
+
+## Evidence
+
+- Live job log, run 30216991768 job 89832864004: bare
+  `python3 ./scripts/validate_session_json.py` returns verdict COMPLIANT with
+  exit 0, so `jsonschema` happens to be on `ubuntu-24.04-arm`.
+- `git_hook_policy.py` imports `yaml` at module level. Nothing guarantees
+  `yaml` on that image, and the failure mode is a traceback in a job whose
+  whole purpose is a clean verdict.
+
+## Decision
+
+Issue #3385's rule lives in `scripts/validation/session_scope.py`, which
+imports only `subprocess`, `collections.abc.Iterable`, and `pathlib.Path`.
+`tests/test_validate_session_json.py::test_the_shared_module_imports_no_third_party_package`
+pins that import list literally, so the constraint fails loudly rather than at
+the next CI run.
+
+**Rule for the next editor:** anything the `validate` job invokes must be
+standard library only, or the job needs a Python setup step first. Do not
+reason from what other jobs in the same file do.

--- a/tests/hooks/test_hook_contracts.py
+++ b/tests/hooks/test_hook_contracts.py
@@ -72,7 +72,7 @@ class TestParseSettings:
             }
         }
         settings_path = tmp_path / "settings.json"
-        settings_path.write_text(json.dumps(settings))
+        settings_path.write_text(json.dumps(settings), encoding="utf-8")
 
         _, entries, _ = hook_contracts.parse_settings(settings_path)
 
@@ -99,7 +99,7 @@ class TestParseSettings:
             }
         }
         settings_path = tmp_path / "settings.json"
-        settings_path.write_text(json.dumps(settings))
+        settings_path.write_text(json.dumps(settings), encoding="utf-8")
 
         _, entries, _ = hook_contracts.parse_settings(settings_path)
         assert len(entries) == 0
@@ -130,14 +130,14 @@ class TestParseSettings:
             }
         }
         settings_path = tmp_path / "settings.json"
-        settings_path.write_text(json.dumps(settings))
+        settings_path.write_text(json.dumps(settings), encoding="utf-8")
 
         _, entries, _ = hook_contracts.parse_settings(settings_path)
         assert len(entries) == 2
 
     def test_no_hooks_section(self, tmp_path):
         settings_path = tmp_path / "settings.json"
-        settings_path.write_text(json.dumps({"other": "config"}))
+        settings_path.write_text(json.dumps({"other": "config"}), encoding="utf-8")
 
         _, entries, _ = hook_contracts.parse_settings(settings_path)
         assert len(entries) == 0
@@ -158,7 +158,7 @@ class TestParseSettings:
             }
         }
         settings_path = tmp_path / "settings.json"
-        settings_path.write_text(json.dumps(settings))
+        settings_path.write_text(json.dumps(settings), encoding="utf-8")
 
         _, entries, _ = hook_contracts.parse_settings(settings_path)
         assert len(entries) == 1
@@ -180,7 +180,7 @@ class TestParseSettings:
             }
         }
         settings_path = tmp_path / "settings.json"
-        settings_path.write_text(json.dumps(settings))
+        settings_path.write_text(json.dumps(settings), encoding="utf-8")
 
         _, entries, violations = hook_contracts.parse_settings(settings_path)
         assert len(entries) == 0
@@ -190,7 +190,7 @@ class TestParseSettings:
     def test_malformed_group_skipped(self, tmp_path):
         settings = {"hooks": {"PreToolUse": [None]}}
         settings_path = tmp_path / "settings.json"
-        settings_path.write_text(json.dumps(settings))
+        settings_path.write_text(json.dumps(settings), encoding="utf-8")
 
         _, entries, _ = hook_contracts.parse_settings(settings_path)
         assert len(entries) == 0
@@ -198,7 +198,7 @@ class TestParseSettings:
     def test_malformed_hook_skipped(self, tmp_path):
         settings = {"hooks": {"PreToolUse": [{"hooks": [None]}]}}
         settings_path = tmp_path / "settings.json"
-        settings_path.write_text(json.dumps(settings))
+        settings_path.write_text(json.dumps(settings), encoding="utf-8")
 
         _, entries, _ = hook_contracts.parse_settings(settings_path)
         assert len(entries) == 0
@@ -213,7 +213,7 @@ class TestValidateScriptExists:
     def test_existing_script(self, tmp_path):
         script = tmp_path / ".claude" / "hooks" / "guard.py"
         script.parent.mkdir(parents=True)
-        script.write_text("# hook")
+        script.write_text("# hook", encoding="utf-8")
 
         entry = hook_contracts.HookEntry(
             hook_type="PreToolUse",
@@ -378,7 +378,8 @@ class TestValidateExitCodeDocs:
                 0 = Allow
                 2 = Block
             """
-        ''')
+        '''),
+            encoding="utf-8",
         )
         entry = hook_contracts.HookEntry(
             hook_type="PreToolUse",
@@ -393,7 +394,8 @@ class TestValidateExitCodeDocs:
             textwrap.dedent('''\
             """Simple guard hook."""
             import sys
-        ''')
+        '''),
+            encoding="utf-8",
         )
         entry = hook_contracts.HookEntry(
             hook_type="PreToolUse",
@@ -406,7 +408,7 @@ class TestValidateExitCodeDocs:
 
     def test_non_blocking_hook_skips_check(self, tmp_path):
         script = tmp_path / "hook.py"
-        script.write_text('"""No exit docs."""\n')
+        script.write_text('"""No exit docs."""\n', encoding="utf-8")
         entry = hook_contracts.HookEntry(
             hook_type="PostToolUse",
             script_path="hook.py",
@@ -448,7 +450,8 @@ class TestValidateExitCodeDocs:
             textwrap.dedent('''\
             """Hook that can block operations."""
             import sys
-        ''')
+        '''),
+            encoding="utf-8",
         )
         entry = hook_contracts.HookEntry(
             hook_type="PreToolUse",
@@ -462,7 +465,7 @@ class TestValidateExitCodeDocs:
         # None here would treat it as "docs present"; instead it must flag an
         # unreadable_script violation (issue #2809).
         script = tmp_path / "hook.py"
-        script.write_text('"""Guard hook."""\n')
+        script.write_text('"""Guard hook."""\n', encoding="utf-8")
 
         def _raise(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
             raise PermissionError("permission denied")
@@ -550,7 +553,7 @@ class TestValidateAll:
     def _create_settings(self, tmp_path, hooks_config):
         settings_path = tmp_path / ".claude" / "settings.json"
         settings_path.parent.mkdir(parents=True, exist_ok=True)
-        settings_path.write_text(json.dumps({"hooks": hooks_config}))
+        settings_path.write_text(json.dumps({"hooks": hooks_config}), encoding="utf-8")
         return settings_path
 
     def _create_script(self, tmp_path, script_path, content=""):
@@ -565,7 +568,8 @@ class TestValidateAll:
                 0 = Allow
                 2 = Block
             """
-        ''')
+        '''),
+            encoding="utf-8",
         )
         return full
 
@@ -723,14 +727,14 @@ class TestMain:
     def test_invalid_json(self, tmp_path):
         settings_dir = tmp_path / ".claude"
         settings_dir.mkdir()
-        (settings_dir / "settings.json").write_text("{invalid json}")
+        (settings_dir / "settings.json").write_text("{invalid json}", encoding="utf-8")
         exit_code = hook_contracts.main(["--path", str(tmp_path)])
         assert exit_code == 2
 
     def test_valid_settings_returns_zero(self, tmp_path):
         settings_dir = tmp_path / ".claude"
         settings_dir.mkdir()
-        (settings_dir / "settings.json").write_text(json.dumps({"hooks": {}}))
+        (settings_dir / "settings.json").write_text(json.dumps({"hooks": {}}), encoding="utf-8")
         exit_code = hook_contracts.main(["--path", str(tmp_path)])
         assert exit_code == 0
 
@@ -751,7 +755,7 @@ class TestMain:
                 ],
             }
         }
-        (settings_dir / "settings.json").write_text(json.dumps(settings))
+        (settings_dir / "settings.json").write_text(json.dumps(settings), encoding="utf-8")
         exit_code = hook_contracts.main(
             [
                 "--path",
@@ -779,14 +783,14 @@ class TestMain:
                 ],
             }
         }
-        (settings_dir / "settings.json").write_text(json.dumps(settings))
+        (settings_dir / "settings.json").write_text(json.dumps(settings), encoding="utf-8")
         exit_code = hook_contracts.main(["--path", str(tmp_path)])
         assert exit_code == 0
 
     def test_json_output_format(self, tmp_path, capsys):
         settings_dir = tmp_path / ".claude"
         settings_dir.mkdir()
-        (settings_dir / "settings.json").write_text(json.dumps({"hooks": {}}))
+        (settings_dir / "settings.json").write_text(json.dumps({"hooks": {}}), encoding="utf-8")
         hook_contracts.main(
             [
                 "--path",
@@ -801,7 +805,7 @@ class TestMain:
 
     def test_custom_settings_path(self, tmp_path):
         custom = tmp_path / "custom.json"
-        custom.write_text(json.dumps({"hooks": {}}))
+        custom.write_text(json.dumps({"hooks": {}}), encoding="utf-8")
         exit_code = hook_contracts.main(
             [
                 "--path",
@@ -1164,7 +1168,9 @@ class TestDispatcherExpansion:
 
     def test_a_malformed_dispatch_groups_file_is_reported(self, tmp_path):
         _tree(tmp_path, settings=_dispatch("g1"))
-        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text("{ not json")
+        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text(
+            "{ not json", encoding="utf-8"
+        )
         report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
 
@@ -1178,7 +1184,7 @@ class TestDispatcherExpansion:
     def test_dispatch_groups_with_non_object_root_is_reported(self, tmp_path):
         """A JSON array or primitive root must be reported, not raise AttributeError."""
         _tree(tmp_path, settings=_dispatch("g1"))
-        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text("[]")
+        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text("[]", encoding="utf-8")
         report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
         assert any("must be a JSON object" in v.message for v in report.violations)
@@ -1201,7 +1207,9 @@ class TestDispatcherExpansion:
             },
             shims=["A/a.py"],
         )
-        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text('{"groups": null}')
+        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text(
+            '{"groups": null}', encoding="utf-8"
+        )
         report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
         assert any("'groups' property must be an object" in v.message for v in report.violations)
@@ -1224,7 +1232,9 @@ class TestDispatcherExpansion:
             },
             shims=["A/a.py"],
         )
-        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text('{"version": 1}')
+        (tmp_path / ".claude" / "hooks" / "dispatch_groups.json").write_text(
+            '{"version": 1}', encoding="utf-8"
+        )
         report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "invalid_dispatch_groups" for v in report.violations)
         assert any("missing" in v.message for v in report.violations)
@@ -1302,7 +1312,7 @@ class TestPluginSurfaceIsCovered:
     def test_a_malformed_plugin_hooks_file_is_reported(self, tmp_path):
         """Invalid JSON in hooks.json must be caught and reported as a violation."""
         _tree(tmp_path, settings={"hooks": {}}, groups={"groups": {}})
-        (tmp_path / ".claude" / "hooks" / "hooks.json").write_text("{ not json")
+        (tmp_path / ".claude" / "hooks" / "hooks.json").write_text("{ not json", encoding="utf-8")
         report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert any(v.category == "invalid_plugin_hooks" for v in report.violations)
 
@@ -1515,20 +1525,20 @@ class TestMalformedPluginHooksAreAttributed:
 
     def test_malformed_plugin_json_is_its_own_category(self, tmp_path):
         _tree(tmp_path, settings=_dispatch("g1"), groups={"groups": {}})
-        (tmp_path / ".claude" / "hooks" / "hooks.json").write_text("{not json")
+        (tmp_path / ".claude" / "hooks" / "hooks.json").write_text("{not json", encoding="utf-8")
         report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert "invalid_plugin_hooks" in {v.category for v in report.violations}
 
     def test_the_message_names_the_plugin_file(self, tmp_path):
         _tree(tmp_path, settings=_dispatch("g1"), groups={"groups": {}})
-        (tmp_path / ".claude" / "hooks" / "hooks.json").write_text("{not json")
+        (tmp_path / ".claude" / "hooks" / "hooks.json").write_text("{not json", encoding="utf-8")
         report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         messages = [v.message for v in report.violations if v.category == "invalid_plugin_hooks"]
         assert messages and "cannot be read" in messages[0]
 
     def test_a_non_object_plugin_file_is_attributed(self, tmp_path):
         _tree(tmp_path, settings=_dispatch("g1"), groups={"groups": {}})
-        (tmp_path / ".claude" / "hooks" / "hooks.json").write_text("[1, 2, 3]")
+        (tmp_path / ".claude" / "hooks" / "hooks.json").write_text("[1, 2, 3]", encoding="utf-8")
         report = hook_contracts.validate_all(tmp_path / ".claude" / "settings.json", tmp_path)
         assert "invalid_plugin_hooks" in {v.category for v in report.violations}
 

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -98,9 +98,16 @@ class TestARestoreFailureBlocks:
             Path, "write_bytes", lambda self, data: (_ for _ in ()).throw(OSError("nope"))
         )
         policy.update_causal_graph(repo)
-        err = capsys.readouterr().err
-        assert _GRAPH in err.replace("\\", "/")
-        assert "--reset-graph" in err
+        err = capsys.readouterr().err.replace("\\", "/")
+        assert _GRAPH in err
+        # The word "rebuild" is not the repair. An operator staring at a blocked
+        # commit needs the command, and a command missing any of these flags
+        # rebuilds the wrong file or from the wrong source (issue #3370).
+        assert "python3" in err, f"no runnable command in stderr: {err!r}"
+        repair = err[err.index("python3") :]
+        for flag in ("--reset-graph", "--episode-path", "--graph-path"):
+            assert flag in repair, f"repair command omits {flag}: {repair!r}"
+        assert _GRAPH in repair, f"repair command does not name the graph: {repair!r}"
 
     def test_it_does_not_raise(self, repo, monkeypatch):
         """The point of the change: an exit code, not a traceback."""


### PR DESCRIPTION
## Summary

### What

Relands two test-hardening changes that were written as review responses on
PRs #3381 and #3398. Both PRs merged while the pushes carrying these commits
were still running the pre-push suite, so the improvements went to the floor
with the deleted source branches.

### Why

Neither change is cosmetic.

**Encoding.** `Path.write_text` and `Path.read_text` fall back to
`locale.getpreferredencoding()` when no encoding is given. That resolves to
cp1252 on a default Windows runner and utf-8 on Linux. This suite runs on both.
A fixture carrying a non-ASCII byte therefore passes on Linux and raises
`UnicodeEncodeError` only in the Windows job, which is the worst shape of
flake: green locally, red in CI, and the traceback points at the fixture rather
than at the encoding. Thirty calls in the file now name utf-8.

Ten of those thirty arrived with #3381 and twenty predate it, all carrying the
same latent split. Fixing only the new ones would leave the file inconsistent
and the next reader guessing which convention is intended.

**Assertion strength.** The assertion that shipped with #3398 checks that
`--reset-graph` appears somewhere in stderr. The repair command carries three
flags, and the two it does not check decide *which* file gets rebuilt and *from
what*. The updater's defaults derive from its own file location, which differs
between the canonical tree and the Copilot CLI mirror, so a command missing
`--graph-path` rebuilds a different file than the one the hook just failed to
restore. That is the failure the operator is trying to escape.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Refs #3360 | Wire hook contracts (the encoding sweep's origin) |
| **Issue** | Refs #3389 | Causal graph restore fails closed |
| **Issue** | Refs #3370 | Name the repair when the graph is corrupt |

## Evidence

Both suites green: 139 passed.

Negative control on the assertion change: dropping `--episode-path` from the
emitted repair command turns exactly one test red and leaves the other ten
green. Under the single-flag assertion that same regression passed, which is
the whole point of the change.

## Notes for Reviewers

The encoding sweep was produced by walking the module's AST for `write_text`
and `read_text` calls without an `encoding` keyword and inserting one before
the closing paren, so it cannot have missed a multi-line call or touched an
unrelated one. A follow-up AST walk confirms zero remaining.
