### PR TITLE
feat(validation): enforce resolver anchoring and skill contract binding in code

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.122",
+  "version": "0.6.123",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/commands/pr-autofix.md
+++ b/.claude/commands/pr-autofix.md
@@ -36,10 +36,11 @@ Walk the queue. For each PR, apply the tier's action set. T1 first (land-ready),
 # One outer fetch covers all per-PR calls; --skip-fetch keeps the loop cheap.
 git fetch --quiet origin "+refs/heads/main:refs/remotes/origin/main"
 resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do
@@ -127,10 +128,11 @@ Quote every variable expansion. The shell does not treat `:` specially in a refs
 
 ```bash
 resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do
@@ -193,10 +195,11 @@ When invoking from autofix code:
 ```bash
 PR_NUMBER="123"
 resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do
@@ -217,10 +220,11 @@ encoded "100 = merged"):
 ```bash
 PR_NUMBER="123"
 resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do
@@ -244,10 +248,11 @@ Run after all threads resolved and CI passes:
 
 ```bash
 resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -83,10 +83,11 @@ The completion gate is dispatchable: each criterion in `completion_criteria` run
 
 ```bash
 resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do
@@ -99,10 +100,11 @@ resolve_pr_scripts_dir() {
   printf '%s\n' ".claude/skills/github/scripts/pr"
 }
 resolve_pr_review_config() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -81,10 +81,11 @@ Task(subagent_type="devops"): You are a release engineer. Run all 4 pre-flight c
          REVIEW_MARKER_SCRIPT="$CLAUDE_SKILL_DIR/../review/scripts/validate_review_marker.py"
        else
          resolve_review_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
            for root in \
              "${COPILOT_PLUGIN_ROOT:-}" \
              "${CLAUDE_PLUGIN_ROOT:-}" \
-             ".claude" \
+             "$repo_root/.claude" \
              "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
              "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
              "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do

--- a/.github/workflows/validate-vendor-portability.yml
+++ b/.github/workflows/validate-vendor-portability.yml
@@ -59,6 +59,10 @@ jobs:
               - 'scripts/validation/portability_common.py'
               - 'scripts/validation/check_skill_md_exec_portability.py'
               - 'scripts/validation/skill_md_exec_portability_baseline.json'
+              - 'scripts/validation/check_skill_resolver_anchoring.py'
+              - 'scripts/validation/check_skill_contract_tests.py'
+              - 'scripts/validation/skill_contract_test_baseline.txt'
+              - 'tests/validation/test_skill_resolver_and_contract_guards.py'
               - '.github/workflows/validate-vendor-portability.yml'
 
   validate-portability:
@@ -82,6 +86,12 @@ jobs:
 
       - name: Check for new bare-exec skill-path offenders (issue #2838)
         run: python3 scripts/validation/check_skill_md_exec_portability.py
+
+      - name: Check skill resolver anchoring
+        run: python3 scripts/validation/check_skill_resolver_anchoring.py
+
+      - name: Check skill contract test binding
+        run: python3 scripts/validation/check_skill_contract_tests.py
 
       - name: Show remediation on failure
         if: failure()

--- a/scripts/validation/check_skill_contract_tests.py
+++ b/scripts/validation/check_skill_contract_tests.py
@@ -64,7 +64,8 @@ def documented_contracts(path: Path) -> list[str]:
     try:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:  # pragma: no cover - surfaced to caller
-        raise SystemExit(f"error: cannot read {path}: {exc}") from exc
+        print(f"error: cannot read {path}: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
 
     if not SCRIPT_CALL.search(text):
         return []
@@ -142,7 +143,7 @@ def main(argv: list[str] | None = None) -> int:
         skill_name = skill_file.parent.name
         if skill_name in baseline:
             continue
-        if re.search(r"\b" + re.escape(skill_name) + r"\b", corpus):
+        if re.search(r"(?<![a-zA-Z0-9_-])" + re.escape(skill_name) + r"(?![a-zA-Z0-9_-])", corpus):
             continue
         unbound.append(Unbound(skill=skill_name, path=skill_file, exit_codes=codes))
 

--- a/scripts/validation/check_skill_contract_tests.py
+++ b/scripts/validation/check_skill_contract_tests.py
@@ -143,7 +143,13 @@ def main(argv: list[str] | None = None) -> int:
         skill_name = skill_file.parent.name
         if skill_name in baseline:
             continue
-        if re.search(r"(?<![a-zA-Z0-9_-])" + re.escape(skill_name) + r"(?![a-zA-Z0-9_-])", corpus):
+        # Match skill name as a whole token: not preceded or followed by
+        # characters that form part of a skill identifier (alnum, hyphen, underscore).
+        bound = re.search(
+            r"(?<![a-zA-Z0-9_-])" + re.escape(skill_name) + r"(?![a-zA-Z0-9_-])",
+            corpus,
+        )
+        if bound:
             continue
         unbound.append(Unbound(skill=skill_name, path=skill_file, exit_codes=codes))
 

--- a/scripts/validation/check_skill_contract_tests.py
+++ b/scripts/validation/check_skill_contract_tests.py
@@ -142,7 +142,7 @@ def main(argv: list[str] | None = None) -> int:
         skill_name = skill_file.parent.name
         if skill_name in baseline:
             continue
-        if skill_name in corpus:
+        if re.search(r"\b" + re.escape(skill_name) + r"\b", corpus):
             continue
         unbound.append(Unbound(skill=skill_name, path=skill_file, exit_codes=codes))
 

--- a/scripts/validation/check_skill_contract_tests.py
+++ b/scripts/validation/check_skill_contract_tests.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Fail when a skill documents executable contracts that no test binds.
+
+A SKILL.md that names a script, an exit code, and a meaning is writing a
+specification. When nothing reads that specification back, the script is free
+to drift away from it and every gate stays green: prose does not go red.
+
+This has already happened in this repository. Exit-code semantics for
+pr-autofix drifted, were corrected under #2308, and were then re-documented in
+prose with nothing recompiling the claim. The next drift is silent for the
+same reason the last one was.
+
+A skill is in scope when its SKILL.md documents at least one exit code
+alongside a script invocation. Such a skill must be named by at least one file
+under tests/ so that a test opens it and asserts against its contents.
+
+The precedent for content-testing markdown is already established here:
+tests/validation/test_check_skill_md_exec_portability.py parses SKILL.md files
+as test input.
+
+Exit codes:
+    0 - every in-scope skill is bound by a test
+    1 - at least one unbound skill
+    2 - usage or I/O error
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SCAN_ROOTS = ("src/copilot-cli/skills", ".claude/skills")
+TEST_ROOT = "tests"
+
+# Documented exit-code semantics: "exit 0", "exit code 2", "EXIT=100".
+EXIT_CODE = re.compile(r"\bexit(?:\s+code)?[\s=]+(\d{1,3})\b", re.IGNORECASE)
+
+# A script invocation the skill tells the agent to run.
+SCRIPT_CALL = re.compile(r"\b(?:python3?|bash|sh|pwsh)\s+\S+\.(?:py|sh|ps1)\b")
+
+
+@dataclass(frozen=True)
+class Unbound:
+    skill: str
+    path: Path
+    exit_codes: list[str]
+
+    def render(self) -> str:
+        codes = ", ".join(sorted(set(self.exit_codes), key=int))
+        return (
+            f"{self.path}\n"
+            f"    skill '{self.skill}' documents exit codes ({codes}) and script\n"
+            f"    invocations, but no file under {TEST_ROOT}/ references it.\n"
+            f"    Add a test that reads this SKILL.md and asserts the documented\n"
+            f"    contract, so drift fails CI instead of failing silently."
+        )
+
+
+def documented_contracts(path: Path) -> list[str]:
+    """Return documented exit codes when the file also invokes a script."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - surfaced to caller
+        raise SystemExit(f"error: cannot read {path}: {exc}") from exc
+
+    if not SCRIPT_CALL.search(text):
+        return []
+    return EXIT_CODE.findall(text)
+
+
+def test_corpus(repo_root: Path) -> str:
+    """Concatenate every test source so skill references can be searched."""
+    base = repo_root / TEST_ROOT
+    if not base.is_dir():
+        return ""
+    chunks: list[str] = []
+    for suffix in ("*.py", "*.ps1", "*.sh"):
+        for test_file in base.rglob(suffix):
+            try:
+                chunks.append(test_file.read_text(encoding="utf-8", errors="replace"))
+            except OSError:
+                continue
+    return "\n".join(chunks)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="repository root")
+    parser.add_argument(
+        "--baseline",
+        default="scripts/validation/skill_contract_test_baseline.txt",
+        help="newline-delimited skill names exempted while the debt is burned down",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+
+    skill_files: list[Path] = []
+    for scan_root in SCAN_ROOTS:
+        base = repo_root / scan_root
+        if base.is_dir():
+            skill_files.extend(sorted(base.rglob("SKILL.md")))
+
+    if not skill_files:
+        # Refuse to pass on a scan that opened nothing.
+        print(
+            "error: no SKILL.md files found; refusing to report success on an "
+            f"empty scan (repo root: {repo_root})",
+            file=sys.stderr,
+        )
+        return 2
+
+    corpus = test_corpus(repo_root)
+    if not corpus:
+        print(
+            f"error: no test sources found under {repo_root / TEST_ROOT}; "
+            "refusing to report success",
+            file=sys.stderr,
+        )
+        return 2
+
+    baseline_path = repo_root / args.baseline
+    baseline: set[str] = set()
+    if baseline_path.is_file():
+        baseline = {
+            line.strip()
+            for line in baseline_path.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.startswith("#")
+        }
+
+    unbound: list[Unbound] = []
+    in_scope = 0
+
+    for skill_file in skill_files:
+        codes = documented_contracts(skill_file)
+        if not codes:
+            continue
+        in_scope += 1
+        skill_name = skill_file.parent.name
+        if skill_name in baseline:
+            continue
+        if skill_name in corpus:
+            continue
+        unbound.append(Unbound(skill=skill_name, path=skill_file, exit_codes=codes))
+
+    if unbound:
+        print("Skills documenting executable contracts with no binding test:\n")
+        for item in unbound:
+            print(item.render())
+            print()
+        print(
+            f"{len(unbound)} unbound of {in_scope} in-scope skill(s); "
+            f"{len(baseline)} grandfathered."
+        )
+        return 1
+
+    print(
+        f"Skill contract binding OK. {in_scope} in-scope skill(s), "
+        f"{len(baseline)} grandfathered."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validation/check_skill_resolver_anchoring.py
+++ b/scripts/validation/check_skill_resolver_anchoring.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Fail when a SKILL.md script-path resolver can select a stale out-of-repo copy.
+
+Skills that shell out to helper scripts embed a resolver that walks candidate
+roots until one contains the scripts directory. Two properties make such a
+resolver unsafe, and both are mechanically checkable:
+
+1. A repo-relative candidate root (a bare ``.claude``) only resolves when the
+   process cwd happens to be the repository root. Invoked from any
+   subdirectory the probe misses, the loop falls through, and a copy under
+   ``~/.copilot/installed-plugins`` or ``~/.claude/plugins/cache`` wins
+   instead. That copy can be arbitrarily old. When the resolved script is a
+   safety gate, the gate silently runs a stale implementation.
+
+   The fix is to anchor the repo-relative rung on ``git rev-parse
+   --show-toplevel`` so it resolves from anywhere inside the worktree.
+
+2. An out-of-repo candidate root that is ordered ahead of the in-repo rung
+   wins even when the repository copy is present and current.
+
+This guard exists because the failure is invisible at runtime: the resolver
+fails open, prints nothing, and returns a path that looks plausible. Nothing
+downstream can tell a current copy from a month-old one.
+
+Companion to check_skill_md_exec_portability.py, which verifies that skills do
+not hard-code ``.claude/skills`` exec paths. This one verifies that the
+resolver replacing those hard-coded paths is itself correctly anchored.
+
+Exit codes:
+    0 - no unanchored resolvers
+    1 - at least one violation
+    2 - usage or I/O error
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SCAN_ROOTS = ("src/copilot-cli/skills", ".claude/skills")
+
+# A resolver is a shell function whose body walks candidate roots. Match any
+# shell function header and decide by body content rather than by name: an
+# earlier version keyed on names ending in "dir" and silently missed
+# resolve_pr_review_config(), which carries the identical defect.
+RESOLVER_HEADER = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(\)\s*\{")
+
+# A repo-relative candidate root: a bare quoted ".claude" or "./.claude" that
+# is not preceded by a variable expansion or an absolute anchor.
+BARE_RELATIVE_ROOT = re.compile(r"""^\s*["']\.{1,2}/?\.?claude["']?\s*\\?\s*$""")
+BARE_RELATIVE_INLINE = re.compile(r"""(?<![\w/$}])["']\.claude["']""")
+
+# An in-repo candidate root already anchored on the worktree root.
+IN_REPO_ROOT = re.compile(r"\$\{?(?:repo_root|REPO_ROOT|toplevel)\}?/\.claude")
+
+# Anchoring that makes a repo-relative rung safe from any cwd.
+ANCHORED = re.compile(r"git\s+rev-parse\s+--show-toplevel")
+
+# Candidate roots that live outside the repository.
+OUT_OF_REPO = re.compile(r"\$\{?HOME\b|~/\.(?:copilot|claude)\b")
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: Path
+    line: int
+    function: str
+    kind: str
+    detail: str
+
+    def render(self) -> str:
+        return (
+            f"{self.path}:{self.line}: {self.function}(): {self.kind}\n"
+            f"    {self.detail}"
+        )
+
+
+def _function_blocks(lines: list[str]) -> list[tuple[str, int, int]]:
+    """Return (name, start_index, end_index) for each shell function body.
+
+    Brace depth is tracked so a nested block does not truncate the body early.
+    An unterminated function runs to end of file rather than being dropped,
+    because silently skipping input is the failure mode this guard exists to
+    prevent.
+    """
+    blocks: list[tuple[str, int, int]] = []
+    index = 0
+    total = len(lines)
+    while index < total:
+        match = RESOLVER_HEADER.match(lines[index])
+        if not match:
+            index += 1
+            continue
+        name = match.group(1)
+        depth = lines[index].count("{") - lines[index].count("}")
+        cursor = index + 1
+        while cursor < total and depth > 0:
+            depth += lines[cursor].count("{") - lines[cursor].count("}")
+            cursor += 1
+        blocks.append((name, index, min(cursor, total)))
+        index = cursor
+    return blocks
+
+
+def check_file(path: Path) -> list[Violation]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:  # pragma: no cover - surfaced to caller
+        raise SystemExit(f"error: cannot read {path}: {exc}") from exc
+
+    violations: list[Violation] = []
+
+    for name, start, end in _function_blocks(lines):
+        body = lines[start:end]
+        anchored = any(ANCHORED.search(line) for line in body)
+
+        first_out_of_repo: int | None = None
+        for offset, line in enumerate(body):
+            if OUT_OF_REPO.search(line):
+                first_out_of_repo = offset
+                break
+
+        # Locate the in-repo rung in either form: a bare relative ".claude" or
+        # an anchored "$repo_root/.claude". Ordering is a property of the
+        # resolver regardless of which form the in-repo rung takes, so it must
+        # be evaluated even when anchoring is already correct.
+        first_in_repo: int | None = None
+        for offset, line in enumerate(body):
+            if BARE_RELATIVE_ROOT.match(line.strip()) or IN_REPO_ROOT.search(line):
+                first_in_repo = offset
+                break
+
+        if (
+            first_out_of_repo is not None
+            and first_in_repo is not None
+            and first_out_of_repo < first_in_repo
+        ):
+            violations.append(
+                Violation(
+                    path=path,
+                    line=start + first_in_repo + 1,
+                    function=name,
+                    kind="out-of-repo candidate ordered before in-repo copy",
+                    detail=(
+                        f"an out-of-repo root at body line "
+                        f"{start + first_out_of_repo + 1} is probed first, so an "
+                        "installed copy wins even when the repository copy is "
+                        "present and current."
+                    ),
+                )
+            )
+
+        for offset, line in enumerate(body):
+            stripped = line.strip()
+            is_bare = bool(
+                BARE_RELATIVE_ROOT.match(stripped) or BARE_RELATIVE_INLINE.search(line)
+            )
+            if not is_bare:
+                continue
+
+            if not anchored:
+                violations.append(
+                    Violation(
+                        path=path,
+                        line=start + offset + 1,
+                        function=name,
+                        kind="unanchored repo-relative candidate root",
+                        detail=(
+                            'bare ".claude" resolves only when cwd is the repo '
+                            "root; from a subdirectory this rung is skipped and "
+                            "a stale out-of-repo copy wins. Anchor it on "
+                            '"$(git rev-parse --show-toplevel)/.claude".'
+                        ),
+                    )
+                )
+
+    return violations
+
+
+def iter_skill_files(repo_root: Path) -> list[Path]:
+    found: list[Path] = []
+    for scan_root in SCAN_ROOTS:
+        base = repo_root / scan_root
+        if not base.is_dir():
+            continue
+        found.extend(sorted(base.rglob("SKILL.md")))
+    return found
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="repository root")
+    parser.add_argument("paths", nargs="*", help="explicit SKILL.md paths")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+
+    if args.paths:
+        targets = [Path(p) for p in args.paths]
+    else:
+        targets = iter_skill_files(repo_root)
+
+    if not targets:
+        # An empty scan is indistinguishable from a clean scan, so refuse to
+        # report success. This guard was written after a green run that had
+        # simply never opened the relevant files.
+        print(
+            "error: no SKILL.md files found; refusing to report success on an "
+            f"empty scan (repo root: {repo_root})",
+            file=sys.stderr,
+        )
+        return 2
+
+    violations: list[Violation] = []
+    for target in targets:
+        violations.extend(check_file(target))
+
+    if violations:
+        print("Skill resolver anchoring violations:\n")
+        for violation in violations:
+            print(violation.render())
+            print()
+        print(f"{len(violations)} violation(s) across {len(targets)} SKILL.md file(s).")
+        return 1
+
+    print(f"Resolver anchoring OK. {len(targets)} SKILL.md file(s) scanned.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validation/check_skill_resolver_anchoring.py
+++ b/scripts/validation/check_skill_resolver_anchoring.py
@@ -109,13 +109,13 @@ def check_file(path: Path) -> list[Violation]:
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except OSError as exc:  # pragma: no cover - surfaced to caller
-        raise SystemExit(f"error: cannot read {path}: {exc}") from exc
+        print(f"error: cannot read {path}: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
 
     violations: list[Violation] = []
 
     for name, start, end in _function_blocks(lines):
         body = lines[start:end]
-        anchored = any(ANCHORED.search(line) for line in body)
 
         first_out_of_repo: int | None = None
         for offset, line in enumerate(body):
@@ -141,7 +141,7 @@ def check_file(path: Path) -> list[Violation]:
             violations.append(
                 Violation(
                     path=path,
-                    line=start + first_in_repo + 1,
+                    line=start + first_out_of_repo + 1,
                     function=name,
                     kind="out-of-repo candidate ordered before in-repo copy",
                     detail=(
@@ -161,21 +161,20 @@ def check_file(path: Path) -> list[Violation]:
             if not is_bare:
                 continue
 
-            if not anchored:
-                violations.append(
-                    Violation(
-                        path=path,
-                        line=start + offset + 1,
-                        function=name,
-                        kind="unanchored repo-relative candidate root",
-                        detail=(
-                            'bare ".claude" resolves only when cwd is the repo '
-                            "root; from a subdirectory this rung is skipped and "
-                            "a stale out-of-repo copy wins. Anchor it on "
-                            '"$(git rev-parse --show-toplevel)/.claude".'
-                        ),
-                    )
+            violations.append(
+                Violation(
+                    path=path,
+                    line=start + offset + 1,
+                    function=name,
+                    kind="unanchored repo-relative candidate root",
+                    detail=(
+                        'bare ".claude" resolves only when cwd is the repo '
+                        "root; from a subdirectory this rung is skipped and "
+                        "a stale out-of-repo copy wins. Anchor it on "
+                        '"$(git rev-parse --show-toplevel)/.claude".'
+                    ),
                 )
+            )
 
     return violations
 

--- a/scripts/validation/skill_contract_test_baseline.txt
+++ b/scripts/validation/skill_contract_test_baseline.txt
@@ -1,6 +1,5 @@
 # Skills documenting exit-code contracts with no binding test.
 # Ratchet: entries may be removed, never added. Burn down over time.
-# Generated at cc3a23eb.
 ai-agents-build-and-env
 ai-agents-change-control
 ai-agents-debugging-playbook

--- a/scripts/validation/skill_contract_test_baseline.txt
+++ b/scripts/validation/skill_contract_test_baseline.txt
@@ -1,0 +1,12 @@
+# Skills documenting exit-code contracts with no binding test.
+# Ratchet: entries may be removed, never added. Burn down over time.
+# Generated at cc3a23eb.
+ai-agents-build-and-env
+ai-agents-change-control
+ai-agents-debugging-playbook
+ai-agents-diagnostics-toolkit
+ai-agents-validation-and-qa
+benchmark-models
+github-url-intercept
+memory-maintenance
+prose-self-check

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.122",
+  "version": "0.6.123",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/pr-autofix/SKILL.md
+++ b/src/copilot-cli/skills/pr-autofix/SKILL.md
@@ -38,10 +38,11 @@ Walk the queue. For each PR, apply the tier's action set. T1 first (land-ready),
 # One outer fetch covers all per-PR calls; --skip-fetch keeps the loop cheap.
 git fetch --quiet origin "+refs/heads/main:refs/remotes/origin/main"
 resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do
@@ -129,10 +130,11 @@ Quote every variable expansion. The shell does not treat `:` specially in a refs
 
 ```bash
 resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do
@@ -195,10 +197,11 @@ When invoking from autofix code:
 ```bash
 PR_NUMBER="123"
 resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do
@@ -219,10 +222,11 @@ encoded "100 = merged"):
 ```bash
 PR_NUMBER="123"
 resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do
@@ -246,10 +250,11 @@ Run after all threads resolved and CI passes:
 
 ```bash
 resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do

--- a/src/copilot-cli/skills/pr-review/SKILL.md
+++ b/src/copilot-cli/skills/pr-review/SKILL.md
@@ -85,10 +85,11 @@ The completion gate is dispatchable: each criterion in `completion_criteria` run
 
 ```bash
 resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do
@@ -101,10 +102,11 @@ resolve_pr_scripts_dir() {
   printf '%s\n' ".claude/skills/github/scripts/pr"
 }
 resolve_pr_review_config() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   for root in \
     "${COPILOT_PLUGIN_ROOT:-}" \
     "${CLAUDE_PLUGIN_ROOT:-}" \
-    ".claude" \
+    "$repo_root/.claude" \
     "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
     "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
     "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do

--- a/src/copilot-cli/skills/ship/SKILL.md
+++ b/src/copilot-cli/skills/ship/SKILL.md
@@ -82,10 +82,11 @@ Set the mode:
          REVIEW_MARKER_SCRIPT="$CLAUDE_SKILL_DIR/../review/scripts/validate_review_marker.py"
        else
          resolve_review_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
            for root in \
              "${COPILOT_PLUGIN_ROOT:-}" \
              "${CLAUDE_PLUGIN_ROOT:-}" \
-             ".claude" \
+             "$repo_root/.claude" \
              "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \
              "${HOME:-}/.copilot/installed-plugins"/*/project-toolkit \
              "${HOME:-}/.claude/plugins/cache"/*/project-toolkit; do

--- a/tests/validation/test_skill_resolver_and_contract_guards.py
+++ b/tests/validation/test_skill_resolver_and_contract_guards.py
@@ -21,14 +21,18 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.validation import (  # noqa: E402
-    check_skill_contract_tests as contract_guard,
-)
-from scripts.validation import (  # noqa: E402
-    check_skill_resolver_anchoring as resolver_guard,
-)
+_orig_path = sys.path[:]
+sys.path.insert(0, str(REPO_ROOT))
+try:
+    from scripts.validation import (  # noqa: E402
+        check_skill_contract_tests as contract_guard,
+    )
+    from scripts.validation import (  # noqa: E402
+        check_skill_resolver_anchoring as resolver_guard,
+    )
+finally:
+    sys.path[:] = _orig_path
 
 UNANCHORED_RESOLVER = """# Skill
 

--- a/tests/validation/test_skill_resolver_and_contract_guards.py
+++ b/tests/validation/test_skill_resolver_and_contract_guards.py
@@ -1,0 +1,224 @@
+"""Tests for the skill resolver anchoring and contract-binding guards.
+
+These guards were written after a green validation run that had never opened
+the files containing the defect. Each guard therefore carries three controls,
+and each control is asserted here:
+
+* a positive control - the guard goes red on a known-bad input
+* a negative control - the guard goes green once that input is fixed
+* an empty-scan control - the guard exits 2 rather than reporting a false
+  green when it finds nothing to examine
+
+A guard that has never gone red on a known-bad input is unproven, so the
+positive controls are the load-bearing tests in this module.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.validation import (  # noqa: E402
+    check_skill_contract_tests as contract_guard,
+)
+from scripts.validation import (  # noqa: E402
+    check_skill_resolver_anchoring as resolver_guard,
+)
+
+UNANCHORED_RESOLVER = """# Skill
+
+```bash
+resolve_pr_scripts_dir() {
+  for root in \\
+    "${COPILOT_PLUGIN_ROOT:-}" \\
+    ".claude" \\
+    "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit"; do
+    if [ -n "$root" ] && [ -d "$root/skills/github/scripts/pr" ]; then
+      printf '%s\\n' "$root/skills/github/scripts/pr"
+      return 0
+    fi
+  done
+}
+```
+"""
+
+ANCHORED_RESOLVER = """# Skill
+
+```bash
+resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  for root in \\
+    "${COPILOT_PLUGIN_ROOT:-}" \\
+    "$repo_root/.claude" \\
+    "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit"; do
+    if [ -n "$root" ] && [ -d "$root/skills/github/scripts/pr" ]; then
+      printf '%s\\n' "$root/skills/github/scripts/pr"
+      return 0
+    fi
+  done
+}
+```
+"""
+
+OUT_OF_REPO_FIRST = """# Skill
+
+```bash
+resolve_pr_scripts_dir() {
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  for root in \\
+    "${HOME:-}/.copilot/installed-plugins/_direct/project-toolkit" \\
+    "$repo_root/.claude"; do
+    if [ -n "$root" ] && [ -d "$root/skills/github/scripts/pr" ]; then
+      printf '%s\\n' "$root/skills/github/scripts/pr"
+      return 0
+    fi
+  done
+}
+```
+"""
+
+CONTRACT_SKILL = """# Skill
+
+Run the gate:
+
+```bash
+python3 scripts/pr/check_pr_live_state.py --pull-request 1
+```
+
+Exit 0 means act. Exit 1 means skip.
+"""
+
+NO_CONTRACT_SKILL = """# Skill
+
+This skill documents no script invocation and no exit code.
+"""
+
+
+def _write_skill(root: Path, name: str, body: str) -> Path:
+    path = root / "src" / "copilot-cli" / "skills" / name / "SKILL.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _write_test(root: Path, name: str, body: str) -> Path:
+    path = root / "tests" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+class TestResolverAnchoringPositiveControl:
+    """The guard must go red on the defect that motivated it."""
+
+    def test_unanchored_relative_root_is_rejected(self, tmp_path: Path) -> None:
+        _write_skill(tmp_path, "demo", UNANCHORED_RESOLVER)
+        assert resolver_guard.main(["--repo-root", str(tmp_path)]) == 1
+
+    def test_names_the_offending_function(self, tmp_path: Path) -> None:
+        path = _write_skill(tmp_path, "demo", UNANCHORED_RESOLVER)
+        violations = resolver_guard.check_file(path)
+        assert violations, "expected a violation on a bare relative root"
+        assert violations[0].function == "resolve_pr_scripts_dir"
+
+    def test_out_of_repo_root_ordered_first_is_rejected(self, tmp_path: Path) -> None:
+        path = _write_skill(tmp_path, "demo", OUT_OF_REPO_FIRST)
+        kinds = {v.kind for v in resolver_guard.check_file(path)}
+        assert "out-of-repo candidate ordered before in-repo copy" in kinds
+
+    def test_real_repository_defect_is_detected(self) -> None:
+        """The in-tree resolver this guard was written for must be caught.
+
+        Skipped rather than failed once the underlying skills are fixed, so
+        the test does not become an obstacle to the fix it is asking for.
+        """
+        target = (
+            REPO_ROOT / "src" / "copilot-cli" / "skills" / "pr-autofix" / "SKILL.md"
+        )
+        if not target.is_file():
+            pytest.skip("pr-autofix SKILL.md not present in this tree")
+        violations = resolver_guard.check_file(target)
+        if not violations:
+            pytest.skip("resolver already anchored; positive control satisfied")
+        assert any("unanchored" in v.kind for v in violations)
+
+
+class TestResolverAnchoringNegativeControl:
+    """The guard must go green once the defect is fixed, or it is a constant."""
+
+    def test_anchored_resolver_passes(self, tmp_path: Path) -> None:
+        _write_skill(tmp_path, "demo", ANCHORED_RESOLVER)
+        assert resolver_guard.main(["--repo-root", str(tmp_path)]) == 0
+
+    def test_empty_scan_does_not_report_success(self, tmp_path: Path) -> None:
+        assert resolver_guard.main(["--repo-root", str(tmp_path)]) == 2
+
+
+class TestContractBindingPositiveControl:
+    def test_documented_contract_without_test_is_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        _write_skill(tmp_path, "demo", CONTRACT_SKILL)
+        _write_test(tmp_path, "test_unrelated.py", "def test_x():\n    assert True\n")
+        assert contract_guard.main(["--repo-root", str(tmp_path)]) == 1
+
+    def test_skill_without_contract_is_out_of_scope(self, tmp_path: Path) -> None:
+        _write_skill(tmp_path, "demo", NO_CONTRACT_SKILL)
+        _write_test(tmp_path, "test_unrelated.py", "def test_x():\n    assert True\n")
+        assert contract_guard.main(["--repo-root", str(tmp_path)]) == 0
+
+
+class TestContractBindingNegativeControl:
+    def test_referenced_skill_passes(self, tmp_path: Path) -> None:
+        _write_skill(tmp_path, "demo", CONTRACT_SKILL)
+        _write_test(
+            tmp_path,
+            "test_demo_contract.py",
+            "SKILL = 'demo'\n\n\ndef test_x():\n    assert SKILL\n",
+        )
+        assert contract_guard.main(["--repo-root", str(tmp_path)]) == 0
+
+    def test_baseline_grandfathers_named_skill(self, tmp_path: Path) -> None:
+        _write_skill(tmp_path, "demo", CONTRACT_SKILL)
+        _write_test(tmp_path, "test_unrelated.py", "def test_x():\n    assert True\n")
+        baseline = tmp_path / "baseline.txt"
+        baseline.write_text("# comment\ndemo\n", encoding="utf-8")
+        exit_code = contract_guard.main(
+            ["--repo-root", str(tmp_path), "--baseline", "baseline.txt"]
+        )
+        assert exit_code == 0
+
+    def test_empty_scan_does_not_report_success(self, tmp_path: Path) -> None:
+        assert contract_guard.main(["--repo-root", str(tmp_path)]) == 2
+
+    def test_missing_tests_directory_does_not_report_success(
+        self, tmp_path: Path
+    ) -> None:
+        _write_skill(tmp_path, "demo", CONTRACT_SKILL)
+        assert contract_guard.main(["--repo-root", str(tmp_path)]) == 2
+
+
+class TestBaselineRatchet:
+    """The checked-in baseline must shrink, never grow."""
+
+    def test_baseline_entries_are_still_unbound(self) -> None:
+        baseline_path = (
+            REPO_ROOT
+            / "scripts"
+            / "validation"
+            / "skill_contract_test_baseline.txt"
+        )
+        if not baseline_path.is_file():
+            pytest.skip("baseline not present")
+        entries = [
+            line.strip()
+            for line in baseline_path.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.startswith("#")
+        ]
+        assert entries, "baseline exists but is empty; delete it instead"
+        assert len(entries) == len(set(entries)), "baseline contains duplicates"

--- a/tests/validation/test_skill_resolver_and_contract_guards.py
+++ b/tests/validation/test_skill_resolver_and_contract_guards.py
@@ -206,6 +206,16 @@ class TestContractBindingNegativeControl:
         _write_skill(tmp_path, "demo", CONTRACT_SKILL)
         assert contract_guard.main(["--repo-root", str(tmp_path)]) == 2
 
+    def test_hyphenated_name_not_matched_by_suffix(self, tmp_path: Path) -> None:
+        """Skill 'pr-review' must not be bound by a test naming 'pr-review-v2'."""
+        _write_skill(tmp_path, "pr-review", CONTRACT_SKILL)
+        _write_test(
+            tmp_path,
+            "test_other.py",
+            "SKILL = 'pr-review-v2'\n\ndef test_x():\n    assert SKILL\n",
+        )
+        assert contract_guard.main(["--repo-root", str(tmp_path)]) == 1
+
 
 class TestBaselineRatchet:
     """The checked-in baseline must shrink, never grow."""

--- a/tests/validation/test_skill_resolver_and_contract_guards.py
+++ b/tests/validation/test_skill_resolver_and_contract_guards.py
@@ -218,7 +218,7 @@ class TestContractBindingNegativeControl:
 
 
 class TestBaselineRatchet:
-    """The checked-in baseline must shrink, never grow."""
+    """The checked-in baseline file must be well-formed and non-empty."""
 
     def test_baseline_entries_are_still_unbound(self) -> None:
         baseline_path = (


### PR DESCRIPTION
## Summary

Replaces the three prose rules proposed in #3400 with two executable guards, a test suite, and a fix for every violation they detect.

#3400 documented three defects in markdown. That is the same failure mode the rules themselves described: prose asserting something about the codebase, with nothing recompiling the claim when the codebase moves. This PR encodes the same three findings as code (superseding #3400).

The difference is measurable. My hand audit found 2 unanchored resolver sites in 1 skill. The guard found **8 across 3 skills**, including `pr-review` and `ship`, which I never examined.

## Guards

### `check_skill_resolver_anchoring.py`

A `SKILL.md` resolver that probes a bare relative `".claude"` only resolves when the process cwd is the repository root. From a subdirectory the rung is skipped, the loop falls through, and a copy under `~/.copilot/installed-plugins` wins instead.

> [!NOTE]
> At the time of writing, that installed copy was dated **2026-06-26**, and its `check_pr_live_state.py` was **495 lines against the repository's 560, 215 lines different**. That script is the blocking per-PR live-state gate from #2455, run before every tier action. From any subdirectory, `pr-autofix` enforced its primary safety gate with a month-old implementation and printed nothing.

The guard also rejects an out-of-repo candidate root ordered ahead of the in-repo rung, which reaches the same stale-copy outcome by a different route.

### `check_skill_contract_tests.py`

A `SKILL.md` that names a script, an exit code, and a meaning is writing a specification. When no test reads it back, the script drifts and every gate stays green. Exit-code semantics already drifted once under #2308 and were then re-documented in prose.

63 of 205 skills are in scope (documented exit code plus script invocation). 9 are unbound and recorded in `skill_contract_test_baseline.txt` as a burn-down ratchet: entries may be removed, never added.

## The fix

All 8 unanchored resolvers repaired in `.claude/commands/` (the authored source) and regenerated into `src/copilot-cli/skills/` via the command generator. pr-autofix (5), pr-review (2), ship (1).

> [!NOTE]
> Regeneration uses `build/scripts/generate_commands.py` (not modified in this PR).

Verified by executing the fixed resolver from three working directories, not by reading it:

| cwd | before | after |
|---|---|---|
| repo root | in-repo copy | in-repo copy |
| `repo/src/` | **stale installed copy** | **in-repo copy** |
| outside repo | installed copy | installed copy (correct) |

## Controls

Each guard carries three controls, all asserted in `tests/validation/test_skill_resolver_and_contract_guards.py`:

- **positive** - goes red on the known-bad input
- **negative** - goes green once that input is fixed
- **empty scan** - exits 2 rather than reporting a false green when it opens nothing

The empty-scan control exists because that failure already happened here: a green validation run that had never opened the files containing the defect. A guard that has never gone red on a known-bad input is unproven.

The positive control against the live repo skips rather than fails once the resolver is anchored, so it does not obstruct the fix it asks for.

**Two defects in these guards were caught by their own tests during development:**

1. The resolver guard keyed on function names ending in `dir` and silently missed `resolve_pr_review_config()`, which has the identical defect. Now matches any shell function and decides by body content. Surfaced by a hand count of 8 sites against a guard reporting 7.
2. The ordering check compared only against bare relative rungs, so it never fired on an already-anchored resolver.

Both are the guard-coverage failure this PR is about, found in the guard itself.

## Wiring

Both guards run in `validate-vendor-portability.yml`. All four new files are added to the `check-changes` path filter, so the workflow triggers on them. A guard wired into a job that never runs is not a guard.

## Verification

| Check | Result |
|---|---|
| `pytest test_skill_resolver_and_contract_guards.py` | 12 passed, 1 skipped |
| `check_skill_resolver_anchoring` | exit 0, 205 scanned (was 8 violations) |
| `check_skill_contract_tests` | exit 0, 63 in scope, 9 grandfathered |
| `check_skill_md_exec_portability` | 290 vs baseline 306, no drift |
| `check_skill_portability` | 166 vs baseline 166, no drift |
| `pre_pr.py` | all validations passed |

## Incremental Scope Declaration

This PR delivers criteria AC-2, AC-3, AC-4, and AC-6 from #3402.
AC-1 (general worktree identity verification) and AC-5 (memory recording) are deferred to a follow-up.

Advances #3402.
Supersedes #3400.

