### PR TITLE
fix(validation): close the last dependency-table hole and pin the import order

### DIFF
--- a/.agents/sessions/2026-07-26-session-3377-table-guards.json
+++ b/.agents/sessions/2026-07-26-session-3377-table-guards.json
@@ -79,12 +79,12 @@
       "markdownLintRun": {
         "complete": true,
         "level": "MUST",
-        "evidence": "No markdown changed on this branch; scoped lint has nothing to run."
+        "evidence": "One markdown file changed: .serena/memories/decision-requirement-typeerror-not-invalidrequirement.md. Ran scoped markdownlint-cli2 on it; the repo config excludes .serena/**, so it reported 'Linting: 0 files, 0 issues'. Nothing to fix, and the exclusion is why."
       },
       "changesCommitted": {
         "complete": true,
         "level": "MUST",
-        "evidence": "Two commits: 2c86e7b395 (table guards) and acb78c20bb (import-order tests). Head is acb78c20bbc2a893e1623f4199d6580468f96df0."
+        "evidence": "Commits on the branch, newest first: 2676ac5a37 docs(session): repoint endingCommit at a commit that is on the branch; 64d23ae67b docs(session): record the table-guard reland and the packaging finding; f22ebf0079 test(validation): pin the skip-before-import order in the pin gate; 687eb5b43e fix(validation): read every dependency table through one pair of guards. SHAs are post-rebase; the pre-rebase values recorded earlier named commits reachable only from the reflog."
       },
       "validationPassed": {
         "complete": true,
@@ -125,10 +125,10 @@
       "outcome": "Two tests block the import via sys.modules and assert MissingScriptSkip; a third runs a tree that does exist so a guard which skipped everything would fail. Moving the import back above the check turns both skip tests red with ModuleNotFoundError."
     }
   ],
-  "endingCommit": "f22ebf0079",
+  "endingCommit": "2676ac5a37",
   "nextSteps": [
     "Open the PR for fix/3377-table-guards and check it before any long push; three PRs merged mid-push this session.",
     "Fix the _HOOK_PATH_RE comment wording on PR #3397.",
-    "The endingCommit above names the last code commit on the branch; the session log commit that carries this file follows it."
+    "endingCommit names the newest commit on the branch at the time this log was last corrected; a later review-fix commit may follow it."
   ]
 }

--- a/.agents/sessions/2026-07-26-session-3377-table-guards.json
+++ b/.agents/sessions/2026-07-26-session-3377-table-guards.json
@@ -125,9 +125,10 @@
       "outcome": "Two tests block the import via sys.modules and assert MissingScriptSkip; a third runs a tree that does exist so a guard which skipped everything would fail. Moving the import back above the check turns both skip tests red with ModuleNotFoundError."
     }
   ],
-  "endingCommit": "acb78c20bbc2a893e1623f4199d6580468f96df0",
+  "endingCommit": "f22ebf0079",
   "nextSteps": [
     "Open the PR for fix/3377-table-guards and check it before any long push; three PRs merged mid-push this session.",
-    "Fix the _HOOK_PATH_RE comment wording on PR #3397."
+    "Fix the _HOOK_PATH_RE comment wording on PR #3397.",
+    "The endingCommit above names the last code commit on the branch; the session log commit that carries this file follows it."
   ]
 }

--- a/.agents/sessions/2026-07-26-session-3377-table-guards.json
+++ b/.agents/sessions/2026-07-26-session-3377-table-guards.json
@@ -1,0 +1,133 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3377,
+    "date": "2026-07-26",
+    "branch": "fix/3377-table-guards",
+    "startingCommit": "cc3a23ebc0baf4d1288bf5da8956174d4a5cbc36",
+    "objective": "Reland the one dependency-table hole PR #3396 left open, and pin the skip-before-import order it shipped untested."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "branchVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "git branch --show-current returned fix/3377-table-guards, branched from origin/main after PR #3396 merged."
+      },
+      "constraintsRead": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Read .agents/governance/PROJECT-CONSTRAINTS.md and .claude/rules/universal.md before touching scripts/validation/."
+      },
+      "gitStateVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "git rev-parse HEAD = acb78c20bbc2a893e1623f4199d6580468f96df0; merge-base with origin/main = cc3a23ebc0baf4d1288bf5da8956174d4a5cbc36 (origin/main head cc3a23ebc0)."
+      },
+      "handoffRead": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Read .agents/HANDOFF.md; did not edit it (ADR-014)."
+      },
+      "notOnMain": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Working branch is fix/3377-table-guards, not main."
+      },
+      "serenaActivated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Serena MCP is live in this harness; serena-initial_instructions and serena-list_memories both returned. Project already active."
+      },
+      "serenaInstructions": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Called serena-initial_instructions and read the returned Serena Instructions Manual before continuing."
+      },
+      "sessionLogCreated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "This file, .agents/sessions/2026-07-26-session-3377-table-guards.json."
+      },
+      "skillScriptsListed": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Used scripts/validation/pre_pr.py and its checks_tooling module directly; no skill script needed for this change."
+      },
+      "usageMandatoryRead": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Read .serena/memories/usage-mandatory.md from disk."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Every item in this file carries evidence written for this session; none inherited from a prior log."
+      },
+      "handoffPreserved": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": ".agents/HANDOFF.md untouched; git status shows no modification to it."
+      },
+      "serenaMemoryUpdated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Wrote decision-requirement-typeerror-not-invalidrequirement via serena-write_memory, recording that Requirement(non_string) raises TypeError and why the type guard has to precede the parse."
+      },
+      "markdownLintRun": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "No markdown changed on this branch; scoped lint has nothing to run."
+      },
+      "changesCommitted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Two commits: 2c86e7b395 (table guards) and acb78c20bb (import-order tests). Head is acb78c20bbc2a893e1623f4199d6580468f96df0."
+      },
+      "validationPassed": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "149 tests pass across tests/validation/test_check_ci_dependency_pins.py and tests/test_validation_pre_pr.py on the origin/main baseline; ruff and mypy clean on the changed files."
+      },
+      "tasksUpdated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "PR #3396 merged before its two threads could be answered in place; this branch carries the answers and its PR description points back at them."
+      },
+      "retrospectiveInvoked": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Carried forward in the session summary; the reusable finding (TypeError vs InvalidRequirement) is stated in the commit body."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "task": "Answer the two review threads on PR #3396 while it was open",
+      "outcome": "Both premises verified real. Fixes and tests were committed on fix/3377-ci-pin-drift, but PR #3396 merged mid-work and took the branch with it. Third time this session; recovery is a fresh branch off main."
+    },
+    {
+      "task": "Diff the merged result against the orphaned work rather than assume it",
+      "outcome": "The merged PR already carries isinstance guards on all three tables, written inline three times, and already carries the skip-before-import order. Only one hole survives: data.get('project') returning a non-dict makes project.get() raise AttributeError before any guard runs."
+    },
+    {
+      "task": "Close the surviving hole and delete the triplication",
+      "outcome": "Two named helpers, _requirement_strings and _requirement_groups, now own the coercion; all three tables route through them. Thirteen lines of repeated isinstance ceremony become three, and the [project] shape is guarded by construction."
+    },
+    {
+      "task": "Re-run the negative control against the merged baseline, not the pre-#3396 one",
+      "outcome": "Restoring the merged body verbatim turns exactly 1 of the 8 parametrized cases red (project-is-not-a-table). The earlier 6-of-8 figure was measured against the pre-#3396 body and does not describe what ships here. The other seven cases hold #3396's fixes against regression."
+    },
+    {
+      "task": "Pin the import ordering that #3396 shipped untested",
+      "outcome": "Two tests block the import via sys.modules and assert MissingScriptSkip; a third runs a tree that does exist so a guard which skipped everything would fail. Moving the import back above the check turns both skip tests red with ModuleNotFoundError."
+    }
+  ],
+  "endingCommit": "acb78c20bbc2a893e1623f4199d6580468f96df0",
+  "nextSteps": [
+    "Open the PR for fix/3377-table-guards and check it before any long push; three PRs merged mid-push this session.",
+    "Fix the _HOOK_PATH_RE comment wording on PR #3397."
+  ]
+}

--- a/.serena/memories/decision-requirement-typeerror-not-invalidrequirement.md
+++ b/.serena/memories/decision-requirement-typeerror-not-invalidrequirement.md
@@ -1,0 +1,55 @@
+# Requirement(non_string) raises TypeError, not InvalidRequirement
+
+## Question
+
+Is `except InvalidRequirement: continue` enough to protect a dependency-parsing
+loop from a malformed `pyproject.toml`?
+
+## Conventional answer
+
+Yes. `packaging.requirements.InvalidRequirement` is the documented error for a
+requirement string the parser cannot understand, so wrapping the call in that
+handler is the idiomatic guard. `scripts/validation/check_ci_dependency_pins.py`
+was written this way.
+
+## First-principles position
+
+No. `InvalidRequirement` covers a *string* that does not parse. It does not
+cover a value that is not a string at all. `Requirement(1)` raises `TypeError`
+from inside the tokenizer, which the handler does not catch, so a non-string
+item in a dependency list escapes and takes the whole validator down.
+
+TOML permits this shape: `dependencies = [1, 2]` is valid TOML and invalid
+metadata. Anything reading a config file written by a human has to type-guard
+before it parses, not after.
+
+## Evidence
+
+Measured directly:
+
+```
+>>> from packaging.requirements import Requirement
+>>> Requirement(1)
+TypeError: expected string or bytes-like object, got 'int'
+```
+
+Restoring the pre-fix body of `declared_constraints` turned 6 of 8 new
+parametrized malformed-table cases red, including the case where a malformed
+section blanked a healthy one.
+
+Two cases survived the pre-fix body, and the reason is worth knowing:
+`list("oops")` yields single characters, each of which parses as a valid
+requirement with no specifiers, so a string where a list belongs degrades
+silently rather than crashing.
+
+## Decision
+
+`check_ci_dependency_pins.py` now has `_requirement_strings(value)` and
+`_requirement_groups(table)` immediately above `declared_constraints`. Both
+filter by `isinstance(..., str)` and `isinstance(..., list)` before any parse.
+All three tables (`[project].dependencies`,
+`[project.optional-dependencies]`, `[dependency-groups]`) route through them,
+which deleted the asymmetric inline guard that previously protected only the
+third one.
+
+Refs #3377, PR #3396.

--- a/scripts/validation/check_ci_dependency_pins.py
+++ b/scripts/validation/check_ci_dependency_pins.py
@@ -119,32 +119,49 @@ class Violation:
         )
 
 
+def _requirement_strings(value: object) -> list[str]:
+    """Return the requirement strings in ``value``; nothing if it is not a list of them.
+
+    pyproject is hand-authored TOML and this function runs inside a gate that
+    reports a verdict, so a malformed table must produce a result rather than a
+    traceback. Anything that is not a list of strings contributes no
+    constraints, which is the same outcome an unparseable requirement gets in
+    ``declared_constraints`` below. Note the shape ``Requirement()`` cannot
+    defend against on its own: a non-string argument raises ``TypeError``, not
+    ``InvalidRequirement``, so it would escape the handler there.
+    """
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _requirement_groups(table: object) -> list[list[str]]:
+    """Return the requirement lists held by a table of named groups."""
+    if not isinstance(table, dict):
+        return []
+    return [_requirement_strings(group) for group in table.values()]
+
+
 def declared_constraints(pyproject: Path) -> dict[str, SpecifierSet]:
     """Return canonical package name -> combined specifier from pyproject.
 
     Merges ``[project].dependencies`` with every entry under
-    ``[project.optional-dependencies]`` and ``[dependency-groups]``.
-    A package declared in more than one place contributes all of its
-    specifiers, so a pin must satisfy the intersection. That is the honest
-    reading: CI installs one version, and it has to work everywhere the
-    project claims to need the package.
+    ``[project.optional-dependencies]`` and ``[dependency-groups]``. A package
+    declared in more than one place contributes all of its specifiers, so a pin
+    must satisfy the intersection. That is the honest reading: CI installs one
+    version, and it has to work everywhere the project claims to need the
+    package.
+
+    Every table is read through the same two helpers, so a malformed section
+    degrades to "declares nothing" wherever it appears rather than only in the
+    one place someone remembered to guard.
     """
     data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
-    project = data.get("project", {})
-    deps = project.get("dependencies", [])
-    groups: list[list[str]] = []
-    if isinstance(deps, list):
-        groups.append([item for item in deps if isinstance(item, str)])
-    optional_deps = project.get("optional-dependencies", {})
-    if isinstance(optional_deps, dict):
-        for extra in optional_deps.values():
-            if isinstance(extra, list):
-                groups.append([item for item in extra if isinstance(item, str)])
-    dep_groups = data.get("dependency-groups", {})
-    if isinstance(dep_groups, dict):
-        for group in dep_groups.values():
-            if isinstance(group, list):
-                groups.append([item for item in group if isinstance(item, str)])
+    project = data.get("project")
+    project = project if isinstance(project, dict) else {}
+    groups: list[list[str]] = [_requirement_strings(project.get("dependencies"))]
+    groups.extend(_requirement_groups(project.get("optional-dependencies")))
+    groups.extend(_requirement_groups(data.get("dependency-groups")))
 
     merged: dict[str, SpecifierSet] = {}
     for group in groups:

--- a/scripts/validation/check_ci_dependency_pins.py
+++ b/scripts/validation/check_ci_dependency_pins.py
@@ -120,15 +120,24 @@ class Violation:
 
 
 def _requirement_strings(value: object) -> list[str]:
-    """Return the requirement strings in ``value``; nothing if it is not a list of them.
+    """Return the requirement strings in ``value``, dropping anything else.
 
-    pyproject is hand-authored TOML and this function runs inside a gate that
-    reports a verdict, so a malformed table must produce a result rather than a
-    traceback. Anything that is not a list of strings contributes no
-    constraints, which is the same outcome an unparseable requirement gets in
-    ``declared_constraints`` below. Note the shape ``Requirement()`` cannot
-    defend against on its own: a non-string argument raises ``TypeError``, not
-    ``InvalidRequirement``, so it would escape the handler there.
+    Filtering is per item, not all or nothing, and that is load bearing rather
+    than lenient. A PEP 735 dependency group legitimately mixes requirement
+    strings with ``{include-group = ...}`` tables, so this repo's own
+    ``[dependency-groups] lint`` reads ``["ruff>=...", {include-group = "dev"}]``.
+    Rejecting the whole list on the first non-string would silently un-guard
+    ruff, which is the failure this gate exists to prevent: a section that
+    declares nothing and a section the gate refused to read are indistinguishable
+    in the verdict.
+
+    A ``value`` that is not a list at all contributes nothing, because there is
+    no item to salvage. pyproject is hand-authored TOML and this function runs
+    inside a gate that reports a verdict, so a malformed table must produce a
+    result rather than a traceback, the same outcome an unparseable requirement
+    gets in ``declared_constraints`` below. Note the shape ``Requirement()``
+    cannot defend against on its own: a non-string argument raises ``TypeError``,
+    not ``InvalidRequirement``, so it would escape the handler there.
     """
     if not isinstance(value, list):
         return []

--- a/tests/test_validation_pre_pr.py
+++ b/tests/test_validation_pre_pr.py
@@ -1355,14 +1355,14 @@ class TestValidateCiDependencyPinsSkipsBeforeImporting:
             validate_ci_dependency_pins(tmp_path)
 
     def test_a_present_tree_still_imports_and_runs(self, tmp_path: Path) -> None:
-        """Negative control. A guard that skips everything is not a guard."""
+        """Negative control: a bad pin returns False, proving the checker ran."""
         from checks_tooling import validate_ci_dependency_pins
 
         (tmp_path / ".github").mkdir()
         (tmp_path / ".github" / "w.yml").write_text(
-            "run: pip install pytest==9.0.3\n", encoding="utf-8"
+            "run: pip install pytest==8.0.0\n", encoding="utf-8"
         )
         (tmp_path / "pyproject.toml").write_text(
             '[project]\nname="x"\ndependencies=["pytest>=9.0.3"]\n', encoding="utf-8"
         )
-        assert validate_ci_dependency_pins(tmp_path) is True
+        assert validate_ci_dependency_pins(tmp_path) is False

--- a/tests/test_validation_pre_pr.py
+++ b/tests/test_validation_pre_pr.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import call, patch
 
+import pytest
+
 from scripts.validation.pre_pr import (
     ValidationState,
     _find_latest_session_log,
@@ -1304,3 +1306,63 @@ class TestValidateReviewMarker:
         self._add_marker(repo)
         monkeypatch.setenv("REVIEW_MARKER_ENFORCED", "1")
         assert validate_review_marker(repo) is True
+
+
+class TestValidateCiDependencyPinsSkipsBeforeImporting:
+    """The skip path must survive a tree that cannot import the checker.
+
+    ``check_ci_dependency_pins`` imports ``packaging``. A downstream install
+    with no ``.github/`` tree is also the install least likely to carry dev
+    dependencies, so importing before the existence check would raise
+    ImportError on exactly the tree the function is written to skip. Issue #3377.
+    """
+
+    @staticmethod
+    def _block_import(monkeypatch: Any) -> None:  # noqa: ANN401
+        import sys
+
+        # A None entry makes ``import check_ci_dependency_pins`` raise
+        # ImportError, which is what a missing ``packaging`` looks like from
+        # the caller's side.
+        monkeypatch.setitem(sys.modules, "check_ci_dependency_pins", None)
+
+    def test_an_absent_github_tree_skips_without_importing(
+        self,
+        tmp_path: Path,
+        monkeypatch: Any,  # noqa: ANN401
+    ) -> None:
+        from checks_tooling import validate_ci_dependency_pins
+
+        from scripts.validation.pre_pr import MissingScriptSkip
+
+        (tmp_path / "pyproject.toml").write_text('[project]\nname="x"\n', encoding="utf-8")
+        self._block_import(monkeypatch)
+        with pytest.raises(MissingScriptSkip):
+            validate_ci_dependency_pins(tmp_path)
+
+    def test_an_absent_pyproject_skips_without_importing(
+        self,
+        tmp_path: Path,
+        monkeypatch: Any,  # noqa: ANN401
+    ) -> None:
+        from checks_tooling import validate_ci_dependency_pins
+
+        from scripts.validation.pre_pr import MissingScriptSkip
+
+        (tmp_path / ".github").mkdir()
+        self._block_import(monkeypatch)
+        with pytest.raises(MissingScriptSkip):
+            validate_ci_dependency_pins(tmp_path)
+
+    def test_a_present_tree_still_imports_and_runs(self, tmp_path: Path) -> None:
+        """Negative control. A guard that skips everything is not a guard."""
+        from checks_tooling import validate_ci_dependency_pins
+
+        (tmp_path / ".github").mkdir()
+        (tmp_path / ".github" / "w.yml").write_text(
+            "run: pip install pytest==9.0.3\n", encoding="utf-8"
+        )
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname="x"\ndependencies=["pytest>=9.0.3"]\n', encoding="utf-8"
+        )
+        assert validate_ci_dependency_pins(tmp_path) is True

--- a/tests/validation/test_check_ci_dependency_pins.py
+++ b/tests/validation/test_check_ci_dependency_pins.py
@@ -95,6 +95,21 @@ class TestDeclaredConstraints:
         path = _pyproject(tmp_path, '[project]\nname="x"\ndependencies=["!!!", "pytest>=9"]\n')
         assert set(gate.declared_constraints(path)) == {"pytest"}
 
+    def test_a_mixed_list_keeps_its_strings_rather_than_being_dropped(self, tmp_path):
+        """PEP 735 groups mix requirement strings with include-group tables.
+
+        This repo's own [dependency-groups] lint is one. Rejecting the whole
+        list on the first non-string would silently un-guard every requirement
+        beside it, which is the outcome this gate exists to prevent.
+        """
+        path = _pyproject(
+            tmp_path,
+            '[project]\nname="x"\ndependencies=["pytest>=9"]\n'
+            "[dependency-groups]\n"
+            'lint=["ruff>=0.15.16", {include-group="dev"}, 7]\n',
+        )
+        assert set(gate.declared_constraints(path)) == {"pytest", "ruff"}
+
     @pytest.mark.parametrize(
         "body",
         [

--- a/tests/validation/test_check_ci_dependency_pins.py
+++ b/tests/validation/test_check_ci_dependency_pins.py
@@ -95,6 +95,52 @@ class TestDeclaredConstraints:
         path = _pyproject(tmp_path, '[project]\nname="x"\ndependencies=["!!!", "pytest>=9"]\n')
         assert set(gate.declared_constraints(path)) == {"pytest"}
 
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param('project = "oops"\n', id="project-is-not-a-table"),
+            pytest.param('[project]\nname="x"\ndependencies="pytest>=9"\n', id="deps-is-a-string"),
+            pytest.param(
+                '[project]\nname="x"\ndependencies=[1, 2]\n',
+                id="deps-holds-non-strings",
+            ),
+            pytest.param(
+                '[project]\nname="x"\noptional-dependencies=["pytest>=9"]\n',
+                id="extras-is-a-list",
+            ),
+            pytest.param(
+                '[project]\nname="x"\n[project.optional-dependencies]\ndev="oops"\n',
+                id="one-extra-is-a-string",
+            ),
+            pytest.param(
+                '[project]\nname="x"\n[project.optional-dependencies]\ndev=[1]\n',
+                id="one-extra-holds-non-strings",
+            ),
+            pytest.param('dependency-groups = "oops"\n', id="groups-is-not-a-table"),
+        ],
+    )
+    def test_a_malformed_table_yields_no_constraints_rather_than_a_traceback(self, tmp_path, body):
+        """Every dependency table degrades the same way.
+
+        This gate runs in CI ahead of the tests that would diagnose a broken
+        pyproject, so a TypeError or AttributeError here surfaces as a pin
+        failure and sends the reader to the wrong file. Note that a non-string
+        item cannot be caught downstream either: ``Requirement(1)`` raises
+        ``TypeError``, not ``InvalidRequirement``, so it escapes the handler in
+        ``declared_constraints``.
+        """
+        assert gate.declared_constraints(_pyproject(tmp_path, body)) == {}
+
+    def test_a_malformed_section_does_not_suppress_a_healthy_one(self, tmp_path):
+        """Negative control: degrading one table must not blank the others."""
+        path = _pyproject(
+            tmp_path,
+            '[project]\nname="x"\ndependencies=["pytest>=9"]\n'
+            "optional-dependencies=[]\n"
+            '[dependency-groups]\ndev="oops"\n',
+        )
+        assert set(gate.declared_constraints(path)) == {"pytest"}
+
 
 class TestFindPins:
     def test_it_reports_the_line_number(self, tmp_path):


### PR DESCRIPTION
## Summary

PR #3396 shipped the dependency-pin gate. Its review raised two shapes; the PR merged before either could be answered in place. This branch answers both against the merged result rather than the code the review saw.

Fixes one hole and pins one ordering that shipped untested.

### The hole

#3396 landed `isinstance` guards on the three dependency tables by writing the same three-line dance three times inline. One shape survives that: if `[project]` itself is not a table, `project.get()` raises `AttributeError` before any of the guards run.

That matters because this gate runs in CI ahead of the tests. A traceback out of the pin checker reads as a pin failure and sends the reader to the wrong file.

Two named helpers now own the coercion and all three tables route through them. Thirteen lines of repeated ceremony become three, and the next table added here is guarded by construction rather than by whoever remembers to copy the dance a fourth time.

One shape is worth naming, and the helper docstring names it: `Requirement(1)` raises `TypeError`, not `InvalidRequirement`, so a non-string item escapes the handler in the merge loop below it. The type guard has to precede the parse.

### The untested ordering

`validate_ci_dependency_pins()` checks for the tree before it imports the checker, which pulls the `packaging` dev dependency. The order is load-bearing: a downstream install with no `.github/` tree is also the install least likely to carry dev dependencies, so an import above the check would raise `ImportError` on exactly the tree `MissingScriptSkip` exists to skip.

#3396 shipped that order correctly with nothing holding it there. Three tests hold it now.

## Verification

149 tests pass across both test files on the `origin/main` baseline. `ruff` and `mypy` clean on the changed files.

Negative controls, each run against the merged baseline rather than the pre-#3396 one:

| Control | Result |
|---|---|
| Restore the merged `declared_constraints` body verbatim, helpers removed | 1 of 8 parametrized cases red (`project-is-not-a-table`) |
| Move the import back above the existence check | Both skip tests red with `ModuleNotFoundError`; the third stays green |

The other seven parametrized cases cover shapes #3396 already fixed. They are regression coverage, not new fixes, and the commit body says so.

The third import test runs a tree that does exist, so a version of the guard that skipped everything would fail rather than pass.

## Notes

An earlier measurement of 6 of 8 red appears in this session's history. That was taken against the pre-#3396 body and does not describe what ships here. The session log records the correction.

Refs #3377
