### PR TITLE
fix(merge-driver): bake portable interpreter name, not worktree venv path

### DIFF
--- a/scripts/maintenance/install_merge_drivers.py
+++ b/scripts/maintenance/install_merge_drivers.py
@@ -14,6 +14,7 @@ if the driver is already registered with the value we want, nothing is written.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -24,18 +25,32 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 def _interpreter() -> str:
     """Return the interpreter to bake into the registered driver command.
 
-    The merge driver is stdlib-only, so any Python that can start will run it.
-    Registering this process's own interpreter is therefore both sufficient and
-    the one path proven to work: it is running right now.
+    A bare, PATH-resolved name (``python3``, falling back to ``python``), never
+    this process's absolute ``sys.executable``. The merge driver needs no
+    project environment (it imports only the standard library), so any Python
+    >=3.10 on PATH runs it, and a bare name is the only form that stays correct
+    across git worktrees. The 3.10 floor is real: the driver imports
+    ``typing.TypeAlias`` and evaluates a PEP 604 ``X | Y`` union at import time,
+    both of which raise on 3.9. Baking a bare name trades one worktree's pinned
+    interpreter for the clone's PATH, which is the contract issue #3418 asks
+    for; a merge-time PATH without a >=3.10 python is out of that scope.
 
-    ``as_posix`` matters because git hands the driver string to ``sh`` even on
+    Linked worktrees share one ``.git/config``, so the first worktree to run the
+    installer would register its own absolute venv path for all of them. When
+    that worktree or its venv is later deleted, the baked path stops resolving,
+    the driver exits 127, and git falls back to the text merge, silently
+    reintroducing the conflict the driver exists to remove (issue #3418). A bare
+    name cannot point at a deleted directory, so it survives the shared config.
+
+    A name also survives ``sh``: git hands the driver string to ``sh`` even on
     Windows, and ``sh`` eats the backslashes in a native ``D:\\...\\python.exe``.
-
-    ``sys.executable`` is documented as possibly empty when the interpreter
-    cannot determine its own path (embedded hosts). ``python3`` is the only
-    fallback left at that point.
+    A bare name has none. ``python3`` is preferred; some Windows installs expose
+    only ``python``. If neither resolves, ``python3`` is the last literal left.
     """
-    return Path(sys.executable).as_posix() if sys.executable else "python3"
+    for name in ("python3", "python"):
+        if shutil.which(name):
+            return name
+    return "python3"
 
 
 # driver name -> (config key suffix, value)
@@ -50,19 +65,22 @@ _DRIVERS: dict[str, dict[str, str]] = {
         # into this string before sh parses it, and today it substitutes bare
         # temp names like .merge_file_yvRBP2 that cannot contain a space.
         #
-        # An absolute interpreter path rather than `uv run --frozen python`.
-        # The driver imports only argparse, json, sys, pathlib and typing, so it
-        # needs no project environment, and routing it through uv would let a
-        # merge fail wherever uv cannot run: offline, before the first sync, or
-        # in a clone that never installed it. A failed driver is not a loud
-        # error, it is a silent fall back to the text merge and the conflict
-        # this driver exists to eliminate.
+        # A bare, PATH-resolved interpreter name rather than `uv run --frozen
+        # python` or an absolute venv path. The driver imports only argparse,
+        # json, sys, pathlib and typing, so it needs no project environment
+        # (any Python >=3.10 on PATH runs it), and routing it through uv would
+        # let a merge fail wherever uv cannot run: offline, before the first
+        # sync, or in a clone that never installed it. A failed driver is not a
+        # loud error, it is a silent fall back to the text merge and the
+        # conflict this driver exists to eliminate.
         #
-        # The path is machine-local, which is the right scope: it is written to
-        # `git config --local`, which is never committed. It self-heals because
-        # the installer runs from pre-commit and rewrites the key whenever the
-        # computed value differs from what is registered, so a recreated or
-        # relocated venv is repaired on the next commit.
+        # The name (not an absolute path) is what keeps this correct across git
+        # worktrees. Linked worktrees share one `.git/config`, so an absolute
+        # venv path baked by one worktree breaks every other worktree the moment
+        # that venv is relocated or deleted (issue #3418). A bare name resolves
+        # against PATH at merge time and cannot dangle. It is written to
+        # `git config --local`, never committed, and re-registered from
+        # pre-commit whenever the computed value differs.
         "driver": (f'"{_interpreter()}" scripts/validation/merge_causal_graph.py "%O" "%A" "%B"'),
     },
 }

--- a/tests/validation/test_merge_causal_graph.py
+++ b/tests/validation/test_merge_causal_graph.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import errno
 import json
 import os
+import shutil
 import stat
 import subprocess
 import sys
@@ -866,13 +867,31 @@ class TestRegistrationIsWiredAndIdempotent:
         assert "uv run" not in command
         assert command.startswith('"')
 
-    def test_the_registered_interpreter_exists_and_runs_the_driver(self, tmp_path: Path) -> None:
-        """The baked path must be a working interpreter, not just a string."""
+    def test_the_registered_interpreter_is_a_bare_name_that_runs_the_driver(
+        self, tmp_path: Path
+    ) -> None:
+        """The baked interpreter must be a PATH name, not a worktree path.
+
+        Issue #3418: linked worktrees share one ``.git/config``, so an absolute
+        venv path baked by the first worktree dangles for every other worktree
+        once that venv is relocated or deleted, and git silently falls back to
+        the text merge. A bare name resolves against PATH at merge time and
+        cannot dangle. Assert the token is a bare name (not absolute, no
+        ``.venv``), still resolves on PATH, and actually runs the driver.
+        """
         from scripts.maintenance.install_merge_drivers import _DRIVERS
 
         interpreter = _DRIVERS["causal-graph"]["driver"].split('"')[1]
 
-        assert Path(interpreter).is_file()
+        assert not Path(interpreter).is_absolute(), (
+            f"interpreter must be a bare PATH name, got absolute {interpreter!r}"
+        )
+        assert ".venv" not in interpreter, (
+            f"interpreter must not embed a worktree venv path, got {interpreter!r}"
+        )
+        assert shutil.which(interpreter) is not None, (
+            f"interpreter {interpreter!r} does not resolve on PATH"
+        )
 
         base = tmp_path / "b.json"
         ours = tmp_path / "o.json"
@@ -900,14 +919,30 @@ class TestRegistrationIsWiredAndIdempotent:
 
         assert "\\" not in _DRIVERS["causal-graph"]["driver"]
 
-    def test_an_interpreter_that_cannot_name_itself_falls_back(
+    def test_interpreter_prefers_python3_then_python_then_literal(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """sys.executable is documented as possibly empty in embedded hosts."""
+        """PATH selection order, plus the fallback when nothing resolves.
+
+        Issue #3418: ``_interpreter`` no longer reads ``sys.executable``; it
+        resolves a bare name against PATH so the baked command survives a shared
+        worktree config. Cover the prefer-python3 path, the python-only fallback,
+        and the no-interpreter-on-PATH literal.
+        """
         from scripts.maintenance import install_merge_drivers
 
-        monkeypatch.setattr(sys, "executable", "")
+        present: set[str] = {"python3", "python"}
+        monkeypatch.setattr(
+            install_merge_drivers.shutil,
+            "which",
+            lambda name: f"/usr/bin/{name}" if name in present else None,
+        )
+        assert install_merge_drivers._interpreter() == "python3"
 
+        present = {"python"}
+        assert install_merge_drivers._interpreter() == "python"
+
+        present = set()
         assert install_merge_drivers._interpreter() == "python3"
 
     def test_a_rejected_config_write_exits_two(


### PR DESCRIPTION
## Summary

The causal-graph merge driver stored this process's absolute `sys.executable` in `git config --local`. Linked git worktrees share one `.git/config`, so the first worktree to run the installer registered its own venv path for every worktree. When that worktree or its venv was relocated or deleted, the baked path stopped resolving: the driver exited 127 and git silently fell back to the text merge, reintroducing the causal-graph conflict the driver exists to remove.

## Fix

`_interpreter()` in `scripts/maintenance/install_merge_drivers.py` now returns a bare, PATH-resolved name (`python3`, falling back to `python`, then a `python3` literal) instead of the absolute interpreter path. A bare name cannot dangle across a shared worktree config, and it keeps the sh-safety the POSIX absolute path had (no backslashes to lose on Windows). This matches option 1 in the issue's Proposed Fix, and the reporter's own workaround, which ran the driver with the system `python3`.

The driver needs no project environment (standard library only), so any Python >=3.10 on PATH runs it. The 3.10 floor is inherent to the driver (it imports `typing.TypeAlias` and evaluates a PEP 604 union at import time), not introduced by this change.

## Tests

Two tests in `tests/validation/test_merge_causal_graph.py` encoded the absolute-path assumption and were updated:

- one now asserts the registered token is a bare on-PATH name (not absolute, no venv segment) and still runs the driver end to end;
- the other covers the python3 then python then literal selection order via a mocked PATH.

All 91 tests in the suite pass; `ruff check`, `ruff format --check`, and `mypy` are clean. The pre-commit hook self-healed the local git config to the portable value, verifying the install path end to end.

## References

- Merge behavior itself lives in `scripts/validation/merge_causal_graph.py` (unchanged here; only the interpreter that launches it changed).

Fixes #3418
