### PR TITLE
feat(validation): always-on instruction budget gate (phase 1, #3419)

### DIFF
--- a/.github/workflows/instruction-budget.yml
+++ b/.github/workflows/instruction-budget.yml
@@ -51,6 +51,7 @@ jobs:
               - 'scripts/validation/instruction_budget.py'
               - 'scripts/validation/token_budget.py'
               - 'tests/validation/test_instruction_budget.py'
+              - '.github/workflows/instruction-budget.yml'
 
       - name: Determine if budget validation should run
         id: determine

--- a/.github/workflows/instruction-budget.yml
+++ b/.github/workflows/instruction-budget.yml
@@ -1,0 +1,95 @@
+# Always-On Instruction Budget Validation
+#
+# Validates that the always-on instruction corpus (rules whose applyTo scopes
+# them to every file of a language) stays within its per-language byte ceiling.
+# A single source edit loads this whole corpus, so unbounded growth degrades
+# instruction-following accuracy (issue #3419).
+#
+# Exit codes: 0 = pass, 1 = budget exceeded, 2 = config error (ADR-035).
+#
+# IMPORTANT: This workflow runs on ALL PRs to satisfy required status checks,
+# but skips actual validation when no relevant files are changed.
+
+name: Instruction Budget
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-paths:
+    name: Detect changes
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    outputs:
+      should-run-budget: ${{ steps.determine.outputs.should-run-budget }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check path filters
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          filters: |
+            rules:
+              - '.claude/rules/**'
+              - '.github/instructions/**'
+            validator:
+              - 'scripts/validation/instruction_budget.py'
+              - 'scripts/validation/token_budget.py'
+              - 'tests/validation/test_instruction_budget.py'
+
+      - name: Determine if budget validation should run
+        id: determine
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          FILTER_OUTPUTS: ${{ toJson(steps.filter.outputs) }}
+          FILTER_KEYS: rules,validator
+          OUTPUT_NAME: should-run-budget
+        run: python3 scripts/workflows/determine_should_run_from_filters.py
+
+  validate-budget:
+    name: Validate budget
+    needs: check-paths
+    if: needs.check-paths.outputs.should-run-budget == 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+
+      - name: Run budget validator
+        run: |
+          python3 -m scripts.validation.instruction_budget --ci
+
+  skip-budget:
+    name: Skip budget (no changes)
+    needs: check-paths
+    if: needs.check-paths.outputs.should-run-budget != 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Skip message
+        run: |
+          echo "No instruction budget changes detected - skipping validation"

--- a/.github/workflows/instruction-budget.yml
+++ b/.github/workflows/instruction-budget.yml
@@ -72,14 +72,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: '3.14'
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run budget validator
         run: |
-          python3 -m scripts.validation.instruction_budget --ci
+          uv run --frozen python3 -m scripts.validation.instruction_budget --ci
 
   skip-budget:
     name: Skip budget (no changes)

--- a/scripts/validation/checks_tooling.py
+++ b/scripts/validation/checks_tooling.py
@@ -369,8 +369,8 @@ def validate_instruction_budget(repo_root: Path) -> bool:
     """Gate the always-on instruction budget per language (Issue #3419).
 
     Sums the bytes of ``.github/instructions/*.instructions.md`` files whose
-    ``applyTo`` scopes them to every file of a language (``**`` or
-    ``**/*.<ext>``) and fails when a language exceeds its non-regression
+    ``applyTo`` scopes them to every file of a language (``**``, ``**/*``,
+    or ``**/*.<ext>``) and fails when a language exceeds its non-regression
     ceiling. Runs the module via ``-m`` from ``repo_root`` so its
     ``scripts.validation`` package import resolves. The instructions tree is
     absent in downstream installs, so SKIP rather than FAIL when it is missing.
@@ -379,7 +379,7 @@ def validate_instruction_budget(repo_root: Path) -> bool:
         raise MissingScriptSkip(
             ".github/instructions not present (downstream install); no budget to gate"
         )
-    exit_code, stdout, _ = _run_subprocess(
+    exit_code, stdout, stderr = _run_subprocess(
         [
             sys.executable,
             "-m",
@@ -390,6 +390,9 @@ def validate_instruction_budget(repo_root: Path) -> bool:
         ],
         cwd=repo_root,
     )
-    if exit_code != 0 and stdout:
-        print(stdout)
+    if exit_code != 0:
+        if stdout:
+            print(stdout)
+        if stderr:
+            print(stderr, file=sys.stderr)
     return bool(exit_code == 0)

--- a/scripts/validation/checks_tooling.py
+++ b/scripts/validation/checks_tooling.py
@@ -363,3 +363,33 @@ def validate_ci_dependency_pins(repo_root: Path) -> bool:
     from check_ci_dependency_pins import check as check_pins
 
     return bool(check_pins(workflows, pyproject) == PIN_OK)
+
+
+def validate_instruction_budget(repo_root: Path) -> bool:
+    """Gate the always-on instruction budget per language (Issue #3419).
+
+    Sums the bytes of ``.github/instructions/*.instructions.md`` files whose
+    ``applyTo`` scopes them to every file of a language (``**`` or
+    ``**/*.<ext>``) and fails when a language exceeds its non-regression
+    ceiling. Runs the module via ``-m`` from ``repo_root`` so its
+    ``scripts.validation`` package import resolves. The instructions tree is
+    absent in downstream installs, so SKIP rather than FAIL when it is missing.
+    """
+    if not (repo_root / ".github" / "instructions").is_dir():
+        raise MissingScriptSkip(
+            ".github/instructions not present (downstream install); no budget to gate"
+        )
+    exit_code, stdout, _ = _run_subprocess(
+        [
+            sys.executable,
+            "-m",
+            "scripts.validation.instruction_budget",
+            "--ci",
+            "--path",
+            str(repo_root),
+        ],
+        cwd=repo_root,
+    )
+    if exit_code != 0 and stdout:
+        print(stdout)
+    return bool(exit_code == 0)

--- a/scripts/validation/checks_tooling.py
+++ b/scripts/validation/checks_tooling.py
@@ -369,8 +369,8 @@ def validate_instruction_budget(repo_root: Path) -> bool:
     """Gate the always-on instruction budget per language (Issue #3419).
 
     Sums the bytes of ``.github/instructions/*.instructions.md`` files whose
-    ``applyTo`` scopes them to every file of a language (``**``, ``**/*``,
-    or ``**/*.<ext>``) and fails when a language exceeds its non-regression
+    ``applyTo`` scopes them to every file of a language (per VS Code applyTo
+    matching semantics) and fails when a language exceeds its non-regression
     ceiling. Runs the module via ``-m`` from ``repo_root`` so its
     ``scripts.validation`` package import resolves. The instructions tree is
     absent in downstream installs, so SKIP rather than FAIL when it is missing.

--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -10,7 +10,7 @@ Without an instrument this corpus grows silently on every rule addition.
 
 This validator computes the *language-baseline always-on budget*: the summed
 bytes of instruction files whose ``applyTo`` includes a language-universal
-pattern (``**`` or ``**/*.<ext>``) for a representative extension. Directory
+pattern (``**``, ``**/*``, or ``**/*.<ext>``) for a representative extension. Directory
 scoped rules (for example ``tests/**``) are situational, not always-on, so they
 are excluded by design.
 
@@ -47,9 +47,6 @@ from scripts.validation.token_budget import estimate_token_count
 
 INSTRUCTIONS_SUBDIR = ".github/instructions"
 INSTRUCTION_GLOB = "*.instructions.md"
-
-# Representative source extensions from issue #3419 acceptance criteria.
-REPRESENTATIVE_EXTENSIONS: tuple[str, ...] = (".py", ".cs", ".ps1", ".md")
 
 # Non-regression ratchet ceilings in bytes, seeded just above current measured
 # values (see module docstring). Lower these as the corpus shrinks.
@@ -362,7 +359,7 @@ def _resolve_safe(repo_root: Path, relative: str) -> Path | None:
     """Resolve a relative path safely within repo_root (CWE-22 protection)."""
     candidate = (repo_root / relative).resolve()
     root_resolved = repo_root.resolve()
-    if not str(candidate).startswith(str(root_resolved) + os.sep) and candidate != root_resolved:
+    if not candidate.is_relative_to(root_resolved):
         return None
     return candidate
 

--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -291,9 +291,14 @@ def parse_applyto(text: str) -> set[str]:
 
 
 def is_language_universal(patterns: set[str], ext: str) -> bool:
-    """True when any pattern scopes the rule to every file of ``ext``."""
-    forms = language_universal_forms(ext)
-    return any(_vscode_effective_glob(pattern) in forms for pattern in patterns)
+    """True when any pattern scopes the rule to every file of ``ext``.
+
+    Case-insensitive: VS Code matches ``applyTo`` globs with ``ignoreCase: true``
+    (same pinned source, line 316), so ``**/*.PY`` is universal for ``.py``. Both
+    the effective glob and the universal forms are case-folded before comparison.
+    """
+    forms = {form.lower() for form in language_universal_forms(ext)}
+    return any(_vscode_effective_glob(pattern).lower() in forms for pattern in patterns)
 
 
 @dataclass(frozen=True)

--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -123,12 +123,15 @@ def language_universal_forms(ext: str) -> frozenset[str]:
 
     - ``**`` and ``**/*`` and ``*`` are the harness all-files wildcards (every
       file of every type).
+    - ``**/*.*`` matches every file whose basename carries a dot, which every
+      file of ``ext`` does, so it is universal for the language too (it also
+      matches other dotted types, but that only widens the match).
     - ``**/*.<ext>`` is every file of the type at any depth. A relative
       ``*.<ext>`` reaches this form via the ``**/`` prepend, so it is universal
       too; a *scoped* relative glob such as ``src/*.<ext>`` prepends to
       ``**/src/*.<ext>`` and stays out of this set.
     """
-    return frozenset({"**", "**/*", "*", f"**/*{ext}"})
+    return frozenset({"**", "**/*", "*", "**/*.*", f"**/*{ext}"})
 
 
 def _split_top_level_commas(raw: str) -> list[str]:
@@ -215,25 +218,42 @@ def _vscode_effective_glob(pattern: str) -> str:
     safe upper bound). Source, pinned:
     https://github.com/microsoft/vscode/blob/018354116a88cb1264790f93663de42198a44594/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts#L294-L310
 
-    Two rules from that matcher:
+    Rules from that matcher:
 
     - Bare ``**``, ``**/*``, and ``*`` are all-files wildcards: a rule scoped to
       any of them attaches even with no file open, so ``*`` is universal (not
       root-only as raw ``minimatch`` would have it).
+    - The harness matches against absolute file paths, so an absolute pattern is
+      anchored at the filesystem root. A leading ``/**/`` therefore spans any
+      directory prefix, the same span as the relative ``**/`` anchor, and bare
+      ``/**`` or ``/**/*`` is the all-files wildcard.
     - Any other pattern that is neither absolute (``/...``) nor already
       ``**/``-anchored gets ``**/`` prepended, so ``*.py`` means ``**/*.py`` and
       loads for every ``.py`` at any depth, while ``src/*.py`` becomes
       ``**/src/*.py`` and stays scoped.
+    - A trailing ``/**`` globstar matches zero or more trailing segments,
+      including the prefix path itself, so ``**/*.py/**`` covers the same files
+      as ``**/*.py`` and is likewise universal.
 
-    After the prepend the glob is folded by ``_normalize_glob`` so equivalent
-    spellings (``**/**.py`` -> ``**/*.py``) collapse to one form.
+    After the anchor folds the glob is passed through ``_normalize_glob`` so
+    equivalent spellings (``**/**.py`` -> ``**/*.py``) collapse to one form.
     """
     p = pattern.strip()
     if p in ("**", "**/*", "*"):
         return p
+    if p in ("/**", "/**/*"):
+        return "**"
+    if p.startswith("/**/"):
+        p = p[1:]
     if not p.startswith("/") and not p.startswith("**/"):
         p = "**/" + p
-    return _normalize_glob(p)
+    normalized = _normalize_glob(p)
+    while normalized.endswith("/**"):
+        stripped = normalized[: -len("/**")]
+        if not stripped:
+            return "**"
+        normalized = _normalize_glob(stripped)
+    return normalized
 
 
 def _iter_applyto_globs(value: object) -> list[str]:
@@ -296,6 +316,12 @@ def is_language_universal(patterns: set[str], ext: str) -> bool:
     Case-insensitive: VS Code matches ``applyTo`` globs with ``ignoreCase: true``
     (same pinned source, line 316), so ``**/*.PY`` is universal for ``.py``. Both
     the effective glob and the universal forms are case-folded before comparison.
+
+    The effective glob folds the harness anchor rules (``_vscode_effective_glob``)
+    so broad spellings reduce to a universal form: ``/**/*.py`` (absolute anchor),
+    ``**/*.py/**`` (trailing globstar), and ``**/*.*`` (any dotted basename) each
+    resolve to universal, closing the bypass where a broad glob would otherwise
+    contribute zero bytes to the always-on budget.
     """
     forms = {form.lower() for form in language_universal_forms(ext)}
     return any(_vscode_effective_glob(pattern).lower() in forms for pattern in patterns)

--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -40,6 +40,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+import yaml
+
 from scripts.validation.token_budget import estimate_token_count
 
 INSTRUCTIONS_SUBDIR = ".github/instructions"
@@ -58,7 +60,15 @@ DEFAULT_CEILINGS_BYTES: dict[str, int] = {
 }
 
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
-_APPLYTO_RE = re.compile(r"^applyTo:\s*(.*)$", re.MULTILINE)
+
+
+class UnsupportedApplyToError(ValueError):
+    """A frontmatter ``applyTo`` is present but is neither a string nor a list of strings.
+
+    Silently excluding such a file would under-count the always-on budget and
+    let a malformed rule bypass the ceiling, so this is surfaced as a
+    configuration error (ADR-035 exit code 2) rather than swallowed.
+    """
 
 
 def language_universal_forms(ext: str) -> frozenset[str]:
@@ -122,36 +132,73 @@ def expand_braces(pattern: str) -> list[str]:
     return expanded
 
 
+def _collapse_globstars(pattern: str) -> str:
+    """Collapse redundant consecutive ``**`` segments to their minimal form.
+
+    ``**/**/*.py`` matches exactly the files ``**/*.py`` matches, because each
+    ``**`` can match zero directories. Folding any run of globstars makes the
+    universality check depend on glob semantics, not on the exact spelling, so
+    a rule cannot dodge the always-on budget by padding its ``applyTo`` with
+    equivalent ``**/`` segments.
+    """
+    previous = ""
+    while previous != pattern:
+        previous = pattern
+        pattern = pattern.replace("**/**", "**")
+    return pattern
+
+
+def _iter_applyto_globs(value: object) -> list[str]:
+    """Flatten a parsed YAML ``applyTo`` value into raw comma-split globs.
+
+    Accepts a single glob string (the repo convention, possibly comma joined)
+    or a YAML list of such strings. Any other shape is a configuration error.
+    """
+    if isinstance(value, str):
+        return _split_top_level_commas(value)
+    if isinstance(value, list):
+        globs: list[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                msg = f"applyTo list entries must be strings, got {type(item).__name__}"
+                raise UnsupportedApplyToError(msg)
+            globs.extend(_split_top_level_commas(item))
+        return globs
+    msg = f"applyTo must be a string or list of strings, got {type(value).__name__}"
+    raise UnsupportedApplyToError(msg)
+
+
 def parse_applyto(text: str) -> set[str]:
     """Extract the ``applyTo`` glob set from a rule file's frontmatter.
 
+    Parses the frontmatter as YAML so quoting, inline comments, flow lists, and
+    block-style lists are handled by the parser rather than a line regex (a
+    regex that grabbed everything after ``applyTo:`` would fold a trailing
+    ``# comment`` into the glob and would miss a block-style list entirely).
     Splits the comma-separated scope list without breaking brace groups, then
     expands each brace group so ``**/*.{py,pyi}`` becomes two concrete globs.
     """
     fm_match = _FRONTMATTER_RE.match(text)
     if fm_match is None:
         return set()
-    apply_match = _APPLYTO_RE.search(fm_match.group(1))
-    if apply_match is None:
+    try:
+        data = yaml.safe_load(fm_match.group(1))
+    except yaml.YAMLError:
         return set()
-    raw = apply_match.group(1).strip()
-    if len(raw) >= 2 and raw[0] in "'\"" and raw[-1] == raw[0]:
-        raw = raw[1:-1]
-    raw = raw.strip()
-    if raw.startswith("[") and raw.endswith("]"):
-        raw = raw[1:-1]
+    if not isinstance(data, dict) or "applyTo" not in data:
+        return set()
     patterns: set[str] = set()
-    for part in _split_top_level_commas(raw):
-        cleaned = part.strip().strip("'\"").strip()
-        if not cleaned:
-            continue
-        patterns.update(expand_braces(cleaned))
+    for glob in _iter_applyto_globs(data["applyTo"]):
+        cleaned = glob.strip()
+        if cleaned:
+            patterns.update(expand_braces(cleaned))
     return patterns
 
 
 def is_language_universal(patterns: set[str], ext: str) -> bool:
     """True when any pattern scopes the rule to every file of ``ext``."""
-    return bool(patterns & language_universal_forms(ext))
+    forms = language_universal_forms(ext)
+    return any(_collapse_globstars(pattern) in forms for pattern in patterns)
 
 
 @dataclass(frozen=True)
@@ -346,7 +393,11 @@ def main(argv: list[str] | None = None) -> int:
     for ext, ceiling in args.ceiling:
         ceilings[ext] = ceiling
 
-    results = evaluate(repo_path, ceilings)
+    try:
+        results = evaluate(repo_path, ceilings)
+    except UnsupportedApplyToError as exc:
+        print(f"Error: unsupported applyTo in an instruction file: {exc}", file=sys.stderr)
+        return 2
     any_over = any(r.over_budget for r in results)
 
     if args.output_format == "json":

--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Measure and gate the always-on instruction budget per file language.
+
+Issue #3419: editing a single ``.py`` file loads ~218 KB of always-on
+instruction text (every ``.github/instructions/*.instructions.md`` whose
+``applyTo`` matches that language regardless of directory). The IFScale
+benchmark (arXiv:2507.11538) shows even the strongest models omit instructions
+as the always-loaded set grows; omission, not modification, is the failure mode.
+Without an instrument this corpus grows silently on every rule addition.
+
+This validator computes the *language-baseline always-on budget*: the summed
+bytes of instruction files whose ``applyTo`` includes a language-universal
+pattern (``**`` or ``**/*.<ext>``) for a representative extension. Directory
+scoped rules (for example ``tests/**``) are situational, not always-on, so they
+are excluded by design.
+
+The per-extension ceilings are a NON-REGRESSION RATCHET seeded just above the
+current measured bytes. Phase 1 (this instrument) makes the budget visible in CI
+and blocks silent growth, for example adding a new all-language rule. The
+follow-up rescope (#3419 AC #2) lowers these ceilings as book-derived rules move
+to task-invoked skills. Lower a ceiling when the corpus shrinks; never raise one
+without recording why in the same change.
+
+Gate is on bytes (exact and reproducible). Estimated tokens are informational
+and reuse the shared estimator from ``token_budget``.
+
+Exit codes follow ADR-035:
+    0 - Success (all extensions within budget, or non-CI mode)
+    1 - Logic error (budget exceeded, CI mode only)
+    2 - Configuration error (invalid path or missing instructions directory)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts.validation.token_budget import estimate_token_count
+
+INSTRUCTIONS_SUBDIR = ".github/instructions"
+INSTRUCTION_GLOB = "*.instructions.md"
+
+# Representative source extensions from issue #3419 acceptance criteria.
+REPRESENTATIVE_EXTENSIONS: tuple[str, ...] = (".py", ".cs", ".ps1", ".md")
+
+# Non-regression ratchet ceilings in bytes, seeded just above current measured
+# values (see module docstring). Lower these as the corpus shrinks.
+DEFAULT_CEILINGS_BYTES: dict[str, int] = {
+    ".py": 220_000,
+    ".cs": 220_000,
+    ".ps1": 220_000,
+    ".md": 83_000,
+}
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+_APPLYTO_RE = re.compile(r"^applyTo:\s*(.*)$", re.MULTILINE)
+
+
+def language_universal_forms(ext: str) -> frozenset[str]:
+    """Return the ``applyTo`` patterns that scope a rule to every file of ``ext``.
+
+    A rule is part of the always-on language baseline when it applies to any
+    file of the language no matter where it lives: the universal ``**`` or the
+    language-universal ``**/*.<ext>`` (``*.<ext>`` accepted defensively).
+    """
+    return frozenset({"**", f"*{ext}", f"**/*{ext}"})
+
+
+def parse_applyto(text: str) -> set[str]:
+    """Extract the ``applyTo`` glob set from a rule file's frontmatter."""
+    fm_match = _FRONTMATTER_RE.match(text)
+    if fm_match is None:
+        return set()
+    apply_match = _APPLYTO_RE.search(fm_match.group(1))
+    if apply_match is None:
+        return set()
+    raw = apply_match.group(1).strip()
+    if len(raw) >= 2 and raw[0] in "'\"" and raw[-1] == raw[0]:
+        raw = raw[1:-1]
+    raw = raw.strip()
+    if raw.startswith("[") and raw.endswith("]"):
+        raw = raw[1:-1]
+    return {part.strip().strip("'\"") for part in raw.split(",") if part.strip()}
+
+
+def is_language_universal(patterns: set[str], ext: str) -> bool:
+    """True when any pattern scopes the rule to every file of ``ext``."""
+    return bool(patterns & language_universal_forms(ext))
+
+
+@dataclass(frozen=True)
+class InstructionFile:
+    """A single instruction file with its measured size and scope."""
+
+    name: str
+    size_bytes: int
+    estimated_tokens: int
+    patterns: frozenset[str]
+
+
+@dataclass(frozen=True)
+class ExtensionResult:
+    """Always-on budget measurement for one representative extension."""
+
+    extension: str
+    matched_files: tuple[str, ...]
+    total_bytes: int
+    estimated_tokens: int
+    ceiling_bytes: int
+
+    @property
+    def usage_percent(self) -> float:
+        if self.ceiling_bytes <= 0:
+            return 0.0
+        return round((self.total_bytes / self.ceiling_bytes) * 100, 1)
+
+    @property
+    def over_budget(self) -> bool:
+        return self.total_bytes > self.ceiling_bytes
+
+
+def _resolve_safe(repo_root: Path, relative: str) -> Path | None:
+    """Resolve a relative path safely within repo_root (CWE-22 protection)."""
+    candidate = (repo_root / relative).resolve()
+    root_resolved = repo_root.resolve()
+    if not str(candidate).startswith(str(root_resolved) + os.sep) and candidate != root_resolved:
+        return None
+    return candidate
+
+
+def load_instruction_files(repo_root: Path) -> list[InstructionFile]:
+    """Read every instruction file, measuring size and parsing ``applyTo``."""
+    instructions_dir = _resolve_safe(repo_root, INSTRUCTIONS_SUBDIR)
+    if instructions_dir is None or not instructions_dir.is_dir():
+        return []
+    files: list[InstructionFile] = []
+    for path in sorted(instructions_dir.glob(INSTRUCTION_GLOB)):
+        content = path.read_text(encoding="utf-8", errors="replace")
+        files.append(
+            InstructionFile(
+                name=path.name,
+                size_bytes=len(content.encode("utf-8")),
+                estimated_tokens=estimate_token_count(content),
+                patterns=frozenset(parse_applyto(content)),
+            )
+        )
+    return files
+
+
+def measure_extension(
+    files: list[InstructionFile],
+    ext: str,
+    ceiling_bytes: int,
+) -> ExtensionResult:
+    """Sum the always-on budget for one extension across all instruction files."""
+    matched = [f for f in files if is_language_universal(set(f.patterns), ext)]
+    return ExtensionResult(
+        extension=ext,
+        matched_files=tuple(f.name for f in matched),
+        total_bytes=sum(f.size_bytes for f in matched),
+        estimated_tokens=sum(f.estimated_tokens for f in matched),
+        ceiling_bytes=ceiling_bytes,
+    )
+
+
+def evaluate(repo_root: Path, ceilings: dict[str, int]) -> list[ExtensionResult]:
+    """Measure the always-on budget for every configured extension."""
+    files = load_instruction_files(repo_root)
+    return [
+        measure_extension(files, ext, ceilings[ext])
+        for ext in sorted(ceilings)
+    ]
+
+
+def format_table(results: list[ExtensionResult]) -> str:
+    """Format results as a readable table."""
+    lines: list[str] = []
+    header = (
+        f"{'Ext':<6} {'Files':>6} {'Bytes':>9} "
+        f"{'Ceiling':>9} {'Tokens~':>9} {'Usage':>8} {'Status':>7}"
+    )
+    lines.append(header)
+    lines.append("-" * len(header))
+    for r in results:
+        status = "FAIL" if r.over_budget else "PASS"
+        lines.append(
+            f"{r.extension:<6} {len(r.matched_files):>6} {r.total_bytes:>9} "
+            f"{r.ceiling_bytes:>9} {r.estimated_tokens:>9} {r.usage_percent:>7.1f}% {status:>7}"
+        )
+    return "\n".join(lines)
+
+
+def format_json(results: list[ExtensionResult]) -> str:
+    """Format results as JSON for machine consumption."""
+    data = [
+        {
+            "extension": r.extension,
+            "matched_files": list(r.matched_files),
+            "file_count": len(r.matched_files),
+            "total_bytes": r.total_bytes,
+            "estimated_tokens": r.estimated_tokens,
+            "ceiling_bytes": r.ceiling_bytes,
+            "usage_percent": r.usage_percent,
+            "over_budget": r.over_budget,
+        }
+        for r in results
+    ]
+    return json.dumps(data, indent=2)
+
+
+def parse_ceiling_override(value: str) -> tuple[str, int]:
+    """Parse a '.ext:bytes' ceiling override string."""
+    parts = value.rsplit(":", 1)
+    if len(parts) != 2:
+        msg = f"Invalid ceiling format '{value}'. Expected '.ext:bytes'."
+        raise argparse.ArgumentTypeError(msg)
+    ext = parts[0] if parts[0].startswith(".") else f".{parts[0]}"
+    try:
+        ceiling = int(parts[1])
+    except ValueError:
+        msg = f"Invalid byte count in '{value}'. Must be an integer."
+        raise argparse.ArgumentTypeError(msg) from None
+    if ceiling <= 0:
+        msg = f"Ceiling must be positive, got {ceiling}."
+        raise argparse.ArgumentTypeError(msg)
+    return ext, ceiling
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Measure and gate the always-on instruction budget per language.",
+    )
+    parser.add_argument(
+        "--path",
+        default=os.environ.get("REPO_PATH", "."),
+        help="Path to the repository root (env: REPO_PATH, default: '.')",
+    )
+    parser.add_argument(
+        "--ci",
+        action="store_true",
+        default=os.environ.get("CI", "").lower() in ("true", "1"),
+        help="CI mode: exit 1 on any budget exceeded (env: CI)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        dest="output_format",
+        help="Output format (default: table)",
+    )
+    parser.add_argument(
+        "--ceiling",
+        action="append",
+        type=parse_ceiling_override,
+        default=[],
+        metavar="EXT:BYTES",
+        help="Override ceiling for an extension (e.g., '.py:200000'). Repeatable.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns ADR-035 exit code."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    repo_path = Path(args.path).resolve()
+    if not repo_path.is_dir():
+        print(f"Error: path is not a directory: {args.path}", file=sys.stderr)
+        return 2
+
+    if _resolve_safe(repo_path, INSTRUCTIONS_SUBDIR) is None or not (
+        repo_path / INSTRUCTIONS_SUBDIR
+    ).is_dir():
+        print(f"Error: instructions directory not found: {INSTRUCTIONS_SUBDIR}", file=sys.stderr)
+        return 2
+
+    ceilings = dict(DEFAULT_CEILINGS_BYTES)
+    for ext, ceiling in args.ceiling:
+        ceilings[ext] = ceiling
+
+    results = evaluate(repo_path, ceilings)
+    any_over = any(r.over_budget for r in results)
+
+    if args.output_format == "json":
+        print(format_json(results))
+    else:
+        print("Always-On Instruction Budget (language baseline)")
+        print()
+        print(format_table(results))
+        if any_over:
+            print()
+            print("FAIL: One or more languages exceed the always-on instruction ceiling.")
+            print()
+            print("Action Required:")
+            print("  1. Move situational or book-derived rules to task-invoked skills (#3419).")
+            print("  2. Scope rules with a narrower applyTo instead of '**' or '**/*.<ext>'.")
+            print("  3. If a raise is truly justified, edit DEFAULT_CEILINGS_BYTES and say why.")
+        else:
+            print()
+            print("PASS: All languages within the always-on instruction ceiling.")
+
+    if any_over and args.ci:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -143,23 +143,40 @@ def _probe_paths(ext: str) -> tuple[str, ...]:
     return tuple(dict.fromkeys(paths))
 
 
-def _split_top_level_commas(raw: str) -> list[str]:
-    """Split on commas that are not inside a ``{...}`` brace group."""
-    parts: list[str] = []
+def _split_glob_aware(pattern: str, split_char: str) -> list[str]:
+    """Split ``pattern`` on ``split_char`` outside ``{...}`` and ``[...]``.
+
+    Port of VS Code ``splitGlobAware`` (glob.ts, pinned SHA
+    018354116a88cb1264790f93663de42198a44594): a leading separator yields an
+    empty leading segment (kept, so a slash-anchored regex starts with a
+    separator), a trailing separator yields an empty trailing segment (dropped),
+    and a separator inside a brace or bracket group does not split. Used for both
+    the comma split of an ``applyTo`` scope list and the ``/`` split of a single
+    glob into path segments.
+    """
+    if not pattern:
+        return []
+    segments: list[str] = []
+    in_braces = False
+    in_brackets = False
     current: list[str] = []
-    depth = 0
-    for ch in raw:
-        if ch == "{":
-            depth += 1
-        elif ch == "}":
-            depth = max(0, depth - 1)
-        if ch == "," and depth == 0:
-            parts.append("".join(current))
+    for char in pattern:
+        if char == split_char and not in_braces and not in_brackets:
+            segments.append("".join(current))
             current = []
-        else:
-            current.append(ch)
-    parts.append("".join(current))
-    return parts
+            continue
+        if char == "{":
+            in_braces = True
+        elif char == "}":
+            in_braces = False
+        elif char == "[":
+            in_brackets = True
+        elif char == "]":
+            in_brackets = False
+        current.append(char)
+    if current:
+        segments.append("".join(current))
+    return segments
 
 
 def expand_braces(pattern: str) -> list[str]:
@@ -184,7 +201,7 @@ def expand_braces(pattern: str) -> list[str]:
     if end == -1:
         return [pattern]
     prefix, suffix = pattern[:start], pattern[end + 1 :]
-    options = _split_top_level_commas(pattern[start + 1 : end])
+    options = _split_glob_aware(pattern[start + 1 : end], ",")
     expanded: list[str] = []
     for opt in options:
         expanded.extend(expand_braces(prefix + opt + suffix))
@@ -214,70 +231,96 @@ def _vscode_effective_glob(pattern: str) -> str:
     return p
 
 
-_GLOBSTAR = object()
+# Faithful port of VS Code's glob-to-regex separator semantics (glob.ts
+# ``parseRegExp``/``starsToRegExp``), pinned at SHA
+# 018354116a88cb1264790f93663de42198a44594
+# (src/vs/base/common/glob.ts L44-L253). Hand-rolling the minimatch->regex
+# translation diverged from the harness at separator edges: the dropped
+# mandatory ``/`` before a non-terminal ``**`` let ``/*/**/*.py`` match a root
+# file ``/probe.py``. Porting VS Code's own segment walker ends that class of
+# drift. Two simplifications are safe here: braces are already expanded by
+# ``expand_braces`` before a pattern reaches this compiler, and ``[...]``
+# character classes are treated as literal text rather than parsed. A char
+# class is scoped by construction (it constrains a character), so it can never
+# match the diverse probe set and is correctly classified non-universal for the
+# upper-bound budget without bracket parsing; treating ``[`` literally only ever
+# makes the regex more restrictive, never falsely universal.
+_GLOB_STAR = "**"
+_PATH_REGEX = r"[/\\]"  # any path separator (slash or backslash)
+_NO_PATH_REGEX = r"[^/\\]"  # any non-separator character
 
 
-def _compile_glob_regex(tokens: list[object]) -> str:
-    """Join translated glob ``tokens`` into a regex body with globstar semantics.
+def _stars_to_regexp(star_count: int, *, is_last_segment: bool) -> str:
+    """Translate a run of ``*`` to regex, mirroring VS Code ``starsToRegExp``.
 
-    A ``_GLOBSTAR`` token matches zero or more whole path segments and supplies
-    its own surrounding separators, so a leading ``**/`` spans any prefix, a
-    trailing ``/**`` covers the prefix path itself, and a bare ``**`` matches
-    everything. Literal tokens are joined with ``/``.
+    ``star_count == 1`` is a single ``*`` (any run of non-separator characters,
+    non-greedy). ``star_count == 2`` is a whole ``**`` segment (zero or more
+    complete path segments); as the last segment it additionally matches a
+    trailing ``separator + segment`` so ``a/**`` covers ``a/b``.
     """
-    last = len(tokens) - 1
+    if star_count == 0:
+        return ""
+    if star_count == 1:
+        return _NO_PATH_REGEX + "*?"
+    tail = f"|{_PATH_REGEX}{_NO_PATH_REGEX}+" if is_last_segment else ""
+    return f"(?:{_PATH_REGEX}|{_NO_PATH_REGEX}+{_PATH_REGEX}{tail})*?"
+
+
+def _segment_to_regex(segment: str) -> str:
+    """Translate one non-globstar path segment to a regex fragment.
+
+    Each ``*`` becomes a single-star run (``starsToRegExp(1)``), ``?`` matches
+    one non-separator character, and every other character is escaped literally.
+    """
     out: list[str] = []
-    for index, token in enumerate(tokens):
-        if token is _GLOBSTAR:
-            if index == 0 and last == 0:
-                out.append(".*")
-            elif index == last:
-                out.append("(?:.*)?")
-            else:
-                out.append("(?:.*/)?")
-            continue
-        out.append(str(token))
-        if index != last:
-            following = tokens[index + 1]
-            if following is _GLOBSTAR and index + 1 == last:
-                out.append("(?:/)?")
-            elif following is not _GLOBSTAR:
-                out.append("/")
+    for char in segment:
+        if char == "*":
+            out.append(_stars_to_regexp(1, is_last_segment=False))
+        elif char == "?":
+            out.append(_NO_PATH_REGEX)
+        else:
+            out.append(re.escape(char))
     return "".join(out)
 
 
 @cache
 def _glob_to_regex(pattern: str) -> re.Pattern[str]:
-    """Compile a ``minimatch``-style glob to an anchored case-insensitive regex.
+    """Compile an ``applyTo`` glob to an anchored case-insensitive regex.
 
-    Path-segment semantics, matching the harness glob engine:
+    Faithful port of VS Code's ``parseRegExp`` segment walker (see the module
+    note above the constants). Path-segment semantics match the harness:
 
-    - ``**`` as a whole segment matches zero or more path segments;
+    - ``**`` as a whole segment matches zero or more complete path segments;
     - ``*`` matches zero or more non-separator characters within one segment;
     - ``?`` matches exactly one non-separator character;
-    - every other character is literal.
+    - a literal separator is emitted after a segment unless the following
+      segment is a *terminal* ``**`` (VS Code's "Tail" rule), so ``some/**/*.js``
+      keeps the ``/`` after ``some`` and a sibling folder ``something`` cannot
+      match, while ``/*/**/*.py`` requires a real first directory and does not
+      match a root file.
 
-    Case-insensitive because VS Code matches ``applyTo`` with ``ignoreCase: true``
-    (same pinned source, line 316). ``is_language_universal`` uses this to decide
-    universality by *matching* diverse probe paths instead of enumerating glob
-    spellings, which closes bypasses such as ``**/*.p?`` and ``/*/**`` that no
-    finite spelling table can cover.
+    Case-insensitive because VS Code matches ``applyTo`` with ``ignoreCase:
+    true``. ``is_language_universal`` uses this to decide universality by
+    *matching* diverse probe paths instead of enumerating glob spellings.
     """
-    tokens: list[object] = []
-    for segment in pattern.split("/"):
-        if segment == "**":
-            tokens.append(_GLOBSTAR)
+    segments = _split_glob_aware(pattern, "/")
+    if segments and all(segment == _GLOB_STAR for segment in segments):
+        return re.compile("^.*$", re.IGNORECASE)
+    body: list[str] = []
+    last = len(segments) - 1
+    previous_was_globstar = False
+    for index, segment in enumerate(segments):
+        if segment == _GLOB_STAR:
+            if previous_was_globstar:
+                continue
+            body.append(_stars_to_regexp(2, is_last_segment=index == last))
+            previous_was_globstar = True
             continue
-        piece: list[str] = []
-        for char in segment:
-            if char == "*":
-                piece.append("[^/]*")
-            elif char == "?":
-                piece.append("[^/]")
-            else:
-                piece.append(re.escape(char))
-        tokens.append("".join(piece))
-    return re.compile("^" + _compile_glob_regex(tokens) + "$", re.IGNORECASE)
+        body.append(_segment_to_regex(segment))
+        if index < last and (segments[index + 1] != _GLOB_STAR or index + 2 < len(segments)):
+            body.append(_PATH_REGEX)
+        previous_was_globstar = False
+    return re.compile("^" + "".join(body) + "$", re.IGNORECASE)
 
 
 def _iter_applyto_globs(value: object) -> list[str]:
@@ -287,14 +330,14 @@ def _iter_applyto_globs(value: object) -> list[str]:
     or a YAML list of such strings. Any other shape is a configuration error.
     """
     if isinstance(value, str):
-        return _split_top_level_commas(value)
+        return _split_glob_aware(value, ",")
     if isinstance(value, list):
         globs: list[str] = []
         for item in value:
             if not isinstance(item, str):
                 msg = f"applyTo list entries must be strings, got {type(item).__name__}"
                 raise UnsupportedApplyToError(msg)
-            globs.extend(_split_top_level_commas(item))
+            globs.extend(_split_glob_aware(item, ","))
         return globs
     msg = f"applyTo must be a string or list of strings, got {type(value).__name__}"
     raise UnsupportedApplyToError(msg)
@@ -335,32 +378,40 @@ def parse_applyto(text: str) -> set[str]:
 
 
 def is_language_universal(patterns: set[str], ext: str) -> bool:
-    """True when any pattern scopes the rule to every file of ``ext``.
+    """True when the rule's ``applyTo`` scopes it to every file of ``ext``.
 
-    Decides universality by *matching*, not by enumerating spellings: each
-    pattern is reduced to its harness-effective form (``_vscode_effective_glob``)
-    and then, unless it is an all-files wildcard, compiled to a faithful
-    ``minimatch`` regex (``_glob_to_regex``) and tested against every probe path
-    for the language (``_probe_paths``). A glob that matches all probes loads for
-    every file of the language regardless of location, so its bytes belong in the
-    always-on baseline.
+    Universality is a property of the *union* of the comma-split patterns, not
+    of any single pattern. VS Code's instruction matcher (``_matches`` in
+    computeAutomaticInstructions.ts, pinned line 293-327) splits ``applyTo`` on
+    commas and attaches the rule to a file if *any* one pattern matches it. So
+    the rule loads for every file of the language exactly when *every* probe
+    path is matched by *at least one* pattern:
+    ``all(any(pattern matches probe) for probe in probes)``. Checking each
+    pattern in isolation would under-count a rule whose depths are split across
+    disjoint globs (``/*.py, /*/*.py, /*/**/*.py``), letting a large rule dodge
+    the always-on budget. Under-count is the dangerous direction for an upper
+    bound, so the union model is required, not merely more precise.
 
-    This containment test closes the whole class of broad forms an exact-form
-    table missed, including ``?`` wildcards (``**/*.p?``), zero-segment trailing
-    globstars (``**/*.py/**``), absolute anchors (``/**/*.py``, ``/*/**``), and
-    any-dotted-basename (``**/*.*``), while keeping scoped globs such as
-    ``**/src/*.py`` and ``/src/*.py`` out of the baseline. Matching is
+    Each pattern is first reduced to its harness-effective form
+    (``_vscode_effective_glob`` prepends ``**/`` to a relative pattern) and then,
+    unless it is an all-files wildcard, compiled to a faithful VS Code regex
+    (``_glob_to_regex``) and tested against every probe (``_probe_paths``).
+    Deciding by *matching* rather than enumerating spellings closes the whole
+    class of broad forms an exact-form table missed (``?`` wildcards,
+    zero-segment globstars, absolute anchors, any-dotted-basename) while keeping
+    scoped globs such as ``**/src/*.py`` out of the baseline. Matching is
     case-insensitive to mirror the harness (``ignoreCase: true``).
     """
     probes = _probe_paths(ext)
+    regexes: list[re.Pattern[str]] = []
     for pattern in patterns:
         effective = _vscode_effective_glob(pattern)
         if effective in _ALL_FILES_FORMS:
             return True
-        regex = _glob_to_regex(effective)
-        if all(regex.match(path) for path in probes):
-            return True
-    return False
+        regexes.append(_glob_to_regex(effective))
+    if not regexes:
+        return False
+    return all(any(regex.match(path) for regex in regexes) for path in probes)
 
 
 @dataclass(frozen=True)

--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -114,16 +114,21 @@ _UniqueKeySafeLoader.add_constructor(
 
 
 def language_universal_forms(ext: str) -> frozenset[str]:
-    """Return the ``applyTo`` patterns that scope a rule to every file of ``ext``.
+    """Return the effective globs that scope a rule to every file of ``ext``.
 
-    A rule is part of the always-on language baseline when it applies to any
-    file of the language no matter where it lives: the universal ``**`` or
-    ``**/*`` (every file, any type) or the language-universal ``**/*.<ext>``
-    (every file of the type, any depth). The root-only ``*.<ext>`` form is
-    deliberately excluded: it scopes to top-level files only, so it is
-    situational rather than an always-on baseline.
+    A rule joins the always-on language baseline when it loads for any file of
+    the language no matter where it lives. Membership is tested against the
+    *effective* glob (see ``_vscode_effective_glob``), so these are the folded
+    forms after the harness prepends ``**/`` to relative patterns:
+
+    - ``**`` and ``**/*`` and ``*`` are the harness all-files wildcards (every
+      file of every type).
+    - ``**/*.<ext>`` is every file of the type at any depth. A relative
+      ``*.<ext>`` reaches this form via the ``**/`` prepend, so it is universal
+      too; a *scoped* relative glob such as ``src/*.<ext>`` prepends to
+      ``**/src/*.<ext>`` and stays out of this set.
     """
-    return frozenset({"**", "**/*", f"**/*{ext}"})
+    return frozenset({"**", "**/*", "*", f"**/*{ext}"})
 
 
 def _split_top_level_commas(raw: str) -> list[str]:
@@ -201,6 +206,36 @@ def _normalize_glob(pattern: str) -> str:
     return "/".join(segments)
 
 
+def _vscode_effective_glob(pattern: str) -> str:
+    """Fold an ``applyTo`` glob to the effective form the harness matches on.
+
+    Mirrors VS Code's instruction matcher, which is authoritative for the
+    ``.github/instructions`` and ``src/copilot-cli/instructions`` trees and is
+    the most permissive of the harnesses (so modeling it keeps the budget a
+    safe upper bound). Source, pinned:
+    https://github.com/microsoft/vscode/blob/018354116a88cb1264790f93663de42198a44594/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts#L294-L310
+
+    Two rules from that matcher:
+
+    - Bare ``**``, ``**/*``, and ``*`` are all-files wildcards: a rule scoped to
+      any of them attaches even with no file open, so ``*`` is universal (not
+      root-only as raw ``minimatch`` would have it).
+    - Any other pattern that is neither absolute (``/...``) nor already
+      ``**/``-anchored gets ``**/`` prepended, so ``*.py`` means ``**/*.py`` and
+      loads for every ``.py`` at any depth, while ``src/*.py`` becomes
+      ``**/src/*.py`` and stays scoped.
+
+    After the prepend the glob is folded by ``_normalize_glob`` so equivalent
+    spellings (``**/**.py`` -> ``**/*.py``) collapse to one form.
+    """
+    p = pattern.strip()
+    if p in ("**", "**/*", "*"):
+        return p
+    if not p.startswith("/") and not p.startswith("**/"):
+        p = "**/" + p
+    return _normalize_glob(p)
+
+
 def _iter_applyto_globs(value: object) -> list[str]:
     """Flatten a parsed YAML ``applyTo`` value into raw comma-split globs.
 
@@ -258,7 +293,7 @@ def parse_applyto(text: str) -> set[str]:
 def is_language_universal(patterns: set[str], ext: str) -> bool:
     """True when any pattern scopes the rule to every file of ``ext``."""
     forms = language_universal_forms(ext)
-    return any(_normalize_glob(pattern) in forms for pattern in patterns)
+    return any(_vscode_effective_glob(pattern) in forms for pattern in patterns)
 
 
 @dataclass(frozen=True)

--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -179,6 +179,40 @@ def _split_glob_aware(pattern: str, split_char: str) -> list[str]:
     return segments
 
 
+def _split_brace_options(content: str) -> list[str]:
+    """Split brace-group content on top-level commas, keeping every option.
+
+    Distinct from ``_split_glob_aware``, which drops a trailing empty segment
+    (correct for path and scope splitting). A brace alternative list must
+    preserve empty options, because an empty alternative is a real "substitute
+    nothing" branch in VS Code's brace expansion: ``{}`` -> [''] (so ``p{}y``
+    folds to ``py``) and ``{x,}`` -> ['x', ''] (so ``py{x,}`` yields ``pyx`` and
+    the universal ``py``). Dropping either empty would erase a universal glob and
+    under-count the budget. A comma inside a nested ``{...}`` or ``[...]`` group
+    does not split.
+    """
+    options: list[str] = []
+    depth_brace = 0
+    depth_bracket = 0
+    current: list[str] = []
+    for char in content:
+        if char == "," and depth_brace == 0 and depth_bracket == 0:
+            options.append("".join(current))
+            current = []
+            continue
+        if char == "{":
+            depth_brace += 1
+        elif char == "}":
+            depth_brace -= 1
+        elif char == "[":
+            depth_bracket += 1
+        elif char == "]":
+            depth_bracket -= 1
+        current.append(char)
+    options.append("".join(current))
+    return options
+
+
 def expand_braces(pattern: str) -> list[str]:
     """Expand a glob brace group into its alternatives.
 
@@ -201,7 +235,7 @@ def expand_braces(pattern: str) -> list[str]:
     if end == -1:
         return [pattern]
     prefix, suffix = pattern[:start], pattern[end + 1 :]
-    options = _split_glob_aware(pattern[start + 1 : end], ",")
+    options = _split_brace_options(pattern[start + 1 : end])
     expanded: list[str] = []
     for opt in options:
         expanded.extend(expand_braces(prefix + opt.strip() + suffix))
@@ -238,13 +272,22 @@ def _vscode_effective_glob(pattern: str) -> str:
 # translation diverged from the harness at separator edges: the dropped
 # mandatory ``/`` before a non-terminal ``**`` let ``/*/**/*.py`` match a root
 # file ``/probe.py``. Porting VS Code's own segment walker ends that class of
-# drift. Two simplifications are safe here: braces are already expanded by
-# ``expand_braces`` before a pattern reaches this compiler, and ``[...]``
-# character classes are treated as literal text rather than parsed. A char
-# class is scoped by construction (it constrains a character), so it can never
-# match the diverse probe set and is correctly classified non-universal for the
-# upper-bound budget without bracket parsing; treating ``[`` literally only ever
-# makes the regex more restrictive, never falsely universal.
+# drift. Braces are already expanded by ``expand_braces`` before a pattern
+# reaches this compiler, so only ``*``, ``?``, and ``**`` need translating.
+# Character classes (``[...]``) are the one glob construct this compiler does
+# not model, and it fails closed on them. Dear future maintainer: an earlier
+# revision treated ``[`` as a literal, reasoning a class is "scoped by
+# construction" and can only over-restrict. That was wrong. ``[p]`` pins its
+# character, so ``**/*.[p]y`` equals ``**/*.py`` and IS universal under the
+# harness, but the literal-``[`` regex ``\[p\]y`` matches nothing and scores the
+# rule non-universal -> the budget UNDER-counts (the one unsafe direction, it
+# lets an always-loaded rule dodge the ceiling). Parsing brackets faithfully
+# (ranges, negation, leading ``]``) is fragile, so instead any ``applyTo`` glob
+# containing ``[`` raises ``UnsupportedApplyToError`` (exit 2). No repo rule uses
+# a bracket class, so this blocks nothing today; a future author who needs one
+# expands it into comma or brace alternatives (``*.[ch]`` -> ``*.c, *.h``).
+# Fail-closed can only over-block (a scoped rule reddens the gate, never dodges
+# it), keeping the budget an honest upper bound without a bracket parser.
 _GLOB_STAR = "**"
 _PATH_REGEX = r"[/\\]"  # any path separator (slash or backslash)
 _NO_PATH_REGEX = r"[^/\\]"  # any non-separator character
@@ -304,6 +347,14 @@ def _glob_to_regex(pattern: str) -> re.Pattern[str]:
     *matching* diverse probe paths instead of enumerating glob spellings.
     """
     segments = _split_glob_aware(pattern, "/")
+    if "[" in pattern:
+        msg = (
+            f"applyTo glob {pattern!r} uses a character class ('['); the budget "
+            "gate does not model bracket expressions and fails closed rather than "
+            "risk under-counting a universal pattern. Expand the class into comma "
+            "or brace alternatives (e.g. '*.[ch]' -> '*.c, *.h')."
+        )
+        raise UnsupportedApplyToError(msg)
     if segments and all(segment == _GLOB_STAR for segment in segments):
         return re.compile("^.*$", re.IGNORECASE)
     body: list[str] = []

--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -204,7 +204,7 @@ def expand_braces(pattern: str) -> list[str]:
     options = _split_glob_aware(pattern[start + 1 : end], ",")
     expanded: list[str] = []
     for opt in options:
-        expanded.extend(expand_braces(prefix + opt + suffix))
+        expanded.extend(expand_braces(prefix + opt.strip() + suffix))
     return expanded
 
 

--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -63,12 +63,46 @@ _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 
 class UnsupportedApplyToError(ValueError):
-    """A frontmatter ``applyTo`` is present but is neither a string nor a list of strings.
+    """A frontmatter ``applyTo`` cannot be resolved to a concrete glob set.
 
-    Silently excluding such a file would under-count the always-on budget and
-    let a malformed rule bypass the ceiling, so this is surfaced as a
-    configuration error (ADR-035 exit code 2) rather than swallowed.
+    Raised for malformed or ambiguous frontmatter: invalid YAML, a duplicate
+    top-level key (the YAML spec requires unique keys; a second ``applyTo``
+    would silently win under a permissive loader), or an ``applyTo`` that is
+    neither a string nor a list of strings. Silently excluding such a file
+    would under-count the always-on budget and let a malformed rule bypass the
+    ceiling, so this fails closed as a configuration error (ADR-035 exit code 2)
+    rather than being swallowed.
     """
+
+
+class _UniqueKeySafeLoader(yaml.SafeLoader):
+    """``SafeLoader`` that rejects duplicate mapping keys instead of last-wins.
+
+    PyYAML (like most YAML parsers) silently keeps the last value when a key
+    repeats. A rule with two ``applyTo`` keys would then be scored on whichever
+    came last, so a universal ``applyTo`` could be masked by a trailing
+    directory-scoped one and dodge the budget. Fail closed on any duplicate.
+    """
+
+
+def _construct_unique_mapping(
+    loader: _UniqueKeySafeLoader, node: yaml.MappingNode, deep: bool = False
+) -> dict[object, object]:
+    """Build a mapping, raising ``UnsupportedApplyToError`` on a duplicate key."""
+    mapping: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            msg = f"duplicate key {key!r} in frontmatter"
+            raise UnsupportedApplyToError(msg)
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
 
 
 def language_universal_forms(ext: str) -> frozenset[str]:
@@ -132,20 +166,31 @@ def expand_braces(pattern: str) -> list[str]:
     return expanded
 
 
-def _collapse_globstars(pattern: str) -> str:
-    """Collapse redundant consecutive ``**`` segments to their minimal form.
+def _normalize_glob(pattern: str) -> str:
+    """Fold a glob to its minimal spelling using ``minimatch`` segment semantics.
 
-    ``**/**/*.py`` matches exactly the files ``**/*.py`` matches, because each
-    ``**`` can match zero directories. Folding any run of globstars makes the
-    universality check depend on glob semantics, not on the exact spelling, so
-    a rule cannot dodge the always-on budget by padding its ``applyTo`` with
-    equivalent ``**/`` segments.
+    Two rewrites, applied per path segment so the universality check depends on
+    glob meaning rather than on the exact spelling:
+
+    - A run of consecutive ``**`` segments collapses to one, because each ``**``
+      matches zero or more directories (``**/**/*.py`` == ``**/*.py``).
+    - Within any non-globstar segment, a run of ``*`` collapses to a single
+      ``*``, because ``minimatch`` treats ``**`` as ``*`` unless the whole
+      segment is ``**`` (``**/**.py`` == ``**/*.py``, a filename-segment match).
+
+    Without the second rewrite a rule could dodge the always-on budget by
+    padding its ``applyTo`` with an equivalent but unrecognized spelling such as
+    ``**/**.py``.
     """
-    previous = ""
-    while previous != pattern:
-        previous = pattern
-        pattern = pattern.replace("**/**", "**")
-    return pattern
+    segments: list[str] = []
+    for segment in pattern.split("/"):
+        if segment == "**":
+            if segments and segments[-1] == "**":
+                continue
+            segments.append("**")
+        else:
+            segments.append(re.sub(r"\*+", "*", segment))
+    return "/".join(segments)
 
 
 def _iter_applyto_globs(value: object) -> list[str]:
@@ -177,14 +222,21 @@ def parse_applyto(text: str) -> set[str]:
     ``# comment`` into the glob and would miss a block-style list entirely).
     Splits the comma-separated scope list without breaking brace groups, then
     expands each brace group so ``**/*.{py,pyi}`` becomes two concrete globs.
+
+    Fails closed: invalid YAML or a duplicate top-level key raises
+    ``UnsupportedApplyToError`` rather than yielding an empty set, so a file the
+    parser cannot resolve cannot silently contribute zero bytes and slip past
+    the ceiling. A file with no frontmatter block, or frontmatter without an
+    ``applyTo`` key, is legitimately unscoped and returns an empty set.
     """
     fm_match = _FRONTMATTER_RE.match(text)
     if fm_match is None:
         return set()
     try:
-        data = yaml.safe_load(fm_match.group(1))
-    except yaml.YAMLError:
-        return set()
+        data = yaml.load(fm_match.group(1), Loader=_UniqueKeySafeLoader)
+    except yaml.YAMLError as exc:
+        msg = f"frontmatter is not valid YAML: {exc}"
+        raise UnsupportedApplyToError(msg) from exc
     if not isinstance(data, dict) or "applyTo" not in data:
         return set()
     patterns: set[str] = set()
@@ -198,7 +250,7 @@ def parse_applyto(text: str) -> set[str]:
 def is_language_universal(patterns: set[str], ext: str) -> bool:
     """True when any pattern scopes the rule to every file of ``ext``."""
     forms = language_universal_forms(ext)
-    return any(_collapse_globstars(pattern) in forms for pattern in patterns)
+    return any(_normalize_glob(pattern) in forms for pattern in patterns)
 
 
 @dataclass(frozen=True)

--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -39,6 +39,7 @@ import re
 import sys
 from collections.abc import Hashable
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 
 import yaml
@@ -110,25 +111,36 @@ _UniqueKeySafeLoader.add_constructor(
 )
 
 
-def language_universal_forms(ext: str) -> frozenset[str]:
-    """Return the effective globs that scope a rule to every file of ``ext``.
+# VS Code's matcher special-cases these three globs as matching every file even
+# with no editor open, so a rule scoped to any of them is always-on for every
+# language. Raw ``minimatch`` would read bare ``*`` as root-only; the harness
+# does not (pinned source lines 294-310), so ``*`` belongs here. These are the
+# only forms whose universality cannot be decided by matching probe paths (bare
+# ``*`` compiles to ``^[^/]*$``, which no multi-segment path can satisfy), so
+# they are recognized directly.
+_ALL_FILES_FORMS = frozenset({"**", "**/*", "*"})
 
-    A rule joins the always-on language baseline when it loads for any file of
-    the language no matter where it lives. Membership is tested against the
-    *effective* glob (see ``_vscode_effective_glob``), so these are the folded
-    forms after the harness prepends ``**/`` to relative patterns:
 
-    - ``**`` and ``**/*`` and ``*`` are the harness all-files wildcards (every
-      file of every type).
-    - ``**/*.*`` matches every file whose basename carries a dot, which every
-      file of ``ext`` does, so it is universal for the language too (it also
-      matches other dotted types, but that only widens the match).
-    - ``**/*.<ext>`` is every file of the type at any depth. A relative
-      ``*.<ext>`` reaches this form via the ``**/`` prepend, so it is universal
-      too; a *scoped* relative glob such as ``src/*.<ext>`` prepends to
-      ``**/src/*.<ext>`` and stays out of this set.
+def _probe_paths(ext: str) -> tuple[str, ...]:
+    """Absolute sample paths of ``ext`` spanning depth, directory, and basename.
+
+    ``is_language_universal`` calls a glob universal for the language when it
+    matches *every* probe. The direction is safe for an upper-bound budget: a
+    truly universal glob matches all paths, so it can never be misjudged
+    non-universal (under-count, the dangerous direction); only a scoped glob that
+    happens to match every probe could be over-counted (the safe direction). The
+    probes therefore span the discriminating axes a scope could restrict:
+
+    - depth, including a root-level file, so a glob requiring an intermediate
+      literal directory segment (``**/src/*.py``) fails the depth-1 probe;
+    - directory names, so a glob pinned to a named tree fails;
+    - basename stems (short, dotted, punctuated), so a filename-scoped glob
+      (``**/foo*.py``) fails.
     """
-    return frozenset({"**", "**/*", "*", "**/*.*", f"**/*{ext}"})
+    stems = ("probe", "X", "a.b.c", "weird-name_123")
+    dirs = ("", "a/", "a/b/c/d/e/", "zzz/")
+    paths = [f"/{directory}{stem}{ext}" for directory in dirs for stem in stems]
+    return tuple(dict.fromkeys(paths))
 
 
 def _split_top_level_commas(raw: str) -> list[str]:
@@ -179,78 +191,93 @@ def expand_braces(pattern: str) -> list[str]:
     return expanded
 
 
-def _normalize_glob(pattern: str) -> str:
-    """Fold a glob to its minimal spelling using ``minimatch`` segment semantics.
-
-    Two rewrites, applied per path segment so the universality check depends on
-    glob meaning rather than on the exact spelling:
-
-    - A run of consecutive ``**`` segments collapses to one, because each ``**``
-      matches zero or more directories (``**/**/*.py`` == ``**/*.py``).
-    - Within any non-globstar segment, a run of ``*`` collapses to a single
-      ``*``, because ``minimatch`` treats ``**`` as ``*`` unless the whole
-      segment is ``**`` (``**/**.py`` == ``**/*.py``, a filename-segment match).
-
-    Without the second rewrite a rule could dodge the always-on budget by
-    padding its ``applyTo`` with an equivalent but unrecognized spelling such as
-    ``**/**.py``.
-    """
-    segments: list[str] = []
-    for segment in pattern.split("/"):
-        if segment == "**":
-            if segments and segments[-1] == "**":
-                continue
-            segments.append("**")
-        else:
-            segments.append(re.sub(r"\*+", "*", segment))
-    return "/".join(segments)
-
-
 def _vscode_effective_glob(pattern: str) -> str:
     """Fold an ``applyTo`` glob to the effective form the harness matches on.
 
-    Mirrors VS Code's instruction matcher, which is authoritative for the
-    ``.github/instructions`` and ``src/copilot-cli/instructions`` trees and is
-    the most permissive of the harnesses (so modeling it keeps the budget a
-    safe upper bound). Source, pinned:
+    Mirrors the one string transformation VS Code's instruction matcher applies
+    before matching: a pattern that is neither absolute (``/...``) nor already
+    ``**/``-anchored gets ``**/`` prepended, so ``*.py`` means ``**/*.py`` and
+    ``src/*.py`` becomes the scoped ``**/src/*.py``. Absolute patterns,
+    ``**/``-anchored patterns, and the all-files wildcards are returned
+    unchanged. Every other equivalence (zero-segment globstars, ``?`` wildcards,
+    absolute-root anchoring) is decided later by matching probe paths in
+    ``is_language_universal``, not by rewriting the string here, so the model
+    stays faithful to the harness rather than chasing glob spellings. Source,
+    pinned:
     https://github.com/microsoft/vscode/blob/018354116a88cb1264790f93663de42198a44594/src/vs/workbench/contrib/chat/common/promptSyntax/computeAutomaticInstructions.ts#L294-L310
-
-    Rules from that matcher:
-
-    - Bare ``**``, ``**/*``, and ``*`` are all-files wildcards: a rule scoped to
-      any of them attaches even with no file open, so ``*`` is universal (not
-      root-only as raw ``minimatch`` would have it).
-    - The harness matches against absolute file paths, so an absolute pattern is
-      anchored at the filesystem root. A leading ``/**/`` therefore spans any
-      directory prefix, the same span as the relative ``**/`` anchor, and bare
-      ``/**`` or ``/**/*`` is the all-files wildcard.
-    - Any other pattern that is neither absolute (``/...``) nor already
-      ``**/``-anchored gets ``**/`` prepended, so ``*.py`` means ``**/*.py`` and
-      loads for every ``.py`` at any depth, while ``src/*.py`` becomes
-      ``**/src/*.py`` and stays scoped.
-    - A trailing ``/**`` globstar matches zero or more trailing segments,
-      including the prefix path itself, so ``**/*.py/**`` covers the same files
-      as ``**/*.py`` and is likewise universal.
-
-    After the anchor folds the glob is passed through ``_normalize_glob`` so
-    equivalent spellings (``**/**.py`` -> ``**/*.py``) collapse to one form.
     """
     p = pattern.strip()
-    if p in ("**", "**/*", "*"):
+    if p in _ALL_FILES_FORMS:
         return p
-    if p in ("/**", "/**/*"):
-        return "**"
-    if p.startswith("/**/"):
-        p = p[1:]
     if not p.startswith("/") and not p.startswith("**/"):
         p = "**/" + p
-    normalized = _normalize_glob(p)
-    while normalized.endswith("/**"):
-        stripped = normalized[: -len("/**")]
-        if not stripped:
-            return "**"
-        normalized = _normalize_glob(stripped)
-    return normalized
+    return p
+
+
+_GLOBSTAR = object()
+
+
+def _compile_glob_regex(tokens: list[object]) -> str:
+    """Join translated glob ``tokens`` into a regex body with globstar semantics.
+
+    A ``_GLOBSTAR`` token matches zero or more whole path segments and supplies
+    its own surrounding separators, so a leading ``**/`` spans any prefix, a
+    trailing ``/**`` covers the prefix path itself, and a bare ``**`` matches
+    everything. Literal tokens are joined with ``/``.
+    """
+    last = len(tokens) - 1
+    out: list[str] = []
+    for index, token in enumerate(tokens):
+        if token is _GLOBSTAR:
+            if index == 0 and last == 0:
+                out.append(".*")
+            elif index == last:
+                out.append("(?:.*)?")
+            else:
+                out.append("(?:.*/)?")
+            continue
+        out.append(str(token))
+        if index != last:
+            following = tokens[index + 1]
+            if following is _GLOBSTAR and index + 1 == last:
+                out.append("(?:/)?")
+            elif following is not _GLOBSTAR:
+                out.append("/")
+    return "".join(out)
+
+
+@cache
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Compile a ``minimatch``-style glob to an anchored case-insensitive regex.
+
+    Path-segment semantics, matching the harness glob engine:
+
+    - ``**`` as a whole segment matches zero or more path segments;
+    - ``*`` matches zero or more non-separator characters within one segment;
+    - ``?`` matches exactly one non-separator character;
+    - every other character is literal.
+
+    Case-insensitive because VS Code matches ``applyTo`` with ``ignoreCase: true``
+    (same pinned source, line 316). ``is_language_universal`` uses this to decide
+    universality by *matching* diverse probe paths instead of enumerating glob
+    spellings, which closes bypasses such as ``**/*.p?`` and ``/*/**`` that no
+    finite spelling table can cover.
+    """
+    tokens: list[object] = []
+    for segment in pattern.split("/"):
+        if segment == "**":
+            tokens.append(_GLOBSTAR)
+            continue
+        piece: list[str] = []
+        for char in segment:
+            if char == "*":
+                piece.append("[^/]*")
+            elif char == "?":
+                piece.append("[^/]")
+            else:
+                piece.append(re.escape(char))
+        tokens.append("".join(piece))
+    return re.compile("^" + _compile_glob_regex(tokens) + "$", re.IGNORECASE)
 
 
 def _iter_applyto_globs(value: object) -> list[str]:
@@ -310,18 +337,30 @@ def parse_applyto(text: str) -> set[str]:
 def is_language_universal(patterns: set[str], ext: str) -> bool:
     """True when any pattern scopes the rule to every file of ``ext``.
 
-    Case-insensitive: VS Code matches ``applyTo`` globs with ``ignoreCase: true``
-    (same pinned source, line 316), so ``**/*.PY`` is universal for ``.py``. Both
-    the effective glob and the universal forms are case-folded before comparison.
+    Decides universality by *matching*, not by enumerating spellings: each
+    pattern is reduced to its harness-effective form (``_vscode_effective_glob``)
+    and then, unless it is an all-files wildcard, compiled to a faithful
+    ``minimatch`` regex (``_glob_to_regex``) and tested against every probe path
+    for the language (``_probe_paths``). A glob that matches all probes loads for
+    every file of the language regardless of location, so its bytes belong in the
+    always-on baseline.
 
-    The effective glob folds the harness anchor rules (``_vscode_effective_glob``)
-    so broad spellings reduce to a universal form: ``/**/*.py`` (absolute anchor),
-    ``**/*.py/**`` (trailing globstar), and ``**/*.*`` (any dotted basename) each
-    resolve to universal, closing the bypass where a broad glob would otherwise
-    contribute zero bytes to the always-on budget.
+    This containment test closes the whole class of broad forms an exact-form
+    table missed, including ``?`` wildcards (``**/*.p?``), zero-segment trailing
+    globstars (``**/*.py/**``), absolute anchors (``/**/*.py``, ``/*/**``), and
+    any-dotted-basename (``**/*.*``), while keeping scoped globs such as
+    ``**/src/*.py`` and ``/src/*.py`` out of the baseline. Matching is
+    case-insensitive to mirror the harness (``ignoreCase: true``).
     """
-    forms = {form.lower() for form in language_universal_forms(ext)}
-    return any(_vscode_effective_glob(pattern).lower() in forms for pattern in patterns)
+    probes = _probe_paths(ext)
+    for pattern in patterns:
+        effective = _vscode_effective_glob(pattern)
+        if effective in _ALL_FILES_FORMS:
+            return True
+        regex = _glob_to_regex(effective)
+        if all(regex.match(path) for path in probes):
+            return True
+    return False
 
 
 @dataclass(frozen=True)

--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -65,14 +65,69 @@ def language_universal_forms(ext: str) -> frozenset[str]:
     """Return the ``applyTo`` patterns that scope a rule to every file of ``ext``.
 
     A rule is part of the always-on language baseline when it applies to any
-    file of the language no matter where it lives: the universal ``**`` or the
-    language-universal ``**/*.<ext>`` (``*.<ext>`` accepted defensively).
+    file of the language no matter where it lives: the universal ``**`` or
+    ``**/*`` (every file, any type) or the language-universal ``**/*.<ext>``
+    (every file of the type, any depth). The root-only ``*.<ext>`` form is
+    deliberately excluded: it scopes to top-level files only, so it is
+    situational rather than an always-on baseline.
     """
-    return frozenset({"**", f"*{ext}", f"**/*{ext}"})
+    return frozenset({"**", "**/*", f"**/*{ext}"})
+
+
+def _split_top_level_commas(raw: str) -> list[str]:
+    """Split on commas that are not inside a ``{...}`` brace group."""
+    parts: list[str] = []
+    current: list[str] = []
+    depth = 0
+    for ch in raw:
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth = max(0, depth - 1)
+        if ch == "," and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    parts.append("".join(current))
+    return parts
+
+
+def expand_braces(pattern: str) -> list[str]:
+    """Expand a glob brace group into its alternatives.
+
+    ``**/*.{py,pyi}`` -> ``['**/*.py', '**/*.pyi']``. Handles multiple and
+    nested groups by recursion. An unbalanced brace is left untouched.
+    """
+    start = pattern.find("{")
+    if start == -1:
+        return [pattern]
+    depth = 0
+    end = -1
+    for i in range(start, len(pattern)):
+        if pattern[i] == "{":
+            depth += 1
+        elif pattern[i] == "}":
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    if end == -1:
+        return [pattern]
+    prefix, suffix = pattern[:start], pattern[end + 1 :]
+    options = _split_top_level_commas(pattern[start + 1 : end])
+    expanded: list[str] = []
+    for opt in options:
+        expanded.extend(expand_braces(prefix + opt + suffix))
+    return expanded
 
 
 def parse_applyto(text: str) -> set[str]:
-    """Extract the ``applyTo`` glob set from a rule file's frontmatter."""
+    """Extract the ``applyTo`` glob set from a rule file's frontmatter.
+
+    Splits the comma-separated scope list without breaking brace groups, then
+    expands each brace group so ``**/*.{py,pyi}`` becomes two concrete globs.
+    """
     fm_match = _FRONTMATTER_RE.match(text)
     if fm_match is None:
         return set()
@@ -85,7 +140,13 @@ def parse_applyto(text: str) -> set[str]:
     raw = raw.strip()
     if raw.startswith("[") and raw.endswith("]"):
         raw = raw[1:-1]
-    return {part.strip().strip("'\"") for part in raw.split(",") if part.strip()}
+    patterns: set[str] = set()
+    for part in _split_top_level_commas(raw):
+        cleaned = part.strip().strip("'\"").strip()
+        if not cleaned:
+            continue
+        patterns.update(expand_braces(cleaned))
+    return patterns
 
 
 def is_language_universal(patterns: set[str], ext: str) -> bool:
@@ -139,7 +200,7 @@ def load_instruction_files(repo_root: Path) -> list[InstructionFile]:
     if instructions_dir is None or not instructions_dir.is_dir():
         return []
     files: list[InstructionFile] = []
-    for path in sorted(instructions_dir.glob(INSTRUCTION_GLOB)):
+    for path in sorted(instructions_dir.rglob(INSTRUCTION_GLOB)):
         content = path.read_text(encoding="utf-8", errors="replace")
         files.append(
             InstructionFile(

--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -37,6 +37,7 @@ import json
 import os
 import re
 import sys
+from collections.abc import Hashable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -92,6 +93,13 @@ def _construct_unique_mapping(
     mapping: dict[object, object] = {}
     for key_node, value_node in node.value:
         key = loader.construct_object(key_node, deep=deep)
+        # SafeLoader.construct_mapping rejects an unhashable key (a YAML complex
+        # key such as ``? [a, b]``) with a ConstructorError; the raw ``key in
+        # mapping`` below would instead raise an uncaught TypeError and escape as
+        # exit 1. Guard it so malformed frontmatter fails closed as exit 2.
+        if not isinstance(key, Hashable):
+            msg = f"unhashable key in frontmatter: {key!r}"
+            raise UnsupportedApplyToError(msg)
         if key in mapping:
             msg = f"duplicate key {key!r} in frontmatter"
             raise UnsupportedApplyToError(msg)

--- a/scripts/validation/pre_pr_sequence.py
+++ b/scripts/validation/pre_pr_sequence.py
@@ -395,7 +395,7 @@ def run_all_validations(
     )
 
     # 7c. Instruction Budget (always-on, Issue #3419). Non-regression ratchet on
-    # the summed bytes of language-universal .github/instructions/*.md files, so
+    # the summed bytes of language-universal .github/instructions/*.instructions.md files, so
     # the always-on corpus cannot grow silently on a new all-language rule.
     run_validation(
         "Instruction Budget (always-on)",

--- a/scripts/validation/pre_pr_sequence.py
+++ b/scripts/validation/pre_pr_sequence.py
@@ -53,6 +53,7 @@ from checks_tooling import (  # noqa: E402
     validate_agent_drift,
     validate_ci_dependency_pins,
     validate_copilot_version_pin,
+    validate_instruction_budget,
     validate_markdown_lint,
     validate_path_normalization,
     validate_pester_tests,
@@ -391,4 +392,13 @@ def run_all_validations(
         "Review Marker (SHA-bound /review)",
         state,
         lambda: validate_review_marker(repo_root),
+    )
+
+    # 7c. Instruction Budget (always-on, Issue #3419). Non-regression ratchet on
+    # the summed bytes of language-universal .github/instructions/*.md files, so
+    # the always-on corpus cannot grow silently on a new all-language rule.
+    run_validation(
+        "Instruction Budget (always-on)",
+        state,
+        lambda: validate_instruction_budget(repo_root),
     )

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -218,6 +218,33 @@ def test_is_language_universal_is_case_insensitive() -> None:
     assert ib.is_language_universal({"**/*.PYX"}, ".py") is False
 
 
+def test_is_language_universal_matches_broad_vscode_forms() -> None:
+    # VS Code's matcher makes several broader globs universal that an exact-form
+    # membership test would miss. Each of these loads for every .py file:
+    #  - '**/*.*' matches any dotted basename (every .py has one).
+    #  - '/**/*.py' is absolute; file paths are absolute, so it spans any dir.
+    #  - '**/*.py/**' has a trailing globstar that matches zero segments,
+    #    covering the .py file itself.
+    assert ib.is_language_universal({"**/*.*"}, ".py") is True
+    assert ib.is_language_universal({"*.*"}, ".py") is True
+    assert ib.is_language_universal({"/**/*.py"}, ".py") is True
+    assert ib.is_language_universal({"**/*.py/**"}, ".py") is True
+    # Absolute all-files and prefix wildcards fold to the all-files form.
+    assert ib.is_language_universal({"/**"}, ".py") is True
+    assert ib.is_language_universal({"/**/*"}, ".py") is True
+    # The folds must not promote a scoped glob: a bounded prefix stays scoped
+    # whether the breadth comes from a trailing globstar or an absolute anchor.
+    assert ib.is_language_universal({"src/**/*.py/**"}, ".py") is False
+    assert ib.is_language_universal({"/src/**/*.py"}, ".py") is False
+    assert ib.is_language_universal({"/src/*.py"}, ".py") is False
+    # Effective-glob folds, spelled out.
+    assert ib._vscode_effective_glob("/**/*.py") == "**/*.py"
+    assert ib._vscode_effective_glob("**/*.py/**") == "**/*.py"
+    assert ib._vscode_effective_glob("/**") == "**"
+    assert ib._vscode_effective_glob("/**/*") == "**"
+    assert ib._vscode_effective_glob("**/*.*") == "**/*.*"
+
+
 # --------------------------------------------------------------------------
 # measure_extension / evaluate (positive)
 # --------------------------------------------------------------------------

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -60,8 +60,33 @@ def test_parse_applyto_flow_list_form() -> None:
     assert ib.parse_applyto(text) == {"**", "**/*.ts"}
 
 
+def test_parse_applyto_block_list_form() -> None:
+    # A YAML block-style list must be read as list entries, not missed by a
+    # single-line regex that only sees the empty value after 'applyTo:'.
+    text = "---\napplyTo:\n  - '**/*.py'\n  - 'tests/**'\n---\nbody\n"
+    assert ib.parse_applyto(text) == {"**/*.py", "tests/**"}
+
+
+def test_parse_applyto_ignores_inline_comment() -> None:
+    # A trailing '# comment' belongs to YAML, not to the glob. A line regex
+    # would fold it into the pattern and never match a universal form.
+    text = "---\napplyTo: '**/*.py' # only python\n---\nbody\n"
+    assert ib.parse_applyto(text) == {"**/*.py"}
+    assert ib.is_language_universal(ib.parse_applyto(text), ".py") is True
+
+
+def test_parse_applyto_unsupported_scalar_raises() -> None:
+    # A present-but-non-string/list applyTo (here an int) is a config error,
+    # not a file to silently drop from the always-on budget.
+    text = "---\napplyTo: 42\n---\nbody\n"
+    with pytest.raises(ib.UnsupportedApplyToError):
+        ib.parse_applyto(text)
+
+
 def test_parse_applyto_expands_brace_group() -> None:
-    text = "---\napplyTo: **/*.{py,pyi},tests/**\n---\nbody\n"
+    # A leading '**' forces quoting in YAML, so the realistic brace form is
+    # quoted; an unquoted '**/*.{...}' is invalid YAML the harness would reject.
+    text = "---\napplyTo: '**/*.{py,pyi},tests/**'\n---\nbody\n"
     assert ib.parse_applyto(text) == {"**/*.py", "**/*.pyi", "tests/**"}
 
 
@@ -91,6 +116,9 @@ def test_parse_applyto_missing_key_returns_empty() -> None:
         ({"**"}, ".py", True),
         ({"**/*"}, ".py", True),
         ({"**/*.py"}, ".py", True),
+        ({"**/**/*.py"}, ".py", True),
+        ({"**/**/*"}, ".py", True),
+        ({"**/**"}, ".py", True),
         ({"*.py"}, ".py", False),
         ({"**/*.py", "**/*.pyi"}, ".py", True),
         ({"**/*.cs"}, ".py", False),
@@ -110,6 +138,16 @@ def test_is_language_universal_is_precise_not_endswith() -> None:
     # root-only '*.py' form is situational, not an always-on baseline.
     assert ib.is_language_universal({"src/foo*.py"}, ".py") is False
     assert ib.is_language_universal({"*.py"}, ".py") is False
+
+
+def test_is_language_universal_collapses_redundant_globstars() -> None:
+    # Padding an applyTo with equivalent '**/' segments matches the same files
+    # as the minimal form, so it must not dodge the always-on budget.
+    assert ib.is_language_universal({"**/**/*.py"}, ".py") is True
+    assert ib.is_language_universal({"**/**/**/*.py"}, ".py") is True
+    assert ib.is_language_universal({"**/**/*.cs"}, ".py") is False
+    assert ib._collapse_globstars("**/**/*.py") == "**/*.py"
+    assert ib._collapse_globstars("**/**") == "**"
 
 
 # --------------------------------------------------------------------------

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -130,6 +130,57 @@ def test_expand_braces_strips_whitespace_around_options() -> None:
     assert ib.expand_braces("**/*.{ cs , fs }") == ["**/*.cs", "**/*.fs"]
 
 
+def test_split_brace_options_keeps_empty_options() -> None:
+    # Unlike path splitting, brace options must preserve empty alternatives:
+    # an empty option is a real "substitute nothing" branch in VS Code.
+    assert ib._split_brace_options("") == [""]
+    assert ib._split_brace_options("x,") == ["x", ""]
+    assert ib._split_brace_options(",x") == ["", "x"]
+    # A comma inside a nested group does not split the outer option.
+    assert ib._split_brace_options("a,{b,c},d") == ["a", "{b,c}", "d"]
+
+
+def test_expand_braces_empty_group_folds_to_nothing() -> None:
+    # VS Code compiles ``{}`` as an empty substitution, so ``p{}y`` is ``py``.
+    # A splitter that dropped the empty option would erase the pattern entirely
+    # (scoring it 0 bytes) and under-count the budget.
+    assert ib.expand_braces("**/*.p{}y") == ["**/*.py"]
+
+
+def test_expand_braces_keeps_trailing_empty_option() -> None:
+    # ``py{x,}`` yields both ``pyx`` and the universal ``py``; dropping the
+    # trailing empty would hide the universal glob from the gate.
+    assert ib.expand_braces("**/*.py{x,}") == ["**/*.pyx", "**/*.py"]
+
+
+def test_empty_brace_group_is_language_universal() -> None:
+    # A future rule spelled with an empty brace group must still be caught.
+    patterns = ib.parse_applyto("---\napplyTo: '**/*.p{}y'\n---\nbody\n")
+    assert ib.is_language_universal(patterns, ".py") is True
+
+
+def test_trailing_empty_brace_option_is_language_universal() -> None:
+    # The universal ``**/*.py`` branch hides behind the trailing empty option.
+    patterns = ib.parse_applyto("---\napplyTo: '**/*.py{x,}'\n---\nbody\n")
+    assert ib.is_language_universal(patterns, ".py") is True
+
+
+def test_glob_to_regex_char_class_fails_closed() -> None:
+    # ``**/*.[p]y`` equals ``**/*.py`` under the harness (universal), but the
+    # compiler does not model brackets. Treating ``[`` as a literal would
+    # under-count (the one unsafe direction), so it fails closed instead.
+    with pytest.raises(ib.UnsupportedApplyToError):
+        ib._glob_to_regex("**/*.[p]y")
+
+
+def test_char_class_applyto_fails_closed() -> None:
+    # End to end: a rule whose ``applyTo`` uses a character class raises rather
+    # than risk silently dodging the always-on budget ceiling.
+    patterns = ib.parse_applyto("---\napplyTo: '**/*.[p]y'\n---\nbody\n")
+    with pytest.raises(ib.UnsupportedApplyToError):
+        ib.is_language_universal(patterns, ".py")
+
+
 def test_parse_applyto_missing_frontmatter_returns_empty() -> None:
     assert ib.parse_applyto("# just a heading\n\nno frontmatter\n") == set()
 

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -205,6 +205,19 @@ def test_is_language_universal_normalizes_equivalent_globs() -> None:
     assert ib._vscode_effective_glob("*") == "*"
 
 
+def test_is_language_universal_is_case_insensitive() -> None:
+    # VS Code matches applyTo globs with { ignoreCase: true }, so an uppercase
+    # or mixed-case extension spelling still loads for every file of the type.
+    # computeAutomaticInstructions.ts line 316 (pinned in the module).
+    assert ib.is_language_universal({"**/*.PY"}, ".py") is True
+    assert ib.is_language_universal({"*.Py"}, ".py") is True
+    assert ib.is_language_universal({"**/*.PS1"}, ".ps1") is True
+    # Case folding does not promote a scoped glob: '**/src/*.py' is still scoped.
+    assert ib.is_language_universal({"SRC/*.py"}, ".py") is False
+    # Nor does it collide across distinct extensions.
+    assert ib.is_language_universal({"**/*.PYX"}, ".py") is False
+
+
 # --------------------------------------------------------------------------
 # measure_extension / evaluate (positive)
 # --------------------------------------------------------------------------

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -1,0 +1,221 @@
+"""Tests for scripts/validation/instruction_budget.py (issue #3419).
+
+The validator measures the always-on instruction budget per language: the summed
+bytes of ``.github/instructions/*.instructions.md`` files whose ``applyTo`` scopes
+them to every file of a language (``**`` or ``**/*.<ext>``). It gates growth via a
+non-regression byte ceiling.
+
+Tests use crafted temporary instruction trees so results are independent of the
+live repo state, plus one anchor test against the real repo to guard the
+measurement methodology from silent regressions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import scripts.validation.instruction_budget as ib  # noqa: E402
+
+
+def _write_rule(root: Path, name: str, apply_to: str, body: str = "body\n") -> int:
+    """Create an instruction file and return its UTF-8 byte length."""
+    inst_dir = root / ib.INSTRUCTIONS_SUBDIR
+    inst_dir.mkdir(parents=True, exist_ok=True)
+    content = f"---\napplyTo: {apply_to}\n---\n\n# {name}\n\n{body}"
+    path = inst_dir / f"{name}.instructions.md"
+    path.write_text(content, encoding="utf-8")
+    return len(content.encode("utf-8"))
+
+
+# --------------------------------------------------------------------------
+# parse_applyto
+# --------------------------------------------------------------------------
+
+
+def test_parse_applyto_bare_string() -> None:
+    text = "---\napplyTo: '**'\n---\n\nbody\n"
+    assert ib.parse_applyto(text) == {"**"}
+
+
+def test_parse_applyto_comma_separated_unquoted() -> None:
+    text = "---\napplyTo: tests/**,**/*.py,docs/x.md\n---\nbody\n"
+    assert ib.parse_applyto(text) == {"tests/**", "**/*.py", "docs/x.md"}
+
+
+def test_parse_applyto_quoted_comma_list() -> None:
+    text = "---\napplyTo: '**/*.py,**/*.cs'\n---\nbody\n"
+    assert ib.parse_applyto(text) == {"**/*.py", "**/*.cs"}
+
+
+def test_parse_applyto_flow_list_form() -> None:
+    text = "---\napplyTo: ['**', '**/*.ts']\n---\nbody\n"
+    assert ib.parse_applyto(text) == {"**", "**/*.ts"}
+
+
+def test_parse_applyto_missing_frontmatter_returns_empty() -> None:
+    assert ib.parse_applyto("# just a heading\n\nno frontmatter\n") == set()
+
+
+def test_parse_applyto_missing_key_returns_empty() -> None:
+    text = "---\ndescription: no applyTo here\n---\nbody\n"
+    assert ib.parse_applyto(text) == set()
+
+
+# --------------------------------------------------------------------------
+# is_language_universal
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("patterns", "ext", "expected"),
+    [
+        ({"**"}, ".py", True),
+        ({"**/*.py"}, ".py", True),
+        ({"*.py"}, ".py", True),
+        ({"**/*.cs"}, ".py", False),
+        ({"tests/**"}, ".py", False),
+        ({"scripts/**", "build/**"}, ".py", False),
+        ({"**/*.py", "**/*.cs"}, ".cs", True),
+        (set(), ".py", False),
+    ],
+)
+def test_is_language_universal(patterns: set[str], ext: str, expected: bool) -> None:
+    assert ib.is_language_universal(patterns, ext) is expected
+
+
+def test_is_language_universal_is_precise_not_endswith() -> None:
+    # A directory-or-prefix glob that merely ends with '*.py' is NOT
+    # language-universal; only '**', '*.py', '**/*.py' count.
+    assert ib.is_language_universal({"src/foo*.py"}, ".py") is False
+
+
+# --------------------------------------------------------------------------
+# measure_extension / evaluate (positive)
+# --------------------------------------------------------------------------
+
+
+def test_measure_extension_sums_only_matching_files(tmp_path: Path) -> None:
+    b_all = _write_rule(tmp_path, "universal", "'**'")
+    b_py = _write_rule(tmp_path, "python", "'**/*.py'")
+    _write_rule(tmp_path, "csharp", "'**/*.cs'")
+    _write_rule(tmp_path, "tests", "tests/**")
+
+    files = ib.load_instruction_files(tmp_path)
+    result = ib.measure_extension(files, ".py", ceiling_bytes=10_000)
+
+    assert set(result.matched_files) == {"universal.instructions.md", "python.instructions.md"}
+    assert result.total_bytes == b_all + b_py
+    assert result.over_budget is False
+    assert result.estimated_tokens > 0
+
+
+def test_evaluate_covers_all_configured_extensions(tmp_path: Path) -> None:
+    _write_rule(tmp_path, "universal", "'**'")
+    results = ib.evaluate(tmp_path, ib.DEFAULT_CEILINGS_BYTES)
+    exts = {r.extension for r in results}
+    assert exts == set(ib.DEFAULT_CEILINGS_BYTES)
+    # The universal rule counts toward every extension baseline.
+    assert all(r.matched_files == ("universal.instructions.md",) for r in results)
+
+
+# --------------------------------------------------------------------------
+# over-budget / gate (negative)
+# --------------------------------------------------------------------------
+
+
+def test_over_budget_flag_when_bytes_exceed_ceiling(tmp_path: Path) -> None:
+    _write_rule(tmp_path, "universal", "'**'", body="x" * 5000)
+    result = ib.evaluate(tmp_path, {".py": 100})[0]
+    assert result.over_budget is True
+    assert result.usage_percent > 100.0
+
+
+def test_main_ci_returns_1_when_over_budget(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_rule(tmp_path, "universal", "'**'")
+    code = ib.main(["--path", str(tmp_path), "--ci", "--ceiling", ".py:10", "--ceiling", ".md:10"])
+    assert code == 1
+    assert "FAIL" in capsys.readouterr().out
+
+
+def test_main_non_ci_returns_0_even_when_over_budget(tmp_path: Path) -> None:
+    _write_rule(tmp_path, "universal", "'**'")
+    code = ib.main(["--path", str(tmp_path), "--ceiling", ".py:10"])
+    assert code == 0
+
+
+def test_main_returns_2_when_instructions_dir_missing(tmp_path: Path) -> None:
+    assert ib.main(["--path", str(tmp_path)]) == 2
+
+
+def test_main_returns_2_when_path_not_a_directory(tmp_path: Path) -> None:
+    missing = tmp_path / "nope"
+    assert ib.main(["--path", str(missing)]) == 2
+
+
+# --------------------------------------------------------------------------
+# parse_ceiling_override (edge)
+# --------------------------------------------------------------------------
+
+
+def test_parse_ceiling_override_adds_leading_dot() -> None:
+    assert ib.parse_ceiling_override("py:200000") == (".py", 200_000)
+
+
+def test_parse_ceiling_override_keeps_leading_dot() -> None:
+    assert ib.parse_ceiling_override(".cs:5000") == (".cs", 5_000)
+
+
+@pytest.mark.parametrize("bad", ["nocolon", ".py:abc", ".py:0", ".py:-5"])
+def test_parse_ceiling_override_rejects_bad(bad: str) -> None:
+    with pytest.raises(argparse.ArgumentTypeError):
+        ib.parse_ceiling_override(bad)
+
+
+def test_ceiling_override_merges_with_defaults(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_rule(tmp_path, "universal", "'**'")
+    # Override only .py; other extensions keep default ceilings and pass.
+    code = ib.main(["--path", str(tmp_path), "--ci", "--format", "json", "--ceiling", ".py:5"])
+    assert code == 1
+    out = capsys.readouterr().out
+    assert '"extension": ".py"' in out
+
+
+# --------------------------------------------------------------------------
+# edge: no-frontmatter file is not counted
+# --------------------------------------------------------------------------
+
+
+def test_file_without_frontmatter_is_not_matched(tmp_path: Path) -> None:
+    inst_dir = tmp_path / ib.INSTRUCTIONS_SUBDIR
+    inst_dir.mkdir(parents=True)
+    (inst_dir / "loose.instructions.md").write_text("# no frontmatter\n", encoding="utf-8")
+    result = ib.evaluate(tmp_path, {".py": 1_000})[0]
+    assert result.matched_files == ()
+    assert result.total_bytes == 0
+
+
+# --------------------------------------------------------------------------
+# anchor: real repo methodology guard
+# --------------------------------------------------------------------------
+
+
+def test_real_repo_python_baseline_is_under_ceiling_and_nonzero() -> None:
+    results = {r.extension: r for r in ib.evaluate(REPO_ROOT, ib.DEFAULT_CEILINGS_BYTES)}
+    py = results[".py"]
+    # The always-on .py baseline is large (the #3419 defect) but must stay
+    # under the ratchet ceiling. A zero here means the matcher broke.
+    assert py.total_bytes > 100_000
+    assert py.total_bytes <= py.ceiling_bytes
+    assert len(py.matched_files) >= 10

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -146,7 +146,12 @@ def test_parse_applyto_missing_key_returns_empty() -> None:
         ({"**/**/*.py"}, ".py", True),
         ({"**/**/*"}, ".py", True),
         ({"**/**"}, ".py", True),
-        ({"*.py"}, ".py", False),
+        # Relative '*.py' -> harness prepends '**/' -> '**/*.py' -> universal.
+        ({"*.py"}, ".py", True),
+        # Bare '*' is an all-files wildcard in the harness -> universal.
+        ({"*"}, ".py", True),
+        # A scoped relative glob prepends to '**/src/*.py' and stays situational.
+        ({"src/*.py"}, ".py", False),
         ({"**/*.py", "**/*.pyi"}, ".py", True),
         ({"**/*.cs"}, ".py", False),
         ({"tests/**"}, ".py", False),
@@ -160,11 +165,16 @@ def test_is_language_universal(patterns: set[str], ext: str, expected: bool) -> 
 
 
 def test_is_language_universal_is_precise_not_endswith() -> None:
-    # A directory-or-prefix glob that merely ends with '*.py' is NOT
-    # language-universal; only '**', '**/*', and '**/*.py' count. The
-    # root-only '*.py' form is situational, not an always-on baseline.
+    # A *scoped* glob that merely ends with '*.py' is NOT language-universal:
+    # the harness prepends '**/' to a relative pattern, so 'src/foo*.py' becomes
+    # '**/src/foo*.py' (only under a src/ dir) and 'foo*.py' becomes
+    # '**/foo*.py' (only basenames starting 'foo'). Neither matches every .py,
+    # so neither is an always-on baseline.
     assert ib.is_language_universal({"src/foo*.py"}, ".py") is False
-    assert ib.is_language_universal({"*.py"}, ".py") is False
+    assert ib.is_language_universal({"src/*.py"}, ".py") is False
+    assert ib.is_language_universal({"foo*.py"}, ".py") is False
+    # But a bare relative '*.py' prepends to '**/*.py' and IS universal.
+    assert ib.is_language_universal({"*.py"}, ".py") is True
 
 
 def test_is_language_universal_normalizes_equivalent_globs() -> None:
@@ -177,18 +187,22 @@ def test_is_language_universal_normalizes_equivalent_globs() -> None:
     # the doubled star to '*'), so the whole glob equals '**/*.py' == universal.
     assert ib.is_language_universal({"**/**.py"}, ".py") is True
     assert ib.is_language_universal({"**/**/*.cs"}, ".py") is False
-    # A doubled star inside the filename segment alone is root-only (no leading
-    # globstar), so it is NOT the always-on baseline, matching bare '*.py'.
-    assert ib.is_language_universal({"**.py"}, ".py") is False
-    # A bare '*' is root-only too (minimatch '*' does not cross '/'), so a rule
-    # scoped '*' does not load when editing a nested file: not always-on. This
-    # is the same deliberate decision as '*.py' above, recorded so a future
-    # "but '*' means all files" change is a conscious one, not an accident.
-    assert ib.is_language_universal({"*"}, ".py") is False
+    # '**.py' has no leading globstar, so the harness prepends '**/' ->
+    # '**/**.py' -> folds to '**/*.py' -> universal (same as bare '*.py').
+    assert ib.is_language_universal({"**.py"}, ".py") is True
+    # A bare '*' is an all-files wildcard in VS Code's matcher (it is special-
+    # cased alongside '**' and '**/*'), so a rule scoped '*' loads always-on.
+    # Source: computeAutomaticInstructions.ts#L294-L310 (pinned in the module).
+    assert ib.is_language_universal({"*"}, ".py") is True
     assert ib._normalize_glob("**/**/*.py") == "**/*.py"
     assert ib._normalize_glob("**/**.py") == "**/*.py"
     assert ib._normalize_glob("**/**") == "**"
     assert ib._normalize_glob("**.py") == "*.py"
+    # The '**/' prepend is what promotes a relative language glob to universal.
+    assert ib._vscode_effective_glob("*.py") == "**/*.py"
+    assert ib._vscode_effective_glob("**.py") == "**/*.py"
+    assert ib._vscode_effective_glob("src/*.py") == "**/src/*.py"
+    assert ib._vscode_effective_glob("*") == "*"
 
 
 # --------------------------------------------------------------------------

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -83,6 +83,24 @@ def test_parse_applyto_unsupported_scalar_raises() -> None:
         ib.parse_applyto(text)
 
 
+def test_parse_applyto_invalid_yaml_raises() -> None:
+    # An unquoted glob starting with '*' is a YAML alias indicator and fails to
+    # parse. Failing closed (config error) beats returning an empty set, which
+    # would let a malformed rule contribute zero bytes and dodge the ceiling.
+    text = "---\napplyTo: **/*.py\n---\nbody\n"
+    with pytest.raises(ib.UnsupportedApplyToError):
+        ib.parse_applyto(text)
+
+
+def test_parse_applyto_duplicate_key_raises() -> None:
+    # PyYAML would keep the last 'applyTo', letting a trailing directory-scoped
+    # value mask a universal one. Reject duplicate keys so the mask cannot hide
+    # always-on bytes from the gate.
+    text = "---\napplyTo: '**/*.py'\napplyTo: tests/**\n---\nbody\n"
+    with pytest.raises(ib.UnsupportedApplyToError):
+        ib.parse_applyto(text)
+
+
 def test_parse_applyto_expands_brace_group() -> None:
     # A leading '**' forces quoting in YAML, so the realistic brace form is
     # quoted; an unquoted '**/*.{...}' is invalid YAML the harness would reject.
@@ -140,14 +158,23 @@ def test_is_language_universal_is_precise_not_endswith() -> None:
     assert ib.is_language_universal({"*.py"}, ".py") is False
 
 
-def test_is_language_universal_collapses_redundant_globstars() -> None:
-    # Padding an applyTo with equivalent '**/' segments matches the same files
-    # as the minimal form, so it must not dodge the always-on budget.
+def test_is_language_universal_normalizes_equivalent_globs() -> None:
+    # Padding an applyTo with equivalent '**/' segments, or spelling the file
+    # segment with a doubled star, matches the same files as the minimal form,
+    # so it must not dodge the always-on budget.
     assert ib.is_language_universal({"**/**/*.py"}, ".py") is True
     assert ib.is_language_universal({"**/**/**/*.py"}, ".py") is True
+    # '**/**.py': segment '**.py' is a filename-segment match (minimatch folds
+    # the doubled star to '*'), so the whole glob equals '**/*.py' == universal.
+    assert ib.is_language_universal({"**/**.py"}, ".py") is True
     assert ib.is_language_universal({"**/**/*.cs"}, ".py") is False
-    assert ib._collapse_globstars("**/**/*.py") == "**/*.py"
-    assert ib._collapse_globstars("**/**") == "**"
+    # A doubled star inside the filename segment alone is root-only (no leading
+    # globstar), so it is NOT the always-on baseline, matching bare '*.py'.
+    assert ib.is_language_universal({"**.py"}, ".py") is False
+    assert ib._normalize_glob("**/**/*.py") == "**/*.py"
+    assert ib._normalize_glob("**/**.py") == "**/*.py"
+    assert ib._normalize_glob("**/**") == "**"
+    assert ib._normalize_glob("**.py") == "*.py"
 
 
 # --------------------------------------------------------------------------
@@ -213,6 +240,19 @@ def test_main_returns_2_when_instructions_dir_missing(tmp_path: Path) -> None:
 def test_main_returns_2_when_path_not_a_directory(tmp_path: Path) -> None:
     missing = tmp_path / "nope"
     assert ib.main(["--path", str(missing)]) == 2
+
+
+def test_main_returns_2_on_malformed_frontmatter(tmp_path: Path) -> None:
+    # End-to-end fail-closed: a real instruction file with a duplicate applyTo
+    # key must surface as a config error (exit 2), not silently score as zero
+    # always-on bytes.
+    inst_dir = tmp_path / ib.INSTRUCTIONS_SUBDIR
+    inst_dir.mkdir(parents=True, exist_ok=True)
+    (inst_dir / "dup.instructions.md").write_text(
+        "---\napplyTo: '**/*.py'\napplyTo: tests/**\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+    assert ib.main(["--path", str(tmp_path)]) == 2
 
 
 # --------------------------------------------------------------------------

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -275,6 +275,53 @@ def test_glob_to_regex_segment_semantics() -> None:
     assert trailing.match("/a/b/c")
 
 
+def test_glob_to_regex_separator_before_nonterminal_globstar() -> None:
+    # Regression (issue #3419 round-9 finding 2): the separator before a
+    # non-terminal '**' is mandatory. VS Code's parseRegExp "Tail" rule emits the
+    # '/' after '/*/' so a globstar cannot swallow the first directory. The old
+    # hand-rolled joiner dropped it, letting '/*/**/*.py' match a root file.
+    depth_scoped = ib._glob_to_regex("/*/**/*.py")
+    assert depth_scoped.match("/a/probe.py")  # exactly one directory
+    assert depth_scoped.match("/a/b/c/probe.py")  # many directories
+    assert not depth_scoped.match("/probe.py")  # root file has no first directory
+    # A sibling folder must not match on a shared prefix: 'some/**/*.js' keeps
+    # the '/' after 'some' so 'something/x.js' cannot match.
+    sibling = ib._glob_to_regex("**/some/**/*.js")
+    assert sibling.match("/pkg/some/x.js")
+    assert not sibling.match("/pkg/something/x.js")
+
+
+def test_is_language_universal_is_or_union_over_patterns() -> None:
+    # Regression (issue #3419 round-9 finding 1): universality is a property of
+    # the UNION of the comma-split patterns, not any single pattern. VS Code
+    # attaches a rule to a file if ANY comma-split pattern matches it
+    # (computeAutomaticInstructions.ts _matches). Three disjoint per-depth globs
+    # whose union covers every depth make the rule load for every .py file, so
+    # it must be scored universal even though no single member is.
+    union = {"/*.py", "/*/*.py", "/*/*/**/*.py"}
+    assert ib.is_language_universal(union, ".py") is True
+    # No single member is universal on its own; scoring per-pattern (the old
+    # behavior) would under-count this rule and let it dodge the budget.
+    assert ib.is_language_universal({"/*.py"}, ".py") is False
+    assert ib.is_language_universal({"/*/*.py"}, ".py") is False
+    assert ib.is_language_universal({"/*/*/**/*.py"}, ".py") is False
+    # The same OR-union holds through the frontmatter parser for a comma-joined
+    # applyTo, the shape a real rule file would carry.
+    text = "---\napplyTo: '/*.py, /*/*.py, /*/*/**/*.py'\n---\nbody\n"
+    assert ib.is_language_universal(ib.parse_applyto(text), ".py") is True
+    # A union that leaves a depth uncovered stays scoped: dropping the globstar
+    # member leaves depth >=2 (e.g. '/a/b/x.py') unmatched, so not universal.
+    bounded = {"/*.py", "/*/*.py"}
+    assert ib.is_language_universal(bounded, ".py") is False
+
+
+def test_is_language_universal_single_scoped_pattern_not_universal() -> None:
+    # The OR-union change must not regress the common single-pattern case: a lone
+    # '/*/**/*.py' does not match a root file, so a depth-0 .py file is uncovered
+    # and the rule is not universal (finding 2 and finding 1 interact here).
+    assert ib.is_language_universal({"/*/**/*.py"}, ".py") is False
+
+
 # --------------------------------------------------------------------------
 # measure_extension / evaluate (positive)
 # --------------------------------------------------------------------------

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -194,13 +194,11 @@ def test_is_language_universal_normalizes_equivalent_globs() -> None:
     # cased alongside '**' and '**/*'), so a rule scoped '*' loads always-on.
     # Source: computeAutomaticInstructions.ts#L294-L310 (pinned in the module).
     assert ib.is_language_universal({"*"}, ".py") is True
-    assert ib._normalize_glob("**/**/*.py") == "**/*.py"
-    assert ib._normalize_glob("**/**.py") == "**/*.py"
-    assert ib._normalize_glob("**/**") == "**"
-    assert ib._normalize_glob("**.py") == "*.py"
-    # The '**/' prepend is what promotes a relative language glob to universal.
+    # The '**/' prepend is what promotes a relative language glob to universal;
+    # every other equivalence is decided by matching, not string rewriting, so
+    # the effective glob keeps its shape and '**.py' stays '**/**.py'.
     assert ib._vscode_effective_glob("*.py") == "**/*.py"
-    assert ib._vscode_effective_glob("**.py") == "**/*.py"
+    assert ib._vscode_effective_glob("**.py") == "**/**.py"
     assert ib._vscode_effective_glob("src/*.py") == "**/src/*.py"
     assert ib._vscode_effective_glob("*") == "*"
 
@@ -220,29 +218,61 @@ def test_is_language_universal_is_case_insensitive() -> None:
 
 def test_is_language_universal_matches_broad_vscode_forms() -> None:
     # VS Code's matcher makes several broader globs universal that an exact-form
-    # membership test would miss. Each of these loads for every .py file:
+    # membership test would miss. Universality is decided by matching probe
+    # paths, so the whole class is covered, not a hand-listed subset. Each of
+    # these loads for every .py file:
     #  - '**/*.*' matches any dotted basename (every .py has one).
     #  - '/**/*.py' is absolute; file paths are absolute, so it spans any dir.
     #  - '**/*.py/**' has a trailing globstar that matches zero segments,
     #    covering the .py file itself.
+    #  - '**/*.p?' uses a single-char wildcard that still matches every .py.
+    #  - '**/*.p*' matches any '.p'-prefixed extension, including '.py'.
+    #  - '/*/**' is an absolute one-segment-plus-globstar all-files form.
     assert ib.is_language_universal({"**/*.*"}, ".py") is True
     assert ib.is_language_universal({"*.*"}, ".py") is True
     assert ib.is_language_universal({"/**/*.py"}, ".py") is True
     assert ib.is_language_universal({"**/*.py/**"}, ".py") is True
-    # Absolute all-files and prefix wildcards fold to the all-files form.
+    assert ib.is_language_universal({"**/*.p?"}, ".py") is True
+    assert ib.is_language_universal({"**/*.p*"}, ".py") is True
+    assert ib.is_language_universal({"/*/**"}, ".py") is True
+    # Absolute all-files and prefix wildcards are universal too.
     assert ib.is_language_universal({"/**"}, ".py") is True
     assert ib.is_language_universal({"/**/*"}, ".py") is True
-    # The folds must not promote a scoped glob: a bounded prefix stays scoped
-    # whether the breadth comes from a trailing globstar or an absolute anchor.
+    # Matching must not promote a scoped glob: a bounded prefix stays scoped
+    # whether the breadth comes from a trailing globstar or an absolute anchor,
+    # and a single-char wildcard that cannot reach '.py' stays out (a '.pyx'
+    # rule is not universal for '.py').
     assert ib.is_language_universal({"src/**/*.py/**"}, ".py") is False
     assert ib.is_language_universal({"/src/**/*.py"}, ".py") is False
     assert ib.is_language_universal({"/src/*.py"}, ".py") is False
-    # Effective-glob folds, spelled out.
-    assert ib._vscode_effective_glob("/**/*.py") == "**/*.py"
-    assert ib._vscode_effective_glob("**/*.py/**") == "**/*.py"
-    assert ib._vscode_effective_glob("/**") == "**"
-    assert ib._vscode_effective_glob("/**/*") == "**"
+    assert ib.is_language_universal({"**/*.py?"}, ".py") is False
+    assert ib.is_language_universal({"**/*.pyx"}, ".py") is False
+    # Effective glob is prepend-only now; the breadth is resolved by matching.
+    assert ib._vscode_effective_glob("/**/*.py") == "/**/*.py"
+    assert ib._vscode_effective_glob("**/*.py/**") == "**/*.py/**"
+    assert ib._vscode_effective_glob("/**") == "/**"
+    assert ib._vscode_effective_glob("/**/*") == "/**/*"
     assert ib._vscode_effective_glob("**/*.*") == "**/*.*"
+
+
+def test_glob_to_regex_segment_semantics() -> None:
+    # The matcher is the load-bearing primitive: '**' spans zero+ segments, '*'
+    # stays within a segment, '?' is exactly one non-separator char.
+    globstar = ib._glob_to_regex("**/*.py")
+    assert globstar.match("/probe.py")  # zero intermediate segments
+    assert globstar.match("/a/b/c/probe.py")  # many segments
+    star = ib._glob_to_regex("/src/*.py")
+    assert star.match("/src/probe.py")
+    assert not star.match("/src/sub/probe.py")  # '*' does not cross '/'
+    assert not star.match("/probe.py")  # literal 'src/' segment required
+    question = ib._glob_to_regex("/x?.py")
+    assert question.match("/xy.py")  # exactly one char
+    assert not question.match("/x.py")  # zero chars fails
+    assert not question.match("/xyz.py")  # two chars fails
+    # Trailing '/**' covers the prefix path itself (zero trailing segments).
+    trailing = ib._glob_to_regex("/a/**")
+    assert trailing.match("/a")
+    assert trailing.match("/a/b/c")
 
 
 # --------------------------------------------------------------------------

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -2,7 +2,7 @@
 
 The validator measures the always-on instruction budget per language: the summed
 bytes of ``.github/instructions/*.instructions.md`` files whose ``applyTo`` scopes
-them to every file of a language (``**`` or ``**/*.<ext>``). It gates growth via a
+them to every file of a language (``**``, ``**/*``, or ``**/*.<ext>``). It gates growth via a
 non-regression byte ceiling.
 
 Tests use crafted temporary instruction trees so results are independent of the

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -123,6 +123,13 @@ def test_parse_applyto_brace_form_is_language_universal() -> None:
     assert ib.is_language_universal(patterns, ".py") is True
 
 
+def test_expand_braces_strips_whitespace_around_options() -> None:
+    # Whitespace after commas in brace groups must not bleed into the expanded
+    # glob. "**/*.{py, pyi}" must produce "**/*.pyi", not "**/*. pyi".
+    assert ib.expand_braces("**/*.{py, pyi}") == ["**/*.py", "**/*.pyi"]
+    assert ib.expand_braces("**/*.{ cs , fs }") == ["**/*.cs", "**/*.fs"]
+
+
 def test_parse_applyto_missing_frontmatter_returns_empty() -> None:
     assert ib.parse_applyto("# just a heading\n\nno frontmatter\n") == set()
 

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -101,6 +101,15 @@ def test_parse_applyto_duplicate_key_raises() -> None:
         ib.parse_applyto(text)
 
 
+def test_parse_applyto_unhashable_key_raises() -> None:
+    # A YAML complex key ('? [a, b]') builds an unhashable dict key. The strict
+    # loader must surface that as a config error (exit 2), not let a raw
+    # 'key in mapping' membership test raise an uncaught TypeError (exit 1).
+    text = "---\napplyTo: '**/*.py'\n? [a, b]\n: c\n---\nbody\n"
+    with pytest.raises(ib.UnsupportedApplyToError):
+        ib.parse_applyto(text)
+
+
 def test_parse_applyto_expands_brace_group() -> None:
     # A leading '**' forces quoting in YAML, so the realistic brace form is
     # quoted; an unquoted '**/*.{...}' is invalid YAML the harness would reject.
@@ -171,6 +180,11 @@ def test_is_language_universal_normalizes_equivalent_globs() -> None:
     # A doubled star inside the filename segment alone is root-only (no leading
     # globstar), so it is NOT the always-on baseline, matching bare '*.py'.
     assert ib.is_language_universal({"**.py"}, ".py") is False
+    # A bare '*' is root-only too (minimatch '*' does not cross '/'), so a rule
+    # scoped '*' does not load when editing a nested file: not always-on. This
+    # is the same deliberate decision as '*.py' above, recorded so a future
+    # "but '*' means all files" change is a conscious one, not an accident.
+    assert ib.is_language_universal({"*"}, ".py") is False
     assert ib._normalize_glob("**/**/*.py") == "**/*.py"
     assert ib._normalize_glob("**/**.py") == "**/*.py"
     assert ib._normalize_glob("**/**") == "**"

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -60,6 +60,17 @@ def test_parse_applyto_flow_list_form() -> None:
     assert ib.parse_applyto(text) == {"**", "**/*.ts"}
 
 
+def test_parse_applyto_expands_brace_group() -> None:
+    text = "---\napplyTo: **/*.{py,pyi},tests/**\n---\nbody\n"
+    assert ib.parse_applyto(text) == {"**/*.py", "**/*.pyi", "tests/**"}
+
+
+def test_parse_applyto_brace_form_is_language_universal() -> None:
+    # A future rule scoped with a brace group must still be caught by the gate.
+    patterns = ib.parse_applyto("---\napplyTo: '**/*.{py,pyi}'\n---\nbody\n")
+    assert ib.is_language_universal(patterns, ".py") is True
+
+
 def test_parse_applyto_missing_frontmatter_returns_empty() -> None:
     assert ib.parse_applyto("# just a heading\n\nno frontmatter\n") == set()
 
@@ -78,8 +89,10 @@ def test_parse_applyto_missing_key_returns_empty() -> None:
     ("patterns", "ext", "expected"),
     [
         ({"**"}, ".py", True),
+        ({"**/*"}, ".py", True),
         ({"**/*.py"}, ".py", True),
-        ({"*.py"}, ".py", True),
+        ({"*.py"}, ".py", False),
+        ({"**/*.py", "**/*.pyi"}, ".py", True),
         ({"**/*.cs"}, ".py", False),
         ({"tests/**"}, ".py", False),
         ({"scripts/**", "build/**"}, ".py", False),
@@ -93,8 +106,10 @@ def test_is_language_universal(patterns: set[str], ext: str, expected: bool) -> 
 
 def test_is_language_universal_is_precise_not_endswith() -> None:
     # A directory-or-prefix glob that merely ends with '*.py' is NOT
-    # language-universal; only '**', '*.py', '**/*.py' count.
+    # language-universal; only '**', '**/*', and '**/*.py' count. The
+    # root-only '*.py' form is situational, not an always-on baseline.
     assert ib.is_language_universal({"src/foo*.py"}, ".py") is False
+    assert ib.is_language_universal({"*.py"}, ".py") is False
 
 
 # --------------------------------------------------------------------------
@@ -214,8 +229,17 @@ def test_file_without_frontmatter_is_not_matched(tmp_path: Path) -> None:
 def test_real_repo_python_baseline_is_under_ceiling_and_nonzero() -> None:
     results = {r.extension: r for r in ib.evaluate(REPO_ROOT, ib.DEFAULT_CEILINGS_BYTES)}
     py = results[".py"]
-    # The always-on .py baseline is large (the #3419 defect) but must stay
-    # under the ratchet ceiling. A zero here means the matcher broke.
-    assert py.total_bytes > 100_000
+    # Methodology guard, not a debt floor. The instrument must detect the
+    # always-on universal rules and stay under the ratchet ceiling. It must
+    # NOT assert a minimum size: the deferred rescoping phase legitimately
+    # shrinks this corpus, and a lower bound would fail on that success.
+    matched = set(py.matched_files)
+    core_universal = {
+        "universal.instructions.md",
+        "voice.instructions.md",
+        "builder-ethos.instructions.md",
+    }
+    missing = core_universal - matched
+    assert not missing, f"matcher missed core always-on rules: {sorted(missing)}"
+    assert py.total_bytes > 0
     assert py.total_bytes <= py.ceiling_bytes
-    assert len(py.matched_files) >= 10


### PR DESCRIPTION
## Summary

Editing a single Python file loads about 218 KB of always-on instruction
text: every instruction file whose `applyTo` scopes it to the language
(`**`, `**/*`, or `**/*.<ext>`). The IFScale benchmark (arXiv:2507.11538) shows
models omit instructions as the always-loaded set grows, and omission is the
dominant failure mode. Nothing measured this corpus, so it grew silently on
every rule addition.

This is phase 1 of #3419: the measurement instrument and a non-regression gate.
It changes no agent-facing instruction content and needs no ADR.

## What this adds

- A validator that sums the bytes of language-universal instruction files per
  representative extension (`.py`, `.cs`, `.ps1`, `.md`) and gates on a
  per-extension byte ceiling seeded just above the current measured size.
- A dedicated CI workflow that runs the gate on any rule, instruction, or
  validator change, so the check is enforced in CI and not only on the local
  pre-PR hook.
- A pre-PR sequence entry (via a `checks_tooling` wrapper) that runs the module
  and SKIPs in downstream installs that lack the instructions tree.
- Positive, negative, and edge tests plus a real-repo methodology anchor.

## Why a ratchet, not the reduction

Directory-scoped rules are situational, not always-on, so they are excluded by
design. The gate is on exact bytes; estimated tokens are reported for context.
Phase 1 blocks silent growth (for example a new all-language rule). The
follow-up rescope lowers the ceilings as book-derived rules move to
task-invoked skills.

## Acceptance criteria

- AC #1 (measure + gate): done here, enforced by a CI workflow.
- AC #2 (rescope so the corpus falls below ceiling), AC #3 (normalize scoping
  metadata), AC #4 (AGENTS.md guidance), AC #5 (ADR): deferred to follow-ups;
  AC #5 needs owner sign-off and adr-review.

## Verification

- 45 tests pass; ruff and mypy clean on changed files.
- 125 reachability and pre-PR tests still pass, including the guard that
  requires the validator to be reachable from a workflow.
- Live run reports `.py` 218603 bytes under the 220000 ceiling (PASS); the
  measured corpus is unchanged by the parser and matcher fixes.

## Adversarial review

Three review rounds by a non-Opus model (gpt-5.6-sol).

Round 1 flagged three defects, all fixed: the missing CI wiring, matcher gaps
for `**/*` and brace groups, and an over-constrained anchor test that would
fail when the deferred rescope succeeds.

Round 2 flagged three bypasses, all fixed: a YAML comment and block-list parse
gap (now parsed with a YAML loader, with an unsupported `applyTo` shape
raising a config error instead of being dropped), a redundant-globstar bypass
so `**/**/*.py` is now caught, and the workflow omitting its own path from its
change filter.

Round 3 flagged four findings, all fixed:

- Invalid YAML frontmatter (an unquoted `applyTo: **/*.py` is a YAML alias
  indicator) silently scored zero always-on bytes; it now fails closed as a
  config error (exit 2).
- Duplicate top-level keys let a trailing directory-scoped `applyTo` mask a
  universal one under last-wins; a strict loader now rejects any duplicate.
- A doubled star in the filename segment (`**/**.py`) was not normalized and
  dodged the universality check; folding now recognizes it as language
  universal.
- The `validate-budget` job used bare setup-python and raised
  ModuleNotFoundError on the PyYAML import in CI; it now runs under
  `uv run --frozen` with uv set up.

Round 4-6 hardened the universality model against the actual harness. The
final and highest-impact finding: VS Code's instruction matcher (authoritative
for the Copilot instruction trees) special-cases bare `*`/`**`/`**/*` as
all-files wildcards and prepends `**/` to every other relative pattern, so
`applyTo: '*.py'` means `**/*.py` and loads for every `.py` at any depth. The
gate had classified such relative language globs as root-only, letting a large
rule scoped `*.py` (or bare `*`) contribute zero always-on bytes. Fixed by
modeling the prepend in `_vscode_effective_glob` (source pinned in the module),
routing classification through it, and adding `*` to the universal forms; a
scoped `src/*.py` becomes `**/src/*.py` and stays situational. Also fixed an
unhashable complex-key crash (now exit 2, not a traceback). A census of all 96
corpus files confirms none use a bare language glob, so the real-repo baseline
is unchanged (`.py` still 19 files / 218603 bytes) and this closes the bypass
for future files. 48 tests pass; live gate PASS all four languages.

## References

- Shared token estimator: see `scripts/validation/token_budget.py`
- Sibling per-file budget: see `scripts/validation/passive_context_budget.py`
- Sibling workflow pattern: see `.github/workflows/passive-context-budget.yml`
- Measured corpus: see `.github/instructions/` instruction mirrors

## Changed Files

- `scripts/validation/instruction_budget.py` (validator plus matcher fixes)
- `tests/validation/test_instruction_budget.py` (tests)
- `.github/workflows/instruction-budget.yml` (CI gate)
- `scripts/validation/checks_tooling.py` (pre-PR wrapper)
- `scripts/validation/pre_pr_sequence.py` (registration)

Refs #3419



