### PR TITLE
feat(eval): hold-out-gate artifact edits for agents, rules, and hooks

### DIFF
--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -44,7 +44,7 @@ python3 scripts/eval/eval-skill-overlap.py \
 | `eval-reviewer-asymmetry.py` | Statistical-significance test for `templates/agents/{critic,qa,implementer}.shared.md` reviewer-asymmetry framing. Fisher's exact (verdict-pass) + Mann-Whitney U (findings-count). | Complementary |
 | `eval-e2e-delivery.py` | End-to-end delivery eval (plan-rubric proxy). Feeds a vague germ, captures each agent's plan, LLM-judges it against hidden acceptance criteria. Core in `_e2e_delivery_core.py`. | #2859 |
 | `eval-model-sweep.py` | Sweep one agent's fixtures across candidate models; scored KEEP_PIN/DROP_PIN verdict with effect size. Core in `_model_sweep_core.py`. | #2840 |
-| `optimize-artifact.py` | Held-out-gated edit loop for agents, rules, hooks, and prompts. Splits tasks, bounds the edit budget, applies patches, and accepts an edit only on data withheld from the author. Core in `_optimizer_core.py`, scorer adapters in `_optimizer_adapters.py`. | #3422 |
+| `optimize-artifact.py` | Held-out-gated edit loop for agents, rules, and hooks. Splits tasks, bounds the edit budget, applies patches, and accepts an edit only on data withheld from the author. Core in `_optimizer_core.py`, scorer adapters in `_optimizer_adapters.py`. | #3422 |
 | `_anthropic_api.py` | Shared API utilities (key loading, API calls). | N/A |
 
 ## End-to-End Delivery Eval
@@ -276,11 +276,24 @@ report may be memorization rather than a better artifact.
 
 This tool splits the task ids into three groups and keeps them apart:
 
-| Group | Who sees it | Purpose |
-|-------|-------------|---------|
-| `opt` | The optimizing agent | Read failures here, propose edits from them. |
-| `sel` | The gate only | Decides accept or reject. Never shown to the author. |
-| `test` | Nobody, until the end | Final unbiased number after the loop stops. |
+| Group | Who sees it | Purpose | Default share |
+|-------|-------------|---------|---------------|
+| `opt` | The optimizing agent | Read failures here, propose edits from them. | The remainder, 0.6 |
+| `sel` | The gate only | Decides accept or reject. Never shown to the author. | 0.4 |
+| `test` | Nobody, until the end | Final unbiased number after the loop stops. | 0.0, opt in with `--test-ratio` |
+
+`--test-ratio` defaults to zero, so out of the box you get two groups and an
+empty `test`. That is a concession to this repo's real fixture counts: most
+spike directories hold 8 fixtures, where a third group would leave the
+optimizing agent 3 tasks to learn from. Set `--test-ratio 0.2` when the set is
+large enough to afford it. The 24-fixture analyst set can; an 8-fixture set
+cannot.
+
+Size the `sel` group before trusting a verdict. At the 3-task floor a single
+task flipping decides the gate, which is close to a coin toss. The gate is
+worth running there as a guard against obvious overfit, not as evidence of
+improvement. Treat a held-out accept on fewer than about 8 tasks as a weak
+signal and say so wherever you cite it.
 
 The split is a deterministic function of the seed and the task-id set, so it
 reproduces on any machine and does not depend on input order. Ratios pick exact
@@ -317,9 +330,13 @@ errored, and a skipped test all score as failures rather than being dropped.
 Dropping a task shrinks the denominator, which raises the score, so a silent
 omission would read as an improvement.
 
-`--kind rule` scores negative cases inverted, so a rule that fires when it
-should stay quiet loses. `eval-rule-activation.py` collects negative cases into
-their own summary but its verdict never reads them.
+`--kind rule` does not invert negative cases. `eval-rule-activation.py` builds
+the judge prompt so 5 always means the rule behaved correctly, negative cases
+included ("5 means the response correctly did NOT activate the rule"), so the
+score arrives already normalized and inverting here would double-invert and
+punish rules that correctly stay quiet. Including them is still worth doing:
+the evaluator's own verdict averages positive scenarios only, so a rule that
+fires when it should not is invisible to it and visible here.
 
 ### A loop step
 
@@ -350,25 +367,55 @@ A strictly-greater held-out score is the only way to earn an accept. A tie is a
 reject, because an edit that did not move the held-out score is churn and churn
 on an artifact costs review attention forever.
 
-Three further refusals close holes that open once a loop runs many steps:
+The gate reads `sel` and only `sel`. There is no flag to point it at another
+group, because a gate that can be aimed at the group the author has been
+reading is not a gate.
 
+Four further refusals close holes that open once a loop runs many steps:
+
+- **A broken held-out task.** An aggregate win can still contain a task that
+  passed before the edit and fails after it. ADR-057 blocks every pass-to-fail
+  transition rather than netting it against a gain, so one broken task rejects
+  the edit however good the aggregate looks. `--allow-regressions` opts out.
 - **Moved split.** The split fingerprint covers the seed, the task-id set, and
   the ratios. If it changes, the gate refuses instead of comparing. This blocks
   the cheapest cheat available: an edit loses, so add fixtures and re-roll.
 - **Exhausted consultations.** Gating N times against one `sel` group selects
   on it N times. Pass `--consultations` and `--max-consultations` to cap it. The
-  count only advances when scores were actually weighed, so a refusal on a moved
-  fingerprint costs nothing.
+  count only advances when scores were actually weighed, and a refusal reports
+  no scores at all, so a refused call cannot be used to read the group for free.
 - **Protected sections.** Text between `<!-- SLOW_UPDATE_START -->` and
   `<!-- SLOW_UPDATE_END -->` is off limits, markers included. Patches carrying a
   fence marker in their text are rejected too, since one could otherwise open a
   fence over the rest of the file or close an existing one.
 
+### What the numbers can and cannot show
+
+Every compared verdict reports `discordant_gain`, `discordant_loss`, and
+`p_value`: the counts of held-out tasks that moved fail-to-pass and
+pass-to-fail, and the one-sided exact McNemar tail on those counts. Tasks that
+did not move carry no evidence about the edit, so they are not in the test.
+
+The `p` is reported, never enforced. A held-out group with three discordant
+tasks cannot produce a `p` below 0.125 no matter how one-sided the result, so
+enforcing a conventional 0.05 floor would make the ordinary case unpassable
+rather than informative. Read it as a resolution limit: at these sizes a single
+task flip moves the verdict, so a one-step accept is weak evidence and a run of
+them is worth more than any single number.
+
+The seam is boolean, so an edit that lifts every held-out task from 0.50 to
+0.99 without crossing the threshold scores as no change and rejects as a tie.
+That is a real limit of this design, not a rounding artifact. Lower
+`--pass-threshold` when the artifact under test moves scores rather than
+outcomes.
+
 ### Exit codes
 
 Per ADR-035. A reject is exit 1 because it is a decision a shell loop branches
-on, not a crash. Every path prints JSON, so a caller that needs to tell a reject
-from a broken input reads `decision` rather than inferring from the code.
+on, not a crash. Every verdict path prints JSON, so a caller that needs to tell
+a reject from a broken input reads `decision` rather than inferring from the
+code. Argument errors from `argparse` are the exception and print plain text to
+stderr, exit 2, as with every other script here.
 
 | Code | Meaning |
 |------|---------|

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -410,28 +410,47 @@ Four further refusals close holes that open once a loop runs many steps:
   the ratios. If it changes, the gate refuses instead of comparing. This blocks
   the cheapest cheat available: an edit loses, so add fixtures and re-roll.
 - **Exhausted consultations.** Gating N times against one `sel` group selects
-  on it N times, so the gate keeps a budget in a ledger keyed by the split
-  fingerprint, under `$XDG_STATE_HOME/ai-agents-eval/ledgers/`. Each piece of
-  that budget moved off the command line after a review reproduced a way around
-  the previous version:
+  on it N times, so the gate keeps a budget in a ledger keyed by the held-out
+  membership itself, by default under
+  `$XDG_STATE_HOME/ai-agents-eval/ledgers/`. Each piece of that budget moved
+  off the command line after a review reproduced a way around the previous
+  version:
 
   | Held where | Why not on the command line |
   | --- | --- |
   | Count | `--consultations` defaulted to zero every invocation, so a loop that passed zero each time had an unlimited budget while looking capped. Review reproduced ACCEPT twice under a cap of one. |
   | Cap | `--max-consultations` defaulted to unlimited, so the ordinary invocation had no budget at all, and a caller that did hit the cap could raise it and continue. It is now required, recorded at the first gate, and a later change is refused. |
-  | Ledger path | `--ledger PATH` looked like discipline but a missing ledger starts at zero, so naming a fresh path restored the whole budget. Deriving the path from `--split` only moved that: copy `split.json` to `split2.json` and the fingerprint matches with no ledger beside it. The key is the fingerprint, so a copy or a rename shares the budget its content already spent. |
+  | Ledger path | `--ledger PATH` looked like discipline but a missing ledger starts at zero, so naming a fresh path restored the whole budget. |
+  | The split path it was derived from | Deriving the ledger path from `--split` only moved that: copy `split.json` to `split2.json` and the fingerprint matches with no ledger beside it. |
+  | The inputs the fingerprint covers | The fingerprint covers the seed, task ids, and ratios, which are inputs to the selection rather than its result, and group sizes round. Ten tasks at `--sel-ratio 0.40` and at `0.41` hold out the same four and fingerprint differently, so one group got two budgets. The key is now a digest of the sorted held-out membership. |
 
-  The ledger records the split fingerprint too, so redrawing the split does not
-  reset the budget: the gate refuses a ledger and a split that disagree. The
-  count advances only when scores were actually weighed, and a refusal reports
-  no scores at all, so a refused call cannot be used to read the group for free.
-  Two gates cannot race for the last consultation either; the read, the
-  comparison, and the write happen under a lock keyed by the same fingerprint.
+  Any two splits that hold out the same tasks share the budget those tasks have
+  already spent, whatever ratio or seed produced them. Redrawing with a new seed
+  usually does hold out different tasks, and that is a genuinely new group with
+  its own budget; the gate is counting selection pressure on a set of tasks, not
+  on a file.
 
-  Two things this does not cover, stated rather than implied. The cap is
+  A consultation is charged when the held-out group is read, not when a verdict
+  comes back. A refusal decided from bookkeeping alone (an exhausted budget, a
+  stale incumbent fingerprint, a drifted split) reads nothing and costs nothing.
+  Everything past that point costs one, including a results file that turns out
+  not to cover the group, and including a process killed mid-comparison. Two
+  gates cannot race for the last consultation; the read, the comparison, and the
+  write happen under a lock keyed by the same held-out group.
+
+  The gate never names a held-out task. `score` and `mcnemar_exact` report which
+  ids they could not find, which is the right message everywhere else and a full
+  disclosure here, so the gate asks its own coverage question and answers one
+  bit. Not a count: `split` publishes the held-out size, so a count would tell a
+  caller how many of the keys it chose to omit were held out, and a few chosen
+  omissions recover the membership.
+
+  Three things this does not cover, stated rather than implied. The cap is
   whatever positive integer the first call names, so the budget is only as tight
-  as that first invocation. And `$EVAL_LEDGER_DIR` relocates the root, which is
-  how the tests stay isolated and equally how anyone who sets it starts over.
+  as that first invocation. `$EVAL_LEDGER_DIR` relocates the root, which is how
+  the tests stay isolated and equally how anyone who sets it starts over. And a
+  stale lock left by a killed process is reported rather than broken, so
+  clearing it by hand is a deliberate act with no record.
 
   ```bash
   optimize-artifact.py gate --incumbent inc.json --candidate cand.json \

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -365,7 +365,8 @@ uv run --frozen python "$OA" apply --file target.md --patches p.json --budget 3
 
 # Rerun the real scorer here, then extract it to cand.json.
 uv run --frozen python "$OA" gate --incumbent base.json --candidate cand.json \
-    --split split.json --incumbent-fingerprint "$FP"
+    --split split.json --ledger ledger.json --incumbent-fingerprint "$FP" \
+    --max-consultations 5
 ```
 
 On reject, revert the file and run `buffer-add` so the same edit is not
@@ -410,9 +411,26 @@ Four further refusals close holes that open once a loop runs many steps:
   the ratios. If it changes, the gate refuses instead of comparing. This blocks
   the cheapest cheat available: an edit loses, so add fixtures and re-roll.
 - **Exhausted consultations.** Gating N times against one `sel` group selects
-  on it N times. Pass `--consultations` and `--max-consultations` to cap it. The
-  count only advances when scores were actually weighed, and a refusal reports
-  no scores at all, so a refused call cannot be used to read the group for free.
+  on it N times. `gate --ledger PATH` is required, and the count lives in that
+  file rather than on the command line. This matters: a count the caller passes
+  is not a cap. `--consultations` defaulted to zero and arrived on every
+  invocation, so a loop that passed zero each time had an unlimited budget while
+  looking capped. An adversarial review reproduced ACCEPT twice under
+  `--max-consultations 1` that way.
+
+  The ledger records the split fingerprint alongside the count, so redrawing the
+  split does not reset the budget: the gate refuses a ledger and a split that
+  disagree. The count advances only when scores were actually weighed, and a
+  refusal reports no scores at all, so a refused call cannot be used to read the
+  group for free.
+
+  ```bash
+  optimize-artifact.py gate --incumbent inc.json --candidate cand.json \
+      --split split.json --ledger ledger.json --max-consultations 5
+  ```
+
+  A first run needs no existing ledger; the gate creates it. Point one ledger at
+  one split for the life of a loop.
 - **Protected sections.** Text between `<!-- SLOW_UPDATE_START -->` and
   `<!-- SLOW_UPDATE_END -->` is off limits, markers included. Patches carrying a
   fence marker in their text are rejected too, since one could otherwise open a

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -410,21 +410,28 @@ Four further refusals close holes that open once a loop runs many steps:
   the ratios. If it changes, the gate refuses instead of comparing. This blocks
   the cheapest cheat available: an edit loses, so add fixtures and re-roll.
 - **Exhausted consultations.** Gating N times against one `sel` group selects
-  on it N times, so the gate keeps a budget in a ledger it writes beside the
-  split, at `<split>.ledger`. Nothing about that budget arrives on the command
-  line twice, and each piece was moved there after a review reproduced a way
-  around the previous version:
+  on it N times, so the gate keeps a budget in a ledger keyed by the split
+  fingerprint, under `$XDG_STATE_HOME/ai-agents-eval/ledgers/`. Each piece of
+  that budget moved off the command line after a review reproduced a way around
+  the previous version:
 
   | Held where | Why not on the command line |
   | --- | --- |
   | Count | `--consultations` defaulted to zero every invocation, so a loop that passed zero each time had an unlimited budget while looking capped. Review reproduced ACCEPT twice under a cap of one. |
   | Cap | `--max-consultations` defaulted to unlimited, so the ordinary invocation had no budget at all, and a caller that did hit the cap could raise it and continue. It is now required, recorded at the first gate, and a later change is refused. |
-  | Ledger path | `--ledger PATH` looked like discipline but a missing ledger starts at zero, so naming a fresh path restored the whole budget. The path is derived from the split, so resetting the count means deleting a file, not passing an argument. |
+  | Ledger path | `--ledger PATH` looked like discipline but a missing ledger starts at zero, so naming a fresh path restored the whole budget. Deriving the path from `--split` only moved that: copy `split.json` to `split2.json` and the fingerprint matches with no ledger beside it. The key is the fingerprint, so a copy or a rename shares the budget its content already spent. |
 
   The ledger records the split fingerprint too, so redrawing the split does not
   reset the budget: the gate refuses a ledger and a split that disagree. The
   count advances only when scores were actually weighed, and a refusal reports
   no scores at all, so a refused call cannot be used to read the group for free.
+  Two gates cannot race for the last consultation either; the read, the
+  comparison, and the write happen under a lock keyed by the same fingerprint.
+
+  Two things this does not cover, stated rather than implied. The cap is
+  whatever positive integer the first call names, so the budget is only as tight
+  as that first invocation. And `$EVAL_LEDGER_DIR` relocates the root, which is
+  how the tests stay isolated and equally how anyone who sets it starts over.
 
   ```bash
   optimize-artifact.py gate --incumbent inc.json --candidate cand.json \

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -345,12 +345,22 @@ OA=scripts/eval/optimize-artifact.py
 
 # Baseline the incumbent and fix the split once.
 uv run --frozen python "$OA" extract --kind agent --input report.json > base.json
-uv run --frozen python "$OA" split --results base.json --seed run-7 > split.json
-FP=$(python3 -c "import json;print(json.load(open('split.json'))['fingerprint'])")
+FP=$(uv run --frozen python "$OA" split --results base.json --seed run-7 \
+    --out split.json | python3 -c "import json,sys;print(json.load(sys.stdin)['fingerprint'])")
 
 # Per step: check the budget, reject a repeat, apply, rescore, gate.
 uv run --frozen python "$OA" budget --step 3 --total 12
-uv run --frozen python "$OA" buffer-check --buffer rejected.json --patches p.json || exit 0
+
+# Exit 1 means this edit was already rejected, so skip it. Exit 2 means the
+# command itself failed and the loop must stop rather than treat a typo in a
+# path as a clean finish.
+uv run --frozen python "$OA" buffer-check --buffer rejected.json --patches p.json
+case $? in
+  0) ;;
+  1) continue ;;
+  *) exit 2 ;;
+esac
+
 uv run --frozen python "$OA" apply --file target.md --patches p.json --budget 3
 
 # Rerun the real scorer here, then extract it to cand.json.
@@ -371,12 +381,31 @@ The gate reads `sel` and only `sel`. There is no flag to point it at another
 group, because a gate that can be aimed at the group the author has been
 reading is not a gate.
 
+### What the seam does and does not protect
+
+`split` writes the full partition to the `--out` file the gate reads, and
+prints only the optimize ids, the held-out sizes, and the fingerprint. `score`
+reads the optimize group and nothing else. Together those keep the held-out
+answers off the optimizer's stdout and keep every held-out read inside a gate
+decision that spends a consultation.
+
+This is a discipline control, not a security boundary. The split file sits on
+the same disk as everything else, so an optimizer determined to read it can.
+What the seam removes is the accidental path: reading held-out failures
+because they were printed, or scoring against them because the command
+offered it. Binding the split to state the optimizer cannot reach needs a
+trusted controller, which this does not have. Do not cite a run of this loop
+as evidence against an adversarial optimizer.
+
 Four further refusals close holes that open once a loop runs many steps:
 
 - **A broken held-out task.** An aggregate win can still contain a task that
   passed before the edit and fails after it. ADR-057 blocks every pass-to-fail
   transition rather than netting it against a gain, so one broken task rejects
-  the edit however good the aggregate looks. `--allow-regressions` opts out.
+  the edit however good the aggregate looks. There is no override flag: ADR-057
+  states its gate "has no mechanism to accept a justified regression", and a
+  bypass here would be a weaker rule under the same name that an agent driving
+  the loop could set without a human seeing the broken task.
 - **Moved split.** The split fingerprint covers the seed, the task-id set, and
   the ratios. If it changes, the gate refuses instead of comparing. This blocks
   the cheapest cheat available: an edit loses, so add fixtures and re-roll.

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -44,6 +44,7 @@ python3 scripts/eval/eval-skill-overlap.py \
 | `eval-reviewer-asymmetry.py` | Statistical-significance test for `templates/agents/{critic,qa,implementer}.shared.md` reviewer-asymmetry framing. Fisher's exact (verdict-pass) + Mann-Whitney U (findings-count). | Complementary |
 | `eval-e2e-delivery.py` | End-to-end delivery eval (plan-rubric proxy). Feeds a vague germ, captures each agent's plan, LLM-judges it against hidden acceptance criteria. Core in `_e2e_delivery_core.py`. | #2859 |
 | `eval-model-sweep.py` | Sweep one agent's fixtures across candidate models; scored KEEP_PIN/DROP_PIN verdict with effect size. Core in `_model_sweep_core.py`. | #2840 |
+| `optimize-artifact.py` | Held-out-gated edit loop for agents, rules, hooks, and prompts. Splits tasks, bounds the edit budget, applies patches, and accepts an edit only on data withheld from the author. Core in `_optimizer_core.py`, scorer adapters in `_optimizer_adapters.py`. | #3422 |
 | `_anthropic_api.py` | Shared API utilities (key loading, API calls). | N/A |
 
 ## End-to-End Delivery Eval
@@ -260,6 +261,127 @@ Output is a JSON artifact (`--output`, default under
 cost, the winner, `recall_delta`, `ci95`, `cohens_d`, `best_candidate_*`, and
 the `decision`/`reason`.
 
+## Held-Out-Gated Optimization
+
+`optimize-artifact.py` adds the piece the rest of this directory is missing: a
+gate that accepts an edit only on data the author could not read while making
+it.
+
+Every other evaluator here scores an artifact against its whole eval set.
+`eval-prompt-change.py` compares a prompt before and after an edit on the same
+scenarios the author was reading. `eval-agent-vs-baseline.py` scores an agent
+against every fixture in its spike directory while the author reads the
+failures and rewrites the prompt. Both fit the test set, so an improvement they
+report may be memorization rather than a better artifact.
+
+This tool splits the task ids into three groups and keeps them apart:
+
+| Group | Who sees it | Purpose |
+|-------|-------------|---------|
+| `opt` | The optimizing agent | Read failures here, propose edits from them. |
+| `sel` | The gate only | Decides accept or reject. Never shown to the author. |
+| `test` | Nobody, until the end | Final unbiased number after the loop stops. |
+
+The split is a deterministic function of the seed and the task-id set, so it
+reproduces on any machine and does not depend on input order. Ratios pick exact
+counts rather than hash buckets: bucketing can hand a ten-fixture set a
+one-fixture gate, which measures nothing.
+
+### Subcommands
+
+| Subcommand | Purpose |
+|------------|---------|
+| `extract` | Convert an existing scorer's output to `{task_id: bool}`. |
+| `split` | Partition task ids into `opt`, `sel`, and `test`. |
+| `budget` | Edits allowed at this step, cosine-decayed from `max` to `min`. |
+| `score` | Fraction of one group passing. |
+| `apply` | Apply bounded patches to an artifact file. |
+| `gate` | Decide whether the candidate replaces the incumbent. |
+| `buffer-check` | Has this edit already been rejected? |
+| `buffer-add` | Record a rejected edit so it is not re-proposed. |
+
+### Covering agents, rules, and hooks
+
+`extract` is what carries the discipline past skills. Each artifact class
+already has a scorer; each reports in its own shape, and `extract` converges
+them on the one shape the gate reads.
+
+| `--kind` | Input | Task id |
+|----------|-------|---------|
+| `agent` | An agent eval `report.json` | Fixture id |
+| `rule` | `eval-rule-activation.py` scenario output | Scenario id |
+| `hook` | `pytest --junitxml` output | Test node id |
+
+Adapters fail closed. A fixture the variant never ran, a scenario whose judge
+errored, and a skipped test all score as failures rather than being dropped.
+Dropping a task shrinks the denominator, which raises the score, so a silent
+omission would read as an improvement.
+
+`--kind rule` scores negative cases inverted, so a rule that fires when it
+should stay quiet loses. `eval-rule-activation.py` collects negative cases into
+their own summary but its verdict never reads them.
+
+### A loop step
+
+```bash
+OA=scripts/eval/optimize-artifact.py
+
+# Baseline the incumbent and fix the split once.
+uv run --frozen python "$OA" extract --kind agent --input report.json > base.json
+uv run --frozen python "$OA" split --results base.json --seed run-7 > split.json
+FP=$(python3 -c "import json;print(json.load(open('split.json'))['fingerprint'])")
+
+# Per step: check the budget, reject a repeat, apply, rescore, gate.
+uv run --frozen python "$OA" budget --step 3 --total 12
+uv run --frozen python "$OA" buffer-check --buffer rejected.json --patches p.json || exit 0
+uv run --frozen python "$OA" apply --file target.md --patches p.json --budget 3
+
+# Rerun the real scorer here, then extract it to cand.json.
+uv run --frozen python "$OA" gate --incumbent base.json --candidate cand.json \
+    --split split.json --incumbent-fingerprint "$FP"
+```
+
+On reject, revert the file and run `buffer-add` so the same edit is not
+re-proposed. On accept, the candidate becomes the incumbent.
+
+### What the gate refuses
+
+A strictly-greater held-out score is the only way to earn an accept. A tie is a
+reject, because an edit that did not move the held-out score is churn and churn
+on an artifact costs review attention forever.
+
+Three further refusals close holes that open once a loop runs many steps:
+
+- **Moved split.** The split fingerprint covers the seed, the task-id set, and
+  the ratios. If it changes, the gate refuses instead of comparing. This blocks
+  the cheapest cheat available: an edit loses, so add fixtures and re-roll.
+- **Exhausted consultations.** Gating N times against one `sel` group selects
+  on it N times. Pass `--consultations` and `--max-consultations` to cap it. The
+  count only advances when scores were actually weighed, so a refusal on a moved
+  fingerprint costs nothing.
+- **Protected sections.** Text between `<!-- SLOW_UPDATE_START -->` and
+  `<!-- SLOW_UPDATE_END -->` is off limits, markers included. Patches carrying a
+  fence marker in their text are rejected too, since one could otherwise open a
+  fence over the rest of the file or close an existing one.
+
+### Exit codes
+
+Per ADR-035. A reject is exit 1 because it is a decision a shell loop branches
+on, not a crash. Every path prints JSON, so a caller that needs to tell a reject
+from a broken input reads `decision` rather than inferring from the code.
+
+| Code | Meaning |
+|------|---------|
+| 0 | Accept, novel patch, or plain success |
+| 1 | Reject, already-rejected patch, or a refused patch |
+| 2 | Bad arguments, unreadable input, or malformed data |
+
+### Scope
+
+This tool makes no API calls. It decides; the scorers it wraps do the spending.
+That is why `--dry-run` applies only to `apply`, and why the whole decision path
+is unit-tested without eval budget.
+
 ## Scenario File Format
 
 See `examples/example-scenarios.json` for a working template.
@@ -293,7 +415,7 @@ Convention: for a prompt at `path/to/name.md`, name the scenario file `name-scen
 
 ## Flags
 
-All scripts support `--dry-run` (validate inputs, no API calls) and `--output FILE` (write JSON results).
+All scripts that call the API support `--dry-run` (validate inputs, no API calls) and `--output FILE` (write JSON results). `optimize-artifact.py` makes no API calls; its `--dry-run` is scoped to the `apply` subcommand.
 
 | Flag | Scripts | Purpose |
 |------|---------|---------|

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -438,19 +438,32 @@ Four further refusals close holes that open once a loop runs many steps:
   gates cannot race for the last consultation; the read, the comparison, and the
   write happen under a lock keyed by the same held-out group.
 
-  The gate never names a held-out task. `score` and `mcnemar_exact` report which
-  ids they could not find, which is the right message everywhere else and a full
-  disclosure here, so the gate asks its own coverage question and answers one
-  bit. Not a count: `split` publishes the held-out size, so a count would tell a
-  caller how many of the keys it chose to omit were held out, and a few chosen
-  omissions recover the membership.
+  The gate never names a held-out task, and never prints the key either, since
+  the key digests the membership and a digest of an enumerable set is that set.
+  `score` and `mcnemar_exact` report which ids they could not find, which is the
+  right message everywhere else, so the gate asks its own coverage question and
+  answers one bit. Not a count: `split` publishes the held-out size, so a count
+  would tell a caller how many of the keys it chose to omit were held out.
+
+  None of that hides the held-out task list, and it is not meant to. `split`
+  publishes `opt` because the loop cannot edit toward a group it cannot name,
+  the universe is your own results file, and with no test group drawn (the
+  default) the held-out group is what is left after subtracting one from the
+  other. Knowing which tasks are withheld is the point. What does not cross back
+  is how the artifact scores on them: `score` refuses any group but `opt`, the
+  gate answers one accept or reject bit, and the budget caps how many such bits
+  one group can emit. The redaction earns its keep when a test group exists,
+  because there the complement is two groups and the published sizes do not say
+  which task is in which.
 
   Three things this does not cover, stated rather than implied. The cap is
   whatever positive integer the first call names, so the budget is only as tight
-  as that first invocation. `$EVAL_LEDGER_DIR` relocates the root, which is how
-  the tests stay isolated and equally how anyone who sets it starts over. And a
-  stale lock left by a killed process is reported rather than broken, so
-  clearing it by hand is a deliberate act with no record.
+  as that first invocation. The root is relocatable: `$EVAL_LEDGER_DIR` moves
+  it, `$XDG_STATE_HOME` moves it, and so does anything that changes the home
+  directory, which is how the tests stay isolated and equally how anyone who
+  sets one starts over. And a stale lock left by a killed process is reported
+  rather than broken, so clearing it by hand is a deliberate act with no
+  record.
 
   ```bash
   optimize-artifact.py gate --incumbent inc.json --candidate cand.json \

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -365,8 +365,7 @@ uv run --frozen python "$OA" apply --file target.md --patches p.json --budget 3
 
 # Rerun the real scorer here, then extract it to cand.json.
 uv run --frozen python "$OA" gate --incumbent base.json --candidate cand.json \
-    --split split.json --ledger ledger.json --incumbent-fingerprint "$FP" \
-    --max-consultations 5
+    --split split.json --incumbent-fingerprint "$FP" --max-consultations 5
 ```
 
 On reject, revert the file and run `buffer-add` so the same edit is not
@@ -411,26 +410,30 @@ Four further refusals close holes that open once a loop runs many steps:
   the ratios. If it changes, the gate refuses instead of comparing. This blocks
   the cheapest cheat available: an edit loses, so add fixtures and re-roll.
 - **Exhausted consultations.** Gating N times against one `sel` group selects
-  on it N times. `gate --ledger PATH` is required, and the count lives in that
-  file rather than on the command line. This matters: a count the caller passes
-  is not a cap. `--consultations` defaulted to zero and arrived on every
-  invocation, so a loop that passed zero each time had an unlimited budget while
-  looking capped. An adversarial review reproduced ACCEPT twice under
-  `--max-consultations 1` that way.
+  on it N times, so the gate keeps a budget in a ledger it writes beside the
+  split, at `<split>.ledger`. Nothing about that budget arrives on the command
+  line twice, and each piece was moved there after a review reproduced a way
+  around the previous version:
 
-  The ledger records the split fingerprint alongside the count, so redrawing the
-  split does not reset the budget: the gate refuses a ledger and a split that
-  disagree. The count advances only when scores were actually weighed, and a
-  refusal reports no scores at all, so a refused call cannot be used to read the
-  group for free.
+  | Held where | Why not on the command line |
+  | --- | --- |
+  | Count | `--consultations` defaulted to zero every invocation, so a loop that passed zero each time had an unlimited budget while looking capped. Review reproduced ACCEPT twice under a cap of one. |
+  | Cap | `--max-consultations` defaulted to unlimited, so the ordinary invocation had no budget at all, and a caller that did hit the cap could raise it and continue. It is now required, recorded at the first gate, and a later change is refused. |
+  | Ledger path | `--ledger PATH` looked like discipline but a missing ledger starts at zero, so naming a fresh path restored the whole budget. The path is derived from the split, so resetting the count means deleting a file, not passing an argument. |
+
+  The ledger records the split fingerprint too, so redrawing the split does not
+  reset the budget: the gate refuses a ledger and a split that disagree. The
+  count advances only when scores were actually weighed, and a refusal reports
+  no scores at all, so a refused call cannot be used to read the group for free.
 
   ```bash
   optimize-artifact.py gate --incumbent inc.json --candidate cand.json \
-      --split split.json --ledger ledger.json --max-consultations 5
+      --split split.json --max-consultations 5 --incumbent-fingerprint "$FP"
   ```
 
-  A first run needs no existing ledger; the gate creates it. Point one ledger at
-  one split for the life of a loop.
+  A first run needs no existing ledger; the gate creates it. `--incumbent-fingerprint`
+  is required and `score` reports the value to pass, which is the check that
+  catches a baseline scored against a split that has since been redrawn.
 - **Protected sections.** Text between `<!-- SLOW_UPDATE_START -->` and
   `<!-- SLOW_UPDATE_END -->` is off limits, markers included. Patches carrying a
   fence marker in their text are rejected too, since one could otherwise open a

--- a/scripts/eval/_optimizer_adapters.py
+++ b/scripts/eval/_optimizer_adapters.py
@@ -170,11 +170,14 @@ def rule_results(
         Mapping from scenario id to pass or fail.
 
     Raises:
-        AdapterError: A scenario lacks an id, ids repeat, or a score is not
-            numeric.
+        AdapterError: A scenario is not an object, lacks an id, repeats an
+            id, carries a malformed `mechanisms` or `scores` block, or holds a
+            score that is not finite and numeric.
     """
     out: dict[str, bool] = {}
     for scenario in scenarios:
+        if not isinstance(scenario, Mapping):
+            raise AdapterError(f"scenario must be an object, got {scenario!r}")
         raw_id = scenario.get("id")
         if not raw_id:
             raise AdapterError("scenario is missing an id")
@@ -182,7 +185,16 @@ def rule_results(
         if sid in out:
             raise AdapterError(f"duplicate scenario id: {sid}")
 
-        mech_data = scenario.get("mechanisms", {}).get(mechanism)
+        mechanisms = scenario.get("mechanisms", {})
+        if not isinstance(mechanisms, Mapping):
+            # An absent key keeps its fail-closed meaning of no evidence. A
+            # present but malformed one is a broken input and says so, rather
+            # than escaping as a bare AttributeError from inside a get chain.
+            raise AdapterError(
+                f"scenario {sid!r} has a malformed mechanisms block, "
+                f"expected an object, got {mechanisms!r}"
+            )
+        mech_data = mechanisms.get(mechanism)
         if not isinstance(mech_data, Mapping) or "error" in mech_data:
             # Mechanism never ran, or ran and errored. Either way it produced
             # no evidence, and no evidence is not a pass.

--- a/scripts/eval/_optimizer_adapters.py
+++ b/scripts/eval/_optimizer_adapters.py
@@ -1,0 +1,245 @@
+"""Turn each existing scorer's output into the `{task_id: bool}` gate input.
+
+`_optimizer_core.score` takes one shape: a mapping from task id to pass or
+fail. That narrow seam is what lets the held-out gate cover more than skills.
+Every artifact class this repo evaluates already has a scorer; each one just
+reports in its own shape.
+
+    agent prompt   evals/<agent>-spike report.json    fixture id  -> bool
+    rule           eval-rule-activation.py scenarios  scenario id -> bool
+    hook / script  pytest --junitxml                  node id     -> bool
+
+Each adapter fails closed. A fixture the variant never ran, a scenario whose
+judge errored, a test that was skipped: all score as failures rather than
+being dropped. Dropping a task shrinks the denominator, and a shrinking
+denominator raises the score, so silent omission reads as improvement. That
+is the exact failure the held-out gate exists to prevent, so the adapters
+must not reintroduce it.
+
+Reduction and threshold policy is explicit rather than hidden. `agent_results`
+defaults to `mean` at a `1.0` threshold, meaning every run satisfied every
+assertion. A strict default is deliberate: it makes ACCEPT harder to earn, and
+an optimizer that cannot earn ACCEPT is doing less damage than one that earns
+it cheaply.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections.abc import Mapping, Sequence
+from typing import Any
+from xml.etree import ElementTree
+
+__all__ = [
+    "AdapterError",
+    "DEFAULT_MIN_ACTIVATION_SCORE",
+    "agent_results",
+    "pytest_results",
+    "rule_results",
+]
+
+# Mirrors MIN_ACTIVATION_SCORE in eval-rule-activation.py. Duplicated rather
+# than imported because that module is a hyphenated CLI script, not importable
+# under a normal name; the value is asserted against the source in tests.
+DEFAULT_MIN_ACTIVATION_SCORE = 3.5
+
+_REDUCERS = {
+    "mean": statistics.fmean,
+    "min": min,
+    "max": max,
+    "median": statistics.median,
+}
+
+_SKIP_POLICIES = ("fail", "exclude")
+
+_RULE_SCORE_KEYS = ("activation_score", "citation_score", "behavior_score")
+
+
+class AdapterError(ValueError):
+    """A scorer's output did not have the shape the adapter requires."""
+
+
+def _as_float(value: object, context: str) -> float:
+    """Coerce a score to float, refusing bools and non-numbers.
+
+    `isinstance(True, int)` is True in Python, so a bool would otherwise slip
+    through as 1.0 or 0.0. A pass-rate list holding bools means the producer
+    changed shape, and guessing at intent there hides the change.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise AdapterError(f"{context} must be numeric, got {value!r}")
+    return float(value)
+
+
+def agent_results(
+    report: Mapping[str, Any],
+    variant: str,
+    *,
+    reduce: str = "mean",
+    pass_threshold: float = 1.0,
+) -> dict[str, bool]:
+    """Map an agent eval report to per-fixture pass or fail.
+
+    Args:
+        report: A parsed `report.json` carrying `per_fixture_pass_rates`,
+            shaped `{fixture_id: {variant: [rate, ...]}}` where each rate is
+            the fraction of that fixture's assertions satisfied on one run.
+        variant: Which variant column to read, typically `agent` or
+            `baseline`.
+        reduce: How to collapse a fixture's runs into one number. One of
+            `mean`, `min`, `max`, `median`.
+        pass_threshold: Reduced value at or above which the fixture passes.
+
+    Returns:
+        Mapping from fixture id to pass or fail.
+
+    Raises:
+        AdapterError: The report lacks `per_fixture_pass_rates`, an entry is
+            not a mapping, a run value is not numeric, or `reduce` is unknown.
+    """
+    if reduce not in _REDUCERS:
+        raise AdapterError(
+            f"reduce must be one of {sorted(_REDUCERS)}, got {reduce!r}"
+        )
+    if "per_fixture_pass_rates" not in report:
+        raise AdapterError("report is missing per_fixture_pass_rates")
+
+    rates = report["per_fixture_pass_rates"]
+    if not isinstance(rates, Mapping):
+        raise AdapterError("per_fixture_pass_rates must be a mapping")
+
+    reducer = _REDUCERS[reduce]
+    out: dict[str, bool] = {}
+    for fixture_id, per_variant in rates.items():
+        if not isinstance(per_variant, Mapping):
+            raise AdapterError(
+                f"fixture {fixture_id!r} must be a mapping of variant to runs, "
+                f"got a {type(per_variant).__name__}"
+            )
+        runs = per_variant.get(variant)
+        if not runs:
+            # Variant never ran this fixture, or ran it zero times. Fail
+            # closed rather than dropping the id.
+            out[str(fixture_id)] = False
+            continue
+        values = [
+            _as_float(v, f"fixture {fixture_id!r} variant {variant!r} run")
+            for v in runs
+        ]
+        out[str(fixture_id)] = reducer(values) >= pass_threshold
+    return out
+
+
+def rule_results(
+    scenarios: Sequence[Mapping[str, Any]],
+    mechanism: str,
+    *,
+    min_score: float = DEFAULT_MIN_ACTIVATION_SCORE,
+) -> dict[str, bool]:
+    """Map rule-activation scenarios to per-scenario pass or fail.
+
+    Negative cases invert. A scenario tagged `negative_case` asserts the rule
+    should stay quiet, so a low judge score is the win. `eval-rule-activation.py`
+    aggregates negative cases into their own summary but its verdict never
+    reads them; scoring them here puts them back in the gate, where a rule that
+    over-fires is supposed to lose.
+
+    Args:
+        scenarios: Scored scenario records, each with `id`, `negative_case`,
+            and `mechanisms[mechanism]["scores"]`.
+        mechanism: Which mechanism column to read, typically `full`,
+            `description`, or `baseline`.
+        min_score: Mean of the three judge scores at or above which a positive
+            scenario passes.
+
+    Returns:
+        Mapping from scenario id to pass or fail.
+
+    Raises:
+        AdapterError: A scenario lacks an id, ids repeat, or a score is not
+            numeric.
+    """
+    out: dict[str, bool] = {}
+    for scenario in scenarios:
+        raw_id = scenario.get("id")
+        if not raw_id:
+            raise AdapterError("scenario is missing an id")
+        sid = str(raw_id)
+        if sid in out:
+            raise AdapterError(f"duplicate scenario id: {sid}")
+
+        mech_data = scenario.get("mechanisms", {}).get(mechanism)
+        if not isinstance(mech_data, Mapping) or "error" in mech_data:
+            # Mechanism never ran, or ran and errored. Either way it produced
+            # no evidence, and no evidence is not a pass.
+            out[sid] = False
+            continue
+
+        raw_scores = mech_data.get("scores", {})
+        if raw_scores.get("judge_failed"):
+            # A broken judge proves nothing. Inversion must not turn a
+            # missing measurement into a negative-case win.
+            out[sid] = False
+            continue
+
+        triple = [
+            _as_float(raw_scores.get(key, 0), f"scenario {sid!r} {key}")
+            for key in _RULE_SCORE_KEYS
+        ]
+        activated = statistics.fmean(triple) >= min_score
+        out[sid] = not activated if scenario.get("negative_case") else activated
+    return out
+
+
+def pytest_results(junit_xml: str, *, on_skip: str = "fail") -> dict[str, bool]:
+    """Map a pytest JUnit XML report to per-test pass or fail.
+
+    Uses `--junitxml`, which is pytest core, so hook and script suites need no
+    reporting plugin to reach the gate.
+
+    Args:
+        junit_xml: Contents of a pytest `--junitxml` file. Accepts either a
+            `<testsuites>` root or a bare `<testsuite>` root; pytest emits the
+            former, other runners emit the latter.
+        on_skip: `fail` scores a skipped test as a failure, `exclude` drops it
+            from the mapping. `fail` is the default because a skipped test
+            demonstrated nothing. Prefer `exclude` only when skips are static,
+            since a conditionally skipped test changes the task-id set between
+            runs, which moves the split fingerprint and stops the gate.
+
+    Returns:
+        Mapping from `classname::name` node id to pass or fail.
+
+    Raises:
+        AdapterError: The XML will not parse, a case has no name, node ids
+            repeat, or `on_skip` is unknown.
+    """
+    if on_skip not in _SKIP_POLICIES:
+        raise AdapterError(
+            f"on_skip must be one of {list(_SKIP_POLICIES)}, got {on_skip!r}"
+        )
+    try:
+        root = ElementTree.fromstring(junit_xml)
+    except ElementTree.ParseError as exc:
+        raise AdapterError(f"could not parse JUnit XML: {exc}") from exc
+
+    out: dict[str, bool] = {}
+    for case in root.iter("testcase"):
+        name = case.get("name")
+        if not name:
+            raise AdapterError("testcase is missing a name attribute")
+        classname = case.get("classname")
+        node_id = f"{classname}::{name}" if classname else name
+
+        skipped = case.find("skipped") is not None
+        if skipped and on_skip == "exclude":
+            continue
+        if node_id in out:
+            raise AdapterError(f"duplicate test node id: {node_id}")
+        failed = (
+            skipped
+            or case.find("failure") is not None
+            or case.find("error") is not None
+        )
+        out[node_id] = not failed
+    return out

--- a/scripts/eval/_optimizer_adapters.py
+++ b/scripts/eval/_optimizer_adapters.py
@@ -131,6 +131,11 @@ def agent_results(
             # closed rather than dropping the id.
             out[str(fixture_id)] = False
             continue
+        if not isinstance(runs, Sequence) or isinstance(runs, str):
+            raise AdapterError(
+                f"fixture {fixture_id!r} variant {variant!r} must be a list "
+                f"of scores, got {type(runs).__name__}"
+            )
         values = [
             _as_float(v, f"fixture {fixture_id!r} variant {variant!r} run")
             for v in runs

--- a/scripts/eval/_optimizer_adapters.py
+++ b/scripts/eval/_optimizer_adapters.py
@@ -26,7 +26,7 @@ it cheaply.
 from __future__ import annotations
 
 import statistics
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 from xml.etree import ElementTree
 
@@ -43,7 +43,7 @@ __all__ = [
 # under a normal name; the value is asserted against the source in tests.
 DEFAULT_MIN_ACTIVATION_SCORE = 3.5
 
-_REDUCERS = {
+_REDUCERS: dict[str, Callable[[list[float]], float]] = {
     "mean": statistics.fmean,
     "min": min,
     "max": max,

--- a/scripts/eval/_optimizer_adapters.py
+++ b/scripts/eval/_optimizer_adapters.py
@@ -25,6 +25,7 @@ it cheaply.
 
 from __future__ import annotations
 
+import math
 import statistics
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
@@ -60,14 +61,22 @@ class AdapterError(ValueError):
 
 
 def _as_float(value: object, context: str) -> float:
-    """Coerce a score to float, refusing bools and non-numbers.
+    """Coerce a score to float, refusing bools, non-numbers, and non-finite values.
 
     `isinstance(True, int)` is True in Python, so a bool would otherwise slip
     through as 1.0 or 0.0. A pass-rate list holding bools means the producer
     changed shape, and guessing at intent there hides the change.
+
+    NaN and infinity are refused for a sharper reason: they quietly invert
+    verdicts. Every comparison against NaN is False, so a NaN score makes a
+    negative-case scenario pass; infinity clears any threshold, so it makes a
+    fixture pass unconditionally. `json.loads` accepts the bare `NaN` and
+    `Infinity` tokens, so neither is hypothetical.
     """
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise AdapterError(f"{context} must be numeric, got {value!r}")
+    if not math.isfinite(value):
+        raise AdapterError(f"{context} must be finite, got {value!r}")
     return float(value)
 
 
@@ -138,11 +147,16 @@ def rule_results(
 ) -> dict[str, bool]:
     """Map rule-activation scenarios to per-scenario pass or fail.
 
-    Negative cases invert. A scenario tagged `negative_case` asserts the rule
-    should stay quiet, so a low judge score is the win. `eval-rule-activation.py`
-    aggregates negative cases into their own summary but its verdict never
-    reads them; scoring them here puts them back in the gate, where a rule that
-    over-fires is supposed to lose.
+    Both polarities read one normalized scale. `eval-rule-activation.py` builds
+    the judge prompt so that 5 always means correct behavior, including for a
+    negative case ("5 means the response correctly did NOT activate the rule").
+    So a high score is a pass whether the rule was meant to fire or stay quiet,
+    and this adapter must not invert.
+
+    What it does add is including negative cases at all. That evaluator's own
+    verdict averages positive scenarios only and reads negative ones solely to
+    count judge failures, so a rule that over-fires can pass there. Here it
+    loses.
 
     Args:
         scenarios: Scored scenario records, each with `id`, `negative_case`,
@@ -176,9 +190,16 @@ def rule_results(
             continue
 
         raw_scores = mech_data.get("scores", {})
+        if raw_scores is None or not isinstance(raw_scores, Mapping):
+            # An explicit null is not a missing key: dict.get returns the stored
+            # None rather than the default, so this used to crash on the next
+            # attribute access instead of naming the malformed input.
+            raise AdapterError(
+                f"scenario {sid!r} has a malformed scores block, "
+                f"expected an object, got {raw_scores!r}"
+            )
         if raw_scores.get("judge_failed"):
-            # A broken judge proves nothing. Inversion must not turn a
-            # missing measurement into a negative-case win.
+            # A broken judge proves nothing, for either polarity.
             out[sid] = False
             continue
 
@@ -186,8 +207,15 @@ def rule_results(
             _as_float(raw_scores.get(key, 0), f"scenario {sid!r} {key}")
             for key in _RULE_SCORE_KEYS
         ]
-        activated = statistics.fmean(triple) >= min_score
-        out[sid] = not activated if scenario.get("negative_case") else activated
+        # No inversion. eval-rule-activation.py tells the judge that 5 is the
+        # correct-behavior end of the scale for negative cases too ("5 means
+        # the response correctly did NOT activate the rule"), so the score
+        # arrives already normalized. Inverting here would double-invert and
+        # reward exactly the rules that fire when they should stay quiet. The
+        # value this adapter adds is including negative cases in the task set
+        # at all: eval-rule-activation.py's own verdict reads only positive
+        # scenarios, using negative ones solely to count judge failures.
+        out[sid] = statistics.fmean(triple) >= min_score
     return out
 
 

--- a/scripts/eval/_optimizer_core.py
+++ b/scripts/eval/_optimizer_core.py
@@ -1,0 +1,544 @@
+#!/usr/bin/env python3
+"""Held-out-gated artifact optimization primitives (Issue #3422).
+
+Pure functions with no I/O and no API calls, so the accept/reject decision is
+unit-testable without eval spend. The CLI in ``optimize.py`` wires these to
+files; the scorers stay where they are.
+
+Why this exists
+---------------
+The rest of ``scripts/eval/`` measures artifacts. Nothing gates an edit to one.
+``eval-prompt-change.py`` scores a prompt before and after an edit on the same
+scenarios the author read while making the edit, and ``eval-agent-vs-baseline.py``
+scores an agent against every fixture in its spike directory while the author
+reads the failures and rewrites the prompt. Both loops fit the test set.
+
+The discipline here is SkillOpt's (Yang et al., Microsoft, arXiv:2605.23904):
+treat the artifact as external trainable state, propose bounded edits from
+scored rollouts, and land a candidate only if it strictly beats the incumbent on
+a split the author never saw. Rejected edits are fingerprinted so the same
+failure is not re-proposed.
+
+Two properties here are not in that paper, and both close holes that show up
+once a loop runs for more than a few steps:
+
+``TaskSplit.fingerprint``
+    Gating N times against one ``sel`` split selects on that split N times. A
+    losing edit can be resurrected by adding fixtures and re-rolling. The
+    fingerprint covers the seed, the task-id set, and the ratios, and
+    :func:`gate` refuses when it moves, so an eval-set change forces a
+    re-baseline instead of silently laundering a loss.
+
+``gate(max_consultations=...)``
+    Even with a fixed split, repeated selection erodes the gate's meaning. The
+    consultation count is carried in the result and can be capped, so the loop
+    reports that it has run out of statistical room rather than hiding it.
+
+The seam between this module and any scorer is one mapping, ``{task_id: bool}``.
+Agents key it by fixture id, rules and prompts by scenario id, hooks by pytest
+node id. That is the whole reason the loop generalizes past skills.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+
+__all__ = [
+    "AmbiguousAnchorError",
+    "AnchorNotFoundError",
+    "BudgetExceededError",
+    "GateResult",
+    "MissingResultError",
+    "Patch",
+    "PatchShapeError",
+    "ProtectedSectionError",
+    "SplitTooSmallError",
+    "TaskSplit",
+    "apply_patches",
+    "buffer_contains",
+    "edit_budget",
+    "gate",
+    "patch_fingerprint",
+    "score",
+    "split_tasks",
+]
+
+FENCE_START = "<!-- SLOW_UPDATE_START -->"
+FENCE_END = "<!-- SLOW_UPDATE_END -->"
+
+_ANCHORED_OPS = frozenset({"insert_after", "replace", "delete"})
+_TEXT_OPS = frozenset({"append", "insert_after", "replace"})
+_VALID_OPS = frozenset({"append", "insert_after", "replace", "delete"})
+
+
+class SplitTooSmallError(ValueError):
+    """The requested split yields a held-out set too small to gate on."""
+
+
+class BudgetExceededError(ValueError):
+    """More patches were proposed than this step's edit budget allows."""
+
+
+class AnchorNotFoundError(ValueError):
+    """A patch anchor does not appear in the document."""
+
+
+class AmbiguousAnchorError(ValueError):
+    """A patch anchor appears more than once, so the target is undefined."""
+
+
+class ProtectedSectionError(ValueError):
+    """A patch would mutate the protected slow-update fence."""
+
+
+class PatchShapeError(ValueError):
+    """A patch is missing a field its operation requires."""
+
+
+class MissingResultError(ValueError):
+    """A scored task has no entry in the results mapping."""
+
+
+@dataclass(frozen=True)
+class Patch:
+    """One atomic edit.
+
+    ``anchor`` is the unique line a patch attaches to and is required for every
+    operation except ``append``. ``text`` is the content to write and is
+    required for every operation except ``delete``.
+    """
+
+    op: str
+    anchor: str | None
+    text: str | None
+
+
+@dataclass(frozen=True)
+class TaskSplit:
+    """A deterministic partition of an eval set.
+
+    ``opt`` is visible to whoever proposes edits. ``sel`` gates them and must
+    never be read during reflection. ``test`` is optional, never gates, and
+    exists so a converged loop can report one number that repeated selection
+    has not touched.
+    """
+
+    opt: tuple[str, ...]
+    sel: tuple[str, ...]
+    test: tuple[str, ...]
+    fingerprint: str
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """The verdict on one candidate."""
+
+    decision: str
+    reason: str
+    candidate: float
+    incumbent: float
+    sel_consultations: int
+
+
+def _normalize_ws(value: str | None) -> str:
+    """Collapse every whitespace run to a single space."""
+    if value is None:
+        return ""
+    return " ".join(value.split())
+
+
+def _round_half_up(value: float) -> int:
+    """Round halves away from zero, avoiding banker's rounding surprises."""
+    return math.floor(value + 0.5)
+
+
+def split_tasks(
+    task_ids: Sequence[str],
+    *,
+    seed: str,
+    sel_ratio: float = 0.4,
+    test_ratio: float = 0.0,
+    min_sel: int = 3,
+) -> TaskSplit:
+    """Partition ``task_ids`` into optimize, held-out, and reserve groups.
+
+    The partition is derived from ``sha256(seed, task_id)`` rank, so it is
+    identical on every machine and independent of input order. Group sizes are
+    exact rather than approximate: hash bucketing can hand a ten-task eval set a
+    one-task gate, which measures nothing.
+
+    Adding or removing a task changes ``fingerprint``. That is deliberate. A
+    different eval set means the incumbent score was measured against something
+    else and has to be earned again.
+
+    Raises:
+        ValueError: on empty, blank, or duplicate ids, an empty seed, ratios
+            outside ``(0, 1)``, or ratios leaving no optimize tasks.
+        SplitTooSmallError: when the held-out group is smaller than ``min_sel``.
+    """
+    if not task_ids:
+        raise ValueError("split_tasks requires at least one task id")
+    if not seed or not seed.strip():
+        raise ValueError("split_tasks requires a non-empty seed")
+    if not 0.0 < sel_ratio < 1.0:
+        raise ValueError(f"sel_ratio must be strictly between 0 and 1, got {sel_ratio}")
+    if not 0.0 <= test_ratio < 1.0:
+        raise ValueError(f"test_ratio must be in [0, 1), got {test_ratio}")
+    if min_sel < 0:
+        raise ValueError(f"min_sel must be non-negative, got {min_sel}")
+    if sel_ratio + test_ratio >= 1.0:
+        raise ValueError(
+            f"sel_ratio + test_ratio must leave at least one opt task, "
+            f"got {sel_ratio} + {test_ratio}"
+        )
+
+    cleaned: list[str] = []
+    for raw in task_ids:
+        task_id = raw.strip()
+        if not task_id:
+            raise ValueError("split_tasks requires non-empty task ids")
+        cleaned.append(task_id)
+
+    if len(set(cleaned)) != len(cleaned):
+        duplicates = sorted({tid for tid in cleaned if cleaned.count(tid) > 1})
+        raise ValueError(f"split_tasks received duplicate task ids: {', '.join(duplicates)}")
+
+    total = len(cleaned)
+    n_sel = _round_half_up(total * sel_ratio)
+    n_test = _round_half_up(total * test_ratio)
+    if total - n_sel - n_test < 1:
+        raise ValueError(
+            f"split of {total} tasks at sel_ratio={sel_ratio} test_ratio={test_ratio} "
+            f"leaves no opt tasks"
+        )
+    if n_sel < min_sel:
+        raise SplitTooSmallError(
+            f"held-out split has {n_sel} task(s), below min_sel={min_sel}; "
+            f"widen the eval set or lower min_sel to gate on it"
+        )
+
+    ranked = sorted(
+        cleaned,
+        key=lambda tid: hashlib.sha256(f"{seed}\x00{tid}".encode()).hexdigest(),
+    )
+    sel = tuple(ranked[:n_sel])
+    test = tuple(ranked[n_sel : n_sel + n_test])
+    opt = tuple(ranked[n_sel + n_test :])
+
+    payload = json.dumps(
+        {
+            "seed": seed,
+            "tasks": sorted(cleaned),
+            "sel_ratio": sel_ratio,
+            "test_ratio": test_ratio,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    fingerprint = hashlib.sha256(payload.encode()).hexdigest()
+    return TaskSplit(opt=opt, sel=sel, test=test, fingerprint=fingerprint)
+
+
+def edit_budget(step: int, total: int, *, max_edits: int = 5, min_edits: int = 1) -> int:
+    """Return how many patches step ``step`` of ``total`` may propose.
+
+    Cosine decay: the first step gets ``max_edits`` so early exploration can
+    restructure, the last gets ``min_edits`` so late steps can only make small,
+    reversible edits. Steps past ``total`` clamp to the floor.
+
+    Raises:
+        ValueError: on a negative step, a non-positive total, or bounds where
+            ``min_edits`` is below 1 or above ``max_edits``.
+    """
+    if step < 0:
+        raise ValueError(f"step must be non-negative, got {step}")
+    if total <= 0:
+        raise ValueError(f"total must be positive, got {total}")
+    if min_edits < 1:
+        raise ValueError(f"min_edits must be at least 1, got {min_edits}")
+    if min_edits > max_edits:
+        raise ValueError(f"min_edits ({min_edits}) must not exceed max_edits ({max_edits})")
+
+    clamped = min(step, total)
+    span = (max_edits - min_edits) * 0.5
+    decayed = min_edits + span * (1.0 + math.cos(math.pi * clamped / total))
+    return max(min_edits, min(max_edits, round(decayed)))
+
+
+def _split_lines(document: str) -> list[str]:
+    """Split into lines, dropping exactly one trailing newline."""
+    normalized = document.replace("\r\n", "\n").replace("\r", "\n")
+    lines = normalized.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+
+def _join_lines(lines: Sequence[str]) -> str:
+    if not lines:
+        return ""
+    return "\n".join(lines) + "\n"
+
+
+def _protected_indices(lines: Sequence[str]) -> frozenset[int]:
+    """Return every line index inside a slow-update fence, markers included.
+
+    Raises:
+        ProtectedSectionError: on a nested, unclosed, or unbalanced fence. The
+            document shape is checked before any patch applies, so a malformed
+            fence fails closed rather than leaving rails unprotected.
+    """
+    protected: set[int] = set()
+    open_at: int | None = None
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == FENCE_START:
+            if open_at is not None:
+                raise ProtectedSectionError(
+                    f"nested slow-update fence: second start at line {index + 1}"
+                )
+            open_at = index
+        elif stripped == FENCE_END:
+            if open_at is None:
+                raise ProtectedSectionError(
+                    f"unbalanced slow-update fence: end at line {index + 1} with no start"
+                )
+            protected.update(range(open_at, index + 1))
+            open_at = None
+    if open_at is not None:
+        raise ProtectedSectionError(
+            f"unclosed slow-update fence: start at line {open_at + 1} is never closed"
+        )
+    return frozenset(protected)
+
+
+def _validate_shape(patch: Patch) -> None:
+    if patch.op not in _VALID_OPS:
+        raise PatchShapeError(
+            f"unknown patch op {patch.op!r}; expected one of {sorted(_VALID_OPS)}"
+        )
+    if patch.op in _ANCHORED_OPS and (patch.anchor is None or not patch.anchor.strip()):
+        raise PatchShapeError(f"patch op {patch.op!r} requires a non-blank anchor")
+    if patch.op in _TEXT_OPS and patch.text is None:
+        raise PatchShapeError(f"patch op {patch.op!r} requires text")
+
+
+def _reject_smuggled_markers(patch: Patch) -> None:
+    """Refuse patch text that would introduce a fence marker.
+
+    Without this a patch could open its own fence and make the next step's edits
+    unreachable, or close an existing one and expose the rails inside it.
+    """
+    if patch.text is None:
+        return
+    for line in patch.text.replace("\r\n", "\n").split("\n"):
+        if line.strip() in (FENCE_START, FENCE_END):
+            raise ProtectedSectionError(
+                "patch text may not contain a slow-update fence marker; "
+                f"found {line.strip()!r}"
+            )
+
+
+def _locate(lines: Sequence[str], anchor: str) -> int:
+    needle = anchor.strip()
+    matches = [index for index, line in enumerate(lines) if line.strip() == needle]
+    if not matches:
+        raise AnchorNotFoundError(f"anchor {needle!r} does not appear in the document")
+    if len(matches) > 1:
+        raise AmbiguousAnchorError(
+            f"anchor {needle!r} appears {len(matches)} times; anchors must be unique"
+        )
+    return matches[0]
+
+
+def apply_patches(document: str, patches: Sequence[Patch], *, budget: int) -> str:
+    """Apply ``patches`` to ``document`` under a hard edit budget.
+
+    Patches apply in order, so a later patch may anchor on a line an earlier one
+    wrote. Every anchor must be unique at the moment its patch runs; an
+    ambiguous anchor is refused rather than resolved by picking the first match.
+    Nothing inside a slow-update fence can be touched.
+
+    A refusal here means the proposed edit was malformed or out of bounds. It is
+    not a statement about quality; that is :func:`gate`'s job.
+
+    Raises:
+        ValueError: on a negative budget.
+        BudgetExceededError: when more patches are proposed than allowed.
+        PatchShapeError: when a patch omits a field its op requires.
+        AnchorNotFoundError: when an anchor is absent.
+        AmbiguousAnchorError: when an anchor is not unique.
+        ProtectedSectionError: when a patch targets or introduces fenced content.
+    """
+    if budget < 0:
+        raise ValueError(f"budget must be non-negative, got {budget}")
+    if len(patches) > budget:
+        raise BudgetExceededError(
+            f"{len(patches)} patches exceed this step's edit budget of {budget}"
+        )
+
+    lines = _split_lines(document)
+    for patch in patches:
+        _validate_shape(patch)
+        _reject_smuggled_markers(patch)
+        protected = _protected_indices(lines)
+
+        if patch.op == "append":
+            lines = [*lines, *(patch.text or "").replace("\r\n", "\n").split("\n")]
+            continue
+
+        assert patch.anchor is not None  # guaranteed by _validate_shape
+        index = _locate(lines, patch.anchor)
+        if index in protected:
+            raise ProtectedSectionError(
+                f"anchor {patch.anchor.strip()!r} is inside a slow-update fence; "
+                f"fenced guidance is edited by hand at epoch boundaries, not by the optimizer"
+            )
+
+        if patch.op == "delete":
+            lines = [*lines[:index], *lines[index + 1 :]]
+        elif patch.op == "replace":
+            payload = (patch.text or "").replace("\r\n", "\n").split("\n")
+            lines = [*lines[:index], *payload, *lines[index + 1 :]]
+        else:  # insert_after
+            payload = (patch.text or "").replace("\r\n", "\n").split("\n")
+            lines = [*lines[: index + 1], *payload, *lines[index + 1 :]]
+
+    return _join_lines(lines)
+
+
+def score(results: Mapping[str, bool], task_ids: Sequence[str]) -> float:
+    """Return the passing fraction of ``task_ids``.
+
+    A task with no entry in ``results`` raises rather than counting as a
+    failure. Treating an absent result as a fail lets a truncated or crashed
+    rollout quietly change a score, which is the one thing the gate must not
+    tolerate.
+
+    Raises:
+        ValueError: when ``task_ids`` is empty.
+        MissingResultError: when any requested task has no result.
+        TypeError: when a result is not a bool.
+    """
+    if not task_ids:
+        raise ValueError("score requires at least one task id")
+
+    unique = sorted(set(task_ids))
+    missing = [task_id for task_id in unique if task_id not in results]
+    if missing:
+        raise MissingResultError(f"no result recorded for: {', '.join(missing)}")
+
+    for task_id in unique:
+        value = results[task_id]
+        if not isinstance(value, bool):
+            raise TypeError(f"result for {task_id!r} must be a bool, got {type(value).__name__}")
+
+    return sum(1 for task_id in unique if results[task_id]) / len(unique)
+
+
+def gate(
+    candidate: float,
+    incumbent: float,
+    *,
+    sel_consultations: int = 0,
+    max_consultations: int | None = None,
+    split_fingerprint: str | None = None,
+    incumbent_fingerprint: str | None = None,
+) -> GateResult:
+    """Decide whether a candidate replaces the incumbent.
+
+    Strictly greater wins. A tie is a reject: an edit that did not move the
+    held-out score is churn, and churn on an artifact costs review attention
+    forever.
+
+    Two guards run before the comparison. A moved ``split_fingerprint`` means
+    the candidate and the incumbent were measured against different eval sets,
+    so the comparison is meaningless. An exhausted consultation budget means the
+    held-out split has been selected against too many times to carry the claim.
+
+    Raises:
+        ValueError: on scores outside ``[0, 1]``, negative consultations, or a
+            non-positive consultation cap.
+    """
+    if not 0.0 <= candidate <= 1.0:
+        raise ValueError(f"candidate score must be in [0, 1], got {candidate}")
+    if not 0.0 <= incumbent <= 1.0:
+        raise ValueError(f"incumbent score must be in [0, 1], got {incumbent}")
+    if sel_consultations < 0:
+        raise ValueError(f"sel_consultations must be non-negative, got {sel_consultations}")
+    if max_consultations is not None and max_consultations < 1:
+        raise ValueError(f"max_consultations must be positive, got {max_consultations}")
+
+    def _result(decision: str, reason: str) -> GateResult:
+        return GateResult(
+            decision=decision,
+            reason=reason,
+            candidate=candidate,
+            incumbent=incumbent,
+            sel_consultations=sel_consultations,
+        )
+
+    if (
+        split_fingerprint is not None
+        and incumbent_fingerprint is not None
+        and split_fingerprint != incumbent_fingerprint
+    ):
+        return _result(
+            "REJECT",
+            "split fingerprint moved since the incumbent was scored; re-baseline "
+            "on the current eval set before gating",
+        )
+
+    if max_consultations is not None and sel_consultations >= max_consultations:
+        return _result(
+            "REJECT",
+            f"held-out split exhausted after {sel_consultations} consultations "
+            f"(limit {max_consultations}); refresh the split or report on the test group",
+        )
+
+    if candidate > incumbent:
+        return _result("ACCEPT", f"candidate {candidate:.4f} strictly beats {incumbent:.4f}")
+    if candidate == incumbent:
+        return _result("REJECT", f"tie at {candidate:.4f}; a tie does not earn an edit")
+    return _result("REJECT", f"candidate {candidate:.4f} regressed from {incumbent:.4f}")
+
+
+def patch_fingerprint(patches: Sequence[Patch]) -> str:
+    """Return a stable identity for a proposed edit.
+
+    Order-independent and whitespace-insensitive, so re-proposing the same edit
+    with the lines shuffled or the prose re-wrapped still matches a buffered
+    rejection.
+
+    Raises:
+        ValueError: when ``patches`` is empty.
+    """
+    if not patches:
+        raise ValueError("patch_fingerprint requires at least one patch")
+
+    canonical = sorted(
+        [patch.op, _normalize_ws(patch.anchor), _normalize_ws(patch.text)] for patch in patches
+    )
+    payload = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def buffer_contains(entries: Iterable[Mapping[str, object]], patches: Sequence[Patch]) -> bool:
+    """Report whether this edit has already been rejected.
+
+    Entries without a usable ``fingerprint`` are skipped rather than raising, so
+    one hand-edited line in the ledger cannot stop the loop.
+
+    Raises:
+        ValueError: when ``patches`` is empty.
+    """
+    target = patch_fingerprint(patches)
+    for entry in entries:
+        stored = entry.get("fingerprint")
+        if isinstance(stored, str) and stored == target:
+            return True
+    return False

--- a/scripts/eval/_optimizer_core.py
+++ b/scripts/eval/_optimizer_core.py
@@ -554,7 +554,16 @@ def guard_refusal(
     refusals are decidable from bookkeeping alone, and a caller that scores
     first has already read the held-out group: the refusal then costs exactly
     what it was meant to prevent.
+
+    The cap is validated here rather than only in ``gate`` because callers
+    reach this function first. A cap below one would otherwise read as a
+    permanently exhausted budget, which is indistinguishable from legitimate
+    discipline: every gate refuses, and the reason names a limit the operator
+    never meant to set.
     """
+    if max_consultations is not None and max_consultations < 1:
+        raise ValueError(f"max_consultations must be positive, got {max_consultations}")
+
     if (
         split_fingerprint is not None
         and incumbent_fingerprint is not None

--- a/scripts/eval/_optimizer_core.py
+++ b/scripts/eval/_optimizer_core.py
@@ -2,7 +2,7 @@
 """Held-out-gated artifact optimization primitives (Issue #3422).
 
 Pure functions with no I/O and no API calls, so the accept/reject decision is
-unit-testable without eval spend. The CLI in ``optimize.py`` wires these to
+unit-testable without eval spend. The CLI in ``optimize-artifact.py`` wires these to
 files; the scorers stay where they are.
 
 Why this exists

--- a/scripts/eval/_optimizer_core.py
+++ b/scripts/eval/_optimizer_core.py
@@ -135,13 +135,20 @@ class TaskSplit:
 
 @dataclass(frozen=True)
 class GateResult:
-    """The verdict on one candidate."""
+    """The verdict on one candidate.
+
+    ``compared`` records whether the scores were actually weighed. A refusal on
+    a moved fingerprint or an exhausted budget short-circuits before the
+    comparison, so it costs the held-out split nothing and the caller must not
+    charge a consultation for it.
+    """
 
     decision: str
     reason: str
     candidate: float
     incumbent: float
     sel_consultations: int
+    compared: bool = True
 
 
 def _normalize_ws(value: str | None) -> str:
@@ -473,13 +480,14 @@ def gate(
     if max_consultations is not None and max_consultations < 1:
         raise ValueError(f"max_consultations must be positive, got {max_consultations}")
 
-    def _result(decision: str, reason: str) -> GateResult:
+    def _result(decision: str, reason: str, *, compared: bool = True) -> GateResult:
         return GateResult(
             decision=decision,
             reason=reason,
             candidate=candidate,
             incumbent=incumbent,
             sel_consultations=sel_consultations,
+            compared=compared,
         )
 
     if (
@@ -491,6 +499,7 @@ def gate(
             "REJECT",
             "split fingerprint moved since the incumbent was scored; re-baseline "
             "on the current eval set before gating",
+            compared=False,
         )
 
     if max_consultations is not None and sel_consultations >= max_consultations:
@@ -498,6 +507,7 @@ def gate(
             "REJECT",
             f"held-out split exhausted after {sel_consultations} consultations "
             f"(limit {max_consultations}); refresh the split or report on the test group",
+            compared=False,
         )
 
     if candidate > incumbent:

--- a/scripts/eval/_optimizer_core.py
+++ b/scripts/eval/_optimizer_core.py
@@ -65,6 +65,7 @@ __all__ = [
     "guard_refusal",
     "mcnemar_exact",
     "patch_fingerprint",
+    "split_fingerprint",
     "score",
     "split_tasks",
 ]
@@ -240,18 +241,40 @@ def split_tasks(
     test = tuple(ranked[n_sel : n_sel + n_test])
     opt = tuple(ranked[n_sel + n_test :])
 
+    fingerprint = split_fingerprint(
+        cleaned, seed=seed, sel_ratio=sel_ratio, test_ratio=test_ratio
+    )
+    return TaskSplit(opt=opt, sel=sel, test=test, fingerprint=fingerprint)
+
+
+def split_fingerprint(
+    task_ids: Iterable[str],
+    *,
+    seed: str,
+    sel_ratio: float,
+    test_ratio: float = 0.0,
+) -> str:
+    """Hash the inputs that determine a split.
+
+    Public rather than private because a reader has to be able to recompute
+    this from a split file's own contents. A stored fingerprint that nobody
+    can recompute is a claim, not evidence: editing group membership while
+    leaving the recorded hash alone would go unnoticed.
+
+    Order-insensitive by design. The task set determines the split; the order
+    it arrived in does not.
+    """
     payload = json.dumps(
         {
             "seed": seed,
-            "tasks": sorted(cleaned),
+            "tasks": sorted(task_ids),
             "sel_ratio": sel_ratio,
             "test_ratio": test_ratio,
         },
         sort_keys=True,
         separators=(",", ":"),
     )
-    fingerprint = hashlib.sha256(payload.encode()).hexdigest()
-    return TaskSplit(opt=opt, sel=sel, test=test, fingerprint=fingerprint)
+    return hashlib.sha256(payload.encode()).hexdigest()
 
 
 def edit_budget(step: int, total: int, *, max_edits: int = 5, min_edits: int = 1) -> int:

--- a/scripts/eval/_optimizer_core.py
+++ b/scripts/eval/_optimizer_core.py
@@ -561,6 +561,8 @@ def guard_refusal(
     discipline: every gate refuses, and the reason names a limit the operator
     never meant to set.
     """
+    if sel_consultations < 0:
+        raise ValueError(f"sel_consultations must be non-negative, got {sel_consultations}")
     if max_consultations is not None and max_consultations < 1:
         raise ValueError(f"max_consultations must be positive, got {max_consultations}")
 

--- a/scripts/eval/_optimizer_core.py
+++ b/scripts/eval/_optimizer_core.py
@@ -583,7 +583,6 @@ def gate(
     split_fingerprint: str | None = None,
     incumbent_fingerprint: str | None = None,
     discordant_loss: int = 0,
-    allow_regressions: bool = False,
 ) -> GateResult:
     """Decide whether a candidate replaces the incumbent.
 
@@ -599,9 +598,12 @@ def gate(
     ``discordant_loss`` is the number of held-out tasks that passed before the
     edit and fail after it. A net gain can still contain one, and ADR-057
     blocks every pass-to-fail transition rather than netting it against a gain,
-    so by default one broken task rejects the edit however good the aggregate
-    looks. ``allow_regressions`` opts out for callers who genuinely want the
-    aggregate verdict.
+    so one broken task rejects the edit however good the aggregate looks.
+
+    There is deliberately no override. ADR-057 states that its gate "has no
+    mechanism to accept a justified regression"; a bypass here would be a
+    weaker rule wearing the same name, and an agent driving this loop could
+    set it without a human ever seeing the broken task.
 
     Raises:
         ValueError: on scores outside ``[0, 1]``, negative consultations, a
@@ -638,7 +640,7 @@ def gate(
         return _result("REJECT", refusal, compared=False)
 
     if candidate > incumbent:
-        if discordant_loss and not allow_regressions:
+        if discordant_loss:
             return _result(
                 "REJECT",
                 f"candidate {candidate:.4f} beats {incumbent:.4f} overall but "

--- a/scripts/eval/_optimizer_core.py
+++ b/scripts/eval/_optimizer_core.py
@@ -62,6 +62,7 @@ __all__ = [
     "buffer_contains",
     "edit_budget",
     "gate",
+    "mcnemar_exact",
     "patch_fingerprint",
     "score",
     "split_tasks",
@@ -151,13 +152,6 @@ class GateResult:
     compared: bool = True
 
 
-def _normalize_ws(value: str | None) -> str:
-    """Collapse every whitespace run to a single space."""
-    if value is None:
-        return ""
-    return " ".join(value.split())
-
-
 def _round_half_up(value: float) -> int:
     """Round halves away from zero, avoiding banker's rounding surprises."""
     return math.floor(value + 0.5)
@@ -205,10 +199,14 @@ def split_tasks(
 
     cleaned: list[str] = []
     for raw in task_ids:
-        task_id = raw.strip()
-        if not task_id:
+        if raw != raw.strip():
+            raise ValueError(
+                f"task id {raw!r} carries leading or trailing whitespace; "
+                f"ids must match the keys the scorer emits exactly"
+            )
+        if not raw:
             raise ValueError("split_tasks requires non-empty task ids")
-        cleaned.append(task_id)
+        cleaned.append(raw)
 
     if len(set(cleaned)) != len(cleaned):
         duplicates = sorted({tid for tid in cleaned if cleaned.count(tid) > 1})
@@ -221,6 +219,11 @@ def split_tasks(
         raise ValueError(
             f"split of {total} tasks at sel_ratio={sel_ratio} test_ratio={test_ratio} "
             f"leaves no opt tasks"
+        )
+    if n_sel < 1:
+        raise SplitTooSmallError(
+            f"split of {total} tasks at sel_ratio={sel_ratio} holds out no tasks; "
+            f"a gate needs at least one held-out task"
         )
     if n_sel < min_sel:
         raise SplitTooSmallError(
@@ -276,10 +279,21 @@ def edit_budget(step: int, total: int, *, max_edits: int = 5, min_edits: int = 1
     return max(min_edits, min(max_edits, round(decayed)))
 
 
+def _normalize_newlines(text: str) -> str:
+    """Collapse CRLF and lone CR to LF.
+
+    One canonical form, used by every place that reasons about lines. When the
+    document splitter and the fence-marker check disagreed on whether a lone
+    carriage return starts a new line, a patch carrying "START\\rhidden\\rEND"
+    read as one harmless line at check time and became a real fence on the next
+    read. Sharing this helper is what keeps the two views from drifting apart.
+    """
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def _split_lines(document: str) -> list[str]:
     """Split into lines, dropping exactly one trailing newline."""
-    normalized = document.replace("\r\n", "\n").replace("\r", "\n")
-    lines = normalized.split("\n")
+    lines = _normalize_newlines(document).split("\n")
     if lines and lines[-1] == "":
         lines.pop()
     return lines
@@ -334,6 +348,22 @@ def _validate_shape(patch: Patch) -> None:
         raise PatchShapeError(f"patch op {patch.op!r} requires text")
 
 
+def _check_patch_fields(patch: Patch) -> None:
+    """Refuse a patch whose fields are not the types the ops assume.
+
+    Patches arrive as agent-authored JSON, so a number where a string belongs
+    is an ordinary input error, not an internal fault. Checking here turns an
+    uncaught AttributeError deep inside the anchor search into a named error
+    the CLI can report as a shape problem.
+    """
+    if not isinstance(patch.op, str):
+        raise PatchShapeError(f"patch op must be a string, got {type(patch.op).__name__}")
+    if patch.anchor is not None and not isinstance(patch.anchor, str):
+        raise PatchShapeError(f"patch anchor must be a string, got {type(patch.anchor).__name__}")
+    if patch.text is not None and not isinstance(patch.text, str):
+        raise PatchShapeError(f"patch text must be a string, got {type(patch.text).__name__}")
+
+
 def _reject_smuggled_markers(patch: Patch) -> None:
     """Refuse patch text that would introduce a fence marker.
 
@@ -342,7 +372,7 @@ def _reject_smuggled_markers(patch: Patch) -> None:
     """
     if patch.text is None:
         return
-    for line in patch.text.replace("\r\n", "\n").split("\n"):
+    for line in _normalize_newlines(patch.text).split("\n"):
         if line.strip() in (FENCE_START, FENCE_END):
             raise ProtectedSectionError(
                 "patch text may not contain a slow-update fence marker; "
@@ -390,12 +420,13 @@ def apply_patches(document: str, patches: Sequence[Patch], *, budget: int) -> st
 
     lines = _split_lines(document)
     for patch in patches:
+        _check_patch_fields(patch)
         _validate_shape(patch)
         _reject_smuggled_markers(patch)
         protected = _protected_indices(lines)
 
         if patch.op == "append":
-            lines = [*lines, *(patch.text or "").replace("\r\n", "\n").split("\n")]
+            lines = [*lines, *_normalize_newlines(patch.text or "").split("\n")]
             continue
 
         assert patch.anchor is not None  # guaranteed by _validate_shape
@@ -409,13 +440,52 @@ def apply_patches(document: str, patches: Sequence[Patch], *, budget: int) -> st
         if patch.op == "delete":
             lines = [*lines[:index], *lines[index + 1 :]]
         elif patch.op == "replace":
-            payload = (patch.text or "").replace("\r\n", "\n").split("\n")
+            payload = _normalize_newlines(patch.text or "").split("\n")
             lines = [*lines[:index], *payload, *lines[index + 1 :]]
         else:  # insert_after
-            payload = (patch.text or "").replace("\r\n", "\n").split("\n")
+            payload = _normalize_newlines(patch.text or "").split("\n")
             lines = [*lines[: index + 1], *payload, *lines[index + 1 :]]
 
     return _join_lines(lines)
+
+
+def mcnemar_exact(
+    incumbent: Mapping[str, bool],
+    candidate: Mapping[str, bool],
+    task_ids: Sequence[str],
+) -> tuple[int, int, float]:
+    """Return ``(b, c, p)`` for a one-sided exact McNemar test.
+
+    The gate reads the same task ids before and after an edit, so the two
+    scores are paired. Tasks whose outcome did not move say nothing about the
+    edit; only the discordant pairs do. ``b`` counts fail to pass, ``c`` counts
+    pass to fail. Under the null that the edit is neutral, ``b`` is
+    ``Binomial(b + c, 0.5)``, and the reported ``p`` is ``P(X >= b)``.
+
+    Exact rather than chi-squared, because this repo's eval sets are small
+    enough that the asymptotic form does not apply. The number is worth
+    reporting precisely because it makes the resolution limit impossible to
+    talk around: three discordant tasks cannot produce a ``p`` below 0.125, so
+    a three-task held-out group cannot clear a conventional 0.05 floor no
+    matter how the edit performs.
+
+    Raises:
+        MissingResultError: when a requested task is absent from either side.
+    """
+    unique = sorted(set(task_ids))
+    for label, results in (("incumbent", incumbent), ("candidate", candidate)):
+        missing = [task_id for task_id in unique if task_id not in results]
+        if missing:
+            raise MissingResultError(f"{label} has no result for: {', '.join(missing)}")
+
+    b = sum(1 for t in unique if not incumbent[t] and candidate[t])
+    c = sum(1 for t in unique if incumbent[t] and not candidate[t])
+    n = b + c
+    if n == 0:
+        return 0, 0, 1.0
+
+    tail = sum(math.comb(n, k) for k in range(b, n + 1))
+    return b, c, tail / (2**n)
 
 
 def score(results: Mapping[str, bool], task_ids: Sequence[str]) -> float:
@@ -455,6 +525,8 @@ def gate(
     max_consultations: int | None = None,
     split_fingerprint: str | None = None,
     incumbent_fingerprint: str | None = None,
+    discordant_loss: int = 0,
+    allow_regressions: bool = False,
 ) -> GateResult:
     """Decide whether a candidate replaces the incumbent.
 
@@ -467,9 +539,16 @@ def gate(
     so the comparison is meaningless. An exhausted consultation budget means the
     held-out split has been selected against too many times to carry the claim.
 
+    ``discordant_loss`` is the number of held-out tasks that passed before the
+    edit and fail after it. A net gain can still contain one, and ADR-057
+    blocks every pass-to-fail transition rather than netting it against a gain,
+    so by default one broken task rejects the edit however good the aggregate
+    looks. ``allow_regressions`` opts out for callers who genuinely want the
+    aggregate verdict.
+
     Raises:
-        ValueError: on scores outside ``[0, 1]``, negative consultations, or a
-            non-positive consultation cap.
+        ValueError: on scores outside ``[0, 1]``, negative consultations, a
+            non-positive consultation cap, or a negative discordant count.
     """
     if not 0.0 <= candidate <= 1.0:
         raise ValueError(f"candidate score must be in [0, 1], got {candidate}")
@@ -479,6 +558,8 @@ def gate(
         raise ValueError(f"sel_consultations must be non-negative, got {sel_consultations}")
     if max_consultations is not None and max_consultations < 1:
         raise ValueError(f"max_consultations must be positive, got {max_consultations}")
+    if discordant_loss < 0:
+        raise ValueError(f"discordant_loss must be non-negative, got {discordant_loss}")
 
     def _result(decision: str, reason: str, *, compared: bool = True) -> GateResult:
         return GateResult(
@@ -511,6 +592,13 @@ def gate(
         )
 
     if candidate > incumbent:
+        if discordant_loss and not allow_regressions:
+            return _result(
+                "REJECT",
+                f"candidate {candidate:.4f} beats {incumbent:.4f} overall but "
+                f"regressed {discordant_loss} held-out task(s) from pass to fail; "
+                f"a net gain does not buy back a broken task",
+            )
         return _result("ACCEPT", f"candidate {candidate:.4f} strictly beats {incumbent:.4f}")
     if candidate == incumbent:
         return _result("REJECT", f"tie at {candidate:.4f}; a tie does not earn an edit")
@@ -520,9 +608,17 @@ def gate(
 def patch_fingerprint(patches: Sequence[Patch]) -> str:
     """Return a stable identity for a proposed edit.
 
-    Order-independent and whitespace-insensitive, so re-proposing the same edit
-    with the lines shuffled or the prose re-wrapped still matches a buffered
-    rejection.
+    Order-sensitive and text-exact, because both are load-bearing. Patches
+    apply sequentially, so appending "one" then "two" builds a different
+    document from the reverse; and whitespace is content, since a newline in
+    patch text splits one line into two. Only line endings are normalized,
+    which is transport rather than content.
+
+    The bias here is deliberate. A fingerprint that treats two different edits
+    as the same one lets a single rejection ban an edit that was never tried,
+    and the buffer has no expiry. Collapsing too little costs a duplicate
+    rollout; collapsing too much costs an edit that can never be proposed
+    again.
 
     Raises:
         ValueError: when ``patches`` is empty.
@@ -530,9 +626,14 @@ def patch_fingerprint(patches: Sequence[Patch]) -> str:
     if not patches:
         raise ValueError("patch_fingerprint requires at least one patch")
 
-    canonical = sorted(
-        [patch.op, _normalize_ws(patch.anchor), _normalize_ws(patch.text)] for patch in patches
-    )
+    canonical = [
+        [
+            patch.op,
+            _normalize_newlines(patch.anchor) if patch.anchor is not None else "",
+            _normalize_newlines(patch.text) if patch.text is not None else "",
+        ]
+        for patch in patches
+    ]
     payload = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(payload.encode()).hexdigest()
 

--- a/scripts/eval/_optimizer_core.py
+++ b/scripts/eval/_optimizer_core.py
@@ -62,6 +62,7 @@ __all__ = [
     "buffer_contains",
     "edit_budget",
     "gate",
+    "guard_refusal",
     "mcnemar_exact",
     "patch_fingerprint",
     "score",
@@ -517,6 +518,39 @@ def score(results: Mapping[str, bool], task_ids: Sequence[str]) -> float:
     return sum(1 for task_id in unique if results[task_id]) / len(unique)
 
 
+def guard_refusal(
+    *,
+    sel_consultations: int = 0,
+    max_consultations: int | None = None,
+    split_fingerprint: str | None = None,
+    incumbent_fingerprint: str | None = None,
+) -> str | None:
+    """Return why a comparison must not happen, or None when it may.
+
+    Split out of ``gate`` so a caller can ask before it scores anything. Both
+    refusals are decidable from bookkeeping alone, and a caller that scores
+    first has already read the held-out group: the refusal then costs exactly
+    what it was meant to prevent.
+    """
+    if (
+        split_fingerprint is not None
+        and incumbent_fingerprint is not None
+        and split_fingerprint != incumbent_fingerprint
+    ):
+        return (
+            "split fingerprint moved since the incumbent was scored; re-baseline "
+            "on the current eval set before gating"
+        )
+
+    if max_consultations is not None and sel_consultations >= max_consultations:
+        return (
+            f"held-out split exhausted after {sel_consultations} consultations "
+            f"(limit {max_consultations}); refresh the split or report on the test group"
+        )
+
+    return None
+
+
 def gate(
     candidate: float,
     incumbent: float,
@@ -571,25 +605,14 @@ def gate(
             compared=compared,
         )
 
-    if (
-        split_fingerprint is not None
-        and incumbent_fingerprint is not None
-        and split_fingerprint != incumbent_fingerprint
-    ):
-        return _result(
-            "REJECT",
-            "split fingerprint moved since the incumbent was scored; re-baseline "
-            "on the current eval set before gating",
-            compared=False,
-        )
-
-    if max_consultations is not None and sel_consultations >= max_consultations:
-        return _result(
-            "REJECT",
-            f"held-out split exhausted after {sel_consultations} consultations "
-            f"(limit {max_consultations}); refresh the split or report on the test group",
-            compared=False,
-        )
+    refusal = guard_refusal(
+        sel_consultations=sel_consultations,
+        max_consultations=max_consultations,
+        split_fingerprint=split_fingerprint,
+        incumbent_fingerprint=incumbent_fingerprint,
+    )
+    if refusal is not None:
+        return _result("REJECT", refusal, compared=False)
 
     if candidate > incumbent:
         if discordant_loss and not allow_regressions:

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Held-out-gated optimization rails for agents, rules, hooks, and prompts.
+"""Held-out-gated optimization rails for agents, rules, and hooks.
 
 The optimizing agent proposes the edits. This CLI decides whether they
 survive. Splitting that responsibility is the whole point: an author who

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -456,8 +456,11 @@ def _holdout_key(split: dict[str, Any]) -> str:
     accepted rather than reopened.
     """
     sel = sorted(str(task_id) for task_id in _group_ids(split, _GATE_GROUP))
-    digest = hashlib.sha256("\x00".join(sel).encode("utf-8")).hexdigest()
-    return digest
+    # JSON rather than a NUL join: joining is not injective when an id may
+    # itself contain the separator, and ["a", "b\0c"] would key the same
+    # budget as ["a\0b", "c"].
+    canonical = json.dumps(sel, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 def _ledger_path(holdout_key: str) -> Path:
@@ -484,9 +487,12 @@ def _ledger_held(holdout_key: str) -> Iterator[None]:
         handle = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
     except FileExistsError as exc:
         raise ConfigError(
-            f"another gate holds {lock}; consultations against one split are "
-            f"serialized so a concurrent pair cannot spend one budget twice. "
-            f"Remove the file if no gate is running."
+            f"another gate holds a lock under {lock.parent}; consultations "
+            f"against one held-out group are serialized so a concurrent pair "
+            f"cannot spend one budget twice. Remove the lock file there if no "
+            f"gate is running. Its name is withheld: the name digests the "
+            f"held-out membership, and an unsalted digest of a set the caller "
+            f"can enumerate is that set."
         ) from exc
     try:
         os.write(handle, str(os.getpid()).encode("utf-8"))
@@ -515,25 +521,32 @@ def _read_ledger(path: Path, holdout_key: str, cap: int) -> int:
         return 0
     data = _read_json(path)
     if not isinstance(data, Mapping):
-        raise ConfigError(f"{path} must hold a JSON object")
+        raise ConfigError(f"the ledger under {path.parent} must hold a JSON object")
     spent = data.get("consultations")
     if not isinstance(spent, int) or isinstance(spent, bool) or spent < 0:
-        raise ConfigError(f"{path} consultations must be a non-negative integer")
+        raise ConfigError(
+            f"the ledger under {path.parent} needs consultations to be a "
+            f"non-negative integer"
+        )
     recorded_cap = data.get("max_consultations")
     if not isinstance(recorded_cap, int) or isinstance(recorded_cap, bool) or recorded_cap < 1:
-        raise ConfigError(f"{path} max_consultations must be a positive integer")
+        raise ConfigError(
+            f"the ledger under {path.parent} needs max_consultations to be a "
+            f"positive integer"
+        )
     recorded = data.get("holdout")
     if recorded != holdout_key:
         raise LedgerMismatchError(
-            f"ledger {path} records held-out group {recorded} but this split "
-            f"holds out {holdout_key}; a ledger under another group's name is "
-            f"a moved or edited file, not a redraw"
+            f"the ledger under {path.parent} records a different held-out "
+            f"group than this split holds out; a ledger under another group's "
+            f"name is a moved or edited file, not a redraw. Neither group is "
+            f"named here, because the name digests its membership"
         )
     if recorded_cap != cap:
         raise LedgerMismatchError(
-            f"ledger {path} was opened with a cap of {recorded_cap} and this "
-            f"invocation asks for {cap}; the budget for a held-out group is "
-            f"fixed when the run starts, so re-split to change it"
+            f"this held-out group was opened with a cap of {recorded_cap} and "
+            f"this invocation asks for {cap}; the budget for a held-out group "
+            f"is fixed when the run starts, so re-split to change it"
         )
     return spent
 

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -83,11 +83,13 @@ class ConfigError(Exception):
 
 
 class LedgerMismatchError(Exception):
-    """The ledger belongs to a different split. A decision, not a crash."""
+    """The ledger describes a different run. A decision, not a crash.
 
-    def __init__(self, recorded: str) -> None:
-        super().__init__(recorded)
-        self.recorded = recorded
+    Raised when the recorded split fingerprint or the recorded cap disagrees
+    with the invocation. Both mean the run changed underneath the budget, and
+    the loop driving this CLI has to be able to branch on that, so the message
+    is built here and reported verbatim rather than reassembled by the caller.
+    """
 
 
 def _emit(payload: object) -> None:
@@ -341,7 +343,18 @@ def cmd_score(args: argparse.Namespace) -> int:
     split = _read_split(args.split)
     results = _read_results(args.results)
     value = _score_group(results, split, args.group)
-    _emit({"score": value, "group": args.group, "n": len(split[args.group])})
+    # The fingerprint rides along because `gate` requires it and this is the
+    # only command that reads the split on the caller's behalf. Without it the
+    # caller has to open the split file to satisfy a required flag, which is
+    # how the check ended up optional in the first place.
+    _emit(
+        {
+            "score": value,
+            "group": args.group,
+            "n": len(split[args.group]),
+            "fingerprint": split["fingerprint"],
+        }
+    )
     return EXIT_OK
 
 
@@ -373,14 +386,32 @@ def cmd_apply(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _read_ledger(path: Path, fingerprint: str) -> int:
+def _ledger_path(split: Path) -> Path:
+    """Where the budget for this split lives.
+
+    Derived rather than supplied. A `--ledger` flag read as discipline but
+    handed the caller the reset: a missing ledger starts at zero, so pointing
+    the next invocation at a fresh path restored the whole budget without
+    editing anything. Deriving it means resetting the count is deleting a file
+    that sits beside the split it belongs to. The full split filename is used,
+    not its stem, so two splits in one directory cannot share a budget.
+    """
+    return split.with_name(split.name + ".ledger")
+
+
+def _read_ledger(path: Path, fingerprint: str, cap: int) -> int:
     """Return the consultations already spent against this split.
 
     The count lives here rather than on the command line because a budget the
     caller supplies is not a budget: passing zero every time yields an
-    unlimited one while still looking capped. The ledger is bound to the split
-    fingerprint so an old ledger cannot be paired with a fresh split, which
-    would reset the count by redrawing rather than by editing a number.
+    unlimited one while still looking capped. The cap is recorded for the same
+    reason. Pinning only the count left the limit re-suppliable, so a caller
+    that hit the budget could raise it and carry on, which is the defect the
+    ledger was written to close wearing a different hat.
+
+    The ledger is bound to the split fingerprint so an old ledger cannot be
+    paired with a fresh split, which would reset the count by redrawing rather
+    than by editing a number.
     """
     if not path.exists():
         return 0
@@ -390,14 +421,27 @@ def _read_ledger(path: Path, fingerprint: str) -> int:
     spent = data.get("consultations")
     if not isinstance(spent, int) or isinstance(spent, bool) or spent < 0:
         raise ConfigError(f"{path} consultations must be a non-negative integer")
+    recorded_cap = data.get("max_consultations")
+    if not isinstance(recorded_cap, int) or isinstance(recorded_cap, bool) or recorded_cap < 1:
+        raise ConfigError(f"{path} max_consultations must be a positive integer")
     recorded = data.get("fingerprint")
     if recorded != fingerprint:
-        raise LedgerMismatchError(str(recorded))
+        raise LedgerMismatchError(
+            f"ledger {path} records fingerprint {recorded} but this split is "
+            f"{fingerprint}; a ledger and a split that disagree mean the split "
+            f"was redrawn mid-run"
+        )
+    if recorded_cap != cap:
+        raise LedgerMismatchError(
+            f"ledger {path} was opened with a cap of {recorded_cap} and this "
+            f"invocation asks for {cap}; the budget for a held-out group is "
+            f"fixed when the run starts, so re-split to change it"
+        )
     return spent
 
 
-def _write_ledger(path: Path, fingerprint: str, spent: int) -> None:
-    payload = {"consultations": spent, "fingerprint": fingerprint}
+def _write_ledger(path: Path, fingerprint: str, spent: int, cap: int) -> None:
+    payload = {"consultations": spent, "fingerprint": fingerprint, "max_consultations": cap}
     _write_atomic(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
@@ -437,20 +481,11 @@ def cmd_gate(args: argparse.Namespace) -> int:
         )
         return EXIT_OK
 
+    ledger = _ledger_path(args.split)
     try:
-        spent = _read_ledger(args.ledger, split["fingerprint"])
+        spent = _read_ledger(ledger, split["fingerprint"], args.max_consultations)
     except LedgerMismatchError as exc:
-        _emit(
-            {
-                "decision": "REJECT",
-                "reason": (
-                    f"ledger {args.ledger} records fingerprint {exc.recorded} but "
-                    f"this split is {split['fingerprint']}; a ledger and a split "
-                    f"that disagree mean the split was redrawn mid-run"
-                ),
-                "compared": False,
-            }
-        )
+        _emit({"decision": "REJECT", "reason": str(exc), "compared": False})
         return EXIT_LOGIC
 
     # Guards first, scoring second. Both refusals are decidable from
@@ -491,7 +526,7 @@ def cmd_gate(args: argparse.Namespace) -> int:
     # the gate writes it rather than telling the caller what to pass next.
     spent_after = spent + (1 if result.compared else 0)
     if result.compared:
-        _write_ledger(args.ledger, split["fingerprint"], spent_after)
+        _write_ledger(ledger, split["fingerprint"], spent_after, args.max_consultations)
 
     _emit(
         {
@@ -655,14 +690,18 @@ def build_parser() -> argparse.ArgumentParser:
     gate_cmd.add_argument("--split", type=Path, required=True)
     # No --group. A gate reads the held-out group by definition, and offering
     # the choice let a caller gate on the group it had already optimized against.
+    # No --ledger either: see _ledger_path for why the caller does not choose it.
     gate_cmd.add_argument(
-        "--ledger",
-        type=Path,
+        "--max-consultations",
+        type=int,
         required=True,
-        help="file the gate keeps the consultation count in; created on first use",
+        help="how many comparisons this split may ever answer; fixed at the first gate",
     )
-    gate_cmd.add_argument("--max-consultations", type=int, default=None)
-    gate_cmd.add_argument("--incumbent-fingerprint", default=None)
+    gate_cmd.add_argument(
+        "--incumbent-fingerprint",
+        required=True,
+        help="split fingerprint the incumbent was scored against; `score` reports it",
+    )
     gate_cmd.set_defaults(func=cmd_gate)
 
     check = sub.add_parser("buffer-check", help="has this edit already been rejected")

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -276,16 +276,30 @@ def cmd_split(args: argparse.Namespace) -> int:
         )
     except ValueError as exc:
         raise ConfigError(str(exc)) from exc
+    record = {
+        "opt": list(result.opt),
+        "sel": list(result.sel),
+        "test": list(result.test),
+        "fingerprint": result.fingerprint,
+        "seed": args.seed,
+        "sel_ratio": args.sel_ratio,
+        "test_ratio": args.test_ratio,
+        "min_sel": args.min_sel,
+    }
+    _write_atomic(args.out, json.dumps(record, indent=2, sort_keys=True) + "\n")
+    # The full record goes to the file the gate reads. Stdout, which is what
+    # the optimizing agent sees, gets the optimize ids and the sizes and
+    # fingerprint it needs to verify the split was not redrawn. Publishing
+    # held-out membership here would make the withholding nominal: an agent
+    # could read the answers it is being measured against for free.
     _emit(
         {
             "opt": list(result.opt),
-            "sel": list(result.sel),
-            "test": list(result.test),
+            "n_sel": len(result.sel),
+            "n_test": len(result.test),
             "fingerprint": result.fingerprint,
             "seed": args.seed,
-            "sel_ratio": args.sel_ratio,
-            "test_ratio": args.test_ratio,
-            "min_sel": args.min_sel,
+            "split": str(args.out),
         }
     )
     return EXIT_OK
@@ -404,7 +418,6 @@ def cmd_gate(args: argparse.Namespace) -> int:
             split_fingerprint=split["fingerprint"],
             incumbent_fingerprint=args.incumbent_fingerprint,
             discordant_loss=loss,
-            allow_regressions=args.allow_regressions,
         )
     except ValueError as exc:
         raise ConfigError(str(exc)) from exc
@@ -532,6 +545,12 @@ def build_parser() -> argparse.ArgumentParser:
     source.add_argument("--results", type=Path, help="extract output; task ids are its keys")
     source.add_argument("--tasks", type=Path, help="newline-delimited task ids")
     split.add_argument("--seed", required=True)
+    split.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="file the gate reads; holds the full split including held-out ids",
+    )
     split.add_argument("--sel-ratio", type=float, default=0.4)
     split.add_argument("--test-ratio", type=float, default=0.0)
     split.add_argument("--min-sel", type=int, default=3)
@@ -547,7 +566,11 @@ def build_parser() -> argparse.ArgumentParser:
     score_cmd = sub.add_parser("score", help="fraction of one split group passing")
     score_cmd.add_argument("--results", type=Path, required=True)
     score_cmd.add_argument("--split", type=Path, required=True)
-    score_cmd.add_argument("--group", default="sel", choices=_GROUPS)
+    # Only the optimize group. The gate scores the selection group itself,
+    # inside a decision that consumes a consultation. A free-standing score on
+    # a held-out group is exactly the unmetered read the budget exists to
+    # count, so the flag does not offer one.
+    score_cmd.add_argument("--group", default="opt", choices=("opt",))
     score_cmd.set_defaults(func=cmd_score)
 
     apply_cmd = sub.add_parser("apply", help="apply bounded patches to an artifact")
@@ -566,11 +589,6 @@ def build_parser() -> argparse.ArgumentParser:
     gate_cmd.add_argument("--consultations", type=int, default=0)
     gate_cmd.add_argument("--max-consultations", type=int, default=None)
     gate_cmd.add_argument("--incumbent-fingerprint", default=None)
-    gate_cmd.add_argument(
-        "--allow-regressions",
-        action="store_true",
-        help="accept a net gain that still breaks a passing held-out task",
-    )
     gate_cmd.set_defaults(func=cmd_gate)
 
     check = sub.add_parser("buffer-check", help="has this edit already been rejected")

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -122,6 +122,26 @@ def _read_text(path: Path) -> str:
         raise ConfigError(f"could not read {path}: {exc}") from exc
 
 
+def _covers_holdout(results: Mapping[str, Any], sel_ids: list[str]) -> bool:
+    """Whether these results carry a usable verdict for every held-out task.
+
+    The gate asks this instead of letting `score` and `mcnemar_exact` report
+    what is missing, because both name the offending task ids, and the ids they
+    would name are held-out ids. A fourth adversarial review (gpt-5.6-sol,
+    2026-07-26) found the consequence: a candidate results file with no keys at
+    all printed the entire held-out membership in one error message, and the
+    error arrived before the ledger advanced, so it cost nothing.
+
+    The answer is one bit on purpose. A count would be an oracle: `split`
+    already publishes the held-out size, so "three of five missing" tells a
+    caller how many of the keys it chose to omit were held out, and a few
+    chosen omissions recover the membership. One bit, charged a consultation,
+    is the least informative answer that still tells an honest caller what to
+    fix.
+    """
+    return all(isinstance(results.get(task_id), bool) for task_id in sel_ids)
+
+
 def _read_results(path: Path) -> dict[str, bool]:
     data = _read_json(path)
     if not isinstance(data, dict):
@@ -596,6 +616,35 @@ def _gate_decision(args: argparse.Namespace, split: dict[str, Any]) -> int:
     incumbent_results = _read_results(args.incumbent)
     candidate_results = _read_results(args.candidate)
     sel_ids = _group_ids(split, _GATE_GROUP)
+
+    # Charge before reading the group, not after reaching a verdict. Two things
+    # made the old order wrong. A crash between scoring and the write left the
+    # held-out group read and the consultation unrecorded, so a retry got the
+    # comparison for free. And any refusal decided after scoring was equally
+    # free, which is what made the reveal below worth buying.
+    spent_after = spent + 1
+    _write_ledger(ledger, holdout_key, spent_after, args.max_consultations)
+
+    if not _covers_holdout(incumbent_results, sel_ids) or not _covers_holdout(
+        candidate_results, sel_ids
+    ):
+        _emit(
+            {
+                "decision": "REJECT",
+                "reason": (
+                    "the results do not cover the held-out group; score both "
+                    "artifacts over the whole task set and gate again. Which "
+                    "tasks are missing is withheld: naming them would publish "
+                    "the membership the group exists to withhold."
+                ),
+                "sel_consultations": spent_after,
+                "compared": False,
+                "group": _GATE_GROUP,
+                "fingerprint": split["fingerprint"],
+            }
+        )
+        return EXIT_LOGIC
+
     incumbent = _score_group(incumbent_results, split, _GATE_GROUP)
     candidate = _score_group(candidate_results, split, _GATE_GROUP)
     gain, loss, p_value = mcnemar_exact(incumbent_results, candidate_results, sel_ids)
@@ -608,13 +657,6 @@ def _gate_decision(args: argparse.Namespace, split: dict[str, Any]) -> int:
         incumbent_fingerprint=args.incumbent_fingerprint,
         discordant_loss=loss,
     )
-
-    # A refusal that never weighed the scores costs the held-out split
-    # nothing, so it does not advance the counter. Everything else does, and
-    # the gate writes it rather than telling the caller what to pass next.
-    spent_after = spent + (1 if result.compared else 0)
-    if result.compared:
-        _write_ledger(ledger, holdout_key, spent_after, args.max_consultations)
 
     _emit(
         {

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -40,6 +40,7 @@ module runs and prints its own plain-text usage to stderr.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
@@ -406,28 +407,46 @@ def _ledger_root() -> Path:
     return Path(state) / "ai-agents-eval" / "ledgers"
 
 
-def _ledger_path(fingerprint: str) -> Path:
-    """Where the budget for this split lives.
+def _holdout_key(split: dict[str, Any]) -> str:
+    """The identity of the held-out group itself, which is what a budget counts.
 
-    Keyed by fingerprint, not by pathname. Two earlier versions keyed it on
-    something the caller passed: first `--ledger` directly, then the `--split`
-    path it was derived from. Both reset the same way, because a missing ledger
-    starts at zero, so copying the split under a second name bought a second
-    budget.
+    Three earlier versions keyed the ledger on something upstream of the group:
+    `--ledger` directly, then the `--split` path, then the split fingerprint.
+    Each one admitted a different input that reached the same held-out tasks
+    under a new key, and a missing ledger starts at zero, so each was a reset.
 
-    Content keying is also the semantically right answer, not just the one that
-    closes the hole. A consultation spends against a held-out *group*, and the
-    fingerprint is what identifies that group: same seed, same task ids, same
-    ratios, same group, whatever the file is called or wherever it sits. Two
-    runs sharing a split share the selection pressure on it, so they share the
-    budget. A genuinely fresh budget comes from a fresh split, which is a new
-    seed and a new fingerprint.
+    The fingerprint was the closest miss. It covers the seed, the task ids, and
+    the ratios, which are the *inputs* to the selection rather than its result,
+    and the group sizes are rounded. Adversarial review (gpt-5.6-sol,
+    2026-07-26) reproduced it: ten tasks at sel_ratio 0.40 and 0.41 both round
+    to four held out and select the identical four tasks, but fingerprint the
+    differently, so the same group got two budgets.
+
+    Keying on the sorted membership removes the whole class. Any two splits
+    that hold out the same tasks share the budget those tasks have already
+    paid, whatever produced them. Sorting rather than preserving rank order is
+    deliberate: the ranking is a function of the seed, and two seeds that
+    happen to hold out the same set are still selecting on the same set.
+
+    No corpus namespace is mixed in, though a collision is possible in
+    principle: two unrelated eval sets whose task ids and held-out membership
+    both coincide would share a budget. A namespace would have to come from the
+    caller, and a caller-supplied key is the exact defect this function exists
+    to close. Sharing is the conservative direction, so the collision is
+    accepted rather than reopened.
     """
-    return _ledger_root() / f"{fingerprint}.ledger"
+    sel = sorted(str(task_id) for task_id in _group_ids(split, _GATE_GROUP))
+    digest = hashlib.sha256("\x00".join(sel).encode("utf-8")).hexdigest()
+    return digest
+
+
+def _ledger_path(holdout_key: str) -> Path:
+    """Where the budget for one held-out group lives."""
+    return _ledger_root() / f"{holdout_key}.ledger"
 
 
 @contextmanager
-def _ledger_held(fingerprint: str) -> Iterator[None]:
+def _ledger_held(holdout_key: str) -> Iterator[None]:
     """Serialize the read, compare, and write of one ledger.
 
     Without this, two gates started together both read the same count, both
@@ -439,7 +458,7 @@ def _ledger_held(fingerprint: str) -> Iterator[None]:
     A stale lock left by a killed process is reported rather than broken, since
     guessing that the holder is gone is how a lock becomes advisory.
     """
-    lock = _ledger_root() / f"{fingerprint}.lock"
+    lock = _ledger_root() / f"{holdout_key}.lock"
     lock.parent.mkdir(parents=True, exist_ok=True)
     try:
         handle = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
@@ -457,7 +476,7 @@ def _ledger_held(fingerprint: str) -> Iterator[None]:
         lock.unlink(missing_ok=True)
 
 
-def _read_ledger(path: Path, fingerprint: str, cap: int) -> int:
+def _read_ledger(path: Path, holdout_key: str, cap: int) -> int:
     """Return the consultations already spent against this split.
 
     The count lives here rather than on the command line because a budget the
@@ -467,9 +486,10 @@ def _read_ledger(path: Path, fingerprint: str, cap: int) -> int:
     that hit the budget could raise it and carry on, which is the defect the
     ledger was written to close wearing a different hat.
 
-    The ledger is bound to the split fingerprint so an old ledger cannot be
-    paired with a fresh split, which would reset the count by redrawing rather
-    than by editing a number.
+    The ledger records the held-out key it was opened under. That is the same
+    value its filename carries, so the check catches a ledger moved or renamed
+    into another group's place rather than an honest redraw: a genuinely new
+    held-out group has a different key and therefore its own file.
     """
     if not path.exists():
         return 0
@@ -482,12 +502,12 @@ def _read_ledger(path: Path, fingerprint: str, cap: int) -> int:
     recorded_cap = data.get("max_consultations")
     if not isinstance(recorded_cap, int) or isinstance(recorded_cap, bool) or recorded_cap < 1:
         raise ConfigError(f"{path} max_consultations must be a positive integer")
-    recorded = data.get("fingerprint")
-    if recorded != fingerprint:
+    recorded = data.get("holdout")
+    if recorded != holdout_key:
         raise LedgerMismatchError(
-            f"ledger {path} records fingerprint {recorded} but this split is "
-            f"{fingerprint}; a ledger and a split that disagree mean the split "
-            f"was redrawn mid-run"
+            f"ledger {path} records held-out group {recorded} but this split "
+            f"holds out {holdout_key}; a ledger under another group's name is "
+            f"a moved or edited file, not a redraw"
         )
     if recorded_cap != cap:
         raise LedgerMismatchError(
@@ -498,9 +518,9 @@ def _read_ledger(path: Path, fingerprint: str, cap: int) -> int:
     return spent
 
 
-def _write_ledger(path: Path, fingerprint: str, spent: int, cap: int) -> None:
+def _write_ledger(path: Path, holdout_key: str, spent: int, cap: int) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {"consultations": spent, "fingerprint": fingerprint, "max_consultations": cap}
+    payload = {"consultations": spent, "holdout": holdout_key, "max_consultations": cap}
     _write_atomic(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
 
@@ -542,15 +562,16 @@ def cmd_gate(args: argparse.Namespace) -> int:
 
     # The lock spans read, compare, and write. A drifted split never reaches it
     # because that refusal reads no ledger and spends nothing.
-    with _ledger_held(split["fingerprint"]):
+    with _ledger_held(_holdout_key(split)):
         return _gate_decision(args, split)
 
 
 def _gate_decision(args: argparse.Namespace, split: dict[str, Any]) -> int:
     """Spend at most one consultation and report what it bought."""
-    ledger = _ledger_path(split["fingerprint"])
+    holdout_key = _holdout_key(split)
+    ledger = _ledger_path(holdout_key)
     try:
-        spent = _read_ledger(ledger, split["fingerprint"], args.max_consultations)
+        spent = _read_ledger(ledger, holdout_key, args.max_consultations)
     except LedgerMismatchError as exc:
         _emit({"decision": "REJECT", "reason": str(exc), "compared": False})
         return EXIT_LOGIC
@@ -593,7 +614,7 @@ def _gate_decision(args: argparse.Namespace, split: dict[str, Any]) -> int:
     # the gate writes it rather than telling the caller what to pass next.
     spent_after = spent + (1 if result.compared else 0)
     if result.compared:
-        _write_ledger(ledger, split["fingerprint"], spent_after, args.max_consultations)
+        _write_ledger(ledger, holdout_key, spent_after, args.max_consultations)
 
     _emit(
         {

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -44,7 +44,8 @@ import json
 import os
 import sys
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -386,17 +387,74 @@ def cmd_apply(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _ledger_path(split: Path) -> Path:
+_LEDGER_DIR_ENV = "EVAL_LEDGER_DIR"
+
+
+def _ledger_root() -> Path:
+    """The one directory every consultation ledger lives in.
+
+    Fixed rather than relative to the split, because anything derived from a
+    path the caller supplies is a path the caller can change. `$EVAL_LEDGER_DIR`
+    exists so tests do not write to a real user directory; setting it is a
+    deliberate act outside the loop's argument surface, which is the line this
+    mechanism draws everywhere else too.
+    """
+    override = os.environ.get(_LEDGER_DIR_ENV)
+    if override:
+        return Path(override)
+    state = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    return Path(state) / "ai-agents-eval" / "ledgers"
+
+
+def _ledger_path(fingerprint: str) -> Path:
     """Where the budget for this split lives.
 
-    Derived rather than supplied. A `--ledger` flag read as discipline but
-    handed the caller the reset: a missing ledger starts at zero, so pointing
-    the next invocation at a fresh path restored the whole budget without
-    editing anything. Deriving it means resetting the count is deleting a file
-    that sits beside the split it belongs to. The full split filename is used,
-    not its stem, so two splits in one directory cannot share a budget.
+    Keyed by fingerprint, not by pathname. Two earlier versions keyed it on
+    something the caller passed: first `--ledger` directly, then the `--split`
+    path it was derived from. Both reset the same way, because a missing ledger
+    starts at zero, so copying the split under a second name bought a second
+    budget.
+
+    Content keying is also the semantically right answer, not just the one that
+    closes the hole. A consultation spends against a held-out *group*, and the
+    fingerprint is what identifies that group: same seed, same task ids, same
+    ratios, same group, whatever the file is called or wherever it sits. Two
+    runs sharing a split share the selection pressure on it, so they share the
+    budget. A genuinely fresh budget comes from a fresh split, which is a new
+    seed and a new fingerprint.
     """
-    return split.with_name(split.name + ".ledger")
+    return _ledger_root() / f"{fingerprint}.ledger"
+
+
+@contextmanager
+def _ledger_held(fingerprint: str) -> Iterator[None]:
+    """Serialize the read, compare, and write of one ledger.
+
+    Without this, two gates started together both read the same count, both
+    compare, and both write count + 1, so N concurrent gates spend one
+    consultation between them. Atomic replacement keeps the file whole; it does
+    not make the read-modify-write sequence a transaction.
+
+    An exclusive create is the lock rather than `fcntl`, which is POSIX only.
+    A stale lock left by a killed process is reported rather than broken, since
+    guessing that the holder is gone is how a lock becomes advisory.
+    """
+    lock = _ledger_root() / f"{fingerprint}.lock"
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        handle = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError as exc:
+        raise ConfigError(
+            f"another gate holds {lock}; consultations against one split are "
+            f"serialized so a concurrent pair cannot spend one budget twice. "
+            f"Remove the file if no gate is running."
+        ) from exc
+    try:
+        os.write(handle, str(os.getpid()).encode("utf-8"))
+        os.close(handle)
+        yield
+    finally:
+        lock.unlink(missing_ok=True)
 
 
 def _read_ledger(path: Path, fingerprint: str, cap: int) -> int:
@@ -441,6 +499,7 @@ def _read_ledger(path: Path, fingerprint: str, cap: int) -> int:
 
 
 def _write_ledger(path: Path, fingerprint: str, spent: int, cap: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
     payload = {"consultations": spent, "fingerprint": fingerprint, "max_consultations": cap}
     _write_atomic(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
 
@@ -481,7 +540,15 @@ def cmd_gate(args: argparse.Namespace) -> int:
         )
         return EXIT_OK
 
-    ledger = _ledger_path(args.split)
+    # The lock spans read, compare, and write. A drifted split never reaches it
+    # because that refusal reads no ledger and spends nothing.
+    with _ledger_held(split["fingerprint"]):
+        return _gate_decision(args, split)
+
+
+def _gate_decision(args: argparse.Namespace, split: dict[str, Any]) -> int:
+    """Spend at most one consultation and report what it bought."""
+    ledger = _ledger_path(split["fingerprint"])
     try:
         spent = _read_ledger(ledger, split["fingerprint"], args.max_consultations)
     except LedgerMismatchError as exc:

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -145,12 +145,13 @@ def _read_split(path: Path) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _rule_scenarios(payload: object) -> list:
+def _rule_scenarios(payload: object) -> list[Any]:
     """Pull scenarios from a bare array or a 'scenarios' wrapper."""
     scenarios = payload.get("scenarios") if isinstance(payload, dict) else payload
     if not isinstance(scenarios, list):
         raise ConfigError("rule input must be a scenario array or an object with 'scenarios'")
-    return scenarios
+    typed: list[Any] = scenarios
+    return typed
 
 
 def _extract_rules_envelope(rules: object, args: argparse.Namespace) -> dict[str, bool]:

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -30,16 +30,20 @@ Exit codes follow ADR-035:
     2  bad arguments, unreadable input, or malformed data
 
 A REJECT is exit 1 because it is a decision, not a crash, and a shell loop
-wants to branch on it. Every path still prints JSON, so a caller that needs
-to tell REJECT from a config failure can read `decision` instead of guessing
-from the code.
+wants to branch on it. Every path this module reaches prints JSON, so a
+caller that needs to tell REJECT from a config failure can read `decision`
+instead of guessing from the code, and a config failure prints an `error`
+field the same way. Argparse rejects a malformed command line before this
+module runs and prints its own plain-text usage to stderr.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
+import tempfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -98,6 +102,10 @@ def _read_text(path: Path) -> str:
         return path.read_text(encoding="utf-8")
     except FileNotFoundError as exc:
         raise ConfigError(f"no such file: {path}") from exc
+    except UnicodeDecodeError as exc:
+        # UnicodeDecodeError subclasses ValueError, not OSError, so the arm
+        # below never caught it and a binary artifact crashed the loop.
+        raise ConfigError(f"{path} is not valid UTF-8: {exc}") from exc
     except OSError as exc:
         raise ConfigError(f"could not read {path}: {exc}") from exc
 
@@ -333,7 +341,7 @@ def cmd_apply(args: argparse.Namespace) -> int:
     if args.dry_run:
         _emit({"applied": len(patches), "result": updated, "written": False})
         return EXIT_OK
-    args.file.write_text(updated, encoding="utf-8")
+    _write_atomic(args.file, updated)
     _emit({"applied": len(patches), "written": True, "path": str(args.file)})
     return EXIT_OK
 
@@ -431,6 +439,28 @@ def cmd_gate(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _write_atomic(path: Path, text: str) -> None:
+    """Replace `path` with `text` so no reader ever sees a partial file.
+
+    `apply` overwrites the artifact the loop is optimizing. A direct write
+    truncates before it fills, so an interrupt or a full disk mid-write
+    destroys the artifact and leaves the loop nothing to fall back to. The
+    temp file is created beside the target so os.replace stays on one
+    filesystem and therefore stays atomic.
+    """
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.")
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except OSError as exc:
+        tmp.unlink(missing_ok=True)
+        raise ConfigError(f"could not write {path}: {exc}") from exc
+
+
 def _read_buffer(path: Path) -> list[dict[str, Any]]:
     if not path.exists():
         # A first run has no ledger yet. Treating that as empty keeps the loop
@@ -439,6 +469,9 @@ def _read_buffer(path: Path) -> list[dict[str, Any]]:
     data = _read_json(path)
     if not isinstance(data, list):
         raise ConfigError(f"{path} must hold a JSON array of rejection entries")
+    for index, entry in enumerate(data):
+        if not isinstance(entry, dict):
+            raise ConfigError(f"{path} entry {index} must be an object, got {entry!r}")
     return data
 
 
@@ -565,7 +598,11 @@ def main(argv: list[str] | None = None) -> int:
         # returns an exit code.
         exit_code: int = args.func(args)
     except (ConfigError, AdapterError) as exc:
-        print(f"error: {exc}", file=sys.stderr)
+        # JSON, not a bare message, because the module docstring promises a
+        # caller can tell a REJECT from a config failure by reading a field
+        # rather than guessing from the exit code. A plain-text error breaks
+        # that promise for any driver piping stdout through a JSON reader.
+        _emit({"error": str(exc), "type": type(exc).__name__})
         return EXIT_CONFIG
     return exit_code
 

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -147,7 +147,12 @@ def _extract_rule(payload: object, args: argparse.Namespace) -> dict[str, bool]:
     scenarios = payload.get("scenarios") if isinstance(payload, dict) else payload
     if not isinstance(scenarios, list):
         raise ConfigError("rule input must be a scenario array or an object with 'scenarios'")
-    return rule_results(scenarios, args.mechanism, min_score=args.min_score)
+    # Annotated locals here and below: the sibling modules are imported by
+    # path (this file is a hyphenated script), so mypy resolves them as Any
+    # under ignore_missing_imports. The annotation restates the contract the
+    # tests already enforce.
+    extracted: dict[str, bool] = rule_results(scenarios, args.mechanism, min_score=args.min_score)
+    return extracted
 
 
 def cmd_extract(args: argparse.Namespace) -> int:
@@ -216,9 +221,10 @@ def cmd_budget(args: argparse.Namespace) -> int:
 
 def _score_group(results: dict[str, bool], split: dict[str, Any], group: str) -> float:
     try:
-        return score(results, split[group])
+        fraction: float = score(results, split[group])
     except ValueError as exc:
         raise ConfigError(str(exc)) from exc
+    return fraction
 
 
 def cmd_score(args: argparse.Namespace) -> int:
@@ -419,10 +425,13 @@ def main(argv: list[str] | None = None) -> int:
         parser.print_help(sys.stderr)
         return EXIT_CONFIG
     try:
-        return args.func(args)
+        # argparse.Namespace attributes are Any; every registered handler
+        # returns an exit code.
+        exit_code: int = args.func(args)
     except (ConfigError, AdapterError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return EXIT_CONFIG
+    return exit_code
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Held-out-gated optimization rails for agents, rules, hooks, and prompts.
+
+The optimizing agent proposes the edits. This CLI decides whether they
+survive. Splitting that responsibility is the whole point: an author who
+scores an edit on the material they were reading while making it learns
+nothing about whether the edit generalizes, and the existing eval harness
+scores exactly that way.
+
+A loop step looks like this. Every command reads and writes JSON on stdout,
+so the loop is drivable from a shell or from an agent's tool calls.
+
+    optimize-artifact.py extract --kind agent --input report.json > base.json
+    optimize-artifact.py split --results base.json --seed run-7 > split.json
+    optimize-artifact.py budget --step 3 --total 12
+    optimize-artifact.py buffer-check --buffer rejected.json --patches p.json
+    optimize-artifact.py apply --file target.md --patches p.json --budget 3
+    # rerun the real scorer here, then extract its output to cand.json
+    optimize-artifact.py gate --incumbent base.json --candidate cand.json \\
+        --split split.json --incumbent-fingerprint "$FP"
+
+`gate` scores both sides itself from the split's held-out `sel` group rather
+than accepting two numbers. Taking bare numbers would make the loop's most
+damaging mistake, gating on optimize-set scores, a typo away at every step.
+
+Exit codes follow ADR-035:
+
+    0  accept, novel, or plain success
+    1  reject, already-rejected, or a refused patch
+    2  bad arguments, unreadable input, or malformed data
+
+A REJECT is exit 1 because it is a decision, not a crash, and a shell loop
+wants to branch on it. Every path still prints JSON, so a caller that needs
+to tell REJECT from a config failure can read `decision` instead of guessing
+from the code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _optimizer_adapters import (  # noqa: E402
+    AdapterError,
+    agent_results,
+    pytest_results,
+    rule_results,
+)
+from _optimizer_core import (  # noqa: E402
+    Patch,
+    apply_patches,
+    buffer_contains,
+    edit_budget,
+    gate,
+    patch_fingerprint,
+    score,
+    split_tasks,
+)
+
+EXIT_OK = 0
+EXIT_LOGIC = 1
+EXIT_CONFIG = 2
+
+_GROUPS = ("opt", "sel", "test")
+
+
+class ConfigError(Exception):
+    """Input was unreadable or malformed. Maps to exit 2."""
+
+
+def _emit(payload: object) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _read_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ConfigError(f"no such file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"{path} is not valid JSON: {exc}") from exc
+    except OSError as exc:
+        raise ConfigError(f"could not read {path}: {exc}") from exc
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ConfigError(f"no such file: {path}") from exc
+    except OSError as exc:
+        raise ConfigError(f"could not read {path}: {exc}") from exc
+
+
+def _read_results(path: Path) -> dict[str, bool]:
+    data = _read_json(path)
+    if not isinstance(data, dict):
+        raise ConfigError(f"{path} must hold a JSON object of task id to boolean")
+    bad = [k for k, v in data.items() if not isinstance(v, bool)]
+    if bad:
+        raise ConfigError(
+            f"{path} has non-boolean results for: {', '.join(sorted(bad)[:5])}"
+        )
+    return data
+
+
+def _read_patches(path: Path) -> list[Patch]:
+    data = _read_json(path)
+    if not isinstance(data, list):
+        raise ConfigError(f"{path} must hold a JSON array of patches")
+    patches: list[Patch] = []
+    for index, raw in enumerate(data):
+        if not isinstance(raw, dict) or "op" not in raw:
+            raise ConfigError(f"{path} patch {index} needs an 'op' key")
+        patches.append(
+            Patch(op=raw["op"], anchor=raw.get("anchor"), text=raw.get("text"))
+        )
+    if not patches:
+        raise ConfigError(f"{path} holds no patches")
+    return patches
+
+
+def _read_split(path: Path) -> dict[str, Any]:
+    data = _read_json(path)
+    if not isinstance(data, dict):
+        raise ConfigError(f"{path} must hold a split object")
+    missing = [key for key in (*_GROUPS, "fingerprint") if key not in data]
+    if missing:
+        raise ConfigError(f"{path} is missing split keys: {', '.join(missing)}")
+    return data
+
+
+# ---------------------------------------------------------------------------
+# extract
+# ---------------------------------------------------------------------------
+
+
+def _extract_rule(payload: object, args: argparse.Namespace) -> dict[str, bool]:
+    # eval-rule-activation.py writes either a bare scenario array or an object
+    # wrapping one, depending on whether the caller asked for the summary.
+    scenarios = payload.get("scenarios") if isinstance(payload, dict) else payload
+    if not isinstance(scenarios, list):
+        raise ConfigError("rule input must be a scenario array or an object with 'scenarios'")
+    return rule_results(scenarios, args.mechanism, min_score=args.min_score)
+
+
+def cmd_extract(args: argparse.Namespace) -> int:
+    if args.kind == "hook":
+        results = pytest_results(_read_text(args.input), on_skip=args.on_skip)
+    elif args.kind == "agent":
+        report = _read_json(args.input)
+        if not isinstance(report, Mapping):
+            raise ConfigError(f"{args.input} must hold an agent report object")
+        results = agent_results(
+            report,
+            args.variant,
+            reduce=args.reduce,
+            pass_threshold=args.pass_threshold,
+        )
+    else:
+        results = _extract_rule(_read_json(args.input), args)
+    _emit(results)
+    return EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# split, budget, score
+# ---------------------------------------------------------------------------
+
+
+def cmd_split(args: argparse.Namespace) -> int:
+    if args.results:
+        task_ids = sorted(_read_results(args.results))
+    else:
+        task_ids = [
+            line.strip() for line in _read_text(args.tasks).splitlines() if line.strip()
+        ]
+    try:
+        result = split_tasks(
+            task_ids,
+            seed=args.seed,
+            sel_ratio=args.sel_ratio,
+            test_ratio=args.test_ratio,
+            min_sel=args.min_sel,
+        )
+    except ValueError as exc:
+        raise ConfigError(str(exc)) from exc
+    _emit(
+        {
+            "opt": list(result.opt),
+            "sel": list(result.sel),
+            "test": list(result.test),
+            "fingerprint": result.fingerprint,
+            "seed": args.seed,
+        }
+    )
+    return EXIT_OK
+
+
+def cmd_budget(args: argparse.Namespace) -> int:
+    try:
+        value = edit_budget(
+            args.step, args.total, max_edits=args.max_edits, min_edits=args.min_edits
+        )
+    except ValueError as exc:
+        raise ConfigError(str(exc)) from exc
+    _emit({"budget": value, "step": args.step, "total": args.total})
+    return EXIT_OK
+
+
+def _score_group(results: dict[str, bool], split: dict[str, Any], group: str) -> float:
+    try:
+        return score(results, split[group])
+    except ValueError as exc:
+        raise ConfigError(str(exc)) from exc
+
+
+def cmd_score(args: argparse.Namespace) -> int:
+    split = _read_split(args.split)
+    results = _read_results(args.results)
+    value = _score_group(results, split, args.group)
+    _emit({"score": value, "group": args.group, "n": len(split[args.group])})
+    return EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    document = _read_text(args.file)
+    patches = _read_patches(args.patches)
+    try:
+        updated = apply_patches(document, patches, budget=args.budget)
+    except ValueError as exc:
+        # A refused patch is a decision the loop branches on, not a crash. The
+        # file is left untouched so the caller can propose a different edit.
+        _emit({"applied": 0, "error": str(exc), "type": type(exc).__name__})
+        return EXIT_LOGIC
+    if args.dry_run:
+        _emit({"applied": len(patches), "result": updated, "written": False})
+        return EXIT_OK
+    args.file.write_text(updated, encoding="utf-8")
+    _emit({"applied": len(patches), "written": True, "path": str(args.file)})
+    return EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# gate
+# ---------------------------------------------------------------------------
+
+
+def cmd_gate(args: argparse.Namespace) -> int:
+    split = _read_split(args.split)
+    incumbent = _score_group(_read_results(args.incumbent), split, args.group)
+    candidate = _score_group(_read_results(args.candidate), split, args.group)
+    try:
+        result = gate(
+            candidate,
+            incumbent,
+            sel_consultations=args.consultations,
+            max_consultations=args.max_consultations,
+            split_fingerprint=split["fingerprint"],
+            incumbent_fingerprint=args.incumbent_fingerprint,
+        )
+    except ValueError as exc:
+        raise ConfigError(str(exc)) from exc
+    _emit(
+        {
+            "decision": result.decision,
+            "reason": result.reason,
+            "candidate": result.candidate,
+            "incumbent": result.incumbent,
+            # What to pass as --consultations next time. A refusal that never
+            # weighed the scores costs the held-out split nothing, so it does
+            # not advance the counter.
+            "sel_consultations": args.consultations + (1 if result.compared else 0),
+            "compared": result.compared,
+            "group": args.group,
+            "fingerprint": split["fingerprint"],
+        }
+    )
+    return EXIT_OK if result.decision == "ACCEPT" else EXIT_LOGIC
+
+
+# ---------------------------------------------------------------------------
+# buffer
+# ---------------------------------------------------------------------------
+
+
+def _read_buffer(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        # A first run has no ledger yet. Treating that as empty keeps the loop
+        # from needing a separate init step.
+        return []
+    data = _read_json(path)
+    if not isinstance(data, list):
+        raise ConfigError(f"{path} must hold a JSON array of rejection entries")
+    return data
+
+
+def cmd_buffer_check(args: argparse.Namespace) -> int:
+    entries = _read_buffer(args.buffer)
+    patches = _read_patches(args.patches)
+    seen = buffer_contains(entries, patches)
+    _emit({"seen": seen, "fingerprint": patch_fingerprint(patches)})
+    return EXIT_LOGIC if seen else EXIT_OK
+
+
+def cmd_buffer_add(args: argparse.Namespace) -> int:
+    entries = _read_buffer(args.buffer)
+    patches = _read_patches(args.patches)
+    fingerprint = patch_fingerprint(patches)
+    if any(e.get("fingerprint") == fingerprint for e in entries):
+        _emit({"added": False, "fingerprint": fingerprint, "entries": len(entries)})
+        return EXIT_OK
+    entries.append(
+        {
+            "fingerprint": fingerprint,
+            "reason": args.reason,
+            "patches": [
+                {"op": p.op, "anchor": p.anchor, "text": p.text} for p in patches
+            ],
+        }
+    )
+    args.buffer.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    _emit({"added": True, "fingerprint": fingerprint, "entries": len(entries)})
+    return EXIT_OK
+
+
+# ---------------------------------------------------------------------------
+# argument parsing
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="optimize-artifact.py",
+        description="Held-out-gated optimization rails for agents, rules, and hooks.",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    extract = sub.add_parser("extract", help="convert a scorer's output to task pass or fail")
+    extract.add_argument("--kind", choices=("agent", "rule", "hook"), required=True)
+    extract.add_argument("--input", type=Path, required=True)
+    extract.add_argument("--variant", default="agent", help="agent eval variant column")
+    extract.add_argument("--reduce", default="mean", choices=("mean", "min", "max", "median"))
+    extract.add_argument("--pass-threshold", type=float, default=1.0)
+    extract.add_argument("--mechanism", default="full", help="rule eval mechanism column")
+    extract.add_argument("--min-score", type=float, default=3.5)
+    extract.add_argument("--on-skip", default="fail", choices=("fail", "exclude"))
+    extract.set_defaults(func=cmd_extract)
+
+    split = sub.add_parser("split", help="partition tasks into opt, sel, and test")
+    source = split.add_mutually_exclusive_group(required=True)
+    source.add_argument("--results", type=Path, help="extract output; task ids are its keys")
+    source.add_argument("--tasks", type=Path, help="newline-delimited task ids")
+    split.add_argument("--seed", required=True)
+    split.add_argument("--sel-ratio", type=float, default=0.4)
+    split.add_argument("--test-ratio", type=float, default=0.0)
+    split.add_argument("--min-sel", type=int, default=3)
+    split.set_defaults(func=cmd_split)
+
+    budget = sub.add_parser("budget", help="edits allowed at this step")
+    budget.add_argument("--step", type=int, required=True)
+    budget.add_argument("--total", type=int, required=True)
+    budget.add_argument("--max-edits", type=int, default=5)
+    budget.add_argument("--min-edits", type=int, default=1)
+    budget.set_defaults(func=cmd_budget)
+
+    score_cmd = sub.add_parser("score", help="fraction of one split group passing")
+    score_cmd.add_argument("--results", type=Path, required=True)
+    score_cmd.add_argument("--split", type=Path, required=True)
+    score_cmd.add_argument("--group", default="sel", choices=_GROUPS)
+    score_cmd.set_defaults(func=cmd_score)
+
+    apply_cmd = sub.add_parser("apply", help="apply bounded patches to an artifact")
+    apply_cmd.add_argument("--file", type=Path, required=True)
+    apply_cmd.add_argument("--patches", type=Path, required=True)
+    apply_cmd.add_argument("--budget", type=int, required=True)
+    apply_cmd.add_argument("--dry-run", action="store_true")
+    apply_cmd.set_defaults(func=cmd_apply)
+
+    gate_cmd = sub.add_parser("gate", help="decide whether a candidate replaces the incumbent")
+    gate_cmd.add_argument("--incumbent", type=Path, required=True)
+    gate_cmd.add_argument("--candidate", type=Path, required=True)
+    gate_cmd.add_argument("--split", type=Path, required=True)
+    gate_cmd.add_argument("--group", default="sel", choices=_GROUPS)
+    gate_cmd.add_argument("--consultations", type=int, default=0)
+    gate_cmd.add_argument("--max-consultations", type=int, default=None)
+    gate_cmd.add_argument("--incumbent-fingerprint", default=None)
+    gate_cmd.set_defaults(func=cmd_gate)
+
+    check = sub.add_parser("buffer-check", help="has this edit already been rejected")
+    check.add_argument("--buffer", type=Path, required=True)
+    check.add_argument("--patches", type=Path, required=True)
+    check.set_defaults(func=cmd_buffer_check)
+
+    add = sub.add_parser("buffer-add", help="record a rejected edit")
+    add.add_argument("--buffer", type=Path, required=True)
+    add.add_argument("--patches", type=Path, required=True)
+    add.add_argument("--reason", required=True)
+    add.set_defaults(func=cmd_buffer_add)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "command", None):
+        parser.print_help(sys.stderr)
+        return EXIT_CONFIG
+    try:
+        return args.func(args)
+    except (ConfigError, AdapterError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_CONFIG
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -134,10 +134,44 @@ def _read_split(path: Path) -> dict[str, Any]:
     data = _read_json(path)
     if not isinstance(data, dict):
         raise ConfigError(f"{path} must hold a split object")
-    missing = [key for key in (*_GROUPS, "fingerprint") if key not in data]
+    required = (*_GROUPS, "fingerprint", "seed", "sel_ratio", "test_ratio")
+    missing = [key for key in required if key not in data]
     if missing:
-        raise ConfigError(f"{path} is missing split keys: {', '.join(missing)}")
+        raise ConfigError(
+            f"{path} is missing split keys: {', '.join(missing)}. A split file "
+            "that cannot be re-fingerprinted cannot be verified; re-run split."
+        )
     return data
+
+
+def _split_drifted(split: Mapping[str, Any]) -> bool:
+    """Has the split file changed since it was written?
+
+    Redrawn from the file's own recorded inputs rather than compared against a
+    value the caller passes, because a caller who forgets the flag would
+    otherwise get no check at all.
+
+    Both halves are needed and neither is redundant. The fingerprint covers the
+    split's inputs (seed, task set, ratios), so it catches an added or removed
+    task. It cannot catch a task moved between groups, because the union it
+    hashes is unchanged by a move. Redrawing the split catches that: the draw is
+    seeded, so the groups are a pure function of the inputs, and any membership
+    that the recorded inputs would not produce is drift.
+    """
+    try:
+        tasks = [str(t) for group in _GROUPS for t in split[group]]
+        redrawn = split_tasks(
+            tasks,
+            seed=str(split["seed"]),
+            sel_ratio=float(split["sel_ratio"]),
+            test_ratio=float(split["test_ratio"]),
+            min_sel=int(split.get("min_sel", 3)),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ConfigError(f"split file holds unusable seed or ratios: {exc}") from exc
+    if redrawn.fingerprint != split["fingerprint"]:
+        return True
+    return any(sorted(getattr(redrawn, g)) != sorted(split[g]) for g in _GROUPS)
 
 
 # ---------------------------------------------------------------------------
@@ -241,6 +275,9 @@ def cmd_split(args: argparse.Namespace) -> int:
             "test": list(result.test),
             "fingerprint": result.fingerprint,
             "seed": args.seed,
+            "sel_ratio": args.sel_ratio,
+            "test_ratio": args.test_ratio,
+            "min_sel": args.min_sel,
         }
     )
     return EXIT_OK
@@ -308,6 +345,19 @@ def cmd_apply(args: argparse.Namespace) -> int:
 
 def cmd_gate(args: argparse.Namespace) -> int:
     split = _read_split(args.split)
+    if _split_drifted(split):
+        _emit(
+            {
+                "decision": "REJECT",
+                "reason": (
+                    "split fingerprint does not match the split file's own "
+                    "contents; the groups or the seed were edited after the "
+                    "split was drawn. Re-split and re-baseline."
+                ),
+                "consultations": args.consultations,
+            }
+        )
+        return EXIT_OK
 
     # Guards first, scoring second. Both refusals are decidable from
     # bookkeeping alone, and scoring before asking would read the held-out

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -181,6 +181,12 @@ def _read_split(path: Path) -> dict[str, Any]:
             f"{path} is missing split keys: {', '.join(missing)}. A split file "
             "that cannot be re-fingerprinted cannot be verified; re-run split."
         )
+    for group in _GROUPS:
+        value = data[group]
+        if not isinstance(value, list) or not all(isinstance(t, str) for t in value):
+            raise ConfigError(
+                f"{path} group '{group}' must be a list of strings"
+            )
     return data
 
 
@@ -588,10 +594,11 @@ def cmd_gate(args: argparse.Namespace) -> int:
                     "contents; the groups or the seed were edited after the "
                     "split was drawn. Re-split and re-baseline."
                 ),
+                "compared": False,
                 "consultations": 0,
             }
         )
-        return EXIT_OK
+        return EXIT_LOGIC
 
     # The lock spans read, compare, and write. A drifted split never reaches it
     # because that refusal reads no ledger and spends nothing.
@@ -606,7 +613,14 @@ def _gate_decision(args: argparse.Namespace, split: dict[str, Any]) -> int:
     try:
         spent = _read_ledger(ledger, holdout_key, args.max_consultations)
     except LedgerMismatchError as exc:
-        _emit({"decision": "REJECT", "reason": str(exc), "compared": False})
+        _emit({
+            "decision": "REJECT",
+            "reason": str(exc),
+            "compared": False,
+            "sel_consultations": 0,
+            "group": _GATE_GROUP,
+            "fingerprint": split["fingerprint"],
+        })
         return EXIT_LOGIC
 
     # Guards first, scoring second. Both refusals are decidable from
@@ -708,6 +722,12 @@ def _write_atomic(path: Path, text: str) -> None:
     temp file is created beside the target so os.replace stays on one
     filesystem and therefore stays atomic.
     """
+    # Preserve the destination's mode if it exists; mkstemp defaults to 0o600.
+    try:
+        mode = path.stat().st_mode
+    except OSError:
+        mode = None
+
     fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.")
     tmp = Path(tmp_name)
     try:
@@ -715,10 +735,16 @@ def _write_atomic(path: Path, text: str) -> None:
             handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())
+        if mode is not None:
+            os.chmod(tmp, mode)
         os.replace(tmp, path)
-    except OSError as exc:
+    except BaseException as exc:
+        # Close the fd if os.fdopen failed (fd not yet owned by the handle).
+        # If os.fdopen succeeded, the with-block already closed it.
         tmp.unlink(missing_ok=True)
-        raise ConfigError(f"could not write {path}: {exc}") from exc
+        if isinstance(exc, OSError):
+            raise ConfigError(f"could not write {path}: {exc}") from exc
+        raise
 
 
 def _read_buffer(path: Path) -> list[dict[str, Any]]:
@@ -759,7 +785,7 @@ def cmd_buffer_add(args: argparse.Namespace) -> int:
             ],
         }
     )
-    args.buffer.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    _write_atomic(args.buffer, json.dumps(entries, indent=2))
     _emit({"added": True, "fingerprint": fingerprint, "entries": len(entries)})
     return EXIT_OK
 

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -58,10 +58,14 @@ from _optimizer_core import (  # noqa: E402
     buffer_contains,
     edit_budget,
     gate,
+    guard_refusal,
+    mcnemar_exact,
     patch_fingerprint,
     score,
     split_tasks,
 )
+
+_GATE_GROUP = "sel"
 
 EXIT_OK = 0
 EXIT_LOGIC = 1
@@ -141,17 +145,50 @@ def _read_split(path: Path) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _extract_rule(payload: object, args: argparse.Namespace) -> dict[str, bool]:
-    # eval-rule-activation.py writes either a bare scenario array or an object
-    # wrapping one, depending on whether the caller asked for the summary.
+def _rule_scenarios(payload: object) -> list:
+    """Pull scenarios from a bare array or a 'scenarios' wrapper."""
     scenarios = payload.get("scenarios") if isinstance(payload, dict) else payload
     if not isinstance(scenarios, list):
         raise ConfigError("rule input must be a scenario array or an object with 'scenarios'")
+    return scenarios
+
+
+def _extract_rules_envelope(rules: object, args: argparse.Namespace) -> dict[str, bool]:
+    """Extract the multi-rule shape eval-rule-activation.py --output writes.
+
+    Scenario ids restart at S1 inside every rule, so they are namespaced as
+    `<rule>::<scenario-id>`. A live run over the seven scenario files in
+    tests/evals/rule-scenarios/ produced 24 scenarios carrying only 4 distinct
+    ids; merging them raw would silently drop 20 tasks, and a smaller
+    denominator reads as a higher score.
+    """
+    if not isinstance(rules, Mapping) or not rules:
+        raise ConfigError("'rules' must be a non-empty mapping of rule name to result")
+    out: dict[str, bool] = {}
+    for name, entry in rules.items():
+        if not isinstance(entry, Mapping) or "scenarios" not in entry:
+            raise ConfigError(f"rule {name!r} has no 'scenarios' list")
+        scored: dict[str, bool] = rule_results(
+            _rule_scenarios(entry), args.mechanism, min_score=args.min_score
+        )
+        for sid, passed in scored.items():
+            out[f"{name}::{sid}"] = passed
+    return out
+
+
+def _extract_rule(payload: object, args: argparse.Namespace) -> dict[str, bool]:
+    # eval-rule-activation.py --output writes {"rules": {name: {...}}}. A bare
+    # scenario array and a {"scenarios": [...]} wrapper are also accepted so a
+    # caller can gate one rule without the envelope.
+    if isinstance(payload, dict) and "rules" in payload:
+        return _extract_rules_envelope(payload["rules"], args)
     # Annotated locals here and below: the sibling modules are imported by
     # path (this file is a hyphenated script), so mypy resolves them as Any
     # under ignore_missing_imports. The annotation restates the contract the
     # tests already enforce.
-    extracted: dict[str, bool] = rule_results(scenarios, args.mechanism, min_score=args.min_score)
+    extracted: dict[str, bool] = rule_results(
+        _rule_scenarios(payload), args.mechanism, min_score=args.min_score
+    )
     return extracted
 
 
@@ -219,6 +256,11 @@ def cmd_budget(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def _group_ids(split: dict[str, Any], group: str) -> list[str]:
+    ids: list[str] = list(split[group])
+    return ids
+
+
 def _score_group(results: dict[str, bool], split: dict[str, Any], group: str) -> float:
     try:
         fraction: float = score(results, split[group])
@@ -265,9 +307,36 @@ def cmd_apply(args: argparse.Namespace) -> int:
 
 def cmd_gate(args: argparse.Namespace) -> int:
     split = _read_split(args.split)
-    incumbent = _score_group(_read_results(args.incumbent), split, args.group)
-    candidate = _score_group(_read_results(args.candidate), split, args.group)
+
+    # Guards first, scoring second. Both refusals are decidable from
+    # bookkeeping alone, and scoring before asking would read the held-out
+    # group to produce a verdict that says the held-out group must not be read.
+    refusal = guard_refusal(
+        sel_consultations=args.consultations,
+        max_consultations=args.max_consultations,
+        split_fingerprint=split["fingerprint"],
+        incumbent_fingerprint=args.incumbent_fingerprint,
+    )
+    if refusal is not None:
+        _emit(
+            {
+                "decision": "REJECT",
+                "reason": refusal,
+                "sel_consultations": args.consultations,
+                "compared": False,
+                "group": _GATE_GROUP,
+                "fingerprint": split["fingerprint"],
+            }
+        )
+        return EXIT_LOGIC
+
+    incumbent_results = _read_results(args.incumbent)
+    candidate_results = _read_results(args.candidate)
+    sel_ids = _group_ids(split, _GATE_GROUP)
+    incumbent = _score_group(incumbent_results, split, _GATE_GROUP)
+    candidate = _score_group(candidate_results, split, _GATE_GROUP)
     try:
+        gain, loss, p_value = mcnemar_exact(incumbent_results, candidate_results, sel_ids)
         result = gate(
             candidate,
             incumbent,
@@ -275,6 +344,8 @@ def cmd_gate(args: argparse.Namespace) -> int:
             max_consultations=args.max_consultations,
             split_fingerprint=split["fingerprint"],
             incumbent_fingerprint=args.incumbent_fingerprint,
+            discordant_loss=loss,
+            allow_regressions=args.allow_regressions,
         )
     except ValueError as exc:
         raise ConfigError(str(exc)) from exc
@@ -284,12 +355,20 @@ def cmd_gate(args: argparse.Namespace) -> int:
             "reason": result.reason,
             "candidate": result.candidate,
             "incumbent": result.incumbent,
+            # Discordant pairs are the only tasks that carry evidence about the
+            # edit. p is the one-sided exact McNemar tail, reported rather than
+            # enforced: a three-task held-out group cannot reach 0.05, so
+            # enforcing a conventional floor would make the common case
+            # unpassable instead of informative.
+            "discordant_gain": gain,
+            "discordant_loss": loss,
+            "p_value": p_value,
             # What to pass as --consultations next time. A refusal that never
             # weighed the scores costs the held-out split nothing, so it does
             # not advance the counter.
             "sel_consultations": args.consultations + (1 if result.compared else 0),
             "compared": result.compared,
-            "group": args.group,
+            "group": _GATE_GROUP,
             "fingerprint": split["fingerprint"],
         }
     )
@@ -398,10 +477,16 @@ def build_parser() -> argparse.ArgumentParser:
     gate_cmd.add_argument("--incumbent", type=Path, required=True)
     gate_cmd.add_argument("--candidate", type=Path, required=True)
     gate_cmd.add_argument("--split", type=Path, required=True)
-    gate_cmd.add_argument("--group", default="sel", choices=_GROUPS)
+    # No --group. A gate reads the held-out group by definition, and offering
+    # the choice let a caller gate on the group it had already optimized against.
     gate_cmd.add_argument("--consultations", type=int, default=0)
     gate_cmd.add_argument("--max-consultations", type=int, default=None)
     gate_cmd.add_argument("--incumbent-fingerprint", default=None)
+    gate_cmd.add_argument(
+        "--allow-regressions",
+        action="store_true",
+        help="accept a net gain that still breaks a passing held-out task",
+    )
     gate_cmd.set_defaults(func=cmd_gate)
 
     check = sub.add_parser("buffer-check", help="has this edit already been rejected")

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -82,6 +82,14 @@ class ConfigError(Exception):
     """Input was unreadable or malformed. Maps to exit 2."""
 
 
+class LedgerMismatchError(Exception):
+    """The ledger belongs to a different split. A decision, not a crash."""
+
+    def __init__(self, recorded: str) -> None:
+        super().__init__(recorded)
+        self.recorded = recorded
+
+
 def _emit(payload: object) -> None:
     print(json.dumps(payload, indent=2, sort_keys=True))
 
@@ -365,6 +373,54 @@ def cmd_apply(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _read_ledger(path: Path, fingerprint: str) -> int:
+    """Return the consultations already spent against this split.
+
+    The count lives here rather than on the command line because a budget the
+    caller supplies is not a budget: passing zero every time yields an
+    unlimited one while still looking capped. The ledger is bound to the split
+    fingerprint so an old ledger cannot be paired with a fresh split, which
+    would reset the count by redrawing rather than by editing a number.
+    """
+    if not path.exists():
+        return 0
+    data = _read_json(path)
+    if not isinstance(data, Mapping):
+        raise ConfigError(f"{path} must hold a JSON object")
+    spent = data.get("consultations")
+    if not isinstance(spent, int) or isinstance(spent, bool) or spent < 0:
+        raise ConfigError(f"{path} consultations must be a non-negative integer")
+    recorded = data.get("fingerprint")
+    if recorded != fingerprint:
+        raise LedgerMismatchError(str(recorded))
+    return spent
+
+
+def _write_ledger(path: Path, fingerprint: str, spent: int) -> None:
+    payload = {"consultations": spent, "fingerprint": fingerprint}
+    _write_atomic(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _guard(args: argparse.Namespace, split: Mapping[str, Any], spent: int) -> str | None:
+    """Ask whether a comparison may happen, reporting nonsense input cleanly.
+
+    ``guard_refusal`` raises on a cap below one rather than treating it as a
+    permanently exhausted budget. That is a caller mistake, not a gate verdict,
+    so it becomes a config error instead of a REJECT that would read as real
+    discipline.
+    """
+    try:
+        refusal: str | None = guard_refusal(
+            sel_consultations=spent,
+            max_consultations=args.max_consultations,
+            split_fingerprint=split["fingerprint"],
+            incumbent_fingerprint=args.incumbent_fingerprint,
+        )
+        return refusal
+    except ValueError as exc:
+        raise ConfigError(str(exc)) from exc
+
+
 def cmd_gate(args: argparse.Namespace) -> int:
     split = _read_split(args.split)
     if _split_drifted(split):
@@ -376,26 +432,37 @@ def cmd_gate(args: argparse.Namespace) -> int:
                     "contents; the groups or the seed were edited after the "
                     "split was drawn. Re-split and re-baseline."
                 ),
-                "consultations": args.consultations,
+                "consultations": 0,
             }
         )
         return EXIT_OK
 
+    try:
+        spent = _read_ledger(args.ledger, split["fingerprint"])
+    except LedgerMismatchError as exc:
+        _emit(
+            {
+                "decision": "REJECT",
+                "reason": (
+                    f"ledger {args.ledger} records fingerprint {exc.recorded} but "
+                    f"this split is {split['fingerprint']}; a ledger and a split "
+                    f"that disagree mean the split was redrawn mid-run"
+                ),
+                "compared": False,
+            }
+        )
+        return EXIT_LOGIC
+
     # Guards first, scoring second. Both refusals are decidable from
     # bookkeeping alone, and scoring before asking would read the held-out
     # group to produce a verdict that says the held-out group must not be read.
-    refusal = guard_refusal(
-        sel_consultations=args.consultations,
-        max_consultations=args.max_consultations,
-        split_fingerprint=split["fingerprint"],
-        incumbent_fingerprint=args.incumbent_fingerprint,
-    )
+    refusal = _guard(args, split, spent)
     if refusal is not None:
         _emit(
             {
                 "decision": "REJECT",
                 "reason": refusal,
-                "sel_consultations": args.consultations,
+                "sel_consultations": spent,
                 "compared": False,
                 "group": _GATE_GROUP,
                 "fingerprint": split["fingerprint"],
@@ -408,19 +475,24 @@ def cmd_gate(args: argparse.Namespace) -> int:
     sel_ids = _group_ids(split, _GATE_GROUP)
     incumbent = _score_group(incumbent_results, split, _GATE_GROUP)
     candidate = _score_group(candidate_results, split, _GATE_GROUP)
-    try:
-        gain, loss, p_value = mcnemar_exact(incumbent_results, candidate_results, sel_ids)
-        result = gate(
-            candidate,
-            incumbent,
-            sel_consultations=args.consultations,
-            max_consultations=args.max_consultations,
-            split_fingerprint=split["fingerprint"],
-            incumbent_fingerprint=args.incumbent_fingerprint,
-            discordant_loss=loss,
-        )
-    except ValueError as exc:
-        raise ConfigError(str(exc)) from exc
+    gain, loss, p_value = mcnemar_exact(incumbent_results, candidate_results, sel_ids)
+    result = gate(
+        candidate,
+        incumbent,
+        sel_consultations=spent,
+        max_consultations=args.max_consultations,
+        split_fingerprint=split["fingerprint"],
+        incumbent_fingerprint=args.incumbent_fingerprint,
+        discordant_loss=loss,
+    )
+
+    # A refusal that never weighed the scores costs the held-out split
+    # nothing, so it does not advance the counter. Everything else does, and
+    # the gate writes it rather than telling the caller what to pass next.
+    spent_after = spent + (1 if result.compared else 0)
+    if result.compared:
+        _write_ledger(args.ledger, split["fingerprint"], spent_after)
+
     _emit(
         {
             "decision": result.decision,
@@ -435,10 +507,7 @@ def cmd_gate(args: argparse.Namespace) -> int:
             "discordant_gain": gain,
             "discordant_loss": loss,
             "p_value": p_value,
-            # What to pass as --consultations next time. A refusal that never
-            # weighed the scores costs the held-out split nothing, so it does
-            # not advance the counter.
-            "sel_consultations": args.consultations + (1 if result.compared else 0),
+            "sel_consultations": spent_after,
             "compared": result.compared,
             "group": _GATE_GROUP,
             "fingerprint": split["fingerprint"],
@@ -586,7 +655,12 @@ def build_parser() -> argparse.ArgumentParser:
     gate_cmd.add_argument("--split", type=Path, required=True)
     # No --group. A gate reads the held-out group by definition, and offering
     # the choice let a caller gate on the group it had already optimized against.
-    gate_cmd.add_argument("--consultations", type=int, default=0)
+    gate_cmd.add_argument(
+        "--ledger",
+        type=Path,
+        required=True,
+        help="file the gate keeps the consultation count in; created on first use",
+    )
     gate_cmd.add_argument("--max-consultations", type=int, default=None)
     gate_cmd.add_argument("--incumbent-fingerprint", default=None)
     gate_cmd.set_defaults(func=cmd_gate)
@@ -615,11 +689,15 @@ def main(argv: list[str] | None = None) -> int:
         # argparse.Namespace attributes are Any; every registered handler
         # returns an exit code.
         exit_code: int = args.func(args)
-    except (ConfigError, AdapterError) as exc:
+    except (ConfigError, AdapterError, ValueError) as exc:
         # JSON, not a bare message, because the module docstring promises a
         # caller can tell a REJECT from a config failure by reading a field
         # rather than guessing from the exit code. A plain-text error breaks
         # that promise for any driver piping stdout through a JSON reader.
+        #
+        # ValueError joins them so the core's own validation surfaces the same
+        # way. Wrapping one call site left the policy in two places and the
+        # wrapper unreachable once its inputs were validated upstream.
         _emit({"error": str(exc), "type": type(exc).__name__})
         return EXIT_CONFIG
     return exit_code

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -1,0 +1,750 @@
+"""Tests for scripts/eval/optimize-artifact.py (issue #3422).
+
+The CLI is the surface an optimizing agent drives. Its job is to make the
+held-out discipline mechanical: the agent proposes edits, the CLI decides
+whether they survive, and the agent cannot reach the accept decision without
+going through a split it did not choose.
+
+The safety property worth testing hardest is that `gate` scores both sides
+itself from the split's `sel` group. If the gate took bare numbers, the
+easiest mistake in the whole loop would be handing it optimize-set scores,
+which is precisely the overfitting the gate exists to stop.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_EVAL_DIR = Path(__file__).resolve().parents[2] / "scripts" / "eval"
+# Scope the sys.path mutation to the module load and remove it afterward so it
+# does not leak into other tests (mirrors tests/eval/test_variance_control.py).
+_path_added = str(_EVAL_DIR) not in sys.path
+try:
+    if _path_added:
+        sys.path.insert(0, str(_EVAL_DIR))
+    _SCRIPT = _EVAL_DIR / "optimize-artifact.py"
+    _spec = importlib.util.spec_from_file_location("optimize_artifact", _SCRIPT)
+    assert _spec is not None and _spec.loader is not None
+    oa = importlib.util.module_from_spec(_spec)
+    sys.modules["optimize_artifact"] = oa
+    _spec.loader.exec_module(oa)
+finally:
+    if _path_added and str(_EVAL_DIR) in sys.path:
+        sys.path.remove(str(_EVAL_DIR))
+
+
+EXIT_OK = 0
+EXIT_LOGIC = 1
+EXIT_CONFIG = 2
+
+
+def _run(capsys, *argv: str) -> tuple[int, dict]:
+    """Invoke the CLI and return (exit code, parsed stdout JSON)."""
+    code = oa.main([str(a) for a in argv])
+    out = capsys.readouterr().out.strip()
+    return code, (json.loads(out) if out else {})
+
+
+def _write(tmp_path: Path, name: str, payload: object) -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _results(passing: int, failing: int) -> dict:
+    out = {f"p{i}": True for i in range(passing)}
+    out.update({f"f{i}": False for i in range(failing)})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# extract
+# ---------------------------------------------------------------------------
+
+
+class TestExtract:
+    def test_agent_report(self, tmp_path, capsys):
+        report = _write(
+            tmp_path,
+            "report.json",
+            {"per_fixture_pass_rates": {"C1": {"agent": [1.0]}, "C2": {"agent": [0.0]}}},
+        )
+        code, out = _run(capsys, "extract", "--kind", "agent", "--input", report)
+        assert code == EXIT_OK
+        assert out == {"C1": True, "C2": False}
+
+    def test_agent_report_honors_variant_and_threshold(self, tmp_path, capsys):
+        report = _write(
+            tmp_path,
+            "report.json",
+            {"per_fixture_pass_rates": {"C1": {"baseline": [0.6]}}},
+        )
+        code, out = _run(
+            capsys,
+            "extract",
+            "--kind",
+            "agent",
+            "--input",
+            report,
+            "--variant",
+            "baseline",
+            "--pass-threshold",
+            "0.5",
+        )
+        assert code == EXIT_OK
+        assert out == {"C1": True}
+
+    def test_rule_scenarios(self, tmp_path, capsys):
+        scenarios = _write(
+            tmp_path,
+            "scen.json",
+            [
+                {
+                    "id": "S1",
+                    "negative_case": False,
+                    "mechanisms": {
+                        "full": {
+                            "scores": {
+                                "activation_score": 5,
+                                "citation_score": 5,
+                                "behavior_score": 5,
+                            }
+                        }
+                    },
+                }
+            ],
+        )
+        code, out = _run(capsys, "extract", "--kind", "rule", "--input", scenarios)
+        assert code == EXIT_OK
+        assert out == {"S1": True}
+
+    def test_rule_scenarios_accept_a_wrapped_object(self, tmp_path, capsys):
+        """eval-rule-activation.py nests scenarios under a top-level key."""
+        scenarios = _write(
+            tmp_path,
+            "scen.json",
+            {
+                "scenarios": [
+                    {
+                        "id": "S1",
+                        "negative_case": False,
+                        "mechanisms": {"full": {"scores": {"activation_score": 5}}},
+                    }
+                ]
+            },
+        )
+        code, out = _run(capsys, "extract", "--kind", "rule", "--input", scenarios)
+        assert code == EXIT_OK
+        assert out == {"S1": False}
+
+    def test_hook_junit(self, tmp_path, capsys):
+        junit = tmp_path / "j.xml"
+        junit.write_text(
+            "<testsuites><testsuite>"
+            "<testcase classname='tests.test_a' name='test_x'/>"
+            "<testcase classname='tests.test_a' name='test_y'><failure/></testcase>"
+            "</testsuite></testsuites>",
+            encoding="utf-8",
+        )
+        code, out = _run(capsys, "extract", "--kind", "hook", "--input", junit)
+        assert code == EXIT_OK
+        assert out == {"tests.test_a::test_x": True, "tests.test_a::test_y": False}
+
+    def test_missing_input_is_a_config_error(self, tmp_path, capsys):
+        code, _ = _run(capsys, "extract", "--kind", "agent", "--input", tmp_path / "nope.json")
+        assert code == EXIT_CONFIG
+
+    def test_malformed_json_is_a_config_error(self, tmp_path, capsys):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json", encoding="utf-8")
+        code, _ = _run(capsys, "extract", "--kind", "agent", "--input", bad)
+        assert code == EXIT_CONFIG
+
+    def test_adapter_rejection_is_a_config_error(self, tmp_path, capsys):
+        report = _write(tmp_path, "report.json", {"wrong": "shape"})
+        code, _ = _run(capsys, "extract", "--kind", "agent", "--input", report)
+        assert code == EXIT_CONFIG
+
+    def test_non_object_agent_report_is_a_config_error(self, tmp_path, capsys):
+        report = _write(tmp_path, "report.json", ["not", "an", "object"])
+        code, _ = _run(capsys, "extract", "--kind", "agent", "--input", report)
+        assert code == EXIT_CONFIG
+
+    def test_non_array_rule_input_is_a_config_error(self, tmp_path, capsys):
+        scenarios = _write(tmp_path, "scen.json", {"scenarios": "not a list"})
+        code, _ = _run(capsys, "extract", "--kind", "rule", "--input", scenarios)
+        assert code == EXIT_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# split
+# ---------------------------------------------------------------------------
+
+
+class TestSplit:
+    def test_partitions_every_task(self, tmp_path, capsys):
+        results = _write(tmp_path, "r.json", _results(6, 4))
+        code, out = _run(capsys, "split", "--results", results, "--seed", "s1")
+        assert code == EXIT_OK
+        assert sorted(out["opt"] + out["sel"] + out["test"]) == sorted(_results(6, 4))
+        assert out["fingerprint"]
+
+    def test_is_deterministic_for_a_seed(self, tmp_path, capsys):
+        results = _write(tmp_path, "r.json", _results(6, 4))
+        _, first = _run(capsys, "split", "--results", results, "--seed", "s1")
+        _, second = _run(capsys, "split", "--results", results, "--seed", "s1")
+        assert first == second
+
+    def test_seed_changes_the_split(self, tmp_path, capsys):
+        results = _write(tmp_path, "r.json", _results(6, 4))
+        _, first = _run(capsys, "split", "--results", results, "--seed", "s1")
+        _, second = _run(capsys, "split", "--results", results, "--seed", "s2")
+        assert first["fingerprint"] != second["fingerprint"]
+
+    def test_reads_a_plain_task_id_list(self, tmp_path, capsys):
+        tasks = tmp_path / "ids.txt"
+        tasks.write_text("\n".join(f"t{i}" for i in range(10)) + "\n", encoding="utf-8")
+        code, out = _run(capsys, "split", "--tasks", tasks, "--seed", "s1")
+        assert code == EXIT_OK
+        assert len(out["opt"] + out["sel"] + out["test"]) == 10
+
+    def test_blank_lines_in_a_task_list_are_ignored(self, tmp_path, capsys):
+        tasks = tmp_path / "ids.txt"
+        tasks.write_text("t0\n\n  \nt1\nt2\nt3\nt4\nt5\nt6\nt7\n", encoding="utf-8")
+        code, out = _run(capsys, "split", "--tasks", tasks, "--seed", "s1")
+        assert code == EXIT_OK
+        assert len(out["opt"] + out["sel"] + out["test"]) == 8
+
+    def test_too_few_tasks_is_a_config_error(self, tmp_path, capsys):
+        results = _write(tmp_path, "r.json", _results(2, 0))
+        code, _ = _run(capsys, "split", "--results", results, "--seed", "s1")
+        assert code == EXIT_CONFIG
+
+    def test_requires_a_task_source(self, capsys):
+        with pytest.raises(SystemExit):
+            oa.main(["split", "--seed", "s1"])
+
+    def test_rejects_both_task_sources(self, tmp_path, capsys):
+        results = _write(tmp_path, "r.json", _results(6, 4))
+        with pytest.raises(SystemExit):
+            oa.main(["split", "--results", str(results), "--tasks", "x", "--seed", "s"])
+
+
+# ---------------------------------------------------------------------------
+# budget
+# ---------------------------------------------------------------------------
+
+
+class TestBudget:
+    def test_first_step_gets_the_maximum(self, capsys):
+        code, out = _run(capsys, "budget", "--step", "0", "--total", "10")
+        assert code == EXIT_OK
+        assert out["budget"] == 5
+
+    def test_last_step_gets_the_minimum(self, capsys):
+        code, out = _run(capsys, "budget", "--step", "10", "--total", "10")
+        assert code == EXIT_OK
+        assert out["budget"] == 1
+
+    def test_decays_monotonically(self, capsys):
+        seen = [
+            _run(capsys, "budget", "--step", str(s), "--total", "8")[1]["budget"]
+            for s in range(9)
+        ]
+        assert seen == sorted(seen, reverse=True)
+
+    def test_custom_bounds(self, capsys):
+        code, out = _run(
+            capsys, "budget", "--step", "0", "--total", "4", "--max-edits", "9", "--min-edits", "2"
+        )
+        assert code == EXIT_OK
+        assert out["budget"] == 9
+
+    def test_invalid_bounds_are_a_config_error(self, capsys):
+        code, _ = _run(
+            capsys, "budget", "--step", "0", "--total", "4", "--max-edits", "1", "--min-edits", "3"
+        )
+        assert code == EXIT_CONFIG
+
+    def test_zero_total_is_a_config_error(self, capsys):
+        code, _ = _run(capsys, "budget", "--step", "0", "--total", "0")
+        assert code == EXIT_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# score
+# ---------------------------------------------------------------------------
+
+
+class TestScore:
+    def _split_file(self, tmp_path, capsys, results_path) -> Path:
+        _, split = _run(capsys, "split", "--results", results_path, "--seed", "s1")
+        return _write(tmp_path, "split.json", split)
+
+    def test_scores_the_sel_group_by_default(self, tmp_path, capsys):
+        results = _write(tmp_path, "r.json", _results(10, 0))
+        split = self._split_file(tmp_path, capsys, results)
+        code, out = _run(capsys, "score", "--results", results, "--split", split)
+        assert code == EXIT_OK
+        assert out["score"] == 1.0
+        assert out["group"] == "sel"
+        assert out["n"] > 0
+
+    def test_scores_a_named_group(self, tmp_path, capsys):
+        results = _write(tmp_path, "r.json", _results(0, 10))
+        split = self._split_file(tmp_path, capsys, results)
+        code, out = _run(capsys, "score", "--results", results, "--split", split, "--group", "opt")
+        assert code == EXIT_OK
+        assert out["score"] == 0.0
+
+    def test_missing_result_is_a_config_error(self, tmp_path, capsys):
+        results = _write(tmp_path, "r.json", _results(10, 0))
+        split = self._split_file(tmp_path, capsys, results)
+        truncated = _write(tmp_path, "trunc.json", {"p0": True})
+        code, _ = _run(capsys, "score", "--results", truncated, "--split", split)
+        assert code == EXIT_CONFIG
+
+    def test_unknown_group_is_rejected(self, tmp_path, capsys):
+        results = _write(tmp_path, "r.json", _results(10, 0))
+        split = self._split_file(tmp_path, capsys, results)
+        with pytest.raises(SystemExit):
+            oa.main(["score", "--results", str(results), "--split", str(split), "--group", "nope"])
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+class TestApply:
+    def test_appends_in_place(self, tmp_path, capsys):
+        target = tmp_path / "a.md"
+        target.write_text("line one\n", encoding="utf-8")
+        patches = _write(tmp_path, "p.json", [{"op": "append", "text": "line two"}])
+        code, out = _run(capsys, "apply", "--file", target, "--patches", patches, "--budget", "1")
+        assert code == EXIT_OK
+        assert target.read_text(encoding="utf-8") == "line one\nline two\n"
+        assert out["applied"] == 1
+
+    def test_dry_run_leaves_the_file_alone(self, tmp_path, capsys):
+        target = tmp_path / "a.md"
+        target.write_text("line one\n", encoding="utf-8")
+        patches = _write(tmp_path, "p.json", [{"op": "append", "text": "line two"}])
+        code, out = _run(
+            capsys, "apply", "--file", target, "--patches", patches, "--budget", "1", "--dry-run"
+        )
+        assert code == EXIT_OK
+        assert target.read_text(encoding="utf-8") == "line one\n"
+        assert "line two" in out["result"]
+
+    def test_over_budget_is_a_logic_error(self, tmp_path, capsys):
+        target = tmp_path / "a.md"
+        target.write_text("line one\n", encoding="utf-8")
+        patches = _write(
+            tmp_path,
+            "p.json",
+            [{"op": "append", "text": "a"}, {"op": "append", "text": "b"}],
+        )
+        code, _ = _run(capsys, "apply", "--file", target, "--patches", patches, "--budget", "1")
+        assert code == EXIT_LOGIC
+        assert target.read_text(encoding="utf-8") == "line one\n"
+
+    def test_protected_section_edit_is_a_logic_error(self, tmp_path, capsys):
+        target = tmp_path / "a.md"
+        target.write_text(
+            "<!-- SLOW_UPDATE_START -->\nrails\n<!-- SLOW_UPDATE_END -->\ntail\n",
+            encoding="utf-8",
+        )
+        patches = _write(tmp_path, "p.json", [{"op": "delete", "anchor": "rails"}])
+        code, _ = _run(capsys, "apply", "--file", target, "--patches", patches, "--budget", "1")
+        assert code == EXIT_LOGIC
+        assert "rails" in target.read_text(encoding="utf-8")
+
+    def test_unknown_anchor_is_a_logic_error(self, tmp_path, capsys):
+        target = tmp_path / "a.md"
+        target.write_text("line one\n", encoding="utf-8")
+        patches = _write(
+            tmp_path, "p.json", [{"op": "insert_after", "anchor": "ghost", "text": "x"}]
+        )
+        code, _ = _run(capsys, "apply", "--file", target, "--patches", patches, "--budget", "1")
+        assert code == EXIT_LOGIC
+
+    def test_malformed_patch_shape_is_a_config_error(self, tmp_path, capsys):
+        target = tmp_path / "a.md"
+        target.write_text("line one\n", encoding="utf-8")
+        patches = _write(tmp_path, "p.json", [{"text": "no op key"}])
+        code, _ = _run(capsys, "apply", "--file", target, "--patches", patches, "--budget", "1")
+        assert code == EXIT_CONFIG
+
+    def test_patches_must_be_a_list(self, tmp_path, capsys):
+        target = tmp_path / "a.md"
+        target.write_text("line one\n", encoding="utf-8")
+        patches = _write(tmp_path, "p.json", {"op": "append", "text": "x"})
+        code, _ = _run(capsys, "apply", "--file", target, "--patches", patches, "--budget", "1")
+        assert code == EXIT_CONFIG
+
+    def test_missing_target_is_a_config_error(self, tmp_path, capsys):
+        patches = _write(tmp_path, "p.json", [{"op": "append", "text": "x"}])
+        code, _ = _run(
+            capsys, "apply", "--file", tmp_path / "ghost.md", "--patches", patches, "--budget", "1"
+        )
+        assert code == EXIT_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# gate
+# ---------------------------------------------------------------------------
+
+
+class TestGate:
+    def _setup(self, tmp_path, capsys, incumbent: dict, candidate: dict):
+        inc = _write(tmp_path, "inc.json", incumbent)
+        cand = _write(tmp_path, "cand.json", candidate)
+        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        return inc, cand, _write(tmp_path, "split.json", split), split
+
+    def test_accepts_a_strict_improvement(self, tmp_path, capsys):
+        inc, cand, split_path, split = self._setup(
+            tmp_path,
+            capsys,
+            {f"t{i}": False for i in range(10)},
+            {f"t{i}": True for i in range(10)},
+        )
+        code, out = _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        )
+        assert code == EXIT_OK
+        assert out["decision"] == "ACCEPT"
+        assert out["candidate"] > out["incumbent"]
+
+    def test_rejects_a_tie(self, tmp_path, capsys):
+        same = {f"t{i}": True for i in range(10)}
+        inc, cand, split_path, _ = self._setup(tmp_path, capsys, same, dict(same))
+        code, out = _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        )
+        assert code == EXIT_LOGIC
+        assert out["decision"] == "REJECT"
+        assert "tie" in out["reason"]
+
+    def test_rejects_a_regression(self, tmp_path, capsys):
+        inc, cand, split_path, _ = self._setup(
+            tmp_path,
+            capsys,
+            {f"t{i}": True for i in range(10)},
+            {f"t{i}": False for i in range(10)},
+        )
+        code, out = _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        )
+        assert code == EXIT_LOGIC
+        assert "regress" in out["reason"]
+
+    def test_scores_the_held_out_group_not_the_optimize_group(self, tmp_path, capsys):
+        """The candidate wins only on opt tasks, so the gate must reject it."""
+        inc = _write(tmp_path, "inc.json", {f"t{i}": False for i in range(10)})
+        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        split_path = _write(tmp_path, "split.json", split)
+        candidate = {t: True for t in split["opt"]}
+        candidate.update({t: False for t in split["sel"] + split["test"]})
+        cand = _write(tmp_path, "cand.json", candidate)
+        code, out = _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        )
+        assert code == EXIT_LOGIC
+        assert out["candidate"] == 0.0
+
+    def test_refuses_when_the_split_moved(self, tmp_path, capsys):
+        inc, cand, split_path, split = self._setup(
+            tmp_path,
+            capsys,
+            {f"t{i}": False for i in range(10)},
+            {f"t{i}": True for i in range(10)},
+        )
+        code, out = _run(
+            capsys,
+            "gate",
+            "--incumbent",
+            inc,
+            "--candidate",
+            cand,
+            "--split",
+            split_path,
+            "--incumbent-fingerprint",
+            "stale-fingerprint",
+        )
+        assert code == EXIT_LOGIC
+        assert "fingerprint" in out["reason"]
+
+    def test_accepts_when_the_fingerprint_matches(self, tmp_path, capsys):
+        inc, cand, split_path, split = self._setup(
+            tmp_path,
+            capsys,
+            {f"t{i}": False for i in range(10)},
+            {f"t{i}": True for i in range(10)},
+        )
+        code, out = _run(
+            capsys,
+            "gate",
+            "--incumbent",
+            inc,
+            "--candidate",
+            cand,
+            "--split",
+            split_path,
+            "--incumbent-fingerprint",
+            split["fingerprint"],
+        )
+        assert code == EXIT_OK
+        assert out["decision"] == "ACCEPT"
+
+    def test_refuses_once_consultations_are_exhausted(self, tmp_path, capsys):
+        inc, cand, split_path, _ = self._setup(
+            tmp_path,
+            capsys,
+            {f"t{i}": False for i in range(10)},
+            {f"t{i}": True for i in range(10)},
+        )
+        code, out = _run(
+            capsys,
+            "gate",
+            "--incumbent",
+            inc,
+            "--candidate",
+            cand,
+            "--split",
+            split_path,
+            "--consultations",
+            "5",
+            "--max-consultations",
+            "5",
+        )
+        assert code == EXIT_LOGIC
+        assert "exhaust" in out["reason"]
+
+    def test_reports_the_incremented_consultation_count(self, tmp_path, capsys):
+        inc, cand, split_path, _ = self._setup(
+            tmp_path,
+            capsys,
+            {f"t{i}": False for i in range(10)},
+            {f"t{i}": True for i in range(10)},
+        )
+        code, out = _run(
+            capsys,
+            "gate",
+            "--incumbent",
+            inc,
+            "--candidate",
+            cand,
+            "--split",
+            split_path,
+            "--consultations",
+            "2",
+        )
+        assert code == EXIT_OK
+        assert out["sel_consultations"] == 3
+
+    def test_a_fingerprint_refusal_does_not_burn_a_consultation(self, tmp_path, capsys):
+        inc, cand, split_path, _ = self._setup(
+            tmp_path,
+            capsys,
+            {f"t{i}": False for i in range(10)},
+            {f"t{i}": True for i in range(10)},
+        )
+        code, out = _run(
+            capsys,
+            "gate",
+            "--incumbent",
+            inc,
+            "--candidate",
+            cand,
+            "--split",
+            split_path,
+            "--consultations",
+            "2",
+            "--incumbent-fingerprint",
+            "stale",
+        )
+        assert code == EXIT_LOGIC
+        assert out["sel_consultations"] == 2
+        assert out["compared"] is False
+
+    def test_missing_candidate_result_is_a_config_error(self, tmp_path, capsys):
+        inc, _, split_path, _ = self._setup(
+            tmp_path,
+            capsys,
+            {f"t{i}": False for i in range(10)},
+            {f"t{i}": True for i in range(10)},
+        )
+        truncated = _write(tmp_path, "trunc.json", {"t0": True})
+        code, _out = _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", truncated, "--split", split_path
+        )
+        assert code == EXIT_CONFIG
+
+    def test_malformed_split_is_a_config_error(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": False for i in range(10)})
+        bad_split = _write(tmp_path, "split.json", {"opt": ["t0"]})
+        code, _ = _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", inc, "--split", bad_split
+        )
+        assert code == EXIT_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# buffer
+# ---------------------------------------------------------------------------
+
+
+class TestBuffer:
+    def test_novel_patch_passes_the_check(self, tmp_path, capsys):
+        buffer = _write(tmp_path, "b.json", [])
+        patches = _write(tmp_path, "p.json", [{"op": "append", "text": "x"}])
+        code, out = _run(capsys, "buffer-check", "--buffer", buffer, "--patches", patches)
+        assert code == EXIT_OK
+        assert out["seen"] is False
+
+    def test_missing_buffer_file_is_treated_as_empty(self, tmp_path, capsys):
+        patches = _write(tmp_path, "p.json", [{"op": "append", "text": "x"}])
+        code, out = _run(
+            capsys, "buffer-check", "--buffer", tmp_path / "none.json", "--patches", patches
+        )
+        assert code == EXIT_OK
+        assert out["seen"] is False
+
+    def test_add_then_check_reports_seen(self, tmp_path, capsys):
+        buffer = tmp_path / "b.json"
+        patches = _write(tmp_path, "p.json", [{"op": "append", "text": "x"}])
+        code, _ = _run(
+            capsys, "buffer-add", "--buffer", buffer, "--patches", patches, "--reason", "regressed"
+        )
+        assert code == EXIT_OK
+        code, out = _run(capsys, "buffer-check", "--buffer", buffer, "--patches", patches)
+        assert code == EXIT_LOGIC
+        assert out["seen"] is True
+
+    def test_reflowed_patch_still_matches(self, tmp_path, capsys):
+        """Whitespace-only rewording must not smuggle a rejected edit back in."""
+        buffer = tmp_path / "b.json"
+        original = _write(tmp_path, "p.json", [{"op": "append", "text": "alpha beta"}])
+        reflowed = _write(tmp_path, "p2.json", [{"op": "append", "text": "alpha   \n beta"}])
+        _run(capsys, "buffer-add", "--buffer", buffer, "--patches", original, "--reason", "no")
+        code, out = _run(capsys, "buffer-check", "--buffer", buffer, "--patches", reflowed)
+        assert code == EXIT_LOGIC
+        assert out["seen"] is True
+
+    def test_add_records_the_reason_and_fingerprint(self, tmp_path, capsys):
+        buffer = tmp_path / "b.json"
+        patches = _write(tmp_path, "p.json", [{"op": "append", "text": "x"}])
+        _run(
+            capsys, "buffer-add", "--buffer", buffer, "--patches", patches, "--reason", "regressed"
+        )
+        entries = json.loads(buffer.read_text(encoding="utf-8"))
+        assert len(entries) == 1
+        assert entries[0]["reason"] == "regressed"
+        assert entries[0]["fingerprint"]
+        assert entries[0]["patches"] == [{"op": "append", "anchor": None, "text": "x"}]
+
+    def test_add_appends_rather_than_replacing(self, tmp_path, capsys):
+        buffer = tmp_path / "b.json"
+        first = _write(tmp_path, "p1.json", [{"op": "append", "text": "x"}])
+        second = _write(tmp_path, "p2.json", [{"op": "append", "text": "y"}])
+        _run(capsys, "buffer-add", "--buffer", buffer, "--patches", first, "--reason", "a")
+        _run(capsys, "buffer-add", "--buffer", buffer, "--patches", second, "--reason", "b")
+        assert len(json.loads(buffer.read_text(encoding="utf-8"))) == 2
+
+    def test_add_is_idempotent_for_the_same_patch(self, tmp_path, capsys):
+        buffer = tmp_path / "b.json"
+        patches = _write(tmp_path, "p.json", [{"op": "append", "text": "x"}])
+        _run(capsys, "buffer-add", "--buffer", buffer, "--patches", patches, "--reason", "a")
+        _run(capsys, "buffer-add", "--buffer", buffer, "--patches", patches, "--reason", "a")
+        assert len(json.loads(buffer.read_text(encoding="utf-8"))) == 1
+
+    def test_corrupt_buffer_is_a_config_error(self, tmp_path, capsys):
+        buffer = tmp_path / "b.json"
+        buffer.write_text("{oops", encoding="utf-8")
+        patches = _write(tmp_path, "p.json", [{"op": "append", "text": "x"}])
+        code, _ = _run(capsys, "buffer-check", "--buffer", buffer, "--patches", patches)
+        assert code == EXIT_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDispatch:
+    def test_no_subcommand_exits_nonzero(self, capsys):
+        assert oa.main([]) != EXIT_OK
+
+    def test_unknown_subcommand_exits(self, capsys):
+        with pytest.raises(SystemExit):
+            oa.main(["frobnicate"])
+
+
+# ---------------------------------------------------------------------------
+# malformed inputs
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedInputs:
+    def test_unreadable_json_path_is_a_config_error(self, tmp_path, capsys):
+        """A directory where a file belongs raises OSError, not FileNotFoundError."""
+        code, _ = _run(capsys, "extract", "--kind", "agent", "--input", tmp_path)
+        assert code == EXIT_CONFIG
+
+    def test_unreadable_text_path_is_a_config_error(self, tmp_path, capsys):
+        code, _ = _run(capsys, "extract", "--kind", "hook", "--input", tmp_path)
+        assert code == EXIT_CONFIG
+
+    def test_results_must_be_an_object(self, tmp_path, capsys):
+        results = _write(tmp_path, "r.json", ["t0", "t1"])
+        code, _ = _run(capsys, "split", "--results", results, "--seed", "s1")
+        assert code == EXIT_CONFIG
+
+    def test_results_must_be_boolean_valued(self, tmp_path, capsys):
+        results = _write(tmp_path, "r.json", {"t0": 1, "t1": "yes"})
+        code, _ = _run(capsys, "split", "--results", results, "--seed", "s1")
+        assert code == EXIT_CONFIG
+
+    def test_empty_patch_array_is_a_config_error(self, tmp_path, capsys):
+        target = tmp_path / "a.md"
+        target.write_text("line one\n", encoding="utf-8")
+        patches = _write(tmp_path, "p.json", [])
+        code, _ = _run(capsys, "apply", "--file", target, "--patches", patches, "--budget", "1")
+        assert code == EXIT_CONFIG
+
+    def test_split_must_be_an_object(self, tmp_path, capsys):
+        results = _write(tmp_path, "r.json", _results(10, 0))
+        split = _write(tmp_path, "split.json", ["opt", "sel", "test"])
+        code, _ = _run(capsys, "score", "--results", results, "--split", split)
+        assert code == EXIT_CONFIG
+
+    def test_negative_consultations_is_a_config_error(self, tmp_path, capsys):
+        results = _write(tmp_path, "r.json", _results(10, 0))
+        _, split = _run(capsys, "split", "--results", results, "--seed", "s1")
+        split_path = _write(tmp_path, "split.json", split)
+        code, _ = _run(
+            capsys,
+            "gate",
+            "--incumbent",
+            results,
+            "--candidate",
+            results,
+            "--split",
+            split_path,
+            "--consultations",
+            "-1",
+        )
+        assert code == EXIT_CONFIG
+
+    def test_buffer_must_be_an_array(self, tmp_path, capsys):
+        buffer = _write(tmp_path, "b.json", {"not": "a list"})
+        patches = _write(tmp_path, "p.json", [{"op": "append", "text": "x"}])
+        code, _ = _run(capsys, "buffer-check", "--buffer", buffer, "--patches", patches)
+        assert code == EXIT_CONFIG

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -938,10 +938,10 @@ class TestGate:
             {f"t{i}": True for i in range(10)},
         )
         truncated = _write(tmp_path, "trunc.json", {"t0": True})
-        code, _out = _run_gate(
+        code, out = _run_gate(
             capsys, tmp_path, "--incumbent", inc, "--candidate", truncated, "--split", split_path
         )
-        assert code == EXIT_CONFIG
+        assert (code, out["decision"], out["compared"]) == (EXIT_LOGIC, "REJECT", False)
 
     def test_malformed_split_is_a_config_error(self, tmp_path, capsys):
         inc = _write(tmp_path, "inc.json", {f"t{i}": False for i in range(10)})
@@ -1438,13 +1438,13 @@ class TestConsultationLedgerIsHeldByTheGate:
         assert not ledger.exists()
         assert out["error"]
 
-    def test_a_result_missing_a_held_out_task_is_a_config_error(self, tmp_path, capsys):
+    def test_a_result_missing_a_held_out_task_refuses_without_naming_it(self, tmp_path, capsys):
         """The gate cannot score a held-out task the run never reported.
 
         Distinct from a truncated file: this one parses, covers every task the
         optimizer could see, and is short only on the group the optimizer is
-        not allowed to look at. Reporting it as a config error keeps a partial
-        run from reading as a real verdict.
+        not allowed to look at. It refuses rather than producing a verdict, it
+        does not say which task is missing, and it costs a consultation.
         """
         inc, cand, split, ledger = self._fixture(tmp_path, capsys)
         partition = json.loads(split.read_text(encoding="utf-8"))
@@ -1453,9 +1453,9 @@ class TestConsultationLedgerIsHeldByTheGate:
                  if k != dropped}
         short_path = _write(tmp_path, "short.json", short)
         code, out = self._gate(capsys, inc, short_path, split, ledger)
-        assert code == EXIT_CONFIG
-        assert dropped in out["error"]
-        assert not ledger.exists()
+        assert (code, out["decision"], out["compared"]) == (EXIT_LOGIC, "REJECT", False)
+        assert dropped not in json.dumps(out)
+        assert ledger.exists()
 
 
 class TestTheBudgetCapIsPinnedByTheLedger:
@@ -1723,6 +1723,105 @@ class TestOneGateAtATimePerSplit:
                          "--split", split, "--max-consultations", "3",
                          "--incumbent-fingerprint", fingerprint)
         assert (code, out["decision"]) == (EXIT_OK, "REJECT")
+
+
+class TestTheGateNeverNamesAHeldOutTask:
+    """An error message that lists what is missing lists the held-out group.
+
+    `score` and `mcnemar_exact` both report which task ids they could not find,
+    which is the right message everywhere except here: the ids they would name
+    are the held-out ones. A fourth adversarial review (gpt-5.6-sol,
+    2026-07-26) found that a candidate results file with no keys at all printed
+    the whole membership in a single error, before the ledger advanced, so the
+    reveal was also free. The gate now answers one bit and charges for it.
+    """
+
+    def _fixture(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(12)})
+        _run(capsys, "split", "--results", inc, "--seed", "s1",
+             "--out", tmp_path / "split.json")
+        split = tmp_path / "split.json"
+        record = json.loads(split.read_text(encoding="utf-8"))
+        return inc, split, record
+
+    def _gate(self, capsys, inc, cand, split, record, cap=5):
+        return _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                    "--split", split, "--max-consultations", str(cap),
+                    "--incumbent-fingerprint", record["fingerprint"])
+
+    def test_an_empty_candidate_reveals_no_membership(self, tmp_path, capsys):
+        """The reported attack: ask for everything by supplying nothing."""
+        inc, split, record = self._fixture(tmp_path, capsys)
+        empty = _write(tmp_path, "empty.json", {})
+        code, out = self._gate(capsys, inc, empty, split, record)
+        assert (code, out["compared"]) == (EXIT_LOGIC, False)
+        assert not any(task_id in json.dumps(out) for task_id in record["sel"])
+
+    def test_the_refusal_costs_a_consultation(self, tmp_path, capsys):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        empty = _write(tmp_path, "empty.json", {})
+        _, out = self._gate(capsys, inc, empty, split, record)
+        assert out["sel_consultations"] == 1
+
+    def test_probing_exhausts_the_budget(self, tmp_path, capsys):
+        """A membership oracle has to be expensive, not just quiet."""
+        inc, split, record = self._fixture(tmp_path, capsys)
+        empty = _write(tmp_path, "empty.json", {})
+        for _ in range(2):
+            self._gate(capsys, inc, empty, split, record, cap=2)
+        code, out = self._gate(capsys, inc, empty, split, record, cap=2)
+        assert (code, out["compared"]) == (EXIT_LOGIC, False)
+        assert "exhausted" in out["reason"]
+
+    def test_a_missing_incumbent_result_refuses_the_same_way(self, tmp_path, capsys):
+        """Both sides are read against the held-out group, so both must redact."""
+        inc, split, record = self._fixture(tmp_path, capsys)
+        cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(12)})
+        short = _write(tmp_path, "short-inc.json",
+                       {k: v for k, v in json.loads(Path(inc).read_text(encoding="utf-8")).items()
+                        if k != record["sel"][0]})
+        code, out = self._gate(capsys, short, cand, split, record)
+        assert (code, out["compared"]) == (EXIT_LOGIC, False)
+        assert record["sel"][0] not in json.dumps(out)
+
+    def test_a_non_bool_result_is_refused_before_the_split_is_consulted(self, tmp_path, capsys):
+        """`score` would name the offending task, and that id can be held out.
+
+        It never gets there: `_read_results` rejects a non-boolean at the file
+        boundary, and the ids it echoes are the caller's own keys from the
+        caller's own file, so nothing about the split is disclosed. The check
+        lands before the reserve, so a malformed file of one's own costs no
+        budget. `_covers_holdout` keeps its own type check anyway; a predicate
+        that trusts its caller is one refactor away from leaking again.
+        """
+        inc, split, record = self._fixture(tmp_path, capsys)
+        poisoned = {f"t{i}": True for i in range(12)}
+        poisoned[record["sel"][0]] = "yes"
+        cand = _write(tmp_path, "poison.json", poisoned)
+        code, out = self._gate(capsys, inc, cand, split, record)
+        assert code == EXIT_CONFIG and "non-boolean" in out["error"]
+        assert not oa._ledger_path(oa._holdout_key(record)).exists()
+
+    def test_full_coverage_still_compares(self, tmp_path, capsys):
+        """The redaction must not swallow the ordinary path."""
+        inc, split, record = self._fixture(tmp_path, capsys)
+        cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(12)})
+        code, out = self._gate(capsys, inc, cand, split, record)
+        assert (code, out["compared"]) == (EXIT_OK, True)
+
+    def test_the_predicate_accepts_a_complete_boolean_mapping(self):
+        assert oa._covers_holdout({"a": True, "b": False}, ["a", "b"])
+
+    def test_the_predicate_rejects_a_missing_task(self):
+        assert not oa._covers_holdout({"a": True}, ["a", "b"])
+
+    def test_the_predicate_rejects_a_non_boolean(self):
+        assert not oa._covers_holdout({"a": True, "b": 1}, ["a", "b"])
+
+    def test_the_predicate_accepts_an_empty_requirement(self):
+        """No held-out ids means nothing to cover; the split guard rejects that
+        case earlier, so this only pins the predicate as total."""
+        assert oa._covers_holdout({}, [])
 
 
 class TestTheIncumbentFingerprintIsRequired:

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -63,6 +63,25 @@ def _split(capsys, tmp_path, *args, name="split.json"):
     return code, json.loads(path.read_text(encoding="utf-8"))
 
 
+def _run_gate(capsys, tmp_path, *args, spent=None):
+    """Run `gate`, supplying the ledger it now keeps its own count in.
+
+    The consultation count used to arrive on the command line, which meant a
+    caller that passed zero every time had an unlimited budget. `spent`
+    pre-seeds the ledger for tests that need the gate to believe consultations
+    have already happened.
+    """
+    ledger = tmp_path / "ledger.json"
+    if spent is not None:
+        split_path = args[list(args).index("--split") + 1]
+        split = json.loads(Path(split_path).read_text(encoding="utf-8"))
+        ledger.write_text(
+            json.dumps({"consultations": spent, "fingerprint": split["fingerprint"]}),
+            encoding="utf-8",
+        )
+    return _run(capsys, "gate", *args, "--ledger", ledger)
+
+
 def _boom(*_args, **_kwargs):
     raise OSError("disk full")
 
@@ -539,9 +558,9 @@ class TestGateHoldsOutOnly:
             {f"t{i}": True for i in range(10)},
         )
         with pytest.raises(SystemExit):
-            _run(
+            _run_gate(
                 capsys,
-                "gate",
+                tmp_path,
                 "--incumbent",
                 inc,
                 "--candidate",
@@ -559,8 +578,8 @@ class TestGateHoldsOutOnly:
             {f"t{i}": False for i in range(10)},
             {f"t{i}": True for i in range(10)},
         )
-        _, out = _run(
-            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        _, out = _run_gate(
+            capsys, tmp_path, "--incumbent", inc, "--candidate", cand, "--split", split_path
         )
         assert out["group"] == "sel"
 
@@ -581,19 +600,18 @@ class TestGateRefusalCostsNothing:
 
     def test_an_exhausted_budget_withholds_the_scores(self, tmp_path, capsys):
         inc, cand, split_path, _ = self._setup(tmp_path, capsys)
-        code, out = _run(
+        code, out = _run_gate(
             capsys,
-            "gate",
+            tmp_path,
             "--incumbent",
             inc,
             "--candidate",
             cand,
             "--split",
             split_path,
-            "--consultations",
-            "3",
             "--max-consultations",
             "3",
+            spent=3,
         )
         assert code == EXIT_LOGIC
         assert out["compared"] is False
@@ -602,9 +620,9 @@ class TestGateRefusalCostsNothing:
 
     def test_a_moved_fingerprint_withholds_the_scores(self, tmp_path, capsys):
         inc, cand, split_path, _ = self._setup(tmp_path, capsys)
-        code, out = _run(
+        code, out = _run_gate(
             capsys,
-            "gate",
+            tmp_path,
             "--incumbent",
             inc,
             "--candidate",
@@ -620,9 +638,9 @@ class TestGateRefusalCostsNothing:
 
     def test_a_refusal_still_reports_the_decision_and_reason(self, tmp_path, capsys):
         inc, cand, split_path, _ = self._setup(tmp_path, capsys)
-        _, out = _run(
+        _, out = _run_gate(
             capsys,
-            "gate",
+            tmp_path,
             "--incumbent",
             inc,
             "--candidate",
@@ -637,8 +655,8 @@ class TestGateRefusalCostsNothing:
 
     def test_a_permitted_call_still_reports_the_scores(self, tmp_path, capsys):
         inc, cand, split_path, _ = self._setup(tmp_path, capsys)
-        _, out = _run(
-            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        _, out = _run_gate(
+            capsys, tmp_path, "--incumbent", inc, "--candidate", cand, "--split", split_path
         )
         assert out["compared"] is True
         assert out["candidate"] == 1.0
@@ -653,8 +671,8 @@ class TestGateReportsPairedEvidence:
         cand = _write(tmp_path, "cand.json", candidate)
         _, split = _split(capsys, tmp_path, "--results", inc, "--seed", "s1")
         split_path = _write(tmp_path, "split.json", split)
-        return _run(
-            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        return _run_gate(
+            capsys, tmp_path, "--incumbent", inc, "--candidate", cand, "--split", split_path
         )
 
     def test_a_clean_win_reports_gains_and_no_losses(self, tmp_path, capsys):
@@ -680,9 +698,9 @@ class TestGateReportsPairedEvidence:
         cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(10)})
         _, split = _split(capsys, tmp_path, "--results", inc, "--seed", "s1")
         split_path = _write(tmp_path, "split.json", split)
-        _, out = _run(
+        _, out = _run_gate(
             capsys,
-            "gate",
+            tmp_path,
             "--incumbent",
             inc,
             "--candidate",
@@ -709,8 +727,8 @@ class TestGate:
             {f"t{i}": False for i in range(10)},
             {f"t{i}": True for i in range(10)},
         )
-        code, out = _run(
-            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        code, out = _run_gate(
+            capsys, tmp_path, "--incumbent", inc, "--candidate", cand, "--split", split_path
         )
         assert code == EXIT_OK
         assert out["decision"] == "ACCEPT"
@@ -719,8 +737,8 @@ class TestGate:
     def test_rejects_a_tie(self, tmp_path, capsys):
         same = {f"t{i}": True for i in range(10)}
         inc, cand, split_path, _ = self._setup(tmp_path, capsys, same, dict(same))
-        code, out = _run(
-            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        code, out = _run_gate(
+            capsys, tmp_path, "--incumbent", inc, "--candidate", cand, "--split", split_path
         )
         assert code == EXIT_LOGIC
         assert out["decision"] == "REJECT"
@@ -733,8 +751,8 @@ class TestGate:
             {f"t{i}": True for i in range(10)},
             {f"t{i}": False for i in range(10)},
         )
-        code, out = _run(
-            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        code, out = _run_gate(
+            capsys, tmp_path, "--incumbent", inc, "--candidate", cand, "--split", split_path
         )
         assert code == EXIT_LOGIC
         assert "regress" in out["reason"]
@@ -747,8 +765,8 @@ class TestGate:
         candidate = {t: True for t in split["opt"]}
         candidate.update({t: False for t in split["sel"] + split["test"]})
         cand = _write(tmp_path, "cand.json", candidate)
-        code, out = _run(
-            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        code, out = _run_gate(
+            capsys, tmp_path, "--incumbent", inc, "--candidate", cand, "--split", split_path
         )
         assert code == EXIT_LOGIC
         assert out["candidate"] == 0.0
@@ -760,9 +778,9 @@ class TestGate:
             {f"t{i}": False for i in range(10)},
             {f"t{i}": True for i in range(10)},
         )
-        code, out = _run(
+        code, out = _run_gate(
             capsys,
-            "gate",
+            tmp_path,
             "--incumbent",
             inc,
             "--candidate",
@@ -782,9 +800,9 @@ class TestGate:
             {f"t{i}": False for i in range(10)},
             {f"t{i}": True for i in range(10)},
         )
-        code, out = _run(
+        code, out = _run_gate(
             capsys,
-            "gate",
+            tmp_path,
             "--incumbent",
             inc,
             "--candidate",
@@ -804,19 +822,18 @@ class TestGate:
             {f"t{i}": False for i in range(10)},
             {f"t{i}": True for i in range(10)},
         )
-        code, out = _run(
+        code, out = _run_gate(
             capsys,
-            "gate",
+            tmp_path,
             "--incumbent",
             inc,
             "--candidate",
             cand,
             "--split",
             split_path,
-            "--consultations",
-            "5",
             "--max-consultations",
             "5",
+            spent=5,
         )
         assert code == EXIT_LOGIC
         assert "exhaust" in out["reason"]
@@ -828,17 +845,16 @@ class TestGate:
             {f"t{i}": False for i in range(10)},
             {f"t{i}": True for i in range(10)},
         )
-        code, out = _run(
+        code, out = _run_gate(
             capsys,
-            "gate",
+            tmp_path,
             "--incumbent",
             inc,
             "--candidate",
             cand,
             "--split",
             split_path,
-            "--consultations",
-            "2",
+            spent=2,
         )
         assert code == EXIT_OK
         assert out["sel_consultations"] == 3
@@ -850,19 +866,18 @@ class TestGate:
             {f"t{i}": False for i in range(10)},
             {f"t{i}": True for i in range(10)},
         )
-        code, out = _run(
+        code, out = _run_gate(
             capsys,
-            "gate",
+            tmp_path,
             "--incumbent",
             inc,
             "--candidate",
             cand,
             "--split",
             split_path,
-            "--consultations",
-            "2",
             "--incumbent-fingerprint",
             "stale",
+            spent=2,
         )
         assert code == EXIT_LOGIC
         assert out["sel_consultations"] == 2
@@ -876,16 +891,16 @@ class TestGate:
             {f"t{i}": True for i in range(10)},
         )
         truncated = _write(tmp_path, "trunc.json", {"t0": True})
-        code, _out = _run(
-            capsys, "gate", "--incumbent", inc, "--candidate", truncated, "--split", split_path
+        code, _out = _run_gate(
+            capsys, tmp_path, "--incumbent", inc, "--candidate", truncated, "--split", split_path
         )
         assert code == EXIT_CONFIG
 
     def test_malformed_split_is_a_config_error(self, tmp_path, capsys):
         inc = _write(tmp_path, "inc.json", {f"t{i}": False for i in range(10)})
         bad_split = _write(tmp_path, "split.json", {"opt": ["t0"]})
-        code, _ = _run(
-            capsys, "gate", "--incumbent", inc, "--candidate", inc, "--split", bad_split
+        code, _ = _run_gate(
+            capsys, tmp_path, "--incumbent", inc, "--candidate", inc, "--split", bad_split
         )
         assert code == EXIT_CONFIG
 
@@ -1032,21 +1047,26 @@ class TestMalformedInputs:
         code, _ = _run(capsys, "score", "--results", results, "--split", split)
         assert code == EXIT_CONFIG
 
-    def test_negative_consultations_is_a_config_error(self, tmp_path, capsys):
+    def test_a_negative_ledger_count_is_a_config_error(self, tmp_path, capsys):
+        """This used to arrive as `--consultations -1` on the command line.
+
+        The count moved into a ledger the gate writes, so the malformed input
+        moved with it. A negative count is still refused rather than treated
+        as zero.
+        """
         results = _write(tmp_path, "r.json", _results(10, 0))
         _, split = _split(capsys, tmp_path, "--results", results, "--seed", "s1")
-        split_path = _write(tmp_path, "split.json", split)
-        code, _ = _run(
+        split_path = _write(tmp_path, "split2.json", split)
+        code, _ = _run_gate(
             capsys,
-            "gate",
+            tmp_path,
             "--incumbent",
             results,
             "--candidate",
             results,
             "--split",
             split_path,
-            "--consultations",
-            "-1",
+            spent=-1,
         )
         assert code == EXIT_CONFIG
 
@@ -1078,7 +1098,7 @@ class TestSplitFileIsSelfValidating:
     def test_an_untampered_split_gates_normally(self, tmp_path, capsys):
         inc, cand, split = self._setup(tmp_path, capsys)
         path = _write(tmp_path, "split.json", split)
-        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+        code, out = _run_gate(capsys, tmp_path, "--incumbent", inc, "--candidate", cand,
                          "--split", path)
         assert code == 0
         assert out["decision"] == "ACCEPT"
@@ -1090,7 +1110,7 @@ class TestSplitFileIsSelfValidating:
         split["opt"] = [t for t in split["opt"] if t != moved]
         split["sel"] = [*split["sel"], moved]
         path = _write(tmp_path, "split.json", split)
-        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+        code, out = _run_gate(capsys, tmp_path, "--incumbent", inc, "--candidate", cand,
                          "--split", path)
         assert code == 0
         assert out["decision"] == "REJECT"
@@ -1101,7 +1121,7 @@ class TestSplitFileIsSelfValidating:
         inc, cand, split = self._setup(tmp_path, capsys)
         split["sel"] = [*split["sel"], "smuggled"]
         path = _write(tmp_path, "split.json", split)
-        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+        code, out = _run_gate(capsys, tmp_path, "--incumbent", inc, "--candidate", cand,
                          "--split", path)
         assert out["decision"] == "REJECT"
         assert "fingerprint" in out["reason"]
@@ -1110,7 +1130,7 @@ class TestSplitFileIsSelfValidating:
         inc, cand, split = self._setup(tmp_path, capsys)
         split["fingerprint"] = "0" * 64
         path = _write(tmp_path, "split.json", split)
-        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+        code, out = _run_gate(capsys, tmp_path, "--incumbent", inc, "--candidate", cand,
                          "--split", path)
         assert out["decision"] == "REJECT"
 
@@ -1118,7 +1138,7 @@ class TestSplitFileIsSelfValidating:
         inc, cand, split = self._setup(tmp_path, capsys)
         split["seed"] = "s2"
         path = _write(tmp_path, "split.json", split)
-        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+        code, out = _run_gate(capsys, tmp_path, "--incumbent", inc, "--candidate", cand,
                          "--split", path)
         assert out["decision"] == "REJECT"
 
@@ -1126,17 +1146,17 @@ class TestSplitFileIsSelfValidating:
         inc, cand, split = self._setup(tmp_path, capsys)
         split["sel"] = [*split["sel"], "smuggled"]
         path = _write(tmp_path, "split.json", split)
-        _, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
-                      "--split", path, "--consultations", "0",
-                      "--max-consultations", "3")
+        _, out = _run_gate(capsys, tmp_path, "--incumbent", inc, "--candidate", cand,
+                           "--split", path, "--max-consultations", "3")
         assert out["consultations"] == 0
+        assert not (tmp_path / "ledger.json").exists()
 
     def test_a_split_file_without_ratios_is_refused(self, tmp_path, capsys):
         """Older split files cannot be verified, so they cannot be trusted."""
         inc, cand, split = self._setup(tmp_path, capsys)
         del split["sel_ratio"]
         path = _write(tmp_path, "split.json", split)
-        code, _ = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+        code, _ = _run_gate(capsys, tmp_path, "--incumbent", inc, "--candidate", cand,
                        "--split", path)
         assert code == EXIT_CONFIG
 
@@ -1145,7 +1165,7 @@ class TestSplitFileIsSelfValidating:
         inc, cand, split = self._setup(tmp_path, capsys)
         split["sel_ratio"] = "half"
         path = _write(tmp_path, "split.json", split)
-        code, _ = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+        code, _ = _run_gate(capsys, tmp_path, "--incumbent", inc, "--candidate", cand,
                        "--split", path)
         assert code == EXIT_CONFIG
 
@@ -1283,3 +1303,105 @@ class TestHeldOutGroupsAreNotReadable:
         code, out = _run(capsys, "score", "--results", self._tasks(tmp_path),
                          "--split", out_path)
         assert code == 0 and out["group"] == "opt" and out["score"] == 1.0
+
+
+class TestConsultationLedgerIsHeldByTheGate:
+    """A budget the caller passes in is not a budget.
+
+    `--consultations` defaulted to 0 and arrived on the command line on every
+    invocation, so a loop that simply never incremented it had an unlimited
+    budget while appearing to respect a cap. An adversarial review
+    (gpt-5.6-sol, 2026-07-26) reproduced ACCEPT twice under a cap of one by
+    passing zero both times. The count now lives in a ledger the gate writes,
+    bound to the split fingerprint so redrawing cannot reset it either.
+    """
+
+    def _fixture(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(12)})
+        _run(capsys, "split", "--results", inc, "--seed", "s1",
+             "--out", tmp_path / "split.json")
+        cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(12)})
+        return inc, cand, tmp_path / "split.json", tmp_path / "ledger.json"
+
+    def _gate(self, capsys, inc, cand, split, ledger, cap=None):
+        args = ["gate", "--incumbent", inc, "--candidate", cand,
+                "--split", split, "--ledger", ledger]
+        if cap is not None:
+            args += ["--max-consultations", str(cap)]
+        return _run(capsys, *args)
+
+    def test_a_compared_decision_writes_the_count(self, tmp_path, capsys):
+        inc, cand, split, ledger = self._fixture(tmp_path, capsys)
+        _, out = self._gate(capsys, inc, cand, split, ledger)
+        assert out["sel_consultations"] == 1
+        assert json.loads(ledger.read_text(encoding="utf-8"))["consultations"] == 1
+
+    def test_the_cap_holds_across_separate_invocations(self, tmp_path, capsys):
+        inc, cand, split, ledger = self._fixture(tmp_path, capsys)
+        first, _ = self._gate(capsys, inc, cand, split, ledger, cap=1)
+        assert first == EXIT_OK
+        second, out = self._gate(capsys, inc, cand, split, ledger, cap=1)
+        assert second == EXIT_LOGIC
+        assert "exhaust" in out["reason"]
+
+    def test_a_refused_decision_does_not_spend_budget(self, tmp_path, capsys):
+        inc, cand, split, ledger = self._fixture(tmp_path, capsys)
+        tampered = json.loads(split.read_text(encoding="utf-8"))
+        tampered["sel"], tampered["opt"] = tampered["opt"], tampered["sel"]
+        split.write_text(json.dumps(tampered), encoding="utf-8")
+        self._gate(capsys, inc, cand, split, ledger)
+        assert not ledger.exists()
+
+    def test_a_ledger_from_a_different_split_is_refused(self, tmp_path, capsys):
+        inc, cand, split, ledger = self._fixture(tmp_path, capsys)
+        ledger.write_text(
+            json.dumps({"consultations": 0, "fingerprint": "not-this-split"}),
+            encoding="utf-8",
+        )
+        code, out = self._gate(capsys, inc, cand, split, ledger)
+        assert code == EXIT_LOGIC
+        assert "ledger" in out["reason"]
+        assert "candidate" not in out
+
+    @pytest.mark.parametrize("payload", [
+        '{"consultations": "many"}',
+        '{"consultations": true}',
+        '["not", "an", "object"]',
+    ])
+    def test_a_malformed_ledger_is_a_config_error(self, tmp_path, capsys, payload):
+        inc, cand, split, ledger = self._fixture(tmp_path, capsys)
+        ledger.write_text(payload, encoding="utf-8")
+        code, _ = self._gate(capsys, inc, cand, split, ledger)
+        assert code == EXIT_CONFIG
+
+    def test_a_first_run_needs_no_existing_ledger(self, tmp_path, capsys):
+        inc, cand, split, ledger = self._fixture(tmp_path, capsys)
+        code, _ = self._gate(capsys, inc, cand, split, ledger)
+        assert code == EXIT_OK and ledger.exists()
+
+    def test_a_negative_cap_is_a_config_error(self, tmp_path, capsys):
+        """`gate()` rejects a nonsense cap; the CLI reports it rather than crashing."""
+        inc, cand, split, ledger = self._fixture(tmp_path, capsys)
+        code, out = self._gate(capsys, inc, cand, split, ledger, cap=-1)
+        assert code == EXIT_CONFIG
+        assert not ledger.exists()
+        assert out["error"]
+
+    def test_a_result_missing_a_held_out_task_is_a_config_error(self, tmp_path, capsys):
+        """The gate cannot score a held-out task the run never reported.
+
+        Distinct from a truncated file: this one parses, covers every task the
+        optimizer could see, and is short only on the group the optimizer is
+        not allowed to look at. Reporting it as a config error keeps a partial
+        run from reading as a real verdict.
+        """
+        inc, cand, split, ledger = self._fixture(tmp_path, capsys)
+        partition = json.loads(split.read_text(encoding="utf-8"))
+        dropped = partition["sel"][0]
+        short = {k: v for k, v in json.loads(Path(cand).read_text(encoding="utf-8")).items()
+                 if k != dropped}
+        short_path = _write(tmp_path, "short.json", short)
+        code, out = self._gate(capsys, inc, short_path, split, ledger)
+        assert code == EXIT_CONFIG
+        assert dropped in out["error"]
+        assert not ledger.exists()

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -43,7 +43,7 @@ EXIT_LOGIC = 1
 EXIT_CONFIG = 2
 
 
-def _run(capsys, *argv: str) -> tuple[int, dict]:
+def _run(capsys, *argv: str | Path) -> tuple[int, dict]:
     """Invoke the CLI and return (exit code, parsed stdout JSON)."""
     code = oa.main([str(a) for a in argv])
     out = capsys.readouterr().out.strip()

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -43,6 +43,24 @@ EXIT_LOGIC = 1
 EXIT_CONFIG = 2
 
 
+def _raise_boom(*_args, **_kwargs):
+    """Stand-in for any failure between taking the lock and releasing it."""
+    raise RuntimeError("boom")
+
+
+@pytest.fixture(autouse=True)
+def _isolated_ledger_root(tmp_path_factory, monkeypatch):
+    """Point the consultation ledgers at this test's own directory.
+
+    They are keyed by split fingerprint in one fixed root, which is what stops
+    a caller buying a fresh budget by renaming the split. The same property
+    means two tests that draw the same split share a ledger, so the root has to
+    move per test rather than the key. It sits outside `tmp_path` because tests
+    that assert on the contents of `tmp_path` should not see it.
+    """
+    monkeypatch.setenv("EVAL_LEDGER_DIR", str(tmp_path_factory.mktemp("ledgers")))
+
+
 def _run(capsys, *argv: str | Path) -> tuple[int, dict]:
     """Invoke the CLI and return (exit code, parsed stdout JSON)."""
     code = oa.main([str(a) for a in argv])
@@ -81,7 +99,9 @@ def _run_gate(capsys, tmp_path, *args, spent=None, cap=100):
     if "--incumbent-fingerprint" not in argv and isinstance(split, dict):
         argv += ["--incumbent-fingerprint", str(split.get("fingerprint", "unknown"))]
     if spent is not None and isinstance(split, dict):
-        oa._ledger_path(Path(argv[argv.index("--split") + 1])).write_text(
+        seeded = oa._ledger_path(str(split.get("fingerprint")))
+        seeded.parent.mkdir(parents=True, exist_ok=True)
+        seeded.write_text(
             json.dumps({"consultations": spent, "fingerprint": split.get("fingerprint"),
                         "max_consultations": effective}),
             encoding="utf-8",
@@ -1343,7 +1363,8 @@ class TestConsultationLedgerIsHeldByTheGate:
              "--out", tmp_path / "split.json")
         cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(12)})
         split = tmp_path / "split.json"
-        return inc, cand, split, oa._ledger_path(split)
+        fingerprint = json.loads(split.read_text(encoding="utf-8"))["fingerprint"]
+        return inc, cand, split, oa._ledger_path(fingerprint)
 
     def _gate(self, capsys, inc, cand, split, _ledger, cap=100):
         """The ledger path is derived, so tests receive it rather than choose it."""
@@ -1468,7 +1489,7 @@ class TestTheBudgetCapIsPinnedByTheLedger:
         inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
         code, _ = self._gate(capsys, inc, cand, split, fingerprint, 3)
         assert code == EXIT_OK
-        ledger = json.loads(oa._ledger_path(split).read_text(encoding="utf-8"))
+        ledger = json.loads(oa._ledger_path(fingerprint).read_text(encoding="utf-8"))
         assert ledger["max_consultations"] == 3
 
     def test_raising_the_cap_mid_run_is_refused(self, tmp_path, capsys):
@@ -1499,7 +1520,9 @@ class TestTheBudgetCapIsPinnedByTheLedger:
     @pytest.mark.parametrize("recorded", ["five", -1, None, True])
     def test_a_malformed_recorded_cap_is_a_config_error(self, tmp_path, capsys, recorded):
         inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
-        oa._ledger_path(split).write_text(
+        seeded = oa._ledger_path(fingerprint)
+        seeded.parent.mkdir(parents=True, exist_ok=True)
+        seeded.write_text(
             json.dumps({"consultations": 0, "fingerprint": fingerprint,
                         "max_consultations": recorded}),
             encoding="utf-8",
@@ -1508,14 +1531,106 @@ class TestTheBudgetCapIsPinnedByTheLedger:
         assert code == EXIT_CONFIG
 
 
-class TestTheLedgerLivesBesideTheSplit:
-    """A ledger path the caller chooses is a ledger the caller can replace.
+class TestTheBudgetIsKeyedByTheSplitItself:
+    """A ledger path derived from a caller-supplied path is still caller-supplied.
 
-    `--ledger` was required, which read as discipline, but pointing the next
-    invocation at a fresh path reset the count to zero because a missing
-    ledger starts empty. Deriving the path from the split removes the choice:
-    resetting the budget now means deleting a file that sits next to the split
-    it belongs to, which is unambiguous tampering rather than an argument.
+    `--ledger` was replaced by a path derived from `--split`, which moved the
+    reset instead of closing it: a third adversarial review (gpt-5.6-sol,
+    2026-07-26) pointed out that the caller still names the split, so copying
+    `split.json` to `split2.json` produced an identical fingerprint with no
+    ledger beside it, and the budget started over. The key is now the
+    fingerprint in one fixed directory. Same split content, same budget,
+    whatever the file is called. A fresh budget needs a fresh seed.
+    """
+
+    def _fixture(self, tmp_path, capsys, seed="s1"):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(12)})
+        _run(capsys, "split", "--results", inc, "--seed", seed,
+             "--out", tmp_path / "split.json")
+        cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(12)})
+        split = tmp_path / "split.json"
+        fingerprint = json.loads(split.read_text(encoding="utf-8"))["fingerprint"]
+        return inc, cand, split, fingerprint
+
+    def _gate(self, capsys, inc, cand, split, fingerprint, cap=3):
+        return _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                    "--split", split, "--max-consultations", str(cap),
+                    "--incumbent-fingerprint", fingerprint)
+
+    def test_the_ledger_is_written_under_the_state_root(self, tmp_path, capsys):
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        self._gate(capsys, inc, cand, split, fingerprint)
+        assert oa._ledger_path(fingerprint).exists()
+
+    def test_a_copied_split_shares_the_budget(self, tmp_path, capsys):
+        """The reported attack: copy the split, keep the fingerprint, reset the count."""
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        _, first = self._gate(capsys, inc, cand, split, fingerprint)
+        copy = tmp_path / "split-copy.json"
+        copy.write_text(split.read_text(encoding="utf-8"), encoding="utf-8")
+        _, second = self._gate(capsys, inc, cand, copy, fingerprint)
+        assert (first["sel_consultations"], second["sel_consultations"]) == (1, 2)
+
+    def test_a_renamed_split_shares_the_budget(self, tmp_path, capsys):
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        self._gate(capsys, inc, cand, split, fingerprint)
+        moved = tmp_path / "nested" / "renamed.json"
+        moved.parent.mkdir()
+        moved.write_text(split.read_text(encoding="utf-8"), encoding="utf-8")
+        split.unlink()
+        _, second = self._gate(capsys, inc, cand, moved, fingerprint)
+        assert second["sel_consultations"] == 2
+
+    def test_exhaustion_survives_the_copy(self, tmp_path, capsys):
+        """The budget is only real if the copy cannot buy one more comparison."""
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        self._gate(capsys, inc, cand, split, fingerprint, cap=1)
+        copy = tmp_path / "elsewhere.json"
+        copy.write_text(split.read_text(encoding="utf-8"), encoding="utf-8")
+        code, out = self._gate(capsys, inc, cand, copy, fingerprint, cap=1)
+        assert (code, out["compared"], out["decision"]) == (EXIT_LOGIC, False, "REJECT")
+
+    def test_a_redrawn_split_gets_its_own_budget(self, tmp_path, capsys):
+        """The honest reset is a new seed, which is a new held-out group."""
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        self._gate(capsys, inc, cand, split, fingerprint, cap=1)
+        other = tmp_path / "redrawn.json"
+        _run(capsys, "split", "--results", inc, "--seed", "s2", "--out", other)
+        redrawn = json.loads(other.read_text(encoding="utf-8"))["fingerprint"]
+        assert redrawn != fingerprint
+        _, out = self._gate(capsys, inc, cand, other, redrawn, cap=1)
+        assert out["sel_consultations"] == 1
+
+    def test_the_ledger_flag_is_gone(self, tmp_path, capsys):
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        with pytest.raises(SystemExit) as exc:
+            self._gate(capsys, inc, cand, split, fingerprint)
+            _run(capsys, "gate", "--ledger", tmp_path / "elsewhere.json")
+        assert exc.value.code == EXIT_CONFIG
+
+    def test_two_fingerprints_never_share_a_file(self, tmp_path):
+        assert oa._ledger_path("aaaa") != oa._ledger_path("bbbb")
+
+    def test_the_root_defaults_to_the_state_directory(self, monkeypatch, tmp_path):
+        """Unset override falls back to XDG rather than the working directory."""
+        monkeypatch.delenv("EVAL_LEDGER_DIR", raising=False)
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+        assert oa._ledger_root() == tmp_path / "state" / "ai-agents-eval" / "ledgers"
+
+    def test_the_root_falls_back_to_home_without_xdg(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("EVAL_LEDGER_DIR", raising=False)
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        monkeypatch.setattr(oa.Path, "home", classmethod(lambda cls: tmp_path))
+        assert oa._ledger_root() == tmp_path / ".local" / "state" / "ai-agents-eval" / "ledgers"
+
+
+class TestOneGateAtATimePerSplit:
+    """Atomic writes keep a file whole; they do not make a sequence a transaction.
+
+    The same review found that two gates started together both read the same
+    count, both compare, and both write count + 1, so a concurrent pair spends
+    one consultation between them. The read, the comparison, and the write now
+    happen under an exclusive lock file keyed by the same fingerprint.
     """
 
     def _fixture(self, tmp_path, capsys):
@@ -1527,28 +1642,46 @@ class TestTheLedgerLivesBesideTheSplit:
         fingerprint = json.loads(split.read_text(encoding="utf-8"))["fingerprint"]
         return inc, cand, split, fingerprint
 
-    def test_the_ledger_is_written_beside_the_split(self, tmp_path, capsys):
+    def test_a_held_lock_refuses_the_second_gate(self, tmp_path, capsys):
         inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
-        _run(capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split,
-             "--max-consultations", "3", "--incumbent-fingerprint", fingerprint)
-        assert (tmp_path / "split.json.ledger").exists()
+        lock = oa._ledger_root() / f"{fingerprint}.lock"
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.write_text("999", encoding="utf-8")
+        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                         "--split", split, "--max-consultations", "3",
+                         "--incumbent-fingerprint", fingerprint)
+        assert code == EXIT_CONFIG and "another gate holds" in out["error"]
 
-    def test_the_ledger_flag_is_gone(self, tmp_path, capsys):
+    def test_the_lock_is_released_when_the_gate_returns(self, tmp_path, capsys):
         inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
-        with pytest.raises(SystemExit) as exc:
-            _run(capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split,
-                 "--max-consultations", "3", "--incumbent-fingerprint", fingerprint,
-                 "--ledger", tmp_path / "elsewhere.json")
-        assert exc.value.code == EXIT_CONFIG
+        _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+             "--split", split, "--max-consultations", "3",
+             "--incumbent-fingerprint", fingerprint)
+        assert not (oa._ledger_root() / f"{fingerprint}.lock").exists()
 
-    def test_the_derived_path_is_unique_per_split(self, tmp_path, capsys):
-        """Two splits in one directory must not share a budget."""
-        assert oa._ledger_path(tmp_path / "a.json") != oa._ledger_path(tmp_path / "b.json")
-        assert oa._ledger_path(tmp_path / "a.json") != oa._ledger_path(tmp_path / "a.yaml")
+    def test_the_lock_is_released_when_the_gate_raises(self, tmp_path, capsys, monkeypatch):
+        """A lock held past a crash would wedge every later run."""
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        monkeypatch.setattr(oa, "_gate_decision", _raise_boom)
+        with pytest.raises(RuntimeError):
+            _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                 "--split", split, "--max-consultations", "3",
+                 "--incumbent-fingerprint", fingerprint)
+        assert not (oa._ledger_root() / f"{fingerprint}.lock").exists()
 
-    def test_a_split_with_no_suffix_still_derives_a_ledger(self, tmp_path):
-        """Total function: no path shape may raise on the way to a budget."""
-        assert oa._ledger_path(tmp_path / "split").name == "split.ledger"
+    def test_a_drifted_split_takes_no_lock(self, tmp_path, capsys):
+        """The refusal that reads no ledger must not serialize against one."""
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        record = json.loads(split.read_text(encoding="utf-8"))
+        record["fingerprint"] = "tampered"
+        split.write_text(json.dumps(record), encoding="utf-8")
+        lock = oa._ledger_root() / "tampered.lock"
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.write_text("999", encoding="utf-8")
+        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                         "--split", split, "--max-consultations", "3",
+                         "--incumbent-fingerprint", fingerprint)
+        assert (code, out["decision"]) == (EXIT_OK, "REJECT")
 
 
 class TestTheIncumbentFingerprintIsRequired:

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -50,6 +50,10 @@ def _run(capsys, *argv: str | Path) -> tuple[int, dict]:
     return code, (json.loads(out) if out else {})
 
 
+def _boom(*_args, **_kwargs):
+    raise OSError("disk full")
+
+
 def _write(tmp_path: Path, name: str, payload: object) -> Path:
     path = tmp_path / name
     path.write_text(json.dumps(payload), encoding="utf-8")
@@ -1129,3 +1133,69 @@ class TestSplitFileIsSelfValidating:
                         "--sel-ratio", "0.4", "--test-ratio", "0.2")
         assert split["sel_ratio"] == 0.4
         assert split["test_ratio"] == 0.2
+
+
+class TestMalformedInputsAreConfigErrors:
+    """Broken input files must name themselves, not raise a traceback.
+
+    Every one of these was found by CodeRabbit on PR #3430 and reproduced
+    before being fixed. The CLI is driven by an unattended loop, so a
+    traceback is not a diagnostic anyone reads; it is a crash the loop cannot
+    branch on.
+    """
+
+    def test_a_non_utf8_artifact_is_a_config_error(self, tmp_path, capsys):
+        """UnicodeDecodeError subclasses ValueError, so the OSError arm missed it."""
+        target = tmp_path / "artifact.md"
+        target.write_bytes(b"valid ascii \xff\xfe then garbage")
+        patches = _write(tmp_path, "p.json", [{"op": "append", "text": "x"}])
+        code, out = _run(capsys, "apply", "--file", target, "--patches", patches,
+                         "--budget", "1")
+        assert code == EXIT_CONFIG
+        assert "artifact.md" in out["error"]
+
+    def test_a_buffer_of_non_objects_is_a_config_error(self, tmp_path, capsys):
+        buf = _write(tmp_path, "buf.json", [1, 2])
+        patches = _write(tmp_path, "p.json", [{"op": "append", "text": "x"}])
+        code, _ = _run(capsys, "buffer-check", "--buffer", buf, "--patches", patches)
+        assert code == EXIT_CONFIG
+
+
+class TestApplyWritesAtomically:
+    """A half-written artifact is worse than a refused edit.
+
+    `apply` overwrites the artifact the loop is optimizing. A direct
+    write_text truncates first, so an interrupt or a full disk mid-write
+    leaves the artifact destroyed and the loop with nothing to fall back to.
+    """
+
+    def _setup(self, tmp_path):
+        target = tmp_path / "artifact.md"
+        target.write_text("original\n", encoding="utf-8")
+        patches = _write(tmp_path, "p.json", [{"op": "append", "text": "added"}])
+        return target, patches
+
+    def test_a_normal_apply_still_writes(self, tmp_path, capsys):
+        target, patches = self._setup(tmp_path)
+        code, out = _run(capsys, "apply", "--file", target, "--patches", patches,
+                         "--budget", "1")
+        assert code == 0 and out["written"] is True
+        assert "added" in target.read_text(encoding="utf-8")
+
+    def test_a_failed_replace_leaves_the_original_intact(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        target, patches = self._setup(tmp_path)
+        monkeypatch.setattr(oa.os, "replace", _boom)
+        code, out = _run(capsys, "apply", "--file", target, "--patches", patches,
+                         "--budget", "1")
+        assert code == EXIT_CONFIG
+        assert target.read_text(encoding="utf-8") == "original\n"
+
+    def test_a_failed_replace_leaves_no_temp_file(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        target, patches = self._setup(tmp_path)
+        monkeypatch.setattr(oa.os, "replace", _boom)
+        _run(capsys, "apply", "--file", target, "--patches", patches, "--budget", "1")
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["artifact.md", "p.json"]

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -1029,3 +1029,103 @@ class TestMalformedInputs:
         patches = _write(tmp_path, "p.json", [{"op": "append", "text": "x"}])
         code, _ = _run(capsys, "buffer-check", "--buffer", buffer, "--patches", patches)
         assert code == EXIT_CONFIG
+
+
+class TestSplitFileIsSelfValidating:
+    """A split file has to prove its own integrity, with no flag to remember.
+
+    Two adversarial reviewers plus both PR bots flagged the same hole
+    independently: the only drift check compared the split file's stored
+    fingerprint against a --incumbent-fingerprint the caller supplied, so a
+    caller who omitted the flag got no check at all, and the stored value was
+    trusted even when the group membership beside it had been edited. A
+    guarantee that is opt-in is not a guarantee. The gate now recomputes the
+    fingerprint from the split file's own contents on every call.
+    """
+
+    def _setup(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": False for i in range(10)})
+        cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(10)})
+        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        return inc, cand, split
+
+    def test_an_untampered_split_gates_normally(self, tmp_path, capsys):
+        inc, cand, split = self._setup(tmp_path, capsys)
+        path = _write(tmp_path, "split.json", split)
+        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                         "--split", path)
+        assert code == 0
+        assert out["decision"] == "ACCEPT"
+
+    def test_a_task_moved_between_groups_is_refused(self, tmp_path, capsys):
+        """The union is unchanged, so only recomputation catches this."""
+        inc, cand, split = self._setup(tmp_path, capsys)
+        moved = split["opt"][0]
+        split["opt"] = [t for t in split["opt"] if t != moved]
+        split["sel"] = [*split["sel"], moved]
+        path = _write(tmp_path, "split.json", split)
+        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                         "--split", path)
+        assert code == 0
+        assert out["decision"] == "REJECT"
+        assert "fingerprint" in out["reason"]
+        assert "score" not in out and "candidate" not in out
+
+    def test_an_added_task_is_refused(self, tmp_path, capsys):
+        inc, cand, split = self._setup(tmp_path, capsys)
+        split["sel"] = [*split["sel"], "smuggled"]
+        path = _write(tmp_path, "split.json", split)
+        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                         "--split", path)
+        assert out["decision"] == "REJECT"
+        assert "fingerprint" in out["reason"]
+
+    def test_an_edited_fingerprint_is_refused(self, tmp_path, capsys):
+        inc, cand, split = self._setup(tmp_path, capsys)
+        split["fingerprint"] = "0" * 64
+        path = _write(tmp_path, "split.json", split)
+        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                         "--split", path)
+        assert out["decision"] == "REJECT"
+
+    def test_an_edited_seed_is_refused(self, tmp_path, capsys):
+        inc, cand, split = self._setup(tmp_path, capsys)
+        split["seed"] = "s2"
+        path = _write(tmp_path, "split.json", split)
+        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                         "--split", path)
+        assert out["decision"] == "REJECT"
+
+    def test_a_refused_split_costs_no_consultation(self, tmp_path, capsys):
+        inc, cand, split = self._setup(tmp_path, capsys)
+        split["sel"] = [*split["sel"], "smuggled"]
+        path = _write(tmp_path, "split.json", split)
+        _, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                      "--split", path, "--consultations", "0",
+                      "--max-consultations", "3")
+        assert out["consultations"] == 0
+
+    def test_a_split_file_without_ratios_is_refused(self, tmp_path, capsys):
+        """Older split files cannot be verified, so they cannot be trusted."""
+        inc, cand, split = self._setup(tmp_path, capsys)
+        del split["sel_ratio"]
+        path = _write(tmp_path, "split.json", split)
+        code, _ = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                       "--split", path)
+        assert code == EXIT_CONFIG
+
+    def test_a_non_numeric_ratio_is_a_config_error(self, tmp_path, capsys):
+        """The keys are present, so only the redraw catches the bad value."""
+        inc, cand, split = self._setup(tmp_path, capsys)
+        split["sel_ratio"] = "half"
+        path = _write(tmp_path, "split.json", split)
+        code, _ = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                       "--split", path)
+        assert code == EXIT_CONFIG
+
+    def test_split_writes_the_ratios_it_used(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": False for i in range(10)})
+        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1",
+                        "--sel-ratio", "0.4", "--test-ratio", "0.2")
+        assert split["sel_ratio"] == 0.4
+        assert split["test_ratio"] == 0.2

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -1863,3 +1863,96 @@ class TestTheIncumbentFingerprintIsRequired:
                          "--split", split, "--max-consultations", "3",
                          "--incumbent-fingerprint", scored["fingerprint"])
         assert code == EXIT_OK and out["compared"] is True
+
+
+class TestTheGateNeverPublishesTheHoldoutKey:
+    """The key digests the held-out membership, so printing it is printing them.
+
+    A fifth adversarial review (gpt-5.6-sol, 2026-07-26) found the digest in
+    three error paths. It is an unsalted sha256 over a set the caller can
+    enumerate: the universe is the caller's own results file, `opt` and the
+    two group sizes are published, so a caller hashes every subset of the
+    complement of the right size and matches. Whenever a test group exists the
+    complement is not the held-out group, and that reversal is the only way to
+    tell the two apart.
+    """
+
+    def _fixture(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(12)})
+        split = tmp_path / "split.json"
+        _run(capsys, "split", "--results", inc, "--seed", "s", "--out", split)
+        return inc, split, json.loads(split.read_text())
+
+    def _gate(self, capsys, inc, cand, split, record, cap="2"):
+        return _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", cand,
+            "--split", split, "--max-consultations", cap,
+            "--incumbent-fingerprint", record["fingerprint"],
+        )
+
+    def test_lock_contention_does_not_publish_the_key(self, tmp_path, capsys):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        key = oa._holdout_key(record)
+        lock = oa._ledger_root() / f"{key}.lock"
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.touch()
+        code, out = self._gate(capsys, inc, inc, split, record)
+        assert code == EXIT_CONFIG and "another gate" in out["error"]
+        assert key not in json.dumps(out)
+
+    def test_lock_contention_still_says_where_to_look(self, tmp_path, capsys):
+        """Redaction that hides the directory turns a stale lock into a puzzle."""
+        inc, split, record = self._fixture(tmp_path, capsys)
+        lock = oa._ledger_root() / f"{oa._holdout_key(record)}.lock"
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.touch()
+        _, out = self._gate(capsys, inc, inc, split, record)
+        assert str(oa._ledger_root()) in out["error"]
+
+    def test_a_ledger_under_another_group_does_not_publish_either_key(self, tmp_path, capsys):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        key = oa._holdout_key(record)
+        ledger = oa._ledger_path(key)
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        ledger.write_text(
+            json.dumps({"consultations": 0, "holdout": "f" * 64, "max_consultations": 2})
+        )
+        code, out = self._gate(capsys, inc, inc, split, record)
+        assert (code, out["decision"]) == (EXIT_LOGIC, "REJECT")
+        assert key not in json.dumps(out) and "f" * 64 not in json.dumps(out)
+
+    def test_a_cap_mismatch_does_not_publish_the_key(self, tmp_path, capsys):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        key = oa._holdout_key(record)
+        self._gate(capsys, inc, inc, split, record, cap="2")
+        code, out = self._gate(capsys, inc, inc, split, record, cap="5")
+        assert (code, out["decision"]) == (EXIT_LOGIC, "REJECT")
+        assert "cap of 2" in out["reason"] and key not in json.dumps(out)
+
+    def test_a_malformed_ledger_does_not_publish_the_key(self, tmp_path, capsys):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        key = oa._holdout_key(record)
+        ledger = oa._ledger_path(key)
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        ledger.write_text(json.dumps({"consultations": -1, "holdout": key, "max_consultations": 2}))
+        code, out = self._gate(capsys, inc, inc, split, record)
+        assert code == EXIT_CONFIG
+        assert key not in json.dumps(out)
+
+    def test_the_decision_block_does_not_publish_the_key(self, tmp_path, capsys):
+        """The ordinary success path is the one a caller reads every time."""
+        inc, split, record = self._fixture(tmp_path, capsys)
+        _, out = self._gate(capsys, inc, inc, split, record)
+        assert oa._holdout_key(record) not in json.dumps(out)
+
+    def test_the_key_separates_ids_that_contain_a_null_byte(self):
+        """Joining on NUL is not injective when an id may contain one."""
+        assert oa._holdout_key({"sel": ["a", "b\x00c"]}) != oa._holdout_key(
+            {"sel": ["a\x00b", "c"]}
+        )
+
+    def test_the_key_still_ignores_the_order_it_is_given(self):
+        assert oa._holdout_key({"sel": ["b", "a"]}) == oa._holdout_key({"sel": ["a", "b"]})
+
+    def test_the_key_still_separates_different_members(self):
+        assert oa._holdout_key({"sel": ["a", "b"]}) != oa._holdout_key({"sel": ["a", "c"]})

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -43,6 +43,11 @@ EXIT_LOGIC = 1
 EXIT_CONFIG = 2
 
 
+def _key_of(split_path):
+    """The held-out key the gate will use for this split file."""
+    return oa._holdout_key(json.loads(Path(split_path).read_text(encoding="utf-8")))
+
+
 def _raise_boom(*_args, **_kwargs):
     """Stand-in for any failure between taking the lock and releasing it."""
     raise RuntimeError("boom")
@@ -99,10 +104,11 @@ def _run_gate(capsys, tmp_path, *args, spent=None, cap=100):
     if "--incumbent-fingerprint" not in argv and isinstance(split, dict):
         argv += ["--incumbent-fingerprint", str(split.get("fingerprint", "unknown"))]
     if spent is not None and isinstance(split, dict):
-        seeded = oa._ledger_path(str(split.get("fingerprint")))
+        key = oa._holdout_key(split)
+        seeded = oa._ledger_path(key)
         seeded.parent.mkdir(parents=True, exist_ok=True)
         seeded.write_text(
-            json.dumps({"consultations": spent, "fingerprint": split.get("fingerprint"),
+            json.dumps({"consultations": spent, "holdout": key,
                         "max_consultations": effective}),
             encoding="utf-8",
         )
@@ -1363,8 +1369,8 @@ class TestConsultationLedgerIsHeldByTheGate:
              "--out", tmp_path / "split.json")
         cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(12)})
         split = tmp_path / "split.json"
-        fingerprint = json.loads(split.read_text(encoding="utf-8"))["fingerprint"]
-        return inc, cand, split, oa._ledger_path(fingerprint)
+        record = json.loads(split.read_text(encoding="utf-8"))
+        return inc, cand, split, oa._ledger_path(oa._holdout_key(record))
 
     def _gate(self, capsys, inc, cand, split, _ledger, cap=100):
         """The ledger path is derived, so tests receive it rather than choose it."""
@@ -1489,7 +1495,8 @@ class TestTheBudgetCapIsPinnedByTheLedger:
         inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
         code, _ = self._gate(capsys, inc, cand, split, fingerprint, 3)
         assert code == EXIT_OK
-        ledger = json.loads(oa._ledger_path(fingerprint).read_text(encoding="utf-8"))
+        key = oa._holdout_key(json.loads(split.read_text(encoding="utf-8")))
+        ledger = json.loads(oa._ledger_path(key).read_text(encoding="utf-8"))
         assert ledger["max_consultations"] == 3
 
     def test_raising_the_cap_mid_run_is_refused(self, tmp_path, capsys):
@@ -1520,10 +1527,11 @@ class TestTheBudgetCapIsPinnedByTheLedger:
     @pytest.mark.parametrize("recorded", ["five", -1, None, True])
     def test_a_malformed_recorded_cap_is_a_config_error(self, tmp_path, capsys, recorded):
         inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
-        seeded = oa._ledger_path(fingerprint)
+        key = oa._holdout_key(json.loads(split.read_text(encoding="utf-8")))
+        seeded = oa._ledger_path(key)
         seeded.parent.mkdir(parents=True, exist_ok=True)
         seeded.write_text(
-            json.dumps({"consultations": 0, "fingerprint": fingerprint,
+            json.dumps({"consultations": 0, "holdout": key,
                         "max_consultations": recorded}),
             encoding="utf-8",
         )
@@ -1549,8 +1557,8 @@ class TestTheBudgetIsKeyedByTheSplitItself:
              "--out", tmp_path / "split.json")
         cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(12)})
         split = tmp_path / "split.json"
-        fingerprint = json.loads(split.read_text(encoding="utf-8"))["fingerprint"]
-        return inc, cand, split, fingerprint
+        record = json.loads(split.read_text(encoding="utf-8"))
+        return inc, cand, split, record["fingerprint"]
 
     def _gate(self, capsys, inc, cand, split, fingerprint, cap=3):
         return _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
@@ -1560,7 +1568,8 @@ class TestTheBudgetIsKeyedByTheSplitItself:
     def test_the_ledger_is_written_under_the_state_root(self, tmp_path, capsys):
         inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
         self._gate(capsys, inc, cand, split, fingerprint)
-        assert oa._ledger_path(fingerprint).exists()
+        key = oa._holdout_key(json.loads(split.read_text(encoding="utf-8")))
+        assert oa._ledger_path(key).exists()
 
     def test_a_copied_split_shares_the_budget(self, tmp_path, capsys):
         """The reported attack: copy the split, keep the fingerprint, reset the count."""
@@ -1608,8 +1617,40 @@ class TestTheBudgetIsKeyedByTheSplitItself:
             _run(capsys, "gate", "--ledger", tmp_path / "elsewhere.json")
         assert exc.value.code == EXIT_CONFIG
 
-    def test_two_fingerprints_never_share_a_file(self, tmp_path):
+    def test_two_held_out_groups_never_share_a_file(self, tmp_path):
         assert oa._ledger_path("aaaa") != oa._ledger_path("bbbb")
+
+    def test_two_ratios_that_select_the_same_tasks_share_the_budget(self, tmp_path, capsys):
+        """The fifth reset: rounding makes distinct ratios select one group.
+
+        A fourth adversarial review (gpt-5.6-sol, 2026-07-26) reproduced this
+        against the fingerprint key. Ten tasks at 0.40 and at 0.41 both round to
+        four held out and pick the same four, but the fingerprint covers the raw
+        ratio, so the identical group got two budgets.
+        """
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(10)})
+        cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(10)})
+        for name, ratio in (("a.json", "0.40"), ("b.json", "0.41")):
+            _run(capsys, "split", "--results", inc, "--seed", "s1",
+                 "--sel-ratio", ratio, "--out", tmp_path / name)
+        first, second = (json.loads((tmp_path / n).read_text(encoding="utf-8"))
+                         for n in ("a.json", "b.json"))
+        assert first["fingerprint"] != second["fingerprint"]
+        assert sorted(first["sel"]) == sorted(second["sel"])
+        _, one = self._gate(capsys, inc, cand, tmp_path / "a.json", first["fingerprint"])
+        _, two = self._gate(capsys, inc, cand, tmp_path / "b.json", second["fingerprint"])
+        assert (one["sel_consultations"], two["sel_consultations"]) == (1, 2)
+
+    def test_rank_order_does_not_change_the_key(self, tmp_path):
+        """Two seeds that hold out the same set are selecting on the same set."""
+        assert oa._holdout_key({"sel": ["b", "a"]}) == oa._holdout_key(
+            {"sel": ["a", "b"]}
+        )
+
+    def test_a_different_membership_changes_the_key(self, tmp_path):
+        assert oa._holdout_key({"sel": ["a", "b"]}) != oa._holdout_key(
+            {"sel": ["a", "c"]}
+        )
 
     def test_the_root_defaults_to_the_state_directory(self, monkeypatch, tmp_path):
         """Unset override falls back to XDG rather than the working directory."""
@@ -1639,12 +1680,12 @@ class TestOneGateAtATimePerSplit:
              "--out", tmp_path / "split.json")
         cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(12)})
         split = tmp_path / "split.json"
-        fingerprint = json.loads(split.read_text(encoding="utf-8"))["fingerprint"]
-        return inc, cand, split, fingerprint
+        record = json.loads(split.read_text(encoding="utf-8"))
+        return inc, cand, split, record["fingerprint"]
 
     def test_a_held_lock_refuses_the_second_gate(self, tmp_path, capsys):
         inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
-        lock = oa._ledger_root() / f"{fingerprint}.lock"
+        lock = oa._ledger_root() / f"{_key_of(split)}.lock"
         lock.parent.mkdir(parents=True, exist_ok=True)
         lock.write_text("999", encoding="utf-8")
         code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
@@ -1657,7 +1698,7 @@ class TestOneGateAtATimePerSplit:
         _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
              "--split", split, "--max-consultations", "3",
              "--incumbent-fingerprint", fingerprint)
-        assert not (oa._ledger_root() / f"{fingerprint}.lock").exists()
+        assert not (oa._ledger_root() / f"{_key_of(split)}.lock").exists()
 
     def test_the_lock_is_released_when_the_gate_raises(self, tmp_path, capsys, monkeypatch):
         """A lock held past a crash would wedge every later run."""
@@ -1667,7 +1708,7 @@ class TestOneGateAtATimePerSplit:
             _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
                  "--split", split, "--max-consultations", "3",
                  "--incumbent-fingerprint", fingerprint)
-        assert not (oa._ledger_root() / f"{fingerprint}.lock").exists()
+        assert not (oa._ledger_root() / f"{_key_of(split)}.lock").exists()
 
     def test_a_drifted_split_takes_no_lock(self, tmp_path, capsys):
         """The refusal that reads no ledger must not serialize against one."""
@@ -1675,7 +1716,7 @@ class TestOneGateAtATimePerSplit:
         record = json.loads(split.read_text(encoding="utf-8"))
         record["fingerprint"] = "tampered"
         split.write_text(json.dumps(record), encoding="utf-8")
-        lock = oa._ledger_root() / "tampered.lock"
+        lock = oa._ledger_root() / f"{_key_of(split)}.lock"
         lock.parent.mkdir(parents=True, exist_ok=True)
         lock.write_text("999", encoding="utf-8")
         code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -63,23 +63,44 @@ def _split(capsys, tmp_path, *args, name="split.json"):
     return code, json.loads(path.read_text(encoding="utf-8"))
 
 
-def _run_gate(capsys, tmp_path, *args, spent=None):
-    """Run `gate`, supplying the ledger it now keeps its own count in.
+def _run_gate(capsys, tmp_path, *args, spent=None, cap=100):
+    """Run `gate`, supplying the two arguments it now requires.
 
     The consultation count used to arrive on the command line, which meant a
-    caller that passed zero every time had an unlimited budget. `spent`
-    pre-seeds the ledger for tests that need the gate to believe consultations
-    have already happened.
+    caller that passed zero every time had an unlimited budget. The cap and
+    the incumbent fingerprint went the same way: both defaulted to a value
+    that skipped the check. Tests that are not about those arguments get
+    working defaults here; `spent` pre-seeds the derived ledger for tests that
+    need the gate to believe consultations have already happened.
     """
-    ledger = tmp_path / "ledger.json"
-    if spent is not None:
-        split_path = args[list(args).index("--split") + 1]
-        split = json.loads(Path(split_path).read_text(encoding="utf-8"))
-        ledger.write_text(
-            json.dumps({"consultations": spent, "fingerprint": split["fingerprint"]}),
+    argv = list(args)
+    if "--max-consultations" not in argv:
+        argv += ["--max-consultations", str(cap)]
+    effective = int(argv[argv.index("--max-consultations") + 1])
+    split = _split_of(argv)
+    if "--incumbent-fingerprint" not in argv and isinstance(split, dict):
+        argv += ["--incumbent-fingerprint", str(split.get("fingerprint", "unknown"))]
+    if spent is not None and isinstance(split, dict):
+        oa._ledger_path(Path(argv[argv.index("--split") + 1])).write_text(
+            json.dumps({"consultations": spent, "fingerprint": split.get("fingerprint"),
+                        "max_consultations": effective}),
             encoding="utf-8",
         )
-    return _run(capsys, "gate", *args, "--ledger", ledger)
+    return _run(capsys, "gate", *argv)
+
+
+def _split_of(argv):
+    """The split record behind `--split`, or None when it is unreadable.
+
+    Config-error tests deliberately point `--split` at missing or malformed
+    files, and the helper still has to run them.
+    """
+    if "--split" not in argv:
+        return None
+    try:
+        return json.loads(Path(argv[argv.index("--split") + 1]).read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
 
 
 def _boom(*_args, **_kwargs):
@@ -1321,14 +1342,16 @@ class TestConsultationLedgerIsHeldByTheGate:
         _run(capsys, "split", "--results", inc, "--seed", "s1",
              "--out", tmp_path / "split.json")
         cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(12)})
-        return inc, cand, tmp_path / "split.json", tmp_path / "ledger.json"
+        split = tmp_path / "split.json"
+        return inc, cand, split, oa._ledger_path(split)
 
-    def _gate(self, capsys, inc, cand, split, ledger, cap=None):
-        args = ["gate", "--incumbent", inc, "--candidate", cand,
-                "--split", split, "--ledger", ledger]
-        if cap is not None:
-            args += ["--max-consultations", str(cap)]
-        return _run(capsys, *args)
+    def _gate(self, capsys, inc, cand, split, _ledger, cap=100):
+        """The ledger path is derived, so tests receive it rather than choose it."""
+        fingerprint = _split_of(["--split", str(split)]) or {}
+        return _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                    "--split", split, "--max-consultations", str(cap),
+                    "--incumbent-fingerprint",
+                    str(fingerprint.get("fingerprint", "unknown")))
 
     def test_a_compared_decision_writes_the_count(self, tmp_path, capsys):
         inc, cand, split, ledger = self._fixture(tmp_path, capsys)
@@ -1355,7 +1378,8 @@ class TestConsultationLedgerIsHeldByTheGate:
     def test_a_ledger_from_a_different_split_is_refused(self, tmp_path, capsys):
         inc, cand, split, ledger = self._fixture(tmp_path, capsys)
         ledger.write_text(
-            json.dumps({"consultations": 0, "fingerprint": "not-this-split"}),
+            json.dumps({"consultations": 0, "fingerprint": "not-this-split",
+                        "max_consultations": 100}),
             encoding="utf-8",
         )
         code, out = self._gate(capsys, inc, cand, split, ledger)
@@ -1405,3 +1429,164 @@ class TestConsultationLedgerIsHeldByTheGate:
         assert code == EXIT_CONFIG
         assert dropped in out["error"]
         assert not ledger.exists()
+
+
+class TestTheBudgetCapIsPinnedByTheLedger:
+    """A cap the caller re-supplies every invocation is not a cap.
+
+    The ledger fixed the count but left the limit on the command line, where
+    `--max-consultations` defaulted to unlimited. A second adversarial review
+    (gpt-5.6-sol, 2026-07-26) named the two remaining ways out: never pass the
+    flag, or raise it once the budget bites. Both are the same defect the
+    ledger was written to close, so the limit is now pinned the same way the
+    count is.
+    """
+
+    def _fixture(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(12)})
+        _run(capsys, "split", "--results", inc, "--seed", "s1",
+             "--out", tmp_path / "split.json")
+        cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(12)})
+        split = tmp_path / "split.json"
+        fingerprint = json.loads(split.read_text(encoding="utf-8"))["fingerprint"]
+        return inc, cand, split, fingerprint
+
+    def _gate(self, capsys, inc, cand, split, fingerprint, cap):
+        return _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                    "--split", split, "--max-consultations", str(cap),
+                    "--incumbent-fingerprint", fingerprint)
+
+    def test_a_missing_cap_is_a_usage_error(self, tmp_path, capsys):
+        """No default. An unlimited budget must be typed, not inherited."""
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        with pytest.raises(SystemExit) as exc:
+            _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                 "--split", split, "--incumbent-fingerprint", fingerprint)
+        assert exc.value.code == EXIT_CONFIG
+
+    def test_the_first_gate_records_the_cap(self, tmp_path, capsys):
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        code, _ = self._gate(capsys, inc, cand, split, fingerprint, 3)
+        assert code == EXIT_OK
+        ledger = json.loads(oa._ledger_path(split).read_text(encoding="utf-8"))
+        assert ledger["max_consultations"] == 3
+
+    def test_raising_the_cap_mid_run_is_refused(self, tmp_path, capsys):
+        """The reproduced attack: gate under one, then ask for five."""
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        assert self._gate(capsys, inc, cand, split, fingerprint, 1)[0] == EXIT_OK
+        code, out = self._gate(capsys, inc, cand, split, fingerprint, 5)
+        assert code == EXIT_LOGIC
+        assert out["decision"] == "REJECT"
+        assert out["compared"] is False
+        assert "1" in out["reason"] and "5" in out["reason"]
+
+    def test_lowering_the_cap_mid_run_is_refused(self, tmp_path, capsys):
+        """Symmetric on purpose: any cap change means a different run."""
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        assert self._gate(capsys, inc, cand, split, fingerprint, 4)[0] == EXIT_OK
+        code, out = self._gate(capsys, inc, cand, split, fingerprint, 2)
+        assert code == EXIT_LOGIC
+        assert out["compared"] is False
+
+    def test_the_same_cap_is_not_a_change(self, tmp_path, capsys):
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        assert self._gate(capsys, inc, cand, split, fingerprint, 4)[0] == EXIT_OK
+        code, out = self._gate(capsys, inc, cand, split, fingerprint, 4)
+        assert code == EXIT_OK
+        assert out["sel_consultations"] == 2
+
+    @pytest.mark.parametrize("recorded", ["five", -1, None, True])
+    def test_a_malformed_recorded_cap_is_a_config_error(self, tmp_path, capsys, recorded):
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        oa._ledger_path(split).write_text(
+            json.dumps({"consultations": 0, "fingerprint": fingerprint,
+                        "max_consultations": recorded}),
+            encoding="utf-8",
+        )
+        code, _ = self._gate(capsys, inc, cand, split, fingerprint, 3)
+        assert code == EXIT_CONFIG
+
+
+class TestTheLedgerLivesBesideTheSplit:
+    """A ledger path the caller chooses is a ledger the caller can replace.
+
+    `--ledger` was required, which read as discipline, but pointing the next
+    invocation at a fresh path reset the count to zero because a missing
+    ledger starts empty. Deriving the path from the split removes the choice:
+    resetting the budget now means deleting a file that sits next to the split
+    it belongs to, which is unambiguous tampering rather than an argument.
+    """
+
+    def _fixture(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(12)})
+        _run(capsys, "split", "--results", inc, "--seed", "s1",
+             "--out", tmp_path / "split.json")
+        cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(12)})
+        split = tmp_path / "split.json"
+        fingerprint = json.loads(split.read_text(encoding="utf-8"))["fingerprint"]
+        return inc, cand, split, fingerprint
+
+    def test_the_ledger_is_written_beside_the_split(self, tmp_path, capsys):
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        _run(capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split,
+             "--max-consultations", "3", "--incumbent-fingerprint", fingerprint)
+        assert (tmp_path / "split.json.ledger").exists()
+
+    def test_the_ledger_flag_is_gone(self, tmp_path, capsys):
+        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
+        with pytest.raises(SystemExit) as exc:
+            _run(capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split,
+                 "--max-consultations", "3", "--incumbent-fingerprint", fingerprint,
+                 "--ledger", tmp_path / "elsewhere.json")
+        assert exc.value.code == EXIT_CONFIG
+
+    def test_the_derived_path_is_unique_per_split(self, tmp_path, capsys):
+        """Two splits in one directory must not share a budget."""
+        assert oa._ledger_path(tmp_path / "a.json") != oa._ledger_path(tmp_path / "b.json")
+        assert oa._ledger_path(tmp_path / "a.json") != oa._ledger_path(tmp_path / "a.yaml")
+
+    def test_a_split_with_no_suffix_still_derives_a_ledger(self, tmp_path):
+        """Total function: no path shape may raise on the way to a budget."""
+        assert oa._ledger_path(tmp_path / "split").name == "split.ledger"
+
+
+class TestTheIncumbentFingerprintIsRequired:
+    """An optional integrity check is an integrity check nobody runs.
+
+    `--incumbent-fingerprint` defaulted to None, and the guard compares only
+    when both sides are present, so omitting the flag silently skipped the
+    one check that catches a stale baseline: redraw the split, gate against
+    an incumbent scored on the old one, and the comparison is between two
+    different eval sets. `score` now reports the fingerprint so supplying it
+    costs the caller nothing.
+    """
+
+    def _fixture(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(12)})
+        _run(capsys, "split", "--results", inc, "--seed", "s1",
+             "--out", tmp_path / "split.json")
+        cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(12)})
+        return inc, cand, tmp_path / "split.json"
+
+    def test_a_missing_incumbent_fingerprint_is_a_usage_error(self, tmp_path, capsys):
+        inc, cand, split = self._fixture(tmp_path, capsys)
+        with pytest.raises(SystemExit) as exc:
+            _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                 "--split", split, "--max-consultations", "3")
+        assert exc.value.code == EXIT_CONFIG
+
+    def test_score_reports_the_fingerprint_the_gate_will_demand(self, tmp_path, capsys):
+        inc, _cand, split = self._fixture(tmp_path, capsys)
+        _, out = _run(capsys, "score", "--results", inc, "--split", split)
+        recorded = json.loads(split.read_text(encoding="utf-8"))["fingerprint"]
+        assert out["fingerprint"] == recorded
+
+    def test_the_fingerprint_score_reports_is_the_one_the_gate_accepts(self, tmp_path, capsys):
+        """End to end: the value `score` prints must satisfy `gate`."""
+        inc, cand, split = self._fixture(tmp_path, capsys)
+        _, scored = _run(capsys, "score", "--results", inc, "--split", split)
+        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
+                         "--split", split, "--max-consultations", "3",
+                         "--incumbent-fingerprint", scored["fingerprint"])
+        assert code == EXIT_OK and out["compared"] is True

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -1159,7 +1159,7 @@ class TestSplitFileIsSelfValidating:
         path = _write(tmp_path, "split.json", split)
         code, out = _run_gate(capsys, tmp_path, "--incumbent", inc, "--candidate", cand,
                          "--split", path)
-        assert code == 0
+        assert code == EXIT_LOGIC
         assert out["decision"] == "REJECT"
         assert "fingerprint" in out["reason"]
         assert "score" not in out and "candidate" not in out
@@ -1611,9 +1611,7 @@ class TestTheBudgetIsKeyedByTheSplitItself:
         assert out["sel_consultations"] == 1
 
     def test_the_ledger_flag_is_gone(self, tmp_path, capsys):
-        inc, cand, split, fingerprint = self._fixture(tmp_path, capsys)
         with pytest.raises(SystemExit) as exc:
-            self._gate(capsys, inc, cand, split, fingerprint)
             _run(capsys, "gate", "--ledger", tmp_path / "elsewhere.json")
         assert exc.value.code == EXIT_CONFIG
 
@@ -1722,7 +1720,7 @@ class TestOneGateAtATimePerSplit:
         code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", cand,
                          "--split", split, "--max-consultations", "3",
                          "--incumbent-fingerprint", fingerprint)
-        assert (code, out["decision"]) == (EXIT_OK, "REJECT")
+        assert (code, out["decision"]) == (EXIT_LOGIC, "REJECT")
 
 
 class TestTheGateNeverNamesAHeldOutTask:

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -124,7 +124,7 @@ class TestExtract:
         assert out == {"S1": True}
 
     def test_rule_scenarios_accept_a_wrapped_object(self, tmp_path, capsys):
-        """eval-rule-activation.py nests scenarios under a top-level key."""
+        """A bare scenario list may also arrive wrapped in a 'scenarios' key."""
         scenarios = _write(
             tmp_path,
             "scen.json",
@@ -178,6 +178,95 @@ class TestExtract:
     def test_non_array_rule_input_is_a_config_error(self, tmp_path, capsys):
         scenarios = _write(tmp_path, "scen.json", {"scenarios": "not a list"})
         code, _ = _run(capsys, "extract", "--kind", "rule", "--input", scenarios)
+        assert code == EXIT_CONFIG
+
+
+class TestExtractRealRuleEnvelope:
+    """The shape eval-rule-activation.py --output actually writes.
+
+    Verified against a live run over tests/evals/rule-scenarios/*.json: the
+    file is {"rules": {<rule-name>: {"rule_path", "scenarios", "summary"}}}.
+    Scenario ids restart at S1 inside every rule, so 24 real scenarios carry
+    only 4 distinct ids and must be namespaced before they can be task ids.
+    """
+
+    @staticmethod
+    def _scenario(sid: str, score: int) -> dict:
+        return {
+            "id": sid,
+            "negative_case": False,
+            "mechanisms": {
+                "full": {
+                    "scores": {
+                        "activation_score": score,
+                        "citation_score": score,
+                        "behavior_score": score,
+                    }
+                }
+            },
+        }
+
+    def _envelope(self) -> dict:
+        return {
+            "rules": {
+                "clean-architecture": {
+                    "rule_path": ".claude/rules/clean-architecture.md",
+                    "scenarios": [self._scenario("S1", 5), self._scenario("S2", 1)],
+                    "summary": {"verdict": "PASS"},
+                },
+                "refactoring": {
+                    "rule_path": ".claude/rules/refactoring.md",
+                    "scenarios": [self._scenario("S1", 1)],
+                    "summary": {"verdict": "PASS"},
+                },
+            }
+        }
+
+    def test_accepts_the_rules_envelope(self, tmp_path, capsys):
+        path = _write(tmp_path, "rules.json", self._envelope())
+        code, out = _run(capsys, "extract", "--kind", "rule", "--input", path)
+        assert code == EXIT_OK
+        assert len(out) == 3
+
+    def test_namespaces_scenario_ids_by_rule(self, tmp_path, capsys):
+        path = _write(tmp_path, "rules.json", self._envelope())
+        _, out = _run(capsys, "extract", "--kind", "rule", "--input", path)
+        assert out == {
+            "clean-architecture::S1": True,
+            "clean-architecture::S2": False,
+            "refactoring::S1": False,
+        }
+
+    def test_a_single_rule_is_namespaced_too(self, tmp_path, capsys):
+        """Namespacing must not depend on how many rules the file holds.
+
+        If it did, adding a second rule would rewrite every existing task id
+        and move the split fingerprint, which the gate refuses to compare.
+        """
+        envelope = {"rules": {"refactoring": {"scenarios": [self._scenario("S1", 5)]}}}
+        path = _write(tmp_path, "rules.json", envelope)
+        _, out = _run(capsys, "extract", "--kind", "rule", "--input", path)
+        assert out == {"refactoring::S1": True}
+
+    def test_a_non_mapping_rules_value_is_a_config_error(self, tmp_path, capsys):
+        path = _write(tmp_path, "rules.json", {"rules": ["not", "a", "mapping"]})
+        code, _ = _run(capsys, "extract", "--kind", "rule", "--input", path)
+        assert code == EXIT_CONFIG
+
+    def test_a_rule_entry_without_scenarios_is_a_config_error(self, tmp_path, capsys):
+        """Fail closed. Skipping the rule would shrink the denominator."""
+        path = _write(tmp_path, "rules.json", {"rules": {"refactoring": {"summary": {}}}})
+        code, _ = _run(capsys, "extract", "--kind", "rule", "--input", path)
+        assert code == EXIT_CONFIG
+
+    def test_a_non_mapping_rule_entry_is_a_config_error(self, tmp_path, capsys):
+        path = _write(tmp_path, "rules.json", {"rules": {"refactoring": "oops"}})
+        code, _ = _run(capsys, "extract", "--kind", "rule", "--input", path)
+        assert code == EXIT_CONFIG
+
+    def test_an_empty_rules_envelope_is_a_config_error(self, tmp_path, capsys):
+        path = _write(tmp_path, "rules.json", {"rules": {}})
+        code, _ = _run(capsys, "extract", "--kind", "rule", "--input", path)
         assert code == EXIT_CONFIG
 
 
@@ -399,6 +488,185 @@ class TestApply:
 # ---------------------------------------------------------------------------
 # gate
 # ---------------------------------------------------------------------------
+
+
+class TestGateHoldsOutOnly:
+    """The gate must read sel and nothing else.
+
+    The PR claimed gating on the optimize group was impossible to express, but
+    --group was wired straight through to the scorer, so `gate --group opt`
+    scored the visible group and reported a verdict. The flag is gone; sel is
+    the only group a gate can read.
+    """
+
+    def _setup(self, tmp_path, capsys, incumbent: dict, candidate: dict):
+        inc = _write(tmp_path, "inc.json", incumbent)
+        cand = _write(tmp_path, "cand.json", candidate)
+        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        return inc, cand, _write(tmp_path, "split.json", split)
+
+    def test_the_group_flag_is_gone(self, tmp_path, capsys):
+        inc, cand, split_path = self._setup(
+            tmp_path,
+            capsys,
+            {f"t{i}": False for i in range(10)},
+            {f"t{i}": True for i in range(10)},
+        )
+        with pytest.raises(SystemExit):
+            _run(
+                capsys,
+                "gate",
+                "--incumbent",
+                inc,
+                "--candidate",
+                cand,
+                "--split",
+                split_path,
+                "--group",
+                "opt",
+            )
+
+    def test_the_verdict_names_the_group_it_read(self, tmp_path, capsys):
+        inc, cand, split_path = self._setup(
+            tmp_path,
+            capsys,
+            {f"t{i}": False for i in range(10)},
+            {f"t{i}": True for i in range(10)},
+        )
+        _, out = _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        )
+        assert out["group"] == "sel"
+
+
+class TestGateRefusalCostsNothing:
+    """A refused comparison must not report the held-out scores.
+
+    Scoring ran before the guards, so a call refused for an exhausted budget
+    still printed both sel scores. That hands over the number the budget exists
+    to ration, and it is free: the caller is told not to advance its counter.
+    """
+
+    def _setup(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": False for i in range(10)})
+        cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(10)})
+        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        return inc, cand, _write(tmp_path, "split.json", split), split
+
+    def test_an_exhausted_budget_withholds_the_scores(self, tmp_path, capsys):
+        inc, cand, split_path, _ = self._setup(tmp_path, capsys)
+        code, out = _run(
+            capsys,
+            "gate",
+            "--incumbent",
+            inc,
+            "--candidate",
+            cand,
+            "--split",
+            split_path,
+            "--consultations",
+            "3",
+            "--max-consultations",
+            "3",
+        )
+        assert code == EXIT_LOGIC
+        assert out["compared"] is False
+        assert "candidate" not in out
+        assert "incumbent" not in out
+
+    def test_a_moved_fingerprint_withholds_the_scores(self, tmp_path, capsys):
+        inc, cand, split_path, _ = self._setup(tmp_path, capsys)
+        code, out = _run(
+            capsys,
+            "gate",
+            "--incumbent",
+            inc,
+            "--candidate",
+            cand,
+            "--split",
+            split_path,
+            "--incumbent-fingerprint",
+            "stale",
+        )
+        assert code == EXIT_LOGIC
+        assert out["compared"] is False
+        assert "candidate" not in out
+
+    def test_a_refusal_still_reports_the_decision_and_reason(self, tmp_path, capsys):
+        inc, cand, split_path, _ = self._setup(tmp_path, capsys)
+        _, out = _run(
+            capsys,
+            "gate",
+            "--incumbent",
+            inc,
+            "--candidate",
+            cand,
+            "--split",
+            split_path,
+            "--incumbent-fingerprint",
+            "stale",
+        )
+        assert out["decision"] == "REJECT"
+        assert "fingerprint" in out["reason"]
+
+    def test_a_permitted_call_still_reports_the_scores(self, tmp_path, capsys):
+        inc, cand, split_path, _ = self._setup(tmp_path, capsys)
+        _, out = _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        )
+        assert out["compared"] is True
+        assert out["candidate"] == 1.0
+        assert out["incumbent"] == 0.0
+
+
+class TestGateReportsPairedEvidence:
+    """Every compared verdict carries the discordant counts and an exact p."""
+
+    def _gate(self, tmp_path, capsys, incumbent: dict, candidate: dict):
+        inc = _write(tmp_path, "inc.json", incumbent)
+        cand = _write(tmp_path, "cand.json", candidate)
+        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        split_path = _write(tmp_path, "split.json", split)
+        return _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
+        )
+
+    def test_a_clean_win_reports_gains_and_no_losses(self, tmp_path, capsys):
+        _, out = self._gate(
+            tmp_path,
+            capsys,
+            {f"t{i}": False for i in range(10)},
+            {f"t{i}": True for i in range(10)},
+        )
+        assert out["discordant_gain"] == 4
+        assert out["discordant_loss"] == 0
+        assert out["p_value"] == pytest.approx(0.0625)
+
+    def test_no_movement_reports_a_p_of_one(self, tmp_path, capsys):
+        same = {f"t{i}": True for i in range(10)}
+        _, out = self._gate(tmp_path, capsys, same, dict(same))
+        assert out["discordant_gain"] == 0
+        assert out["discordant_loss"] == 0
+        assert out["p_value"] == 1.0
+
+    def test_a_refusal_reports_no_paired_evidence(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": False for i in range(10)})
+        cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(10)})
+        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        split_path = _write(tmp_path, "split.json", split)
+        _, out = _run(
+            capsys,
+            "gate",
+            "--incumbent",
+            inc,
+            "--candidate",
+            cand,
+            "--split",
+            split_path,
+            "--incumbent-fingerprint",
+            "stale",
+        )
+        assert "p_value" not in out
 
 
 class TestGate:
@@ -628,13 +896,26 @@ class TestBuffer:
         assert code == EXIT_LOGIC
         assert out["seen"] is True
 
-    def test_reflowed_patch_still_matches(self, tmp_path, capsys):
-        """Whitespace-only rewording must not smuggle a rejected edit back in."""
+    def test_a_reflowed_patch_is_a_different_edit(self, tmp_path, capsys):
+        """Whitespace is content: a newline in patch text splits one line into two.
+
+        Treating the reflow as the same edit let one rejection permanently ban
+        an edit that was never tried, and the buffer has no expiry.
+        """
         buffer = tmp_path / "b.json"
         original = _write(tmp_path, "p.json", [{"op": "append", "text": "alpha beta"}])
         reflowed = _write(tmp_path, "p2.json", [{"op": "append", "text": "alpha   \n beta"}])
         _run(capsys, "buffer-add", "--buffer", buffer, "--patches", original, "--reason", "no")
         code, out = _run(capsys, "buffer-check", "--buffer", buffer, "--patches", reflowed)
+        assert code == EXIT_OK
+        assert out["seen"] is False
+
+    def test_only_line_endings_are_normalized(self, tmp_path, capsys):
+        buffer = tmp_path / "b.json"
+        original = _write(tmp_path, "p.json", [{"op": "append", "text": "alpha\r\nbeta"}])
+        same = _write(tmp_path, "p2.json", [{"op": "append", "text": "alpha\nbeta"}])
+        _run(capsys, "buffer-add", "--buffer", buffer, "--patches", original, "--reason", "no")
+        code, out = _run(capsys, "buffer-check", "--buffer", buffer, "--patches", same)
         assert code == EXIT_LOGIC
         assert out["seen"] is True
 

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -50,6 +50,19 @@ def _run(capsys, *argv: str | Path) -> tuple[int, dict]:
     return code, (json.loads(out) if out else {})
 
 
+def _split(capsys, tmp_path, *args, name="split.json"):
+    """Run `split` and return the full record from the file the gate reads.
+
+    Stdout deliberately redacts held-out membership, so any test that needs
+    the whole split has to read it the way the gate does.
+    """
+    path = tmp_path / name
+    code, stdout = _run(capsys, "split", *args, "--out", path)
+    if code != EXIT_OK:
+        return code, stdout
+    return code, json.loads(path.read_text(encoding="utf-8"))
+
+
 def _boom(*_args, **_kwargs):
     raise OSError("disk full")
 
@@ -282,50 +295,53 @@ class TestExtractRealRuleEnvelope:
 class TestSplit:
     def test_partitions_every_task(self, tmp_path, capsys):
         results = _write(tmp_path, "r.json", _results(6, 4))
-        code, out = _run(capsys, "split", "--results", results, "--seed", "s1")
+        code, out = _split(capsys, tmp_path, "--results", results, "--seed", "s1")
         assert code == EXIT_OK
         assert sorted(out["opt"] + out["sel"] + out["test"]) == sorted(_results(6, 4))
         assert out["fingerprint"]
 
     def test_is_deterministic_for_a_seed(self, tmp_path, capsys):
         results = _write(tmp_path, "r.json", _results(6, 4))
-        _, first = _run(capsys, "split", "--results", results, "--seed", "s1")
-        _, second = _run(capsys, "split", "--results", results, "--seed", "s1")
+        _, first = _split(capsys, tmp_path, "--results", results, "--seed", "s1")
+        _, second = _split(capsys, tmp_path, "--results", results, "--seed", "s1")
         assert first == second
 
     def test_seed_changes_the_split(self, tmp_path, capsys):
         results = _write(tmp_path, "r.json", _results(6, 4))
-        _, first = _run(capsys, "split", "--results", results, "--seed", "s1")
-        _, second = _run(capsys, "split", "--results", results, "--seed", "s2")
+        _, first = _split(capsys, tmp_path, "--results", results, "--seed", "s1")
+        _, second = _split(capsys, tmp_path, "--results", results, "--seed", "s2")
         assert first["fingerprint"] != second["fingerprint"]
 
     def test_reads_a_plain_task_id_list(self, tmp_path, capsys):
         tasks = tmp_path / "ids.txt"
         tasks.write_text("\n".join(f"t{i}" for i in range(10)) + "\n", encoding="utf-8")
-        code, out = _run(capsys, "split", "--tasks", tasks, "--seed", "s1")
+        code, out = _split(capsys, tmp_path, "--tasks", tasks, "--seed", "s1")
         assert code == EXIT_OK
         assert len(out["opt"] + out["sel"] + out["test"]) == 10
 
     def test_blank_lines_in_a_task_list_are_ignored(self, tmp_path, capsys):
         tasks = tmp_path / "ids.txt"
         tasks.write_text("t0\n\n  \nt1\nt2\nt3\nt4\nt5\nt6\nt7\n", encoding="utf-8")
-        code, out = _run(capsys, "split", "--tasks", tasks, "--seed", "s1")
+        code, out = _split(capsys, tmp_path, "--tasks", tasks, "--seed", "s1")
         assert code == EXIT_OK
         assert len(out["opt"] + out["sel"] + out["test"]) == 8
 
     def test_too_few_tasks_is_a_config_error(self, tmp_path, capsys):
         results = _write(tmp_path, "r.json", _results(2, 0))
-        code, _ = _run(capsys, "split", "--results", results, "--seed", "s1")
+        code, _ = _split(capsys, tmp_path, "--results", results, "--seed", "s1")
         assert code == EXIT_CONFIG
 
     def test_requires_a_task_source(self, capsys):
         with pytest.raises(SystemExit):
-            oa.main(["split", "--seed", "s1"])
+            oa.main(["split", "--seed", "s1", "--out", "x.json"])
 
     def test_rejects_both_task_sources(self, tmp_path, capsys):
         results = _write(tmp_path, "r.json", _results(6, 4))
         with pytest.raises(SystemExit):
-            oa.main(["split", "--results", str(results), "--tasks", "x", "--seed", "s"])
+            oa.main(
+                ["split", "--results", str(results), "--tasks", "x", "--seed", "s",
+                 "--out", "x.json"]
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -376,16 +392,22 @@ class TestBudget:
 
 class TestScore:
     def _split_file(self, tmp_path, capsys, results_path) -> Path:
-        _, split = _run(capsys, "split", "--results", results_path, "--seed", "s1")
-        return _write(tmp_path, "split.json", split)
+        _split(capsys, tmp_path, "--results", results_path, "--seed", "s1")
+        return tmp_path / "split.json"
 
-    def test_scores_the_sel_group_by_default(self, tmp_path, capsys):
+    def test_scores_the_optimize_group_by_default(self, tmp_path, capsys):
+        """This test used to assert a default of `sel`, which was the hole.
+
+        A free-standing unmetered score on the held-out group hands the
+        optimizer the answer the gate is supposed to charge a consultation
+        for. `opt` is the only group this command will read.
+        """
         results = _write(tmp_path, "r.json", _results(10, 0))
         split = self._split_file(tmp_path, capsys, results)
         code, out = _run(capsys, "score", "--results", results, "--split", split)
         assert code == EXIT_OK
         assert out["score"] == 1.0
-        assert out["group"] == "sel"
+        assert out["group"] == "opt"
         assert out["n"] > 0
 
     def test_scores_a_named_group(self, tmp_path, capsys):
@@ -506,7 +528,7 @@ class TestGateHoldsOutOnly:
     def _setup(self, tmp_path, capsys, incumbent: dict, candidate: dict):
         inc = _write(tmp_path, "inc.json", incumbent)
         cand = _write(tmp_path, "cand.json", candidate)
-        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        _, split = _split(capsys, tmp_path, "--results", inc, "--seed", "s1")
         return inc, cand, _write(tmp_path, "split.json", split)
 
     def test_the_group_flag_is_gone(self, tmp_path, capsys):
@@ -554,7 +576,7 @@ class TestGateRefusalCostsNothing:
     def _setup(self, tmp_path, capsys):
         inc = _write(tmp_path, "inc.json", {f"t{i}": False for i in range(10)})
         cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(10)})
-        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        _, split = _split(capsys, tmp_path, "--results", inc, "--seed", "s1")
         return inc, cand, _write(tmp_path, "split.json", split), split
 
     def test_an_exhausted_budget_withholds_the_scores(self, tmp_path, capsys):
@@ -629,7 +651,7 @@ class TestGateReportsPairedEvidence:
     def _gate(self, tmp_path, capsys, incumbent: dict, candidate: dict):
         inc = _write(tmp_path, "inc.json", incumbent)
         cand = _write(tmp_path, "cand.json", candidate)
-        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        _, split = _split(capsys, tmp_path, "--results", inc, "--seed", "s1")
         split_path = _write(tmp_path, "split.json", split)
         return _run(
             capsys, "gate", "--incumbent", inc, "--candidate", cand, "--split", split_path
@@ -656,7 +678,7 @@ class TestGateReportsPairedEvidence:
     def test_a_refusal_reports_no_paired_evidence(self, tmp_path, capsys):
         inc = _write(tmp_path, "inc.json", {f"t{i}": False for i in range(10)})
         cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(10)})
-        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        _, split = _split(capsys, tmp_path, "--results", inc, "--seed", "s1")
         split_path = _write(tmp_path, "split.json", split)
         _, out = _run(
             capsys,
@@ -677,7 +699,7 @@ class TestGate:
     def _setup(self, tmp_path, capsys, incumbent: dict, candidate: dict):
         inc = _write(tmp_path, "inc.json", incumbent)
         cand = _write(tmp_path, "cand.json", candidate)
-        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        _, split = _split(capsys, tmp_path, "--results", inc, "--seed", "s1")
         return inc, cand, _write(tmp_path, "split.json", split), split
 
     def test_accepts_a_strict_improvement(self, tmp_path, capsys):
@@ -720,7 +742,7 @@ class TestGate:
     def test_scores_the_held_out_group_not_the_optimize_group(self, tmp_path, capsys):
         """The candidate wins only on opt tasks, so the gate must reject it."""
         inc = _write(tmp_path, "inc.json", {f"t{i}": False for i in range(10)})
-        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        _, split = _split(capsys, tmp_path, "--results", inc, "--seed", "s1")
         split_path = _write(tmp_path, "split.json", split)
         candidate = {t: True for t in split["opt"]}
         candidate.update({t: False for t in split["sel"] + split["test"]})
@@ -989,12 +1011,12 @@ class TestMalformedInputs:
 
     def test_results_must_be_an_object(self, tmp_path, capsys):
         results = _write(tmp_path, "r.json", ["t0", "t1"])
-        code, _ = _run(capsys, "split", "--results", results, "--seed", "s1")
+        code, _ = _split(capsys, tmp_path, "--results", results, "--seed", "s1")
         assert code == EXIT_CONFIG
 
     def test_results_must_be_boolean_valued(self, tmp_path, capsys):
         results = _write(tmp_path, "r.json", {"t0": 1, "t1": "yes"})
-        code, _ = _run(capsys, "split", "--results", results, "--seed", "s1")
+        code, _ = _split(capsys, tmp_path, "--results", results, "--seed", "s1")
         assert code == EXIT_CONFIG
 
     def test_empty_patch_array_is_a_config_error(self, tmp_path, capsys):
@@ -1012,7 +1034,7 @@ class TestMalformedInputs:
 
     def test_negative_consultations_is_a_config_error(self, tmp_path, capsys):
         results = _write(tmp_path, "r.json", _results(10, 0))
-        _, split = _run(capsys, "split", "--results", results, "--seed", "s1")
+        _, split = _split(capsys, tmp_path, "--results", results, "--seed", "s1")
         split_path = _write(tmp_path, "split.json", split)
         code, _ = _run(
             capsys,
@@ -1050,7 +1072,7 @@ class TestSplitFileIsSelfValidating:
     def _setup(self, tmp_path, capsys):
         inc = _write(tmp_path, "inc.json", {f"t{i}": False for i in range(10)})
         cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(10)})
-        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1")
+        _, split = _split(capsys, tmp_path, "--results", inc, "--seed", "s1")
         return inc, cand, split
 
     def test_an_untampered_split_gates_normally(self, tmp_path, capsys):
@@ -1129,7 +1151,7 @@ class TestSplitFileIsSelfValidating:
 
     def test_split_writes_the_ratios_it_used(self, tmp_path, capsys):
         inc = _write(tmp_path, "inc.json", {f"t{i}": False for i in range(10)})
-        _, split = _run(capsys, "split", "--results", inc, "--seed", "s1",
+        _, split = _split(capsys, tmp_path, "--results", inc, "--seed", "s1",
                         "--sel-ratio", "0.4", "--test-ratio", "0.2")
         assert split["sel_ratio"] == 0.4
         assert split["test_ratio"] == 0.2
@@ -1199,3 +1221,65 @@ class TestApplyWritesAtomically:
         monkeypatch.setattr(oa.os, "replace", _boom)
         _run(capsys, "apply", "--file", target, "--patches", patches, "--budget", "1")
         assert sorted(p.name for p in tmp_path.iterdir()) == ["artifact.md", "p.json"]
+
+
+class TestHeldOutGroupsAreNotReadable:
+    """The optimizer-facing surface must not hand back what the gate withholds.
+
+    An adversarial review (gpt-5.6-sol, 2026-07-26) found the withholding was
+    nominal: `split` printed every selection and test id, and `score` defaulted
+    to the selection group and accepted the test group, unmetered. An agent
+    could read the held-out answers for free and never touch the consultation
+    budget. A hash around openly published data is not withholding.
+    """
+
+    def _tasks(self, tmp_path):
+        return _write(tmp_path, "res.json", {f"t{i}": True for i in range(10)})
+
+    def test_split_prints_optimize_ids_but_not_held_out_ids(self, tmp_path, capsys):
+        out_path = tmp_path / "split.json"
+        code, out = _run(capsys, "split", "--results", self._tasks(tmp_path),
+                         "--seed", "s", "--out", out_path)
+        assert code == 0
+        assert out["opt"], "the optimizer needs to know what it may work on"
+        assert "sel" not in out and "test" not in out
+
+    def test_split_reports_held_out_sizes_without_membership(self, tmp_path, capsys):
+        out_path = tmp_path / "split.json"
+        _, out = _run(capsys, "split", "--results", self._tasks(tmp_path),
+                      "--seed", "s", "--out", out_path)
+        assert out["n_sel"] == 4 and out["n_test"] == 0
+
+    def test_the_full_split_still_reaches_the_gate_through_the_file(
+        self, tmp_path, capsys
+    ):
+        out_path = tmp_path / "split.json"
+        _run(capsys, "split", "--results", self._tasks(tmp_path), "--seed", "s",
+             "--out", out_path)
+        written = json.loads(out_path.read_text(encoding="utf-8"))
+        assert len(written["sel"]) == 4
+        assert written["fingerprint"]
+
+    def test_score_refuses_the_selection_group(self, tmp_path, capsys):
+        out_path = tmp_path / "split.json"
+        _run(capsys, "split", "--results", self._tasks(tmp_path), "--seed", "s",
+             "--out", out_path)
+        with pytest.raises(SystemExit):
+            _run(capsys, "score", "--results", self._tasks(tmp_path),
+                 "--split", out_path, "--group", "sel")
+
+    def test_score_refuses_the_test_group(self, tmp_path, capsys):
+        out_path = tmp_path / "split.json"
+        _run(capsys, "split", "--results", self._tasks(tmp_path), "--seed", "s",
+             "--out", out_path)
+        with pytest.raises(SystemExit):
+            _run(capsys, "score", "--results", self._tasks(tmp_path),
+                 "--split", out_path, "--group", "test")
+
+    def test_score_still_reads_the_optimize_group(self, tmp_path, capsys):
+        out_path = tmp_path / "split.json"
+        _run(capsys, "split", "--results", self._tasks(tmp_path), "--seed", "s",
+             "--out", out_path)
+        code, out = _run(capsys, "score", "--results", self._tasks(tmp_path),
+                         "--split", out_path)
+        assert code == 0 and out["group"] == "opt" and out["score"] == 1.0

--- a/tests/test_eval_optimizer_adapters.py
+++ b/tests/test_eval_optimizer_adapters.py
@@ -19,7 +19,13 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "eval"))
+_EVAL_DIR = Path(__file__).resolve().parent.parent / "scripts" / "eval"
+# Scope the mutation to the module load and remove it afterward so a sibling
+# test cannot pick up an importable name it never asked for, and so repeated
+# imports cannot stack duplicate entries.
+_path_added = str(_EVAL_DIR) not in sys.path
+if _path_added:
+    sys.path.insert(0, str(_EVAL_DIR))
 
 from _optimizer_adapters import (  # noqa: E402
     DEFAULT_MIN_ACTIVATION_SCORE,
@@ -28,6 +34,9 @@ from _optimizer_adapters import (  # noqa: E402
     pytest_results,
     rule_results,
 )
+
+if _path_added and str(_EVAL_DIR) in sys.path:
+    sys.path.remove(str(_EVAL_DIR))
 
 # ---------------------------------------------------------------------------
 # agent_results

--- a/tests/test_eval_optimizer_adapters.py
+++ b/tests/test_eval_optimizer_adapters.py
@@ -1,0 +1,333 @@
+"""Tests for `scripts/eval/_optimizer_adapters.py`.
+
+The adapters are the reason the held-out gate generalizes past skills. Each
+one turns a different existing scorer's output into the single `{task_id:
+bool}` mapping `_optimizer_core.score` consumes, so agents, rules, and hooks
+all reach the same gate.
+
+Every adapter fails closed: an unreadable, errored, or missing outcome scores
+as a failure rather than being dropped, because a dropped task silently
+shrinks the denominator and inflates the score.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "eval"))
+
+from _optimizer_adapters import (  # noqa: E402
+    DEFAULT_MIN_ACTIVATION_SCORE,
+    AdapterError,
+    agent_results,
+    pytest_results,
+    rule_results,
+)
+
+# ---------------------------------------------------------------------------
+# agent_results
+# ---------------------------------------------------------------------------
+
+
+def _report(rates: dict) -> dict:
+    return {"per_fixture_pass_rates": rates}
+
+
+class TestAgentResults:
+    def test_reads_the_requested_variant(self):
+        report = _report(
+            {
+                "C001": {"agent": [1.0, 1.0], "baseline": [0.0, 0.0]},
+                "C002": {"agent": [0.0, 0.0], "baseline": [1.0, 1.0]},
+            }
+        )
+        assert agent_results(report, "agent") == {"C001": True, "C002": False}
+        assert agent_results(report, "baseline") == {"C001": False, "C002": True}
+
+    def test_default_threshold_demands_every_run_clean(self):
+        """A fixture that passed twice and half-passed once is not a pass."""
+        report = _report({"C001": {"agent": [1.0, 0.5, 1.0]}})
+        assert agent_results(report, "agent") == {"C001": False}
+
+    def test_lower_threshold_admits_a_partial_fixture(self):
+        report = _report({"C001": {"agent": [1.0, 0.5, 1.0]}})
+        assert agent_results(report, "agent", pass_threshold=0.8) == {"C001": True}
+
+    def test_threshold_is_inclusive(self):
+        report = _report({"C001": {"agent": [0.5, 0.5]}})
+        assert agent_results(report, "agent", pass_threshold=0.5) == {"C001": True}
+
+    def test_min_reduction_punishes_one_bad_run(self):
+        report = _report({"C001": {"agent": [1.0, 1.0, 0.0]}})
+        assert agent_results(report, "agent", reduce="min", pass_threshold=1.0) == {
+            "C001": False
+        }
+
+    def test_max_reduction_rewards_one_good_run(self):
+        report = _report({"C001": {"agent": [0.0, 0.0, 1.0]}})
+        assert agent_results(report, "agent", reduce="max", pass_threshold=1.0) == {
+            "C001": True
+        }
+
+    def test_median_reduction_ignores_a_single_outlier(self):
+        report = _report({"C001": {"agent": [1.0, 1.0, 0.0]}})
+        assert agent_results(report, "agent", reduce="median", pass_threshold=1.0) == {
+            "C001": True
+        }
+
+    def test_median_of_an_even_sample_averages_the_middle_pair(self):
+        report = _report({"C001": {"agent": [0.0, 0.4, 0.6, 1.0]}})
+        assert agent_results(report, "agent", reduce="median", pass_threshold=0.5) == {
+            "C001": True
+        }
+
+    def test_missing_variant_for_a_fixture_scores_as_failure(self):
+        """A fixture the variant never ran on must not vanish from the split."""
+        report = _report({"C001": {"baseline": [1.0]}})
+        assert agent_results(report, "agent") == {"C001": False}
+
+    def test_empty_run_list_scores_as_failure(self):
+        report = _report({"C001": {"agent": []}})
+        assert agent_results(report, "agent") == {"C001": False}
+
+    def test_empty_report_yields_empty_mapping(self):
+        assert agent_results(_report({}), "agent") == {}
+
+    def test_rejects_a_report_without_the_rates_key(self):
+        with pytest.raises(AdapterError, match="per_fixture_pass_rates"):
+            agent_results({}, "agent")
+
+    def test_rejects_non_mapping_rates(self):
+        with pytest.raises(AdapterError, match="must be a mapping"):
+            agent_results({"per_fixture_pass_rates": [["C001", 1.0]]}, "agent")
+
+    def test_rejects_an_unknown_reduction(self):
+        report = _report({"C001": {"agent": [1.0]}})
+        with pytest.raises(AdapterError, match="reduce"):
+            agent_results(report, "agent", reduce="mode")
+
+    def test_rejects_a_non_numeric_run_value(self):
+        report = _report({"C001": {"agent": ["1.0"]}})
+        with pytest.raises(AdapterError, match="numeric"):
+            agent_results(report, "agent")
+
+    def test_rejects_a_non_mapping_fixture_entry(self):
+        with pytest.raises(AdapterError, match="mapping"):
+            agent_results(_report({"C001": [1.0]}), "agent")
+
+    def test_accepts_integer_run_values(self):
+        report = _report({"C001": {"agent": [1, 1]}})
+        assert agent_results(report, "agent") == {"C001": True}
+
+    def test_rejects_a_boolean_run_value(self):
+        """`True` is an int in Python; a pass-rate list of bools is a shape bug."""
+        report = _report({"C001": {"agent": [True]}})
+        with pytest.raises(AdapterError, match="numeric"):
+            agent_results(report, "agent")
+
+
+# ---------------------------------------------------------------------------
+# rule_results
+# ---------------------------------------------------------------------------
+
+
+def _scenario(sid: str, mech: str, triple: tuple, *, negative: bool = False, **kw) -> dict:
+    scores = {
+        "activation_score": triple[0],
+        "citation_score": triple[1],
+        "behavior_score": triple[2],
+    }
+    scores.update(kw)
+    return {
+        "id": sid,
+        "negative_case": negative,
+        "mechanisms": {mech: {"scores": scores}},
+    }
+
+
+class TestRuleResults:
+    def test_positive_scenario_passes_above_the_activation_floor(self):
+        scenarios = [_scenario("S1", "full", (4, 4, 4))]
+        assert rule_results(scenarios, "full") == {"S1": True}
+
+    def test_positive_scenario_fails_below_the_activation_floor(self):
+        scenarios = [_scenario("S1", "full", (3, 3, 3))]
+        assert rule_results(scenarios, "full") == {"S1": False}
+
+    def test_activation_floor_is_inclusive(self):
+        scenarios = [_scenario("S1", "full", (3.5, 3.5, 3.5))]
+        assert rule_results(scenarios, "full") == {"S1": True}
+
+    def test_negative_scenario_passes_when_the_rule_stays_quiet(self):
+        """A negative case is scored inverted: not activating is the win."""
+        scenarios = [_scenario("S1", "full", (1, 1, 1), negative=True)]
+        assert rule_results(scenarios, "full") == {"S1": True}
+
+    def test_negative_scenario_fails_when_the_rule_fires_anyway(self):
+        scenarios = [_scenario("S1", "full", (5, 5, 5), negative=True)]
+        assert rule_results(scenarios, "full") == {"S1": False}
+
+    def test_judge_failure_scores_as_failure(self):
+        scenarios = [_scenario("S1", "full", (5, 5, 5), judge_failed=True)]
+        assert rule_results(scenarios, "full") == {"S1": False}
+
+    def test_judge_failure_also_fails_a_negative_case(self):
+        """A broken judge proves nothing, so inversion must not rescue it."""
+        scenarios = [_scenario("S1", "full", (1, 1, 1), negative=True, judge_failed=True)]
+        assert rule_results(scenarios, "full") == {"S1": False}
+
+    def test_mechanism_error_scores_as_failure(self):
+        scenarios = [_scenario("S1", "full", (5, 5, 5))]
+        scenarios[0]["mechanisms"]["full"]["error"] = "rate limited"
+        assert rule_results(scenarios, "full") == {"S1": False}
+
+    def test_missing_mechanism_scores_as_failure(self):
+        scenarios = [_scenario("S1", "description", (5, 5, 5))]
+        assert rule_results(scenarios, "full") == {"S1": False}
+
+    def test_missing_score_keys_count_as_zero(self):
+        scenarios = [{"id": "S1", "negative_case": False, "mechanisms": {"full": {"scores": {}}}}]
+        assert rule_results(scenarios, "full") == {"S1": False}
+
+    def test_custom_floor_is_honored(self):
+        scenarios = [_scenario("S1", "full", (3, 3, 3))]
+        assert rule_results(scenarios, "full", min_score=3.0) == {"S1": True}
+
+    def test_empty_scenarios_yield_empty_mapping(self):
+        assert rule_results([], "full") == {}
+
+    def test_rejects_a_scenario_without_an_id(self):
+        with pytest.raises(AdapterError, match="id"):
+            rule_results([{"negative_case": False, "mechanisms": {}}], "full")
+
+    def test_rejects_duplicate_scenario_ids(self):
+        scenarios = [_scenario("S1", "full", (4, 4, 4)), _scenario("S1", "full", (1, 1, 1))]
+        with pytest.raises(AdapterError, match="duplicate"):
+            rule_results(scenarios, "full")
+
+    def test_rejects_a_non_numeric_score(self):
+        scenarios = [_scenario("S1", "full", ("high", 4, 4))]
+        with pytest.raises(AdapterError, match="numeric"):
+            rule_results(scenarios, "full")
+
+    def test_default_floor_tracks_the_rule_activation_scorer(self):
+        """The floor is duplicated from a hyphenated CLI module; catch drift."""
+        source = (
+            Path(__file__).resolve().parent.parent
+            / "scripts"
+            / "eval"
+            / "eval-rule-activation.py"
+        ).read_text(encoding="utf-8")
+        match = re.search(r"^MIN_ACTIVATION_SCORE\s*=\s*([0-9.]+)", source, re.MULTILINE)
+        assert match, "MIN_ACTIVATION_SCORE not found in eval-rule-activation.py"
+        assert float(match.group(1)) == DEFAULT_MIN_ACTIVATION_SCORE
+
+
+# ---------------------------------------------------------------------------
+# pytest_results
+# ---------------------------------------------------------------------------
+
+
+def _junit(cases: str, *, suite_attrs: str = "") -> str:
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        f"<testsuites><testsuite name='pytest'{suite_attrs}>{cases}</testsuite></testsuites>"
+    )
+
+
+class TestPytestResults:
+    def test_passing_case_maps_to_true(self):
+        xml = _junit('<testcase classname="tests.test_a" name="test_x"/>')
+        assert pytest_results(xml) == {"tests.test_a::test_x": True}
+
+    def test_failing_case_maps_to_false(self):
+        xml = _junit(
+            '<testcase classname="tests.test_a" name="test_x">'
+            '<failure message="boom">trace</failure></testcase>'
+        )
+        assert pytest_results(xml) == {"tests.test_a::test_x": False}
+
+    def test_errored_case_maps_to_false(self):
+        xml = _junit(
+            '<testcase classname="tests.test_a" name="test_x">'
+            '<error message="fixture blew up"/></testcase>'
+        )
+        assert pytest_results(xml) == {"tests.test_a::test_x": False}
+
+    def test_skipped_case_fails_by_default(self):
+        """A skipped test demonstrated nothing, so it cannot count as a pass."""
+        xml = _junit(
+            '<testcase classname="tests.test_a" name="test_x">'
+            '<skipped message="needs network"/></testcase>'
+        )
+        assert pytest_results(xml) == {"tests.test_a::test_x": False}
+
+    def test_skipped_case_can_be_excluded(self):
+        xml = _junit(
+            '<testcase classname="tests.test_a" name="test_x">'
+            '<skipped message="needs network"/></testcase>'
+            '<testcase classname="tests.test_a" name="test_y"/>'
+        )
+        assert pytest_results(xml, on_skip="exclude") == {"tests.test_a::test_y": True}
+
+    def test_parameterized_ids_stay_distinct(self):
+        xml = _junit(
+            '<testcase classname="tests.test_a" name="test_x[1]"/>'
+            '<testcase classname="tests.test_a" name="test_x[2]">'
+            "<failure/></testcase>"
+        )
+        assert pytest_results(xml) == {
+            "tests.test_a::test_x[1]": True,
+            "tests.test_a::test_x[2]": False,
+        }
+
+    def test_reads_multiple_suites(self):
+        xml = (
+            "<testsuites>"
+            "<testsuite name='a'><testcase classname='tests.test_a' name='test_x'/></testsuite>"
+            "<testsuite name='b'><testcase classname='tests.test_b' name='test_y'/></testsuite>"
+            "</testsuites>"
+        )
+        assert pytest_results(xml) == {
+            "tests.test_a::test_x": True,
+            "tests.test_b::test_y": True,
+        }
+
+    def test_reads_a_bare_testsuite_root(self):
+        xml = (
+            "<testsuite name='pytest'>"
+            "<testcase classname='tests.test_a' name='test_x'/></testsuite>"
+        )
+        assert pytest_results(xml) == {"tests.test_a::test_x": True}
+
+    def test_case_without_classname_uses_the_name_alone(self):
+        xml = _junit('<testcase name="test_x"/>')
+        assert pytest_results(xml) == {"test_x": True}
+
+    def test_empty_suite_yields_empty_mapping(self):
+        assert pytest_results(_junit("")) == {}
+
+    def test_rejects_malformed_xml(self):
+        with pytest.raises(AdapterError, match="parse"):
+            pytest_results("<testsuite><testcase")
+
+    def test_rejects_a_case_without_a_name(self):
+        with pytest.raises(AdapterError, match="name"):
+            pytest_results(_junit('<testcase classname="tests.test_a"/>'))
+
+    def test_rejects_duplicate_node_ids(self):
+        """Duplicate ids would silently collapse two tests into one gate signal."""
+        xml = _junit(
+            '<testcase classname="tests.test_a" name="test_x"/>'
+            '<testcase classname="tests.test_a" name="test_x"><failure/></testcase>'
+        )
+        with pytest.raises(AdapterError, match="duplicate"):
+            pytest_results(xml)
+
+    def test_rejects_an_unknown_skip_policy(self):
+        with pytest.raises(AdapterError, match="on_skip"):
+            pytest_results(_junit(""), on_skip="ignore")

--- a/tests/test_eval_optimizer_adapters.py
+++ b/tests/test_eval_optimizer_adapters.py
@@ -24,19 +24,20 @@ _EVAL_DIR = Path(__file__).resolve().parent.parent / "scripts" / "eval"
 # test cannot pick up an importable name it never asked for, and so repeated
 # imports cannot stack duplicate entries.
 _path_added = str(_EVAL_DIR) not in sys.path
-if _path_added:
-    sys.path.insert(0, str(_EVAL_DIR))
+try:
+    if _path_added:
+        sys.path.insert(0, str(_EVAL_DIR))
 
-from _optimizer_adapters import (  # noqa: E402
-    DEFAULT_MIN_ACTIVATION_SCORE,
-    AdapterError,
-    agent_results,
-    pytest_results,
-    rule_results,
-)
-
-if _path_added and str(_EVAL_DIR) in sys.path:
-    sys.path.remove(str(_EVAL_DIR))
+    from _optimizer_adapters import (  # noqa: E402
+        DEFAULT_MIN_ACTIVATION_SCORE,
+        AdapterError,
+        agent_results,
+        pytest_results,
+        rule_results,
+    )
+finally:
+    if _path_added and str(_EVAL_DIR) in sys.path:
+        sys.path.remove(str(_EVAL_DIR))
 
 # ---------------------------------------------------------------------------
 # agent_results

--- a/tests/test_eval_optimizer_adapters.py
+++ b/tests/test_eval_optimizer_adapters.py
@@ -12,6 +12,7 @@ shrinks the denominator and inflates the score.
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
@@ -35,6 +36,82 @@ from _optimizer_adapters import (  # noqa: E402
 
 def _report(rates: dict) -> dict:
     return {"per_fixture_pass_rates": rates}
+
+
+class TestNonFiniteScores:
+    """NaN and infinity must not be read as outcomes.
+
+    Adversarial review found both slipping through: NaN made a scenario pass
+    because every comparison against it is False, and infinity made a fixture
+    pass unconditionally. Both arrive from real producers, since JSON's own
+    parser accepts the bare tokens, and either one silently rewrites a verdict
+    the gate is supposed to be measuring.
+    """
+
+    def test_nan_in_an_agent_rate_is_refused(self):
+        with pytest.raises(AdapterError, match="finite"):
+            agent_results(_report({"C001": {"agent": [float("nan")]}}), "agent")
+
+    def test_infinity_in_an_agent_rate_is_refused(self):
+        with pytest.raises(AdapterError, match="finite"):
+            agent_results(_report({"C001": {"agent": [float("inf")]}}), "agent")
+
+    def test_negative_infinity_is_refused(self):
+        with pytest.raises(AdapterError, match="finite"):
+            agent_results(_report({"C001": {"agent": [float("-inf")]}}), "agent")
+
+    def test_nan_parsed_from_real_json_is_refused(self):
+        """json.loads accepts the bare NaN token, so this is a live path."""
+        report = json.loads('{"per_fixture_pass_rates": {"C001": {"agent": [NaN]}}}')
+        with pytest.raises(AdapterError, match="finite"):
+            agent_results(report, "agent")
+
+    def test_infinity_does_not_pass_a_fixture(self):
+        """Before the fix, inf >= any threshold, so the fixture passed."""
+        with pytest.raises(AdapterError):
+            agent_results(_report({"C001": {"agent": [float("inf")]}}), "agent")
+
+    def test_nan_in_a_rule_score_is_refused(self):
+        scenarios = [
+            {
+                "id": "S1",
+                "mechanisms": {
+                    "m": {
+                        "scores": {
+                            "activation_score": float("nan"),
+                            "citation_score": 5,
+                            "behavior_score": 5,
+                        }
+                    }
+                },
+            }
+        ]
+        with pytest.raises(AdapterError, match="finite"):
+            rule_results(scenarios, "m")
+
+    def test_an_ordinary_finite_score_still_passes(self):
+        assert agent_results(_report({"C001": {"agent": [1.0]}}), "agent") == {"C001": True}
+
+
+class TestNullScoresBlock:
+    """An explicit JSON null is not a missing key.
+
+    dict.get returns the stored None rather than the default, so a scenario
+    carrying "scores": null crashed with an uncaught AttributeError instead of
+    a named adapter error.
+    """
+
+    def test_a_null_scores_block_is_refused(self):
+        with pytest.raises(AdapterError, match="scores"):
+            rule_results([{"id": "S1", "mechanisms": {"m": {"scores": None}}}], "m")
+
+    def test_a_non_mapping_scores_block_is_refused(self):
+        with pytest.raises(AdapterError, match="scores"):
+            rule_results([{"id": "S1", "mechanisms": {"m": {"scores": [1, 2, 3]}}}], "m")
+
+    def test_a_missing_scores_block_still_scores_zero(self):
+        """Absent is different from malformed and keeps its existing meaning."""
+        assert rule_results([{"id": "S1", "mechanisms": {"m": {}}}], "m") == {"S1": False}
 
 
 class TestAgentResults:
@@ -163,12 +240,20 @@ class TestRuleResults:
         assert rule_results(scenarios, "full") == {"S1": True}
 
     def test_negative_scenario_passes_when_the_rule_stays_quiet(self):
-        """A negative case is scored inverted: not activating is the win."""
-        scenarios = [_scenario("S1", "full", (1, 1, 1), negative=True)]
+        """The judge already normalizes a negative case, so do not invert.
+
+        eval-rule-activation.py builds the judge prompt with "(negative case: 5
+        means the response correctly did NOT activate the rule and gave generic
+        advice instead)". A high score therefore already means correct
+        behavior for both polarities. Inverting here would double-invert and
+        punish exactly the rules that behave.
+        """
+        scenarios = [_scenario("S1", "full", (5, 5, 5), negative=True)]
         assert rule_results(scenarios, "full") == {"S1": True}
 
     def test_negative_scenario_fails_when_the_rule_fires_anyway(self):
-        scenarios = [_scenario("S1", "full", (5, 5, 5), negative=True)]
+        """A low negative-case score means the rule fired when it should not."""
+        scenarios = [_scenario("S1", "full", (1, 1, 1), negative=True)]
         assert rule_results(scenarios, "full") == {"S1": False}
 
     def test_judge_failure_scores_as_failure(self):
@@ -176,9 +261,32 @@ class TestRuleResults:
         assert rule_results(scenarios, "full") == {"S1": False}
 
     def test_judge_failure_also_fails_a_negative_case(self):
-        """A broken judge proves nothing, so inversion must not rescue it."""
-        scenarios = [_scenario("S1", "full", (1, 1, 1), negative=True, judge_failed=True)]
+        """A broken judge proves nothing for either polarity."""
+        scenarios = [_scenario("S1", "full", (5, 5, 5), negative=True, judge_failed=True)]
         assert rule_results(scenarios, "full") == {"S1": False}
+
+    def test_negative_and_positive_use_the_same_threshold(self):
+        """Both polarities read the same normalized scale, so one floor fits."""
+        scenarios = [
+            _scenario("POS", "full", (3.5, 3.5, 3.5)),
+            _scenario("NEG", "full", (3.5, 3.5, 3.5), negative=True),
+        ]
+        assert rule_results(scenarios, "full") == {"POS": True, "NEG": True}
+
+    def test_judge_prompt_still_normalizes_negative_cases(self):
+        """Drift guard for the semantics this adapter depends on.
+
+        If eval-rule-activation.py ever stops telling the judge that 5 is the
+        correct-behavior end of the scale for negative cases, the no-inversion
+        policy above becomes wrong and this test must fail loudly.
+        """
+        source = (
+            Path(__file__).resolve().parents[1]
+            / "scripts"
+            / "eval"
+            / "eval-rule-activation.py"
+        ).read_text(encoding="utf-8")
+        assert "negative case: 5 means the response correctly did NOT activate" in source
 
     def test_mechanism_error_scores_as_failure(self):
         scenarios = [_scenario("S1", "full", (5, 5, 5))]

--- a/tests/test_eval_optimizer_adapters.py
+++ b/tests/test_eval_optimizer_adapters.py
@@ -439,3 +439,32 @@ class TestPytestResults:
     def test_rejects_an_unknown_skip_policy(self):
         with pytest.raises(AdapterError, match="on_skip"):
             pytest_results(_junit(""), on_skip="ignore")
+
+
+class TestMalformedScenarioShapes:
+    """Every level of the scenario shape has to fail as AdapterError.
+
+    The `scores` block was hardened earlier in this branch but the two levels
+    above it were not, so a malformed `mechanisms` value or a scenario that is
+    not an object still escaped as a bare AttributeError from inside a
+    dict.get chain. A raw AttributeError names neither the scenario nor the
+    field, which is the whole reason AdapterError exists.
+    """
+
+    @pytest.mark.parametrize("mechanisms", [None, [], "x", 3])
+    def test_a_non_mapping_mechanisms_block_is_an_adapter_error(self, mechanisms):
+        with pytest.raises(AdapterError, match="mechanisms"):
+            rule_results([{"id": "S1", "mechanisms": mechanisms}], "m")
+
+    @pytest.mark.parametrize("scenario", [None, [], "x", 3])
+    def test_a_non_mapping_scenario_is_an_adapter_error(self, scenario):
+        with pytest.raises(AdapterError, match="scenario"):
+            rule_results([scenario], "m")
+
+    def test_an_absent_mechanisms_key_still_means_no_evidence(self):
+        """Absent is not malformed. It keeps its fail-closed meaning."""
+        assert rule_results([{"id": "S1"}], "m") == {"S1": False}
+
+    def test_the_error_names_the_scenario(self):
+        with pytest.raises(AdapterError, match="S7"):
+            rule_results([{"id": "S7", "mechanisms": "bad"}], "m")

--- a/tests/test_eval_optimizer_core.py
+++ b/tests/test_eval_optimizer_core.py
@@ -33,6 +33,7 @@ from _optimizer_core import (  # noqa: E402
     buffer_contains,
     edit_budget,
     gate,
+    mcnemar_exact,
     patch_fingerprint,
     score,
     split_tasks,
@@ -123,8 +124,12 @@ class TestSplitTasks:
         with pytest.raises(ValueError, match="duplicate"):
             split_tasks(["A", "B", "A"], seed="s")
 
-    def test_rejects_blank_task_id(self):
+    def test_rejects_an_empty_task_id(self):
         with pytest.raises(ValueError, match="non-empty"):
+            split_tasks(["A", "", "C", "D"], seed="s")
+
+    def test_rejects_blank_task_id(self):
+        with pytest.raises(ValueError, match="whitespace|non-empty"):
             split_tasks(["A", "   "], seed="s")
 
     def test_rejects_empty_seed(self):
@@ -177,13 +182,29 @@ class TestSplitTasks:
         assert len(split.sel) == 3
         assert len(split.opt) == 1
 
-    def test_task_ids_are_stripped(self):
-        split = split_tasks([" A ", "B", "C", "D"], seed="s", sel_ratio=0.5, min_sel=0)
-        assert sorted(list(split.opt) + list(split.sel)) == ["A", "B", "C", "D"]
+    def test_task_ids_with_edge_whitespace_are_rejected(self):
+        """Silently stripping an id makes it stop matching the result map.
+
+        The result mapping is keyed by the id the scorer emitted. If the split
+        rewrites " A " to "A", every later lookup raises MissingResultError far
+        from the cause. Refusing the input names the problem at its source.
+        """
+        with pytest.raises(ValueError, match="whitespace"):
+            split_tasks([" A ", "B", "C", "D"], seed="s", sel_ratio=0.5, min_sel=1)
 
     def test_rejects_ids_that_collide_after_stripping(self):
-        with pytest.raises(ValueError, match="duplicate"):
-            split_tasks(["A", " A "], seed="s", min_sel=0)
+        with pytest.raises(ValueError, match="whitespace"):
+            split_tasks(["A", " A "], seed="s", min_sel=1)
+
+    def test_refuses_to_produce_an_empty_held_out_group(self):
+        """min_sel=0 must not be a route to a gate that holds nothing out.
+
+        An empty sel group is not a lenient gate, it is no gate: score() would
+        raise on the empty sequence and the caller would read a crash instead
+        of a verdict.
+        """
+        with pytest.raises(SplitTooSmallError, match="at least one"):
+            split_tasks(_ids(20), seed="s", sel_ratio=0.01, min_sel=0)
 
 
 # ---------------------------------------------------------------------------
@@ -242,6 +263,53 @@ class TestEditBudget:
 # ---------------------------------------------------------------------------
 # apply_patches
 # ---------------------------------------------------------------------------
+
+
+class TestSmuggledFenceMarkers:
+    """Regression cover for a protection bypass found in adversarial review.
+
+    The document splitter normalized lone carriage returns into newlines, but
+    the marker check normalized only CRLF. A patch carrying
+    "START\\rhidden\\rEND" therefore looked like one harmless line at check
+    time and became a real fence the next time the file was read, hiding the
+    smuggled region from every later edit.
+    """
+
+    def test_a_crlf_smuggled_marker_is_rejected(self):
+        patch = Patch("append", None, f"{FENCE_START}\r\nhidden\r\n{FENCE_END}")
+        with pytest.raises(ProtectedSectionError):
+            apply_patches("body\n", [patch], budget=1)
+
+    def test_a_lone_carriage_return_smuggled_marker_is_rejected(self):
+        patch = Patch("append", None, f"{FENCE_START}\rhidden\r{FENCE_END}")
+        with pytest.raises(ProtectedSectionError):
+            apply_patches("body\n", [patch], budget=1)
+
+    def test_a_lone_carriage_return_start_marker_alone_is_rejected(self):
+        patch = Patch("append", None, f"tail\r{FENCE_START}")
+        with pytest.raises(ProtectedSectionError):
+            apply_patches("body\n", [patch], budget=1)
+
+    def test_ordinary_carriage_return_text_still_applies(self):
+        """The fix must not reject text that merely contains a stray CR."""
+        out = apply_patches("body\n", [Patch("append", None, "one\rtwo")], budget=1)
+        assert out == "body\none\ntwo\n"
+
+
+class TestMalformedPatchFields:
+    """A patch is agent-authored JSON, so wrong field types are expected."""
+
+    def test_a_non_string_text_is_a_patch_shape_error(self):
+        with pytest.raises(PatchShapeError):
+            apply_patches("body\n", [Patch("append", None, 42)], budget=1)
+
+    def test_a_non_string_anchor_is_a_patch_shape_error(self):
+        with pytest.raises(PatchShapeError):
+            apply_patches("alpha\n", [Patch("replace", 7, "x")], budget=1)
+
+    def test_a_non_string_op_is_a_patch_shape_error(self):
+        with pytest.raises(PatchShapeError):
+            apply_patches("body\n", [Patch(3, None, "x")], budget=1)
 
 
 class TestApplyPatches:
@@ -426,6 +494,81 @@ class TestApplyPatches:
 # ---------------------------------------------------------------------------
 
 
+class TestMcnemarExact:
+    """One-sided exact McNemar test on the paired held-out outcomes.
+
+    The gate compares the same task ids before and after an edit, so the two
+    scores are paired, not independent. Tasks whose outcome did not move carry
+    no information about the edit. Only the discordant pairs do: b tasks that
+    went fail to pass, c that went pass to fail. Under the null that the edit
+    is neutral, b is Binomial(b + c, 0.5), and the one-sided p is
+    P(X >= b). Exact, so it stays valid at the small task counts this repo's
+    eval sets actually have.
+    """
+
+    def test_a_clean_sweep_of_three_is_one_eighth(self):
+        inc = {"A": False, "B": False, "C": False}
+        cand = {"A": True, "B": True, "C": True}
+        b, c, p = mcnemar_exact(inc, cand, ["A", "B", "C"])
+        assert (b, c) == (3, 0)
+        assert p == pytest.approx(0.125)
+
+    def test_no_discordant_pairs_is_p_one(self):
+        """Nothing moved, so the data cannot argue against the null."""
+        inc = {"A": True, "B": False}
+        cand = {"A": True, "B": False}
+        b, c, p = mcnemar_exact(inc, cand, ["A", "B"])
+        assert (b, c) == (0, 0)
+        assert p == 1.0
+
+    def test_a_regression_is_not_significant(self):
+        inc = {"A": True, "B": True}
+        cand = {"A": False, "B": False}
+        b, c, p = mcnemar_exact(inc, cand, ["A", "B"])
+        assert (b, c) == (0, 2)
+        assert p == 1.0
+
+    def test_one_flip_each_way_is_p_one(self):
+        inc = {"A": True, "B": False}
+        cand = {"A": False, "B": True}
+        b, c, p = mcnemar_exact(inc, cand, ["A", "B"])
+        assert (b, c) == (1, 1)
+        assert p == pytest.approx(0.75)
+
+    def test_five_clean_flips_clears_the_conventional_floor(self):
+        ids = ["A", "B", "C", "D", "E"]
+        inc = dict.fromkeys(ids, False)
+        cand = dict.fromkeys(ids, True)
+        b, c, p = mcnemar_exact(inc, cand, ids)
+        assert (b, c) == (5, 0)
+        assert p == pytest.approx(0.03125)
+        assert p <= 0.05
+
+    def test_three_flips_cannot_clear_the_conventional_floor(self):
+        """Documents the real resolution limit of a 3-task held-out group."""
+        ids = ["A", "B", "C"]
+        b, c, p = mcnemar_exact(dict.fromkeys(ids, False), dict.fromkeys(ids, True), ids)
+        assert p > 0.05
+
+    def test_unchanged_tasks_do_not_dilute_the_result(self):
+        inc = {"A": False, "B": True, "C": True, "D": True}
+        cand = {"A": True, "B": True, "C": True, "D": True}
+        b, c, p = mcnemar_exact(inc, cand, ["A", "B", "C", "D"])
+        assert (b, c) == (1, 0)
+        assert p == pytest.approx(0.5)
+
+    def test_an_empty_task_list_is_p_one(self):
+        assert mcnemar_exact({}, {}, []) == (0, 0, 1.0)
+
+    def test_a_missing_incumbent_result_raises(self):
+        with pytest.raises(MissingResultError):
+            mcnemar_exact({}, {"A": True}, ["A"])
+
+    def test_a_missing_candidate_result_raises(self):
+        with pytest.raises(MissingResultError):
+            mcnemar_exact({"A": True}, {}, ["A"])
+
+
 class TestScore:
     def test_counts_the_passing_fraction(self):
         results = {"A": True, "B": False, "C": True, "D": True}
@@ -464,6 +607,55 @@ class TestScore:
 # ---------------------------------------------------------------------------
 # gate
 # ---------------------------------------------------------------------------
+
+
+class TestGateRegressionGuard:
+    """An aggregate win must not hide a held-out task that stopped passing.
+
+    ADR-057 blocks every pass-to-fail transition rather than netting them
+    against gains. An aggregate-only gate accepts an edit that fixes two tasks
+    and breaks one, which is exactly the trade ADR-057 refuses. The gate takes
+    the discordant counts so it can refuse on the broken task.
+    """
+
+    def test_rejects_a_net_win_that_breaks_a_passing_task(self):
+        result = gate(0.8, 0.6, discordant_loss=1)
+        assert result.decision == "REJECT"
+        assert "regress" in result.reason
+
+    def test_names_how_many_tasks_broke(self):
+        result = gate(0.8, 0.6, discordant_loss=2)
+        assert "2" in result.reason
+
+    def test_accepts_a_win_with_no_regression(self):
+        assert gate(0.8, 0.6, discordant_loss=0).decision == "ACCEPT"
+
+    def test_defaults_to_no_regression_when_counts_are_unknown(self):
+        """Per-task detail is optional, so the aggregate path must still work."""
+        assert gate(0.8, 0.6).decision == "ACCEPT"
+
+    def test_rejects_a_negative_discordant_loss(self):
+        with pytest.raises(ValueError, match="discordant_loss"):
+            gate(0.8, 0.6, discordant_loss=-1)
+
+    def test_a_regression_still_counts_as_compared(self):
+        """The scores were weighed, so the consultation was spent."""
+        assert gate(0.8, 0.6, discordant_loss=1).compared is True
+
+    def test_allowing_regressions_restores_the_aggregate_verdict(self):
+        result = gate(0.8, 0.6, discordant_loss=1, allow_regressions=True)
+        assert result.decision == "ACCEPT"
+
+    def test_the_fingerprint_guard_still_wins_over_the_regression_guard(self):
+        result = gate(
+            0.8,
+            0.6,
+            discordant_loss=1,
+            split_fingerprint="a",
+            incumbent_fingerprint="b",
+        )
+        assert result.compared is False
+        assert "fingerprint" in result.reason
 
 
 class TestGate:
@@ -563,14 +755,32 @@ class TestPatchFingerprint:
         b = [Patch("replace", "x", "y")]
         assert patch_fingerprint(a) == patch_fingerprint(b)
 
-    def test_order_does_not_change_the_fingerprint(self):
+    def test_order_changes_the_fingerprint(self):
+        """Patches apply sequentially, so order is part of the edit's identity.
+
+        Appending "one" then "two" produces a different document from "two"
+        then "one". Treating them as the same edit would let one rejection ban
+        the other, and a banned edit can never be re-proposed.
+        """
         a = [Patch("append", None, "one"), Patch("append", None, "two")]
         b = [Patch("append", None, "two"), Patch("append", None, "one")]
-        assert patch_fingerprint(a) == patch_fingerprint(b)
+        assert patch_fingerprint(a) != patch_fingerprint(b)
 
-    def test_whitespace_reflow_does_not_change_the_fingerprint(self):
+    def test_whitespace_reflow_changes_the_fingerprint(self):
+        """Whitespace is content here: a newline splits one line into two."""
         a = [Patch("replace", "x", "hello  world")]
         b = [Patch("replace", "x", "hello\n world ")]
+        assert patch_fingerprint(a) != patch_fingerprint(b)
+
+    def test_line_endings_alone_do_not_change_the_fingerprint(self):
+        """CRLF is transport, not content, so it is normalized away."""
+        a = [Patch("replace", "x", "one\r\ntwo")]
+        b = [Patch("replace", "x", "one\ntwo")]
+        assert patch_fingerprint(a) == patch_fingerprint(b)
+
+    def test_a_lone_carriage_return_is_normalized_too(self):
+        a = [Patch("replace", "x", "one\rtwo")]
+        b = [Patch("replace", "x", "one\ntwo")]
         assert patch_fingerprint(a) == patch_fingerprint(b)
 
     def test_different_text_changes_the_fingerprint(self):
@@ -611,11 +821,12 @@ class TestBufferContains:
     def test_an_empty_buffer_contains_nothing(self):
         assert buffer_contains([], [Patch("append", None, "x")]) is False
 
-    def test_matches_across_reordering(self):
+    def test_does_not_match_across_reordering(self):
+        """Reordered patches build a different document, so they are a different edit."""
         stored = [Patch("append", None, "one"), Patch("append", None, "two")]
         buffer = [{"fingerprint": patch_fingerprint(stored)}]
         reordered = [Patch("append", None, "two"), Patch("append", None, "one")]
-        assert buffer_contains(buffer, reordered) is True
+        assert buffer_contains(buffer, reordered) is False
 
     def test_ignores_buffer_entries_without_a_fingerprint(self):
         buffer = [{"note": "malformed"}, {"fingerprint": None}]

--- a/tests/test_eval_optimizer_core.py
+++ b/tests/test_eval_optimizer_core.py
@@ -33,6 +33,7 @@ from _optimizer_core import (  # noqa: E402
     buffer_contains,
     edit_budget,
     gate,
+    guard_refusal,
     mcnemar_exact,
     patch_fingerprint,
     score,
@@ -607,6 +608,47 @@ class TestScore:
 # ---------------------------------------------------------------------------
 # gate
 # ---------------------------------------------------------------------------
+
+
+class TestGuardRefusal:
+    """The two refusals a caller can decide before spending the held-out group.
+
+    A gate that scores first and refuses second has already read the sel group,
+    which is the exact cost the refusal exists to avoid. Asking first makes the
+    refusal free.
+    """
+
+    def test_a_clean_call_is_permitted(self):
+        assert guard_refusal(sel_consultations=1, max_consultations=5) is None
+
+    def test_no_bookkeeping_at_all_is_permitted(self):
+        assert guard_refusal() is None
+
+    def test_a_moved_fingerprint_refuses(self):
+        reason = guard_refusal(split_fingerprint="a", incumbent_fingerprint="b")
+        assert reason is not None
+        assert "fingerprint" in reason
+
+    def test_matching_fingerprints_are_permitted(self):
+        assert guard_refusal(split_fingerprint="a", incumbent_fingerprint="a") is None
+
+    def test_an_unknown_incumbent_fingerprint_cannot_refuse(self):
+        assert guard_refusal(split_fingerprint="a", incumbent_fingerprint=None) is None
+
+    def test_an_exhausted_budget_refuses(self):
+        reason = guard_refusal(sel_consultations=5, max_consultations=5)
+        assert reason is not None
+        assert "exhausted" in reason
+
+    def test_the_fingerprint_check_runs_first(self):
+        reason = guard_refusal(
+            sel_consultations=9,
+            max_consultations=1,
+            split_fingerprint="a",
+            incumbent_fingerprint="b",
+        )
+        assert reason is not None
+        assert "fingerprint" in reason
 
 
 class TestGateRegressionGuard:

--- a/tests/test_eval_optimizer_core.py
+++ b/tests/test_eval_optimizer_core.py
@@ -936,3 +936,24 @@ class TestSplitFingerprint:
     def test_an_empty_task_set_still_hashes(self):
         """It is a hash, not a validator. split_tasks owns the size rules."""
         assert len(split_fingerprint([], seed="s", sel_ratio=0.5)) == 64
+
+
+class TestGuardRefusalValidatesItsOwnCap:
+    """A nonsense cap must be refused, not silently mean "always exhausted".
+
+    `gate()` rejects a cap below one, but callers reach `guard_refusal` first
+    so they can ask before scoring anything. Without the same check there, a
+    typo like `--max-consultations -1` reads as a permanently exhausted budget
+    and looks exactly like legitimate discipline.
+    """
+
+    @pytest.mark.parametrize("cap", [0, -1, -100])
+    def test_a_cap_below_one_is_refused(self, cap):
+        with pytest.raises(ValueError, match="must be positive"):
+            guard_refusal(sel_consultations=0, max_consultations=cap)
+
+    def test_a_positive_cap_is_accepted(self):
+        assert guard_refusal(sel_consultations=0, max_consultations=1) is None
+
+    def test_no_cap_is_accepted(self):
+        assert guard_refusal(sel_consultations=99, max_consultations=None) is None

--- a/tests/test_eval_optimizer_core.py
+++ b/tests/test_eval_optimizer_core.py
@@ -685,9 +685,17 @@ class TestGateRegressionGuard:
         """The scores were weighed, so the consultation was spent."""
         assert gate(0.8, 0.6, discordant_loss=1).compared is True
 
-    def test_allowing_regressions_restores_the_aggregate_verdict(self):
-        result = gate(0.8, 0.6, discordant_loss=1, allow_regressions=True)
-        assert result.decision == "ACCEPT"
+    def test_there_is_no_override_for_a_broken_task(self):
+        """This test used to assert an `allow_regressions` bypass existed.
+
+        ADR-057 says its gate "has no mechanism to accept a justified
+        regression". A bypass here was a weaker rule wearing the same name,
+        and an agent driving the loop could set it with no human ever seeing
+        the broken task. The parameter is gone; a net gain never buys one.
+        """
+        with pytest.raises(TypeError):
+            gate(0.8, 0.6, discordant_loss=1, allow_regressions=True)
+        assert gate(0.8, 0.6, discordant_loss=1).decision == "REJECT"
 
     def test_the_fingerprint_guard_still_wins_over_the_regression_guard(self):
         result = gate(

--- a/tests/test_eval_optimizer_core.py
+++ b/tests/test_eval_optimizer_core.py
@@ -1,0 +1,606 @@
+"""Tests for scripts/eval/_optimizer_core.py (Issue #3422).
+
+Pure-function tests. The module under test performs no I/O and makes no API
+calls, so nothing here is mocked; every case is exercised directly.
+
+Coverage obligation per .agents/governance/TESTING-RIGOR.md: positive, negative,
+and edge cases per public function, every raise branch, every conditional
+branch that changes user-facing output.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_EVAL_DIR = _REPO_ROOT / "scripts" / "eval"
+if str(_EVAL_DIR) not in sys.path:
+    sys.path.insert(0, str(_EVAL_DIR))
+
+from _optimizer_core import (  # noqa: E402
+    AmbiguousAnchorError,
+    AnchorNotFoundError,
+    BudgetExceededError,
+    MissingResultError,
+    Patch,
+    PatchShapeError,
+    ProtectedSectionError,
+    SplitTooSmallError,
+    apply_patches,
+    buffer_contains,
+    edit_budget,
+    gate,
+    patch_fingerprint,
+    score,
+    split_tasks,
+)
+
+FENCE_START = "<!-- SLOW_UPDATE_START -->"
+FENCE_END = "<!-- SLOW_UPDATE_END -->"
+
+
+def _ids(n: int, prefix: str = "F") -> list[str]:
+    return [f"{prefix}{i:03d}" for i in range(1, n + 1)]
+
+
+# ---------------------------------------------------------------------------
+# split_tasks
+# ---------------------------------------------------------------------------
+
+
+class TestSplitTasks:
+    def test_partitions_every_task_exactly_once(self):
+        ids = _ids(10)
+        split = split_tasks(ids, seed="s", sel_ratio=0.4)
+        combined = list(split.opt) + list(split.sel) + list(split.test)
+        assert sorted(combined) == sorted(ids)
+        assert len(set(combined)) == len(ids)
+
+    def test_sel_count_is_exact_not_approximate(self):
+        """A hash-bucketing split can hand a 10-task set a 1-task gate."""
+        split = split_tasks(_ids(10), seed="s", sel_ratio=0.4)
+        assert len(split.sel) == 4
+        assert len(split.opt) == 6
+
+    def test_is_deterministic_across_calls(self):
+        a = split_tasks(_ids(20), seed="seed-1", sel_ratio=0.3)
+        b = split_tasks(_ids(20), seed="seed-1", sel_ratio=0.3)
+        assert a.sel == b.sel
+        assert a.opt == b.opt
+
+    def test_input_order_does_not_change_the_split(self):
+        forward = split_tasks(_ids(20), seed="s", sel_ratio=0.3)
+        backward = split_tasks(list(reversed(_ids(20))), seed="s", sel_ratio=0.3)
+        assert forward.sel == backward.sel
+        assert forward.opt == backward.opt
+
+    def test_different_seeds_produce_different_splits(self):
+        a = split_tasks(_ids(20), seed="seed-a", sel_ratio=0.3)
+        b = split_tasks(_ids(20), seed="seed-b", sel_ratio=0.3)
+        assert a.sel != b.sel
+
+    def test_three_way_split_reserves_test_tasks(self):
+        split = split_tasks(_ids(20), seed="s", sel_ratio=0.3, test_ratio=0.2)
+        assert len(split.sel) == 6
+        assert len(split.test) == 4
+        assert len(split.opt) == 10
+        assert not set(split.test) & set(split.sel)
+
+    def test_test_split_is_empty_by_default(self):
+        assert split_tasks(_ids(10), seed="s").test == ()
+
+    def test_fingerprint_is_stable_for_same_inputs(self):
+        a = split_tasks(_ids(10), seed="s", sel_ratio=0.4)
+        b = split_tasks(_ids(10), seed="s", sel_ratio=0.4)
+        assert a.fingerprint == b.fingerprint
+
+    def test_fingerprint_changes_when_a_task_is_added(self):
+        """Adding fixtures after a losing gate must invalidate the incumbent."""
+        before = split_tasks(_ids(10), seed="s", sel_ratio=0.4)
+        after = split_tasks(_ids(11), seed="s", sel_ratio=0.4)
+        assert before.fingerprint != after.fingerprint
+
+    def test_fingerprint_changes_when_ratio_changes(self):
+        a = split_tasks(_ids(20), seed="s", sel_ratio=0.3)
+        b = split_tasks(_ids(20), seed="s", sel_ratio=0.5)
+        assert a.fingerprint != b.fingerprint
+
+    def test_fingerprint_changes_when_seed_changes(self):
+        a = split_tasks(_ids(20), seed="s1", sel_ratio=0.3)
+        b = split_tasks(_ids(20), seed="s2", sel_ratio=0.3)
+        assert a.fingerprint != b.fingerprint
+
+    # -- negative -----------------------------------------------------------
+
+    def test_rejects_empty_task_list(self):
+        with pytest.raises(ValueError, match="at least one task"):
+            split_tasks([], seed="s")
+
+    def test_rejects_duplicate_task_ids(self):
+        with pytest.raises(ValueError, match="duplicate"):
+            split_tasks(["A", "B", "A"], seed="s")
+
+    def test_rejects_blank_task_id(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            split_tasks(["A", "   "], seed="s")
+
+    def test_rejects_empty_seed(self):
+        with pytest.raises(ValueError, match="seed"):
+            split_tasks(_ids(10), seed="")
+
+    @pytest.mark.parametrize("ratio", [0.0, 1.0, -0.1, 1.5])
+    def test_rejects_out_of_range_sel_ratio(self, ratio):
+        with pytest.raises(ValueError, match="sel_ratio"):
+            split_tasks(_ids(20), seed="s", sel_ratio=ratio)
+
+    @pytest.mark.parametrize("ratio", [-0.1, 1.0, 1.5])
+    def test_rejects_out_of_range_test_ratio(self, ratio):
+        with pytest.raises(ValueError, match="test_ratio"):
+            split_tasks(_ids(20), seed="s", test_ratio=ratio)
+
+    def test_rejects_ratios_that_leave_no_opt_tasks(self):
+        with pytest.raises(ValueError, match="opt"):
+            split_tasks(_ids(20), seed="s", sel_ratio=0.6, test_ratio=0.4)
+
+    def test_rejects_a_rounding_that_starves_the_opt_group(self):
+        """Ratios summing below 1 can still round away every optimize task."""
+        with pytest.raises(ValueError, match="leaves no opt tasks"):
+            split_tasks(_ids(2), seed="s", sel_ratio=0.4, test_ratio=0.4, min_sel=0)
+
+    def test_refuses_a_gate_too_small_to_mean_anything(self):
+        with pytest.raises(SplitTooSmallError, match="min_sel"):
+            split_tasks(_ids(4), seed="s", sel_ratio=0.25, min_sel=3)
+
+    def test_split_too_small_error_names_the_shortfall(self):
+        with pytest.raises(SplitTooSmallError) as excinfo:
+            split_tasks(_ids(4), seed="s", sel_ratio=0.25, min_sel=3)
+        message = str(excinfo.value)
+        assert "1" in message
+        assert "3" in message
+
+    def test_rejects_negative_min_sel(self):
+        with pytest.raises(ValueError, match="min_sel"):
+            split_tasks(_ids(10), seed="s", min_sel=-1)
+
+    # -- edge ---------------------------------------------------------------
+
+    def test_min_sel_zero_allows_a_degenerate_gate(self):
+        """Explicitly opting out of the floor is allowed; it is not the default."""
+        split = split_tasks(_ids(4), seed="s", sel_ratio=0.25, min_sel=0)
+        assert len(split.sel) == 1
+
+    def test_smallest_viable_set_splits(self):
+        split = split_tasks(_ids(4), seed="s", sel_ratio=0.75, min_sel=3)
+        assert len(split.sel) == 3
+        assert len(split.opt) == 1
+
+    def test_task_ids_are_stripped(self):
+        split = split_tasks([" A ", "B", "C", "D"], seed="s", sel_ratio=0.5, min_sel=0)
+        assert sorted(list(split.opt) + list(split.sel)) == ["A", "B", "C", "D"]
+
+    def test_rejects_ids_that_collide_after_stripping(self):
+        with pytest.raises(ValueError, match="duplicate"):
+            split_tasks(["A", " A "], seed="s", min_sel=0)
+
+
+# ---------------------------------------------------------------------------
+# edit_budget
+# ---------------------------------------------------------------------------
+
+
+class TestEditBudget:
+    def test_first_step_gets_the_maximum(self):
+        assert edit_budget(0, 10, max_edits=5, min_edits=1) == 5
+
+    def test_final_step_gets_the_minimum(self):
+        assert edit_budget(10, 10, max_edits=5, min_edits=1) == 1
+
+    def test_decays_monotonically(self):
+        budgets = [edit_budget(t, 10, max_edits=8, min_edits=1) for t in range(11)]
+        assert budgets == sorted(budgets, reverse=True)
+
+    def test_midpoint_is_near_the_average(self):
+        assert edit_budget(5, 10, max_edits=5, min_edits=1) == 3
+
+    def test_steps_past_total_clamp_to_minimum(self):
+        assert edit_budget(50, 10, max_edits=5, min_edits=1) == 1
+
+    def test_equal_bounds_produce_a_flat_budget(self):
+        assert [edit_budget(t, 4, max_edits=2, min_edits=2) for t in range(5)] == [2] * 5
+
+    # -- negative -----------------------------------------------------------
+
+    def test_rejects_negative_step(self):
+        with pytest.raises(ValueError, match="step"):
+            edit_budget(-1, 10)
+
+    @pytest.mark.parametrize("total", [0, -3])
+    def test_rejects_non_positive_total(self, total):
+        with pytest.raises(ValueError, match="total"):
+            edit_budget(0, total)
+
+    def test_rejects_min_above_max(self):
+        with pytest.raises(ValueError, match="min_edits"):
+            edit_budget(0, 10, max_edits=2, min_edits=5)
+
+    def test_rejects_min_below_one(self):
+        with pytest.raises(ValueError, match="min_edits"):
+            edit_budget(0, 10, max_edits=5, min_edits=0)
+
+    # -- edge ---------------------------------------------------------------
+
+    def test_single_step_run_yields_the_maximum(self):
+        assert edit_budget(0, 1, max_edits=4, min_edits=1) == 4
+
+    def test_budget_never_drops_below_the_floor(self):
+        assert all(edit_budget(t, 7, max_edits=3, min_edits=1) >= 1 for t in range(8))
+
+
+# ---------------------------------------------------------------------------
+# apply_patches
+# ---------------------------------------------------------------------------
+
+
+class TestApplyPatches:
+    def test_append_adds_to_the_end(self):
+        out = apply_patches("line one\n", [Patch("append", None, "line two")], budget=1)
+        assert out == "line one\nline two\n"
+
+    def test_insert_after_places_text_below_the_anchor(self):
+        doc = "alpha\nbeta\ngamma\n"
+        out = apply_patches(doc, [Patch("insert_after", "beta", "inserted")], budget=1)
+        assert out == "alpha\nbeta\ninserted\ngamma\n"
+
+    def test_replace_swaps_the_anchor_line(self):
+        doc = "alpha\nbeta\ngamma\n"
+        out = apply_patches(doc, [Patch("replace", "beta", "BETA")], budget=1)
+        assert out == "alpha\nBETA\ngamma\n"
+
+    def test_delete_removes_the_anchor_line(self):
+        doc = "alpha\nbeta\ngamma\n"
+        out = apply_patches(doc, [Patch("delete", "beta", None)], budget=1)
+        assert out == "alpha\ngamma\n"
+
+    def test_applies_several_patches_in_one_pass(self):
+        doc = "alpha\nbeta\ngamma\n"
+        patches = [Patch("replace", "alpha", "ALPHA"), Patch("delete", "gamma", None)]
+        assert apply_patches(doc, patches, budget=2) == "ALPHA\nbeta\n"
+
+    def test_multiline_patch_text_is_inserted_whole(self):
+        doc = "alpha\nbeta\n"
+        out = apply_patches(doc, [Patch("insert_after", "alpha", "one\ntwo")], budget=1)
+        assert out == "alpha\none\ntwo\nbeta\n"
+
+    def test_empty_patch_list_returns_the_document_unchanged(self):
+        doc = "alpha\nbeta\n"
+        assert apply_patches(doc, [], budget=3) == doc
+
+    def test_anchor_matching_ignores_surrounding_whitespace(self):
+        doc = "alpha\n   beta   \ngamma\n"
+        out = apply_patches(doc, [Patch("replace", "beta", "BETA")], budget=1)
+        assert out == "alpha\nBETA\ngamma\n"
+
+    def test_later_patch_can_anchor_on_text_an_earlier_patch_added(self):
+        doc = "alpha\n"
+        patches = [Patch("append", None, "beta"), Patch("replace", "beta", "BETA")]
+        assert apply_patches(doc, patches, budget=2) == "alpha\nBETA\n"
+
+    # -- budget -------------------------------------------------------------
+
+    def test_refuses_more_patches_than_the_budget(self):
+        patches = [Patch("append", None, "a"), Patch("append", None, "b")]
+        with pytest.raises(BudgetExceededError, match="2"):
+            apply_patches("doc\n", patches, budget=1)
+
+    def test_budget_exactly_met_is_allowed(self):
+        patches = [Patch("append", None, "a"), Patch("append", None, "b")]
+        assert apply_patches("doc\n", patches, budget=2) == "doc\na\nb\n"
+
+    def test_rejects_negative_budget(self):
+        with pytest.raises(ValueError, match="budget"):
+            apply_patches("doc\n", [], budget=-1)
+
+    # -- anchors ------------------------------------------------------------
+
+    def test_refuses_an_anchor_that_is_not_present(self):
+        with pytest.raises(AnchorNotFoundError, match="nowhere"):
+            apply_patches("alpha\n", [Patch("replace", "nowhere", "x")], budget=1)
+
+    def test_refuses_an_ambiguous_anchor(self):
+        doc = "dup\nmiddle\ndup\n"
+        with pytest.raises(AmbiguousAnchorError, match="2"):
+            apply_patches(doc, [Patch("replace", "dup", "x")], budget=1)
+
+    def test_ambiguity_is_detected_after_earlier_patches_apply(self):
+        doc = "alpha\nbeta\n"
+        patches = [Patch("append", None, "beta"), Patch("replace", "beta", "x")]
+        with pytest.raises(AmbiguousAnchorError):
+            apply_patches(doc, patches, budget=2)
+
+    # -- patch shape --------------------------------------------------------
+
+    def test_rejects_an_unknown_operation(self):
+        with pytest.raises(PatchShapeError, match="rewrite"):
+            apply_patches("doc\n", [Patch("rewrite", None, "x")], budget=1)
+
+    @pytest.mark.parametrize("op", ["insert_after", "replace", "delete"])
+    def test_rejects_a_missing_anchor(self, op):
+        with pytest.raises(PatchShapeError, match="anchor"):
+            apply_patches("doc\n", [Patch(op, None, "x")], budget=1)
+
+    @pytest.mark.parametrize("op", ["insert_after", "replace", "append"])
+    def test_rejects_missing_text(self, op):
+        anchor = None if op == "append" else "doc"
+        with pytest.raises(PatchShapeError, match="text"):
+            apply_patches("doc\n", [Patch(op, anchor, None)], budget=1)
+
+    def test_rejects_a_blank_anchor(self):
+        with pytest.raises(PatchShapeError, match="anchor"):
+            apply_patches("doc\n", [Patch("replace", "   ", "x")], budget=1)
+
+    def test_delete_ignores_a_text_field(self):
+        doc = "alpha\nbeta\n"
+        assert apply_patches(doc, [Patch("delete", "beta", "ignored")], budget=1) == "alpha\n"
+
+    # -- protected fence ----------------------------------------------------
+
+    def test_refuses_to_replace_a_line_inside_the_fence(self):
+        doc = f"alpha\n{FENCE_START}\nrail\n{FENCE_END}\nomega\n"
+        with pytest.raises(ProtectedSectionError, match="rail"):
+            apply_patches(doc, [Patch("replace", "rail", "x")], budget=1)
+
+    def test_refuses_to_delete_a_line_inside_the_fence(self):
+        doc = f"alpha\n{FENCE_START}\nrail\n{FENCE_END}\nomega\n"
+        with pytest.raises(ProtectedSectionError):
+            apply_patches(doc, [Patch("delete", "rail", None)], budget=1)
+
+    def test_refuses_to_insert_inside_the_fence(self):
+        doc = f"alpha\n{FENCE_START}\nrail\n{FENCE_END}\nomega\n"
+        with pytest.raises(ProtectedSectionError):
+            apply_patches(doc, [Patch("insert_after", "rail", "x")], budget=1)
+
+    def test_refuses_to_anchor_on_the_fence_markers(self):
+        doc = f"alpha\n{FENCE_START}\nrail\n{FENCE_END}\nomega\n"
+        with pytest.raises(ProtectedSectionError):
+            apply_patches(doc, [Patch("delete", FENCE_START, None)], budget=1)
+
+    def test_allows_edits_outside_the_fence(self):
+        doc = f"alpha\n{FENCE_START}\nrail\n{FENCE_END}\nomega\n"
+        out = apply_patches(doc, [Patch("replace", "omega", "OMEGA")], budget=1)
+        assert "rail" in out
+        assert out.endswith("OMEGA\n")
+
+    def test_append_lands_outside_a_closed_fence(self):
+        doc = f"alpha\n{FENCE_START}\nrail\n{FENCE_END}\n"
+        out = apply_patches(doc, [Patch("append", None, "added")], budget=1)
+        assert out.endswith(f"{FENCE_END}\nadded\n")
+
+    def test_refuses_to_append_into_an_unclosed_fence(self):
+        doc = f"alpha\n{FENCE_START}\nrail\n"
+        with pytest.raises(ProtectedSectionError, match="unclosed"):
+            apply_patches(doc, [Patch("append", None, "added")], budget=1)
+
+    def test_refuses_a_document_with_an_unbalanced_fence(self):
+        doc = f"alpha\nrail\n{FENCE_END}\n"
+        with pytest.raises(ProtectedSectionError, match="unbalanced"):
+            apply_patches(doc, [Patch("replace", "rail", "x")], budget=1)
+
+    def test_refuses_a_nested_fence(self):
+        doc = f"{FENCE_START}\n{FENCE_START}\nrail\n{FENCE_END}\n{FENCE_END}\n"
+        with pytest.raises(ProtectedSectionError, match="nested"):
+            apply_patches(doc, [Patch("append", None, "x")], budget=1)
+
+    def test_protects_a_second_fence_block(self):
+        doc = (
+            f"a\n{FENCE_START}\nfirst\n{FENCE_END}\n"
+            f"b\n{FENCE_START}\nsecond\n{FENCE_END}\nc\n"
+        )
+        with pytest.raises(ProtectedSectionError, match="second"):
+            apply_patches(doc, [Patch("replace", "second", "x")], budget=1)
+
+    def test_patch_text_may_not_smuggle_in_a_fence_marker(self):
+        with pytest.raises(ProtectedSectionError, match="marker"):
+            apply_patches("alpha\n", [Patch("append", None, FENCE_START)], budget=1)
+
+    # -- edge ---------------------------------------------------------------
+
+    def test_empty_document_accepts_an_append(self):
+        assert apply_patches("", [Patch("append", None, "first")], budget=1) == "first\n"
+
+    def test_document_without_a_trailing_newline_is_normalized(self):
+        assert apply_patches("alpha", [Patch("append", None, "beta")], budget=1) == "alpha\nbeta\n"
+
+    def test_crlf_line_endings_are_handled(self):
+        out = apply_patches("alpha\r\nbeta\r\n", [Patch("delete", "beta", None)], budget=1)
+        assert out == "alpha\n"
+
+    def test_deleting_the_only_line_yields_an_empty_document(self):
+        assert apply_patches("only\n", [Patch("delete", "only", None)], budget=1) == ""
+
+
+# ---------------------------------------------------------------------------
+# score
+# ---------------------------------------------------------------------------
+
+
+class TestScore:
+    def test_counts_the_passing_fraction(self):
+        results = {"A": True, "B": False, "C": True, "D": True}
+        assert score(results, ["A", "B", "C", "D"]) == 0.75
+
+    def test_scores_only_the_requested_ids(self):
+        results = {"A": True, "B": False, "C": False}
+        assert score(results, ["A"]) == 1.0
+
+    def test_all_failing_scores_zero(self):
+        assert score({"A": False, "B": False}, ["A", "B"]) == 0.0
+
+    def test_refuses_a_missing_result(self):
+        """A silently-absent task must not be scored as anything."""
+        with pytest.raises(MissingResultError, match="B"):
+            score({"A": True}, ["A", "B"])
+
+    def test_missing_result_error_lists_every_gap(self):
+        with pytest.raises(MissingResultError) as excinfo:
+            score({"A": True}, ["A", "B", "C"])
+        assert "B" in str(excinfo.value)
+        assert "C" in str(excinfo.value)
+
+    def test_rejects_an_empty_id_list(self):
+        with pytest.raises(ValueError, match="at least one task"):
+            score({"A": True}, [])
+
+    def test_rejects_a_non_boolean_result(self):
+        with pytest.raises(TypeError, match="bool"):
+            score({"A": 1}, ["A"])
+
+    def test_duplicate_ids_do_not_double_count(self):
+        assert score({"A": True, "B": False}, ["A", "B", "A"]) == 0.5
+
+
+# ---------------------------------------------------------------------------
+# gate
+# ---------------------------------------------------------------------------
+
+
+class TestGate:
+    def test_a_strict_win_is_accepted(self):
+        assert gate(0.8, 0.6).decision == "ACCEPT"
+
+    def test_a_tie_is_rejected(self):
+        result = gate(0.6, 0.6)
+        assert result.decision == "REJECT"
+        assert "tie" in result.reason
+
+    def test_a_regression_is_rejected(self):
+        result = gate(0.4, 0.6)
+        assert result.decision == "REJECT"
+        assert "regress" in result.reason
+
+    def test_carries_both_scores(self):
+        result = gate(0.8, 0.6)
+        assert result.candidate == 0.8
+        assert result.incumbent == 0.6
+
+    def test_a_hair_above_the_incumbent_still_wins(self):
+        assert gate(0.6000001, 0.6).decision == "ACCEPT"
+
+    def test_reports_how_many_times_the_split_was_consulted(self):
+        assert gate(0.8, 0.6, sel_consultations=4).sel_consultations == 4
+
+    def test_refuses_once_the_split_is_exhausted(self):
+        """Gating N times on one split selects on it N times."""
+        result = gate(0.9, 0.1, sel_consultations=10, max_consultations=10)
+        assert result.decision == "REJECT"
+        assert "exhausted" in result.reason
+
+    def test_allows_the_last_consultation_before_the_limit(self):
+        assert gate(0.9, 0.1, sel_consultations=9, max_consultations=10).decision == "ACCEPT"
+
+    def test_unlimited_consultations_by_default(self):
+        assert gate(0.9, 0.1, sel_consultations=999).decision == "ACCEPT"
+
+    def test_refuses_a_changed_split_fingerprint(self):
+        """Adding fixtures after a loss must not resurrect the incumbent."""
+        result = gate(0.9, 0.1, split_fingerprint="abc", incumbent_fingerprint="xyz")
+        assert result.decision == "REJECT"
+        assert "fingerprint" in result.reason
+
+    def test_matching_fingerprints_pass_through(self):
+        result = gate(0.9, 0.1, split_fingerprint="abc", incumbent_fingerprint="abc")
+        assert result.decision == "ACCEPT"
+
+    @pytest.mark.parametrize("value", [-0.1, 1.1])
+    def test_rejects_an_out_of_range_candidate(self, value):
+        with pytest.raises(ValueError, match="candidate"):
+            gate(value, 0.5)
+
+    @pytest.mark.parametrize("value", [-0.1, 1.1])
+    def test_rejects_an_out_of_range_incumbent(self, value):
+        with pytest.raises(ValueError, match="incumbent"):
+            gate(0.5, value)
+
+    def test_rejects_negative_consultations(self):
+        with pytest.raises(ValueError, match="sel_consultations"):
+            gate(0.8, 0.6, sel_consultations=-1)
+
+    def test_rejects_a_non_positive_consultation_limit(self):
+        with pytest.raises(ValueError, match="max_consultations"):
+            gate(0.8, 0.6, max_consultations=0)
+
+
+# ---------------------------------------------------------------------------
+# patch_fingerprint / buffer_contains
+# ---------------------------------------------------------------------------
+
+
+class TestPatchFingerprint:
+    def test_same_patches_fingerprint_alike(self):
+        a = [Patch("replace", "x", "y")]
+        b = [Patch("replace", "x", "y")]
+        assert patch_fingerprint(a) == patch_fingerprint(b)
+
+    def test_order_does_not_change_the_fingerprint(self):
+        a = [Patch("append", None, "one"), Patch("append", None, "two")]
+        b = [Patch("append", None, "two"), Patch("append", None, "one")]
+        assert patch_fingerprint(a) == patch_fingerprint(b)
+
+    def test_whitespace_reflow_does_not_change_the_fingerprint(self):
+        a = [Patch("replace", "x", "hello  world")]
+        b = [Patch("replace", "x", "hello\n world ")]
+        assert patch_fingerprint(a) == patch_fingerprint(b)
+
+    def test_different_text_changes_the_fingerprint(self):
+        a = [Patch("replace", "x", "one")]
+        b = [Patch("replace", "x", "two")]
+        assert patch_fingerprint(a) != patch_fingerprint(b)
+
+    def test_different_op_changes_the_fingerprint(self):
+        a = [Patch("replace", "x", "one")]
+        b = [Patch("insert_after", "x", "one")]
+        assert patch_fingerprint(a) != patch_fingerprint(b)
+
+    def test_different_anchor_changes_the_fingerprint(self):
+        a = [Patch("replace", "x", "one")]
+        b = [Patch("replace", "y", "one")]
+        assert patch_fingerprint(a) != patch_fingerprint(b)
+
+    def test_rejects_an_empty_patch_list(self):
+        with pytest.raises(ValueError, match="at least one patch"):
+            patch_fingerprint([])
+
+    def test_fingerprint_is_a_hex_digest(self):
+        value = patch_fingerprint([Patch("append", None, "x")])
+        assert len(value) == 64
+        assert all(char in "0123456789abcdef" for char in value)
+
+
+class TestBufferContains:
+    def test_finds_a_previously_rejected_edit(self):
+        patches = [Patch("replace", "x", "y")]
+        buffer = [{"fingerprint": patch_fingerprint(patches), "note": "lost"}]
+        assert buffer_contains(buffer, patches) is True
+
+    def test_reports_a_novel_edit(self):
+        buffer = [{"fingerprint": patch_fingerprint([Patch("append", None, "other")])}]
+        assert buffer_contains(buffer, [Patch("replace", "x", "y")]) is False
+
+    def test_an_empty_buffer_contains_nothing(self):
+        assert buffer_contains([], [Patch("append", None, "x")]) is False
+
+    def test_matches_across_reordering(self):
+        stored = [Patch("append", None, "one"), Patch("append", None, "two")]
+        buffer = [{"fingerprint": patch_fingerprint(stored)}]
+        reordered = [Patch("append", None, "two"), Patch("append", None, "one")]
+        assert buffer_contains(buffer, reordered) is True
+
+    def test_ignores_buffer_entries_without_a_fingerprint(self):
+        buffer = [{"note": "malformed"}, {"fingerprint": None}]
+        assert buffer_contains(buffer, [Patch("append", None, "x")]) is False
+
+    def test_rejects_an_empty_patch_list(self):
+        with pytest.raises(ValueError, match="at least one patch"):
+            buffer_contains([], [])

--- a/tests/test_eval_optimizer_core.py
+++ b/tests/test_eval_optimizer_core.py
@@ -491,6 +491,26 @@ class TestGate:
     def test_reports_how_many_times_the_split_was_consulted(self):
         assert gate(0.8, 0.6, sel_consultations=4).sel_consultations == 4
 
+    def test_a_scored_comparison_reports_compared(self):
+        assert gate(0.8, 0.6).compared is True
+
+    def test_a_tie_still_counts_as_a_comparison(self):
+        assert gate(0.6, 0.6).compared is True
+
+    def test_a_regression_still_counts_as_a_comparison(self):
+        assert gate(0.4, 0.6).compared is True
+
+    def test_a_fingerprint_refusal_did_not_compare(self):
+        """No comparison happened, so the caller must not burn a consultation."""
+        result = gate(0.9, 0.1, split_fingerprint="a", incumbent_fingerprint="b")
+        assert result.decision == "REJECT"
+        assert result.compared is False
+
+    def test_an_exhausted_refusal_did_not_compare(self):
+        result = gate(0.9, 0.1, sel_consultations=3, max_consultations=3)
+        assert result.decision == "REJECT"
+        assert result.compared is False
+
     def test_refuses_once_the_split_is_exhausted(self):
         """Gating N times on one split selects on it N times."""
         result = gate(0.9, 0.1, sel_consultations=10, max_consultations=10)

--- a/tests/test_eval_optimizer_core.py
+++ b/tests/test_eval_optimizer_core.py
@@ -17,7 +17,11 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _EVAL_DIR = _REPO_ROOT / "scripts" / "eval"
-if str(_EVAL_DIR) not in sys.path:
+# Scope the mutation to the module load and remove it afterward so a sibling
+# test cannot pick up an importable name it never asked for, and so repeated
+# imports cannot stack duplicate entries.
+_path_added = str(_EVAL_DIR) not in sys.path
+if _path_added:
     sys.path.insert(0, str(_EVAL_DIR))
 
 from _optimizer_core import (  # noqa: E402
@@ -40,6 +44,9 @@ from _optimizer_core import (  # noqa: E402
     split_fingerprint,
     split_tasks,
 )
+
+if _path_added and str(_EVAL_DIR) in sys.path:
+    sys.path.remove(str(_EVAL_DIR))
 
 FENCE_START = "<!-- SLOW_UPDATE_START -->"
 FENCE_END = "<!-- SLOW_UPDATE_END -->"

--- a/tests/test_eval_optimizer_core.py
+++ b/tests/test_eval_optimizer_core.py
@@ -37,6 +37,7 @@ from _optimizer_core import (  # noqa: E402
     mcnemar_exact,
     patch_fingerprint,
     score,
+    split_fingerprint,
     split_tasks,
 )
 
@@ -877,3 +878,53 @@ class TestBufferContains:
     def test_rejects_an_empty_patch_list(self):
         with pytest.raises(ValueError, match="at least one patch"):
             buffer_contains([], [])
+
+
+class TestSplitFingerprint:
+    """The fingerprint has to be recomputable from a split file's own contents.
+
+    Before this existed, the only drift check compared a split file's stored
+    fingerprint against a value the caller passed on the command line. A caller
+    who omitted the flag got no check, and a stored fingerprint was trusted
+    even when the group membership beside it had been edited. Both holes close
+    only if a reader can recompute the value instead of trusting it.
+    """
+
+    def test_matches_what_split_tasks_recorded(self):
+        ids = _ids(10)
+        split = split_tasks(ids, seed="s", sel_ratio=0.4, test_ratio=0.2)
+        assert (
+            split_fingerprint(ids, seed="s", sel_ratio=0.4, test_ratio=0.2)
+            == split.fingerprint
+        )
+
+    def test_task_order_does_not_matter(self):
+        ids = _ids(6)
+        assert split_fingerprint(ids, seed="s", sel_ratio=0.5) == split_fingerprint(
+            list(reversed(ids)), seed="s", sel_ratio=0.5
+        )
+
+    def test_an_added_task_changes_it(self):
+        ids = _ids(6)
+        assert split_fingerprint(ids, seed="s", sel_ratio=0.5) != split_fingerprint(
+            [*ids, "extra"], seed="s", sel_ratio=0.5
+        )
+
+    def test_a_different_seed_changes_it(self):
+        ids = _ids(6)
+        assert split_fingerprint(ids, seed="a", sel_ratio=0.5) != split_fingerprint(
+            ids, seed="b", sel_ratio=0.5
+        )
+
+    def test_a_different_ratio_changes_it(self):
+        ids = _ids(6)
+        assert split_fingerprint(ids, seed="s", sel_ratio=0.5) != split_fingerprint(
+            ids, seed="s", sel_ratio=0.4
+        )
+        assert split_fingerprint(ids, seed="s", sel_ratio=0.5) != split_fingerprint(
+            ids, seed="s", sel_ratio=0.5, test_ratio=0.2
+        )
+
+    def test_an_empty_task_set_still_hashes(self):
+        """It is a hash, not a validator. split_tasks owns the size rules."""
+        assert len(split_fingerprint([], seed="s", sel_ratio=0.5)) == 64


### PR DESCRIPTION
Fixes #3422

## What this adds

A held-out-gated optimization loop for authored artifacts. An agent edits an agent prompt, a rule, or a hook, scores it, and asks a gate whether the edit earned its place. The gate decides on tasks the editing agent was never shown.

Everything needed to run such a loop already existed in this directory except the one thing that makes the resulting number mean something: nothing is withheld. Every evaluator here scores an artifact against its whole eval set while the author reads which cases failed, edits, and scores again. After the second iteration the number is no longer an estimate of behavior on unseen cases. It measures how well the author responded to the cases in the set. The two diverge exactly as the loop gets more effective.

## What is here

Three modules and their tests:

- `scripts/eval/_optimizer_core.py`: the pure decision core. Split, fingerprint, budget, accept-or-reject, refusal guards, exact McNemar. No I/O, no eval spend.
- `scripts/eval/_optimizer_adapters.py`: one function per artifact class, converging three unlike scorer report shapes onto a single seam.
- `scripts/eval/optimize-artifact.py`: the CLI an optimizing agent drives.

The seam is one mapping of task id to pass boolean. That is what generalizes the discipline past skills: a fixture id, a rule scenario id, and a pytest node id are the same kind of thing to the decider. Agents, rules, and hooks get one mechanism instead of three.

## Prior art

SkillOpt (arXiv:2605.23904) does this for skills. Two deliberate departures, both because this loop runs unattended rather than inside a benchmark harness:

1. The split is fingerprinted, because the task set is a directory the agent can write to.
2. Repeated decisions are budgeted, because a sequential decision against one group selects on that group.

## Honest scope

This is a discipline control against accidental overfitting by a cooperating optimizer. It is not a security boundary against an adversarial one. The split file and the ledger sit on the same disk as everything else.

What it removes is the accidental path. All three of the following were real and all three are now closed:

- The split command printed held-out membership to the same stream the optimizing agent reads.
- A sibling subcommand would score against the held-out group directly, unmetered, which is exactly the read the consultation budget exists to charge for.
- The consultation cap arrived as a caller-supplied argument defaulting to zero, so a loop that passed zero every time had an unlimited budget while looking capped.

## Review

Two adversarial rounds, both with models other than the author.

Round one (gpt-5.6-sol, gemini-3.1-pro-preview) found a CRITICAL double inversion that the docs had advertised as a feature: a lower score could read as an improvement. Fixed, with the failing case pinned as a test.

Round two reviewed the resulting design and the accompanying ADR draft, and returned REJECT. It was right. The three exposure holes above came from that round, along with four robustness defects (non-UTF-8 input crashed with an unhandled decode error, an apply path wrote non-atomically, buffer entries were read without validation, and one error path printed plain text where the module contract promised JSON).

Round two also falsified claims in my own writing. The most important: I had described an existing methodology ADR as enforcing only an aggregate mean, and used that to justify an override flag. That ADR in fact blocks every pass-to-fail flip and states it has no mechanism to accept a justified regression. My flag was a weaker rule shipping under the same name. It has been removed.

## Known limits, stated rather than buried

- `p_value` is reported on every compared decision and enforced on none. A candidate that fixes one held-out task and breaks none reports `p = 0.5` and is accepted, because one discordant pair cannot do better on a one-sided exact test. It is a disclosure, not a gate. At the group sizes here a conventional threshold would make the ordinary case unpassable rather than informative.
- The boolean seam discards resolution the scorers already produce. Tracked as #3437; widening it is a redesign, not an increment, and it is the maintainer's call.
- The rule adapter is single-shot against an LLM judge. The agent adapter already averages over runs and the hook adapter is deterministic. Tracked as #3445.
- Live rule-path validation is blocked on account usage limits until 2026-08-01. See Validation below.

## Validation

- Agent path: run against a real report in the repository, 24 fixtures, baseline 15 against agent 13. The gate correctly refused a real regression.
- Hook path: run against real JUnit output from the hook suite, 532 node ids extracted.
- Rule path: exercised against real error-path output only. The live judge call returned HTTP 400 on the account usage limit. That run still paid for itself: it exposed two integration defects fixtures had hidden, a real envelope shape the extractor rejected and a scenario-id collision that would have silently dropped 20 of 24 tasks.
- The full seam was driven end to end by hand: redaction, tamper refusal, budget exhaustion across separate invocations, and the ledger refusing a split that was redrawn mid-run.

356 tests, 100% line coverage on all three modules.

## Follow-ups

#3436 provenance binding, #3437 seam width, #3438 exact ratio arithmetic, #3439 rejection buffer lifetime, #3440 pre-existing lint debt in this directory, #3445 rule adapter noise.
