### PR TITLE
docs(rules): record the plugin self-containment boundary as a rule

### DIFF
--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -20842,6 +20842,15 @@
         "episode-2026-07-26-session-3402-plugin-self-containment"
       ],
       "created": "2026-07-27T05:22:38.695619+00:00"
+    },
+    {
+      "id": "57b08bd5a568",
+      "type": "commit",
+      "label": "commit: Commit: d3eefa86b0",
+      "episodes": [
+        "episode-2026-07-26-session-3402-plugin-self-containment"
+      ],
+      "created": "2026-07-27T05:58:30.440248+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -20779,6 +20779,69 @@
         "episode-2026-07-27-session-3429-pr-autofix"
       ],
       "created": "2026-07-27T06:00:12.151297+00:00"
+    },
+    {
+      "id": "51e2bd81bfaf",
+      "type": "milestone",
+      "label": "milestone: The boundary is verified from the manifests, and every number in the rule comes from a command a reader can rerun",
+      "episodes": [
+        "episode-2026-07-26-session-3402-plugin-self-containment"
+      ],
+      "created": "2026-07-27T05:22:38.695149+00:00"
+    },
+    {
+      "id": "3e1e4726fcc6",
+      "type": "milestone",
+      "label": "milestone: The draft was materially wrong in three ways and the review caught all three",
+      "episodes": [
+        "episode-2026-07-26-session-3402-plugin-self-containment"
+      ],
+      "created": "2026-07-27T05:22:38.695240+00:00"
+    },
+    {
+      "id": "6ac170478837",
+      "type": "milestone",
+      "label": "milestone: The rule now documents an existing system rather than competing with it",
+      "episodes": [
+        "episode-2026-07-26-session-3402-plugin-self-containment"
+      ],
+      "created": "2026-07-27T05:22:38.695317+00:00"
+    },
+    {
+      "id": "abba30ac6918",
+      "type": "milestone",
+      "label": "milestone: The rule distinguishes the three cases a grep cannot, and the coverage gap it reports is scoped to what the data supports",
+      "episodes": [
+        "episode-2026-07-26-session-3402-plugin-self-containment"
+      ],
+      "created": "2026-07-27T05:22:38.695391+00:00"
+    },
+    {
+      "id": "d7f71c12a9c8",
+      "type": "milestone",
+      "label": "milestone: One canonical rule, one augmented memory, no third representation to drift",
+      "episodes": [
+        "episode-2026-07-26-session-3402-plugin-self-containment"
+      ],
+      "created": "2026-07-27T05:22:38.695464+00:00"
+    },
+    {
+      "id": "1f62d89a5f47",
+      "type": "commit",
+      "label": "commit: Commit: 120528e74c",
+      "episodes": [
+        "episode-2026-07-26-session-3402-plugin-self-containment"
+      ],
+      "created": "2026-07-27T05:22:38.695537+00:00"
+    },
+    {
+      "id": "9f2b809b4f7a",
+      "type": "outcome",
+      "label": "Outcome: success - Bake the plugin self-containment boundary into binding knowledge after the user reported that plugin-shipped content cannot reference paths outside its plugin root",
+      "episodes": [
+        "episode-2026-07-26-session-3402-plugin-self-containment"
+      ],
+      "created": "2026-07-27T05:22:38.695619+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/episodes/episode-2026-07-26-session-3402-plugin-self-containment.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3402-plugin-self-containment.json
@@ -12,7 +12,7 @@
       "type": "milestone",
       "content": "The boundary is verified from the manifests, and every number in the rule comes from a command a reader can rerun",
       "caused_by": [
-        "e006"
+        "e007"
       ],
       "leads_to": [
         "e002"
@@ -71,6 +71,18 @@
       "content": "Commit: 120528e74c",
       "caused_by": [],
       "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: d3eefa86b0",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": [
         "e001"
       ]
     }
@@ -80,8 +92,8 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
-    "files_changed": 5
+    "commits": 2,
+    "files_changed": 9
   },
   "lessons": []
 }

--- a/.agents/memory/episodes/episode-2026-07-26-session-3402-plugin-self-containment.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3402-plugin-self-containment.json
@@ -1,0 +1,87 @@
+{
+  "id": "episode-2026-07-26-session-3402-plugin-self-containment",
+  "session": "2026-07-26-session-3402-plugin-self-containment",
+  "timestamp": "2026-07-26T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Bake the plugin self-containment boundary into binding knowledge after the user reported that plugin-shipped content cannot reference paths outside its plugin root",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "The boundary is verified from the manifests, and every number in the rule comes from a command a reader can rerun",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "The draft was materially wrong in three ways and the review caught all three",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "The rule now documents an existing system rather than competing with it",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "The rule distinguishes the three cases a grep cannot, and the coverage gap it reports is scoped to what the data supports",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "One canonical rule, one augmented memory, no third representation to drift",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 120528e74c",
+      "caused_by": [],
+      "leads_to": [
+        "e001"
+      ]
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 5
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-26-session-3402-plugin-self-containment.json
+++ b/.agents/sessions/2026-07-26-session-3402-plugin-self-containment.json
@@ -150,7 +150,7 @@
       "outcome": "One canonical rule, one augmented memory, no third representation to drift"
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "d3eefa86b0",
   "nextSteps": [
     "Add templates/ to UPSTREAM_PATTERNS in check_skill_md_portability.py and regenerate the baseline, which closes the measured gap",
     "Revisit whether contributor-facing knowledge skills should ship to consumers at all, which is the deeper fix behind most vendor-portability declarations"

--- a/.agents/sessions/2026-07-26-session-3402-plugin-self-containment.json
+++ b/.agents/sessions/2026-07-26-session-3402-plugin-self-containment.json
@@ -145,7 +145,7 @@
       "actions": [
         "Deleted the standalone Serena memory after confirming deployment-001-agent-self-containment.md already carries the principle",
         "Augmented that memory with only the context the rule does not carry: the roots, the three-kind distinction, the declaration, the ratchet caveat, and the gap",
-        "Bumped both project-toolkit manifests to 0.6.130, stacked above the open plugin PRs"
+        "Bumped both project-toolkit manifests to 0.6.131 after main advanced to 0.6.130 mid-review, stacked above the open plugin PRs"
       ],
       "outcome": "One canonical rule, one augmented memory, no third representation to drift"
     }

--- a/.agents/sessions/2026-07-26-session-3402-plugin-self-containment.json
+++ b/.agents/sessions/2026-07-26-session-3402-plugin-self-containment.json
@@ -1,0 +1,158 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3402,
+    "date": "2026-07-26",
+    "branch": "docs/plugin-self-containment-rule",
+    "startingCommit": "c05b686eb3",
+    "objective": "Bake the plugin self-containment boundary into binding knowledge after the user reported that plugin-shipped content cannot reference paths outside its plugin root"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "branchVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "git branch --show-current returned docs/plugin-self-containment-rule"
+      },
+      "constraintsRead": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "AGENTS.md and .claude/rules/*.md loaded as session context; knowledge-persistence.md consulted to choose the persistence surface"
+      },
+      "gitStateVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Branched from main after a fast-forward pull; git status reviewed before every commit"
+      },
+      "handoffRead": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": ".agents/HANDOFF.md read at session start and left unmodified per ADR-014"
+      },
+      "notOnMain": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "git branch --show-current = docs/plugin-self-containment-rule"
+      },
+      "serenaActivated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "serena activate_project run at session start; .serena/memories edited this session"
+      },
+      "serenaInstructions": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "serena initial_instructions called and read at session start"
+      },
+      "sessionLogCreated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "complete": true,
+        "level": "SHOULD",
+        "evidence": "Enumerated the portability validators under scripts/validation/ before writing the rule, which changed the deliverable"
+      },
+      "usageMandatoryRead": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "usage-mandatory read during Serena init"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "This section"
+      },
+      "handoffPreserved": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": ".agents/HANDOFF.md absent from git status"
+      },
+      "serenaMemoryUpdated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Augmented .serena/memories/ci/deployment-001-agent-self-containment.md rather than adding a duplicate memory"
+      },
+      "markdownLintRun": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "markdown-autofix and markdown-check ran in the pre-commit hook on all four changed markdown files"
+      },
+      "changesCommitted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Commit 120528e74c carries the rule, both mirrors, and the memory; a follow-up commit carries the manifest bumps"
+      },
+      "validationPassed": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "validate_plugin_version_bump.py reported OK; generate_rules.py produced no drift; taste-lints found no violations"
+      },
+      "tasksUpdated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Tracked as an atomic PR; described in workLog"
+      },
+      "retrospectiveInvoked": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Deferred to the objective-level retrospective; the knowledge audit is still open"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "phase": "Verify the boundary and measure it",
+      "actions": [
+        "Read both marketplace manifests and confirmed exactly three directories ship: .claude, src/claude, src/copilot-cli",
+        "Measured outbound references with git ls-files rather than a repository-wide grep, because several worktrees in the tree inflate counts by orders of magnitude",
+        "Recorded 3,192 matching lines across 538 files so the number in the rule is reproducible from the command the rule ships"
+      ],
+      "outcome": "The boundary is verified from the manifests, and every number in the rule comes from a command a reader can rerun"
+    },
+    {
+      "phase": "Adversarial review, which changed the deliverable",
+      "actions": [
+        "Ran a code-review agent on gpt-5.6-sol against the draft rule; it returned one blocker and eight further findings",
+        "Verified each finding independently rather than accepting it: the manifests were genuinely unbumped, and the worked example was genuinely wrong",
+        "Found that the reported docs/agent-catalog.md instance already carries an explicit vendor-portability declaration, so it is a declared reference rather than a defect"
+      ],
+      "outcome": "The draft was materially wrong in three ways and the review caught all three"
+    },
+    {
+      "phase": "Search before building, applied late",
+      "actions": [
+        "Discovered the repository already solves this: a paths.py helper, a vendor-portability declaration used by 170 files, four portability ratchets, and a dedicated CI workflow, all from issue #2050",
+        "Rewrote the rule to point at that mechanism instead of restating the principle from scratch",
+        "Read check_skill_md_portability.py and confirmed its pattern list covers only .agents/, .claude/lib/, and .claude/review-axes/"
+      ],
+      "outcome": "The rule now documents an existing system rather than competing with it"
+    },
+    {
+      "phase": "Establish the distinction that makes the rule usable",
+      "actions": [
+        "Tested the reviewer claim that the draft banned legitimate behavior and confirmed it: shipped agents write to consumer paths such as .agents/planning/ by design",
+        "Separated bundled dependency, consumer-workspace path, and upstream-only path, and made only the third a defect",
+        "Measured 32 undeclared references and classified them, finding docs/ and build/ ambiguous while templates/ is unambiguously upstream-only"
+      ],
+      "outcome": "The rule distinguishes the three cases a grep cannot, and the coverage gap it reports is scoped to what the data supports"
+    },
+    {
+      "phase": "Persist without duplicating",
+      "actions": [
+        "Deleted the standalone Serena memory after confirming deployment-001-agent-self-containment.md already carries the principle",
+        "Augmented that memory with only the context the rule does not carry: the roots, the three-kind distinction, the declaration, the ratchet caveat, and the gap",
+        "Bumped both project-toolkit manifests to 0.6.130, stacked above the open plugin PRs"
+      ],
+      "outcome": "One canonical rule, one augmented memory, no third representation to drift"
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Add templates/ to UPSTREAM_PATTERNS in check_skill_md_portability.py and regenerate the baseline, which closes the measured gap",
+    "Revisit whether contributor-facing knowledge skills should ship to consumers at all, which is the deeper fix behind most vendor-portability declarations"
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.130",
+  "version": "0.6.131",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/rules/plugin-self-containment.md
+++ b/.claude/rules/plugin-self-containment.md
@@ -1,0 +1,127 @@
+---
+paths:
+  - ".claude/**"
+  - "src/claude/**"
+  - "src/copilot-cli/**"
+  - "templates/agents/**"
+  - "**/.claude-plugin/plugin.json"
+priority: high
+---
+
+# Plugin Self-Containment
+
+## The boundary
+
+Three directories ship as installable plugins. Nothing else in this repository reaches a consumer.
+
+| Plugin root | Plugin name | Marketplace |
+|---|---|---|
+| `.claude/` | `project-toolkit` | `.claude-plugin/marketplace.json` |
+| `src/claude/` | `claude-agents` | `.claude-plugin/marketplace.json` |
+| `src/copilot-cli/` | `project-toolkit` | `.github/plugin/marketplace.json` |
+
+Each marketplace entry names exactly one `source` directory. A consumer who installs the plugin receives that directory and nothing above it. `docs/`, `.agents/`, `build/`, `scripts/`, `templates/`, and the repository root stay behind.
+
+`templates/agents/**` is in scope for this rule because it is the canonical source that generates shipped agent files. An outward reference introduced there lands in a plugin root on the next build.
+
+## Three kinds of path, only one of which is a defect
+
+The distinction below is the whole rule. Getting it wrong in either direction is expensive.
+
+| Kind | Example | Verdict |
+|---|---|---|
+| **Bundled dependency**: a file the plugin ships and must resolve at runtime | a sibling skill's script under the same plugin root | Fine. Address it through the plugin-root env vars. |
+| **Consumer-workspace path**: a location in the installing repository that the agent reads or writes | an agent told to write its output to `.agents/planning/` or `docs/adr/` in the consumer's repo | Fine. This is the plugin doing its job. Not a defect. |
+| **Upstream-only dependency**: a path that exists only in `rjmurillo/ai-agents` | `templates/agents/security.shared.md`, `docs/agent-catalog.md`, `build/scripts/build_all.py` | **Defect**, unless declared. Dangles for every consumer. |
+
+A grep cannot tell these apart. A reviewer can. When the target exists only upstream and the text instructs the reader to open, run, or resolve it, that is the defect.
+
+### Why it is invisible in development
+
+This repository self-hosts its own plugins. `.claude/` is both the plugin source and the live configuration, so every upstream reference resolves here and the tests pass here. CI does load the shipped `src/copilot-cli/` plugin from a separate working directory in the plugin-load smoke test, so plugin isolation itself is covered. What no gate checks is whether the *prose inside a shipped file* names a path the consumer does not have.
+
+## The mechanism already exists
+
+Do not invent a new one. Issue #2050 built this stack:
+
+- `.claude/lib/paths.py`. The portability helper. `resolve_artifact_root` and `artifact_dir` for write paths, `resolve_skill_resource` for read paths. Route through it instead of hard-coding.
+- `check_vendor_portability.py`. Ratchet over Python files under skill script roots.
+- `check_skill_md_portability.py`. Ratchet over upstream paths in Markdown prose.
+- `check_skill_md_exec_portability.py`. Ratchet over executable invocations in `SKILL.md`.
+- `check_skill_portability.py`. Ratchet over hard-coded upstream paths in skill scripts.
+- `validate-vendor-portability.yml`. Runs the vendor ratchet in CI.
+
+Every one is a **regression ratchet with a baseline**, not a universal enforcer. They block new offenders and grandfather existing ones. Passing them means "no new debt", not "this file is portable".
+
+### The declaration
+
+A file that legitimately depends on upstream paths declares it with an HTML comment, which suppresses the ratchet:
+
+```markdown
+<!-- vendor-portability: contributor-facing knowledge pack for the rjmurillo/ai-agents repo
+     itself; intentionally references upstream paths because its audience is repo
+     contributors, not plugin consumers (issue #2050) -->
+```
+
+170 files inside the plugin roots carry it. Use it when the reference is real and intended. Do not use it to silence a reference you should have fixed.
+
+## Known coverage gap
+
+`check_skill_md_portability.py` flags only `.agents/`, `.claude/lib/`, and `.claude/review-axes/` in prose. It does not flag `templates/agents/` or `templates/platforms/`, which exist only in this repository and generate shipped output.
+
+Do not widen that to a bare `templates/`. The directory name is overloaded three ways, and only the first is a defect:
+
+- `templates/agents/`, `templates/platforms/`. Upstream-only. Never present inside a plugin root.
+- A bundled `templates/` directory inside a skill, for example `.claude/skills/threat-modeling/templates/threat-model-template.md`. Ships with the plugin and resolves fine.
+- A framework convention in prose, for example Flask's `templates/` named in a project-detection table. Not a path anyone resolves.
+
+`assets/templates/` under a skill compounds it: a pattern matching the bare substring would flag shipped files such as `.claude/skills/codebase-documenter/assets/templates/API.template.md`.
+
+The declaration is the wrong tool for these. It suppresses every portability check for the whole file, so applying it to silence a legitimate `templates/` mention would also hide a later real `.agents/` regression in the same file. Narrow the pattern instead of declaring the file.
+
+Measured while writing this rule: 32 Markdown files inside the plugin roots carry undeclared `docs/`, `build/`, or `templates/` references. Most are consumer-workspace paths or prose collisions such as "build/buy/partner". The genuine ones point at `templates/agents/*.shared.md`.
+
+Until those two patterns are added, such references are on the reviewer, not the gate.
+
+## MUST
+
+1. **No undeclared upstream-only dependency in a shipped file.** A file under a plugin root, or under `templates/agents/`, MUST NOT instruct the reader to open, run, or resolve a path that exists only in this repository, unless it carries the `vendor-portability` declaration. Consumer-workspace paths are exempt; they are the point.
+2. **Address in-root executables through the plugin-root env vars.** Use `"${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/<name>/scripts/<file>"`, never a bare `.claude/skills/...` path, which resolves only when the consumer's working directory happens to match. `check_skill_md_exec_portability.py` ratchets new violations.
+3. **Do not cross-reference between plugin roots.** `.claude/` and `src/copilot-cli/` install separately. Neither may reach into the other. The generator mirrors content for exactly this reason.
+
+## SHOULD
+
+1. **Prefer inlining a short fact over copying a long document.** If a shipped file needs three lines from an ADR, quote the three lines. Copying the document creates a second copy to keep in sync.
+2. **Say whose path it is when the reference is contributor-scoped.** Write "in the `rjmurillo/ai-agents` repository" so a consumer reading it knows the path is not theirs to resolve, and add the declaration.
+3. **Question whether a repo-specific artifact belongs in a plugin root at all.** A skill whose entire subject is this repository's internals ships dead weight to consumers. That is the deeper fix behind most declarations. See ADR-083.
+
+## MUST NOT
+
+1. MUST NOT assume a path resolves because it resolves locally. Self-hosting guarantees every wrong path looks right here.
+2. MUST NOT read a passing portability check as proof of portability. The checks are baselined ratchets.
+
+## Checking a change
+
+Scope the question to what you changed. For each file you added or edited under a plugin root or `templates/agents/`, list the paths it tells the reader to read or run, and classify each one against the three-kind table above.
+
+```bash
+git diff --name-only origin/main... -- .claude src/claude src/copilot-cli templates/agents \
+  | xargs --no-run-if-empty grep -nP '(?<![\w/.-])(docs|\.agents|build|scripts|templates)/[A-Za-z0-9_./-]+'
+```
+
+Then run the ratchets that cover the change:
+
+```bash
+uv run python scripts/validation/check_skill_md_portability.py
+uv run python scripts/validation/check_vendor_portability.py
+```
+
+## References
+
+Contributor-scoped, per SHOULD 2. These paths live in the `rjmurillo/ai-agents` repository and do not ship. A consumer reading this rule inside an installed plugin cannot resolve them and does not need to.
+
+- `.claude-plugin/marketplace.json`, `.github/plugin/marketplace.json`. The manifests that define what ships.
+- `.claude/rules/plugin-version-bump.md`. Version parity across the shipping roots. This one does ship.
+- `.agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md`. Defines the plugin-root env var contract and how each host exports it.
+- `.agents/architecture/ADR-045-framework-extraction-via-plugin-marketplace.md`. Why the marketplace split exists.
+- `.agents/architecture/ADR-083-copilot-dogfood-surface-separation.md`. Which surfaces are dogfood-only.

--- a/.claude/rules/plugin-self-containment.md
+++ b/.claude/rules/plugin-self-containment.md
@@ -10,6 +10,10 @@ priority: high
 
 # Plugin Self-Containment
 
+<!-- vendor-portability: contributor-facing rule for the rjmurillo/ai-agents repo itself;
+     it must name upstream-only paths because naming them is the subject of the rule
+     (issue #2050) -->
+
 ## The boundary
 
 Three directories ship as installable plugins. Nothing else in this repository reaches a consumer.
@@ -44,12 +48,14 @@ This repository self-hosts its own plugins. `.claude/` is both the plugin source
 
 Do not invent a new one. Issue #2050 built this stack:
 
-- `.claude/lib/paths.py`. The portability helper. `resolve_artifact_root` and `artifact_dir` for write paths, `resolve_skill_resource` for read paths. Route through it instead of hard-coding.
+- `.claude/lib/paths.py`, mirrored byte-identical at `src/copilot-cli/lib/paths.py`. The portability helper. `resolve_artifact_root` and `artifact_dir` for write paths, `resolve_skill_resource` for read paths. Route through it instead of hard-coding. Import the copy inside your own root: a Copilot-side caller reaching for the `.claude/` copy is the defect this rule describes.
 - `check_vendor_portability.py`. Ratchet over Python files under skill script roots.
 - `check_skill_md_portability.py`. Ratchet over upstream paths in Markdown prose.
 - `check_skill_md_exec_portability.py`. Ratchet over executable invocations in `SKILL.md`.
 - `check_skill_portability.py`. Ratchet over hard-coded upstream paths in skill scripts.
 - `validate-vendor-portability.yml`. Runs the vendor ratchet in CI.
+
+The four ratchets live in `scripts/validation/`, the workflow in `.github/workflows/`. Both stay upstream; a consumer never runs them.
 
 Every one is a **regression ratchet with a baseline**, not a universal enforcer. They block new offenders and grandfather existing ones. Passing them means "no new debt", not "this file is portable".
 

--- a/.github/instructions/plugin-self-containment.instructions.md
+++ b/.github/instructions/plugin-self-containment.instructions.md
@@ -1,0 +1,121 @@
+---
+applyTo: .claude/**,src/claude/**,src/copilot-cli/**,templates/agents/**,**/.claude-plugin/plugin.json
+---
+
+# Plugin Self-Containment
+
+## The boundary
+
+Three directories ship as installable plugins. Nothing else in this repository reaches a consumer.
+
+| Plugin root | Plugin name | Marketplace |
+|---|---|---|
+| `.claude/` | `project-toolkit` | `.claude-plugin/marketplace.json` |
+| `src/claude/` | `claude-agents` | `.claude-plugin/marketplace.json` |
+| `src/copilot-cli/` | `project-toolkit` | `.github/plugin/marketplace.json` |
+
+Each marketplace entry names exactly one `source` directory. A consumer who installs the plugin receives that directory and nothing above it. `docs/`, `.agents/`, `build/`, `scripts/`, `templates/`, and the repository root stay behind.
+
+`templates/agents/**` is in scope for this rule because it is the canonical source that generates shipped agent files. An outward reference introduced there lands in a plugin root on the next build.
+
+## Three kinds of path, only one of which is a defect
+
+The distinction below is the whole rule. Getting it wrong in either direction is expensive.
+
+| Kind | Example | Verdict |
+|---|---|---|
+| **Bundled dependency**: a file the plugin ships and must resolve at runtime | a sibling skill's script under the same plugin root | Fine. Address it through the plugin-root env vars. |
+| **Consumer-workspace path**: a location in the installing repository that the agent reads or writes | an agent told to write its output to `.agents/planning/` or `docs/adr/` in the consumer's repo | Fine. This is the plugin doing its job. Not a defect. |
+| **Upstream-only dependency**: a path that exists only in `rjmurillo/ai-agents` | `templates/agents/security.shared.md`, `docs/agent-catalog.md`, `build/scripts/build_all.py` | **Defect**, unless declared. Dangles for every consumer. |
+
+A grep cannot tell these apart. A reviewer can. When the target exists only upstream and the text instructs the reader to open, run, or resolve it, that is the defect.
+
+### Why it is invisible in development
+
+This repository self-hosts its own plugins. `.claude/` is both the plugin source and the live configuration, so every upstream reference resolves here and the tests pass here. CI does load the shipped `src/copilot-cli/` plugin from a separate working directory in the plugin-load smoke test, so plugin isolation itself is covered. What no gate checks is whether the *prose inside a shipped file* names a path the consumer does not have.
+
+## The mechanism already exists
+
+Do not invent a new one. Issue #2050 built this stack:
+
+- `.claude/lib/paths.py`. The portability helper. `resolve_artifact_root` and `artifact_dir` for write paths, `resolve_skill_resource` for read paths. Route through it instead of hard-coding.
+- `check_vendor_portability.py`. Ratchet over Python files under skill script roots.
+- `check_skill_md_portability.py`. Ratchet over upstream paths in Markdown prose.
+- `check_skill_md_exec_portability.py`. Ratchet over executable invocations in `SKILL.md`.
+- `check_skill_portability.py`. Ratchet over hard-coded upstream paths in skill scripts.
+- `validate-vendor-portability.yml`. Runs the vendor ratchet in CI.
+
+Every one is a **regression ratchet with a baseline**, not a universal enforcer. They block new offenders and grandfather existing ones. Passing them means "no new debt", not "this file is portable".
+
+### The declaration
+
+A file that legitimately depends on upstream paths declares it with an HTML comment, which suppresses the ratchet:
+
+```markdown
+<!-- vendor-portability: contributor-facing knowledge pack for the rjmurillo/ai-agents repo
+     itself; intentionally references upstream paths because its audience is repo
+     contributors, not plugin consumers (issue #2050) -->
+```
+
+170 files inside the plugin roots carry it. Use it when the reference is real and intended. Do not use it to silence a reference you should have fixed.
+
+## Known coverage gap
+
+`check_skill_md_portability.py` flags only `.agents/`, `.claude/lib/`, and `.claude/review-axes/` in prose. It does not flag `templates/agents/` or `templates/platforms/`, which exist only in this repository and generate shipped output.
+
+Do not widen that to a bare `templates/`. The directory name is overloaded three ways, and only the first is a defect:
+
+- `templates/agents/`, `templates/platforms/`. Upstream-only. Never present inside a plugin root.
+- A bundled `templates/` directory inside a skill, for example `.claude/skills/threat-modeling/templates/threat-model-template.md`. Ships with the plugin and resolves fine.
+- A framework convention in prose, for example Flask's `templates/` named in a project-detection table. Not a path anyone resolves.
+
+`assets/templates/` under a skill compounds it: a pattern matching the bare substring would flag shipped files such as `.claude/skills/codebase-documenter/assets/templates/API.template.md`.
+
+The declaration is the wrong tool for these. It suppresses every portability check for the whole file, so applying it to silence a legitimate `templates/` mention would also hide a later real `.agents/` regression in the same file. Narrow the pattern instead of declaring the file.
+
+Measured while writing this rule: 32 Markdown files inside the plugin roots carry undeclared `docs/`, `build/`, or `templates/` references. Most are consumer-workspace paths or prose collisions such as "build/buy/partner". The genuine ones point at `templates/agents/*.shared.md`.
+
+Until those two patterns are added, such references are on the reviewer, not the gate.
+
+## MUST
+
+1. **No undeclared upstream-only dependency in a shipped file.** A file under a plugin root, or under `templates/agents/`, MUST NOT instruct the reader to open, run, or resolve a path that exists only in this repository, unless it carries the `vendor-portability` declaration. Consumer-workspace paths are exempt; they are the point.
+2. **Address in-root executables through the plugin-root env vars.** Use `"${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/<name>/scripts/<file>"`, never a bare `.claude/skills/...` path, which resolves only when the consumer's working directory happens to match. `check_skill_md_exec_portability.py` ratchets new violations.
+3. **Do not cross-reference between plugin roots.** `.claude/` and `src/copilot-cli/` install separately. Neither may reach into the other. The generator mirrors content for exactly this reason.
+
+## SHOULD
+
+1. **Prefer inlining a short fact over copying a long document.** If a shipped file needs three lines from an ADR, quote the three lines. Copying the document creates a second copy to keep in sync.
+2. **Say whose path it is when the reference is contributor-scoped.** Write "in the `rjmurillo/ai-agents` repository" so a consumer reading it knows the path is not theirs to resolve, and add the declaration.
+3. **Question whether a repo-specific artifact belongs in a plugin root at all.** A skill whose entire subject is this repository's internals ships dead weight to consumers. That is the deeper fix behind most declarations. See ADR-083.
+
+## MUST NOT
+
+1. MUST NOT assume a path resolves because it resolves locally. Self-hosting guarantees every wrong path looks right here.
+2. MUST NOT read a passing portability check as proof of portability. The checks are baselined ratchets.
+
+## Checking a change
+
+Scope the question to what you changed. For each file you added or edited under a plugin root or `templates/agents/`, list the paths it tells the reader to read or run, and classify each one against the three-kind table above.
+
+```bash
+git diff --name-only origin/main... -- .claude src/claude src/copilot-cli templates/agents \
+  | xargs --no-run-if-empty grep -nP '(?<![\w/.-])(docs|\.agents|build|scripts|templates)/[A-Za-z0-9_./-]+'
+```
+
+Then run the ratchets that cover the change:
+
+```bash
+uv run python scripts/validation/check_skill_md_portability.py
+uv run python scripts/validation/check_vendor_portability.py
+```
+
+## References
+
+Contributor-scoped, per SHOULD 2. These paths live in the `rjmurillo/ai-agents` repository and do not ship. A consumer reading this rule inside an installed plugin cannot resolve them and does not need to.
+
+- `.claude-plugin/marketplace.json`, `.github/plugin/marketplace.json`. The manifests that define what ships.
+- `.claude/rules/plugin-version-bump.md`. Version parity across the shipping roots. This one does ship.
+- `.agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md`. Defines the plugin-root env var contract and how each host exports it.
+- `.agents/architecture/ADR-045-framework-extraction-via-plugin-marketplace.md`. Why the marketplace split exists.
+- `.agents/architecture/ADR-083-copilot-dogfood-surface-separation.md`. Which surfaces are dogfood-only.

--- a/.github/instructions/plugin-self-containment.instructions.md
+++ b/.github/instructions/plugin-self-containment.instructions.md
@@ -4,6 +4,10 @@ applyTo: .claude/**,src/claude/**,src/copilot-cli/**,templates/agents/**,**/.cla
 
 # Plugin Self-Containment
 
+<!-- vendor-portability: contributor-facing rule for the rjmurillo/ai-agents repo itself;
+     it must name upstream-only paths because naming them is the subject of the rule
+     (issue #2050) -->
+
 ## The boundary
 
 Three directories ship as installable plugins. Nothing else in this repository reaches a consumer.
@@ -38,12 +42,14 @@ This repository self-hosts its own plugins. `.claude/` is both the plugin source
 
 Do not invent a new one. Issue #2050 built this stack:
 
-- `.claude/lib/paths.py`. The portability helper. `resolve_artifact_root` and `artifact_dir` for write paths, `resolve_skill_resource` for read paths. Route through it instead of hard-coding.
+- `.claude/lib/paths.py`, mirrored byte-identical at `src/copilot-cli/lib/paths.py`. The portability helper. `resolve_artifact_root` and `artifact_dir` for write paths, `resolve_skill_resource` for read paths. Route through it instead of hard-coding. Import the copy inside your own root: a Copilot-side caller reaching for the `.claude/` copy is the defect this rule describes.
 - `check_vendor_portability.py`. Ratchet over Python files under skill script roots.
 - `check_skill_md_portability.py`. Ratchet over upstream paths in Markdown prose.
 - `check_skill_md_exec_portability.py`. Ratchet over executable invocations in `SKILL.md`.
 - `check_skill_portability.py`. Ratchet over hard-coded upstream paths in skill scripts.
 - `validate-vendor-portability.yml`. Runs the vendor ratchet in CI.
+
+The four ratchets live in `scripts/validation/`, the workflow in `.github/workflows/`. Both stay upstream; a consumer never runs them.
 
 Every one is a **regression ratchet with a baseline**, not a universal enforcer. They block new offenders and grandfather existing ones. Passing them means "no new debt", not "this file is portable".
 

--- a/.serena/memories/ci/deployment-001-agent-self-containment.md
+++ b/.serena/memories/ci/deployment-001-agent-self-containment.md
@@ -57,3 +57,49 @@ Referencing external files from agent prompts that ship to end-user machines:
 - Agent file contains all required content inline
 - No references to paths outside deployment location
 - Agent works independently when copied to ~/.claude/, ~/.copilot/, ~/.vscode/
+
+## Update 2026-07-26: the plugin-marketplace form of this principle
+
+The 2025-12-19 evidence above predates the plugin marketplace (ADR-045) and the
+issue #2050 portability work. The principle held; the delivery model and the
+tooling around it changed. Canonical rule is now
+`.claude/rules/plugin-self-containment.md`. This section carries only the
+retrieval context that is not in that rule.
+
+**Three roots ship, nothing else.** `.claude/` and `src/copilot-cli/` both as
+`project-toolkit`, `src/claude/` as `claude-agents`. A consumer receives one
+source directory and nothing above it.
+
+**The distinction that matters most.** A path outside the plugin root is not
+automatically a defect. Three kinds:
+
+- Bundled dependency, resolved through the plugin-root env vars: fine.
+- Consumer-workspace path, for example an agent writing to `.agents/planning/`
+  in the installing repo: fine, that is the plugin working.
+- Upstream-only path that exists solely in `rjmurillo/ai-agents`: defect unless
+  declared.
+
+Conflating the second and third kinds is the common review error in both
+directions. A grep cannot separate them.
+
+**The declaration.** A legitimate upstream dependency is declared with a
+`vendor-portability:` HTML comment, which suppresses the ratchets. 170 files
+inside the plugin roots carry it.
+
+**Every portability check is a baselined ratchet**, not a universal enforcer.
+`check_vendor_portability.py`, `check_skill_md_portability.py`,
+`check_skill_md_exec_portability.py`, `check_skill_portability.py`. Passing
+means "no new debt", never "this file is portable". Do not cite a green check
+as proof of portability.
+
+**Known gap as of this date.** The Markdown ratchet flags only `.agents/`,
+`.claude/lib/`, and `.claude/review-axes/`. It does not flag
+`templates/agents/` or `templates/platforms/`, which exist only upstream. Do
+not widen this to a bare `templates/`: skills bundle their own `templates/`
+and `assets/templates/` directories that ship correctly, and prose names
+Flask's `templates/` convention. Narrow the pattern rather than declaring the
+file, because the declaration suppresses every portability check for that file
+and would hide a later real `.agents/` regression.
+
+**Why it stays invisible.** The repository self-hosts its own plugins, so every
+upstream path resolves during development and in most of CI.

--- a/.serena/memories/ci/deployment-001-agent-self-containment.md
+++ b/.serena/memories/ci/deployment-001-agent-self-containment.md
@@ -87,8 +87,9 @@ directions. A grep cannot separate them.
 inside the plugin roots carry it.
 
 **Every portability check is a baselined ratchet**, not a universal enforcer.
-`check_vendor_portability.py`, `check_skill_md_portability.py`,
-`check_skill_md_exec_portability.py`, `check_skill_portability.py`. Passing
+All four live in `scripts/validation/`: `check_vendor_portability.py`,
+`check_skill_md_portability.py`, `check_skill_md_exec_portability.py`,
+`check_skill_portability.py`. Passing
 means "no new debt", never "this file is portable". Do not cite a green check
 as proof of portability.
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.130",
+  "version": "0.6.131",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/instructions/plugin-self-containment.instructions.md
+++ b/src/copilot-cli/instructions/plugin-self-containment.instructions.md
@@ -4,6 +4,10 @@ applyTo: src/claude/**,src/copilot-cli/**,templates/agents/**,**/.claude-plugin/
 
 # Plugin Self-Containment
 
+<!-- vendor-portability: contributor-facing rule for the rjmurillo/ai-agents repo itself;
+     it must name upstream-only paths because naming them is the subject of the rule
+     (issue #2050) -->
+
 ## The boundary
 
 Three directories ship as installable plugins. Nothing else in this repository reaches a consumer.
@@ -38,12 +42,14 @@ This repository self-hosts its own plugins. `.claude/` is both the plugin source
 
 Do not invent a new one. Issue #2050 built this stack:
 
-- `.claude/lib/paths.py`. The portability helper. `resolve_artifact_root` and `artifact_dir` for write paths, `resolve_skill_resource` for read paths. Route through it instead of hard-coding.
+- `.claude/lib/paths.py`, mirrored byte-identical at `src/copilot-cli/lib/paths.py`. The portability helper. `resolve_artifact_root` and `artifact_dir` for write paths, `resolve_skill_resource` for read paths. Route through it instead of hard-coding. Import the copy inside your own root: a Copilot-side caller reaching for the `.claude/` copy is the defect this rule describes.
 - `check_vendor_portability.py`. Ratchet over Python files under skill script roots.
 - `check_skill_md_portability.py`. Ratchet over upstream paths in Markdown prose.
 - `check_skill_md_exec_portability.py`. Ratchet over executable invocations in `SKILL.md`.
 - `check_skill_portability.py`. Ratchet over hard-coded upstream paths in skill scripts.
 - `validate-vendor-portability.yml`. Runs the vendor ratchet in CI.
+
+The four ratchets live in `scripts/validation/`, the workflow in `.github/workflows/`. Both stay upstream; a consumer never runs them.
 
 Every one is a **regression ratchet with a baseline**, not a universal enforcer. They block new offenders and grandfather existing ones. Passing them means "no new debt", not "this file is portable".
 

--- a/src/copilot-cli/instructions/plugin-self-containment.instructions.md
+++ b/src/copilot-cli/instructions/plugin-self-containment.instructions.md
@@ -1,0 +1,121 @@
+---
+applyTo: src/claude/**,src/copilot-cli/**,templates/agents/**,**/.claude-plugin/plugin.json
+---
+
+# Plugin Self-Containment
+
+## The boundary
+
+Three directories ship as installable plugins. Nothing else in this repository reaches a consumer.
+
+| Plugin root | Plugin name | Marketplace |
+|---|---|---|
+| `.claude/` | `project-toolkit` | `.claude-plugin/marketplace.json` |
+| `src/claude/` | `claude-agents` | `.claude-plugin/marketplace.json` |
+| `src/copilot-cli/` | `project-toolkit` | `.github/plugin/marketplace.json` |
+
+Each marketplace entry names exactly one `source` directory. A consumer who installs the plugin receives that directory and nothing above it. `docs/`, `.agents/`, `build/`, `scripts/`, `templates/`, and the repository root stay behind.
+
+`templates/agents/**` is in scope for this rule because it is the canonical source that generates shipped agent files. An outward reference introduced there lands in a plugin root on the next build.
+
+## Three kinds of path, only one of which is a defect
+
+The distinction below is the whole rule. Getting it wrong in either direction is expensive.
+
+| Kind | Example | Verdict |
+|---|---|---|
+| **Bundled dependency**: a file the plugin ships and must resolve at runtime | a sibling skill's script under the same plugin root | Fine. Address it through the plugin-root env vars. |
+| **Consumer-workspace path**: a location in the installing repository that the agent reads or writes | an agent told to write its output to `.agents/planning/` or `docs/adr/` in the consumer's repo | Fine. This is the plugin doing its job. Not a defect. |
+| **Upstream-only dependency**: a path that exists only in `rjmurillo/ai-agents` | `templates/agents/security.shared.md`, `docs/agent-catalog.md`, `build/scripts/build_all.py` | **Defect**, unless declared. Dangles for every consumer. |
+
+A grep cannot tell these apart. A reviewer can. When the target exists only upstream and the text instructs the reader to open, run, or resolve it, that is the defect.
+
+### Why it is invisible in development
+
+This repository self-hosts its own plugins. `.claude/` is both the plugin source and the live configuration, so every upstream reference resolves here and the tests pass here. CI does load the shipped `src/copilot-cli/` plugin from a separate working directory in the plugin-load smoke test, so plugin isolation itself is covered. What no gate checks is whether the *prose inside a shipped file* names a path the consumer does not have.
+
+## The mechanism already exists
+
+Do not invent a new one. Issue #2050 built this stack:
+
+- `.claude/lib/paths.py`. The portability helper. `resolve_artifact_root` and `artifact_dir` for write paths, `resolve_skill_resource` for read paths. Route through it instead of hard-coding.
+- `check_vendor_portability.py`. Ratchet over Python files under skill script roots.
+- `check_skill_md_portability.py`. Ratchet over upstream paths in Markdown prose.
+- `check_skill_md_exec_portability.py`. Ratchet over executable invocations in `SKILL.md`.
+- `check_skill_portability.py`. Ratchet over hard-coded upstream paths in skill scripts.
+- `validate-vendor-portability.yml`. Runs the vendor ratchet in CI.
+
+Every one is a **regression ratchet with a baseline**, not a universal enforcer. They block new offenders and grandfather existing ones. Passing them means "no new debt", not "this file is portable".
+
+### The declaration
+
+A file that legitimately depends on upstream paths declares it with an HTML comment, which suppresses the ratchet:
+
+```markdown
+<!-- vendor-portability: contributor-facing knowledge pack for the rjmurillo/ai-agents repo
+     itself; intentionally references upstream paths because its audience is repo
+     contributors, not plugin consumers (issue #2050) -->
+```
+
+170 files inside the plugin roots carry it. Use it when the reference is real and intended. Do not use it to silence a reference you should have fixed.
+
+## Known coverage gap
+
+`check_skill_md_portability.py` flags only `.agents/`, `.claude/lib/`, and `.claude/review-axes/` in prose. It does not flag `templates/agents/` or `templates/platforms/`, which exist only in this repository and generate shipped output.
+
+Do not widen that to a bare `templates/`. The directory name is overloaded three ways, and only the first is a defect:
+
+- `templates/agents/`, `templates/platforms/`. Upstream-only. Never present inside a plugin root.
+- A bundled `templates/` directory inside a skill, for example `.claude/skills/threat-modeling/templates/threat-model-template.md`. Ships with the plugin and resolves fine.
+- A framework convention in prose, for example Flask's `templates/` named in a project-detection table. Not a path anyone resolves.
+
+`assets/templates/` under a skill compounds it: a pattern matching the bare substring would flag shipped files such as `.claude/skills/codebase-documenter/assets/templates/API.template.md`.
+
+The declaration is the wrong tool for these. It suppresses every portability check for the whole file, so applying it to silence a legitimate `templates/` mention would also hide a later real `.agents/` regression in the same file. Narrow the pattern instead of declaring the file.
+
+Measured while writing this rule: 32 Markdown files inside the plugin roots carry undeclared `docs/`, `build/`, or `templates/` references. Most are consumer-workspace paths or prose collisions such as "build/buy/partner". The genuine ones point at `templates/agents/*.shared.md`.
+
+Until those two patterns are added, such references are on the reviewer, not the gate.
+
+## MUST
+
+1. **No undeclared upstream-only dependency in a shipped file.** A file under a plugin root, or under `templates/agents/`, MUST NOT instruct the reader to open, run, or resolve a path that exists only in this repository, unless it carries the `vendor-portability` declaration. Consumer-workspace paths are exempt; they are the point.
+2. **Address in-root executables through the plugin-root env vars.** Use `"${COPILOT_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-.claude}}/skills/<name>/scripts/<file>"`, never a bare `.claude/skills/...` path, which resolves only when the consumer's working directory happens to match. `check_skill_md_exec_portability.py` ratchets new violations.
+3. **Do not cross-reference between plugin roots.** `.claude/` and `src/copilot-cli/` install separately. Neither may reach into the other. The generator mirrors content for exactly this reason.
+
+## SHOULD
+
+1. **Prefer inlining a short fact over copying a long document.** If a shipped file needs three lines from an ADR, quote the three lines. Copying the document creates a second copy to keep in sync.
+2. **Say whose path it is when the reference is contributor-scoped.** Write "in the `rjmurillo/ai-agents` repository" so a consumer reading it knows the path is not theirs to resolve, and add the declaration.
+3. **Question whether a repo-specific artifact belongs in a plugin root at all.** A skill whose entire subject is this repository's internals ships dead weight to consumers. That is the deeper fix behind most declarations. See ADR-083.
+
+## MUST NOT
+
+1. MUST NOT assume a path resolves because it resolves locally. Self-hosting guarantees every wrong path looks right here.
+2. MUST NOT read a passing portability check as proof of portability. The checks are baselined ratchets.
+
+## Checking a change
+
+Scope the question to what you changed. For each file you added or edited under a plugin root or `templates/agents/`, list the paths it tells the reader to read or run, and classify each one against the three-kind table above.
+
+```bash
+git diff --name-only origin/main... -- .claude src/claude src/copilot-cli templates/agents \
+  | xargs --no-run-if-empty grep -nP '(?<![\w/.-])(docs|\.agents|build|scripts|templates)/[A-Za-z0-9_./-]+'
+```
+
+Then run the ratchets that cover the change:
+
+```bash
+uv run python scripts/validation/check_skill_md_portability.py
+uv run python scripts/validation/check_vendor_portability.py
+```
+
+## References
+
+Contributor-scoped, per SHOULD 2. These paths live in the `rjmurillo/ai-agents` repository and do not ship. A consumer reading this rule inside an installed plugin cannot resolve them and does not need to.
+
+- `.claude-plugin/marketplace.json`, `.github/plugin/marketplace.json`. The manifests that define what ships.
+- `.claude/rules/plugin-version-bump.md`. Version parity across the shipping roots. This one does ship.
+- `.agents/architecture/ADR-071-plugin-hook-runtime-contract-verification.md`. Defines the plugin-root env var contract and how each host exports it.
+- `.agents/architecture/ADR-045-framework-extraction-via-plugin-marketplace.md`. Why the marketplace split exists.
+- `.agents/architecture/ADR-083-copilot-dogfood-surface-separation.md`. Which surfaces are dogfood-only.


### PR DESCRIPTION
## Summary

### What

Adds `.claude/rules/plugin-self-containment.md`: a rule stating that the three
plugin roots ship alone, and that a reference reaching above a root is a defect
only when the target exists nowhere but this repository. Regenerates the two
instruction mirrors and refreshes the existing Serena deployment memory.

### Why

Reported by @rjmurillo: a skill inside a plugin root cited a repository doc that
does not ship with the plugin. The consumer installs one directory. Anything the
skill needs must resolve inside it.

The failure mode is invisible in development because this repository self-hosts
its own plugins, so every upstream path resolves locally. It only breaks after
install.

The prior state had the mechanism (helpers, four ratchets, a suppression
declaration, a CI workflow) but no rule anyone reads before writing a path.

## Specification References

| Type | Reference | Description |
|------|-----------|-------------|
| **Issue** | Fixes #3441 | Plugin roots ship alone: record the boundary as a rule |

## Changes

- `.claude/rules/plugin-self-containment.md`: new canonical rule
- `.github/instructions/plugin-self-containment.instructions.md`: generated mirror
- `src/copilot-cli/instructions/plugin-self-containment.instructions.md`: generated mirror
- `.serena/memories/ci/deployment-001-agent-self-containment.md`: augmented the
  existing memory rather than writing a duplicate
- `.claude/.claude-plugin/plugin.json` and `src/copilot-cli/.claude-plugin/plugin.json`:
  bumped to 0.6.131 in parity, rebumped after main advanced to 0.6.130 mid-review

## The load-bearing distinction

A path outside the plugin root is not automatically a defect. Three kinds:

| Kind | Example | Verdict |
|------|---------|---------|
| Bundled dependency | a file the skill ships alongside itself | fine |
| Consumer-workspace path | an agent writing a plan into the installing repository | fine, this is the plugin working |
| Upstream-only path | a target that exists only in this repository | defect unless declared |

Conflating the second and third is the common review error, in both directions.
A grep cannot separate them. The rule names the distinction so a reviewer can.

## Type of Change

- [x] Documentation update

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard, no rush

**Focus areas**: whether the three-kind table draws the line where you would draw
it, and whether the coverage gap section is scoped narrowly enough.

## Testing

- [x] No testing required (documentation only)

Verification performed:

- Mirror regeneration is byte-clean: 66 rules written, zero drift
- Plugin version parity gate passes against origin/main
- Zero em-dash or en-dash bytes in the rule and both mirrors
- Every path and API cited in the rule was confirmed to exist at the cited line
- Session log validates PASS

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [x] Critic validated implementation plan

An adversarial review ran on a different model family than the authoring one
(GPT 5.6 Sol, high effort) across two rounds. It returned one blocker and seven
major findings. Every finding was independently verified before acting on it.
The blocker was correct: the manifests were not bumped, a bump lost in an earlier
revert. Two findings changed the design materially:

1. The first draft banned legitimate consumer-workspace paths. That would have
   made the rule tell contributors to break working agents.
2. Chasing a third finding surfaced that this problem already has a mechanism
   in the repository from issue #2050. The draft was reinventing it in prose.
   The rule was rewritten to point at the existing mechanism instead of
   competing with it.

A third round asked whether to widen a validator pattern to a bare `templates/`
match. The reviewer said no and supplied three counterexamples. All three were
verified and the reviewer was right, so the rule now carries an explicit warning
against that widening.

## Author Pre-flight

- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed

The self-review found three defects before the reviewer saw the draft: an
attribution to a rule file that does not contain the claim, a skill-count that
was off by eleven, and a reference count that the rule's own shipped command
could not reproduce. All three were corrected.

## Out of Scope

Widening `scripts/validation/check_skill_md_portability.py` to flag
`templates/agents/` and `templates/platforms/` is the follow-up this review
produced. It needs negative tests first, so it ships separately.

## References

- `.claude-plugin/marketplace.json` and `.github/plugin/marketplace.json`: the
  two manifests that define which directories ship
- `.claude/lib/paths.py`: the portability helpers the rule points at
- `.claude/rules/knowledge-persistence.md`: the rule that forbids duplicating an
  existing memory, which is why this augments rather than adds
- `docs/agent-catalog.md`: the reported instance that started this

## Related Issues

Fixes #3441

