### PR TITLE
feat(validation): add SKILL.md byte ceiling to skill_size gate (Refs #3421)

### DIFF
--- a/scripts/validation/skill_size.py
+++ b/scripts/validation/skill_size.py
@@ -72,6 +72,31 @@ SKILL_BYTE_WARNING: int = 12_288  # 12 KiB, progressive-disclosure trigger
 # Pattern matching staged/changed SKILL.md files
 _SKILL_MD_PATTERN: str = r"^\.claude/skills/.*/SKILL\.md$"
 
+# Git stores a symlink's *target path text* as its blob content, not the bytes
+# of the file it points to. A staged symlink SKILL.md therefore measures the
+# short link text and would slip a 30 KiB target past the ceiling, so the gate
+# rejects it (see StagedBlobError / read_staged_blob_bytes).
+_GIT_SYMLINK_MODE: str = "120000"
+
+
+class StagedBlobError(RuntimeError):
+    """A staged SKILL.md blob could not be certified for size measurement.
+
+    Raised in staged mode when the index blob is missing, is a symlink (git
+    stores the link target text as the blob, not the linked file's bytes, so
+    measuring it under-counts), or ``git show`` fails. The gate fails closed on
+    this rather than fall back to the working tree, which a pre-commit hook must
+    never trust for what is about to be committed.
+    """
+
+
+def _relative_display(file_path: Path) -> str:
+    """Best-effort cwd-relative string for display; absolute path on failure."""
+    try:
+        return str(file_path.relative_to(Path.cwd()))
+    except ValueError:
+        return str(file_path)
+
 
 @dataclass
 class SizeCheckResult:
@@ -84,6 +109,21 @@ class SizeCheckResult:
     passed: bool = True
     warning: bool = False
     errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _Tally:
+    """Running counts across the SKILL.md files a single run inspects.
+
+    ``uncertifiable`` counts staged blobs the gate could not measure (missing
+    index entry, symlink, or failed ``git show``); it drives an unconditional
+    fail-closed exit so an unmeasurable blob can never be reported as passing.
+    """
+
+    passed: int = 0
+    warnings: int = 0
+    failed: int = 0
+    uncertifiable: int = 0
 
 
 def check_skill_size(
@@ -108,10 +148,7 @@ def check_skill_size(
     keeps a staged gate honest: an oversized staged body cannot be masked by a
     shrunk unstaged working copy, and only a staged exception is honored.
     """
-    try:
-        relative = file_path.relative_to(Path.cwd())
-    except ValueError:
-        relative = file_path
+    relative = _relative_display(file_path)
 
     if content_bytes is not None:
         raw = content_bytes
@@ -120,7 +157,7 @@ def check_skill_size(
             raw = file_path.read_bytes()
         except OSError:
             return SizeCheckResult(
-                file_path=str(relative),
+                file_path=relative,
                 line_count=0,
                 passed=False,
                 errors=["File is unreadable"],
@@ -132,7 +169,7 @@ def check_skill_size(
     exception = has_size_exception(content)
 
     result = SizeCheckResult(
-        file_path=str(relative),
+        file_path=relative,
         line_count=line_count,
         byte_count=byte_count,
         has_exception=exception,
@@ -186,34 +223,72 @@ def get_staged_skill_files() -> list[Path]:
 
     files: list[Path] = []
     for line in result.stdout.strip().split("\n"):
-        if re.search(_SKILL_MD_PATTERN, line):
-            path = Path(line)
-            if path.exists():
-                files.append(path)
+        if line and re.search(_SKILL_MD_PATTERN, line):
+            files.append(Path(line))
     return files
 
 
-def read_staged_blob_bytes(path: Path) -> bytes | None:
-    """Return the staged (indexed) bytes for ``path``, or None if unavailable.
+def _staged_index_mode(path: Path) -> str | None:
+    """Return the git index mode for ``path`` (e.g. '100644', '120000'), or None.
+
+    ``git ls-files -s`` prints ``<mode> <sha> <stage>\\t<path>``; the first token
+    is the mode. None means the path has no index entry (or git is unavailable).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-s", "--", path.as_posix()],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if result.returncode != 0:
+        return None
+    out = result.stdout.strip()
+    if not out:
+        return None
+    return out.split(maxsplit=1)[0]
+
+
+def read_staged_blob_bytes(path: Path) -> bytes:
+    """Return the staged (indexed) bytes for ``path``; fail closed on any doubt.
 
     A pre-commit gate must judge what will be committed, not the working tree.
     ``git show :<path>`` reads the blob from the index, so an oversized staged
     body cannot be masked by a shrunk (unstaged) working copy, and a staged
     ``size-exception`` is honored while an unstaged one is ignored. The path is
     emitted as POSIX because git indexes forward-slash paths on every platform.
+
+    Raises ``StagedBlobError`` when the blob cannot be certified: no index entry,
+    a symlink (git stores the link target text as the blob, which under-measures
+    a link to a large file), or a failed/timed-out ``git show``. The caller must
+    never fall back to the working tree in staged mode.
     """
+    mode = _staged_index_mode(path)
+    if mode is None:
+        msg = f"{path.as_posix()}: no staged index entry; cannot measure staged bytes"
+        raise StagedBlobError(msg)
+    if mode == _GIT_SYMLINK_MODE:
+        msg = (
+            f"{path.as_posix()}: staged entry is a symlink (mode 120000); git "
+            "stores the link target as the blob, so its size cannot certify the "
+            "linked file. Commit a real SKILL.md, not a symlink."
+        )
+        raise StagedBlobError(msg)
     try:
         result = subprocess.run(
             ["git", "show", f":{path.as_posix()}"],
             capture_output=True,
             timeout=10,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return None
-
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        msg = f"{path.as_posix()}: git show failed ({exc})"
+        raise StagedBlobError(msg) from exc
     if result.returncode != 0:
-        return None
-
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        msg = f"{path.as_posix()}: git show exited {result.returncode}: {stderr}"
+        raise StagedBlobError(msg)
     return result.stdout
 
 
@@ -297,6 +372,54 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _report_summary(files_count: int, tally: _Tally, args: argparse.Namespace) -> int:
+    """Print the run summary and return the ADR-035 exit code.
+
+    An uncertifiable staged blob is a fail-closed integrity failure and returns
+    2 unconditionally (even outside ``--ci``): the gate refuses to pass a blob it
+    could not measure. This takes priority over the ordinary oversize failure
+    (exit 1 in CI), because a blob whose size is unknown is a stronger signal
+    than one that is known to be too large.
+    """
+    print()
+    print("=" * 40)
+    print("Skill Size Summary")
+    print("=" * 40)
+    print(f"  Total:    {files_count}")
+    print(f"  Passed:   {tally.passed}")
+    print(f"  Warnings: {tally.warnings}")
+    print(f"  Failed:   {tally.failed}")
+    if tally.uncertifiable:
+        print(f"  Uncertifiable (staged): {tally.uncertifiable}")
+    print(f"  Limit:    {args.limit} lines / {args.byte_limit} bytes")
+    print()
+
+    if tally.uncertifiable > 0:
+        print(
+            f"{tally.uncertifiable} staged SKILL.md file(s) could not be certified "
+            "for size. Failing closed: a pre-commit gate must not pass a blob it "
+            "cannot measure. Fix the staged entry (commit a real file, not a "
+            "symlink; ensure it is actually staged) and retry."
+        )
+        return 2
+
+    if tally.failed > 0:
+        print("Fix oversized skills by refactoring to progressive disclosure:")
+        print("  - Move reference docs to references/")
+        print("  - Extract scripts to scripts/")
+        print("  - Use modules/ for reusable logic")
+        print("  - Add 'size-exception: true' to frontmatter if justified")
+
+        if args.ci:
+            return 1
+
+        print("\nNot in CI mode. Continuing...")
+    else:
+        print("All skill files within size limits.")
+
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point. Returns ADR-035 exit code."""
     parser = build_parser()
@@ -322,12 +445,22 @@ def main(argv: list[str] | None = None) -> int:
 
     print(f"Found {len(files)} SKILL.md file(s) to check.\n")
 
-    pass_count = 0
-    warn_count = 0
-    fail_count = 0
+    tally = _Tally()
 
     for file_path in files:
-        content_bytes = read_staged_blob_bytes(file_path) if args.staged_only else None
+        content_bytes: bytes | None = None
+        if args.staged_only:
+            try:
+                content_bytes = read_staged_blob_bytes(file_path)
+            except StagedBlobError as exc:
+                tally.uncertifiable += 1
+                print(
+                    f"  [FAIL] {_relative_display(file_path)} "
+                    "(staged blob uncertifiable)"
+                )
+                print(f"    {exc}")
+                continue
+
         result = check_skill_size(
             file_path,
             limit=limit,
@@ -339,15 +472,15 @@ def main(argv: list[str] | None = None) -> int:
         size = f"{result.line_count} lines, {result.byte_count} bytes"
 
         if not result.passed:
-            fail_count += 1
+            tally.failed += 1
             print(f"  [FAIL] {result.file_path} ({size})")
             for error in result.errors:
                 print(f"    {error}")
             continue
 
-        pass_count += 1
+        tally.passed += 1
         if result.warning:
-            warn_count += 1
+            tally.warnings += 1
             if result.has_exception:
                 print(
                     f"  [EXCEPTION] {result.file_path} ({size})"
@@ -356,33 +489,7 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 print(f"  [WARN] {result.file_path} ({size})")
 
-    print()
-    print("=" * 40)
-    print("Skill Size Summary")
-    print("=" * 40)
-    print(f"  Total:    {len(files)}")
-    print(f"  Passed:   {pass_count}")
-    print(f"  Warnings: {warn_count}")
-    print(f"  Failed:   {fail_count}")
-    print(f"  Limit:    {limit} lines / {byte_limit} bytes")
-    print()
-
-    if fail_count > 0:
-        print("Fix oversized skills by refactoring to progressive disclosure:")
-        print("  - Move reference docs to references/")
-        print("  - Extract scripts to scripts/")
-        print("  - Use modules/ for reusable logic")
-        print("  - Add 'size-exception: true' to frontmatter if justified")
-
-        if args.ci:
-            return 1
-
-        print("\nNot in CI mode. Continuing...")
-
-    else:
-        print("All skill files within size limits.")
-
-    return 0
+    return _report_summary(len(files), tally, args)
 
 
 if __name__ == "__main__":

--- a/scripts/validation/skill_size.py
+++ b/scripts/validation/skill_size.py
@@ -72,21 +72,33 @@ SKILL_BYTE_WARNING: int = 12_288  # 12 KiB, progressive-disclosure trigger
 # Pattern matching staged/changed SKILL.md files
 _SKILL_MD_PATTERN: str = r"^\.claude/skills/.*/SKILL\.md$"
 
-# Git stores a symlink's *target path text* as its blob content, not the bytes
-# of the file it points to. A staged symlink SKILL.md therefore measures the
-# short link text and would slip a 30 KiB target past the ceiling, so the gate
-# rejects it (see StagedBlobError / read_staged_blob_bytes).
-_GIT_SYMLINK_MODE: str = "120000"
+# Git index modes for a *regular* file blob: 100644 (non-exec) and 100755
+# (exec). Only these carry the file's real bytes as the blob. A symlink (120000)
+# stores the target *path text* as its blob, and a gitlink/submodule (160000)
+# stores a commit id, so measuring either under-counts and would slip a large
+# target past the ceiling. The staged gate whitelists the regular modes and
+# rejects everything else (see StagedBlobError / read_staged_blob_bytes).
+_GIT_REGULAR_BLOB_MODES: frozenset[str] = frozenset({"100644", "100755"})
+
+
+class StagedDiscoveryError(RuntimeError):
+    """Staged SKILL.md discovery could not complete, so the gate fails closed.
+
+    Raised when the ``git diff --cached`` that enumerates staged files fails
+    (nonzero exit, timeout, or git missing). A pre-commit gate must not treat a
+    broken discovery as "no staged skills" (exit 0); an unknown staged set is a
+    stronger red than a known-oversize file, so this routes to exit 2.
+    """
 
 
 class StagedBlobError(RuntimeError):
     """A staged SKILL.md blob could not be certified for size measurement.
 
-    Raised in staged mode when the index blob is missing, is a symlink (git
-    stores the link target text as the blob, not the linked file's bytes, so
-    measuring it under-counts), or ``git show`` fails. The gate fails closed on
-    this rather than fall back to the working tree, which a pre-commit hook must
-    never trust for what is about to be committed.
+    Raised in staged mode when the index blob is missing, is not a regular-file
+    blob (a symlink stores the link target text, a gitlink stores a commit id,
+    so measuring either under-counts), or ``git show`` fails. The gate fails
+    closed on this rather than fall back to the working tree, which a pre-commit
+    hook must never trust for what is about to be committed.
     """
 
 
@@ -207,87 +219,125 @@ def check_skill_size(
 
 
 def get_staged_skill_files() -> list[Path]:
-    """Get staged SKILL.md files from git."""
+    """Return staged SKILL.md paths from the index; fail closed on git error.
+
+    Uses ``-z`` so paths are emitted raw and NUL-separated, immune to
+    ``core.quotePath`` (which by default octal-escapes and quotes non-ASCII
+    paths like ``.claude/skills/caf\\303\\251/SKILL.md`` and would dodge a
+    newline-split, anchored match). ``--diff-filter=ACMRT`` includes a
+    file->symlink *typechange* (status ``T``) so it is discovered and then
+    rejected by the index-mode check, rather than silently skipped.
+
+    A git command failure (nonzero exit, timeout, or missing git) raises
+    ``StagedDiscoveryError``. An empty result with a clean exit legitimately
+    means "no staged SKILL.md" and returns ``[]``; only a *failed* discovery
+    fails closed, so the common no-skills commit is not penalized.
+    """
     try:
         result = subprocess.run(
-            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+            ["git", "diff", "--cached", "--name-only", "-z", "--diff-filter=ACMRT"],
             capture_output=True,
-            text=True,
             timeout=10,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return []
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        msg = f"staged SKILL.md discovery failed ({exc}); failing closed"
+        raise StagedDiscoveryError(msg) from exc
 
     if result.returncode != 0:
-        return []
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        msg = f"staged SKILL.md discovery failed: git diff exited {result.returncode}: {stderr}"
+        raise StagedDiscoveryError(msg)
 
     files: list[Path] = []
-    for line in result.stdout.strip().split("\n"):
-        if line and re.search(_SKILL_MD_PATTERN, line):
+    for raw in result.stdout.split(b"\x00"):
+        if not raw:
+            continue
+        # surrogateescape round-trips undecodable bytes so the path re-encodes
+        # correctly when handed back to git (os/subprocess use the same codec).
+        line = raw.decode("utf-8", errors="surrogateescape")
+        if re.search(_SKILL_MD_PATTERN, line):
             files.append(Path(line))
     return files
 
 
-def _staged_index_mode(path: Path) -> str | None:
-    """Return the git index mode for ``path`` (e.g. '100644', '120000'), or None.
+def _staged_index_entry(path: Path) -> tuple[str, str]:
+    """Return the ``(mode, object_id)`` of the stage-0 index entry for ``path``.
 
-    ``git ls-files -s`` prints ``<mode> <sha> <stage>\\t<path>``; the first token
-    is the mode. None means the path has no index entry (or git is unavailable).
+    Parses ``git ls-files -s -z`` records (``<mode> <oid> <stage>\\t<path>``,
+    NUL-terminated so the path is never quoted). Only the stage-0 (non-conflict)
+    entry certifies what a commit will contain; a merge-conflicted path has only
+    stages 1/2/3 and cannot be committed, so it is treated as uncertifiable.
+
+    Raises ``StagedBlobError`` when there is no stage-0 entry (path not staged,
+    conflicted, or git unavailable) or the listing command fails.
     """
     try:
         result = subprocess.run(
-            ["git", "ls-files", "-s", "--", path.as_posix()],
+            ["git", "ls-files", "-s", "-z", "--", path.as_posix()],
             capture_output=True,
-            text=True,
             timeout=10,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return None
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        msg = f"{path.as_posix()}: git ls-files failed ({exc})"
+        raise StagedBlobError(msg) from exc
     if result.returncode != 0:
-        return None
-    out = result.stdout.strip()
-    if not out:
-        return None
-    return out.split(maxsplit=1)[0]
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        msg = f"{path.as_posix()}: git ls-files exited {result.returncode}: {stderr}"
+        raise StagedBlobError(msg)
+    for record in result.stdout.split(b"\x00"):
+        if not record:
+            continue
+        meta = record.partition(b"\t")[0]
+        parts = meta.split()
+        if len(parts) < 3:
+            continue
+        mode, oid, stage = parts[0], parts[1], parts[2]
+        if stage == b"0":
+            return mode.decode("ascii"), oid.decode("ascii")
+    msg = (
+        f"{path.as_posix()}: no stage-0 index entry (unstaged or merge-conflicted); "
+        "cannot certify staged bytes"
+    )
+    raise StagedBlobError(msg)
 
 
 def read_staged_blob_bytes(path: Path) -> bytes:
     """Return the staged (indexed) bytes for ``path``; fail closed on any doubt.
 
     A pre-commit gate must judge what will be committed, not the working tree.
-    ``git show :<path>`` reads the blob from the index, so an oversized staged
-    body cannot be masked by a shrunk (unstaged) working copy, and a staged
-    ``size-exception`` is honored while an unstaged one is ignored. The path is
-    emitted as POSIX because git indexes forward-slash paths on every platform.
+    The bytes are read from the exact index object: ``git ls-files -s`` yields
+    the staged ``(mode, oid)`` and ``git cat-file blob <oid>`` returns that
+    object's raw bytes. Reading by object id (rather than ``git show :<path>``)
+    ties the measurement to the listed entry with no path re-quoting and no
+    time-of-check/time-of-use gap between the mode check and the read.
 
-    Raises ``StagedBlobError`` when the blob cannot be certified: no index entry,
-    a symlink (git stores the link target text as the blob, which under-measures
-    a link to a large file), or a failed/timed-out ``git show``. The caller must
-    never fall back to the working tree in staged mode.
+    Raises ``StagedBlobError`` when the blob cannot be certified: no stage-0
+    entry, a non-regular mode (a symlink stores the link target text and a
+    gitlink stores a commit id, both of which under-measure the real file), or a
+    failed/timed-out git call. The caller must never fall back to the working
+    tree in staged mode.
     """
-    mode = _staged_index_mode(path)
-    if mode is None:
-        msg = f"{path.as_posix()}: no staged index entry; cannot measure staged bytes"
-        raise StagedBlobError(msg)
-    if mode == _GIT_SYMLINK_MODE:
+    mode, oid = _staged_index_entry(path)
+    if mode not in _GIT_REGULAR_BLOB_MODES:
         msg = (
-            f"{path.as_posix()}: staged entry is a symlink (mode 120000); git "
-            "stores the link target as the blob, so its size cannot certify the "
-            "linked file. Commit a real SKILL.md, not a symlink."
+            f"{path.as_posix()}: staged entry mode {mode} is not a regular file "
+            "(100644/100755). A symlink (120000) stores the link target text and a "
+            "gitlink (160000) stores a commit id, so neither blob size certifies "
+            "the SKILL.md body. Commit a real file, not a symlink or submodule."
         )
         raise StagedBlobError(msg)
     try:
         result = subprocess.run(
-            ["git", "show", f":{path.as_posix()}"],
+            ["git", "cat-file", "blob", oid],
             capture_output=True,
             timeout=10,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
-        msg = f"{path.as_posix()}: git show failed ({exc})"
+        msg = f"{path.as_posix()}: git cat-file failed ({exc})"
         raise StagedBlobError(msg) from exc
     if result.returncode != 0:
         stderr = result.stderr.decode("utf-8", errors="replace").strip()
-        msg = f"{path.as_posix()}: git show exited {result.returncode}: {stderr}"
+        msg = f"{path.as_posix()}: git cat-file exited {result.returncode}: {stderr}"
         raise StagedBlobError(msg)
     return result.stdout
 
@@ -433,11 +483,19 @@ def main(argv: list[str] | None = None) -> int:
 
     print("Validating skill prompt sizes...")
 
-    files = get_skill_files(
-        path=args.path,
-        staged_only=args.staged_only,
-        changed_files=args.changed_files,
-    )
+    try:
+        files = get_skill_files(
+            path=args.path,
+            staged_only=args.staged_only,
+            changed_files=args.changed_files,
+        )
+    except StagedDiscoveryError as exc:
+        print(f"  [FAIL] staged discovery could not complete: {exc}")
+        print(
+            "\nFailing closed: a pre-commit gate must not treat a broken staged "
+            "discovery as 'no skills to check'. Ensure git is available and retry."
+        )
+        return 2
 
     if not files:
         print("No SKILL.md files found to validate.")

--- a/scripts/validation/skill_size.py
+++ b/scripts/validation/skill_size.py
@@ -21,7 +21,7 @@ procedures and tables in references/*.md) keeps the always-loaded body small.
 Exit codes follow ADR-035:
     0 - Success: All skill files within size limits
     1 - Error: One or more files exceed limit (CI mode only)
-    2 - Config error (path not found)
+    2 - Uncertifiable staged blob or staged discovery failure (fail-closed)
 
 Related: Issue #676 (Skill Prompt Size Limits), Issue #3421 (byte ceiling)
 """
@@ -45,8 +45,10 @@ _FRONTMATTER_PATH = (
 )
 try:
     _spec = importlib.util.spec_from_file_location("skill_frontmatter_utils", _FRONTMATTER_PATH)
-    _mod = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
-    _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+    if _spec is None or _spec.loader is None:
+        raise TypeError("importlib could not create spec for frontmatter module")
+    _mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)
     has_size_exception = _mod.has_size_exception
 except (FileNotFoundError, TypeError, AttributeError) as _exc:
     print(
@@ -96,7 +98,7 @@ class StagedBlobError(RuntimeError):
 
     Raised in staged mode when the index blob is missing, is not a regular-file
     blob (a symlink stores the link target text, a gitlink stores a commit id,
-    so measuring either under-counts), or ``git show`` fails. The gate fails
+    so measuring either under-counts), or ``git cat-file`` fails. The gate fails
     closed on this rather than fall back to the working tree, which a pre-commit
     hook must never trust for what is about to be committed.
     """
@@ -128,7 +130,7 @@ class _Tally:
     """Running counts across the SKILL.md files a single run inspects.
 
     ``uncertifiable`` counts staged blobs the gate could not measure (missing
-    index entry, symlink, or failed ``git show``); it drives an unconditional
+    index entry, symlink, or failed ``git cat-file``); it drives an unconditional
     fail-closed exit so an unmeasurable blob can never be reported as passing.
     """
 

--- a/scripts/validation/skill_size.py
+++ b/scripts/validation/skill_size.py
@@ -7,14 +7,23 @@ the limit should use progressive disclosure (references/, modules/).
 
 Size limits:
     - SKILL.md: 500 lines (warning at 300)
+    - SKILL.md: 20,480 bytes target ceiling (warning at 12,288); enforced as a
+      ratchet seeded above today's largest body, lowered toward the target as
+      oversized skills decompose into references/ (see SKILL_BYTE_LIMIT)
     - Exception: documented in frontmatter with 'size-exception: true'
+
+The byte ceiling exists because the line ceiling misses table-heavy or
+long-line bodies: a skill can sit under 500 lines yet carry 24 KB, so invoking
+it to check one procedure pays for the whole document. Progressive disclosure
+(a lean SKILL.md that states triggers, the routing decision, and pointers, with
+procedures and tables in references/*.md) keeps the always-loaded body small.
 
 Exit codes follow ADR-035:
     0 - Success: All skill files within size limits
     1 - Error: One or more files exceed limit (CI mode only)
     2 - Config error (path not found)
 
-Related: Issue #676 (Skill Prompt Size Limits)
+Related: Issue #676 (Skill Prompt Size Limits), Issue #3421 (byte ceiling)
 """
 
 from __future__ import annotations
@@ -50,6 +59,16 @@ except (FileNotFoundError, TypeError, AttributeError) as _exc:
 SKILL_SIZE_LIMIT: int = 500
 SKILL_SIZE_WARNING: int = 300
 
+# Size thresholds (bytes). The hard limit is a ratchet: it is seeded just above
+# the largest SKILL.md body in the corpus so it blocks further growth and any
+# new oversized skill without redding an already-green main. Lower it toward
+# SKILL_BYTE_TARGET (20 KiB, Issue #3421 AC-3) as the over-limit skills
+# decompose their bodies into references/. The warning marks the 12 KiB soft
+# ceiling that signals a skill should adopt progressive disclosure.
+SKILL_BYTE_TARGET: int = 20_480  # 20 KiB, the documented goal (Issue #3421)
+SKILL_BYTE_LIMIT: int = 24_576  # 24 KiB, current ratchet (max body is 24,210 B)
+SKILL_BYTE_WARNING: int = 12_288  # 12 KiB, progressive-disclosure trigger
+
 # Pattern matching staged/changed SKILL.md files
 _SKILL_MD_PATTERN: str = r"^\.claude/skills/.*/SKILL\.md$"
 
@@ -60,6 +79,7 @@ class SizeCheckResult:
 
     file_path: str
     line_count: int
+    byte_count: int = 0
     has_exception: bool = False
     passed: bool = True
     warning: bool = False
@@ -70,15 +90,23 @@ def check_skill_size(
     file_path: Path,
     limit: int = SKILL_SIZE_LIMIT,
     warn: int = SKILL_SIZE_WARNING,
+    byte_limit: int = SKILL_BYTE_LIMIT,
+    byte_warn: int = SKILL_BYTE_WARNING,
 ) -> SizeCheckResult:
-    """Check a single SKILL.md file against size limits."""
+    """Check a single SKILL.md file against line and byte size limits.
+
+    Lines and bytes are independent dimensions: a body can pass one and fail the
+    other (a table-heavy skill stays under 500 lines yet exceeds the byte
+    ceiling). Both honor the same ``size-exception: true`` frontmatter escape,
+    which downgrades a hard failure to a warning.
+    """
     try:
         relative = file_path.relative_to(Path.cwd())
     except ValueError:
         relative = file_path
 
     try:
-        content = file_path.read_text(encoding="utf-8")
+        raw = file_path.read_bytes()
     except OSError:
         return SizeCheckResult(
             file_path=str(relative),
@@ -87,12 +115,15 @@ def check_skill_size(
             errors=["File is unreadable"],
         )
 
+    content = raw.decode("utf-8", errors="replace")
     line_count = len(content.splitlines())
+    byte_count = len(raw)
     exception = has_size_exception(content)
 
     result = SizeCheckResult(
         file_path=str(relative),
         line_count=line_count,
+        byte_count=byte_count,
         has_exception=exception,
     )
 
@@ -108,6 +139,20 @@ def check_skill_size(
                 f"if overage is justified."
             )
     elif line_count > warn:
+        result.warning = True
+
+    if byte_count > byte_limit:
+        if exception:
+            result.warning = True
+        else:
+            result.passed = False
+            result.errors.append(
+                f"SKILL.md exceeds {byte_limit} bytes ({byte_count} bytes). "
+                f"Refactor using progressive disclosure: move procedures, tables, and "
+                f"examples to references/ so the always-loaded body stays lean. Add "
+                f"'size-exception: true' to frontmatter if overage is justified."
+            )
+    elif byte_count > byte_warn:
         result.warning = True
 
     return result
@@ -202,6 +247,18 @@ def build_parser() -> argparse.ArgumentParser:
         default=SKILL_SIZE_WARNING,
         help=f"Warning threshold in lines (default: {SKILL_SIZE_WARNING})",
     )
+    parser.add_argument(
+        "--byte-limit",
+        type=int,
+        default=SKILL_BYTE_LIMIT,
+        help=f"Maximum bytes allowed (default: {SKILL_BYTE_LIMIT})",
+    )
+    parser.add_argument(
+        "--byte-warn",
+        type=int,
+        default=SKILL_BYTE_WARNING,
+        help=f"Warning threshold in bytes (default: {SKILL_BYTE_WARNING})",
+    )
     return parser
 
 
@@ -213,6 +270,8 @@ def main(argv: list[str] | None = None) -> int:
     # Use local variables instead of modifying globals
     limit = args.limit
     warn = args.warn
+    byte_limit = args.byte_limit
+    byte_warn = args.byte_warn
 
     print("Validating skill prompt sizes...")
 
@@ -233,11 +292,14 @@ def main(argv: list[str] | None = None) -> int:
     fail_count = 0
 
     for file_path in files:
-        result = check_skill_size(file_path, limit=limit, warn=warn)
+        result = check_skill_size(
+            file_path, limit=limit, warn=warn, byte_limit=byte_limit, byte_warn=byte_warn
+        )
+        size = f"{result.line_count} lines, {result.byte_count} bytes"
 
         if not result.passed:
             fail_count += 1
-            print(f"  [FAIL] {result.file_path} ({result.line_count} lines)")
+            print(f"  [FAIL] {result.file_path} ({size})")
             for error in result.errors:
                 print(f"    {error}")
             continue
@@ -247,11 +309,11 @@ def main(argv: list[str] | None = None) -> int:
             warn_count += 1
             if result.has_exception:
                 print(
-                    f"  [EXCEPTION] {result.file_path} ({result.line_count} lines)"
+                    f"  [EXCEPTION] {result.file_path} ({size})"
                     " - size-exception declared"
                 )
             else:
-                print(f"  [WARN] {result.file_path} ({result.line_count} lines)")
+                print(f"  [WARN] {result.file_path} ({size})")
 
     print()
     print("=" * 40)
@@ -261,7 +323,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"  Passed:   {pass_count}")
     print(f"  Warnings: {warn_count}")
     print(f"  Failed:   {fail_count}")
-    print(f"  Limit:    {limit} lines")
+    print(f"  Limit:    {limit} lines / {byte_limit} bytes")
     print()
 
     if fail_count > 0:

--- a/scripts/validation/skill_size.py
+++ b/scripts/validation/skill_size.py
@@ -92,6 +92,8 @@ def check_skill_size(
     warn: int = SKILL_SIZE_WARNING,
     byte_limit: int = SKILL_BYTE_LIMIT,
     byte_warn: int = SKILL_BYTE_WARNING,
+    *,
+    content_bytes: bytes | None = None,
 ) -> SizeCheckResult:
     """Check a single SKILL.md file against line and byte size limits.
 
@@ -99,21 +101,30 @@ def check_skill_size(
     other (a table-heavy skill stays under 500 lines yet exceeds the byte
     ceiling). Both honor the same ``size-exception: true`` frontmatter escape,
     which downgrades a hard failure to a warning.
+
+    Pass ``content_bytes`` to measure a specific byte payload (the staged index
+    blob) instead of reading the working tree. When it is None the working-tree
+    file is read. Measuring bytes and parsing the exception from the SAME source
+    keeps a staged gate honest: an oversized staged body cannot be masked by a
+    shrunk unstaged working copy, and only a staged exception is honored.
     """
     try:
         relative = file_path.relative_to(Path.cwd())
     except ValueError:
         relative = file_path
 
-    try:
-        raw = file_path.read_bytes()
-    except OSError:
-        return SizeCheckResult(
-            file_path=str(relative),
-            line_count=0,
-            passed=False,
-            errors=["File is unreadable"],
-        )
+    if content_bytes is not None:
+        raw = content_bytes
+    else:
+        try:
+            raw = file_path.read_bytes()
+        except OSError:
+            return SizeCheckResult(
+                file_path=str(relative),
+                line_count=0,
+                passed=False,
+                errors=["File is unreadable"],
+            )
 
     content = raw.decode("utf-8", errors="replace")
     line_count = len(content.splitlines())
@@ -180,6 +191,30 @@ def get_staged_skill_files() -> list[Path]:
             if path.exists():
                 files.append(path)
     return files
+
+
+def read_staged_blob_bytes(path: Path) -> bytes | None:
+    """Return the staged (indexed) bytes for ``path``, or None if unavailable.
+
+    A pre-commit gate must judge what will be committed, not the working tree.
+    ``git show :<path>`` reads the blob from the index, so an oversized staged
+    body cannot be masked by a shrunk (unstaged) working copy, and a staged
+    ``size-exception`` is honored while an unstaged one is ignored. The path is
+    emitted as POSIX because git indexes forward-slash paths on every platform.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "show", f":{path.as_posix()}"],
+            capture_output=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    return result.stdout
 
 
 def get_skill_files(
@@ -292,8 +327,14 @@ def main(argv: list[str] | None = None) -> int:
     fail_count = 0
 
     for file_path in files:
+        content_bytes = read_staged_blob_bytes(file_path) if args.staged_only else None
         result = check_skill_size(
-            file_path, limit=limit, warn=warn, byte_limit=byte_limit, byte_warn=byte_warn
+            file_path,
+            limit=limit,
+            warn=warn,
+            byte_limit=byte_limit,
+            byte_warn=byte_warn,
+            content_bytes=content_bytes,
         )
         size = f"{result.line_count} lines, {result.byte_count} bytes"
 

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -19,7 +19,9 @@ from scripts.validation.skill_size import (
     SKILL_SIZE_LIMIT,
     SKILL_SIZE_WARNING,
     StagedBlobError,
+    StagedDiscoveryError,
     check_skill_size,
+    get_staged_skill_files,
     has_size_exception,
     main,
     read_staged_blob_bytes,
@@ -342,7 +344,8 @@ class TestStagedBlobValidation:
     oversized body, then shrink or add an exception in the worktree without
     staging, and the oversized blob would still get committed. These tests build
     a real repo and drive ``main(["--staged-only", "--ci"])`` to prove the gate
-    reads ``git show :<path>``.
+    reads the staged index object (``git ls-files -s`` + ``git cat-file blob``),
+    never the working tree.
     """
 
     @staticmethod
@@ -508,3 +511,117 @@ class TestStagedBlobValidation:
 
         monkeypatch.chdir(tmp_path)
         assert main(["--staged-only", "--ci"]) == 2
+
+    def test_staged_gitlink_skill_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Round-3 finding: a gitlink/submodule entry (mode 160000) stores a commit
+        # id as its "blob", not the file bytes, so measuring it under-counts. The
+        # mode whitelist (100644/100755) must reject it. Staged via cacheinfo so
+        # the test needs no real submodule and is OS-independent.
+        self._init_repo(tmp_path)
+        # A gitlink cacheinfo needs a non-null commit id; git rejects the all-zero
+        # SHA. Reuse a real commit id from an initial commit in this repo.
+        (tmp_path / "seed.txt").write_text("seed\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "add", "seed.txt"], cwd=tmp_path, check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "commit", "-qm", "seed"], cwd=tmp_path, check=True, capture_output=True
+        )
+        commit_sha = (
+            subprocess.run(
+                ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, check=True
+            )
+            .stdout.decode()
+            .strip()
+        )
+        subprocess.run(
+            [
+                "git",
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                f"160000,{commit_sha},.claude/skills/big/SKILL.md",
+            ],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        monkeypatch.chdir(tmp_path)
+        assert main(["--staged-only", "--ci"]) == 2
+
+    def test_typechange_to_symlink_is_discovered_and_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Round-3 finding: replacing a committed regular SKILL.md with a symlink is
+        # a typechange (git status ``T``). ``--diff-filter=ACMR`` excluded ``T``, so
+        # discovery skipped it and the gate passed (exit 0) while an oversized-target
+        # symlink was commit-ready. ``--diff-filter=ACMRT`` must discover it, and the
+        # mode whitelist must then reject it (exit 2).
+        self._init_repo(tmp_path)
+        skill = self._write_skill(tmp_path, b"---\nname: big\n---\nsmall real body")
+        self._stage_all(tmp_path)
+        subprocess.run(
+            ["git", "commit", "-qm", "add skill"], cwd=tmp_path, check=True, capture_output=True
+        )
+        # Replace the regular file with a symlink blob at the same path (typechange).
+        sha = (
+            subprocess.run(
+                ["git", "hash-object", "-w", "--stdin"],
+                input=b"../../../some/large/target",
+                cwd=tmp_path,
+                capture_output=True,
+                check=True,
+            )
+            .stdout.decode()
+            .strip()
+        )
+        skill.unlink()
+        subprocess.run(
+            [
+                "git",
+                "update-index",
+                "--cacheinfo",
+                f"120000,{sha},.claude/skills/big/SKILL.md",
+            ],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        monkeypatch.chdir(tmp_path)
+        assert main(["--staged-only", "--ci"]) == 2
+
+    def test_non_ascii_staged_path_is_discovered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Round-3 finding: with default ``core.quotePath``, a non-ASCII path like
+        # ``café`` is emitted octal-escaped and double-quoted by a newline-split
+        # ``git diff --name-only``, so an anchored match missed it and the oversized
+        # blob dodged the gate. ``-z`` emits raw NUL-separated paths, so discovery
+        # sees it and the gate fails on the oversized staged blob.
+        self._init_repo(tmp_path)
+        skill = tmp_path / ".claude" / "skills" / "café" / "SKILL.md"
+        skill.parent.mkdir(parents=True, exist_ok=True)
+        skill.write_bytes(b"---\nname: cafe\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64))
+        self._stage_all(tmp_path)
+
+        monkeypatch.chdir(tmp_path)
+        discovered = get_staged_skill_files()
+        assert any("caf" in p.as_posix() for p in discovered)
+        assert main(["--staged-only", "--ci"]) == 1
+
+    def test_discovery_failure_fails_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Round-3 finding: a failed ``git diff`` (nonzero/timeout/git missing) must
+        # not become an empty successful run (exit 0). It raises StagedDiscoveryError,
+        # which main routes to exit 2 (fail closed), unconditionally (no --ci).
+        def _boom() -> list[Path]:
+            raise StagedDiscoveryError("simulated git diff failure")
+
+        monkeypatch.setattr(_skill_size_mod, "get_staged_skill_files", _boom)
+        monkeypatch.chdir(tmp_path)
+        assert main(["--staged-only"]) == 2

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -11,15 +11,18 @@ from pathlib import Path
 
 import pytest
 
+from scripts.validation import skill_size as _skill_size_mod
 from scripts.validation.skill_size import (
     SKILL_BYTE_LIMIT,
     SKILL_BYTE_TARGET,
     SKILL_BYTE_WARNING,
     SKILL_SIZE_LIMIT,
     SKILL_SIZE_WARNING,
+    StagedBlobError,
     check_skill_size,
     has_size_exception,
     main,
+    read_staged_blob_bytes,
 )
 
 # ---------------------------------------------------------------------------
@@ -421,3 +424,87 @@ class TestStagedBlobValidation:
 
         monkeypatch.chdir(tmp_path)
         assert main(["--staged-only", "--ci"]) == 0
+
+    def test_staged_deletion_of_oversized_add_fails_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Finding A (fail-open): stage an oversized ADD, then delete the worktree
+        # file WITHOUT staging the deletion. The index still carries the oversized
+        # blob, so it is commit-ready. The old discovery filtered by
+        # ``path.exists()`` and dropped it -> gate found nothing -> exit 0. The
+        # gate must instead measure the staged blob and FAIL.
+        import os
+
+        self._init_repo(tmp_path)
+        skill = self._write_skill(
+            tmp_path, b"---\nname: big\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64)
+        )
+        self._stage_all(tmp_path)
+        os.remove(skill)  # worktree gone; staged ADD remains commit-ready
+
+        monkeypatch.chdir(tmp_path)
+        assert main(["--staged-only", "--ci"]) == 1
+
+    def test_read_staged_blob_bytes_raises_when_not_staged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A path with no index entry cannot be measured; fail closed rather than
+        # return None (which the old code let fall back to the working tree).
+        self._init_repo(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(StagedBlobError):
+            read_staged_blob_bytes(Path(".claude/skills/ghost/SKILL.md"))
+
+    def test_git_show_failure_fails_closed_in_main(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # If reading the staged blob fails for any reason, main must fail closed
+        # (exit 2, unconditionally) and never silently pass the file.
+        self._init_repo(tmp_path)
+        self._write_skill(tmp_path, b"---\nname: big\n---\nsmall")
+        self._stage_all(tmp_path)
+
+        def _boom(path: Path) -> bytes:
+            msg = f"{path.as_posix()}: simulated git show failure"
+            raise StagedBlobError(msg)
+
+        monkeypatch.setattr(_skill_size_mod, "read_staged_blob_bytes", _boom)
+        monkeypatch.chdir(tmp_path)
+        # Not --ci: fail-closed on an uncertifiable blob is unconditional.
+        assert main(["--staged-only"]) == 2
+
+    def test_staged_symlink_skill_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Finding B (symlink): git stores a symlink's target text as its blob, so
+        # a staged SKILL.md symlink to a 30 KiB file measures only the short link
+        # text and would slip past the ceiling. Staged via update-index cacheinfo
+        # (mode 120000) so the test is OS-independent (no real filesystem symlink,
+        # works on Windows CI). The gate must reject it (fail closed, exit 2).
+        self._init_repo(tmp_path)
+        sha = (
+            subprocess.run(
+                ["git", "hash-object", "-w", "--stdin"],
+                input=b"../../../some/large/target/file",
+                cwd=tmp_path,
+                capture_output=True,
+                check=True,
+            )
+            .stdout.decode()
+            .strip()
+        )
+        subprocess.run(
+            [
+                "git",
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                f"120000,{sha},.claude/skills/big/SKILL.md",
+            ],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        monkeypatch.chdir(tmp_path)
+        assert main(["--staged-only", "--ci"]) == 2

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from scripts.validation.skill_size import (
+    SKILL_BYTE_LIMIT,
+    SKILL_BYTE_TARGET,
+    SKILL_BYTE_WARNING,
     SKILL_SIZE_LIMIT,
     SKILL_SIZE_WARNING,
     check_skill_size,
@@ -116,12 +119,97 @@ class TestCheckSkillSize:
 
 
 # ---------------------------------------------------------------------------
-# main (CLI)
+# check_skill_size: byte dimension (Issue #3421)
 # ---------------------------------------------------------------------------
 
 
-class TestMain:
-    """Tests for CLI entry point."""
+class TestCheckSkillSizeBytes:
+    """Tests for the byte-size dimension, independent of the line dimension."""
+
+    def test_byte_thresholds_are_ordered(self) -> None:
+        # The ratchet invariant: warn < documented target <= enforced ceiling.
+        assert SKILL_BYTE_WARNING < SKILL_BYTE_TARGET
+        assert SKILL_BYTE_TARGET <= SKILL_BYTE_LIMIT
+
+    def test_small_file_no_byte_warning(self, tmp_path: Path) -> None:
+        skill = tmp_path / "SKILL.md"
+        skill.write_text("---\nname: test\n---\nSmall body", encoding="utf-8")
+
+        result = check_skill_size(skill)
+
+        assert result.passed is True
+        assert result.warning is False
+        assert result.byte_count == len(skill.read_bytes())
+
+    def test_byte_warning_threshold(self, tmp_path: Path) -> None:
+        # Over the 12 KiB soft ceiling but under the enforced limit and under
+        # the 500-line limit: warns on bytes alone.
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(
+            "---\nname: test\n---\n" + ("x" * 200 + "\n") * 70, encoding="utf-8"
+        )
+
+        result = check_skill_size(skill)
+
+        assert result.byte_count > SKILL_BYTE_WARNING
+        assert result.byte_count <= SKILL_BYTE_LIMIT
+        assert result.line_count <= SKILL_SIZE_LIMIT
+        assert result.passed is True
+        assert result.warning is True
+
+    def test_exceeds_byte_limit_under_line_limit(self, tmp_path: Path) -> None:
+        # The case the line check misses: a table-heavy body sits well under
+        # 500 lines yet blows the byte ceiling. It must FAIL on bytes.
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(
+            "---\nname: test\n---\n" + ("x" * 600 + "\n") * 50, encoding="utf-8"
+        )
+
+        result = check_skill_size(skill)
+
+        assert result.line_count <= SKILL_SIZE_LIMIT
+        assert result.byte_count > SKILL_BYTE_LIMIT
+        assert result.passed is False
+        assert len(result.errors) == 1
+        assert "bytes" in result.errors[0]
+        assert "progressive disclosure" in result.errors[0]
+
+    def test_exceeds_byte_limit_with_exception(self, tmp_path: Path) -> None:
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(
+            "---\nname: test\nsize-exception: true\n---\n" + ("x" * 600 + "\n") * 50,
+            encoding="utf-8",
+        )
+
+        result = check_skill_size(skill)
+
+        assert result.passed is True
+        assert result.warning is True
+        assert result.has_exception is True
+
+    def test_byte_count_is_raw_bytes_not_chars(self, tmp_path: Path) -> None:
+        # Multi-byte UTF-8 must count as raw bytes (matching `wc -c`), not code
+        # points, so the measure cannot be dodged with wide characters.
+        skill = tmp_path / "SKILL.md"
+        body = "---\nname: test\n---\n" + "é" * 100  # 'é' is 2 bytes in UTF-8
+        skill.write_text(body, encoding="utf-8")
+
+        result = check_skill_size(skill)
+
+        assert result.byte_count == len(body.encode("utf-8"))
+        assert result.byte_count > len(body)
+
+    def test_custom_byte_limit_triggers_failure(self, tmp_path: Path) -> None:
+        skill = tmp_path / "SKILL.md"
+        skill.write_text("---\nname: test\n---\n" + "x" * 500, encoding="utf-8")
+
+        result = check_skill_size(skill, byte_limit=100, byte_warn=50)
+
+        assert result.passed is False
+        assert any("bytes" in e for e in result.errors)
+
+
+
 
     def test_no_files_returns_zero(self, tmp_path: Path) -> None:
         exit_code = main(["--path", str(tmp_path)])
@@ -174,4 +262,30 @@ class TestMain:
         )
 
         exit_code = main(["--path", str(tmp_path), "--ci"])
+        assert exit_code == 0
+
+    def test_custom_byte_limit_fails_in_ci(self, tmp_path: Path) -> None:
+        # A body that is fine on lines but over a tightened byte limit fails CI.
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test\n---\n" + "x" * 500, encoding="utf-8"
+        )
+
+        exit_code = main(
+            ["--path", str(tmp_path), "--ci", "--byte-limit", "100", "--byte-warn", "50"]
+        )
+        assert exit_code == 1
+
+    def test_byte_exception_bypasses_failure_in_ci(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test\nsize-exception: true\n---\n" + "x" * 500,
+            encoding="utf-8",
+        )
+
+        exit_code = main(
+            ["--path", str(tmp_path), "--ci", "--byte-limit", "100", "--byte-warn", "50"]
+        )
         assert exit_code == 0

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -6,7 +6,10 @@ Covers size checking, exception handling, CLI modes, and edge cases.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from scripts.validation.skill_size import (
     SKILL_BYTE_LIMIT,
@@ -189,15 +192,20 @@ class TestCheckSkillSizeBytes:
 
     def test_byte_count_is_raw_bytes_not_chars(self, tmp_path: Path) -> None:
         # Multi-byte UTF-8 must count as raw bytes (matching `wc -c`), not code
-        # points, so the measure cannot be dodged with wide characters.
+        # points, so the measure cannot be dodged with wide characters. Write raw
+        # bytes (not write_text) so the on-disk size is identical on Windows and
+        # POSIX: write_text translates LF to CRLF on Windows and would inflate the
+        # count, failing this test spuriously. The embedded CRLF also proves the
+        # counter preserves bytes verbatim rather than normalizing newlines.
         skill = tmp_path / "SKILL.md"
-        body = "---\nname: test\n---\n" + "é" * 100  # 'é' is 2 bytes in UTF-8
-        skill.write_text(body, encoding="utf-8")
+        payload = b"---\r\nname: test\r\n---\r\n" + "\u00e9".encode("utf-8") * 100
+        skill.write_bytes(payload)
 
         result = check_skill_size(skill)
 
-        assert result.byte_count == len(body.encode("utf-8"))
-        assert result.byte_count > len(body)
+        assert result.byte_count == len(payload)
+        # 100 two-byte 'é' plus the prefix: more raw bytes than decoded code points.
+        assert result.byte_count > len(payload.decode("utf-8"))
 
     def test_custom_byte_limit_triggers_failure(self, tmp_path: Path) -> None:
         skill = tmp_path / "SKILL.md"
@@ -208,8 +216,41 @@ class TestCheckSkillSizeBytes:
         assert result.passed is False
         assert any("bytes" in e for e in result.errors)
 
+    def test_byte_limit_boundary_is_inclusive(self, tmp_path: Path) -> None:
+        # Pin ``>`` (not ``>=``): a body of EXACTLY the limit passes; one byte
+        # over fails. Guards the ratchet against an off-by-one that would red a
+        # file sitting on the boundary or pass one just past it.
+        at_limit = tmp_path / "at.md"
+        at_limit.write_bytes(b"x" * SKILL_BYTE_LIMIT)
+        result_at = check_skill_size(at_limit)
+        assert result_at.byte_count == SKILL_BYTE_LIMIT
+        assert result_at.passed is True
 
+        over = tmp_path / "over.md"
+        over.write_bytes(b"x" * (SKILL_BYTE_LIMIT + 1))
+        result_over = check_skill_size(over)
+        assert result_over.byte_count == SKILL_BYTE_LIMIT + 1
+        assert result_over.passed is False
 
+    def test_real_corpus_within_byte_ratchet(self) -> None:
+        # Main must stay green: every shipped SKILL.md is within the seeded
+        # ratchet. If a new skill lands oversized, or the ratchet is lowered
+        # below the current largest body, this fails, exactly when a human must
+        # decide to decompose the skill or re-seed the constant. Mirrors the
+        # instruction-budget anchor test. Reads raw bytes directly so it pins the
+        # byte dimension without coupling to the line check.
+        repo_root = Path(__file__).resolve().parents[1]
+        skills = sorted((repo_root / ".claude" / "skills").rglob("SKILL.md"))
+        assert skills, "expected shipped skills under .claude/skills"
+        oversized = [
+            (str(skill), len(skill.read_bytes()))
+            for skill in skills
+            if len(skill.read_bytes()) > SKILL_BYTE_LIMIT
+        ]
+        assert not oversized, (
+            f"ratchet seed too low: these bodies exceed "
+            f"SKILL_BYTE_LIMIT={SKILL_BYTE_LIMIT}: {oversized}"
+        )
 
     def test_no_files_returns_zero(self, tmp_path: Path) -> None:
         exit_code = main(["--path", str(tmp_path)])
@@ -289,3 +330,94 @@ class TestCheckSkillSizeBytes:
             ["--path", str(tmp_path), "--ci", "--byte-limit", "100", "--byte-warn", "50"]
         )
         assert exit_code == 0
+
+
+class TestStagedBlobValidation:
+    """Staged mode judges the indexed blob, not the working tree (#3421 review).
+
+    A pre-commit gate that measured the working tree could be fooled: stage an
+    oversized body, then shrink or add an exception in the worktree without
+    staging, and the oversized blob would still get committed. These tests build
+    a real repo and drive ``main(["--staged-only", "--ci"])`` to prove the gate
+    reads ``git show :<path>``.
+    """
+
+    @staticmethod
+    def _init_repo(repo: Path) -> None:
+        for args in (
+            ["git", "init", "-q"],
+            ["git", "config", "user.email", "test@example.com"],
+            ["git", "config", "user.name", "Test"],
+        ):
+            subprocess.run(args, cwd=repo, check=True, capture_output=True)
+
+    @staticmethod
+    def _write_skill(repo: Path, payload: bytes) -> Path:
+        skill = repo / ".claude" / "skills" / "big" / "SKILL.md"
+        skill.parent.mkdir(parents=True, exist_ok=True)
+        skill.write_bytes(payload)
+        return skill
+
+    @staticmethod
+    def _stage_all(repo: Path) -> None:
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+
+    def test_oversized_staged_blob_fails_despite_small_worktree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Stage an oversized body, then shrink the worktree WITHOUT staging. The
+        # gate must fail on the staged (committed) blob, not the small worktree.
+        self._init_repo(tmp_path)
+        skill = self._write_skill(
+            tmp_path, b"---\nname: big\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64)
+        )
+        self._stage_all(tmp_path)
+        skill.write_bytes(b"---\nname: big\n---\nsmall")  # unstaged shrink
+
+        monkeypatch.chdir(tmp_path)
+        assert main(["--staged-only", "--ci"]) == 1
+
+    def test_unstaged_growth_does_not_fail_gate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Stage a small body, then grow the worktree oversized WITHOUT staging.
+        # The gate must pass: only the staged blob (small) is committed.
+        self._init_repo(tmp_path)
+        skill = self._write_skill(tmp_path, b"---\nname: big\n---\nsmall")
+        self._stage_all(tmp_path)
+        skill.write_bytes(b"---\nname: big\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64))
+
+        monkeypatch.chdir(tmp_path)
+        assert main(["--staged-only", "--ci"]) == 0
+
+    def test_unstaged_exception_does_not_bypass_gate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The reviewer's exact concern: an oversized body is staged WITHOUT an
+        # exception; the worktree adds `size-exception: true` unstaged. The gate
+        # must still FAIL, because the staged blob carries no exception.
+        self._init_repo(tmp_path)
+        big = b"x" * (SKILL_BYTE_LIMIT + 64)
+        skill = self._write_skill(tmp_path, b"---\nname: big\n---\n" + big)
+        self._stage_all(tmp_path)
+        skill.write_bytes(b"---\nname: big\nsize-exception: true\n---\n" + big)
+
+        monkeypatch.chdir(tmp_path)
+        assert main(["--staged-only", "--ci"]) == 1
+
+    def test_staged_exception_is_honored(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A staged oversized body WITH an exception downgrades to a warning
+        # (exit 0), even though the worktree removes the exception unstaged.
+        # Proves exception parsing reads the staged blob too.
+        self._init_repo(tmp_path)
+        big = b"x" * (SKILL_BYTE_LIMIT + 64)
+        skill = self._write_skill(
+            tmp_path, b"---\nname: big\nsize-exception: true\n---\n" + big
+        )
+        self._stage_all(tmp_path)
+        skill.write_bytes(b"---\nname: big\n---\n" + big)  # exception removed, unstaged
+
+        monkeypatch.chdir(tmp_path)
+        assert main(["--staged-only", "--ci"]) == 0

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -458,7 +458,7 @@ class TestStagedBlobValidation:
         with pytest.raises(StagedBlobError):
             read_staged_blob_bytes(Path(".claude/skills/ghost/SKILL.md"))
 
-    def test_git_show_failure_fails_closed_in_main(
+    def test_git_cat_file_failure_fails_closed_in_main(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # If reading the staged blob fails for any reason, main must fail closed
@@ -468,7 +468,7 @@ class TestStagedBlobValidation:
         self._stage_all(tmp_path)
 
         def _boom(path: Path) -> bytes:
-            msg = f"{path.as_posix()}: simulated git show failure"
+            msg = f"{path.as_posix()}: simulated git cat-file failure"
             raise StagedBlobError(msg)
 
         monkeypatch.setattr(_skill_size_mod, "read_staged_blob_bytes", _boom)


### PR DESCRIPTION
## Summary

Adds a byte-size dimension to the `skill_size` validation gate. The existing
500-line ceiling misses table-heavy or long-line skill bodies: a skill can sit
under 500 lines yet carry 24 KB, so invoking it to check one procedure pays for
the whole document. This closes that gap and gives progressive disclosure a
measurable signal.

Refs #3421.

## What changed

- WARN at 12,288 bytes (12 KiB), the progressive-disclosure soft target. This
  reports every over-target skill (36 in the current corpus) so authors see
  which bodies to decompose.
- FAIL above 24,576 bytes (24 KiB). This is a ratchet seeded just above the
  largest body today (24,210 bytes), so it blocks further growth and any new
  oversized skill without redding an already-green main.
- Documented goal is 20,480 bytes (20 KiB). Lower the enforced ceiling toward
  it as the oversized skills decompose into references.
- Reuses the existing `size-exception: true` frontmatter escape for both the
  line and byte dimensions.
- Measures raw bytes to match the issue's census command, so multi-byte UTF-8
  cannot dodge the ceiling.
- New `--byte-limit` and `--byte-warn` flags plus nine tests (byte warn, byte
  fail under the line limit, exception bypass, raw-byte counting, ratchet
  ordering, and CLI wiring).

## Scope

This PR delivers the tooling and policy half of #3421 (acceptance criteria 1
and 2: a documented ceiling and a validation check that reports skills over
it). The issue's own AI-triage recommended splitting the tooling from the
per-skill refactoring ("too_broad, needs_decomposition"). Decomposing the five
skills over 20 KB into lean bodies plus references (acceptance criteria 3 and 4)
is the follow-up, tracked on #3421. The ratchet prevents any regression while
that work proceeds.

## Verification

- `uv run --frozen python -m pytest tests/test_validation_skill_size.py -q` (26 pass)
- `uv run --frozen ruff check scripts/validation/skill_size.py` clean
- `uv run --frozen mypy scripts/validation/skill_size.py` clean
- Live report over `.claude/skills`: 36 skills WARN, zero FAIL (all under the
  ratchet), main stays green.

## Notes

Scripts-only change, no plugin manifest bump required.
