### PR TITLE
docs(orphan-ref-validator): correct the unreachable type-claim example

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.131",
+  "version": "0.6.132",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/orphan-ref-validator/scripts/scan.py
+++ b/.claude/skills/orphan-ref-validator/scripts/scan.py
@@ -202,7 +202,7 @@ def _check_skill_refs(
 
     Sibling resolution applies only to references that make no type claim.
     When the prose explicitly calls the token a skill ("the ``ship`` skill",
-    ``skill=`ship```), REQ-009 AC-2 governs and the token must resolve
+    ``skill=`ship` ``), REQ-009 AC-2 governs and the token must resolve
     against ``.claude/skills/`` alone: a same-named agent or memory does not
     make the sentence true. Skipping that distinction would trade a false
     positive for a wrong pass.

--- a/.claude/skills/orphan-ref-validator/scripts/scan.py
+++ b/.claude/skills/orphan-ref-validator/scripts/scan.py
@@ -202,10 +202,17 @@ def _check_skill_refs(
 
     Sibling resolution applies only to references that make no type claim.
     When the prose explicitly calls the token a skill ("the ``ship`` skill",
-    ``skill="ship"``), REQ-009 AC-2 governs and the token must resolve
+    ``skill=`ship```), REQ-009 AC-2 governs and the token must resolve
     against ``.claude/skills/`` alone: a same-named agent or memory does not
     make the sentence true. Skipping that distinction would trade a false
     positive for a wrong pass.
+
+    A type claim only strengthens resolution for a token that is already a
+    candidate, and both extractors require backticks. So a quoted
+    ``skill="ship"`` with no backticked ``ship`` anywhere on the line is
+    never checked at all; the same line written as
+    ``Use `ship` (skill="ship")`` is, because the backticks supply the
+    candidate and the quoted form supplies the type claim.
     """
     findings: list[Finding] = []
     refs_checked = 0

--- a/.claude/skills/orphan-ref-validator/tests/test_scan.py
+++ b/.claude/skills/orphan-ref-validator/tests/test_scan.py
@@ -1223,3 +1223,42 @@ def test_quoted_type_claim_types_a_backticked_token_on_the_same_line(
     rc = main(["--targets", "notes", "--repo-root", str(sibling_repo)])
     assert rc == 1
     assert "decision-rigor" in capsys.readouterr().out
+
+
+def test_type_claim_does_not_reach_a_candidate_on_another_line(
+    sibling_repo, capsys
+):
+    """Type claims are line-scoped, and the scoping is what makes them safe.
+
+    Both extractors return ``(lineno, token)`` pairs and ``_check_skill_refs``
+    tests the pair, not the bare token. Collapsing that to a token-only set
+    would let one config line retroactively retype every prose mention of the
+    same name in the file, turning sibling artifacts into orphans document
+    wide.
+    """
+    write(
+        sibling_repo / "notes" / "s.md",
+        'Use `decision-rigor`.\nConfig sets skill="decision-rigor".\n',
+    )
+    rc = main(["--targets", "notes", "--repo-root", str(sibling_repo)])
+    assert rc == 0
+    assert "VERDICT: PASS" in capsys.readouterr().out
+
+
+def test_type_claim_does_not_reach_a_different_token_on_its_own_line(
+    sibling_repo, capsys
+):
+    """A claim types the token it names, not every candidate beside it.
+
+    Matching on line number alone is the cheaper implementation and passes a
+    naive same-line test, so pin the token half of the pair too. Here the
+    claim names ``alpha-skill`` while the backticks supply ``decision-rigor``,
+    a review axis that must keep resolving through the sibling namespace.
+    """
+    write(
+        sibling_repo / "notes" / "s.md",
+        'Use `decision-rigor` (skill="alpha-skill").\n',
+    )
+    rc = main(["--targets", "notes", "--repo-root", str(sibling_repo)])
+    assert rc == 0
+    assert "VERDICT: PASS" in capsys.readouterr().out

--- a/.claude/skills/orphan-ref-validator/tests/test_scan.py
+++ b/.claude/skills/orphan-ref-validator/tests/test_scan.py
@@ -1182,3 +1182,44 @@ def test_type_claim_on_a_living_skill_still_passes(sibling_repo, capsys):
     rc = main(["--targets", "notes", "--repo-root", str(sibling_repo)])
     assert rc == 0
     assert "VERDICT: PASS" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "prose",
+    [
+        'Config sets skill="decision-rigor" here.',
+        'Config sets skill: "decision-rigor" here.',
+        "Config sets skill='decision-rigor' here.",
+    ],
+)
+def test_quoted_type_claim_alone_is_not_a_reference(sibling_repo, prose, capsys):
+    """A type claim strengthens resolution; it never creates a candidate.
+
+    Both extractors require backticks, so a quoted ``skill="x"`` with no
+    backticked ``x`` on the line yields a type claim about a token the
+    scanner never examines. Pinned because the natural "fix" on reading the
+    type-claim regex is to widen the extractors to quoted values, which would
+    flag every YAML and JSON config key that happens to be named ``skill``.
+    """
+    write(sibling_repo / "notes" / "s.md", prose + "\n")
+    rc = main(["--targets", "notes", "--repo-root", str(sibling_repo)])
+    assert rc == 0
+    assert "VERDICT: PASS" in capsys.readouterr().out
+
+
+def test_quoted_type_claim_types_a_backticked_token_on_the_same_line(
+    sibling_repo, capsys
+):
+    """The quoted arm is live: it types a candidate the backticks supply.
+
+    ``decision-rigor`` is a review axis, so a bare mention resolves through
+    the sibling namespace. The quoted type claim on the same line asserts it
+    is a skill, which forces strict resolution and the finding.
+    """
+    write(
+        sibling_repo / "notes" / "s.md",
+        'Use `decision-rigor` (skill="decision-rigor").\n',
+    )
+    rc = main(["--targets", "notes", "--repo-root", str(sibling_repo)])
+    assert rc == 1
+    assert "decision-rigor" in capsys.readouterr().out

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.131",
+  "version": "0.6.132",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/orphan-ref-validator/scripts/scan.py
+++ b/src/copilot-cli/skills/orphan-ref-validator/scripts/scan.py
@@ -202,7 +202,7 @@ def _check_skill_refs(
 
     Sibling resolution applies only to references that make no type claim.
     When the prose explicitly calls the token a skill ("the ``ship`` skill",
-    ``skill=`ship```), REQ-009 AC-2 governs and the token must resolve
+    ``skill=`ship` ``), REQ-009 AC-2 governs and the token must resolve
     against ``.claude/skills/`` alone: a same-named agent or memory does not
     make the sentence true. Skipping that distinction would trade a false
     positive for a wrong pass.

--- a/src/copilot-cli/skills/orphan-ref-validator/scripts/scan.py
+++ b/src/copilot-cli/skills/orphan-ref-validator/scripts/scan.py
@@ -202,10 +202,17 @@ def _check_skill_refs(
 
     Sibling resolution applies only to references that make no type claim.
     When the prose explicitly calls the token a skill ("the ``ship`` skill",
-    ``skill="ship"``), REQ-009 AC-2 governs and the token must resolve
+    ``skill=`ship```), REQ-009 AC-2 governs and the token must resolve
     against ``.claude/skills/`` alone: a same-named agent or memory does not
     make the sentence true. Skipping that distinction would trade a false
     positive for a wrong pass.
+
+    A type claim only strengthens resolution for a token that is already a
+    candidate, and both extractors require backticks. So a quoted
+    ``skill="ship"`` with no backticked ``ship`` anywhere on the line is
+    never checked at all; the same line written as
+    ``Use `ship` (skill="ship")`` is, because the backticks supply the
+    candidate and the quoted form supplies the type claim.
     """
     findings: list[Finding] = []
     refs_checked = 0

--- a/src/copilot-cli/skills/orphan-ref-validator/tests/test_scan.py
+++ b/src/copilot-cli/skills/orphan-ref-validator/tests/test_scan.py
@@ -1223,3 +1223,42 @@ def test_quoted_type_claim_types_a_backticked_token_on_the_same_line(
     rc = main(["--targets", "notes", "--repo-root", str(sibling_repo)])
     assert rc == 1
     assert "decision-rigor" in capsys.readouterr().out
+
+
+def test_type_claim_does_not_reach_a_candidate_on_another_line(
+    sibling_repo, capsys
+):
+    """Type claims are line-scoped, and the scoping is what makes them safe.
+
+    Both extractors return ``(lineno, token)`` pairs and ``_check_skill_refs``
+    tests the pair, not the bare token. Collapsing that to a token-only set
+    would let one config line retroactively retype every prose mention of the
+    same name in the file, turning sibling artifacts into orphans document
+    wide.
+    """
+    write(
+        sibling_repo / "notes" / "s.md",
+        'Use `decision-rigor`.\nConfig sets skill="decision-rigor".\n',
+    )
+    rc = main(["--targets", "notes", "--repo-root", str(sibling_repo)])
+    assert rc == 0
+    assert "VERDICT: PASS" in capsys.readouterr().out
+
+
+def test_type_claim_does_not_reach_a_different_token_on_its_own_line(
+    sibling_repo, capsys
+):
+    """A claim types the token it names, not every candidate beside it.
+
+    Matching on line number alone is the cheaper implementation and passes a
+    naive same-line test, so pin the token half of the pair too. Here the
+    claim names ``alpha-skill`` while the backticks supply ``decision-rigor``,
+    a review axis that must keep resolving through the sibling namespace.
+    """
+    write(
+        sibling_repo / "notes" / "s.md",
+        'Use `decision-rigor` (skill="alpha-skill").\n',
+    )
+    rc = main(["--targets", "notes", "--repo-root", str(sibling_repo)])
+    assert rc == 0
+    assert "VERDICT: PASS" in capsys.readouterr().out

--- a/src/copilot-cli/skills/orphan-ref-validator/tests/test_scan.py
+++ b/src/copilot-cli/skills/orphan-ref-validator/tests/test_scan.py
@@ -1182,3 +1182,44 @@ def test_type_claim_on_a_living_skill_still_passes(sibling_repo, capsys):
     rc = main(["--targets", "notes", "--repo-root", str(sibling_repo)])
     assert rc == 0
     assert "VERDICT: PASS" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "prose",
+    [
+        'Config sets skill="decision-rigor" here.',
+        'Config sets skill: "decision-rigor" here.',
+        "Config sets skill='decision-rigor' here.",
+    ],
+)
+def test_quoted_type_claim_alone_is_not_a_reference(sibling_repo, prose, capsys):
+    """A type claim strengthens resolution; it never creates a candidate.
+
+    Both extractors require backticks, so a quoted ``skill="x"`` with no
+    backticked ``x`` on the line yields a type claim about a token the
+    scanner never examines. Pinned because the natural "fix" on reading the
+    type-claim regex is to widen the extractors to quoted values, which would
+    flag every YAML and JSON config key that happens to be named ``skill``.
+    """
+    write(sibling_repo / "notes" / "s.md", prose + "\n")
+    rc = main(["--targets", "notes", "--repo-root", str(sibling_repo)])
+    assert rc == 0
+    assert "VERDICT: PASS" in capsys.readouterr().out
+
+
+def test_quoted_type_claim_types_a_backticked_token_on_the_same_line(
+    sibling_repo, capsys
+):
+    """The quoted arm is live: it types a candidate the backticks supply.
+
+    ``decision-rigor`` is a review axis, so a bare mention resolves through
+    the sibling namespace. The quoted type claim on the same line asserts it
+    is a skill, which forces strict resolution and the finding.
+    """
+    write(
+        sibling_repo / "notes" / "s.md",
+        'Use `decision-rigor` (skill="decision-rigor").\n',
+    )
+    rc = main(["--targets", "notes", "--repo-root", str(sibling_repo)])
+    assert rc == 1
+    assert "decision-rigor" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

The `_check_skill_refs` docstring in the orphan-ref-validator taught an example that the code never executes. It offered `skill="ship"` as prose that forces strict resolution against skills only. Measured, that form produces a type claim about a token the scanner never examines, so the branch it illustrates is unreachable from that input.

This corrects the example to the backtick form, states the candidate-versus-type-claim split explicitly, and pins the boundary with two tests.

Fixes #3446

## Why the old example was wrong

The scanner has two independent extractor families:

- Candidate extractors produce the tokens that get checked for existence. Both require the token to appear in backticks.
- The type-claim extractor produces the set of tokens a line asserts are skills specifically. Its regex accepts a quote, a backtick, or a colon.

A type claim only matters for a token that is already a candidate. With `skill="ship"` and no backticked `ship` on the line, no candidate is produced, so the type claim is consulted for nothing.

Measured over four prose shapes:

| Input | Candidate | Type claim | Reaches the strict path |
| --- | --- | --- | --- |
| `skill="ship"` | no | yes | no |
| `` skill=`ship` `` | yes | yes | yes |
| the `ship` skill | yes | yes | yes |
| `` use `ship`, skill="ship" `` | yes | yes | yes |

## What did not change

The quoted arm of the type-claim regex stays. It is live at line scope: when backticks supply a candidate elsewhere on the same line, the quoted assignment still types it. Only the docstring was wrong.

## Tests

Four controls, added to the canonical suite and its generated mirror. Two came from writing the fix; two came from an adversarial review that mutated the production code and proved the first two were not enough.

The negative control carries the weight. The natural reading of the type-claim regex invites a future author to widen the candidate extractors to accept quoted values so the documented example starts working. That change would flag every YAML and JSON key named `skill` in the repository. The test now fails first and explains why.

The positive control proves the quoted arm is not dead code, so nobody deletes it while cleaning up after the docstring fix.

The review then found both tests survive two wrong implementations. `_check_skill_refs` compares the `(lineno, ref)` tuple, and neither test forced both halves:

| Mutation | Plausible because | Now caught by |
| --- | --- | --- |
| Token-only comparison | Reading the type-claim set as "names claimed to be skills" and forgetting it is line-scoped. Lets one config line retype every prose mention of that name in the file. | the another-line test |
| Line-only comparison | The cheaper comparison, and it passes any same-line test written with a single token. | the different-token test |

Each new test fails under exactly its own mutation and passes under the other, so the pair pins independent properties rather than restating one.

## Changes

| File | Change |
| --- | --- |
| `.claude/skills/orphan-ref-validator/scripts/scan.py` | Corrected the `_check_skill_refs` docstring example |
| `.claude/skills/orphan-ref-validator/tests/test_scan.py` | Added four tests pinning the type-claim boundary |
| `src/copilot-cli/skills/orphan-ref-validator/scripts/scan.py` | Regenerated mirror |
| `src/copilot-cli/skills/orphan-ref-validator/tests/test_scan.py` | Regenerated mirror |
| `.claude/.claude-plugin/plugin.json` | project-toolkit to 0.6.132 |
| `src/copilot-cli/.claude-plugin/plugin.json` | project-toolkit to 0.6.132 |

## Verification

```
uv run pytest .claude/skills/orphan-ref-validator/tests/ src/copilot-cli/skills/orphan-ref-validator/tests/ -q
202 passed in 1.84s

uv run ruff check .
All checks passed

uv run python build/scripts/validate_plugin_version_bump.py --base origin/main
plugin-version-bump: OK
```

`build_all.py` regenerated the mirror and `cmp` confirms byte parity on both files.

## Background

Reported by copilot-pull-request-reviewer on PR #3434, which merged before the fix landed, so the work moved to a fresh branch under a new issue.

Manifests go to 0.6.132 rather than 0.6.131 because PR #3443 is open holding 0.6.131.
