### PR TITLE
fix(validation): deterministic applyTo universality + inline brace compilation (#3419 follow-up)

### DIFF
--- a/scripts/validation/instruction_budget.py
+++ b/scripts/validation/instruction_budget.py
@@ -179,69 +179,6 @@ def _split_glob_aware(pattern: str, split_char: str) -> list[str]:
     return segments
 
 
-def _split_brace_options(content: str) -> list[str]:
-    """Split brace-group content on top-level commas, keeping every option.
-
-    Distinct from ``_split_glob_aware``, which drops a trailing empty segment
-    (correct for path and scope splitting). A brace alternative list must
-    preserve empty options, because an empty alternative is a real "substitute
-    nothing" branch in VS Code's brace expansion: ``{}`` -> [''] (so ``p{}y``
-    folds to ``py``) and ``{x,}`` -> ['x', ''] (so ``py{x,}`` yields ``pyx`` and
-    the universal ``py``). Dropping either empty would erase a universal glob and
-    under-count the budget. A comma inside a nested ``{...}`` or ``[...]`` group
-    does not split.
-    """
-    options: list[str] = []
-    depth_brace = 0
-    depth_bracket = 0
-    current: list[str] = []
-    for char in content:
-        if char == "," and depth_brace == 0 and depth_bracket == 0:
-            options.append("".join(current))
-            current = []
-            continue
-        if char == "{":
-            depth_brace += 1
-        elif char == "}":
-            depth_brace -= 1
-        elif char == "[":
-            depth_bracket += 1
-        elif char == "]":
-            depth_bracket -= 1
-        current.append(char)
-    options.append("".join(current))
-    return options
-
-
-def expand_braces(pattern: str) -> list[str]:
-    """Expand a glob brace group into its alternatives.
-
-    ``**/*.{py,pyi}`` -> ``['**/*.py', '**/*.pyi']``. Handles multiple and
-    nested groups by recursion. An unbalanced brace is left untouched.
-    """
-    start = pattern.find("{")
-    if start == -1:
-        return [pattern]
-    depth = 0
-    end = -1
-    for i in range(start, len(pattern)):
-        if pattern[i] == "{":
-            depth += 1
-        elif pattern[i] == "}":
-            depth -= 1
-            if depth == 0:
-                end = i
-                break
-    if end == -1:
-        return [pattern]
-    prefix, suffix = pattern[:start], pattern[end + 1 :]
-    options = _split_brace_options(pattern[start + 1 : end])
-    expanded: list[str] = []
-    for opt in options:
-        expanded.extend(expand_braces(prefix + opt.strip() + suffix))
-    return expanded
-
-
 def _vscode_effective_glob(pattern: str) -> str:
     """Fold an ``applyTo`` glob to the effective form the harness matches on.
 
@@ -272,8 +209,9 @@ def _vscode_effective_glob(pattern: str) -> str:
 # translation diverged from the harness at separator edges: the dropped
 # mandatory ``/`` before a non-terminal ``**`` let ``/*/**/*.py`` match a root
 # file ``/probe.py``. Porting VS Code's own segment walker ends that class of
-# drift. Braces are already expanded by ``expand_braces`` before a pattern
-# reaches this compiler, so only ``*``, ``?``, and ``**`` need translating.
+# drift. Braces are compiled inline as a regex alternation by
+# ``_segment_to_regex`` (each choice re-parsed as a full glob, faithful to VS
+# Code), so ``*``, ``?``, ``**``, and ``{...}`` are all translated here.
 # Character classes (``[...]``) are the one glob construct this compiler does
 # not model, and it fails closed on them. Dear future maintainer: an earlier
 # revision treated ``[`` as a literal, reasoning a class is "scoped by
@@ -312,30 +250,91 @@ def _stars_to_regexp(star_count: int, *, is_last_segment: bool) -> str:
 def _segment_to_regex(segment: str) -> str:
     """Translate one non-globstar path segment to a regex fragment.
 
-    Each ``*`` becomes a single-star run (``starsToRegExp(1)``), ``?`` matches
-    one non-separator character, and every other character is escaped literally.
+    Mirrors VS Code's per-character walk inside a segment (``parseRegExp``,
+    glob.ts): ``*`` becomes a single-star run (``starsToRegExp(1)``), ``?``
+    matches one non-separator character, a ``{...}`` group compiles *inline* to a
+    regex alternation whose choices are each parsed as a full glob
+    (``{a,b}`` -> ``(?:<a>|<b>)``), and every other character is escaped
+    literally. Compiling braces inline, rather than pre-expanding them into
+    concrete strings, is what keeps the model faithful for options that carry
+    path syntax (``{**/*}``), nest (``{a,{b,c}}``), or leave a trailing empty
+    (``{x,}`` matches only ``x`` because VS Code's ``splitGlobAware`` drops the
+    trailing empty, whereas ``{}`` is a real empty substitution). Bracket
+    classes never reach here: ``_glob_to_regex`` fails closed on any ``[``.
     """
     out: list[str] = []
+    in_braces = False
+    brace_val: list[str] = []
     for char in segment:
+        if char != "}" and in_braces:
+            brace_val.append(char)
+            continue
+        if char == "{":
+            in_braces = True
+            continue
+        if char == "}":
+            choices = _split_glob_aware("".join(brace_val), ",")
+            out.append("(?:" + "|".join(_parse_regexp(choice) for choice in choices) + ")")
+            in_braces = False
+            brace_val = []
+            continue
         if char == "*":
             out.append(_stars_to_regexp(1, is_last_segment=False))
-        elif char == "?":
+            continue
+        if char == "?":
             out.append(_NO_PATH_REGEX)
-        else:
-            out.append(re.escape(char))
+            continue
+        out.append(re.escape(char))
     return "".join(out)
+
+
+def _parse_regexp(pattern: str) -> str:
+    """Compile a single glob to a regex body, porting VS Code ``parseRegExp``.
+
+    Splits the glob into path segments (brace- and bracket-aware), translates a
+    whole-segment ``**`` to the globstar regex, and joins segments with the
+    harness "Tail" separator rule. Returns the regex *body* (no anchors) so a
+    brace choice can be spliced back into its parent segment; ``_glob_to_regex``
+    wraps the result in ``^...$``. Recurses through ``_segment_to_regex`` for
+    each brace alternative, so a choice may itself contain ``/`` and ``**``
+    exactly as VS Code allows.
+    """
+    if not pattern:
+        return ""
+    segments = _split_glob_aware(pattern, "/")
+    if segments and all(segment == _GLOB_STAR for segment in segments):
+        return ".*"
+    body: list[str] = []
+    last = len(segments) - 1
+    previous_was_globstar = False
+    for index, segment in enumerate(segments):
+        if segment == _GLOB_STAR:
+            if not previous_was_globstar:
+                body.append(_stars_to_regexp(2, is_last_segment=index == last))
+            previous_was_globstar = True
+            continue
+        body.append(_segment_to_regex(segment))
+        if index < last and (segments[index + 1] != _GLOB_STAR or index + 2 < len(segments)):
+            body.append(_PATH_REGEX)
+        previous_was_globstar = False
+    return "".join(body)
 
 
 @cache
 def _glob_to_regex(pattern: str) -> re.Pattern[str]:
     """Compile an ``applyTo`` glob to an anchored case-insensitive regex.
 
-    Faithful port of VS Code's ``parseRegExp`` segment walker (see the module
-    note above the constants). Path-segment semantics match the harness:
+    Faithful port of VS Code's ``parseRegExp`` (see the module note above the
+    constants). Fails closed on a character class before compiling: the compiler
+    models ``*``, ``?``, ``**``, and ``{...}`` inline, but not ``[...]`` (see the
+    note for why a literal ``[`` would under-count). Path-segment semantics match
+    the harness:
 
     - ``**`` as a whole segment matches zero or more complete path segments;
     - ``*`` matches zero or more non-separator characters within one segment;
     - ``?`` matches exactly one non-separator character;
+    - ``{a,b}`` compiles inline to ``(?:<a>|<b>)`` with each choice parsed as a
+      full glob;
     - a literal separator is emitted after a segment unless the following
       segment is a *terminal* ``**`` (VS Code's "Tail" rule), so ``some/**/*.js``
       keeps the ``/`` after ``some`` and a sibling folder ``something`` cannot
@@ -346,7 +345,6 @@ def _glob_to_regex(pattern: str) -> re.Pattern[str]:
     true``. ``is_language_universal`` uses this to decide universality by
     *matching* diverse probe paths instead of enumerating glob spellings.
     """
-    segments = _split_glob_aware(pattern, "/")
     if "[" in pattern:
         msg = (
             f"applyTo glob {pattern!r} uses a character class ('['); the budget "
@@ -355,23 +353,7 @@ def _glob_to_regex(pattern: str) -> re.Pattern[str]:
             "or brace alternatives (e.g. '*.[ch]' -> '*.c, *.h')."
         )
         raise UnsupportedApplyToError(msg)
-    if segments and all(segment == _GLOB_STAR for segment in segments):
-        return re.compile("^.*$", re.IGNORECASE)
-    body: list[str] = []
-    last = len(segments) - 1
-    previous_was_globstar = False
-    for index, segment in enumerate(segments):
-        if segment == _GLOB_STAR:
-            if previous_was_globstar:
-                continue
-            body.append(_stars_to_regexp(2, is_last_segment=index == last))
-            previous_was_globstar = True
-            continue
-        body.append(_segment_to_regex(segment))
-        if index < last and (segments[index + 1] != _GLOB_STAR or index + 2 < len(segments)):
-            body.append(_PATH_REGEX)
-        previous_was_globstar = False
-    return re.compile("^" + "".join(body) + "$", re.IGNORECASE)
+    return re.compile("^" + _parse_regexp(pattern) + "$", re.IGNORECASE)
 
 
 def _iter_applyto_globs(value: object) -> list[str]:
@@ -401,8 +383,11 @@ def parse_applyto(text: str) -> set[str]:
     block-style lists are handled by the parser rather than a line regex (a
     regex that grabbed everything after ``applyTo:`` would fold a trailing
     ``# comment`` into the glob and would miss a block-style list entirely).
-    Splits the comma-separated scope list without breaking brace groups, then
-    expands each brace group so ``**/*.{py,pyi}`` becomes two concrete globs.
+    Splits the comma-separated scope list without breaking brace groups. Each
+    glob keeps its brace group intact; ``is_language_universal`` compiles it with
+    VS Code's inline brace semantics, so ``**/*.{py,pyi}`` is matched as one
+    pattern rather than textually pre-expanded (which was unfaithful for nested
+    or path-bearing brace options).
 
     Fails closed: invalid YAML or a duplicate top-level key raises
     ``UnsupportedApplyToError`` rather than yielding an empty set, so a file the
@@ -424,7 +409,7 @@ def parse_applyto(text: str) -> set[str]:
     for glob in _iter_applyto_globs(data["applyTo"]):
         cleaned = glob.strip()
         if cleaned:
-            patterns.update(expand_braces(cleaned))
+            patterns.add(cleaned)
     return patterns
 
 
@@ -454,12 +439,10 @@ def is_language_universal(patterns: set[str], ext: str) -> bool:
     case-insensitive to mirror the harness (``ignoreCase: true``).
     """
     probes = _probe_paths(ext)
-    regexes: list[re.Pattern[str]] = []
-    for pattern in patterns:
-        effective = _vscode_effective_glob(pattern)
-        if effective in _ALL_FILES_FORMS:
-            return True
-        regexes.append(_glob_to_regex(effective))
+    effectives = [_vscode_effective_glob(pattern) for pattern in patterns]
+    if any(effective in _ALL_FILES_FORMS for effective in effectives):
+        return True
+    regexes = [_glob_to_regex(effective) for effective in effectives]
     if not regexes:
         return False
     return all(any(regex.match(path) for regex in regexes) for path in probes)

--- a/tests/validation/test_instruction_budget.py
+++ b/tests/validation/test_instruction_budget.py
@@ -110,11 +110,13 @@ def test_parse_applyto_unhashable_key_raises() -> None:
         ib.parse_applyto(text)
 
 
-def test_parse_applyto_expands_brace_group() -> None:
+def test_parse_applyto_keeps_brace_group_intact() -> None:
     # A leading '**' forces quoting in YAML, so the realistic brace form is
     # quoted; an unquoted '**/*.{...}' is invalid YAML the harness would reject.
+    # parse_applyto no longer textually expands braces: the brace group is kept
+    # whole and compiled inline (VS Code semantics) by is_language_universal.
     text = "---\napplyTo: '**/*.{py,pyi},tests/**'\n---\nbody\n"
-    assert ib.parse_applyto(text) == {"**/*.py", "**/*.pyi", "tests/**"}
+    assert ib.parse_applyto(text) == {"**/*.{py,pyi}", "tests/**"}
 
 
 def test_parse_applyto_brace_form_is_language_universal() -> None:
@@ -123,46 +125,36 @@ def test_parse_applyto_brace_form_is_language_universal() -> None:
     assert ib.is_language_universal(patterns, ".py") is True
 
 
-def test_expand_braces_strips_whitespace_around_options() -> None:
-    # Whitespace after commas in brace groups must not bleed into the expanded
-    # glob. "**/*.{py, pyi}" must produce "**/*.pyi", not "**/*. pyi".
-    assert ib.expand_braces("**/*.{py, pyi}") == ["**/*.py", "**/*.pyi"]
-    assert ib.expand_braces("**/*.{ cs , fs }") == ["**/*.cs", "**/*.fs"]
+def test_brace_option_with_path_syntax_is_language_universal() -> None:
+    # ``{**/*}`` holds path syntax the old textual splitter could not expand
+    # faithfully; inline compilation makes each choice a full glob, so the rule
+    # is correctly seen as universal instead of being under-counted to 0 bytes.
+    patterns = ib.parse_applyto("---\napplyTo: '{**/*}'\n---\nbody\n")
+    assert ib.is_language_universal(patterns, ".py") is True
 
 
-def test_split_brace_options_keeps_empty_options() -> None:
-    # Unlike path splitting, brace options must preserve empty alternatives:
-    # an empty option is a real "substitute nothing" branch in VS Code.
-    assert ib._split_brace_options("") == [""]
-    assert ib._split_brace_options("x,") == ["x", ""]
-    assert ib._split_brace_options(",x") == ["", "x"]
-    # A comma inside a nested group does not split the outer option.
-    assert ib._split_brace_options("a,{b,c},d") == ["a", "{b,c}", "d"]
-
-
-def test_expand_braces_empty_group_folds_to_nothing() -> None:
-    # VS Code compiles ``{}`` as an empty substitution, so ``p{}y`` is ``py``.
-    # A splitter that dropped the empty option would erase the pattern entirely
-    # (scoring it 0 bytes) and under-count the budget.
-    assert ib.expand_braces("**/*.p{}y") == ["**/*.py"]
-
-
-def test_expand_braces_keeps_trailing_empty_option() -> None:
-    # ``py{x,}`` yields both ``pyx`` and the universal ``py``; dropping the
-    # trailing empty would hide the universal glob from the gate.
-    assert ib.expand_braces("**/*.py{x,}") == ["**/*.pyx", "**/*.py"]
+def test_nested_brace_group_is_language_universal() -> None:
+    # A nested alternative ``{py,{pyi,pyc}}`` recurses through the compiler; the
+    # ``py`` branch matches every ``.py`` path, so the rule is universal.
+    patterns = ib.parse_applyto("---\napplyTo: '**/*.{py,{pyi,pyc}}'\n---\nbody\n")
+    assert ib.is_language_universal(patterns, ".py") is True
 
 
 def test_empty_brace_group_is_language_universal() -> None:
     # A future rule spelled with an empty brace group must still be caught.
+    # VS Code compiles ``{}`` as an empty substitution, so ``p{}y`` is ``py``.
     patterns = ib.parse_applyto("---\napplyTo: '**/*.p{}y'\n---\nbody\n")
     assert ib.is_language_universal(patterns, ".py") is True
 
 
-def test_trailing_empty_brace_option_is_language_universal() -> None:
-    # The universal ``**/*.py`` branch hides behind the trailing empty option.
+def test_trailing_empty_brace_option_is_not_language_universal() -> None:
+    # Faithful to VS Code: ``splitGlobAware('x,', ',')`` DROPS the trailing empty,
+    # so ``**/*.py{x,}`` compiles to ``(?:x)`` and matches only ``.pyx`` -- it is
+    # genuinely NOT universal for ``.py``. The prior textual splitter kept the
+    # empty option and over-counted this as universal. Reporting it non-universal
+    # is not an under-count: no ``.py`` path matches ``**/*.pyx``.
     patterns = ib.parse_applyto("---\napplyTo: '**/*.py{x,}'\n---\nbody\n")
-    assert ib.is_language_universal(patterns, ".py") is True
+    assert ib.is_language_universal(patterns, ".py") is False
 
 
 def test_glob_to_regex_char_class_fails_closed() -> None:
@@ -179,6 +171,19 @@ def test_char_class_applyto_fails_closed() -> None:
     patterns = ib.parse_applyto("---\napplyTo: '**/*.[p]y'\n---\nbody\n")
     with pytest.raises(ib.UnsupportedApplyToError):
         ib.is_language_universal(patterns, ".py")
+
+
+def test_all_files_form_short_circuits_before_bracket_compile() -> None:
+    # Determinism guard (Finding 3): when a scope list mixes an all-files wildcard
+    # with a bracket pattern, universality must be decided by the all-files form
+    # BEFORE any pattern is compiled. Iterating the set and compiling per-pattern
+    # made the result depend on set order (PYTHONHASHSEED): sometimes True via the
+    # wildcard, sometimes UnsupportedApplyToError via the bracket. The two-pass
+    # check compiles no regex once an all-files form is present, so the union is
+    # deterministically universal regardless of iteration order.
+    union = {"**/*", "**/*.[p]y"}
+    for _ in range(50):
+        assert ib.is_language_universal(set(union), ".py") is True
 
 
 def test_parse_applyto_missing_frontmatter_returns_empty() -> None:


### PR DESCRIPTION
## Summary

Follow-up hardening on the always-on instruction budget gate merged in #3427. Fixes two defects in the `applyTo` glob matcher (`scripts/validation/instruction_budget.py`). Both are latent on the current rule corpus (live `--ci` baselines are unchanged) but real.

### Defect 1: nondeterministic universality

`is_language_universal` iterated the pattern `set` and, in a single loop, both checked `_ALL_FILES_FORMS` (early `return True`) and compiled each glob (`_glob_to_regex` raises `UnsupportedApplyToError` on a `[` character class). For a rule mixing an all-files form with a bracket glob (`applyTo: '**, *.[ch]'`), the outcome depended on set iteration order (`PYTHONHASHSEED`):

- order `[**, *.[ch]]` returns `True`
- order `[*.[ch], **]` raises `UnsupportedApplyToError`

Proven directly against the merged code by simulating both orderings. Fix: two passes. Reduce every pattern to its effective form, short-circuit `True` if **any** is an all-files form, and only then compile regexes. The all-files short-circuit now always wins, independent of order.

### Defect 2: textual brace pre-expansion to inline compilation

The old `expand_braces` enumerated brace spellings into separate patterns before compilation, mishandling nested braces and globstars inside a choice (`{**/*}`, `{py,{pyi,pyc}}`). This ports VS Code's `parseRegExp` faithfully: `_parse_regexp` compiles a glob body recursively and `_segment_to_regex` turns a `{a,b}` run into a `(?:a|b)` alternation, recursing per choice. `parse_applyto` no longer expands braces; it keeps the raw comma-split pattern.

## Verification

- 61 tests pass, including a determinism regression (all-files short-circuit precedes any bracket compile) and inline-brace cases (`{**/*}`, nested, trailing-empty `{x,}` matching only `.pyx`).
- `ruff`, `mypy`, `C901<=10` clean.
- Live `--ci` gate PASS with baselines unchanged (`.py=218603`, `.cs=218480`, `.md=81622`, `.ps1=218312`): behavior-preserving on the real corpus.
- Faithful to VS Code `glob.ts` pinned at `018354116a`.

## Out of Scope

The taste-lint advisory flags `scripts/validation/instruction_budget.py` at 674 lines (>500). This is pre-existing (the merged file was already over the threshold) and this change is net -12 lines. A module split is separate refactoring, not folded into this correctness fix.

Refs #3419
