### PR TITLE
fix(eval): stop the held-out digest leaking on lock release

### DIFF
--- a/.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md
+++ b/.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md
@@ -31,13 +31,16 @@ the first draft made.
 | 6 | gemini-3.1-pro-preview | REJECT |
 | 7 | gpt-5.6-sol | REJECT |
 | 8 | Copilot (PR #3458) | REJECT |
-
-No round returned ACCEPT. Round 8 arrived as a PR review on the follow-up branch and found a defect inside the round-7 fix itself, which is the cleanest illustration in this log of why the count kept climbing.
+| 9 | gemini-3.1-pro-preview | REJECT |
 
 No round returned ACCEPT. Every finding was verified at source before being
 acted on, rather than accepted on the reviewer's authority; all of them held.
-The ADR is recorded with its defeats visible because seven consecutive
+The ADR is recorded with its defeats visible because nine consecutive
 falsifications are evidence about the claim, not noise to be smoothed over.
+
+Rounds 8 and 9 are the cleanest illustration in this log of why the count
+kept climbing. Round 8 found a defect inside the round-7 fix. Round 9 then
+found one inside the round-8 fix.
 
 ## The finding that changed the decision
 
@@ -70,8 +73,10 @@ characterization now leads both the ADR and the README.
 
 ## The recurring defect
 
-Six of the seven rounds found the same shape. Any part of a budget the caller
+Eight of the nine rounds found the same shape. Any part of a budget the caller
 can restate, or move by renaming something else, is not part of the budget.
+The same holds for what the budget is meant to withhold: any path by which the
+withheld thing is readable is not withholding it.
 
 1. The count. `--consultations` defaulted to 0 every call, so a loop passing
    zero each time had an unlimited budget while looking capped. Review
@@ -89,6 +94,13 @@ can restate, or move by renaming something else, is not part of the budget.
    membership, so any error interpolating a path leaked the withheld thing.
    Closing it per call site missed lock release, which runs after the
    decision is already emitted.
+7. The pathless `OSError`. Two failures inside the lock operate on a file
+   descriptor and carry no filename, so they fell past the redaction branch
+   into a raw re-raise that `main` does not catch, leaving the JSON contract
+   for a stack trace.
+8. The unredacted cause. Redacting the message and chaining the original with
+   `raise ... from exc` leaves the digest one `__cause__` hop away, which is
+   exactly where a printed traceback goes.
 
 ## Round 7 blocking findings
 
@@ -127,6 +139,41 @@ was made: `LedgerMismatchError` derives from `Exception` rather than
 intact; and both of its messages name `path.parent` rather than the
 digest-bearing filename.
 
+## Round 9 blocking findings
+
+Round 9 was asked for the ninth defect by name, on the theory that eight
+consecutive rounds each finding something says more about the code than
+about the reviewers. It returned two, and both reproduced.
+
+The first is the ninth shape of the recurring defect: the seam redacted the
+digest from the message and then attached the unredacted exception as
+`__cause__`. `key in str(exc)` was False and `key in traceback` was True. The
+lock-contention branch was worse, because its message deliberately withholds
+the lock name and then handed back the `FileExistsError` that spells it out.
+A redacted message with an unredacted cause is not redacted.
+
+The reviewer proposed severing every chain. That was wider than the evidence
+supported, so the fix severs the two branches that provably carry the digest
+and leaves `from exc` on the pathless-`OSError` branch, where `str(exc)` has
+no filename to leak and the original raise site is worth keeping. That the
+`holdout_key in text` test is a sound detector was checked rather than
+assumed: `str(OSError(2, "m", "/p"))` includes the filename and
+`str(OSError(28, "No space"))` does not.
+
+The second finding was not a leak. Release runs in a `finally`, after the
+decision is already on stdout, so an unlink failure reached `main`, which
+printed a second JSON document after the first and returned the
+config-failure code for a comparison that had succeeded. Verified: exit code
+2 on a passing gate, and `json.loads` on stdout raising "Extra data". The
+module docstring promises a caller reads a field rather than guessing from
+the exit code, and two documents break every reader of the first. Cleanup now
+catches `OSError` locally and warns on stderr.
+
+Worth recording plainly: this session had already observed the two-document
+stdout while writing round-7 tests, recorded it as a test-harness quirk, and
+worked around it. The reviewer reclassified it correctly. A workaround that
+makes a symptom stop being visible in tests is not a finding closed.
+
 ## Corrections applied without dispute
 
 - The path root comes from `$EVAL_LEDGER_DIR`, `$XDG_STATE_HOME`, or home,
@@ -149,5 +196,5 @@ digest-bearing filename.
 - \#3453: bound what each consultation discloses. There is no fixed
   multiplier to document, so the statable property is the output alphabet.
 - \#3437: widen the seam from `{task_id: bool}` to `{task_id: float}`. Every
-  reviewer across all seven rounds argued for it. Left to the user, since it
+  reviewer across all nine rounds argued for it. Left to the user, since it
   is a redesign rather than a tweak.

--- a/.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md
+++ b/.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md
@@ -33,18 +33,20 @@ the first draft made.
 | 8 | Copilot (PR #3458) | REJECT |
 | 9 | gemini-3.1-pro-preview | REJECT |
 | 10 | gpt-5.6-terra | REJECT |
+| 11 | gpt-5.6-luna | REJECT |
 
 No round returned ACCEPT. Every finding was verified at source before being
 acted on, rather than accepted on the reviewer's authority; all of them held.
-The ADR is recorded with its defeats visible because ten consecutive
+The ADR is recorded with its defeats visible because eleven consecutive
 falsifications are evidence about the claim, not noise to be smoothed over.
 
-Rounds 8 through 10 are the cleanest illustration in this log of why the
-count kept climbing. Round 8 found a defect inside the round-7 fix. Round 9
-found one inside the round-8 fix. Round 10 found one inside the round-9 fix.
-Round 10 was also given explicit permission to return ACCEPT and told that a
-false finding costs more here than a missed one, so the streak is not an
-artifact of the prompt asking for a defect.
+Rounds 8 through 11 are the cleanest illustration in this log of why the
+count kept climbing. Each found its defect inside the previous round's fix.
+Rounds 10 and 11 were both given explicit permission to return ACCEPT and
+told that a false finding costs more here than a missed one, so the streak is
+not an artifact of the prompt asking for a defect. Round 11 is also the first
+round whose report was partly declined, which is the other half of taking
+reviews seriously.
 
 ## The finding that changed the decision
 
@@ -77,7 +79,7 @@ characterization now leads both the ADR and the README.
 
 ## The recurring defect
 
-Nine of the ten rounds found the same shape. Any part of a budget the caller
+Ten of the eleven rounds found the same shape. Any part of a budget the caller
 can restate, or move by renaming something else, is not part of the budget.
 The same holds for what the budget is meant to withhold: any path by which the
 withheld thing is readable is not withholding it.
@@ -108,6 +110,10 @@ withheld thing is readable is not withholding it.
 9. The line above the seam. `lock.parent.mkdir(...)` sat one line outside the
    scrub that covers everything below it, so the first thing the lock does was
    the one thing nothing protected.
+10. The new line above the seam. Moving the `mkdir` in left `_ledger_root()`
+    above it, and that call resolves the home directory, which can fail
+    outright. Fixing a boundary by moving one line inward leaves whatever was
+    above that line as the new boundary.
 
 ## Round 7 blocking findings
 
@@ -213,6 +219,44 @@ rounds finding a defect at a hand-written redaction site is the argument for
 having exactly one. A plain root is still named in the warning, under test,
 because redaction that redacts everything is silence rather than redaction.
 
+## Round 11: three findings taken, one declined
+
+Round 11 was given the same explicit permission to return ACCEPT. It returned
+four findings. Three were reproduced and fixed; one was reproduced and
+declined, which is recorded here because a review process that accepts
+everything is not reviewing.
+
+Taken, and the only one that matters on its own: `_ledger_root()` sat above
+the scrub after round 10 moved the `mkdir` inside it. `Path.home()` raises
+`RuntimeError` when `$HOME` is unset and the uid has no passwd entry. That is
+an ordinary container running as a numeric user, and it fires on the default
+configuration, because the root consults home only when neither
+`$EVAL_LEDGER_DIR` nor `$XDG_STATE_HOME` is set. `main` does not catch
+`RuntimeError`. Verified before the fix as `RuntimeError` with `main catches
+it: False`, and after as `ConfigError` with `True`. Realism was checked rather
+than argued: with `$HOME` unset and `pwd.getpwuid` raising, `Path.home()`
+raises "Could not determine home directory."
+
+Taken, small: `os.write` and `os.close` shared one `try`, so a write failing
+on a full disk jumped to the `finally`, which unlinks the lock and never
+closes the descriptor. The close now has its own `finally`, and is not
+retried, because POSIX frees the descriptor even when close reports EIO.
+
+Taken, smallest: `_scrub` matched case-sensitively and a hex digest has an
+uppercase spelling that `$EVAL_LEDGER_DIR` can carry. Only reachable by a
+caller who already knows the digest. Fixed for the stated property, not the
+threat, and because hex is the one alphabet where case folding has no
+surprises.
+
+Declined: the report that resolving the root twice lets the lock and the
+ledger disagree, letting concurrent gates double-spend. It reproduces only by
+mutating `$EVAL_LEDGER_DIR` between the two resolutions. No in-process
+environment mutation exists in any of the three modules, checked rather than
+assumed, so the CLI cannot reach it. Threading a derivable parameter through
+two signatures to defend an unreachable case is plumbing this codebase
+declines on purpose. Recorded rather than silently dropped, so that anyone who
+later adds environment mutation knows this was weighed.
+
 ## Corrections applied without dispute
 
 - The path root comes from `$EVAL_LEDGER_DIR`, `$XDG_STATE_HOME`, or home,
@@ -235,5 +279,5 @@ because redaction that redacts everything is silence rather than redaction.
 - \#3453: bound what each consultation discloses. There is no fixed
   multiplier to document, so the statable property is the output alphabet.
 - \#3437: widen the seam from `{task_id: bool}` to `{task_id: float}`. Every
-  reviewer across all ten rounds argued for it. Left to the user, since it
+  reviewer across all eleven rounds argued for it. Left to the user, since it
   is a redesign rather than a tweak.

--- a/.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md
+++ b/.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md
@@ -1,0 +1,127 @@
+---
+status: recorded
+process: adr-review adversarial rounds (7 rounds, 2 non-Claude models)
+adr: ADR-087
+---
+
+# ADR-087 Held-Out Gate Debate Log
+
+Adversarial review of ADR-087 and the code it describes, session 3422, PR
+\#3430. Recorded honestly: this was not the six-persona architect / critic /
+security panel the adr-review skill usually convenes. The objective required
+adversarial review by models different from the authoring model, so every
+round was run by `gpt-5.6-sol` or `gemini-3.1-pro-preview` against work
+authored by Claude, with the reviewer told to assume a defect existed and to
+produce the strongest available falsification.
+
+Seven rounds ran. Every one of them falsified at least one load-bearing
+claim. That record is the reason ADR-087 carries a defeat table instead of a
+clean argument, and the reason its Decision statement is weaker than the one
+the first draft made.
+
+## Votes
+
+| Round | Reviewer | Verdict |
+| --- | --- | --- |
+| 1 | gpt-5.6-sol | REJECT |
+| 2 | gemini-3.1-pro-preview | REJECT |
+| 3 | gpt-5.6-sol | REJECT |
+| 4 | gemini-3.1-pro-preview | REJECT |
+| 5 | gpt-5.6-sol | REJECT |
+| 6 | gemini-3.1-pro-preview | REJECT |
+| 7 | gpt-5.6-sol | REJECT |
+
+No round returned ACCEPT. Every finding was verified at source before being
+acted on, rather than accepted on the reviewer's authority; all of them held.
+The ADR is recorded with its defeats visible because seven consecutive
+falsifications are evidence about the claim, not noise to be smoothed over.
+
+## The finding that changed the decision
+
+Round 6 falsified the ADR's central argument: that withholding the decision
+group's membership bounds what the loop can tune toward. Both halves are
+false, and both were verified at source.
+
+1. Outcomes are not withheld. `cmd_extract` calls `_emit(results)` on the
+   full mapping and its parser has no group argument, and the documented
+   workflow has the optimizer run `extract` itself. Held-out results were
+   already sitting in the optimizer's own files, uncharged. Tracked as
+   \#3452.
+2. Membership is public and sufficient. Task ids resolve to readable
+   definitions that carry their own grading criteria: a fixture's expected
+   verdict and regex, a scenario's expected vocabulary, a pytest assertion.
+   Naming a held-out task is enough to hand-tune for it.
+
+The reviewer also inverted the ADR's own reasoning. "The loop cannot edit
+toward a group it cannot name" is backwards: an optimizer edits toward the
+optimize group and needs no knowledge of the selection group at all. Only the
+optimize group must be exposed for the discipline to work.
+
+Resolution: the Decision statement was weakened, four paragraphs recording
+why both halves are false replaced the original argument, and the honest
+characterization now leads both the ADR and the README.
+
+> A consultation-budgeted comparison over a public benchmark, relying on a
+> cooperating optimizer not to inspect accessible task definitions or result
+> files. It is not yet held-out validation of unseen tasks.
+
+## The recurring defect
+
+Six of the seven rounds found the same shape. Any part of a budget the caller
+can restate, or move by renaming something else, is not part of the budget.
+
+1. The count. `--consultations` defaulted to 0 every call, so a loop passing
+   zero each time had an unlimited budget while looking capped. Review
+   reproduced two ACCEPTs under a cap of one.
+2. The cap. `--max-consultations` defaulted to unlimited.
+3. The ledger path. A missing ledger starts at zero, so `--ledger PATH`
+   naming a fresh file restored the whole budget.
+4. The split path the ledger derived from. Copying the split to a new name
+   reset the budget with identical membership inside.
+5. The fingerprint. It hashed the split's inputs rather than its drawn
+   result, so it caught an added or removed task but not a task moved between
+   groups.
+6. The digest in error paths, then the digest reachable from generic I/O
+   failures. Every ledger filename ends in the digest of the held-out
+   membership, so any error interpolating a path leaked the withheld thing.
+   Closing it per call site missed lock release, which runs after the
+   decision is already emitted.
+
+## Round 7 blocking findings
+
+1. The digest scrub covered the lock's acquire and left its release outside.
+   `lock.unlink(missing_ok=True)` in the `finally` names the lock file, and
+   `main()` catches `ConfigError` but not `OSError`, so a cleanup failure
+   printed the whole held-out group as an uncaught traceback one line below
+   where the leak was supposedly closed. RESOLVED in `97817c0ba`: the scrub
+   now spans the whole lifecycle. Safe over the `yield` because
+   `LedgerMismatchError` is a sibling of `ConfigError`, not a subclass.
+2. Both documents said the budget bounds "the loop's own selection pressure."
+   False: `extract` and `score` reach results without touching the ledger, so
+   the budget bounds gate comparisons only. RESOLVED in `f690ce24b` for the
+   README and in this ADR's Consequences section.
+
+## Corrections applied without dispute
+
+- The path root comes from `$EVAL_LEDGER_DIR`, `$XDG_STATE_HOME`, or home,
+  and the cap's first value comes from `--max-consultations`. Only a budget
+  already in progress is immovable.
+- No `reveal` command exists. The subcommands are `extract`, `split`,
+  `budget`, `score`, `apply`, `gate`, `buffer-check`, `buffer-add`. Any claim
+  that the test group is scored once at the end describes an open
+  requirement, not the implementation.
+- A consultation is reserved before the group is read and before coverage is
+  validated. That ordering is deliberate, but "charged when the gate reaches
+  the comparison" had it backwards.
+
+## Deferred rather than rushed
+
+- \#3452: make `extract` group-aware and replace the one-bit coverage
+  predicate with a whole-universe check. These do not compose without a
+  controller holding the complete mapping, so the issue is sequenced as a
+  prerequisite for Open Requirement 1.
+- \#3453: bound what each consultation discloses. There is no fixed
+  multiplier to document, so the statable property is the output alphabet.
+- \#3437: widen the seam from `{task_id: bool}` to `{task_id: float}`. Every
+  reviewer across all seven rounds argued for it. Left to the user, since it
+  is a redesign rather than a tweak.

--- a/.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md
+++ b/.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md
@@ -34,15 +34,16 @@ the first draft made.
 | 9 | gemini-3.1-pro-preview | REJECT |
 | 10 | gpt-5.6-terra | REJECT |
 | 11 | gpt-5.6-luna | REJECT |
+| 12 | gpt-5.6-sol | REJECT |
 
 No round returned ACCEPT. Every finding was verified at source before being
 acted on, rather than accepted on the reviewer's authority; all of them held.
-The ADR is recorded with its defeats visible because eleven consecutive
+The ADR is recorded with its defeats visible because twelve consecutive
 falsifications are evidence about the claim, not noise to be smoothed over.
 
-Rounds 8 through 11 are the cleanest illustration in this log of why the
+Rounds 8 through 12 are the cleanest illustration in this log of why the
 count kept climbing. Each found its defect inside the previous round's fix.
-Rounds 10 and 11 were both given explicit permission to return ACCEPT and
+Rounds 10, 11, and 12 were all given explicit permission to return ACCEPT and
 told that a false finding costs more here than a missed one, so the streak is
 not an artifact of the prompt asking for a defect. Round 11 is also the first
 round whose report was partly declined, which is the other half of taking
@@ -79,7 +80,7 @@ characterization now leads both the ADR and the README.
 
 ## The recurring defect
 
-Ten of the eleven rounds found the same shape. Any part of a budget the caller
+Eleven of the twelve rounds found the same shape. Any part of a budget the caller
 can restate, or move by renaming something else, is not part of the budget.
 The same holds for what the budget is meant to withhold: any path by which the
 withheld thing is readable is not withholding it.
@@ -114,6 +115,10 @@ withheld thing is readable is not withholding it.
     above it, and that call resolves the home directory, which can fail
     outright. Fixing a boundary by moving one line inward leaves whatever was
     above that line as the new boundary.
+11. The guard in front of the redaction. `_scrub` learned to fold case and the
+    `if holdout_key in text` deciding whether to call it did not, so the input
+    the fix was written for skipped the fix. The one-definition rule has to
+    cover the predicate, not just the replacement.
 
 ## Round 7 blocking findings
 
@@ -257,6 +262,33 @@ two signatures to defend an unreachable case is plumbing this codebase
 declines on purpose. Recorded rather than silently dropped, so that anyone who
 later adds environment mutation knows this was weighed.
 
+## Round 12: the previous round's fix, applied to half the pair
+
+Round 12 got the same explicit permission to return ACCEPT and returned one
+finding, reproduced through the real `gate` entry point with only the stdlib
+`Path.mkdir` patched to deny.
+
+Round 11 taught `_scrub` to fold case because a hex digest has an uppercase
+spelling that `$EVAL_LEDGER_DIR` can carry. The line deciding whether to call
+it still read `if holdout_key in text`, which does not fold case. So the exact
+input round 11 was written for failed the guard, skipped the corrected scrub,
+and printed whole. Severity is the stated property rather than
+confidentiality, on the standing rule: reaching it requires the caller to have
+put the digest in the environment variable, so the reader already knows it.
+
+The fix deletes the second predicate instead of teaching it to fold. `_scrub`
+returning a different string answers both "is it here" and "what does it look
+like without it", so there is nothing left to keep in step. The one-definition
+rule that came out of rounds 9 and 10 had been applied to the replacement and
+not to the test in front of it.
+
+The tests are the other half of the finding and the more useful half. Round 11
+added four tests for case folding and every one called `_scrub` directly. They
+passed while the CLI printed the digest, because they asserted that the
+function had changed rather than that the property held. A test that exercises
+the unit you edited will confirm your edit. Only a test through the seam can
+contradict it.
+
 ## Corrections applied without dispute
 
 - The path root comes from `$EVAL_LEDGER_DIR`, `$XDG_STATE_HOME`, or home,
@@ -279,5 +311,5 @@ later adds environment mutation knows this was weighed.
 - \#3453: bound what each consultation discloses. There is no fixed
   multiplier to document, so the statable property is the output alphabet.
 - \#3437: widen the seam from `{task_id: bool}` to `{task_id: float}`. Every
-  reviewer across all eleven rounds argued for it. Left to the user, since it
+  reviewer across all twelve rounds argued for it. Left to the user, since it
   is a redesign rather than a tweak.

--- a/.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md
+++ b/.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md
@@ -32,15 +32,19 @@ the first draft made.
 | 7 | gpt-5.6-sol | REJECT |
 | 8 | Copilot (PR #3458) | REJECT |
 | 9 | gemini-3.1-pro-preview | REJECT |
+| 10 | gpt-5.6-terra | REJECT |
 
 No round returned ACCEPT. Every finding was verified at source before being
 acted on, rather than accepted on the reviewer's authority; all of them held.
-The ADR is recorded with its defeats visible because nine consecutive
+The ADR is recorded with its defeats visible because ten consecutive
 falsifications are evidence about the claim, not noise to be smoothed over.
 
-Rounds 8 and 9 are the cleanest illustration in this log of why the count
-kept climbing. Round 8 found a defect inside the round-7 fix. Round 9 then
-found one inside the round-8 fix.
+Rounds 8 through 10 are the cleanest illustration in this log of why the
+count kept climbing. Round 8 found a defect inside the round-7 fix. Round 9
+found one inside the round-8 fix. Round 10 found one inside the round-9 fix.
+Round 10 was also given explicit permission to return ACCEPT and told that a
+false finding costs more here than a missed one, so the streak is not an
+artifact of the prompt asking for a defect.
 
 ## The finding that changed the decision
 
@@ -73,7 +77,7 @@ characterization now leads both the ADR and the README.
 
 ## The recurring defect
 
-Eight of the nine rounds found the same shape. Any part of a budget the caller
+Nine of the ten rounds found the same shape. Any part of a budget the caller
 can restate, or move by renaming something else, is not part of the budget.
 The same holds for what the budget is meant to withhold: any path by which the
 withheld thing is readable is not withholding it.
@@ -101,6 +105,9 @@ withheld thing is readable is not withholding it.
 8. The unredacted cause. Redacting the message and chaining the original with
    `raise ... from exc` leaves the digest one `__cause__` hop away, which is
    exactly where a printed traceback goes.
+9. The line above the seam. `lock.parent.mkdir(...)` sat one line outside the
+   scrub that covers everything below it, so the first thing the lock does was
+   the one thing nothing protected.
 
 ## Round 7 blocking findings
 
@@ -174,6 +181,38 @@ stdout while writing round-7 tests, recorded it as a test-harness quirk, and
 worked around it. The reviewer reclassified it correctly. A workaround that
 makes a symptom stop being visible in tests is not a finding closed.
 
+## Round 10 blocking finding
+
+Round 10 was told plainly that a false finding costs more than a missed one
+here and that ACCEPT was an acceptable answer. It returned REJECT with one
+finding that has two legs, and both reproduced.
+
+The leak leg is the weaker one and is recorded as such rather than at the
+severity the reviewer assigned. `$EVAL_LEDGER_DIR` can name a directory
+containing the digest, and both the `mkdir` traceback and the round-9 release
+warning render that directory. A caller who set that variable already knows
+the digest, so this discloses a secret to the party holding it. It is fixed
+anyway, for two reasons that do not depend on the threat model: the standing
+rule from nine rounds is that a path by which the withheld thing is readable
+is not withholding it, and the release warning was justified in review by the
+claim that a directory carries no digest, which this falsifies.
+
+The contract leg is the stronger one and needs no digest anywhere. `mkdir` on
+a ledger root the process cannot create raises `PermissionError`; `main`
+catches `ConfigError`, `AdapterError`, and `ValueError`. A read-only home or a
+sandboxed runner therefore got a traceback where the module docstring promises
+a JSON error document. That is the round-8 defect, still live at the one line
+that was outside the seam, reachable with no contrivance at all. Verified
+before the fix as `PermissionError` with `main would catch it: False`, and
+after as `ConfigError` with `True`.
+
+The fix moves the `mkdir` inside the scrub and gives redaction one definition,
+`_scrub`, used by the seam and by the warning. The round-9 warning was a
+second redaction site written by hand, and it was wrong. Two consecutive
+rounds finding a defect at a hand-written redaction site is the argument for
+having exactly one. A plain root is still named in the warning, under test,
+because redaction that redacts everything is silence rather than redaction.
+
 ## Corrections applied without dispute
 
 - The path root comes from `$EVAL_LEDGER_DIR`, `$XDG_STATE_HOME`, or home,
@@ -196,5 +235,5 @@ makes a symptom stop being visible in tests is not a finding closed.
 - \#3453: bound what each consultation discloses. There is no fixed
   multiplier to document, so the statable property is the output alphabet.
 - \#3437: widen the seam from `{task_id: bool}` to `{task_id: float}`. Every
-  reviewer across all nine rounds argued for it. Left to the user, since it
+  reviewer across all ten rounds argued for it. Left to the user, since it
   is a redesign rather than a tweak.

--- a/.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md
+++ b/.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md
@@ -30,6 +30,9 @@ the first draft made.
 | 5 | gpt-5.6-sol | REJECT |
 | 6 | gemini-3.1-pro-preview | REJECT |
 | 7 | gpt-5.6-sol | REJECT |
+| 8 | Copilot (PR #3458) | REJECT |
+
+No round returned ACCEPT. Round 8 arrived as a PR review on the follow-up branch and found a defect inside the round-7 fix itself, which is the cleanest illustration in this log of why the count kept climbing.
 
 No round returned ACCEPT. Every finding was verified at source before being
 acted on, rather than accepted on the reviewer's authority; all of them held.
@@ -100,6 +103,29 @@ can restate, or move by renaming something else, is not part of the budget.
    False: `extract` and `score` reach results without touching the ledger, so
    the budget bounds gate comparisons only. RESOLVED in `f690ce24b` for the
    README and in this ADR's Consequences section.
+
+## Round 8 blocking finding
+
+The scrub added in round 7 re-raised `OSError` untouched whenever the message
+did not contain the digest, and `main` catches `ConfigError`, `AdapterError`,
+and `ValueError` but not `OSError`. Ledger failures that name a path stayed
+inside the CLI's JSON error contract; ones that name no path escaped as
+tracebacks. Two are reachable inside the lock: `os.write` filling the disk and
+`os.close` hitting EIO both operate on a file descriptor, so neither message
+carries a filename, so neither reached the redaction branch that also happened
+to be the branch keeping them in the contract.
+
+This is the recurring defect one layer down. The handled paths were the ones
+somebody enumerated. RESOLVED: the seam converts every `OSError` and redacts
+only when the digest is present, so the contract and the redaction stop being
+the same branch. A `ConfigError` without the digest is re-raised as itself so
+nothing inspecting the exception object loses it.
+
+Two adjacent claims were checked while fixing it and both held, so no change
+was made: `LedgerMismatchError` derives from `Exception` rather than
+`ConfigError`, so the scrub never touches it and it reaches its handler
+intact; and both of its messages name `path.parent` rather than the
+digest-bearing filename.
 
 ## Corrections applied without dispute
 

--- a/.agents/architecture/ADR-087-held-out-validated-improvement.md
+++ b/.agents/architecture/ADR-087-held-out-validated-improvement.md
@@ -1,0 +1,619 @@
+---
+id: ADR-087
+status: proposed
+date: 2026-07-26
+decision-makers: [rjmurillo]
+supersedes: []
+superseded-by: null
+explainer: null
+implemented: false
+---
+
+# ADR-087: Held-Out Validation for Iterated Improvement Claims
+
+## Status
+
+Proposed. Requested by two independent adversarial reviews on PR #3430
+(gpt-5.6-sol and gemini-3.1-pro-preview), both of which concluded that the
+mechanism that PR adds asserts a norm the repository has not written down.
+
+A second adversarial round reviewed the resulting draft and returned REJECT.
+It was right on the substance: the draft mischaracterized ADR-057, cited two
+`proposed` ADRs as authority, overstated what the mechanism guarantees across a
+loop, and claimed an enforcement property the code did not yet have. This
+revision corrects each of those and adds an Open Requirements section naming
+what still blocks acceptance. The document now describes a mechanism and its
+limits rather than asserting a norm. Refs #3422.
+
+## Date
+
+2026-07-26
+
+## Context
+
+This repository evaluates three kinds of authored artifact empirically. Each
+has its own methodology ADR and its own evaluator:
+
+| Artifact | Evaluator | ADR |
+|----------|-----------|-----|
+| Prompt or rule | `eval-prompt-change.py`, `eval-rule-activation.py` | ADR-057 |
+| Agent | `eval-agent-vs-baseline.py` | ADR-058 |
+| Hook | `pytest tests/hooks` | Testing rigor, not an ADR |
+
+All three answer the same question: did this edit make the artifact better.
+All three answer it the same way, and that way has a defect that none of them
+name.
+
+The evaluator scores the artifact against the whole evaluation set. The author
+reads which cases failed. The author edits the artifact. The evaluator scores
+it against the same whole set again. Repeat until the number goes up.
+
+That is fitting the test set. After the second iteration the reported score is
+no longer an estimate of how the artifact behaves on cases it has not seen; it
+is an estimate of how well the author responded to the specific cases in the
+set. The two diverge exactly as the loop gets more effective, which is the
+worst possible direction for the error to run.
+
+Verified rather than asserted, and stated precisely because two drafts
+overstated it in turn. None of the artifact evaluators that predate this ADR
+performs a *pre-registered withholding*. `eval-agent-vs-baseline.py` loads
+fixtures at lines 1095-1115 via `_load_fixture_paths` then `validate_fixtures`,
+with no split. The same is true of `eval-prompt-change.py`.
+
+Two narrower corrections, both from review. It is not true that no evaluator
+subsets at all: `_report_aggregator.py` lines 406-422 drop flaky fixtures and
+compute the headline delta on the surviving `stable_ids`, which
+`eval-agent-vs-baseline.py` then reports (its own lines 1046-1062 only warn
+that the threshold was crossed). That is a post-hoc exclusion chosen after
+seeing which tasks misbehaved, the opposite of what this ADR asks for, and it
+does not weaken the case. And the claim is now false of the directory as a
+whole, because `optimize-artifact.py` from this ADR withholds by construction.
+
+Two merged commits already ran this loop and said so in their messages,
+marked `(SkillOpt-gated)`, #3056 and #3057. They went through an out-of-repo
+harness in a dotfiles repository, they applied only to skills, and the
+repository has no record of what was held out or whether anything was. The
+practice arrived before the policy, which is the ordinary order and the reason
+to write the policy now.
+
+### What the existing ADRs do and do not cover
+
+ADR-010 caps an evaluator-optimizer loop at three iterations and terminates on
+a rubric score of 70% or above. It bounds how long the loop runs. It says
+nothing about what evidence the loop is allowed to see, so three iterations
+against a fully-visible set is fully compliant and fully overfit.
+
+ADR-057 requires that a prompt change "must not degrade existing behavior
+without explicit justification," and its gate is stricter than that sentence
+reads: "Every pass-to-fail flip is recorded in `regressions` and blocks the
+gate automatically; the gate has no mechanism to accept a 'justified'
+regression." An earlier draft of this ADR claimed ADR-057 enforced only an
+aggregate mean. That was false, and the error mattered: it was used here to
+justify an override flag that would have been a weaker rule shipping under the
+same name. The flag is gone and requirement 4 below now restates ADR-057's
+no-bypass position rather than relaxing it.
+
+What ADR-057 does not cover is iteration. Its gate reads the whole scenario
+set, which is also the set the author reads while editing. It stops a
+regression on a task the author can see. It says nothing about whether the
+aggregate gain generalizes past the tasks the author was looking at.
+
+ADR-058 is between-subjects, agent against baseline. It is the right shape for
+"is this agent better than no agent" and the wrong shape for "is revision 7 of
+this agent better than revision 6," which is the question an improvement loop
+asks on every step. ADR-058 is itself `proposed`, so it is cited here as the
+existing shape of the practice rather than as settled authority.
+
+ADR-022's split criteria are the reason this is filed as an ADR: it constrains
+what the evaluation machinery is structurally allowed to observe at decision
+time, and it changes the shape of every future evaluator, rather than adding a
+compliance step to an existing one. Two caveats a reader deserves. ADR-022 is
+also `proposed`. And its own matrix calls for an ADR *plus* a governance
+document when a decision carries an enforcement obligation, which this one
+does. The governance half is not written; that gap is named under Open
+Requirements below rather than papered over.
+
+### Why this is not solved by discipline
+
+The obvious alternative is to write the norm as guidance and expect authors to
+follow it. Two reasons that fails here.
+
+First, the party being disciplined is increasingly not a human. An agent
+iterating unattended will optimize whatever number it is shown. If it is shown
+a score computed on data it can read, it will fit that data, and it will do so
+faster and more thoroughly than a human would.
+
+Second, the task set is a directory the agent can write to. Guidance that says
+"hold out a portion" is satisfiable by holding out a portion, losing, and
+choosing a different portion. The hold-out has to be tamper-evident to mean
+anything, and tamper-evidence is a mechanism, not a norm.
+
+## Decision
+
+**An improvement claim about an authored artifact, made by a loop that reads
+its own evaluation results, MUST be validated against a group whose number of
+consultations is bounded and counted by a mechanism the loop cannot move
+through its own arguments.**
+
+The stronger statement, that validation happens on tasks withheld from the
+party making the edit, is what this ADR originally asserted. A sixth review
+falsified it against the implementation, and the falsification is recorded in
+Consequences. Withholding is the goal; a counted budget is what the current
+mechanism delivers, and it is what the requirements below can honestly
+demand.
+
+Four requirements follow.
+
+### 1. The decision group is fixed before the first edit
+
+The evaluation set is split into an optimize group, a selection group, and
+optionally a test group. The author, human or agent, may read results on the
+optimize group. The accept decision reads the selection group and nothing else.
+The test group, when present, is read once at the end and never gates. That
+lifecycle is stated, not yet enforced: `--test-ratio` defaults to `0.0` and no
+command reveals the group, so the one-time read is an open requirement below
+rather than a property of the code.
+
+The split is committed before the first edit. It is not re-drawn because a
+candidate lost.
+
+### 2. The split is tamper-evident
+
+The split is fingerprinted over the seed, the full task-id set, and the group
+ratios. A decision made against a fingerprint that does not match the recorded
+one is refused rather than computed.
+
+This closes the cheapest available cheat, which is also the ordinary accident:
+an edit loses, so tasks are added and the split is re-drawn, and the new split
+happens to be kinder.
+
+### 3. Repeated decisions against one held-out group are budgeted
+
+Each accept decision against a selection group is a selection event on that
+group. Enough of them and the selection group is an optimize group that nobody
+labelled. The number of decisions is capped, and the count, the cap, and the
+file they live in are held by the mechanism rather than re-derived from what the
+caller passed.
+
+The distinction is not pedantic, and it took five rounds to get right. Each
+round fixed the part under review and left the rest reachable, where the same
+defect reappeared in a new form:
+
+| Round | What the caller still controlled | How review defeated it |
+| --- | --- | --- |
+| 1 | The count | `--consultations` defaulted to zero on every invocation. Two accepts reproduced under a cap of one by passing zero twice. |
+| 2 | The cap | `--max-consultations` defaulted to unlimited, so the ordinary invocation had no budget, and a caller that hit the cap could raise it on the next call. |
+| 3 | The ledger path | A missing ledger starts at zero, so `--ledger` pointed at a fresh path restored the whole budget without editing anything. |
+| 4 | The split path the ledger was derived from | Deriving the ledger from `--split` moved the reset instead of closing it. Copying `split.json` to `split2.json` kept the fingerprint and left no ledger beside it, so the budget started over. |
+| 5 | The inputs the fingerprint covers | Keying on the fingerprint keyed on the selection's inputs (seed, task ids, ratios) rather than its result, and group sizes round. Ten tasks at `--sel-ratio 0.40` and at `0.41` hold out the same four tasks and fingerprint differently, so one held-out group had two budgets. |
+
+| 6 | The digest of the group, reachable from any I/O failure under the ledger root | Round five redacted three hand-written messages. Every other way to fail on a ledger path, a malformed ledger, a write that cannot land, an `os.open` failing for any errno but EEXIST, still printed the filename, and the filename ends in the digest. |
+
+What holds now: the cap is required and recorded at the first decision, a later
+cap change is refused, and the ledger is keyed by a digest of the sorted
+held-out membership in a fixed state directory. A copy, a rename, or a differently
+parameterized redraw that lands on the same tasks all share the budget those
+tasks have already spent. The general rule this ADR extracts is that any part of
+a budget the caller can restate, or can move by renaming something else, is not
+part of the budget, and that the key has to name what is being spent rather than
+what produced it.
+
+Keying on membership deliberately has no corpus namespace. Two unrelated eval
+sets whose task ids and held-out membership both coincide will share a budget.
+The seam between this loop and its scorers carries task ids and pass booleans
+and nothing else, so there is no corpus identity in it that the caller did not
+supply, and a caller-supplied key is the defect this round closed. A namespace
+derived from task contents or from trusted corpus provenance would work; it
+needs a seam that carries one. Sharing is the conservative direction, so the
+collision is accepted until that seam exists.
+
+The key is a digest, and a digest of a set the caller can enumerate is that
+set. It is therefore kept out of error output. A fifth round found it in three
+hand-written lock and ledger messages; a sixth found the three fixes had missed
+every generic I/O failure under the ledger root, since those interpolate the
+filename and the filename ends in the digest. The scrub now sits at the seam
+rather than at each call site, so paths added later inherit it. The redaction
+is bookkeeping hygiene, not a boundary: as the next section records, membership
+is recoverable by subtraction regardless.
+
+The cap itself is still whatever positive integer the first call names. Nothing
+constrains a first invocation that passes a thousand. That is operator policy,
+and inventing a ceiling here would be a number with no evidence behind it; it is
+listed under Open Requirements instead.
+
+`$EVAL_LEDGER_DIR` relocates the ledger root. It exists so tests do not write to
+a real user state directory, and it reopens the reset for anyone who sets it.
+Naming it here is deliberate: it is an escape hatch, not a closure.
+
+A consultation is charged before any held-out coverage or outcome is queried,
+not when a verdict comes back. The split file is opened and its membership
+hashed before that point, which is how the ledger is found at all; what the
+charge precedes is every question whose answer depends on held-out results. A refusal decidable from bookkeeping alone (exhausted budget, stale
+incumbent fingerprint, drifted split) reads nothing and costs nothing. Anything
+past that point costs one, including a results file that turns out not to cover
+the group and a process killed mid-comparison. An earlier version wrote the
+count after the verdict, which made both of those free. Two gates running at
+once cannot both spend the same remaining consultation, because the read, the
+comparison, and the write happen under an exclusive lock keyed by the same
+held-out group.
+
+The gate also never names a held-out task. `score` and `mcnemar_exact` report
+which ids they could not find, which is the right message for direct scoring and
+a full disclosure inside the gate, where those ids are the withheld ones. A
+candidate results file with no keys at all printed the entire membership in one
+error. The gate now asks its own coverage question and answers that question
+with one bit. (The *decision* payload is not one bit; see Consequences. This
+paragraph is about the coverage predicate alone, and #3452 proposes replacing
+even that with a whole-universe check, which removes the membership oracle it
+still constitutes.) Not a count: `split` publishes the held-out size, so a count would tell a caller how
+many of the keys it chose to omit were held out, and a few chosen omissions
+recover the membership.
+
+### 4. No pass-to-fail transition is accepted on an aggregate gain
+
+The decision counts discordant pairs: tasks that went fail-to-pass and tasks
+that went pass-to-fail. Any pass-to-fail transition refuses the edit, whatever
+the aggregate did.
+
+There is no override. This restates ADR-057's position rather than extending
+it; that ADR already states its gate "has no mechanism to accept a 'justified'
+regression." An earlier draft of this ADR provided an opt-out flag, described
+as something a human would pass. It was not human-only, nothing distinguished a
+human caller from the agent driving the loop, and it would have been a weaker
+rule than the ADR it claimed to source from. It has been removed.
+
+### What the mechanism protects against, and what it does not
+
+This is a discipline control against accidental overfitting by a cooperating
+optimizer. It is not a security boundary against an adversarial one.
+
+**Held-out membership is public, and has to be.** `split` publishes `opt` on
+stdout because the loop cannot edit toward a group it cannot name. The task
+universe is the caller's own results file. So when no test group was drawn, and
+the default `--test-ratio` of 0.0 draws none, the held-out group is the
+complement of a published set inside a set the caller supplied, and subtraction
+recovers it exactly. Verified directly: a twelve-task run publishes seven
+optimize ids, and `universe - opt` is the five held-out ids on the nose.
+
+An earlier revision of this ADR argued that publishing membership is harmless
+because identity is public while outcomes stay withheld. A sixth review
+falsified both halves.
+
+**Outcomes are not withheld.** `cmd_extract` calls `_emit` on the complete
+task-to-outcome mapping and its parser takes no group argument. The workflow
+this ADR describes has the optimizer run `extract` itself to produce `base.json`
+and `cand.json`, so held-out outcomes sit in the optimizer's own files before
+the gate is called. `score --group` is group-aware; nothing routes the loop
+through it.
+
+**Publishing membership is sufficient to defeat the intent even without
+outcomes,** because a task id resolves to a readable definition carrying its own
+grading criteria. `evals/analyst-spike/fixtures/F001.json` holds the input, the
+expected verdict, and the regex the scorer asserts.
+`tests/evals/rule-scenarios/clean-architecture.json` holds the expected
+vocabulary and rationale. `tests/hooks/test_dash_guard.py` is the assertion
+itself. Naming a held-out task is therefore enough to hand-tune for it.
+
+**The argument that the loop must name what it may not touch is backwards.** An
+optimizer edits toward `opt` and needs no knowledge of `sel` at all, which is
+how an ordinary train and validation split works. Only `opt` has to be exposed.
+Dwork's reusable holdout (arXiv:1506.02629) assumes the analyst reaches the
+holdout only through the mechanism, and that assumption is exactly what does not
+hold here.
+
+**The gate does not return one bit either.** Its payload carries both scores,
+both discordant counts, and the p-value. The ledger bounds how many times the
+loop may ask, not how much each answer tells it.
+
+Two things follow. Redacting held-out ids from gate errors buys nothing in the
+default configuration, and is kept for the configuration where it buys
+something: with a test group drawn, the complement is the union of two groups,
+the published sizes do not say which is which, and an error that named ids or
+printed the membership digest would say exactly that. And no claim in this ADR
+should be read as hiding the held-out task list, because it does not.
+
+The split file, the ledger, and the results all sit on the same disk as
+everything else, and an agent with write access can edit any of them. What the
+mechanism removes is one accidental path and leaves another open. It removes
+scoring against the held-out group because a sibling subcommand offered it,
+and exhausting a budget that was never actually counted. It does not remove
+reading held-out outcomes, because `extract` still emits every task's outcome
+with no group argument and the documented workflow calls it (#3452).
+Those were all real and all present in the first implementation. Each has a
+deliberate path around it that survives: delete the ledger, set
+`$EVAL_LEDGER_DIR`, edit the split, remove a stale lock, name a huge cap on the
+first call. What closed is the version an ordinary invocation could reach by
+accident.
+
+Making this a real boundary needs a controller the optimizing agent cannot
+write to. That is named under Open Requirements rather than claimed here.
+
+### What this does not require
+
+- It does not require a p-value threshold. Paired evidence (McNemar's exact
+  test on the discordant counts) is reported on every compared decision and
+  enforced on none. At the group sizes this repository actually has, three
+  discordant tasks cannot produce a p below 0.125, so a conventional 0.05 floor
+  would make the ordinary case unpassable rather than informative. Reporting it
+  keeps the reader honest about how thin the evidence is. Enforcing it would
+  only teach the loop to grow the eval set until the arithmetic cooperates.
+- It does not require a test group. At this repository's fixture counts, where
+  the mode is 8, a three-way split can leave a selection group too small to
+  decide anything. The default is optimize and selection only, and that default
+  is stated rather than hidden.
+- It does not apply to a single evaluated change. One edit, evaluated once,
+  against a set the author had already seen, is the situation ADR-057 and
+  ADR-058 already govern. The failure this ADR addresses needs iteration to
+  appear.
+
+## Consequences
+
+### Positive
+
+- An improvement claim means something it did not mean before, and the bound
+  has to be stated exactly or it will be overread. What the mechanism delivers
+  is this: **a consultation-budgeted comparison over a public benchmark,
+  relying on a cooperating optimizer not to inspect task definitions and result
+  files it can already reach.** It is not held-out validation of unseen tasks.
+  Three drafts of this ADR claimed the stronger thing in three different
+  phrasings, and each was falsified by reading the implementation. What holds
+  regardless of the optimizer's cooperation is the budget: the consultation
+  count, its cap, its storage path, and its key are derived from the held-out
+  membership, with two exceptions worth stating rather than glossing: the
+  path's root comes from the environment or the home directory, and the cap's
+  first value comes from `--max-consultations` before it is pinned. So a budget
+  already in progress cannot be moved by a caller argument; a first invocation
+  still chooses its own cap, and filesystem access still relocates or deletes
+  the root. What that bounds is **gate comparisons** against the held-out
+  group, not total selection pressure, since `extract` and `score` reach
+  results without touching the ledger. Gate comparisons are the quantity
+  is the quantity multiple-comparison correction is about and the failure this
+  directory actually had.
+- The rule generalizes past skills, which is where the practice started. The
+  seam between the decision and any scorer is one mapping of task id to pass
+  boolean, so a fixture id, a scenario id, and a pytest node id are the same
+  kind of thing to it. Agents, rules, and hooks are covered by one mechanism
+  rather than three. Prompts are not: the ADR opens on prompt evaluation, but
+  no prompt adapter exists yet, so prompt work goes through the rule adapter or
+  not at all.
+- ADR-057's degradation clause is enforced at the point of decision as well as
+  at the point of review, on the held-out group specifically.
+- The comparison itself is pure and unit-testable without eval budget. The
+  scorers spend; the decider does not. The gate around that comparison is not
+  pure, and an earlier draft of this ADR claimed it was: it takes a lock, reads
+  a ledger, and writes one before it decides anything.
+
+### Negative
+
+- Fewer tasks inform each decision. A ten-task set at default ratios decides on
+  four. That is a real loss of statistical power, accepted knowingly, and it is
+  the cost paid for a benefit the mechanism only partly delivers. Under a
+  cooperating optimizer the four carry a generalization claim the ten cannot;
+  under one that reads its own `extract` output they carry a weaker claim than
+  that, bounded by the budget rather than by ignorance. Four of anything is thin
+  evidence either way.
+- Reporting a p-value without enforcing it means accepted edits will carry
+  weak evidence and say so. A candidate that fixes one held-out task and breaks
+  none reports `p = 0.5` and is accepted, because one discordant pair cannot do
+  better than 0.5 on a one-sided exact test. Anyone reading `p_value` as an
+  accept criterion will misread it. It is a disclosure, not a gate, and the
+  README says so at the point of output.
+- Scorer noise is not handled uniformly across the three adapters. A held-out
+  task that flips for reasons unrelated to the edit refuses a good edit under
+  requirement 4. The exposure differs by artifact: the hook adapter is
+  deterministic, the agent adapter already reduces over multiple runs (mean by
+  default), and the rule adapter is single-shot against an LLM judge and
+  therefore carries the full exposure. That gap is real and specific; it is not
+  a reason to weaken requirement 4, because the costs are asymmetric. A
+  spurious reject costs one rollout. A spurious accept ships a regression and
+  raises the baseline it will be measured against next time.
+- Small evaluation sets get more expensive to grow. Adding tasks mid-loop
+  invalidates the fingerprint by design, so a set that turns out to be too small
+  costs a restart rather than an append.
+- The consultation budget will sometimes stop a loop that was making genuine
+  progress. That is the cost of the guarantee; an unbudgeted loop cannot
+  distinguish progress from selection.
+- The boolean seam discards information the scorers already produce. An edit
+  that lifts every held-out task from 0.50 to 0.99 without crossing the
+  threshold is invisible to this decision. Tracked as issue #3437; the boolean
+  is what makes three unlike scorers commensurable, so widening it is a
+  redesign rather than an increment.
+
+### Neutral
+
+- Existing evaluators are unchanged. This ADR governs iterated improvement
+  claims, and an evaluator invoked once for a single verdict is unaffected.
+
+## Open Requirements
+
+These block a move from `proposed` to `accepted`. They are listed as
+requirements rather than nice-to-haves because each one is a place where the
+document currently claims less than a reader might assume.
+
+Requirement 1 is not in that category. It is a **prerequisite for the Decision
+statement's stronger form**, not future hardening, and it is listed first for
+that reason.
+
+1. **A trusted controller that owns task definitions, scoring, and result
+   files, and hands the optimizer only the optimize group.** Three separate
+   facts make this a prerequisite rather than an improvement. `extract` emits
+   every task's outcome with no group argument, and the documented workflow has
+   the optimizer run it. Task ids resolve to readable definitions carrying
+   their own grading criteria, so membership alone is enough to hand-tune.
+   `split` publishes `opt`, and with the default `--test-ratio` of 0.0 the
+   complement is the held-out group by subtraction. Until a controller owns
+   those three surfaces, this ADR must not be read as validating on unseen
+   tasks; it validates under a bounded number of consultations, assuming
+   cooperation. Two narrower changes were identified and deferred to their own
+   issues rather than built here, since each changes behavior and this change
+   is already large: making `extract` group-aware alongside a whole-universe
+   coverage check in the gate (#3452), and minimizing the gate payload so
+   diagnostics travel on a controller-only channel (#3453). The second carries a real tension:
+   reporting `p` always and never enforcing it is load-bearing elsewhere in
+   this ADR, and a `--diagnostics` flag the loop passes itself would be the
+   same caller-supplied-restriction defect this document catalogs five times
+   over. Under the current architecture that can only be a default.
+2. **Provenance binding between the compared artifacts and the results files**
+   (#3436). Nothing currently proves `candidate.json` was produced by the edit
+   under test rather than by a previous run.
+3. **A decision on the boolean seam** (#3437). Both code reviewers and both ADR
+   reviewers argued for `{task_id: float}`. The boolean is what makes three
+   unlike scorers commensurable, so this is a redesign, and it is the user's
+   call rather than the author's.
+4. **A governance document, per ADR-022's own matrix.** This ADR carries an
+   enforcement obligation, and ADR-022 asks for both halves in that case.
+5. **A live rule-path validation run.** See Validation Status. Blocked on
+   account usage limits until 2026-08-01.
+6. **Multi-run reduction for the rule adapter** (#3445). The agent adapter
+   already averages over runs; the rule adapter is single-shot against an LLM
+   judge, which is the noisiest of the three and the only one with no defense.
+7. **A one-time reveal path for the test group.** Requirement 1 says the group
+   is read once at the end, but no command reads it: `score` accepts `--group
+   opt` only, and `gate` always reads `sel`. Either implement the reveal with
+   its own once-ever record, or drop the third group from the design.
+8. **A noise-parameter study before any reusable-holdout work.** See
+   Alternatives Considered. `Thresholdout` is not rejected on merit; it is
+   unadopted because nobody has chosen its parameters for the held-out sizes
+   this loop actually produces.
+9. **A policy for the initial cap.** The first call names any positive integer
+   and the ledger then pins it. Nothing constrains that first number, so the
+   budget is only as tight as the caller's first invocation. A ceiling belongs
+   in whatever governs the loop, not in an argument the loop passes itself.
+10. **A ledger root the loop cannot relocate.** `$EVAL_LEDGER_DIR` moves the
+    state directory, which is how the tests stay isolated and also how anyone
+    who sets it starts over. `$XDG_STATE_HOME` moves it too, and so does
+    anything that changes what `Path.home()` returns, so the requirement is a
+    root the process cannot relocate rather than one environment variable.
+    Closing it means requirement 1's controller, or a root pinned by whatever
+    launches the loop.
+11. **A lock that expires rather than being cleared by hand.** A lock left by a
+    killed process is reported rather than broken, because guessing the holder
+    is gone makes the lock advisory. The consequence is that clearing it is a
+    manual act with no record, and the process that clears it is the same one
+    the budget constrains. An expiry alone does not close this: a paused holder
+    can wake after its lease lapsed and another process took the lock, and both
+    then write. It needs renewal plus a fencing token checked at the ledger
+    write, which is enough machinery to want its own decision.
+12. **A corpus namespace with a trusted source.** Requirement 3 accepts that two
+    unrelated corpora with identical task ids and identical held-out membership
+    share a budget, because the seam offers no corpus identity the caller did
+    not supply. A namespace derived from task contents would fix it and needs a
+    seam that carries them.
+
+The default `--test-ratio` is 0.0, so the ordinary invocation produces optimize
+and selection groups only. Requirement 1's "test group, when present" describes
+an option that the default does not exercise. A reader should not assume a
+final untouched group exists unless the split was drawn with one.
+
+## Alternatives Considered
+
+**A reusable holdout with noise-based protection.** Dwork et al., "The reusable
+holdout: Preserving validity in adaptive data analysis," Science 348(6248),
+2015, show that a held-out set can answer many more adaptive queries than a
+naive budget allows if the answers are perturbed and thresholded, spending a
+differential-privacy budget instead of a query count. That is the principled
+version of requirement 3, and it directly addresses this ADR's weakest point:
+the leak across a loop that the consultation cap bounds but does not remove.
+
+Not adopted, and an earlier draft gave two reasons that review showed were
+claims about the paper rather than about this repository. Both are withdrawn:
+the companion (arXiv:1506.02629) states finite-sample bounds, and its
+`SparseValidate` returns a single bit for threshold checks, which is the shape
+this gate needs. The two are distinct constructions and an earlier draft
+conflated them. `Thresholdout` is the noise-and-threshold mechanism that spends
+a differential-privacy budget; `SparseValidate` is the Boolean,
+description-length-bounded one. The parameter work below is `Thresholdout`'s.
+
+The reason that survives is about our own state. Adopting `Thresholdout` means
+choosing noise scale, threshold, and query budget against a specific held-out
+size, then showing the chosen parameters leave usable signal. The task sets this
+loop has actually been pointed at run from 12 tasks in the CLI fixtures to 532
+hook nodes, and held-out size is that count times the selection ratio, so the
+groups vary by more than an order of magnitude and move whenever the ratio does.
+Nobody has done that parameter work here. Shipping a noise-based holdout without it would replace a
+budget whose failure mode is visible, refusing to compare, with one whose
+failure mode is a wrong answer that still looks like an answer. The
+consultation cap is the conservative placeholder; the parameter study is listed
+as an open requirement, and this is the first place to revisit if the eval sets
+grow.
+
+**Cross-validation instead of a fixed split.** Rotating the held-out group
+across folds uses every task for both purposes and would recover the lost
+power. Rejected for this application: each fold costs a full scoring run, and
+scoring runs cost API budget in three of the four cases. It also weakens
+tamper-evidence, because a rotating split is harder to fingerprint in a way a
+reader can check. Worth revisiting if scoring ever becomes cheap.
+
+**A rubric threshold, per ADR-010.** Terminate when the artifact scores above a
+bar rather than when a held-out comparison says stop. Rejected because it
+answers a different question. A threshold says the artifact is good enough; it
+does not say this edit is what made it so, and the loop is making the second
+claim.
+
+**Guidance without mechanism.** Documented in the context above. Rejected
+because the party being disciplined can write to the task set.
+
+**Statistical significance as the accept rule.** Rejected on arithmetic. The
+group sizes here cannot produce conventional p-values, so the rule would either
+never accept or would push the loop to inflate the eval set for reasons that
+have nothing to do with coverage.
+
+## Implementation
+
+The mechanism ships in PR #3430:
+
+- `scripts/eval/_optimizer_core.py`: split, fingerprint, budget, decision,
+  refusal guards, McNemar. Pure, no I/O.
+- `scripts/eval/_optimizer_adapters.py`: one function per artifact class,
+  converging each scorer's report shape onto the task-id-to-bool seam.
+- `scripts/eval/optimize-artifact.py`: the CLI an optimizing agent drives.
+
+Documented in `scripts/eval/README.md`.
+
+Open follow-ups: #3436 (bind extraction provenance into the compared
+artifacts), #3437 (widen the seam past booleans), #3438 (exact ratio
+arithmetic), #3439 (rejection buffer lifetime).
+
+## Validation Status
+
+Honest statement of what has and has not been exercised against real data.
+
+- **Agent path**: validated against a real report,
+  `evals/analyst-spike/reports/20260528T050708Z-91be1106/report.json`, 24
+  fixtures. Baseline 15/24 against agent 13/24; the decision correctly refused
+  a real regression.
+- **Hook path**: validated against real `pytest tests/hooks` JUnit output, 532
+  node ids extracted.
+- **Rule path**: validated against real error-path output only. The live judge
+  call returned HTTP 400, account usage limit reached until 2026-08-01. That run
+  still earned its cost: it exposed two integration defects that fixtures had
+  hidden, a real envelope shape the extractor rejected and a scenario-id
+  collision that would have silently dropped 20 of 24 tasks.
+
+The rule path should be re-run against live judge output before this ADR moves
+from proposed to accepted.
+
+## References
+
+- ADR-010: Quality Gates with Evaluator-Optimizer Pattern. Bounds iteration
+  count; does not bound what the loop may observe.
+- ADR-057: Prompt Behavioral Evaluation Methodology. Source of the degradation
+  clause this ADR makes operative.
+- ADR-058: Agent Eval Discipline. Between-subjects; complementary rather than
+  overlapping. Status `proposed`, cited as existing practice not as authority.
+- ADR-022: Architecture vs Governance Decision Split Criteria. Basis for filing
+  this as an ADR. Status `proposed`, and its matrix also asks for a governance
+  document here; see Open Requirements.
+- Dwork, Feldman, Hardt, Pitassi, Reingold, and Roth, "The reusable holdout:
+  Preserving validity in adaptive data analysis," Science 348(6248):636-638,
+  2015, and the technical companion "Generalization in Adaptive Data Analysis
+  and Holdout Reuse," arXiv:1506.02629. The principled treatment of repeated
+  queries against one held-out set, and the standard requirement 3 approximates
+  with a plain counter.
+- Issue #3422: the investigation that produced the mechanism.
+- PR #3430: the implementation.
+- Yang et al., "SkillOpt," arXiv:2605.23904. Prior art for held-out-gated skill
+  optimization. This ADR departs from it in two places, both because the loop
+  runs unattended rather than in a benchmark harness: the split is
+  fingerprinted because the task set is writable, and repeated decisions are
+  budgeted because a sequential decision against one group selects on it.

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-07-27T08:22:20.888124+00:00",
+  "updated": "2026-07-27T08:38:18.609291+00:00",
   "nodes": [
     {
       "id": "b1cc1534da48",
@@ -21130,6 +21130,24 @@
         "episode-2026-07-26-session-3422-eval-holdout-gate"
       ],
       "created": "2026-07-27T08:22:20.882220+00:00"
+    },
+    {
+      "id": "bc54b6618ea1",
+      "type": "milestone",
+      "label": "milestone: Ran a tenth adversarial round (gpt-5.6-terra) with explicit permission to return ACCEPT, then fixed the finding it returned",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T08:38:18.603393+00:00"
+    },
+    {
+      "id": "098d2909e45d",
+      "type": "commit",
+      "label": "commit: Commit: 1ed89118d",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T08:38:18.603479+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-07-27T06:00:12.157256+00:00",
+  "updated": "2026-07-27T07:40:47.337311+00:00",
   "nodes": [
     {
       "id": "b1cc1534da48",
@@ -20851,6 +20851,258 @@
         "episode-2026-07-26-session-3402-plugin-self-containment"
       ],
       "created": "2026-07-27T05:58:30.440248+00:00"
+    },
+    {
+      "id": "0100c10367bc",
+      "type": "milestone",
+      "label": "milestone: Read the external skillopt skill bundle and the whole scripts/eval catalog. Confirmed the harness measures but never gates an artifact edit, and that no fixture set carries a train/held-out split despite the Fixture docstring calling fixtures held-out.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.034583+00:00"
+    },
+    {
+      "id": "055d45989520",
+      "type": "milestone",
+      "label": "milestone: Placed the change against prior art. ADR-010 is a runtime output-quality loop, ADR-057 is before/after regression on one artifact, ADR-058 is agent versus baseline. None gates an artifact edit on data withheld from the author. SkillOpt-gated commits b4070e7ad and 869a03ed9 prove the discipline works here but used an out-of-repo harness on skills only.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.034674+00:00"
+    },
+    {
+      "id": "aa80ed7291b6",
+      "type": "milestone",
+      "label": "milestone: Three TDD cycles produced the decision core (split, fingerprint, budget, gate, refusal guards, exact McNemar; pure, no I/O), the adapters converging agent reports, rule scenario scores, and pytest JUnit onto one task-id-to-bool seam, and the CLI an optimizing agent drives. The boolean seam is what generalizes the discipline past skills: a fixture id, a scenario id, and a pytest node id are the same kind of thing to the decider.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.034754+00:00"
+    },
+    {
+      "id": "c78c3a06eb37",
+      "type": "milestone",
+      "label": "milestone: First adversarial round (gpt-5.6-sol, gemini-3.1-pro-preview, both non-Claude per the user instruction). Found a CRITICAL double inversion the README had advertised as a feature: rule_results flipped negative cases and the caller flipped them again, so a lower activation score read as an improvement. Fixed with the failing case pinned.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.034831+00:00"
+    },
+    {
+      "id": "2bb86b4adb88",
+      "type": "milestone",
+      "label": "milestone: Second adversarial round returned REJECT on the ADR draft and found the held-out discipline was, in the reviewer phrase, an honor system wrapped in a hash. Three exposure holes, all real: split printed held-out membership to the stream the optimizing agent reads; score accepted --group sel and test unmetered, which is exactly the read the consultation budget exists to charge for; and --allow-regressions let any caller accept a broken held-out task. All three closed.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.034909+00:00"
+    },
+    {
+      "id": "e746a699b010",
+      "type": "milestone",
+      "label": "milestone: Replaced the consultation counter with a ledger the gate writes. --consultations defaulted to 0 and arrived on every invocation, so a loop that passed zero each time had an unlimited budget while looking capped; the reviewer reproduced ACCEPT twice under a cap of one. The ledger is bound to the split fingerprint so redrawing cannot reset it. Two defects found while testing it: guard_refusal turned a cap below one into a permanently exhausted budget indistinguishable from real discipline, and an except ValueError arm was unreachable once its inputs were validated upstream.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.034987+00:00"
+    },
+    {
+      "id": "23f8114da372",
+      "type": "milestone",
+      "label": "milestone: The second review falsified six claims in my own ADR draft, three of which were about this repository governance. The worst: I described ADR-057 as enforcing only an aggregate mean and used that to justify an override flag. ADR-057 in fact blocks every pass-to-fail flip and states it has no mechanism to accept a justified regression, so my flag was a weaker rule shipping under the same name. Removed the flag, corrected the ADR, and added an Open Requirements section naming what still blocks acceptance.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035065+00:00"
+    },
+    {
+      "id": "bcff8764fade",
+      "type": "milestone",
+      "label": "milestone: 356 tests and 100% line coverage on all three modules. Full repository suite 14863 passed, 28 skipped, 45 xfailed. Live end-to-end runs confirmed split redaction, tamper refusal, budget exhaustion across separate invocations, and a ledger refusing a split redrawn mid-run. Agent path validated against a real 24-fixture report (baseline 15, agent 13; the gate correctly refused a real regression) and the hook path against real pytest JUnit output (532 node ids). Rule path exercised on real error-path output only: the live judge call returned HTTP 400 on an account usage limit until 2026-08-01.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035135+00:00"
+    },
+    {
+      "id": "bb6d41e48ab8",
+      "type": "test",
+      "label": "test: 356 tests and 100% line coverage on all three modules. Full repository suite 14863 passed, 28 skipped, 45 xfailed. Live end-to-end runs confirmed split redaction, tamper refusal, budget exhaustion across separate invocations, and a ledger refusing a split redrawn mid-run. Agent path validated against a real 24-fixture report (baseline 15, agent 13; the gate correctly refused a real regression) and the hook path against real pytest JUnit output (532 node ids). Rule path exercised on real error-path output only: the live judge call returned HTTP 400 on an account usage limit until 2026-08-01.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035208+00:00"
+    },
+    {
+      "id": "08e14c6d0a0b",
+      "type": "milestone",
+      "label": "milestone: Third review round found the ledger had fixed the count and left everything around it on the command line. Three ways back out, each the same defect wearing a different hat: the cap defaulted to unlimited so the ordinary invocation had no budget, a caller that hit the cap could raise it, and pointing --ledger at a fresh path restored the whole budget because a missing ledger starts at zero. Fixed by pinning the cap in the ledger, deriving the ledger path from the split, and requiring the incumbent fingerprint that had been optional. The general rule extracted: any part of a budget the caller restates each time is not part of the budget.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035278+00:00"
+    },
+    {
+      "id": "4be1ded20001",
+      "type": "milestone",
+      "label": "milestone: Fourth review round reproduced a rounding alias in the ledger key. The fingerprint hashes the selection's inputs (seed, task ids, ratios) rather than its result, and group sizes round, so ten tasks at --sel-ratio 0.40 and at 0.41 hold out the same four tasks under two different fingerprints, giving one held-out group two budgets. Rekeyed the ledger, its lock, and the ledger's own identity field onto a digest of the sorted held-out membership. Declined the reviewer's corpus namespace, because a caller-supplied key is the defect class being closed.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035351+00:00"
+    },
+    {
+      "id": "34dc534dc1ec",
+      "type": "milestone",
+      "label": "milestone: Same round found the last free read of the held-out group. score() and mcnemar_exact() name the ids they cannot find, which is correct everywhere except the gate, where those ids are the withheld ones, and an empty candidate results file printed the whole membership before the ledger advanced. Added a one-bit coverage predicate and moved the consultation reserve ahead of scoring, which also closed the crash window that let a killed process retry a comparison for free. A count was rejected as a membership oracle, since split publishes the held-out size.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035426+00:00"
+    },
+    {
+      "id": "4168cb5f4e40",
+      "type": "milestone",
+      "label": "milestone: Fifth review round found the fix had relocated the disclosure again, the fourth consecutive round in which that happened. The new ledger key is an unsalted digest of the held-out ids, and three error paths printed it: lock contention carried the lock path, two ledger errors carried the ledger path and both digests, and none was charged a consultation. Redacted all three to the ledger directory alone. Also fixed an injectivity defect: joining ids on NUL is not injective when an id may contain one.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035497+00:00"
+    },
+    {
+      "id": "ad57590db863",
+      "type": "milestone",
+      "label": "milestone: Verifying that review finding produced the session's most important result. The reviewer argued the digest was reversible from the published group sizes. It is, but reversal is unnecessary: split publishes opt in full, the task universe is the caller's own results file, and --test-ratio defaults to 0.0, so sel = universe - opt by subtraction. Verified live on a twelve-task run. Held-out membership is public by construction and closing that would break the loop, since an optimizer that cannot name the group it must not touch cannot avoid touching it. The property that has to hold is that held-out outcomes do not cross back, not that held-out identity is secret. Both the ADR and the README now say so; several sentences had read as though the task list were hidden.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035568+00:00"
+    },
+    {
+      "id": "b63f72de694b",
+      "type": "milestone",
+      "label": "milestone: Closed the sixth review's code finding. Three hand-written ledger errors had been redacted in round five, but every generic I/O failure under the ledger root still printed a filename ending in the digest of the held-out membership. Added a _digest_scrubbed contextmanager at the seam rather than sanitizing three more call sites, so paths added later inherit it, and nested the lock-contention branch inside so its operator-facing message survives. Also corrected two source comments the review found stale. 410 tests, 100% coverage, ruff and mypy clean. Commit 81ad4283b.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035638+00:00"
+    },
+    {
+      "id": "94c0cffaa735",
+      "type": "milestone",
+      "label": "milestone: Rewrote the README seam section around the reviewer's characterization: a consultation-budgeted comparison over a public benchmark relying on a cooperating optimizer, not held-out validation of unseen tasks. Recorded that cmd_extract emits every task's outcome with no group argument, that task ids resolve to readable fixtures carrying their own grading criteria, and that the gate returns six fields rather than one bit. Separated what the mechanism enforces regardless of cooperation from what it merely encourages. Commit 7a08a60b5.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035715+00:00"
+    },
+    {
+      "id": "c5baae508e85",
+      "type": "milestone",
+      "label": "milestone: Rewrote ADR-087 for the eight claims the sixth review falsified. Weakened the Decision statement from validation on withheld tasks to validation under a counted consultation budget, recording the falsification rather than hiding it. Replaced the identity-public-outcomes-withheld argument with four paragraphs explaining why both halves are false, why the loop needs no knowledge of sel at all, and why Dwork's reusable holdout assumes an access path this does not have. Added round six to the defeat table and restated Open Requirement 1 as a prerequisite for the central claim.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035785+00:00"
+    },
+    {
+      "id": "6b518c052ec7",
+      "type": "milestone",
+      "label": "milestone: Opened #3452 (make extract group-aware, replace the one-bit coverage predicate with a whole-universe check) and #3453 (budget what each consultation discloses, not just how many there are). Both deferred rather than built: each changes behavior and needs its own review round, and this PR is already about 5,400 lines. #3453 records the tension that a --diagnostics flag the loop passes itself would be the same caller-supplied-restriction defect the ADR catalogs six times.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035856+00:00"
+    },
+    {
+      "id": "47b9e0eb3e56",
+      "type": "milestone",
+      "label": "milestone: Seventh adversarial review returned REJECT with two blocking findings, both verified at source. The digest scrub covered the lock's acquire and left its release outside: the unlink in the finally block names the lock, the lock's name is the digest, and main() catches ConfigError but not OSError, so a cleanup failure printed the held-out group as an uncaught traceback one line below where the leak was closed. Widened the scrub over the whole lifecycle, safe because LedgerMismatchError is a sibling of ConfigError rather than a subclass. Regression test asserts on raw stdout since release runs after the decision is emitted. Commit 97817c0ba.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035927+00:00"
+    },
+    {
+      "id": "34e3d158a038",
+      "type": "milestone",
+      "label": "milestone: Rebased onto cd56ce09f, an incoming commit addressing seven PR review threads. It dropped all three optimizer modules from 100% to 99% coverage by shipping four defensive branches with no test. Added positive, negative, and edge cases for each: guard_refusal on a negative spend, agent_results on a non-list run value (with the string trap, since str is a Sequence), _read_split on four wrong group shapes plus a well-formed control, and _write_atomic on a non-OSError so an interrupt keeps its type. 925 tests, 100% coverage restored. Commit 148bfd8a8.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.035997+00:00"
+    },
+    {
+      "id": "292d3d516eb0",
+      "type": "milestone",
+      "label": "milestone: Corrected six more README claims the seventh review falsified, each verified at source first. The budget bounds gate comparisons, not selection pressure, since extract and score reach results without touching the ledger. The path root and the first cap value are not membership-derived. The fingerprint covers the split's inputs rather than its drawn result, and catching a moved task takes the redraw comparison as well. A consultation is reserved before the group is read and before coverage is checked. No command scores the test group at all. Commit f690ce24b.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.036068+00:00"
+    },
+    {
+      "id": "3a2917df2ff4",
+      "type": "milestone",
+      "label": "milestone: Applied the same corrections to ADR-087 and to the two deferred issues. Requirement 1's heading no longer claims the decision group is withheld. The Decision statement now says the loop cannot move the mechanism through its own arguments, which is what holds. Commented on #3452 that its two changes do not compose without a controller owning the complete mapping, and on #3453 that there is no fixed multiplier to document, so the statable property is the output alphabet.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.036138+00:00"
+    },
+    {
+      "id": "3611db1ed86a",
+      "type": "milestone",
+      "label": "milestone: Ran the adr-review skill against ADR-087 across seven rounds, every reviewer a non-Claude model (gpt-5.6-sol, gemini-3.1-pro-preview) per the objective's adversarial-review requirement. Every round falsified at least one load-bearing claim, so the ADR carries a defeat table instead of a clean argument. Round 6 was the most expensive: it showed that withholding the decision group's membership bounds nothing, because cmd_extract emits every task's outcome with no group argument and because task ids resolve to definitions carrying their own grading criteria. Round 7 returned REJECT on two blocking findings, both verified at source before fixing: the digest scrub left lock release uncovered, and both documents claimed the budget bounds selection pressure when it bounds gate comparisons only. Each finding was verified independently rather than accepted on the reviewer's authority; all held. Deferred design changes opened as #3452 and #3453 rather than rushed into this PR.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.036213+00:00"
+    },
+    {
+      "id": "fb420a28a044",
+      "type": "commit",
+      "label": "commit: Commit: f690ce24b",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.036283+00:00"
+    },
+    {
+      "id": "d42b5623b1d9",
+      "type": "commit",
+      "label": "commit: Commit: b7966f9d2",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.036355+00:00"
+    },
+    {
+      "id": "3f775bd925ff",
+      "type": "outcome",
+      "label": "Outcome: success - Give the eval harness a held-out-gated optimization loop for agents, rules, and hooks (issue #3422)",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:33:06.036426+00:00"
+    },
+    {
+      "id": "57ec39346492",
+      "type": "milestone",
+      "label": "milestone: PR #3430 was squash-merged as 98caa0e54 and its branch deleted while six commits were still unpushed, so the merged code carries the per-call-site digest scrub but not the seam-level one, not the lock-release fix, not the coverage for the four branches the review-thread commit added, and none of the corrected documents. Rebased all six onto main as fix/eval-holdout-gate-digest-leak and confirmed they apply cleanly: 426 tests pass with 100% coverage on all three optimizer modules, ruff and mypy clean. The follow-up PR carries the round-seven blocking fix, which is a real leak of the withheld group on a cleanup failure, so it should not wait.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:40:47.331112+00:00"
+    },
+    {
+      "id": "7ea70fe47ff9",
+      "type": "commit",
+      "label": "commit: Commit: 98caa0e54",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:40:47.331196+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-07-27T08:38:18.609291+00:00",
+  "updated": "2026-07-27T08:55:41.817982+00:00",
   "nodes": [
     {
       "id": "b1cc1534da48",
@@ -21148,6 +21148,24 @@
         "episode-2026-07-26-session-3422-eval-holdout-gate"
       ],
       "created": "2026-07-27T08:38:18.603479+00:00"
+    },
+    {
+      "id": "0f08983b6bc5",
+      "type": "milestone",
+      "label": "milestone: Ran an eleventh adversarial round (gpt-5.6-luna), fixed three of its four findings and declined the fourth with the reason recorded",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T08:55:41.812054+00:00"
+    },
+    {
+      "id": "6470dce49f3f",
+      "type": "commit",
+      "label": "commit: Commit: c66939a96",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T08:55:41.812138+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-07-27T07:57:27.934500+00:00",
+  "updated": "2026-07-27T08:22:20.888124+00:00",
   "nodes": [
     {
       "id": "b1cc1534da48",
@@ -21112,6 +21112,24 @@
         "episode-2026-07-26-session-3422-eval-holdout-gate"
       ],
       "created": "2026-07-27T07:57:27.929056+00:00"
+    },
+    {
+      "id": "904f9b86dcb6",
+      "type": "milestone",
+      "label": "milestone: Fixed the two round-nine findings: the digest reachable through __cause__, and cleanup failure rewriting an already-emitted decision",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T08:22:20.882135+00:00"
+    },
+    {
+      "id": "d08f46121cef",
+      "type": "commit",
+      "label": "commit: Commit: 4e2284053",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T08:22:20.882220+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-07-27T08:55:41.817982+00:00",
+  "updated": "2026-07-27T09:04:44.449936+00:00",
   "nodes": [
     {
       "id": "b1cc1534da48",
@@ -21166,6 +21166,24 @@
         "episode-2026-07-26-session-3422-eval-holdout-gate"
       ],
       "created": "2026-07-27T08:55:41.812138+00:00"
+    },
+    {
+      "id": "892d53c9c0dc",
+      "type": "milestone",
+      "label": "milestone: Ran a twelfth adversarial round (gpt-5.6-sol) and fixed the single finding, which was the round-eleven fix applied to half the pair",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T09:04:44.443858+00:00"
+    },
+    {
+      "id": "015ce33e50b9",
+      "type": "commit",
+      "label": "commit: Commit: ff16b4dc8",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T09:04:44.443947+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/causality/causal-graph.json
+++ b/.agents/memory/causality/causal-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "updated": "2026-07-27T07:40:47.337311+00:00",
+  "updated": "2026-07-27T07:57:27.934500+00:00",
   "nodes": [
     {
       "id": "b1cc1534da48",
@@ -21103,6 +21103,15 @@
         "episode-2026-07-26-session-3422-eval-holdout-gate"
       ],
       "created": "2026-07-27T07:40:47.331196+00:00"
+    },
+    {
+      "id": "4ca5cd1194cf",
+      "type": "milestone",
+      "label": "milestone: An eighth review, this one Copilot's on PR #3458, found a defect inside the round-seven fix. The scrub re-raised OSError untouched when the message lacked the digest, and main catches ConfigError, AdapterError, and ValueError but not OSError, so pathless ledger failures escaped as tracebacks instead of JSON. os.write on a full disk and os.close hitting EIO both qualify and both sit inside the lock. Reproduced with a failing end-to-end test before fixing. Checked two adjacent claims the reviewer did not raise: LedgerMismatchError derives from Exception rather than ConfigError so the scrub never touches it, and its two messages name path.parent rather than the digest-bearing filename. Both held, so neither was changed. 432 tests, 100% coverage on all three modules.",
+      "episodes": [
+        "episode-2026-07-26-session-3422-eval-holdout-gate"
+      ],
+      "created": "2026-07-27T07:57:27.929056+00:00"
     }
   ],
   "patterns": [

--- a/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
@@ -108,7 +108,7 @@
       "type": "test",
       "content": "356 tests and 100% line coverage on all three modules. Full repository suite 14863 passed, 28 skipped, 45 xfailed. Live end-to-end runs confirmed split redaction, tamper refusal, budget exhaustion across separate invocations, and a ledger refusing a split redrawn mid-run. Agent path validated against a real 24-fixture report (baseline 15, agent 13; the gate correctly refused a real regression) and the hook path against real pytest JUnit output (532 node ids). Rule path exercised on real error-path output only: the live judge call returned HTTP 400 on an account usage limit until 2026-08-01.",
       "caused_by": [
-        "e034"
+        "e036"
       ],
       "leads_to": [
         "e001"
@@ -396,7 +396,9 @@
       "caused_by": [
         "e031"
       ],
-      "leads_to": []
+      "leads_to": [
+        "e035"
+      ]
     },
     {
       "id": "e034",
@@ -405,6 +407,28 @@
       "content": "Commit: c66939a96",
       "caused_by": [
         "e032"
+      ],
+      "leads_to": [
+        "e036"
+      ]
+    },
+    {
+      "id": "e035",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran a twelfth adversarial round (gpt-5.6-sol) and fixed the single finding, which was the round-eleven fix applied to half the pair",
+      "caused_by": [
+        "e033"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e036",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: ff16b4dc8",
+      "caused_by": [
+        "e034"
       ],
       "leads_to": [
         "e009"
@@ -416,7 +440,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 6,
+    "commits": 7,
     "files_changed": 5
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
@@ -108,7 +108,7 @@
       "type": "test",
       "content": "356 tests and 100% line coverage on all three modules. Full repository suite 14863 passed, 28 skipped, 45 xfailed. Live end-to-end runs confirmed split redaction, tamper refusal, budget exhaustion across separate invocations, and a ledger refusing a split redrawn mid-run. Agent path validated against a real 24-fixture report (baseline 15, agent 13; the gate correctly refused a real regression) and the hook path against real pytest JUnit output (532 node ids). Rule path exercised on real error-path output only: the live judge call returned HTTP 400 on an account usage limit until 2026-08-01.",
       "caused_by": [
-        "e030"
+        "e032"
       ],
       "leads_to": [
         "e001"
@@ -348,7 +348,9 @@
       "caused_by": [
         "e028"
       ],
-      "leads_to": []
+      "leads_to": [
+        "e031"
+      ]
     },
     {
       "id": "e030",
@@ -357,6 +359,28 @@
       "content": "Commit: 4e2284053",
       "caused_by": [
         "e027"
+      ],
+      "leads_to": [
+        "e032"
+      ]
+    },
+    {
+      "id": "e031",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran a tenth adversarial round (gpt-5.6-terra) with explicit permission to return ACCEPT, then fixed the finding it returned",
+      "caused_by": [
+        "e029"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e032",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 1ed89118d",
+      "caused_by": [
+        "e030"
       ],
       "leads_to": [
         "e009"
@@ -368,7 +392,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 4,
+    "commits": 5,
     "files_changed": 5
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
@@ -312,7 +312,9 @@
       "caused_by": [
         "e023"
       ],
-      "leads_to": []
+      "leads_to": [
+        "e028"
+      ]
     },
     {
       "id": "e027",
@@ -325,6 +327,16 @@
       "leads_to": [
         "e009"
       ]
+    },
+    {
+      "id": "e028",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "An eighth review, this one Copilot's on PR #3458, found a defect inside the round-seven fix. The scrub re-raised OSError untouched when the message lacked the digest, and main catches ConfigError, AdapterError, and ValueError but not OSError, so pathless ledger failures escaped as tracebacks instead of JSON. os.write on a full disk and os.close hitting EIO both qualify and both sit inside the lock. Reproduced with a failing end-to-end test before fixing. Checked two adjacent claims the reviewer did not raise: LedgerMismatchError derives from Exception rather than ConfigError so the scrub never touches it, and its two messages name path.parent rather than the digest-bearing filename. Both held, so neither was changed. 432 tests, 100% coverage on all three modules.",
+      "caused_by": [
+        "e026"
+      ],
+      "leads_to": []
     }
   ],
   "metrics": {

--- a/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
@@ -108,7 +108,7 @@
       "type": "test",
       "content": "356 tests and 100% line coverage on all three modules. Full repository suite 14863 passed, 28 skipped, 45 xfailed. Live end-to-end runs confirmed split redaction, tamper refusal, budget exhaustion across separate invocations, and a ledger refusing a split redrawn mid-run. Agent path validated against a real 24-fixture report (baseline 15, agent 13; the gate correctly refused a real regression) and the hook path against real pytest JUnit output (532 node ids). Rule path exercised on real error-path output only: the live judge call returned HTTP 400 on an account usage limit until 2026-08-01.",
       "caused_by": [
-        "e027"
+        "e030"
       ],
       "leads_to": [
         "e001"
@@ -325,7 +325,7 @@
         "e025"
       ],
       "leads_to": [
-        "e009"
+        "e030"
       ]
     },
     {
@@ -336,7 +336,31 @@
       "caused_by": [
         "e026"
       ],
+      "leads_to": [
+        "e029"
+      ]
+    },
+    {
+      "id": "e029",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fixed the two round-nine findings: the digest reachable through __cause__, and cleanup failure rewriting an already-emitted decision",
+      "caused_by": [
+        "e028"
+      ],
       "leads_to": []
+    },
+    {
+      "id": "e030",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 4e2284053",
+      "caused_by": [
+        "e027"
+      ],
+      "leads_to": [
+        "e009"
+      ]
     }
   ],
   "metrics": {
@@ -344,7 +368,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 3,
+    "commits": 4,
     "files_changed": 5
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
@@ -108,7 +108,7 @@
       "type": "test",
       "content": "356 tests and 100% line coverage on all three modules. Full repository suite 14863 passed, 28 skipped, 45 xfailed. Live end-to-end runs confirmed split redaction, tamper refusal, budget exhaustion across separate invocations, and a ledger refusing a split redrawn mid-run. Agent path validated against a real 24-fixture report (baseline 15, agent 13; the gate correctly refused a real regression) and the hook path against real pytest JUnit output (532 node ids). Rule path exercised on real error-path output only: the live judge call returned HTTP 400 on an account usage limit until 2026-08-01.",
       "caused_by": [
-        "e032"
+        "e034"
       ],
       "leads_to": [
         "e001"
@@ -372,7 +372,9 @@
       "caused_by": [
         "e029"
       ],
-      "leads_to": []
+      "leads_to": [
+        "e033"
+      ]
     },
     {
       "id": "e032",
@@ -381,6 +383,28 @@
       "content": "Commit: 1ed89118d",
       "caused_by": [
         "e030"
+      ],
+      "leads_to": [
+        "e034"
+      ]
+    },
+    {
+      "id": "e033",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran an eleventh adversarial round (gpt-5.6-luna), fixed three of its four findings and declined the fourth with the reason recorded",
+      "caused_by": [
+        "e031"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e034",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: c66939a96",
+      "caused_by": [
+        "e032"
       ],
       "leads_to": [
         "e009"
@@ -392,7 +416,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 5,
+    "commits": 6,
     "files_changed": 5
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
@@ -1,0 +1,339 @@
+{
+  "id": "episode-2026-07-26-session-3422-eval-holdout-gate",
+  "session": "2026-07-26-session-3422-eval-holdout-gate",
+  "timestamp": "2026-07-26T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Give the eval harness a held-out-gated optimization loop for agents, rules, and hooks (issue #3422)",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read the external skillopt skill bundle and the whole scripts/eval catalog. Confirmed the harness measures but never gates an artifact edit, and that no fixture set carries a train/held-out split despite the Fixture docstring calling fixtures held-out.",
+      "caused_by": [
+        "e009"
+      ],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Placed the change against prior art. ADR-010 is a runtime output-quality loop, ADR-057 is before/after regression on one artifact, ADR-058 is agent versus baseline. None gates an artifact edit on data withheld from the author. SkillOpt-gated commits b4070e7ad and 869a03ed9 prove the discipline works here but used an out-of-repo harness on skills only.",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Three TDD cycles produced the decision core (split, fingerprint, budget, gate, refusal guards, exact McNemar; pure, no I/O), the adapters converging agent reports, rule scenario scores, and pytest JUnit onto one task-id-to-bool seam, and the CLI an optimizing agent drives. The boolean seam is what generalizes the discipline past skills: a fixture id, a scenario id, and a pytest node id are the same kind of thing to the decider.",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "First adversarial round (gpt-5.6-sol, gemini-3.1-pro-preview, both non-Claude per the user instruction). Found a CRITICAL double inversion the README had advertised as a feature: rule_results flipped negative cases and the caller flipped them again, so a lower activation score read as an improvement. Fixed with the failing case pinned.",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Second adversarial round returned REJECT on the ADR draft and found the held-out discipline was, in the reviewer phrase, an honor system wrapped in a hash. Three exposure holes, all real: split printed held-out membership to the stream the optimizing agent reads; score accepted --group sel and test unmetered, which is exactly the read the consultation budget exists to charge for; and --allow-regressions let any caller accept a broken held-out task. All three closed.",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": [
+        "e006"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Replaced the consultation counter with a ledger the gate writes. --consultations defaulted to 0 and arrived on every invocation, so a loop that passed zero each time had an unlimited budget while looking capped; the reviewer reproduced ACCEPT twice under a cap of one. The ledger is bound to the split fingerprint so redrawing cannot reset it. Two defects found while testing it: guard_refusal turned a cap below one into a permanently exhausted budget indistinguishable from real discipline, and an except ValueError arm was unreachable once its inputs were validated upstream.",
+      "caused_by": [
+        "e005"
+      ],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "The second review falsified six claims in my own ADR draft, three of which were about this repository governance. The worst: I described ADR-057 as enforcing only an aggregate mean and used that to justify an override flag. ADR-057 in fact blocks every pass-to-fail flip and states it has no mechanism to accept a justified regression, so my flag was a weaker rule shipping under the same name. Removed the flag, corrected the ADR, and added an Open Requirements section naming what still blocks acceptance.",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "356 tests and 100% line coverage on all three modules. Full repository suite 14863 passed, 28 skipped, 45 xfailed. Live end-to-end runs confirmed split redaction, tamper refusal, budget exhaustion across separate invocations, and a ledger refusing a split redrawn mid-run. Agent path validated against a real 24-fixture report (baseline 15, agent 13; the gate correctly refused a real regression) and the hook path against real pytest JUnit output (532 node ids). Rule path exercised on real error-path output only: the live judge call returned HTTP 400 on an account usage limit until 2026-08-01.",
+      "caused_by": [
+        "e007"
+      ],
+      "leads_to": [
+        "e010"
+      ]
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "test",
+      "content": "356 tests and 100% line coverage on all three modules. Full repository suite 14863 passed, 28 skipped, 45 xfailed. Live end-to-end runs confirmed split redaction, tamper refusal, budget exhaustion across separate invocations, and a ledger refusing a split redrawn mid-run. Agent path validated against a real 24-fixture report (baseline 15, agent 13; the gate correctly refused a real regression) and the hook path against real pytest JUnit output (532 node ids). Rule path exercised on real error-path output only: the live judge call returned HTTP 400 on an account usage limit until 2026-08-01.",
+      "caused_by": [
+        "e027"
+      ],
+      "leads_to": [
+        "e001"
+      ]
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Third review round found the ledger had fixed the count and left everything around it on the command line. Three ways back out, each the same defect wearing a different hat: the cap defaulted to unlimited so the ordinary invocation had no budget, a caller that hit the cap could raise it, and pointing --ledger at a fresh path restored the whole budget because a missing ledger starts at zero. Fixed by pinning the cap in the ledger, deriving the ledger path from the split, and requiring the incumbent fingerprint that had been optional. The general rule extracted: any part of a budget the caller restates each time is not part of the budget.",
+      "caused_by": [
+        "e008"
+      ],
+      "leads_to": [
+        "e011"
+      ]
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fourth review round reproduced a rounding alias in the ledger key. The fingerprint hashes the selection's inputs (seed, task ids, ratios) rather than its result, and group sizes round, so ten tasks at --sel-ratio 0.40 and at 0.41 hold out the same four tasks under two different fingerprints, giving one held-out group two budgets. Rekeyed the ledger, its lock, and the ledger's own identity field onto a digest of the sorted held-out membership. Declined the reviewer's corpus namespace, because a caller-supplied key is the defect class being closed.",
+      "caused_by": [
+        "e010"
+      ],
+      "leads_to": [
+        "e012"
+      ]
+    },
+    {
+      "id": "e012",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Same round found the last free read of the held-out group. score() and mcnemar_exact() name the ids they cannot find, which is correct everywhere except the gate, where those ids are the withheld ones, and an empty candidate results file printed the whole membership before the ledger advanced. Added a one-bit coverage predicate and moved the consultation reserve ahead of scoring, which also closed the crash window that let a killed process retry a comparison for free. A count was rejected as a membership oracle, since split publishes the held-out size.",
+      "caused_by": [
+        "e011"
+      ],
+      "leads_to": [
+        "e013"
+      ]
+    },
+    {
+      "id": "e013",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fifth review round found the fix had relocated the disclosure again, the fourth consecutive round in which that happened. The new ledger key is an unsalted digest of the held-out ids, and three error paths printed it: lock contention carried the lock path, two ledger errors carried the ledger path and both digests, and none was charged a consultation. Redacted all three to the ledger directory alone. Also fixed an injectivity defect: joining ids on NUL is not injective when an id may contain one.",
+      "caused_by": [
+        "e012"
+      ],
+      "leads_to": [
+        "e014"
+      ]
+    },
+    {
+      "id": "e014",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verifying that review finding produced the session's most important result. The reviewer argued the digest was reversible from the published group sizes. It is, but reversal is unnecessary: split publishes opt in full, the task universe is the caller's own results file, and --test-ratio defaults to 0.0, so sel = universe - opt by subtraction. Verified live on a twelve-task run. Held-out membership is public by construction and closing that would break the loop, since an optimizer that cannot name the group it must not touch cannot avoid touching it. The property that has to hold is that held-out outcomes do not cross back, not that held-out identity is secret. Both the ADR and the README now say so; several sentences had read as though the task list were hidden.",
+      "caused_by": [
+        "e013"
+      ],
+      "leads_to": [
+        "e015"
+      ]
+    },
+    {
+      "id": "e015",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Closed the sixth review's code finding. Three hand-written ledger errors had been redacted in round five, but every generic I/O failure under the ledger root still printed a filename ending in the digest of the held-out membership. Added a _digest_scrubbed contextmanager at the seam rather than sanitizing three more call sites, so paths added later inherit it, and nested the lock-contention branch inside so its operator-facing message survives. Also corrected two source comments the review found stale. 410 tests, 100% coverage, ruff and mypy clean. Commit 81ad4283b.",
+      "caused_by": [
+        "e014"
+      ],
+      "leads_to": [
+        "e016"
+      ]
+    },
+    {
+      "id": "e016",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rewrote the README seam section around the reviewer's characterization: a consultation-budgeted comparison over a public benchmark relying on a cooperating optimizer, not held-out validation of unseen tasks. Recorded that cmd_extract emits every task's outcome with no group argument, that task ids resolve to readable fixtures carrying their own grading criteria, and that the gate returns six fields rather than one bit. Separated what the mechanism enforces regardless of cooperation from what it merely encourages. Commit 7a08a60b5.",
+      "caused_by": [
+        "e015"
+      ],
+      "leads_to": [
+        "e017"
+      ]
+    },
+    {
+      "id": "e017",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rewrote ADR-087 for the eight claims the sixth review falsified. Weakened the Decision statement from validation on withheld tasks to validation under a counted consultation budget, recording the falsification rather than hiding it. Replaced the identity-public-outcomes-withheld argument with four paragraphs explaining why both halves are false, why the loop needs no knowledge of sel at all, and why Dwork's reusable holdout assumes an access path this does not have. Added round six to the defeat table and restated Open Requirement 1 as a prerequisite for the central claim.",
+      "caused_by": [
+        "e016"
+      ],
+      "leads_to": [
+        "e018"
+      ]
+    },
+    {
+      "id": "e018",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Opened #3452 (make extract group-aware, replace the one-bit coverage predicate with a whole-universe check) and #3453 (budget what each consultation discloses, not just how many there are). Both deferred rather than built: each changes behavior and needs its own review round, and this PR is already about 5,400 lines. #3453 records the tension that a --diagnostics flag the loop passes itself would be the same caller-supplied-restriction defect the ADR catalogs six times.",
+      "caused_by": [
+        "e017"
+      ],
+      "leads_to": [
+        "e019"
+      ]
+    },
+    {
+      "id": "e019",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Seventh adversarial review returned REJECT with two blocking findings, both verified at source. The digest scrub covered the lock's acquire and left its release outside: the unlink in the finally block names the lock, the lock's name is the digest, and main() catches ConfigError but not OSError, so a cleanup failure printed the held-out group as an uncaught traceback one line below where the leak was closed. Widened the scrub over the whole lifecycle, safe because LedgerMismatchError is a sibling of ConfigError rather than a subclass. Regression test asserts on raw stdout since release runs after the decision is emitted. Commit 97817c0ba.",
+      "caused_by": [
+        "e018"
+      ],
+      "leads_to": [
+        "e020"
+      ]
+    },
+    {
+      "id": "e020",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rebased onto cd56ce09f, an incoming commit addressing seven PR review threads. It dropped all three optimizer modules from 100% to 99% coverage by shipping four defensive branches with no test. Added positive, negative, and edge cases for each: guard_refusal on a negative spend, agent_results on a non-list run value (with the string trap, since str is a Sequence), _read_split on four wrong group shapes plus a well-formed control, and _write_atomic on a non-OSError so an interrupt keeps its type. 925 tests, 100% coverage restored. Commit 148bfd8a8.",
+      "caused_by": [
+        "e019"
+      ],
+      "leads_to": [
+        "e021"
+      ]
+    },
+    {
+      "id": "e021",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Corrected six more README claims the seventh review falsified, each verified at source first. The budget bounds gate comparisons, not selection pressure, since extract and score reach results without touching the ledger. The path root and the first cap value are not membership-derived. The fingerprint covers the split's inputs rather than its drawn result, and catching a moved task takes the redraw comparison as well. A consultation is reserved before the group is read and before coverage is checked. No command scores the test group at all. Commit f690ce24b.",
+      "caused_by": [
+        "e020"
+      ],
+      "leads_to": [
+        "e022"
+      ]
+    },
+    {
+      "id": "e022",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Applied the same corrections to ADR-087 and to the two deferred issues. Requirement 1's heading no longer claims the decision group is withheld. The Decision statement now says the loop cannot move the mechanism through its own arguments, which is what holds. Commented on #3452 that its two changes do not compose without a controller owning the complete mapping, and on #3453 that there is no fixed multiplier to document, so the statable property is the output alphabet.",
+      "caused_by": [
+        "e021"
+      ],
+      "leads_to": [
+        "e023"
+      ]
+    },
+    {
+      "id": "e023",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran the adr-review skill against ADR-087 across seven rounds, every reviewer a non-Claude model (gpt-5.6-sol, gemini-3.1-pro-preview) per the objective's adversarial-review requirement. Every round falsified at least one load-bearing claim, so the ADR carries a defeat table instead of a clean argument. Round 6 was the most expensive: it showed that withholding the decision group's membership bounds nothing, because cmd_extract emits every task's outcome with no group argument and because task ids resolve to definitions carrying their own grading criteria. Round 7 returned REJECT on two blocking findings, both verified at source before fixing: the digest scrub left lock release uncovered, and both documents claimed the budget bounds selection pressure when it bounds gate comparisons only. Each finding was verified independently rather than accepted on the reviewer's authority; all held. Deferred design changes opened as #3452 and #3453 rather than rushed into this PR.",
+      "caused_by": [
+        "e022"
+      ],
+      "leads_to": [
+        "e026"
+      ]
+    },
+    {
+      "id": "e024",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: f690ce24b",
+      "caused_by": [],
+      "leads_to": [
+        "e025"
+      ]
+    },
+    {
+      "id": "e025",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: b7966f9d2",
+      "caused_by": [
+        "e024"
+      ],
+      "leads_to": [
+        "e027"
+      ]
+    },
+    {
+      "id": "e026",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "PR #3430 was squash-merged as 98caa0e54 and its branch deleted while six commits were still unpushed, so the merged code carries the per-call-site digest scrub but not the seam-level one, not the lock-release fix, not the coverage for the four branches the review-thread commit added, and none of the corrected documents. Rebased all six onto main as fix/eval-holdout-gate-digest-leak and confirmed they apply cleanly: 426 tests pass with 100% coverage on all three optimizer modules, ruff and mypy clean. The follow-up PR carries the round-seven blocking fix, which is a real leak of the withheld group on a cleanup failure, so it should not wait.",
+      "caused_by": [
+        "e023"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e027",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 98caa0e54",
+      "caused_by": [
+        "e025"
+      ],
+      "leads_to": [
+        "e009"
+      ]
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 3,
+    "files_changed": 5
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
@@ -218,9 +218,19 @@
         "scripts/eval/optimize-artifact.py",
         "tests/eval/test_optimize_artifact_cli.py"
       ]
+    },
+    {
+      "timestamp": "2026-07-27T09:55:00Z",
+      "action": "Ran a tenth adversarial round (gpt-5.6-terra) with explicit permission to return ACCEPT, then fixed the finding it returned",
+      "outcome": "REJECT again, one finding with two legs, both reproduced by execution. The mkdir of the ledger root sat one line above the scrub that covers everything below it. The weaker leg is a leak only when $EVAL_LEDGER_DIR itself names the digest, which means the caller already knows it. The stronger leg needs no digest: an unwritable ledger root raised PermissionError past main's handler list, so a read-only home got a traceback where the docstring promises a JSON error document. That is the round-eight defect still live at the one unprotected line. Fix moves the mkdir inside the seam and gives redaction one definition, _scrub, used by the seam and by the round-nine warning, which was a second hand-written redaction site and was wrong. 448 tests pass, 100% line coverage on all three optimizer modules, ruff and mypy clean.",
+      "artifacts": [
+        "scripts/eval/optimize-artifact.py",
+        "tests/eval/test_optimize_artifact_cli.py",
+        ".agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md"
+      ]
     }
   ],
-  "endingCommit": "4e2284053",
+  "endingCommit": "1ed89118d",
   "nextSteps": [
     "Drive PR #3430 CI to green.",
     "Decide issue #3437, whether the gate seam should carry {task_id: float} instead of {task_id: bool}. Every reviewer across five rounds pushed for it. Surfaced rather than decided, because it changes what the mechanism can express.",

--- a/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
@@ -205,6 +205,10 @@
     {
       "phase": "implementation",
       "summary": "PR #3430 was squash-merged as 98caa0e54 and its branch deleted while six commits were still unpushed, so the merged code carries the per-call-site digest scrub but not the seam-level one, not the lock-release fix, not the coverage for the four branches the review-thread commit added, and none of the corrected documents. Rebased all six onto main as fix/eval-holdout-gate-digest-leak and confirmed they apply cleanly: 426 tests pass with 100% coverage on all three optimizer modules, ruff and mypy clean. The follow-up PR carries the round-seven blocking fix, which is a real leak of the withheld group on a cleanup failure, so it should not wait."
+    },
+    {
+      "phase": "review",
+      "summary": "An eighth review, this one Copilot's on PR #3458, found a defect inside the round-seven fix. The scrub re-raised OSError untouched when the message lacked the digest, and main catches ConfigError, AdapterError, and ValueError but not OSError, so pathless ledger failures escaped as tracebacks instead of JSON. os.write on a full disk and os.close hitting EIO both qualify and both sit inside the lock. Reproduced with a failing end-to-end test before fixing. Checked two adjacent claims the reviewer did not raise: LedgerMismatchError derives from Exception rather than ConfigError so the scrub never touches it, and its two messages name path.parent rather than the digest-bearing filename. Both held, so neither was changed. 432 tests, 100% coverage on all three modules."
     }
   ],
   "endingCommit": "f690ce24b",

--- a/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
@@ -209,9 +209,18 @@
     {
       "phase": "review",
       "summary": "An eighth review, this one Copilot's on PR #3458, found a defect inside the round-seven fix. The scrub re-raised OSError untouched when the message lacked the digest, and main catches ConfigError, AdapterError, and ValueError but not OSError, so pathless ledger failures escaped as tracebacks instead of JSON. os.write on a full disk and os.close hitting EIO both qualify and both sit inside the lock. Reproduced with a failing end-to-end test before fixing. Checked two adjacent claims the reviewer did not raise: LedgerMismatchError derives from Exception rather than ConfigError so the scrub never touches it, and its two messages name path.parent rather than the digest-bearing filename. Both held, so neither was changed. 432 tests, 100% coverage on all three modules."
+    },
+    {
+      "timestamp": "2026-07-27T09:10:00Z",
+      "action": "Fixed the two round-nine findings: the digest reachable through __cause__, and cleanup failure rewriting an already-emitted decision",
+      "outcome": "Both reproduced by execution before any code moved. Fix 1 raises `from None` on the two branches that provably carry the digest and keeps `from exc` where str(exc) has no filename. Fix 2 catches OSError inside the finally and warns on stderr naming the lock's directory, so stdout keeps exactly one document and a passing gate keeps its exit code. One round-seven test asserted the two-document behavior; its assertions now cover the leak invariant across both streams. 440 tests pass, 100% line coverage on all three optimizer modules, ruff and mypy clean on the touched files.",
+      "artifacts": [
+        "scripts/eval/optimize-artifact.py",
+        "tests/eval/test_optimize_artifact_cli.py"
+      ]
     }
   ],
-  "endingCommit": "f690ce24b",
+  "endingCommit": "4e2284053",
   "nextSteps": [
     "Drive PR #3430 CI to green.",
     "Decide issue #3437, whether the gate seam should carry {task_id: float} instead of {task_id: bool}. Every reviewer across five rounds pushed for it. Surfaced rather than decided, because it changes what the mechanism can express.",

--- a/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
@@ -1,0 +1,217 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3422,
+    "date": "2026-07-26",
+    "branch": "fix/eval-holdout-gate-digest-leak",
+    "startingCommit": "2b3bf6dd5",
+    "objective": "Give the eval harness a held-out-gated optimization loop for agents, rules, and hooks (issue #3422)"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP active; initial_instructions and list_memories returned project data"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena initial_instructions read before any edit"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read; it is the read-only stale dashboard, left unchanged"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read the external skillopt skill bundle and the full scripts/eval catalog before designing"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "AGENTS.md skill-first table and boundaries read from always-on instructions"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "TESTING-RIGOR.md read; ADR-010, ADR-057, ADR-058 read to place the change"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena list_memories on topic eval returned eval/eval-multiprovider-transport"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "feat/eval-holdout-gated-optimizer at session start; rebased to fix/eval-holdout-gate-digest-leak after PR #3430 squash-merged and deleted the original"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Branched off main at 2b3bf6dd5 before the first edit"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "git status inspected at session start; found and repaired a stale stash conflict that blocked all commits"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "2b3bf6dd5"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Every MUST item below carries evidence from a command run this session"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md unchanged"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".serena/memories/eval/eval-held-out-gated-optimization.md written with the seam, the budget lesson, and the discipline-not-security framing"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "markdownlint-cli2 on scripts/eval/README.md: 0 issues. ADR-087 byte-checked for em/en dashes: 0"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "16 commits merged to main as 98caa0e54 via PR #3430; six later commits rebased onto main as fix/eval-holdout-gate-digest-leak for the follow-up PR"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "scripts/validation/pre_pr.py: RESULT: All validations passed. 372 optimizer tests, 100% line coverage on all three modules. Full suite 14863 passed"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Filed issue #3422 recording the missing-split defect and the acceptance criteria"
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": "Not invoked. Three adversarial review rounds already produced the findings a retro would look for, and they are recorded in ADR-087 Open Requirements and issues #3436 to #3440 and #3445"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "phase": "investigation",
+      "summary": "Read the external skillopt skill bundle and the whole scripts/eval catalog. Confirmed the harness measures but never gates an artifact edit, and that no fixture set carries a train/held-out split despite the Fixture docstring calling fixtures held-out."
+    },
+    {
+      "phase": "investigation",
+      "summary": "Placed the change against prior art. ADR-010 is a runtime output-quality loop, ADR-057 is before/after regression on one artifact, ADR-058 is agent versus baseline. None gates an artifact edit on data withheld from the author. SkillOpt-gated commits b4070e7ad and 869a03ed9 prove the discipline works here but used an out-of-repo harness on skills only."
+    },
+    {
+      "phase": "implementation",
+      "summary": "Three TDD cycles produced the decision core (split, fingerprint, budget, gate, refusal guards, exact McNemar; pure, no I/O), the adapters converging agent reports, rule scenario scores, and pytest JUnit onto one task-id-to-bool seam, and the CLI an optimizing agent drives. The boolean seam is what generalizes the discipline past skills: a fixture id, a scenario id, and a pytest node id are the same kind of thing to the decider."
+    },
+    {
+      "phase": "review",
+      "summary": "First adversarial round (gpt-5.6-sol, gemini-3.1-pro-preview, both non-Claude per the user instruction). Found a CRITICAL double inversion the README had advertised as a feature: rule_results flipped negative cases and the caller flipped them again, so a lower activation score read as an improvement. Fixed with the failing case pinned."
+    },
+    {
+      "phase": "review",
+      "summary": "Second adversarial round returned REJECT on the ADR draft and found the held-out discipline was, in the reviewer phrase, an honor system wrapped in a hash. Three exposure holes, all real: split printed held-out membership to the stream the optimizing agent reads; score accepted --group sel and test unmetered, which is exactly the read the consultation budget exists to charge for; and --allow-regressions let any caller accept a broken held-out task. All three closed."
+    },
+    {
+      "phase": "implementation",
+      "summary": "Replaced the consultation counter with a ledger the gate writes. --consultations defaulted to 0 and arrived on every invocation, so a loop that passed zero each time had an unlimited budget while looking capped; the reviewer reproduced ACCEPT twice under a cap of one. The ledger is bound to the split fingerprint so redrawing cannot reset it. Two defects found while testing it: guard_refusal turned a cap below one into a permanently exhausted budget indistinguishable from real discipline, and an except ValueError arm was unreachable once its inputs were validated upstream."
+    },
+    {
+      "phase": "correction",
+      "summary": "The second review falsified six claims in my own ADR draft, three of which were about this repository governance. The worst: I described ADR-057 as enforcing only an aggregate mean and used that to justify an override flag. ADR-057 in fact blocks every pass-to-fail flip and states it has no mechanism to accept a justified regression, so my flag was a weaker rule shipping under the same name. Removed the flag, corrected the ADR, and added an Open Requirements section naming what still blocks acceptance."
+    },
+    {
+      "phase": "validation",
+      "summary": "356 tests and 100% line coverage on all three modules. Full repository suite 14863 passed, 28 skipped, 45 xfailed. Live end-to-end runs confirmed split redaction, tamper refusal, budget exhaustion across separate invocations, and a ledger refusing a split redrawn mid-run. Agent path validated against a real 24-fixture report (baseline 15, agent 13; the gate correctly refused a real regression) and the hook path against real pytest JUnit output (532 node ids). Rule path exercised on real error-path output only: the live judge call returned HTTP 400 on an account usage limit until 2026-08-01."
+    },
+    {
+      "phase": "correction",
+      "summary": "Third review round found the ledger had fixed the count and left everything around it on the command line. Three ways back out, each the same defect wearing a different hat: the cap defaulted to unlimited so the ordinary invocation had no budget, a caller that hit the cap could raise it, and pointing --ledger at a fresh path restored the whole budget because a missing ledger starts at zero. Fixed by pinning the cap in the ledger, deriving the ledger path from the split, and requiring the incumbent fingerprint that had been optional. The general rule extracted: any part of a budget the caller restates each time is not part of the budget."
+    },
+    {
+      "phase": "correction",
+      "summary": "Fourth review round reproduced a rounding alias in the ledger key. The fingerprint hashes the selection's inputs (seed, task ids, ratios) rather than its result, and group sizes round, so ten tasks at --sel-ratio 0.40 and at 0.41 hold out the same four tasks under two different fingerprints, giving one held-out group two budgets. Rekeyed the ledger, its lock, and the ledger's own identity field onto a digest of the sorted held-out membership. Declined the reviewer's corpus namespace, because a caller-supplied key is the defect class being closed."
+    },
+    {
+      "phase": "correction",
+      "summary": "Same round found the last free read of the held-out group. score() and mcnemar_exact() name the ids they cannot find, which is correct everywhere except the gate, where those ids are the withheld ones, and an empty candidate results file printed the whole membership before the ledger advanced. Added a one-bit coverage predicate and moved the consultation reserve ahead of scoring, which also closed the crash window that let a killed process retry a comparison for free. A count was rejected as a membership oracle, since split publishes the held-out size."
+    },
+    {
+      "phase": "correction",
+      "summary": "Fifth review round found the fix had relocated the disclosure again, the fourth consecutive round in which that happened. The new ledger key is an unsalted digest of the held-out ids, and three error paths printed it: lock contention carried the lock path, two ledger errors carried the ledger path and both digests, and none was charged a consultation. Redacted all three to the ledger directory alone. Also fixed an injectivity defect: joining ids on NUL is not injective when an id may contain one."
+    },
+    {
+      "phase": "finding",
+      "summary": "Verifying that review finding produced the session's most important result. The reviewer argued the digest was reversible from the published group sizes. It is, but reversal is unnecessary: split publishes opt in full, the task universe is the caller's own results file, and --test-ratio defaults to 0.0, so sel = universe - opt by subtraction. Verified live on a twelve-task run. Held-out membership is public by construction and closing that would break the loop, since an optimizer that cannot name the group it must not touch cannot avoid touching it. The property that has to hold is that held-out outcomes do not cross back, not that held-out identity is secret. Both the ADR and the README now say so; several sentences had read as though the task list were hidden."
+    },
+    {
+      "phase": "implementation",
+      "summary": "Closed the sixth review's code finding. Three hand-written ledger errors had been redacted in round five, but every generic I/O failure under the ledger root still printed a filename ending in the digest of the held-out membership. Added a _digest_scrubbed contextmanager at the seam rather than sanitizing three more call sites, so paths added later inherit it, and nested the lock-contention branch inside so its operator-facing message survives. Also corrected two source comments the review found stale. 410 tests, 100% coverage, ruff and mypy clean. Commit 81ad4283b."
+    },
+    {
+      "phase": "documentation",
+      "summary": "Rewrote the README seam section around the reviewer's characterization: a consultation-budgeted comparison over a public benchmark relying on a cooperating optimizer, not held-out validation of unseen tasks. Recorded that cmd_extract emits every task's outcome with no group argument, that task ids resolve to readable fixtures carrying their own grading criteria, and that the gate returns six fields rather than one bit. Separated what the mechanism enforces regardless of cooperation from what it merely encourages. Commit 7a08a60b5."
+    },
+    {
+      "phase": "documentation",
+      "summary": "Rewrote ADR-087 for the eight claims the sixth review falsified. Weakened the Decision statement from validation on withheld tasks to validation under a counted consultation budget, recording the falsification rather than hiding it. Replaced the identity-public-outcomes-withheld argument with four paragraphs explaining why both halves are false, why the loop needs no knowledge of sel at all, and why Dwork's reusable holdout assumes an access path this does not have. Added round six to the defeat table and restated Open Requirement 1 as a prerequisite for the central claim."
+    },
+    {
+      "phase": "planning",
+      "summary": "Opened #3452 (make extract group-aware, replace the one-bit coverage predicate with a whole-universe check) and #3453 (budget what each consultation discloses, not just how many there are). Both deferred rather than built: each changes behavior and needs its own review round, and this PR is already about 5,400 lines. #3453 records the tension that a --diagnostics flag the loop passes itself would be the same caller-supplied-restriction defect the ADR catalogs six times."
+    },
+    {
+      "phase": "implementation",
+      "summary": "Seventh adversarial review returned REJECT with two blocking findings, both verified at source. The digest scrub covered the lock's acquire and left its release outside: the unlink in the finally block names the lock, the lock's name is the digest, and main() catches ConfigError but not OSError, so a cleanup failure printed the held-out group as an uncaught traceback one line below where the leak was closed. Widened the scrub over the whole lifecycle, safe because LedgerMismatchError is a sibling of ConfigError rather than a subclass. Regression test asserts on raw stdout since release runs after the decision is emitted. Commit 97817c0ba."
+    },
+    {
+      "phase": "implementation",
+      "summary": "Rebased onto cd56ce09f, an incoming commit addressing seven PR review threads. It dropped all three optimizer modules from 100% to 99% coverage by shipping four defensive branches with no test. Added positive, negative, and edge cases for each: guard_refusal on a negative spend, agent_results on a non-list run value (with the string trap, since str is a Sequence), _read_split on four wrong group shapes plus a well-formed control, and _write_atomic on a non-OSError so an interrupt keeps its type. 925 tests, 100% coverage restored. Commit 148bfd8a8."
+    },
+    {
+      "phase": "documentation",
+      "summary": "Corrected six more README claims the seventh review falsified, each verified at source first. The budget bounds gate comparisons, not selection pressure, since extract and score reach results without touching the ledger. The path root and the first cap value are not membership-derived. The fingerprint covers the split's inputs rather than its drawn result, and catching a moved task takes the redraw comparison as well. A consultation is reserved before the group is read and before coverage is checked. No command scores the test group at all. Commit f690ce24b."
+    },
+    {
+      "phase": "documentation",
+      "summary": "Applied the same corrections to ADR-087 and to the two deferred issues. Requirement 1's heading no longer claims the decision group is withheld. The Decision statement now says the loop cannot move the mechanism through its own arguments, which is what holds. Commented on #3452 that its two changes do not compose without a controller owning the complete mapping, and on #3453 that there is no fixed multiplier to document, so the statable property is the output alphabet."
+    },
+    {
+      "phase": "review",
+      "summary": "Ran the adr-review skill against ADR-087 across seven rounds, every reviewer a non-Claude model (gpt-5.6-sol, gemini-3.1-pro-preview) per the objective's adversarial-review requirement. Every round falsified at least one load-bearing claim, so the ADR carries a defeat table instead of a clean argument. Round 6 was the most expensive: it showed that withholding the decision group's membership bounds nothing, because cmd_extract emits every task's outcome with no group argument and because task ids resolve to definitions carrying their own grading criteria. Round 7 returned REJECT on two blocking findings, both verified at source before fixing: the digest scrub left lock release uncovered, and both documents claimed the budget bounds selection pressure when it bounds gate comparisons only. Each finding was verified independently rather than accepted on the reviewer's authority; all held. Deferred design changes opened as #3452 and #3453 rather than rushed into this PR."
+    },
+    {
+      "phase": "implementation",
+      "summary": "PR #3430 was squash-merged as 98caa0e54 and its branch deleted while six commits were still unpushed, so the merged code carries the per-call-site digest scrub but not the seam-level one, not the lock-release fix, not the coverage for the four branches the review-thread commit added, and none of the corrected documents. Rebased all six onto main as fix/eval-holdout-gate-digest-leak and confirmed they apply cleanly: 426 tests pass with 100% coverage on all three optimizer modules, ruff and mypy clean. The follow-up PR carries the round-seven blocking fix, which is a real leak of the withheld group on a cleanup failure, so it should not wait."
+    }
+  ],
+  "endingCommit": "f690ce24b",
+  "nextSteps": [
+    "Drive PR #3430 CI to green.",
+    "Decide issue #3437, whether the gate seam should carry {task_id: float} instead of {task_id: bool}. Every reviewer across five rounds pushed for it. Surfaced rather than decided, because it changes what the mechanism can express.",
+    "Open Requirement 11 (a lock lease with renewal and a fencing token) and 12 (a corpus namespace with a trusted source) are both live and unowned.",
+    "Live LLM eval spend is unavailable until 2026-08-01, so the rule adapter has been validated against real error-path output only."
+  ]
+}

--- a/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
@@ -228,9 +228,20 @@
         "tests/eval/test_optimize_artifact_cli.py",
         ".agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md"
       ]
+    },
+    {
+      "timestamp": "2026-07-27T10:40:00Z",
+      "action": "Ran an eleventh adversarial round (gpt-5.6-luna), fixed three of its four findings and declined the fourth with the reason recorded",
+      "outcome": "The seam's first line had moved rather than vanished: round ten pulled the mkdir inside the scrub and left _ledger_root() above it, and Path.home() raises RuntimeError when HOME is unset and the uid has no passwd entry, which is an ordinary container and fires on the default configuration. main does not catch RuntimeError. Also fixed a lock descriptor that leaked when os.write failed, and case-sensitive redaction against a hex digest that has an uppercase spelling. Declined the double-root-resolution finding: it reproduces only by mutating EVAL_LEDGER_DIR mid-process, and no in-process environment mutation exists in any of the three modules. 458 tests pass, 100% line coverage on all three optimizer modules, ruff and mypy clean.",
+      "artifacts": [
+        "scripts/eval/optimize-artifact.py",
+        "tests/eval/test_optimize_artifact_cli.py",
+        ".agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md",
+        ".serena/memories/eval/eval-held-out-gated-optimization.md"
+      ]
     }
   ],
-  "endingCommit": "1ed89118d",
+  "endingCommit": "c66939a96",
   "nextSteps": [
     "Drive PR #3430 CI to green.",
     "Decide issue #3437, whether the gate seam should carry {task_id: float} instead of {task_id: bool}. Every reviewer across five rounds pushed for it. Surfaced rather than decided, because it changes what the mechanism can express.",

--- a/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
@@ -239,9 +239,20 @@
         ".agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md",
         ".serena/memories/eval/eval-held-out-gated-optimization.md"
       ]
+    },
+    {
+      "timestamp": "2026-07-27T11:20:00Z",
+      "action": "Ran a twelfth adversarial round (gpt-5.6-sol) and fixed the single finding, which was the round-eleven fix applied to half the pair",
+      "outcome": "Round 11 taught _scrub to fold case; the line deciding whether to call it kept reading `if holdout_key in text`, which does not, so an uppercase digest failed the guard and skipped the corrected scrub. Reproduced through the real gate entry point with only stdlib Path.mkdir patched. Fixed by deleting the second predicate: _scrub returning a different string answers both questions. The more useful half of the finding is the tests: round 11's four case-folding tests all called _scrub directly, so they passed while the CLI printed the digest. The eight new tests go through the seam and through main. 466 tests pass, 100% line coverage on all three optimizer modules, ruff and mypy clean, and the reviewer's own repro now redacts.",
+      "artifacts": [
+        "scripts/eval/optimize-artifact.py",
+        "tests/eval/test_optimize_artifact_cli.py",
+        ".agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md",
+        ".serena/memories/eval/eval-held-out-gated-optimization.md"
+      ]
     }
   ],
-  "endingCommit": "c66939a96",
+  "endingCommit": "ff16b4dc8",
   "nextSteps": [
     "Drive PR #3430 CI to green.",
     "Decide issue #3437, whether the gate seam should carry {task_id: float} instead of {task_id: bool}. Every reviewer across five rounds pushed for it. Surfaced rather than decided, because it changes what the mechanism can express.",

--- a/.serena/memories/eval/eval-held-out-gated-optimization.md
+++ b/.serena/memories/eval/eval-held-out-gated-optimization.md
@@ -21,7 +21,7 @@ What holds now: count and cap are recorded at the first decision in `<split>.led
 
 ## Framing that must not be softened
 
-Eleven adversarial rounds, every one of which falsified something, converged on this sentence. Use it verbatim; it is the most expensive result of the session.
+Twelve adversarial rounds, every one of which falsified something, converged on this sentence. Use it verbatim; it is the most expensive result of the session.
 
 > A consultation-budgeted comparison over a public benchmark, relying on a cooperating optimizer not to inspect accessible task definitions or result files. It is not yet held-out validation of unseen tasks.
 
@@ -41,15 +41,16 @@ The reflex to resist: "the loop cannot edit toward a group it cannot name" is ba
 
 ## The rule that generalizes past this file
 
-Eleven rounds, ten of them the same shape: any part of a budget the caller can restate, or move by renaming something else, is not part of the budget; and any path by which the withheld thing is readable is not withholding it. The last three rounds are the useful ones to remember, because each found a defect inside the previous round's fix:
+Twelve rounds, eleven of them the same shape: any part of a budget the caller can restate, or move by renaming something else, is not part of the budget; and any path by which the withheld thing is readable is not withholding it. The last three rounds are the useful ones to remember, because each found a defect inside the previous round's fix:
 
 - Round 8: a pathless `OSError` fell past a redaction branch that was also the branch converting it to a type `main` catches, so it escaped as a traceback.
 - Round 9: a redacted message chained the unredacted original with `raise ... from exc`, and `__cause__` is exactly where a printed traceback goes. Separately, cleanup in a `finally` ran after the decision was on stdout, so a failure there printed a second JSON document and overwrote a successful exit code.
 - Round 10: the first line of the lock helper, `lock.parent.mkdir(...)`, sat one line above the scrub covering everything below it. A seam is only a seam from its first line.
+- Round 12: `_scrub` learned to fold case in round 11 and the `if holdout_key in text` deciding whether to call it did not, so the exact input the fix was written for skipped the fix. One definition has to cover the predicate, not just the replacement.
 - Round 11: moving that `mkdir` inward left `_ledger_root()` as the new first line, and it resolves the home directory, which raises `RuntimeError` when `$HOME` is unset and the uid has no passwd entry. That is an ordinary container running as a numeric user, and it fires on the default configuration. Fixing a boundary by moving one line inward leaves whatever was above that line as the new boundary.
 
 Round 11 is also the first round partly declined: its double-resolution finding reproduced only by mutating `$EVAL_LEDGER_DIR` mid-process, and no in-process environment mutation exists in any of the three modules. Accepting every reported finding is not reviewing either; the decline and its reason are in the debate log so nobody re-litigates it.
 
-Three operational lessons worth more than the defect list. First, a workaround that stops a symptom appearing in tests is not a finding closed: the round-9 double-document bug had already been seen while writing round-7 tests and recorded as a test-harness quirk. Second, hand-written redaction sites are where rounds 9 and 10 both found defects, which is why redaction now has one definition, `_scrub`, rather than a `.replace` per site. Third, when a review is asked to find a defect, give it explicit permission to return ACCEPT and tell it a false finding costs more than a missed one; rounds 10 and 11 both got that instruction and both still returned real findings, which is what makes the streak evidence rather than an artifact of the prompt.
+Four operational lessons worth more than the defect list. First, a workaround that stops a symptom appearing in tests is not a finding closed: the round-9 double-document bug had already been seen while writing round-7 tests and recorded as a test-harness quirk. Second, hand-written redaction sites are where rounds 9 and 10 both found defects, which is why redaction now has one definition, `_scrub`, rather than a `.replace` per site. Third, when a review is asked to find a defect, give it explicit permission to return ACCEPT and tell it a false finding costs more than a missed one; rounds 10, 11, and 12 all got that instruction and all still returned real findings, which is what makes the streak evidence rather than an artifact of the prompt. Fourth, and this is the one that generalizes furthest: test the property through the seam, not the unit you edited. Round 11 added four passing tests for case folding and every one called `_scrub` directly, so they confirmed the edit while the CLI still printed the digest. A test aimed at the function you just changed will agree with you. Only a test aimed at the property can disagree.
 
 Evidence: issue #3422, PR #3430, PR #3458, branch `fix/eval-holdout-gate-digest-leak`, ADR-087, debate log `.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md`, session log `.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json`.

--- a/.serena/memories/eval/eval-held-out-gated-optimization.md
+++ b/.serena/memories/eval/eval-held-out-gated-optimization.md
@@ -1,0 +1,42 @@
+# Eval held-out gated optimization
+
+`scripts/eval/optimize-artifact.py` plus `_optimizer_core.py` and `_optimizer_adapters.py` add the one thing the rest of `scripts/eval/` never had: a comparison the party making the edit cannot repeat without a budget. Every other evaluator scores an artifact against its whole eval set while the author reads the failures, so the score stops estimating behavior on unseen cases and starts estimating how well the author answered these cases. The two diverge exactly as the loop gets better.
+
+## The seam
+
+Adapters converge three unlike scorers onto `{task_id: bool}`: `agent_results` from an agent-vs-baseline report, `rule_results` from rule scenario scores, `pytest_results` from JUnit XML. That boolean mapping is what generalizes the discipline past skills. A fixture id, a scenario id, and a pytest node id are the same kind of thing to the decider, so agents, rules, and hooks all reach the same gate. Whether to widen the seam to `{task_id: float}` is open (#3437); both code reviewers and both ADR reviewers argued for it, and it is a redesign rather than a tweak.
+
+## The lesson worth carrying elsewhere
+
+Any part of a budget the caller restates on every invocation is not part of the budget. Three adversarial rounds each fixed the piece under review and left the rest on the command line, where the identical defect reappeared:
+
+1. The count. `--consultations` defaulted to 0 every call, so a loop that passed zero each time had an unlimited budget while looking capped. Review reproduced two ACCEPTs under a cap of one.
+2. The cap. `--max-consultations` defaulted to unlimited, so the ordinary invocation had no budget, and a caller that did hit the cap could raise it on the next call.
+3. The ledger path. `--ledger PATH` looked like discipline, but a missing ledger starts at zero, so naming a fresh path restored the whole budget without editing anything.
+4. The split path the ledger derived from. Deriving the ledger name from the split file's path meant copying the split to a new name reset the budget, with the identical membership inside.
+5. The fingerprint. It hashed the split's inputs rather than its drawn result, so it caught an added or removed task but not a task moved between groups. Catching the move needs the redraw comparison as well, and crediting the fingerprint alone was wrong.
+6. The digest printed in uncharged error paths, then the digest reachable from *generic* I/O failures. Every ledger filename ends in the digest of the held-out membership, so any error interpolating a path leaked the thing being withheld. Closing it per call site missed lock release, which runs after the decision is already emitted.
+
+What holds now: count and cap are recorded at the first decision in `<split>.ledger`, a later cap change is refused, and the path is derived from the split so resetting means deleting a file. `--incumbent-fingerprint` is required for the same reason; optional integrity checks are integrity checks nobody runs.
+
+## Framing that must not be softened
+
+Seven adversarial rounds, every one of which falsified something, converged on this sentence. Use it verbatim; it is the most expensive result of the session.
+
+> A consultation-budgeted comparison over a public benchmark, relying on a cooperating optimizer not to inspect accessible task definitions or result files. It is not yet held-out validation of unseen tasks.
+
+Three separate reasons it is not the stronger thing, all verified at source, all recorded in ADR-087:
+
+1. **Outcomes are not withheld.** `cmd_extract` emits the full mapping and has no group argument, and the documented workflow has the optimizer call it. Held-out results are already in the optimizer's own files, uncharged (#3452).
+2. **Membership is public and sufficient.** Task ids resolve to readable definitions carrying their own grading criteria: a fixture's expected verdict, a scenario's expected vocabulary, a pytest assertion. Naming a held-out task is enough to hand-tune for it.
+3. **The budget bounds gate comparisons, not selection pressure.** `extract` and `score` reach results without touching the ledger, so nothing counts the loop's other reads.
+
+The reflex to resist: "the loop cannot edit toward a group it cannot name" is backwards. An optimizer edits toward `opt` and needs no knowledge of `sel` at all. Only `opt` must be exposed for the discipline to work, which is exactly why exposing `sel` costs nothing to fix and everything to leave. Dwork's reusable holdout (arXiv:1506.02629) assumes the analyst reaches the holdout only through the mechanism; a controller the optimizing agent cannot write to is the missing prerequisite, tracked as ADR-087 Open Requirement 1.
+
+## Gotchas
+
+- Coverage must be `--cov=scripts/eval` (the directory). `--cov=scripts/eval/_optimizer_core` collects nothing because the CLI module name is hyphenated.
+- `mcnemar_exact` is reported, never enforced. A single discordant gain yields `p_value: 0.5` and still ACCEPTs, because a three-task held-out group cannot reach 0.05 and enforcing a conventional floor would make the common case unpassable.
+- Only `rule_results` is single-shot against an LLM judge; `agent_results` reduces over runs and `pytest_results` is deterministic. Noise arithmetic that treats all three as single-shot overstates spurious rejection (#3445).
+
+Evidence: issue #3422, PR #3430, branch `feat/eval-holdout-gated-optimizer`, ADR-087, session log `.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json`.

--- a/.serena/memories/eval/eval-held-out-gated-optimization.md
+++ b/.serena/memories/eval/eval-held-out-gated-optimization.md
@@ -21,7 +21,7 @@ What holds now: count and cap are recorded at the first decision in `<split>.led
 
 ## Framing that must not be softened
 
-Ten adversarial rounds, every one of which falsified something, converged on this sentence. Use it verbatim; it is the most expensive result of the session.
+Eleven adversarial rounds, every one of which falsified something, converged on this sentence. Use it verbatim; it is the most expensive result of the session.
 
 > A consultation-budgeted comparison over a public benchmark, relying on a cooperating optimizer not to inspect accessible task definitions or result files. It is not yet held-out validation of unseen tasks.
 
@@ -41,12 +41,15 @@ The reflex to resist: "the loop cannot edit toward a group it cannot name" is ba
 
 ## The rule that generalizes past this file
 
-Ten rounds, nine of them the same shape: any part of a budget the caller can restate, or move by renaming something else, is not part of the budget; and any path by which the withheld thing is readable is not withholding it. The last three rounds are the useful ones to remember, because each found a defect inside the previous round's fix:
+Eleven rounds, ten of them the same shape: any part of a budget the caller can restate, or move by renaming something else, is not part of the budget; and any path by which the withheld thing is readable is not withholding it. The last three rounds are the useful ones to remember, because each found a defect inside the previous round's fix:
 
 - Round 8: a pathless `OSError` fell past a redaction branch that was also the branch converting it to a type `main` catches, so it escaped as a traceback.
 - Round 9: a redacted message chained the unredacted original with `raise ... from exc`, and `__cause__` is exactly where a printed traceback goes. Separately, cleanup in a `finally` ran after the decision was on stdout, so a failure there printed a second JSON document and overwrote a successful exit code.
 - Round 10: the first line of the lock helper, `lock.parent.mkdir(...)`, sat one line above the scrub covering everything below it. A seam is only a seam from its first line.
+- Round 11: moving that `mkdir` inward left `_ledger_root()` as the new first line, and it resolves the home directory, which raises `RuntimeError` when `$HOME` is unset and the uid has no passwd entry. That is an ordinary container running as a numeric user, and it fires on the default configuration. Fixing a boundary by moving one line inward leaves whatever was above that line as the new boundary.
 
-Two operational lessons worth more than the defect list. First, a workaround that stops a symptom appearing in tests is not a finding closed: the round-9 double-document bug had already been seen while writing round-7 tests and recorded as a test-harness quirk. Second, hand-written redaction sites are where rounds 9 and 10 both found defects, which is why redaction now has one definition, `_scrub`, rather than a `.replace` per site.
+Round 11 is also the first round partly declined: its double-resolution finding reproduced only by mutating `$EVAL_LEDGER_DIR` mid-process, and no in-process environment mutation exists in any of the three modules. Accepting every reported finding is not reviewing either; the decline and its reason are in the debate log so nobody re-litigates it.
+
+Three operational lessons worth more than the defect list. First, a workaround that stops a symptom appearing in tests is not a finding closed: the round-9 double-document bug had already been seen while writing round-7 tests and recorded as a test-harness quirk. Second, hand-written redaction sites are where rounds 9 and 10 both found defects, which is why redaction now has one definition, `_scrub`, rather than a `.replace` per site. Third, when a review is asked to find a defect, give it explicit permission to return ACCEPT and tell it a false finding costs more than a missed one; rounds 10 and 11 both got that instruction and both still returned real findings, which is what makes the streak evidence rather than an artifact of the prompt.
 
 Evidence: issue #3422, PR #3430, PR #3458, branch `fix/eval-holdout-gate-digest-leak`, ADR-087, debate log `.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md`, session log `.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json`.

--- a/.serena/memories/eval/eval-held-out-gated-optimization.md
+++ b/.serena/memories/eval/eval-held-out-gated-optimization.md
@@ -21,7 +21,7 @@ What holds now: count and cap are recorded at the first decision in `<split>.led
 
 ## Framing that must not be softened
 
-Seven adversarial rounds, every one of which falsified something, converged on this sentence. Use it verbatim; it is the most expensive result of the session.
+Ten adversarial rounds, every one of which falsified something, converged on this sentence. Use it verbatim; it is the most expensive result of the session.
 
 > A consultation-budgeted comparison over a public benchmark, relying on a cooperating optimizer not to inspect accessible task definitions or result files. It is not yet held-out validation of unseen tasks.
 
@@ -39,4 +39,14 @@ The reflex to resist: "the loop cannot edit toward a group it cannot name" is ba
 - `mcnemar_exact` is reported, never enforced. A single discordant gain yields `p_value: 0.5` and still ACCEPTs, because a three-task held-out group cannot reach 0.05 and enforcing a conventional floor would make the common case unpassable.
 - Only `rule_results` is single-shot against an LLM judge; `agent_results` reduces over runs and `pytest_results` is deterministic. Noise arithmetic that treats all three as single-shot overstates spurious rejection (#3445).
 
-Evidence: issue #3422, PR #3430, branch `feat/eval-holdout-gated-optimizer`, ADR-087, session log `.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json`.
+## The rule that generalizes past this file
+
+Ten rounds, nine of them the same shape: any part of a budget the caller can restate, or move by renaming something else, is not part of the budget; and any path by which the withheld thing is readable is not withholding it. The last three rounds are the useful ones to remember, because each found a defect inside the previous round's fix:
+
+- Round 8: a pathless `OSError` fell past a redaction branch that was also the branch converting it to a type `main` catches, so it escaped as a traceback.
+- Round 9: a redacted message chained the unredacted original with `raise ... from exc`, and `__cause__` is exactly where a printed traceback goes. Separately, cleanup in a `finally` ran after the decision was on stdout, so a failure there printed a second JSON document and overwrote a successful exit code.
+- Round 10: the first line of the lock helper, `lock.parent.mkdir(...)`, sat one line above the scrub covering everything below it. A seam is only a seam from its first line.
+
+Two operational lessons worth more than the defect list. First, a workaround that stops a symptom appearing in tests is not a finding closed: the round-9 double-document bug had already been seen while writing round-7 tests and recorded as a test-harness quirk. Second, hand-written redaction sites are where rounds 9 and 10 both found defects, which is why redaction now has one definition, `_scrub`, rather than a `.replace` per site.
+
+Evidence: issue #3422, PR #3430, PR #3458, branch `fix/eval-holdout-gate-digest-leak`, ADR-087, debate log `.agents/analysis/2026-07-26-adr-087-holdout-gate-debate.md`, session log `.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json`.

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -282,7 +282,7 @@ This tool splits the task ids into three groups and keeps them apart:
 |-------|-------------|---------|---------------|
 | `opt` | The optimizing agent | Read failures here, propose edits from them. | The remainder, 0.6 |
 | `sel` | The gate | Decides accept or reject. Each decision spends one consultation from a fixed budget. | 0.4 |
-| `test` | The final report | Scored once after the loop stops, so it carries no consultation history. | 0.0, opt in with `--test-ratio` |
+| `test` | Nothing yet | Reserved for a final report. **No command scores it**, so today it only shrinks `opt` and `sel`. See ADR-087 Open Requirement 7. | 0.0, opt in with `--test-ratio` |
 
 `--test-ratio` defaults to zero, so out of the box you get two groups and an
 empty `test`. That is a concession to this repo's real fixture counts: most
@@ -415,12 +415,22 @@ Three things make that the honest description rather than an overcautious one:
 optimizer cooperates:
 
 - The consultation count, its cap, its storage path, and the key it is stored
-  under are all derived from the held-out membership itself. None of the four
-  can be moved by an argument the caller supplies.
+  under are derived from the held-out membership, with two stated exceptions.
+  The path's *root* comes from `$EVAL_LEDGER_DIR`, `$XDG_STATE_HOME`, or the
+  home directory, and only the filename inside it is membership-derived. The
+  cap's *first* value comes from `--max-consultations`, after which it is
+  pinned and a later change is refused. So what cannot be moved by a caller
+  argument is a budget already in progress; a first invocation still chooses
+  its own cap, and an operator with filesystem access can relocate or delete
+  the root.
 - Concurrent gates against one split serialize on a lock, so a parallel pair
   cannot spend one budget twice.
-- The split record is structurally tamper-evident: the fingerprint covers the
-  drawn result, so editing a group after the fact is detected.
+- The split record is structurally tamper-evident, in two parts because
+  neither alone suffices. The fingerprint covers the split's *inputs* (seed,
+  task-id set, ratios), which catches an added or removed task but not a task
+  moved between groups, since the union it hashes is unchanged by a move. The
+  gate also redraws the split from those recorded inputs and compares
+  memberships, which catches the move. Both run on every gate.
 - `score --group opt` refuses to read any other group.
 
 **What that combination buys.** An author who is trying to improve an artifact,
@@ -463,11 +473,11 @@ Four further refusals close holes that open once a loop runs many steps:
   Any two splits that hold out the same tasks share the budget those tasks have
   already spent, whatever ratio or seed produced them. Redrawing with a new seed
   usually does hold out different tasks, and that is a genuinely new group with
-  its own budget; the gate is counting selection pressure on a set of tasks, not
-  on a file.
+  its own budget; the gate is counting gate comparisons against a set of tasks,
+  not against a file.
 
-  A consultation is charged when the gate reaches the comparison, not when a
-  verdict comes back. A refusal decided from bookkeeping alone (an exhausted budget, a
+  A consultation is reserved before the held-out group is read and before the
+  results are checked for coverage, not when a verdict comes back. A refusal decided from bookkeeping alone (an exhausted budget, a
   stale incumbent fingerprint, a drifted split) reads nothing and costs nothing.
   Everything past that point costs one, including a results file that turns out
   not to cover the group, and including a process killed mid-comparison. Two
@@ -492,8 +502,12 @@ Four further refusals close holes that open once a loop runs many steps:
   group-aware, but `extract` is not, and the workflow above has the optimizer
   run `extract` itself. What the budget bounds is how many times an edit may be
   compared against the held-out group through the gate, which is the loop's
-  own selection pressure on that group. That is the quantity multiple-comparison
-  correction is about, and it is the one this mechanism actually holds.
+  own **gate comparisons** against that group. It is not a bound on total
+  selection pressure, and the difference matters: `extract` and `score` reach
+  results without touching the ledger, so an optimizer that inspects its own
+  files applies pressure the count never sees. Closing that needs #3452 and a
+  controller. Gate comparisons are the quantity multiple-comparison correction
+  is about, and it is the one this mechanism actually holds.
 
   Three things this does not cover, stated rather than implied. The cap is
   whatever positive integer the first call names, so the budget is only as tight

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -44,7 +44,7 @@ python3 scripts/eval/eval-skill-overlap.py \
 | `eval-reviewer-asymmetry.py` | Statistical-significance test for `templates/agents/{critic,qa,implementer}.shared.md` reviewer-asymmetry framing. Fisher's exact (verdict-pass) + Mann-Whitney U (findings-count). | Complementary |
 | `eval-e2e-delivery.py` | End-to-end delivery eval (plan-rubric proxy). Feeds a vague germ, captures each agent's plan, LLM-judges it against hidden acceptance criteria. Core in `_e2e_delivery_core.py`. | #2859 |
 | `eval-model-sweep.py` | Sweep one agent's fixtures across candidate models; scored KEEP_PIN/DROP_PIN verdict with effect size. Core in `_model_sweep_core.py`. | #2840 |
-| `optimize-artifact.py` | Held-out-gated edit loop for agents, rules, and hooks. Splits tasks, bounds the edit budget, applies patches, and accepts an edit only on data withheld from the author. Core in `_optimizer_core.py`, scorer adapters in `_optimizer_adapters.py`. | #3422 |
+| `optimize-artifact.py` | Held-out-gated edit loop for agents, rules, and hooks. Splits tasks, bounds how many times an edit may be measured against the held-out group, and applies patches. A budgeted comparison, not an access boundary; see the seam section below. Core in `_optimizer_core.py`, scorer adapters in `_optimizer_adapters.py`. | #3422 |
 | `_anthropic_api.py` | Shared API utilities (key loading, API calls). | N/A |
 
 ## End-to-End Delivery Eval
@@ -264,8 +264,10 @@ the `decision`/`reason`.
 ## Held-Out-Gated Optimization
 
 `optimize-artifact.py` adds the piece the rest of this directory is missing: a
-gate that accepts an edit only on data the author could not read while making
-it.
+bound on how many times an edit may be measured against a group before the
+measurement stops meaning anything. Every other evaluator here scores an
+artifact against its whole eval set and reports the number, so an author who
+edits until that number rises has fitted the eval and has no way to know it.
 
 Every other evaluator here scores an artifact against its whole eval set.
 `eval-prompt-change.py` compares a prompt before and after an edit on the same
@@ -279,8 +281,8 @@ This tool splits the task ids into three groups and keeps them apart:
 | Group | Who sees it | Purpose | Default share |
 |-------|-------------|---------|---------------|
 | `opt` | The optimizing agent | Read failures here, propose edits from them. | The remainder, 0.6 |
-| `sel` | The gate only | Decides accept or reject. Never shown to the author. | 0.4 |
-| `test` | Nobody, until the end | Final unbiased number after the loop stops. | 0.0, opt in with `--test-ratio` |
+| `sel` | The gate | Decides accept or reject. Each decision spends one consultation from a fixed budget. | 0.4 |
+| `test` | The final report | Scored once after the loop stops, so it carries no consultation history. | 0.0, opt in with `--test-ratio` |
 
 `--test-ratio` defaults to zero, so out of the box you get two groups and an
 empty `test`. That is a concession to this repo's real fixture counts: most
@@ -383,19 +385,53 @@ reading is not a gate.
 
 ### What the seam does and does not protect
 
-`split` writes the full partition to the `--out` file the gate reads, and
-prints only the optimize ids, the held-out sizes, and the fingerprint. `score`
-reads the optimize group and nothing else. Together those keep the held-out
-answers off the optimizer's stdout and keep every held-out read inside a gate
-decision that spends a consultation.
+Read this before citing a run of this loop as evidence.
 
-This is a discipline control, not a security boundary. The split file sits on
-the same disk as everything else, so an optimizer determined to read it can.
-What the seam removes is the accidental path: reading held-out failures
-because they were printed, or scoring against them because the command
-offered it. Binding the split to state the optimizer cannot reach needs a
-trusted controller, which this does not have. Do not cite a run of this loop
-as evidence against an adversarial optimizer.
+**What it is.** A consultation-budgeted comparison over a public benchmark,
+relying on a cooperating optimizer not to inspect task definitions and result
+files it can already reach. **It is not held-out validation of unseen tasks.**
+
+Three things make that the honest description rather than an overcautious one:
+
+- **`extract` emits every task's outcome, uncharged.** It takes `--kind`,
+  `--input`, and scoring flags. It takes no group argument, so the mapping it
+  writes covers `opt`, `sel`, and `test` alike. The documented workflow has the
+  optimizer run `extract` itself to build `base.json` and `cand.json`, which
+  means held-out outcomes are already in the optimizer's own files before the
+  gate is called. Only `score --group` is group-aware, and nothing forces the
+  loop through it.
+- **Task ids resolve to readable definitions that carry their own grading
+  criteria.** `evals/analyst-spike/fixtures/F001.json` holds the input, the
+  expected verdict, and the regex the scorer asserts.
+  `tests/evals/rule-scenarios/clean-architecture.json` holds the expected
+  vocabulary. `tests/hooks/test_dash_guard.py` is the assertion. So naming a
+  held-out task is enough to hand-tune for it, and `split` publishes the
+  optimize ids by design, from which the complement follows by subtraction.
+- **The gate returns diagnostics, not a verdict alone.** Its payload carries
+  both scores, both discordant counts, and the p-value. The ledger bounds how
+  many times you may ask, not how much each answer tells you.
+
+**What is actually enforced by the mechanism**, and holds whether or not the
+optimizer cooperates:
+
+- The consultation count, its cap, its storage path, and the key it is stored
+  under are all derived from the held-out membership itself. None of the four
+  can be moved by an argument the caller supplies.
+- Concurrent gates against one split serialize on a lock, so a parallel pair
+  cannot spend one budget twice.
+- The split record is structurally tamper-evident: the fingerprint covers the
+  drawn result, so editing a group after the fact is detected.
+- `score --group opt` refuses to read any other group.
+
+**What that combination buys.** An author who is trying to improve an artifact,
+rather than to defeat the gate, gets a number that has been asked for a bounded
+number of times and cannot silently become a number asked a hundred times. That
+is the failure this directory actually had. Dwork's reusable holdout
+(arXiv:1506.02629) gives the stronger guarantee, but assumes the analyst reaches
+the holdout only through the mechanism. Closing that gap needs a trusted
+controller that owns task definitions, scoring, and result files, and hands the
+optimizer only the optimize group. See ADR-087 Open Requirement 1. Until then,
+do not cite a run of this loop as evidence against an adversarial optimizer.
 
 Four further refusals close holes that open once a loop runs many steps:
 
@@ -430,8 +466,8 @@ Four further refusals close holes that open once a loop runs many steps:
   its own budget; the gate is counting selection pressure on a set of tasks, not
   on a file.
 
-  A consultation is charged when the held-out group is read, not when a verdict
-  comes back. A refusal decided from bookkeeping alone (an exhausted budget, a
+  A consultation is charged when the gate reaches the comparison, not when a
+  verdict comes back. A refusal decided from bookkeeping alone (an exhausted budget, a
   stale incumbent fingerprint, a drifted split) reads nothing and costs nothing.
   Everything past that point costs one, including a results file that turns out
   not to cover the group, and including a process killed mid-comparison. Two
@@ -445,16 +481,19 @@ Four further refusals close holes that open once a loop runs many steps:
   answers one bit. Not a count: `split` publishes the held-out size, so a count
   would tell a caller how many of the keys it chose to omit were held out.
 
-  None of that hides the held-out task list, and it is not meant to. `split`
-  publishes `opt` because the loop cannot edit toward a group it cannot name,
-  the universe is your own results file, and with no test group drawn (the
-  default) the held-out group is what is left after subtracting one from the
-  other. Knowing which tasks are withheld is the point. What does not cross back
-  is how the artifact scores on them: `score` refuses any group but `opt`, the
-  gate answers one accept or reject bit, and the budget caps how many such bits
-  one group can emit. The redaction earns its keep when a test group exists,
-  because there the complement is two groups and the published sizes do not say
-  which task is in which.
+  None of that hides the held-out task list, and it cannot. `split` publishes
+  `opt` in full, the universe is your own results file, and with no test group
+  drawn (the default) the held-out group is the complement by plain
+  subtraction. The redaction is worth keeping for the case where a test group
+  exists, since there the complement spans two groups and the published sizes
+  do not say which task is in which. It is not worth describing as a boundary.
+
+  Held-out outcomes do not stay behind that line either. `score --group` is
+  group-aware, but `extract` is not, and the workflow above has the optimizer
+  run `extract` itself. What the budget bounds is how many times an edit may be
+  compared against the held-out group through the gate, which is the loop's
+  own selection pressure on that group. That is the quantity multiple-comparison
+  correction is about, and it is the one this mechanism actually holds.
 
   Three things this does not cover, stated rather than implied. The cap is
   whatever positive integer the first call names, so the budget is only as tight

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -515,9 +515,12 @@ def _ledger_held(holdout_key: str) -> Iterator[None]:
     """
     lock = _ledger_root() / f"{holdout_key}.lock"
     lock.parent.mkdir(parents=True, exist_ok=True)
-    # The scrub sits outside so any errno but EEXIST loses the digest in the
-    # lock's name, and the contention branch sits inside so its own message,
-    # which carries no digest, reaches the caller intact.
+    # The scrub spans the whole lifecycle, not just the acquire. A seventh
+    # review found the release outside it: the unlink in the finally block
+    # names the lock, the lock's name is the digest, and main() does not catch
+    # OSError, so a cleanup failure printed the group as an uncaught traceback.
+    # The contention branch nests inside because its own message carries no
+    # digest and an operator needs it to clear a stale lock.
     with _digest_scrubbed(holdout_key):
         try:
             handle = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
@@ -530,12 +533,12 @@ def _ledger_held(holdout_key: str) -> Iterator[None]:
                 f"digests the held-out membership, and an unsalted digest of a "
                 f"set the caller can enumerate is that set."
             ) from exc
-    try:
-        os.write(handle, str(os.getpid()).encode("utf-8"))
-        os.close(handle)
-        yield
-    finally:
-        lock.unlink(missing_ok=True)
+        try:
+            os.write(handle, str(os.getpid()).encode("utf-8"))
+            os.close(handle)
+            yield
+        finally:
+            lock.unlink(missing_ok=True)
 
 
 def _read_ledger(path: Path, holdout_key: str, cap: int) -> int:

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -485,14 +485,25 @@ def _digest_scrubbed(holdout_key: str) -> Iterator[None]:
     A wrapper covers the paths someone remembered; a seam covers the one
     added next year. The message survives with the name replaced, because an
     error that says nothing about what failed is a worse trade than the leak.
+
+    Every `OSError` becomes a `ConfigError` whether or not it carried the
+    digest, because `main` catches `ConfigError` and not `OSError`, and an
+    eighth review found the first draft re-raising the pathless ones raw. An
+    `os.write` that runs out of space and an `os.close` that hits EIO name no
+    file, so they missed the redaction branch and escaped as tracebacks: the
+    same shape of defect the scrub exists to fix, one layer down. A
+    `ConfigError` without the digest is re-raised as itself rather than
+    rewrapped, so nothing that inspects the exception object loses it.
     """
     try:
         yield
     except (ConfigError, OSError) as exc:
         text = str(exc)
-        if holdout_key not in text:
+        if holdout_key in text:
+            raise ConfigError(text.replace(holdout_key, "<held-out group>")) from exc
+        if isinstance(exc, ConfigError):
             raise
-        raise ConfigError(text.replace(holdout_key, "<held-out group>")) from exc
+        raise ConfigError(text) from exc
 
 
 def _ledger_path(holdout_key: str) -> Path:

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -458,8 +458,10 @@ def _holdout_key(split: dict[str, Any]) -> str:
     principle: two unrelated eval sets whose task ids and held-out membership
     both coincide would share a budget. A namespace would have to come from the
     caller, and a caller-supplied key is the exact defect this function exists
-    to close. Sharing is the conservative direction, so the collision is
-    accepted rather than reopened.
+    to close. A namespace derived from task contents or from trusted corpus
+    provenance would work and needs a seam that carries one; the seam here
+    carries task ids and pass booleans. Sharing is the conservative direction,
+    so the collision is accepted rather than reopened.
     """
     sel = sorted(str(task_id) for task_id in _group_ids(split, _GATE_GROUP))
     # JSON rather than a NUL join: joining is not injective when an id may
@@ -467,6 +469,30 @@ def _holdout_key(split: dict[str, Any]) -> str:
     # budget as ["a\0b", "c"].
     canonical = json.dumps(sel, separators=(",", ":"), ensure_ascii=True)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+@contextmanager
+def _digest_scrubbed(holdout_key: str) -> Iterator[None]:
+    """Keep the held-out digest out of whatever goes wrong under the ledger.
+
+    Every ledger and lock filename ends in the digest, and the digest is an
+    unsalted hash of a set the caller can enumerate. The three hand-written
+    errors were redacted one at a time and that left every other way to fail
+    intact: a ledger that is not JSON, a write that cannot land, an os.open
+    that fails for any errno but EEXIST. Each raises with the full path.
+
+    Scrubbing at the seam rather than sanitizing each call site is the point.
+    A wrapper covers the paths someone remembered; a seam covers the one
+    added next year. The message survives with the name replaced, because an
+    error that says nothing about what failed is a worse trade than the leak.
+    """
+    try:
+        yield
+    except (ConfigError, OSError) as exc:
+        text = str(exc)
+        if holdout_key not in text:
+            raise
+        raise ConfigError(text.replace(holdout_key, "<held-out group>")) from exc
 
 
 def _ledger_path(holdout_key: str) -> Path:
@@ -489,17 +515,21 @@ def _ledger_held(holdout_key: str) -> Iterator[None]:
     """
     lock = _ledger_root() / f"{holdout_key}.lock"
     lock.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        handle = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-    except FileExistsError as exc:
-        raise ConfigError(
-            f"another gate holds a lock under {lock.parent}; consultations "
-            f"against one held-out group are serialized so a concurrent pair "
-            f"cannot spend one budget twice. Remove the lock file there if no "
-            f"gate is running. Its name is withheld: the name digests the "
-            f"held-out membership, and an unsalted digest of a set the caller "
-            f"can enumerate is that set."
-        ) from exc
+    # The scrub sits outside so any errno but EEXIST loses the digest in the
+    # lock's name, and the contention branch sits inside so its own message,
+    # which carries no digest, reaches the caller intact.
+    with _digest_scrubbed(holdout_key):
+        try:
+            handle = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError as exc:
+            raise ConfigError(
+                f"another gate holds a lock under {lock.parent}; consultations "
+                f"against one held-out group are serialized so a concurrent "
+                f"pair cannot spend one budget twice. Remove the lock file "
+                f"there if no gate is running. Its name is withheld: the name "
+                f"digests the held-out membership, and an unsalted digest of a "
+                f"set the caller can enumerate is that set."
+            ) from exc
     try:
         os.write(handle, str(os.getpid()).encode("utf-8"))
         os.close(handle)
@@ -611,7 +641,8 @@ def _gate_decision(args: argparse.Namespace, split: dict[str, Any]) -> int:
     holdout_key = _holdout_key(split)
     ledger = _ledger_path(holdout_key)
     try:
-        spent = _read_ledger(ledger, holdout_key, args.max_consultations)
+        with _digest_scrubbed(holdout_key):
+            spent = _read_ledger(ledger, holdout_key, args.max_consultations)
     except LedgerMismatchError as exc:
         _emit({
             "decision": "REJECT",
@@ -650,7 +681,8 @@ def _gate_decision(args: argparse.Namespace, split: dict[str, Any]) -> int:
     # comparison for free. And any refusal decided after scoring was equally
     # free, which is what made the reveal below worth buying.
     spent_after = spent + 1
-    _write_ledger(ledger, holdout_key, spent_after, args.max_consultations)
+    with _digest_scrubbed(holdout_key):
+        _write_ledger(ledger, holdout_key, spent_after, args.max_consultations)
 
     if not _covers_holdout(incumbent_results, sel_ids) or not _covers_holdout(
         candidate_results, sel_ids
@@ -661,8 +693,9 @@ def _gate_decision(args: argparse.Namespace, split: dict[str, Any]) -> int:
                 "reason": (
                     "the results do not cover the held-out group; score both "
                     "artifacts over the whole task set and gate again. Which "
-                    "tasks are missing is withheld: naming them would publish "
-                    "the membership the group exists to withhold."
+                    "tasks are missing is withheld: with a test group drawn, "
+                    "naming them would say which of the two withheld groups "
+                    "each one belongs to."
                 ),
                 "sel_consultations": spent_after,
                 "compared": False,

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -500,7 +500,11 @@ def _digest_scrubbed(holdout_key: str) -> Iterator[None]:
     except (ConfigError, OSError) as exc:
         text = str(exc)
         if holdout_key in text:
-            raise ConfigError(text.replace(holdout_key, "<held-out group>")) from exc
+            # `from None`, not `from exc`. Chaining would set __cause__ to the
+            # exception whose message is the reason this branch exists, and a
+            # printed traceback walks the chain. Round 9 found the redaction
+            # handing the digest straight back that way.
+            raise ConfigError(text.replace(holdout_key, "<held-out group>")) from None
         if isinstance(exc, ConfigError):
             raise
         raise ConfigError(text) from exc
@@ -535,7 +539,7 @@ def _ledger_held(holdout_key: str) -> Iterator[None]:
     with _digest_scrubbed(holdout_key):
         try:
             handle = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-        except FileExistsError as exc:
+        except FileExistsError:
             raise ConfigError(
                 f"another gate holds a lock under {lock.parent}; consultations "
                 f"against one held-out group are serialized so a concurrent "
@@ -543,13 +547,28 @@ def _ledger_held(holdout_key: str) -> Iterator[None]:
                 f"there if no gate is running. Its name is withheld: the name "
                 f"digests the held-out membership, and an unsalted digest of a "
                 f"set the caller can enumerate is that set."
-            ) from exc
+            ) from None
         try:
             os.write(handle, str(os.getpid()).encode("utf-8"))
             os.close(handle)
             yield
         finally:
-            lock.unlink(missing_ok=True)
+            try:
+                lock.unlink(missing_ok=True)
+            except OSError as exc:
+                # The decision is already on stdout. Letting this reach main
+                # would print a second JSON document after it and return the
+                # config-failure code for a comparison that succeeded, and the
+                # module docstring promises one readable document. Silence
+                # would hide a lock that now blocks the next run, so it goes to
+                # stderr, named by its directory rather than by itself.
+                print(
+                    f"warning: could not remove the lock under {lock.parent} "
+                    f"({exc.strerror or exc.errno}); the next gate against this "
+                    f"held-out group reports contention until it is removed. "
+                    f"Its name is withheld: the name digests the membership.",
+                    file=sys.stderr,
+                )
 
 
 def _read_ledger(path: Path, holdout_key: str, cap: int) -> int:

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -415,6 +415,7 @@ def cmd_apply(args: argparse.Namespace) -> int:
 
 
 _LEDGER_DIR_ENV = "EVAL_LEDGER_DIR"
+_HELD_OUT_PLACEHOLDER = "<held-out group>"
 
 
 def _ledger_root() -> Path:
@@ -471,6 +472,18 @@ def _holdout_key(split: dict[str, Any]) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _scrub(text: str, holdout_key: str) -> str:
+    """Replace the held-out digest wherever it appears in `text`.
+
+    One definition rather than a `.replace` at each site. A tenth review found
+    the release warning redacting by hand and getting it wrong, one round after
+    a ninth review found the same at the cause chain. Two consecutive rounds
+    finding a defect at a hand-written redaction site is the argument for
+    having exactly one.
+    """
+    return text.replace(holdout_key, _HELD_OUT_PLACEHOLDER)
+
+
 @contextmanager
 def _digest_scrubbed(holdout_key: str) -> Iterator[None]:
     """Keep the held-out digest out of whatever goes wrong under the ledger.
@@ -504,7 +517,7 @@ def _digest_scrubbed(holdout_key: str) -> Iterator[None]:
             # exception whose message is the reason this branch exists, and a
             # printed traceback walks the chain. Round 9 found the redaction
             # handing the digest straight back that way.
-            raise ConfigError(text.replace(holdout_key, "<held-out group>")) from None
+            raise ConfigError(_scrub(text, holdout_key)) from None
         if isinstance(exc, ConfigError):
             raise
         raise ConfigError(text) from exc
@@ -529,14 +542,18 @@ def _ledger_held(holdout_key: str) -> Iterator[None]:
     guessing that the holder is gone is how a lock becomes advisory.
     """
     lock = _ledger_root() / f"{holdout_key}.lock"
-    lock.parent.mkdir(parents=True, exist_ok=True)
     # The scrub spans the whole lifecycle, not just the acquire. A seventh
     # review found the release outside it: the unlink in the finally block
     # names the lock, the lock's name is the digest, and main() does not catch
     # OSError, so a cleanup failure printed the group as an uncaught traceback.
+    # A tenth review found the mkdir outside it too, which cost more than the
+    # leak: an unwritable ledger root raised PermissionError past main's
+    # handler list, so a read-only home returned a traceback where the module
+    # docstring promises a JSON error document.
     # The contention branch nests inside because its own message carries no
     # digest and an operator needs it to clear a stale lock.
     with _digest_scrubbed(holdout_key):
+        lock.parent.mkdir(parents=True, exist_ok=True)
         try:
             handle = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
         except FileExistsError:
@@ -562,11 +579,19 @@ def _ledger_held(holdout_key: str) -> Iterator[None]:
                 # module docstring promises one readable document. Silence
                 # would hide a lock that now blocks the next run, so it goes to
                 # stderr, named by its directory rather than by itself.
+                #
+                # Through _scrub, because naming the directory was justified in
+                # review by the claim that a directory carries no digest, and a
+                # tenth review falsified it: $EVAL_LEDGER_DIR can name one.
                 print(
-                    f"warning: could not remove the lock under {lock.parent} "
-                    f"({exc.strerror or exc.errno}); the next gate against this "
-                    f"held-out group reports contention until it is removed. "
-                    f"Its name is withheld: the name digests the membership.",
+                    _scrub(
+                        f"warning: could not remove the lock under {lock.parent} "
+                        f"({exc.strerror or exc.errno}); the next gate against "
+                        f"this held-out group reports contention until it is "
+                        f"removed. Its name is withheld: the name digests the "
+                        f"membership.",
+                        holdout_key,
+                    ),
                     file=sys.stderr,
                 )
 

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -535,12 +535,19 @@ def _digest_scrubbed(holdout_key: str) -> Iterator[None]:
         yield
     except (ConfigError, OSError) as exc:
         text = str(exc)
-        if holdout_key in text:
+        # `_scrub` decides whether the digest is here, rather than a separate
+        # `holdout_key in text`. A twelfth review found that guard reading case
+        # sensitively one round after `_scrub` learned to fold case, so an
+        # uppercase digest failed the test, skipped the scrub, and printed
+        # whole. Two answers to one question is what keeps going wrong; asking
+        # `_scrub` leaves nothing to keep in step.
+        scrubbed = _scrub(text, holdout_key)
+        if scrubbed != text:
             # `from None`, not `from exc`. Chaining would set __cause__ to the
             # exception whose message is the reason this branch exists, and a
             # printed traceback walks the chain. Round 9 found the redaction
             # handing the digest straight back that way.
-            raise ConfigError(_scrub(text, holdout_key)) from None
+            raise ConfigError(scrubbed) from None
         if isinstance(exc, ConfigError):
             raise
         raise ConfigError(text) from exc

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -43,6 +43,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import sys
 import tempfile
 from collections.abc import Iterator, Mapping
@@ -430,7 +431,24 @@ def _ledger_root() -> Path:
     override = os.environ.get(_LEDGER_DIR_ENV)
     if override:
         return Path(override)
-    state = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    state = os.environ.get("XDG_STATE_HOME")
+    if not state:
+        try:
+            state = str(Path.home() / ".local" / "state")
+        except RuntimeError as exc:
+            # An eleventh review found this escaping as RuntimeError, which main
+            # does not catch, so the caller got a traceback where the module
+            # docstring promises a JSON error document. Reached on the default
+            # configuration by any container running as a uid with no passwd
+            # entry: Path.home() consults $HOME first and the passwd database
+            # second, and gives up when both are absent.
+            raise ConfigError(
+                f"cannot resolve a ledger directory ({exc}). Neither "
+                f"${_LEDGER_DIR_ENV} nor $XDG_STATE_HOME is set and the home "
+                f"directory is undeterminable, which is what a container running "
+                f"as a numeric uid with no passwd entry looks like. Set "
+                f"${_LEDGER_DIR_ENV} to a writable path."
+            ) from exc
     return Path(state) / "ai-agents-eval" / "ledgers"
 
 
@@ -480,8 +498,13 @@ def _scrub(text: str, holdout_key: str) -> str:
     a ninth review found the same at the cause chain. Two consecutive rounds
     finding a defect at a hand-written redaction site is the argument for
     having exactly one.
+
+    Case-insensitive because a hex digest has an uppercase spelling and
+    `$EVAL_LEDGER_DIR` can carry it. Hex is the one alphabet where folding has
+    no surprises. That path only fires for a caller who already knows the
+    digest, so the reason to close it is the stated property, not the threat.
     """
-    return text.replace(holdout_key, _HELD_OUT_PLACEHOLDER)
+    return re.sub(re.escape(holdout_key), _HELD_OUT_PLACEHOLDER, text, flags=re.IGNORECASE)
 
 
 @contextmanager
@@ -566,8 +589,13 @@ def _ledger_held(holdout_key: str) -> Iterator[None]:
                 f"set the caller can enumerate is that set."
             ) from None
         try:
-            os.write(handle, str(os.getpid()).encode("utf-8"))
-            os.close(handle)
+            try:
+                os.write(handle, str(os.getpid()).encode("utf-8"))
+            finally:
+                # Its own finally, so a write that fails on a full disk still
+                # releases the descriptor. POSIX frees the descriptor even when
+                # close reports EIO, so this must never be retried.
+                os.close(handle)
             yield
         finally:
             try:

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -2346,3 +2346,120 @@ class TestCleanupFailureDoesNotRewriteTheDecision:
         inc, split, record = self._fixture(tmp_path, capsys)
         self._gate(inc, split, record)
         assert capsys.readouterr().err == ""
+
+
+class TestTheLedgerRootIsNotOutsideTheSeam:
+    """One line in `_ledger_held` sat outside the scrub, and it was the first one.
+
+    A tenth review found `lock.parent.mkdir(...)` above the `with` rather than
+    inside it. That has two costs and only the second one needs a contrived
+    setup.
+
+    The first is the round-8 contract defect, unfixed at this line. `mkdir` on a
+    ledger root the process cannot create raises `PermissionError`, `main`
+    catches `(ConfigError, AdapterError, ValueError)` and not `OSError`, so the
+    caller piping stdout through a JSON reader gets a traceback instead of the
+    error document the module docstring promises. A read-only home or a
+    sandboxed runner reaches this with no help from anyone.
+
+    The second is the leak. `$EVAL_LEDGER_DIR` can name a directory that
+    contains the digest, and both the `mkdir` traceback and the release warning
+    render that directory. A caller who set that variable already knows the
+    digest, so this leaks to someone holding the secret. It is fixed anyway,
+    because the standing rule from nine rounds is that a path by which the
+    withheld thing is readable is not withholding it, and because the release
+    warning was justified in review by the claim that a directory carries no
+    digest. That justification was wrong, which is reason enough.
+    """
+
+    def _fixture(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(12)})
+        split = tmp_path / "split.json"
+        _run(capsys, "split", "--results", inc, "--seed", "s", "--out", split)
+        return inc, split, json.loads(split.read_text())
+
+    def _gate(self, inc, split, record):
+        return oa.main([
+            "gate", "--incumbent", str(inc), "--candidate", str(inc),
+            "--split", str(split), "--max-consultations", "2",
+            "--incumbent-fingerprint", record["fingerprint"],
+        ])
+
+    def _break(self, monkeypatch, method):
+        original = getattr(Path, method)
+
+        def refuse(self, *args, **kwargs):
+            if method == "mkdir" or str(self).endswith(".lock"):
+                raise PermissionError(13, "Permission denied", str(self))
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, method, refuse)
+
+    def test_an_unwritable_ledger_root_keeps_the_json_contract(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """No digest anywhere. The contract still has to hold."""
+        monkeypatch.setenv("EVAL_LEDGER_DIR", str(tmp_path / "plain"))
+        inc, split, record = self._fixture(tmp_path, capsys)
+        self._break(monkeypatch, "mkdir")
+        code = self._gate(inc, split, record)
+        payload = json.loads(capsys.readouterr().out)
+        assert code == EXIT_CONFIG
+        assert payload["type"] == "ConfigError"
+
+    def test_a_digest_bearing_root_is_scrubbed_from_the_mkdir_failure(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        key = oa._holdout_key(record)
+        monkeypatch.setenv("EVAL_LEDGER_DIR", str(tmp_path / f"root-{key}"))
+        self._break(monkeypatch, "mkdir")
+        self._gate(inc, split, record)
+        captured = capsys.readouterr()
+        assert key not in captured.out + captured.err
+
+    def test_a_digest_bearing_root_is_scrubbed_from_the_release_warning(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        key = oa._holdout_key(record)
+        monkeypatch.setenv("EVAL_LEDGER_DIR", str(tmp_path / f"root-{key}"))
+        self._break(monkeypatch, "unlink")
+        self._gate(inc, split, record)
+        captured = capsys.readouterr()
+        assert key not in captured.out + captured.err
+        assert "<held-out group>" in captured.err
+
+    def test_a_plain_root_is_still_named_so_the_lock_can_be_cleared(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Redaction that redacts everything is not redaction, it is silence."""
+        root = tmp_path / "plain"
+        monkeypatch.setenv("EVAL_LEDGER_DIR", str(root))
+        inc, split, record = self._fixture(tmp_path, capsys)
+        self._break(monkeypatch, "unlink")
+        self._gate(inc, split, record)
+        assert str(root) in capsys.readouterr().err
+
+
+class TestOneDefinitionOfHowWeRedact:
+    """The release warning was a second, hand-written redaction site, and it was wrong.
+
+    Two rounds in a row found a redaction defect at a site that had been
+    written by hand rather than routed through the seam. The rule the code now
+    states once is the rule every site gets.
+    """
+
+    def test_a_digest_in_the_text_is_replaced(self):
+        assert oa._scrub("under /x/abc123/y", "abc123") == "under /x/<held-out group>/y"
+
+    def test_text_without_the_digest_is_returned_unchanged(self):
+        assert oa._scrub("under /x/y", "abc123") == "under /x/y"
+
+    def test_every_occurrence_is_replaced_not_only_the_first(self):
+        out = oa._scrub("abc123 and abc123", "abc123")
+        assert "abc123" not in out
+        assert out.count("<held-out group>") == 2
+
+    def test_empty_text_is_not_a_special_case(self):
+        assert oa._scrub("", "abc123") == ""

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -1954,3 +1954,89 @@ class TestTheGateNeverPublishesTheHoldoutKey:
 
     def test_the_key_still_separates_different_members(self):
         assert oa._holdout_key({"sel": ["a", "b"]}) != oa._holdout_key({"sel": ["a", "c"]})
+
+
+class TestNoLedgerFailureLeaksTheDigest:
+    """The explicit messages were redacted; the generic ones still carried it.
+
+    A sixth adversarial review (gpt-5.6-sol, 2026-07-26) found that redacting
+    the three hand-written errors left every other way of failing on a ledger
+    path intact: `_read_json` interpolates the file it could not parse, the
+    atomic write interpolates the file it could not replace, and `os.open`
+    raises with the lock's name for any errno but EEXIST. All three names end
+    in the digest. The fix is one scrub at the exception seam rather than
+    three sanitized wrappers, because a wrapper covers the paths someone
+    remembered and a seam covers the ones added later.
+    """
+
+    def _fixture(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(12)})
+        split = tmp_path / "split.json"
+        _run(capsys, "split", "--results", inc, "--seed", "s", "--out", split)
+        return inc, split, json.loads(split.read_text())
+
+    def _gate(self, capsys, inc, split, record):
+        return _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", inc,
+            "--split", split, "--max-consultations", "2",
+            "--incumbent-fingerprint", record["fingerprint"],
+        )
+
+    def test_an_unparseable_ledger_does_not_leak_the_digest(self, tmp_path, capsys):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        key = oa._holdout_key(record)
+        ledger = oa._ledger_path(key)
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        ledger.write_text("{not json")
+        code, out = self._gate(capsys, inc, split, record)
+        assert code == EXIT_CONFIG and key not in json.dumps(out)
+
+    def test_an_unparseable_ledger_still_says_it_could_not_be_read(self, tmp_path, capsys):
+        """Scrubbing that erases the diagnosis is worse than the leak."""
+        inc, split, record = self._fixture(tmp_path, capsys)
+        ledger = oa._ledger_path(oa._holdout_key(record))
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        ledger.write_text("{not json")
+        _, out = self._gate(capsys, inc, split, record)
+        assert "not valid JSON" in out["error"] and "ledger" in out["error"]
+
+    def test_an_unwritable_ledger_does_not_leak_the_digest(self, tmp_path, capsys, monkeypatch):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        key = oa._holdout_key(record)
+
+        def _deny(path, _text):
+            raise OSError(28, "No space left on device", str(path))
+
+        monkeypatch.setattr(oa, "_write_atomic", _deny)
+        code, out = self._gate(capsys, inc, split, record)
+        assert code == EXIT_CONFIG and key not in json.dumps(out)
+
+    def test_a_lock_that_fails_for_any_other_reason_does_not_leak(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """os.open raises for more than EEXIST, and the name is the digest."""
+        inc, split, record = self._fixture(tmp_path, capsys)
+        key = oa._holdout_key(record)
+
+        def _deny(path, *args, **kwargs):
+            raise PermissionError(13, "Permission denied", str(path))
+
+        monkeypatch.setattr(oa.os, "open", _deny)
+        code, out = self._gate(capsys, inc, split, record)
+        assert code == EXIT_CONFIG and key not in json.dumps(out)
+
+    def test_the_scrub_leaves_messages_without_the_digest_alone(self):
+        with pytest.raises(oa.ConfigError, match="plain trouble"):
+            with oa._digest_scrubbed("a" * 64):
+                raise oa.ConfigError("plain trouble")
+
+    def test_the_scrub_replaces_the_digest_wherever_it_appears(self):
+        key = "a" * 64
+        with pytest.raises(oa.ConfigError) as caught:
+            with oa._digest_scrubbed(key):
+                raise oa.ConfigError(f"could not read /x/{key}.ledger")
+        assert key not in str(caught.value) and "/x/" in str(caught.value)
+
+    def test_the_scrub_passes_a_clean_block_through(self):
+        with oa._digest_scrubbed("a" * 64):
+            pass

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import sys
 import traceback
 from pathlib import Path
@@ -2463,3 +2464,135 @@ class TestOneDefinitionOfHowWeRedact:
 
     def test_empty_text_is_not_a_special_case(self):
         assert oa._scrub("", "abc123") == ""
+
+
+class TestTheRootResolvesInsideTheContract:
+    """An eleventh review found the seam's first line had moved, not vanished.
+
+    Round 10 pulled `lock.parent.mkdir(...)` inside `_digest_scrubbed` and left
+    `_ledger_root()` on the line above it. `Path.home()` raises `RuntimeError`
+    when `$HOME` is unset and the uid has no passwd entry, which is an ordinary
+    container running as a numeric user, and it happens on the DEFAULT
+    configuration: `_ledger_root` consults home only when neither
+    `$EVAL_LEDGER_DIR` nor `$XDG_STATE_HOME` is set.
+
+    `main` catches `(ConfigError, AdapterError, ValueError)`, so that escaped as
+    a traceback where the module docstring promises a JSON error document. The
+    conversion belongs in `_ledger_root` rather than at either call site,
+    because the failure is there and both callers need it.
+    """
+
+    @staticmethod
+    def _no_home(monkeypatch):
+        monkeypatch.delenv("EVAL_LEDGER_DIR", raising=False)
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        monkeypatch.setattr(
+            Path, "home",
+            staticmethod(lambda: (_ for _ in ()).throw(RuntimeError("no home"))),
+        )
+
+    def test_an_unresolvable_home_is_a_config_error_not_a_runtime_error(self, monkeypatch):
+        self._no_home(monkeypatch)
+        with pytest.raises(oa.ConfigError) as caught:
+            oa._ledger_root()
+        assert "EVAL_LEDGER_DIR" in str(caught.value)
+
+    def test_the_gate_still_emits_one_json_document(self, tmp_path, capsys, monkeypatch):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(12)})
+        split = tmp_path / "split.json"
+        _run(capsys, "split", "--results", inc, "--seed", "s", "--out", split)
+        record = json.loads(split.read_text())
+        self._no_home(monkeypatch)
+        code = oa.main([
+            "gate", "--incumbent", str(inc), "--candidate", str(inc),
+            "--split", str(split), "--max-consultations", "2",
+            "--incumbent-fingerprint", record["fingerprint"],
+        ])
+        assert code == EXIT_CONFIG
+        assert json.loads(capsys.readouterr().out)["type"] == "ConfigError"
+
+    def test_an_explicit_root_never_consults_home(self, tmp_path, monkeypatch):
+        self._no_home(monkeypatch)
+        monkeypatch.setenv("EVAL_LEDGER_DIR", str(tmp_path / "explicit"))
+        assert oa._ledger_root() == tmp_path / "explicit"
+
+    def test_xdg_state_home_also_never_consults_home(self, tmp_path, monkeypatch):
+        self._no_home(monkeypatch)
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg"))
+        assert oa._ledger_root().is_relative_to(tmp_path / "xdg")
+
+
+class TestTheLockDescriptorIsAlwaysReleased:
+    """The write and the close were in one try, so a failed write skipped the close.
+
+    `os.write` on a full disk jumped straight to the `finally`, which unlinks
+    the lock and never closes the descriptor. A one-shot CLI exits and the
+    kernel reclaims it, so the practical cost is small; the reason to fix it is
+    that `main` is importable and the module is used from tests, where the leak
+    accumulates across a session.
+    """
+
+    def _fd_state(self, monkeypatch, tmp_path, fail_write):
+        monkeypatch.setenv("EVAL_LEDGER_DIR", str(tmp_path / "root"))
+        seen = {}
+        real_open = oa.os.open
+
+        def spy(*args, **kwargs):
+            seen["fd"] = real_open(*args, **kwargs)
+            return seen["fd"]
+
+        monkeypatch.setattr(oa.os, "open", spy)
+        if fail_write:
+            monkeypatch.setattr(
+                oa.os, "write",
+                lambda *a, **k: (_ for _ in ()).throw(OSError(28, "No space left")),
+            )
+        return seen
+
+    @staticmethod
+    def _is_open(fd):
+        try:
+            os.fstat(fd)
+        except OSError:
+            return False
+        return True
+
+    def test_a_failed_write_still_closes_the_descriptor(self, tmp_path, monkeypatch):
+        seen = self._fd_state(monkeypatch, tmp_path, fail_write=True)
+        with pytest.raises(oa.ConfigError):
+            with oa._ledger_held("d" * 64):
+                pass
+        assert self._is_open(seen["fd"]) is False
+
+    def test_the_normal_path_closes_it_exactly_once(self, tmp_path, monkeypatch):
+        seen = self._fd_state(monkeypatch, tmp_path, fail_write=False)
+        with oa._ledger_held("e" * 64):
+            pass
+        assert self._is_open(seen["fd"]) is False
+
+
+class TestRedactionIsNotCaseSensitive:
+    """A hex digest has an uppercase spelling, and a path can carry either.
+
+    Only reachable when the caller put the digest in `$EVAL_LEDGER_DIR`, which
+    means the caller already knows it, so this is not a confidentiality bypass.
+    It is fixed because the stated property is that the key is never printed,
+    and hex is the one alphabet where case-insensitive matching carries no
+    folding surprises.
+    """
+
+    def test_an_uppercase_digest_is_replaced(self):
+        key = "f" * 60 + "abcd"
+        assert key.upper() not in oa._scrub(f"/root-{key.upper()}/x", key)
+
+    def test_a_mixed_case_digest_is_replaced(self):
+        key = "abcdef" + "0" * 58
+        mixed = "AbCdEf" + "0" * 58
+        assert mixed not in oa._scrub(f"/root-{mixed}/x", key)
+
+    def test_the_lowercase_case_still_works(self):
+        key = "a" * 64
+        assert oa._scrub(f"/root-{key}/x", key) == "/root-<held-out group>/x"
+
+    def test_unrelated_text_is_untouched(self):
+        assert oa._scrub("/root/ABCDEF/x", "a" * 64) == "/root/ABCDEF/x"

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -2011,6 +2011,36 @@ class TestNoLedgerFailureLeaksTheDigest:
         code, out = self._gate(capsys, inc, split, record)
         assert code == EXIT_CONFIG and key not in json.dumps(out)
 
+    def test_a_lock_cleanup_failure_does_not_leak(self, tmp_path, capsys, monkeypatch):
+        """The unlink in the finally block names the lock, and the lock is the digest.
+
+        Release runs after the decision is emitted, so stdout carries two
+        documents here and the assertion is on the raw text rather than on a
+        parse. Before the fix this escaped as an uncaught PermissionError,
+        since main() catches ConfigError and not OSError.
+        """
+        inc, split, record = self._fixture(tmp_path, capsys)
+        key = oa._holdout_key(record)
+        real_unlink = Path.unlink
+
+        def _boom(self, missing_ok=False):
+            if self.suffix == ".lock":
+                raise OSError(13, "Permission denied", str(self))
+            return real_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", _boom)
+        code = oa.main([
+            "gate", "--incumbent", str(inc), "--candidate", str(inc),
+            "--split", str(split), "--max-consultations", "2",
+            "--incumbent-fingerprint", record["fingerprint"],
+        ])
+        text = capsys.readouterr().out
+        assert code == EXIT_CONFIG
+        assert key not in text
+        assert "<held-out group>" in text
+        for task in record["sel"]:
+            assert task not in text
+
     def test_a_lock_that_fails_for_any_other_reason_does_not_leak(
         self, tmp_path, capsys, monkeypatch
     ):

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import traceback
 from pathlib import Path
 
 import pytest
@@ -2103,10 +2104,13 @@ class TestNoLedgerFailureLeaksTheDigest:
     def test_a_lock_cleanup_failure_does_not_leak(self, tmp_path, capsys, monkeypatch):
         """The unlink in the finally block names the lock, and the lock is the digest.
 
-        Release runs after the decision is emitted, so stdout carries two
-        documents here and the assertion is on the raw text rather than on a
-        parse. Before the fix this escaped as an uncaught PermissionError,
-        since main() catches ConfigError and not OSError.
+        Before round 7 this escaped as an uncaught PermissionError, since main
+        catches ConfigError and not OSError. Round 9 then stopped it reaching
+        main at all, because release runs after the decision is emitted and a
+        second document on stdout breaks every reader of the first. So the
+        assertions here are on the leak, which is the invariant, and both
+        streams are checked; the exit code and the stream split belong to
+        TestCleanupFailureDoesNotRewriteTheDecision.
         """
         inc, split, record = self._fixture(tmp_path, capsys)
         key = oa._holdout_key(record)
@@ -2123,10 +2127,10 @@ class TestNoLedgerFailureLeaksTheDigest:
             "--split", str(split), "--max-consultations", "2",
             "--incumbent-fingerprint", record["fingerprint"],
         ])
-        text = capsys.readouterr().out
-        assert code == EXIT_CONFIG
+        captured = capsys.readouterr()
+        text = captured.out + captured.err
+        assert code != EXIT_CONFIG
         assert key not in text
-        assert "<held-out group>" in text
         for task in record["sel"]:
             assert task not in text
 
@@ -2230,3 +2234,115 @@ class TestLedgerFailuresKeepTheJsonErrorContract:
         with pytest.raises(KeyboardInterrupt):
             with oa._digest_scrubbed("d" * 64):
                 raise KeyboardInterrupt
+
+
+class TestTheSeamLeaksNothingThroughTheCauseChain:
+    """A scrubbed message with an unscrubbed `__cause__` is not scrubbed.
+
+    A ninth review (gemini-3.1-pro-preview, 2026-07-26) found the redaction
+    handing the digest straight back: `raise ConfigError(scrubbed) from exc`
+    sets `__cause__` to the original, and a printed traceback walks the chain.
+    The contention branch was worse, because its message withholds the lock
+    name on purpose and then attached the `FileExistsError` that spells it out.
+
+    The chain is severed exactly where it carries the digest. Where the message
+    never had it, `from exc` stays, because the original raise site is worth
+    keeping and there is nothing there to leak.
+    """
+
+    def _traceback(self, exc):
+        return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+
+    def test_a_scrubbed_oserror_leaks_nothing_through_the_chain(self):
+        key = "a" * 64
+        with pytest.raises(oa.ConfigError) as caught:
+            with oa._digest_scrubbed(key):
+                raise OSError(2, "No such file", f"/state/{key}.lock")
+        assert key not in self._traceback(caught.value)
+
+    def test_lock_contention_leaks_nothing_through_the_chain(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("EVAL_LEDGER_DIR", str(tmp_path / "ledgers"))
+        key = "b" * 64
+        root = oa._ledger_root()
+        root.mkdir(parents=True, exist_ok=True)
+        (root / f"{key}.lock").write_text("999")
+        with pytest.raises(oa.ConfigError) as caught:
+            with oa._ledger_held(key):
+                pass
+        assert key not in self._traceback(caught.value)
+
+    def test_a_pathless_oserror_keeps_its_cause_for_debugging(self):
+        with pytest.raises(oa.ConfigError) as caught:
+            with oa._digest_scrubbed("c" * 64):
+                raise OSError(28, "No space left on device")
+        assert isinstance(caught.value.__cause__, OSError)
+
+
+class TestCleanupFailureDoesNotRewriteTheDecision:
+    """The gate had already answered; removing the lock is bookkeeping.
+
+    The same ninth review found that an unlink failure in the `finally` reached
+    `main` after `_emit` had printed the decision, so stdout carried two JSON
+    documents and a successful comparison returned the config-failure exit
+    code. The module docstring promises a caller can read a field instead of
+    guessing from the exit code, and two documents break every reader of it.
+
+    Swallowing it silently would hide a lock that now blocks the next run, so
+    the failure goes to stderr and the decision keeps stdout to itself.
+    """
+
+    def _fixture(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(12)})
+        split = tmp_path / "split.json"
+        _run(capsys, "split", "--results", inc, "--seed", "s", "--out", split)
+        return inc, split, json.loads(split.read_text())
+
+    def _gate(self, inc, split, record):
+        return oa.main([
+            "gate", "--incumbent", str(inc), "--candidate", str(inc),
+            "--split", str(split), "--max-consultations", "2",
+            "--incumbent-fingerprint", record["fingerprint"],
+        ])
+
+    def _break_unlink(self, monkeypatch):
+        original = Path.unlink
+
+        def refuse(self, missing_ok=False):
+            if str(self).endswith(".lock"):
+                raise OSError(13, "Permission denied", str(self))
+            return original(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", refuse)
+
+    def test_stdout_still_holds_exactly_one_document(self, tmp_path, capsys, monkeypatch):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        self._break_unlink(monkeypatch)
+        self._gate(inc, split, record)
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["decision"] in {"ACCEPT", "REJECT"}
+
+    def test_the_decision_keeps_its_exit_code(self, tmp_path, capsys, monkeypatch):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        self._break_unlink(monkeypatch)
+        code = self._gate(inc, split, record)
+        assert code != oa.EXIT_CONFIG
+
+    def test_the_stale_lock_is_reported_on_stderr(self, tmp_path, capsys, monkeypatch):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        self._break_unlink(monkeypatch)
+        self._gate(inc, split, record)
+        assert "Permission denied" in capsys.readouterr().err
+
+    def test_the_warning_withholds_the_digest(self, tmp_path, capsys, monkeypatch):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        key = oa._holdout_key(record)
+        self._break_unlink(monkeypatch)
+        self._gate(inc, split, record)
+        captured = capsys.readouterr()
+        assert key not in captured.err
+        assert key not in captured.out
+
+    def test_a_clean_release_says_nothing(self, tmp_path, capsys):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        self._gate(inc, split, record)
+        assert capsys.readouterr().err == ""

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -2596,3 +2596,102 @@ class TestRedactionIsNotCaseSensitive:
 
     def test_unrelated_text_is_untouched(self):
         assert oa._scrub("/root/ABCDEF/x", "a" * 64) == "/root/ABCDEF/x"
+
+
+class TestTheGuardIsNotASecondDefinitionOfRedaction:
+    """A twelfth review found the round-11 fix applied to only half the pair.
+
+    Round 11 made `_scrub` case-insensitive and left the call site that decides
+    whether to call it reading `if holdout_key in text`, which is case
+    sensitive. So an uppercase digest failed the guard, skipped the scrub the
+    round-11 fix had just corrected, and printed whole.
+
+    That is the recurring shape once more, in its twelfth spelling: two places
+    answer "does this text carry the key" and only one of them was fixed. The
+    round-11 tests asserted on `_scrub` directly, which is why four passing
+    tests said the case bug was closed while the CLI still printed the digest.
+    Testing the function that changed is not testing the property that matters.
+
+    Fixed by deleting the second definition rather than teaching it to fold
+    case: `_scrub` returning a different string is the answer to both questions,
+    so there is nothing left to keep in step.
+    """
+
+    def _fixture(self, tmp_path, capsys):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(12)})
+        split = tmp_path / "split.json"
+        _run(capsys, "split", "--results", inc, "--seed", "s", "--out", split)
+        return inc, split, json.loads(split.read_text())
+
+    def _gate_denied(self, monkeypatch, tmp_path, capsys, spell):
+        inc, split, record = self._fixture(tmp_path, capsys)
+        key = oa._holdout_key(record)
+        monkeypatch.setenv(oa._LEDGER_DIR_ENV, str(tmp_path / f"denied-{spell(key)}"))
+        monkeypatch.setattr(
+            Path,
+            "mkdir",
+            lambda self, *a, **k: (_ for _ in ()).throw(
+                PermissionError(13, "Permission denied", str(self))
+            ),
+        )
+        code = oa.main([
+            "gate", "--incumbent", str(inc), "--candidate", str(inc),
+            "--split", str(split), "--max-consultations", "2",
+            "--incumbent-fingerprint", record["fingerprint"],
+        ])
+        return key, code, capsys.readouterr()
+
+    def test_an_uppercase_digest_does_not_reach_stdout(self, tmp_path, monkeypatch, capsys):
+        key, code, out = self._gate_denied(monkeypatch, tmp_path, capsys, str.upper)
+        assert code == oa.EXIT_CONFIG
+        assert key.upper() not in out.out
+        assert key.upper() not in out.err
+
+    def test_an_uppercase_digest_still_leaves_a_readable_error(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        _key, _code, out = self._gate_denied(monkeypatch, tmp_path, capsys, str.upper)
+        payload = json.loads(out.out)
+        assert payload["type"] == "ConfigError"
+        assert oa._HELD_OUT_PLACEHOLDER in payload["error"]
+
+    def test_a_lowercase_digest_does_not_reach_stdout(self, tmp_path, monkeypatch, capsys):
+        key, code, out = self._gate_denied(monkeypatch, tmp_path, capsys, str.lower)
+        assert code == oa.EXIT_CONFIG
+        assert key not in out.out
+        assert key not in out.err
+
+    def test_the_seam_scrubs_an_uppercase_digest_in_an_oserror(self):
+        key = "b" * 64
+        with pytest.raises(oa.ConfigError) as caught:
+            with oa._digest_scrubbed(key):
+                raise OSError(13, "denied", f"/root-{key.upper()}/x")
+        assert key.upper() not in str(caught.value)
+        assert oa._HELD_OUT_PLACEHOLDER in str(caught.value)
+
+    def test_the_seam_scrubs_a_mixed_case_digest(self):
+        key = "abcdef" + "0" * 58
+        with pytest.raises(oa.ConfigError) as caught:
+            with oa._digest_scrubbed(key):
+                raise oa.ConfigError(f"/root-{'AbCdEf' + '0' * 58}/x")
+        assert "AbCdEf" not in str(caught.value)
+
+    def test_a_scrubbed_error_still_breaks_the_cause_chain(self):
+        key = "c" * 64
+        with pytest.raises(oa.ConfigError) as caught:
+            with oa._digest_scrubbed(key):
+                raise OSError(13, "denied", f"/root-{key.upper()}/x")
+        assert caught.value.__cause__ is None
+
+    def test_an_error_without_the_digest_keeps_its_message(self):
+        with pytest.raises(oa.ConfigError) as caught:
+            with oa._digest_scrubbed("d" * 64):
+                raise OSError(28, "No space left on device")
+        assert "No space left on device" in str(caught.value)
+
+    def test_a_config_error_without_the_digest_is_reraised_as_itself(self):
+        original = oa.ConfigError("nothing secret here")
+        with pytest.raises(oa.ConfigError) as caught:
+            with oa._digest_scrubbed("e" * 64):
+                raise original
+        assert caught.value is original

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -2159,3 +2159,74 @@ class TestNoLedgerFailureLeaksTheDigest:
     def test_the_scrub_passes_a_clean_block_through(self):
         with oa._digest_scrubbed("a" * 64):
             pass
+
+
+class TestLedgerFailuresKeepTheJsonErrorContract:
+    """A scrub that re-raises a raw OSError breaks the promise it protects.
+
+    An eighth review (Copilot, PR #3458) found that `_digest_scrubbed` re-raised
+    `OSError` untouched whenever the message did not contain the digest, and
+    `main` catches `ConfigError`, `AdapterError`, and `ValueError` but not
+    `OSError`. So the failures that name a path stayed inside the contract while
+    the failures that do not, an `os.write` that runs out of space or an
+    `os.close` that hits EIO, escaped as an uncaught traceback.
+
+    That is the same defect the scrub was added to fix, one layer down: the
+    handled paths are the ones somebody enumerated. The seam now converts every
+    `OSError` it sees, and redacts the digest only when the message carries it,
+    so the two concerns stay separate.
+    """
+
+    def test_an_oserror_without_the_digest_still_emits_json(self, capsys):
+        with pytest.raises(oa.ConfigError) as caught:
+            with oa._digest_scrubbed("a" * 64):
+                raise OSError(28, "No space left on device")
+        assert "No space left on device" in str(caught.value)
+
+    def test_the_json_contract_holds_end_to_end_for_a_pathless_oserror(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i % 3 != 0 for i in range(12)})
+        split = tmp_path / "split.json"
+        _run(capsys, "split", "--results", inc, "--seed", "s", "--out", split)
+        record = json.loads(split.read_text())
+
+        def _boom(_handle, _payload):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(oa.os, "write", _boom)
+        code = oa.main([
+            "gate", "--incumbent", str(inc), "--candidate", str(inc),
+            "--split", str(split), "--max-consultations", "2",
+            "--incumbent-fingerprint", record["fingerprint"],
+        ])
+        out = capsys.readouterr().out
+        assert code == oa.EXIT_CONFIG
+        payload = json.loads(out)
+        assert payload["type"] == "ConfigError"
+        assert "No space left on device" in payload["error"]
+
+    def test_an_oserror_carrying_the_digest_is_still_redacted(self, capsys):
+        key = "b" * 64
+        with pytest.raises(oa.ConfigError) as caught:
+            with oa._digest_scrubbed(key):
+                raise OSError(13, f"Permission denied: /state/{key}.lock")
+        assert key not in str(caught.value)
+        assert "<held-out group>" in str(caught.value)
+
+    def test_a_config_error_without_the_digest_is_reraised_as_itself(self, capsys):
+        original = oa.ConfigError("the split file is not JSON")
+        with pytest.raises(oa.ConfigError) as caught:
+            with oa._digest_scrubbed("c" * 64):
+                raise original
+        assert caught.value is original
+
+    def test_a_ledger_mismatch_passes_through_the_seam_untouched(self, capsys):
+        with pytest.raises(oa.LedgerMismatchError):
+            with oa._digest_scrubbed("c" * 64):
+                raise oa.LedgerMismatchError("the cap moved")
+
+    def test_a_non_oserror_passes_through_untouched(self, capsys):
+        with pytest.raises(KeyboardInterrupt):
+            with oa._digest_scrubbed("d" * 64):
+                raise KeyboardInterrupt

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -1956,6 +1956,95 @@ class TestTheGateNeverPublishesTheHoldoutKey:
         assert oa._holdout_key({"sel": ["a", "b"]}) != oa._holdout_key({"sel": ["a", "c"]})
 
 
+class TestAtomicWriteDoesNotDisguiseNonIOFailures:
+    """A ConfigError means the disk refused. Anything else must keep its type.
+
+    The cleanup arm catches BaseException so an interrupt still removes the
+    temp file. Converting everything it caught into ConfigError would tell a
+    caller the write failed when what actually happened was Ctrl-C, and would
+    swallow an interrupt the operator meant to be immediate.
+    """
+
+    def test_an_interrupt_propagates_unchanged(self, tmp_path, monkeypatch):
+        target = tmp_path / "artifact.md"
+        target.write_text("before", encoding="utf-8")
+
+        def _interrupt(src, dst):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(oa.os, "replace", _interrupt)
+        with pytest.raises(KeyboardInterrupt):
+            oa._write_atomic(target, "after")
+        assert target.read_text(encoding="utf-8") == "before"
+        assert list(tmp_path.iterdir()) == [target]
+
+    def test_an_os_error_becomes_a_config_error(self, tmp_path, monkeypatch):
+        target = tmp_path / "artifact.md"
+        target.write_text("before", encoding="utf-8")
+
+        def _refuse(src, dst):
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(oa.os, "replace", _refuse)
+        with pytest.raises(oa.ConfigError, match="could not write"):
+            oa._write_atomic(target, "after")
+        assert list(tmp_path.iterdir()) == [target]
+
+    def test_a_write_that_works_replaces_the_file(self, tmp_path):
+        target = tmp_path / "artifact.md"
+        target.write_text("before", encoding="utf-8")
+        oa._write_atomic(target, "after")
+        assert target.read_text(encoding="utf-8") == "after"
+        assert list(tmp_path.iterdir()) == [target]
+
+
+class TestASplitFileMustHoldGroupsOfTaskIds:
+    """The gate indexes into every group, so a wrong shape must fail at the file.
+
+    Added by the incoming review-thread commit; these cover its branch. A
+    group holding numbers, or holding a bare string instead of a list, would
+    otherwise surface as a TypeError deep in the comparison, long after the
+    file that caused it went out of scope.
+    """
+
+    def _split_with(self, tmp_path, groups):
+        record = {"opt": ["a"], "sel": ["b"], "test": [],
+                  "seed": "s", "sel_ratio": 0.4, "test_ratio": 0.0,
+                  "fingerprint": "x" * 64}
+        record.update(groups)
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps(record), encoding="utf-8")
+        return path
+
+    @pytest.mark.parametrize("groups", [
+        {"opt": "a"},
+        {"sel": [1, 2]},
+        {"test": [None]},
+        {"opt": {"a": True}},
+    ])
+    def test_a_group_that_is_not_a_list_of_strings_is_refused(
+        self, tmp_path, capsys, groups
+    ):
+        split = self._split_with(tmp_path, groups)
+        inc = _write(tmp_path, "inc.json", {"a": True, "b": True})
+        code, out = _run(capsys, "gate", "--incumbent", inc, "--candidate", inc,
+                         "--split", split, "--max-consultations", "2",
+                         "--incumbent-fingerprint", "x" * 64)
+        assert code == EXIT_CONFIG
+        assert "must be a list of strings" in out["error"]
+
+    def test_a_well_formed_split_passes_the_shape_check(self, tmp_path, capsys):
+        """The negative cases must not be passing for an unrelated reason."""
+        split = self._split_with(tmp_path, {})
+        assert "must be a list of strings" not in json.dumps(
+            _run(capsys, "gate", "--incumbent",
+                 _write(tmp_path, "i.json", {"a": True, "b": True}),
+                 "--candidate", _write(tmp_path, "c.json", {"a": True, "b": True}),
+                 "--split", split, "--max-consultations", "2",
+                 "--incumbent-fingerprint", "x" * 64)[1]
+        )
+
+
 class TestNoLedgerFailureLeaksTheDigest:
     """The explicit messages were redacted; the generic ones still carried it.
 

--- a/tests/test_eval_optimizer_adapters.py
+++ b/tests/test_eval_optimizer_adapters.py
@@ -148,6 +148,23 @@ class TestAgentResults:
         report = _report({"C001": {"agent": [0.5, 0.5]}})
         assert agent_results(report, "agent", pass_threshold=0.5) == {"C001": True}
 
+    @pytest.mark.parametrize("runs", [0.9, {"score": 0.9}, "0.9"])
+    def test_a_run_list_that_is_not_a_list_is_refused(self, runs):
+        """A bare score, a dict, and a string all iterate or index wrongly.
+
+        A string is the trap: it is a Sequence, so a bare `isinstance` check
+        admits it and then `mean` over its characters raises somewhere far
+        from the malformed file. Refusing here names the fixture.
+        """
+        report = _report({"C001": {"agent": runs}})
+        with pytest.raises(AdapterError, match="must be a list of scores"):
+            agent_results(report, "agent")
+
+    def test_an_empty_run_list_is_a_fixture_that_did_not_run(self):
+        """Empty is not malformed: the variant never ran it, so fail closed."""
+        report = _report({"C001": {"agent": []}})
+        assert agent_results(report, "agent") == {"C001": False}
+
     def test_min_reduction_punishes_one_bad_run(self):
         report = _report({"C001": {"agent": [1.0, 1.0, 0.0]}})
         assert agent_results(report, "agent", reduce="min", pass_threshold=1.0) == {

--- a/tests/test_eval_optimizer_core.py
+++ b/tests/test_eval_optimizer_core.py
@@ -964,3 +964,18 @@ class TestGuardRefusalValidatesItsOwnCap:
 
     def test_no_cap_is_accepted(self):
         assert guard_refusal(sel_consultations=99, max_consultations=None) is None
+
+    @pytest.mark.parametrize("spent", [-1, -7])
+    def test_a_negative_spend_is_refused(self, spent):
+        """A negative count is a corrupt ledger, not an unspent budget.
+
+        Reading one as "less than the cap" would hand back consultations the
+        group already spent, which is the budget defect this whole mechanism
+        exists to prevent, arriving through arithmetic instead of through a
+        flag.
+        """
+        with pytest.raises(ValueError, match="must be non-negative"):
+            guard_refusal(sel_consultations=spent, max_consultations=3)
+
+    def test_a_zero_spend_is_accepted(self):
+        assert guard_refusal(sel_consultations=0, max_consultations=3) is None


### PR DESCRIPTION
## Summary

Follow-up to #3430, which squash-merged as 98caa0e54 while six commits were still unpushed. The merged code carries the per-call-site digest scrub but not the seam-level one, not the lock-release fix, not the coverage for four branches a late review-thread commit added, and none of the corrected documents.

The headline is a real leak. Every ledger filename ends in the sha256 digest of the held-out membership. `_ledger_held` scrubbed that digest out of errors raised while *acquiring* the lock, and left the `finally` that unlinks it outside the scrub. `main()` catches `ConfigError` but not `OSError`, so a cleanup failure printed the withheld group as an uncaught traceback, one line below where the leak was supposedly closed. The scrub now spans acquire, write, yield, and release.

Found by the seventh consecutive adversarial review round, each of which falsified something.

## What changed

| Commit | Change |
| --- | --- |
| `9fe0c41c3` | Move the digest scrub to the seam instead of repeating it per call site |
| `99aec9dfa` | Rewrite the README section that overstated what the loop enforces |
| `90c5e4134` | Widen the scrub over lock release, with a regression test |
| `e8565805a` | Cover the four defensive branches the review-thread commit shipped untested |
| `4a1cdef17` | Correct six README claims round seven falsified |
| `9b67d970c` | ADR-087, its debate log, the session log, and the Serena memory |

## Why the scrub can widen over the yield

`LedgerMismatchError` is a sibling of `ConfigError`, not a subclass (both defined at `optimize-artifact.py:83` and `:87`). Widening the scrub does not swallow or reshape it. The scrub re-raises untouched anything whose message does not contain the key.

## What the documents now say

The ADR's original argument was that withholding the decision group's membership bounds what the loop can tune toward. Review falsified both halves, verified at source:

1. `cmd_extract` calls `_emit(results)` on the full mapping and its parser has no group argument, and the documented workflow has the optimizer run `extract` itself. Held-out outcomes already sit in the optimizer's own files, uncharged. Tracked as #3452.
2. Task ids resolve to readable definitions carrying their own grading criteria, so naming a held-out task is enough to hand-tune for it.

Both documents now lead with what the mechanism actually is: a consultation-budgeted comparison over a public benchmark, relying on a cooperating optimizer not to inspect accessible task definitions or result files. Not yet held-out validation of unseen tasks. The budget bounds gate comparisons, not selection pressure, because `extract` and `score` reach results without touching the ledger.

## Verification

- 426 tests pass across the three optimizer test modules
- 100% line coverage on `optimize-artifact.py`, `_optimizer_core.py`, `_optimizer_adapters.py`
- `ruff check` and `mypy` clean on all changed files
- Full push gate green: `pre-pr-validation`, `python-tests`, `build-all-check`, `plugin-load-e2e`, `security-scan`, `path-normalization`

## Follow-ups opened rather than rushed here

- #3452 make `extract` group-aware and replace the one-bit coverage predicate with a whole-universe check. These do not compose without a controller owning the complete mapping, so the issue is sequenced as a prerequisite.
- #3453 bound what each consultation discloses. There is no fixed multiplier, so the statable property is the output alphabet.
- #3437 widen the seam from `{task_id: bool}` to `{task_id: float}`. Every reviewer across all seven rounds argued for it. Left for a decision rather than taken unilaterally, since it is a redesign.

Refs #3422
