### PR TITLE
fix(validation): harden skill byte-ceiling gate against under-count vectors

### DIFF
--- a/scripts/validation/skill_size.py
+++ b/scripts/validation/skill_size.py
@@ -71,8 +71,22 @@ SKILL_BYTE_TARGET: int = 20_480  # 20 KiB, the documented goal (Issue #3421)
 SKILL_BYTE_LIMIT: int = 24_576  # 24 KiB, current ratchet (max body is 24,210 B)
 SKILL_BYTE_WARNING: int = 12_288  # 12 KiB, progressive-disclosure trigger
 
-# Pattern matching staged/changed SKILL.md files
-_SKILL_MD_PATTERN: str = r"^\.claude/skills/.*/SKILL\.md$"
+# Skill trees whose staged/changed SKILL.md bodies the gate measures. Both the
+# canonical Claude tree and the generated Copilot mirror ship skills and are
+# staged by the lefthook ``**/SKILL.md`` glob, so both must be discoverable here
+# or a staged oversized mirror SKILL.md slips the ceiling (under-count, exit 0).
+# ``evals/`` fixtures are excluded by omission: they intentionally reuse skill
+# bodies verbatim and are exempt from skill validation upstream.
+_SKILL_TREE_PREFIXES: tuple[str, ...] = (".claude/skills", "src/copilot-cli/skills")
+# ``re.DOTALL`` so ``.*`` spans a path with an embedded newline (a legal git path
+# byte that ``-z`` discovery preserves); ``\Z`` anchors the true string end so a
+# trailing-newline path cannot smuggle a suffix past ``$``. Without DOTALL a
+# newline-bearing skill path fails the match, drops from discovery, and
+# under-counts. ``re.match`` anchors the start, so no leading ``^`` is needed.
+_SKILL_MD_RE: re.Pattern[str] = re.compile(
+    r"(?:" + "|".join(re.escape(p) for p in _SKILL_TREE_PREFIXES) + r")/.*/SKILL\.md\Z",
+    re.DOTALL,
+)
 
 # Git index modes for a *regular* file blob: 100644 (non-exec) and 100755
 # (exec). Only these carry the file's real bytes as the blob. A symlink (120000)
@@ -257,7 +271,7 @@ def get_staged_skill_files() -> list[Path]:
         # surrogateescape round-trips undecodable bytes so the path re-encodes
         # correctly when handed back to git (os/subprocess use the same codec).
         line = raw.decode("utf-8", errors="surrogateescape")
-        if re.search(_SKILL_MD_PATTERN, line):
+        if _SKILL_MD_RE.match(line):
             files.append(Path(line))
     return files
 
@@ -275,7 +289,7 @@ def _staged_index_entry(path: Path) -> tuple[str, str]:
     """
     try:
         result = subprocess.run(
-            ["git", "ls-files", "-s", "-z", "--", path.as_posix()],
+            ["git", "ls-files", "-s", "-z", "--", f":(literal){path.as_posix()}"],
             capture_output=True,
             timeout=10,
         )
@@ -289,13 +303,20 @@ def _staged_index_entry(path: Path) -> tuple[str, str]:
     for record in result.stdout.split(b"\x00"):
         if not record:
             continue
-        meta = record.partition(b"\t")[0]
+        meta, _, raw_path = record.partition(b"\t")
         parts = meta.split()
         if len(parts) < 3:
             continue
         mode, oid, stage = parts[0], parts[1], parts[2]
-        if stage == b"0":
-            return mode.decode("ascii"), oid.decode("ascii")
+        if stage != b"0":
+            continue
+        # ``:(literal)`` above disables pathspec glob magic; confirming the
+        # listed pathname equals the requested path closes any residual gap
+        # where a pathspec could resolve to a different (smaller) blob than the
+        # SKILL.md under test. A mismatch is not our entry, so keep scanning.
+        if raw_path.decode("utf-8", errors="surrogateescape") != path.as_posix():
+            continue
+        return mode.decode("ascii"), oid.decode("ascii")
     msg = (
         f"{path.as_posix()}: no stage-0 index entry (unstaged or merge-conflicted); "
         "cannot certify staged bytes"
@@ -329,8 +350,11 @@ def read_staged_blob_bytes(path: Path) -> bytes:
         )
         raise StagedBlobError(msg)
     try:
+        # ``--no-replace-objects`` so a ``refs/replace/`` entry cannot swap the
+        # indexed blob for a smaller substitute at read time. The mode/oid come
+        # from the index; the byte count must come from that same object.
         result = subprocess.run(
-            ["git", "cat-file", "blob", oid],
+            ["git", "--no-replace-objects", "cat-file", "blob", oid],
             capture_output=True,
             timeout=10,
         )
@@ -351,7 +375,7 @@ def get_skill_files(
 ) -> list[Path]:
     """Get list of SKILL.md files to validate."""
     if changed_files:
-        skill_files = [f for f in changed_files if re.search(_SKILL_MD_PATTERN, f)]
+        skill_files = [f for f in changed_files if _SKILL_MD_RE.match(f)]
         if not skill_files:
             return []
         return [Path(f) for f in skill_files if Path(f).exists()]

--- a/scripts/validation/skill_size.py
+++ b/scripts/validation/skill_size.py
@@ -248,10 +248,24 @@ def get_staged_skill_files() -> list[Path]:
     ``StagedDiscoveryError``. An empty result with a clean exit legitimately
     means "no staged SKILL.md" and returns ``[]``; only a *failed* discovery
     fails closed, so the common no-skills commit is not penalized.
+
+    ``--no-replace-objects`` runs discovery against the real HEAD, so a
+    ``refs/replace/*`` entry cannot swap in a doctored HEAD tree that already
+    contains the oversized staged skill (which would make ``diff --cached``
+    report no change and drop the file from discovery while the real commit
+    still writes it).
     """
     try:
         result = subprocess.run(
-            ["git", "diff", "--cached", "--name-only", "-z", "--diff-filter=ACMRT"],
+            [
+                "git",
+                "--no-replace-objects",
+                "diff",
+                "--cached",
+                "--name-only",
+                "-z",
+                "--diff-filter=ACMRT",
+            ],
             capture_output=True,
             timeout=10,
         )

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -625,3 +625,154 @@ class TestStagedBlobValidation:
         monkeypatch.setattr(_skill_size_mod, "get_staged_skill_files", _boom)
         monkeypatch.chdir(tmp_path)
         assert main(["--staged-only"]) == 2
+
+    def test_pathspec_glob_dir_name_measures_own_blob(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Finding 1 (pathspec glob collision): a skill dir whose name holds a glob
+        # metacharacter (``x?``) was passed to ``git ls-files -- <path>`` as a
+        # pathspec, so it glob-matched a smaller sibling (``x0``). ``git ls-files``
+        # emits ``x0`` first (it sorts before ``x?``), so a first-match read
+        # measured the small decoy and the oversized body slipped (under-count,
+        # exit 0). ``:(literal)`` plus a returned-pathname check must bind the read
+        # to the exact path. Staged via cacheinfo so the ``?`` path is
+        # OS-independent (Windows cannot create it on disk, but the index never
+        # touches the filesystem).
+        self._init_repo(tmp_path)
+        big = (
+            subprocess.run(
+                ["git", "hash-object", "-w", "--stdin"],
+                input=b"---\nname: xq\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64),
+                cwd=tmp_path,
+                capture_output=True,
+                check=True,
+            )
+            .stdout.decode()
+            .strip()
+        )
+        small = (
+            subprocess.run(
+                ["git", "hash-object", "-w", "--stdin"],
+                input=b"small",
+                cwd=tmp_path,
+                capture_output=True,
+                check=True,
+            )
+            .stdout.decode()
+            .strip()
+        )
+        for cacheinfo in (
+            f"100644,{big},.claude/skills/x?/SKILL.md",
+            f"100644,{small},.claude/skills/x0/SKILL.md",
+        ):
+            subprocess.run(
+                ["git", "update-index", "--add", "--cacheinfo", cacheinfo],
+                cwd=tmp_path,
+                check=True,
+                capture_output=True,
+            )
+
+        monkeypatch.chdir(tmp_path)
+        # The read binds to x?'s own oversized blob, not the small x0 decoy that
+        # the glob pathspec would have matched first.
+        measured = read_staged_blob_bytes(Path(".claude/skills/x?/SKILL.md"))
+        assert len(measured) > SKILL_BYTE_LIMIT
+        assert main(["--staged-only", "--ci"]) == 1
+
+    def test_replace_ref_does_not_swap_measured_blob(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Finding 2 (replace-refs): ``git cat-file blob <oid>`` honors
+        # ``refs/replace/`` by default, so a replace ref pointing the oversized
+        # index blob at a tiny substitute would make the gate measure the small
+        # bytes (under-count, exit 0). ``--no-replace-objects`` must read the true
+        # indexed object (exit 1).
+        self._init_repo(tmp_path)
+        self._write_skill(
+            tmp_path, b"---\nname: big\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64)
+        )
+        self._stage_all(tmp_path)
+        big_oid = (
+            subprocess.run(
+                ["git", "rev-parse", ":.claude/skills/big/SKILL.md"],
+                cwd=tmp_path,
+                capture_output=True,
+                check=True,
+            )
+            .stdout.decode()
+            .strip()
+        )
+        small_oid = (
+            subprocess.run(
+                ["git", "hash-object", "-w", "--stdin"],
+                input=b"tiny",
+                cwd=tmp_path,
+                capture_output=True,
+                check=True,
+            )
+            .stdout.decode()
+            .strip()
+        )
+        subprocess.run(
+            ["git", "update-ref", f"refs/replace/{big_oid}", small_oid],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        monkeypatch.chdir(tmp_path)
+        # Setup proof: a default cat-file honors the replacement (reads "tiny"),
+        # so the substitution is genuinely active in this repo.
+        swapped = subprocess.run(
+            ["git", "cat-file", "blob", big_oid],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+        ).stdout
+        assert swapped == b"tiny"
+        # The gate reads with --no-replace-objects, so it measures the real blob.
+        measured = read_staged_blob_bytes(Path(".claude/skills/big/SKILL.md"))
+        assert len(measured) > SKILL_BYTE_LIMIT
+        assert main(["--staged-only", "--ci"]) == 1
+
+    def test_newline_in_staged_path_is_discovered(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Finding 3 (newline path): a newline is a legal git path byte that ``-z``
+        # keeps inside one NUL record. The prior ``^...$`` match (no DOTALL) let
+        # ``.*`` stop at the newline, so a newline-bearing skill path failed the
+        # match, dropped from discovery, and under-counted (exit 0). The
+        # DOTALL/\Z pattern must still discover it. Driven through a stubbed
+        # ``git diff`` so the newline path needs no filesystem staging (a newline
+        # path is unstageable on some platforms).
+        payload = b".claude/skills/ev\nil/SKILL.md\x00.claude/skills/ok/SKILL.md\x00"
+        completed = subprocess.CompletedProcess(
+            args=["git", "diff"], returncode=0, stdout=payload, stderr=b""
+        )
+        monkeypatch.setattr(
+            _skill_size_mod.subprocess, "run", lambda *a, **k: completed
+        )
+        discovered = {p.as_posix() for p in get_staged_skill_files()}
+        assert ".claude/skills/ev\nil/SKILL.md" in discovered
+        assert ".claude/skills/ok/SKILL.md" in discovered
+
+    def test_staged_mirror_tree_skill_is_discovered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Finding 4 (mirror-tree scope): the lefthook ``**/SKILL.md`` glob stages
+        # both the canonical Claude tree and the generated Copilot mirror, but
+        # discovery matched only ``.claude/skills``. An oversized staged mirror
+        # SKILL.md was silently dropped (exit 0). The pattern must also cover
+        # ``src/copilot-cli/skills``.
+        self._init_repo(tmp_path)
+        mirror = tmp_path / "src" / "copilot-cli" / "skills" / "big" / "SKILL.md"
+        mirror.parent.mkdir(parents=True, exist_ok=True)
+        mirror.write_bytes(
+            b"---\nname: big\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64)
+        )
+        self._stage_all(tmp_path)
+
+        monkeypatch.chdir(tmp_path)
+        discovered = {p.as_posix() for p in get_staged_skill_files()}
+        assert "src/copilot-cli/skills/big/SKILL.md" in discovered
+        assert main(["--staged-only", "--ci"]) == 1

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -97,8 +97,7 @@ class TestCheckSkillSize:
     def test_exceeds_limit_with_exception(self, tmp_path: Path) -> None:
         skill = tmp_path / "SKILL.md"
         skill.write_text(
-            "---\nname: test\nsize-exception: true\n---\n"
-            + "line\n" * SKILL_SIZE_LIMIT
+            "---\nname: test\nsize-exception: true\n---\n" + "line\n" * SKILL_SIZE_LIMIT
         )
 
         result = check_skill_size(skill)
@@ -153,9 +152,7 @@ class TestCheckSkillSizeBytes:
         # Over the 12 KiB soft ceiling but under the enforced limit and under
         # the 500-line limit: warns on bytes alone.
         skill = tmp_path / "SKILL.md"
-        skill.write_text(
-            "---\nname: test\n---\n" + ("x" * 200 + "\n") * 70, encoding="utf-8"
-        )
+        skill.write_text("---\nname: test\n---\n" + ("x" * 200 + "\n") * 70, encoding="utf-8")
 
         result = check_skill_size(skill)
 
@@ -169,9 +166,7 @@ class TestCheckSkillSizeBytes:
         # The case the line check misses: a table-heavy body sits well under
         # 500 lines yet blows the byte ceiling. It must FAIL on bytes.
         skill = tmp_path / "SKILL.md"
-        skill.write_text(
-            "---\nname: test\n---\n" + ("x" * 600 + "\n") * 50, encoding="utf-8"
-        )
+        skill.write_text("---\nname: test\n---\n" + ("x" * 600 + "\n") * 50, encoding="utf-8")
 
         result = check_skill_size(skill)
 
@@ -272,9 +267,7 @@ class TestCheckSkillSizeBytes:
     def test_oversized_fails_in_ci(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / "big-skill"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text(
-            "---\nname: test\n---\n" + "line\n" * 600
-        )
+        (skill_dir / "SKILL.md").write_text("---\nname: test\n---\n" + "line\n" * 600)
 
         exit_code = main(["--path", str(tmp_path), "--ci"])
         assert exit_code == 1
@@ -283,9 +276,7 @@ class TestCheckSkillSizeBytes:
         monkeypatch.delenv("CI", raising=False)
         skill_dir = tmp_path / "big-skill"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text(
-            "---\nname: test\n---\n" + "line\n" * 600
-        )
+        (skill_dir / "SKILL.md").write_text("---\nname: test\n---\n" + "line\n" * 600)
 
         exit_code = main(["--path", str(tmp_path)])
         assert exit_code == 0
@@ -293,9 +284,7 @@ class TestCheckSkillSizeBytes:
     def test_custom_limit(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / "skill"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text(
-            "---\nname: test\n---\n" + "line\n" * 150
-        )
+        (skill_dir / "SKILL.md").write_text("---\nname: test\n---\n" + "line\n" * 150)
 
         exit_code = main(["--path", str(tmp_path), "--ci", "--limit", "100"])
         assert exit_code == 1
@@ -314,9 +303,7 @@ class TestCheckSkillSizeBytes:
         # A body that is fine on lines but over a tightened byte limit fails CI.
         skill_dir = tmp_path / "skill"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text(
-            "---\nname: test\n---\n" + "x" * 500, encoding="utf-8"
-        )
+        (skill_dir / "SKILL.md").write_text("---\nname: test\n---\n" + "x" * 500, encoding="utf-8")
 
         exit_code = main(
             ["--path", str(tmp_path), "--ci", "--byte-limit", "100", "--byte-warn", "50"]
@@ -419,9 +406,7 @@ class TestStagedBlobValidation:
         # Proves exception parsing reads the staged blob too.
         self._init_repo(tmp_path)
         big = b"x" * (SKILL_BYTE_LIMIT + 64)
-        skill = self._write_skill(
-            tmp_path, b"---\nname: big\nsize-exception: true\n---\n" + big
-        )
+        skill = self._write_skill(tmp_path, b"---\nname: big\nsize-exception: true\n---\n" + big)
         self._stage_all(tmp_path)
         skill.write_bytes(b"---\nname: big\n---\n" + big)  # exception removed, unstaged
 
@@ -523,9 +508,7 @@ class TestStagedBlobValidation:
         # A gitlink cacheinfo needs a non-null commit id; git rejects the all-zero
         # SHA. Reuse a real commit id from an initial commit in this repo.
         (tmp_path / "seed.txt").write_text("seed\n", encoding="utf-8")
-        subprocess.run(
-            ["git", "add", "seed.txt"], cwd=tmp_path, check=True, capture_output=True
-        )
+        subprocess.run(["git", "add", "seed.txt"], cwd=tmp_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "commit", "-qm", "seed"], cwd=tmp_path, check=True, capture_output=True
         )
@@ -688,9 +671,7 @@ class TestStagedBlobValidation:
         # bytes (under-count, exit 0). ``--no-replace-objects`` must read the true
         # indexed object (exit 1).
         self._init_repo(tmp_path)
-        self._write_skill(
-            tmp_path, b"---\nname: big\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64)
-        )
+        self._write_skill(tmp_path, b"---\nname: big\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64))
         self._stage_all(tmp_path)
         big_oid = (
             subprocess.run(
@@ -735,9 +716,77 @@ class TestStagedBlobValidation:
         assert len(measured) > SKILL_BYTE_LIMIT
         assert main(["--staged-only", "--ci"]) == 1
 
-    def test_newline_in_staged_path_is_discovered(
-        self, monkeypatch: pytest.MonkeyPatch
+    def test_replace_ref_head_does_not_hide_staged_skill_from_discovery(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # Discovery-side replace-refs (PR #3462 round-2 review): ``git diff
+        # --cached`` honors ``refs/replace/`` by default. A replacement HEAD
+        # whose tree already contains the oversized staged skill makes the diff
+        # report no change for that path, dropping it from discovery while the
+        # real commit still writes the index (including the oversized file).
+        # Discovery must run with ``--no-replace-objects`` so it diffs the real
+        # HEAD and still finds the file (exit 1).
+        self._init_repo(tmp_path)
+        # Real HEAD C0: a seed commit that does NOT contain the skill.
+        (tmp_path / "README.md").write_bytes(b"seed\n")
+        subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-qm", "seed"], cwd=tmp_path, check=True, capture_output=True
+        )
+        head = (
+            subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=tmp_path,
+                capture_output=True,
+                check=True,
+            )
+            .stdout.decode()
+            .strip()
+        )
+        # Stage the oversized skill: the index now differs from the real HEAD.
+        self._write_skill(tmp_path, b"---\nname: big\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64))
+        self._stage_all(tmp_path)
+        # Doctored HEAD C0': a commit whose tree equals the current index, so it
+        # already carries the oversized skill.
+        index_tree = (
+            subprocess.run(["git", "write-tree"], cwd=tmp_path, capture_output=True, check=True)
+            .stdout.decode()
+            .strip()
+        )
+        doctored = (
+            subprocess.run(
+                ["git", "commit-tree", index_tree, "-m", "doctored"],
+                cwd=tmp_path,
+                capture_output=True,
+                check=True,
+            )
+            .stdout.decode()
+            .strip()
+        )
+        subprocess.run(
+            ["git", "update-ref", f"refs/replace/{head}", doctored],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        monkeypatch.chdir(tmp_path)
+        # Setup proof: a default diff --cached honors the replacement, so a
+        # replace-honoring discovery would not list the oversized skill.
+        default_listed = subprocess.run(
+            ["git", "diff", "--cached", "--name-only", "-z", "--diff-filter=ACMRT"],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+        ).stdout
+        assert b".claude/skills/big/SKILL.md" not in default_listed
+        # The gate discovers with --no-replace-objects, so it diffs the real HEAD
+        # and still finds the oversized file.
+        discovered = {p.as_posix() for p in get_staged_skill_files()}
+        assert ".claude/skills/big/SKILL.md" in discovered
+        assert main(["--staged-only", "--ci"]) == 1
+
+    def test_newline_in_staged_path_is_discovered(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Finding 3 (newline path): a newline is a legal git path byte that ``-z``
         # keeps inside one NUL record. The prior ``^...$`` match (no DOTALL) let
         # ``.*`` stop at the newline, so a newline-bearing skill path failed the
@@ -749,9 +798,7 @@ class TestStagedBlobValidation:
         completed = subprocess.CompletedProcess(
             args=["git", "diff"], returncode=0, stdout=payload, stderr=b""
         )
-        monkeypatch.setattr(
-            _skill_size_mod.subprocess, "run", lambda *a, **k: completed
-        )
+        monkeypatch.setattr(_skill_size_mod.subprocess, "run", lambda *a, **k: completed)
         discovered = {p.as_posix() for p in get_staged_skill_files()}
         assert ".claude/skills/ev\nil/SKILL.md" in discovered
         assert ".claude/skills/ok/SKILL.md" in discovered
@@ -767,9 +814,7 @@ class TestStagedBlobValidation:
         self._init_repo(tmp_path)
         mirror = tmp_path / "src" / "copilot-cli" / "skills" / "big" / "SKILL.md"
         mirror.parent.mkdir(parents=True, exist_ok=True)
-        mirror.write_bytes(
-            b"---\nname: big\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64)
-        )
+        mirror.write_bytes(b"---\nname: big\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64))
         self._stage_all(tmp_path)
 
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary

Follow-up to #3444, which added the SKILL.md byte ceiling to the skill-size gate. That gate measures the staged index blob, but four paths let an oversized SKILL.md under-count and slip the ceiling. Under-counting is the cardinal failure for a size gate: reporting fewer bytes than will actually be committed.

This PR closes all four vectors and adds one regression test each.

Refs #3421

## The four under-count vectors

1. **Pathspec glob collision.** A skill directory name holding a glob metacharacter (`x?`, `a[x]`) was handed to git ls-files as a pathspec, so it matched a smaller sibling. git ls-files emits the decoy first when it sorts lower, so a first-match read measured the wrong, smaller blob. Fixed with `:(literal)` pathspec magic plus a returned-pathname equality check that binds the read to the exact path under test.

2. **Replace-refs substitution.** git cat-file honors refs/replace/ by default, so a replace ref could swap the indexed blob for a tiny substitute at read time. Fixed with `--no-replace-objects` so the true indexed object is measured.

3. **Newline-bearing path.** A newline is a legal git path byte that the -z discovery stream keeps inside one NUL record. The old anchored match (no DOTALL) let the wildcard stop at the newline, so the path failed to match and dropped from discovery. Fixed with a compiled DOTALL pattern anchored by end-of-string.

4. **Mirror-tree scope.** The lefthook hook stages both the canonical Claude tree and the generated Copilot mirror, but discovery matched only the Claude tree. An oversized staged mirror SKILL.md was silently dropped. Fixed by also matching the Copilot mirror tree via a shared prefix tuple.

## Testing

Four regression tests added, one per vector. Each was verified to fail on pre-fix code and pass with the fix:

- pathspec glob: pre-fix measured 5 bytes (the small decoy) instead of the oversized blob
- replace-refs: pre-fix measured 4 bytes (the substitute) instead of the real blob
- newline path: pre-fix dropped the newline path from discovery
- mirror tree: pre-fix dropped the mirror path from discovery entirely

Full suite: 44 passed. ruff, mypy, complexity (C901 at or below 10), and the live gate are all clean.

## Out of Scope

The byte-ceiling ratchet values and the decomposition of existing oversized skills are handled separately in #3444 and #3460.

## Files Changed

- `scripts/validation/skill_size.py`: the four gate fixes
- `tests/test_validation_skill_size.py`: four regression tests

