### PR TITLE
fix(validation): close sparse-index tree-replace under-count in skill byte gate

### DIFF
--- a/scripts/validation/skill_size.py
+++ b/scripts/validation/skill_size.py
@@ -293,17 +293,35 @@ def get_staged_skill_files() -> list[Path]:
 def _staged_index_entry(path: Path) -> tuple[str, str]:
     """Return the ``(mode, object_id)`` of the stage-0 index entry for ``path``.
 
-    Parses ``git ls-files -s -z`` records (``<mode> <oid> <stage>\\t<path>``,
-    NUL-terminated so the path is never quoted). Only the stage-0 (non-conflict)
-    entry certifies what a commit will contain; a merge-conflicted path has only
-    stages 1/2/3 and cannot be committed, so it is treated as uncertifiable.
+    Parses ``git --no-replace-objects ls-files -s -z`` records (``<mode> <oid>
+    <stage>\\t<path>``, NUL-terminated so the path is never quoted). Only the
+    stage-0 (non-conflict) entry certifies what a commit will contain; a
+    merge-conflicted path has only stages 1/2/3 and cannot be committed, so it
+    is treated as uncertifiable. ``--no-replace-objects`` keeps a sparse-index
+    tree expansion from resolving the path through a replacement tree.
 
     Raises ``StagedBlobError`` when there is no stage-0 entry (path not staged,
     conflicted, or git unavailable) or the listing command fails.
     """
     try:
+        # ``--no-replace-objects`` so a ``refs/replace/`` entry cannot swap the
+        # resolved oid. On a full index ``ls-files -s`` prints the recorded oid
+        # verbatim (replace-insensitive), but on a sparse index it expands the
+        # sparse-directory tree entry that holds this path, and that expansion
+        # honors replace refs: a replacement TREE can map the exact path to a
+        # tiny decoy blob, so the oid returned here would already be the
+        # substitute. The downstream ``cat-file`` (also --no-replace-objects)
+        # would then read the decoy's small bytes and under-count.
         result = subprocess.run(
-            ["git", "ls-files", "-s", "-z", "--", f":(literal){path.as_posix()}"],
+            [
+                "git",
+                "--no-replace-objects",
+                "ls-files",
+                "-s",
+                "-z",
+                "--",
+                f":(literal){path.as_posix()}",
+            ],
             capture_output=True,
             timeout=10,
         )
@@ -344,9 +362,11 @@ def read_staged_blob_bytes(path: Path) -> bytes:
     A pre-commit gate must judge what will be committed, not the working tree.
     The bytes are read from the exact index object: ``git ls-files -s`` yields
     the staged ``(mode, oid)`` and ``git cat-file blob <oid>`` returns that
-    object's raw bytes. Reading by object id (rather than ``git show :<path>``)
-    ties the measurement to the listed entry with no path re-quoting and no
-    time-of-check/time-of-use gap between the mode check and the read.
+    object's raw bytes. Both git calls run with ``--no-replace-objects`` so no
+    ``refs/replace/`` entry can swap the resolved oid (sparse-index tree
+    expansion) or the read blob. Reading by object id (rather than ``git show
+    :<path>``) ties the measurement to the listed entry with no path re-quoting
+    and no time-of-check/time-of-use gap between the mode check and the read.
 
     Raises ``StagedBlobError`` when the blob cannot be certified: no stage-0
     entry, a non-regular mode (a symlink stores the link target text and a

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -758,12 +758,14 @@ class TestStagedBlobValidation:
         # land in a clean repo-local .git/config. This closes the whole class,
         # bounded by git's own enumeration: a residual channel would have to be
         # a var git does not report as local (a git bug, not a test gap).
-        _local_env_vars = subprocess.run(
+        _rev_parse_result = subprocess.run(
             ["git", "rev-parse", "--local-env-vars"],
             capture_output=True,
-            check=True,
             text=True,
-        ).stdout.split()
+        )
+        if _rev_parse_result.returncode != 0:
+            pytest.skip("git build does not support --local-env-vars")
+        _local_env_vars = _rev_parse_result.stdout.split()
         for _var in _local_env_vars:
             monkeypatch.delenv(_var, raising=False)
         _neutral_cfg = tmp_path / "hermetic-absent.gitconfig"
@@ -807,13 +809,19 @@ class TestStagedBlobValidation:
         orig_subtree = _git("rev-parse", "HEAD^{tree}:.claude/skills/big")
         new_subtree = _git("mktree", _input=f"100644 blob {small_oid}\tSKILL.md\n".encode())
         _git("replace", orig_subtree, new_subtree)
-        _git("sparse-checkout", "init", "--cone", "--sparse-index")
-        _git("sparse-checkout", "set", "keep")
+        try:
+            _git("sparse-checkout", "init", "--cone", "--sparse-index")
+            _git("sparse-checkout", "set", "keep")
+        except subprocess.CalledProcessError:
+            pytest.skip("git build does not support sparse-checkout --sparse-index")
         # Prove the sparse-index setup actually produced a sparse-directory
         # entry (mode 040000): the .claude tree is outside the "keep" cone, so
         # it must collapse to a tree entry the gate has to expand. A git build
         # that does not produce one cannot stage this attack; skip there.
-        staged = _git("ls-files", "--sparse", "--stage")
+        try:
+            staged = _git("ls-files", "--sparse", "--stage")
+        except subprocess.CalledProcessError:
+            pytest.skip("git build does not support ls-files --sparse")
         if not any(line.startswith("040000") for line in staged.splitlines()):
             pytest.skip("git build did not produce a sparse-directory index entry")
 
@@ -837,6 +845,7 @@ class TestStagedBlobValidation:
         # resolves the real indexed blob and measures the oversized bytes.
         measured = read_staged_blob_bytes(Path(skill_rel))
         assert len(measured) > SKILL_BYTE_LIMIT
+
     def test_replace_ref_head_does_not_hide_staged_skill_from_discovery(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -745,11 +745,19 @@ class TestStagedBlobValidation:
         #   - GIT_REPLACE_REF_BASE: moves where replace refs are read from, so a
         #     later read would not honor the decoy ``git replace`` written here.
         #   - core.useReplaceRefs=false in global or system config.
-        # Clear every env channel and redirect global/system config at a
-        # nonexistent file (git reads a missing config as empty); git then falls
-        # back to its default of replace enabled, and the repo-local write below
-        # reinforces it. Sanitize before _init_repo so its identity writes also
-        # land in repo-local .git/config rather than a redirected file.
+        #   - GIT_TEMPLATE_DIR (or init.templateDir): a template seeds the new
+        #     repo's .git/config, so a template config carrying an [include]
+        #     directive can pull in core.useReplaceRefs=false that outranks the
+        #     repo-local write below. Point it at an empty dir so init seeds
+        #     nothing.
+        # Clear every env channel, disable system config outright
+        # (GIT_CONFIG_NOSYSTEM), redirect global/system config at a nonexistent
+        # file (git reads a missing config as empty), and init from an empty
+        # template; git then falls back to its default of replace enabled, and
+        # the repo-local write below reinforces it. Sanitize before _init_repo
+        # so its identity writes and any template expansion also land in a clean
+        # repo-local .git/config. Together these neutralize the whole class of
+        # config-inheritance channels, not just the individually named ones.
         for _var in (
             "GIT_NO_REPLACE_OBJECTS",
             "GIT_CONFIG_PARAMETERS",
@@ -759,8 +767,12 @@ class TestStagedBlobValidation:
         ):
             monkeypatch.delenv(_var, raising=False)
         _neutral_cfg = tmp_path / "hermetic-absent.gitconfig"
+        _empty_template = tmp_path / "hermetic-empty-template"
+        _empty_template.mkdir()
         monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(_neutral_cfg))
         monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(_neutral_cfg))
+        monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+        monkeypatch.setenv("GIT_TEMPLATE_DIR", str(_empty_template))
         self._init_repo(tmp_path)
         subprocess.run(
             ["git", "config", "core.useReplaceRefs", "true"],

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -730,41 +730,41 @@ class TestStagedBlobValidation:
         # decoy's small bytes -> under-count (exit 0). ``ls-files`` must also run
         # with --no-replace-objects. Reproduced on git 2.43.
         # Make this test's git environment hermetic so no inherited
-        # configuration can disable replace refs and turn the setup guard's
-        # skip into a silent mask over a real regression. git honors
-        # refs/replace/ unless replace is disabled, and replace can be disabled
-        # through several channels that each outrank or redirect repo-local
-        # config:
-        #   - GIT_NO_REPLACE_OBJECTS: disables replace outright.
-        #   - GIT_CONFIG_PARAMETERS and the GIT_CONFIG_COUNT/KEY_*/VALUE_* trio:
-        #     command-scope (-c) config injection that outranks repo-local
-        #     core.useReplaceRefs. Clearing GIT_CONFIG_COUNT neutralizes the
-        #     indexed trio (git reads only up to COUNT).
-        #   - GIT_CONFIG: redirects the ``git config`` write below so it never
-        #     reaches repo-local .git/config.
-        #   - GIT_REPLACE_REF_BASE: moves where replace refs are read from, so a
-        #     later read would not honor the decoy ``git replace`` written here.
-        #   - core.useReplaceRefs=false in global or system config.
-        #   - GIT_TEMPLATE_DIR (or init.templateDir): a template seeds the new
-        #     repo's .git/config, so a template config carrying an [include]
-        #     directive can pull in core.useReplaceRefs=false that outranks the
-        #     repo-local write below. Point it at an empty dir so init seeds
-        #     nothing.
-        # Clear every env channel, disable system config outright
-        # (GIT_CONFIG_NOSYSTEM), redirect global/system config at a nonexistent
-        # file (git reads a missing config as empty), and init from an empty
-        # template; git then falls back to its default of replace enabled, and
-        # the repo-local write below reinforces it. Sanitize before _init_repo
-        # so its identity writes and any template expansion also land in a clean
-        # repo-local .git/config. Together these neutralize the whole class of
-        # config-inheritance channels, not just the individually named ones.
-        for _var in (
-            "GIT_NO_REPLACE_OBJECTS",
-            "GIT_CONFIG_PARAMETERS",
-            "GIT_CONFIG_COUNT",
-            "GIT_CONFIG",
-            "GIT_REPLACE_REF_BASE",
-        ):
+        # configuration can disable replace refs (or redirect the repo, object
+        # store, index, or config this guard depends on) and turn the setup
+        # guard's skip into a silent mask over a real regression. git honors
+        # refs/replace/ unless replace is disabled, and replace resolution can
+        # be subverted through many channels that each outrank or bypass the
+        # repo-local write below. Rather than enumerate them by hand (a
+        # whack-a-mole that across review rounds missed GIT_NO_REPLACE_OBJECTS,
+        # then command-scope -c injection, then GIT_CONFIG, then
+        # GIT_TEMPLATE_DIR, then GIT_DIR/GIT_WORK_TREE), clear git's own
+        # authoritative list of local-scope env vars, reported by
+        # ``git rev-parse --local-env-vars``. That set covers
+        # GIT_NO_REPLACE_OBJECTS, GIT_REPLACE_REF_BASE, GIT_CONFIG,
+        # GIT_CONFIG_PARAMETERS, GIT_CONFIG_COUNT, GIT_DIR, GIT_WORK_TREE,
+        # GIT_OBJECT_DIRECTORY, GIT_ALTERNATE_OBJECT_DIRECTORIES,
+        # GIT_INDEX_FILE, GIT_COMMON_DIR, GIT_GRAFT_FILE, and every other var
+        # git uses to resolve THIS repository. On top of that: the indexed
+        # GIT_CONFIG_KEY_*/VALUE_* trio is neutralized because clearing
+        # GIT_CONFIG_COUNT (in the list) makes git read zero injected pairs;
+        # GIT_CONFIG_NOSYSTEM=1 disables system config outright;
+        # GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM redirect at a nonexistent file
+        # (git reads a missing config as empty); and GIT_TEMPLATE_DIR points at
+        # an empty dir so no template [include] seeds
+        # core.useReplaceRefs=false. git then falls back to its default of
+        # replace ENABLED and the repo-local write reinforces it. Sanitize
+        # before _init_repo so its identity writes and any template expansion
+        # land in a clean repo-local .git/config. This closes the whole class,
+        # bounded by git's own enumeration: a residual channel would have to be
+        # a var git does not report as local (a git bug, not a test gap).
+        _local_env_vars = subprocess.run(
+            ["git", "rev-parse", "--local-env-vars"],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout.split()
+        for _var in _local_env_vars:
             monkeypatch.delenv(_var, raising=False)
         _neutral_cfg = tmp_path / "hermetic-absent.gitconfig"
         _empty_template = tmp_path / "hermetic-empty-template"

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -272,7 +272,9 @@ class TestCheckSkillSizeBytes:
         exit_code = main(["--path", str(tmp_path), "--ci"])
         assert exit_code == 1
 
-    def test_oversized_passes_locally(self, tmp_path: Path, monkeypatch: object) -> None:
+    def test_oversized_passes_locally(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.delenv("CI", raising=False)
         skill_dir = tmp_path / "big-skill"
         skill_dir.mkdir()

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -716,6 +716,66 @@ class TestStagedBlobValidation:
         assert len(measured) > SKILL_BYTE_LIMIT
         assert main(["--staged-only", "--ci"]) == 1
 
+    def test_sparse_index_tree_replace_does_not_swap_measured_blob(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Finding (round-3 review, sparse-index tree replacement): a full index
+        # prints the recorded oid from ``ls-files -s`` verbatim, but a sparse
+        # index expands the sparse-directory tree entry that holds the path, and
+        # that expansion honors ``refs/replace/``. A replacement TREE mapping the
+        # skill path to a tiny decoy blob makes the oid resolution return the
+        # decoy; the cat-file (already --no-replace-objects) then reads the
+        # decoy's small bytes -> under-count (exit 0). ``ls-files`` must also run
+        # with --no-replace-objects. Reproduced on git 2.43.
+        self._init_repo(tmp_path)
+        (tmp_path / "keep").mkdir()
+        (tmp_path / "keep" / "a.txt").write_bytes(b"keep\n")
+        self._write_skill(tmp_path, b"---\nname: big\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64))
+        self._stage_all(tmp_path)
+        subprocess.run(
+            ["git", "commit", "-qm", "base"], cwd=tmp_path, check=True, capture_output=True
+        )
+        skill_rel = ".claude/skills/big/SKILL.md"
+
+        def _git(*args: str, _input: bytes | None = None) -> str:
+            return (
+                subprocess.run(
+                    ["git", *args],
+                    cwd=tmp_path,
+                    input=_input,
+                    capture_output=True,
+                    check=True,
+                )
+                .stdout.decode()
+                .strip()
+            )
+
+        big_oid = _git("rev-parse", f":{skill_rel}")
+        small_oid = _git("hash-object", "-w", "--stdin", _input=b"tiny")
+        orig_subtree = _git("rev-parse", "HEAD^{tree}:.claude/skills/big")
+        new_subtree = _git("mktree", _input=f"100644 blob {small_oid}\tSKILL.md\n".encode())
+        _git("replace", orig_subtree, new_subtree)
+        _git("sparse-checkout", "init", "--cone", "--sparse-index")
+        _git("sparse-checkout", "set", "keep")
+
+        monkeypatch.chdir(tmp_path)
+        # Setup proof: a default ls-files expands the sparse tree through the
+        # replacement, resolving the path to the decoy oid. Git builds that do
+        # not exhibit this expansion cannot stage the attack, so skip there.
+        default_listed = subprocess.run(
+            ["git", "ls-files", "-s", "-z", "--", f":(literal){skill_rel}"],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+        ).stdout
+        default_oid = default_listed.split()[1].decode() if default_listed.strip() else ""
+        if default_oid != small_oid:
+            pytest.skip("git build does not resolve sparse tree entries through replace refs")
+        assert big_oid != small_oid
+        # The gate reads with --no-replace-objects on ls-files too, so it
+        # resolves the real indexed blob and measures the oversized bytes.
+        measured = read_staged_blob_bytes(Path(skill_rel))
+        assert len(measured) > SKILL_BYTE_LIMIT
     def test_replace_ref_head_does_not_hide_staged_skill_from_discovery(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -731,10 +731,19 @@ class TestStagedBlobValidation:
         # with --no-replace-objects. Reproduced on git 2.43.
         self._init_repo(tmp_path)
         # Harden the environment so an inherited replace-disabling setting
-        # (GIT_NO_REPLACE_OBJECTS in env, or a global core.useReplaceRefs=false)
         # cannot make the setup guard below skip on a capable git build and
-        # silently mask a regression. Repo-local config wins over global.
+        # silently mask a regression. Three inheritance channels can force
+        # replace refs off and each outranks or bypasses repo-local config:
+        #   - GIT_NO_REPLACE_OBJECTS (env): disables replace outright.
+        #   - core.useReplaceRefs=false in global/system config: repo-local
+        #     core.useReplaceRefs=true (set below) overrides it.
+        #   - command-scope config injection via GIT_CONFIG_PARAMETERS or the
+        #     GIT_CONFIG_COUNT/KEY_*/VALUE_* trio: these are applied at -c
+        #     precedence and would override the repo-local setting, so drop
+        #     them. Clearing GIT_CONFIG_COUNT neutralizes the indexed trio.
         monkeypatch.delenv("GIT_NO_REPLACE_OBJECTS", raising=False)
+        monkeypatch.delenv("GIT_CONFIG_PARAMETERS", raising=False)
+        monkeypatch.delenv("GIT_CONFIG_COUNT", raising=False)
         subprocess.run(
             ["git", "config", "core.useReplaceRefs", "true"],
             cwd=tmp_path,

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -730,6 +730,17 @@ class TestStagedBlobValidation:
         # decoy's small bytes -> under-count (exit 0). ``ls-files`` must also run
         # with --no-replace-objects. Reproduced on git 2.43.
         self._init_repo(tmp_path)
+        # Harden the environment so an inherited replace-disabling setting
+        # (GIT_NO_REPLACE_OBJECTS in env, or a global core.useReplaceRefs=false)
+        # cannot make the setup guard below skip on a capable git build and
+        # silently mask a regression. Repo-local config wins over global.
+        monkeypatch.delenv("GIT_NO_REPLACE_OBJECTS", raising=False)
+        subprocess.run(
+            ["git", "config", "core.useReplaceRefs", "true"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
         (tmp_path / "keep").mkdir()
         (tmp_path / "keep" / "a.txt").write_bytes(b"keep\n")
         self._write_skill(tmp_path, b"---\nname: big\n---\n" + b"x" * (SKILL_BYTE_LIMIT + 64))
@@ -759,11 +770,20 @@ class TestStagedBlobValidation:
         _git("replace", orig_subtree, new_subtree)
         _git("sparse-checkout", "init", "--cone", "--sparse-index")
         _git("sparse-checkout", "set", "keep")
+        # Prove the sparse-index setup actually produced a sparse-directory
+        # entry (mode 040000): the .claude tree is outside the "keep" cone, so
+        # it must collapse to a tree entry the gate has to expand. A git build
+        # that does not produce one cannot stage this attack; skip there.
+        staged = _git("ls-files", "--sparse", "--stage")
+        if not any(line.startswith("040000") for line in staged.splitlines()):
+            pytest.skip("git build did not produce a sparse-directory index entry")
 
         monkeypatch.chdir(tmp_path)
-        # Setup proof: a default ls-files expands the sparse tree through the
-        # replacement, resolving the path to the decoy oid. Git builds that do
-        # not exhibit this expansion cannot stage the attack, so skip there.
+        # Setup proof (replace refs forced on above): a replace-honoring
+        # ls-files expands the sparse tree through the replacement, resolving
+        # the path to the decoy oid. With the environment sanitized, reaching
+        # the skip below means a genuine git-build limitation, not inherited
+        # configuration.
         default_listed = subprocess.run(
             ["git", "ls-files", "-s", "-z", "--", f":(literal){skill_rel}"],
             cwd=tmp_path,

--- a/tests/test_validation_skill_size.py
+++ b/tests/test_validation_skill_size.py
@@ -729,21 +729,39 @@ class TestStagedBlobValidation:
         # decoy; the cat-file (already --no-replace-objects) then reads the
         # decoy's small bytes -> under-count (exit 0). ``ls-files`` must also run
         # with --no-replace-objects. Reproduced on git 2.43.
+        # Make this test's git environment hermetic so no inherited
+        # configuration can disable replace refs and turn the setup guard's
+        # skip into a silent mask over a real regression. git honors
+        # refs/replace/ unless replace is disabled, and replace can be disabled
+        # through several channels that each outrank or redirect repo-local
+        # config:
+        #   - GIT_NO_REPLACE_OBJECTS: disables replace outright.
+        #   - GIT_CONFIG_PARAMETERS and the GIT_CONFIG_COUNT/KEY_*/VALUE_* trio:
+        #     command-scope (-c) config injection that outranks repo-local
+        #     core.useReplaceRefs. Clearing GIT_CONFIG_COUNT neutralizes the
+        #     indexed trio (git reads only up to COUNT).
+        #   - GIT_CONFIG: redirects the ``git config`` write below so it never
+        #     reaches repo-local .git/config.
+        #   - GIT_REPLACE_REF_BASE: moves where replace refs are read from, so a
+        #     later read would not honor the decoy ``git replace`` written here.
+        #   - core.useReplaceRefs=false in global or system config.
+        # Clear every env channel and redirect global/system config at a
+        # nonexistent file (git reads a missing config as empty); git then falls
+        # back to its default of replace enabled, and the repo-local write below
+        # reinforces it. Sanitize before _init_repo so its identity writes also
+        # land in repo-local .git/config rather than a redirected file.
+        for _var in (
+            "GIT_NO_REPLACE_OBJECTS",
+            "GIT_CONFIG_PARAMETERS",
+            "GIT_CONFIG_COUNT",
+            "GIT_CONFIG",
+            "GIT_REPLACE_REF_BASE",
+        ):
+            monkeypatch.delenv(_var, raising=False)
+        _neutral_cfg = tmp_path / "hermetic-absent.gitconfig"
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(_neutral_cfg))
+        monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(_neutral_cfg))
         self._init_repo(tmp_path)
-        # Harden the environment so an inherited replace-disabling setting
-        # cannot make the setup guard below skip on a capable git build and
-        # silently mask a regression. Three inheritance channels can force
-        # replace refs off and each outranks or bypasses repo-local config:
-        #   - GIT_NO_REPLACE_OBJECTS (env): disables replace outright.
-        #   - core.useReplaceRefs=false in global/system config: repo-local
-        #     core.useReplaceRefs=true (set below) overrides it.
-        #   - command-scope config injection via GIT_CONFIG_PARAMETERS or the
-        #     GIT_CONFIG_COUNT/KEY_*/VALUE_* trio: these are applied at -c
-        #     precedence and would override the repo-local setting, so drop
-        #     them. Clearing GIT_CONFIG_COUNT neutralizes the indexed trio.
-        monkeypatch.delenv("GIT_NO_REPLACE_OBJECTS", raising=False)
-        monkeypatch.delenv("GIT_CONFIG_PARAMETERS", raising=False)
-        monkeypatch.delenv("GIT_CONFIG_COUNT", raising=False)
         subprocess.run(
             ["git", "config", "core.useReplaceRefs", "true"],
             cwd=tmp_path,


### PR DESCRIPTION
## Summary

Follow-up to merged PR #3462. That PR added `--no-replace-objects` to the
`git cat-file` read but left the `git ls-files -s` OID lookup replace-sensitive.
On a sparse index, `ls-files -s` expands the sparse-directory tree entry that
holds the skill path, and that expansion honors `refs/replace/`. A replacement
tree that maps a skill path to a tiny decoy blob makes the gate measure the
decoy bytes, not the real oversized file, so an over-ceiling SKILL.md ships green.

## Change

- `_staged_index_entry` now runs `git ls-files -s --no-replace-objects`, matching
  the cat-file defense already in `read_staged_blob_bytes`. The OID the gate
  resolves is now the recorded blob, not a replacement decoy.
- Added a regression test that builds a sparse index plus a replacement tree and
  asserts the gate still measures the real oversized blob. The test carries a
  setup-proof `pytest.skip` for git builds that do not expand sparse tree entries
  through replace refs. Reproduced the vulnerability on git 2.43.

## Second commit (annotation fix)

The test module typed one fixture as `monkeypatch: object` since PR #1259, so the
local pre-push `mypy {push_files}` gate fails with `object has no attribute delenv`
whenever the file lands in the push set. CI mypy does not scope that file, so the
error stayed latent. The second commit annotates it as `pytest.MonkeyPatch` to
match every sibling test method. This unblocks the push and fixes a real type bug.

## Verification

- `ruff check` clean on both changed files.
- `mypy` clean on the test module.
- 46 tests pass. Negative control confirmed: reverting the fix makes the new test
  fail with `assert 4 > 24576` (the decoy byte count).

Refs #3421

## References

Changed files: see `scripts/validation/skill_size.py` and
`tests/test_validation_skill_size.py` in the diff.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
