### PR TITLE
chore(eval): fix 13 pre-existing ruff errors in scripts/eval

### DIFF
--- a/scripts/eval/_report_writer.py
+++ b/scripts/eval/_report_writer.py
@@ -232,14 +232,18 @@ def _render_ci_section(aggregate: AggregateResult) -> str:
         )
     else:
         caveat = ""
+    effect_text = (
+        "statistically distinguishable from no effect"
+        if excludes_zero
+        else "not statistically distinguishable from no effect at the 95% level"
+    )
     return (
         "## Confidence Interval\n\n"
         f"{caveat}"
         f"Paired bootstrap, n=10000 resamples at fixture level. The 95% CI on the "
         f"signed recall delta is **[{_format_pp(ci_low)}, {_format_pp(ci_high)}]**. "
         f"The interval {'**excludes** zero' if excludes_zero else '**includes** zero'}, "
-        f"so the observed delta is "
-        f"{'statistically distinguishable from no effect' if excludes_zero else 'not statistically distinguishable from no effect at the 95% level'}.\n"
+        f"so the observed delta is {effect_text}.\n"
     )
 
 

--- a/scripts/eval/_run_persistence.py
+++ b/scripts/eval/_run_persistence.py
@@ -30,15 +30,16 @@ import dataclasses
 import json
 import os
 import tempfile
+from collections.abc import Iterable
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, cast
 
 from _eval_agent_types import (
+    SCHEMA_VERSION,
     AssertionKind,
     AssertionResult,
     RunRecord,
-    SCHEMA_VERSION,
     SchemaVersionError,
 )
 
@@ -206,7 +207,7 @@ class RunPersistence:
                 if None in key:
                     missing = [
                         name
-                        for name, value in zip(identity_fields, key)
+                        for name, value in zip(identity_fields, key, strict=True)
                         if value is None
                     ]
                     raise MalformedRunRecordError(
@@ -237,9 +238,10 @@ class RunPersistence:
                             f"{name!r} has wrong type (expected "
                             f"{expected_type.__name__}, got {type(value).__name__})"
                         )
-                self._seen.add(key)  # type: ignore[arg-type]
+                record_key = cast(tuple[str, str, int], key)
+                self._seen.add(record_key)
                 if payload.get("outcome") == "success":
-                    self._completed.add(key)  # type: ignore[arg-type]
+                    self._completed.add(record_key)
 
     def is_completed(self, fixture_id: str, variant: str, run_index: int) -> bool:
         """True only when the prior record was `outcome="success"`.

--- a/scripts/eval/eval-agents.py
+++ b/scripts/eval/eval-agents.py
@@ -46,10 +46,9 @@ from typing import Any
 # ---------------------------------------------------------------------------
 # API utilities (shared module)
 # ---------------------------------------------------------------------------
-from _anthropic_api import DEFAULT_MODEL
+from _anthropic_api import DEFAULT_MODEL, load_custom_prompts, verify_model_available
 from _anthropic_api import call_api as _call_api
 from _anthropic_api import load_api_key as _load_api_key
-from _anthropic_api import load_custom_prompts, verify_model_available
 from _eval_common import EST_TOKENS_PER_CALL, aggregate_multi_run_scores
 
 # ---------------------------------------------------------------------------

--- a/scripts/eval/eval-knowledge-integration.py
+++ b/scripts/eval/eval-knowledge-integration.py
@@ -29,10 +29,9 @@ from typing import Any
 # ---------------------------------------------------------------------------
 # API utilities (shared module)
 # ---------------------------------------------------------------------------
-from _anthropic_api import DEFAULT_MODEL
+from _anthropic_api import DEFAULT_MODEL, load_custom_prompts, verify_model_available
 from _anthropic_api import call_api as _call_api
 from _anthropic_api import load_api_key as _load_api_key
-from _anthropic_api import load_custom_prompts, verify_model_available
 from _eval_common import EST_TOKENS_PER_CALL, aggregate_multi_run_scores
 
 # ---------------------------------------------------------------------------

--- a/scripts/eval/eval-reviewer-asymmetry.py
+++ b/scripts/eval/eval-reviewer-asymmetry.py
@@ -34,10 +34,10 @@ import argparse
 import json
 import math
 import re
-import statistics
 import subprocess
 import sys
 import time
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -293,11 +293,10 @@ def mann_whitney_u(x: list[float], y: list[float]) -> tuple[float, float, float]
         for _ in range(j - i + 1):
             ranks.append(avg_rank)
         i = j + 1
-    rank_y = sum(r for r, (_, lbl) in zip(ranks, combined) if lbl == "y")
+    rank_y = sum(r for r, (_, lbl) in zip(ranks, combined, strict=True) if lbl == "y")
     u_y = rank_y - n2 * (n2 + 1) / 2
     n = n1 + n2
-    from collections import Counter as _C
-    counts = _C(combined[i][0] for i in range(n))
+    counts = Counter(combined[i][0] for i in range(n))
     tie_sum = sum(t * (t * t - 1) for t in counts.values() if t > 1)
     mean_u = n1 * n2 / 2
     var_u = (n1 * n2 / 12) * ((n + 1) - tie_sum / (n * (n - 1))) if n > 1 else 0.0

--- a/scripts/eval/eval-rule-activation.py
+++ b/scripts/eval/eval-rule-activation.py
@@ -49,10 +49,9 @@ import time
 from pathlib import Path
 from typing import Any
 
-from _anthropic_api import DEFAULT_MODEL
+from _anthropic_api import DEFAULT_MODEL, verify_model_available
 from _anthropic_api import call_api as _call_api
 from _anthropic_api import load_api_key as _load_api_key
-from _anthropic_api import verify_model_available
 from _eval_common import EST_TOKENS_PER_CALL
 
 # ---------------------------------------------------------------------------

--- a/scripts/eval/eval_skill_router.py
+++ b/scripts/eval/eval_skill_router.py
@@ -62,7 +62,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from _anthropic_api import load_api_key, call_api
+from _anthropic_api import call_api, load_api_key
 
 MODEL = "claude-sonnet-4-6"
 BEFORE_REF = "origin/main"
@@ -110,7 +110,7 @@ def load_fixtures(path: str) -> list[dict[str, Any]]:
 
 
 def _validate_fixture(
-    fx: Any, index: int, path: str, seen_ids: set[str]
+    fx: object, index: int, path: str, seen_ids: set[str]
 ) -> None:
     """Validate one fixture's shape. Raises RuntimeError on any violation."""
     if not isinstance(fx, dict):
@@ -137,9 +137,10 @@ def _validate_fixture(
 
     candidates = fx["candidates"]
     if not isinstance(candidates, list) or not (2 <= len(candidates) <= 4):
+        got = len(candidates) if isinstance(candidates, list) else type(candidates).__name__
         raise RuntimeError(
             f"Fixture {fid} in {path}: 'candidates' must be a list of 2-4 names "
-            f"(got {len(candidates) if isinstance(candidates, list) else type(candidates).__name__})."
+            f"(got {got})."
         )
     if len(set(candidates)) != len(candidates):
         raise RuntimeError(f"Fixture {fid} in {path}: 'candidates' contains duplicates.")


### PR DESCRIPTION
Fixes #3440

## Summary
- Fixed the 13 ruff findings under scripts/eval.
- Kept the change limited to import sorting, unused imports, explicit zip strictness, one line split, and typed key narrowing needed by the push gate.

## Validation
- PASS: uv run --frozen ruff check scripts/eval/
- PASS: uv run --frozen python -m pytest tests/ -k eval -q, 1391 passed, 2 skipped, 13716 deselected
- FAIL pre-existing: uv run --frozen mypy scripts/eval/ reports 36 existing errors across 14 files. Targeted changed-file check passed for scripts/eval/_run_persistence.py after removing the push-blocking type ignores.

## Transport
- Verified local HEAD equals origin/chore/3440-ruff-scripts-eval after push.