### PR TITLE
fix(eval): refuse degraded runs and thread OpenAI seed/fingerprint (#3474, #3475)

### DIFF
--- a/scripts/eval/_anthropic_api.py
+++ b/scripts/eval/_anthropic_api.py
@@ -14,7 +14,7 @@ import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 # Single source of truth for the default eval model. Every eval script imports
 # this instead of hard-coding an id, so a model bump is a one-line change here
@@ -90,6 +90,8 @@ def call_api(
     max_tokens: int = 1024,
     temperature: float = 0.0,
     provider: str | None = None,
+    seed: int | None = None,
+    metadata: dict[str, object] | None = None,
 ) -> str:
     """Call the Anthropic Messages API.
 
@@ -105,6 +107,10 @@ def call_api(
             urllib path unchanged; any other value routes through
             `_providers.resolve_provider` (openai, github, anthropic-sdk).
             `api_key` is ignored for non-Anthropic providers.
+        seed: Optional seed forwarded to OpenAI-compatible providers. None
+            omits the argument.
+        metadata: Optional output mapping for provider response metadata such
+            as OpenAI-compatible `system_fingerprint`.
 
     Returns:
         The assistant's text response.
@@ -119,13 +125,21 @@ def call_api(
         from _providers import is_default_anthropic, resolve_provider
 
         if not is_default_anthropic(selected):
-            return resolve_provider(selected).complete(
-                messages=messages,
-                system=system,
-                model=model,
-                max_tokens=max_tokens,
-                temperature=temperature,
-            )
+            selected_provider = resolve_provider(selected)
+            kwargs: dict[str, object] = {
+                "messages": messages,
+                "system": system,
+                "model": model,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            }
+            if seed is not None:
+                kwargs["seed"] = seed
+            text = cast(str, selected_provider.complete(**kwargs))
+            fingerprint = getattr(selected_provider, "system_fingerprint", None)
+            if metadata is not None and isinstance(fingerprint, str):
+                metadata["system_fingerprint"] = fingerprint
+            return text
     body: dict[str, Any] = {
         "model": model,
         "max_tokens": max_tokens,

--- a/scripts/eval/_eval_agent_types.py
+++ b/scripts/eval/_eval_agent_types.py
@@ -150,6 +150,7 @@ class RunRecord:
     error_category: str | None
     attempts: int
     tokens_estimated: bool = True
+    system_fingerprint: str | None = None
     schema_version: int = SCHEMA_VERSION
 
 
@@ -184,6 +185,7 @@ class Report:
     flaky_fixtures_excluded: list[str] = field(default_factory=list)
     flaky_halt_threshold_crossed: bool = False
     tokens_estimated: bool = True
+    system_fingerprints: list[str] = field(default_factory=list)
     recommendation: RecommendationLiteral | None = None
     recommendation_default: str | None = None
     schema_version: int = SCHEMA_VERSION

--- a/scripts/eval/_eval_api_adapter.py
+++ b/scripts/eval/_eval_api_adapter.py
@@ -25,7 +25,7 @@ import sys
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Protocol, cast
 
 # Sibling import; loaded under the same EVAL_DIR sys.path entry that the CLI uses.
 from _anthropic_api import call_api, load_api_key
@@ -71,6 +71,7 @@ class APICallResult:
     error_category: str | None
     attempts: int
     tokens_estimated: bool = True
+    system_fingerprint: str | None = None
 
 
 # Match the HTTP-status hint that `_anthropic_api.call_api` puts into its
@@ -142,7 +143,60 @@ def _emit_log(record: dict[str, object]) -> None:
 Transport = Callable[[str, str, str], str]
 
 
-def _default_transport_factory() -> Transport:
+class _ProviderWithFingerprint(Protocol):
+    system_fingerprint: str | None
+
+    def complete(self, **kwargs: object) -> str: ...
+
+
+class _OpenAIProviderTransport:
+    def __init__(self, provider: _ProviderWithFingerprint, *, seed: int | None) -> None:
+        self._provider = provider
+        self._seed = seed
+        self.system_fingerprint: str | None = None
+
+    def __call__(self, prompt: str, model_id: str, system: str) -> str:
+        kwargs: dict[str, object] = {
+            "messages": [{"role": "user", "content": prompt}],
+            "system": system,
+            "model": model_id,
+            "max_tokens": 1024,
+            "temperature": 0.0,
+        }
+        if self._seed is not None:
+            kwargs["seed"] = self._seed
+        text = self._provider.complete(**kwargs)
+        fingerprint = getattr(self._provider, "system_fingerprint", None)
+        self.system_fingerprint = fingerprint if isinstance(fingerprint, str) else None
+        return text
+
+
+class _AnthropicTransport:
+    def __init__(self, api_key: str, *, seed: int | None) -> None:
+        self._api_key = api_key
+        self._seed = seed
+        self.system_fingerprint: str | None = None
+
+    def __call__(self, prompt: str, model_id: str, system: str) -> str:
+        metadata: dict[str, object] = {}
+        text = cast(
+            str,
+            call_api(
+                api_key=self._api_key,
+                messages=[{"role": "user", "content": prompt}],
+                system=system,
+                model=model_id,
+                temperature=0.0,
+                seed=self._seed,
+                metadata=metadata,
+            ),
+        )
+        fingerprint = metadata.get("system_fingerprint")
+        self.system_fingerprint = fingerprint if isinstance(fingerprint, str) else None
+        return text
+
+
+def _default_transport_factory(seed: int | None = None) -> Transport:
     """Build the production transport selected by EVAL_PROVIDER.
 
     The default Anthropic urllib path reads ANTHROPIC_API_KEY once here and
@@ -158,34 +212,10 @@ def _default_transport_factory() -> Transport:
 
     if provider and not is_default_anthropic(provider):
         selected_provider = resolve_provider(provider)
-
-        def _call_provider(prompt: str, model_id: str, system: str) -> str:
-            return selected_provider.complete(
-                messages=[{"role": "user", "content": prompt}],
-                system=system,
-                model=model_id,
-                max_tokens=1024,
-                temperature=0.0,
-            )
-
-        return _call_provider
+        return _OpenAIProviderTransport(selected_provider, seed=seed)
 
     api_key = load_api_key()
-
-    def _call(prompt: str, model_id: str, system: str) -> str:
-        # Determinism is contractual for this adapter (REQ-004 AC-3 /
-        # ADR-058 §"Experimental Design Symmetry"). Pass temperature=0
-        # explicitly here rather than relying on `call_api`'s default so
-        # a future helper change cannot silently break reproducibility.
-        return call_api(
-            api_key=api_key,
-            messages=[{"role": "user", "content": prompt}],
-            system=system,
-            model=model_id,
-            temperature=0.0,
-        )
-
-    return _call
+    return _AnthropicTransport(api_key, seed=seed)
 
 
 class AnthropicAPIAdapter:
@@ -197,6 +227,7 @@ class AnthropicAPIAdapter:
         sleep: Callable[[float], None] = time.sleep,
         clock: Callable[[], float] = time.monotonic,
         total_timeout_seconds: float = DEFAULT_TOTAL_TIMEOUT_SEC,
+        seed: int | None = None,
     ) -> None:
         # Lazy default: only resolve the API key when the adapter actually
         # needs the production transport. Tests inject `transport` directly.
@@ -204,10 +235,11 @@ class AnthropicAPIAdapter:
         self._sleep = sleep
         self._clock = clock
         self._total_timeout_seconds = total_timeout_seconds
+        self._seed = seed
 
     def _resolve_transport(self) -> Transport:
         if self._transport is None:
-            self._transport = _default_transport_factory()
+            self._transport = _default_transport_factory(seed=self._seed)
         return self._transport
 
     def call_model(
@@ -271,6 +303,7 @@ class AnthropicAPIAdapter:
                 error_category=category,
                 attempts=0,
                 tokens_estimated=True,
+                system_fingerprint=None,
             )
         attempt = 0
         last_category: str | None = None
@@ -307,6 +340,7 @@ class AnthropicAPIAdapter:
                     error_category=ERR_TOTAL_TIMEOUT,
                     attempts=attempt - 1,
                     tokens_estimated=True,
+                    system_fingerprint=None,
                 )
             attempt_start = self._clock()
             try:
@@ -340,6 +374,7 @@ class AnthropicAPIAdapter:
                         error_category=category,
                         attempts=attempt,
                         tokens_estimated=True,
+                        system_fingerprint=None,
                     )
                 # Transient + budget remaining → backoff and retry, but only
                 # if the next attempt + its backoff fits inside the wall
@@ -371,6 +406,7 @@ class AnthropicAPIAdapter:
                         error_category=ERR_TOTAL_TIMEOUT,
                         attempts=attempt,
                         tokens_estimated=True,
+                        system_fingerprint=None,
                     )
                 self._sleep(backoff)
                 continue
@@ -405,6 +441,7 @@ class AnthropicAPIAdapter:
                 error_category=None,
                 attempts=attempt,
                 tokens_estimated=True,
+                system_fingerprint=getattr(transport, "system_fingerprint", None),
             )
 
         # Exhausted retries on transient error without ever getting an
@@ -418,6 +455,7 @@ class AnthropicAPIAdapter:
             latency_ms=round(total_latency_ms, 2),
             error_category=last_category or ERR_UNKNOWN,
             attempts=attempt,
+            system_fingerprint=None,
         )
 
 

--- a/scripts/eval/_providers.py
+++ b/scripts/eval/_providers.py
@@ -33,15 +33,16 @@ from __future__ import annotations
 
 import os
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 
 # GitHub Models inference endpoint (OpenAI-compatible). Verified 2026-06:
 # https://models.github.ai/inference with a GitHub PAT as the bearer token.
 GITHUB_MODELS_BASE_URL = "https://models.github.ai/inference"
 
 if TYPE_CHECKING:  # imported lazily at runtime; typed here for the client factory
+    from anthropic.types import MessageParam
     from openai import OpenAI
 
 
@@ -49,6 +50,7 @@ class EvalProvider(Protocol):
     """Strategy interface. One method: text in, text out, normalized errors."""
 
     name: str
+    system_fingerprint: str | None
 
     def complete(
         self,
@@ -58,6 +60,7 @@ class EvalProvider(Protocol):
         model: str,
         max_tokens: int = 1024,
         temperature: float = 0.0,
+        seed: int | None = None,
     ) -> str:
         """Return assistant text. Raise RuntimeError on any failure."""
         ...
@@ -173,6 +176,7 @@ class _OpenAICompatibleProvider:
         self._provider_label = provider_label
         self._key_names = key_names
         self._base_url = base_url
+        self.system_fingerprint: str | None = None
 
     def _client(self) -> OpenAI:
         try:
@@ -201,8 +205,10 @@ class _OpenAICompatibleProvider:
         model: str,
         max_tokens: int = 1024,
         temperature: float = 0.0,
+        seed: int | None = None,
     ) -> str:
         client = self._client()
+        self.system_fingerprint = None
         full_messages: list[dict[str, str]] = []
         if system:
             full_messages.append({"role": "system", "content": system})
@@ -215,6 +221,8 @@ class _OpenAICompatibleProvider:
         else:
             create_kwargs["max_tokens"] = max_tokens
             create_kwargs["temperature"] = temperature
+        if seed is not None:
+            create_kwargs["seed"] = seed
         try:
             resp = client.chat.completions.create(**create_kwargs)
         except Exception as exc:  # noqa: BLE001 - normalize then re-raise
@@ -230,6 +238,8 @@ class _OpenAICompatibleProvider:
             raise RuntimeError(
                 f"{self._provider_label} API returned non-text content for model {model}."
             )
+        fingerprint = getattr(resp, "system_fingerprint", None)
+        self.system_fingerprint = fingerprint if isinstance(fingerprint, str) else None
         return content
 
 
@@ -243,6 +253,7 @@ class _AnthropicSDKProvider:
 
     name = "anthropic-sdk"
     _provider_label = "Anthropic"
+    system_fingerprint: str | None = None
 
     def complete(
         self,
@@ -252,6 +263,7 @@ class _AnthropicSDKProvider:
         model: str,
         max_tokens: int = 1024,
         temperature: float = 0.0,
+        seed: int | None = None,
     ) -> str:
         try:
             from anthropic import Anthropic
@@ -262,12 +274,13 @@ class _AnthropicSDKProvider:
             ) from exc
         api_key = _read_env_key(["ANTHROPIC_API_KEY"])
         client = Anthropic(api_key=api_key, timeout=120.0, max_retries=0)
+        anthropic_messages = cast("Iterable[MessageParam]", messages)
         try:
             resp = client.messages.create(
                 model=model,
                 max_tokens=max_tokens,
                 system=system or "",
-                messages=messages,
+                messages=anthropic_messages,
                 temperature=temperature,
             )
         except Exception as exc:  # noqa: BLE001 - normalize then re-raise

--- a/scripts/eval/_report_writer.py
+++ b/scripts/eval/_report_writer.py
@@ -67,8 +67,9 @@ def _build_report_json(
     fixture_set_sha: str,
     wall_clock_seconds: float,
     recommendation: str | None = None,
+    system_fingerprints: list[str] | None = None,
     form_factor: FormFactorComparison | None = None,
-) -> dict:
+) -> dict[str, object]:
     """Serialize the AggregateResult into the report.json shape.
 
     `recommendation` is `null` until a caller supplies the verdict
@@ -106,6 +107,7 @@ def _build_report_json(
         "tokens_estimated": aggregate.tokens_estimated,
         "error_count": aggregate.error_count,
         "pricing_rate_as_of": aggregate.pricing_rate_as_of,
+        "system_fingerprints": system_fingerprints or [],
         "recommendation": recommendation,
     }
     if form_factor is not None:
@@ -113,7 +115,7 @@ def _build_report_json(
     return payload
 
 
-def _form_factor_payload(form_factor: FormFactorComparison) -> dict:
+def _form_factor_payload(form_factor: FormFactorComparison) -> dict[str, object]:
     return {
         "schemaVersion": form_factor.schema_version,
         "agent_recall": round(form_factor.agent_recall, 6),
@@ -308,6 +310,7 @@ def _render_markdown(
     fixture_set_sha: str,
     wall_clock_seconds: float,
     recommendation: str | None = None,
+    system_fingerprints: list[str] | None = None,
     form_factor: FormFactorComparison | None = None,
 ) -> str:
     """Compose REPORT.md in stepdown order: header → summary → details."""
@@ -318,6 +321,9 @@ def _render_markdown(
         f"- Baseline prompt SHA: `{baseline_prompt_sha[:16]}...`\n"
         f"- Fixture set SHA: `{fixture_set_sha[:16]}...`\n"
     )
+    if system_fingerprints:
+        rendered = ", ".join(f"`{value}`" for value in system_fingerprints)
+        header += f"- System fingerprints: {rendered}\n"
     sections = [
         header,
         _render_summary_table(aggregate),
@@ -348,6 +354,7 @@ class ReportWriter:
         fixture_set_sha: str,
         wall_clock_seconds: float,
         recommendation: str | None = None,
+        system_fingerprints: list[str] | None = None,
         form_factor: FormFactorComparison | None = None,
     ) -> tuple[Path, Path]:
         """Render both files. Returns (json_path, markdown_path)."""
@@ -361,6 +368,7 @@ class ReportWriter:
             fixture_set_sha=fixture_set_sha,
             wall_clock_seconds=wall_clock_seconds,
             recommendation=recommendation,
+            system_fingerprints=system_fingerprints,
             form_factor=form_factor,
         )
         report_md = _render_markdown(
@@ -372,6 +380,7 @@ class ReportWriter:
             fixture_set_sha=fixture_set_sha,
             wall_clock_seconds=wall_clock_seconds,
             recommendation=recommendation,
+            system_fingerprints=system_fingerprints,
             form_factor=form_factor,
         )
         json_path = run_reports_dir / "report.json"

--- a/scripts/eval/eval-agent-vs-baseline.py
+++ b/scripts/eval/eval-agent-vs-baseline.py
@@ -71,6 +71,7 @@ EXIT_AUTH = 4
 
 DEFAULT_MODEL = "claude-sonnet-4-6"
 DEFAULT_N_RUNS = 3
+DEFAULT_SEED = 0
 ALLOWED_PROVENANCE = frozenset(
     {"synthetic", "public-cve", "paraphrased-from-public"}
 )
@@ -545,6 +546,15 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "comparable (ADR-058)."
         ),
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help=(
+            "Optional seed forwarded to OpenAI-compatible providers. The "
+            f"default for eval runs is {DEFAULT_SEED}."
+        ),
+    )
     return parser
 
 
@@ -666,6 +676,7 @@ def _execute_one(
         error_category=api_result.error_category,
         attempts=api_result.attempts,
         tokens_estimated=getattr(api_result, "tokens_estimated", True),
+        system_fingerprint=api_result.system_fingerprint,
     )
 
 
@@ -745,7 +756,7 @@ def _run_live(
     fixture_path_by_id = {
         f.id: p for f, p in zip(fixtures, fixture_paths, strict=True)
     }
-    adapter = AnthropicAPIAdapter()
+    adapter = AnthropicAPIAdapter(seed=args.seed)
     engine = build_default_engine()
 
     import time as _time
@@ -929,6 +940,13 @@ def _generate_report(
 ) -> int:
     """Aggregate records and write report. Halts on >30% flakiness."""
     aggregator = ReportAggregator(records, model_id=model_id)
+    system_fingerprints = sorted(
+        {
+            record.system_fingerprint
+            for record in records
+            if isinstance(record.system_fingerprint, str)
+        }
+    )
     try:
         aggregate = aggregator.aggregate()
     except EmptyRunError as exc:
@@ -979,6 +997,7 @@ def _generate_report(
                 fixture_set_sha=_fixture_set_sha(fixture_paths),
                 wall_clock_seconds=wall_clock_seconds,
                 recommendation="form-factor-invalid",
+                system_fingerprints=system_fingerprints,
             )
             print(
                 json.dumps(
@@ -1009,6 +1028,7 @@ def _generate_report(
         fixture_set_sha=_fixture_set_sha(fixture_paths),
         wall_clock_seconds=wall_clock_seconds,
         recommendation="halt-due-to-flakiness" if halt else None,
+        system_fingerprints=system_fingerprints,
         form_factor=form_factor,
     )
     if halt:

--- a/scripts/eval/eval-rule-activation.py
+++ b/scripts/eval/eval-rule-activation.py
@@ -67,6 +67,7 @@ MECHANISMS = ("baseline", "description", "full")
 # AND that mechanism beats baseline by >= MIN_DELTA_VS_BASELINE.
 MIN_ACTIVATION_SCORE = 3.5
 MIN_DELTA_VS_BASELINE = 0.5
+DEFAULT_SEED = 0
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +127,7 @@ def score_response(
     scenario: dict[str, Any],
     response: str,
     model: str = DEFAULT_MODEL,
+    seed: int | None = None,
 ) -> dict[str, Any]:
     """Use the API to score a response on rule activation."""
     expected_signals = scenario.get("expected_signals", [])
@@ -179,7 +181,14 @@ Score on these dimensions (1=absent, 5=clearly present):
 Respond in JSON only, no other text:
 {json_schema}"""
 
-    raw = _call_api(api_key, [{"role": "user", "content": judge_prompt}], model=model)
+    metadata: dict[str, object] = {}
+    raw = _call_api(
+        api_key,
+        [{"role": "user", "content": judge_prompt}],
+        model=model,
+        seed=seed,
+        metadata=metadata,
+    )
 
     text = raw.strip()
     if "```" in text:
@@ -205,13 +214,17 @@ Respond in JSON only, no other text:
             "reasoning": f"judge returned non-object JSON: {text[:200]}",
             "judge_failed": True,
         }
-    return {
+    result = {
         "activation_score": _clamp_score(parsed.get("activation_score")),
         "citation_score": _clamp_score(parsed.get("citation_score")),
         "behavior_score": _clamp_score(parsed.get("behavior_score")),
         "reasoning": str(parsed.get("reasoning", ""))[:300],
         "judge_failed": False,
     }
+    fingerprint = metadata.get("system_fingerprint")
+    if isinstance(fingerprint, str):
+        result["judge_system_fingerprint"] = fingerprint
+    return result
 
 
 def _clamp_score(value: object) -> int:
@@ -237,6 +250,7 @@ def eval_one_scenario(
     scenario: dict[str, Any],
     model: str,
     dry_run: bool,
+    seed: int | None = None,
 ) -> dict[str, Any]:
     """Run all mechanisms on one scenario."""
     result: dict[str, Any] = {
@@ -257,12 +271,15 @@ def eval_one_scenario(
             continue
 
         try:
+            metadata: dict[str, object] = {}
             response = _call_api(
                 api_key,
                 [{"role": "user", "content": scenario["input"]}],
                 system=system,
                 model=model,
                 max_tokens=600,
+                seed=seed,
+                metadata=metadata,
             )
         except RuntimeError as e:
             result["mechanisms"][mechanism] = {
@@ -273,7 +290,7 @@ def eval_one_scenario(
 
         time.sleep(RATE_LIMIT_SLEEP_SEC)
         try:
-            scores = score_response(api_key, scenario, response, model=model)
+            scores = score_response(api_key, scenario, response, model=model, seed=seed)
         except RuntimeError as e:
             result["mechanisms"][mechanism] = {
                 "error": f"judge API failure: {e}",
@@ -282,11 +299,15 @@ def eval_one_scenario(
             }
             continue
         time.sleep(RATE_LIMIT_SLEEP_SEC)
-        result["mechanisms"][mechanism] = {
+        mechanism_result = {
             "response_preview": response[:400] + ("..." if len(response) > 400 else ""),
             "scores": scores,
             "system_prompt_chars": len(system),
         }
+        fingerprint = metadata.get("system_fingerprint")
+        if isinstance(fingerprint, str):
+            mechanism_result["system_fingerprint"] = fingerprint
+        result["mechanisms"][mechanism] = mechanism_result
     return result
 
 
@@ -431,6 +452,15 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--model", default=DEFAULT_MODEL, help="Model identifier.")
     parser.add_argument("--output", help="Write detailed JSON results to this path.")
     parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help=(
+            "Optional seed forwarded to OpenAI-compatible providers "
+            f"(default: {DEFAULT_SEED})."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Skip API calls, print plan.",
@@ -570,7 +600,15 @@ def _process_one_rule(
     for sc in scenarios:
         preview = sc.get("desc", "")[:60]
         print(f"  scenario {sc['id']}: {preview}...", file=sys.stderr)
-        r = eval_one_scenario(api_key, rule, rule_id, sc, args.model, dry_run=False)
+        r = eval_one_scenario(
+            api_key,
+            rule,
+            rule_id,
+            sc,
+            args.model,
+            dry_run=False,
+            seed=args.seed,
+        )
         scenario_results.append(r)
 
     summary = aggregate(scenario_results)

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -256,6 +256,9 @@ def _rule_degraded_scenario_ids(
         scores = mech_data.get("scores")
         if isinstance(scores, Mapping) and scores.get("judge_failed"):
             degraded.append(task_id)
+        elif not isinstance(scores, Mapping) or not scores:
+            # Missing or empty scores: scoring never completed. Fail closed.
+            degraded.append(task_id)
     return degraded
 
 
@@ -267,7 +270,7 @@ def _refuse_degraded_rule_report(task_ids: list[str]) -> None:
     raise ConfigError(
         "refusing to extract degraded rule report: "
         f"{len(task_ids)} scenario(s) have missing mechanism output, mechanism "
-        f"errors, or judge failures: {shown}{suffix}"
+        f"errors, missing scores, or judge failures: {shown}{suffix}"
     )
 
 

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -46,7 +46,7 @@ import os
 import re
 import sys
 import tempfile
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -235,6 +235,42 @@ def _rule_scenarios(payload: object) -> list[Any]:
     return typed
 
 
+def _rule_degraded_scenario_ids(
+    scenarios: Sequence[object], mechanism: str, *, prefix: str | None = None
+) -> list[str]:
+    degraded: list[str] = []
+    for index, scenario in enumerate(scenarios, 1):
+        if not isinstance(scenario, Mapping):
+            continue
+        raw_id = scenario.get("id") or f"S{index}"
+        sid = str(raw_id)
+        task_id = f"{prefix}::{sid}" if prefix is not None else sid
+        mechanisms = scenario.get("mechanisms")
+        if not isinstance(mechanisms, Mapping):
+            degraded.append(task_id)
+            continue
+        mech_data = mechanisms.get(mechanism)
+        if not isinstance(mech_data, Mapping) or "error" in mech_data:
+            degraded.append(task_id)
+            continue
+        scores = mech_data.get("scores")
+        if isinstance(scores, Mapping) and scores.get("judge_failed"):
+            degraded.append(task_id)
+    return degraded
+
+
+def _refuse_degraded_rule_report(task_ids: list[str]) -> None:
+    if not task_ids:
+        return
+    shown = ", ".join(sorted(task_ids)[:20])
+    suffix = "" if len(task_ids) <= 20 else f", and {len(task_ids) - 20} more"
+    raise ConfigError(
+        "refusing to extract degraded rule report: "
+        f"{len(task_ids)} scenario(s) have missing mechanism output, mechanism "
+        f"errors, or judge failures: {shown}{suffix}"
+    )
+
+
 def _extract_rules_envelope(rules: object, args: argparse.Namespace) -> dict[str, bool]:
     """Extract the multi-rule shape eval-rule-activation.py --output writes.
 
@@ -247,14 +283,24 @@ def _extract_rules_envelope(rules: object, args: argparse.Namespace) -> dict[str
     if not isinstance(rules, Mapping) or not rules:
         raise ConfigError("'rules' must be a non-empty mapping of rule name to result")
     out: dict[str, bool] = {}
+    degraded: list[str] = []
     for name, entry in rules.items():
         if not isinstance(entry, Mapping) or "scenarios" not in entry:
             raise ConfigError(f"rule {name!r} has no 'scenarios' list")
+        scenarios = _rule_scenarios(entry)
+        degraded.extend(
+            _rule_degraded_scenario_ids(scenarios, args.mechanism, prefix=str(name))
+        )
+        summary = entry.get("summary")
+        if isinstance(summary, Mapping) and summary.get("verdict") == "FAIL_JUDGE_ERRORS":
+            if not any(task_id.startswith(f"{name}::") for task_id in degraded):
+                degraded.append(f"{name}::<FAIL_JUDGE_ERRORS>")
         scored: dict[str, bool] = rule_results(
-            _rule_scenarios(entry), args.mechanism, min_score=args.min_score
+            scenarios, args.mechanism, min_score=args.min_score
         )
         for sid, passed in scored.items():
             out[f"{name}::{sid}"] = passed
+    _refuse_degraded_rule_report(degraded)
     return out
 
 
@@ -268,8 +314,12 @@ def _extract_rule(payload: object, args: argparse.Namespace) -> dict[str, bool]:
     # path (this file is a hyphenated script), so mypy resolves them as Any
     # under ignore_missing_imports. The annotation restates the contract the
     # tests already enforce.
+    scenarios = _rule_scenarios(payload)
+    _refuse_degraded_rule_report(
+        _rule_degraded_scenario_ids(scenarios, args.mechanism)
+    )
     extracted: dict[str, bool] = rule_results(
-        _rule_scenarios(payload), args.mechanism, min_score=args.min_score
+        scenarios, args.mechanism, min_score=args.min_score
     )
     return extracted
 

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -208,6 +208,85 @@ class TestExtract:
         assert code == EXIT_OK
         assert out == {"S1": True}
 
+    def test_rule_extract_refuses_errored_mechanism(self, tmp_path, capsys):
+        scenarios = _write(
+            tmp_path,
+            "scen.json",
+            [
+                {
+                    "id": "S1",
+                    "negative_case": False,
+                    "mechanisms": {
+                        "full": {
+                            "error": "model timeout",
+                            "scores": {
+                                "activation_score": 0,
+                                "citation_score": 0,
+                                "behavior_score": 0,
+                            },
+                        }
+                    },
+                }
+            ],
+        )
+        code, out = _run(capsys, "extract", "--kind", "rule", "--input", scenarios)
+        assert code == EXIT_CONFIG
+        assert "degraded rule report" in out["error"]
+        assert "S1" in out["error"]
+
+    def test_rule_extract_clean_report_succeeds(self, tmp_path, capsys):
+        scenarios = _write(
+            tmp_path,
+            "scen.json",
+            [
+                {
+                    "id": "S2",
+                    "negative_case": False,
+                    "mechanisms": {
+                        "full": {
+                            "scores": {
+                                "activation_score": 5,
+                                "citation_score": 4,
+                                "behavior_score": 5,
+                            }
+                        }
+                    },
+                }
+            ],
+        )
+        code, out = _run(capsys, "extract", "--kind", "rule", "--input", scenarios)
+        assert code == EXIT_OK
+        assert out == {"S2": True}
+
+    def test_rule_extract_refuses_judge_failure_verdict(self, tmp_path, capsys):
+        envelope = {
+            "rules": {
+                "refactoring": {
+                    "summary": {"verdict": "FAIL_JUDGE_ERRORS"},
+                    "scenarios": [
+                        {
+                            "id": "S3",
+                            "negative_case": False,
+                            "mechanisms": {
+                                "full": {
+                                    "scores": {
+                                        "activation_score": 0,
+                                        "citation_score": 0,
+                                        "behavior_score": 0,
+                                        "judge_failed": True,
+                                    }
+                                }
+                            },
+                        }
+                    ],
+                }
+            }
+        }
+        path = _write(tmp_path, "rules.json", envelope)
+        code, out = _run(capsys, "extract", "--kind", "rule", "--input", path)
+        assert code == EXIT_CONFIG
+        assert "refactoring::S3" in out["error"]
+
     def test_rule_scenarios_accept_a_wrapped_object(self, tmp_path, capsys):
         """A bare scenario list may also arrive wrapped in a 'scenarios' key."""
         scenarios = _write(

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -234,6 +234,48 @@ class TestExtract:
         assert "degraded rule report" in out["error"]
         assert "S1" in out["error"]
 
+    def test_rule_extract_refuses_empty_scores(self, tmp_path, capsys):
+        """Missing or empty scores block is degraded (fail closed)."""
+        scenarios = _write(
+            tmp_path,
+            "scen.json",
+            [
+                {
+                    "id": "S1",
+                    "negative_case": False,
+                    "mechanisms": {
+                        "full": {
+                            "scores": {},
+                        }
+                    },
+                }
+            ],
+        )
+        code, out = _run(capsys, "extract", "--kind", "rule", "--input", scenarios)
+        assert code == EXIT_CONFIG
+        assert "degraded rule report" in out["error"]
+        assert "S1" in out["error"]
+
+    def test_rule_extract_refuses_missing_scores(self, tmp_path, capsys):
+        """None scores block is degraded (fail closed)."""
+        scenarios = _write(
+            tmp_path,
+            "scen.json",
+            [
+                {
+                    "id": "S1",
+                    "negative_case": False,
+                    "mechanisms": {
+                        "full": {}
+                    },
+                }
+            ],
+        )
+        code, out = _run(capsys, "extract", "--kind", "rule", "--input", scenarios)
+        assert code == EXIT_CONFIG
+        assert "degraded rule report" in out["error"]
+        assert "S1" in out["error"]
+
     def test_rule_extract_clean_report_succeeds(self, tmp_path, capsys):
         scenarios = _write(
             tmp_path,

--- a/tests/eval/test_providers.py
+++ b/tests/eval/test_providers.py
@@ -86,8 +86,10 @@ class _FakeChoice:
 
 
 class _FakeResponse:
-    def __init__(self, content: object) -> None:
+    def __init__(self, content: object, system_fingerprint: str | None = "fp-test") -> None:
         self.choices = [_FakeChoice(content)]
+        if system_fingerprint is not None:
+            self.system_fingerprint = system_fingerprint
 
 
 class _FakeCompletions:
@@ -149,6 +151,73 @@ def test_openai_provider_returns_message_content(
     )
 
     assert result == "answer-for-gpt-4o"
+
+
+def test_openai_provider_passes_seed_when_provided(
+    fake_openai: type[_FakeOpenAI], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[_FakeOpenAI] = []
+    original_init = _FakeOpenAI.__init__
+
+    def _record_init(self: _FakeOpenAI, **kwargs: object) -> None:
+        original_init(self, **kwargs)
+        captured.append(self)
+
+    monkeypatch.setattr(_FakeOpenAI, "__init__", _record_init)
+    provider = _providers.resolve_provider("openai")
+
+    provider.complete(
+        messages=[{"role": "user", "content": "hi"}],
+        model="gpt-4o",
+        seed=3475,
+    )
+
+    assert captured[0].recorder[0]["seed"] == 3475
+
+
+def test_openai_provider_omits_seed_when_unset(
+    fake_openai: type[_FakeOpenAI], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[_FakeOpenAI] = []
+    original_init = _FakeOpenAI.__init__
+
+    def _record_init(self: _FakeOpenAI, **kwargs: object) -> None:
+        original_init(self, **kwargs)
+        captured.append(self)
+
+    monkeypatch.setattr(_FakeOpenAI, "__init__", _record_init)
+    provider = _providers.resolve_provider("openai")
+
+    provider.complete(messages=[{"role": "user", "content": "hi"}], model="gpt-4o")
+
+    assert "seed" not in captured[0].recorder[0]
+
+
+def test_openai_provider_captures_system_fingerprint(
+    fake_openai: type[_FakeOpenAI],
+) -> None:
+    provider = _providers.resolve_provider("openai")
+
+    provider.complete(messages=[{"role": "user", "content": "hi"}], model="gpt-4o")
+
+    assert provider.system_fingerprint == "fp-test"
+
+
+def test_openai_provider_tolerates_missing_system_fingerprint(
+    fake_openai: type[_FakeOpenAI], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _return_without_fingerprint(
+        self: _FakeCompletions, **kwargs: object
+    ) -> _FakeResponse:
+        self._recorder.append(kwargs)
+        return _FakeResponse("answer", system_fingerprint=None)
+
+    monkeypatch.setattr(_FakeCompletions, "create", _return_without_fingerprint)
+    provider = _providers.resolve_provider("openai")
+
+    provider.complete(messages=[{"role": "user", "content": "hi"}], model="gpt-4o")
+
+    assert provider.system_fingerprint is None
 
 
 def test_openai_provider_raises_on_non_text_content(

--- a/tests/evals/test_eval_agent_vs_baseline.py
+++ b/tests/evals/test_eval_agent_vs_baseline.py
@@ -1067,7 +1067,7 @@ class TestRunnerLiveLoop:
             for _ in range(6)
         ]
         adapter = _StubAdapter(results)
-        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda: adapter)
+        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda **_: adapter)
 
         rc = cli_main([
             "--agent",
@@ -1117,7 +1117,7 @@ class TestRunnerLiveLoop:
             for _ in range(6)
         ]
         adapter1 = _StubAdapter(list(all_six))
-        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda: adapter1)
+        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda **_: adapter1)
         run_id = "20260503T130000Z-cafebabe"
         rc = cli_main([
             "--agent",
@@ -1135,7 +1135,7 @@ class TestRunnerLiveLoop:
         # Resume: adapter should not be called at all because all 6 triples
         # are already completed.
         adapter2 = _StubAdapter([])  # empty: any call would IndexError
-        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda: adapter2)
+        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda **_: adapter2)
         rc2 = cli_main([
             "--agent",
             "security",
@@ -1170,7 +1170,7 @@ class TestRunnerLiveLoop:
             for _ in range(6)
         ]
         adapter = _StubAdapter(all_errors)
-        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda: adapter)
+        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda **_: adapter)
         rc = cli_main([
             "--agent",
             "security",
@@ -1700,6 +1700,23 @@ class TestReportWriter:
             assert key in payload, f"missing field: {key}"
         assert payload["schemaVersion"] == 1
         assert payload["recommendation"] is None  # T4-7 fills in
+        assert payload["system_fingerprints"] == []
+
+    def test_report_json_includes_system_fingerprints(self, tmp_path):
+        writer = ReportWriter(tmp_path / "reports")
+        json_path, md_path = writer.write(
+            aggregate=self._aggregate(),
+            run_id="r-fp",
+            model_id="gpt-4o",
+            agent_prompt_sha="a" * 64,
+            baseline_prompt_sha="b" * 64,
+            fixture_set_sha="c" * 64,
+            wall_clock_seconds=10.0,
+            system_fingerprints=["fp-a"],
+        )
+        payload = json.loads(json_path.read_text(encoding="utf-8"))
+        assert payload["system_fingerprints"] == ["fp-a"]
+        assert "fp-a" in md_path.read_text(encoding="utf-8")
 
     def test_report_md_contains_required_sections(self, tmp_path):
         writer = ReportWriter(tmp_path / "reports")
@@ -1761,7 +1778,7 @@ class TestRunnerEndToEndReport:
                 for _ in range(6)
             ]
         )
-        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda: adapter)
+        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda **_: adapter)
         rc = cli_main([
             "--agent",
             "security",
@@ -1782,6 +1799,44 @@ class TestRunnerEndToEndReport:
         payload = json.loads(report_json.read_text(encoding="utf-8"))
         assert payload["schemaVersion"] == 1
         assert payload["recommendation"] is None
+
+    def test_e2e_writes_system_fingerprint_to_report(self, tmp_path, monkeypatch):
+        self._setup(tmp_path, monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-e2e")
+        fixtures_dir = tmp_path / "fixtures"
+        fixtures_dir.mkdir()
+        _write_fixture(fixtures_dir, "F001.json", _valid_fixture_payload())
+
+        adapter = _StubAdapter(
+            [
+                APICallResult(
+                    outcome="success",
+                    raw_response="IDENTIFY: clean",
+                    tokens_in=100,
+                    tokens_out=50,
+                    latency_ms=10.0,
+                    error_category=None,
+                    attempts=1,
+                    system_fingerprint="fp-3475",
+                )
+                for _ in range(6)
+            ]
+        )
+        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda **_: adapter)
+        rc = cli_main([
+            "--agent",
+            "security",
+            "--fixtures",
+            str(fixtures_dir),
+            "--n-runs",
+            "3",
+        ])
+        assert rc == 0
+
+        reports_root = tmp_path / "evals" / "security-spike" / "reports"
+        report_json = next(reports_root.iterdir()) / "report.json"
+        payload = json.loads(report_json.read_text(encoding="utf-8"))
+        assert payload["system_fingerprints"] == ["fp-3475"]
 
     def test_e2e_include_skill_writes_form_factor_report(
         self, tmp_path, monkeypatch
@@ -1809,7 +1864,7 @@ class TestRunnerEndToEndReport:
                 for _ in range(9)
             ]
         )
-        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda: adapter)
+        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda **_: adapter)
         rc = cli_main([
             "--agent",
             "security",
@@ -1901,7 +1956,7 @@ class TestRunnerFreshRunMode:
         first.write_record(_make_record())
 
         adapter = _StubAdapter([])  # any call IndexErrors → proves no calls
-        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda: adapter)
+        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda **_: adapter)
         rc = cli_main([
             "--agent",
             "security",
@@ -2207,7 +2262,7 @@ class TestResumeSkipLogging:
                 for _ in range(6)
             ]
         )
-        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda: adapter1)
+        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda **_: adapter1)
         run_id = "20260503T160000Z-skiplog0"
         rc = cli_main([
             "--agent",
@@ -2224,7 +2279,7 @@ class TestResumeSkipLogging:
 
         # Phase 2: resume; every triple is already complete → 6 skips.
         adapter2 = _StubAdapter([])
-        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda: adapter2)
+        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda **_: adapter2)
         rc2 = cli_main([
             "--agent",
             "security",
@@ -2584,7 +2639,7 @@ class TestPerFixtureHaltThreshold:
             for _ in range(29)
         ]
         adapter = _StubAdapter(results)
-        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda: adapter)
+        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda **_: adapter)
         rc = cli_main([
             "--agent", "security",
             "--fixtures", str(fixtures_dir),


### PR DESCRIPTION
Fixes #3474
Fixes #3475

## Summary

- Refuses degraded rule extract reports before paired gates run.
- Threads an OpenAI-compatible seed through eval providers and eval entry points.
- Records system fingerprints in run records and report output.

## Tests

```text
uv run ruff check scripts/eval/
uv run mypy scripts/eval/_providers.py scripts/eval/_optimizer_adapters.py scripts/eval/optimize-artifact.py 2>&1 | head -40
uv run --frozen python -m pytest tests/eval/test_providers.py tests/eval/test_optimize_artifact_cli.py tests/evals/test_eval_agent_vs_baseline.py -q
```

Push hook completed with exit code 0.

## References

- scripts/eval/optimize-artifact.py
- scripts/eval/_providers.py
- scripts/eval/_anthropic_api.py
- scripts/eval/_eval_api_adapter.py
- scripts/eval/_eval_agent_types.py
- scripts/eval/_report_writer.py
- scripts/eval/eval-agent-vs-baseline.py
- scripts/eval/eval-rule-activation.py
- tests/eval/test_optimize_artifact_cli.py
- tests/eval/test_providers.py
- tests/evals/test_eval_agent_vs_baseline.py
