### PR TITLE
fix(ci): re-trigger the instruction-budget gate on split budget modules

### DIFF
--- a/.github/workflows/instruction-budget.yml
+++ b/.github/workflows/instruction-budget.yml
@@ -50,7 +50,7 @@ jobs:
             validator:
               - 'scripts/validation/instruction_budget*.py'
               - 'scripts/validation/token_budget.py'
-              - 'tests/validation/test_instruction_budget.py'
+              - 'tests/validation/test_instruction_budget*.py'
               - '.github/workflows/instruction-budget.yml'
 
       - name: Determine if budget validation should run

--- a/.github/workflows/instruction-budget.yml
+++ b/.github/workflows/instruction-budget.yml
@@ -48,7 +48,7 @@ jobs:
               - '.claude/rules/**'
               - '.github/instructions/**'
             validator:
-              - 'scripts/validation/instruction_budget.py'
+              - 'scripts/validation/instruction_budget*.py'
               - 'scripts/validation/token_budget.py'
               - 'tests/validation/test_instruction_budget.py'
               - '.github/workflows/instruction-budget.yml'


### PR DESCRIPTION
## Summary

The instruction-budget CI gate only re-ran when the exact path
`scripts/validation/instruction_budget.py` changed. PR #3477 split that module
into several sibling modules, so edits to the split-out modules (constants,
globs, types) no longer triggered the gate. A ceiling change could land
without the gate ever running.

Widened the path filter glob so every sibling module re-triggers the gate.

## Change

One line in the workflow path filter: the literal module path becomes a glob
covering the split modules.

## Testing

- Pre-push gates green: bot-cascade-advisory, build-all-check,
  workflow-local-run, pre-pr-validation, python-tests (all pass).
- The gate itself runs via `python3 -m scripts.validation.instruction_budget`
  from the repo root and is unchanged by this PR.

## Notes

No plugin version bump: this change touches only the workflow tree, which is
outside the plugin-bump path scope.

Fixes #3491
