### PR TITLE
fix(eval): harden paired eval run integrity follow-up (#3474, #3475)

### DIFF
--- a/scripts/eval/_eval_agent_types.py
+++ b/scripts/eval/_eval_agent_types.py
@@ -1,8 +1,8 @@
 """Dataclasses and exceptions for eval-agent-vs-baseline runner.
 
 DESIGN-004 §5.2 (Fixture), §5.3 (Assertion + AssertionResult), §5.3a
-(ExecutionPlan), §5.5 (RunRecord), §5.6 (Report). All serializable types
-carry schemaVersion: 1 (REQ-004 AC-7).
+(ExecutionPlan), §5.5 (RunRecord), §5.6 (Report). Serializable types carry a
+schemaVersion matching their persisted shape (REQ-004 AC-7).
 """
 
 from __future__ import annotations
@@ -12,6 +12,8 @@ from enum import Enum
 from typing import Literal
 
 SCHEMA_VERSION: int = 1
+RUN_RECORD_SCHEMA_VERSION: int = 2
+REPORT_SCHEMA_VERSION: int = 2
 
 # Provenance values per REQ-004 AC-4.
 ProvenanceLiteral = Literal["synthetic", "public-cve", "paraphrased-from-public"]
@@ -151,7 +153,8 @@ class RunRecord:
     attempts: int
     tokens_estimated: bool = True
     system_fingerprint: str | None = None
-    schema_version: int = SCHEMA_VERSION
+    seed: int | None = None
+    schema_version: int = RUN_RECORD_SCHEMA_VERSION
 
 
 @dataclass
@@ -186,9 +189,10 @@ class Report:
     flaky_halt_threshold_crossed: bool = False
     tokens_estimated: bool = True
     system_fingerprints: list[str] = field(default_factory=list)
+    seed: int | None = None
     recommendation: RecommendationLiteral | None = None
     recommendation_default: str | None = None
-    schema_version: int = SCHEMA_VERSION
+    schema_version: int = REPORT_SCHEMA_VERSION
 
 
 @dataclass

--- a/scripts/eval/_report_writer.py
+++ b/scripts/eval/_report_writer.py
@@ -17,7 +17,7 @@ import os
 import tempfile
 from pathlib import Path
 
-from _eval_agent_types import SCHEMA_VERSION
+from _eval_agent_types import REPORT_SCHEMA_VERSION
 from _report_aggregator import AggregateResult, FormFactorComparison
 
 
@@ -68,6 +68,7 @@ def _build_report_json(
     wall_clock_seconds: float,
     recommendation: str | None = None,
     system_fingerprints: list[str] | None = None,
+    seed: int | None = None,
     form_factor: FormFactorComparison | None = None,
 ) -> dict[str, object]:
     """Serialize the AggregateResult into the report.json shape.
@@ -80,7 +81,7 @@ def _build_report_json(
     external consumers can rely on them.
     """
     payload = {
-        "schemaVersion": SCHEMA_VERSION,
+        "schemaVersion": REPORT_SCHEMA_VERSION,
         "run_id": run_id,
         "model_id": model_id,
         "agent_prompt_sha": agent_prompt_sha,
@@ -108,6 +109,7 @@ def _build_report_json(
         "error_count": aggregate.error_count,
         "pricing_rate_as_of": aggregate.pricing_rate_as_of,
         "system_fingerprints": system_fingerprints or [],
+        "seed": seed,
         "recommendation": recommendation,
     }
     if form_factor is not None:
@@ -311,6 +313,7 @@ def _render_markdown(
     wall_clock_seconds: float,
     recommendation: str | None = None,
     system_fingerprints: list[str] | None = None,
+    seed: int | None = None,
     form_factor: FormFactorComparison | None = None,
 ) -> str:
     """Compose REPORT.md in stepdown order: header → summary → details."""
@@ -324,6 +327,8 @@ def _render_markdown(
     if system_fingerprints:
         rendered = ", ".join(f"`{value}`" for value in system_fingerprints)
         header += f"- System fingerprints: {rendered}\n"
+    if seed is not None:
+        header += f"- Seed: `{seed}`\n"
     sections = [
         header,
         _render_summary_table(aggregate),
@@ -355,6 +360,7 @@ class ReportWriter:
         wall_clock_seconds: float,
         recommendation: str | None = None,
         system_fingerprints: list[str] | None = None,
+        seed: int | None = None,
         form_factor: FormFactorComparison | None = None,
     ) -> tuple[Path, Path]:
         """Render both files. Returns (json_path, markdown_path)."""
@@ -369,6 +375,7 @@ class ReportWriter:
             wall_clock_seconds=wall_clock_seconds,
             recommendation=recommendation,
             system_fingerprints=system_fingerprints,
+            seed=seed,
             form_factor=form_factor,
         )
         report_md = _render_markdown(
@@ -381,6 +388,7 @@ class ReportWriter:
             wall_clock_seconds=wall_clock_seconds,
             recommendation=recommendation,
             system_fingerprints=system_fingerprints,
+            seed=seed,
             form_factor=form_factor,
         )
         json_path = run_reports_dir / "report.json"

--- a/scripts/eval/_run_persistence.py
+++ b/scripts/eval/_run_persistence.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from _eval_agent_types import (
-    SCHEMA_VERSION,
+    RUN_RECORD_SCHEMA_VERSION,
     AssertionKind,
     AssertionResult,
     RunRecord,
@@ -74,9 +74,14 @@ class RunDirectoryNotFreshError(Exception):
     only safe under explicit `--resume`."""
 
 
+class RunSeedMismatchError(Exception):
+    """Raised when resume attempts to mix records written with another seed."""
+
+
 # Public to make the format obvious at the call site and to give tests a
 # stable name to reference.
 RUNS_FILENAME = "runs.jsonl"
+SUPPORTED_RUN_RECORD_SCHEMA_VERSIONS = {1, RUN_RECORD_SCHEMA_VERSION}
 
 
 def _record_key(record: RunRecord) -> tuple[str, str, int]:
@@ -106,21 +111,22 @@ def _parse_record(line: str) -> RunRecord | None:
     Re-hydrates `AssertionResult` from the nested dicts so downstream
     consumers (the report aggregator) can call `.passed` directly.
 
-    Raises `SchemaVersionError` on incompatible `schemaVersion`. A resume
-    against an older or newer record set MUST fail fast rather than seed
-    the writer with rows that violate the current schema invariants.
+    Raises `SchemaVersionError` on incompatible `schemaVersion`. Version 1 is
+    read for compatibility and normalized with v2 optional provenance defaults.
     """
     line = line.strip()
     if not line:
         return None
     payload = json.loads(line)
     schema_version = payload.pop("schemaVersion", None)
-    if schema_version != SCHEMA_VERSION:
+    if schema_version not in SUPPORTED_RUN_RECORD_SCHEMA_VERSIONS:
         raise SchemaVersionError(
             f"unsupported schemaVersion={schema_version!r} on record "
-            f"(supported: {SCHEMA_VERSION})"
+            f"(supported: {RUN_RECORD_SCHEMA_VERSION})"
         )
     payload["schema_version"] = schema_version
+    payload.setdefault("system_fingerprint", None)
+    payload.setdefault("seed", None)
     raw_assertions = payload.get("assertions", []) or []
     payload["assertions"] = [
         AssertionResult(
@@ -144,9 +150,12 @@ class _Counters:
 class RunPersistence:
     """JSONL writer with idempotency guard. DESIGN-004 §5.5."""
 
-    def __init__(self, run_dir: Path, *, resume: bool = False) -> None:
+    def __init__(
+        self, run_dir: Path, *, resume: bool = False, seed: int | None = None
+    ) -> None:
         self._run_dir = run_dir
         self._resume = resume
+        self._seed = seed
         self._jsonl_path = run_dir / RUNS_FILENAME
         # All triples that already exist on disk, regardless of outcome.
         self._seen: set[tuple[str, str, int]] = set()
@@ -196,11 +205,17 @@ class RunPersistence:
                 # `_seen`/`_completed` get seeded with rows whose shape
                 # the writer would otherwise accept.
                 schema_version = payload.get("schemaVersion")
-                if schema_version != SCHEMA_VERSION:
+                if schema_version not in SUPPORTED_RUN_RECORD_SCHEMA_VERSIONS:
                     raise SchemaVersionError(
                         f"{self._jsonl_path}: line {line_no} has "
                         f"schemaVersion={schema_version!r} (supported: "
-                        f"{SCHEMA_VERSION})"
+                        f"{RUN_RECORD_SCHEMA_VERSION})"
+                    )
+                existing_seed = payload.get("seed")
+                if self._resume and existing_seed != self._seed:
+                    raise RunSeedMismatchError(
+                        f"{self._jsonl_path}: line {line_no} has seed="
+                        f"{existing_seed!r}, current seed={self._seed!r}"
                     )
                 identity_fields = ("fixture_id", "variant", "run_index")
                 key = tuple(payload.get(name) for name in identity_fields)
@@ -264,10 +279,10 @@ class RunPersistence:
         `outcome="error"` is replaced in place: the errored line is
         removed and the new record is appended.
         """
-        if record.schema_version != SCHEMA_VERSION:
+        if record.schema_version != RUN_RECORD_SCHEMA_VERSION:
             raise SchemaVersionError(
                 f"unsupported schemaVersion={record.schema_version} "
-                f"(supported: {SCHEMA_VERSION})"
+                f"(supported: {RUN_RECORD_SCHEMA_VERSION})"
             )
         key = _record_key(record)
         if key in self._seen:

--- a/scripts/eval/eval-agent-vs-baseline.py
+++ b/scripts/eval/eval-agent-vs-baseline.py
@@ -60,6 +60,7 @@ from _run_persistence import (
     MalformedRunRecordError,
     RunDirectoryNotFreshError,
     RunPersistence,
+    RunSeedMismatchError,
 )
 from _scoring_engine import ScoringEngine, build_default_engine
 
@@ -625,6 +626,7 @@ def _execute_one(
     agent_prompt_ref: str,
     adapter: AnthropicAPIAdapter,
     scoring_engine: ScoringEngine,
+    seed: int | None,
     skill_prompt: str | None = None,
     skill_prompt_ref: str | None = None,
 ) -> RunRecord:
@@ -677,6 +679,7 @@ def _execute_one(
         attempts=api_result.attempts,
         tokens_estimated=getattr(api_result, "tokens_estimated", True),
         system_fingerprint=api_result.system_fingerprint,
+        seed=seed,
     )
 
 
@@ -736,7 +739,9 @@ def _run_live(
     )
 
     try:
-        persistence = RunPersistence(run_dir, resume=bool(args.resume))
+        persistence = RunPersistence(
+            run_dir, resume=bool(args.resume), seed=args.seed
+        )
     except RunDirectoryNotFreshError as exc:
         # Fresh-run mode is forbidden against a populated runs.jsonl.
         print(f"error: {exc}", file=sys.stderr)
@@ -745,7 +750,7 @@ def _run_live(
         # Bad existing JSONL detected at startup.
         print(f"error: {exc}", file=sys.stderr)
         return EXIT_LOGIC
-    except (SchemaVersionError, MalformedRunRecordError) as exc:
+    except (SchemaVersionError, MalformedRunRecordError, RunSeedMismatchError) as exc:
         # Existing JSONL carries an unsupported schemaVersion, or a
         # line cannot be parsed back into a record. Per DESIGN-004
         # §Failure Modes, both are config-class failures: the on-disk
@@ -811,6 +816,7 @@ def _run_live(
                         agent_prompt_ref=agent_prompt_ref,
                         adapter=adapter,
                         scoring_engine=engine,
+                        seed=args.seed,
                         skill_prompt=skill_prompt,
                         skill_prompt_ref=skill_prompt_ref,
                     )
@@ -947,6 +953,8 @@ def _generate_report(
             if isinstance(record.system_fingerprint, str)
         }
     )
+    seeds = {record.seed for record in records}
+    seed = seeds.pop() if len(seeds) == 1 else None
     try:
         aggregate = aggregator.aggregate()
     except EmptyRunError as exc:
@@ -998,6 +1006,7 @@ def _generate_report(
                 wall_clock_seconds=wall_clock_seconds,
                 recommendation="form-factor-invalid",
                 system_fingerprints=system_fingerprints,
+                seed=seed,
             )
             print(
                 json.dumps(
@@ -1029,6 +1038,7 @@ def _generate_report(
         wall_clock_seconds=wall_clock_seconds,
         recommendation="halt-due-to-flakiness" if halt else None,
         system_fingerprints=system_fingerprints,
+        seed=seed,
         form_factor=form_factor,
     )
     if halt:

--- a/scripts/eval/eval-rule-activation.py
+++ b/scripts/eval/eval-rule-activation.py
@@ -214,10 +214,19 @@ Respond in JSON only, no other text:
             "reasoning": f"judge returned non-object JSON: {text[:200]}",
             "judge_failed": True,
         }
+    score_error = _judge_score_shape_error(parsed)
+    if score_error is not None:
+        return {
+            "activation_score": 0,
+            "citation_score": 0,
+            "behavior_score": 0,
+            "reasoning": score_error,
+            "judge_failed": True,
+        }
     result = {
-        "activation_score": _clamp_score(parsed.get("activation_score")),
-        "citation_score": _clamp_score(parsed.get("citation_score")),
-        "behavior_score": _clamp_score(parsed.get("behavior_score")),
+        "activation_score": _clamp_score(parsed["activation_score"]),
+        "citation_score": _clamp_score(parsed["citation_score"]),
+        "behavior_score": _clamp_score(parsed["behavior_score"]),
         "reasoning": str(parsed.get("reasoning", ""))[:300],
         "judge_failed": False,
     }
@@ -228,7 +237,7 @@ Respond in JSON only, no other text:
 
 
 def _clamp_score(value: object) -> int:
-    """Coerce a judge-supplied score to int in [0, 5]. Strings/None/out-of-range -> 0 or clamped."""
+    """Coerce a judge-supplied score to int in [0, 5]."""
     if not isinstance(value, (int, float, str)):
         return 0
     try:
@@ -236,6 +245,24 @@ def _clamp_score(value: object) -> int:
     except (TypeError, ValueError):
         return 0
     return max(0, min(5, n))
+
+
+def _judge_score_shape_error(parsed: dict[str, Any]) -> str | None:
+    required_fields = ("activation_score", "citation_score", "behavior_score")
+    missing = [field for field in required_fields if field not in parsed]
+    if missing:
+        return f"judge returned missing score field(s): {', '.join(missing)}"
+    for field in required_fields:
+        value = parsed[field]
+        if (
+            not isinstance(value, (int, float))
+            or isinstance(value, bool)
+        ):
+            return (
+                f"judge returned non-numeric {field}: "
+                f"{type(value).__name__}"
+            )
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -254,12 +254,27 @@ def _rule_degraded_scenario_ids(
             degraded.append(task_id)
             continue
         scores = mech_data.get("scores")
-        if isinstance(scores, Mapping) and scores.get("judge_failed"):
+        if _rule_score_block_is_degraded(scores):
             degraded.append(task_id)
         elif not isinstance(scores, Mapping) or not scores:
             # Missing or empty scores: scoring never completed. Fail closed.
             degraded.append(task_id)
     return degraded
+
+
+def _rule_score_block_is_degraded(scores: object) -> bool:
+    if not isinstance(scores, Mapping) or not scores:
+        return True
+    if scores.get("judge_failed"):
+        return True
+    for field in ("activation_score", "citation_score", "behavior_score"):
+        value = scores.get(field)
+        if (
+            not isinstance(value, (int, float))
+            or isinstance(value, bool)
+        ):
+            return True
+    return False
 
 
 def _refuse_degraded_rule_report(task_ids: list[str]) -> None:
@@ -327,6 +342,20 @@ def _extract_rule(payload: object, args: argparse.Namespace) -> dict[str, bool]:
     return extracted
 
 
+def _refuse_degraded_agent_report(report: Mapping[str, object]) -> None:
+    error_count = report.get("error_count", 0)
+    if (
+        not isinstance(error_count, (int, float))
+        or isinstance(error_count, bool)
+        or error_count <= 0
+    ):
+        return
+    raise ConfigError(
+        "refusing to extract degraded agent report: "
+        f"error_count={error_count}; rerun until all records succeed"
+    )
+
+
 def cmd_extract(args: argparse.Namespace) -> int:
     if args.kind == "hook":
         results = pytest_results(_read_text(args.input), on_skip=args.on_skip)
@@ -334,6 +363,7 @@ def cmd_extract(args: argparse.Namespace) -> int:
         report = _read_json(args.input)
         if not isinstance(report, Mapping):
             raise ConfigError(f"{args.input} must hold an agent report object")
+        _refuse_degraded_agent_report(report)
         results = agent_results(
             report,
             args.variant,

--- a/tests/eval/test_eval_rule_activation.py
+++ b/tests/eval/test_eval_rule_activation.py
@@ -136,6 +136,30 @@ class TestAggregateVerdicts:
         assert summary["verdict"] == "FAIL_JUDGE_ERRORS"
 
 
+class TestScoreResponseJudgeShape:
+    @pytest.mark.parametrize(
+        "judge_json",
+        [
+            "{}",
+            '{"activation_score": 5, "citation_score": "5", "behavior_score": 5}',
+            '{"activation_score": 5, "citation_score": 5}',
+        ],
+    )
+    def test_malformed_judge_score_object_sets_judge_failed(
+        self, monkeypatch, judge_json
+    ):
+        monkeypatch.setattr(eval_mod, "_call_api", lambda *_args, **_kwargs: judge_json)
+
+        scores = eval_mod.score_response(
+            "sk-test",
+            {"input": "x", "expected_gate": "apply-rule"},
+            "response",
+        )
+
+        assert scores["judge_failed"] is True
+        assert scores["activation_score"] == 0
+
+
 # ---------------------------------------------------------------------------
 # _load_scenarios_file() path validation
 # ---------------------------------------------------------------------------

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -184,6 +184,20 @@ class TestExtract:
         assert code == EXIT_OK
         assert out == {"C1": True}
 
+    def test_agent_report_refuses_error_count(self, tmp_path, capsys):
+        report = _write(
+            tmp_path,
+            "report.json",
+            {
+                "error_count": 1,
+                "per_fixture_pass_rates": {"C1": {"agent": [1.0]}},
+            },
+        )
+        code, out = _run(capsys, "extract", "--kind", "agent", "--input", report)
+        assert code == EXIT_CONFIG
+        assert "degraded agent report" in out["error"]
+        assert "error_count=1" in out["error"]
+
     def test_rule_scenarios(self, tmp_path, capsys):
         scenarios = _write(
             tmp_path,
@@ -329,6 +343,33 @@ class TestExtract:
         assert code == EXIT_CONFIG
         assert "refactoring::S3" in out["error"]
 
+    @pytest.mark.parametrize(
+        "scores",
+        [
+            {},
+            {"activation_score": 5, "citation_score": 5},
+            {"activation_score": 5, "citation_score": "5", "behavior_score": 5},
+        ],
+    )
+    def test_rule_extract_refuses_malformed_judge_scores(
+        self, tmp_path, capsys, scores
+    ):
+        scenarios = _write(
+            tmp_path,
+            "scen.json",
+            [
+                {
+                    "id": "S4",
+                    "negative_case": False,
+                    "mechanisms": {"full": {"scores": scores}},
+                }
+            ],
+        )
+        code, out = _run(capsys, "extract", "--kind", "rule", "--input", scenarios)
+        assert code == EXIT_CONFIG
+        assert "degraded rule report" in out["error"]
+        assert "S4" in out["error"]
+
     def test_rule_scenarios_accept_a_wrapped_object(self, tmp_path, capsys):
         """A bare scenario list may also arrive wrapped in a 'scenarios' key."""
         scenarios = _write(
@@ -339,7 +380,15 @@ class TestExtract:
                     {
                         "id": "S1",
                         "negative_case": False,
-                        "mechanisms": {"full": {"scores": {"activation_score": 5}}},
+                        "mechanisms": {
+                            "full": {
+                                "scores": {
+                                    "activation_score": 1,
+                                    "citation_score": 1,
+                                    "behavior_score": 1,
+                                }
+                            }
+                        },
                     }
                 ]
             },

--- a/tests/evals/test_eval_agent_vs_baseline.py
+++ b/tests/evals/test_eval_agent_vs_baseline.py
@@ -4,7 +4,7 @@ Covers:
 - ScoringEngine and concrete scorers (REGEX, VERDICT)
 - FixtureValidator (REQ-004 AC-4) including schemaVersion guard
 - PlanRunner.build_plan (DESIGN-004 §5.3a, REQ-004 AC-8)
-- All dataclasses carry schemaVersion=1
+- Serializable dataclasses carry the schemaVersion for their persisted shape
 
 No live API calls. T4-2 will add adapter and persistence tests.
 """
@@ -64,6 +64,12 @@ Report = types_mod.Report
 RunRecord = types_mod.RunRecord
 SchemaVersionError = types_mod.SchemaVersionError
 SCHEMA_VERSION = types_mod.SCHEMA_VERSION
+RUN_RECORD_SCHEMA_VERSION = getattr(
+    types_mod, "RUN_RECORD_SCHEMA_VERSION", SCHEMA_VERSION + 1
+)
+REPORT_SCHEMA_VERSION = getattr(
+    types_mod, "REPORT_SCHEMA_VERSION", SCHEMA_VERSION + 1
+)
 
 ScoringEngine = scoring_mod.ScoringEngine
 RegexScorer = scoring_mod.RegexScorer
@@ -450,7 +456,7 @@ class TestPlanRunner:
 
 
 # ---------------------------------------------------------------------------
-# Schema version sanity (every serializable dataclass carries schemaVersion=1)
+# Schema version sanity
 # ---------------------------------------------------------------------------
 
 
@@ -482,7 +488,7 @@ class TestDataclassSchemaVersions:
             error_category=None,
             attempts=1,
         )
-        assert record.schema_version == 1
+        assert record.schema_version == RUN_RECORD_SCHEMA_VERSION
 
     def test_report_default_schema_version(self):
         report = Report(
@@ -506,7 +512,7 @@ class TestDataclassSchemaVersions:
             error_count=0,
             pricing_rate_as_of="2026-05-03",
         )
-        assert report.schema_version == 1
+        assert report.schema_version == REPORT_SCHEMA_VERSION
         assert report.recommendation is None  # T4-5 leaves null; T4-7 sets
 
     def test_assertion_requires_pattern_or_expected_value(self):
@@ -794,6 +800,7 @@ def _make_record(
     variant: str = "agent",
     run_index: int = 0,
     outcome: str = "success",
+    seed: int | None = None,
 ) -> RunRecord:
     return RunRecord(
         fixture_id=fixture_id,
@@ -819,7 +826,12 @@ def _make_record(
         tokens_out=20,
         error_category=None,
         attempts=1,
+        seed=seed,
     )
+
+
+def _record_json_for_test(record: RunRecord) -> str:
+    return persistence_mod._record_to_json_line(record)
 
 
 class TestRunPersistenceFresh:
@@ -831,7 +843,7 @@ class TestRunPersistenceFresh:
         line = persistence.jsonl_path.read_text(encoding="utf-8").strip()
         payload = json.loads(line)
         assert payload["fixture_id"] == "F001"
-        assert payload["schemaVersion"] == 1
+        assert payload["schemaVersion"] == RUN_RECORD_SCHEMA_VERSION
         assert payload["assertions"][0]["kind"] == "verdict"
 
     def test_duplicate_write_raises_in_fresh_mode(self, tmp_path):
@@ -881,6 +893,14 @@ class TestRunPersistenceResume:
         assert reopened.is_completed("F001", "agent", 1)
         assert not reopened.is_completed("F001", "agent", 2)
 
+    def test_resume_rejects_seed_mismatch(self, tmp_path):
+        run_dir = tmp_path / "run-seed-mismatch"
+        first = RunPersistence(run_dir, resume=False, seed=111)
+        first.write_record(_make_record(seed=111))
+
+        with pytest.raises(Exception, match="seed"):
+            RunPersistence(run_dir, resume=True, seed=222)
+
 
 class TestRunPersistenceJsonlRoundTrip:
     def test_iter_records_round_trips(self, tmp_path):
@@ -893,7 +913,25 @@ class TestRunPersistenceJsonlRoundTrip:
         assert records[0].fixture_id == original.fixture_id
         assert records[0].variant == original.variant
         assert records[0].run_index == original.run_index
+        assert records[0].schema_version == RUN_RECORD_SCHEMA_VERSION
+
+    def test_v1_record_without_system_fingerprint_reads_cleanly(self, tmp_path):
+        run_dir = tmp_path / "rt-v1"
+        run_dir.mkdir()
+        payload = json.loads(_record_json_for_test(_make_record()))
+        payload["schemaVersion"] = 1
+        payload.pop("system_fingerprint", None)
+        payload.pop("seed", None)
+        (run_dir / "runs.jsonl").write_text(
+            json.dumps(payload) + "\n", encoding="utf-8"
+        )
+
+        records = list(RunPersistence(run_dir, resume=True).iter_records())
+
+        assert len(records) == 1
         assert records[0].schema_version == 1
+        assert records[0].system_fingerprint is None
+        assert records[0].seed is None
 
 
 class TestRunPersistenceSchemaGuard:
@@ -1091,7 +1129,7 @@ class TestRunnerLiveLoop:
         assert len(lines) == 6
         for line in lines:
             payload = json.loads(line)
-            assert payload["schemaVersion"] == 1
+            assert payload["schemaVersion"] == RUN_RECORD_SCHEMA_VERSION
             assert payload["model_id"] == "claude-sonnet-4-6"
 
     def test_resume_does_not_recall_completed_triples(
@@ -1698,7 +1736,7 @@ class TestReportWriter:
             "recommendation",
         ):
             assert key in payload, f"missing field: {key}"
-        assert payload["schemaVersion"] == 1
+        assert payload["schemaVersion"] == REPORT_SCHEMA_VERSION
         assert payload["recommendation"] is None  # T4-7 fills in
         assert payload["system_fingerprints"] == []
 
@@ -1797,7 +1835,7 @@ class TestRunnerEndToEndReport:
         assert report_json.exists()
         assert report_md.exists()
         payload = json.loads(report_json.read_text(encoding="utf-8"))
-        assert payload["schemaVersion"] == 1
+        assert payload["schemaVersion"] == REPORT_SCHEMA_VERSION
         assert payload["recommendation"] is None
 
     def test_e2e_writes_system_fingerprint_to_report(self, tmp_path, monkeypatch):
@@ -1837,6 +1875,50 @@ class TestRunnerEndToEndReport:
         report_json = next(reports_root.iterdir()) / "report.json"
         payload = json.loads(report_json.read_text(encoding="utf-8"))
         assert payload["system_fingerprints"] == ["fp-3475"]
+
+    def test_e2e_persists_seed_to_records_and_report(self, tmp_path, monkeypatch):
+        self._setup(tmp_path, monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-e2e")
+        fixtures_dir = tmp_path / "fixtures"
+        fixtures_dir.mkdir()
+        _write_fixture(fixtures_dir, "F001.json", _valid_fixture_payload())
+
+        adapter = _StubAdapter(
+            [
+                APICallResult(
+                    outcome="success",
+                    raw_response="IDENTIFY: clean",
+                    tokens_in=100,
+                    tokens_out=50,
+                    latency_ms=10.0,
+                    error_category=None,
+                    attempts=1,
+                )
+                for _ in range(6)
+            ]
+        )
+        monkeypatch.setattr(cli_mod, "AnthropicAPIAdapter", lambda **_: adapter)
+        rc = cli_main([
+            "--agent",
+            "security",
+            "--fixtures",
+            str(fixtures_dir),
+            "--n-runs",
+            "3",
+            "--seed",
+            "3475",
+        ])
+        assert rc == 0
+
+        runs_root = tmp_path / "evals" / "security-spike" / "runs"
+        run_jsonl = next(runs_root.iterdir()) / "runs.jsonl"
+        first_record = json.loads(run_jsonl.read_text(encoding="utf-8").splitlines()[0])
+        assert first_record["seed"] == 3475
+
+        reports_root = tmp_path / "evals" / "security-spike" / "reports"
+        report_json = next(reports_root.iterdir()) / "report.json"
+        payload = json.loads(report_json.read_text(encoding="utf-8"))
+        assert payload["seed"] == 3475
 
     def test_e2e_include_skill_writes_form_factor_report(
         self, tmp_path, monkeypatch


### PR DESCRIPTION
Fixes #3474
Fixes #3475

## Summary
- Reject rule extracts when judge score blocks are empty, partial, or mistyped.
- Reject agent extracts when report error_count is greater than zero.
- Persist eval seed in run records and reports, and reject resume attempts with a different seed.
- Bump run and report schemas to version 2 while reading v1 run records.

## Validation
- uv run --frozen ruff check scripts/eval/
- uv run --frozen mypy scripts/eval/_eval_agent_types.py scripts/eval/_report_writer.py scripts/eval/_run_persistence.py scripts/eval/eval-agent-vs-baseline.py scripts/eval/eval-rule-activation.py scripts/eval/optimize-artifact.py
- uv run --frozen python -m pytest tests/eval/test_eval_rule_activation.py tests/eval/test_optimize_artifact_cli.py tests/evals/test_eval_agent_vs_baseline.py -q

## References
scripts/eval/eval-rule-activation.py
scripts/eval/optimize-artifact.py
scripts/eval/_eval_agent_types.py
scripts/eval/_run_persistence.py
scripts/eval/_report_writer.py
scripts/eval/eval-agent-vs-baseline.py
tests/eval/test_eval_rule_activation.py
tests/eval/test_optimize_artifact_cli.py
tests/evals/test_eval_agent_vs_baseline.py

## Notes
PR #3485 was already merged, so this follow-up uses the same branch name with new commits on current main.