### PR TITLE
docs(memory): record two findings that prevent rebuilding existing work

### DIFF
--- a/.serena/memories/decision-the-instruction-budget-gate-already-exists.md
+++ b/.serena/memories/decision-the-instruction-budget-gate-already-exists.md
@@ -27,8 +27,9 @@ and check the git log dates on the artifacts the note says are missing.
 figure, references the same issue (#3419), implements exactly the prescribed
 per-language ratchet, and is wired into `.github/workflows/instruction-budget.yml`
 as `uv run --frozen python3 -m scripts.validation.instruction_budget --ci`.
-Supporting modules: `instruction_budget_globs.py`, `_constants.py`, `_types.py`,
-plus `passive_context_budget.py`.
+Supporting modules: `instruction_budget_globs.py`,
+`instruction_budget_constants.py`, `instruction_budget_types.py`, plus
+`passive_context_budget.py`.
 
 It landed in `db46e0305` on 2026-07-27. The note was written 2026-07-26. The
 repo shipped the fix the day after the gap was recorded.
@@ -45,11 +46,20 @@ Ext     Files     Bytes   Ceiling   Tokens~    Usage  Status
 
 Two figures can both be right and disagree. An independent count of the same
 tree gave 222,475 bytes across 20 files. The gate reports 218,603 across 19
-because it counts only *language-universal* `applyTo` patterns (`**`, `**/*`,
-`**/*.<ext>`); directory-scoped rules such as `scripts/**` are excluded by
-design, since they do not load on an arbitrary edit. Neither number is wrong.
-Read `is_language_universal` in `instruction_budget_globs.py` before quoting
-either one.
+because it counts only *language-universal* rules; directory-scoped rules such
+as `scripts/**` are excluded by design, since they do not load on an arbitrary
+edit. Neither number is wrong.
+
+Do not read universality as a list of blessed spellings. `is_language_universal`
+decides it by *matching*, not by enumeration: it splits `applyTo` on commas,
+reduces each pattern to its harness-effective form, and asks whether every probe
+path for the extension is matched by at least one pattern, plus a special case
+for all-files wildcards (`_ALL_FILES_FORMS`). Universality is a property of the
+union, so a rule whose depths are split across disjoint globs still counts.
+That is deliberate: under-counting is the dangerous direction for an upper
+bound, and an exact-form table let broad shapes (`?` wildcards, zero-segment
+globstars, absolute anchors) dodge the budget. Read the function before quoting
+either number.
 
 ## The headroom is the story
 

--- a/.serena/memories/decision-the-instruction-budget-gate-already-exists.md
+++ b/.serena/memories/decision-the-instruction-budget-gate-already-exists.md
@@ -1,0 +1,88 @@
+# The always-on instruction budget gate already exists, and it is nearly full
+
+## Question
+
+An analysis note says this repo has no instrument measuring the passive context
+cost of always-on instruction files, and prescribes building a ratchet. Do you
+build it?
+
+## Conventional answer
+
+The note is specific and the numbers check out. A single `.py` edit really does
+load about 218 KB of always-on rules, `AGENTS.md:31` really does carry the only
+budget line (`Knowledge -> context (<8KB)`), and
+`.agents/analysis/context-engineering.md` really is stale. The gap is real, so
+close it.
+
+## First-principles position
+
+Every premise in the note can be true and the conclusion still wrong, because
+the note is dated. It describes the repo on the day it was written, not today.
+Before building the prescribed fix, check whether the repo already shipped it,
+and check the git log dates on the artifacts the note says are missing.
+
+## Evidence
+
+`scripts/validation/instruction_budget.py` exists. It cites the same ~218 KB
+figure, references the same issue (#3419), implements exactly the prescribed
+per-language ratchet, and is wired into `.github/workflows/instruction-budget.yml`
+as `uv run --frozen python3 -m scripts.validation.instruction_budget --ci`.
+Supporting modules: `instruction_budget_globs.py`, `_constants.py`, `_types.py`,
+plus `passive_context_budget.py`.
+
+It landed in `db46e0305` on 2026-07-27. The note was written 2026-07-26. The
+repo shipped the fix the day after the gap was recorded.
+
+Live reading:
+
+```text
+Ext     Files     Bytes   Ceiling   Tokens~    Usage  Status
+.cs        19    218480    220000     57555    99.3%    PASS
+.md         9     81622     83000     21564    98.3%    PASS
+.ps1       19    218312    220000     57588    99.2%    PASS
+.py        19    218603    220000     57651    99.4%    PASS
+```
+
+Two figures can both be right and disagree. An independent count of the same
+tree gave 222,475 bytes across 20 files. The gate reports 218,603 across 19
+because it counts only *language-universal* `applyTo` patterns (`**`, `**/*`,
+`**/*.<ext>`); directory-scoped rules such as `scripts/**` are excluded by
+design, since they do not load on an arbitrary edit. Neither number is wrong.
+Read `is_language_universal` in `instruction_budget_globs.py` before quoting
+either one.
+
+## The headroom is the story
+
+Subtracting current from ceiling:
+
+```text
+.cs    1520 bytes free
+.md    1378 bytes free
+.ps1   1688 bytes free
+.py    1397 bytes free
+```
+
+A rule whose `applyTo` is `**` counts against all four languages at once, so the
+binding constraint is the smallest headroom. **The largest always-on rule that
+can be added today is 1,378 bytes.** A rule file with frontmatter and any real
+content exceeds that. The next always-on rule addition breaks the build.
+
+That is also why this note is a memory and not a rule. Documenting the budget in
+an always-on rule file would consume the budget it documents, and there is not
+room. The tier choice here is a measurement, not a preference.
+
+## Decision
+
+Do not build a context-budget instrument. Read
+`scripts/validation/instruction_budget.py` first.
+
+When adding steering that would otherwise be always-on, scope `applyTo` to the
+narrowest path glob that fires where the guidance applies. Directory-scoped
+rules do not count against these ceilings. Reserve `**` for guidance that
+genuinely binds every file in every language.
+
+Rule to carry forward: an analysis note asserting an artifact is missing is a
+claim about a date, not about the tree. Check `git log` on the thing it says
+does not exist before building it.
+
+Refs #3419, `db46e0305`.

--- a/.serena/memories/skills/orphan-ref-validator-implementation-2026-05-10.md
+++ b/.serena/memories/skills/orphan-ref-validator-implementation-2026-05-10.md
@@ -141,9 +141,9 @@ syntax (`any-glob-to-any-file`, `all-globs-to-all-files`), HTTP response headers
 (`skill-pr-enum-001`), language constructs (`try-catch`, `if-then-else`),
 software-engineering vocabulary (`hexagonal-architecture`,
 `branch-by-abstraction`, `swarm-intelligence`), and one placeholder,
-`your-api-key-here`. A 100 percent false-positive rate on the dominant kind.
+`your-api-key-here`. A 100% false-positive rate on the dominant kind.
 
-The 21 `script_path` findings are worse than false, they are *correct*. Eighteen
+The 21 `script_path` findings are not merely false. They are *correct*. Eighteen
 of them name `.ps1` files from the pre-ADR-042 PowerShell era
 (`Invoke-PRMaintenance.ps1`, `Validate-PrePR.ps1`,
 `Review-MemoryExportSecurity.ps1`). Those scripts genuinely existed when the

--- a/.serena/memories/skills/orphan-ref-validator-implementation-2026-05-10.md
+++ b/.serena/memories/skills/orphan-ref-validator-implementation-2026-05-10.md
@@ -120,3 +120,45 @@ the directive rather than use it. State the filter when quoting either number.
 line, so one directive covers a line carrying two findings. File scope must appear
 in the first 50 lines or it silently fails. Appending the directive after a table
 row works when the directive is placed inside the last cell's text (before the closing pipe). Appending after the closing pipe introduces an extra column.
+
+## `.serena/memories/` is out of scope by design, not by omission
+
+Proposing memories as a scan target looks like an obvious coverage win. It is a
+category error, and the measurement is unambiguous.
+
+Run: `scan.py --targets .serena/memories --output json`. Result: **174 findings,
+`VERDICT: CRITICAL_FAIL`, exit 1**. Split by kind: 153 `skill_name` across 115
+distinct tokens, 21 `script_path` across 13 scripts.
+
+**Zero of the 115 `skill_name` tokens is a skill.** The full set is CI runner
+labels (`ubuntu-latest`, `macos-latest`, `self-hosted`), CodeRabbit path-filter
+syntax (`any-glob-to-any-file`, `all-globs-to-all-files`), HTTP response headers
+(`x-ratelimit-remaining`, `retry-after`), model IDs (`gpt-5-mini`,
+`gemini-3-pro`), Actions inputs and permissions (`copilot-token`, `bot-pat`,
+`write-all`, `retention-days`), git hook lifecycle names (`post-merge`,
+`pre-remove`), issue labels (`area-skills`, `area-workflows`), agent names
+(`agent-architect`, `agent-qa`, which are agents and not skills), memory IDs
+(`skill-pr-enum-001`), language constructs (`try-catch`, `if-then-else`),
+software-engineering vocabulary (`hexagonal-architecture`,
+`branch-by-abstraction`, `swarm-intelligence`), and one placeholder,
+`your-api-key-here`. A 100 percent false-positive rate on the dominant kind.
+
+The 21 `script_path` findings are worse than false, they are *correct*. Eighteen
+of them name `.ps1` files from the pre-ADR-042 PowerShell era
+(`Invoke-PRMaintenance.ps1`, `Validate-PrePR.ps1`,
+`Review-MemoryExportSecurity.ps1`). Those scripts genuinely existed when the
+memory was written and genuinely do not exist now. The reference is accurate.
+
+That is the load-bearing point. **A memory is a dated record of what was true
+then. An orphan-ref scan asks whether an entity exists now.** Those two
+questions are incompatible, so a hit against a memory carries no signal about
+either. Extending the denylist would suppress the first 153 and leave the 21
+that are working exactly as intended.
+
+The same reasoning already justifies the narrow default scope above: ADRs and
+docs are excluded because they reference proposed-but-unimplemented or
+superseded-and-deleted entities. Memories are the strongest form of that case,
+not an exception to it.
+
+Do not add `.serena/memories/` as a target, and do not accept a denylist patch
+that exists to make this scan pass.


### PR DESCRIPTION
## Summary

Two negative results from auditing this repo's encoded knowledge against the documented knowledge in the wiki. Both are findings a future session re-derives expensively, and neither is written down anywhere today.

A negative result is worth recording when it stops work. These two stop work.

## Finding 1: the instruction-budget gate already exists, and it is nearly full

A wiki analysis note dated 2026-07-26 says this repo has no instrument measuring the passive context cost of always-on instruction files, and prescribes building a per-language ratchet.

Every premise in that note is true. A single `.py` edit really does load about 218 KB of always-on rules. `AGENTS.md:31` really does carry the only budget line. `.agents/analysis/context-engineering.md` really is stale.

The conclusion is still wrong, because `scripts/validation/instruction_budget.py` already exists, cites the same figure and the same issue (#3419), implements exactly the prescribed ratchet, and is wired into `.github/workflows/instruction-budget.yml`. It landed in `db46e0305` on **2026-07-27**, the day after the note was written.

Live reading:

```
Ext     Files     Bytes   Ceiling    Usage  Status
.cs        19    218480    220000    99.3%    PASS
.md         9     81622     83000    98.3%    PASS
.ps1       19    218312    220000    99.2%    PASS
.py        19    218603    220000    99.4%    PASS
```

The headroom is the operational point. A rule whose `applyTo` is `**` counts against all four languages at once, so the binding constraint is the smallest gap: **1,378 bytes**. The next always-on rule addition breaks the build.

That also settles why this is a memory and not a rule, empirically rather than by preference: documenting the budget in an always-on rule file would consume the budget it documents, and there is not room.

The generalizable rule: an analysis note asserting an artifact is missing is a claim about a date, not about the tree. Check `git log` on the thing it says does not exist before building it.

## Finding 2: scanning Serena memories for orphan refs is a category error

Adding `.serena/memories/` to the orphan-ref validator's targets looks like an obvious coverage win. Measured:

```
scan.py --targets .serena/memories  ->  174 findings, CRITICAL_FAIL, exit 1
  skill_name  : 153 findings across 115 distinct tokens
  script_path :  21 findings across  13 distinct scripts
```

**Zero of the 115 `skill_name` tokens is a skill.** The complete set is CI runner labels (`ubuntu-latest`, `self-hosted`), CodeRabbit path-filter syntax (`any-glob-to-any-file`), HTTP response headers (`x-ratelimit-remaining`, `retry-after`), model IDs (`gpt-5-mini`), Actions inputs and permissions (`copilot-token`, `write-all`), git hook lifecycle names (`post-merge`, `pre-remove`), issue labels (`area-skills`), agent names (agents are not skills), memory IDs, language constructs (`try-catch`), software-engineering vocabulary (`hexagonal-architecture`), and one placeholder, `your-api-key-here`.

The 21 `script_path` findings are worse than false. They are *correct*: 18 name `.ps1` files from the pre-ADR-042 PowerShell era, which genuinely existed when the memory was written and genuinely do not exist now.

That is the load-bearing point. **A memory is a dated record of what was true then. An orphan-ref scan asks whether an entity exists now.** The two questions are incompatible, so a hit carries no signal either way. Extending the denylist would suppress the 153 that are noise and leave the 21 that are working as intended.

This is the same reasoning that already excludes ADRs and docs from the default scope. Memories are the strongest form of that case, not an exception to it.

## Verification

```
full pre-push suite: 15,382 passed / 26 skipped
dash bytes:          0 in both files
```

Both figures above were measured on this branch, not quoted from an earlier session.

## Changed Files

* `.serena/memories/decision-the-instruction-budget-gate-already-exists.md`: new decision record, house Question/Conventional/First-principles/Evidence/Decision format
* `.serena/memories/skills/orphan-ref-validator-implementation-2026-05-10.md`: append the measured out-of-scope rationale to the existing record rather than create a competing memory

`.serena/` is not a plugin root, so no manifest bump applies.
