### PR TITLE
docs(memory): record that neither session store carries usable authorship

### DIFF
--- a/.serena/memories/decision-neither-session-store-carries-usable-authorship.md
+++ b/.serena/memories/decision-neither-session-store-carries-usable-authorship.md
@@ -1,0 +1,121 @@
+# Neither session store tells you who wrote a prompt
+
+Read this before building anything that treats stored prompts as human input.
+Four attempts to measure "what has an operator actually typed" failed on this
+one point. Each attempt trusted a different provenance premise, none of them
+held, and each produced a confident number that was wrong.
+
+Verified 2026-07-27 against the live stores. Issue #3509, PR #3513 (withdrawn).
+
+## The Copilot store: `turns.user_message` is not the human turn
+
+`~/.copilot/session-store.db` is SQLite. Tables: `sessions`, `turns`,
+`checkpoints`, `session_files`, `session_refs`, `assistant_usage_events`,
+`search_index`. Open read-only with
+`sqlite3.connect(f"file:{path}?mode=ro", uri=True)`.
+
+The tempting premise is that `turns.user_message` holds the human half of the
+turn by construction, so it needs no provenance filter. That is false. The
+column has **no author field**, and the harness writes machine text into it.
+
+Scoped to `sessions.repository LIKE '%ai-agents%'`, after rejecting the
+obvious synthetic shapes, 264 unique texts survive. Of those:
+
+| Injected shape | Texts |
+|---|---|
+| `Additional context from PreToolUse hook ...` | 88 |
+| `Autopilot objective: ...` | 12 |
+| **Total machine-authored** | **100 of 264** |
+
+By volume it is worse, because injected context is long and human turns are
+short: **304,939 of 353,725 characters, 86%**. A corpus built from this column
+is mostly machine text wearing a human column name.
+
+Prefix rejection is not a fix. It is a blacklist against an open set, and it
+cannot be validated because there is nothing to validate against. Any hook
+added tomorrow writes a shape the list does not know.
+
+## The Claude store: the label exists but covers 1%
+
+`~/.claude/projects/**/*.jsonl`. Entries with `type == "user"` and no `isMeta`
+carry an optional `promptSource`. Counted directly:
+
+| Scope | Non-meta user entries | Labelled | `typed` |
+|---|---|---|---|
+| All projects | 16,669 | 604 | 55 |
+| `ai-agents` only | 12,285 | 120 | 26 |
+
+Observed `promptSource` values across all projects: `sdk` (394), `system`
+(140), `typed` (55), `queued` (14), `suggestion_accepted` (1).
+
+So the ground truth exists and is trustworthy where present, but it is present
+on **1.0%** of the ai-agents entries. Two readings follow, and the choice
+between them is the whole design:
+
+- **Accept only `promptSource == "typed"`.** Sound, and yields 26 instances /
+  23 unique texts for ai-agents. Far too few to measure anything.
+- **Reject known non-human sources, keep the unlabelled majority.** Yields a
+  usable count, but the unlabelled majority is unverified by definition. It is
+  an assumption, not a filter.
+
+An earlier note in this repo recorded the denominator as "120 of 3,331". That
+was wrong. It is 120 of 12,285.
+
+## Why the two stores cannot be pooled or compared
+
+They differ on every axis that matters, so a difference between them attributes
+to nothing:
+
+| | Copilot store | Claude transcripts |
+|---|---|---|
+| Author label | none | `promptSource`, 1% coverage |
+| Machine text | injected into the human column | separate entry kinds |
+| Share of a pooled operator corpus | 92% | 8% |
+
+A comparison across them changes source, harness, workflow, and register at
+once. Pooling them hides that under one label.
+
+## Exposure, not authorship, drives phrase-match counts
+
+A finding from the same review, worth keeping because it generalizes past this
+eval. When you count "how many of N documented phrases appear at least once",
+the answer scales with how much text you searched, not only with who wrote it.
+
+Two corpora at 358,399 and 2,614,603 characters, a 7.3x gap, produced 3 and 28
+phrase matches. Subsampling the larger corpus down to the smaller one's
+character count, 50 iterations, collapsed 28 to a mean of **7.6** with a 95%
+range of 1 to 13. Most of the apparent effect was exposure.
+
+Two further traps in the same shape:
+
+- **Pseudo-replication.** 428 phrases are not 428 independent trials. They
+  cluster into 93 skills, and near-duplicates within a skill covary perfectly.
+  Rolled up to skills the gap fell from 9.3x to 4.3x before any volume
+  correction. Confidence intervals computed over the phrase count are far too
+  narrow.
+- **One-armed guards.** A minimum-corpus guard on the treatment arm only will
+  happily publish `0 of 428 (0.0%)` for an empty control. Guard every arm you
+  intend to print.
+
+## What a valid instrument needs
+
+Do not start from the matcher. Start from provenance. All four are required:
+
+1. An authoritative event-level author label distinguishing typed input from
+   hook, autopilot, scheduled, and agent-authored injection. Not a prefix list.
+2. One source, or a per-source result that is never pooled.
+3. Equal exposure fixed in advance, measured in characters, not prompt counts.
+4. Eligibility guards on every arm that appears in the output.
+
+Absent these, report that the question cannot be measured yet. That is a real
+answer. A number from a corpus you have not audited is not.
+
+## The pattern worth remembering
+
+Every one of the four failures had the same shape: a premise about where clean
+data lives, adopted without checking, then built on. The corpus was assumed
+human because of a column name, a store choice, or a filter that looked
+principled. Verifying takes one query. Each failure cost a full rework.
+
+Check the data before the code. Then check that your test of the check can
+fail.

--- a/.serena/memories/decision-neither-session-store-carries-usable-authorship.md
+++ b/.serena/memories/decision-neither-session-store-carries-usable-authorship.md
@@ -1,13 +1,33 @@
 # Neither session store tells you who wrote a prompt
 
-Read this before building anything that treats stored prompts as human input.
-Four attempts to measure "what has an operator actually typed" failed on this
-one point. Each attempt trusted a different provenance premise, none of them
-held, and each produced a confident number that was wrong.
-
 Verified 2026-07-27 against the live stores. Issue #3509, PR #3513 (withdrawn).
 
-## The Copilot store: `turns.user_message` is not the human turn
+## Question
+
+Can either session store measure what an operator has actually typed, so that
+stored prompts can be treated as human input?
+
+## Conventional answer
+
+Both stores look like they answer it. Copilot's `turns.user_message` reads as
+the human half of the turn by construction, so no provenance filter appears
+necessary. Claude's transcripts carry an explicit `promptSource` label, so
+filtering on it appears sufficient. Four attempts adopted one of those two
+premises and went straight to the matcher.
+
+## First-principles position
+
+Neither store carries usable authorship, and provenance binds before any
+matcher does. Copilot has no author field at all, and the harness writes
+machine text into the column named for the human. Claude's label is trustworthy
+where present but covers 1% of entries, so accepting only it leaves too little
+to measure, while keeping the unlabelled majority is an assumption rather than
+a filter. Every one of the four attempts produced a confident number that was
+wrong for this single reason.
+
+## Evidence
+
+### The Copilot store: `turns.user_message` is not the human turn
 
 `~/.copilot/session-store.db` is SQLite. Tables: `sessions`, `turns`,
 `checkpoints`, `session_files`, `session_refs`, `assistant_usage_events`,
@@ -35,7 +55,7 @@ Prefix rejection is not a fix. It is a blacklist against an open set, and it
 cannot be validated because there is nothing to validate against. Any hook
 added tomorrow writes a shape the list does not know.
 
-## The Claude store: the label exists but covers 1%
+### The Claude store: the label exists but covers 1%
 
 `~/.claude/projects/**/*.jsonl`. Entries with `type == "user"` and no `isMeta`
 carry an optional `promptSource`. Counted directly:
@@ -61,7 +81,7 @@ between them is the whole design:
 An earlier note in this repo recorded the denominator as "120 of 3,331". That
 was wrong. It is 120 of 12,285.
 
-## Why the two stores cannot be pooled or compared
+### Why the two stores cannot be pooled or compared
 
 They differ on every axis that matters, so a difference between them attributes
 to nothing:
@@ -75,7 +95,7 @@ to nothing:
 A comparison across them changes source, harness, workflow, and register at
 once. Pooling them hides that under one label.
 
-## Exposure, not authorship, drives phrase-match counts
+### Exposure, not authorship, drives phrase-match counts
 
 A finding from the same review, worth keeping because it generalizes past this
 eval. When you count "how many of N documented phrases appear at least once",
@@ -97,18 +117,20 @@ Two further traps in the same shape:
   happily publish `0 of 428 (0.0%)` for an empty control. Guard every arm you
   intend to print.
 
-## What a valid instrument needs
+## Decision
 
-Do not start from the matcher. Start from provenance. All four are required:
+PR #3513 was withdrawn rather than repaired, and the question was reported as
+not yet measurable. That is a real answer. A number from a corpus nobody has
+audited is not.
+
+A valid instrument does not start from the matcher. It starts from provenance,
+and all four of these are required:
 
 1. An authoritative event-level author label distinguishing typed input from
    hook, autopilot, scheduled, and agent-authored injection. Not a prefix list.
 2. One source, or a per-source result that is never pooled.
 3. Equal exposure fixed in advance, measured in characters, not prompt counts.
 4. Eligibility guards on every arm that appears in the output.
-
-Absent these, report that the question cannot be measured yet. That is a real
-answer. A number from a corpus you have not audited is not.
 
 ## The pattern worth remembering
 

--- a/.serena/memories/decision-neither-session-store-carries-usable-authorship.md
+++ b/.serena/memories/decision-neither-session-store-carries-usable-authorship.md
@@ -38,8 +38,8 @@ The tempting premise is that `turns.user_message` holds the human half of the
 turn by construction, so it needs no provenance filter. That is false. The
 column has **no author field**, and the harness writes machine text into it.
 
-Scoped to `sessions.repository LIKE '%ai-agents%'`, after rejecting the
-obvious synthetic shapes, 264 unique texts survive. Of those:
+Scoped to `sessions.repository LIKE '%ai-agents%'`, the column holds 264
+unique texts. Two injected shapes account for 100 of them:
 
 | Injected shape | Texts |
 |---|---|


### PR DESCRIPTION
## Summary

Records what the two session stores actually contain, so the next attempt to measure operator language starts from measured provenance instead of a column name.

Four attempts at that measurement produced four wrong numbers. Every one failed on the same point: a premise about where clean human text lives, adopted without checking. PR #3513 is withdrawn; this is the part of it that survived review.

## What the audit found

The Copilot store was the last premise to fall. `turns.user_message` reads like the human half of the turn, and the eval treated it as human by construction. It is not:

| Injected shape | Texts |
|---|---|
| `Additional context from PreToolUse hook ...` | 88 |
| `Autopilot objective: ...` | 12 |
| **Machine-authored** | **100 of 264** |

By volume that is 304,939 of 353,725 characters, so **86% of the corpus was machine text**. The column carries no author field, so a prefix blacklist is the only available filter, and a blacklist against an open set cannot be validated.

The Claude transcripts do carry ground truth in `promptSource`, but it covers **120 of 12,285** non-meta user entries for this repo, 1.0%. A prior note in this tree recorded that denominator as 3,331, which was also wrong. The memory states both available readings, accept-only-`typed` (sound, 23 unique texts, too few) and reject-known-machine (usable, but the unlabelled majority is unverified), rather than pretending either is free.

Two statistical traps are recorded because they generalize past this eval:

- Phrase-match counts scale with text volume. A 7.3x exposure gap explained most of an apparent 9x authorship effect once the larger corpus was subsampled to equal characters: 28 matches fell to a mean of 7.6.
- 428 phrases clustered into 93 skills are not 428 independent trials. Rolled up, the gap fell from 9.3x to 4.3x before any volume correction.

## Verification

Every figure was recomputed directly against the live stores before it was written down, not carried over from the withdrawn PR. The Copilot counts come from a read-only SQLite query scoped to `sessions.repository LIKE '%ai-agents%'`; the Claude counts from a direct pass over `~/.claude/projects/**/*.jsonl`. Both reproduce the numbers two independent adversarial reviewers computed on different model families.

No prompt text is reproduced here or in the memory. Only counts and the two injected prefix shapes, which are harness strings, not user content.

Dash bytes: 0. `markdownlint-cli2` linted 0 files, because `.markdownlint-cli2.yaml` excludes `.serena/**`; read that as not covered, not as passed.

## Changed Files

- `.serena/memories/decision-neither-session-store-carries-usable-authorship.md`: new memory recording store-by-store provenance, the two readings of the Claude label, the exposure and pseudo-replication traps, and the four requirements a valid instrument would need.

## Notes

No plugin root is touched, so no manifest bump applies.

Refs #3509
