### PR TITLE
test(pytest): isolate repo-local temp roots (#3511)

### DIFF
--- a/build/scripts/validate_plugin_manifests.py
+++ b/build/scripts/validate_plugin_manifests.py
@@ -315,7 +315,15 @@ def find_manifests(root: Path) -> list[Path]:
     """
     import os
 
-    excluded_dirs = {".worktrees", "worktrees", "node_modules", ".git", "cache", ".pytest_tmp"}
+    excluded_dirs = {
+        ".worktrees",
+        "worktrees",
+        "node_modules",
+        ".git",
+        "cache",
+        ".pytest_cache",
+        ".pytest_tmp",
+    }
     results: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(root):
         # Prune excluded directories in-place so os.walk does not descend.

--- a/tests/ci/test_classify_semantic_title_result.py
+++ b/tests/ci/test_classify_semantic_title_result.py
@@ -171,8 +171,8 @@ def test_main_missing_log_file_is_tolerated(capsys, tmp_path):
     assert exit_code == 0
 
 
-def test_main_ignores_log_file_outside_repo(capsys, tmp_path):
-    outside_log = tmp_path / "outside.log"
+def test_main_ignores_log_file_outside_repo(capsys, external_tmp_path):
+    outside_log = external_tmp_path / "outside.log"
     outside_log.write_text(UNICORN_LOG, encoding="utf-8")
 
     exit_code = main(

--- a/tests/claude/skills/context_optimizer/test_path_validation.py
+++ b/tests/claude/skills/context_optimizer/test_path_validation.py
@@ -49,9 +49,9 @@ def repo_root() -> Path:
 
 
 @pytest.fixture
-def temp_dir_outside_repo(tmp_path: Path) -> Path:
+def temp_dir_outside_repo(external_tmp_path: Path) -> Path:
     """Create a temp directory guaranteed to be outside the repo."""
-    outside_dir = tmp_path / "outside_repo"
+    outside_dir = external_tmp_path / "outside_repo"
     outside_dir.mkdir()
     return outside_dir
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import os
+import shutil
 import sys
+import uuid
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -74,6 +76,33 @@ def _default_project_repo(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AI_AGENTS_PROJECT_REPO", "1")
 
 
+@pytest.fixture(autouse=True)
+def _isolate_tmp_path_from_parent_git_repo(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prevent repo-local pytest temp dirs from discovering the parent checkout."""
+    if "tmp_path" not in request.fixturenames:
+        return
+    tmp_path = request.getfixturevalue("tmp_path")
+    existing = os.environ.get("GIT_CEILING_DIRECTORIES")
+    ceiling = str(tmp_path.parent)
+    value = ceiling if not existing else f"{ceiling}{os.pathsep}{existing}"
+    monkeypatch.setenv("GIT_CEILING_DIRECTORIES", value)
+
+
+@pytest.fixture
+def external_tmp_path() -> Iterator[Path]:
+    """Create a temp directory outside the checkout for path-boundary tests."""
+    root = PROJECT_ROOT.parent / f".pytest-external-{PROJECT_ROOT.name}"
+    path = root / uuid.uuid4().hex
+    path.mkdir(parents=True)
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
 def assert_validation_result(
     result: ValidationResult,
     *,
@@ -130,4 +159,3 @@ def temp_test_dir(tmp_path: Path) -> Path:
     test_dir = tmp_path / "test_workspace"
     test_dir.mkdir(parents=True, exist_ok=True)
     return test_dir
-

--- a/tests/skills/work-operating-model/test_validate_operating_model.py
+++ b/tests/skills/work-operating-model/test_validate_operating_model.py
@@ -279,8 +279,8 @@ class TestLoadDocument:
         with pytest.raises(json.JSONDecodeError):
             load_document(str(target), validate_path=False)
 
-    def test_path_traversal_blocked(self, tmp_path: Path) -> None:
-        target = tmp_path / "model.json"
+    def test_path_traversal_blocked(self, external_tmp_path: Path) -> None:
+        target = external_tmp_path / "model.json"
         target.write_text(json.dumps(_minimal_valid_document()))
         with pytest.raises(PermissionError, match="path traversal blocked"):
             load_document(str(target))
@@ -330,9 +330,9 @@ class TestMainCLI:
         assert "invalid JSON" in captured.err
 
     def test_main_blocks_traversal(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+        self, external_tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        target = tmp_path / "model.json"
+        target = external_tmp_path / "model.json"
         target.write_text(json.dumps(_minimal_valid_document()))
         rc = main([str(target)])
         captured = capsys.readouterr()

--- a/tests/test_close_issue.py
+++ b/tests/test_close_issue.py
@@ -263,10 +263,10 @@ class TestMain:
 
         assert _mod._comment_base_dir() == Path(__file__).resolve().parents[1]
 
-    def test_comment_base_falls_back_to_script_parent(self, tmp_path, monkeypatch):
-        script_dir = tmp_path / "installed" / "scripts"
+    def test_comment_base_falls_back_to_script_parent(self, external_tmp_path, monkeypatch):
+        script_dir = external_tmp_path / "installed" / "scripts"
         script_dir.mkdir(parents=True)
-        nested = tmp_path / "cwd"
+        nested = external_tmp_path / "cwd"
         nested.mkdir()
         monkeypatch.chdir(nested)
         monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
@@ -275,13 +275,13 @@ class TestMain:
         assert _mod._comment_base_dir() == script_dir.resolve()
 
     def test_comment_base_ignores_unrelated_parent_claude_dir(
-        self, tmp_path, monkeypatch
+        self, external_tmp_path, monkeypatch
     ):
-        parent = tmp_path / "parent"
+        parent = external_tmp_path / "parent"
         script_dir = parent / "installed" / "scripts"
         script_dir.mkdir(parents=True)
         (parent / ".claude").mkdir()
-        nested = tmp_path / "cwd"
+        nested = external_tmp_path / "cwd"
         nested.mkdir()
         monkeypatch.chdir(nested)
         monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)

--- a/tests/test_context_optimizer_path_validation.py
+++ b/tests/test_context_optimizer_path_validation.py
@@ -92,9 +92,11 @@ class TestValidatePathWithinRepo:
         )
         assert result.is_relative_to(repo_root)
 
-    def test_symlink_outside_repo_rejected(self, repo_root: Path, tmp_path: Path) -> None:
+    def test_symlink_outside_repo_rejected(
+        self, repo_root: Path, external_tmp_path: Path
+    ) -> None:
         """Symlink pointing outside repo root is rejected."""
-        external_dir = tmp_path / "external"
+        external_dir = external_tmp_path / "external"
         external_dir.mkdir()
         external_file = external_dir / "secret.txt"
         external_file.write_text("secret")

--- a/tests/test_github_core.py
+++ b/tests/test_github_core.py
@@ -16,6 +16,7 @@ from scripts.github_core import (
     RepoInfo,
     assert_gh_authenticated,
     assert_valid_body_file,
+    bot_config,
     check_workflow_rate_limit,
     count_unresolved_threads,
     create_issue_comment,
@@ -40,7 +41,6 @@ from scripts.github_core import (
     update_issue_comment,
 )
 from scripts.github_core.api import _403_PATTERN, _retry_after_delay
-from scripts.github_core import bot_config
 from scripts.github_core.bot_config import _DEFAULT_BOTS
 from tests.mock_fidelity import assert_mock_keys_match
 
@@ -227,15 +227,15 @@ class TestAssertValidBodyFile:
             Path(tmp_file).unlink(missing_ok=True)
 
     def test_rejects_file_outside_repo_and_all_tempdirs(
-        self, tmp_path: Path, monkeypatch
+        self, external_tmp_path: Path, monkeypatch
     ):
         """File outside both repo and every candidate temp root is rejected."""
-        outside_dir = tmp_path / "not-a-temp-dir"
+        outside_dir = external_tmp_path / "not-a-temp-dir"
         outside_dir.mkdir()
         outside_file = outside_dir / "body.md"
         outside_file.write_text("hello")
 
-        unrelated_tmp = tmp_path / "unrelated-tmp"
+        unrelated_tmp = external_tmp_path / "unrelated-tmp"
         unrelated_tmp.mkdir()
         monkeypatch.setenv("TMPDIR", str(unrelated_tmp))
 
@@ -1016,7 +1016,7 @@ class TestFetchStatus:
         unlike a bare-string sentinel which would silently miss.
         """
         with pytest.raises(AttributeError):
-            _ = getattr(FetchStatus, "OK_TYPO")
+            _ = FetchStatus.OK_TYPO
 
 
 class TestCountUnresolvedThreads:

--- a/tests/test_github_core.py
+++ b/tests/test_github_core.py
@@ -1039,7 +1039,7 @@ class TestCountUnresolvedThreads:
         ]
         assert count_unresolved_threads(nodes) == 2
 
-    def test_missing_isResolved_defaults_to_resolved(self):
+    def test_missing_is_resolved_defaults_to_resolved(self):
         """A malformed thread without isResolved defaults to resolved
         (treated as not unresolved). Prevents a missing field from
         silently inflating the unresolved count.
@@ -1047,7 +1047,7 @@ class TestCountUnresolvedThreads:
         nodes = [{}, {"id": "x"}]
         assert count_unresolved_threads(nodes) == 0
 
-    def test_explicit_null_isResolved_defaults_to_resolved(self):
+    def test_explicit_null_is_resolved_defaults_to_resolved(self):
         """An explicit null isResolved from the GraphQL payload is treated the
         same as a missing field (resolved), so it is not counted as unresolved.
         """
@@ -1199,7 +1199,9 @@ class TestGetUnresolvedReviewThreads:
         assert mock_run.call_count == 2, (
             "Pagination loop did not call gh twice; pageInfo.hasNextPage=true was ignored"
         )
-        assert len(result) == 105, f"Expected 105 unresolved threads across pages, got {len(result)}"
+        assert len(result) == 105, (
+            f"Expected 105 unresolved threads across pages, got {len(result)}"
+        )
         page1_ids = {f"page1-{i}" for i in range(100)}
         page2_ids = {f"page2-{i}" for i in range(5)}
         actual_ids = {t["id"] for t in result}

--- a/tests/test_hook_utilities.py
+++ b/tests/test_hook_utilities.py
@@ -37,13 +37,13 @@ class TestGetProjectDirectory:
         assert get_project_directory() == str(tmp_path)
 
     def test_returns_cwd_when_no_git_found(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+        self, monkeypatch: pytest.MonkeyPatch, external_tmp_path: Path
     ) -> None:
         monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
-        monkeypatch.chdir(tmp_path)
+        monkeypatch.chdir(external_tmp_path)
         with pytest.warns(UserWarning, match="not found"):
             result = get_project_directory()
-        assert result == str(tmp_path)
+        assert result == str(external_tmp_path)
 
     def test_finds_git_by_walking_up(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)

--- a/tests/test_skill_bundle_suites_run.py
+++ b/tests/test_skill_bundle_suites_run.py
@@ -63,7 +63,9 @@ def _run_tree(root: Path) -> subprocess.CompletedProcess[str]:
     targets = [str(p.relative_to(_REPO_ROOT)) for p in _suite_dirs(root)]
     temp_root = _REPO_ROOT.parent / f".pytest-external-{_REPO_ROOT.name}" / uuid.uuid4().hex
     env = os.environ.copy()
-    env["TMPDIR"] = str(temp_root)
+    # tempfile consults TMPDIR, TEMP, and TMP (Windows tools may ignore TMPDIR);
+    # set all three so isolation holds across platforms.
+    env["TMPDIR"] = env["TEMP"] = env["TMP"] = str(temp_root)
     try:
         temp_root.mkdir(parents=True)
         return subprocess.run(

--- a/tests/test_skill_bundle_suites_run.py
+++ b/tests/test_skill_bundle_suites_run.py
@@ -24,9 +24,12 @@ exactly the way these 82 directories did.
 
 from __future__ import annotations
 
+import os
 import re
+import shutil
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 
 import pytest
@@ -58,25 +61,33 @@ def _suite_dirs(root: Path) -> list[Path]:
 def _run_tree(root: Path) -> subprocess.CompletedProcess[str]:
     """Run every bundle suite under one tree root in a dedicated subprocess."""
     targets = [str(p.relative_to(_REPO_ROOT)) for p in _suite_dirs(root)]
-    return subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pytest",
-            *targets,
-            "-q",
-            "--no-header",
-            "-p",
-            "no:cacheprovider",
-        ],
-        cwd=_REPO_ROOT,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        timeout=900,
-        check=False,
-    )
+    temp_root = _REPO_ROOT.parent / f".pytest-external-{_REPO_ROOT.name}" / uuid.uuid4().hex
+    env = os.environ.copy()
+    env["TMPDIR"] = str(temp_root)
+    try:
+        temp_root.mkdir(parents=True)
+        return subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                *targets,
+                "-q",
+                "--no-header",
+                "-p",
+                "no:cacheprovider",
+            ],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=900,
+            check=False,
+            env=env,
+        )
+    finally:
+        shutil.rmtree(temp_root, ignore_errors=True)
 
 
 @pytest.mark.parametrize("root", _BUNDLE_TREE_ROOTS, ids=lambda p: p.as_posix())

--- a/tests/test_skill_output.py
+++ b/tests/test_skill_output.py
@@ -245,9 +245,9 @@ class TestValidateSkillOutputScript:
         assert "Path traversal attempt detected" in result.stdout
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Symlinks require privileges on Windows")
-    def test_rejects_symlink_traversal(self, tmp_path: Path) -> None:
+    def test_rejects_symlink_traversal(self, external_tmp_path: Path) -> None:
         # Create external file outside repo
-        external_file = tmp_path / "external.json"
+        external_file = external_tmp_path / "external.json"
         external_file.write_text('{"Success": true}')
 
         # Create symlink inside repo pointing outside

--- a/tests/validation/test_check_ci_dependency_pins.py
+++ b/tests/validation/test_check_ci_dependency_pins.py
@@ -374,9 +374,9 @@ class TestPinsInstallIntoTheSelectedInterpreter:
         """Vacuity control: a glob that matches nothing passes for free."""
         assert len(self._INSTALL_FILES) > 5
 
-    def test_the_detector_recognizes_a_bare_call(self, tmp_path: Path):
+    def test_the_detector_recognizes_a_bare_call(self, external_tmp_path: Path):
         """Negative control on the detector, not on the tree."""
-        bad = tmp_path / "action.yml"
+        bad = external_tmp_path / "action.yml"
         bad.write_text("runs:\n  steps:\n    - run: pip install 'x==1'\n", encoding="utf-8")
         assert self._bare_pip_lines(bad) == [f"{bad}:3"]
 

--- a/tests/validation/test_check_skill_portability.py
+++ b/tests/validation/test_check_skill_portability.py
@@ -157,11 +157,13 @@ RUNTIME_PATH = ".claude/skills/runtime"
 
 
 class TestRepoRoot:
-    def test_fallback_is_parent_directory_when_start_is_file(self, tmp_path: Path) -> None:
-        script = tmp_path / "script.py"
+    def test_fallback_is_parent_directory_when_start_is_file(
+        self, external_tmp_path: Path
+    ) -> None:
+        script = external_tmp_path / "script.py"
         script.write_text("print('ok')\n", encoding="utf-8")
 
-        assert csp._repo_root(script) == tmp_path
+        assert csp._repo_root(script) == external_tmp_path
 
 
 class TestDiffAgainstBaseline:

--- a/tests/validation/test_validate_skill_shells.py
+++ b/tests/validation/test_validate_skill_shells.py
@@ -177,10 +177,10 @@ class TestMain:
         assert "[SHELL] .claude/skills/ghost" in out
 
     def test_exit_2_when_repo_root_not_found(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+        self, external_tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
         # A directory with no .claude/skills above it: config error.
-        bare = tmp_path / "no-skills"
+        bare = external_tmp_path / "no-skills"
         bare.mkdir()
 
         assert vss.main(["--repo-root", str(bare)]) == 2


### PR DESCRIPTION
Fixes #3511

## Summary
- Makes pytest temp fixtures safe when TMPDIR and basetemp live inside the checkout.
- Keeps generated pytest artifacts out of repo scans.
- Runs nested skill bundle suites with an external temp root.

## Validation
- `uv run ruff check ...`: passed
- `uv run mypy ...`: passed
- repo-local TMPDIR repro: 15865 passed, 26 skipped, 2 warnings
- CI pytest command: 15865 passed, 26 skipped, 2 warnings
- pre-push pytest gate: 15806 passed, 26 skipped, 59 deselected, 2 warnings

## References
- `tests/conftest.py`
- `build/scripts/validate_plugin_manifests.py`
- `tests/test_skill_bundle_suites_run.py`
- `tests/test_github_core.py`
