### PR TITLE
test(pytest): guard repo-local temp roots

### DIFF
--- a/tests/test_pytest_repo_local_temp_roots.py
+++ b/tests/test_pytest_repo_local_temp_roots.py
@@ -1,0 +1,48 @@
+"""Regression guards for repo-local pytest temp roots."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+
+def test_repo_local_tmpdir_and_basetemp_keep_git_isolation(project_root: Path) -> None:
+    """Run representative tests with both pytest temp roots inside the checkout."""
+    run_id = uuid.uuid4().hex
+    tmpdir = project_root / ".pytest_cache" / "tmp" / "repo-local-guard" / run_id
+    basetemp = project_root / ".pytest_cache" / "basetemp" / "repo-local-guard" / run_id
+    tmpdir.mkdir(parents=True)
+    basetemp.mkdir(parents=True)
+
+    env = os.environ.copy()
+    env.pop("GIT_CEILING_DIRECTORIES", None)
+    env["TMPDIR"] = str(tmpdir)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            "--tb=short",
+            f"--basetemp={basetemp}",
+            "tests/build_scripts/test_build_all.py::test_ignored_paths_empty_when_not_a_git_repo",
+            "tests/test_hook_utilities.py::TestGetProjectDirectory::test_returns_cwd_when_no_git_found",
+        ],
+        cwd=project_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        "repo-local pytest temp root guard failed\n"
+        f"TMPDIR={tmpdir}\n"
+        f"--basetemp={basetemp}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
Refs #3511.
Refs #3583.

Adds the CI-selected regression guard requested after PR #3583 review. The test is collected by the default pytest testpaths and spawns a child pytest run with both TMPDIR and --basetemp inside the checkout.

It selects one representative for each load-bearing half:

- Git ceiling: fails if parent repo discovery is not blocked.
- External temp relocation: fails if the external fixture falls back under the repo-local temp root.

## References

- `tests/test_pytest_repo_local_temp_roots.py`
- `tests/conftest.py`
- `tests/build_scripts/test_build_all.py`
- `tests/test_hook_utilities.py`