### PR TITLE
fix(eval): refuse an unparseable report before the budget guard can rule

### DIFF
--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -1833,17 +1833,14 @@ def _refuse_unparseable_input(path: Path) -> None:
     guards are written for and the reason this is not simply an early
     `_read_results`.
 
-    Parsing twice on the failure path buys one voice for the message.
-    `_read_results` raises the complaint every other reader raises, so the
-    peek stays the layer that cannot name a failure, and `RecursionError`
-    joins `ValueError` for the same reason it does in `_corpus_header`: a
-    deeply nested array exhausts the decoder's stack rather than failing its
-    grammar, and letting it out would surface as a traceback.
+    `_read_json` is the parse and nothing above it, so it is exactly the
+    question this asks and it raises the complaint every other reader raises.
+    Repeating the decode here would mean a second place that has to remember
+    duplicate keys, a nested array exhausting the decoder's stack rather than
+    failing its grammar, and that `UnicodeDecodeError` is a `ValueError`. The
+    result is discarded; the call is made for the refusal it can raise.
     """
-    try:
-        json.loads(_read_text(path), object_pairs_hook=_no_duplicate_keys)
-    except (ValueError, RecursionError):
-        _read_results(path)
+    _read_json(path)
 
 
 def _corpus_refused(

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -360,10 +360,16 @@ def _corpus_header(path: Path) -> str | _Unreadable | None:
 
     Best-effort on purpose: every content problem answers `_UNREADABLE` rather
     than raising. This runs before the ledger lock so the corpus refusal costs
-    nothing, and a read that could raise there would let a malformed verdict
-    mapping answer in place of the ledger. An exhausted budget is the
-    authoritative refusal and must not be masked by a parse error that the full
-    read, after the guards, reports properly anyway.
+    nothing, and a read that could raise here would let a malformed verdict
+    mapping answer in place of the ledger. A file that parses and declares this
+    schema is understood whatever its verdicts say, so an exhausted budget
+    still outranks a bad verdict mapping.
+
+    Answering `_UNREADABLE` is not the whole story, but it is not the trigger
+    for anything either. `cmd_gate` refuses a file that will not parse through
+    `_refuse_unparseable_input`, which asks its own question rather than
+    reading this one's answer. It has to: the bare mapping form declares no
+    schema, so a valid legacy report answers `_UNREADABLE` here as well.
 
     Three answers, not two. `None` means the file parsed and names no corpus,
     which conflicts with a pin on purpose, because that is the envelope strip.
@@ -1788,11 +1794,11 @@ def cmd_gate(args: argparse.Namespace) -> int:
         pin = split.get("corpus", _UNPINNED)
         incumbent_corpus = _corpus_header(args.incumbent)
         candidate_corpus = _corpus_header(args.candidate)
-    # A file nobody could parse gets no opinion here. It has declared no
-    # corpus, so comparing it would report a corpus disagreement as the reason
-    # a malformed file was refused, and report it as REJECT, which is a
-    # decision. The full read below raises the ConfigError that says what is
-    # actually wrong, and exits 2 like every other unreadable input.
+        _refuse_unparseable_input(args.incumbent)
+        _refuse_unparseable_input(args.candidate)
+    # A file nobody could parse gets no opinion on the corpus, and the read
+    # above already asked the authority to say why. Past this point both
+    # headers are values the conflict rule can compare.
     if _corpus_refused(pin, incumbent_corpus, candidate_corpus):
         _emit(_corpus_refusal())
         return EXIT_LOGIC
@@ -1801,6 +1807,43 @@ def cmd_gate(args: argparse.Namespace) -> int:
     # because that refusal reads no ledger and spends nothing.
     with _ledger_held(_holdout_key(split)):
         return _gate_decision(args, split)
+
+
+def _refuse_unparseable_input(path: Path) -> None:
+    """Refuse a report that is not a JSON document before any guard can rule.
+
+    A missing file already outranks an exhausted budget, because the peek
+    reads through `_read_text` and that reader's `ConfigError` travels out. A
+    file that opens but does not parse reached the operator as REJECT instead:
+    `_corpus_header` catches `ValueError`, `_corpus_refused` declines to
+    decide on an unreadable file, and `_guard` is what runs next. The reason
+    said the split was exhausted, so the operator's fix was to re-split, which
+    discards a held-out group's whole history to answer a typo in a file.
+
+    Both are the same situation and the file already states the rule for it. A
+    cap below one "is a caller mistake, not a gate verdict, so it becomes a
+    config error instead of a REJECT that would read as real discipline."
+
+    The line is drawn at parsing, not at approval, and that is the whole of
+    the narrowing. This asks one question no interpretation of the document
+    can answer differently: is there a document at all. Every later judgment,
+    the schema it declares, the corpus it names, whether its verdicts are
+    booleans, stays behind the guard where an exhausted budget outranks it. A
+    bad verdict mapping still yields to the ledger, which is the ordering the
+    guards are written for and the reason this is not simply an early
+    `_read_results`.
+
+    Parsing twice on the failure path buys one voice for the message.
+    `_read_results` raises the complaint every other reader raises, so the
+    peek stays the layer that cannot name a failure, and `RecursionError`
+    joins `ValueError` for the same reason it does in `_corpus_header`: a
+    deeply nested array exhausts the decoder's stack rather than failing its
+    grammar, and letting it out would surface as a traceback.
+    """
+    try:
+        json.loads(_read_text(path), object_pairs_hook=_no_duplicate_keys)
+    except (ValueError, RecursionError):
+        _read_results(path)
 
 
 def _corpus_refused(

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -4424,9 +4424,17 @@ class TestTheCorpusPinCannotBeStrippedAway:
         assert out["decision"] == "REJECT"
         assert "consultation" in out["reason"]
 
-    def test_unreadable_results_do_not_preempt_an_exhausted_ledger(
+    def test_unreadable_results_now_preempt_an_exhausted_ledger(
         self, tmp_path, capsys
     ):
+        """Reversed in round fifty; the sibling above still holds the line.
+
+        This file does not parse, so the gate never learned anything about it
+        to weigh against the budget. Answering REJECT named the split as the
+        problem and sent the operator to re-split over a truncated write. The
+        test above keeps the distinction honest: a report that parses and
+        merely carries the wrong verdict type still yields to the ledger.
+        """
         inc = _write(tmp_path, "inc.json", {f"t{i}": i < 5 for i in range(10)})
         _, split = _split(capsys, tmp_path, "--results", inc, "--seed", "pb")
         split_path = _write(tmp_path, "split.json", split)
@@ -4436,9 +4444,8 @@ class TestTheCorpusPinCannotBeStrippedAway:
             capsys, tmp_path, "--incumbent", inc, "--candidate", junk,
             "--split", split_path, cap=1, spent=1,
         )
-        assert code == EXIT_LOGIC
-        assert out["decision"] == "REJECT"
-        assert "consultation" in out["reason"]
+        assert code == EXIT_CONFIG, out
+        assert "decision" not in out
 
     def test_malformed_results_still_fail_loudly_when_the_budget_allows(
         self, tmp_path, capsys
@@ -4748,8 +4755,23 @@ class TestAParserFailureNeverPreemptsTheLedger:
         assert code == EXIT_CONFIG
         assert out["type"] == "ConfigError"
 
-    def test_an_exhausted_budget_still_answers_first(self, tmp_path, capsys):
-        """The defect: a parse crash in the preflight outranked the ledger."""
+    def test_an_exhausted_budget_no_longer_masks_a_parse_crash(self, tmp_path, capsys):
+        """Round sixteen pinned the opposite; rounds forty-nine and fifty reversed it.
+
+        Round sixteen read "a parse crash in the preflight outranked the
+        ledger" as the defect and made the budget answer first. The half of
+        that worth keeping is the sibling test below: a report the gate can
+        parse but dislikes must not answer in place of the ledger, or the
+        caller is told to fix the wrong thing.
+
+        The half that did not survive is this one. Round forty-nine found the
+        same ordering turning a missing file into REJECT, and the reason told
+        the operator to re-split, which discards a held-out group's history to
+        answer a typo. Round fifty found the identical harm one input class
+        over. A document that does not parse is the same caller mistake as a
+        file that does not open, so `_refuse_unparseable_input` now refuses
+        both before any guard can emit a decision.
+        """
         inc = _write(tmp_path, "inc.json", {f"t{i}": True for i in range(10)})
         _, split = _split(capsys, tmp_path, "--results", inc, "--seed", "deep2")
         split_path = _write(tmp_path, "split.json", split)
@@ -4762,9 +4784,9 @@ class TestAParserFailureNeverPreemptsTheLedger:
             "--candidate", self._deep(tmp_path, "cand.json"),
             "--split", split_path, cap=1,
         )
-        assert code == EXIT_LOGIC
-        assert "consultation" in out["reason"]
-        assert out["compared"] is False
+        assert code == EXIT_CONFIG, out
+        assert out["type"] == "ConfigError"
+        assert "decision" not in out
 
 
 class TestEveryWriteFailurePrintsOneJsonDocument:
@@ -10256,6 +10278,185 @@ class TestEveryMissingFileReadsTheSameWay:
         )
         assert code == EXIT_CONFIG
         assert out["error"].startswith(f"could not read {adir}: ")
+
+
+class TestAnUnparseableReportOutranksAnExhaustedBudget:
+    """The same guarantee as the class above, one input class over.
+
+    A missing file now reaches the operator as a config error even with the
+    budget spent, because the peek reads through `_read_text` and lets that
+    reader's `ConfigError` out. A file that opens but does not parse took the
+    other path: `_corpus_header` catches `ValueError` and answers
+    `_UNREADABLE`, `_corpus_refused` declines to decide on it, and `_guard`
+    runs next. With the budget exhausted the operator was told to re-split
+    when the real fix was to repair the file.
+
+    Both are the same situation. The candidate cannot be used, and that is a
+    caller mistake rather than a gate verdict. The file already states the
+    principle for a cap below one: a caller mistake "becomes a config error
+    instead of a REJECT that would read as real discipline." Answering REJECT
+    here spent the operator's attention on the wrong problem and buried a
+    broken artifact behind a plausible refusal.
+
+    The fix stays narrow on purpose, and the first attempt was not. It keyed
+    the refusal on `_corpus_header` answering `_UNREADABLE`, which reads as
+    "the peek understood nothing" until you notice the bare mapping form
+    declares no schema and answers exactly that. Every legacy report would
+    have been read in full before the guard, and a bad verdict mapping inside
+    one would have preempted the ledger, which is the ordering round sixteen
+    was right about. Two tests in this file caught it.
+
+    So the line is drawn at parsing rather than at approval. Is there a
+    document at all is a question no reading of the document can answer
+    differently. The schema it declares, the corpus it names and whether its
+    verdicts are booleans are judgments about the document, and those stay
+    behind the guard. The last three tests here are the negative controls for
+    that line, one on each side of it.
+    """
+
+    def _exhausted(self, tmp_path, capsys):
+        """A split whose only consultation has already been spent."""
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i < 2 for i in range(10)})
+        cand = _write(tmp_path, "cand.json", {f"t{i}": True for i in range(10)})
+        _, record = _split(capsys, tmp_path, "--results", inc, "--seed", "pin")
+        split_path = _write(tmp_path, "split.json", record)
+        fp = str(record["fingerprint"])
+        code, out = _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", cand,
+            "--split", split_path, "--max-consultations", "1",
+            "--incumbent-fingerprint", fp,
+        )
+        assert code == EXIT_OK, out
+        spent, out = _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", cand,
+            "--split", split_path, "--max-consultations", "1",
+            "--incumbent-fingerprint", fp,
+        )
+        assert spent == EXIT_LOGIC, out
+        return inc, split_path, fp
+
+    def _gate(self, capsys, inc, cand, split_path, fp):
+        return _run(
+            capsys, "gate", "--incumbent", inc, "--candidate", cand,
+            "--split", split_path, "--max-consultations", "1",
+            "--incumbent-fingerprint", fp,
+        )
+
+    def test_a_candidate_that_is_not_json_outranks_an_exhausted_budget(
+        self, tmp_path, capsys
+    ):
+        inc, split_path, fp = self._exhausted(tmp_path, capsys)
+        bad = tmp_path / "torn.json"
+        bad.write_text('{"schema": "optimizer-results/1", "results": {,}}', encoding="utf-8")
+        code, out = self._gate(capsys, inc, bad, split_path, fp)
+        assert code == EXIT_CONFIG, out
+        assert "decision" not in out
+        assert str(bad) in out["error"]
+
+    def test_a_duplicate_key_outranks_an_exhausted_budget(self, tmp_path, capsys):
+        """`_DuplicateKeyError` subclasses `ValueError`, so it took the same path."""
+        inc, split_path, fp = self._exhausted(tmp_path, capsys)
+        bad = tmp_path / "twice.json"
+        bad.write_text(
+            '{"schema": "optimizer-results/1", "results": {"t0": true, "t0": false}}',
+            encoding="utf-8",
+        )
+        code, out = self._gate(capsys, inc, bad, split_path, fp)
+        assert code == EXIT_CONFIG, out
+        assert "decision" not in out
+
+    def test_a_schema_this_build_cannot_read_still_yields_to_the_budget(
+        self, tmp_path, capsys
+    ):
+        """Second negative control, on the other side of the line.
+
+        This file parses. What the gate objects to is the version it declares,
+        which is a judgment about the document rather than the question of
+        whether a document exists. Refusing it here would have been the easy
+        extension and the wrong one: the peek answers `_UNREADABLE` for the
+        bare mapping form too, which declares no schema and is perfectly
+        valid, so a refusal keyed on that answer promotes every legacy report
+        and every bad verdict mapping inside one along with it. That is the
+        ordering round sixteen was right about, and this pins the line where
+        parsing ends rather than where approval begins.
+        """
+        inc, split_path, fp = self._exhausted(tmp_path, capsys)
+        bad = _write(tmp_path, "future.json", {"schema": "optimizer-results/99", "results": {}})
+        code, out = self._gate(capsys, inc, bad, split_path, fp)
+        assert code == EXIT_LOGIC, out
+        assert out["decision"] == "REJECT"
+        assert "exhausted" in out["reason"]
+
+    def test_an_unparseable_incumbent_is_refused_the_same_way(self, tmp_path, capsys):
+        """Both peeked flags, so neither regresses alone."""
+        inc, split_path, fp = self._exhausted(tmp_path, capsys)
+        bad = tmp_path / "torn-inc.json"
+        bad.write_text("not json at all", encoding="utf-8")
+        code, out = self._gate(capsys, bad, inc, split_path, fp)
+        assert code == EXIT_CONFIG, out
+        assert "decision" not in out
+
+    def test_the_same_file_is_refused_identically_with_budget_to_spare(
+        self, tmp_path, capsys
+    ):
+        """The refusal must not depend on how much budget is left.
+
+        Without this the fix could have been an ordering accident that only
+        showed up once the ledger filled, which is the shape of the defect it
+        replaces.
+        """
+        inc = _write(tmp_path, "inc.json", {f"t{i}": i < 2 for i in range(10)})
+        _, record = _split(capsys, tmp_path, "--results", inc, "--seed", "pin")
+        split_path = _write(tmp_path, "split.json", record)
+        bad = tmp_path / "torn.json"
+        bad.write_text("{", encoding="utf-8")
+        code, out = self._gate(capsys, inc, bad, split_path, str(record["fingerprint"]))
+        assert code == EXIT_CONFIG, out
+        assert "decision" not in out
+
+    def test_a_bare_mapping_with_bad_verdicts_still_yields_to_the_budget(
+        self, tmp_path, capsys
+    ):
+        """Third negative control, and the one that caught the first attempt.
+
+        The legacy form is a plain task id to boolean object with no envelope
+        around it, so it declares no schema and the header peek answers
+        `_UNREADABLE` for a report the gate reads happily. A refusal keyed on
+        that answer runs the full read on every legacy file, and this one's
+        verdicts are strings, so the read raises and a bad verdict mapping
+        preempts the ledger. Refusing on the parse alone leaves it where it
+        belongs, behind the guard.
+        """
+        inc, split_path, fp = self._exhausted(tmp_path, capsys)
+        bad = _write(tmp_path, "legacy.json", {f"t{i}": "yes" for i in range(10)})
+        code, out = self._gate(capsys, inc, bad, split_path, fp)
+        assert code == EXIT_LOGIC, out
+        assert out["decision"] == "REJECT"
+        assert "exhausted" in out["reason"]
+
+    def test_a_readable_report_with_bad_verdicts_still_yields_to_the_budget(
+        self, tmp_path, capsys
+    ):
+        """Negative control: the fix must not promote every content problem.
+
+        This file parses, declares the schema this build reads, and names no
+        corpus, so the peek understands it perfectly well and answers `None`.
+        Its verdicts are strings rather than booleans, which the full read
+        refuses, but that read is deliberately behind the guard so a bad
+        verdict mapping cannot answer in place of an exhausted budget. Without
+        this the fix could have been "raise on anything the full read would
+        refuse", which reverses an ordering the file argues for by name.
+        """
+        inc, split_path, fp = self._exhausted(tmp_path, capsys)
+        bad = _write(
+            tmp_path,
+            "verdicts.json",
+            {"schema": "optimizer-results/1", "results": {"t0": "yes"}},
+        )
+        code, out = self._gate(capsys, inc, bad, split_path, fp)
+        assert code == EXIT_LOGIC, out
+        assert out["decision"] == "REJECT"
+        assert "exhausted" in out["reason"]
 
 
 class TestDuplicateKeysAreRefusedBeforeAnythingReadsTheObject:

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -10195,12 +10195,13 @@ class TestEveryMissingFileReadsTheSameWay:
     def test_a_missing_file_outranks_an_exhausted_budget(self, tmp_path, capsys):
         """The peek must refuse before anything that can emit a decision.
 
-        `_gate_entry` runs the header peek, then takes the ledger lock, then
-        runs `_guard`, and only then does the authoritative read. So a peek
-        that answers instead of raising hands the next decision-producing
-        guard a file nobody could open. With the budget already spent, the
-        gate reported REJECT at exit 1 for a path that does not exist, telling
-        the operator to re-split when the real fix was to fix the typo.
+        `cmd_gate` runs the header peek, then takes the ledger lock, and
+        only inside `_gate_decision` does `_guard` run and the authoritative
+        read follow. So a peek that answers instead of raising hands the next
+        decision-producing guard a file nobody could open. With the budget
+        already spent, the gate reported REJECT at exit 1 for a path that does
+        not exist, telling the operator to re-split when the real fix was to
+        fix the typo.
 
         This is the test the first version of the fix would have failed. It
         does not assert the message, only that a config error still outranks a


### PR DESCRIPTION
## Summary

The consultation gate answers a truncated candidate report with `REJECT` at
exit 1 when the ledger is already spent, and with a config error at exit 2 when
it is not. Same broken file, two different answers, and the answer the operator
is most likely to hit is the wrong one. `REJECT` tells them to re-split, which
throws away a held-out group's entire history to answer a file that never
parsed.

This makes a parse failure refuse before the budget guard can rule, so the
operator is told to fix the file instead.

Fixes #3665

## Background

PR #3659 fixed the same ordering for `OSError`: a missing file and a directory
now raise a config error ahead of the ledger. It did not fix `ValueError`. The
gate still had two answers for one situation, split on how the file was
unusable:

| candidate | failure class | exit | verdict |
| --- | --- | --- | --- |
| missing file | `OSError` | 2 | ConfigError |
| directory | `OSError` | 2 | ConfigError |
| invalid JSON | `ValueError` | 1 | REJECT |
| duplicate keys | `ValueError` | 1 | REJECT |
| wrong schema | structural | 1 | REJECT |

Reproduced by hand against a real split, a real ledger, and a real exhausted
budget before any code changed.

## The design line: parsing, not approval

The first version of the fix keyed the refusal on the header peek answering
"unreadable". That reads narrow and is not. The legacy bare-mapping report form
declares no schema key, so a perfectly valid legacy file answers "unreadable"
too. Keying on it ran a full authoritative read on every legacy file before the
guard, which let a bad verdict mapping preempt the ledger. Two existing tests
caught it.

The shipped version asks one question: does the file parse as JSON at all.
Schema version, corpus name, and verdict types are judgments about a document
that already parsed, and they stay behind the guard where they were.

The last row of the table above is deliberately unchanged. A wrong-schema file
parses, so it is a report the gate dislikes rather than a file it could not
read, and it still loses to the ledger.

## Changes

- `scripts/eval/optimize-artifact.py`: adds `_refuse_unparseable_input`, called
  for the incumbent and the candidate ahead of the corpus-refusal check. It
  raises a config error only when the file fails to parse as JSON, and it
  catches `RecursionError` alongside `ValueError` so a deeply nested document
  cannot slip through as a verdict. The header-peek docstring is rewritten to
  say what its answer does and does not mean.
- `tests/eval/test_optimize_artifact_cli.py`: adds
  `TestAnUnparseableReportOutranksAnExhaustedBudget`, seven tests of which
  three are negative controls holding the line the over-broad version crossed.
  Also reverses two existing tests, and fixes a round-49 docstring that named a
  function which does not exist.

Round 51 found the class docstring counting to its negative controls by
position, calling them the last three when one of them sits third of seven. It
names them now, which is both accurate and stable under reordering.

## Reversing a prior decision

Round 16 deliberately pinned budget-first and left a test saying so. This
reverses that half of it. The reasoning is written into the reversed tests'
docstrings so a future reader sees the argument rather than a silent flip:
under budget-first the operator is told to re-split, which discards a held-out
group's history to answer a file nobody could read. Round 49 already overturned
the same ordering for `OSError`; this finishes it for `ValueError`.

The half of round 16 worth keeping survives unchanged. A report that parses but
the gate dislikes must not answer in place of the ledger, and its original test
passes without modification.

> [!NOTE]
> Flagging this for review because it reverses a deliberate earlier decision
> rather than filling a gap.

## Verification

- 1286 passed, 1 skipped in `tests/eval/`.
- Five-way mutation proof, every mutant caught by a distinct test: remove both
  refusal calls; refuse the candidate only; widen the refusal to a full read
  (caught by all three negative controls plus the round-16 test); drop
  `RecursionError`; drop the duplicate-key hook.
- `ruff` clean, `mypy` clean, zero em-dashes or en-dashes byte-verified.

## Provenance

Found by adversarial review round 50 on `gemini-3.1-pro-preview`, Finding 1.
All three Criticals and the Nit that round returned were real.

