### PR TITLE
fix(hooks): require merged ADR content to arrive with the merge

### DIFF
--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -817,16 +817,14 @@ def check_adr_review_policy(paths: Sequence[str], repo_root: Path) -> int:
 
 
 def _merge_authored_adr_paths(paths: Sequence[str], repo_root: Path) -> list[str]:
-    # `origin/main` is checked alongside the approved parents because a branch
-    # takes main's work two ways and only one of them leaves a main ancestor in
-    # MERGE_HEAD. Merging main in directly does. Merging the shared branch's
-    # own remote tip, after a collaborator merged main there and pushed, does
-    # not: the parent is the branch. Without this every ADR main contributed
-    # reads as branch-authored and the gate demands review evidence for a file
-    # the author never opened. Comparing content rather than ancestry does not
-    # widen the gate, since a blob already on main cleared this same policy on
-    # the pull request that put it there.
-    parent_commits = [*_approved_merge_head_commits(repo_root), "origin/main"]
+    # A branch takes main's work two ways and only one of them leaves a main
+    # ancestor in MERGE_HEAD. Merging main in directly does. Merging the shared
+    # branch's own remote tip, after a collaborator merged main there and
+    # pushed, does not: the parent is the branch. Without the second rule below
+    # every ADR main contributed reads as branch-authored and the gate demands
+    # review evidence for a file the author never opened.
+    approved_parents = _approved_merge_head_commits(repo_root)
+    merge_parents = _merge_head_commits(repo_root)
     authored: list[str] = []
     for path in paths:
         staged_blob = _read_index_blob(repo_root, path)
@@ -835,13 +833,40 @@ def _merge_authored_adr_paths(paths: Sequence[str], repo_root: Path) -> list[str
             continue
         if _read_head_blob(repo_root, path) == staged_blob:
             continue
-        if any(
-            _read_commit_blob_bytes(repo_root, parent, path) == staged_blob
-            for parent in parent_commits
-        ):
+        if _blob_is_at_any(repo_root, approved_parents, path, staged_blob):
+            continue
+        if _blob_arrived_through_the_merge(repo_root, merge_parents, path, staged_blob):
             continue
         authored.append(path)
     return authored
+
+
+def _blob_is_at_any(
+    repo_root: Path,
+    commits: Sequence[str],
+    path: str,
+    blob: bytes,
+) -> bool:
+    return any(_read_commit_blob_bytes(repo_root, commit, path) == blob for commit in commits)
+
+
+def _blob_arrived_through_the_merge(
+    repo_root: Path,
+    merge_parents: Sequence[str],
+    path: str,
+    blob: bytes,
+) -> bool:
+    """Report whether a staged blob is main's content carried in by the merge.
+
+    Both halves are load-bearing. Matching `origin/main` alone would let an
+    author revert an ADR to a stale local ref mid-merge and walk past the gate,
+    and that revert would overwrite the newer copy on the next push. Requiring
+    the content to sit on a merge parent as well means it arrived with the
+    merge rather than being typed during it.
+    """
+    if not _blob_is_at_any(repo_root, merge_parents, path, blob):
+        return False
+    return _read_commit_blob_bytes(repo_root, "origin/main", path) == blob
 
 
 def _approved_merge_head_commits(repo_root: Path) -> list[str]:

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -856,7 +856,13 @@ def _blob_arrived_through_the_merge(
     path: str,
     blob: bytes,
 ) -> bool:
-    """Report whether a staged blob is main's content carried in by the merge.
+    """Report whether a staged blob looks like content the merge carried in.
+
+    "Looks like" is the honest verb. Every comparison here is against the
+    local `refs/remotes/origin/main`, which is a cached answer to what main
+    held at the last fetch, not what main holds now. The gate is offline and
+    cannot do better, so it is proving a resemblance rather than provenance,
+    and that is the ceiling on what this function can be trusted for.
 
     Three questions, each closing a way past the other two.
 
@@ -868,9 +874,9 @@ def _blob_arrived_through_the_merge(
     Those two alone still lose to an author who builds the merge: branch off
     the newer commit, commit the older text there, merge it back, and both
     hold. So the third question asks about the copy this branch already has.
-    Main's content arriving is an upgrade, and the copy being replaced is one
-    main has carried at some point. A reversion is not, because the newer text
-    it overwrites was written locally and main has never seen it.
+    Content arriving from main is an upgrade, and the copy being replaced is
+    one that ref has carried at some point. A reversion is not, because the
+    newer text it overwrites was written locally and never pushed.
     """
     if not _blob_is_at_any(repo_root, merge_parents, path, blob):
         return False
@@ -880,12 +886,17 @@ def _blob_arrived_through_the_merge(
 
 
 def _head_copy_is_one_main_has_carried(repo_root: Path, path: str) -> bool:
-    """Report whether HEAD's copy of a path is a state main has ever held.
+    """Report whether HEAD's copy of a path is a state `origin/main` has held.
 
     A path HEAD does not carry cannot be a regression of local work, so it
     passes. Otherwise the copy has to appear somewhere in `origin/main`'s
     history for that path. Walking the path's own history keeps this to the
     handful of commits that touched one ADR rather than the whole branch.
+
+    `origin/main` is a local cache of main, so a branch that has not fetched
+    in a while can fail this on content main really does carry. That
+    direction is the safe one: the answer is review evidence demanded for a
+    file that did not need it, and a fetch clears it.
     """
     head_blob = _read_head_blob(repo_root, path)
     if head_blob is None:

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -858,15 +858,47 @@ def _blob_arrived_through_the_merge(
 ) -> bool:
     """Report whether a staged blob is main's content carried in by the merge.
 
-    Both halves are load-bearing. Matching `origin/main` alone would let an
-    author revert an ADR to a stale local ref mid-merge and walk past the gate,
-    and that revert would overwrite the newer copy on the next push. Requiring
-    the content to sit on a merge parent as well means it arrived with the
-    merge rather than being typed during it.
+    Three questions, each closing a way past the other two.
+
+    The blob has to sit on a merge parent, or an author can type a reversion
+    during someone else's merge and the stale `origin/main` it matches will
+    wave it through. It has to match `origin/main`, or any pair of branches
+    can walk an unreviewed ADR onto main because the merge carried it.
+
+    Those two alone still lose to an author who builds the merge: branch off
+    the newer commit, commit the older text there, merge it back, and both
+    hold. So the third question asks about the copy this branch already has.
+    Main's content arriving is an upgrade, and the copy being replaced is one
+    main has carried at some point. A reversion is not, because the newer text
+    it overwrites was written locally and main has never seen it.
     """
     if not _blob_is_at_any(repo_root, merge_parents, path, blob):
         return False
-    return _read_commit_blob_bytes(repo_root, "origin/main", path) == blob
+    if _read_commit_blob_bytes(repo_root, "origin/main", path) != blob:
+        return False
+    return _head_copy_is_one_main_has_carried(repo_root, path)
+
+
+def _head_copy_is_one_main_has_carried(repo_root: Path, path: str) -> bool:
+    """Report whether HEAD's copy of a path is a state main has ever held.
+
+    A path HEAD does not carry cannot be a regression of local work, so it
+    passes. Otherwise the copy has to appear somewhere in `origin/main`'s
+    history for that path. Walking the path's own history keeps this to the
+    handful of commits that touched one ADR rather than the whole branch.
+    """
+    head_blob = _read_head_blob(repo_root, path)
+    if head_blob is None:
+        return True
+    carried = _origin_main_commits_touching(repo_root, path)
+    return _blob_is_at_any(repo_root, carried, path, head_blob)
+
+
+def _origin_main_commits_touching(repo_root: Path, path: str) -> list[str]:
+    result = _run_git(repo_root, ["rev-list", "origin/main", "--", path])
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
 def _approved_merge_head_commits(repo_root: Path) -> list[str]:
@@ -885,13 +917,27 @@ def _merge_head_commits(repo_root: Path) -> list[str]:
     if not merge_head.is_absolute():
         merge_head = repo_root / merge_head
     try:
-        return [
+        named = [
             line.strip()
             for line in merge_head.read_text(encoding="utf-8").splitlines()
             if line.strip()
         ]
     except OSError:
         return []
+    return [commit for commit in named if not _head_already_contains(repo_root, commit)]
+
+
+def _head_already_contains(repo_root: Path, commit: str) -> bool:
+    """Report whether HEAD already contains a commit named by `MERGE_HEAD`.
+
+    `git merge <ancestor>` says "Already up to date" and writes no `MERGE_HEAD`
+    at all, so a `MERGE_HEAD` naming something HEAD already has was written by
+    something other than git. Reading it as a merge in progress hands the
+    exemption to anyone who can write one file, and the ancestor it names is an
+    approved parent by construction, which is the whole gate.
+    """
+    result = _run_git(repo_root, ["merge-base", "--is-ancestor", commit, "HEAD"])
+    return result.returncode == 0
 
 
 def _commit_is_origin_main_ancestor(repo_root: Path, commit: str) -> bool:

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -702,10 +702,154 @@ class TestAdrReviewPolicyMergeScope:
         )
         monkeypatch.setattr(
             policy,
+            "_merge_head_commits",
+            lambda root: ["the-shared-branch-tip"],
+            raising=False,
+        )
+        blobs = {"the-shared-branch-tip": b"main adr", "origin/main": b"main adr"}
+        monkeypatch.setattr(
+            policy,
             "_read_commit_blob_bytes",
-            lambda root, commit, relative_path: (
-                b"main adr" if commit == "origin/main" else None
-            ),
+            lambda root, commit, relative_path: blobs.get(commit),
+            raising=False,
+        )
+
+        assert policy.check_adr_review_policy([path], tmp_path) == 0
+
+    def test_an_adr_reverted_to_a_stale_origin_main_during_a_merge_is_still_gated(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ):
+        """Content sitting on main is not a licence to put it back.
+
+        A local `origin/main` ref goes stale the moment someone else pushes.
+        Matching content against it alone would let an author revert an ADR to
+        the stale state mid-merge and walk past the gate, and the revert would
+        then overwrite the newer copy on the next push. Reverting is a fresh
+        decision no matter how old the bytes are, so the content has to arrive
+        through the merge as well as match main.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "test@example.invalid")
+        _git(repo, "config", "user.name", "Test User")
+        adr_dir = repo / ".agents" / "architecture"
+        adr_dir.mkdir(parents=True)
+        adr = adr_dir / "ADR-001-superseded.md"
+        adr.write_text("# ADR 001\n\nthe old position.\n", encoding="utf-8")
+        _commit(repo, "old position")
+        # The local ref stops here. Someone else already pushed the revision.
+        head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        _git(repo, "update-ref", "refs/remotes/origin/main", head)
+        adr.write_text("# ADR 001\n\nthe revised position.\n", encoding="utf-8")
+        _commit(repo, "revised position")
+
+        _git(repo, "checkout", "-b", "feature")
+        (repo / "feature.txt").write_text("feature\n", encoding="utf-8")
+        _commit(repo, "feature work")
+        _git(repo, "branch", "sibling")
+        _git(repo, "checkout", "sibling")
+        (repo / "sibling.txt").write_text("sibling\n", encoding="utf-8")
+        _commit(repo, "sibling work")
+        _git(repo, "checkout", "feature")
+        merge = _run(["git", "merge", "--no-edit", "--no-commit", "sibling"], repo)
+        assert merge.returncode == 0, merge.stderr
+
+        relative = ".agents/architecture/ADR-001-superseded.md"
+        adr.write_text("# ADR 001\n\nthe old position.\n", encoding="utf-8")
+        _git(repo, "add", relative)
+
+        assert policy._merge_authored_adr_paths([relative], repo) == [relative]
+
+        monkeypatch.setattr(policy, "_gated_adr_review_paths", lambda paths, root: list(paths))
+        monkeypatch.setattr(policy, "_today_session_log", lambda sessions_dir: None)
+        assert policy.check_adr_review_policy([relative], repo) == 1
+        assert "ADR changes require adr-review evidence" in capsys.readouterr().err
+
+    def test_an_adr_a_collaborator_wrote_on_the_shared_branch_is_still_gated(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ):
+        """Arriving through the merge is not enough on its own.
+
+        A collaborator can write an ADR on the shared branch and push it. The
+        content then sits on a merge parent without ever having been reviewed
+        on main. Exempting it because the merge carried it would let any pair
+        of branches walk an ADR onto main with no review evidence at all, so
+        the content has to match main as well as arrive through the merge.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "test@example.invalid")
+        _git(repo, "config", "user.name", "Test User")
+        adr_dir = repo / ".agents" / "architecture"
+        adr_dir.mkdir(parents=True)
+        adr = adr_dir / "ADR-003-collaborator.md"
+        adr.write_text("# ADR 003\n\nthe reviewed position.\n", encoding="utf-8")
+        _commit(repo, "reviewed position")
+        head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+        _git(repo, "update-ref", "refs/remotes/origin/main", head)
+
+        _git(repo, "checkout", "-b", "shared")
+        adr.write_text("# ADR 003\n\nthe collaborator position.\n", encoding="utf-8")
+        _commit(repo, "collaborator writes the adr on the branch")
+
+        _git(repo, "checkout", "main")
+        _git(repo, "checkout", "-b", "feature")
+        (repo / "feature.txt").write_text("feature\n", encoding="utf-8")
+        _commit(repo, "feature work")
+        merge = _run(["git", "merge", "--no-edit", "--no-commit", "shared"], repo)
+        assert merge.returncode == 0, merge.stderr
+
+        relative = ".agents/architecture/ADR-003-collaborator.md"
+        assert policy._merge_authored_adr_paths([relative], repo) == [relative]
+
+        monkeypatch.setattr(policy, "_gated_adr_review_paths", lambda paths, root: list(paths))
+        monkeypatch.setattr(policy, "_today_session_log", lambda sessions_dir: None)
+        assert policy.check_adr_review_policy([relative], repo) == 1
+        assert "ADR changes require adr-review evidence" in capsys.readouterr().err
+
+    def test_an_approved_merge_parent_exempts_content_origin_main_does_not_carry(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """The approved-parent rule has to keep working on its own.
+
+        Merging an older main commit brings content that the local `origin/main`
+        tip no longer carries, so the blob comparison against main cannot
+        exempt it and the ancestry rule is the only thing that can. Without
+        this the ancestry rule could be deleted outright and every other test
+        here would stay green.
+        """
+        path = ".agents/architecture/ADR-002-an-earlier-main.md"
+        blobs = {"an-approved-parent": b"earlier main", "origin/main": b"later main"}
+        monkeypatch.setattr(policy, "_gated_adr_review_paths", lambda paths, root: list(paths))
+        monkeypatch.setattr(policy, "_merge_in_progress", lambda root: True)
+        monkeypatch.setattr(policy, "_read_index_blob", lambda root, relative_path: b"earlier main")
+        monkeypatch.setattr(policy, "_read_head_blob", lambda root, relative_path: None)
+        monkeypatch.setattr(
+            policy,
+            "_approved_merge_head_commits",
+            lambda root: ["an-approved-parent"],
+            raising=False,
+        )
+        monkeypatch.setattr(
+            policy,
+            "_merge_head_commits",
+            lambda root: ["an-approved-parent"],
+            raising=False,
+        )
+        monkeypatch.setattr(
+            policy,
+            "_read_commit_blob_bytes",
+            lambda root, commit, relative_path: blobs.get(commit),
             raising=False,
         )
 
@@ -851,10 +995,15 @@ class TestAdrReviewPolicyMergeScope:
         )
         monkeypatch.setattr(
             policy,
+            "_merge_head_commits",
+            lambda root: ["the-shared-branch-tip"],
+            raising=False,
+        )
+        blobs = {"the-shared-branch-tip": b"main adr", "origin/main": b"main adr"}
+        monkeypatch.setattr(
+            policy,
             "_read_commit_blob_bytes",
-            lambda root, commit, relative_path: (
-                b"main adr" if commit == "origin/main" else None
-            ),
+            lambda root, commit, relative_path: blobs.get(commit),
             raising=False,
         )
         monkeypatch.setattr(policy, "_today_session_log", lambda sessions_dir: None)

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -855,6 +855,112 @@ class TestAdrReviewPolicyMergeScope:
 
         assert policy.check_adr_review_policy([path], tmp_path) == 0
 
+    def test_a_carrier_branch_cannot_launder_a_reversion_past_a_stale_origin_main(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ):
+        """Matching a stale `origin/main` is not evidence of review.
+
+        Requiring the blob to sit on a merge parent stops an author typing a
+        reversion during someone else's merge, but it does not stop an author
+        who builds the merge. Branch off the newer commit, commit the older
+        ADR text there, merge that branch back, and both halves of the rule
+        are satisfied: the blob is on a merge parent because the author put it
+        there, and it matches `origin/main` because `origin/main` is stale.
+
+        The gate cannot tell a stale ref from a current one offline, so it
+        asks a different question instead: is the copy this branch already has
+        one that main has ever carried. Here it is not, because the newer text
+        was written locally and never pushed, which makes the merge a
+        regression of local work rather than main's content arriving.
+
+        Found by adversarial security review, Finding 3. It reproduces with no
+        write to `.git` and no ref surgery, which is what separates it from
+        the other two findings that round returned.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "test@example.invalid")
+        _git(repo, "config", "user.name", "Test User")
+        adr_dir = repo / ".agents" / "architecture"
+        adr_dir.mkdir(parents=True)
+        adr = adr_dir / "ADR-004-carrier.md"
+        adr.write_text("# ADR 004\n\nold reviewed position.\n", encoding="utf-8")
+        old = _commit(repo, "the old position")
+        _git(repo, "update-ref", "refs/remotes/origin/main", old)
+
+        adr.write_text("# ADR 004\n\nnewer reviewed position.\n", encoding="utf-8")
+        newer = _commit(repo, "the newer position, not yet pushed")
+
+        _git(repo, "update-ref", "refs/heads/carrier", newer)
+        _git(repo, "checkout", "carrier")
+        adr.write_text("# ADR 004\n\nold reviewed position.\n", encoding="utf-8")
+        _commit(repo, "carrier quietly restores the old text")
+
+        _git(repo, "checkout", "main")
+        merge = _run(["git", "merge", "--no-edit", "--no-commit", "--no-ff", "carrier"], repo)
+        assert merge.returncode == 0, merge.stderr
+
+        relative = ".agents/architecture/ADR-004-carrier.md"
+        assert policy._merge_authored_adr_paths([relative], repo) == [relative]
+
+        monkeypatch.setattr(policy, "_gated_adr_review_paths", lambda paths, root: list(paths))
+        monkeypatch.setattr(policy, "_today_session_log", lambda sessions_dir: None)
+        assert policy.check_adr_review_policy([relative], repo) == 1
+        assert "ADR changes require adr-review evidence" in capsys.readouterr().err
+
+    def test_a_synthetic_merge_head_that_head_already_contains_is_not_a_merge(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ):
+        """A hand-written `MERGE_HEAD` naming an ancestor is never a real merge.
+
+        `git merge <ancestor>` reports "Already up to date" and writes no
+        `MERGE_HEAD` at all, so any `MERGE_HEAD` that HEAD already contains
+        was placed there by something other than git. Reading it as a merge
+        in progress hands the whole merge exemption to anyone who can write a
+        file, and the older commit it names is an approved parent by
+        construction, so the reversion it authorises is the exact thing the
+        gate exists to catch.
+
+        Found by adversarial security review, Finding 2. Unlike the carrier
+        case this one needs a write inside `.git`, and an author who has that
+        can also skip the hook outright. It is fixed anyway because the check
+        costs one ancestry query and removes a way to get the same result
+        while the hook still reports success.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "test@example.invalid")
+        _git(repo, "config", "user.name", "Test User")
+        adr_dir = repo / ".agents" / "architecture"
+        adr_dir.mkdir(parents=True)
+        adr = adr_dir / "ADR-005-synthetic.md"
+        adr.write_text("# ADR 005\n\nold reviewed position.\n", encoding="utf-8")
+        old = _commit(repo, "the old position")
+
+        adr.write_text("# ADR 005\n\nnewer reviewed position.\n", encoding="utf-8")
+        newer = _commit(repo, "the newer position")
+        _git(repo, "update-ref", "refs/remotes/origin/main", newer)
+
+        adr.write_text("# ADR 005\n\nold reviewed position.\n", encoding="utf-8")
+        _git(repo, "add", ".")
+        (repo / ".git" / "MERGE_HEAD").write_text(f"{old}\n", encoding="utf-8")
+
+        relative = ".agents/architecture/ADR-005-synthetic.md"
+        assert policy._merge_authored_adr_paths([relative], repo) == [relative]
+
+        monkeypatch.setattr(policy, "_gated_adr_review_paths", lambda paths, root: list(paths))
+        monkeypatch.setattr(policy, "_today_session_log", lambda sessions_dir: None)
+        assert policy.check_adr_review_policy([relative], repo) == 1
+        assert "ADR changes require adr-review evidence" in capsys.readouterr().err
+
     def test_a_real_merge_of_a_shared_branch_tip_exempts_the_adr_main_contributed(
         self,
         tmp_path,


### PR DESCRIPTION
## Summary

PR #3662 let a merged branch tip carry main's own ADRs past the review gate. The
exemption it added asks one question: does the staged blob match the same path
at `origin/main`. That question is too wide, and the first narrowing of it was
still too wide.

Fixes #3666

## The rule

Content is exempt from the ADR review gate when either holds:

1. The blob matches the same path on an approved merge parent. Unchanged, this
   is the rule that already existed.
2. All three of: the blob sits on a `MERGE_HEAD` parent, the blob matches
   `origin/main`, and the copy this branch already has is one main has carried
   at some point.

Every clause of rule 2 is load-bearing, and each one closes a way past the
other two:

- Drop the merge-parent clause and an author can type a reversion during
  someone else's merge, because a stale `origin/main` will match it.
- Drop the `origin/main` clause and a collaborator's branch-authored ADR is
  exempted by the merge that brings it in, so nobody reviews it.
- Drop the head-copy clause and an author who builds the merge gets through:
  branch off the newer commit, commit the older text there, merge it back, and
  the first two clauses both hold.

The third clause exists because the gate cannot tell a stale `origin/main` from
a current one while offline. So it asks a question it can answer instead. Main's
content arriving is an upgrade, and the copy it replaces is one main has carried.
A reversion is not, because the newer text it overwrites was written locally and
main has never seen it.

Separately, a `MERGE_HEAD` naming a commit HEAD already contains is now ignored.
`git merge <ancestor>` reports "Already up to date" and writes no `MERGE_HEAD`
at all, so one that exists was written by something other than git, and the
ancestor it names is an approved parent by construction.

## Changes

- `scripts/validation/git_hook_policy.py`: narrows the merge exemption in
  `_merge_authored_adr_paths`. Adds `_blob_is_at_any`,
  `_blob_arrived_through_the_merge`, `_head_copy_is_one_main_has_carried`,
  `_blob_id_at`, `_origin_main_blob_ids`, and `_head_already_contains`, so each
  clause is named and separately testable. `_merge_head_commits` now drops
  synthetic entries. The three blob readers now run `git show` through the
  existing bytes runner rather than a text pipe.
- `tests/validation/test_git_hook_policy_causal_restore.py`: adds twelve tests
  against a real git repository rather than mocks. A stale-`origin/main`
  reversion stays gated. A collaborator's ADR authored on the shared branch
  stays gated. A carrier branch built to satisfy the conjunction stays gated. A
  hand-written `MERGE_HEAD` naming an ancestor is not read as a merge. An
  approved merge parent still exempts content `origin/main` does not carry. Two
  pre-existing mocks are made commit-aware, because they returned the same blob
  for every commit argument and so could not tell which parent matched. Round
  51 added seven more: two byte collisions that let content through, two
  legitimate CRLF flows the same bug turned into false positives, a
  discriminator for the merge-parent clause, a rename that used to be read as
  branch authorship, and the helper rewrite that supports them.

## Round 51: what an adversarial review found after the above was written

An earlier revision of this section claimed a seven-way mutation proof with
every clause covered. Round 51 checked it and the claim was false. Replacing
the merge-parent clause with `if False:` left all 34 tests green, because the
one test reaching that clause also failed the clause after it, so nothing told
the two apart. A discriminator now separates them and kills the mutant.

The same round found the blob readers were not reading blobs. `_run_command`
passes `encoding="utf-8", errors="replace"`, which puts the pipe in text mode:
`\r\n` and lone `\r` fold to `\n`, and every undecodable byte becomes one
replacement character. Distinct blobs came back equal, and this gate reads
equal as "the merge carried main's content". It also ran the other way, since
only one side of a comparison was normalized in some paths, so untouched files
were reported as branch-authored.

Last, the head-copy clause walked `rev-list origin/main -- <path>`, which stops
at a rename. It now reads blob ids from `git log --follow --raw --no-abbrev`,
which crosses the rename and compares identities git already computed rather
than bytes any pipe could alter.

## Verification

- 1183 passed, 1 skipped in `tests/validation/`.
- Eleven-way mutation proof, every mutant caught by a named test: drop the
  `origin/main` clause; drop the merge-parent clause; drop the head-copy clause;
  delete rule 1; blanket-exempt during a merge; drop the synthetic-merge filter;
  invert the absent-path pass; revert each of the three blob readers to text
  mode; drop `--follow`; and hardcode the head-copy clause to True.
- Both remaining findings from the security review were reproduced against a
  real repository before being accepted, and the carrier bypass was re-checked
  against the live reproduction after the fix.
- `ruff` clean, `mypy` clean, zero em-dashes or en-dashes byte-verified.

## What this does not fix

> [!IMPORTANT]
> This hook is a guardrail against accident, not a security boundary, and this
> PR does not change that. The gate runs only as a lefthook client-side step.
> Every input to its decision is author-controlled: `origin/main` is a local
> ref, `MERGE_HEAD` is a file, and the index is the author's by definition. An
> author who can rewrite a local ref can also skip the hook outright.
>
> Two of the three security findings reduce to that, and no local narrowing can
> close them. They are filed as #3670 with the two options and are an owner
> call, not a fold-in. The third finding needed no write inside the git
> directory, which is why it is fixed here rather than deferred with the others.

## Provenance

The first version of this fix came from adversarial review round 50 on
`gemini-3.1-pro-preview`, Finding 3, against my own change in #3662. My claim
there that adding the `origin/main` comparison "cannot widen the gate" was
false.

The carrier bypass and the synthetic-merge bypass came from a security review on
`gpt-5.6-sol` against that first version. Its Finding 3 defeated the conjunction
this PR originally shipped, so the rule grew a third clause.

> [!NOTE]
> The mutation proof found a real gap in my own tests three times, and the
> third was in the proof itself. Dropping the `origin/main` clause survived 31
> green tests. Dropping the merge-parent clause survived 34, after this PR body
> had already claimed every clause was covered. Passing tests were not the
> proof, and neither was a written claim that mutations had been run.

Round 51 ran on `gpt-5.6-terra` against the two change sets above.

