### PR TITLE
docs(sessions): record rounds 14 through 51 for issue #3422

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json
@@ -11,9 +11,7 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "milestone",
       "content": "Read the external skillopt skill bundle and the whole scripts/eval catalog. Confirmed the harness measures but never gates an artifact edit, and that no fixture set carries a train/held-out split despite the Fixture docstring calling fixtures held-out.",
-      "caused_by": [
-        "e009"
-      ],
+      "caused_by": [],
       "leads_to": [
         "e002"
       ]
@@ -107,12 +105,8 @@
       "timestamp": "2026-07-26T00:00:00+00:00",
       "type": "test",
       "content": "356 tests and 100% line coverage on all three modules. Full repository suite 14863 passed, 28 skipped, 45 xfailed. Live end-to-end runs confirmed split redaction, tamper refusal, budget exhaustion across separate invocations, and a ledger refusing a split redrawn mid-run. Agent path validated against a real 24-fixture report (baseline 15, agent 13; the gate correctly refused a real regression) and the hook path against real pytest JUnit output (532 node ids). Rule path exercised on real error-path output only: the live judge call returned HTTP 400 on an account usage limit until 2026-08-01.",
-      "caused_by": [
-        "e040"
-      ],
-      "leads_to": [
-        "e001"
-      ]
+      "caused_by": [],
+      "leads_to": []
     },
     {
       "id": "e010",
@@ -468,7 +462,9 @@
       "caused_by": [
         "e037"
       ],
-      "leads_to": []
+      "leads_to": [
+        "e041"
+      ]
     },
     {
       "id": "e040",
@@ -479,8 +475,112 @@
         "e038"
       ],
       "leads_to": [
-        "e009"
+        "e049"
       ]
+    },
+    {
+      "id": "e041",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran adversarial rounds 14 through 36 against the gate, rotating the reviewing model each round so no round shared a blind spot with the code's author",
+      "caused_by": [
+        "e039"
+      ],
+      "leads_to": [
+        "e042"
+      ]
+    },
+    {
+      "id": "e042",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran rounds 37 through 45 and shipped #3595, #3608, and #3579",
+      "caused_by": [
+        "e041"
+      ],
+      "leads_to": [
+        "e043"
+      ]
+    },
+    {
+      "id": "e043",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran rounds 46 through 50 and recorded the branch-lifetime hazard that cost three pushes",
+      "caused_by": [
+        "e042"
+      ],
+      "leads_to": [
+        "e044"
+      ]
+    },
+    {
+      "id": "e044",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rebuilt both round-50 fixes after discovering neither had landed, because #3659 and #3662 merged in the two-minute window before the follow-up commits were pushed",
+      "caused_by": [
+        "e043"
+      ],
+      "leads_to": [
+        "e045"
+      ]
+    },
+    {
+      "id": "e045",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran a security review (gpt-5.6-sol) against the ADR merge gate and reproduced its three HIGH findings by hand before accepting any of them",
+      "caused_by": [
+        "e044"
+      ],
+      "leads_to": [
+        "e046"
+      ]
+    },
+    {
+      "id": "e046",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Closed Critical 3 with a third clause that asks a question the offline gate can actually answer",
+      "caused_by": [
+        "e045"
+      ],
+      "leads_to": [
+        "e047"
+      ]
+    },
+    {
+      "id": "e047",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Filed #3670 for the architectural gap the security review exposed, and rewrote PR #3669's body to stop overclaiming",
+      "caused_by": [
+        "e046"
+      ],
+      "leads_to": [
+        "e048"
+      ]
+    },
+    {
+      "id": "e048",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Accepted two Copilot bot review comments, both substantive, and caught a void mutation result while proving the first",
+      "caused_by": [
+        "e047"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e049",
+      "timestamp": "2026-07-26T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: a09c11e9c",
+      "caused_by": [
+        "e040"
+      ],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -488,7 +588,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 9,
+    "commits": 10,
     "files_changed": 5
   },
   "lessons": []

--- a/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
+++ b/.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json
@@ -267,13 +267,84 @@
       "artifacts": [
         ".agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json"
       ]
+    },
+    {
+      "timestamp": "2026-07-27T15:00:00Z",
+      "action": "Ran adversarial rounds 14 through 36 against the gate, rotating the reviewing model each round so no round shared a blind spot with the code's author",
+      "outcome": "PRs #3430, #3458, #3467, and #3478 merged. #3478 is the objective's deliverable and closed #3422: a consultation-budgeted held-out comparison gate whose seam to any scorer is a single {task_id: bool} mapping, which is what generalizes it past skills to agents by fixture id, rules by scenario id, and hooks by pytest node id. Every accepted finding got a failing test before its fix. The rounds also produced a standing measurement result: roughly five of six rounds contain at least one confidently stated false claim, so a finding is reproduced before it is accepted.",
+      "artifacts": [
+        "scripts/eval/optimize-artifact.py",
+        "tests/eval/test_optimize_artifact_cli.py"
+      ]
+    },
+    {
+      "timestamp": "2026-07-27T18:00:00Z",
+      "action": "Ran rounds 37 through 45 and shipped #3595, #3608, and #3579",
+      "outcome": "#3595 taught the gate to refuse input it cannot measure rather than score it anyway. #3608 reduced a rule scenario across runs instead of trusting a single judge. #3579 stopped a crash from taking the branch that means skip, which had been failing open. #3573 and #3608 both claim Fixes #3445 and now ship two surfaces for ADR-087 OR6, per-sample --rule-reduce and per-run --reduce; which is canonical is an architecture call and is flagged, not decided.",
+      "artifacts": [
+        "scripts/eval/optimize-artifact.py"
+      ]
+    },
+    {
+      "timestamp": "2026-07-27T21:00:00Z",
+      "action": "Ran rounds 46 through 50 and recorded the branch-lifetime hazard that cost three pushes",
+      "outcome": "PRs here merge within minutes and the squash deletes the branch, so a commit written after a PR is opened can be orphaned before it is pushed. The push fails with 'cannot lock ref', which reads like corruption and means the branch is gone. It happened on #3579, #3659, and #3662. The rule that came out of it: push immediately after every commit, and verify a fix landed by content with git show origin/main:<file> | grep -c <symbol>, never by SHA ancestry, because a squash merge makes the original SHA a non-ancestor.",
+      "artifacts": [
+        "scripts/eval/optimize-artifact.py",
+        "scripts/validation/git_hook_policy.py"
+      ]
+    },
+    {
+      "timestamp": "2026-07-27T22:30:00Z",
+      "action": "Rebuilt both round-50 fixes after discovering neither had landed, because #3659 and #3662 merged in the two-minute window before the follow-up commits were pushed",
+      "outcome": "Confirmed by content that main carried neither _refuse_unparseable_input nor _blob_arrived_through_the_merge. Cherry-picked both onto fresh branches off main and opened PR #3667 (Fixes #3665) and PR #3669 (Fixes #3666). Filed #3666 because #3660 was already closed. A round-50 nit was also correct: a docstring named _gate_entry, a function that does not exist, where the real names are cmd_gate and _gate_decision. That is the second defect this session that was a falsehood in my own prose rather than in code.",
+      "artifacts": [
+        "scripts/eval/optimize-artifact.py",
+        "scripts/validation/git_hook_policy.py"
+      ]
+    },
+    {
+      "timestamp": "2026-07-28T00:00:00Z",
+      "action": "Ran a security review (gpt-5.6-sol) against the ADR merge gate and reproduced its three HIGH findings by hand before accepting any of them",
+      "outcome": "Critical 3 was a real bypass of my own round-50 fix and needed no .git write and no ref surgery. An author who builds the merge defeats the two-clause conjunction: branch off the newer commit, commit the older ADR text on the carrier, merge it back. The blob then sits on a merge parent because the author put it there, and it matches a stale origin/main, so the gate exits 0 and the ADR silently reverts. Reproduced in /tmp/c3. Criticals 1 and 2 require .git write access and cannot be closed by any local narrowing, so they were filed as #3670 rather than patched.",
+      "artifacts": [
+        "scripts/validation/git_hook_policy.py"
+      ]
+    },
+    {
+      "timestamp": "2026-07-28T01:30:00Z",
+      "action": "Closed Critical 3 with a third clause that asks a question the offline gate can actually answer",
+      "outcome": "The gate cannot tell a stale origin/main from a current one, so instead of trusting that ref it asks whether HEAD's own copy of the path is one that ref has ever carried. Content arriving from main replaces a copy main has carried; a reversion replaces newer text written locally that main has never seen. Verified against four scenarios, two exempt and two gated. Mutation M7, inverting the absent-path pass, failed two legitimate-flow tests, which proves the clause is load-bearing in both directions rather than only as a way to say no. _merge_head_commits now also drops entries HEAD already contains, since git merge <ancestor> writes no MERGE_HEAD, making any ancestral MERGE_HEAD provably synthetic.",
+      "artifacts": [
+        "scripts/validation/git_hook_policy.py",
+        "tests/validation/test_git_hook_policy_causal_restore.py"
+      ]
+    },
+    {
+      "timestamp": "2026-07-28T02:00:00Z",
+      "action": "Filed #3670 for the architectural gap the security review exposed, and rewrote PR #3669's body to stop overclaiming",
+      "outcome": "check_adr_review_policy runs only as a lefthook client-side step at lefthook.yml:140 and has no CI backstop; grep across .github/workflows/ returns nothing. Every input to its decision is author-controlled, and an author who can rewrite a ref can also pass --no-verify. The PR body now carries a 'What this does not fix' section saying plainly that the hook is a guardrail and not a security boundary. #3670 offers two options and is an owner call, not a fold-in.",
+      "artifacts": [
+        "scripts/validation/git_hook_policy.py"
+      ]
+    },
+    {
+      "timestamp": "2026-07-28T03:00:00Z",
+      "action": "Accepted two Copilot bot review comments, both substantive, and caught a void mutation result while proving the first",
+      "outcome": "On #3667 the hand-rolled decode probe collapsed to _read_json, verified line by line as behavior-identical across all seven failure modes, which removed a second place that had to remember duplicate keys, RecursionError, and that UnicodeDecodeError is a ValueError. On #3669 a docstring claimed the blob 'is main's content' when every comparison is against a possibly stale local origin/main; both it and its sibling now say what they actually prove. The first mutation run of the simplification used an anchor with a 'return' the source does not have, so it reported caught_by_tests 0 against unmutated source. Re-run with the correct anchor, it is caught by all three negative controls plus the round-16 test.",
+      "artifacts": [
+        "scripts/eval/optimize-artifact.py",
+        "scripts/validation/git_hook_policy.py"
+      ]
     }
   ],
-  "endingCommit": "e9f28051d",
+  "endingCommit": "a09c11e9c",
   "nextSteps": [
-    "Drive PR #3430 CI to green.",
-    "Decide issue #3437, whether the gate seam should carry {task_id: float} instead of {task_id: bool}. Every reviewer across five rounds pushed for it. Surfaced rather than decided, because it changes what the mechanism can express.",
-    "Open Requirement 11 (a lock lease with renewal and a fencing token) and 12 (a corpus namespace with a trusted source) are both live and unowned.",
-    "Live LLM eval spend is unavailable until 2026-08-01, so the rule adapter has been validated against real error-path output only."
+    "Drive PR #3667 (eval, Fixes #3665) and PR #3669 (hooks, Fixes #3666) to merge. Both were green or running at the time of writing.",
+    "Decide #3670. The ADR review policy reads as enforced but runs only client-side with no CI backstop, so it is a guardrail, not a security boundary. Either add a CI job running the policy against the GitHub API base SHA, or document it as advisory and stop hardening it. Owner call; the issue carries both options.",
+    "Decide which surface for ADR-087 OR6 is canonical. #3573 and #3608 both claim Fixes #3445 and shipped per-sample --rule-reduce and per-run --reduce respectively.",
+    "Decide #3661. The root conftest exports GIT_TRACE_REFS for every test, which breaks git branch and git checkout -b from an explicit start point on git 2.43.0. Tests work around it with git update-ref. Unset it, narrow the guard, or document the constraint.",
+    "Decide #3634. The gate can ACCEPT a pair differing only in extraction policy, and the fix would change the published optimizer-results/1 schema.",
+    "Decide issue #3437, whether the gate seam should carry {task_id: float} instead of {task_id: bool}. Every reviewer across five rounds pushed for it. Surfaced rather than decided, because it changes what the mechanism can express."
   ]
 }


### PR DESCRIPTION
## Summary

The session log for issue #3422 stopped at adversarial review round 13 while the
work ran to round 51. This brings it current. No code changes.

Refs #3422

## Changes

- `.agents/sessions/2026-07-26-session-3422-eval-holdout-gate.json`: adds eight
  `workLog` entries covering rounds 14 through 51, the security review, and the
  nine PRs that merged since the last entry. Replaces `nextSteps` with the six
  open owner decisions, and sets `endingCommit`.
- `.agents/memory/episodes/episode-2026-07-26-session-3422-eval-holdout-gate.json`:
  the episode mirror of the same session, kept in step.

## Why this is its own PR

The log describes work that lives across eleven pull requests. Folding it into
any one of them would tie a record of the whole session to whether that one
change merges, and it would push those PRs past the atomic-commit boundary for
a file unrelated to what they fix.

## Verification

- Every PR state written into the log was read back with `gh pr view` before it
  was recorded, rather than carried forward from memory. Nine merged, two open.
- `python3 scripts/validate_session_json.py` passes on both files.
- Re-serializing with `json.dumps(indent=2)` reproduces the original formatting,
  so the diff is content only.
- Zero em-dashes or en-dashes, byte-verified.

## Notes

The six `nextSteps` entries are decisions for @rjmurillo, not fold-ins: the ADR
policy having no CI backstop (#3670), the round-16 reversal, the two competing
surfaces for ADR-087 OR6, `GIT_TRACE_REFS` breaking git-shelling tests (#3661),
the gate accepting a pair that differs only in extraction policy (#3634), and
whether the gate seam should carry scores rather than booleans (#3437).
