### PR TITLE
fix(hooks): read git blobs as bytes and follow an ADR through renames

### DIFF
--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1005,18 +1005,25 @@ def _origin_main_blob_ids(repo_root: Path, path: str) -> set[str]:
     at those older commits the current name does not exist yet. The widening
     is exactly one file's lineage, not any blob main happens to contain.
 
-    `-m` is what makes merges count. `--raw` prints nothing for a merge commit
-    unless asked, so an ADR whose only appearance in some state was a conflict
-    main resolved left no id behind, and a branch sitting on that resolution
-    failed on content main really had carried. `-m` splits the merge into one
-    diff per parent, which keeps the single-parent `:` raw form rather than
-    the `::` combined form, so the post-image stays the fourth field.
+    `--diff-merges=separate` is what makes merges count. `--raw` prints nothing
+    for a merge commit unless asked, so an ADR whose only appearance in some
+    state was a conflict main resolved left no id behind, and a branch sitting
+    on that resolution failed on content main really had carried. `separate`
+    splits the merge into one diff per parent, which keeps the single-parent
+    `:` raw form, so the post-image stays the fourth field.
+
+    The format is named rather than left to `-m`, which means
+    `--diff-merges=on` and takes its format from the user's `log.diffMerges`.
+    Set to `combined` or `dense-combined`, a merge prints one `::` record whose
+    fourth field is the first parent's pre-image, so the resolution went
+    missing again and a blob nobody asked about took its place. What this gate
+    accepts is not a readability preference.
     """
     result = _run_git(
         repo_root,
         [
             "log",
-            "-m",
+            "--diff-merges=separate",
             "--follow",
             "--format=",
             "--raw",
@@ -1030,7 +1037,11 @@ def _origin_main_blob_ids(repo_root: Path, path: str) -> set[str]:
         return set()
     blob_ids: set[str] = set()
     for line in result.stdout.splitlines():
-        if not line.startswith(":"):
+        if not line.startswith(":") or line.startswith("::"):
+            # A `::` record lists one pre-image per parent before the
+            # post-image, so its fourth field is a pre-image and its width
+            # depends on the parent count. Naming the format should keep these
+            # away; skipping them is what keeps that true if one arrives.
             continue
         fields = line.split()
         if len(fields) < 4:

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -35,11 +35,15 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PROHIBITED_DASHES = ("\N{EN DASH}", "\N{EM DASH}")
 SESSION_PATH_RE = re.compile(r"^\.agents/sessions/\d{4}-\d{2}-\d{2}-session-\d+.*\.json$")
 EPISODE_ID_RE = re.compile(r"^episode-[A-Za-z0-9._-]+$")
+ADR_PATH_RE = re.compile(r"(?:^|[\\/])ADR-\d+(?:-\w+)*\.md$", re.IGNORECASE)
+SESSION_PROTOCOL_PATH_RE = re.compile(r"(?:^|[\\/])SESSION-PROTOCOL\.md$", re.IGNORECASE)
+# Composed rather than written out again: the two halves disagreed about
+# anchoring for as long as they were separate strings, and a path merely ending
+# in the protocol's filename read as the protocol itself.
 ADR_REVIEW_PATH_RE = re.compile(
-    r"(?:^|[\\/])ADR-\d+(?:-\w+)*\.md$|(?:^|[\\/])SESSION-PROTOCOL\.md$",
+    f"{ADR_PATH_RE.pattern}|{SESSION_PROTOCOL_PATH_RE.pattern}",
     re.IGNORECASE,
 )
-ADR_PATH_RE = re.compile(r"(?:^|[\\/])ADR-\d+(?:-\w+)*\.md$", re.IGNORECASE)
 ADR_ID_RE = re.compile(r"ADR-\d+", re.IGNORECASE)
 FRONTMATTER_FIELD_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
 ADR_REVIEW_PATTERNS = (
@@ -991,6 +995,25 @@ def _blob_id_at(repo_root: Path, commit: str, path: str) -> str | None:
     return result.stdout.strip() or None
 
 
+def _governed_document_identity(path: str) -> str | None:
+    """Which record `path` holds, or None if this gate does not govern it.
+
+    Scoping a followed history to governed paths does not tell two decision
+    records apart: both are governed. Records written from one template share
+    most of their lines, so git reads a commit that drops one and adds another
+    as a rename of it, and the walk crosses from one decision into the other.
+
+    The number in the filename is what says which decision a path holds. The
+    protocol has no number and stands for itself.
+    """
+    if ADR_PATH_RE.search(path):
+        identifier = ADR_ID_RE.search(path)
+        return identifier.group(0).upper() if identifier else None
+    if SESSION_PROTOCOL_PATH_RE.search(path):
+        return "SESSION-PROTOCOL"
+    return None
+
+
 def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]:
     """Blob ids from one `--follow` traversal of `path` on `origin/main`.
 
@@ -1028,6 +1051,10 @@ def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]
     )
     if result.returncode != 0:
         return set()
+    # An unrecognised path carries no identity, so nothing below matches it and
+    # the caller is told main has carried nothing here. That refuses; it cannot
+    # exempt.
+    followed = _governed_document_identity(path)
     blob_ids: set[str] = set()
     fields = result.stdout.split("\0")
     index = 0
@@ -1051,13 +1078,15 @@ def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]
         index += wanted
         if len(paths) < wanted:
             break
-        if ADR_REVIEW_PATH_RE.search(paths[-1]) is None:
+        if _governed_document_identity(paths[-1]) != followed:
             # `--follow` rewrites the path it tracks whenever it scores a drop
             # and an add as a rename, which is similarity and not provenance.
             # Crossing into a file this gate does not govern would read that
-            # file's states as states of this ADR, and they never faced ADR
-            # review. The post-image belongs to the record's destination path,
-            # so that is the path that has to qualify.
+            # file's states as states of this record, and they never faced ADR
+            # review; crossing into another record would read a decision
+            # somebody reviewed under a different number as this one. The
+            # post-image belongs to the record's destination path, so that is
+            # the path that has to qualify.
             continue
         blob_ids.add(metadata[3])
     blob_ids.discard("0" * 40)

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -662,14 +662,37 @@ def _today_session_log(sessions_dir: Path) -> Path | None:
     return best
 
 
-def _split_frontmatter(content: str) -> tuple[str, str]:
+def _split_frontmatter(content: bytes) -> tuple[bytes, bytes]:
+    """Split a document into its frontmatter and its body, without decoding.
+
+    The body is what callers compare for "unchanged", and that question is
+    about bytes. Decoding first with ``errors="replace"`` maps every byte the
+    decoder cannot read to the same replacement character, so two bodies
+    holding different invalid bytes came back equal and a real body edit rode
+    in under a metadata change.
+    """
     lines = content.splitlines(keepends=True)
-    if not lines or lines[0].strip() != "---":
-        return "", content
+    if not lines or lines[0].strip() != b"---":
+        return b"", content
     for index in range(1, len(lines)):
-        if lines[index].strip() == "---":
-            return "".join(lines[1:index]), "".join(lines[index + 1 :])
-    return "", content
+        if lines[index].strip() == b"---":
+            return b"".join(lines[1:index]), b"".join(lines[index + 1 :])
+    return b"", content
+
+
+def _decoded_frontmatter(raw: bytes) -> str | None:
+    """Decode frontmatter strictly, or report that it cannot be reasoned about.
+
+    Frontmatter has to become text to be parsed as YAML. Decoding it lossily
+    would let two different field values collide on the replacement character
+    and drop out of the changed-key set, hiding an edit the exemption was never
+    meant to cover. Bytes YAML could not have meant are a reason to run the
+    validator, so this fails closed instead.
+    """
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
 
 
 def _has_duplicate_frontmatter_keys(frontmatter: str) -> bool:
@@ -715,16 +738,37 @@ def _only_implemented_field_changed(
     return bool(changed) and changed <= {"implemented"}
 
 
-def _is_frontmatter_only_metadata_change(path: str, repo_root: Path) -> bool:
+def _frontmatter_pair_for_a_body_unchanged_edit(
+    path: str,
+    repo_root: Path,
+) -> tuple[str, str] | None:
+    """Return HEAD and staged frontmatter for an edit that left the body alone.
+
+    `None` means no exemption is on offer: a blob is missing, either document
+    has no frontmatter, the bodies differ, or a frontmatter holds bytes UTF-8
+    cannot read. Both exemptions ask this same question and differ only in
+    which changed fields they will then accept.
+    """
     old_blob = _read_head_blob(repo_root, path)
     new_blob = _read_index_blob(repo_root, path)
     if old_blob is None or new_blob is None:
-        return False
-    old_frontmatter, old_body = _split_frontmatter(old_blob.decode("utf-8", errors="replace"))
-    new_frontmatter, new_body = _split_frontmatter(new_blob.decode("utf-8", errors="replace"))
+        return None
+    old_frontmatter, old_body = _split_frontmatter(old_blob)
+    new_frontmatter, new_body = _split_frontmatter(new_blob)
     if not old_frontmatter or not new_frontmatter or old_body != new_body:
+        return None
+    old_text = _decoded_frontmatter(old_frontmatter)
+    new_text = _decoded_frontmatter(new_frontmatter)
+    if old_text is None or new_text is None:
+        return None
+    return old_text, new_text
+
+
+def _is_frontmatter_only_metadata_change(path: str, repo_root: Path) -> bool:
+    pair = _frontmatter_pair_for_a_body_unchanged_edit(path, repo_root)
+    if pair is None:
         return False
-    return _only_implemented_field_changed(old_frontmatter, new_frontmatter)
+    return _only_implemented_field_changed(*pair)
 
 
 def _is_skill_frontmatter_only_change(path: str, repo_root: Path) -> bool:
@@ -735,8 +779,8 @@ def _is_skill_frontmatter_only_change(path: str, repo_root: Path) -> bool:
     (required and allowed keys). A body-unchanged edit cannot regress the
     structural verdict, but a frontmatter edit still can, so this exemption is
     deliberately narrow: it skips validation only when the body text is
-    unchanged from HEAD (bodies decoded as UTF-8 with ``errors="replace"`` and
-    compared as strings, not raw bytes) AND the sole changed frontmatter keys
+    unchanged from HEAD (bodies compared as the bytes git stored, never as
+    decoded text) AND the sole changed frontmatter keys
     are the ADR-080 model-pin
     fields (``model``, ``model-rationale``). Any other frontmatter delta, for
     example deleting ``name``/``description`` or introducing an unexpected key,
@@ -746,15 +790,10 @@ def _is_skill_frontmatter_only_change(path: str, repo_root: Path) -> bool:
     Returns False for newly added skills (no HEAD blob) so genuinely new skills
     are always validated.
     """
-    old_blob = _read_head_blob(repo_root, path)
-    new_blob = _read_index_blob(repo_root, path)
-    if old_blob is None or new_blob is None:
+    pair = _frontmatter_pair_for_a_body_unchanged_edit(path, repo_root)
+    if pair is None:
         return False
-    old_frontmatter, old_body = _split_frontmatter(old_blob.decode("utf-8", errors="replace"))
-    new_frontmatter, new_body = _split_frontmatter(new_blob.decode("utf-8", errors="replace"))
-    if not old_frontmatter or not new_frontmatter or old_body != new_body:
-        return False
-    return _only_model_pin_fields_changed(old_frontmatter, new_frontmatter)
+    return _only_model_pin_fields_changed(*pair)
 
 
 _ADR080_MODEL_PIN_FIELDS = frozenset({"model", "model-rationale"})

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -36,7 +36,7 @@ PROHIBITED_DASHES = ("\N{EN DASH}", "\N{EM DASH}")
 SESSION_PATH_RE = re.compile(r"^\.agents/sessions/\d{4}-\d{2}-\d{2}-session-\d+.*\.json$")
 EPISODE_ID_RE = re.compile(r"^episode-[A-Za-z0-9._-]+$")
 ADR_REVIEW_PATH_RE = re.compile(
-    r"(?:^|[\\/])ADR-\d+(?:-\w+)*\.md$|SESSION-PROTOCOL\.md$",
+    r"(?:^|[\\/])ADR-\d+(?:-\w+)*\.md$|(?:^|[\\/])SESSION-PROTOCOL\.md$",
     re.IGNORECASE,
 )
 ADR_PATH_RE = re.compile(r"(?:^|[\\/])ADR-\d+(?:-\w+)*\.md$", re.IGNORECASE)

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1029,7 +1029,16 @@ def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]
             # depends on the parent count. Naming the format should keep these
             # away; skipping them is what keeps that true if one arrives.
             continue
-        fields = line.split()
+        parts = line.split("\t")
+        if len(parts) < 2 or ADR_REVIEW_PATH_RE.search(parts[-1]) is None:
+            # `--follow` rewrites the path it tracks whenever it scores a drop
+            # and an add as a rename, which is similarity and not provenance.
+            # Crossing into a file this gate does not govern would read that
+            # file's states as states of this ADR, and they never faced ADR
+            # review. The post-image belongs to the record's destination path,
+            # so that is the path that has to qualify.
+            continue
+        fields = parts[0].split()
         if len(fields) < 4:
             continue
         blob_ids.add(fields[3])

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -927,27 +927,70 @@ def _head_copy_is_one_main_has_carried(repo_root: Path, path: str) -> bool:
     """Report whether HEAD's copy of a path is a state `origin/main` has held.
 
     A path HEAD does not carry cannot be a regression of local work, so it
-    passes. Otherwise the copy has to appear somewhere in `origin/main`'s
-    history for that path. Walking the path's own history keeps this to the
-    handful of commits that touched one ADR rather than the whole branch.
+    passes. Otherwise the copy has to be one of the blobs this file has held
+    in `origin/main`. Walking the file's own history keeps this to the handful
+    of commits that touched one ADR rather than the whole branch.
+
+    Identity is the blob id, not the bytes, because git already computed the
+    answer and an id cannot be normalized into agreeing with a different blob.
 
     `origin/main` is a local cache of main, so a branch that has not fetched
     in a while can fail this on content main really does carry. That
     direction is the safe one: the answer is review evidence demanded for a
     file that did not need it, and a fetch clears it.
     """
-    head_blob = _read_head_blob(repo_root, path)
-    if head_blob is None:
+    head_blob_id = _blob_id_at(repo_root, "HEAD", path)
+    if head_blob_id is None:
         return True
-    carried = _origin_main_commits_touching(repo_root, path)
-    return _blob_is_at_any(repo_root, carried, path, head_blob)
+    return head_blob_id in _origin_main_blob_ids(repo_root, path)
 
 
-def _origin_main_commits_touching(repo_root: Path, path: str) -> list[str]:
-    result = _run_git(repo_root, ["rev-list", "origin/main", "--", path])
+def _blob_id_at(repo_root: Path, commit: str, path: str) -> str | None:
+    result = _run_git(repo_root, ["rev-parse", f"{commit}:{path}"])
     if result.returncode != 0:
-        return []
-    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        return None
+    return result.stdout.strip() or None
+
+
+def _origin_main_blob_ids(repo_root: Path, path: str) -> set[str]:
+    """Every blob `path` has held in `origin/main`, following it through renames.
+
+    Asking `rev-list` for one pathname stops at the rename, so an ADR that was
+    moved and revised on main left its earlier states behind under the former
+    name. A branch that had also moved the file then held a copy main really
+    had carried, failed this check on the name alone, and had review evidence
+    demanded of it for someone else's revision.
+
+    `--follow` crosses the rename, and reading blob ids out of the raw diff
+    rather than re-reading the file at each commit is what makes that useful:
+    at those older commits the current name does not exist yet. The widening
+    is exactly one file's lineage, not any blob main happens to contain.
+    """
+    result = _run_git(
+        repo_root,
+        [
+            "log",
+            "--follow",
+            "--format=",
+            "--raw",
+            "--no-abbrev",
+            "origin/main",
+            "--",
+            path,
+        ],
+    )
+    if result.returncode != 0:
+        return set()
+    blob_ids: set[str] = set()
+    for line in result.stdout.splitlines():
+        if not line.startswith(":"):
+            continue
+        fields = line.split()
+        if len(fields) < 4:
+            continue
+        blob_ids.add(fields[3])
+    blob_ids.discard("0" * 40)
+    return blob_ids
 
 
 def _approved_merge_head_commits(repo_root: Path) -> list[str]:

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -467,17 +467,17 @@ def check_generated_paths(kind: str, repo_root: Path) -> int:
 
 
 def _read_index_blob(repo_root: Path, relative_path: str) -> bytes | None:
-    result = _run_git(repo_root, ["show", f":{relative_path}"])
+    result = _run_git_bytes(repo_root, ["show", f":{relative_path}"])
     if result.returncode != 0:
         return None
-    return result.stdout.encode("utf-8")
+    return result.stdout
 
 
 def _read_head_blob(repo_root: Path, relative_path: str) -> bytes | None:
-    result = _run_git(repo_root, ["show", f"HEAD:{relative_path}"])
+    result = _run_git_bytes(repo_root, ["show", f"HEAD:{relative_path}"])
     if result.returncode != 0:
         return None
-    return result.stdout.encode("utf-8")
+    return result.stdout
 
 
 def check_branch(repo_root: Path) -> int:
@@ -995,10 +995,19 @@ def _commit_is_origin_main_ancestor(repo_root: Path, commit: str) -> bool:
 
 
 def _read_commit_blob_bytes(repo_root: Path, commit: str, relative_path: str) -> bytes | None:
-    result = _run_git(repo_root, ["show", f"{commit}:{relative_path}"])
+    """Read a blob as the bytes git stored, not as text that survived a decode.
+
+    The three readers here answer one question, whether two blobs are the same
+    blob, and a text pipe cannot answer it. `encoding=` puts the pipe in text
+    mode, which folds `\\r\\n` and lone `\\r` into `\\n`, and `errors="replace"`
+    turns every byte the decoder cannot read into one replacement character.
+    Both are lossy in the same direction: distinct blobs come back equal, and
+    the ADR gate reads equal as "the merge carried main's content".
+    """
+    result = _run_git_bytes(repo_root, ["show", f"{commit}:{relative_path}"])
     if result.returncode != 0:
         return None
-    return result.stdout.encode("utf-8")
+    return result.stdout
 
 
 def _session_has_retrospective_evidence(session_log: Path) -> bool:

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -3055,11 +3055,13 @@ def _contains_main_merge(update: PushUpdate, repo_root: Path) -> bool:
     result = _run_git(repo_root, ["rev-list", "--merges", update.range_spec])
     if result.returncode != 0:
         return False
-    return any(
-        _merge_has_main_parent(merge_sha, repo_root)
-        for merge_sha in result.stdout.splitlines()
-        if merge_sha
-    )
+    merges = [merge_sha for merge_sha in result.stdout.splitlines() if merge_sha]
+    if not merges:
+        return False
+    # Every merge is read against the same trunk, and a push may carry many.
+    # Reading it here keeps the walk once per push rather than once per merge.
+    trunk = _main_trunk_commits(repo_root)
+    return any(_merge_has_main_parent(merge_sha, repo_root, trunk) for merge_sha in merges)
 
 
 def _main_trunk_commits(repo_root: Path) -> frozenset[str]:
@@ -3077,7 +3079,11 @@ def _main_trunk_commits(repo_root: Path) -> frozenset[str]:
     return frozenset(result.stdout.split())
 
 
-def _merge_has_main_parent(merge_sha: str, repo_root: Path) -> bool:
+def _merge_has_main_parent(
+    merge_sha: str,
+    repo_root: Path,
+    trunk: frozenset[str] | None = None,
+) -> bool:
     # `log.showSignature` makes `show` report the signature check before the
     # commit, and the first field of the split is then a word of that report
     # rather than the merge's own first parent. Skipping the first field would
@@ -3091,7 +3097,8 @@ def _merge_has_main_parent(merge_sha: str, repo_root: Path) -> bool:
     if result.returncode != 0:
         return False
     parents = result.stdout.split()[1:]
-    trunk = _main_trunk_commits(repo_root)
+    if trunk is None:
+        trunk = _main_trunk_commits(repo_root)
     return any(parent in trunk for parent in parents)
 
 

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1038,6 +1038,14 @@ def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]
         [
             "log",
             f"--diff-merges={diff_merges}",
+            # `log.showSignature` prefixes each commit's raw records with the
+            # verification result, and the first field of the stream then
+            # begins with that text rather than the colon a record starts
+            # with. Every record is skipped and the walk reports that main
+            # carried nothing here, which refuses records main did carry, for
+            # whichever developers hold that setting. What this gate accepts
+            # is not a display preference.
+            "--no-show-signature",
             "--follow",
             "--format=",
             "--raw",
@@ -3036,7 +3044,16 @@ def _contains_main_merge(update: PushUpdate, repo_root: Path) -> bool:
 
 
 def _merge_has_main_parent(merge_sha: str, repo_root: Path) -> bool:
-    result = _run_git(repo_root, ["show", "-s", "--format=%P", merge_sha])
+    # `log.showSignature` makes `show` report the signature check before the
+    # commit, and the first field of the split is then a word of that report
+    # rather than the merge's own first parent. Skipping the first field would
+    # then leave the first parent in the parents searched for main, and a merge
+    # of a side branch would read as a merge of main and double the commit
+    # limit. What this gate accepts is not a display preference.
+    result = _run_git(
+        repo_root,
+        ["show", "-s", "--no-show-signature", "--format=%P", merge_sha],
+    )
     if result.returncode != 0:
         return False
     parents = result.stdout.split()

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1052,7 +1052,7 @@ def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]
     would be the wrong blob. What this gate accepts is not a readability
     preference.
     """
-    result = _run_git(
+    result = _run_git_bytes(
         repo_root,
         [
             "log",
@@ -1088,7 +1088,17 @@ def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]
     # exempt.
     followed = _governed_document_identity(path)
     blob_ids: set[str] = set()
-    fields = result.stdout.split("\0")
+    # Decoded here rather than by the pipe. A text mode read applies universal
+    # newline translation, so a path ending in a carriage return arrives ending
+    # in a newline, and the scope test below anchors with `$`, which matches
+    # before a trailing newline. A path this gate does not govern then reads as
+    # one and its blobs join the carried set, which exempts content that never
+    # sat at a governed path. That is what this read fixes. The error handler
+    # is `surrogateescape` because it round trips and costs nothing, not
+    # because it changes a verdict: identity here is the record's number, so a
+    # byte spent elsewhere in the path reaches no decision either way, and a
+    # mutation to `replace` survives the suite for that reason.
+    fields = result.stdout.decode("utf-8", "surrogateescape").split("\0")
     index = 0
     while index < len(fields):
         record = fields[index]

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -45,6 +45,7 @@ ADR_REVIEW_PATH_RE = re.compile(
     re.IGNORECASE,
 )
 ADR_ID_RE = re.compile(r"ADR-\d+", re.IGNORECASE)
+PATH_SEPARATOR_RE = re.compile(r"[\\/]")
 FRONTMATTER_FIELD_RE = re.compile(r"^([A-Za-z0-9_-]+):(.*)$")
 ADR_REVIEW_PATTERNS = (
     re.compile(r"/adr-review"),
@@ -1007,7 +1008,11 @@ def _governed_document_identity(path: str) -> str | None:
     protocol has no number and stands for itself.
     """
     if ADR_PATH_RE.search(path):
-        identifier = ADR_ID_RE.search(path)
+        # Read the number from the final segment, which is where the path test
+        # anchors. Across the whole path the first number wins, so a directory
+        # named for another record would shadow the one the file holds and two
+        # decisions would share one identity.
+        identifier = ADR_ID_RE.search(PATH_SEPARATOR_RE.split(path)[-1])
         return identifier.group(0).upper() if identifier else None
     if SESSION_PROTOCOL_PATH_RE.search(path):
         return "SESSION-PROTOCOL"

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -991,39 +991,25 @@ def _blob_id_at(repo_root: Path, commit: str, path: str) -> str | None:
     return result.stdout.strip() or None
 
 
-def _origin_main_blob_ids(repo_root: Path, path: str) -> set[str]:
-    """Every blob `path` has held in `origin/main`, following it through renames.
+def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]:
+    """Blob ids from one `--follow` traversal of `path` on `origin/main`.
 
-    Asking `rev-list` for one pathname stops at the rename, so an ADR that was
-    moved and revised on main left its earlier states behind under the former
-    name. A branch that had also moved the file then held a copy main really
-    had carried, failed this check on the name alone, and had review evidence
-    demanded of it for someone else's revision.
+    Reading ids out of the raw diff rather than re-reading the file at each
+    commit is what makes `--follow` useful here: at the older commits the
+    current name does not exist yet.
 
-    `--follow` crosses the rename, and reading blob ids out of the raw diff
-    rather than re-reading the file at each commit is what makes that useful:
-    at those older commits the current name does not exist yet. The widening
-    is exactly one file's lineage, not any blob main happens to contain.
-
-    `--diff-merges=separate` is what makes merges count. `--raw` prints nothing
-    for a merge commit unless asked, so an ADR whose only appearance in some
-    state was a conflict main resolved left no id behind, and a branch sitting
-    on that resolution failed on content main really had carried. `separate`
-    splits the merge into one diff per parent, which keeps the single-parent
-    `:` raw form, so the post-image stays the fourth field.
-
-    The format is named rather than left to `-m`, which means
+    `diff_merges` is named rather than left to `-m`, which means
     `--diff-merges=on` and takes its format from the user's `log.diffMerges`.
     Set to `combined` or `dense-combined`, a merge prints one `::` record whose
-    fourth field is the first parent's pre-image, so the resolution went
-    missing again and a blob nobody asked about took its place. What this gate
-    accepts is not a readability preference.
+    fourth field is the first parent's pre-image, so the post-image this reads
+    would be the wrong blob. What this gate accepts is not a readability
+    preference.
     """
     result = _run_git(
         repo_root,
         [
             "log",
-            "--diff-merges=separate",
+            f"--diff-merges={diff_merges}",
             "--follow",
             "--format=",
             "--raw",
@@ -1049,6 +1035,39 @@ def _origin_main_blob_ids(repo_root: Path, path: str) -> set[str]:
         blob_ids.add(fields[3])
     blob_ids.discard("0" * 40)
     return blob_ids
+
+
+def _origin_main_blob_ids(repo_root: Path, path: str) -> set[str]:
+    """Every blob `path` has held in `origin/main`, following it through renames.
+
+    Asking `rev-list` for one pathname stops at the rename, so an ADR that was
+    moved and revised on main left its earlier states behind under the former
+    name. A branch that had also moved the file then held a copy main really
+    had carried, failed this check on the name alone, and had review evidence
+    demanded of it for someone else's revision.
+
+    Two traversals, because neither answers the question alone.
+
+    `separate` splits a merge into one diff per parent, which is what makes a
+    conflict main resolved leave an id behind. `--raw` prints nothing for a
+    merge otherwise, so an ADR whose only appearance in some state was a
+    resolution was invisible here.
+
+    `off` is not redundant with it. `--follow` rewrites the path it follows
+    each time it detects a rename, so which renames are visible decides which
+    lineage it walks. With merge diffs asked for, the merge-versus-first-parent
+    rename becomes visible, following it walks main's side, and a side branch
+    that renamed the file is reported as a deletion rather than crossed into.
+    The states on that side are states of this file on `origin/main`, and
+    asking for the resolution must not cost them.
+
+    Every id either traversal reports comes from a commit reachable from
+    `origin/main`, so the union widens exactly one file's lineage rather than
+    admitting any blob the branch happens to contain.
+    """
+    return _followed_blob_ids(repo_root, path, "off") | _followed_blob_ids(
+        repo_root, path, "separate"
+    )
 
 
 def _approved_merge_head_commits(repo_root: Path) -> list[str]:

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -3062,6 +3062,21 @@ def _contains_main_merge(update: PushUpdate, repo_root: Path) -> bool:
     )
 
 
+def _main_trunk_commits(repo_root: Path) -> frozenset[str]:
+    """Read the commits `origin/main` reaches by first parent alone.
+
+    A branch main has landed is an ancestor of main, but it is not one of
+    these. It sits on the second parent of the merge that landed it. Merging
+    such a branch brings in no history main had not already handed out, so
+    asking only whether main can reach a parent answers a wider question than
+    the raised limit is for.
+    """
+    result = _run_git(repo_root, ["rev-list", "--first-parent", "origin/main"])
+    if result.returncode != 0:
+        return frozenset()
+    return frozenset(result.stdout.split())
+
+
 def _merge_has_main_parent(merge_sha: str, repo_root: Path) -> bool:
     # `log.showSignature` makes `show` report the signature check before the
     # commit, and the first field of the split is then a word of that report
@@ -3075,15 +3090,9 @@ def _merge_has_main_parent(merge_sha: str, repo_root: Path) -> bool:
     )
     if result.returncode != 0:
         return False
-    parents = result.stdout.split()
-    for parent in parents[1:]:
-        ancestor = _run_git(
-            repo_root,
-            ["merge-base", "--is-ancestor", parent, "origin/main"],
-        )
-        if ancestor.returncode == 0:
-            return True
-    return False
+    parents = result.stdout.split()[1:]
+    trunk = _main_trunk_commits(repo_root)
+    return any(parent in trunk for parent in parents)
 
 
 def _check_commit_limit(update: PushUpdate, repo_root: Path) -> int:

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1013,10 +1013,29 @@ def _governed_document_identity(path: str) -> str | None:
         # named for another record would shadow the one the file holds and two
         # decisions would share one identity.
         identifier = ADR_ID_RE.search(PATH_SEPARATOR_RE.split(path)[-1])
-        return identifier.group(0).upper() if identifier else None
+        return _normalized_record_number(identifier.group(0)) if identifier else None
     if SESSION_PROTOCOL_PATH_RE.search(path):
         return "SESSION-PROTOCOL"
     return None
+
+
+def _normalized_record_number(identifier: str) -> str:
+    """One record's number, written the one way, so a repad is not a new record.
+
+    This repo renamed `ADR-0003-...` to `ADR-003-...`. Compared as text those
+    are two identities, and the walk stops at the rename between them, which
+    refuses states the record plainly held.
+
+    Only the leading zeros go, and they go as text. Reading the number as an
+    integer instead would fold two records together twice over: `\\d` matches
+    every decimal digit, so a name written in another script is governed too
+    and would take the identity of the ASCII record holding the same value,
+    and a new file would inherit a real record's reviewed history. Stripping
+    zeros anywhere rather than in front would fold `ADR-100` into `ADR-1` the
+    same way. Text stripping leaves both pairs distinct.
+    """
+    prefix, _, number = identifier.upper().partition("-")
+    return f"{prefix}-{number.lstrip('0') or '0'}"
 
 
 def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]:

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -965,11 +965,19 @@ def _origin_main_blob_ids(repo_root: Path, path: str) -> set[str]:
     rather than re-reading the file at each commit is what makes that useful:
     at those older commits the current name does not exist yet. The widening
     is exactly one file's lineage, not any blob main happens to contain.
+
+    `-m` is what makes merges count. `--raw` prints nothing for a merge commit
+    unless asked, so an ADR whose only appearance in some state was a conflict
+    main resolved left no id behind, and a branch sitting on that resolution
+    failed on content main really had carried. `-m` splits the merge into one
+    diff per parent, which keeps the single-parent `:` raw form rather than
+    the `::` combined form, so the post-image stays the fourth field.
     """
     result = _run_git(
         repo_root,
         [
             "log",
+            "-m",
             "--follow",
             "--format=",
             "--raw",

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1094,8 +1094,9 @@ def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]
             # the path that has to qualify.
             continue
         blob_ids.add(metadata[3])
-    blob_ids.discard("0" * 40)
-    return blob_ids
+    # A deletion names no blob afterwards, and the width of that field follows
+    # the repository's hash.
+    return {blob_id for blob_id in blob_ids if not _is_zero_sha(blob_id)}
 
 
 def _origin_main_blob_ids(repo_root: Path, path: str) -> set[str]:

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -1014,6 +1014,13 @@ def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]
             "--format=",
             "--raw",
             "--no-abbrev",
+            # Paths arrive raw and NUL-separated. Left to the default, git
+            # quotes any path outside ASCII or carrying a quote, a backslash
+            # or a control character, and the scope test below ends on an
+            # anchor the closing quote defeats, so such an ADR would read as
+            # having no history. It also stops a tab inside a name from
+            # looking like the separator before a second path.
+            "-z",
             "origin/main",
             "--",
             path,
@@ -1022,15 +1029,29 @@ def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]
     if result.returncode != 0:
         return set()
     blob_ids: set[str] = set()
-    for line in result.stdout.splitlines():
-        if not line.startswith(":") or line.startswith("::"):
+    fields = result.stdout.split("\0")
+    index = 0
+    while index < len(fields):
+        record = fields[index]
+        index += 1
+        if not record.startswith(":") or record.startswith("::"):
             # A `::` record lists one pre-image per parent before the
             # post-image, so its fourth field is a pre-image and its width
             # depends on the parent count. Naming the format should keep these
-            # away; skipping them is what keeps that true if one arrives.
+            # away; skipping them is what keeps that true if one arrives. The
+            # paths that follow one fail this same test and are skipped too.
             continue
-        parts = line.split("\t")
-        if len(parts) < 2 or ADR_REVIEW_PATH_RE.search(parts[-1]) is None:
+        metadata = record.split()
+        if len(metadata) < 5:
+            continue
+        # A rename or a copy names a source and then a destination. Every
+        # other status names one path.
+        wanted = 2 if metadata[4][:1] in ("R", "C") else 1
+        paths = fields[index : index + wanted]
+        index += wanted
+        if len(paths) < wanted:
+            break
+        if ADR_REVIEW_PATH_RE.search(paths[-1]) is None:
             # `--follow` rewrites the path it tracks whenever it scores a drop
             # and an add as a rename, which is similarity and not provenance.
             # Crossing into a file this gate does not govern would read that
@@ -1038,10 +1059,7 @@ def _followed_blob_ids(repo_root: Path, path: str, diff_merges: str) -> set[str]
             # review. The post-image belongs to the record's destination path,
             # so that is the path that has to qualify.
             continue
-        fields = parts[0].split()
-        if len(fields) < 4:
-            continue
-        blob_ids.add(fields[3])
+        blob_ids.add(metadata[3])
     blob_ids.discard("0" * 40)
     return blob_ids
 

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -5079,6 +5079,8 @@ def test_commit_limit_relaxes_for_merge_from_main(
             return _completed(0, "30\n")
         if args[:2] == ["rev-list", "--merges"]:
             return _completed(0, "merge-sha\n")
+        if args[:2] == ["rev-list", "--first-parent"]:
+            return _completed(0, "main-parent\nolder-main\n")
         if args[0] == "show" and "--format=%P" in args:
             return _completed(0, "first-parent main-parent\n")
         return _completed(0)
@@ -5086,6 +5088,38 @@ def test_commit_limit_relaxes_for_merge_from_main(
     monkeypatch.setattr(policy, "_run_git", fake_git)
 
     assert policy._check_commit_limit(update, tmp_path) == 0
+
+
+def test_commit_limit_holds_when_the_merged_parent_is_off_main_trunk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The negative control for the test above.
+
+    Only the trunk answer changes. A parent main can reach but did not reach
+    by first parent is a branch main landed, and the wider limit is refused.
+    """
+    update = _push_update()
+
+    def fake_git(_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ["rev-list", "--count"]:
+            return _completed(0, "30\n")
+        if args[:2] == ["rev-list", "--merges"]:
+            return _completed(0, "merge-sha\n")
+        if args[:2] == ["rev-list", "--first-parent"]:
+            return _completed(0, "some-other-main-commit\n")
+        if args[0] == "show" and "--format=%P" in args:
+            return _completed(0, "first-parent landed-parent\n")
+        return _completed(0)
+
+    monkeypatch.setattr(policy, "_run_git", fake_git)
+    monkeypatch.setattr(
+        policy,
+        "_run_command",
+        lambda *_args, **_kwargs: _completed(1, stderr="no bypass\n"),
+    )
+
+    assert policy._check_commit_limit(update, tmp_path) == 1
 
 
 def test_main_merge_detection_handles_git_errors(
@@ -5195,6 +5229,114 @@ def test_main_merge_detection_still_reads_a_signed_merge_of_main(
     repo, merge = _repo_with_a_signed_merge(tmp_path, of_main=True)
 
     assert policy._merge_has_main_parent(merge, repo) is True
+
+
+def _repo_where_main_has_landed_a_branch(tmp_path: Path, name: str) -> Path:
+    """Build a repo whose main landed a feature branch through a merge.
+
+    `origin/main` then contains that branch's tip, but the tip is the second
+    parent of the merge that landed it, not a commit on main's own trunk.
+    Branch `trunk-landing` names the landing merge, and main carries one
+    commit past it, so a merge of an older trunk commit can be told from a
+    merge of main's tip.
+    """
+    repo = tmp_path / name
+    _init_repo(repo, branch="main")
+    _commit_file(repo, "base.md", "base\n")
+    # Named refs only. A raw sha as a branch point is not resolvable under this
+    # suite's git environment (Refs #3661).
+    _git(repo, "branch", "local")
+    _git(repo, "branch", "landed")
+    _git(repo, "checkout", "-q", "landed")
+    _commit_file(repo, "landed.md", "landed\n")
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "merge", "-q", "--no-ff", "-m", "land the feature", "landed")
+    _git(repo, "branch", "trunk-landing")
+    _commit_file(repo, "after.md", "after\n")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    _git(repo, "checkout", "-q", "local")
+    return repo
+
+
+def _merge_into_local(repo: Path, ref: str) -> str:
+    _git(repo, "merge", "-q", "--no-ff", "-m", f"merge {ref}", ref)
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def test_merging_a_branch_main_already_landed_is_not_a_merge_of_main(
+    tmp_path: Path,
+) -> None:
+    """A landed branch is an ancestor of main, and that is not enough.
+
+    Merging a branch main has already landed brings in no history main did
+    not already hand out, so it is not the case the raised limit exists for.
+    Reading the parent as main's because main can reach it lets any developer
+    take the wider limit by merging a branch whose pull request has landed,
+    which is ordinary git usage rather than an attack.
+    """
+    repo = _repo_where_main_has_landed_a_branch(tmp_path, "landed-branch")
+    merge = _merge_into_local(repo, "landed")
+
+    assert policy._merge_has_main_parent(merge, repo) is False
+
+
+def test_merging_main_itself_is_still_a_merge_of_main(tmp_path: Path) -> None:
+    """The negative control. The case the raised limit exists for still reads."""
+    repo = _repo_where_main_has_landed_a_branch(tmp_path, "merge-of-main")
+    merge = _merge_into_local(repo, "main")
+
+    assert policy._merge_has_main_parent(merge, repo) is True
+
+
+def test_merging_an_older_commit_on_main_is_a_merge_of_main(tmp_path: Path) -> None:
+    """Main's trunk is not just its tip.
+
+    A developer who merges main and then falls behind has still merged main,
+    so every commit main reaches by first parent counts, not only the newest.
+    """
+    repo = _repo_where_main_has_landed_a_branch(tmp_path, "older-main")
+    merge = _merge_into_local(repo, "trunk-landing")
+
+    assert policy._merge_has_main_parent(merge, repo) is True
+
+
+def test_a_landed_branch_does_not_widen_the_commit_limit(tmp_path: Path) -> None:
+    """The consumer reads the same way the detector does.
+
+    The limit is what this gate actually holds a push to, so the detector's
+    verdict is checked where it is spent as well as where it is made.
+    """
+    repo = _repo_where_main_has_landed_a_branch(tmp_path, "limit-landed")
+    base = _git(repo, "rev-parse", "local").stdout.strip()
+    for index in range(21):
+        _git(repo, "commit", "-q", "--allow-empty", "-m", f"local {index:02d}")
+    head = _merge_into_local(repo, "landed")
+    update = policy.PushUpdate(
+        policy.PushRef("refs/heads/local", head, "refs/heads/local", base),
+        base,
+        head,
+        f"{base}..{head}",
+        "local",
+    )
+
+    assert policy._contains_main_merge(update, repo) is False
+
+
+def test_a_merge_is_not_a_merge_of_main_when_there_is_no_origin_main(
+    tmp_path: Path,
+) -> None:
+    """The edge case. An unreadable trunk must not widen the limit.
+
+    A clone that has never fetched `origin/main` cannot say what main's trunk
+    holds. Reading nothing as reaching everything would hand the wider limit
+    to exactly the repos the gate knows least about.
+    """
+    repo = _repo_where_main_has_landed_a_branch(tmp_path, "no-origin")
+    _git(repo, "update-ref", "-d", "refs/remotes/origin/main")
+    merge = _merge_into_local(repo, "main")
+
+    assert policy._main_trunk_commits(repo) == frozenset()
+    assert policy._merge_has_main_parent(merge, repo) is False
 
 
 def test_review_marker_reports_git_error(

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -94,7 +94,7 @@ def _init_repo(repo: Path, branch: str = "feature/test") -> None:
 def _commit_file(repo: Path, relative_path: str, content: str) -> str:
     path = repo / relative_path
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content, encoding="utf-8")
+    path.write_bytes(content.encode("utf-8"))
     _git(repo, "add", "--", relative_path)
     _git(repo, "commit", "-qm", f"test: add {Path(relative_path).name}")
     return _git(repo, "rev-parse", "HEAD").stdout.strip()
@@ -4546,6 +4546,44 @@ def test_head_blob_reader_returns_content(tmp_path: Path) -> None:
     _commit_file(repo, "tracked", "content\n")
 
     assert policy._read_head_blob(repo, "tracked") == b"content\n"
+
+
+def test_committed_crlf_survives_the_trip_through_the_test_helper(tmp_path: Path) -> None:
+    """`_commit_file` has to store the bytes it was handed, on every platform.
+
+    The helper used `Path.write_text`, whose default newline handling
+    translates `\\n` to `os.linesep`. On Windows this content reached git as
+    `a\\r\\r\\nb\\r\\n`, so the reader below correctly returned bytes the
+    caller never asked for and the fixture looked like a broken reader. A
+    text-mode reader hid it by folding the endings back on the way out.
+
+    `os.linesep` is `\\n` here, so this test cannot fail on Linux. It pins the
+    contract that the helper stores the bytes it was handed, and Windows CI is
+    what exercises it.
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _commit_file(repo, "tracked", "a\r\nb\n")
+
+    assert policy._read_head_blob(repo, "tracked") == b"a\r\nb\n"
+
+
+def test_a_committed_lone_carriage_return_is_not_expanded(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _commit_file(repo, "tracked", "a\rb")
+
+    assert policy._read_head_blob(repo, "tracked") == b"a\rb"
+
+
+def test_the_head_blob_reader_returns_none_for_a_path_no_commit_holds(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    _commit_file(repo, "tracked", "content\n")
+
+    assert policy._read_head_blob(repo, "absent") is None
 
 
 def test_branch_policy_reports_git_configuration_error(

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -5339,6 +5339,37 @@ def test_a_merge_is_not_a_merge_of_main_when_there_is_no_origin_main(
     assert policy._merge_has_main_parent(merge, repo) is False
 
 
+def test_the_main_trunk_is_read_once_for_one_push(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reading main's trunk per merge walks the same history many times.
+
+    The walk is cheap on a small repo and is not cheap on a long-lived one,
+    and a push may legitimately carry many merges. Reading it once per push
+    keeps the cost flat in the number of merges pushed.
+    """
+    update = _push_update()
+    trunk_reads: list[Sequence[str]] = []
+
+    def fake_git(_root: Path, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ["rev-list", "--count"]:
+            return _completed(0, "5\n")
+        if args[:2] == ["rev-list", "--merges"]:
+            return _completed(0, "".join(f"merge-{index}\n" for index in range(25)))
+        if args[:2] == ["rev-list", "--first-parent"]:
+            trunk_reads.append(args)
+            return _completed(0, "a-main-commit\n")
+        if args[0] == "show" and "--format=%P" in args:
+            return _completed(0, "first-parent a-landed-branch\n")
+        return _completed(0)
+
+    monkeypatch.setattr(policy, "_run_git", fake_git)
+
+    assert policy._contains_main_merge(update, tmp_path) is False
+    assert len(trunk_reads) == 1
+
+
 def test_review_marker_reports_git_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -5079,7 +5079,7 @@ def test_commit_limit_relaxes_for_merge_from_main(
             return _completed(0, "30\n")
         if args[:2] == ["rev-list", "--merges"]:
             return _completed(0, "merge-sha\n")
-        if args[:3] == ["show", "-s", "--format=%P"]:
+        if args[0] == "show" and "--format=%P" in args:
             return _completed(0, "first-parent main-parent\n")
         return _completed(0)
 
@@ -5107,6 +5107,94 @@ def test_main_merge_detection_rejects_non_main_second_parent(
     monkeypatch.setattr(policy, "_run_git", lambda *_args: next(responses))
 
     assert not policy._merge_has_main_parent("merge", tmp_path)
+
+
+# A session fixture in tests/conftest.py injects `commit.gpgsign=false` through
+# GIT_CONFIG_COUNT, which outranks repo config. The command line outranks the
+# injection in turn, so signing is requested there and nowhere else.
+_SIGNING = ("-c", "commit.gpgsign=true")
+
+
+def _sign_with_ssh(repo: Path) -> None:
+    """Make this repo sign its commits, using the backend that needs no keyring.
+
+    Verification is left to fail. An unknown signer still makes git print a
+    verification line, which is the decoration under test.
+    """
+    keygen = shutil.which("ssh-keygen")
+    if keygen is None:
+        pytest.skip("ssh-keygen is required to build a signed history")
+    key = repo / "signing-key"
+    subprocess.run(
+        [keygen, "-q", "-t", "ed25519", "-N", "", "-C", "t", "-f", str(key)],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+    )
+    if not key.with_suffix(".pub").exists():
+        pytest.skip("ssh-keygen produced no key on this host")
+    _git(repo, "config", "gpg.format", "ssh")
+    _git(repo, "config", "user.signingkey", str(key.with_suffix(".pub")))
+
+
+def _repo_with_a_signed_merge(tmp_path: Path, of_main: bool) -> tuple[Path, str]:
+    """Build a repo holding one signed merge, and ask to see the signatures.
+
+    `of_main` chooses which merge. False builds one whose second parent is a
+    side branch and whose first parent is an ancestor of `origin/main`, which
+    is not a merge of main and must not raise the commit limit. True builds a
+    real merge of main, the case the limit is raised for.
+    """
+    repo = tmp_path / ("merge-of-main" if of_main else "merge-of-side")
+    _init_repo(repo, branch="main")
+    _sign_with_ssh(repo)
+    _commit_file(repo, "base.md", "base\n")
+    # Named refs only. A raw sha as a branch point is not resolvable under this
+    # suite's git environment (Refs #3661).
+    _git(repo, "branch", "side")
+    _git(repo, "branch", "pivot")
+    main_head = _commit_file(repo, "main-only.md", "main\n")
+    _git(repo, "update-ref", "refs/remotes/origin/main", main_head)
+    _git(repo, "checkout", "-q", "side")
+    _commit_file(repo, "side-only.md", "side\n")
+    if of_main:
+        _git(repo, *_SIGNING, "merge", "-q", "--no-ff", "-m", "merge main", "main")
+    else:
+        _git(repo, "checkout", "-q", "pivot")
+        _git(repo, *_SIGNING, "merge", "-q", "--no-ff", "-m", "merge side", "side")
+    merge = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert "gpgsig" in _git(repo, "cat-file", "commit", merge).stdout
+    # The setting under test lives in the developer's own config.
+    _git(repo, "config", "log.showSignature", "true")
+    return repo, merge
+
+
+def test_main_merge_detection_reads_a_signed_merge(tmp_path: Path) -> None:
+    """`log.showSignature` decorates `git show` as well as `git log`.
+
+    The parents are read by splitting that output and skipping the first
+    field, which is the merge's own first parent. Prefixed with a
+    verification report, the first field is a word of that report instead,
+    so the first parent joins the parents searched for main. A merge of a
+    side branch made from a commit main already holds then reports as a
+    merge of main, which doubles the commit limit this push is held to.
+    """
+    repo, merge = _repo_with_a_signed_merge(tmp_path, of_main=False)
+
+    assert policy._merge_has_main_parent(merge, repo) is False
+
+
+def test_main_merge_detection_still_reads_a_signed_merge_of_main(
+    tmp_path: Path,
+) -> None:
+    """The negative control for the test above.
+
+    Naming the signature behaviour must not stop a real merge of main from
+    being found, which is the case the raised limit exists for.
+    """
+    repo, merge = _repo_with_a_signed_merge(tmp_path, of_main=True)
+
+    assert policy._merge_has_main_parent(merge, repo) is True
 
 
 def test_review_marker_reports_git_error(

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import io
 import json
 import os
@@ -2597,12 +2598,11 @@ def test_pushed_suppression_scan_ignores_clean_worktree_override(tmp_path: Path)
     repo = tmp_path / "repo"
     _init_repo(repo)
     base = _commit_file(repo, "nested/source.py", "value = 1\n")
-    source = repo / "nested/source.py"
-    source.write_text(f"value = 1  {'# no' + 'sec'}\n", encoding="utf-8")
+    _write_file(repo, "nested/source.py", f"value = 1  {'# no' + 'sec'}\n")
     _git(repo, "add", "nested/source.py")
     _git(repo, "commit", "-qm", "test: pushed suppression")
     head = _git(repo, "rev-parse", "HEAD").stdout.strip()
-    source.write_text("value = 1\n", encoding="utf-8")
+    _write_file(repo, "nested/source.py", "value = 1\n")
     stream = io.StringIO(f"refs/heads/feature/test {head} refs/heads/feature/test {base}\n")
 
     assert policy.check_pushed_suppressions(stream, repo) == 1
@@ -2643,8 +2643,7 @@ def test_pushed_suppression_scan_ignores_unchanged_legacy_suppressions(
     _init_repo(repo)
     _commit_file(repo, "legacy.py", f"value = 1  {'# no' + 'sec'}\n")
     base = _commit_file(repo, "source.py", "value = 1\n")
-    source = repo / "source.py"
-    source.write_text("value = 2\n", encoding="utf-8")
+    _write_file(repo, "source.py", "value = 2\n")
     _git(repo, "add", "source.py")
     _git(repo, "commit", "-qm", "test: update clean source")
     head = _git(repo, "rev-parse", "HEAD").stdout.strip()
@@ -2661,12 +2660,11 @@ def test_pushed_semgrep_scan_materializes_immutable_head(
     _init_repo(repo)
     _commit_file(repo, "nested/source.py", "value = 1\n")
     base = _commit_file(repo, "unchanged.py", "dangerous = True\n")
-    source = repo / "nested/source.py"
-    source.write_text("dangerous = True\n", encoding="utf-8")
+    _write_file(repo, "nested/source.py", "dangerous = True\n")
     _git(repo, "add", "nested/source.py")
     _git(repo, "commit", "-qm", "test: pushed finding")
     head = _git(repo, "rev-parse", "HEAD").stdout.strip()
-    source.write_text("dangerous = False\n", encoding="utf-8")
+    _write_file(repo, "nested/source.py", "dangerous = False\n")
 
     def fake_scan(
         tree: Path,
@@ -4635,6 +4633,113 @@ def test_seeding_and_revising_a_file_differ_only_where_the_text_differs(
 
     assert changed is not None
     assert changed["mod.py"] == {2}
+
+
+def _repo_relative_path(node: ast.expr) -> str | None:
+    """Return `repo:a/b` for `repo / "a" / "b"`, else None."""
+    parts: list[str] = []
+    while isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+        if not isinstance(node.right, ast.Constant) or not isinstance(node.right.value, str):
+            return None
+        parts.append(node.right.value)
+        node = node.left
+    if not (isinstance(node, ast.Name) and parts):
+        return None
+    return node.id + ":" + "/".join(reversed(parts))
+
+
+def _functions_writing_one_path_two_ways(source: str) -> dict[str, list[str]]:
+    """Name every function that writes one repo path with both primitives.
+
+    Resolves single-assignment local aliases. A scan that only matched literal
+    paths reported this module clean while three functions still mixed, because
+    each bound the path to a local first. That blind spot is why this is a test
+    rather than a claim in a description.
+    """
+    found: dict[str, list[str]] = {}
+    for fn in ast.walk(ast.parse(source)):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        alias: dict[str, str] = {}
+        committed: set[str] = set()
+        texted: set[str] = set()
+        for node in ast.walk(fn):
+            if (
+                isinstance(node, ast.Assign)
+                and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+            ):
+                key = _repo_relative_path(node.value)
+                if key is not None:
+                    alias[node.targets[0].id] = key
+            if not isinstance(node, ast.Call):
+                continue
+            if (
+                isinstance(node.func, ast.Name)
+                and node.func.id in {"_commit_file", "_write_file"}
+                and len(node.args) >= 2
+                and isinstance(node.args[0], ast.Name)
+                and isinstance(node.args[1], ast.Constant)
+                and isinstance(node.args[1].value, str)
+            ):
+                committed.add(f"{node.args[0].id}:{node.args[1].value}")
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "write_text":
+                key = _repo_relative_path(node.func.value)
+                if key is None and isinstance(node.func.value, ast.Name):
+                    key = alias.get(node.func.value.id)
+                if key is not None:
+                    texted.add(key)
+        shared = sorted(committed & texted)
+        if shared:
+            found[fn.name] = shared
+    return found
+
+
+def test_no_function_writes_one_repo_path_with_both_primitives() -> None:
+    """The fixture writers must not disagree about newlines within one path.
+
+    `_commit_file` and `_write_file` write bytes; `Path.write_text` translates
+    `\n` to `os.linesep`. A function that seeds a path one way and revises it
+    the other produced two revisions differing on every line under Windows, so
+    any diff taken across them measured the line endings rather than the edit.
+    """
+    source = Path(__file__).read_text(encoding="utf-8")
+
+    assert _functions_writing_one_path_two_ways(source) == {}
+
+
+def test_the_mixed_writer_scan_sees_a_write_named_inline() -> None:
+    source = (
+        "def t(repo):\n"
+        "    _commit_file(repo, 'a.py', 'x\\n')\n"
+        "    (repo / 'a.py').write_text('y\\n')\n"
+    )
+
+    assert _functions_writing_one_path_two_ways(source) == {"t": ["repo:a.py"]}
+
+
+def test_the_mixed_writer_scan_sees_a_write_through_a_local_alias() -> None:
+    """The shape a literal-only scan missed, which let three of these through."""
+    source = (
+        "def t(repo):\n"
+        "    _commit_file(repo, 'nested/a.py', 'x\\n')\n"
+        "    source = repo / 'nested' / 'a.py'\n"
+        "    source.write_text('y\\n')\n"
+    )
+
+    assert _functions_writing_one_path_two_ways(source) == {"t": ["repo:nested/a.py"]}
+
+
+def test_the_mixed_writer_scan_leaves_two_different_paths_alone() -> None:
+    """Only one path written both ways is a defect; two paths are not."""
+    source = (
+        "def t(repo):\n"
+        "    _commit_file(repo, 'a.py', 'x\\n')\n"
+        "    other = repo / 'b.py'\n"
+        "    other.write_text('y\\n')\n"
+    )
+
+    assert _functions_writing_one_path_two_ways(source) == {}
 
 
 def test_the_head_blob_reader_returns_none_for_a_path_no_commit_holds(

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -100,6 +100,21 @@ def _commit_file(repo: Path, relative_path: str, content: str) -> str:
     return _git(repo, "rev-parse", "HEAD").stdout.strip()
 
 
+def _write_file(repo: Path, relative_path: str, content: str) -> None:
+    """Write a worktree file as the bytes it was handed.
+
+    `Path.write_text` translates `\n` to `os.linesep`, so a caller asking for
+    `a\nb` puts `a\r\nb` on disk under Windows. `_commit_file` writes bytes, so
+    a test that seeded a path one way and revised it the other produced two
+    revisions differing on every line, and any diff taken across them was of
+    the line endings rather than the edit. This is the same primitive, so the
+    two agree on every platform.
+    """
+    path = repo / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content.encode("utf-8"))
+
+
 def _copy_runtime_config(repo: Path) -> None:
     config = yaml.safe_load((PROJECT_ROOT / "lefthook.yml").read_text(encoding="utf-8"))
     for hook_name in ("commit-msg", "pre-commit", "pre-push"):
@@ -1461,7 +1476,7 @@ def test_stage_fixed_restages_only_the_formatted_input(tmp_path: Path) -> None:
     _commit_file(repo, "source.py", "before\n")
     _git(repo, "add", "lefthook.yml", "fixer.py")
     _git(repo, "commit", "-qm", "test: add formatter")
-    (repo / "source.py").write_text("changed\n", encoding="utf-8")
+    _write_file(repo, "source.py", "changed\n")
     _git(repo, "add", "source.py")
 
     _run_lefthook(repo, "run", "pre-commit", "--force")
@@ -1949,9 +1964,9 @@ def test_staged_dash_policy_reads_the_index_blob(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _init_repo(repo)
     _commit_file(repo, "doc.md", "clean\n")
-    (repo / "doc.md").write_text(f"bad {chr(0x2014)} text\n", encoding="utf-8")
+    _write_file(repo, "doc.md", f"bad {chr(0x2014)} text\n")
     _git(repo, "add", "doc.md")
-    (repo / "doc.md").write_text("working tree clean\n", encoding="utf-8")
+    _write_file(repo, "doc.md", "working tree clean\n")
 
     assert policy.check_staged_dashes(["doc.md"], repo) == 1
     assert policy.check_staged_dashes([], repo) == 0
@@ -2174,7 +2189,7 @@ def test_alternate_index_controls_staged_blob_and_generated_staging(
     alternate_index = repo / ".git/alternate-index"
     shutil.copy2(repo / ".git/index", alternate_index)
     monkeypatch.setenv("GIT_INDEX_FILE", str(alternate_index))
-    (repo / "doc.md").write_text(f"bad {chr(0x2014)} text\n", encoding="utf-8")
+    _write_file(repo, "doc.md", f"bad {chr(0x2014)} text\n")
     _git(repo, "add", "doc.md")
     generated.unlink()
 
@@ -2399,7 +2414,7 @@ def test_generated_staging_uses_the_named_allowlist(tmp_path: Path) -> None:
     _init_repo(repo)
     _commit_file(repo, ".vscode/mcp.json", '{"version": 1}\n')
     (repo / ".factory").mkdir()
-    (repo / ".vscode/mcp.json").write_text('{"version": 2}\n', encoding="utf-8")
+    _write_file(repo, ".vscode/mcp.json", '{"version": 2}\n')
     (repo / ".factory/mcp.json").write_text("{}\n", encoding="utf-8")
     (repo / "unrelated.txt").write_text("do not stage\n", encoding="utf-8")
 
@@ -2676,7 +2691,7 @@ def test_pushed_semgrep_scan_reads_export_ignored_changed_blob(
     repo = tmp_path / "repo"
     _init_repo(repo)
     base = _commit_file(repo, "nested/source.py", "value = 1\n")
-    (repo / "nested/source.py").write_text("dangerous = True\n", encoding="utf-8")
+    _write_file(repo, "nested/source.py", "dangerous = True\n")
     (repo / ".gitattributes").write_text(
         "nested/source.py export-ignore\n",
         encoding="utf-8",
@@ -2707,10 +2722,7 @@ def test_pushed_semgrep_scan_reads_unsubstituted_changed_blob(
     repo = tmp_path / "repo"
     _init_repo(repo)
     base = _commit_file(repo, "source.js", "const safe = true;\n")
-    (repo / "source.js").write_text(
-        "const value = '$Format:a%eval(userInput);$';\n",
-        encoding="utf-8",
-    )
+    _write_file(repo, "source.js", "const value = '$Format:a%eval(userInput);$';\n")
     (repo / ".gitattributes").write_text("source.js export-subst\n", encoding="utf-8")
     _git(repo, "add", "source.js", ".gitattributes")
     _git(repo, "commit", "-qm", "test: substitute pushed finding")
@@ -2738,7 +2750,7 @@ def test_pushed_semgrep_scan_ignores_local_replacement_blob(
     repo = tmp_path / "repo"
     _init_repo(repo)
     base = _commit_file(repo, "source.py", "dangerous = False\n")
-    (repo / "source.py").write_text("dangerous = True\n", encoding="utf-8")
+    _write_file(repo, "source.py", "dangerous = True\n")
     _git(repo, "add", "source.py")
     _git(repo, "commit", "-qm", "test: pushed finding")
     head = _git(repo, "rev-parse", "HEAD").stdout.strip()
@@ -4097,10 +4109,7 @@ def test_changed_line_map_reads_real_git_diff(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _init_repo(repo, branch="main")
     base = _commit_file(repo, "mod.py", "line one\nline two\nline three\n")
-    (repo / "mod.py").write_text(
-        "line one\nline TWO changed\nline three\nline four\nline five\n",
-        encoding="utf-8",
-    )
+    _write_file(repo, "mod.py", "line one\nline TWO changed\nline three\nline four\nline five\n")
     _git(repo, "add", "--", "mod.py")
     _git(repo, "commit", "-qm", "test: modify mod.py")
 
@@ -4574,6 +4583,58 @@ def test_a_committed_lone_carriage_return_is_not_expanded(tmp_path: Path) -> Non
     _commit_file(repo, "tracked", "a\rb")
 
     assert policy._read_head_blob(repo, "tracked") == b"a\rb"
+
+
+def test_a_worktree_write_stores_the_bytes_it_was_handed(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    _write_file(repo, "tracked", "one\ntwo\n")
+
+    assert (repo / "tracked").read_bytes() == b"one\ntwo\n"
+
+
+def test_a_worktree_write_leaves_carriage_returns_alone(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    _write_file(repo, "tracked", "one\r\ntwo\r")
+
+    assert (repo / "tracked").read_bytes() == b"one\r\ntwo\r"
+
+
+def test_a_worktree_write_creates_the_parent_directory(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    _write_file(repo, "nested/deeper/tracked", "content\n")
+
+    assert (repo / "nested/deeper/tracked").read_bytes() == b"content\n"
+
+
+def test_seeding_and_revising_a_file_differ_only_where_the_text_differs(
+    tmp_path: Path,
+) -> None:
+    """Pin the two fixture writers against each other.
+
+    `_commit_file` seeds a path and `_write_file` revises it, so a diff across
+    the pair has to show the edited line and nothing else. When the two used
+    different newline handling this diff was every line under Windows, which is
+    how `test_changed_line_map_reads_real_git_diff` failed there while passing
+    everywhere else. `os.linesep` is `\n` on Linux, so this cannot go red here;
+    Windows CI is what exercises it.
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo, branch="main")
+    base = _commit_file(repo, "mod.py", "one\ntwo\nthree\n")
+    _write_file(repo, "mod.py", "one\nTWO\nthree\n")
+    _git(repo, "add", "--", "mod.py")
+    _git(repo, "commit", "-qm", "test: revise mod.py")
+
+    changed = policy._changed_line_map(["mod.py"], repo, base)
+
+    assert changed is not None
+    assert changed["mod.py"] == {2}
 
 
 def test_the_head_blob_reader_returns_none_for_a_path_no_commit_holds(

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -1311,6 +1311,64 @@ class TestAdrReviewPolicyMergeScope:
         assert policy.check_adr_review_policy([relative], repo) == 1
         assert "ADR changes require adr-review evidence" in capsys.readouterr().err
 
+    def test_a_rename_does_not_hide_the_history_the_head_copy_came_from(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Renaming an ADR must not turn main's own revision into gated work.
+
+        The head-copy clause asked `rev-list` for the commits touching one
+        pathname, which stops at the rename. An ADR renamed on both branches
+        and revised on main then failed the clause on the branch's own copy,
+        because that copy lived under the former name, and a merge that only
+        brought main's revision in demanded review evidence for it.
+
+        Found by adversarial review round 51.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "test@example.invalid")
+        _git(repo, "config", "user.name", "Test User")
+        adr_dir = repo / ".agents" / "architecture"
+        adr_dir.mkdir(parents=True)
+        old_name = ".agents/architecture/ADR-093-old.md"
+        new_name = ".agents/architecture/ADR-093-new.md"
+        # Long enough that a one-line revision still scores as a rename. Git
+        # pairs paths at 50% similarity by default, and a three-line fixture
+        # would need the threshold lowered to pass, which would be tuning the
+        # gate to the test rather than to the documents it guards.
+        body = "\n".join(f"Context paragraph {index}." for index in range(20))
+        first = f"# ADR 093\n\n{body}\n\nDecision: first position.\n"
+        second = f"# ADR 093\n\n{body}\n\nDecision: second position.\n"
+        (repo / old_name).write_text(first, encoding="utf-8")
+        _commit(repo, "first position")
+        _git(repo, "branch", "local")
+
+        _git(repo, "mv", old_name, new_name)
+        (repo / new_name).write_text(second, encoding="utf-8")
+        _commit(repo, "rename and revise on main")
+        _point_origin_main_at_head(repo)
+
+        _git(repo, "checkout", "local")
+        _git(repo, "mv", old_name, new_name)
+        _commit(repo, "the branch renamed it too")
+
+        # Both sides moved the file, so the merge pairs the renames and takes
+        # main's revision on its own. Nothing here is authored by the branch.
+        merge = _run(["git", "merge", "--no-edit", "--no-commit", "--no-ff", "main"], repo)
+        assert merge.returncode == 0, merge.stderr
+        assert policy._read_index_blob(repo, new_name) == second.encode("utf-8")
+
+        assert policy._head_copy_is_one_main_has_carried(repo, new_name) is True
+        assert policy._merge_authored_adr_paths([new_name], repo) == []
+
+        monkeypatch.setattr(policy, "_gated_adr_review_paths", lambda paths, root: list(paths))
+        monkeypatch.setattr(policy, "_today_session_log", lambda sessions_dir: None)
+        assert policy.check_adr_review_policy([new_name], repo) == 0
+
+
 def _merge_carrying_main_adr(tmp_path: Path, adr_bytes: bytes, name: str) -> Path:
     """Build a repo mid-merge whose staged ADR is the one main contributed.
 

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -1631,6 +1631,43 @@ class TestAdrReviewPolicyMergeScope:
         # a state main really held at this path.
         assert moved_in in carried
 
+    def test_a_file_merely_ending_in_the_protocol_name_is_not_carried(
+        self,
+        tmp_path,
+    ):
+        """A suffix match is not a path this gate governs.
+
+        The ADR half of the path test is anchored to a path segment, so
+        `docs/not-ADR-096-x.md` is correctly foreign. The protocol half was
+        not, so any name ending in the protocol's filename matched it:
+        `docs/fake-SESSION-PROTOCOL.md` read as governed, and a lineage
+        `--follow` crossed into it was admitted as one main had carried.
+
+        Found by review on PR #3680.
+        """
+        repo, adr_path, foreign = _repo_where_a_merge_linked_a_non_adr_file(
+            tmp_path,
+            ordinary="docs/fake-SESSION-PROTOCOL.md",
+        )
+
+        carried = policy._origin_main_blob_ids(repo, adr_path)
+
+        assert foreign not in carried
+        assert policy._head_copy_is_one_main_has_carried(repo, adr_path) is False
+
+    def test_the_protocol_itself_is_still_a_path_this_gate_governs(
+        self,
+        tmp_path,
+    ):
+        """The negative control for the test above.
+
+        Anchoring the protocol half must not narrow it past the real file,
+        which lives one directory down and is the reason the alternative
+        exists. Checked at both the segment boundary and the repository root.
+        """
+        assert policy.ADR_REVIEW_PATH_RE.search(".agents/SESSION-PROTOCOL.md")
+        assert policy.ADR_REVIEW_PATH_RE.search("SESSION-PROTOCOL.md")
+
     def test_a_rename_between_two_adrs_is_still_carried(
         self,
         tmp_path,
@@ -1647,7 +1684,10 @@ class TestAdrReviewPolicyMergeScope:
         assert side_blob in policy._origin_main_blob_ids(repo, name)
 
 
-def _repo_where_a_merge_linked_a_non_adr_file(tmp_path: Path) -> tuple[Path, str, str]:
+def _repo_where_a_merge_linked_a_non_adr_file(
+    tmp_path: Path,
+    ordinary: str = "notes.md",
+) -> tuple[Path, str, str]:
     """Build a repo where `--follow` crosses from an ADR into an ordinary file.
 
     One branch edits `notes.md`; another drops it and adds an ADR holding that
@@ -1664,9 +1704,9 @@ def _repo_where_a_merge_linked_a_non_adr_file(tmp_path: Path) -> tuple[Path, str
     _git(repo, "config", "user.name", "Test User")
     _git(repo, "config", "diff.renames", "true")
 
-    ordinary = "notes.md"
     adr = ".agents/architecture/ADR-096-linked.md"
     (repo / ".agents" / "architecture").mkdir(parents=True)
+    (repo / ordinary).parent.mkdir(parents=True, exist_ok=True)
     (repo / ordinary).write_bytes(b"the state that was never an adr\n")
     _git(repo, "add", "--", ordinary)
     _git(repo, "commit", "-qm", "an ordinary file")

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -1803,6 +1803,35 @@ class TestGovernedDocumentIdentity:
             ".agents/architecture/ADR-201-first.md"
         )
 
+    def test_a_directory_named_for_a_record_does_not_shadow_the_file(self):
+        """The number is read where the path test anchors: the last segment.
+
+        Read across the whole path, the first number wins, so a file under a
+        directory carrying another record's number reports that record. Two
+        different decisions would then share one identity and a walk would
+        cross between them, which is the hole scoping the walk closed.
+        """
+        nested = ".agents/ADR-201-old/ADR-202-new.md"
+
+        assert policy._governed_document_identity(
+            nested
+        ) == policy._governed_document_identity(
+            ".agents/architecture/ADR-202-second.md"
+        )
+        assert policy._governed_document_identity(
+            nested
+        ) != policy._governed_document_identity(
+            ".agents/architecture/ADR-201-first.md"
+        )
+
+    def test_a_windows_separator_still_names_the_last_segment(self):
+        """The path test accepts a backslash, so reading the number must too."""
+        assert policy._governed_document_identity(
+            r".agents\ADR-201-old\ADR-202-new.md"
+        ) == policy._governed_document_identity(
+            ".agents/architecture/ADR-202-second.md"
+        )
+
     @pytest.mark.parametrize(
         "path",
         [

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -1368,6 +1368,61 @@ class TestAdrReviewPolicyMergeScope:
         monkeypatch.setattr(policy, "_today_session_log", lambda sessions_dir: None)
         assert policy.check_adr_review_policy([new_name], repo) == 0
 
+    def test_a_conflict_main_resolved_in_a_merge_is_a_state_main_has_carried(
+        self,
+        tmp_path,
+    ):
+        """`git log --raw` says nothing about a merge unless it is asked to.
+
+        Without `-m`, git prints no diff for a merge commit, so an ADR whose
+        only appearance in that state was a conflict resolution left no blob id
+        behind. A branch sitting on that resolution held content main really
+        had carried and still failed the head-copy clause, which demands review
+        evidence for a file the branch never opened.
+
+        The revision after the merge is what makes this observable: without it
+        the resolution is `origin/main`'s tip and the tip lookup covers it.
+
+        Found by adversarial review round 52.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "test@example.invalid")
+        _git(repo, "config", "user.name", "Test User")
+        adr_dir = repo / ".agents" / "architecture"
+        adr_dir.mkdir(parents=True)
+        name = ".agents/architecture/ADR-096-contested.md"
+        (repo / name).write_text("# ADR 096\n\nbase.\n", encoding="utf-8")
+        _commit(repo, "base")
+
+        _git(repo, "checkout", "-b", "sideways")
+        (repo / name).write_text("# ADR 096\n\nsideways.\n", encoding="utf-8")
+        _commit(repo, "sideways position")
+
+        _git(repo, "checkout", "main")
+        (repo / name).write_text("# ADR 096\n\nmainline.\n", encoding="utf-8")
+        _commit(repo, "mainline position")
+
+        conflicted = _run(["git", "merge", "--no-edit", "sideways"], repo)
+        assert conflicted.returncode != 0, "the fixture needs a real conflict"
+        resolved = "# ADR 096\n\nresolved in the merge.\n"
+        (repo / name).write_text(resolved, encoding="utf-8")
+        _git(repo, "add", name)
+        _git(repo, "commit", "--no-edit", "-m", "resolve the ADR while merging")
+        _git(repo, "branch", "local")
+
+        # Main moves past the resolution, so it is no longer the tip blob and
+        # only the merge commit's own diff can account for it.
+        (repo / name).write_text("# ADR 096\n\nlater still.\n", encoding="utf-8")
+        _commit(repo, "revise after the merge")
+        _point_origin_main_at_head(repo)
+
+        _git(repo, "checkout", "local")
+        assert policy._read_head_blob(repo, name) == resolved.encode("utf-8")
+
+        assert policy._head_copy_is_one_main_has_carried(repo, name) is True
+
 
 def _merge_carrying_main_adr(tmp_path: Path, adr_bytes: bytes, name: str) -> Path:
     """Build a repo mid-merge whose staged ADR is the one main contributed.

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -1248,6 +1248,69 @@ class TestAdrReviewPolicyMergeScope:
         assert policy._read_head_blob(repo, relative) == policy._read_index_blob(repo, relative)
         assert policy._merge_authored_adr_paths([relative], repo) == []
 
+    def test_typing_mains_text_during_an_unrelated_merge_is_not_the_merge_carrying_it(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ):
+        """The merge-parent clause had no test that failed when it was removed.
+
+        Round 50 claimed every clause of this rule was mutation-proved. It was
+        not. The stale-`origin/main` test fails the head-copy clause as well,
+        so deleting the merge-parent clause left the whole class green. This
+        is the discriminator that separates them: the staged blob matches
+        `origin/main`, the copy it replaces is one `origin/main` has carried,
+        and the merge carried nothing of the kind.
+
+        The exemption is for what a merge brought in. An author who types the
+        text during someone else's merge has not been reviewed by that merge,
+        and whether the text is current or a reversion depends on how stale
+        `origin/main` is, which this gate cannot see.
+
+        Found by adversarial review round 51.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "test@example.invalid")
+        _git(repo, "config", "user.name", "Test User")
+        adr_dir = repo / ".agents" / "architecture"
+        adr_dir.mkdir(parents=True)
+        adr = adr_dir / "ADR-092-typed.md"
+        adr.write_text("# ADR 092\n\nfirst position.\n", encoding="utf-8")
+        _commit(repo, "first position")
+        _git(repo, "branch", "local")
+        _git(repo, "branch", "side")
+
+        adr.write_text("# ADR 092\n\nsecond position.\n", encoding="utf-8")
+        _commit(repo, "second position")
+        _point_origin_main_at_head(repo)
+
+        _git(repo, "checkout", "side")
+        (repo / "side.txt").write_text("side work\n", encoding="utf-8")
+        _commit(repo, "side work")
+
+        _git(repo, "checkout", "local")
+        merge = _run(["git", "merge", "--no-edit", "--no-commit", "--no-ff", "side"], repo)
+        assert merge.returncode == 0, merge.stderr
+
+        relative = ".agents/architecture/ADR-092-typed.md"
+        adr.write_text("# ADR 092\n\nsecond position.\n", encoding="utf-8")
+        _git(repo, "add", relative)
+
+        staged = policy._read_index_blob(repo, relative)
+        merge_parents = policy._merge_head_commits(repo)
+        assert policy._blob_is_at_any(repo, merge_parents, relative, staged) is False
+        assert policy._read_commit_blob_bytes(repo, "origin/main", relative) == staged
+        assert policy._head_copy_is_one_main_has_carried(repo, relative) is True
+
+        assert policy._merge_authored_adr_paths([relative], repo) == [relative]
+        monkeypatch.setattr(policy, "_gated_adr_review_paths", lambda paths, root: list(paths))
+        monkeypatch.setattr(policy, "_today_session_log", lambda sessions_dir: None)
+        assert policy.check_adr_review_policy([relative], repo) == 1
+        assert "ADR changes require adr-review evidence" in capsys.readouterr().err
+
 def _merge_carrying_main_adr(tmp_path: Path, adr_bytes: bytes, name: str) -> Path:
     """Build a repo mid-merge whose staged ADR is the one main contributed.
 

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -1426,14 +1426,27 @@ class TestAdrReviewPolicyMergeScope:
     ):
         """No user preference may change what this gate accepts.
 
-        `log.diffMerges` has five values and `-m` honours all of them, so the
-        set the gate reasons about moved with a setting the developer chose for
-        readability. Naming the format instead makes the answer the same on
-        every machine, which is the property worth asserting: not that one
-        value works, but that the setting is not an input.
+        `log.diffMerges` has seven values in git 2.43 and `-m` honours all of
+        them, so the set the gate reasons about moved with a setting the
+        developer chose for readability. Naming the format instead makes the
+        answer the same on every machine, which is the property worth
+        asserting: not that one value works, but that the setting is not an
+        input.
+
+        `remerge` is included so the enumeration is the whole set rather than
+        the values that happened to come to mind. It reconstructs the merge
+        rather than reporting it, so it is the value least like the others.
         """
         answers = {}
-        for setting in ("combined", "dense-combined", "separate", "on", "first-parent", "off"):
+        for setting in (
+            "combined",
+            "dense-combined",
+            "separate",
+            "on",
+            "first-parent",
+            "off",
+            "remerge",
+        ):
             repo, name, _ = _repo_where_main_resolved_an_adr_in_a_merge(
                 tmp_path / setting,
                 diff_merges=setting,
@@ -1496,14 +1509,27 @@ class TestAdrReviewPolicyMergeScope:
         """
         repo = tmp_path / "repo"
         repo.mkdir()
+        adr = ".agents/architecture/ADR-095-synthetic.md"
         combined = (
             "::100644 100644 100644 "
             "1111111111111111111111111111111111111111 "
             "2222222222222222222222222222222222222222 "
-            "3333333333333333333333333333333333333333 MM\tdoc.md\n"
+            "3333333333333333333333333333333333333333 MM\t" + adr + "\n"
             ":100644 100644 "
             "4444444444444444444444444444444444444444 "
-            "5555555555555555555555555555555555555555 M\tdoc.md\n"
+            "5555555555555555555555555555555555555555 M\t" + adr + "\n"
+            # Contains "ADR" and is not a path this gate governs. The
+            # membership test the records are filtered by is the gate's own,
+            # not a substring the name happens to carry.
+            ":100644 100644 "
+            "6666666666666666666666666666666666666666 "
+            "7777777777777777777777777777777777777777 M\tdocs/ADR-overview.md\n"
+            # A file moved in to become an ADR. The post-image is at the ADR
+            # path from this commit on, so the destination is what decides it,
+            # and reading the source instead would drop a state main holds.
+            ":100644 100644 "
+            "9999999999999999999999999999999999999999 "
+            "8888888888888888888888888888888888888888 R100\tnotes.md\t" + adr + "\n"
         )
         monkeypatch.setattr(
             policy,
@@ -1511,7 +1537,103 @@ class TestAdrReviewPolicyMergeScope:
             lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=combined),
         )
 
-        assert policy._origin_main_blob_ids(repo, "doc.md") == {"5" * 40}
+        assert policy._origin_main_blob_ids(repo, adr) == {"5" * 40, "8" * 40}
+
+    def test_a_lineage_the_gate_does_not_govern_is_not_carried(
+        self,
+        tmp_path,
+    ):
+        """`--follow` will cross into a file that was never an ADR.
+
+        Rename detection is similarity, not provenance. A commit that drops one
+        file and adds another is indistinguishable from a move, so `--follow`
+        rewrites the path it is tracking onto the dropped file and keeps
+        walking. Every state that file ever held then reads as a state of this
+        ADR.
+
+        When the file it crossed into is not one this gate governs, those
+        states never faced ADR review at all: an ordinary file changes under
+        ordinary review, and its contents were never a decision record. A
+        branch placing one of them at an ADR path would be exempted from the
+        review it exists to require, on content main never carried there.
+
+        Found independently by two reviewers on PR #3680.
+        """
+        repo, adr_path, foreign = _repo_where_a_merge_linked_a_non_adr_file(tmp_path)
+        moved_in = _git(repo, "rev-parse", "side:" + adr_path).stdout.strip()
+
+        carried = policy._origin_main_blob_ids(repo, adr_path)
+
+        assert foreign not in carried
+        assert policy._head_copy_is_one_main_has_carried(repo, adr_path) is False
+        # The state the file held once it was an ADR is main's to carry: the
+        # record that moved it in has the ADR as its destination. Qualifying on
+        # the source path instead would drop it and demand review evidence for
+        # a state main really held at this path.
+        assert moved_in in carried
+
+    def test_a_rename_between_two_adrs_is_still_carried(
+        self,
+        tmp_path,
+    ):
+        """Refusing foreign lineages must not refuse the one this gate wants.
+
+        The negative control for the test above. An ADR that main moved and
+        revised is the false positive the rename-aware lookup exists to
+        remove, and both of its names are paths this gate governs, so the
+        states under the former name stay carried.
+        """
+        repo, name, side_blob = _repo_where_a_rename_crossed_a_merge(tmp_path)
+
+        assert side_blob in policy._origin_main_blob_ids(repo, name)
+
+
+def _repo_where_a_merge_linked_a_non_adr_file(tmp_path: Path) -> tuple[Path, str, str]:
+    """Build a repo where `--follow` crosses from an ADR into an ordinary file.
+
+    One branch edits `notes.md`; another drops it and adds an ADR holding that
+    same text, which git scores as a rename. Merging the two puts the link on
+    `origin/main`, so following the ADR walks into the file's history.
+
+    Returns the repo, the ADR path, and a blob `notes.md` held before the link
+    that was never at the ADR path in any commit.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "diff.renames", "true")
+
+    ordinary = "notes.md"
+    adr = ".agents/architecture/ADR-096-linked.md"
+    (repo / ".agents" / "architecture").mkdir(parents=True)
+    (repo / ordinary).write_bytes(b"the state that was never an adr\n")
+    _git(repo, "add", "--", ordinary)
+    _git(repo, "commit", "-qm", "an ordinary file")
+    foreign = _git(repo, "rev-parse", "HEAD:" + ordinary).stdout.strip()
+
+    _git(repo, "checkout", "-qb", "side", "HEAD")
+    _git(repo, "rm", "-q", "--", ordinary)
+    (repo / adr).write_bytes(b"carried text\n")
+    _git(repo, "add", "--", adr)
+    _git(repo, "commit", "-qm", "side drops the file and adds an adr")
+
+    _git(repo, "checkout", "-q", "main")
+    (repo / ordinary).write_bytes(b"carried text\n")
+    _git(repo, "commit", "-qam", "main edits the ordinary file")
+
+    _run(["git", "merge", "--no-edit", "side"], repo)
+    (repo / ordinary).unlink(missing_ok=True)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "merge keeps the adr and drops the file")
+
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+    _git(repo, "checkout", "-qb", "feature")
+    (repo / adr).write_bytes(b"the state that was never an adr\n")
+    _git(repo, "commit", "-qam", "place the file's old text at the adr path")
+    return repo, adr, foreign
 
 
 def _repo_where_a_rename_crossed_a_merge(tmp_path: Path) -> tuple[Path, str, str]:

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -36,6 +36,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -1385,43 +1386,149 @@ class TestAdrReviewPolicyMergeScope:
 
         Found by adversarial review round 52.
         """
-        repo = tmp_path / "repo"
-        repo.mkdir()
-        _git(repo, "init", "-b", "main")
-        _git(repo, "config", "user.email", "test@example.invalid")
-        _git(repo, "config", "user.name", "Test User")
-        adr_dir = repo / ".agents" / "architecture"
-        adr_dir.mkdir(parents=True)
-        name = ".agents/architecture/ADR-096-contested.md"
-        (repo / name).write_text("# ADR 096\n\nbase.\n", encoding="utf-8")
-        _commit(repo, "base")
+        repo, name, resolved = _repo_where_main_resolved_an_adr_in_a_merge(tmp_path)
 
-        _git(repo, "checkout", "-b", "sideways")
-        (repo / name).write_text("# ADR 096\n\nsideways.\n", encoding="utf-8")
-        _commit(repo, "sideways position")
-
-        _git(repo, "checkout", "main")
-        (repo / name).write_text("# ADR 096\n\nmainline.\n", encoding="utf-8")
-        _commit(repo, "mainline position")
-
-        conflicted = _run(["git", "merge", "--no-edit", "sideways"], repo)
-        assert conflicted.returncode != 0, "the fixture needs a real conflict"
-        resolved = "# ADR 096\n\nresolved in the merge.\n"
-        (repo / name).write_text(resolved, encoding="utf-8")
-        _git(repo, "add", name)
-        _git(repo, "commit", "--no-edit", "-m", "resolve the ADR while merging")
-        _git(repo, "branch", "local")
-
-        # Main moves past the resolution, so it is no longer the tip blob and
-        # only the merge commit's own diff can account for it.
-        (repo / name).write_text("# ADR 096\n\nlater still.\n", encoding="utf-8")
-        _commit(repo, "revise after the merge")
-        _point_origin_main_at_head(repo)
-
-        _git(repo, "checkout", "local")
-        assert policy._read_head_blob(repo, name) == resolved.encode("utf-8")
+        assert policy._read_head_blob(repo, name) == resolved
 
         assert policy._head_copy_is_one_main_has_carried(repo, name) is True
+
+    def test_a_users_diff_merges_setting_does_not_hide_the_resolution(
+        self,
+        tmp_path,
+    ):
+        """`-m` takes its output format from the user's `log.diffMerges`.
+
+        `-m` means `--diff-merges=on`, and `on` defers to whatever
+        `log.diffMerges` says. Set to `combined` or `dense-combined`, the merge
+        prints one `::` record instead of one `:` record per parent, and that
+        record is laid out differently: the fourth field is the first parent's
+        pre-image rather than the post-image. So the resolution blob went
+        missing again, and a blob nobody asked about took its place in the set.
+
+        Asking for `separate` by name pins the format the parser was written
+        for. The setting is a normal user preference, not an attack, and the
+        gate runs on whatever machine the developer configured.
+
+        Found by a bot reviewer on PR #3680.
+        """
+        repo, name, resolved = _repo_where_main_resolved_an_adr_in_a_merge(
+            tmp_path,
+            diff_merges="combined",
+        )
+
+        assert policy._read_head_blob(repo, name) == resolved
+
+        assert policy._head_copy_is_one_main_has_carried(repo, name) is True
+
+    def test_the_blob_set_is_the_same_under_every_diff_merges_setting(
+        self,
+        tmp_path,
+    ):
+        """No user preference may change what this gate accepts.
+
+        `log.diffMerges` has five values and `-m` honours all of them, so the
+        set the gate reasons about moved with a setting the developer chose for
+        readability. Naming the format instead makes the answer the same on
+        every machine, which is the property worth asserting: not that one
+        value works, but that the setting is not an input.
+        """
+        answers = {}
+        for setting in ("combined", "dense-combined", "separate", "on", "first-parent"):
+            repo, name, _ = _repo_where_main_resolved_an_adr_in_a_merge(
+                tmp_path / setting,
+                diff_merges=setting,
+            )
+            answers[setting] = policy._origin_main_blob_ids(repo, name)
+
+        assert len(set(map(frozenset, answers.values()))) == 1, answers
+
+    def test_a_combined_diff_record_is_never_read_as_a_post_image(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Refuse a record shape the field positions do not describe.
+
+        A `::` record carries one pre-image per parent before the post-image,
+        so its fourth field is a pre-image and its width grows with the parent
+        count. Reading it as a post-image puts a blob in the carried set that
+        answers a question nobody asked.
+
+        Naming the format should mean these never arrive. Skipping them is what
+        keeps that true when a later git, or a flag someone adds here, produces
+        one anyway, and the field positions are not self-describing enough to
+        notice on their own.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        combined = (
+            "::100644 100644 100644 "
+            "1111111111111111111111111111111111111111 "
+            "2222222222222222222222222222222222222222 "
+            "3333333333333333333333333333333333333333 MM\tdoc.md\n"
+            ":100644 100644 "
+            "4444444444444444444444444444444444444444 "
+            "5555555555555555555555555555555555555555 M\tdoc.md\n"
+        )
+        monkeypatch.setattr(
+            policy,
+            "_run_git",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=combined),
+        )
+
+        assert policy._origin_main_blob_ids(repo, "doc.md") == {"5" * 40}
+
+
+def _repo_where_main_resolved_an_adr_in_a_merge(
+    tmp_path: Path,
+    diff_merges: str | None = None,
+) -> tuple[Path, str, bytes]:
+    """Build a repo whose ADR reached its current text inside a merge.
+
+    Main and a side branch each revise the ADR, the merge conflicts, and main
+    resolves it by hand. Main then revises the file again, which is what makes
+    the resolution observable: without that last commit the resolution is
+    `origin/main`'s tip and the separate tip lookup accounts for it.
+
+    `local` sits on the resolution, so it holds content main really carried
+    and any answer other than True demands review evidence for a file the
+    branch never opened.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    if diff_merges is not None:
+        _git(repo, "config", "log.diffMerges", diff_merges)
+    adr_dir = repo / ".agents" / "architecture"
+    adr_dir.mkdir(parents=True)
+    name = ".agents/architecture/ADR-096-contested.md"
+    (repo / name).write_text("# ADR 096\n\nbase.\n", encoding="utf-8")
+    _commit(repo, "base")
+
+    _git(repo, "checkout", "-b", "sideways")
+    (repo / name).write_text("# ADR 096\n\nsideways.\n", encoding="utf-8")
+    _commit(repo, "sideways position")
+
+    _git(repo, "checkout", "main")
+    (repo / name).write_text("# ADR 096\n\nmainline.\n", encoding="utf-8")
+    _commit(repo, "mainline position")
+
+    conflicted = _run(["git", "merge", "--no-edit", "sideways"], repo)
+    assert conflicted.returncode != 0, "the fixture needs a real conflict"
+    resolved = "# ADR 096\n\nresolved in the merge.\n"
+    (repo / name).write_text(resolved, encoding="utf-8")
+    _git(repo, "add", name)
+    _git(repo, "commit", "--no-edit", "-m", "resolve the ADR while merging")
+    _git(repo, "branch", "local")
+
+    (repo / name).write_text("# ADR 096\n\nlater still.\n", encoding="utf-8")
+    _commit(repo, "revise after the merge")
+    _point_origin_main_at_head(repo)
+
+    _git(repo, "checkout", "local")
+    return repo, name, resolved.encode("utf-8")
 
 
 def _merge_carrying_main_adr(tmp_path: Path, adr_bytes: bytes, name: str) -> Path:

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -1598,6 +1598,41 @@ class TestAdrReviewPolicyMergeScope:
 
         assert policy._origin_main_blob_ids(repo, adr) == {"5" * 40, "8" * 40}
 
+    def test_a_deletions_empty_post_image_is_never_carried(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A record that removes a file names no blob afterwards.
+
+        Its post-image field is all zeros, which is not a state main carried
+        and not an object at all. The width of that field follows the
+        repository's hash, so dropping only the shorter one leaves the longer
+        one in the set.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        adr = ".agents/architecture/ADR-098-deleted.md"
+        records = (
+            ":100644 000000 "
+            "1111111111111111111111111111111111111111 "
+            + "0" * 40
+            + " D\0"
+            + adr
+            + "\0"
+            ":100644 000000 " + "2" * 64 + " " + "0" * 64 + " D\0" + adr + "\0"
+            ":100644 100644 "
+            "3333333333333333333333333333333333333333 "
+            "4444444444444444444444444444444444444444 M\0" + adr + "\0"
+        )
+        monkeypatch.setattr(
+            policy,
+            "_run_git",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=records),
+        )
+
+        assert policy._origin_main_blob_ids(repo, adr) == {"4" * 40}
+
     def test_a_lineage_the_gate_does_not_govern_is_not_carried(
         self,
         tmp_path,

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -1745,6 +1745,79 @@ class TestAdrReviewPolicyMergeScope:
 
         assert side_blob in policy._origin_main_blob_ids(repo, name)
 
+    def test_a_rename_that_only_repads_the_number_is_still_carried(
+        self,
+        tmp_path,
+    ):
+        """One record padded differently is still the same record.
+
+        The identity is read as the literal text of the number, so `ADR-0003`
+        and `ADR-003` compare unequal and the walk stops at the rename between
+        them. This repo really made that rename, so a branch restoring a state
+        the record held under its wider name is refused for no reason.
+        """
+        repo, name, before = _repo_where_a_rename_repadded_the_number(tmp_path, "ADR-003")
+
+        assert before in policy._origin_main_blob_ids(repo, name)
+
+    def test_a_rename_that_changes_the_number_is_still_refused(
+        self,
+        tmp_path,
+    ):
+        """The negative control. Repadding is not licence to cross records.
+
+        Reading `ADR-0003` and `ADR-003` as one record must not also read
+        `ADR-0003` and `ADR-004` as one: those are two decisions, and a state
+        of the first is not a reviewed state of the second.
+        """
+        repo, name, before = _repo_where_a_rename_repadded_the_number(tmp_path, "ADR-004")
+
+        assert before not in policy._origin_main_blob_ids(repo, name)
+
+    def test_a_number_written_in_other_digits_stays_its_own_record(
+        self,
+        tmp_path,
+    ):
+        """Normalizing the padding must not normalize away the digits.
+
+        `\\d` matches every decimal digit, not only ASCII, so a name written
+        in Arabic-Indic digits is governed too. Reading its number as an
+        integer would give it the identity of the ASCII record holding the
+        same value, and a brand new file would inherit that record's reviewed
+        history. Padding is normalized by text, so this stays distinct.
+        """
+        arabic = policy._governed_document_identity("ADR-\u0660\u0660\u0663.md")
+
+        assert arabic is not None
+        assert arabic != policy._governed_document_identity("ADR-3.md")
+
+    def test_a_zero_inside_the_number_is_not_stripped(
+        self,
+        tmp_path,
+    ):
+        """Dropping the padding must not drop the value.
+
+        Only the zeros in front are padding. Removing every zero would read
+        `ADR-100` as `ADR-1`, and a hundredth record would inherit the first
+        record's reviewed history.
+        """
+        hundredth = policy._governed_document_identity("ADR-100.md")
+
+        assert hundredth != policy._governed_document_identity("ADR-1.md")
+        assert hundredth == "ADR-100"
+
+    def test_a_record_numbered_zero_keeps_a_number(
+        self,
+        tmp_path,
+    ):
+        """Stripping the padding off `ADR-000` must leave a number behind.
+
+        The edge case of the strip: every digit is padding. The identity has
+        to stay a number rather than become the bare prefix, or `ADR-000` and
+        a name carrying no digits at all would read alike.
+        """
+        assert policy._governed_document_identity("ADR-000.md") == "ADR-0"
+
     def test_a_signed_history_is_still_read(
         self,
         tmp_path,
@@ -2149,6 +2222,44 @@ def _repo_where_the_history_is_signed(
 
     carried = _git(repo, "rev-parse", "HEAD:" + adr).stdout.strip()
     return repo, adr, carried
+
+
+def _repo_where_a_rename_repadded_the_number(
+    tmp_path: Path,
+    renamed_to: str,
+) -> tuple[Path, str, str]:
+    """Build a history where main renamed one record and kept its value.
+
+    Modelled on this repo's own `ADR-0003-...` to `ADR-003-...` rename. The
+    caller chooses the new number so the same fixture serves the negative
+    control, where the rename really does cross into another record.
+    """
+    repo = tmp_path / ("repad-" + renamed_to)
+    repo.mkdir()
+    _init_push_repo(repo)
+
+    before_name = ".agents/architecture/ADR-0003-tool-selection.md"
+    after_name = f".agents/architecture/{renamed_to}-tool-selection.md"
+    # Git reads a rename by similarity, so the revision has to leave most of
+    # the body alone or there is no rename for the walk to cross.
+    body = ["# Tool selection", "", "## Context", "", "One line per criterion.", ""]
+    body += [f"criterion {n}" for n in range(20)]
+    document = repo / before_name
+    document.parent.mkdir(parents=True, exist_ok=True)
+    document.write_text("\n".join(body) + "\n", encoding="utf-8")
+    _git(repo, "add", before_name)
+    _git(repo, "commit", "-m", "record the decision")
+    before = _git(repo, "rev-parse", "HEAD:" + before_name).stdout.strip()
+
+    _git(repo, "mv", before_name, after_name)
+    body[4] = "One line per criterion, revised."
+    (repo / after_name).write_text("\n".join(body) + "\n", encoding="utf-8")
+    _git(repo, "add", after_name)
+    _git(repo, "commit", "-m", "drop the extra zero")
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    _git(repo, "update-ref", "refs/remotes/origin/main", head)
+
+    return repo, after_name, before
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -1478,6 +1478,65 @@ class TestAdrReviewPolicyMergeScope:
 
         assert side_blob in policy._origin_main_blob_ids(repo, name)
 
+    def test_an_adr_whose_name_needs_quoting_is_still_read(
+        self,
+        tmp_path,
+    ):
+        """A path git quotes has to reach the scope test as git spells it.
+
+        `core.quotePath` is on by default, so a name outside ASCII prints
+        octal-escaped inside double quotes. The trailing quote alone defeats
+        the end anchor the scope pattern ends on, and the escapes defeat the
+        word characters before it, so every record for the file drops and its
+        history reads as empty. The gate governs the file either way, so the
+        answer would be review evidence demanded for an ADR whose only
+        peculiarity is its name.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir(parents=True)
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "t@example.com")
+        _git(repo, "config", "user.name", "T")
+        # On by default. Named so the test states what it exercises rather
+        # than inheriting it from whoever runs it.
+        _git(repo, "config", "core.quotePath", "true")
+        name = ".agents/architecture/ADR-100-caf\u00e9.md"
+        (repo / ".agents" / "architecture").mkdir(parents=True)
+        (repo / name).write_text("decision\n", encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "add")
+        _git(repo, "update-ref", "refs/remotes/origin/main", "main")
+        blob = _git(repo, "rev-parse", "main:" + name).stdout.strip()
+
+        assert blob in policy._origin_main_blob_ids(repo, name)
+
+    def test_an_adr_under_a_quoted_directory_is_still_read(
+        self,
+        tmp_path,
+    ):
+        """Turning quoting off is not the same as never being quoted.
+
+        git quotes a path carrying a double quote, a backslash or a control
+        character whatever `core.quotePath` says, so suppressing the setting
+        answers only the accented-name half. Reading the records in a format
+        that separates paths by NUL answers both.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir(parents=True)
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "t@example.com")
+        _git(repo, "config", "user.name", "T")
+        directory = repo / '.agents' / 'arch"itecture'
+        directory.mkdir(parents=True)
+        name = '.agents/arch"itecture/ADR-101-quoted.md'
+        (repo / name).write_text("decision\n", encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "add")
+        _git(repo, "update-ref", "refs/remotes/origin/main", "main")
+        blob = _git(repo, "rev-parse", "main:" + name).stdout.strip()
+
+        assert blob in policy._origin_main_blob_ids(repo, name)
+
     def test_the_resolution_and_the_side_state_are_both_carried(
         self,
         tmp_path,
@@ -1514,22 +1573,22 @@ class TestAdrReviewPolicyMergeScope:
             "::100644 100644 100644 "
             "1111111111111111111111111111111111111111 "
             "2222222222222222222222222222222222222222 "
-            "3333333333333333333333333333333333333333 MM\t" + adr + "\n"
+            "3333333333333333333333333333333333333333 MM\0" + adr + "\0"
             ":100644 100644 "
             "4444444444444444444444444444444444444444 "
-            "5555555555555555555555555555555555555555 M\t" + adr + "\n"
+            "5555555555555555555555555555555555555555 M\0" + adr + "\0"
             # Contains "ADR" and is not a path this gate governs. The
             # membership test the records are filtered by is the gate's own,
             # not a substring the name happens to carry.
             ":100644 100644 "
             "6666666666666666666666666666666666666666 "
-            "7777777777777777777777777777777777777777 M\tdocs/ADR-overview.md\n"
+            "7777777777777777777777777777777777777777 M\0docs/ADR-overview.md\0"
             # A file moved in to become an ADR. The post-image is at the ADR
             # path from this commit on, so the destination is what decides it,
             # and reading the source instead would drop a state main holds.
             ":100644 100644 "
             "9999999999999999999999999999999999999999 "
-            "8888888888888888888888888888888888888888 R100\tnotes.md\t" + adr + "\n"
+            "8888888888888888888888888888888888888888 R100\0notes.md\0" + adr + "\0"
         )
         monkeypatch.setattr(
             policy,

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -1668,16 +1668,43 @@ class TestAdrReviewPolicyMergeScope:
         assert policy.ADR_REVIEW_PATH_RE.search(".agents/SESSION-PROTOCOL.md")
         assert policy.ADR_REVIEW_PATH_RE.search("SESSION-PROTOCOL.md")
 
-    def test_a_rename_between_two_adrs_is_still_carried(
+    def test_a_lineage_into_a_different_decision_record_is_not_carried(
+        self,
+        tmp_path,
+    ):
+        """Two ADRs are two decisions, however alike their text.
+
+        Records written from one template share most of their lines, so git
+        scores a commit that drops one and adds another as a rename of it.
+        `--follow` then walks from the new record into the old one and every
+        state the old one held reads as a state of the new.
+
+        Both are paths this gate governs, so scoping the walk to governed
+        paths does not refuse it. The content did face ADR review, but it
+        faced it as a different decision. Placing it under this record's
+        number is a decision nobody reviewed.
+
+        Found by review on PR #3680.
+        """
+        repo, target, only_ever_elsewhere = _repo_where_a_merge_linked_two_adrs(
+            tmp_path
+        )
+
+        carried = policy._origin_main_blob_ids(repo, target)
+
+        assert only_ever_elsewhere not in carried
+        assert policy._head_copy_is_one_main_has_carried(repo, target) is False
+
+    def test_a_rename_within_one_adr_is_still_carried(
         self,
         tmp_path,
     ):
         """Refusing foreign lineages must not refuse the one this gate wants.
 
-        The negative control for the test above. An ADR that main moved and
-        revised is the false positive the rename-aware lookup exists to
-        remove, and both of its names are paths this gate governs, so the
-        states under the former name stay carried.
+        The negative control for the two tests above. One decision record
+        that main moved and revised keeps its number across the rename, so
+        the states under its former name are still states of this record and
+        stay carried.
         """
         repo, name, side_blob = _repo_where_a_rename_crossed_a_merge(tmp_path)
 
@@ -1733,6 +1760,111 @@ def _repo_where_a_merge_linked_a_non_adr_file(
     (repo / adr).write_bytes(b"the state that was never an adr\n")
     _git(repo, "commit", "-qam", "place the file's old text at the adr path")
     return repo, adr, foreign
+
+
+class TestGovernedDocumentIdentity:
+    """The record a path holds, which is what scopes a followed history."""
+
+    def test_one_record_keeps_its_identity_when_it_is_renamed(self):
+        """The name after the number is free to change; the number is not."""
+        assert policy._governed_document_identity(
+            ".agents/architecture/ADR-201-old-name.md"
+        ) == policy._governed_document_identity(
+            ".agents/architecture/ADR-201-new-name.md"
+        )
+
+    def test_a_number_written_in_either_case_is_one_record(self):
+        """The path test ignores case, so the identity read out of it must too.
+
+        Read case-sensitively, a record renamed from a lowercased name to an
+        uppercased one would look like two records and its earlier states
+        would be refused, which is the false refusal following renames exists
+        to remove.
+        """
+        assert policy._governed_document_identity(
+            ".agents/architecture/adr-201-old-name.md"
+        ) == policy._governed_document_identity(
+            ".agents/architecture/ADR-201-new-name.md"
+        )
+
+    def test_two_numbers_are_two_records(self):
+        assert policy._governed_document_identity(
+            ".agents/architecture/ADR-201-first.md"
+        ) != policy._governed_document_identity(
+            ".agents/architecture/ADR-202-second.md"
+        )
+
+    def test_the_protocol_stands_for_itself(self):
+        """It carries no number, and it is not any record's."""
+        protocol = policy._governed_document_identity(".agents/SESSION-PROTOCOL.md")
+
+        assert protocol is not None
+        assert protocol != policy._governed_document_identity(
+            ".agents/architecture/ADR-201-first.md"
+        )
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "docs/ADR-overview.md",
+            "docs/fake-SESSION-PROTOCOL.md",
+            "notes.md",
+            "",
+        ],
+    )
+    def test_a_path_this_gate_does_not_govern_holds_no_record(self, path):
+        assert policy._governed_document_identity(path) is None
+
+
+def _repo_where_a_merge_linked_two_adrs(tmp_path: Path) -> tuple[Path, str, str]:
+    """Build a repo where `--follow` crosses from one ADR into another.
+
+    Both records carry the same template body and differ only in their title
+    and their decision, which is enough alike that git reads a commit
+    dropping the first and adding the second as a rename. Merging that branch
+    puts the link on `origin/main`.
+
+    Returns the repo, the second record's path, and a blob the first record
+    held that the second one's path never held in any commit on main.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "diff.renames", "true")
+    shared = "".join(f"a line every record from the template carries {i}\n" for i in range(60))
+
+    first = ".agents/architecture/ADR-201-first.md"
+    second = ".agents/architecture/ADR-202-second.md"
+    (repo / ".agents" / "architecture").mkdir(parents=True)
+    (repo / first).write_text("# ADR-201\n" + shared + "decision alpha\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "the first record")
+    only_ever_elsewhere = _git(repo, "rev-parse", "HEAD:" + first).stdout.strip()
+
+    (repo / first).write_text("# ADR-201\n" + shared + "decision alpha revised\n", encoding="utf-8")
+    _git(repo, "commit", "-qam", "revise the first record")
+
+    _git(repo, "checkout", "-qb", "side", "HEAD~1")
+    _git(repo, "rm", "-q", "--", first)
+    (repo / ".agents" / "architecture").mkdir(parents=True, exist_ok=True)
+    (repo / second).write_text("# ADR-202\n" + shared + "decision beta\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "side replaces it with a second record")
+
+    _git(repo, "checkout", "-q", "main")
+    (repo / ".agents" / "architecture").mkdir(parents=True, exist_ok=True)
+    _run(["git", "merge", "--no-edit", "side"], repo)
+    (repo / first).unlink(missing_ok=True)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "the merge keeps only the second record")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+    _git(repo, "checkout", "-qb", "feature")
+    (repo / second).write_text("# ADR-201\n" + shared + "decision alpha\n", encoding="utf-8")
+    _git(repo, "commit", "-qam", "place the first record's old text under the second number")
+    return repo, second, only_ever_elsewhere
 
 
 def _repo_where_a_rename_crossed_a_merge(tmp_path: Path) -> tuple[Path, str, str]:

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -1745,6 +1745,40 @@ class TestAdrReviewPolicyMergeScope:
 
         assert side_blob in policy._origin_main_blob_ids(repo, name)
 
+    def test_a_signed_history_is_still_read(
+        self,
+        tmp_path,
+    ):
+        """`log.showSignature` decorates the stream this gate parses.
+
+        Set in the developer's own git config, it prefixes each commit's raw
+        records with the verification result. The first field of the stream
+        then begins with that text rather than with the colon every record
+        starts with, so every record is skipped and the walk reports that
+        main has carried nothing here. That refuses a record main plainly
+        did carry, and it refuses it only for developers holding that
+        setting.
+        """
+        repo, adr, carried = _repo_where_the_history_is_signed(tmp_path)
+
+        assert carried in policy._origin_main_blob_ids(repo, adr)
+
+    def test_an_unsigned_history_is_read_the_same_way(
+        self,
+        tmp_path,
+    ):
+        """The negative control for the test above.
+
+        Naming the signature behaviour must not change what an ordinary
+        repository reports, which is the whole point of naming it.
+        """
+        repo, adr, carried = _repo_where_the_history_is_signed(
+            tmp_path,
+            sign=False,
+        )
+
+        assert carried in policy._origin_main_blob_ids(repo, adr)
+
 
 def _repo_where_a_merge_linked_a_non_adr_file(
     tmp_path: Path,
@@ -2062,6 +2096,59 @@ def _merge_carrying_main_adr(tmp_path: Path, adr_bytes: bytes, name: str) -> Pat
     merge = _run(["git", "merge", "--no-edit", "--no-commit", "--no-ff", "main"], repo)
     assert merge.returncode == 0, merge.stderr
     return repo
+
+
+def _repo_where_the_history_is_signed(
+    tmp_path: Path,
+    sign: bool = True,
+) -> tuple[Path, str, str]:
+    """Build a repo whose commits carry signatures the developer asks to see.
+
+    Signing uses the ssh backend so the fixture needs only `ssh-keygen`, and
+    verification is left to fail: an unknown signer still makes git print a
+    verification line, which is the decoration under test. `sign=False`
+    builds the same history without signatures for the negative control.
+    """
+    repo = tmp_path / "signed"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    if sign:
+        key = repo / "signing-key"
+        _run(
+            [_tool("ssh-keygen"), "-q", "-t", "ed25519", "-N", "", "-C", "t", "-f", str(key)],
+            repo,
+        )
+        assert key.with_suffix(".pub").exists(), "ssh-keygen produced no public key"
+        _git(repo, "config", "gpg.format", "ssh")
+        _git(repo, "config", "user.signingkey", str(key.with_suffix(".pub")))
+        _git(repo, "config", "commit.gpgsign", "true")
+    # The setting under test lives in the developer's own config, so the
+    # fixture puts it there rather than passing it on the command line.
+    _git(repo, "config", "log.showSignature", "true")
+
+    # A session fixture in tests/conftest.py injects `commit.gpgsign=false`
+    # through GIT_CONFIG_COUNT, which outranks the repo config written above.
+    # Passing the setting on the command line outranks the injection in turn.
+    signing = ("-c", "commit.gpgsign=true") if sign else ()
+
+    adr = ".agents/architecture/ADR-099-signed.md"
+    document = repo / adr
+    document.parent.mkdir(parents=True, exist_ok=True)
+    document.write_text("first\n", encoding="utf-8")
+    _git(repo, "add", adr)
+    _git(repo, *signing, "commit", "-m", "add a decision")
+    document.write_text("second\n", encoding="utf-8")
+    _git(repo, *signing, "commit", "-am", "revise it")
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    _git(repo, "update-ref", "refs/remotes/origin/main", head)
+    if sign:
+        signed = _git(repo, "cat-file", "commit", "HEAD").stdout
+        assert "gpgsig" in signed, "the fixture did not actually sign the commit"
+
+    carried = _git(repo, "rev-parse", "HEAD:" + adr).stdout.strip()
+    return repo, adr, carried
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -147,6 +147,13 @@ def _commit(repo: Path, message: str) -> str:
     return _git(repo, "rev-parse", "HEAD").stdout.strip()
 
 
+def _point_origin_main_at_head(repo: Path) -> str:
+    """Make the local `origin/main` cache agree with what this repo has at HEAD."""
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    _git(repo, "update-ref", "refs/remotes/origin/main", head)
+    return head
+
+
 def _run_real_suppression_push(repo: Path, head: str) -> int:
     stdin = io.StringIO(f"refs/heads/topic {head} refs/heads/topic {'0' * 40}\n")
     return policy.check_pushed_suppressions(stdin, repo)
@@ -1116,6 +1123,161 @@ class TestAdrReviewPolicyMergeScope:
 
         assert policy.check_adr_review_policy([path], tmp_path) == 1
         assert "ADR changes require adr-review evidence" in capsys.readouterr().err
+
+    def test_line_endings_alone_do_not_make_a_staged_adr_mains_content(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ):
+        """The exemption is byte identity, so it has to be read in bytes.
+
+        The blob readers ran `git show` through a text-mode pipe, which
+        translates every `\\r\\n` and every lone `\\r` to `\\n` before the bytes are
+        handed back. Two blobs that differ only in how they end their lines
+        arrived identical, so a staged ADR the merge never carried satisfied
+        both blob halves of the rule and left through main's exemption.
+
+        Found by adversarial review round 51.
+        """
+        repo = _merge_carrying_main_adr(
+            tmp_path, b"# ADR 090\n\nmain wrote this.\n", "ADR-090-endings.md"
+        )
+        relative = ".agents/architecture/ADR-090-endings.md"
+        (repo / relative).write_bytes(b"# ADR 090\r\n\r\nmain wrote this.\r\n")
+        _git(repo, "add", relative)
+
+        assert policy._read_index_blob(repo, relative) != policy._read_head_blob(repo, relative)
+        assert policy._merge_authored_adr_paths([relative], repo) == [relative]
+
+        monkeypatch.setattr(policy, "_gated_adr_review_paths", lambda paths, root: list(paths))
+        monkeypatch.setattr(policy, "_today_session_log", lambda sessions_dir: None)
+        assert policy.check_adr_review_policy([relative], repo) == 1
+        assert "ADR changes require adr-review evidence" in capsys.readouterr().err
+
+    def test_two_different_undecodable_blobs_are_not_one_blob(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ):
+        """Decoding with `errors="replace"` collapses distinct bytes to one.
+
+        Every byte the decoder cannot read becomes U+FFFD, so any two blobs
+        that differ only inside undecodable runs compared equal. This is the
+        same defect as the line-ending case and the wider half of it: the
+        collision needs no agreement about what the differing bytes mean.
+
+        Found by adversarial review round 51.
+        """
+        repo = _merge_carrying_main_adr(
+            tmp_path, b"# ADR 091\n\nmain \xff\xfe wrote this.\n", "ADR-091-endings.md"
+        )
+        relative = ".agents/architecture/ADR-091-endings.md"
+        (repo / relative).write_bytes(b"# ADR 091\n\nmain \x80\x81 wrote this.\n")
+        _git(repo, "add", relative)
+
+        assert policy._read_index_blob(repo, relative) != policy._read_head_blob(repo, relative)
+        assert policy._merge_authored_adr_paths([relative], repo) == [relative]
+
+        monkeypatch.setattr(policy, "_gated_adr_review_paths", lambda paths, root: list(paths))
+        monkeypatch.setattr(policy, "_today_session_log", lambda sessions_dir: None)
+        assert policy.check_adr_review_policy([relative], repo) == 1
+        assert "ADR changes require adr-review evidence" in capsys.readouterr().err
+
+    def test_a_merge_that_carries_crlf_content_keeps_mains_exemption(
+        self,
+        tmp_path,
+    ):
+        """Reading the merge parent as text costs the exemption it should grant.
+
+        This is the same normalization seen from the other side. When main's
+        own ADR ends its lines with `\r\n`, a text-mode read of the parent
+        hands back `\n` while the staged blob still holds what git stored, so
+        the two stop matching and an ADR the author never opened is reported
+        as branch-authored. Nothing is let through, but review evidence is
+        demanded for someone else's file, which is how a gate loses its
+        audience.
+
+        Found by adversarial review round 51.
+        """
+        relative = ".agents/architecture/ADR-094-carried.md"
+        carried = b"# ADR 094\r\n\r\nmain wrote this.\r\n"
+        repo = _merge_carrying_main_adr(tmp_path, carried, "ADR-094-carried.md")
+
+        assert policy._read_index_blob(repo, relative) == carried
+        assert policy._merge_authored_adr_paths([relative], repo) == []
+
+    def test_crlf_content_the_merge_left_alone_is_still_unchanged_from_head(
+        self,
+        tmp_path,
+    ):
+        """A path the merge did not touch is recognized by HEAD's bytes.
+
+        The branch wrote this ADR itself and the merge brought something
+        else, so the staged copy is what HEAD already had and no merge
+        exemption is involved. A text-mode read of HEAD folds the `\r\n`
+        endings the branch committed, the staged copy no longer matches, and
+        an untouched file is pushed down the merge-exemption path to be
+        reported as authored by a merge that never saw it.
+
+        Found by adversarial review round 51.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "test@example.invalid")
+        _git(repo, "config", "user.name", "Test User")
+        (repo / ".gitattributes").write_text("* -text\n", encoding="utf-8")
+        (repo / "README.md").write_text("base\n", encoding="utf-8")
+        _commit(repo, "base")
+        _git(repo, "branch", "local")
+
+        (repo / "README.md").write_text("main moved on\n", encoding="utf-8")
+        _commit(repo, "main work")
+        _point_origin_main_at_head(repo)
+
+        _git(repo, "checkout", "local")
+        relative = ".agents/architecture/ADR-095-branch.md"
+        (repo / relative).parent.mkdir(parents=True)
+        (repo / relative).write_bytes(b"# ADR 095\r\n\r\nthe branch wrote this.\r\n")
+        _commit(repo, "branch adr")
+        merge = _run(["git", "merge", "--no-edit", "--no-commit", "--no-ff", "main"], repo)
+        assert merge.returncode == 0, merge.stderr
+
+        assert policy._read_head_blob(repo, relative) == policy._read_index_blob(repo, relative)
+        assert policy._merge_authored_adr_paths([relative], repo) == []
+
+def _merge_carrying_main_adr(tmp_path: Path, adr_bytes: bytes, name: str) -> Path:
+    """Build a repo mid-merge whose staged ADR is the one main contributed.
+
+    The exemption holds here, which is the point: each caller then restages
+    bytes that differ from main's only in ways a text-mode pipe erases, so a
+    test that still sees an exemption is reporting the normalization and not
+    the rule.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / ".gitattributes").write_text("* -text\n", encoding="utf-8")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _commit(repo, "base")
+    _git(repo, "branch", "local")
+
+    adr_dir = repo / ".agents" / "architecture"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / name).write_bytes(adr_bytes)
+    _commit(repo, "adr on main")
+    _point_origin_main_at_head(repo)
+
+    _git(repo, "checkout", "local")
+    (repo / "local.txt").write_text("local work\n", encoding="utf-8")
+    _commit(repo, "local work")
+    merge = _run(["git", "merge", "--no-edit", "--no-commit", "--no-ff", "main"], repo)
+    assert merge.returncode == 0, merge.stderr
+    return repo
 
 
 if __name__ == "__main__":

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -1433,7 +1433,7 @@ class TestAdrReviewPolicyMergeScope:
         value works, but that the setting is not an input.
         """
         answers = {}
-        for setting in ("combined", "dense-combined", "separate", "on", "first-parent"):
+        for setting in ("combined", "dense-combined", "separate", "on", "first-parent", "off"):
             repo, name, _ = _repo_where_main_resolved_an_adr_in_a_merge(
                 tmp_path / setting,
                 diff_merges=setting,
@@ -1441,6 +1441,41 @@ class TestAdrReviewPolicyMergeScope:
             answers[setting] = policy._origin_main_blob_ids(repo, name)
 
         assert len(set(map(frozenset, answers.values()))) == 1, answers
+
+    def test_a_state_only_the_plain_traversal_reaches_is_still_carried(
+        self,
+        tmp_path,
+    ):
+        """Asking for merge diffs must not cost a state main already had.
+
+        `--follow` rewrites the path it is following each time it detects a
+        rename, so which rename it sees decides which lineage it walks. Asking
+        for merge diffs makes the merge-versus-first-parent rename visible, and
+        following that one walks main's side of the history and reports the
+        side branch's file as a deletion rather than crossing into it.
+
+        The side branch's revision is a state of this file on `origin/main`,
+        and the implementation before merge diffs were asked for returned it.
+        Trading it away for the resolution blob swaps one silent gap for
+        another: a branch sitting on that revision holds content main really
+        carried, and demanding review evidence for it is the false positive
+        this whole lookup exists to prevent.
+        """
+        repo, name, side_blob = _repo_where_a_rename_crossed_a_merge(tmp_path)
+
+        assert side_blob in policy._origin_main_blob_ids(repo, name)
+
+    def test_the_resolution_and_the_side_state_are_both_carried(
+        self,
+        tmp_path,
+    ):
+        """Neither traversal alone answers the question, so both must run."""
+        repo, name, side_blob = _repo_where_a_rename_crossed_a_merge(tmp_path)
+        resolution = _git(repo, "rev-parse", "HEAD~1:" + name).stdout.strip()
+
+        carried = policy._origin_main_blob_ids(repo, name)
+
+        assert {side_blob, resolution} <= carried
 
     def test_a_combined_diff_record_is_never_read_as_a_post_image(
         self,
@@ -1477,6 +1512,55 @@ class TestAdrReviewPolicyMergeScope:
         )
 
         assert policy._origin_main_blob_ids(repo, "doc.md") == {"5" * 40}
+
+
+def _repo_where_a_rename_crossed_a_merge(tmp_path: Path) -> tuple[Path, str, str]:
+    """Build a repo where the rename is detectable on both sides of a merge.
+
+    The side branch renames and edits, main edits the old name, and the merge
+    resolves at the new name. The bodies are long enough that both the side
+    rename and the merge-versus-first-parent rename clear git's similarity
+    threshold, which is what makes the two traversals disagree about which
+    lineage to follow. Short fixtures do not reproduce it.
+
+    Returns the repo, the followed path, and the blob the side branch left.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "diff.renames", "true")
+    body = "header\n" + "same line\n" * 30
+
+    old_name = ".agents/architecture/ADR-097-moved.md"
+    new_name = ".agents/architecture/ADR-097-renamed.md"
+    (repo / ".agents" / "architecture").mkdir(parents=True)
+    (repo / old_name).write_bytes((body + "base\n").encode("utf-8"))
+    _git(repo, "add", "--", old_name)
+    _git(repo, "commit", "-qm", "base")
+
+    _git(repo, "checkout", "-qb", "side")
+    _git(repo, "mv", old_name, new_name)
+    (repo / new_name).write_bytes((body + "side renamed\n").encode("utf-8"))
+    _git(repo, "commit", "-qam", "side renames and edits")
+    side_blob = _git(repo, "rev-parse", "HEAD:" + new_name).stdout.strip()
+
+    _git(repo, "checkout", "-q", "main")
+    (repo / old_name).write_bytes((body + "main edit\n").encode("utf-8"))
+    _git(repo, "commit", "-qam", "main edits the old name")
+
+    merge = _run(["git", "merge", "--no-edit", "side"], repo)
+    assert merge.returncode != 0, "the fixture needs the merge to conflict"
+    (repo / old_name).unlink(missing_ok=True)
+    (repo / new_name).write_bytes((body + "resolved renamed\n").encode("utf-8"))
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "merge resolves at the new name")
+
+    (repo / new_name).write_bytes((body + "later\n").encode("utf-8"))
+    _git(repo, "commit", "-qam", "later edit")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    return repo, new_name, side_blob
 
 
 def _repo_where_main_resolved_an_adr_in_a_merge(

--- a/tests/validation/test_git_hook_policy_causal_restore.py
+++ b/tests/validation/test_git_hook_policy_causal_restore.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -1537,6 +1538,73 @@ class TestAdrReviewPolicyMergeScope:
 
         assert blob in policy._origin_main_blob_ids(repo, name)
 
+    def test_a_path_that_only_a_newline_rewrite_makes_governed_is_not_carried(
+        self,
+        tmp_path,
+    ):
+        """A carriage return in a path must not turn it into a governed one.
+
+        `-z` is passed so paths arrive raw, but reading the stream in text mode
+        applies universal newline translation, so a trailing carriage return
+        becomes a newline, and `$` matches before a trailing newline. A path
+        this gate does not govern then reads as one, and content that never sat
+        at a governed path joins the set of blobs main is treated as having
+        carried. A branch holding that content is then exempted from review
+        (issue #3722).
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir(parents=True)
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "t@example.com")
+        _git(repo, "config", "user.name", "T")
+        directory = repo / ".agents" / "architecture"
+        directory.mkdir(parents=True)
+        governed = ".agents/architecture/ADR-101-real.md"
+        ungoverned = governed + "\r"
+        (repo / ungoverned).write_text("never reviewed\n" + "a\n" * 40, encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "add under a carriage return name")
+        unreviewed = _git(repo, "rev-parse", "main:" + ungoverned).stdout.strip()
+        _git(repo, "mv", ungoverned, governed)
+        (repo / governed).write_text("the reviewed decision\n" + "a\n" * 40, encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "rename onto the governed name and revise")
+        reviewed = _git(repo, "rev-parse", "main:" + governed).stdout.strip()
+        _git(repo, "update-ref", "refs/remotes/origin/main", "main")
+
+        carried = policy._origin_main_blob_ids(repo, governed)
+
+        assert unreviewed not in carried
+        assert reviewed in carried
+
+    def test_a_path_carrying_invalid_utf8_survives_the_read(
+        self,
+        tmp_path,
+    ):
+        """Reading bytes must not drop a governed record on undecodable bytes.
+
+        This pins the read path rather than the error handler. Identity here is
+        the record's number, so a byte spent elsewhere in the path reaches no
+        decision, and a `replace` handler passes this too. What would fail it is
+        a read that errors or drops the record outright.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir(parents=True)
+        _git(repo, "init", "-b", "main")
+        _git(repo, "config", "user.email", "t@example.com")
+        _git(repo, "config", "user.name", "T")
+        directory_name = os.fsdecode(b"arch\xffitecture")
+        directory = repo / ".agents" / directory_name
+        directory.mkdir(parents=True)
+        name = f".agents/{directory_name}/ADR-102-undecodable.md"
+        (repo / name).write_text("decision\n", encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "add")
+        _git(repo, "update-ref", "refs/remotes/origin/main", "main")
+        blob = _git(repo, "rev-parse", "main:" + name).stdout.strip()
+
+        assert blob in policy._origin_main_blob_ids(repo, name)
+
     def test_the_resolution_and_the_side_state_are_both_carried(
         self,
         tmp_path,
@@ -1592,8 +1660,10 @@ class TestAdrReviewPolicyMergeScope:
         )
         monkeypatch.setattr(
             policy,
-            "_run_git",
-            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=combined),
+            "_run_git_bytes",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=0, stdout=combined.encode("utf-8", "surrogateescape")
+            ),
         )
 
         assert policy._origin_main_blob_ids(repo, adr) == {"5" * 40, "8" * 40}
@@ -1627,8 +1697,10 @@ class TestAdrReviewPolicyMergeScope:
         )
         monkeypatch.setattr(
             policy,
-            "_run_git",
-            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=records),
+            "_run_git_bytes",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=0, stdout=records.encode("utf-8", "surrogateescape")
+            ),
         )
 
         assert policy._origin_main_blob_ids(repo, adr) == {"4" * 40}

--- a/tests/validation/test_skillforge_frontmatter_exemption.py
+++ b/tests/validation/test_skillforge_frontmatter_exemption.py
@@ -3,8 +3,8 @@
 SkillForge validation (``validate-skill.py``) checks both the body (Triggers,
 Process, Verification, Scripts sections) and the frontmatter (required and
 allowed keys). The exemption is deliberately narrow: it skips validation only
-when the body text is unchanged (bodies decoded as UTF-8 with
-``errors="replace"`` and compared as strings, not raw bytes) AND the sole
+when the body is unchanged (compared as the bytes git stored, never as
+decoded text) AND the sole
 changed frontmatter keys are the
 ADR-080 model-pin fields (``model``, ``model-rationale``), so a pin migration
 is not forced to pay down unrelated pre-existing structural debt while any other
@@ -16,7 +16,10 @@ frontmatter change still reaches the validator. These tests pin that behavior:
   new skill (no HEAD); each is not exempt (validate). ``run_skillforge`` also
   invokes the validator and propagates its failure when not exempt;
 - edge: a file without frontmatter, and a no-op (identical) blob, are both not
-  exempt.
+  exempt; bodies and frontmatter holding bytes UTF-8 cannot read are compared
+  as bytes and refused rather than collapsed onto the replacement character
+  (round 52). The ADR gate's ``implemented``-field exemption shares the code
+  under test, so its cases live here too.
 """
 
 from __future__ import annotations
@@ -190,3 +193,94 @@ def test_pin_change_mixed_with_other_field_is_not_exempt(monkeypatch, tmp_path):
     new = _doc("name: example\ndescription: new\n", _BODY)
     _patch_blobs(monkeypatch, old, new)
     assert ghp._is_skill_frontmatter_only_change(_SKILL, tmp_path) is False
+
+
+_ADR = ".agents/architecture/ADR-042-example.md"
+
+
+def test_a_body_that_differs_only_in_undecodable_bytes_is_not_unchanged(
+    monkeypatch, tmp_path
+):
+    """Two different bodies must not be one body because neither decodes.
+
+    `errors="replace"` maps every byte the decoder cannot read to the same
+    replacement character, so bodies holding different invalid bytes compared
+    equal and a real body edit rode in under a model-pin change.
+
+    Found by adversarial review round 52.
+    """
+    old = _doc("name: example\ndescription: x\nmodel: haiku\n", "body ")
+    new = _doc("name: example\ndescription: x\nmodel: sonnet\n", "body ")
+    _patch_blobs(monkeypatch, old + b"\xff", new + b"\xfe")
+    assert ghp._is_skill_frontmatter_only_change(_SKILL, tmp_path) is False
+
+
+def test_an_identical_undecodable_body_still_earns_the_pin_exemption(
+    monkeypatch, tmp_path
+):
+    old = _doc("name: example\ndescription: x\nmodel: haiku\n", "body ")
+    new = _doc("name: example\ndescription: x\nmodel: sonnet\n", "body ")
+    _patch_blobs(monkeypatch, old + b"\xff", new + b"\xff")
+    assert ghp._is_skill_frontmatter_only_change(_SKILL, tmp_path) is True
+
+
+def test_undecodable_bytes_in_skill_frontmatter_refuse_the_exemption(
+    monkeypatch, tmp_path
+):
+    """A frontmatter the decoder cannot read is not one this can reason about."""
+    old = _doc("name: example\ndescription: x\nmodel: haiku\n", _BODY)
+    new = b"---\nname: example\ndescription: x\nmodel: sonnet\n"
+    new += b"note: \xff\n---\n" + _BODY.encode()
+    _patch_blobs(monkeypatch, old, new)
+    assert ghp._is_skill_frontmatter_only_change(_SKILL, tmp_path) is False
+
+
+def test_an_adr_body_differing_only_in_undecodable_bytes_is_not_unchanged(
+    monkeypatch, tmp_path
+):
+    """The ADR gate carries the same exemption and had the same hole."""
+    old = _doc("implemented: false\n", "body ")
+    new = _doc("implemented: true\n", "body ")
+    _patch_blobs(monkeypatch, old + b"\xff", new + b"\xfe")
+    assert ghp._is_frontmatter_only_metadata_change(_ADR, tmp_path) is False
+
+
+def test_an_adr_with_an_identical_undecodable_body_stays_exempt(monkeypatch, tmp_path):
+    old = _doc("implemented: false\n", "body ")
+    new = _doc("implemented: true\n", "body ")
+    _patch_blobs(monkeypatch, old + b"\xff", new + b"\xff")
+    assert ghp._is_frontmatter_only_metadata_change(_ADR, tmp_path) is True
+
+
+def test_undecodable_bytes_in_adr_frontmatter_refuse_the_exemption(
+    monkeypatch, tmp_path
+):
+    old = _doc("implemented: false\n", _BODY)
+    new = b"---\nimplemented: true\nnote: \xff\n---\n" + _BODY.encode()
+    _patch_blobs(monkeypatch, old, new)
+    assert ghp._is_frontmatter_only_metadata_change(_ADR, tmp_path) is False
+
+
+def test_a_frontmatter_field_hidden_behind_undecodable_bytes_is_not_unchanged(
+    monkeypatch, tmp_path
+):
+    """A lossy frontmatter decode drops a changed field out of the change set.
+
+    `note` really changed here. Decoded with `errors="replace"` both values
+    become the same replacement character, the changed set collapses to the
+    model pin alone, and the exemption is granted for an edit that touched a
+    field it was never meant to cover.
+    """
+    old = b"---\nname: example\ndescription: x\nmodel: haiku\nnote: \xff\n---\n"
+    new = b"---\nname: example\ndescription: x\nmodel: sonnet\nnote: \xfe\n---\n"
+    _patch_blobs(monkeypatch, old + _BODY.encode(), new + _BODY.encode())
+    assert ghp._is_skill_frontmatter_only_change(_SKILL, tmp_path) is False
+
+
+def test_an_adr_field_hidden_behind_undecodable_bytes_is_not_unchanged(
+    monkeypatch, tmp_path
+):
+    old = b"---\nimplemented: false\nnote: \xff\n---\n"
+    new = b"---\nimplemented: true\nnote: \xfe\n---\n"
+    _patch_blobs(monkeypatch, old + _BODY.encode(), new + _BODY.encode())
+    assert ghp._is_frontmatter_only_metadata_change(_ADR, tmp_path) is False


### PR DESCRIPTION
Fixes #3679

Adversarial review round 51 (`gpt-5.6-terra`) found three defects in the ADR merge gate. PR #3669 merged at a commit that predates these fixes, so they arrive here.

## 1. The blob readers were not reading blobs

`_run_command` passes `encoding="utf-8", errors="replace"` to `subprocess.run`. That puts the pipe in text mode, so two lossy transforms stack before a caller sees anything:

1. universal-newline translation folds `\r\n` and a lone `\r` into `\n`
2. `errors="replace"` maps every undecodable byte to one replacement character

`_read_index_blob`, `_read_head_blob`, and `_read_commit_blob_bytes` then re-encoded that normalized text and handed it back as bytes. Two blobs that differ only in line endings compared equal. Two blobs holding different binary garbage compared equal. This gate reads equal as "the merge carried main's content", so a CRLF copy of an ADR that the merge never carried satisfied the exemption.

The loss runs the other way too. A comparison with one normalized side stops matching, so an untouched file gets review evidence demanded of it.

Fix: the three readers call `_run_git_bytes`, a thin existing wrapper over `_run_command_bytes` in `scripts/validation/git_hook_policy.py`. That path was already there, with no `encoding=` and byte-safe timeout handling. No new subprocess wrapper.

## 2. The merge-parent clause had no test

The clause had no test of its own. The single test that reached it also failed the clause after it, so nothing separated the two, and widening the clause changed no result.

The new test, `test_typing_mains_text_during_an_unrelated_merge_is_not_the_merge_carrying_it`, builds a merge that carries an unrelated ADR while the author types a stale reversion of a second ADR during the conflict resolution. Clause 3 passes (the content is somewhere in main's history) and the merge-parent clause is the only thing that refuses.

A correction, from a later review. This test kills the clause in one direction only: removing the guard so the clause over-exempts. That is the mutation the table below measures. The opposite edit, stubbing the whole call to `False` so the clause never exempts, is killed by two different tests that predate this one, `test_merge_of_a_shared_branch_tip_allows_content_already_on_main` and `test_a_real_merge_of_a_shared_branch_tip_exempts_the_adr_main_contributed`. An earlier version of this section credited the new test with killing both. It does not.

## 3. The head-copy clause stopped at a rename

`_head_copy_is_one_main_has_carried` walked `git rev-list origin/main -- <path>`, which does not cross renames. When main moved an ADR and revised it in one commit, the earlier states stayed behind under the former name. A branch holding a copy main really had carried failed on the pathname alone.

`git log --follow` crosses the rename, but re-reading the file at those commits does not, because the current name does not exist there yet. The rewrite collects blob ids from the `--follow` diff output instead: `_followed_blob_ids` reads `git log --diff-merges=<mode> --follow --format= --raw --no-abbrev origin/main`, takes the post-image id from the fourth field of each single-parent raw line, and discards the all-zero id. `_origin_main_blob_ids` runs it twice and unions, for the reason in the sixth and seventh defects below. `_head_copy_is_one_main_has_carried` reads HEAD's own copy with `_blob_id_at` and asks whether that id is in the set. `_origin_main_commits_touching` had no callers left and is deleted.

An earlier version of this paragraph said `--format=%H`, said combined-diff lines are what merge commits emit, and said the tip is added with `_blob_id_at`. None of the three was true of the code. They are corrected here rather than quietly dropped, because a description that describes a draft is the defect this PR keeps finding in itself.

## Why this is not a wider exemption

An OID set is exactly the set of contents that path has held across the rename, which is what the clause always meant to ask. Rename similarity decides which file git follows, not which contents get admitted: every OID in the set was a real state of the followed path. The pre-existing clauses that gate the exemption are unchanged.

## Changes

- `scripts/validation/git_hook_policy.py`: the three blob readers move to the byte-mode runner, `_head_copy_is_one_main_has_carried` becomes a blob-OID membership test over a rename-following log, and the now-callerless `_origin_main_commits_touching` is deleted.
- `tests/validation/test_git_hook_policy_causal_restore.py`: six new tests, one per defect plus the three reader mutants.
- `tests/test_lefthook_integration.py`: the commit fixture stores the bytes it was handed, plus three tests pinning that contract.

## Verification

`tests/validation/test_git_hook_policy_causal_restore.py` grows from 34 tests to 48 and `tests/validation/test_skillforge_frontmatter_exemption.py` from 15 to 23. 1240 passed, 1 skipped in `tests/validation/`; 428 passed in `tests/test_lefthook_integration.py`.

Eighteen mutations, every one killed. Counts are what the run printed:

| Mutation | Tests failed |
| --- | --- |
| drop the merge-parent clause | 1 test |
| drop the origin/main clause | 1 test |
| clause 3 (head-copy) hardcoded True | 1 test |
| drop the approved-parent shortcut | 2 tests |
| blanket-exempt during a merge | 11 tests |
| drop the synthetic-MERGE_HEAD filter | 1 test |
| invert the absent-path pass | 2 tests |
| _read_index_blob back to text | 3 tests |
| _read_head_blob back to text | 1 test |
| _read_commit_blob_bytes back to text | 1 test |
| drop --follow | 1 test |
| drop the merge diff format | 3 tests |
| inherit the format from log.diffMerges (-m) | 4 tests |
| drop the merge-diff traversal | 3 tests |
| drop the plain traversal | 2 tests |
| drop the :: combined-record skip | 1 test |
| bodies compared as replace-decoded text | 2 tests |
| frontmatter decoded with errors=replace | 2 tests |

Command: `uv run --frozen python -m pytest tests/validation/test_git_hook_policy_causal_restore.py tests/validation/test_skillforge_frontmatter_exemption.py -p no:cacheprovider`, applying one mutation at a time and restoring between. Every killing test names the behaviour its mutation removes.

The three reader mutants are each killed by a distinct test. That took two rounds to get right. The first version of this fix covered only `_read_index_blob`, because a false *exemption* needs both sides of a comparison normalized: a single-reader mutant leaves the staged bytes differing from the normalized parent, so no exemption is granted and a "content leaked through" test cannot see it. The other two mutants are only reachable from the false-positive side, where main legitimately carries CRLF content.

Each reader mutant keeps the byte return type and only reintroduces the text pipe, so what the test sees is the normalization loss rather than a type mismatch.

## Round 51 also found a false claim in a PR body

PR #3669 described a seven-way mutation proof with "every mutant caught by a distinct test", naming the merge-parent clause among them. Finding 2 above shows that clause had no test at all when that sentence was written.

The first version of this body then repeated the mistake. It printed a twelve-row table under the word "Eleven", listed the head-copy clause and "clause 3 hardcoded True" as separate mutations when clause 3 *is* the head-copy call and both edits produce the same function, and carried six counts that no run had produced. A later review caught it. The table above was rebuilt by scripting each edit, running the suite once per edit, and printing the failure count, so the numbers are output rather than recollection. Later defects added further edits. Each time, the whole battery was re-run rather than extended on paper, and the table is the output of the most recent full run against the code as it now stands.

## A fourth defect, found by Windows CI

Making the readers byte-exact turned `test_head_blob_reader_returns_content` red on Windows and green everywhere else. The readers were not at fault. `_commit_file` wrote with `Path.write_text`, whose default newline handling translates `\n` to `os.linesep`, so a caller asking for `content\n` put `content\r\n` in the commit on Windows. The reader returned exactly what git stored. Text mode had been folding the endings back on the way out, which is why the fixture defect stayed invisible until the readers stopped losing content.

Before changing anything I checked whether `git show <rev>:<path>` applies the working-tree eol filter, since that would have made the reader wrong instead. It does not: under `core.autocrlf=true` and under a `* eol=crlf` attribute it returns the same bytes as `git cat-file blob`. The reader keeps using `git show`.

The fixture now uses `write_bytes`, which has no platform-dependent behavior. Three tests pin the contract: an LF round trip, a CRLF round trip, and a lone carriage return. `os.linesep` is `\n` on Linux, so none of the three can fail there. Reverting the fixture leaves them green locally. Windows CI is the only thing that exercises them, and that is stated here rather than counted as a mutation kill.

## A fifth defect, found by fixing the fourth

Making `_commit_file` byte-exact left the module writing the same path two ways. Eight tests seeded a file through the fixture and then revised it with `Path.write_text`, so under Windows the seed held `\n`, the revision held `\r\n`, and every line of the diff between them was a line-ending change. `test_changed_line_map_reads_real_git_diff` therefore saw all five lines changed on Windows and two lines changed everywhere else.

`_write_file` is the primitive `_commit_file` uses. Nine call sites were converted, and a scan reported the module clean.

The scan was wrong, which the seventh defect below covers. The other seven sites were the same defect without an assertion sharp enough to notice it. Every `write_text` call in the module was also checked for an explicit `\r\n`, which text mode would have expanded to `\r\r\n`; there are none.

Four tests cover it: the byte round trip, carriage returns left alone, the parent directory, and a seed-then-revise pair asserting the diff names only the edited line. These cannot fail on Linux either. Replacing the helper's write with the exact translation Windows applies (`content.replace("\n", "\r\n")`) fails all four plus `test_changed_line_map_reads_real_git_diff`, which is the reported failure, so the guard is load-bearing on the platform that has it.

`tests/test_lefthook_integration.py`: 424 passed.

## A sixth defect, found by a reviewer bot

`-m` means `--diff-merges=on`, and `on` takes its output format from the user's `log.diffMerges`. Set to `combined` or `dense-combined`, a merge that resolved a conflict prints one combined record instead of one record per parent:

```
::100644 100644 100644 30305bba 2299c379 0c2b3db1 MM	f.md
```

That record lists one pre-image per parent before the post-image, so the fourth field the parser reads is the first parent's pre-image, and its width grows with the parent count. Two losses at once: the resolution blob goes missing, which is the whole point of asking about merges, and a blob nobody asked about enters the carried set. What this gate accepts moved with a setting a developer chose for readability.

`--diff-merges=separate` names the format. It produces zero combined records under all five config values, still collects the resolution, and is supported on git 2.43.0. Combined records are skipped as well: naming the format should mean they never arrive, and the skip is what keeps that true under a later git or a flag someone adds here.

The bot's stated mechanism was wrong. A real three-parent octopus merge under `-m` emits three single-parent records and zero combined ones, which is what earlier testing found and why the claim looked dismissable. Testing the conclusion rather than the reasoning is what surfaced the config path.

Three tests: the resolution still found under `log.diffMerges=combined`, the blob set identical under all five settings, and a combined record never read as a post-image. The two halves are proved separately, listed in the table above.

## A seventh defect: asking for merge diffs was subtractive

Fixing the merge blind spot cost a different set of states, and the mutation battery could not see it because no test covered the shape.

`--follow` rewrites the path it follows each time it detects a rename, so which renames are visible decides which lineage it walks. With merge diffs asked for, the merge-versus-first-parent rename becomes visible, `--follow` takes that one, walks main's side of the history, and reports a side branch that renamed the file as a deletion instead of crossing into it. The side branch's revisions are states of the file on `origin/main`, and the implementation before merge diffs were asked for returned them.

So the earlier fix traded one silent gap for another. A branch sitting on one of those revisions holds content main really carried, and demanding review evidence for it is the false positive this lookup exists to prevent.

Both traversals now run and the ids are unioned. `separate` is what makes a resolution leave an id behind; `off` is what keeps the rename lineage the merge diffs hide. Every id either traversal reports comes from a commit reachable from `origin/main`, so the union widens one file's lineage rather than admitting any blob a branch contains.

Three shapes of merge-plus-rename fixture showed a superset and hid this. The reproducing fixture needs bodies long enough that both the side rename and the merge-versus-first-parent rename clear git's similarity threshold. That is now the fixture, and dropping either traversal fails tests.

The config-independence test also covers `log.diffMerges=off`, which git accepts and an explicit `--diff-merges` overrides.

## An eighth defect: the scan that cleared the fifth was wrong

The fifth defect above was found by scanning for functions that write one path with both primitives. That scan matched literal path arguments, and three functions bind the path to a local first:

```python
base = _commit_file(repo, "nested/source.py", "value = 1\n")
source = repo / "nested/source.py"
source.write_text(...)
```

So it reported the module clean while three functions still seeded with bytes and revised with text, which is the defect the fifth was supposed to remove. A reviewer found them by reading.

The five calls now go through `_write_file`. The scan is a test rather than a sentence: it resolves single-assignment aliases, the shape that got past the first attempt is its own negative control, and a two-different-paths case must stay quiet. Reverting any one conversion fails it. Every other test file that writes bytes was scanned; none mixes.

## Probing the union's soundness argument: what git ignores

The union rests on the claim that it widens one file's lineage rather than admitting whatever a branch contains. Two settings could break that if `--follow` read them: `diff.renames=copies` could in principle walk into a file this path was copied from, and `diff.renames=false` or `diff.renameLimit` could change which renames are visible at all.

Measured, not argued. A repo where one ADR is created on main as a byte copy of another, then both revise:

```
git -c diff.renames=copies -c diff.findCopiesHarder=true \
  log --follow --format= --raw --no-abbrev origin-main -- docs/adr/new.md
```

The copy carries the one blob it genuinely held, and none of the states the source went on to hold. A rename fixture queried under `diff.renames` of `true`, `false` and `copies`, under `diff.findCopiesHarder=true`, and under `diff.renameLimit=1` returns the same set every time: `--follow` carries its own rename detection and does not read those settings.

This is recorded as measurement rather than as a test. Tests written for both properties survived every mutation of this module, including replacing `--follow` with `-M`, adding `-C -C --find-copies-harder`, and dropping `--follow` altogether, because the properties belong to git and not to this code. Publishing them would have claimed a guard that does not exist.

The clause of the argument that is this module's own is locked: replacing `origin/main` with `HEAD` in the traversal fails three existing tests.

## A ninth defect: the soundness argument above was wrong

Two review models, running independently on different providers, filed the same Critical against the section above. They were right.

`--follow` rewrites the path it tracks whenever git scores a delete and an add as a rename. That is similarity, not provenance. The section above treats crossing a rename as widening *this file's* lineage, which is the tolerance the third defect deliberately bought. The flaw is that the path crossed into need not be an ADR at all. An ordinary file changes under ordinary review. Its contents were never a decision record. Once the traversal steps onto it, every state it ever held reads as a state of this ADR, and the gate exempts them.

My first response was a rebuttal. The reasoning was that a rename means those states genuinely are this file's states, so admitting them is intended. Then I reproduced it.

A repo where a merge links notes.md to an ADR path. Enumerating every commit on `origin/main` shows the ADR path only ever held one blob, `ef3f9d8`. The gate was then asked about `c7869b2c`, a blob that only ever lived at notes.md:

```
EXEMPTED: True
```

That is a false exemption for content no ADR review ever saw. The rebuttal was withdrawn.

Fix: filter each raw record on its destination path against `ADR_REVIEW_PATH_RE`, the gate's own scope predicate.

The destination is the field that decides it, not the source. A raw record is `<metadata>\t<path>[\t<newpath>]`, and for a rename the post-image blob belongs to the destination. So a record that moves a file *into* ADR-hood still counts, which is correct: from that commit on, main really does carry that blob at the ADR path. Every record from before the move drops. Qualifying on the source instead would drop the move-in record and demand review evidence for a state main genuinely holds.

The same commit splits on tab before parsing metadata. The previous `line.split()` on whitespace happened to work only while paths carried no spaces.

Three mutations, all killed:

| Mutation | Tests failed |
| --- | --- |
| drop the governed-path filter | 2 tests |
| qualify on the source path instead | 1 test |
| accept any path whose name mentions ADR | 1 test |

The third needed a negative control rather than a fixture: docs/ADR-overview.md contains the letters but is not a path this gate governs. The second needed a record whose post-image no other record supplies, because in a natural fixture the plain traversal already carries that blob and the source-path edit changes nothing.

One reviewer's reproduction printed `True`, but that `True` was trivial: the script staged the attacker's content without committing it, and the reader it compared against reads `HEAD`, so it was reading main's own blob back. The finding was real anyway. The evidence had to be rebuilt to show it. Running a reviewer's script verbatim is necessary and not sufficient.

## An accepted limit: parallel renames onto one name

A reviewer measured that `--follow` locks onto the first parent's path at a merge and does not walk the second parent's pre-rename lineage. That is true. Filed as a gap, it turns out to be a bounded one, and the direction it fails in is the safe one.

Two branches each rename a different reviewed ADR onto the same filename, and the merge resolves to the second branch's later revision:

```
B early state (reviewed ADR, second parent, pre-rename): False
B late state  (the merge resolution)                   : True
set size: 2
```

The merge resolution is admitted. Only the second parent's states from *before* its rename are missing.

Two reasons this is not a hole. The set is consumed by exactly one expression, `head_blob_id in _origin_main_blob_ids(...)`, and it has to be true to pass. A smaller set can only refuse more, never exempt more. And any blob main truly carried at the ADR path is emitted by the traversal at that path itself, from the merge record, so the blobs that go missing are only ever ones that lived under the other name.

The cost is a developer resolving a merge to a state that was reviewed under a different ADR filename and being asked for review evidence again. This is the same direction the function already documents for a stale `origin/main`: review demanded for a file that did not need it.

Not fixed, and deliberately not locked with a test. Fixing it means running `--follow` once per parent, which doubles a traversal already measured at about 185ms per path, to recover states only reachable when two branches rename two different ADRs onto one name. Writing a test that asserts the miss would claim the friction is intended rather than tolerated.

## A tenth defect: paths git does not print plainly

Found by review. The traversal read `--raw` output and split each record on a tab. git does not promise a path survives that.

`core.quotePath` defaults to on, so a governed record with an accented name is emitted octal-escaped inside double quotes. The gate's own path test ends on an anchor the closing quote defeats, so the record failed it, the traversal returned an empty set, and every merge touching that record was refused. My first fix passed `core.quotePath=false`. The reviewer pointed out that is only half of it: git quotes a path containing a double quote, a backslash or a control character whatever the setting says, so a record under a directory named with a quote would still be dropped. A literal tab inside a name would also split a record in the wrong place.

Measured the alternative rather than reasoning about it. With `-z`, fields arrive NUL-separated and paths arrive raw regardless of the setting, renames carry two path fields and everything else carries one, and a tab inside a name stays literal and correctly fails the path test. So `-z` subsumes the quoting fix and removes the tab question at the same time.

Six mutations killed, including dropping `-z`, reading the source path instead of the destination, and treating every status as carrying one path or two.

## An eleventh defect: a suffix is not a path

Found by review. The two halves of the path test disagreed. The ADR half was anchored to a path segment; the protocol half was a bare suffix. Any name ending in the protocol's filename therefore matched it.

That mattered twice. As the main gate's scope predicate it demanded ADR review of a file that is not the protocol, which is only noise. As the filter on followed history it admitted that file's blobs as ones main had carried at a governed path, which is an exemption from the review the gate exists to require.

Anchored the protocol half the way the ADR half already was, and composed the combined pattern from the two named halves rather than writing it out a second time, since writing it twice is how they drifted apart. Three mutations killed, including narrowing past the root form.

## A twelfth defect: two records are two decisions

Found by review, on the trail of the ninth. Scoping the walk to paths this gate governs stopped it crossing into an ordinary file. It did not stop it crossing into another decision record.

Records written from one template share most of their lines, so git reads a commit that drops one and adds another as a rename of it. `--follow` then walks from the new number into the old one, and every state the old record held reads as a state of the new. Both paths are governed, so the ninth defect's filter passes them.

Reproduced on a constructed pair sharing a 60-line body: a blob that only ever lived at ADR-201's path came back as one main had carried at ADR-202's.

The content did face ADR review. It faced it as a different decision. Fixed by qualifying each record on the document its destination holds, the ADR number folded to upper case, or the protocol, which carries no number and stands for itself. A rename within one record keeps its number and stays carried. An ungoverned path holds no document and never matches, which subsumes the ninth defect's check rather than sitting beside it.

Two mutations of that helper survived the first battery, which said the tests were thin rather than that the code was right:

| mutation | why it mattered | killed by |
| --- | --- | --- |
| drop the case fold | the path test ignores case, so a record renamed from a lowercased name would read as two records and be falsely refused | a direct identity test |
| the protocol holds no document | the protocol's carried set would empty and every branch touching it would be falsely refused | a direct identity test |

Six mutations killed after adding those.

One reviewer's demonstration of this reported the staged blob as already equal to origin/main's, which an earlier clause exempts on by itself, so that particular evidence did not isolate the defect. The finding was right regardless. Rebuilt with a blob main never held at the target path.

## A thirteenth defect: a directory can wear a record's name

Found by writing the twelfth defect's fix and then asking which segment each half reads.

The path test anchors a record's number to the final segment, because that is where a file's name lives. The identity read searched the whole path and took the first number it found. A directory named for one record holding a file named for another therefore answered with the directory's number: .agents/ADR-201-old/ADR-202-new.md read as ADR-201.

Two decisions then share one identity, and the twelfth defect's filter passes lineage between them, which is the hole that fix was written to close. Nothing in the repository is laid out that way today, and nothing stops it.

Fixed by reading the number from the final segment only, splitting on either separator because the path test accepts both. Three mutations killed, including reading the first segment and splitting on the forward slash alone.

## A fourteenth defect: an empty post-image is not one width

Found by mutation. Deleting the line that drops a deletion's all-zero post-image left every test passing, which is its own finding.

A deletion records a post-image of all zeros whose width follows the repository's hash, so a SHA-256 repository writes sixty-four of them. The reader discarded the forty-zero form by writing that width out, so the wider one stayed in the carried set as a blob no commit can name.

A real staged blob is never all zeros, so this is dead weight rather than an exemption. It is still half a rule. The module already knows both widths through `_is_zero_sha`, which reads `ZERO_SHA_LENGTHS`; the set is now filtered through that instead of naming one width inline. Three mutations killed.

## A fifteenth defect: asking to see signatures blinds two readers

Found by sweeping the git settings that change what these commands print, rather than by reading the code.

`log.showSignature=true` makes git assume `--show-signature` for `log`, `show`, and `whatchanged`. It is a setting a developer sets once, in their own config, and both of this gate's history readers honour it.

`git log --format= --raw -z` glues the verification lines to the front of each commit's first raw record. The field count does not change, so nothing looks wrong; the fields simply stop starting with the colon every record starts with. Measured on this repository: 0 of 77 fields start with a colon, against 38 with the setting off. Every record is skipped, the carried set is empty for every path, and every decision record is falsely refused. Fail-closed, and only for developers holding that setting.

`git show -s --format=%P` gets three verification lines prepended. `stdout.split()` then puts a verification word at index 0, so the slice that skips the first parent skips that word instead and the merge's own first parent joins the parents searched for main. A merge of a side branch reads as a merge of main and the push commit limit rises from 20 to 40. Fail-open.

Both now pass `--no-show-signature`. The trailer reader was checked and deliberately left alone: the decoration lines cannot begin with the review marker, and an extra match would only run the stricter validator, so it is fail-closed and no case could be demonstrated.

Reproduced without a keyring by signing the fixtures with ssh, where verification is left to fail; an unknown signer still prints a verification line, which is the decoration under test. Both fixtures carry an unsigned negative control. Three mutations killed, including dropping either flag alone.

Eleven other settings were measured and cleared: `color.ui`, `color.diff`, `log.decorate`, `diff.submodule`, `notes.displayRef`, `format.pretty`, `log.abbrevCommit` and `diff.noprefix` leave the stream byte-identical, and `diff.renames=false` and `diff.renameLimit=1` can only shrink the carried set, which is fail-closed.

## A sixteenth defect: a record repadded is not a new record

Found by an adversarial review, which proposed a fix that is itself a fail-open.

A record's identity was the literal text of its number, so `ADR-0003` and `ADR-003` compared unequal. The walk stops where the identity changes, so it stopped at the rename between them and dropped every state the record held under its wider name. This repository really made that rename: `ADR-0003-agent-tool-selection-criteria.md` to `ADR-003-agent-tool-selection-criteria.md`. A branch restoring a state from before it was refused for no reason.

The review proposed reading the number as an integer. `\d` matches every decimal digit, not only the ASCII ones, so a name written in another script is governed too and `int` reads it as the same value as the ASCII record. A brand new file would inherit a real record's reviewed history: a false exemption in place of a false refusal, which is the wrong trade for this gate. It also raises on any identifier the proposed slice does not cleanly cover.

Fixed by stripping the leading zeros as text. Only ASCII zeros are stripped, so another script's digits stay their own record; a zero inside the number stays, so `ADR-100` does not fold into `ADR-1`; and `ADR-000` keeps a number rather than becoming the bare prefix.

An explicit guard against non-ASCII digits was written first and then deleted: a mutation battery showed it survived deletion, because stripping ASCII zeros already leaves other digits alone. It was dead code. Five mutations killed.

The first fixture for this was vacuous and said so only under mutation: the revision replaced the whole body, git saw no rename at all, and the negative control passed for the wrong reason. Rebuilt as a one-line edit to a longer body.

## A seventeenth defect: a branch main has landed is not main

Found by an adversarial review, and the highest reachability of the seventeen.

The push limit doubles from 20 to 40 when the push carries a merge of main, because merging main legitimately brings in commits the author did not write. A merge counted as a merge of main when any parent past the first was an ancestor of `origin/main`.

A feature branch that main has already landed is an ancestor of `origin/main`. So merging a branch whose pull request has merged took the wider limit. Nothing exotic is required: no octopus merge, no ref manipulation, no crafted history. Merging a shared topic branch after it lands is ordinary git usage, which is what makes this worth closing rather than a curiosity.

The counted range starts at the merge base of `origin/main` and the pushed head, and that is what settles whether the relaxation was earned. Merging a landed branch advances the merge base past that branch, so its commits are already excluded from the count: a repository built with 15 landed commits and 10 local ones counts 11, with or without the merge. The relaxation was buying an author nothing they needed. Merging main still counts 11 and still relaxes, so the case the wider limit exists for is untouched.

Fixed by reading main's first-parent trunk instead of asking what main can reach. A landed branch sits on the second parent of the merge that landed it, so main reaches it without it being on main. Merging main still relaxes the limit, whether the tip or an older trunk commit, so a developer who merged main and then fell behind is unaffected. Reading the trunk costs one rev walk, 14ms over 1880 commits here.

The first version of the fix read that trunk inside the per-merge check, so a push carrying 25 merges walked main 25 times. Hoisted to the caller and pinned by a test that counts the walks.

A repository with no `origin/main` yields an empty trunk and refuses the wider limit. That edge case was found by the mutation battery rather than by reading: four mutations ran and one survived, and the survivor was thin coverage rather than dead code. A test for the missing ref killed it and killed a second, more realistic mutation that treats an unreadable trunk as reaching everything. Five killed in total.

## An eighteenth defect: a path is not what a text pipe says it is

`-z` was added to this walk so paths arrive unquoted, and then the stream was read through a text mode pipe. Text mode applies universal newline translation. A path ending in a carriage return arrives ending in a newline, and the scope test anchors with `$`, which matches before a trailing newline. So a path this gate does not govern read as one.

Reachable, and measured rather than argued. Main holds a file at a carriage return name, then renames it onto the governed name and revises it:

| blob | ever sat at a governed path | in the carried set before the fix |
|---|---|---|
| the pre-image, written under the carriage return name | no | yes |
| the post-image, written under the governed name | yes | yes |

The first row is the defect. That content never faced review as a decision, and a branch holding it was exempted.

Fixed by reading the bytes and decoding them here instead of letting the pipe do it. Raised by the Copilot reviewer on this pull request; the reachable construction and the measurement are mine. Two of the three mechanisms the report named do not reach: an embedded carriage return does not change the verdict, and invalid UTF-8 collapsing to the replacement character does not either, because neither that character nor a surrogate is a word character and the pattern needs one.

That last point cuts both ways, and the honest version is that one mutation survived. Swapping the error handler back to `replace` passes the whole suite, because identity here is the record's number and a byte spent elsewhere in the path reaches no decision. `surrogateescape` is kept because it round trips and costs nothing, not because a test proves it necessary. The mutation that does die is the one that reintroduces the newline rewrite. Both the code comment and the test docstring say so, so the next reader does not mistake the handler for the fix.

## Two findings from the same review, adjudicated as not defects

Recorded because rejecting a finding is a claim that needs evidence too.

The review reported that a repad written in another script's digits is still refused, since only ASCII zeros are stripped. That is accurate and it is the deliberate trade described in the previous section: the alternative folds another script's record onto the ASCII one, which is a false exemption. A false refusal is the safe direction for this gate. All 760 Unicode decimal digits were then run through the identity chain: no two produce the same identity, and only the ASCII zero is stripped.

The review also reported that folding `ADR-0003` onto `ADR-003` lets the walk import blobs from a different decision that reused the number, and supplied a working repro. The repro reproduces. The same repro was then run with both names written at the same width, so no folding is involved, and it accepts identically. The fold is not what makes it work. Identity has been the record's number alone since the twelfth defect above, so any two governed documents sharing a number already share a lineage. This repository has 47 such identities live right now, mostly a decision plus its debate log, critique, or review report.

Whether that is the right identity is an owner call, because narrowing it to the whole filename would refuse every legitimate retitle of a record. It is not a regression from this branch, and it is not exercised: across 10,536 paths in all history, every followed blob set was compared against the blobs that ever lived at each same-number sibling, and no set crosses. Raised on the tracking issue rather than folded in here.

## A note on the mutation batteries

One battery aborted on a stale anchor after the code it targeted changed, leaving a mutation on disk. The next battery then read that mutated file as its baseline. Two of the three batteries now restore the file in a `finally` block and refuse to run at all unless the baseline suite is green first, which is how the second run caught it.
