### PR TITLE
docs(eval): name the negative controls instead of counting to them

### DIFF
--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -10311,8 +10311,11 @@ class TestAnUnparseableReportOutranksAnExhaustedBudget:
     document at all is a question no reading of the document can answer
     differently. The schema it declares, the corpus it names and whether its
     verdicts are booleans are judgments about the document, and those stay
-    behind the guard. The last three tests here are the negative controls for
-    that line, one on each side of it.
+    behind the guard. Three tests hold that line from the far side, by name
+    rather than by position: `test_a_schema_this_build_cannot_read_...`,
+    `test_a_bare_mapping_with_bad_verdicts_...` and
+    `test_a_readable_report_with_bad_verdicts_...`. Each parses, so each is
+    still the guard's to decide, and each must still yield to the budget.
     """
 
     def _exhausted(self, tmp_path, capsys):

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -10312,10 +10312,12 @@ class TestAnUnparseableReportOutranksAnExhaustedBudget:
     differently. The schema it declares, the corpus it names and whether its
     verdicts are booleans are judgments about the document, and those stay
     behind the guard. Three tests hold that line from the far side, by name
-    rather than by position: `test_a_schema_this_build_cannot_read_...`,
-    `test_a_bare_mapping_with_bad_verdicts_...` and
-    `test_a_readable_report_with_bad_verdicts_...`. Each parses, so each is
-    still the guard's to decide, and each must still yield to the budget.
+    rather than by position:
+    `test_a_schema_this_build_cannot_read_still_yields_to_the_budget`,
+    `test_a_bare_mapping_with_bad_verdicts_still_yields_to_the_budget` and
+    `test_a_readable_report_with_bad_verdicts_still_yields_to_the_budget`.
+    Each parses, so each is still the guard's to decide, and each must still
+    yield to the budget.
     """
 
     def _exhausted(self, tmp_path, capsys):


### PR DESCRIPTION
Fixes #3681

Adversarial review round 51 (`gpt-5.6-terra`) checked a claim in a class docstring and found it false.

`TestAnUnparseableReportOutranksAnExhaustedBudget` in `tests/eval/test_optimize_artifact_cli.py` said "the last three tests here are the negative controls". An AST count of the class returns seven tests, and one of the three controls sits third, not last. The sentence was true when written and stopped being true when tests were appended after it.

Positional prose about a test class decays on every append. This replaces the position with the three test names, so the sentence either stays true or breaks loudly when a test is renamed. No test behavior changes.

## Verification

The three names in the new docstring were taken from an AST walk of the class, not from reading the file top to bottom. `uv run --frozen python -m pytest tests/eval/test_optimize_artifact_cli.py -q` is unchanged and green.
