### PR TITLE
docs(memory): capture the markdownlint exclusion verification trap

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-28-session-3650-markdownlint-exclusion-trap.json
+++ b/.agents/memory/episodes/episode-2026-07-28-session-3650-markdownlint-exclusion-trap.json
@@ -1,0 +1,58 @@
+{
+  "id": "episode-2026-07-28-session-3650-markdownlint-exclusion-trap",
+  "session": "2026-07-28-session-3650-markdownlint-exclusion-trap",
+  "timestamp": "2026-07-28T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Record in the linting-exclusions memory that a markdownlint run against an excluded path reports success because zero files were selected, not because the files are clean, and record the correct out-of-tree procedure.",
+  "decisions": [
+    {
+      "id": "d001",
+      "timestamp": "2026-07-28T00:00:00+00:00",
+      "type": "implementation",
+      "context": "Established the trap empirically rather than from recollection. Wrote identical bytes carrying one MD032 violation to two locations and ran markdownlint-cli2 v0.23.2 against each. In tree at .serena/memories/: 'Linting: 0 files', 'Summary: 0 issues in 0 files', exit 0. Out of tree: 'Linting: 1 file', MD032 reported at line 4, exit 1. The in-tree run is green because .serena/** is ignore pattern 12 of 44, so zero files were selected. Read Linting: N files, not the summary, because the summary's trailing count is files-with-issues and reads 0 in both the vacuous and the genuinely clean case.",
+      "chosen": "Established the trap empirically rather than from recollection. Wrote identical bytes carrying one MD032 violation to two locations and ran markdownlint-cli2 v0.23.2 against each. In tree at .serena/memories/: 'Linting: 0 files', 'Summary: 0 issues in 0 files', exit 0. Out of tree: 'Linting: 1 file', MD032 reported at line 4, exit 1. The in-tree run is green because .serena/** is ignore pattern 12 of 44, so zero files were selected. Read Linting: N files, not the summary, because the summary's trailing count is files-with-issues and reads 0 in both the vacuous and the genuinely clean case.",
+      "rationale": "",
+      "outcome": "success",
+      "effects": []
+    }
+  ],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-28T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Established the trap empirically rather than from recollection. Wrote identical bytes carrying one MD032 violation to two locations and ran markdownlint-cli2 v0.23.2 against each. In tree at .serena/memories/: 'Linting: 0 files', 'Summary: 0 issues in 0 files', exit 0. Out of tree: 'Linting: 1 file', MD032 reported at line 4, exit 1. The in-tree run is green because .serena/** is ignore pattern 12 of 44, so zero files were selected. Read Linting: N files, not the summary, because the summary's trailing count is files-with-issues and reads 0 in both the vacuous and the genuinely clean case.",
+      "caused_by": [],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-28T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Caught and corrected a wrong instruction in my own draft before committing it. The first draft told the reader to lint out of tree with no config, on the reasoning that the absent config means no ignores apply. Running that way against the memory reported 9 issues, all false: this repo disables MD003, MD013, MD029, MD048, MD049, MD050, and MD060, and the flagged MD013 line-length and MD060 table-style rules are among them. Rewrote the procedure to copy the repo config and strip only the ignores and globs keys. Re-verified: Linting: 1 file, 0 issues, exit 0. Also corrected an earlier misreading in the same check, where a tail pipe had masked the true exit codes and made a failing run look like it exited 0; the true codes are 1 out of tree and 0 in tree.",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-28T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 1cde48c0d9",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 1
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-28-session-3650-markdownlint-exclusion-trap.json
+++ b/.agents/memory/episodes/episode-2026-07-28-session-3650-markdownlint-exclusion-trap.json
@@ -43,6 +43,78 @@
       "type": "commit",
       "content": "Commit: 1cde48c0d9",
       "caused_by": [],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-28T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 806392cff",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-28T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 1cde48c0d",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": [
+        "e006"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-28T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 5285286c4",
+      "caused_by": [
+        "e005"
+      ],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-28T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 51af06095",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-28T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 788a93e94",
+      "caused_by": [
+        "e007"
+      ],
+      "leads_to": [
+        "e009"
+      ]
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-28T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 70a57614a",
+      "caused_by": [
+        "e008"
+      ],
       "leads_to": []
     }
   ],
@@ -51,7 +123,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
+    "commits": 7,
     "files_changed": 1
   },
   "lessons": []

--- a/.agents/sessions/2026-07-28-session-3650-markdownlint-exclusion-trap.json
+++ b/.agents/sessions/2026-07-28-session-3650-markdownlint-exclusion-trap.json
@@ -69,7 +69,7 @@
       "changesCommitted": {
         "complete": true,
         "level": "MUST",
-        "evidence": "The memory commit carries the single-file change; the session-log commit carries this file. Both on docs/markdownlint-exclusion-trap."
+        "evidence": "Commits on docs/markdownlint-exclusion-trap: 1cde48c0d the memory record, 5285286c4 this session log, 51af06095 the re-verification command, 788a93e94 the globs guidance and path count, 70a57614a the pattern accuracy and procedure completion, 806392cff the globs strip in the out-of-tree lint."
       },
       "validationPassed": {
         "complete": true,
@@ -91,7 +91,7 @@
       "step": "Caught and corrected a wrong instruction in my own draft before committing it. The first draft told the reader to lint out of tree with no config, on the reasoning that the absent config means no ignores apply. Running that way against the memory reported 9 issues, all false: this repo disables MD003, MD013, MD029, MD048, MD049, MD050, and MD060, and the flagged MD013 line-length and MD060 table-style rules are among them. Rewrote the procedure to copy the repo config and strip only the ignores and globs keys. Re-verified: Linting: 1 file, 0 issues, exit 0. Also corrected an earlier misreading in the same check, where a tail pipe had masked the true exit codes and made a failing run look like it exited 0; the true codes are 1 out of tree and 0 in tree."
     }
   ],
-  "endingCommit": "1cde48c0d9",
+  "endingCommit": "806392cff",
   "nextSteps": [
     "The naive category counter in scripts/memory/validate_memory_sizes.py reads YAML comment lines inside fenced code blocks as H1 headings. This memory reports Categories: 4 against a true count of 1, leaving one slot before a legitimate edit would falsely trip the limit of 5. Filed as issue #3696; the fix is deferred because the script is mirrored into src/copilot-cli/skills/memory/scripts/ and carries plugin manifest bumps.",
     "Session log 2026-07-28-session-3629-memory-stale-script-refs.json already recorded the out-of-tree workaround in its markdownLintRun evidence, but a session log is not a retrieval surface. That is the reason this belongs in a memory, and it suggests other operational knowledge is sitting only in session-log evidence fields."

--- a/.agents/sessions/2026-07-28-session-3650-markdownlint-exclusion-trap.json
+++ b/.agents/sessions/2026-07-28-session-3650-markdownlint-exclusion-trap.json
@@ -1,0 +1,99 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3650,
+    "date": "2026-07-28",
+    "branch": "docs/markdownlint-exclusion-trap",
+    "startingCommit": "95da12691b",
+    "objective": "Record in the linting-exclusions memory that a markdownlint run against an excluded path reports success because zero files were selected, not because the files are clean, and record the correct out-of-tree procedure."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "branchVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "git checkout -b docs/markdownlint-exclusion-trap origin/main, then git branch --show-current returned docs/markdownlint-exclusion-trap"
+      },
+      "notOnMain": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Branch is docs/markdownlint-exclusion-trap, not main. Created fresh from origin/main so the change stays off the clean PR #3647 branch."
+      },
+      "handoffRead": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Not re-read for this branch. The work continues an in-flight session whose context was already established, and the change is a single-file memory correction with no dependency on the handoff dashboard."
+      },
+      "sessionLogCreated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "This file, created before the memory commit. The branch-context-policy hook rejected the first commit attempt because the newest log on this branch named fix/memory-stale-script-refs."
+      },
+      "serenaActivated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Serena MCP tools were not invoked in this unit of work. The memory was located and edited through direct file reads under .serena/memories/, and validated with scripts/memory/validate_memory_sizes.py."
+      },
+      "serenaInstructions": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Not loaded in this unit of work, for the same reason serenaActivated is false."
+      },
+      "constraintsRead": {
+        "complete": true,
+        "level": "SHOULD",
+        "evidence": "Applied the knowledge-persistence rule, which directs new facts to the closest existing memory rather than a new file, so the content extended .serena/memories/linting/linting-exclusions.md. Checked the plugin-version-bump path globs and confirmed .serena/** is outside the plugin roots, so no manifest bump applies."
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Both work-log entries closed with measured evidence"
+      },
+      "handoffPreserved": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "HANDOFF.md not modified; it is read-only per ADR-014"
+      },
+      "serenaMemoryUpdated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": ".serena/memories/linting/linting-exclusions.md extended with a verification-trap section and two new anti-pattern bullets; 36 insertions, no deletions"
+      },
+      "markdownLintRun": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "markdownlint-cli2 v0.23.2 run out of tree in /tmp/mdl-verify with the repo config copied and the ignores and globs keys stripped. Result: Linting: 1 file, 0 issues, exit 0. The Linting line confirms the file was actually selected and checked."
+      },
+      "changesCommitted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "The memory commit carries the single-file change; the session-log commit carries this file. Both on docs/markdownlint-exclusion-trap."
+      },
+      "validationPassed": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "scripts/memory/validate_memory_sizes.py returned PASS at 3,006 characters against the 10,000 limit. scripts/validate_session_json.py run against this log."
+      },
+      "retrospectiveInvoked": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Single-file memory correction extracted from an in-flight session; the retrospective belongs to the parent session that produced the finding."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": "Established the trap empirically rather than from recollection. Wrote identical bytes carrying one MD032 violation to two locations and ran markdownlint-cli2 v0.23.2 against each. In tree at .serena/memories/: 'Linting: 0 files', 'Summary: 0 issues in 0 files', exit 0. Out of tree: 'Linting: 1 file', MD032 reported at line 4, exit 1. The in-tree run is green because .serena/** is ignore pattern 12 of 44, so zero files were selected. Read Linting: N files, not the summary, because the summary's trailing count is files-with-issues and reads 0 in both the vacuous and the genuinely clean case."
+    },
+    {
+      "step": "Caught and corrected a wrong instruction in my own draft before committing it. The first draft told the reader to lint out of tree with no config, on the reasoning that the absent config means no ignores apply. Running that way against the memory reported 9 issues, all false: this repo disables MD003, MD013, MD029, MD048, MD049, MD050, and MD060, and the flagged MD013 line-length and MD060 table-style rules are among them. Rewrote the procedure to copy the repo config and strip only the ignores and globs keys. Re-verified: Linting: 1 file, 0 issues, exit 0. Also corrected an earlier misreading in the same check, where a tail pipe had masked the true exit codes and made a failing run look like it exited 0; the true codes are 1 out of tree and 0 in tree."
+    }
+  ],
+  "endingCommit": "1cde48c0d9",
+  "nextSteps": [
+    "The naive category counter in scripts/memory/validate_memory_sizes.py reads YAML comment lines inside fenced code blocks as H1 headings. This memory reports Categories: 4 against a true count of 1, leaving one slot before a legitimate edit would falsely trip the limit of 5. Filed as issue #3696; the fix is deferred because the script is mirrored into src/copilot-cli/skills/memory/scripts/ and carries plugin manifest bumps.",
+    "Session log 2026-07-28-session-3629-memory-stale-script-refs.json already recorded the out-of-tree workaround in its markdownLintRun evidence, but a session log is not a retrieval surface. That is the reason this belongs in a memory, and it suggests other operational knowledge is sitting only in session-log evidence fields."
+  ]
+}

--- a/.serena/memories/linting/linting-exclusions.md
+++ b/.serena/memories/linting/linting-exclusions.md
@@ -39,10 +39,46 @@ Document known false positives in config comments:
 # - roadmap.md: nested templates trigger MD040
 ```
 
+## Verification trap: an excluded path lints green because it never lints
+
+The exclusions make an in-tree run vacuous for the paths they cover. The run
+reports success and exits 0 because zero files were selected, not because the
+files are clean.
+
+Verified 2026-07-28 on identical bytes (a file with one MD032 violation):
+
+| Run | Output | Exit |
+|---|---|---|
+| In tree, at `.serena/memories/probe.md` | `Linting: 0 files` / `0 issues in 0 files` | 0 |
+| Out of tree, same bytes | `Linting: 1 file` / `1 issue in 1 file`, MD032 reported | 1 |
+
+Read `Linting: N files`, not the summary. `0 issues in 0 files` is a green that
+means nothing. The trailing count in the summary is *files with issues*, so
+`0 issues in 0 files` and a real clean run are indistinguishable without the
+`Linting:` line.
+
+This surface is large. `ignores` currently holds 44 patterns and covers most of
+the markdown that gets edited here: `.claude/skills/**`, `src/copilot-cli/skills/**`,
+`.serena/**`, `.agents/**`, `**/CLAUDE.md`, `.github/agents/**/*.agent.md`,
+`docs/autonomous-pr-monitor.md`, and the five lifecycle command files.
+
+To actually lint an excluded file, copy it to a scratch directory outside the
+repo, copy `.markdownlint-cli2.yaml` alongside it, and delete the `ignores` and
+`globs` keys from that copy. Keep the rest of the config. Running with the
+stock default rule set instead produces false positives, because this repo
+disables MD003, MD013, MD029, MD048, MD049, MD050, and MD060. Linting this
+memory with defaults reported 9 issues; with the repo rules and `ignores`
+stripped it reported 0 at `Linting: 1 file`.
+
+Cost of not knowing this: two MD032 errors and a banned word survived into a
+commit in `docs/autonomous-pr-monitor.md` because the in-tree run said clean.
+
 ## Anti-Pattern
 
 - Disabling rules without documentation
 - **Prevention**: Add inline comments explaining why
+- Treating a green in-tree markdownlint run as proof a file is clean
+- **Prevention**: Check `Linting: N files` shows N > 0, or lint out of tree
 
 ## Related
 

--- a/.serena/memories/linting/linting-exclusions.md
+++ b/.serena/memories/linting/linting-exclusions.md
@@ -1,6 +1,6 @@
 # Skill-Lint-005: Exclude Generated Directories
 
-**Statement**: Exclude generated artifact directories from linting using both globs and ignores
+**Statement**: Exclude generated artifact directories from linting using `ignores`
 
 **Context**: Managing linting for mixed codebase with generated content
 
@@ -17,9 +17,14 @@ ignores:
   - ".agents/**"
   - "node_modules/**"
   - "dist/**"
-globs:
-  - "!.agents/**"
 ```
+
+Do not add a top-level `globs:` key. This config carried one once and it was
+removed deliberately, with the reason recorded inline at the removal site:
+markdownlint-cli2 ADDS config globs to any files passed on the command line, so
+a hook that lints one touched file also walks every `**/*.md` in the repo and
+takes minutes per invocation. The current config has exactly two top-level
+keys, `config` and `ignores`.
 
 ## Why Exclude .agents/
 
@@ -57,11 +62,12 @@ means nothing. The trailing count in the summary is *files with issues*, so
 `0 issues in 0 files` and a real clean run are indistinguishable without the
 `Linting:` line.
 
-This surface is large. At the time of writing, `ignores` held 44 patterns and
-covered most of the markdown that gets edited here: `.claude/skills/**`,
-`src/copilot-cli/skills/**`, `.serena/**`, `.agents/**`, `**/CLAUDE.md`,
-`.github/agents/**/*.agent.md`, `docs/autonomous-pr-monitor.md`, and the five
-lifecycle command files.
+This surface is large. At the time of writing, `ignores` held 44 patterns
+covering 89.7% of tracked markdown (3,529 of 3,935 files), including
+`.claude/skills/**`, `src/copilot-cli/skills/**`, `.serena/**`, `.agents/**`,
+`**/CLAUDE.md`, `.github/agents/**/*.agent.md`, `docs/autonomous-pr-monitor.md`,
+and the five lifecycle commands across ten explicit paths (the `.claude/commands/`
+files and their `src/copilot-cli/skills/` mirrors).
 
 Both that count and the disabled-rule list below drift as the config changes.
 Regenerate them instead of trusting this text:
@@ -76,12 +82,16 @@ print('disabled rules:', sorted(k for k, v in d.get('config', {}).items() if v i
 ```
 
 To actually lint an excluded file, copy it to a scratch directory outside the
-repo, copy `.markdownlint-cli2.yaml` alongside it, and delete the `ignores` and
-`globs` keys from that copy. Keep the rest of the config. Running with the
-stock default rule set instead produces false positives, because this repo
-disables MD003, MD013, MD029, MD048, MD049, MD050, and MD060 as of this
-writing. Linting this memory with defaults reported 9 issues; with the repo
-rules and `ignores` stripped it reported 0 at `Linting: 1 file`.
+repo, copy `.markdownlint-cli2.yaml` alongside it, and delete the `ignores` key
+from that copy. Keep the rest of the config. Nothing else in it needs changing:
+the only other top-level key is `config`, and it holds no relative paths, no
+`extends`, and no `customRules`, so it travels intact. Running with the stock
+default rule set instead produces false positives, because this repo disables
+MD003, MD013, MD029, MD048, MD049, MD050, and MD060 as of this writing. A
+default run on this memory reported 9 issues, every one of them MD013
+line-length or MD060 table-style; the repo rules with `ignores` stripped
+reported 0 at `Linting: 1 file`. That count moves with every edit to this file,
+so re-run it rather than checking against the number.
 
 Cost of not knowing this: two MD032 errors and a banned word survived into a
 commit in `docs/autonomous-pr-monitor.md` because the in-tree run said clean.

--- a/.serena/memories/linting/linting-exclusions.md
+++ b/.serena/memories/linting/linting-exclusions.md
@@ -57,18 +57,31 @@ means nothing. The trailing count in the summary is *files with issues*, so
 `0 issues in 0 files` and a real clean run are indistinguishable without the
 `Linting:` line.
 
-This surface is large. `ignores` currently holds 44 patterns and covers most of
-the markdown that gets edited here: `.claude/skills/**`, `src/copilot-cli/skills/**`,
-`.serena/**`, `.agents/**`, `**/CLAUDE.md`, `.github/agents/**/*.agent.md`,
-`docs/autonomous-pr-monitor.md`, and the five lifecycle command files.
+This surface is large. At the time of writing, `ignores` held 44 patterns and
+covered most of the markdown that gets edited here: `.claude/skills/**`,
+`src/copilot-cli/skills/**`, `.serena/**`, `.agents/**`, `**/CLAUDE.md`,
+`.github/agents/**/*.agent.md`, `docs/autonomous-pr-monitor.md`, and the five
+lifecycle command files.
+
+Both that count and the disabled-rule list below drift as the config changes.
+Regenerate them instead of trusting this text:
+
+```bash
+python3 -c "
+import yaml
+d = yaml.safe_load(open('.markdownlint-cli2.yaml'))
+print('ignore patterns:', len(d.get('ignores', [])))
+print('disabled rules:', sorted(k for k, v in d.get('config', {}).items() if v is False))
+"
+```
 
 To actually lint an excluded file, copy it to a scratch directory outside the
 repo, copy `.markdownlint-cli2.yaml` alongside it, and delete the `ignores` and
 `globs` keys from that copy. Keep the rest of the config. Running with the
 stock default rule set instead produces false positives, because this repo
-disables MD003, MD013, MD029, MD048, MD049, MD050, and MD060. Linting this
-memory with defaults reported 9 issues; with the repo rules and `ignores`
-stripped it reported 0 at `Linting: 1 file`.
+disables MD003, MD013, MD029, MD048, MD049, MD050, and MD060 as of this
+writing. Linting this memory with defaults reported 9 issues; with the repo
+rules and `ignores` stripped it reported 0 at `Linting: 1 file`.
 
 Cost of not knowing this: two MD032 errors and a banned word survived into a
 commit in `docs/autonomous-pr-monitor.md` because the in-tree run said clean.

--- a/.serena/memories/linting/linting-exclusions.md
+++ b/.serena/memories/linting/linting-exclusions.md
@@ -15,16 +15,23 @@ In `.markdownlint-cli2.yaml`:
 ```yaml
 ignores:
   - ".agents/**"
-  - "node_modules/**"
+  - "**/node_modules/**"
   - "dist/**"
 ```
+
+Note the leading `**/` on the `node_modules` pattern. `node_modules/**` matches
+only a root-level directory; `**/node_modules/**` also catches nested ones such
+as `foo/node_modules/a.md`. The live config uses the recursive form.
 
 Do not add a top-level `globs:` key. This config carried one once and it was
 removed deliberately, with the reason recorded inline at the removal site:
 markdownlint-cli2 ADDS config globs to any files passed on the command line, so
 a hook that lints one touched file also walks every `**/*.md` in the repo and
 takes minutes per invocation. The current config has exactly two top-level
-keys, `config` and `ignores`.
+keys, `config` and `ignores`. That matters beyond the `globs` warning: because
+`config` holds no relative paths, no `extends`, and no `customRules`, the file
+can be copied to a scratch directory and still behave identically, which is
+what the out-of-tree procedure below relies on.
 
 ## Why Exclude .agents/
 
@@ -69,29 +76,53 @@ covering 89.7% of tracked markdown (3,529 of 3,935 files), including
 and the five lifecycle commands across ten explicit paths (the `.claude/commands/`
 files and their `src/copilot-cli/skills/` mirrors).
 
-Both that count and the disabled-rule list below drift as the config changes.
-Regenerate them instead of trusting this text:
+These figures drift as the config and the tree change. Regenerate them instead
+of trusting this text:
 
 ```bash
 python3 -c "
-import yaml
-d = yaml.safe_load(open('.markdownlint-cli2.yaml'))
-print('ignore patterns:', len(d.get('ignores', [])))
-print('disabled rules:', sorted(k for k, v in d.get('config', {}).items() if v is False))
+import subprocess, yaml, pathspec
+cfg = yaml.safe_load(open('.markdownlint-cli2.yaml'))
+ignores = cfg.get('ignores', [])
+files = subprocess.run(['git','ls-files','*.md'], capture_output=True, text=True).stdout.split()
+spec = pathspec.PathSpec.from_lines('gitwildmatch', ignores)
+hit = sum(1 for f in files if spec.match_file(f))
+print('ignore patterns:', len(ignores))
+print('disabled rules:', sorted(k for k, v in cfg.get('config', {}).items() if v is False))
+print(f'markdown ignored: {hit} of {len(files)} ({100*hit/len(files):.1f}%)')
 "
 ```
 
+Run it under `uv run` if `pathspec` is missing from the ambient interpreter; it
+resolves through `uv.lock`. The coverage figure is an estimate: this uses
+gitwildmatch semantics while markdownlint-cli2 uses picomatch. The two agree on
+the patterns in this config, so treat the percentage as close rather than
+exact.
+
 To actually lint an excluded file, copy it to a scratch directory outside the
-repo, copy `.markdownlint-cli2.yaml` alongside it, and delete the `ignores` key
-from that copy. Keep the rest of the config. Nothing else in it needs changing:
-the only other top-level key is `config`, and it holds no relative paths, no
-`extends`, and no `customRules`, so it travels intact. Running with the stock
-default rule set instead produces false positives, because this repo disables
-MD003, MD013, MD029, MD048, MD049, MD050, and MD060 as of this writing. A
-default run on this memory reported 9 issues, every one of them MD013
-line-length or MD060 table-style; the repo rules with `ignores` stripped
-reported 0 at `Linting: 1 file`. That count moves with every edit to this file,
-so re-run it rather than checking against the number.
+repo, copy `.markdownlint-cli2.yaml` alongside it, delete the `ignores` key from
+that copy, and run the linter there:
+
+```bash
+mkdir -p /tmp/mdl && cp path/to/excluded.md /tmp/mdl/
+python3 -c "
+import yaml
+d = yaml.safe_load(open('.markdownlint-cli2.yaml'))
+d.pop('ignores', None)
+yaml.safe_dump(d, open('/tmp/mdl/.markdownlint-cli2.yaml','w'), sort_keys=False)
+"
+cd /tmp/mdl && npx --yes markdownlint-cli2 "*.md"
+```
+
+Confirm the output says `Linting: 1 file` before you read the summary. If it
+says `Linting: 0 files` you are still being excluded and the result is
+meaningless. Keep the rest of the config: it travels intact for the reason given
+under Implementation. Running with the stock default rule set instead produces
+false positives, because this repo disables MD003, MD013, MD029, MD048, MD049,
+MD050, and MD060 as of this writing. A default run on this memory reported 9
+issues, every one of them MD013 line-length or MD060 table-style; the repo rules
+with `ignores` stripped reported 0 at `Linting: 1 file`. That count moves with
+every edit to this file, so re-run it rather than checking against the number.
 
 Cost of not knowing this: two MD032 errors and a banned word survived into a
 commit in `docs/autonomous-pr-monitor.md` because the in-tree run said clean.

--- a/.serena/memories/linting/linting-exclusions.md
+++ b/.serena/memories/linting/linting-exclusions.md
@@ -100,8 +100,8 @@ the patterns in this config, so treat the percentage as close rather than
 exact.
 
 To actually lint an excluded file, copy it to a scratch directory outside the
-repo, copy `.markdownlint-cli2.yaml` alongside it, delete the `ignores` key from
-that copy, and run the linter there:
+repo, copy `.markdownlint-cli2.yaml` alongside it, delete the `ignores` and
+`globs` keys from that copy, and run the linter there:
 
 ```bash
 mkdir -p /tmp/mdl && cp path/to/excluded.md /tmp/mdl/
@@ -109,10 +109,20 @@ python3 -c "
 import yaml
 d = yaml.safe_load(open('.markdownlint-cli2.yaml'))
 d.pop('ignores', None)
+d.pop('globs', None)
 yaml.safe_dump(d, open('/tmp/mdl/.markdownlint-cli2.yaml','w'), sort_keys=False)
 "
 cd /tmp/mdl && npx --yes markdownlint-cli2 "*.md"
 ```
+
+The `globs` pop is defensive: this repo's config has no `globs` key today, so
+the line is a no-op against the current file. It matters because a config
+`globs` list does not narrow the command-line argument, it adds to it.
+Measured with markdownlint-cli2 v0.23.2: a scratch config carrying
+`globs: ['other.md']`, invoked as `markdownlint-cli2 "target.md"`, printed
+`Finding: target.md other.md` and `Linting: 2 files`. The verification step
+below would then read `2` where you expected `1`, and the summary would mix a
+file you did not ask about into the result you are reading.
 
 Confirm the output says `Linting: 1 file` before you read the summary. If it
 says `Linting: 0 files` you are still being excluded and the result is


### PR DESCRIPTION
## Summary

Captures a verified markdownlint failure mode in the linting memory, and fixes
a pre-existing defect in that memory that was actively steering readers wrong.

Refs #3710
Refs #3696

## The trap

The repo config excludes 89.7% of tracked markdown (3,529 of 3,935 files) across
44 ignore patterns. Lint an excluded path in the tree and markdownlint-cli2
selects zero files, prints `Summary: 0 issues in 0 files`, and exits 0. The run
looks green. Nothing was checked.

The summary line cannot tell the two cases apart. Its trailing count is *files
with issues*, so a genuinely clean file and a file that was never selected print
the same thing. The only honest signal is the `Linting: N files` line.

## Evidence

Identical bytes carrying one MD032 violation, written to two locations:

| Run | Output | Exit |
|---|---|---|
| In tree, excluded path | `Linting: 0 files` / `0 issues in 0 files` | 0 |
| Out of tree, same bytes | `Linting: 1 file`, MD032 reported | 1 |

Excluded prefixes cover most of what anyone edits here, including
`.claude/skills/**`, `src/copilot-cli/skills/**`, `.serena/**`, and `.agents/**`.
Real cost already paid: two MD032 errors and a banned word reached a commit
because the in-tree run said clean.

## The pre-existing defect

Round-1 adversarial review found the memory instructing readers to configure
exclusions with a top-level `globs:` key. That key was removed from the config
deliberately. The reason is recorded inline at the removal site: markdownlint-cli2
adds config globs to any files passed on the command line, so a hook linting one
touched file would also walk all 3,935. The memory was recommending the exact
pattern the config exists to avoid. Fixed in the statement, the example, and the
prose.

Round 2 found three more: the example ignore pattern read `node_modules/**`,
which misses nested copies where the live config uses `**/node_modules/**`; the
out-of-tree procedure never stated the command to run; and the re-verification
block regenerated two of the four numbers the memory quotes.

## Verification

- Both bash blocks were extracted from the committed file and executed. The
  procedure block, followed verbatim, reports `Linting: 1 file`, 0 issues, exit 0.
- The re-verification block regenerates all four quoted figures (44 patterns,
  7 disabled rules, 3,529 of 3,935, 89.7%). Output matches the prose exactly.
- Coverage measured independently by me and by the reviewer, same result.
- Memory size validator: PASS at 5,677 chars. Session log validator: PASS.
- The pre-PR validation suite reported all validations passed, and every
  pre-push gate ran green.
- Two rounds of adversarial review on gpt-5.6-sol, a different model family from
  the author. Every finding independently reproduced before acting on it.

## Notes

Applies the executable-maintenance pattern already used elsewhere in the repo:
prose carries intent, commands carry the numbers that decay. Quoted figures are
scoped to time of writing and paired with the command that regenerates them.

## Out of scope

- The memory category counter double-count, tracked in #3696. Reproduced live
  here: this file reports 4 categories against a true 1, because YAML comments
  inside fenced blocks are read as H1 headings.
- 112 of 875 memories exceed size thresholds. Pre-existing; the pre-commit hook
  only gates changed files.

## References

- See `.markdownlint-cli2.yaml` for the ignore list and the inline note on why
  the globs key was removed.
- The banned word and MD032 errors landed in `docs/autonomous-pr-monitor.md`.
