### PR TITLE
fix(validation): agree with the local hook on the commit limit boundary

### DIFF
--- a/scripts/validation/pr_commit_count.py
+++ b/scripts/validation/pr_commit_count.py
@@ -23,7 +23,7 @@ Behavior:
 
 The commit count is fetched with ``per_page=100`` (the GitHub REST maximum for
 a single page) and is not paginated, so the reported count saturates at 100.
-Classification is unaffected: any PR at or above ``BLOCK_THRESHOLD`` (20) is
+Classification is unaffected: any PR above ``BLOCK_THRESHOLD`` (20) is
 ``BLOCKED``, and 100 far exceeds 20, so a PR with more than 100 commits is
 always ``BLOCKED`` regardless of the exact count. For such PRs the emitted
 ``commit_count`` is a floor.
@@ -50,9 +50,10 @@ sys.path.insert(0, str(_PROJECT_ROOT))
 
 from scripts.github_core.api import resolve_repo_params  # noqa: E402
 
-# Commit-count thresholds (issue #362). A PR at or above BLOCK_THRESHOLD is
+# Commit-count thresholds (issue #362). A PR above BLOCK_THRESHOLD is
 # blocked by the downstream Enforce Blocking Issues step unless it carries the
-# commit-limit-bypass label.
+# commit-limit-bypass label. The comparison is strict so this agrees with the
+# local pre-push hook, which allows ``commit_count <= 20`` (issue #3721).
 WARNING_THRESHOLD = 10
 ALERT_THRESHOLD = 15
 BLOCK_THRESHOLD = 20
@@ -95,7 +96,7 @@ class CountResult:
 
 def classify_count(count: int) -> str:
     """Map a commit count to a threshold status (issue #362)."""
-    if count >= BLOCK_THRESHOLD:
+    if count > BLOCK_THRESHOLD:
         return "BLOCKED"
     if count >= ALERT_THRESHOLD:
         return "ALERT"
@@ -146,7 +147,7 @@ def fetch_commit_count(pr_number: int, owner: str, repo: str) -> CountResult:
     raises FileNotFoundError so the caller can exit 2 (config error, ADR-035).
 
     The count is fetched with ``per_page=100`` and is not paginated, so it
-    saturates at 100. This does not change classification: any count at or above
+    saturates at 100. This does not change classification: any count above
     BLOCK_THRESHOLD (20) is BLOCKED, and 100 >> 20.
     """
     endpoint = f"repos/{owner}/{repo}/pulls/{pr_number}/commits?per_page=100"
@@ -251,7 +252,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"PR #{args.pr_number} has {count} commits (status: {outcome.status})")
     if outcome.status == "BLOCKED":
         print(
-            f"::error::PR exceeds commit limit ({count} >= {BLOCK_THRESHOLD}). "
+            f"::error::PR exceeds commit limit ({count} > {BLOCK_THRESHOLD}). "
             "Consider splitting this PR."
         )
     elif outcome.status == "ALERT":

--- a/scripts/validation/pr_commit_count.py
+++ b/scripts/validation/pr_commit_count.py
@@ -53,7 +53,14 @@ from scripts.github_core.api import resolve_repo_params  # noqa: E402
 # Commit-count thresholds (issue #362). A PR above BLOCK_THRESHOLD is
 # blocked by the downstream Enforce Blocking Issues step unless it carries the
 # commit-limit-bypass label. The comparison is strict so this agrees with the
-# local pre-push hook, which allows ``commit_count <= 20`` (issue #3721).
+# default local pre-push limit (issue #3721). The local hook in
+# ``git_hook_policy._check_commit_limit`` allows ``commit_count <= limit``,
+# where ``limit`` is this same 20 by default but widens to 40 when the update
+# contains a merge of main. This check has no notion of that widening, so a
+# main-merge push the hook accepts at 21 through 40 still lands a blocked pull
+# request; the commit-limit-bypass label is the escape hatch for that case.
+# Aligning the widening too would need the workflow to know the push shape,
+# which it does not receive.
 WARNING_THRESHOLD = 10
 ALERT_THRESHOLD = 15
 BLOCK_THRESHOLD = 20

--- a/tests/validation/test_pr_commit_count.py
+++ b/tests/validation/test_pr_commit_count.py
@@ -45,12 +45,25 @@ def _commits_json(n: int) -> str:
         (14, "WARNING"),
         (15, "ALERT"),
         (19, "ALERT"),
-        (20, "BLOCKED"),
+        (20, "ALERT"),
+        (21, "BLOCKED"),
         (99, "BLOCKED"),
     ],
 )
 def test_classify_count_thresholds(count: int, expected: str) -> None:
     assert mod.classify_count(count) == expected
+
+
+@pytest.mark.parametrize(("count", "blocked"), [(19, False), (20, False), (21, True)])
+def test_the_block_boundary_agrees_with_the_local_hook(count: int, blocked: bool) -> None:
+    """The two enforcement points must draw the line in the same place.
+
+    The local hook in ``scripts/validation/git_hook_policy.py`` allows a push
+    when ``commit_count <= 20``, and ``AGENTS.md`` states the rule as ``<=20``.
+    A count of 20 that pushes cleanly and then fails the pull request check
+    gives an author a red pull request with no local signal (issue #3721).
+    """
+    assert (mod.classify_count(count) == "BLOCKED") is blocked
 
 
 # ---------------------------------------------------------------------------
@@ -102,11 +115,19 @@ def test_fetch_healthy_below_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_fetch_healthy_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(0, _commits_json(20)))
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(0, _commits_json(21)))
     result = mod.fetch_commit_count(42, "o", "r")
     assert result.status == "BLOCKED"
-    assert result.count == 20
+    assert result.count == 21
     assert result.transient is False
+
+
+def test_fetch_at_the_limit_is_not_blocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A count the local hook accepts must survive the fetch path too (#3721)."""
+    monkeypatch.setattr(mod, "_run_gh", lambda argv: _completed(0, _commits_json(20)))
+    result = mod.fetch_commit_count(42, "o", "r")
+    assert result.status == "ALERT"
+    assert result.count == 20
 
 
 def test_fetch_empty_list_is_ok_not_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/validation/test_pr_commit_count.py
+++ b/tests/validation/test_pr_commit_count.py
@@ -59,9 +59,17 @@ def test_the_block_boundary_agrees_with_the_local_hook(count: int, blocked: bool
     """The two enforcement points must draw the line in the same place.
 
     The local hook in ``scripts/validation/git_hook_policy.py`` allows a push
-    when ``commit_count <= 20``, and ``AGENTS.md`` states the rule as ``<=20``.
-    A count of 20 that pushes cleanly and then fails the pull request check
-    gives an author a red pull request with no local signal (issue #3721).
+    when ``commit_count <= limit``, and ``AGENTS.md`` states the rule as
+    ``<=20``. That ``limit`` is 20 by default, so at the default the two
+    points now agree: 20 passes both, 21 fails both. A count of 20 that
+    pushed cleanly and then failed the pull request check gave an author a red
+    pull request with no local signal (issue #3721).
+
+    The hook widens ``limit`` to 40 when the update contains a merge of main.
+    This check never sees the push shape, so it cannot mirror that widening,
+    and a main-merge push of 21 through 40 still needs the
+    commit-limit-bypass label. That gap is out of scope here and is not what
+    this test pins.
     """
     assert (mod.classify_count(count) == "BLOCKED") is blocked
 


### PR DESCRIPTION
## Summary

The commit limit is enforced twice and the two disagreed at exactly 20 commits. The pre-push hook allows `commit_count <= 20`. The pull request check blocked at `count >= 20`. An author sitting on the boundary got a clean local push and then a red pull request, with no local signal that anything was wrong.

Made the blocking comparison strict so both sides draw the line in the same place.

Fixes #3721

## How it was found

By hitting it. #3680 stood at exactly 20 commits, pushed cleanly, and then failed the `Enforce Blocking Issues` step with `COMMIT_COUNT: 20`, `COMMIT_STATUS: BLOCKED`. Recovering it cost a `commit-limit-bypass` label, which is a human override spent on a count the documentation calls legal.

## Which side was wrong

`AGENTS.md` states the rule as `git rev-list --count HEAD ^origin/main` `<=20`, warn `>15`. Twenty is documented as allowed, so the hook matched the documented constraint and the pull request check did not. The CI message was self contradicting as well: it reported "exceeds commit limit (20 >= 20)" for a count that does not exceed the limit.

## Scope

Only the blocking comparison changed. The alert and warning thresholds are advisory, nothing gates on them, and they keep their current comparisons. The bypass label path is untouched.

## Evidence

Test first, and it failed for the stated reason before the change: two failures, both at 20, with the 19 and 21 controls passing. After the change, 46 pass.

Both mutations of the new comparison die. Restoring `>=` fails 3 tests. Flipping to `<` fails 15.

```
mutation '>=': 3 failed, 43 passed
mutation '<': 15 failed, 31 passed
```

Boundary coverage is at 19, 20, and 21 on the classifier and at 20 and 21 on the fetch path, so an off by one in either direction is caught rather than only the one that was there.

## Why this class keeps recurring

It is the fourth time one rule with two enforcement points has diverged in this area. The earlier three were git configuration reads: `core.quotePath`, `log.diffMerges`, and `log.showSignature` in two consumers. This one is an off by one rather than a configuration read, but the shape is the same, and the cost lands on whoever hits the boundary rather than on whoever wrote the second copy.


## Files changed

- `scripts/validation/pr_commit_count.py`, the blocking comparison and the comments describing it
- `tests/validation/test_pr_commit_count.py`, the boundary table and two added tests

## What this does not fix

The local hook allows `commit_count <= limit`, not a flat 20. That limit widens to 40 when the update contains a merge of main. The pull request check never receives the push shape, so it blocks above 20 regardless.

| push shape | local hook allows | this check blocks above | agree |
|---|---|---|---|
| ordinary | 20 | 20 | yes, after this change |
| contains a merge of main | 40 | 20 | no, 21 through 40 still needs the bypass label |

A Copilot reviewer caught the comment and docstring overstating this as flat agreement. Both are corrected in `6beaa66ec` to name the conditional limit.

I did not mirror the widening, and the reason is a measurement rather than a scoping excuse. The counted range is `merge-base(origin/main, HEAD)..HEAD`, so merging a branch that already landed advances the merge base past it and merging main does not inflate the count either. Neither shape the relaxation exists to forgive actually inflates the number it forgives, and the commit that introduced it carried it forward from a shell hook with no rationale. Deleting the widening and mirroring it are both defensible, and picking between them is an owner call, so it is written up on the issue rather than folded in here.
