### PR TITLE
docs(governance): record trigger-phrase provenance evidence in the skill standard

### DIFF
--- a/.agents/governance/skill-description-trigger-standard.md
+++ b/.agents/governance/skill-description-trigger-standard.md
@@ -264,6 +264,71 @@ Before marking skill complete:
 - [ ] No changelog section in body
 - [ ] No version/date metadata in body
 
+### Independent-Distribution Validation
+
+Every check above scores a phrase the author wrote against a rule the author
+wrote. That is a closed loop, and a closed loop cannot tell you whether anyone
+would ever type the phrase.
+
+**Measured.** Trigger phrases were matched against real user prompts mined from
+local Claude Code transcripts, on word boundaries, excluding slash commands and
+single words.
+
+| Corpus | Phrase set | Ever said | Share |
+|---|---|---|---|
+| 640 prompts, 480 transcripts (issue #3509) | documented in a `## Triggers` table | 22 of 212 | 10.4% |
+| 640 prompts, 480 transcripts (issue #3509) | promoted into a description | 8 of 140 | 5.7% |
+| 524 prompts, 1713 transcripts (2026-07-29) | documented in a `## Triggers` table | 5 of 211 | 2.4% |
+| 524 prompts, 1713 transcripts (2026-07-29) | promoted into a description | 7 of 280 | 2.5% |
+
+Two independent corpora agree on direction. Most documented trigger phrases have
+never been typed by a real user. The phrases that do occur are short and
+conversational: `do it`, `your call`, `security review`, `create a PR`,
+`create session log`, `compare models`.
+
+**What this claims.** This is evidence about provenance, not about the router.
+The router is a model doing semantic matching, so a phrase nobody typed verbatim
+can still route correctly. What the number establishes is that the phrases were
+authored rather than observed.
+
+**Why provenance matters.** A practitioner's skill-activation classifier scored
+93 percent precision and recall on 40 prompts he wrote, then 27 percent
+precision on 86 prompts mined from his own transcripts. Same classifier, same
+author. The only variable was who wrote the prompts.
+
+**Two authoring rules.**
+
+1. Prefer an observed phrase to an invented one. The best example in this
+   document already follows the rule: `session-log-fixer` quotes the exact CI
+   error strings a user will paste, not phrasings its author imagined.
+2. Never benchmark trigger phrases on prompts you wrote. A score against your
+   own prompts measures your consistency, not the phrase.
+
+**Two matching rules that are load-bearing** when you measure this yourself.
+
+- Anchor on word boundaries. A bare substring test counted `analyze` 60 times in
+  one corpus, every occurrence inside ordinary prose.
+- Exclude slash commands and single words. A slash command is dispatched by name
+  and never consults a description, so counting it measures the dispatcher.
+
+**Reproducing the measurement.** No CI gate enforces this, and none should. The
+transcript store is local to a developer machine and absent on a runner, so a CI
+arm would be silently inert. Run it on demand instead. Collect user turns from
+`~/.claude/projects/**/*.jsonl` where `type` is `user`, `isSidechain` is falsy,
+and `message.content` is a string. Match each phrase with `\b<phrase>\b`,
+case-insensitively, after dropping slash commands and single words.
+
+**A caution on the corpus.** In the 2026-07-29 run only 59 of 524 prompts
+carried `promptSource: typed`. The rest were `sdk`, `system`, or unlabelled,
+meaning much of the corpus is agent-injected rather than human-typed. Report the
+`promptSource` split alongside any realism figure.
+
+**What this does not license.** Do not bulk-promote table phrases into
+descriptions to raise a coverage score. That optimizes the closed loop and adds
+permanent context cost for phrases with a 2 to 10 percent chance of ever being
+typed. Promote a phrase when it names a capability the description omits, not to
+make a table and a description agree.
+
 ---
 
 ## Part 5: Examples by Skill Type

--- a/.agents/memory/episodes/episode-2026-07-29-session-3509-trigger-phrase-provenance.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-3509-trigger-phrase-provenance.json
@@ -1,0 +1,119 @@
+{
+  "id": "episode-2026-07-29-session-3509-trigger-phrase-provenance",
+  "session": "2026-07-29-session-3509-trigger-phrase-provenance",
+  "timestamp": "2026-07-29T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Close the closed-loop gap in the skill trigger standard. Reproduce the claim that documented trigger phrases are authored rather than observed, record the measurement and the authoring rules in the standard, and settle sibling issue #3494 with data instead of shipping the phrase promotion it proposed.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read issue #3494 and reproduced its measurement before trusting it. The issue claims 150 documented trigger phrases across 21 skills never reach the router. My first probe extracted the frontmatter description with a single-line regex and reported 15 skills and 70 phrases, with several descriptions measuring 2 bytes. Those 2-byte values were the YAML block scalar marker, which proved the probe was truncating multi-line descriptions rather than reading them.",
+      "caused_by": [],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-measured with a real YAML parse. Correct exact-substring figures are 48 skills carrying a Triggers table, 8 whose description matches zero documented phrases, 37 phrases in those 8, and 108 across all skills. The issue's headline of 150 phrases across 21 skills does not reproduce.",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Checked the issue's designated first change, the 13 skills said to carry no quoted user phrase of any kind. That set is now empty. Every one of the 8 remaining skills carries between 1 and 4 quoted phrases in its description, so the scope the issue marked as actionable no longer exists.",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Replaced the exact-substring test with a content-word overlap test, because the router is a language model doing semantic matching and not a substring matcher. Found and fixed a second probe defect on the way: the tokenizer kept hyphens, so the skill name chestertons-fence never matched the phrase chestertons fence. Corrected figures are 29 of 224 phrases below 50 percent coverage, across 21 skills.",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Classified all 29 by hand. Eleven are not promotable at all: template placeholders such as improve skill {name} and execute the plan at plans/X.md, slash commands such as /spec, and single generic words such as research and scan that would cause false routing. The rest are near-miss paraphrases already covered by the description in prose.",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": [
+        "e006"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Investigated a suspected over-claim in security-scan, whose description states that CWE-22 is delegated to CodeQL while its Triggers table lists check for path traversal. Read the table row before editing. The Operation column already reads NOT handled by this scanner, CWE-22 detection is delegated to CodeQL. The row is an honest redirect, not an over-claim, so no edit was made. This is the fourth time this session that reading the artifact before claiming a defect prevented a wrong change.",
+      "caused_by": [
+        "e005"
+      ],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read sibling issue #3509 and found it refutes #3494's fix direction. Mined 1713 local Claude Code transcripts for 524 unique user prompts and matched trigger phrases on word boundaries after dropping slash commands and single words. 5 of 211 table phrases and 7 of 280 description phrases have ever been typed, which is 2.4 and 2.5 percent against the 10.4 and 5.7 percent reported in #3509. Two independent corpora agree on direction. Also recorded that only 59 of 524 prompts carry promptSource typed, so most of the corpus is agent-injected and any realism figure must report that split.",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rejected two candidate changes with reasons rather than shipping them. First, bulk promotion of table phrases into descriptions, because it optimizes the closed loop and buys permanent context cost for phrases with a 2 to 10 percent chance of ever being typed. Second, the CI eval requested by #3509 item 1, because the transcript store lives on a developer machine and is absent on a runner, so the arm would be silently inert in the same way a git-history lookup would be under a depth-1 checkout. Recorded the reproduction procedure in the standard instead, and folded #3509 item 3 into the document because the knowledge-persistence rule puts binding conventions in the governance tree rather than in memory alone.",
+      "caused_by": [
+        "e007"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 87c2439de3",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-29-session-3509-trigger-phrase-provenance.json
+++ b/.agents/sessions/2026-07-29-session-3509-trigger-phrase-provenance.json
@@ -1,0 +1,117 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3509,
+    "date": "2026-07-29",
+    "branch": "fix/3509-trigger-phrase-provenance",
+    "startingCommit": "0f78e62fd5",
+    "objective": "Close the closed-loop gap in the skill trigger standard. Reproduce the claim that documented trigger phrases are authored rather than observed, record the measurement and the authoring rules in the standard, and settle sibling issue #3494 with data instead of shipping the phrase promotion it proposed."
+  },
+  "endingCommit": "87c2439de3",
+  "protocolCompliance": {
+    "sessionStart": {
+      "branchVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "git checkout -b fix/3509-trigger-phrase-provenance origin/main, then git branch --show-current returned fix/3509-trigger-phrase-provenance"
+      },
+      "notOnMain": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Branch is fix/3509-trigger-phrase-provenance, cut fresh from origin/main so it does not sit on the in-flight fix/3602 branch."
+      },
+      "handoffRead": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Not re-read for this branch. Work continues an in-flight autopilot campaign against the open issue queue whose state is tracked in the session triage table."
+      },
+      "sessionLogCreated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": ".agents/sessions/2026-07-29-session-3509-trigger-phrase-provenance.json created before the first commit."
+      },
+      "serenaActivated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Serena MCP tools were unavailable for the whole session. No serena/ or mcp__serena__ tool was exposed by the harness, so activate_project could not be called. Fell back to reading .agents/ and .claude/ directly as AGENTS.md directs."
+      },
+      "serenaInstructions": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "initial_instructions could not be called because Serena MCP was unavailable. Retrieval used the governance tree and the skill catalog on disk instead."
+      }
+    },
+    "sessionEnd": {
+      "logCompleted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "workLog carries eight steps covering the failed probes, the corrected measurement, the reproduction, and the two narrowings that were rejected with data."
+      },
+      "qaSkipDocumented": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "No QA skip claimed. The change is a governance document with no executable surface, so the evidence is the reproduction itself: two independent corpora measured and reported in the added section."
+      },
+      "markdownLintRun": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "markdownlint-cli2 selected zero files because .agents/** is excluded by .markdownlint-cli2.yaml. That is the trap recorded in session 3650, so the run is not evidence of cleanliness. Verified instead by byte scan: zero U+2014 and zero U+2013 in the file, and zero banned-vocabulary hits across the added lines."
+      },
+      "validationPassed": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "scripts/validate_session_json.py returned PASS on this log. Pre-push hooks ran the full gate set on the branch before the push was accepted."
+      },
+      "checklistComplete": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Every protocolCompliance item in this log carries an explicit complete flag and evidence string, including the two Serena items recorded as incomplete."
+      },
+      "serenaMemoryUpdated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Serena MCP was unavailable, so write_memory could not be called. Per the knowledge-persistence rule a binding convention belongs in the governance tree rather than in memory alone, and the finding was written to .agents/governance/skill-description-trigger-standard.md instead, which is the durable cross-harness surface."
+      },
+      "handoffPreserved": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": ".agents/HANDOFF.md was not modified. git status shows the branch touching only the governance standard and this session log."
+      },
+      "changesCommitted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Single commit touching one governance file plus this session log."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": "Read issue #3494 and reproduced its measurement before trusting it. The issue claims 150 documented trigger phrases across 21 skills never reach the router. My first probe extracted the frontmatter description with a single-line regex and reported 15 skills and 70 phrases, with several descriptions measuring 2 bytes. Those 2-byte values were the YAML block scalar marker, which proved the probe was truncating multi-line descriptions rather than reading them."
+    },
+    {
+      "step": "Re-measured with a real YAML parse. Correct exact-substring figures are 48 skills carrying a Triggers table, 8 whose description matches zero documented phrases, 37 phrases in those 8, and 108 across all skills. The issue's headline of 150 phrases across 21 skills does not reproduce."
+    },
+    {
+      "step": "Checked the issue's designated first change, the 13 skills said to carry no quoted user phrase of any kind. That set is now empty. Every one of the 8 remaining skills carries between 1 and 4 quoted phrases in its description, so the scope the issue marked as actionable no longer exists."
+    },
+    {
+      "step": "Replaced the exact-substring test with a content-word overlap test, because the router is a language model doing semantic matching and not a substring matcher. Found and fixed a second probe defect on the way: the tokenizer kept hyphens, so the skill name chestertons-fence never matched the phrase chestertons fence. Corrected figures are 29 of 224 phrases below 50 percent coverage, across 21 skills."
+    },
+    {
+      "step": "Classified all 29 by hand. Eleven are not promotable at all: template placeholders such as improve skill {name} and execute the plan at plans/X.md, slash commands such as /spec, and single generic words such as research and scan that would cause false routing. The rest are near-miss paraphrases already covered by the description in prose."
+    },
+    {
+      "step": "Investigated a suspected over-claim in security-scan, whose description states that CWE-22 is delegated to CodeQL while its Triggers table lists check for path traversal. Read the table row before editing. The Operation column already reads NOT handled by this scanner, CWE-22 detection is delegated to CodeQL. The row is an honest redirect, not an over-claim, so no edit was made. This is the fourth time this session that reading the artifact before claiming a defect prevented a wrong change."
+    },
+    {
+      "step": "Read sibling issue #3509 and found it refutes #3494's fix direction. Mined 1713 local Claude Code transcripts for 524 unique user prompts and matched trigger phrases on word boundaries after dropping slash commands and single words. 5 of 211 table phrases and 7 of 280 description phrases have ever been typed, which is 2.4 and 2.5 percent against the 10.4 and 5.7 percent reported in #3509. Two independent corpora agree on direction. Also recorded that only 59 of 524 prompts carry promptSource typed, so most of the corpus is agent-injected and any realism figure must report that split."
+    },
+    {
+      "step": "Rejected two candidate changes with reasons rather than shipping them. First, bulk promotion of table phrases into descriptions, because it optimizes the closed loop and buys permanent context cost for phrases with a 2 to 10 percent chance of ever being typed. Second, the CI eval requested by #3509 item 1, because the transcript store lives on a developer machine and is absent on a runner, so the arm would be silently inert in the same way a git-history lookup would be under a depth-1 checkout. Recorded the reproduction procedure in the standard instead, and folded #3509 item 3 into the document because the knowledge-persistence rule puts binding conventions in the governance tree rather than in memory alone."
+    }
+  ],
+  "nextSteps": [
+    "Close #3494 with the corrected measurement and the provenance evidence from #3509.",
+    "Continue the open-issue campaign against the remaining P1 queue."
+  ]
+}


### PR DESCRIPTION
Fixes #3509
Refs #3494

## Problem

Every check in the skill description and trigger standard scores a phrase the author wrote against a rule the author wrote. That is a closed loop, and a closed loop cannot tell you whether anyone would ever type the phrase.

## Reproduced on a second corpus

The issue measured 640 prompts from 480 local Claude Code transcripts. I mined a different snapshot: 1713 transcripts, 524 unique user prompts, word-boundary matching, slash commands and single words excluded.

| Corpus | Table phrases ever said | Description phrases ever said |
|---|---|---|
| issue #3509 (640 prompts) | 22 of 212 = 10.4% | 8 of 140 = 5.7% |
| this run (524 prompts) | 5 of 211 = 2.4% | 7 of 280 = 2.5% |

Two independent corpora agree on direction. The phrases that do occur are short and conversational: `do it`, `your call`, `security review`, `create a PR`, `create session log`, `compare models`.

One extra finding the issue did not have: only 59 of 524 prompts carry `promptSource: typed`. The rest are `sdk`, `system`, or unlabelled, so most of the corpus is agent-injected rather than human-typed. Any realism figure has to report that split, and the section says so.

## Changes

`.agents/governance/skill-description-trigger-standard.md` gains an Independent-Distribution Validation subsection under Part 4. It carries both measurements, the two authoring rules, the two load-bearing matching rules, the reproduction procedure, and an explicit prohibition on bulk-promoting table phrases to raise a coverage score.

`.agents/sessions/2026-07-29-session-3509-trigger-phrase-provenance.json` is the session log. It records the two probe defects that had to be corrected before any number was trustworthy.

## Two requested items were rejected with reasons

The issue asks for three things. Item 2 shipped as written. The other two did not, and the reasoning is in the document rather than omitted silently.

Item 1 asks for an eval that mines the local transcript store. Not added. The store lives at `~/.claude/projects` on a developer machine and is absent on a runner, so the arm would be green for the wrong reason on every CI run. That is the same inert-arm shape as a `git log --all` lookup under a depth-1 checkout. The reproduction procedure is documented instead so the measurement stays runnable on demand.

Item 3 asks for a Serena decision memory. Serena MCP was unavailable for the whole session, and the knowledge-persistence rule puts a binding convention in the governance tree rather than in memory alone. The governance section is the durable cross-harness surface, so item 3 is subsumed by item 2.

## Sibling issue closed with data

#3494 proposed promoting documented trigger phrases into descriptions. Closed as not planned. Its headline count of 150 phrases across 21 skills does not reproduce: a single-line regex over the frontmatter truncates every YAML block scalar, and a real parse gives 8 skills and 37 phrases. Its designated first change, the 13 skills said to carry no quoted phrase at all, is now an empty set. The measurement in this PR shows the promotion it proposed would spend permanent context budget on phrases with a 2 to 10 percent chance of ever being typed.

## Verification

The change is a governance document with no executable surface.

- `scripts/validate_session_json.py` returns PASS on the session log.
- Byte scan: zero U+2014 and zero U+2013 across the file.
- Zero banned-vocabulary hits across the added lines.
- markdownlint selects zero files here because `.agents/**` is excluded, which is the trap recorded in session 3650, so it is not cited as evidence of cleanliness.

## Notes

The scan that produced the phrase inventory reads `.claude/skills/*/SKILL.md` and `.agents/governance/skill-description-trigger-standard.md`; only the latter is modified.
