### PR TITLE
fix(validation): check that endingCommit names a reachable commit

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-29-session-3618-ending-commit-reachability.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-3618-ending-commit-reachability.json
@@ -209,6 +209,42 @@
       "caused_by": [
         "e015"
       ],
+      "leads_to": [
+        "e017"
+      ]
+    },
+    {
+      "id": "e017",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "CI failed one of the new tests and the cause was a hidden dependency on how CI clones. test_an_orphaned_ending_commit_warns called validate_session_log with no repo argument, so the check ran against the ambient checkout rather than a purpose-built repo. The pytest job checks out at the actions/checkout default depth of 1, and the helper stays deliberately silent in a shallow clone, so the warning never appeared and the assertion failed. The same code passed locally against a full clone. Reproduced the split directly: commit_reachability_problem('0'*40, <shallow clone>) returns None while the identical call against the full repository returns 'names no commit in this repository'.",
+      "caused_by": [
+        "e016"
+      ],
+      "leads_to": [
+        "e018"
+      ]
+    },
+    {
+      "id": "e018",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "The sibling test had the mirror-image defect and would never have been caught by a red run. test_a_sound_ending_commit_does_not_warn asserts that no warning appears, which a silent helper satisfies vacuously, so in CI it passed for the wrong reason and measured nothing. Both tests now pin _PROJECT_ROOT to the class fixture's temp repo with monkeypatch, the pattern already used elsewhere in this file, which makes them hermetic and independent of clone depth.",
+      "caused_by": [
+        "e017"
+      ],
+      "leads_to": [
+        "e019"
+      ]
+    },
+    {
+      "id": "e019",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-proved both repaired tests discriminate, with a two-sided control on the helper. Forcing it to always return None fails four tests including the orphan test; forcing it to always return a complaint fails seven including the sound-commit test. Each repaired test fails in its own direction, so neither is vacuous. session_scope.py was restored byte-identical afterwards and the full file passes at 233.",
+      "caused_by": [
+        "e018"
+      ],
       "leads_to": []
     }
   ],

--- a/.agents/memory/episodes/episode-2026-07-29-session-3618-ending-commit-reachability.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-3618-ending-commit-reachability.json
@@ -175,7 +175,9 @@
       "type": "commit",
       "content": "Commit: 309f8e141568b88cdb4bf46140f8a3887240caa2",
       "caused_by": [],
-      "leads_to": []
+      "leads_to": [
+        "e020"
+      ]
     },
     {
       "id": "e014",
@@ -246,6 +248,16 @@
         "e018"
       ],
       "leads_to": []
+    },
+    {
+      "id": "e020",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: aabc1ef5985b07cefccc9d9e716364b475f66bff",
+      "caused_by": [
+        "e013"
+      ],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -253,7 +265,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
+    "commits": 2,
     "files_changed": 5
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-29-session-3618-ending-commit-reachability.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-3618-ending-commit-reachability.json
@@ -1,0 +1,180 @@
+{
+  "id": "episode-2026-07-29-session-3618-ending-commit-reachability",
+  "session": "2026-07-29-session-3618-ending-commit-reachability",
+  "timestamp": "2026-07-29T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Make endingCommit a checked claim instead of a write-only field. A session log records the final commit SHA at authoring time and nothing ever looks at it again, so a value orphaned by a later amend or rebase survives into the record and seeds a causal-graph node pointing at a commit that does not exist (issue #3618).",
+  "decisions": [
+    {
+      "id": "d001",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "implementation",
+      "context": "",
+      "chosen": "Chose warning over error, and recorded why. An error is satisfiable through the tool's default path, because complete_session_log.py writes the pre-commit HEAD which then becomes the parent of the commit carrying the log. But a rebase orphans the SHA through no fault of the author, and the log stays new relative to the recomputed merge base, so the gate would go red on honest work with no clean remedy. Two gates were already rejected this campaign for that same property (the git log arm for #3637 under a depth-1 checkout, the transcript-mining arm for #3509 absent on a runner). Consistency requires rejecting the error here.",
+      "rationale": "",
+      "outcome": "success",
+      "effects": []
+    },
+    {
+      "id": "d002",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "test",
+      "context": "",
+      "chosen": "Caught an eighth probe defect while validating. A pytest invocation naming one real path and one path that does not exist reported success having collected zero items. Re-ran against real paths: 572 pass. Same family as the markdownlint exclusion trap, where a green result means nothing was selected rather than nothing was wrong.",
+      "rationale": "",
+      "outcome": "success",
+      "effects": []
+    }
+  ],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Measured the field before changing anything. Across 1003 committed session logs, 542 leave endingCommit empty, 332 name a SHA that is not an object in this repository at all, 95 name a real commit that is off the current history, and 34 are sound. Of the 461 non-empty values, 7.4 percent are usable. The field was write-only, so nothing ever noticed.",
+      "caused_by": [],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Read the issue discourse. It is bot noise apart from the proposed first step, which asks for existence and reachability checks in validate_session_json.py. Confirmed that shape and scoped to it.",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Nearly shipped a false negative. Reasoned that the CI validate job checks out at the actions/checkout default depth of 1, so a correct endingCommit naming a non-HEAD branch commit would be absent and the check would be a false-positive generator. Tested the reasoning instead of trusting it: cloned the repo at --depth 1 on a five-commit branch, ran the workflow's own 'git fetch origin main --unshallow', and found every branch SHA present. --unshallow drops the shallow boundary for the whole repository and backfills all local refs, not only the ref fetched. The check is viable in CI. This is the seventh time this campaign that a confident assumption failed an empirical check.",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Found the severity split already built. validate_evidence_agrees_with_session runs only when existing_log is false, so the check reaches new claims and never the 427 historical records that could not be repaired by any honest edit. That is the issue #3385 record-versus-claim line, and endingCommit soundness sits on the claim side. No new scoping code was needed.",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Chose warning over error, and recorded why. An error is satisfiable through the tool's default path, because complete_session_log.py writes the pre-commit HEAD which then becomes the parent of the commit carrying the log. But a rebase orphans the SHA through no fault of the author, and the log stays new relative to the recomputed merge base, so the gate would go red on honest work with no clean remedy. Two gates were already rejected this campaign for that same property (the git log arm for #3637 under a depth-1 checkout, the transcript-mining arm for #3509 absent on a runner). Consistency requires rejecting the error here.",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": [
+        "e006"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Put the git question in scripts/validation/session_scope.py rather than teaching a second module to shell out. It already owns read-only git questions asked by this validator and already has the timeout, encoding, and check=False idiom right. Added commit_reachability_problem(sha, repo_root), reusing _git. The module stays standard-library-only, which the workflow's bare python3 requires; the one new import is re.",
+      "caused_by": [
+        "e005"
+      ],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Guarded the argument boundary. The SHA reaches git through argv, where a leading dash reads as an option (CWE-88), so a value that is not a bare hex SHA is rejected without asking git. The schema pattern already constrains the field, but schema errors are collected rather than fatal, so a malformed value still reaches this code.",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Guarded the two cases where no honest answer exists: outside a work tree, and in a shallow clone where older commits are genuinely absent and any complaint would describe the clone rather than the log.",
+      "caused_by": [
+        "e007"
+      ],
+      "leads_to": [
+        "e009"
+      ]
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Wrote 11 tests covering positive, negative, and edge per TESTING-RIGOR: reachable, absent, present-but-off-history, dash-leading, shallow, non-repository, the integration warning, its negative direction, existing-log suppression, malformed-value deferral to the schema, and the empty-value warning staying distinct. Git-dependent tests build real temporary repositories rather than mocking, including a real --depth 1 clone.",
+      "caused_by": [
+        "e008"
+      ],
+      "leads_to": [
+        "e010"
+      ]
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ran a five-part isolating negative control. Neutralising the call site fails only the integration test; removing the ancestry check fails only the off-history test; removing the existence check fails only the absent-SHA test; removing the shallow guard fails only the shallow test; removing the SHA boundary guard fails only the dash-leading test. Every component is individually load-bearing and every test is individually discriminating.",
+      "caused_by": [
+        "e009"
+      ],
+      "leads_to": [
+        "e011"
+      ]
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Repaired a test the change would have silently invalidated. tests/test_validate_session_json.py asserts session_scope's exact import list to enforce the standard-library-only rule; the new re import is stdlib, so the assertion was updated rather than weakened.",
+      "caused_by": [
+        "e010"
+      ],
+      "leads_to": [
+        "e012"
+      ]
+    },
+    {
+      "id": "e012",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Caught an eighth probe defect while validating. A pytest invocation naming one real path and one path that does not exist reported success having collected zero items. Re-ran against real paths: 572 pass. Same family as the markdownlint exclusion trap, where a green result means nothing was selected rather than nothing was wrong.",
+      "caused_by": [
+        "e011"
+      ],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 5
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-29-session-3618-ending-commit-reachability.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-3618-ending-commit-reachability.json
@@ -166,6 +166,14 @@
         "e011"
       ],
       "leads_to": []
+    },
+    {
+      "id": "e013",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 309f8e141568b88cdb4bf46140f8a3887240caa2",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -173,7 +181,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 5
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-29-session-3618-ending-commit-reachability.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-3618-ending-commit-reachability.json
@@ -165,7 +165,9 @@
       "caused_by": [
         "e011"
       ],
-      "leads_to": []
+      "leads_to": [
+        "e014"
+      ]
     },
     {
       "id": "e013",
@@ -173,6 +175,40 @@
       "type": "commit",
       "content": "Commit: 309f8e141568b88cdb4bf46140f8a3887240caa2",
       "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e014",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Answered the open question about merge strategy, and it corrected the diagnosis. The repository allows squash merges only: allow_merge_commit and allow_rebase_merge are both false. A squash merge replaces every branch commit with one new commit on main, so a SHA naming the session's own final branch commit is unreachable from main the moment the PR lands. The 427 broken values are therefore mostly structural, not authoring mistakes, and the amend-and-rebase framing in the commit message understates that.",
+      "caused_by": [
+        "e012"
+      ],
+      "leads_to": [
+        "e015"
+      ]
+    },
+    {
+      "id": "e015",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Checked the survivors rather than assuming. Only 12 endingCommit values are ancestors of origin/main, and their commit subjects all carry the (#NNNN) suffix that GitHub appends on squash merge, so they name commits that were already on main when the log was written. No session log in the corpus records its own final branch commit and survives. This does not weaken the check: it runs only on new logs, on the branch, before any squash, which is exactly where a correct value is reachable and an amended one is not.",
+      "caused_by": [
+        "e014"
+      ],
+      "leads_to": [
+        "e016"
+      ]
+    },
+    {
+      "id": "e016",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "The push gate rejected the first attempt and the fix went in at source. security-suppression-policy flagged a new '# noqa: E402' at scripts/validate_session_json.py:51, which appeared only because widening the existing single-name import into a parenthesized list rewrote the line that already carried that suppression. Restored the line byte-for-byte to match origin/main and moved the new name to a function-local import, which is below module scope and needs no E402 suppression at all. The net diff against origin/main now adds zero suppression comments.",
+      "caused_by": [
+        "e015"
+      ],
       "leads_to": []
     }
   ],

--- a/.agents/sessions/2026-07-29-session-3618-ending-commit-reachability.json
+++ b/.agents/sessions/2026-07-29-session-3618-ending-commit-reachability.json
@@ -121,7 +121,7 @@
       "step": "Caught an eighth probe defect while validating. A pytest invocation naming one real path and one path that does not exist reported success having collected zero items. Re-ran against real paths: 572 pass. Same family as the markdownlint exclusion trap, where a green result means nothing was selected rather than nothing was wrong."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "309f8e141568b88cdb4bf46140f8a3887240caa2",
   "nextSteps": [
     "complete_session_log.py line 368 guards on 'if ending_commit and not session.get(\"endingCommit\")', so it fills the field only when empty and never refreshes a stale value. That file is mirrored under src/copilot-cli/skills/session-end/scripts/, so fixing it costs a mirror sync plus a plugin manifest bump. Separable from this change and deliberately out of scope.",
     "The consumer side is untouched. extract_session_episode.py seeds a causal-graph node from endingCommit without checking it, so the 427 historical bad values still pollute the graph. Skipping unreachable SHAs at the consumer would fix the pollution durably, independent of log hygiene.",

--- a/.agents/sessions/2026-07-29-session-3618-ending-commit-reachability.json
+++ b/.agents/sessions/2026-07-29-session-3618-ending-commit-reachability.json
@@ -119,12 +119,21 @@
     },
     {
       "step": "Caught an eighth probe defect while validating. A pytest invocation naming one real path and one path that does not exist reported success having collected zero items. Re-ran against real paths: 572 pass. Same family as the markdownlint exclusion trap, where a green result means nothing was selected rather than nothing was wrong."
+    },
+    {
+      "step": "Answered the open question about merge strategy, and it corrected the diagnosis. The repository allows squash merges only: allow_merge_commit and allow_rebase_merge are both false. A squash merge replaces every branch commit with one new commit on main, so a SHA naming the session's own final branch commit is unreachable from main the moment the PR lands. The 427 broken values are therefore mostly structural, not authoring mistakes, and the amend-and-rebase framing in the commit message understates that."
+    },
+    {
+      "step": "Checked the survivors rather than assuming. Only 12 endingCommit values are ancestors of origin/main, and their commit subjects all carry the (#NNNN) suffix that GitHub appends on squash merge, so they name commits that were already on main when the log was written. No session log in the corpus records its own final branch commit and survives. This does not weaken the check: it runs only on new logs, on the branch, before any squash, which is exactly where a correct value is reachable and an amended one is not."
+    },
+    {
+      "step": "The push gate rejected the first attempt and the fix went in at source. security-suppression-policy flagged a new '# noqa: E402' at scripts/validate_session_json.py:51, which appeared only because widening the existing single-name import into a parenthesized list rewrote the line that already carried that suppression. Restored the line byte-for-byte to match origin/main and moved the new name to a function-local import, which is below module scope and needs no E402 suppression at all. The net diff against origin/main now adds zero suppression comments."
     }
   ],
   "endingCommit": "309f8e141568b88cdb4bf46140f8a3887240caa2",
   "nextSteps": [
     "complete_session_log.py line 368 guards on 'if ending_commit and not session.get(\"endingCommit\")', so it fills the field only when empty and never refreshes a stale value. That file is mirrored under src/copilot-cli/skills/session-end/scripts/, so fixing it costs a mirror sync plus a plugin manifest bump. Separable from this change and deliberately out of scope.",
     "The consumer side is untouched. extract_session_episode.py seeds a causal-graph node from endingCommit without checking it, so the 427 historical bad values still pollute the graph. Skipping unreachable SHAs at the consumer would fix the pollution durably, independent of log hygiene.",
-    "Consider whether endingCommit earns its place at all. A commit cannot contain its own SHA, so the field is always at least one commit behind and is only ever satisfiable as 'a commit reachable from HEAD'. If the repository squash-merges, every value is orphaned at merge by construction."
+    "Reconsider whether endingCommit earns its place, now that the merge strategy is known. The repository squash-merges only, so a value naming the session's own final commit is unreachable from main by construction the moment the PR lands. Only 12 of 1003 logs hold a value that is an ancestor of origin/main, and every one of those names a commit that was already merged before the log was written. Either the field should name something that survives, such as the pull request number, or it should be removed. Filed for separate discussion rather than decided here."
   ]
 }

--- a/.agents/sessions/2026-07-29-session-3618-ending-commit-reachability.json
+++ b/.agents/sessions/2026-07-29-session-3618-ending-commit-reachability.json
@@ -1,0 +1,130 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3618,
+    "date": "2026-07-29",
+    "branch": "fix/3618-ending-commit-reachability",
+    "startingCommit": "0f78e62fd5",
+    "objective": "Make endingCommit a checked claim instead of a write-only field. A session log records the final commit SHA at authoring time and nothing ever looks at it again, so a value orphaned by a later amend or rebase survives into the record and seeds a causal-graph node pointing at a commit that does not exist (issue #3618)."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "branchVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "git checkout -b fix/3618-ending-commit-reachability origin/main; git branch --show-current returned fix/3618-ending-commit-reachability"
+      },
+      "notOnMain": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Branch is fix/3618-ending-commit-reachability, not main. Created fresh from origin/main so it does not sit on any of the ten open PR branches."
+      },
+      "handoffRead": {
+        "complete": true,
+        "level": "SHOULD",
+        "evidence": "Read earlier in this multi-issue campaign; the dashboard has not changed and this issue was already triaged into the P1 queue from it."
+      },
+      "sessionLogCreated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "This file, created before the code commit."
+      },
+      "serenaActivated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Serena MCP has been unavailable for the whole campaign; no serena/ or mcp__serena__ tools were exposed. Context came from direct reads of scripts/validate_session_json.py and scripts/validation/session_scope.py."
+      },
+      "serenaInstructions": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Not loaded, for the same reason serenaActivated is false."
+      }
+    },
+    "sessionEnd": {
+      "logCompleted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "This file."
+      },
+      "qaSkipDocumented": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Full QA ran. 233 tests in tests/test_validate_session_json.py pass, plus 572 in the downstream suites that import session_scope. A five-part isolating negative control proves each new guard is load-bearing."
+      },
+      "markdownLintRun": {
+        "complete": true,
+        "level": "SHOULD",
+        "evidence": "No markdown changed. The three changed files are Python."
+      },
+      "validationPassed": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "uv run ruff check on the three changed files: All checks passed. git_hook_policy.py mypy on the same three: Success, exit 0."
+      },
+      "checklistComplete": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "All items recorded with evidence."
+      },
+      "serenaMemoryUpdated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Serena MCP unavailable all session, so no memory could be written. The finding that git fetch --unshallow backfills every local ref, not just the fetched one, is recorded in the workLog below and in the PR description."
+      },
+      "handoffPreserved": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "HANDOFF.md not modified (ADR-014)."
+      },
+      "changesCommitted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Code, tests, and this log committed on fix/3618-ending-commit-reachability. The SHA is recorded in a follow-up commit rather than by amending, which is exactly the pattern this change teaches."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": "Measured the field before changing anything. Across 1003 committed session logs, 542 leave endingCommit empty, 332 name a SHA that is not an object in this repository at all, 95 name a real commit that is off the current history, and 34 are sound. Of the 461 non-empty values, 7.4 percent are usable. The field was write-only, so nothing ever noticed."
+    },
+    {
+      "step": "Read the issue discourse. It is bot noise apart from the proposed first step, which asks for existence and reachability checks in validate_session_json.py. Confirmed that shape and scoped to it."
+    },
+    {
+      "step": "Nearly shipped a false negative. Reasoned that the CI validate job checks out at the actions/checkout default depth of 1, so a correct endingCommit naming a non-HEAD branch commit would be absent and the check would be a false-positive generator. Tested the reasoning instead of trusting it: cloned the repo at --depth 1 on a five-commit branch, ran the workflow's own 'git fetch origin main --unshallow', and found every branch SHA present. --unshallow drops the shallow boundary for the whole repository and backfills all local refs, not only the ref fetched. The check is viable in CI. This is the seventh time this campaign that a confident assumption failed an empirical check."
+    },
+    {
+      "step": "Found the severity split already built. validate_evidence_agrees_with_session runs only when existing_log is false, so the check reaches new claims and never the 427 historical records that could not be repaired by any honest edit. That is the issue #3385 record-versus-claim line, and endingCommit soundness sits on the claim side. No new scoping code was needed."
+    },
+    {
+      "step": "Chose warning over error, and recorded why. An error is satisfiable through the tool's default path, because complete_session_log.py writes the pre-commit HEAD which then becomes the parent of the commit carrying the log. But a rebase orphans the SHA through no fault of the author, and the log stays new relative to the recomputed merge base, so the gate would go red on honest work with no clean remedy. Two gates were already rejected this campaign for that same property (the git log arm for #3637 under a depth-1 checkout, the transcript-mining arm for #3509 absent on a runner). Consistency requires rejecting the error here."
+    },
+    {
+      "step": "Put the git question in scripts/validation/session_scope.py rather than teaching a second module to shell out. It already owns read-only git questions asked by this validator and already has the timeout, encoding, and check=False idiom right. Added commit_reachability_problem(sha, repo_root), reusing _git. The module stays standard-library-only, which the workflow's bare python3 requires; the one new import is re."
+    },
+    {
+      "step": "Guarded the argument boundary. The SHA reaches git through argv, where a leading dash reads as an option (CWE-88), so a value that is not a bare hex SHA is rejected without asking git. The schema pattern already constrains the field, but schema errors are collected rather than fatal, so a malformed value still reaches this code."
+    },
+    {
+      "step": "Guarded the two cases where no honest answer exists: outside a work tree, and in a shallow clone where older commits are genuinely absent and any complaint would describe the clone rather than the log."
+    },
+    {
+      "step": "Wrote 11 tests covering positive, negative, and edge per TESTING-RIGOR: reachable, absent, present-but-off-history, dash-leading, shallow, non-repository, the integration warning, its negative direction, existing-log suppression, malformed-value deferral to the schema, and the empty-value warning staying distinct. Git-dependent tests build real temporary repositories rather than mocking, including a real --depth 1 clone."
+    },
+    {
+      "step": "Ran a five-part isolating negative control. Neutralising the call site fails only the integration test; removing the ancestry check fails only the off-history test; removing the existence check fails only the absent-SHA test; removing the shallow guard fails only the shallow test; removing the SHA boundary guard fails only the dash-leading test. Every component is individually load-bearing and every test is individually discriminating."
+    },
+    {
+      "step": "Repaired a test the change would have silently invalidated. tests/test_validate_session_json.py asserts session_scope's exact import list to enforce the standard-library-only rule; the new re import is stdlib, so the assertion was updated rather than weakened."
+    },
+    {
+      "step": "Caught an eighth probe defect while validating. A pytest invocation naming one real path and one path that does not exist reported success having collected zero items. Re-ran against real paths: 572 pass. Same family as the markdownlint exclusion trap, where a green result means nothing was selected rather than nothing was wrong."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "complete_session_log.py line 368 guards on 'if ending_commit and not session.get(\"endingCommit\")', so it fills the field only when empty and never refreshes a stale value. That file is mirrored under src/copilot-cli/skills/session-end/scripts/, so fixing it costs a mirror sync plus a plugin manifest bump. Separable from this change and deliberately out of scope.",
+    "The consumer side is untouched. extract_session_episode.py seeds a causal-graph node from endingCommit without checking it, so the 427 historical bad values still pollute the graph. Skipping unreachable SHAs at the consumer would fix the pollution durably, independent of log hygiene.",
+    "Consider whether endingCommit earns its place at all. A commit cannot contain its own SHA, so the field is always at least one commit behind and is only ever satisfiable as 'a commit reachable from HEAD'. If the repository squash-merges, every value is orphaned at merge by construction."
+  ]
+}

--- a/.agents/sessions/2026-07-29-session-3618-ending-commit-reachability.json
+++ b/.agents/sessions/2026-07-29-session-3618-ending-commit-reachability.json
@@ -128,6 +128,15 @@
     },
     {
       "step": "The push gate rejected the first attempt and the fix went in at source. security-suppression-policy flagged a new '# noqa: E402' at scripts/validate_session_json.py:51, which appeared only because widening the existing single-name import into a parenthesized list rewrote the line that already carried that suppression. Restored the line byte-for-byte to match origin/main and moved the new name to a function-local import, which is below module scope and needs no E402 suppression at all. The net diff against origin/main now adds zero suppression comments."
+    },
+    {
+      "step": "CI failed one of the new tests and the cause was a hidden dependency on how CI clones. test_an_orphaned_ending_commit_warns called validate_session_log with no repo argument, so the check ran against the ambient checkout rather than a purpose-built repo. The pytest job checks out at the actions/checkout default depth of 1, and the helper stays deliberately silent in a shallow clone, so the warning never appeared and the assertion failed. The same code passed locally against a full clone. Reproduced the split directly: commit_reachability_problem('0'*40, <shallow clone>) returns None while the identical call against the full repository returns 'names no commit in this repository'."
+    },
+    {
+      "step": "The sibling test had the mirror-image defect and would never have been caught by a red run. test_a_sound_ending_commit_does_not_warn asserts that no warning appears, which a silent helper satisfies vacuously, so in CI it passed for the wrong reason and measured nothing. Both tests now pin _PROJECT_ROOT to the class fixture's temp repo with monkeypatch, the pattern already used elsewhere in this file, which makes them hermetic and independent of clone depth."
+    },
+    {
+      "step": "Re-proved both repaired tests discriminate, with a two-sided control on the helper. Forcing it to always return None fails four tests including the orphan test; forcing it to always return a complaint fails seven including the sound-commit test. Each repaired test fails in its own direction, so neither is vacuous. session_scope.py was restored byte-identical afterwards and the full file passes at 233."
     }
   ],
   "endingCommit": "309f8e141568b88cdb4bf46140f8a3887240caa2",

--- a/.agents/sessions/2026-07-29-session-3618-ending-commit-reachability.json
+++ b/.agents/sessions/2026-07-29-session-3618-ending-commit-reachability.json
@@ -139,7 +139,7 @@
       "step": "Re-proved both repaired tests discriminate, with a two-sided control on the helper. Forcing it to always return None fails four tests including the orphan test; forcing it to always return a complaint fails seven including the sound-commit test. Each repaired test fails in its own direction, so neither is vacuous. session_scope.py was restored byte-identical afterwards and the full file passes at 233."
     }
   ],
-  "endingCommit": "309f8e141568b88cdb4bf46140f8a3887240caa2",
+  "endingCommit": "aabc1ef5985b07cefccc9d9e716364b475f66bff",
   "nextSteps": [
     "complete_session_log.py line 368 guards on 'if ending_commit and not session.get(\"endingCommit\")', so it fills the field only when empty and never refreshes a stale value. That file is mirrored under src/copilot-cli/skills/session-end/scripts/, so fixing it costs a mirror sync plus a plugin manifest bump. Separable from this change and deliberately out of scope.",
     "The consumer side is untouched. extract_session_episode.py seeds a causal-graph node from endingCommit without checking it, so the 427 historical bad values still pollute the graph. Skipping unreachable SHAs at the consumer would fix the pollution durably, independent of log hygiene.",

--- a/scripts/validate_session_json.py
+++ b/scripts/validate_session_json.py
@@ -48,10 +48,7 @@ sys.path.insert(0, str(_PROJECT_ROOT))
 
 from scripts.utils.path_validation import validate_safe_path  # noqa: E402
 from scripts.validation.models import ValidationResult  # noqa: E402
-from scripts.validation.session_scope import (  # noqa: E402
-    commit_reachability_problem,
-    session_log_is_new,
-)
+from scripts.validation.session_scope import session_log_is_new  # noqa: E402
 
 SCHEMA_PATH = _PROJECT_ROOT / ".agents" / "schemas" / "session-log.schema.json"
 
@@ -575,6 +572,13 @@ def validate_evidence_agrees_with_session(data: dict[str, Any], result: Validati
     elif ending and COMMIT_SHA_PATTERN.match(ending):
         # A malformed value is the schema's to report; restating it here would
         # print the same fact under two spellings.
+        #
+        # Imported here rather than at module scope: every module-level import
+        # in this file sits below a sys.path insert and so needs an E402
+        # suppression, and a new suppression is exactly what the push gate
+        # refuses. Function scope needs none, and the module is already loaded.
+        from scripts.validation.session_scope import commit_reachability_problem
+
         problem = commit_reachability_problem(ending, _PROJECT_ROOT)
         if problem is not None:
             result.warnings.append(

--- a/scripts/validate_session_json.py
+++ b/scripts/validate_session_json.py
@@ -48,7 +48,10 @@ sys.path.insert(0, str(_PROJECT_ROOT))
 
 from scripts.utils.path_validation import validate_safe_path  # noqa: E402
 from scripts.validation.models import ValidationResult  # noqa: E402
-from scripts.validation.session_scope import session_log_is_new  # noqa: E402
+from scripts.validation.session_scope import (  # noqa: E402
+    commit_reachability_problem,
+    session_log_is_new,
+)
 
 SCHEMA_PATH = _PROJECT_ROOT / ".agents" / "schemas" / "session-log.schema.json"
 
@@ -563,11 +566,23 @@ def validate_evidence_agrees_with_session(data: dict[str, Any], result: Validati
     claims_commit = isinstance(committed, dict) and (
         get_case_insensitive(committed, "complete") is True
     )
-    if claims_commit and not str(data.get("endingCommit") or "").strip():
+    ending = str(data.get("endingCommit") or "").strip()
+    if claims_commit and not ending:
         result.warnings.append(
             "changesCommitted is complete but endingCommit is empty; "
             "record the final commit SHA or mark the item incomplete"
         )
+    elif ending and COMMIT_SHA_PATTERN.match(ending):
+        # A malformed value is the schema's to report; restating it here would
+        # print the same fact under two spellings.
+        problem = commit_reachability_problem(ending, _PROJECT_ROOT)
+        if problem is not None:
+            result.warnings.append(
+                f"endingCommit {ending!r} {problem}; the SHA was most likely "
+                "orphaned by amending or rebasing the commit that carried it. "
+                "Record the SHA in a follow-up commit instead of amending "
+                "afterwards (issue #3618)"
+            )
 
 
 def validate_must_item(

--- a/scripts/validation/session_scope.py
+++ b/scripts/validation/session_scope.py
@@ -5,6 +5,10 @@ session-protocol workflow, which invokes ``validate_session_json.py`` directly.
 The rule lives here rather than in either caller so they cannot disagree, and
 so the workflow does not restate it in YAML (ADR-006).
 
+The same validator also needs to ask git whether a commit a log names is
+really there (issue #3618), so that question lives here too rather than
+teaching a second module how to shell out to git.
+
 Standard library only, on purpose. The workflow's ``validate`` job installs no
 dependencies and runs a bare ``python3``; importing ``git_hook_policy`` there
 would drag in PyYAML and fail.
@@ -12,11 +16,13 @@ would drag in PyYAML and fail.
 
 from __future__ import annotations
 
+import re
 import subprocess
 from collections.abc import Iterable
 from pathlib import Path
 
 _GIT_TIMEOUT_SECONDS = 30
+_COMMIT_SHA = re.compile(r"^[0-9a-f]{7,40}$")
 
 
 def _git(args: list[str], repo_root: Path) -> subprocess.CompletedProcess[str]:
@@ -30,6 +36,45 @@ def _git(args: list[str], repo_root: Path) -> subprocess.CompletedProcess[str]:
         timeout=_GIT_TIMEOUT_SECONDS,
         check=False,
     )
+
+
+def commit_reachability_problem(sha: str, repo_root: Path) -> str | None:
+    """Describe why ``sha`` is not a usable commit reference here, else None.
+
+    None means "no complaint", and it covers two different situations on
+    purpose. The commit may be present and reachable from HEAD, or this
+    checkout may be unable to answer at all: not a work tree, or a shallow
+    clone where older commits are genuinely absent. Complaining in the second
+    case would describe the clone rather than the log.
+
+    A commit cannot contain its own SHA, so a recorded ending commit is always
+    at least one commit behind the log that names it. The satisfiable contract
+    is therefore "names a commit reachable from HEAD", not "names HEAD".
+
+    Args:
+        sha: Candidate commit SHA. A value that is not a bare hex SHA is
+            rejected without asking git: it reaches git as an argument, where a
+            leading dash would be read as an option (CWE-88).
+        repo_root: Repository to ask.
+
+    Returns:
+        A sentence fragment naming the problem, or None when there is none.
+    """
+    if not _COMMIT_SHA.match(sha):
+        return "is not a commit SHA"
+    try:
+        if _git(["rev-parse", "--is-inside-work-tree"], repo_root).returncode != 0:
+            return None
+        shallow = _git(["rev-parse", "--is-shallow-repository"], repo_root)
+        if shallow.returncode != 0 or shallow.stdout.strip() == "true":
+            return None
+        if _git(["cat-file", "-e", f"{sha}^{{commit}}"], repo_root).returncode != 0:
+            return "names no commit in this repository"
+        if _git(["merge-base", "--is-ancestor", sha, "HEAD"], repo_root).returncode != 0:
+            return "names a commit that is not an ancestor of HEAD"
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return None
 
 
 def session_merge_base(repo_root: Path) -> str:

--- a/tests/test_validate_session_json.py
+++ b/tests/test_validate_session_json.py
@@ -13,9 +13,10 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import Callable
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import TYPE_CHECKING, Any
 from unittest import mock
+from urllib.parse import urlparse
 
 import pytest
 
@@ -2300,7 +2301,7 @@ class TestEndingCommitReachability:
         repo, _, _ = self._make_repo(tmp_path)
         shallow = tmp_path / "shallow"
         subprocess.run(
-            ["git", "clone", "-q", "--depth", "1", f"file://{repo}", str(shallow)],
+            ["git", "clone", "-q", "--depth", "1", repo.as_uri(), str(shallow)],
             capture_output=True,
             text=True,
             check=True,
@@ -2318,6 +2319,28 @@ class TestEndingCommitReachability:
         bare = tmp_path / "plain"
         bare.mkdir()
         assert commit_reachability_problem("0" * 40, bare) is None
+
+    def test_a_clone_source_is_built_as_a_uri_not_a_concatenation(
+        self, tmp_path: Path
+    ) -> None:
+        """`"file://" + path` is a URL only where the separator is already `/`.
+
+        On Windows the drive path carries no leading slash, so everything after
+        `file://` parses as the URL host and the path comes back empty. `git
+        clone` then looks for a host named `C:\\Users\\...` and the shallow-clone
+        test fails on the Windows job for a reason that has nothing to do with
+        reachability. `Path.as_uri()` emits the third slash and forward
+        separators, so the host stays empty on both platforms.
+        """
+        windows = PureWindowsPath(r"C:\Users\runner\Temp\repo")
+        naive = urlparse(f"file://{windows}")
+        assert naive.netloc == "C:\\Users\\runner\\Temp\\repo"
+        assert naive.path == ""
+
+        built = urlparse(tmp_path.as_uri())
+        assert built.netloc == ""
+        assert "\\" not in built.path
+        assert built.path.startswith("/")
 
     def test_an_orphaned_ending_commit_warns(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_validate_session_json.py
+++ b/tests/test_validate_session_json.py
@@ -44,6 +44,7 @@ from scripts.validate_session_json import (
     validate_session_section,
     validate_session_start,
 )
+from scripts.validation.session_scope import commit_reachability_problem
 
 
 def _make_complete_start_section(**overrides: dict) -> dict:
@@ -1929,6 +1930,7 @@ class TestSessionScopeIsDecidedOnceForBothCallSites:
             if line.startswith(("import ", "from ")) and "__future__" not in line
         ]
         assert imports == [
+            "import re",
             "import subprocess",
             "from collections.abc import Iterable",
             "from pathlib import Path",
@@ -2234,3 +2236,127 @@ class TestBranchEvidenceMayDescribeARelationship:
         """Logs abbreviate their own branch; that is not a second session."""
         log = _log_with_evidence(notOnMain="On fix/3346-session-schema, not main")
         assert not any("names a different branch" in e for e in validate_session_log(log).errors)
+
+
+class TestEndingCommitReachability:
+    """`endingCommit` was written once and never revalidated (issue #3618).
+
+    Of 1003 committed logs, 542 leave the field empty, 332 name a SHA that is
+    not an object in this repository at all, and 95 name a real commit that is
+    off the current history. 34 are sound. Nothing ever looked, so a value
+    orphaned by a later amend or rebase stayed in the record and seeded a
+    causal-graph node pointing at a commit that does not exist.
+    """
+
+    @staticmethod
+    def _make_repo(tmp_path: Path) -> tuple[Path, str, str]:
+        """Build a repo and return (root, reachable_sha, existing_offbranch_sha)."""
+        repo = tmp_path / "r"
+        repo.mkdir()
+
+        def git(*args: str) -> str:
+            return subprocess.run(
+                ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+            ).stdout.strip()
+
+        git("init", "-q", "-b", "main")
+        git("config", "user.email", "t@example.com")
+        git("config", "user.name", "T")
+        (repo / "a.txt").write_text("a", encoding="utf-8")
+        git("add", "a.txt")
+        git("commit", "-qm", "a")
+        reachable = git("rev-parse", "HEAD")
+        git("checkout", "-qb", "side")
+        (repo / "b.txt").write_text("b", encoding="utf-8")
+        git("add", "b.txt")
+        git("commit", "-qm", "b")
+        offbranch = git("rev-parse", "HEAD")
+        git("checkout", "-q", "main")
+        return repo, reachable, offbranch
+
+    def test_a_reachable_commit_raises_no_complaint(self, tmp_path: Path) -> None:
+        repo, reachable, _ = self._make_repo(tmp_path)
+        assert commit_reachability_problem(reachable, repo) is None
+
+    def test_a_sha_that_is_no_object_is_named(self, tmp_path: Path) -> None:
+        repo, _, _ = self._make_repo(tmp_path)
+        assert commit_reachability_problem("0" * 40, repo) == "names no commit in this repository"
+
+    def test_a_real_commit_off_the_history_is_named(self, tmp_path: Path) -> None:
+        """The amend case: the commit still exists, but nothing reaches it."""
+        repo, _, offbranch = self._make_repo(tmp_path)
+        assert (
+            commit_reachability_problem(offbranch, repo)
+            == "names a commit that is not an ancestor of HEAD"
+        )
+
+    def test_a_dash_leading_value_never_reaches_git(self, tmp_path: Path) -> None:
+        """The value lands in argv, where a leading dash reads as an option (CWE-88)."""
+        repo, _, _ = self._make_repo(tmp_path)
+        assert commit_reachability_problem("--upload-pack=touch", repo) == "is not a commit SHA"
+
+    def test_a_shallow_clone_stays_silent(self, tmp_path: Path) -> None:
+        """Older commits are genuinely absent, so any complaint describes the clone."""
+        repo, _, _ = self._make_repo(tmp_path)
+        shallow = tmp_path / "shallow"
+        subprocess.run(
+            ["git", "clone", "-q", "--depth", "1", f"file://{repo}", str(shallow)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert subprocess.run(
+            ["git", "rev-parse", "--is-shallow-repository"],
+            cwd=shallow,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip() == "true"
+        assert commit_reachability_problem("0" * 40, shallow) is None
+
+    def test_a_directory_that_is_no_repository_stays_silent(self, tmp_path: Path) -> None:
+        bare = tmp_path / "plain"
+        bare.mkdir()
+        assert commit_reachability_problem("0" * 40, bare) is None
+
+    def test_an_orphaned_ending_commit_warns(self) -> None:
+        log = _make_valid_log()
+        log["endingCommit"] = "0" * 40
+        assert any(
+            "issue #3618" in w for w in validate_session_log(log).warnings
+        ), "an unresolvable endingCommit must be reported"
+
+    def test_a_sound_ending_commit_does_not_warn(self) -> None:
+        """Guards against a check that simply always complains."""
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parents[1],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        log = _make_valid_log()
+        log["endingCommit"] = head
+        assert not any("issue #3618" in w for w in validate_session_log(log).warnings)
+
+    def test_an_existing_log_is_never_rechecked(self) -> None:
+        """427 committed logs carry a broken SHA. They are records, not claims,
+        and no honest edit could repair them, so the check sits on the claim
+        side of the issue #3385 line with the other cross-field checks."""
+        log = _make_valid_log()
+        log["endingCommit"] = "0" * 40
+        result = validate_session_log(log, existing_log=True)
+        assert not any("issue #3618" in w for w in result.warnings)
+
+    def test_a_malformed_value_is_left_to_the_schema(self) -> None:
+        """Reporting it here too would print one fact under two spellings."""
+        log = _make_valid_log()
+        log["endingCommit"] = "not-a-sha"
+        assert not any("issue #3618" in w for w in validate_session_log(log).warnings)
+
+    def test_an_empty_value_keeps_its_own_warning(self) -> None:
+        log = _make_valid_log()
+        log["endingCommit"] = ""
+        warnings = validate_session_log(log).warnings
+        assert any("endingCommit is empty" in w for w in warnings)
+        assert not any("issue #3618" in w for w in warnings)

--- a/tests/test_validate_session_json.py
+++ b/tests/test_validate_session_json.py
@@ -2319,24 +2319,40 @@ class TestEndingCommitReachability:
         bare.mkdir()
         assert commit_reachability_problem("0" * 40, bare) is None
 
-    def test_an_orphaned_ending_commit_warns(self) -> None:
+    def test_an_orphaned_ending_commit_warns(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pinned to a purpose-built repo, not the ambient checkout.
+
+        Reading the ambient repository made this test depend on how CI clones.
+        The pytest job checks out at the actions/checkout default depth of 1, and
+        the helper stays deliberately silent in a shallow clone because older
+        commits are genuinely absent there. The assertion therefore passed
+        locally against a full clone and failed in CI against a shallow one, on
+        identical code. The sibling test below had the mirror-image defect: it
+        passed in CI for the wrong reason, because a silent helper satisfies a
+        no-warning assertion vacuously.
+        """
+        from scripts import validate_session_json
+
+        repo, _, _ = self._make_repo(tmp_path)
+        monkeypatch.setattr(validate_session_json, "_PROJECT_ROOT", repo)
         log = _make_valid_log()
         log["endingCommit"] = "0" * 40
         assert any(
             "issue #3618" in w for w in validate_session_log(log).warnings
         ), "an unresolvable endingCommit must be reported"
 
-    def test_a_sound_ending_commit_does_not_warn(self) -> None:
+    def test_a_sound_ending_commit_does_not_warn(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Guards against a check that simply always complains."""
-        head = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=Path(__file__).resolve().parents[1],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
+        from scripts import validate_session_json
+
+        repo, reachable, _ = self._make_repo(tmp_path)
+        monkeypatch.setattr(validate_session_json, "_PROJECT_ROOT", repo)
         log = _make_valid_log()
-        log["endingCommit"] = head
+        log["endingCommit"] = reachable
         assert not any("issue #3618" in w for w in validate_session_log(log).warnings)
 
     def test_an_existing_log_is_never_rechecked(self) -> None:


### PR DESCRIPTION
## Summary

`endingCommit` was written once and never read again. A value orphaned by a later amend or rebase stayed in the record, and the episode extractor seeded a causal-graph node for a commit that does not exist.

This makes the field a checked claim at the moment the claim is made.

## Measurement

Across 1003 committed session logs:

| State | Count |
|---|---|
| Empty | 542 |
| Names no object in this repository | 332 |
| Names a real commit off the current history | 95 |
| Sound | 34 |

Of the 461 non-empty values, 7.4 percent are usable.

## Changes

`scripts/validation/session_scope.py` gains `commit_reachability_problem`. That module already owns read-only git questions for this validator and already has the timeout, encoding, and `check=False` idiom right, so the alternative was teaching a second module to shell out. It stays standard library only, which the workflow's bare `python3` requires. The one new import is `re`.

`scripts/validate_session_json.py` calls it from the cross-field evidence check.

`tests/test_validate_session_json.py` gains 11 tests covering positive, negative, and edge cases. Git-dependent tests build real temporary repositories rather than mocking, including a real `--depth 1` clone.

## Why a warning and not an error

An error is satisfiable through the normal path, because the session-end tool writes the pre-commit HEAD, which then becomes the parent of the commit carrying the log.

But a rebase orphans the SHA through no fault of the author, and the log stays new relative to the recomputed merge base, so the gate would go red on honest work with no clean remedy. Two gates were already rejected in this campaign for that same property: a `git log --all` lookup that would be blind under a depth-1 checkout, and a transcript-mining arm whose corpus is absent on a runner.

## Scoping needed no new code

`validate_evidence_agrees_with_session` already runs only when the log is new. That is the record-versus-claim line from issue #3385, and endingCommit soundness sits on the claim side. The 427 broken historical records are never asked to repair themselves.

## Negative control

Five isolating runs, each failing exactly one test:

| Component removed | Test that fails |
|---|---|
| Call site | `test_an_orphaned_ending_commit_warns` |
| Ancestry check | `test_a_real_commit_off_the_history_is_named` |
| Existence check | `test_a_sha_that_is_no_object_is_named` |
| Shallow guard | `test_a_shallow_clone_stays_silent` |
| SHA boundary guard | `test_a_dash_leading_value_never_reaches_git` |

Every component is load-bearing and every test is discriminating.

## Security

The SHA reaches git through argv, where a leading dash reads as an option (CWE-88). A value that is not a bare hex SHA is rejected without asking git. The schema pattern already constrains the field, but schema errors are collected rather than fatal, so a malformed value still reaches this code.

## Evidence

An assumption nearly shipped a false negative. The CI validate job checks out at the `actions/checkout` default depth of 1, which suggested a correct endingCommit naming a non-HEAD branch commit would be absent and the check would be a false-positive generator. Tested rather than trusted: cloned at `--depth 1` on a five-commit branch, ran the workflow's own `git fetch origin main --unshallow`, and found every branch SHA present. `--unshallow` drops the shallow boundary for the whole repository and backfills all local refs, not only the ref fetched. The check is viable in CI.

The repository allows squash merges only: `allow_merge_commit` and `allow_rebase_merge` are both false. A squash merge replaces every branch commit with one new commit on main, so a SHA naming a session's own final branch commit is unreachable from main the moment the PR lands. The 427 broken values are therefore mostly structural rather than authoring mistakes. Only 12 values are ancestors of origin/main, and all 12 name commits that were already merged when the log was written.

That does not weaken this check, which runs only on new logs, on the branch, before any squash, exactly where a correct value is reachable and an amended one is not. It does raise a separate question about whether the field should exist at all, filed separately rather than decided here.

## Out of Scope

The session-end completion script fills the field only when it is empty and never refreshes a stale value. That file is mirrored under the Copilot CLI skills tree, so fixing it costs a mirror sync plus a plugin manifest bump.

The consumer side is untouched. The episode extractor still seeds a graph node from `endingCommit` without checking it, so historical bad values keep polluting the graph.

## Verification

- 233 tests pass in the validator suite, 572 in the downstream suites that import the shared module.
- `ruff check` clean on all changed files.
- Changed-line mypy ratchet: exit 0.
- This branch's own session log records its ending commit in a follow-up commit rather than by amending, which is the pattern the warning teaches. It validates with zero warnings.

Fixes #3618
