### PR TITLE
fix(eval): make the ledger write survive a Windows power cut

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-29-session-3591-windows-write-through.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-3591-windows-write-through.json
@@ -1,0 +1,212 @@
+{
+  "id": "episode-2026-07-29-session-3591-windows-write-through",
+  "session": "2026-07-29-session-3591-windows-write-through",
+  "timestamp": "2026-07-29T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Make the eval atomic write crash-durable on Windows. CPython's os.replace calls MoveFileExW without MOVEFILE_WRITE_THROUGH, so a host that loses power just after a consultation is charged can come back with the charge undone, which defeats the charge-before-scoring ordering (issue #3591).",
+  "decisions": [
+    {
+      "id": "d001",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "implementation",
+      "context": "",
+      "chosen": "Chose raise over warn for a failed move, matching os.replace and diverging from _fsync_dir on purpose. Every failure in _write_atomic up to and including this call leaves the destination untouched, so refusing costs the caller nothing. _fsync_dir warns because it runs after the entry is already published, where raising would spend a consultation and return no verdict. Verified the raise lands inside _write_atomic's existing handler, which unlinks the temp and converts OSError to ConfigError, rather than escaping as a traceback.",
+      "rationale": "",
+      "outcome": "success",
+      "effects": []
+    },
+    {
+      "id": "d002",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "implementation",
+      "context": "",
+      "chosen": "Chose warn over raise when the Win32 layer cannot be resolved at all. Refusing the write would turn a durability gap into an outage, which is worse than the status quo. Unlike the unconditional skip this replaced, an unreachable kernel32 is an anomaly on that host rather than a property of every write, so it does not spend the stderr channel's signal.",
+      "rationale": "",
+      "outcome": "success",
+      "effects": []
+    }
+  ],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Checked the issue's own stated blocker before accepting its recommended outcome. The issue says both remaining options 'need a Windows runner to verify, which this repo's CI does not currently provide', and the _fsync_dir docstring repeated the claim as 'a Windows-only write-through path that this repo's CI cannot exercise'. The claim is false: .github/workflows/pytest.yml carries a test-windows-pwsh job on windows-latest that already runs uv run pytest across five steps. Counted across all workflows: 134 ubuntu-24.04-arm, 7 ubuntu-latest, 4 ubuntu-24.04, and 1 windows-latest. That reopened the fix rather than the accept-the-gap exit.",
+      "caused_by": [],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Confirmed the durability gap itself is real and is about durability rather than atomicity. CPython Modules/posixmodule.c passes MOVEFILE_REPLACE_EXISTING alone to MoveFileExW and omits MOVEFILE_WRITE_THROUGH, the flag Microsoft documents as waiting for the move to reach disk. Atomicity says no reader sees a half-written entry; durability says the entry survives a power cut. The ledger charges before it scores so a crash cannot hand back a look for free, so only the second one protects the ordering.",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added _durable_replace as the single seam _write_atomic calls, replacing the previous os.replace plus _fsync_dir pair at the call site. POSIX keeps both steps unchanged. Windows resolves MoveFileExW through ctypes and calls it with MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH, which is the same operation CPython already performs plus the wait.",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Chose raise over warn for a failed move, matching os.replace and diverging from _fsync_dir on purpose. Every failure in _write_atomic up to and including this call leaves the destination untouched, so refusing costs the caller nothing. _fsync_dir warns because it runs after the entry is already published, where raising would spend a consultation and return no verdict. Verified the raise lands inside _write_atomic's existing handler, which unlinks the temp and converts OSError to ConfigError, rather than escaping as a traceback.",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Chose warn over raise when the Win32 layer cannot be resolved at all. Refusing the write would turn a durability gap into an outage, which is worse than the status quo. Unlike the unconditional skip this replaced, an unreachable kernel32 is an anomaly on that host rather than a property of every write, so it does not spend the stderr channel's signal.",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": [
+        "e006"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Measured before trusting: the constants combine to 0x9 and _win32_move_file_ex() returns None on Linux, both confirmed by importing the module and printing the values rather than by reading the source.",
+      "caused_by": [
+        "e005"
+      ],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Broken probe caught by running it. The first fixture took the Windows branch by monkeypatching os.name to 'nt'. That assigns to the real os module, and CPython's ctypes/__init__.py reads os.name at import time and pulls Windows-only symbols when it says 'nt', so the test broke 'import ctypes' inside the very branch it was trying to reach and reported ImportError: cannot import name 'COMError' as though it were a product failure. Replaced with a module-level _is_windows() predicate the test patches instead, so no global interpreter state is touched. _fsync_dir now routes through the same predicate.",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Second portability defect found the same way. ctypes.get_last_error and ctypes.FormatError are both Windows-only attributes, so the error path raised AttributeError on any host that reached it, replacing the move failure with a fault in the description of the move failure. Extracted _win32_last_error() with both lookups guarded, so a failed move is always reported as a failed move.",
+      "caused_by": [
+        "e007"
+      ],
+      "leads_to": [
+        "e009"
+      ]
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Wrote 14 tests. Eleven run everywhere by driving the Windows branch through a recording stand-in; three run only on Windows and exercise the real ctypes call. The Windows-only class is explicit that it does not prove durability, since power loss is not injectable here: it proves the call is reachable, correctly bound, and correct about the bytes, and the durability half rests on Microsoft's documented meaning of the flag, which is the same standard the POSIX side takes from fsync.",
+      "caused_by": [
+        "e008"
+      ],
+      "leads_to": [
+        "e010"
+      ]
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Mutation-tested the suite rather than assuming it was load-bearing. Dropping MOVEFILE_WRITE_THROUGH from the call fails test_write_through_is_requested on the bit assertion. Changing the constant from 0x8 to 0x4 fails that test and test_the_flag_values_match_winbase, which matters because MoveFileExW ignores unknown bits, so a wrong value would still return success and still lose the charge. Reverting the dispatch to plain os.replace fails five tests. Restoring the file returns to 11 passed, 3 skipped.",
+      "caused_by": [
+        "e009"
+      ],
+      "leads_to": [
+        "e012"
+      ]
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "test",
+      "content": "Mutation-tested the suite rather than assuming it was load-bearing. Dropping MOVEFILE_WRITE_THROUGH from the call fails test_write_through_is_requested on the bit assertion. Changing the constant from 0x8 to 0x4 fails that test and test_the_flag_values_match_winbase, which matters because MoveFileExW ignores unknown bits, so a wrong value would still return success and still lose the charge. Reverting the dispatch to plain os.replace fails five tests. Restoring the file returns to 11 passed, 3 skipped.",
+      "caused_by": [],
+      "leads_to": [
+        "e015"
+      ]
+    },
+    {
+      "id": "e012",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added an isolating control for the fallback warning. test_the_fallback_is_not_what_a_healthy_host_takes asserts the success path emits nothing on stderr, so the warning assertion in the test above it cannot pass without the fallback branch actually existing.",
+      "caused_by": [
+        "e010"
+      ],
+      "leads_to": [
+        "e013"
+      ]
+    },
+    {
+      "id": "e013",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Wired the new file into the test-windows-pwsh job in .github/workflows/pytest.yml with a comment naming the reason, so the ctypes path is not shipped unrun. Without that step it would never execute on any CI leg.",
+      "caused_by": [
+        "e012"
+      ],
+      "leads_to": [
+        "e014"
+      ]
+    },
+    {
+      "id": "e014",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Regression checked the base. tests/eval/test_optimize_artifact_cli.py: 758 passed. tests/workflows plus tests/ci/test_pytest_non_tmp_policy.py: 155 passed, so no workflow-shape contract objects to the new step. Re-ran both suites after rebasing onto origin/main: 769 passed, 3 skipped.",
+      "caused_by": [
+        "e013"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e015",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "test",
+      "content": "Regression checked the base. tests/eval/test_optimize_artifact_cli.py: 758 passed. tests/workflows plus tests/ci/test_pytest_non_tmp_policy.py: 155 passed, so no workflow-shape contract objects to the new step. Re-ran both suites after rebasing onto origin/main: 769 passed, 3 skipped.",
+      "caused_by": [
+        "e011"
+      ],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 5
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-29-session-3591-windows-write-through.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-3591-windows-write-through.json
@@ -198,6 +198,14 @@
         "e011"
       ],
       "leads_to": []
+    },
+    {
+      "id": "e016",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 2c4100a351831dd656b92b7674de01e30e91e4a9",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -205,7 +213,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 5
   },
   "lessons": []

--- a/.agents/sessions/2026-07-29-session-3591-windows-write-through.json
+++ b/.agents/sessions/2026-07-29-session-3591-windows-write-through.json
@@ -128,5 +128,5 @@
     "The Windows-only class cannot prove durability without power-cut injection. If that ever becomes available, the three tests in TestOnRealWindows are where the real proof belongs.",
     "_write_atomic has four callers and only the ledger needs crash persistence. Making all four durable was simpler than special-casing one and costs a flag bit per write, so no caller-specific path was added."
   ],
-  "endingCommit": ""
+  "endingCommit": "2c4100a351831dd656b92b7674de01e30e91e4a9"
 }

--- a/.agents/sessions/2026-07-29-session-3591-windows-write-through.json
+++ b/.agents/sessions/2026-07-29-session-3591-windows-write-through.json
@@ -1,0 +1,132 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3591,
+    "date": "2026-07-29",
+    "branch": "fix/3591-windows-write-through",
+    "startingCommit": "95da12691",
+    "objective": "Make the eval atomic write crash-durable on Windows. CPython's os.replace calls MoveFileExW without MOVEFILE_WRITE_THROUGH, so a host that loses power just after a consultation is charged can come back with the charge undone, which defeats the charge-before-scoring ordering (issue #3591)."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "branchVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "git checkout -b fix/3591-windows-write-through origin/main; branch reported as fix/3591-windows-write-through."
+      },
+      "notOnMain": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Branch cut fresh from origin/main so it carries none of the other open PR branches in this campaign."
+      },
+      "handoffRead": {
+        "complete": true,
+        "level": "SHOULD",
+        "evidence": "Read earlier in this multi-issue campaign. The dashboard has not changed since."
+      },
+      "sessionLogCreated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "This file, written before the first commit on the branch."
+      },
+      "serenaActivated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Serena MCP has been unavailable for the whole campaign; no serena/ or mcp__serena__ tool is exposed."
+      },
+      "serenaInstructions": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Same cause. Fell back to reading the tree directly."
+      }
+    },
+    "sessionEnd": {
+      "logCompleted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "All workLog steps recorded with the measurements that produced them."
+      },
+      "qaSkipDocumented": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Full QA ran. 11 passed and 3 Windows-only skips in the new durability suite, 758 passed in tests/eval/test_optimize_artifact_cli.py, 155 passed across tests/workflows and tests/ci/test_pytest_non_tmp_policy.py."
+      },
+      "markdownLintRun": {
+        "complete": true,
+        "level": "SHOULD",
+        "evidence": "No markdown changed. The three changed files are Python, a test, and a workflow YAML."
+      },
+      "validationPassed": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "uv run ruff check on both Python files: All checks passed. pytest.yml parses under yaml.safe_load."
+      },
+      "checklistComplete": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Every item recorded with evidence."
+      },
+      "serenaMemoryUpdated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Serena MCP unavailable, so no memory could be written. The reusable finding, that monkeypatching os.name breaks CPython's own ctypes import, is recorded in the workLog and in the fixture docstring."
+      },
+      "handoffPreserved": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "HANDOFF.md not modified (ADR-014)."
+      },
+      "changesCommitted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Fix, tests, workflow step, and this log committed on fix/3591-windows-write-through. The endingCommit SHA is recorded in a follow-up commit rather than by amending."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": "Checked the issue's own stated blocker before accepting its recommended outcome. The issue says both remaining options 'need a Windows runner to verify, which this repo's CI does not currently provide', and the _fsync_dir docstring repeated the claim as 'a Windows-only write-through path that this repo's CI cannot exercise'. The claim is false: .github/workflows/pytest.yml carries a test-windows-pwsh job on windows-latest that already runs uv run pytest across five steps. Counted across all workflows: 134 ubuntu-24.04-arm, 7 ubuntu-latest, 4 ubuntu-24.04, and 1 windows-latest. That reopened the fix rather than the accept-the-gap exit."
+    },
+    {
+      "step": "Confirmed the durability gap itself is real and is about durability rather than atomicity. CPython Modules/posixmodule.c passes MOVEFILE_REPLACE_EXISTING alone to MoveFileExW and omits MOVEFILE_WRITE_THROUGH, the flag Microsoft documents as waiting for the move to reach disk. Atomicity says no reader sees a half-written entry; durability says the entry survives a power cut. The ledger charges before it scores so a crash cannot hand back a look for free, so only the second one protects the ordering."
+    },
+    {
+      "step": "Added _durable_replace as the single seam _write_atomic calls, replacing the previous os.replace plus _fsync_dir pair at the call site. POSIX keeps both steps unchanged. Windows resolves MoveFileExW through ctypes and calls it with MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH, which is the same operation CPython already performs plus the wait."
+    },
+    {
+      "step": "Chose raise over warn for a failed move, matching os.replace and diverging from _fsync_dir on purpose. Every failure in _write_atomic up to and including this call leaves the destination untouched, so refusing costs the caller nothing. _fsync_dir warns because it runs after the entry is already published, where raising would spend a consultation and return no verdict. Verified the raise lands inside _write_atomic's existing handler, which unlinks the temp and converts OSError to ConfigError, rather than escaping as a traceback."
+    },
+    {
+      "step": "Chose warn over raise when the Win32 layer cannot be resolved at all. Refusing the write would turn a durability gap into an outage, which is worse than the status quo. Unlike the unconditional skip this replaced, an unreachable kernel32 is an anomaly on that host rather than a property of every write, so it does not spend the stderr channel's signal."
+    },
+    {
+      "step": "Measured before trusting: the constants combine to 0x9 and _win32_move_file_ex() returns None on Linux, both confirmed by importing the module and printing the values rather than by reading the source."
+    },
+    {
+      "step": "Broken probe caught by running it. The first fixture took the Windows branch by monkeypatching os.name to 'nt'. That assigns to the real os module, and CPython's ctypes/__init__.py reads os.name at import time and pulls Windows-only symbols when it says 'nt', so the test broke 'import ctypes' inside the very branch it was trying to reach and reported ImportError: cannot import name 'COMError' as though it were a product failure. Replaced with a module-level _is_windows() predicate the test patches instead, so no global interpreter state is touched. _fsync_dir now routes through the same predicate."
+    },
+    {
+      "step": "Second portability defect found the same way. ctypes.get_last_error and ctypes.FormatError are both Windows-only attributes, so the error path raised AttributeError on any host that reached it, replacing the move failure with a fault in the description of the move failure. Extracted _win32_last_error() with both lookups guarded, so a failed move is always reported as a failed move."
+    },
+    {
+      "step": "Wrote 14 tests. Eleven run everywhere by driving the Windows branch through a recording stand-in; three run only on Windows and exercise the real ctypes call. The Windows-only class is explicit that it does not prove durability, since power loss is not injectable here: it proves the call is reachable, correctly bound, and correct about the bytes, and the durability half rests on Microsoft's documented meaning of the flag, which is the same standard the POSIX side takes from fsync."
+    },
+    {
+      "step": "Mutation-tested the suite rather than assuming it was load-bearing. Dropping MOVEFILE_WRITE_THROUGH from the call fails test_write_through_is_requested on the bit assertion. Changing the constant from 0x8 to 0x4 fails that test and test_the_flag_values_match_winbase, which matters because MoveFileExW ignores unknown bits, so a wrong value would still return success and still lose the charge. Reverting the dispatch to plain os.replace fails five tests. Restoring the file returns to 11 passed, 3 skipped."
+    },
+    {
+      "step": "Added an isolating control for the fallback warning. test_the_fallback_is_not_what_a_healthy_host_takes asserts the success path emits nothing on stderr, so the warning assertion in the test above it cannot pass without the fallback branch actually existing."
+    },
+    {
+      "step": "Wired the new file into the test-windows-pwsh job in .github/workflows/pytest.yml with a comment naming the reason, so the ctypes path is not shipped unrun. Without that step it would never execute on any CI leg."
+    },
+    {
+      "step": "Regression checked the base. tests/eval/test_optimize_artifact_cli.py: 758 passed. tests/workflows plus tests/ci/test_pytest_non_tmp_policy.py: 155 passed, so no workflow-shape contract objects to the new step. Re-ran both suites after rebasing onto origin/main: 769 passed, 3 skipped."
+    }
+  ],
+  "nextSteps": [
+    "The Windows-only class cannot prove durability without power-cut injection. If that ever becomes available, the three tests in TestOnRealWindows are where the real proof belongs.",
+    "_write_atomic has four callers and only the ledger needs crash persistence. Making all four durable was simpler than special-casing one and costs a flag bit per write, so no caller-specific path was added."
+  ],
+  "endingCommit": ""
+}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -396,3 +396,13 @@ jobs:
         env:
           UV_PYTHON: '3.14'
         run: uv run pytest tests/integration/test_e2e_install.py -q
+
+      # Issue #3591: the ledger charge is only durable on Windows if the move
+      # asks for MOVEFILE_WRITE_THROUGH, which CPython's os.replace omits. The
+      # ctypes path that adds it cannot run on the POSIX legs, so without this
+      # step it would ship unexercised.
+      - name: Run atomic-write durability contract tests
+        shell: pwsh
+        env:
+          UV_PYTHON: '3.14'
+        run: uv run pytest tests/eval/test_optimize_artifact_durability.py -v

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -2461,18 +2461,26 @@ def _win32_move_file_ex() -> Callable[[str, str, int], int] | None:
     A missing Win32 layer is not a reason to refuse a write the caller can
     still perform less durably.
     """
+    # getattr rather than ctypes.WinDLL because WinDLL is a Windows-only
+    # attribute, so the direct reference is unresolvable to a type checker on
+    # every other platform. The three-argument form makes the POSIX answer an
+    # ordinary value instead of an exception, and it is the same guarded
+    # lookup _win32_last_error uses for get_last_error and FormatError.
+    load_library = getattr(ctypes, "WinDLL", None)
+    if load_library is None:
+        return None
     try:
         from ctypes import wintypes
 
-        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+        kernel32 = load_library("kernel32", use_last_error=True)
         move = kernel32.MoveFileExW
         move.argtypes = (wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD)
         move.restype = wintypes.BOOL
         return cast(Callable[[str, str, int], int], move)
     except (AttributeError, ImportError, OSError):
-        # AttributeError is the POSIX answer: ctypes imports fine and has no
-        # WinDLL. The other two cover a Windows host whose kernel32 or whose
-        # wintypes cannot be loaded.
+        # A Windows host that has WinDLL but whose kernel32, whose
+        # MoveFileExW, or whose wintypes cannot be loaded. The plain POSIX
+        # case never reaches here; it left at the guard above.
         return None
 
 

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -2507,8 +2507,8 @@ def _win32_last_error() -> str:
 def _durable_replace(source: Path, destination: Path) -> None:
     """Move `source` onto `destination` so the entry survives a power cut.
 
-    Atomicity and durability are different guarantees and both callers need
-    the second one. Atomicity says no reader sees a half-written entry.
+    Atomicity and durability are different guarantees, and this function
+    exists for the second one. Atomicity says no reader sees a half-written entry.
     Durability says the entry is still there after the host loses power. The
     consultation ledger charges before it scores precisely so a crash cannot
     hand back a look for free, and a charge a crash can erase defeats that

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -41,6 +41,7 @@ module runs and prints its own plain-text usage to stderr.
 from __future__ import annotations
 
 import argparse
+import ctypes
 import hashlib
 import io
 import json
@@ -2400,25 +2401,13 @@ def _fsync_dir(directory: Path) -> None:
     parses.
 
     Windows cannot open a directory as a descriptor, so there is nothing to
-    sync and the step is skipped. The skip is a real gap, not a no-op, and
-    the reason usually offered for it answers a different question than the
-    one this function asks. ``os.replace`` is atomic on Windows, but the
-    paragraph above is about durability, not atomicity. CPython calls
-    ``MoveFileExW`` with ``MOVEFILE_REPLACE_EXISTING`` alone (see
-    ``Modules/posixmodule.c``), omitting ``MOVEFILE_WRITE_THROUGH``, the flag
-    Microsoft documents as waiting for the move to reach disk. A Windows host
-    that loses power just after a ledger charge can therefore come back with
-    the charge undone, which is the same loss an unsynced POSIX host takes.
-
-    The skip stays silent rather than warning like the failure path above,
-    because it is a property of the platform and not an anomaly in this run.
-    It holds for every write, so warning on each one would spend the stderr
-    channel's signal and teach the operator to ignore it. Recording it here
-    is the report. Closing it needs a Windows-only write-through path that
-    this repo's CI cannot exercise, so it is tracked in issue #3591 rather
-    than guessed at here.
+    sync and this function is not the durability primitive there.
+    ``_durable_replace`` reaches the same guarantee a different way, by asking
+    the move itself to write through, and only calls this on POSIX. The guard
+    below stays anyway: it costs one comparison and keeps the function total
+    if a second caller ever appears on a platform where the open would fail.
     """
-    if os.name == "nt":  # pragma: no cover - POSIX-only durability primitive
+    if _is_windows():  # pragma: no cover - POSIX-only durability primitive
         return
     try:
         fd = os.open(str(directory), os.O_RDONLY)
@@ -2439,6 +2428,127 @@ def _fsync_dir(directory: Path) -> None:
             f"directory ({exc}); the file is intact and its durability across a "
             "host crash is not guaranteed"
         )
+
+
+# Win32 MoveFileEx flags (winbase.h). REPLACE_EXISTING is what CPython already
+# passes; WRITE_THROUGH is the one it omits, and the one durability needs.
+_MOVEFILE_REPLACE_EXISTING = 0x1
+_MOVEFILE_WRITE_THROUGH = 0x8
+
+
+def _is_windows() -> bool:
+    """The platform question both durability paths ask.
+
+    A function rather than an inline ``os.name`` test so a test can take the
+    other branch without assigning to the real ``os`` module. That assignment
+    is not inert: CPython's own ``ctypes`` package reads ``os.name`` at import
+    and tries to pull Windows-only symbols when it says ``nt``, so a test that
+    flipped it globally broke an unrelated stdlib import inside the very
+    branch it was trying to reach.
+    """
+    return os.name == "nt"
+
+
+def _win32_move_file_ex() -> Callable[[str, str, int], int] | None:
+    """Resolve ``MoveFileExW``, or None when the Win32 layer is unreachable.
+
+    Resolved per call rather than cached at import. These writes are rare
+    (a ledger charge, a split, an artifact apply), so the lookup costs
+    nothing measurable, and module-level state would have to be reset between
+    tests to stay honest about which platform a test believes it is on.
+
+    Returning None instead of raising keeps the caller's fallback decidable.
+    A missing Win32 layer is not a reason to refuse a write the caller can
+    still perform less durably.
+    """
+    try:
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+        move = kernel32.MoveFileExW
+        move.argtypes = (wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD)
+        move.restype = wintypes.BOOL
+        return cast(Callable[[str, str, int], int], move)
+    except (AttributeError, ImportError, OSError):
+        # AttributeError is the POSIX answer: ctypes imports fine and has no
+        # WinDLL. The other two cover a Windows host whose kernel32 or whose
+        # wintypes cannot be loaded.
+        return None
+
+
+def _win32_last_error() -> str:
+    """Describe the Win32 error the last call left behind.
+
+    Every lookup is guarded because ``get_last_error`` and ``FormatError``
+    are both Windows-only attributes of ``ctypes``. This runs only while
+    another failure is already being reported, so an ``AttributeError`` raised
+    here would replace the cause with a fault in the description of the cause,
+    which is the same trap ``_write_atomic``'s cleanup handler is written to
+    avoid. Reporting an unknown code is worse than a real one and much better
+    than losing the move failure entirely.
+    """
+    read_code = getattr(ctypes, "get_last_error", None)
+    if read_code is None:
+        return "Win32 error unavailable on this platform"
+    code = read_code()
+    describe = getattr(ctypes, "FormatError", None)
+    detail = describe(code) if describe is not None else "Win32 error"
+    return f"{detail} ({code})"
+
+
+def _durable_replace(source: Path, destination: Path) -> None:
+    """Move `source` onto `destination` so the entry survives a power cut.
+
+    Atomicity and durability are different guarantees and both callers need
+    the second one. Atomicity says no reader sees a half-written entry.
+    Durability says the entry is still there after the host loses power. The
+    consultation ledger charges before it scores precisely so a crash cannot
+    hand back a look for free, and a charge a crash can erase defeats that
+    ordering.
+
+    POSIX reaches durability in two steps: ``os.replace`` publishes the entry
+    and ``_fsync_dir`` pushes the parent directory to disk.
+
+    Windows cannot open a directory as a descriptor, so the second step has
+    nowhere to go and the guarantee has to come from the move itself.
+    ``os.replace`` alone does not supply it: CPython calls ``MoveFileExW``
+    with ``MOVEFILE_REPLACE_EXISTING`` and no ``MOVEFILE_WRITE_THROUGH``
+    (``Modules/posixmodule.c``), and Microsoft documents that second flag as
+    the one that waits for the move to reach disk. Calling ``MoveFileExW``
+    directly with both flags is the same operation CPython already performs
+    plus the wait, so it keeps the atomicity that was never in question and
+    adds the durability that was.
+
+    A failure raises, matching ``os.replace``. Every failure in
+    ``_write_atomic`` up to and including this call leaves the destination
+    untouched, so refusing costs the caller nothing; that is the same reason
+    ``_fsync_dir``, which runs after the entry is already published, warns
+    instead.
+    """
+    if not _is_windows():
+        os.replace(source, destination)
+        _fsync_dir(destination.parent)
+        return
+
+    move = _win32_move_file_ex()
+    if move is None:
+        # Warned rather than raised. The durability gap is worse than the
+        # status quo ante and better than refusing the write outright, and
+        # unlike the skip this replaced it is a genuine anomaly on this host
+        # rather than a property of every write, so it does not spend the
+        # stderr channel's signal the way a per-write notice would.
+        os.replace(source, destination)
+        _warn(
+            f"warning: wrote and renamed onto {destination}, but the Win32 "
+            "write-through move was unavailable; the file is intact and its "
+            "durability across a host crash is not guaranteed"
+        )
+        return
+
+    if not move(
+        str(source), str(destination), _MOVEFILE_REPLACE_EXISTING | _MOVEFILE_WRITE_THROUGH
+    ):
+        raise OSError(f"could not move {source} onto {destination}: {_win32_last_error()}")
 
 
 def _write_atomic(path: Path, text: str) -> None:
@@ -2488,8 +2598,7 @@ def _write_atomic(path: Path, text: str) -> None:
             os.fsync(handle.fileno())
         if mode is not None:
             os.chmod(tmp, mode)
-        os.replace(tmp, path)
-        _fsync_dir(path.parent)
+        _durable_replace(tmp, path)
     except BaseException as exc:
         # Cleanup cannot stand in for the failure it cleans up after. An
         # OSError raised here would propagate from inside the handler, so the

--- a/tests/eval/test_optimize_artifact_durability.py
+++ b/tests/eval/test_optimize_artifact_durability.py
@@ -1,0 +1,256 @@
+"""Durability of the atomic write across a host crash (issue #3591).
+
+`os.replace` publishes a new directory entry atomically on both platforms.
+Atomicity is not durability: it says no reader sees a half-written entry, not
+that the entry survives a power cut. The consultation ledger charges before it
+scores so a crash cannot hand back a look for free, so an erasable charge
+defeats the ordering it exists to protect.
+
+POSIX closes that with `_fsync_dir`. Windows cannot open a directory as a
+descriptor, so the guarantee has to come from the move, which means asking for
+`MOVEFILE_WRITE_THROUGH` explicitly because CPython does not.
+
+Most tests here drive the Windows branch through a stand-in so the flag word
+is checkable on any host. `TestOnRealWindows` is the one that runs the real
+Win32 call, and it is wired into the `test-windows-pwsh` job in
+`.github/workflows/pytest.yml` so the ctypes path is not shipped unrun.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_EVAL_DIR = Path(__file__).resolve().parents[2] / "scripts" / "eval"
+# Scope the sys.path mutation to the module load and remove it afterward so it
+# does not leak into other tests (mirrors tests/eval/test_optimize_artifact_cli.py).
+_path_added = str(_EVAL_DIR) not in sys.path
+try:
+    if _path_added:
+        sys.path.insert(0, str(_EVAL_DIR))
+    _SCRIPT = _EVAL_DIR / "optimize-artifact.py"
+    _spec = importlib.util.spec_from_file_location("optimize_artifact", _SCRIPT)
+    assert _spec is not None and _spec.loader is not None
+    oa = importlib.util.module_from_spec(_spec)
+    sys.modules["optimize_artifact"] = oa
+    _spec.loader.exec_module(oa)
+finally:
+    if _path_added and str(_EVAL_DIR) in sys.path:
+        sys.path.remove(str(_EVAL_DIR))
+
+
+ON_WINDOWS = os.name == "nt"
+
+
+class Mover:
+    """A stand-in for `MoveFileExW` that records how it was called."""
+
+    def __init__(self, *, succeed: bool = True, perform: bool = True) -> None:
+        self.succeed = succeed
+        self.perform = perform
+        self.calls: list[tuple[str, str, int]] = []
+
+    def __call__(self, source: str, destination: str, flags: int) -> int:
+        self.calls.append((source, destination, flags))
+        if self.perform and self.succeed:
+            os.replace(source, destination)
+        return 1 if self.succeed else 0
+
+
+@pytest.fixture
+def as_windows(monkeypatch: pytest.MonkeyPatch):
+    """Take the Windows branch of `_durable_replace` on any host.
+
+    Patching the module's own platform predicate, never `os.name`. Assigning
+    to the real `os` module is not inert: CPython's `ctypes` package reads
+    `os.name` at import and pulls Windows-only symbols when it says `nt`, so
+    the first draft of this fixture broke `import ctypes` inside the branch it
+    was trying to reach and reported it as a product failure.
+    """
+    monkeypatch.setattr(oa, "_is_windows", lambda: True)
+
+
+def _pair(tmp_path: Path) -> tuple[Path, Path]:
+    source = tmp_path / "src.tmp"
+    source.write_text("new", encoding="utf-8")
+    destination = tmp_path / "dst.json"
+    destination.write_text("old", encoding="utf-8")
+    return source, destination
+
+
+class TestTheFlagsWeAskFor:
+    """The whole fix is one bit. These make that bit falsifiable."""
+
+    def test_write_through_is_requested(self, tmp_path, as_windows, monkeypatch):
+        mover = Mover()
+        monkeypatch.setattr(oa, "_win32_move_file_ex", lambda: mover)
+        source, destination = _pair(tmp_path)
+
+        oa._durable_replace(source, destination)
+
+        assert len(mover.calls) == 1
+        _, _, flags = mover.calls[0]
+        # Spelled as a bit test rather than only an equality so a future edit
+        # that keeps the call and drops the durability fails on the reason.
+        assert flags & oa._MOVEFILE_WRITE_THROUGH, (
+            "MOVEFILE_WRITE_THROUGH is the only thing this call adds over "
+            "os.replace; without it the move is atomic but not durable"
+        )
+        assert flags & oa._MOVEFILE_REPLACE_EXISTING, (
+            "without REPLACE_EXISTING the move fails whenever the "
+            "destination already exists, which is every rewrite"
+        )
+        assert flags == 0x9
+
+    def test_the_flag_values_match_winbase(self):
+        """Pinned against the Win32 header, not against our own arithmetic.
+
+        A typo here is invisible: MoveFileExW ignores unknown bits, so a wrong
+        WRITE_THROUGH value still returns success and still loses the charge.
+        """
+        assert oa._MOVEFILE_REPLACE_EXISTING == 0x1
+        assert oa._MOVEFILE_WRITE_THROUGH == 0x8
+
+    def test_the_paths_are_passed_through_unchanged(self, tmp_path, as_windows, monkeypatch):
+        mover = Mover()
+        monkeypatch.setattr(oa, "_win32_move_file_ex", lambda: mover)
+        source, destination = _pair(tmp_path)
+
+        oa._durable_replace(source, destination)
+
+        assert mover.calls[0][0] == str(source)
+        assert mover.calls[0][1] == str(destination)
+
+
+class TestTheWindowsBranch:
+    def test_a_successful_move_publishes_the_new_content(
+        self, tmp_path, as_windows, monkeypatch
+    ):
+        mover = Mover()
+        monkeypatch.setattr(oa, "_win32_move_file_ex", lambda: mover)
+        source, destination = _pair(tmp_path)
+
+        oa._durable_replace(source, destination)
+
+        assert destination.read_text(encoding="utf-8") == "new"
+        assert not source.exists()
+
+    def test_a_failed_move_raises(self, tmp_path, as_windows, monkeypatch):
+        """Matching os.replace. This runs before the entry is published, so
+        refusing costs the caller nothing, which is why it raises where
+        `_fsync_dir` warns."""
+        monkeypatch.setattr(oa, "_win32_move_file_ex", lambda: Mover(succeed=False))
+        source, destination = _pair(tmp_path)
+
+        with pytest.raises(OSError, match="could not move"):
+            oa._durable_replace(source, destination)
+
+        assert destination.read_text(encoding="utf-8") == "old"
+
+    def test_a_failed_move_reaches_the_caller_as_one_config_error(
+        self, tmp_path, as_windows, monkeypatch
+    ):
+        """`_write_atomic` owns the conversion; this proves the new raise
+        lands inside its handler rather than escaping as a traceback."""
+        monkeypatch.setattr(oa, "_win32_move_file_ex", lambda: Mover(succeed=False))
+        destination = tmp_path / "dst.json"
+        destination.write_text("old", encoding="utf-8")
+
+        with pytest.raises(oa.ConfigError, match="could not write"):
+            oa._write_atomic(destination, "new")
+
+        assert destination.read_text(encoding="utf-8") == "old"
+        leftovers = [p.name for p in tmp_path.iterdir() if p.name.startswith(".dst.json.")]
+        assert leftovers == [], f"temp file survived a failed move: {leftovers}"
+
+    def test_an_unavailable_win32_layer_still_writes_and_says_so(
+        self, tmp_path, as_windows, monkeypatch, capsys
+    ):
+        """Availability beats durability when the two conflict.
+
+        Refusing the write would turn a durability gap into an outage, so the
+        fallback publishes the entry the old way and reports the weaker
+        guarantee on stderr.
+        """
+        monkeypatch.setattr(oa, "_win32_move_file_ex", lambda: None)
+        source, destination = _pair(tmp_path)
+
+        oa._durable_replace(source, destination)
+
+        assert destination.read_text(encoding="utf-8") == "new"
+        err = capsys.readouterr()
+        assert "durability across a host crash is not guaranteed" in err.err
+        assert err.out == "", "a warning must not contaminate the one JSON document on stdout"
+
+    def test_the_fallback_is_not_what_a_healthy_host_takes(
+        self, tmp_path, as_windows, monkeypatch, capsys
+    ):
+        """Isolating control for the test above. If the success path also
+        warned, that assertion would pass without the fallback existing."""
+        monkeypatch.setattr(oa, "_win32_move_file_ex", lambda: Mover())
+        source, destination = _pair(tmp_path)
+
+        oa._durable_replace(source, destination)
+
+        assert capsys.readouterr().err == ""
+
+
+class TestThePosixBranch:
+    def test_posix_replaces_and_fsyncs_the_parent(self, tmp_path, monkeypatch):
+        synced: list[Path] = []
+        monkeypatch.setattr(oa, "_fsync_dir", synced.append)
+        # If the Windows branch were taken by mistake this stand-in would
+        # record the call, so the assertion below is two-sided.
+        mover = Mover()
+        monkeypatch.setattr(oa, "_win32_move_file_ex", lambda: mover)
+        source, destination = _pair(tmp_path)
+
+        oa._durable_replace(source, destination)
+
+        assert destination.read_text(encoding="utf-8") == "new"
+        assert synced == [tmp_path]
+        assert mover.calls == [], "POSIX must not reach the Win32 mover"
+
+    @pytest.mark.skipif(ON_WINDOWS, reason="asserts the POSIX-only resolver answer")
+    def test_the_resolver_reports_no_win32_layer_on_posix(self):
+        assert oa._win32_move_file_ex() is None
+
+    def test_write_atomic_round_trips(self, tmp_path):
+        target = tmp_path / "ledger.json"
+        oa._write_atomic(target, '{"n": 1}')
+        assert target.read_text(encoding="utf-8") == '{"n": 1}'
+        oa._write_atomic(target, '{"n": 2}')
+        assert target.read_text(encoding="utf-8") == '{"n": 2}'
+        assert [p.name for p in tmp_path.iterdir()] == ["ledger.json"]
+
+
+@pytest.mark.skipif(not ON_WINDOWS, reason="exercises the real Win32 MoveFileExW")
+class TestOnRealWindows:
+    """The only tests that run the shipped ctypes path.
+
+    Power loss is not injectable here, so these do not prove durability. They
+    prove the call is reachable, correctly bound, and correct about the bytes,
+    which is the half that a stand-in cannot check. The durability half rests
+    on Microsoft's documented meaning of the flag, the same standard the POSIX
+    side takes from fsync.
+    """
+
+    def test_the_win32_entry_point_resolves(self):
+        assert oa._win32_move_file_ex() is not None
+
+    def test_a_real_write_through_move_publishes_the_content(self, tmp_path):
+        source, destination = _pair(tmp_path)
+        oa._durable_replace(source, destination)
+        assert destination.read_text(encoding="utf-8") == "new"
+        assert not source.exists()
+
+    def test_write_atomic_round_trips_over_the_real_call(self, tmp_path):
+        target = tmp_path / "ledger.json"
+        oa._write_atomic(target, '{"n": 1}')
+        oa._write_atomic(target, '{"n": 2}')
+        assert target.read_text(encoding="utf-8") == '{"n": 2}'
+        assert [p.name for p in tmp_path.iterdir()] == ["ledger.json"]

--- a/tests/eval/test_optimize_artifact_durability.py
+++ b/tests/eval/test_optimize_artifact_durability.py
@@ -202,6 +202,14 @@ class TestTheWindowsBranch:
 
 class TestThePosixBranch:
     def test_posix_replaces_and_fsyncs_the_parent(self, tmp_path, monkeypatch):
+        # Force the POSIX arm rather than inferring it from the host. On
+        # Windows the real `_is_windows` sends this through the Win32 arm, so
+        # the parent fsync never runs and the assertion below reads an empty
+        # list; measured as a CI failure on the Windows runner. Pinning the
+        # branch tests it on every platform, which skipping would not, and
+        # costs nothing here because the one POSIX-only syscall in the arm,
+        # the directory fsync, is already replaced by the recorder below.
+        monkeypatch.setattr(oa, "_is_windows", lambda: False)
         synced: list[Path] = []
         monkeypatch.setattr(oa, "_fsync_dir", synced.append)
         # If the Windows branch were taken by mistake this stand-in would

--- a/tests/eval/test_optimize_artifact_durability.py
+++ b/tests/eval/test_optimize_artifact_durability.py
@@ -22,6 +22,7 @@ import importlib.util
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -226,6 +227,47 @@ class TestThePosixBranch:
         oa._write_atomic(target, '{"n": 2}')
         assert target.read_text(encoding="utf-8") == '{"n": 2}'
         assert [p.name for p in tmp_path.iterdir()] == ["ledger.json"]
+
+
+class TestTheResolverFallsBackInsteadOfRaising:
+    """The resolver answers None for every reason it cannot produce a mover.
+
+    Two routes reach None and they are not the same. A host with no ``WinDLL``
+    at all leaves at the guard, which is the ordinary POSIX answer. A host that
+    has ``WinDLL`` but cannot complete the lookup leaves through the handler.
+    Both matter: the resolver runs on the write path, so a raise here would
+    turn a durability gap into a failed write.
+
+    ``test_a_healthy_lookup_still_produces_a_mover`` is the control. On POSIX
+    the guard returns None for its own reason, so without it every assertion
+    in this class would pass against a resolver that had been broken to
+    return None unconditionally.
+    """
+
+    @staticmethod
+    def _install(monkeypatch, win_dll):
+        monkeypatch.setattr(oa.ctypes, "WinDLL", win_dll, raising=False)
+
+    def test_a_healthy_lookup_still_produces_a_mover(self, monkeypatch):
+        def load(name, use_last_error):
+            return SimpleNamespace(MoveFileExW=Mover())
+
+        self._install(monkeypatch, load)
+
+        assert oa._win32_move_file_ex() is not None
+
+    def test_an_unloadable_kernel32_is_not_raised_at_the_caller(self, monkeypatch):
+        def refuse(name, use_last_error):
+            raise OSError("kernel32 not found")
+
+        self._install(monkeypatch, refuse)
+
+        assert oa._win32_move_file_ex() is None
+
+    def test_a_kernel32_without_the_entry_point_is_not_raised_either(self, monkeypatch):
+        self._install(monkeypatch, lambda name, use_last_error: SimpleNamespace())
+
+        assert oa._win32_move_file_ex() is None
 
 
 @pytest.mark.skipif(not ON_WINDOWS, reason="exercises the real Win32 MoveFileExW")


### PR DESCRIPTION
## Summary

The optimizer charges a consultation to the ledger before it scores, so a
crash can never hand back a free look. On Windows that ordering did not hold.

CPython's `os.replace` calls `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING`
alone and omits `MOVEFILE_WRITE_THROUGH` (`Modules/posixmodule.c`), the flag
Microsoft documents as waiting for the move to reach disk. The rename was
atomic but not durable. Atomicity says no reader sees a half-written entry.
Durability says the entry is still there after the host loses power. Only the
second one protects the charge-before-scoring ordering, and Windows had only
the first.

Fixes #3591

## The issue's stated blocker was false

The issue says both remaining options need a Windows runner "which this repo's
CI does not currently provide", and the product docstring repeated the claim.
Measured instead of believed:

```
$ grep -rhoP "runs-on:\s*\K.*" .github/workflows/*.yml | sort | uniq -c
    134 ubuntu-24.04-arm
      7 ubuntu-latest
      4 ubuntu-24.04
      1 windows-latest
```

That one is the `test-windows-pwsh` job in the pytest workflow, which already
runs pytest against an allowlist of test files. The tracked "cannot be
verified" fix was verifiable all along. The new suite is wired into that job
so the ctypes path is not shipped unrun, and the stale docstring paragraph is
rewritten.

## What changed

`_write_atomic` now calls a single `_durable_replace` seam.

- POSIX is unchanged: `os.replace` publishes the entry, `_fsync_dir` pushes the
  parent directory to disk.
- Windows resolves `MoveFileExW` through ctypes and passes
  `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH`. That is the same
  operation CPython already performs plus the wait, so it keeps the atomicity
  that was never in question and adds the durability that was. Windows cannot
  open a directory as a descriptor, so `_fsync_dir` has nowhere to go there and
  the guarantee has to come from the move itself.

Two failure policies, chosen for different reasons:

- A failed move **raises**, matching `os.replace`. Every failure up to and
  including this call leaves the destination untouched, so refusing costs the
  caller nothing. The raise lands inside `_write_atomic`'s existing handler,
  which unlinks the temp and converts `OSError` to `ConfigError`.
- An unresolvable Win32 layer **warns and falls back**. Turning a durability
  gap into an outage is worse than the status quo.

## Two portability defects the tests caught

Both were found by running the tests, not by reading the code.

The first was in the test, not the product. The original fixture took the
Windows branch by monkeypatching `os.name` to `"nt"`. That assigns to the real
`os` module, and CPython's own `ctypes/__init__.py` reads `os.name` at import
and pulls Windows-only symbols when it says `nt`. The patch broke `import
ctypes` inside the very branch the test was trying to reach and reported an
`ImportError` as though it were a product failure. Fixed by adding an
`_is_windows()` predicate the test patches instead, so no global interpreter
state is touched.

The second was real. `ctypes.get_last_error` and `ctypes.FormatError` are both
Windows-only attributes, so the error path raised `AttributeError` on any host
that reached it, replacing the move failure with a fault in the description of
the move failure. `_win32_last_error()` now guards both lookups.

## Evidence

17 tests. Fourteen run everywhere by driving the Windows branch through a
recording stand-in; three run only on Windows and exercise the real ctypes
call.

The Windows-only class is explicit that it does not prove durability, since
power loss is not injectable here. It proves the call is reachable, correctly
bound, and correct about the bytes. The durability half rests on Microsoft's
documented meaning of the flag, which is the same standard the POSIX side
takes from `fsync`.

Mutation-tested five ways, each turning the suite red and each restore
returning it green:

| Mutation | Caught by |
|---|---|
| Drop `MOVEFILE_WRITE_THROUGH` from the call | 1 test |
| Set the constant to `0x4` instead of `0x8` | 2 tests |
| Revert the dispatch to plain `os.replace` | 5 tests |
| Force the resolver to always answer `None` | 1 test (the control) |
| Narrow the resolver's `except` tuple | 2 tests |

The wrong-value mutation is the one that matters most: `MoveFileExW` ignores
unknown bits, so a bad constant would still report success and still lose the
charge.

## Suppression removed rather than justified

The push gate flagged a `type: ignore` on the `ctypes.WinDLL` reference and it
was right to. The repo's rule is that a suppression is a last resort, and the
idiomatic fix was already two functions below: `_win32_last_error` reads its
Windows-only ctypes attributes through `getattr`. `WinDLL` now uses the same
seam. The three-argument form is better than the suppression it replaces, not
just quieter: the ordinary POSIX answer becomes a value at a guard instead of
an `AttributeError` caught several lines later, which leaves the handler
meaning only what it says.

## Test plan

- `tests/eval/test_optimize_artifact_durability.py`: 14 passed, 3 skipped on Linux
- `tests/eval/test_optimize_artifact_cli.py`: 758 passed, no regression
- `tests/workflows/` plus `tests/ci/test_pytest_non_tmp_policy.py`: 155 passed,
  so no workflow-shape contract objects to the new step
- `uv run ruff check` clean on both Python files

## Notes

`_write_atomic` has four callers and only the ledger needs crash persistence.
Making all four durable was simpler than special-casing one and costs a flag
bit per write, so no caller-specific path was added.
