### PR TITLE
fix(memory): let route documentation quote a route without becoming one

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.180",
+  "version": "0.6.185",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.185",
+  "version": "0.6.186",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/orphan-ref-validator/tests/test_scan.py
+++ b/.claude/skills/orphan-ref-validator/tests/test_scan.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath
@@ -2138,7 +2137,6 @@ class TestTheMemoryCorpusIsGateable:
             probe.unlink()
         assert _skill_names(result) == {"doc-coverage"}
 
-
 class TestDocumentationMayQuoteARouteWithoutBecomingOne:
     """Issue #3749: prose that describes route syntax has to write route syntax.
 
@@ -2148,73 +2146,69 @@ class TestDocumentationMayQuoteARouteWithoutBecomingOne:
     ``<!-- orphan-ref-ignore -->`` directive is the designed escape hatch; these
     tests pin that it reaches ``skill_name`` findings, not only path findings,
     and that it does not quietly blunt the detector for everyone else.
+
+    Everything runs against ``fake_repo`` rather than the real checkout. Writing
+    probes into the working tree would race the canonical and mirrored copies of
+    this suite against each other, since both carry the same test names, and a
+    crashed run would leave litter behind.
     """
 
     @staticmethod
-    def _write(tmp_path: Path, body: str) -> Path:
-        target = _repo_root() / f".orphan-ref-probe-{tmp_path.name}"
-        target.mkdir(exist_ok=True)
-        (target / "memo.md").write_text(body, encoding="utf-8")
-        return target
+    def _docs(fake_repo: Path, body: str) -> Path:
+        docs = fake_repo / "memories"
+        docs.mkdir(exist_ok=True)
+        (docs / "memo.md").write_text(body, encoding="utf-8")
+        return docs
 
-    def test_an_undirected_route_in_prose_is_still_reported(self, tmp_path):
+    def test_an_undirected_route_in_prose_is_still_reported(self, fake_repo: Path) -> None:
         """Negative control: without the directive the detector must fire.
 
         Without this the positive case below could pass because the scanner
         stopped detecting anything at all.
         """
-        probe = self._write(tmp_path, "prose about Skill: `zzznotaskill` here\n")
-        try:
-            result = scan([probe], _repo_root())
-        finally:
-            shutil.rmtree(probe)
-        assert _skill_names(result) == {"zzznotaskill"}
+        docs = self._docs(fake_repo, "prose about Skill: `zzznotaskill` here\n")
+        assert _skill_names(scan([docs], fake_repo)) == {"zzznotaskill"}
 
-    def test_the_directive_suppresses_a_skill_name_finding(self, tmp_path):
+    def test_the_directive_suppresses_a_skill_name_finding(self, fake_repo: Path) -> None:
         """Positive: the same line, plus the directive, is not a finding."""
-        probe = self._write(
-            tmp_path,
+        docs = self._docs(
+            fake_repo,
             "prose about Skill: `zzznotaskill` here <!-- orphan-ref-ignore -->\n",
         )
-        try:
-            result = scan([probe], _repo_root())
-        finally:
-            shutil.rmtree(probe)
-        assert _skill_names(result) == set()
+        assert _skill_names(scan([docs], fake_repo)) == set()
 
-    def test_a_suppressed_route_is_recorded_rather_than_dropped(self, tmp_path):
+    def test_a_suppressed_route_is_recorded_rather_than_dropped(self, fake_repo: Path) -> None:
         """Edge: suppression must stay auditable.
 
         A directive that silently deleted the reference would make the escape
         hatch impossible to review. The reference has to survive in
         ``directive_suppressed`` with its file and line.
+
+        ``target_file`` is built with ``str()`` on a relative path, so it is
+        separator-native and reads ``memories\\memo.md`` on Windows. The
+        comparison normalises rather than pinning the POSIX form.
         """
-        probe = self._write(
-            tmp_path,
+        docs = self._docs(
+            fake_repo,
             "prose about Skill: `zzznotaskill` here <!-- orphan-ref-ignore -->\n",
         )
-        try:
-            result = scan([probe], _repo_root())
-        finally:
-            shutil.rmtree(probe)
-        assert [(ref.target_file, ref.line) for ref in result.directive_suppressed] == [
-            (f"{probe.name}/memo.md", 1)
+        result = scan([docs], fake_repo)
+        recorded = [
+            (Path(ref.target_file).as_posix(), ref.line)
+            for ref in result.directive_suppressed
         ]
+        assert recorded == [("memories/memo.md", 1)]
 
-    def test_the_directive_is_scoped_to_its_own_line(self, tmp_path):
+    def test_the_directive_is_scoped_to_its_own_line(self, fake_repo: Path) -> None:
         """Edge: a directive on one line must not cover the next one.
 
         A file-wide effect would let one directive hide every later drift in
         the same memory. ``<!-- orphan-ref-ignore-file -->`` is the opt-in for
         that, and it is a different directive.
         """
-        probe = self._write(
-            tmp_path,
+        docs = self._docs(
+            fake_repo,
             "first Skill: `zzzfirstskill` here <!-- orphan-ref-ignore -->\n"
             "second Skill: `zzzsecondskill` here\n",
         )
-        try:
-            result = scan([probe], _repo_root())
-        finally:
-            shutil.rmtree(probe)
-        assert _skill_names(result) == {"zzzsecondskill"}
+        assert _skill_names(scan([docs], fake_repo)) == {"zzzsecondskill"}

--- a/.claude/skills/orphan-ref-validator/tests/test_scan.py
+++ b/.claude/skills/orphan-ref-validator/tests/test_scan.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath
@@ -2136,3 +2137,84 @@ class TestTheMemoryCorpusIsGateable:
         finally:
             probe.unlink()
         assert _skill_names(result) == {"doc-coverage"}
+
+
+class TestDocumentationMayQuoteARouteWithoutBecomingOne:
+    """Issue #3749: prose that describes route syntax has to write route syntax.
+
+    The memory corpus documents the parser's own route-versus-documentation
+    rule, and to state the rule it spells both forms out. The scanner reads the
+    live form as a reference and blocks the push. The line-scoped
+    ``<!-- orphan-ref-ignore -->`` directive is the designed escape hatch; these
+    tests pin that it reaches ``skill_name`` findings, not only path findings,
+    and that it does not quietly blunt the detector for everyone else.
+    """
+
+    @staticmethod
+    def _write(tmp_path: Path, body: str) -> Path:
+        target = _repo_root() / f".orphan-ref-probe-{tmp_path.name}"
+        target.mkdir(exist_ok=True)
+        (target / "memo.md").write_text(body, encoding="utf-8")
+        return target
+
+    def test_an_undirected_route_in_prose_is_still_reported(self, tmp_path):
+        """Negative control: without the directive the detector must fire.
+
+        Without this the positive case below could pass because the scanner
+        stopped detecting anything at all.
+        """
+        probe = self._write(tmp_path, "prose about Skill: `zzznotaskill` here\n")
+        try:
+            result = scan([probe], _repo_root())
+        finally:
+            shutil.rmtree(probe)
+        assert _skill_names(result) == {"zzznotaskill"}
+
+    def test_the_directive_suppresses_a_skill_name_finding(self, tmp_path):
+        """Positive: the same line, plus the directive, is not a finding."""
+        probe = self._write(
+            tmp_path,
+            "prose about Skill: `zzznotaskill` here <!-- orphan-ref-ignore -->\n",
+        )
+        try:
+            result = scan([probe], _repo_root())
+        finally:
+            shutil.rmtree(probe)
+        assert _skill_names(result) == set()
+
+    def test_a_suppressed_route_is_recorded_rather_than_dropped(self, tmp_path):
+        """Edge: suppression must stay auditable.
+
+        A directive that silently deleted the reference would make the escape
+        hatch impossible to review. The reference has to survive in
+        ``directive_suppressed`` with its file and line.
+        """
+        probe = self._write(
+            tmp_path,
+            "prose about Skill: `zzznotaskill` here <!-- orphan-ref-ignore -->\n",
+        )
+        try:
+            result = scan([probe], _repo_root())
+        finally:
+            shutil.rmtree(probe)
+        assert [(ref.target_file, ref.line) for ref in result.directive_suppressed] == [
+            (f"{probe.name}/memo.md", 1)
+        ]
+
+    def test_the_directive_is_scoped_to_its_own_line(self, tmp_path):
+        """Edge: a directive on one line must not cover the next one.
+
+        A file-wide effect would let one directive hide every later drift in
+        the same memory. ``<!-- orphan-ref-ignore-file -->`` is the opt-in for
+        that, and it is a different directive.
+        """
+        probe = self._write(
+            tmp_path,
+            "first Skill: `zzzfirstskill` here <!-- orphan-ref-ignore -->\n"
+            "second Skill: `zzzsecondskill` here\n",
+        )
+        try:
+            result = scan([probe], _repo_root())
+        finally:
+            shutil.rmtree(probe)
+        assert _skill_names(result) == {"zzzsecondskill"}

--- a/.serena/memories/architecture/shipped-tree-route-resolution.md
+++ b/.serena/memories/architecture/shipped-tree-route-resolution.md
@@ -154,7 +154,7 @@ correct. Round three found three of these and one false negative:
 - `` Skill: `merge-resolver` `` was reported malformed because every code span
   was dropped from the cell text. The shared parser now yields segments tagged
   code or text; the validator blanks a code span only when that span carries a
-  whole route, so `` `Skill: x` `` stays documentation and `` Skill: `x` ``
+  whole route, so `` `Skill: x` `` stays documentation and `` Skill: `x` `` <!-- orphan-ref-ignore -->
   stays a route. Policy belongs to the caller, not to `markdown_parser.py`.
 - `"Skill: x"` and `[Skill: x]` kept their punctuation. `_TRAILING` now strips
   quotes, brackets and braces.

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.180",
+  "version": "0.6.185",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.185",
+  "version": "0.6.186",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/orphan-ref-validator/tests/test_scan.py
+++ b/src/copilot-cli/skills/orphan-ref-validator/tests/test_scan.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath
@@ -2138,7 +2137,6 @@ class TestTheMemoryCorpusIsGateable:
             probe.unlink()
         assert _skill_names(result) == {"doc-coverage"}
 
-
 class TestDocumentationMayQuoteARouteWithoutBecomingOne:
     """Issue #3749: prose that describes route syntax has to write route syntax.
 
@@ -2148,73 +2146,69 @@ class TestDocumentationMayQuoteARouteWithoutBecomingOne:
     ``<!-- orphan-ref-ignore -->`` directive is the designed escape hatch; these
     tests pin that it reaches ``skill_name`` findings, not only path findings,
     and that it does not quietly blunt the detector for everyone else.
+
+    Everything runs against ``fake_repo`` rather than the real checkout. Writing
+    probes into the working tree would race the canonical and mirrored copies of
+    this suite against each other, since both carry the same test names, and a
+    crashed run would leave litter behind.
     """
 
     @staticmethod
-    def _write(tmp_path: Path, body: str) -> Path:
-        target = _repo_root() / f".orphan-ref-probe-{tmp_path.name}"
-        target.mkdir(exist_ok=True)
-        (target / "memo.md").write_text(body, encoding="utf-8")
-        return target
+    def _docs(fake_repo: Path, body: str) -> Path:
+        docs = fake_repo / "memories"
+        docs.mkdir(exist_ok=True)
+        (docs / "memo.md").write_text(body, encoding="utf-8")
+        return docs
 
-    def test_an_undirected_route_in_prose_is_still_reported(self, tmp_path):
+    def test_an_undirected_route_in_prose_is_still_reported(self, fake_repo: Path) -> None:
         """Negative control: without the directive the detector must fire.
 
         Without this the positive case below could pass because the scanner
         stopped detecting anything at all.
         """
-        probe = self._write(tmp_path, "prose about Skill: `zzznotaskill` here\n")
-        try:
-            result = scan([probe], _repo_root())
-        finally:
-            shutil.rmtree(probe)
-        assert _skill_names(result) == {"zzznotaskill"}
+        docs = self._docs(fake_repo, "prose about Skill: `zzznotaskill` here\n")
+        assert _skill_names(scan([docs], fake_repo)) == {"zzznotaskill"}
 
-    def test_the_directive_suppresses_a_skill_name_finding(self, tmp_path):
+    def test_the_directive_suppresses_a_skill_name_finding(self, fake_repo: Path) -> None:
         """Positive: the same line, plus the directive, is not a finding."""
-        probe = self._write(
-            tmp_path,
+        docs = self._docs(
+            fake_repo,
             "prose about Skill: `zzznotaskill` here <!-- orphan-ref-ignore -->\n",
         )
-        try:
-            result = scan([probe], _repo_root())
-        finally:
-            shutil.rmtree(probe)
-        assert _skill_names(result) == set()
+        assert _skill_names(scan([docs], fake_repo)) == set()
 
-    def test_a_suppressed_route_is_recorded_rather_than_dropped(self, tmp_path):
+    def test_a_suppressed_route_is_recorded_rather_than_dropped(self, fake_repo: Path) -> None:
         """Edge: suppression must stay auditable.
 
         A directive that silently deleted the reference would make the escape
         hatch impossible to review. The reference has to survive in
         ``directive_suppressed`` with its file and line.
+
+        ``target_file`` is built with ``str()`` on a relative path, so it is
+        separator-native and reads ``memories\\memo.md`` on Windows. The
+        comparison normalises rather than pinning the POSIX form.
         """
-        probe = self._write(
-            tmp_path,
+        docs = self._docs(
+            fake_repo,
             "prose about Skill: `zzznotaskill` here <!-- orphan-ref-ignore -->\n",
         )
-        try:
-            result = scan([probe], _repo_root())
-        finally:
-            shutil.rmtree(probe)
-        assert [(ref.target_file, ref.line) for ref in result.directive_suppressed] == [
-            (f"{probe.name}/memo.md", 1)
+        result = scan([docs], fake_repo)
+        recorded = [
+            (Path(ref.target_file).as_posix(), ref.line)
+            for ref in result.directive_suppressed
         ]
+        assert recorded == [("memories/memo.md", 1)]
 
-    def test_the_directive_is_scoped_to_its_own_line(self, tmp_path):
+    def test_the_directive_is_scoped_to_its_own_line(self, fake_repo: Path) -> None:
         """Edge: a directive on one line must not cover the next one.
 
         A file-wide effect would let one directive hide every later drift in
         the same memory. ``<!-- orphan-ref-ignore-file -->`` is the opt-in for
         that, and it is a different directive.
         """
-        probe = self._write(
-            tmp_path,
+        docs = self._docs(
+            fake_repo,
             "first Skill: `zzzfirstskill` here <!-- orphan-ref-ignore -->\n"
             "second Skill: `zzzsecondskill` here\n",
         )
-        try:
-            result = scan([probe], _repo_root())
-        finally:
-            shutil.rmtree(probe)
-        assert _skill_names(result) == {"zzzsecondskill"}
+        assert _skill_names(scan([docs], fake_repo)) == {"zzzsecondskill"}

--- a/src/copilot-cli/skills/orphan-ref-validator/tests/test_scan.py
+++ b/src/copilot-cli/skills/orphan-ref-validator/tests/test_scan.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath
@@ -2136,3 +2137,84 @@ class TestTheMemoryCorpusIsGateable:
         finally:
             probe.unlink()
         assert _skill_names(result) == {"doc-coverage"}
+
+
+class TestDocumentationMayQuoteARouteWithoutBecomingOne:
+    """Issue #3749: prose that describes route syntax has to write route syntax.
+
+    The memory corpus documents the parser's own route-versus-documentation
+    rule, and to state the rule it spells both forms out. The scanner reads the
+    live form as a reference and blocks the push. The line-scoped
+    ``<!-- orphan-ref-ignore -->`` directive is the designed escape hatch; these
+    tests pin that it reaches ``skill_name`` findings, not only path findings,
+    and that it does not quietly blunt the detector for everyone else.
+    """
+
+    @staticmethod
+    def _write(tmp_path: Path, body: str) -> Path:
+        target = _repo_root() / f".orphan-ref-probe-{tmp_path.name}"
+        target.mkdir(exist_ok=True)
+        (target / "memo.md").write_text(body, encoding="utf-8")
+        return target
+
+    def test_an_undirected_route_in_prose_is_still_reported(self, tmp_path):
+        """Negative control: without the directive the detector must fire.
+
+        Without this the positive case below could pass because the scanner
+        stopped detecting anything at all.
+        """
+        probe = self._write(tmp_path, "prose about Skill: `zzznotaskill` here\n")
+        try:
+            result = scan([probe], _repo_root())
+        finally:
+            shutil.rmtree(probe)
+        assert _skill_names(result) == {"zzznotaskill"}
+
+    def test_the_directive_suppresses_a_skill_name_finding(self, tmp_path):
+        """Positive: the same line, plus the directive, is not a finding."""
+        probe = self._write(
+            tmp_path,
+            "prose about Skill: `zzznotaskill` here <!-- orphan-ref-ignore -->\n",
+        )
+        try:
+            result = scan([probe], _repo_root())
+        finally:
+            shutil.rmtree(probe)
+        assert _skill_names(result) == set()
+
+    def test_a_suppressed_route_is_recorded_rather_than_dropped(self, tmp_path):
+        """Edge: suppression must stay auditable.
+
+        A directive that silently deleted the reference would make the escape
+        hatch impossible to review. The reference has to survive in
+        ``directive_suppressed`` with its file and line.
+        """
+        probe = self._write(
+            tmp_path,
+            "prose about Skill: `zzznotaskill` here <!-- orphan-ref-ignore -->\n",
+        )
+        try:
+            result = scan([probe], _repo_root())
+        finally:
+            shutil.rmtree(probe)
+        assert [(ref.target_file, ref.line) for ref in result.directive_suppressed] == [
+            (f"{probe.name}/memo.md", 1)
+        ]
+
+    def test_the_directive_is_scoped_to_its_own_line(self, tmp_path):
+        """Edge: a directive on one line must not cover the next one.
+
+        A file-wide effect would let one directive hide every later drift in
+        the same memory. ``<!-- orphan-ref-ignore-file -->`` is the opt-in for
+        that, and it is a different directive.
+        """
+        probe = self._write(
+            tmp_path,
+            "first Skill: `zzzfirstskill` here <!-- orphan-ref-ignore -->\n"
+            "second Skill: `zzzsecondskill` here\n",
+        )
+        try:
+            result = scan([probe], _repo_root())
+        finally:
+            shutil.rmtree(probe)
+        assert _skill_names(result) == {"zzzsecondskill"}


### PR DESCRIPTION
## Summary

`main` was red and **every push in the repository was blocked**. The
pre-push hook runs the full suite, and the orphan-ref memory-corpus gate
failed on both bundle trees:

```
FAILED tests/test_skill_bundle_suites_run.py::test_bundle_tree_suite_passes[.claude/skills]
FAILED tests/test_skill_bundle_suites_run.py::test_bundle_tree_suite_passes[src/copilot-cli/skills]

TestTheMemoryCorpusIsGateable::test_the_memory_corpus_reports_no_unowned_skill_orphans
AssertionError: assert {'x'} == set()
```

Fixes #3749

## Root cause: a merge race, not a defect in either change

Two PRs merged four minutes apart. Each was green alone. Together they are
red, and neither PR's CI could have seen it.

| PR | Merged | Contribution |
|----|--------|--------------|
| #3741 | 04:07:30Z | Added a memory documenting the parser's route-versus-documentation rule. To state the rule, it writes the live route form. |
| #3735 | 04:11:59Z | Shipped the memory-corpus gate that reads that line as a real reference. |

The scanner produced exactly the finding it was built to produce:

```
{'kind': 'skill_name', 'severity': 'critical',
 'target_file': '.serena/memories/architecture/shipped-tree-route-resolution.md',
 'line': 157, 'referenced_entity': 'x'}
```

The prose is describing route syntax, and to describe it, it writes it.

## Fix

The scanner is right, so it keeps its verdict. The offending line takes the
line-scoped `<!-- orphan-ref-ignore -->` directive the validator already
ships for prose that quotes a route. No gate was weakened for anyone else.

## Why the tests were needed

Before assuming the directive was the fix, I probed whether it even reaches
`skill_name` findings. It had only ever been exercised against path
findings. It does reach them, and four tests now pin that.

Both mutations kill a **distinct** subset, so no test is decorative:

| Mutation | Killed | Survived |
|----------|--------|----------|
| Neuter the ignore-directive regex | the 3 suppression tests | the detector control (correctly, it does not use the directive) |
| Stub the `skill_name` emitter to return nothing | the detector control and the line-scope test | the 2 pure-suppression tests |

Coverage is positive (directive suppresses), negative (no directive still
fires), and edge (suppression stays auditable in `directive_suppressed`;
a directive on one line does not cover the next).

## Verification

- 198 pass in the canonical validator suite, was 197 passed / 1 failed.
- 8 pass in the bundle-suite gate that was red on both trees.
- ruff clean on both changed test files.
- Generated mirror rebuilt, manifests bumped to parity at 0.6.185.

## Follow-up worth considering

This class of failure is invisible to per-PR CI: a corpus gate merged after
the content that trips it. Whether the merge queue should re-run corpus
gates against the post-merge tree is a separate decision, noted in the
issue rather than decided here.
