### PR TITLE
fix(eval): bound producer data in reported errors (#3641)

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-29-session-3641-eval-error-truncation.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-3641-eval-error-truncation.json
@@ -189,13 +189,45 @@
       "caused_by": [
         "e013"
       ],
-      "leads_to": []
+      "leads_to": [
+        "e016"
+      ]
     },
     {
       "id": "e015",
       "timestamp": "2026-07-29T00:00:00+00:00",
       "type": "test",
       "content": "Full suite green: tests/eval/test_optimize_artifact_cli.py reports 766 passed, 8 of them new.",
+      "caused_by": [],
+      "leads_to": [
+        "e017"
+      ]
+    },
+    {
+      "id": "e016",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Rebased onto origin/main at c77d2bf89 after pull request #3752 restored the corpus gate. Re-ran the gate that had been red on main: TestTheMemoryCorpusIsGateable reports 2 passed, so this branch builds on a green base rather than inheriting the breakage.",
+      "caused_by": [
+        "e014"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e017",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "test",
+      "content": "Rebased onto origin/main at c77d2bf89 after pull request #3752 restored the corpus gate. Re-ran the gate that had been red on main: TestTheMemoryCorpusIsGateable reports 2 passed, so this branch builds on a green base rather than inheriting the breakage.",
+      "caused_by": [
+        "e015"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e018",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 098ccb9f3d2bfc2310a6468e3ced6901f9558028",
       "caused_by": [],
       "leads_to": []
     }
@@ -205,7 +237,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-29-session-3641-eval-error-truncation.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-3641-eval-error-truncation.json
@@ -1,0 +1,212 @@
+{
+  "id": "episode-2026-07-29-session-3641-eval-error-truncation",
+  "session": "2026-07-29-session-3641-eval-error-truncation",
+  "timestamp": "2026-07-29T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Issue #3641 lists five pre-existing robustness gaps in the eval optimizer CLI and asserts that pull requests #3478, #3505, and #3560 do not cover them. Re-measure every claim before acting on it, fix what is genuinely open, and report the rest with evidence rather than re-fixing work that already shipped.",
+  "decisions": [
+    {
+      "id": "d001",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "design",
+      "context": "",
+      "chosen": "Implemented the reclassification, then withdrew it on the evidence. Adding an except Exception arm that maps a crash to EXIT_CONFIG turned five tests red, each an explicit negative control: test_a_non_io_failure_from_mkstemp_still_escapes is documented as 'Negative control: the new arm must not swallow unrelated failures', and four siblings assert the same escape behaviour for locks, cleanup, and writes. The escape is a deliberate, test-enforced contract, so reversing it is an owner design decision and not a unilateral change. Reverted; the branch carries no gap 4 change.",
+      "rationale": "",
+      "outcome": "success",
+      "effects": []
+    },
+    {
+      "id": "d002",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "recovery",
+      "context": "",
+      "chosen": "Chose middle elision over truncation on measured evidence. The reproduction's message reads \"fixture '<padding>' variant 'agent' run must be numeric, got 'not-a-number'\", so the part naming what was wrong sits at the tail and a head cut would have kept only the padding. The helper keeps both ends and states the dropped count between them.",
+      "rationale": "",
+      "outcome": "success",
+      "effects": []
+    }
+  ],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-measured gap 1 (a --min-sel of 1e309 overflowing to infinity) rather than trusting the issue. The guard already exists: _check_split_drift catches OverflowError alongside TypeError and ValueError at optimize-artifact.py:681. Landed by pull request #3478 in commit 102e9976f. Gap 1 is closed and needed no change.",
+      "caused_by": [],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-measured gap 2 (a 309-digit integer score defeating math.isfinite). _as_float in _optimizer_adapters.py asks finiteness of floats only, so a 309-digit integer raises a clean AdapterError instead of reaching float() and overflowing. Verified by running the value through the adapter, not by reading the docstring. Gap 2 is closed.",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-measured gap 3 (huge budget integers reaching float arithmetic). The _arith_int argparse type at optimize-artifact.py:2661 rejects them at the command line with exit 2 and a readable message, not exit 1 with a traceback. Verified end to end through the real CLI. Gap 3 is closed at the boundary. Also confirmed the two remaining plain type=int arguments cannot overflow because they only reach integer comparison in apply_patches, so _arith_int's coverage is deliberate rather than partial.",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Probed gap 4 (a forced MemoryError) under a hard address-space limit rather than reasoning about it. It reproduces: with RLIMIT_AS at 80 MB and a 40 MB report, the command exits 1 with 0 bytes on stdout and a 1129-byte traceback ending in MemoryError at f.read().",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Established why that exit code matters before proposing a fix. The module docstring reserves exit 1 for 'reject, already-rejected, or a refused patch' and states that a REJECT is exit 1 'because it is a decision, not a crash'. Line 2444 returns EXIT_LOGIC for a REJECT decision. Python also exits 1 for an uncaught exception, and stdout is empty, so the decision field the docstring points a caller at is not present to tell a crash from a verdict.",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": [
+        "e006"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Implemented the reclassification, then withdrew it on the evidence. Adding an except Exception arm that maps a crash to EXIT_CONFIG turned five tests red, each an explicit negative control: test_a_non_io_failure_from_mkstemp_still_escapes is documented as 'Negative control: the new arm must not swallow unrelated failures', and four siblings assert the same escape behaviour for locks, cleanup, and writes. The escape is a deliberate, test-enforced contract, so reversing it is an owner design decision and not a unilateral change. Reverted; the branch carries no gap 4 change.",
+      "caused_by": [
+        "e005"
+      ],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Confirmed gap 5 (unbounded interpolation) end to end and bounded its scope. Only the string half is open: CPython caps JSON integer literals at 4300 digits (sys.get_int_max_str_digits), so the integer vector the issue describes is already mitigated by the interpreter. A 5,000,000-character fixture id in a report drove 5,000,110 bytes onto stdout, the stream the module docstring promises is machine-readable JSON.",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Located the single fix point instead of patching call sites. _dispatch has exactly one error-emit boundary, the _emit({'error': ...}) at optimize-artifact.py:2845, and it is the only such site in the file. Truncating there is one edit and covers all 193 raise sites, present and future; wrapping call sites would have been 45 edits and forgettable. Confirmed the two outer handlers in main and _final_exit_code report stream-write failures only, so they carry no producer data and needed no change.",
+      "caused_by": [
+        "e007"
+      ],
+      "leads_to": [
+        "e009"
+      ]
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Calibrated the limit rather than picking a round number. Walked the AST of all three eval modules and measured the literal text of every raised message: 466 messages, longest fixed sentence 226 characters. Set the cap at 4096, about eighteen times the longest sentence, so no message the command raises today can reach it.",
+      "caused_by": [
+        "e008"
+      ],
+      "leads_to": [
+        "e010"
+      ]
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Chose middle elision over truncation on measured evidence. The reproduction's message reads \"fixture '<padding>' variant 'agent' run must be numeric, got 'not-a-number'\", so the part naming what was wrong sits at the tail and a head cut would have kept only the padding. The helper keeps both ends and states the dropped count between them.",
+      "caused_by": [
+        "e009"
+      ],
+      "leads_to": [
+        "e011"
+      ]
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Verified the fix end to end. The same 5,000,000-character reproduction now exits 2 with 4,140 bytes on stdout, down from 5,000,110. The reported error is exactly 4096 characters, starts with \"fixture '\", ends with \"must be numeric, got 'not-a-number'\", and carries the marker '[4996007 characters elided]'. Both ends of the diagnostic survive.",
+      "caused_by": [
+        "e010"
+      ],
+      "leads_to": [
+        "e012"
+      ]
+    },
+    {
+      "id": "e012",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Mutation tested with two independent mutations, each caught by different tests. Removing the call at the emit boundary failed only the end-to-end test. Replacing middle elision with head truncation failed three tests, including the tail-survival control and the exact-accounting control, which is what proves middle elision is individually load-bearing rather than merely 'some truncation'. Restored: 8 of 8 green.",
+      "caused_by": [
+        "e011"
+      ],
+      "leads_to": [
+        "e013"
+      ]
+    },
+    {
+      "id": "e013",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Checked the formatter before touching style. ruff format --check fails on both files at pristine origin/main, so the repository gates ruff check rather than ruff format here; reformatting would have produced 246 hunks of unrelated churn. Confirmed the only format hunk touching new code wants to join a signature the surrounding file also keeps wrapped, so the new code matches its neighbours. ruff check passes.",
+      "caused_by": [
+        "e012"
+      ],
+      "leads_to": [
+        "e014"
+      ]
+    },
+    {
+      "id": "e014",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Full suite green: tests/eval/test_optimize_artifact_cli.py reports 766 passed, 8 of them new.",
+      "caused_by": [
+        "e013"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e015",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "test",
+      "content": "Full suite green: tests/eval/test_optimize_artifact_cli.py reports 766 passed, 8 of them new.",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 4
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-29-session-3641-eval-error-truncation.json
+++ b/.agents/sessions/2026-07-29-session-3641-eval-error-truncation.json
@@ -4,7 +4,7 @@
     "number": 3641,
     "date": "2026-07-29",
     "branch": "fix/3641-eval-error-truncation",
-    "startingCommit": "02bb54f7cc",
+    "startingCommit": "c77d2bf89",
     "objective": "Issue #3641 lists five pre-existing robustness gaps in the eval optimizer CLI and asserts that pull requests #3478, #3505, and #3560 do not cover them. Re-measure every claim before acting on it, fix what is genuinely open, and report the rest with evidence rather than re-fixing work that already shipped."
   },
   "protocolCompliance": {
@@ -125,11 +125,14 @@
     },
     {
       "step": "Full suite green: tests/eval/test_optimize_artifact_cli.py reports 766 passed, 8 of them new."
+    },
+    {
+      "step": "Rebased onto origin/main at c77d2bf89 after pull request #3752 restored the corpus gate. Re-ran the gate that had been red on main: TestTheMemoryCorpusIsGateable reports 2 passed, so this branch builds on a green base rather than inheriting the breakage."
     }
   ],
   "nextSteps": [
     "Gap 4 is real and reproducible but its remedy reverses a contract five explicit negative controls defend. Recorded on issue #3641 with the failing test names so the owner can decide whether an unexpected crash should keep exiting 1 or be reclassified.",
     "The success path echoes producer data too: a 20 MB fixture id produced 20,000,640 bytes of stdout on a successful extract. That is output proportional to input for a command whose job is extraction, so it is treated as by design and not changed."
   ],
-  "endingCommit": ""
+  "endingCommit": "098ccb9f3d2bfc2310a6468e3ced6901f9558028"
 }

--- a/.agents/sessions/2026-07-29-session-3641-eval-error-truncation.json
+++ b/.agents/sessions/2026-07-29-session-3641-eval-error-truncation.json
@@ -1,0 +1,135 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3641,
+    "date": "2026-07-29",
+    "branch": "fix/3641-eval-error-truncation",
+    "startingCommit": "02bb54f7cc",
+    "objective": "Issue #3641 lists five pre-existing robustness gaps in the eval optimizer CLI and asserts that pull requests #3478, #3505, and #3560 do not cover them. Re-measure every claim before acting on it, fix what is genuinely open, and report the rest with evidence rather than re-fixing work that already shipped."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "branchVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "git checkout -b fix/3641-eval-error-truncation origin/main; branch reported as fix/3641-eval-error-truncation at 02bb54f7c."
+      },
+      "notOnMain": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Branch is fix/3641-eval-error-truncation, cut fresh from origin/main."
+      },
+      "handoffRead": {
+        "complete": true,
+        "level": "SHOULD",
+        "evidence": "Read earlier in this multi-issue campaign; the dashboard has not changed since."
+      },
+      "sessionLogCreated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "This file, written before the first commit on the branch."
+      },
+      "serenaActivated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Serena MCP has been unavailable for the whole campaign; no serena/ or mcp__serena__ tool is exposed."
+      },
+      "serenaInstructions": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Same cause. Fell back to reading the tree directly."
+      }
+    },
+    "sessionEnd": {
+      "logCompleted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Every workLog step carries the measurement that produced it."
+      },
+      "qaSkipDocumented": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Full QA ran. tests/eval/test_optimize_artifact_cli.py reports 766 passing tests, and the fix was mutation tested with two independent mutations."
+      },
+      "markdownLintRun": {
+        "complete": true,
+        "level": "SHOULD",
+        "evidence": "No markdown file changed. The change is one Python module and its test module."
+      },
+      "validationPassed": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "uv run pytest tests/eval/test_optimize_artifact_cli.py: 766 passed. uv run ruff check on both changed files: all checks passed."
+      },
+      "checklistComplete": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Every item recorded with evidence."
+      },
+      "serenaMemoryUpdated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Serena MCP unavailable. The reusable finding, that an issue listing several gaps can have most of them already closed by later work and each claim must be re-measured before it is acted on, is recorded in the workLog and on issue #3641."
+      },
+      "handoffPreserved": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "HANDOFF.md not modified (ADR-014)."
+      },
+      "changesCommitted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "The fix, its tests, and this log committed on fix/3641-eval-error-truncation. The endingCommit SHA is recorded in a follow-up commit rather than by amending."
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": "Re-measured gap 1 (a --min-sel of 1e309 overflowing to infinity) rather than trusting the issue. The guard already exists: _check_split_drift catches OverflowError alongside TypeError and ValueError at optimize-artifact.py:681. Landed by pull request #3478 in commit 102e9976f. Gap 1 is closed and needed no change."
+    },
+    {
+      "step": "Re-measured gap 2 (a 309-digit integer score defeating math.isfinite). _as_float in _optimizer_adapters.py asks finiteness of floats only, so a 309-digit integer raises a clean AdapterError instead of reaching float() and overflowing. Verified by running the value through the adapter, not by reading the docstring. Gap 2 is closed."
+    },
+    {
+      "step": "Re-measured gap 3 (huge budget integers reaching float arithmetic). The _arith_int argparse type at optimize-artifact.py:2661 rejects them at the command line with exit 2 and a readable message, not exit 1 with a traceback. Verified end to end through the real CLI. Gap 3 is closed at the boundary. Also confirmed the two remaining plain type=int arguments cannot overflow because they only reach integer comparison in apply_patches, so _arith_int's coverage is deliberate rather than partial."
+    },
+    {
+      "step": "Probed gap 4 (a forced MemoryError) under a hard address-space limit rather than reasoning about it. It reproduces: with RLIMIT_AS at 80 MB and a 40 MB report, the command exits 1 with 0 bytes on stdout and a 1129-byte traceback ending in MemoryError at f.read()."
+    },
+    {
+      "step": "Established why that exit code matters before proposing a fix. The module docstring reserves exit 1 for 'reject, already-rejected, or a refused patch' and states that a REJECT is exit 1 'because it is a decision, not a crash'. Line 2444 returns EXIT_LOGIC for a REJECT decision. Python also exits 1 for an uncaught exception, and stdout is empty, so the decision field the docstring points a caller at is not present to tell a crash from a verdict."
+    },
+    {
+      "step": "Implemented the reclassification, then withdrew it on the evidence. Adding an except Exception arm that maps a crash to EXIT_CONFIG turned five tests red, each an explicit negative control: test_a_non_io_failure_from_mkstemp_still_escapes is documented as 'Negative control: the new arm must not swallow unrelated failures', and four siblings assert the same escape behaviour for locks, cleanup, and writes. The escape is a deliberate, test-enforced contract, so reversing it is an owner design decision and not a unilateral change. Reverted; the branch carries no gap 4 change."
+    },
+    {
+      "step": "Confirmed gap 5 (unbounded interpolation) end to end and bounded its scope. Only the string half is open: CPython caps JSON integer literals at 4300 digits (sys.get_int_max_str_digits), so the integer vector the issue describes is already mitigated by the interpreter. A 5,000,000-character fixture id in a report drove 5,000,110 bytes onto stdout, the stream the module docstring promises is machine-readable JSON."
+    },
+    {
+      "step": "Located the single fix point instead of patching call sites. _dispatch has exactly one error-emit boundary, the _emit({'error': ...}) at optimize-artifact.py:2845, and it is the only such site in the file. Truncating there is one edit and covers all 193 raise sites, present and future; wrapping call sites would have been 45 edits and forgettable. Confirmed the two outer handlers in main and _final_exit_code report stream-write failures only, so they carry no producer data and needed no change."
+    },
+    {
+      "step": "Calibrated the limit rather than picking a round number. Walked the AST of all three eval modules and measured the literal text of every raised message: 466 messages, longest fixed sentence 226 characters. Set the cap at 4096, about eighteen times the longest sentence, so no message the command raises today can reach it."
+    },
+    {
+      "step": "Chose middle elision over truncation on measured evidence. The reproduction's message reads \"fixture '<padding>' variant 'agent' run must be numeric, got 'not-a-number'\", so the part naming what was wrong sits at the tail and a head cut would have kept only the padding. The helper keeps both ends and states the dropped count between them."
+    },
+    {
+      "step": "Verified the fix end to end. The same 5,000,000-character reproduction now exits 2 with 4,140 bytes on stdout, down from 5,000,110. The reported error is exactly 4096 characters, starts with \"fixture '\", ends with \"must be numeric, got 'not-a-number'\", and carries the marker '[4996007 characters elided]'. Both ends of the diagnostic survive."
+    },
+    {
+      "step": "Mutation tested with two independent mutations, each caught by different tests. Removing the call at the emit boundary failed only the end-to-end test. Replacing middle elision with head truncation failed three tests, including the tail-survival control and the exact-accounting control, which is what proves middle elision is individually load-bearing rather than merely 'some truncation'. Restored: 8 of 8 green."
+    },
+    {
+      "step": "Checked the formatter before touching style. ruff format --check fails on both files at pristine origin/main, so the repository gates ruff check rather than ruff format here; reformatting would have produced 246 hunks of unrelated churn. Confirmed the only format hunk touching new code wants to join a signature the surrounding file also keeps wrapped, so the new code matches its neighbours. ruff check passes."
+    },
+    {
+      "step": "Full suite green: tests/eval/test_optimize_artifact_cli.py reports 766 passed, 8 of them new."
+    }
+  ],
+  "nextSteps": [
+    "Gap 4 is real and reproducible but its remedy reverses a contract five explicit negative controls defend. Recorded on issue #3641 with the failing test names so the owner can decide whether an unexpected crash should keep exiting 1 or be reclassified.",
+    "The success path echoes producer data too: a 20 MB fixture id produced 20,000,640 bytes of stdout on a successful extract. That is output proportional to input for a command whose job is extraction, so it is treated as by design and not changed."
+  ],
+  "endingCommit": ""
+}

--- a/scripts/eval/optimize-artifact.py
+++ b/scripts/eval/optimize-artifact.py
@@ -115,6 +115,43 @@ def _emit(payload: object) -> None:
     print(json.dumps(payload, indent=2, sort_keys=True))
 
 
+_MAX_ERROR_CHARS = 4096
+
+
+def _elide_middle(text: str, limit: int = _MAX_ERROR_CHARS) -> str:
+    """Bound a reported message, keeping both ends of the diagnostic.
+
+    Error text here is built by interpolating producer-controlled values into
+    a fixed sentence, so its length is the input's length. Measured: a report
+    naming a 5,000,000-character fixture id drove 5,000,110 bytes onto stdout,
+    the stream the module docstring promises is machine-readable JSON, so the
+    driver reading it wears the cost of a value it never chose.
+
+    The limit is calibrated, not picked. Across the 466 raised messages in
+    this command and its two helper modules, the longest fixed sentence is 226
+    characters, so this leaves roughly eighteen times that for the values
+    interpolated into it. No message the command raises today reaches it.
+
+    Elision is from the middle because the diagnostic lives at both ends. In
+    the measured case the message reads "fixture '<5MB of A>' variant 'agent'
+    run must be numeric, got 'not-a-number'": a head cut keeps the useless
+    half and drops the part naming what was actually wrong. Keeping both ends
+    keeps the subject and the verdict, and the marker states the count
+    dropped so the reader knows the value was long rather than absent.
+    """
+    if len(text) <= limit:
+        return text
+    template = " ... [{} characters elided] ... "
+    # Size the budget against the widest the marker can get, so the result
+    # cannot exceed the limit once the real (smaller) count is filled in.
+    budget = limit - len(template.format(len(text)))
+    if budget < 2:
+        return text[:limit]
+    head = budget // 2
+    tail = budget - head
+    return text[:head] + template.format(len(text) - budget) + text[-tail:]
+
+
 class _DuplicateKeyError(ValueError):
     """A JSON object stated the same key more than once.
 
@@ -2805,7 +2842,7 @@ def _dispatch(argv: list[str] | None) -> int:
         # ValueError joins them so the core's own validation surfaces the same
         # way. Wrapping one call site left the policy in two places and the
         # wrapper unreachable once its inputs were validated upstream.
-        _emit({"error": str(exc), "type": type(exc).__name__})
+        _emit({"error": _elide_middle(str(exc)), "type": type(exc).__name__})
         return EXIT_CONFIG
     return exit_code
 

--- a/tests/eval/test_optimize_artifact_cli.py
+++ b/tests/eval/test_optimize_artifact_cli.py
@@ -10968,3 +10968,91 @@ class TestDuplicateKeysAreRefusedBeforeAnythingReadsTheObject:
         the subclassing is what keeps that promise true.
         """
         assert issubclass(oa._DuplicateKeyError, ValueError)
+
+
+_ELISION_RE = re.compile(r" \.\.\. \[(\d+) characters elided\] \.\.\. ")
+
+
+def _elision_parts(result: str) -> tuple[str, int, str]:
+    """Split an elided message into (head, stated drop count, tail)."""
+    match = _ELISION_RE.search(result)
+    assert match is not None, f"no elision marker in {result[:120]!r}"
+    return result[: match.start()], int(match.group(1)), result[match.end() :]
+
+
+class TestAReportedErrorCannotBeLongerThanTheValueThatCausedIt:
+    """Issue #3641 gap 5: producer data reaches the error stream unbounded.
+
+    Every error the command reports is a fixed sentence with producer-supplied
+    values interpolated into it, and `_dispatch` writes all of them through one
+    `_emit`. Measured before the fix: a report naming a 5,000,000-character
+    fixture id put 5,000,110 bytes on stdout, the stream the module docstring
+    promises is machine-readable JSON.
+
+    The elision is from the middle on purpose. The measured message reads
+    "fixture '<padding>' variant 'agent' run must be numeric, got
+    'not-a-number'", so the part naming what was wrong is at the tail; a
+    head-truncating fix would have kept the padding and dropped the diagnosis.
+    """
+
+    def test_a_message_within_the_limit_is_reported_verbatim(self):
+        message = "fixture 'a' variant 'agent' run must be numeric"
+        assert oa._elide_middle(message) == message
+        assert _ELISION_RE.search(oa._elide_middle(message)) is None
+
+    def test_a_message_exactly_at_the_limit_is_reported_verbatim(self):
+        message = "x" * oa._MAX_ERROR_CHARS
+        assert oa._elide_middle(message) == message
+
+    def test_one_character_past_the_limit_is_elided(self):
+        message = "x" * (oa._MAX_ERROR_CHARS + 1)
+        result = oa._elide_middle(message)
+        assert result != message
+        assert len(result) <= oa._MAX_ERROR_CHARS
+
+    def test_an_oversized_message_is_bounded_by_the_limit(self):
+        result = oa._elide_middle("x" * 5_000_000)
+        assert len(result) <= oa._MAX_ERROR_CHARS
+
+    def test_both_ends_of_the_diagnostic_survive_elision(self):
+        # The head names the subject and the tail names the verdict. A
+        # prefix-cutting fix passes the length assertion above and fails here,
+        # which is the whole reason this control is separate from it.
+        message = f"fixture '{'A' * 5_000_000}' run must be numeric, got 'nan'"
+        result = oa._elide_middle(message)
+        assert result.startswith("fixture '")
+        assert result.endswith("run must be numeric, got 'nan'")
+
+    def test_the_marker_accounts_for_every_dropped_character(self):
+        message = "y" * 100_000
+        head, dropped, tail = _elision_parts(oa._elide_middle(message))
+        assert len(head) + dropped + len(tail) == len(message)
+        assert head and tail
+
+    def test_a_limit_too_small_for_the_marker_still_bounds_the_result(self):
+        # Guards the branch where the marker cannot fit in the budget.
+        result = oa._elide_middle("z" * 500, limit=8)
+        assert len(result) <= 8
+
+    def test_the_cli_bounds_an_error_naming_an_oversized_fixture_id(
+        self, tmp_path, capsys
+    ):
+        # End-to-end regression for the reported reproduction, at a size that
+        # keeps the suite fast while staying far past the limit.
+        big = "A" * 200_000
+        report = tmp_path / "report.json"
+        report.write_text(
+            json.dumps(
+                {
+                    "error_count": 0,
+                    "fixture_ids": [big],
+                    "per_fixture_pass_rates": {big: {"agent": ["not-a-number"]}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        code, out = _run(capsys, "extract", "--kind", "agent", "--input", report)
+        assert code == EXIT_CONFIG
+        assert out["type"] == "AdapterError"
+        assert len(out["error"]) <= oa._MAX_ERROR_CHARS
+        assert out["error"].endswith("must be numeric, got 'not-a-number'")


### PR DESCRIPTION
## Summary

Fixes the one gap in #3641 that is genuinely still open, and reports the other four with measurements instead of re-fixing shipped work.

Every error this CLI reports is a fixed sentence with producer-supplied values interpolated into it, and `_dispatch` writes all of them through a single `_emit`. So the length of an error message is the length of the input that caused it.

Measured before: a report naming a 5,000,000 character fixture id put **5,000,110 bytes onto stdout**, the stream the module docstring promises is machine-readable JSON. A driver piping stdout through a JSON reader wears the cost of a value it never chose.

Measured after: same reproduction, **4,140 bytes**, exit code unchanged at 2.

## Three design decisions worth the review time

**One fix point, not 45.** `_dispatch` has exactly one error-emit boundary and it is the only such site in the file. Truncating there covers all 193 raise sites, including ones nobody has written yet. Wrapping call sites would have been 45 edits and forgettable. The two outer handlers were checked and left alone: they report stream-write failures, so they carry no producer data.

**The limit is calibrated, not picked.** I walked the AST of all three eval modules and measured the literal text of every raised message: 466 messages, longest fixed sentence 226 characters. The cap is 4096, about eighteen times that, so no message the command raises today can reach it.

**Middle elision, not truncation.** The measured message reads `fixture '<padding>' variant 'agent' run must be numeric, got 'not-a-number'`. The diagnosis sits at the tail, so a head cut keeps the padding and throws away the answer. The result now keeps both ends and states the dropped count between them:

```
fixture 'AAAA...  ... [4996007 characters elided] ...  ...AAAA' variant 'agent' run must be numeric, got 'not-a-number'
```

## The other four gaps

Re-measured every claim before acting on it. The issue asserts that #3478, #3505, and #3560 do not cover gaps 1 through 3. That does not hold.

| Gap | Measured result |
|---|---|
| 1, `--min-sel 1e309` | Already fixed. `_check_split_drift` catches `OverflowError`. Landed by #3478 in `102e9976f`. |
| 2, 309-digit score | Already fixed. `_as_float` asks finiteness of floats only, so the value raises a clean `AdapterError`. Verified by running it through the adapter, not by reading the docstring. |
| 3, huge budget ints | Already fixed at the boundary. The `_arith_int` argparse type rejects them with exit 2 and a readable message. Verified end to end through the real CLI. |
| 4, forced `MemoryError` | Real, and deliberately not changed here. See below. |

Gap 4 reproduces (exit 1, empty stdout, a 1129-byte traceback under a hard address-space limit), and the exit code is the sharper defect: this module reserves exit 1 for a REJECT decision, so a crash is indistinguishable from a verdict. I implemented the reclassification and then withdrew it, because it turned five tests red, each an explicit negative control, one of them documented as *"the new arm must not swallow unrelated failures"*. Escaping on an unexpected exception is a defended contract, so reversing it is an owner decision rather than a unilateral change. Full evidence and the five test names are on the issue.

## Testing

8 new tests: positive, edge (at the limit and one past it), negative, an exact-accounting control proving no character is lost or double counted, a branch control for a limit too small to hold the marker, and an end-to-end regression through the real CLI.

Mutation tested with two independent mutations, each caught by different tests:

| Mutation | Result |
|---|---|
| Remove the call at the emit boundary | 1 failed (end-to-end only) |
| Replace middle elision with head truncation | 3 failed, including the tail-survival and accounting controls |
| Restored | 8 of 8 green |

That second mutation is the point: a naive truncation passes the length assertion and still fails, which is what proves middle elision is individually load-bearing rather than merely "some truncation".

Suite: 766 passed.

## Notes

Also confirmed and left alone: the interpreter already caps JSON integer literals at 4300 digits, so the raw-integer vector the issue describes is mitigated upstream; and a successful extract emitting output proportional to its input is by design for an extractor, unlike an error message sized by a value the operator did not choose.

The formatter was checked before any style change: `ruff format --check` fails on both touched files at pristine `origin/main`, so the enforced gate here is `ruff check`, which passes. Reformatting would have produced 246 hunks of unrelated churn.

## References

Gap 2 and gap 3 evidence involves the two helper modules alongside the CLI, see scripts/eval/_optimizer_adapters.py and scripts/eval/_optimizer_core.py; neither needed a change.

Refs #3641
