### PR TITLE
fix(git): ignore the PR validation report written to the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,10 @@ ENV/
 .agents/audit/pr*-reply.md
 .agents/audit/pr*-body-*.md
 
+# scripts/ci/build_pr_validation_report.py writes this to the repo root.
+# Harmless on an ephemeral runner, untracked litter in a working tree.
+/pr-validation-report.md
+
 # Hook runtime logs and caches
 .claude/hooks/audit.log
 

--- a/tests/ci/test_pr_validation_report_is_ignored.py
+++ b/tests/ci/test_pr_validation_report_is_ignored.py
@@ -1,0 +1,73 @@
+"""The PR validation report is generated into the repo root, so git must ignore it.
+
+`scripts/ci/build_pr_validation_report.py` writes its output to a relative path.
+On an ephemeral CI runner that is harmless. In a working tree it leaves untracked
+litter at the repository root, where `git add -A` sweeps it into a commit.
+
+These tests read the path from the writing script rather than from a literal, so
+renaming the output cannot silently reopen the hole.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRITER = REPO_ROOT / "scripts" / "ci" / "build_pr_validation_report.py"
+
+
+def _report_path() -> Path:
+    """Load the writer module and return the path it actually writes to."""
+    spec = importlib.util.spec_from_file_location("_pr_report_writer", WRITER)
+    if spec is None or spec.loader is None:
+        pytest.fail(f"cannot load the report writer at {WRITER}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return Path(module.REPORT_PATH)
+
+
+def _is_ignored(relative_path: str) -> bool:
+    """Ask git whether a path is ignored, without needing the file to exist."""
+    completed = subprocess.run(
+        ["git", "check-ignore", "-q", "--no-index", "--", relative_path],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    if completed.returncode not in (0, 1):
+        pytest.fail(
+            f"git check-ignore failed for {relative_path!r}: "
+            f"rc={completed.returncode} stderr={completed.stderr.decode(errors='replace')}"
+        )
+    return completed.returncode == 0
+
+
+class TestTheGeneratedReportStaysOutOfCommits:
+    def test_the_writer_declares_a_relative_path_at_the_repo_root(self) -> None:
+        """Edge: the risk only exists because the path is relative and unnested."""
+        report = _report_path()
+        assert not report.is_absolute()
+        assert report.parent == Path("."), (
+            "the report is no longer written to the repo root; "
+            "this test guards a root-level litter path"
+        )
+
+    def test_the_path_the_writer_uses_is_ignored(self) -> None:
+        """Positive: the exact path the script writes is ignored by git."""
+        report = _report_path()
+        assert _is_ignored(report.as_posix()), (
+            f"{report.as_posix()} is generated into the working tree but git does "
+            "not ignore it, so `git add -A` will commit it"
+        )
+
+    def test_a_tracked_file_is_not_reported_as_ignored(self) -> None:
+        """Negative control: the probe distinguishes ignored from not ignored."""
+        assert not _is_ignored("README.md"), (
+            "the ignore probe reports a tracked file as ignored, so a passing "
+            "result in the positive test would prove nothing"
+        )


### PR DESCRIPTION
## Summary

`scripts/ci/build_pr_validation_report.py` writes its report to a
relative path at the repository root. On an ephemeral CI runner that is
harmless. In a working tree the file stays behind as untracked litter,
where `git add -A` sweeps it into a commit.

Fixes #3756

## How this was found

I hit it. While resolving a manifest conflict I staged with `git add -A`
and committed 34 unrelated lines of generated report alongside the
intended change. It was caught before reaching a shared branch, but only
because an unrelated push rejection made me re-read the diff.

## The fix

One ignore entry, placed next to the existing rules for generated
report markdown, plus a test.

The test derives the path from the writer module rather than hard coding
the string. If someone renames the output, the test follows it instead
of silently passing against a path nothing writes anymore.

## Why three tests

The obvious single test would pass for the wrong reason. `git
check-ignore` returning 0 proves a rule matched, not that the right rule
matched, and an over-broad rule would satisfy it just as well.

| Test | What it holds |
| --- | --- |
| positive | the exact path the writer uses is ignored |
| negative control | a tracked file is still reported as not ignored |
| edge | the writer still targets a relative root-level path |

## Mutation proof

Each mutation kills a different subset, so no test is decorative.

| Mutation | Kills | Survives |
| --- | --- | --- |
| Remove the ignore entry | positive | edge, control |
| Broaden the rule to `*.md` | control | positive, edge |
| Writer emits to `build/` instead | edge, positive | control |

The second one is the interesting case. It is the realistic bad fix, and
without the negative control it would look like a pass.

## Verification

```
uv run --frozen python -m pytest tests/ci/test_pr_validation_report_is_ignored.py -q
3 passed

uv run --frozen ruff check tests/ci/test_pr_validation_report_is_ignored.py
All checks passed!

uv run --frozen mypy tests/ci/test_pr_validation_report_is_ignored.py
Success: no issues found in 1 source file
```

No manifest bump: this touches no plugin content.
