### PR TITLE
fix(github): reject the two directory aliases GitHub itself refuses

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.210",
+  "version": "0.6.211",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/lib/github_core/validation.py
+++ b/.claude/lib/github_core/validation.py
@@ -12,6 +12,12 @@ _OWNER_PATTERN = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$")
 # Repo: alphanumeric, hyphens, underscores, periods, 1-100 chars
 _REPO_PATTERN = re.compile(r"^[a-zA-Z0-9._-]{1,100}$")
 
+# `.` and `..` are the two names GitHub refuses outright, because both are
+# directory aliases. Callers interpolate these values into URL paths, so a
+# name that means "parent directory" must not reach that position. Longer
+# dot runs such as `...` are legal repository names and stay allowed.
+_DIRECTORY_ALIASES = frozenset({".", ".."})
+
 _TRAVERSAL_PATTERN = re.compile(r"\.\.[/\\]")
 
 
@@ -28,6 +34,9 @@ def is_github_name_valid(name: str, name_type: str) -> bool:
         True if the name conforms to GitHub's rules.
     """
     if not name or not name.strip():
+        return False
+
+    if name in _DIRECTORY_ALIASES:
         return False
 
     normalized = name_type.lower()

--- a/scripts/github_core/validation.py
+++ b/scripts/github_core/validation.py
@@ -12,6 +12,12 @@ _OWNER_PATTERN = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$")
 # Repo: alphanumeric, hyphens, underscores, periods, 1-100 chars
 _REPO_PATTERN = re.compile(r"^[a-zA-Z0-9._-]{1,100}$")
 
+# `.` and `..` are the two names GitHub refuses outright, because both are
+# directory aliases. Callers interpolate these values into URL paths, so a
+# name that means "parent directory" must not reach that position. Longer
+# dot runs such as `...` are legal repository names and stay allowed.
+_DIRECTORY_ALIASES = frozenset({".", ".."})
+
 _TRAVERSAL_PATTERN = re.compile(r"\.\.[/\\]")
 
 
@@ -28,6 +34,9 @@ def is_github_name_valid(name: str, name_type: str) -> bool:
         True if the name conforms to GitHub's rules.
     """
     if not name or not name.strip():
+        return False
+
+    if name in _DIRECTORY_ALIASES:
         return False
 
     normalized = name_type.lower()

--- a/scripts/issue_triage.py
+++ b/scripts/issue_triage.py
@@ -54,6 +54,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from scripts.github_core.validation import is_github_name_valid
+
 DEFAULT_STALE_DAYS = 60
 DEFAULT_DUP_THRESHOLD = 0.7
 PRIORITY_LABEL_PREFIX = "priority:"
@@ -458,6 +460,25 @@ def _run_gh(cmd: list[str]) -> str:
     return result.stdout or ""
 
 
+def _require_repo_identity(owner: str, repo: str) -> None:
+    """Reject owner/repo values that would change which endpoint gh talks to.
+
+    Both values are interpolated into a gh argument: ``--repo owner/repo`` for
+    the issue list and ``repos/{owner}/{repo}/...`` for the timeline API. A
+    value such as ``..`` silently retargets that path, so it is refused here
+    rather than at the CLI, which leaves direct importers and the
+    ``GITHUB_REPOSITORY`` fallback covered by the same check.
+
+    Raises:
+        ValueError: When either name fails GitHub's naming rules.
+    """
+
+    if not is_github_name_valid(owner, "owner"):
+        raise ValueError(f"invalid repository owner: {owner!r}")
+    if not is_github_name_valid(repo, "repo"):
+        raise ValueError(f"invalid repository name: {repo!r}")
+
+
 def fetch_open_issues(
     owner: str, repo: str, *, limit: int, since: str | None = None
 ) -> list[dict[str, Any]]:
@@ -470,6 +491,7 @@ def fetch_open_issues(
 
     if not 0 <= limit <= 1000:
         raise ValueError("limit must be between 0 and 1000")
+    _require_repo_identity(owner, repo)
     if limit == 0:
         return []
 
@@ -502,6 +524,7 @@ class LinkedPrFetchError(RuntimeError):
 def fetch_linked_prs(owner: str, repo: str, number: int) -> tuple[tuple[int, str], ...]:
     """Return (pr_number, state) for PRs cross-referenced from an issue timeline."""
 
+    _require_repo_identity(owner, repo)
     cmd = [
         "gh", "api",
         f"repos/{owner}/{repo}/issues/{number}/timeline",

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.210",
+  "version": "0.6.211",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/lib/github_core/validation.py
+++ b/src/copilot-cli/lib/github_core/validation.py
@@ -12,6 +12,12 @@ _OWNER_PATTERN = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$")
 # Repo: alphanumeric, hyphens, underscores, periods, 1-100 chars
 _REPO_PATTERN = re.compile(r"^[a-zA-Z0-9._-]{1,100}$")
 
+# `.` and `..` are the two names GitHub refuses outright, because both are
+# directory aliases. Callers interpolate these values into URL paths, so a
+# name that means "parent directory" must not reach that position. Longer
+# dot runs such as `...` are legal repository names and stay allowed.
+_DIRECTORY_ALIASES = frozenset({".", ".."})
+
 _TRAVERSAL_PATTERN = re.compile(r"\.\.[/\\]")
 
 
@@ -28,6 +34,9 @@ def is_github_name_valid(name: str, name_type: str) -> bool:
         True if the name conforms to GitHub's rules.
     """
     if not name or not name.strip():
+        return False
+
+    if name in _DIRECTORY_ALIASES:
         return False
 
     normalized = name_type.lower()

--- a/tests/test_github_core.py
+++ b/tests/test_github_core.py
@@ -126,18 +126,24 @@ class TestIsGitHubNameValid:
     def test_invalid_type_returns_false(self):
         assert is_github_name_valid("foo", "Invalid") is False
 
-    def test_repo_rejects_the_two_directory_aliases(self):
+    @pytest.mark.parametrize("name", [".", ".."])
+    @pytest.mark.parametrize("name_type", ["repo", "Repo", "REPO"])
+    def test_repo_rejects_the_two_directory_aliases(self, name: str, name_type: str):
         """`.` and `..` are the only names GitHub refuses outright.
 
         They are also the two that carry traversal meaning once a caller
         interpolates them into a URL path, which several callers do.
-        """
-        assert is_github_name_valid(".", "Repo") is False
-        assert is_github_name_valid("..", "Repo") is False
 
-    def test_owner_rejects_the_two_directory_aliases(self):
-        assert is_github_name_valid(".", "Owner") is False
-        assert is_github_name_valid("..", "Owner") is False
+        `name_type` is documented case-insensitive, so the rejection has to
+        hold for every spelling a caller may pass. Testing one spelling would
+        let a guard that keys off a single literal survive.
+        """
+        assert is_github_name_valid(name, name_type) is False
+
+    @pytest.mark.parametrize("name", [".", ".."])
+    @pytest.mark.parametrize("name_type", ["owner", "Owner", "OWNER"])
+    def test_owner_rejects_the_two_directory_aliases(self, name: str, name_type: str):
+        assert is_github_name_valid(name, name_type) is False
 
     def test_longer_dot_runs_stay_valid(self):
         """Only the two aliases are reserved. `...` is a legal repository name.

--- a/tests/test_github_core.py
+++ b/tests/test_github_core.py
@@ -106,6 +106,11 @@ class TestIsGitHubNameValid:
     def test_valid_repo(self):
         assert is_github_name_valid("ai-agents", "Repo") is True
 
+    @pytest.mark.parametrize("name_type", ["repo", "Repo", "REPO"])
+    def test_repo_name_type_is_case_insensitive(self, name_type: str):
+        assert is_github_name_valid("ai-agents", name_type) is True
+        assert is_github_name_valid("..", name_type) is False
+
     def test_repo_allows_dots(self):
         assert is_github_name_valid("my.repo.name", "Repo") is True
 

--- a/tests/test_github_core.py
+++ b/tests/test_github_core.py
@@ -126,6 +126,34 @@ class TestIsGitHubNameValid:
     def test_invalid_type_returns_false(self):
         assert is_github_name_valid("foo", "Invalid") is False
 
+    def test_repo_rejects_the_two_directory_aliases(self):
+        """`.` and `..` are the only names GitHub refuses outright.
+
+        They are also the two that carry traversal meaning once a caller
+        interpolates them into a URL path, which several callers do.
+        """
+        assert is_github_name_valid(".", "Repo") is False
+        assert is_github_name_valid("..", "Repo") is False
+
+    def test_owner_rejects_the_two_directory_aliases(self):
+        assert is_github_name_valid(".", "Owner") is False
+        assert is_github_name_valid("..", "Owner") is False
+
+    def test_longer_dot_runs_stay_valid(self):
+        """Only the two aliases are reserved. `...` is a legal repository name.
+
+        Rejecting every all-dot name would be a wider rule than GitHub's and
+        would fail a name a user can really create.
+        """
+        assert is_github_name_valid("...", "Repo") is True
+        assert is_github_name_valid("....", "Repo") is True
+
+    def test_dots_elsewhere_in_a_name_stay_valid(self):
+        """The guard matches whole names, not substrings."""
+        assert is_github_name_valid("..leading", "Repo") is True
+        assert is_github_name_valid("trailing..", "Repo") is True
+        assert is_github_name_valid("mid..dle", "Repo") is True
+
 
 # ---------------------------------------------------------------------------
 # Validation: is_safe_file_path

--- a/tests/test_issue_triage.py
+++ b/tests/test_issue_triage.py
@@ -19,8 +19,8 @@ from scripts.issue_triage import (
     AGENT_LABEL_PREFIX,
     AREA_LABEL_PREFIX,
     DEFAULT_STALE_DAYS,
-    PRIORITY_LABEL_PREFIX,
     ISO_TIMESTAMP_PATTERN,
+    PRIORITY_LABEL_PREFIX,
     IssueFinding,
     IssueRecord,
     LinkedPrFetchError,
@@ -31,6 +31,7 @@ from scripts.issue_triage import (
     classify,
     detect_duplicates,
     detect_linked_pr_status,
+    fetch_linked_prs,
     fetch_open_issues,
     format_human,
     has_agent_label,
@@ -379,6 +380,28 @@ class TestFetchOpenIssues:
         with pytest.raises(ValueError):
             fetch_open_issues("o", "r", limit=10_000)
 
+    @pytest.mark.parametrize(
+        ("owner", "repo"), [(".", "r"), ("..", "r"), ("o", "."), ("o", "..")]
+    )
+    def test_rejects_directory_aliases_without_calling_gh(self, owner: str, repo: str):
+        """Both names are interpolated into a gh argument, so they are validated.
+
+        The rejection has to happen before the subprocess call, otherwise the
+        traversal shape has already left the process.
+        """
+        with patch("scripts.issue_triage.subprocess.run") as run:
+            with pytest.raises(ValueError, match="owner|repo"):
+                fetch_open_issues(owner, repo, limit=10)
+        assert not run.called
+
+    def test_accepts_names_with_dots_elsewhere(self):
+        completed = type(
+            "Completed", (), {"returncode": 0, "stdout": "[]", "stderr": ""},
+        )
+        with patch("scripts.issue_triage.subprocess.run", return_value=completed) as run:
+            assert fetch_open_issues("my-org", "my.repo", limit=10) == []
+        assert run.called
+
     def test_returns_parsed_payload(self):
         completed = type(
             "Completed", (), {"returncode": 0, "stdout": '[{"number": 1}]', "stderr": ""},
@@ -421,6 +444,28 @@ class TestFetchOpenIssues:
         with patch("scripts.issue_triage.subprocess.run", return_value=completed):
             with pytest.raises(RuntimeError, match="non-list"):
                 fetch_open_issues("o", "r", limit=10)
+
+
+class TestFetchLinkedPrsIdentity:
+    """`fetch_linked_prs` interpolates owner and repo into a REST path."""
+
+    @pytest.mark.parametrize(
+        ("owner", "repo"), [(".", "r"), ("..", "r"), ("o", "."), ("o", "..")]
+    )
+    def test_rejects_directory_aliases_without_calling_gh(self, owner: str, repo: str):
+        """`..` here yields `repos/o/../issues/1/timeline`, a different endpoint."""
+        with patch("scripts.issue_triage.subprocess.run") as run:
+            with pytest.raises(ValueError, match="owner|repo"):
+                fetch_linked_prs(owner, repo, 1)
+        assert not run.called
+
+    def test_valid_names_reach_gh_with_the_expected_path(self):
+        completed = type(
+            "Completed", (), {"returncode": 0, "stdout": "[]", "stderr": ""},
+        )
+        with patch("scripts.issue_triage.subprocess.run", return_value=completed) as run:
+            assert fetch_linked_prs("my-org", "my.repo", 7) == ()
+        assert "repos/my-org/my.repo/issues/7/timeline" in run.call_args[0][0]
 
 
 class TestLoadIssuesFromInput:


### PR DESCRIPTION
## Summary

`is_github_name_valid` accepted `.` and `..` as repository names. Those two are the only names GitHub refuses outright, because both are directory aliases. The helper's docstring says it "Prevents command injection (CWE-78) by enforcing GitHub naming rules", and callers interpolate its output straight into gh arguments, so the two names that mean "this directory" and "the parent directory" must not reach that position.

Fixes #3768

## What was actually wrong

Two layers, both fixed here.

**The validator accepted the aliases.** The guard is a two-element frozenset membership test in `scripts/github_core/validation.py`, the canonical copy. The generated mirrors `.claude/lib/github_core/validation.py` and `src/copilot-cli/lib/github_core/validation.py` were regenerated by the syncer and the build, not hand-edited. `_TRAVERSAL_PATTERN` already existed in the same module but only `is_safe_file_path` consulted it, so name validation had no traversal check at all.

**The caller never called the validator.** `scripts/issue_triage.py` builds two gh arguments by interpolation and validated neither value:

```
$ uv run --frozen python -c '
from unittest.mock import patch
from scripts.issue_triage import fetch_linked_prs
with patch("scripts.issue_triage._run_gh", side_effect=lambda c: print("CMD:", c) or "[]"):
    fetch_linked_prs("x", "..", 1)'
CMD: ['gh', 'api', 'repos/x/../issues/1/timeline', '--paginate']
```

That is a request for a different endpoint than the caller named. After the change the same call raises `ValueError` and the CLI exits 2 (config error) without issuing the request.

The guard sits in the two fetch functions rather than in argument parsing, matching how `limit` is already validated at the sink. That placement also covers the `GITHUB_REPOSITORY` fallback and direct importers, both of which bypass `argparse`.

## Honest scope: not exploitable today

I could not turn this into a live exploit, and the body should say so. gh does not normalize dot segments:

```
$ gh api "repos/x/../../user"
HTTP 404
```

The value of the fix is that it removes a silent endpoint-retarget primitive from a helper whose stated job is to prevent exactly that, and closes it at the sink so a future client that does normalize (or a different transport) inherits the guard rather than the gap.

## Why exactly two names, not "all dots"

`...` and `....` are legal repository names on GitHub. A rule that rejected every all-dot name would be wider than GitHub's own and would refuse a name a user can really create. The guard is a membership test against a two-element frozenset, and mutation 2 below is what holds that line.

## Mutation evidence

Four mutants, four distinct kill sets, each verified by editing the file, running the suite, and restoring:

| Mutation | Tests that fail |
| --- | --- |
| delete the guard | repo alias cases |
| widen to any all-dot name | `test_longer_dot_runs_stay_valid` |
| substring match instead of equality | `test_dots_elsewhere_in_a_name_stay_valid`, `test_repo_allows_dots`, `test_longer_dot_runs_stay_valid` |
| gate the guard on `name_type == "Repo"` | lowercase and uppercase repo cases |

The fourth came from adversarial review by a different model. The original tests only passed the title-cased `"Repo"`, so a guard keyed to that one literal passed all 188 tests while still returning `True` for `is_github_name_valid("..", "repo")`. `name_type` is documented case-insensitive and lowercased before dispatch, so the tests are now parametrized over case.

Three more mutants cover the caller-side guard: dropping it from either fetch function kills that function's alias cases, and swapping the two `name_type` arguments kills both positive tests, because dots are legal in a repo name and not in an owner name.

`test_owner_rejects_the_two_directory_aliases` passed before the fix, because `_OWNER_PATTERN` already requires an alphanumeric start. It is a regression guard, not a RED test.

## Verification

- 306 passed across `tests/test_github_core.py` and `tests/test_issue_triage.py`
- RED confirmed before each fix: 4 failures for the validator tests under the surviving mutant, 8 for the caller tests
- `ruff check` clean on all four changed source and test files
- `mypy` reports one pre-existing error in `scripts/issue_triage.py` (present on main at line 593, unchanged by this PR)
- Plugin lib copies in sync, no build drift

## Related files, not changed here

Three modules answer "is this a valid repo name" three different ways. Converging them is a separate change with its own blast radius, so this PR fixes the canonical helper and the one caller with a proven path to a URL. See `scripts/validation/active_plan_closeout.py`, which carries a bespoke `_REPO_RE`, and see `scripts/github_core/api.py`, which already routes through the canonical helper.
