### PR TITLE
fix(scripts): pin UTF-8 on every text-capturing subprocess call

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.216",
+  "version": "0.6.240",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.214",
+  "version": "0.6.216",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/lib/ai_review_common/workflow.py
+++ b/.claude/lib/ai_review_common/workflow.py
@@ -51,6 +51,7 @@ def get_pr_changed_files(pr_number: int, pattern: str = ".*") -> list[str]:
                 ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
                 timeout=10,
             )
             repo = result.stdout.strip() if result.returncode == 0 else ""
@@ -70,6 +71,7 @@ def get_pr_changed_files(pr_number: int, pattern: str = ".*") -> list[str]:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=30,
         )
         if result.returncode != 0 or not result.stdout.strip():
@@ -95,6 +97,7 @@ def get_workflow_runs_by_pr(
                 ["git", "remote", "get-url", "origin"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
                 timeout=10,
             )
             match = re.search(r"github\.com[:/]([^/]+)/([^/.]+)", result.stdout)
@@ -113,6 +116,7 @@ def get_workflow_runs_by_pr(
         ],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=30,
     )
     if result.returncode != 0:

--- a/.claude/lib/github_core/gh_client.py
+++ b/.claude/lib/github_core/gh_client.py
@@ -30,7 +30,6 @@ def _run(args: list[str], *, stdin: str | None = None) -> subprocess.CompletedPr
         capture_output=True,
         text=True,
         encoding="utf-8",
-        errors="replace",
         timeout=_TIMEOUT,
     )
 

--- a/.claude/lib/github_core/gh_client.py
+++ b/.claude/lib/github_core/gh_client.py
@@ -20,8 +20,9 @@ def _run(args: list[str], *, stdin: str | None = None) -> subprocess.CompletedPr
     preferred codec, so a cp1252 or cp932 runner decodes the same bytes into
     different characters and ``json.loads`` accepts the result. That is silent
     corruption, and a caller that writes the value back to GitHub persists it.
-    ``errors="replace"`` keeps a truncated multi-byte read from raising in the
-    middle of an otherwise usable response.
+    Decoding stays strict: a byte sequence that is not valid UTF-8 raises
+    instead of being silently replaced, because a mangled identifier written
+    back to GitHub is worse than a visible failure.
     """
 
     return subprocess.run(

--- a/.claude/lib/github_core/gh_client.py
+++ b/.claude/lib/github_core/gh_client.py
@@ -12,6 +12,29 @@ logger = logging.getLogger(__name__)
 _TIMEOUT = 30
 
 
+def _run(args: list[str], *, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    """Run a ``gh`` command and capture its output as UTF-8 text.
+
+    ``gh`` writes raw UTF-8, including in JSON string values, which are not
+    escaped. Without an explicit ``encoding`` Python decodes with the locale's
+    preferred codec, so a cp1252 or cp932 runner decodes the same bytes into
+    different characters and ``json.loads`` accepts the result. That is silent
+    corruption, and a caller that writes the value back to GitHub persists it.
+    ``errors="replace"`` keeps a truncated multi-byte read from raising in the
+    middle of an otherwise usable response.
+    """
+
+    return subprocess.run(
+        args,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=_TIMEOUT,
+    )
+
+
 class GhCliClient:
     """GitHubClient implementation that delegates to ``gh`` CLI subprocess calls.
 
@@ -21,12 +44,7 @@ class GhCliClient:
 
     def rest_get(self, endpoint: str) -> dict[str, Any]:
         """GET a single GitHub REST endpoint and return parsed JSON."""
-        result = subprocess.run(
-            ["gh", "api", endpoint],
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT,
-        )
+        result = _run(["gh", "api", endpoint])
         if result.returncode != 0:
             raise RuntimeError(
                 f"gh api GET {endpoint} failed: {result.stderr.strip()}"
@@ -36,12 +54,9 @@ class GhCliClient:
 
     def rest_post(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         """POST to a GitHub REST endpoint and return parsed JSON."""
-        result = subprocess.run(
+        result = _run(
             ["gh", "api", endpoint, "-X", "POST", "--input", "-"],
-            input=json.dumps(payload),
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT,
+            stdin=json.dumps(payload),
         )
         if result.returncode != 0:
             raise RuntimeError(
@@ -52,12 +67,9 @@ class GhCliClient:
 
     def rest_patch(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         """PATCH a GitHub REST endpoint and return parsed JSON."""
-        result = subprocess.run(
+        result = _run(
             ["gh", "api", endpoint, "-X", "PATCH", "--input", "-"],
-            input=json.dumps(payload),
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT,
+            stdin=json.dumps(payload),
         )
         if result.returncode != 0:
             raise RuntimeError(
@@ -80,12 +92,7 @@ class GhCliClient:
             else:
                 gh_args.extend(["-f", f"{key}={value}"])
 
-        result = subprocess.run(
-            gh_args,
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT,
-        )
+        result = _run(gh_args)
         if result.returncode != 0:
             raise RuntimeError(
                 f"GraphQL request failed: {result.stderr.strip()}"
@@ -102,12 +109,7 @@ class GhCliClient:
     def is_authenticated(self) -> bool:
         """Return True if ``gh auth status`` exits 0."""
         try:
-            result = subprocess.run(
-                ["gh", "auth", "status"],
-                capture_output=True,
-                text=True,
-                timeout=_TIMEOUT,
-            )
+            result = _run(["gh", "auth", "status"])
             return result.returncode == 0
         except FileNotFoundError:
             logger.debug("GitHub CLI (gh) not found on PATH")

--- a/.claude/lib/github_core/rate_limit.py
+++ b/.claude/lib/github_core/rate_limit.py
@@ -40,6 +40,8 @@ def _fetch_rate_limit() -> dict:
         ["gh", "api", "rate_limit"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
     if result.returncode != 0:

--- a/.claude/lib/github_core/rate_limit.py
+++ b/.claude/lib/github_core/rate_limit.py
@@ -41,7 +41,6 @@ def _fetch_rate_limit() -> dict:
         capture_output=True,
         text=True,
         encoding="utf-8",
-        errors="replace",
         timeout=30,
     )
     if result.returncode != 0:

--- a/.claude/lib/github_core/repo.py
+++ b/.claude/lib/github_core/repo.py
@@ -37,6 +37,8 @@ def get_repo_root(
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError):

--- a/.claude/lib/github_core/repo.py
+++ b/.claude/lib/github_core/repo.py
@@ -38,10 +38,9 @@ def get_repo_root(
             capture_output=True,
             text=True,
             encoding="utf-8",
-            errors="replace",
             timeout=timeout,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+    except (subprocess.TimeoutExpired, FileNotFoundError, UnicodeDecodeError):
         return None
 
     if result.returncode != 0:

--- a/.claude/skills/review/scripts/validate_review_marker.py
+++ b/.claude/skills/review/scripts/validate_review_marker.py
@@ -113,10 +113,16 @@ def _run_git(args: list[str], repo_root: Path) -> tuple[int, str, str]:
             ["git", "-C", str(repo_root), *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=15,
         )
     except subprocess.TimeoutExpired:
         return -1, "", "git command timed out after 15s"
+    except UnicodeDecodeError:
+        # Commit messages and paths are raw bytes on POSIX. Strict UTF-8 keeps
+        # a bad decode from becoming a plausible wrong string, and this gate
+        # already reports failure through the return value rather than raising.
+        return -1, "", "git output was not valid UTF-8"
     return result.returncode, result.stdout, result.stderr
 
 

--- a/.claude/skills/review/scripts/validate_review_marker.py
+++ b/.claude/skills/review/scripts/validate_review_marker.py
@@ -57,7 +57,8 @@ MARKER_TRAILER_KEY = "Reviewed-By"
 # more comma-separated stems; it must be non-empty. The SHA is 40 (sha1) or 64
 # (sha256) lowercase hex characters, matching git object-name widths.
 _MARKER_VALUE_RE = re.compile(
-    r"^/review@(?P<axes>[A-Za-z0-9_-]+(?:,[A-Za-z0-9_-]+)*) on (?P<sha>[0-9A-Fa-f]{40}|[0-9A-Fa-f]{64})$"
+    r"^/review@(?P<axes>[A-Za-z0-9_-]+(?:,[A-Za-z0-9_-]+)*)"
+    r" on (?P<sha>[0-9A-Fa-f]{40}|[0-9A-Fa-f]{64})$"
 )
 
 

--- a/scripts/ai_review_common/workflow.py
+++ b/scripts/ai_review_common/workflow.py
@@ -51,6 +51,7 @@ def get_pr_changed_files(pr_number: int, pattern: str = ".*") -> list[str]:
                 ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
                 timeout=10,
             )
             repo = result.stdout.strip() if result.returncode == 0 else ""
@@ -70,6 +71,7 @@ def get_pr_changed_files(pr_number: int, pattern: str = ".*") -> list[str]:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=30,
         )
         if result.returncode != 0 or not result.stdout.strip():
@@ -95,6 +97,7 @@ def get_workflow_runs_by_pr(
                 ["git", "remote", "get-url", "origin"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
                 timeout=10,
             )
             match = re.search(r"github\.com[:/]([^/]+)/([^/.]+)", result.stdout)
@@ -113,6 +116,7 @@ def get_workflow_runs_by_pr(
         ],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=30,
     )
     if result.returncode != 0:

--- a/scripts/eval/software_engineering_library_activation_ci.py
+++ b/scripts/eval/software_engineering_library_activation_ci.py
@@ -127,6 +127,7 @@ def open_issue_number() -> str:
         check=True,
         capture_output=True,
         text=True,
+        encoding="utf-8",
     )
     return result.stdout.strip()
 

--- a/scripts/github_core/gh_client.py
+++ b/scripts/github_core/gh_client.py
@@ -30,7 +30,6 @@ def _run(args: list[str], *, stdin: str | None = None) -> subprocess.CompletedPr
         capture_output=True,
         text=True,
         encoding="utf-8",
-        errors="replace",
         timeout=_TIMEOUT,
     )
 

--- a/scripts/github_core/gh_client.py
+++ b/scripts/github_core/gh_client.py
@@ -20,8 +20,9 @@ def _run(args: list[str], *, stdin: str | None = None) -> subprocess.CompletedPr
     preferred codec, so a cp1252 or cp932 runner decodes the same bytes into
     different characters and ``json.loads`` accepts the result. That is silent
     corruption, and a caller that writes the value back to GitHub persists it.
-    ``errors="replace"`` keeps a truncated multi-byte read from raising in the
-    middle of an otherwise usable response.
+    Decoding stays strict: a byte sequence that is not valid UTF-8 raises
+    instead of being silently replaced, because a mangled identifier written
+    back to GitHub is worse than a visible failure.
     """
 
     return subprocess.run(

--- a/scripts/github_core/gh_client.py
+++ b/scripts/github_core/gh_client.py
@@ -12,6 +12,29 @@ logger = logging.getLogger(__name__)
 _TIMEOUT = 30
 
 
+def _run(args: list[str], *, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    """Run a ``gh`` command and capture its output as UTF-8 text.
+
+    ``gh`` writes raw UTF-8, including in JSON string values, which are not
+    escaped. Without an explicit ``encoding`` Python decodes with the locale's
+    preferred codec, so a cp1252 or cp932 runner decodes the same bytes into
+    different characters and ``json.loads`` accepts the result. That is silent
+    corruption, and a caller that writes the value back to GitHub persists it.
+    ``errors="replace"`` keeps a truncated multi-byte read from raising in the
+    middle of an otherwise usable response.
+    """
+
+    return subprocess.run(
+        args,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=_TIMEOUT,
+    )
+
+
 class GhCliClient:
     """GitHubClient implementation that delegates to ``gh`` CLI subprocess calls.
 
@@ -21,12 +44,7 @@ class GhCliClient:
 
     def rest_get(self, endpoint: str) -> dict[str, Any]:
         """GET a single GitHub REST endpoint and return parsed JSON."""
-        result = subprocess.run(
-            ["gh", "api", endpoint],
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT,
-        )
+        result = _run(["gh", "api", endpoint])
         if result.returncode != 0:
             raise RuntimeError(
                 f"gh api GET {endpoint} failed: {result.stderr.strip()}"
@@ -36,12 +54,9 @@ class GhCliClient:
 
     def rest_post(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         """POST to a GitHub REST endpoint and return parsed JSON."""
-        result = subprocess.run(
+        result = _run(
             ["gh", "api", endpoint, "-X", "POST", "--input", "-"],
-            input=json.dumps(payload),
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT,
+            stdin=json.dumps(payload),
         )
         if result.returncode != 0:
             raise RuntimeError(
@@ -52,12 +67,9 @@ class GhCliClient:
 
     def rest_patch(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         """PATCH a GitHub REST endpoint and return parsed JSON."""
-        result = subprocess.run(
+        result = _run(
             ["gh", "api", endpoint, "-X", "PATCH", "--input", "-"],
-            input=json.dumps(payload),
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT,
+            stdin=json.dumps(payload),
         )
         if result.returncode != 0:
             raise RuntimeError(
@@ -80,12 +92,7 @@ class GhCliClient:
             else:
                 gh_args.extend(["-f", f"{key}={value}"])
 
-        result = subprocess.run(
-            gh_args,
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT,
-        )
+        result = _run(gh_args)
         if result.returncode != 0:
             raise RuntimeError(
                 f"GraphQL request failed: {result.stderr.strip()}"
@@ -102,12 +109,7 @@ class GhCliClient:
     def is_authenticated(self) -> bool:
         """Return True if ``gh auth status`` exits 0."""
         try:
-            result = subprocess.run(
-                ["gh", "auth", "status"],
-                capture_output=True,
-                text=True,
-                timeout=_TIMEOUT,
-            )
+            result = _run(["gh", "auth", "status"])
             return result.returncode == 0
         except FileNotFoundError:
             logger.debug("GitHub CLI (gh) not found on PATH")

--- a/scripts/github_core/rate_limit.py
+++ b/scripts/github_core/rate_limit.py
@@ -40,6 +40,8 @@ def _fetch_rate_limit() -> dict:
         ["gh", "api", "rate_limit"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
     if result.returncode != 0:

--- a/scripts/github_core/rate_limit.py
+++ b/scripts/github_core/rate_limit.py
@@ -41,7 +41,6 @@ def _fetch_rate_limit() -> dict:
         capture_output=True,
         text=True,
         encoding="utf-8",
-        errors="replace",
         timeout=30,
     )
     if result.returncode != 0:

--- a/scripts/github_core/repo.py
+++ b/scripts/github_core/repo.py
@@ -37,6 +37,8 @@ def get_repo_root(
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError):

--- a/scripts/github_core/repo.py
+++ b/scripts/github_core/repo.py
@@ -38,10 +38,9 @@ def get_repo_root(
             capture_output=True,
             text=True,
             encoding="utf-8",
-            errors="replace",
             timeout=timeout,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+    except (subprocess.TimeoutExpired, FileNotFoundError, UnicodeDecodeError):
         return None
 
     if result.returncode != 0:

--- a/scripts/validation/validate_review_marker.py
+++ b/scripts/validation/validate_review_marker.py
@@ -113,10 +113,16 @@ def _run_git(args: list[str], repo_root: Path) -> tuple[int, str, str]:
             ["git", "-C", str(repo_root), *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=15,
         )
     except subprocess.TimeoutExpired:
         return -1, "", "git command timed out after 15s"
+    except UnicodeDecodeError:
+        # Commit messages and paths are raw bytes on POSIX. Strict UTF-8 keeps
+        # a bad decode from becoming a plausible wrong string, and this gate
+        # already reports failure through the return value rather than raising.
+        return -1, "", "git output was not valid UTF-8"
     return result.returncode, result.stdout, result.stderr
 
 

--- a/scripts/validation/validate_review_marker.py
+++ b/scripts/validation/validate_review_marker.py
@@ -57,7 +57,8 @@ MARKER_TRAILER_KEY = "Reviewed-By"
 # more comma-separated stems; it must be non-empty. The SHA is 40 (sha1) or 64
 # (sha256) lowercase hex characters, matching git object-name widths.
 _MARKER_VALUE_RE = re.compile(
-    r"^/review@(?P<axes>[A-Za-z0-9_-]+(?:,[A-Za-z0-9_-]+)*) on (?P<sha>[0-9A-Fa-f]{40}|[0-9A-Fa-f]{64})$"
+    r"^/review@(?P<axes>[A-Za-z0-9_-]+(?:,[A-Za-z0-9_-]+)*)"
+    r" on (?P<sha>[0-9A-Fa-f]{40}|[0-9A-Fa-f]{64})$"
 )
 
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.216",
+  "version": "0.6.240",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.214",
+  "version": "0.6.216",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/lib/ai_review_common/workflow.py
+++ b/src/copilot-cli/lib/ai_review_common/workflow.py
@@ -51,6 +51,7 @@ def get_pr_changed_files(pr_number: int, pattern: str = ".*") -> list[str]:
                 ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
                 timeout=10,
             )
             repo = result.stdout.strip() if result.returncode == 0 else ""
@@ -70,6 +71,7 @@ def get_pr_changed_files(pr_number: int, pattern: str = ".*") -> list[str]:
             ],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=30,
         )
         if result.returncode != 0 or not result.stdout.strip():
@@ -95,6 +97,7 @@ def get_workflow_runs_by_pr(
                 ["git", "remote", "get-url", "origin"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
                 timeout=10,
             )
             match = re.search(r"github\.com[:/]([^/]+)/([^/.]+)", result.stdout)
@@ -113,6 +116,7 @@ def get_workflow_runs_by_pr(
         ],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=30,
     )
     if result.returncode != 0:

--- a/src/copilot-cli/lib/github_core/gh_client.py
+++ b/src/copilot-cli/lib/github_core/gh_client.py
@@ -30,7 +30,6 @@ def _run(args: list[str], *, stdin: str | None = None) -> subprocess.CompletedPr
         capture_output=True,
         text=True,
         encoding="utf-8",
-        errors="replace",
         timeout=_TIMEOUT,
     )
 

--- a/src/copilot-cli/lib/github_core/gh_client.py
+++ b/src/copilot-cli/lib/github_core/gh_client.py
@@ -20,8 +20,9 @@ def _run(args: list[str], *, stdin: str | None = None) -> subprocess.CompletedPr
     preferred codec, so a cp1252 or cp932 runner decodes the same bytes into
     different characters and ``json.loads`` accepts the result. That is silent
     corruption, and a caller that writes the value back to GitHub persists it.
-    ``errors="replace"`` keeps a truncated multi-byte read from raising in the
-    middle of an otherwise usable response.
+    Decoding stays strict: a byte sequence that is not valid UTF-8 raises
+    instead of being silently replaced, because a mangled identifier written
+    back to GitHub is worse than a visible failure.
     """
 
     return subprocess.run(

--- a/src/copilot-cli/lib/github_core/gh_client.py
+++ b/src/copilot-cli/lib/github_core/gh_client.py
@@ -12,6 +12,29 @@ logger = logging.getLogger(__name__)
 _TIMEOUT = 30
 
 
+def _run(args: list[str], *, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    """Run a ``gh`` command and capture its output as UTF-8 text.
+
+    ``gh`` writes raw UTF-8, including in JSON string values, which are not
+    escaped. Without an explicit ``encoding`` Python decodes with the locale's
+    preferred codec, so a cp1252 or cp932 runner decodes the same bytes into
+    different characters and ``json.loads`` accepts the result. That is silent
+    corruption, and a caller that writes the value back to GitHub persists it.
+    ``errors="replace"`` keeps a truncated multi-byte read from raising in the
+    middle of an otherwise usable response.
+    """
+
+    return subprocess.run(
+        args,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=_TIMEOUT,
+    )
+
+
 class GhCliClient:
     """GitHubClient implementation that delegates to ``gh`` CLI subprocess calls.
 
@@ -21,12 +44,7 @@ class GhCliClient:
 
     def rest_get(self, endpoint: str) -> dict[str, Any]:
         """GET a single GitHub REST endpoint and return parsed JSON."""
-        result = subprocess.run(
-            ["gh", "api", endpoint],
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT,
-        )
+        result = _run(["gh", "api", endpoint])
         if result.returncode != 0:
             raise RuntimeError(
                 f"gh api GET {endpoint} failed: {result.stderr.strip()}"
@@ -36,12 +54,9 @@ class GhCliClient:
 
     def rest_post(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         """POST to a GitHub REST endpoint and return parsed JSON."""
-        result = subprocess.run(
+        result = _run(
             ["gh", "api", endpoint, "-X", "POST", "--input", "-"],
-            input=json.dumps(payload),
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT,
+            stdin=json.dumps(payload),
         )
         if result.returncode != 0:
             raise RuntimeError(
@@ -52,12 +67,9 @@ class GhCliClient:
 
     def rest_patch(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         """PATCH a GitHub REST endpoint and return parsed JSON."""
-        result = subprocess.run(
+        result = _run(
             ["gh", "api", endpoint, "-X", "PATCH", "--input", "-"],
-            input=json.dumps(payload),
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT,
+            stdin=json.dumps(payload),
         )
         if result.returncode != 0:
             raise RuntimeError(
@@ -80,12 +92,7 @@ class GhCliClient:
             else:
                 gh_args.extend(["-f", f"{key}={value}"])
 
-        result = subprocess.run(
-            gh_args,
-            capture_output=True,
-            text=True,
-            timeout=_TIMEOUT,
-        )
+        result = _run(gh_args)
         if result.returncode != 0:
             raise RuntimeError(
                 f"GraphQL request failed: {result.stderr.strip()}"
@@ -102,12 +109,7 @@ class GhCliClient:
     def is_authenticated(self) -> bool:
         """Return True if ``gh auth status`` exits 0."""
         try:
-            result = subprocess.run(
-                ["gh", "auth", "status"],
-                capture_output=True,
-                text=True,
-                timeout=_TIMEOUT,
-            )
+            result = _run(["gh", "auth", "status"])
             return result.returncode == 0
         except FileNotFoundError:
             logger.debug("GitHub CLI (gh) not found on PATH")

--- a/src/copilot-cli/lib/github_core/rate_limit.py
+++ b/src/copilot-cli/lib/github_core/rate_limit.py
@@ -40,6 +40,8 @@ def _fetch_rate_limit() -> dict:
         ["gh", "api", "rate_limit"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
     if result.returncode != 0:

--- a/src/copilot-cli/lib/github_core/rate_limit.py
+++ b/src/copilot-cli/lib/github_core/rate_limit.py
@@ -41,7 +41,6 @@ def _fetch_rate_limit() -> dict:
         capture_output=True,
         text=True,
         encoding="utf-8",
-        errors="replace",
         timeout=30,
     )
     if result.returncode != 0:

--- a/src/copilot-cli/lib/github_core/repo.py
+++ b/src/copilot-cli/lib/github_core/repo.py
@@ -37,6 +37,8 @@ def get_repo_root(
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError):

--- a/src/copilot-cli/lib/github_core/repo.py
+++ b/src/copilot-cli/lib/github_core/repo.py
@@ -38,10 +38,9 @@ def get_repo_root(
             capture_output=True,
             text=True,
             encoding="utf-8",
-            errors="replace",
             timeout=timeout,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+    except (subprocess.TimeoutExpired, FileNotFoundError, UnicodeDecodeError):
         return None
 
     if result.returncode != 0:

--- a/src/copilot-cli/skills/review/scripts/validate_review_marker.py
+++ b/src/copilot-cli/skills/review/scripts/validate_review_marker.py
@@ -113,10 +113,16 @@ def _run_git(args: list[str], repo_root: Path) -> tuple[int, str, str]:
             ["git", "-C", str(repo_root), *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=15,
         )
     except subprocess.TimeoutExpired:
         return -1, "", "git command timed out after 15s"
+    except UnicodeDecodeError:
+        # Commit messages and paths are raw bytes on POSIX. Strict UTF-8 keeps
+        # a bad decode from becoming a plausible wrong string, and this gate
+        # already reports failure through the return value rather than raising.
+        return -1, "", "git output was not valid UTF-8"
     return result.returncode, result.stdout, result.stderr
 
 

--- a/src/copilot-cli/skills/review/scripts/validate_review_marker.py
+++ b/src/copilot-cli/skills/review/scripts/validate_review_marker.py
@@ -57,7 +57,8 @@ MARKER_TRAILER_KEY = "Reviewed-By"
 # more comma-separated stems; it must be non-empty. The SHA is 40 (sha1) or 64
 # (sha256) lowercase hex characters, matching git object-name widths.
 _MARKER_VALUE_RE = re.compile(
-    r"^/review@(?P<axes>[A-Za-z0-9_-]+(?:,[A-Za-z0-9_-]+)*) on (?P<sha>[0-9A-Fa-f]{40}|[0-9A-Fa-f]{64})$"
+    r"^/review@(?P<axes>[A-Za-z0-9_-]+(?:,[A-Za-z0-9_-]+)*)"
+    r" on (?P<sha>[0-9A-Fa-f]{40}|[0-9A-Fa-f]{64})$"
 )
 
 

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -278,3 +278,69 @@ class TestCreateIssueCommentWithClient:
             with pytest.raises(SystemExit) as exc:
                 create_issue_comment("o", "r", 42, "text")
             assert exc.value.code == 3
+
+
+# ---------------------------------------------------------------------------
+# GhCliClient: captured-text decoding
+# ---------------------------------------------------------------------------
+
+
+_CAPTURING_CALLS = (
+    ("rest_get", lambda c: c.rest_get("repos/o/r/issues/1")),
+    ("rest_post", lambda c: c.rest_post("repos/o/r/issues/1/comments", {"body": "x"})),
+    ("rest_patch", lambda c: c.rest_patch("repos/o/r/issues/1", {"state": "closed"})),
+    ("graphql", lambda c: c.graphql("query { viewer { login } }")),
+    ("is_authenticated", lambda c: c.is_authenticated()),
+)
+
+
+class TestGhCliClientDecoding:
+    """`gh` emits raw UTF-8, so every captured-text call has to pin the codec.
+
+    Without an explicit ``encoding``, Python decodes with the locale's
+    preferred codec. On a cp1252 or cp932 runner the bytes still decode, into
+    different characters, and ``json.loads`` accepts the result. The failure is
+    silent: no exception, wrong text.
+    """
+
+    @pytest.mark.parametrize(
+        ("name", "invoke"), _CAPTURING_CALLS, ids=[c[0] for c in _CAPTURING_CALLS]
+    )
+    def test_pins_utf8(self, name, invoke):
+        with patch("subprocess.run", return_value=_completed(stdout="{}")) as run:
+            invoke(GhCliClient())
+        assert run.called, f"{name} did not invoke subprocess.run"
+        assert run.call_args.kwargs.get("encoding") == "utf-8", f"{name} does not pin encoding"
+
+    @pytest.mark.parametrize(
+        ("name", "invoke"), _CAPTURING_CALLS, ids=[c[0] for c in _CAPTURING_CALLS]
+    )
+    def test_replaces_undecodable_bytes(self, name, invoke):
+        """A truncated multi-byte read should not raise mid-response."""
+        with patch("subprocess.run", return_value=_completed(stdout="{}")) as run:
+            invoke(GhCliClient())
+        assert run.call_args.kwargs.get("errors") == "replace", f"{name} does not pin errors"
+
+    @pytest.mark.parametrize(
+        ("name", "invoke"), _CAPTURING_CALLS, ids=[c[0] for c in _CAPTURING_CALLS]
+    )
+    def test_keeps_the_timeout(self, name, invoke):
+        """One helper now feeds every call, so a dropped timeout would hang all five."""
+        with patch("subprocess.run", return_value=_completed(stdout="{}")) as run:
+            invoke(GhCliClient())
+        assert run.call_args.kwargs.get("timeout") == 30, f"{name} does not set a timeout"
+
+    def test_real_api_bytes_survive_the_round_trip(self):
+        """Bytes taken from a live `gh api` comment payload, not invented.
+
+        cp1252 decodes the same bytes to 'ðŸ”´' and json.loads accepts it, so
+        the assertion is on the decoded text, not on the absence of an error.
+        """
+        raw = b'{"body": "Semgrep identified a blocking \xf0\x9f\x94\xb4 issue"}'
+        with patch(
+            "subprocess.run",
+            return_value=_completed(stdout=raw.decode("utf-8")),
+        ):
+            result = GhCliClient().rest_get("repos/o/r/issues/1")
+        assert result["body"] == "Semgrep identified a blocking \U0001f534 issue"
+        assert "\u00f0\u0178" not in result["body"]

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -315,11 +315,17 @@ class TestGhCliClientDecoding:
     @pytest.mark.parametrize(
         ("name", "invoke"), _CAPTURING_CALLS, ids=[c[0] for c in _CAPTURING_CALLS]
     )
-    def test_replaces_undecodable_bytes(self, name, invoke):
-        """A truncated multi-byte read should not raise mid-response."""
+    def test_leaves_decode_errors_strict(self, name, invoke):
+        """Undecodable bytes must raise, not become U+FFFD inside parsed JSON.
+
+        ``json.loads`` accepts a replacement character without complaint, so a
+        lenient error handler would hand the caller a silently corrupted body.
+        The GitHub API emits valid UTF-8, so a decode failure means the stream
+        is broken and the caller needs to hear about it.
+        """
         with patch("subprocess.run", return_value=_completed(stdout="{}")) as run:
             invoke(GhCliClient())
-        assert run.call_args.kwargs.get("errors") == "replace", f"{name} does not pin errors"
+        assert "errors" not in run.call_args.kwargs, f"{name} weakens strict decoding"
 
     @pytest.mark.parametrize(
         ("name", "invoke"), _CAPTURING_CALLS, ids=[c[0] for c in _CAPTURING_CALLS]

--- a/tests/test_github_core.py
+++ b/tests/test_github_core.py
@@ -1756,3 +1756,45 @@ class TestMirrorParity:
             "src/copilot-cli/lib/github_core/bot_config.py",
         ):
             assert (_REPO_ROOT / mirror).read_text(encoding="utf-8") == expected, mirror
+
+
+# ---------------------------------------------------------------------------
+# Captured-text decoding across github_core
+# ---------------------------------------------------------------------------
+
+
+class TestCapturedTextDecoding:
+    """Every captured-text reader in this package pins its codec.
+
+    Without an explicit ``encoding`` Python decodes with the locale's
+    preferred codec, so a cp1252 or cp932 runner turns the same bytes into
+    different characters without raising. `gh` emits raw UTF-8 and `git`
+    emits raw filesystem bytes, so both readers are exposed.
+    """
+
+    def test_rate_limit_pins_utf8(self):
+        from scripts.github_core import rate_limit
+
+        with patch("subprocess.run", return_value=_completed(stdout=RATE_LIMIT_ALL_OK)) as run:
+            rate_limit._fetch_rate_limit()
+        assert run.call_args.kwargs.get("encoding") == "utf-8"
+        assert run.call_args.kwargs.get("errors") == "replace"
+
+    def test_repo_root_pins_utf8(self, tmp_path: Path):
+        from scripts.github_core import repo
+
+        with patch(
+            "subprocess.run", return_value=_completed(stdout=str(tmp_path))
+        ) as run:
+            repo.get_repo_root()
+        assert run.call_args.kwargs.get("encoding") == "utf-8"
+        assert run.call_args.kwargs.get("errors") == "replace"
+
+    def test_repo_root_survives_a_non_ascii_path(self, tmp_path: Path):
+        """The repo root seeds every derived path, so a mojibake read is load-bearing."""
+        from scripts.github_core import repo
+
+        root = tmp_path / "\u30d7\u30ed\u30b8\u30a7\u30af\u30c8"
+        root.mkdir()
+        with patch("subprocess.run", return_value=_completed(stdout=f"{root}\n")):
+            assert repo.get_repo_root() == root

--- a/tests/test_github_core.py
+++ b/tests/test_github_core.py
@@ -1778,7 +1778,7 @@ class TestCapturedTextDecoding:
         with patch("subprocess.run", return_value=_completed(stdout=RATE_LIMIT_ALL_OK)) as run:
             rate_limit._fetch_rate_limit()
         assert run.call_args.kwargs.get("encoding") == "utf-8"
-        assert run.call_args.kwargs.get("errors") == "replace"
+        assert "errors" not in run.call_args.kwargs
 
     def test_repo_root_pins_utf8(self, tmp_path: Path):
         from scripts.github_core import repo
@@ -1788,7 +1788,21 @@ class TestCapturedTextDecoding:
         ) as run:
             repo.get_repo_root()
         assert run.call_args.kwargs.get("encoding") == "utf-8"
-        assert run.call_args.kwargs.get("errors") == "replace"
+        assert "errors" not in run.call_args.kwargs
+
+    def test_repo_root_returns_none_when_git_output_will_not_decode(self):
+        """Strict decoding must not crash a helper documented to return None.
+
+        Filesystem paths on POSIX are bytes, so a checkout under a name that is
+        not valid UTF-8 makes ``subprocess.run`` raise while decoding. The
+        function promises ``None`` on failure, and every caller anchors paths on
+        the result, so an escaping decode error would take out unrelated tools.
+        """
+        from scripts.github_core import repo
+
+        boom = UnicodeDecodeError("utf-8", b"\x80", 0, 1, "invalid start byte")
+        with patch("subprocess.run", side_effect=boom):
+            assert repo.get_repo_root() is None
 
     def test_repo_root_survives_a_non_ascii_path(self, tmp_path: Path):
         """The repo root seeds every derived path, so a mojibake read is load-bearing."""

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -56,11 +56,6 @@ def _keyword(call: ast.Call, name: str) -> ast.expr | None:
     return None
 
 
-def _has_splat(call: ast.Call) -> bool:
-    """Report whether *call* forwards ``**kwargs``."""
-    return any(keyword.arg is None for keyword in call.keywords)
-
-
 def _is_literal_false(node: ast.expr | None) -> bool:
     """Report whether *node* is the literal ``False``."""
     return isinstance(node, ast.Constant) and node.value is False

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -12,10 +12,19 @@ succeeds and returns different characters than the tool wrote. ``json.loads``
 accepts the result, so the corruption reaches the caller silently.
 
 This module is the standing guard. It walks the AST rather than the text so a
-reformatted call site cannot slip past, and it checks only ``encoding``.
-``errors`` is deliberately left to each call site: the default is ``strict``,
-which fails loudly, and a lenient handler would reintroduce the silent
-corruption this guard exists to prevent.
+reformatted call site cannot slip past.
+
+It checks ``encoding`` only. ``errors`` is deliberately left to each call site:
+the default is ``strict``, which fails loudly, and a lenient handler would
+reintroduce the silent corruption this guard exists to prevent.
+
+The checks below are deliberately conservative, because a guard meant to hold
+forever is worth more than any single call site it protects. An adversarial
+review found five ways to write a genuinely locale-decoding call that an
+earlier, looser version waved through: ``encoding=None``, an aliased or
+directly imported ``run``, a non-literal ``text`` or ``capture_output`` flag,
+``getoutput`` and its siblings, and ``utf-8-sig``. Each has a case in
+``test_detector_closes_the_evasions``.
 """
 
 from __future__ import annotations
@@ -30,6 +39,14 @@ _SCRIPTS_DIR = _REPO_ROOT / "scripts"
 
 _CAPTURING_ATTRS = frozenset({"run", "check_output", "Popen"})
 
+# getoutput and getstatusoutput take no capture or text flags. They always
+# return decoded text, and their encoding parameter defaults to None.
+_ALWAYS_TEXT_ATTRS = frozenset({"getoutput", "getstatusoutput"})
+
+_SUBPROCESS_ATTRS = _CAPTURING_ATTRS | _ALWAYS_TEXT_ATTRS
+
+_PINNED_CODEC = "utf-8"
+
 
 def _keyword(call: ast.Call, name: str) -> ast.expr | None:
     """Return the value node for keyword *name*, or ``None`` when absent."""
@@ -39,50 +56,104 @@ def _keyword(call: ast.Call, name: str) -> ast.expr | None:
     return None
 
 
-def _is_literal_true(node: ast.expr | None) -> bool:
-    """Report whether *node* is the literal ``True``."""
-    return isinstance(node, ast.Constant) and node.value is True
+def _has_splat(call: ast.Call) -> bool:
+    """Report whether *call* forwards ``**kwargs``."""
+    return any(keyword.arg is None for keyword in call.keywords)
 
 
-def _is_subprocess_call(call: ast.Call) -> bool:
-    """Report whether *call* targets a capturing ``subprocess`` entry point."""
+def _is_literal_false(node: ast.expr | None) -> bool:
+    """Report whether *node* is the literal ``False``."""
+    return isinstance(node, ast.Constant) and node.value is False
+
+
+def _subprocess_names(tree: ast.Module) -> tuple[set[str], dict[str, str]]:
+    """Collect the module aliases and directly imported names for subprocess.
+
+    ``import subprocess as sp`` and ``from subprocess import run`` are both
+    ordinary Python, and an owner-name check that only knows the literal word
+    ``subprocess`` misses each of them.
+    """
+    modules = {"subprocess"}
+    functions: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "subprocess":
+                    modules.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+            for alias in node.names:
+                if alias.name in _SUBPROCESS_ATTRS:
+                    functions[alias.asname or alias.name] = alias.name
+    return modules, functions
+
+
+def _target(call: ast.Call, modules: set[str], functions: dict[str, str]) -> str | None:
+    """Return the subprocess entry point *call* reaches, or ``None``."""
     func = call.func
-    if not isinstance(func, ast.Attribute) or func.attr not in _CAPTURING_ATTRS:
-        return False
-    owner = func.value
-    if isinstance(owner, ast.Name):
-        return owner.id == "subprocess"
-    return isinstance(owner, ast.Attribute) and owner.attr == "subprocess"
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        owner, attr = func.value.id, func.attr
+        if owner in modules and attr in _SUBPROCESS_ATTRS:
+            return attr
+        if owner == "os" and attr == "popen":
+            return "os.popen"
+    if isinstance(func, ast.Name) and func.id in functions:
+        return functions[func.id]
+    return None
 
 
 def _captures_text(call: ast.Call) -> bool:
-    """Report whether *call* decodes captured output into ``str``.
+    """Report whether *call* may decode captured output into ``str``.
 
-    Both halves matter. Without ``text``/``universal_newlines`` the call yields
-    bytes and no decoding happens, and without a captured stream there is
-    nothing to decode in the first place.
+    Deliberately conservative. Anything other than a literal ``False`` counts,
+    because ``text=1`` and ``capture_output=flag`` both decode at runtime while
+    reading as compliant to a check that only recognises ``True``.
     """
-    if not (
-        _is_literal_true(_keyword(call, "text"))
-        or _is_literal_true(_keyword(call, "universal_newlines"))
+    text = _keyword(call, "text")
+    legacy = _keyword(call, "universal_newlines")
+    if (text is None or _is_literal_false(text)) and (
+        legacy is None or _is_literal_false(legacy)
     ):
         return False
-    if _is_literal_true(_keyword(call, "capture_output")):
+    capture = _keyword(call, "capture_output")
+    if capture is not None and not _is_literal_false(capture):
         return True
     return _keyword(call, "stdout") is not None or _keyword(call, "stderr") is not None
 
 
+def _pins_utf8(call: ast.Call) -> bool:
+    """Report whether *call* proves its codec is UTF-8 at the call site.
+
+    ``encoding=None`` is an explicit request for the locale codec, a name or
+    attribute cannot be resolved statically, and ``utf-8-sig`` quietly strips a
+    byte order mark, so only the literal string counts.
+    """
+    encoding = _keyword(call, "encoding")
+    if encoding is None:
+        return False
+    return isinstance(encoding, ast.Constant) and encoding.value == _PINNED_CODEC
+
+
 def unpinned_lines(source: str) -> list[int]:
-    """Return the line numbers of text-capturing calls that omit ``encoding``."""
+    """Return the line numbers of text-capturing calls that do not pin UTF-8."""
+    tree = ast.parse(source)
+    modules, functions = _subprocess_names(tree)
     offenders: list[int] = []
-    for node in ast.walk(ast.parse(source)):
+    for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
-        if not _is_subprocess_call(node) or not _captures_text(node):
+        target = _target(node, modules, functions)
+        if target is None:
             continue
-        if _keyword(node, "encoding") is None:
+        if target == "os.popen":
+            # os.popen has no encoding parameter at all, so the only compliant
+            # move is to not use it.
             offenders.append(node.lineno)
-    return offenders
+            continue
+        if target not in _ALWAYS_TEXT_ATTRS and not _captures_text(node):
+            continue
+        if not _pins_utf8(node):
+            offenders.append(node.lineno)
+    return sorted(offenders)
 
 
 def _python_sources() -> list[Path]:
@@ -163,10 +234,6 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'import shutil\nshutil.run(["x"], capture_output=True, text=True)',
             "a same-named method on another module is not ours",
         ),
-        (
-            'import subprocess\nsubprocess.run(["x"], capture_output=True, text=flag)',
-            "a non-literal text argument is not provably a decode",
-        ),
     ],
 )
 def test_detector_stays_quiet(source: str, why: str) -> None:
@@ -183,3 +250,65 @@ def test_detector_reports_every_offender_in_one_file() -> None:
         "subprocess.run(['c'], capture_output=True, text=True)\n"
     )
     assert unpinned_lines(source) == [2, 4]
+
+
+@pytest.mark.parametrize(
+    ("source", "why"),
+    [
+        (
+            'import subprocess\n'
+            'subprocess.run(["x"], capture_output=True, text=True, encoding=None)',
+            "encoding=None is an explicit request for the locale codec",
+        ),
+        (
+            'from subprocess import run\nrun(["x"], capture_output=True, text=True)',
+            "a direct import evades an owner-name check",
+        ),
+        (
+            'import subprocess as sp\nsp.run(["x"], capture_output=True, text=True)',
+            "a module alias evades an owner-name check",
+        ),
+        (
+            'from subprocess import check_output as co\nco(["x"], text=True, stdout=1)',
+            "a renamed import evades a function-name check",
+        ),
+        (
+            'import subprocess\nsubprocess.getoutput("x")',
+            "getoutput always decodes and defaults to encoding=None",
+        ),
+        (
+            'import subprocess\nsubprocess.getstatusoutput("x")',
+            "getstatusoutput has the same default",
+        ),
+        (
+            'import os\nos.popen("x")',
+            "os.popen decodes with no way to pin a codec",
+        ),
+        (
+            'import subprocess\n'
+            'subprocess.run(["x"], capture_output=True, text=True, encoding="utf-8-sig")',
+            "utf-8-sig silently strips a BOM, so it is not the pinned codec",
+        ),
+        (
+            'import subprocess\n'
+            'subprocess.run(["x"], capture_output=True, text=True, encoding=CODEC)',
+            "a non-literal encoding cannot be proven to be utf-8",
+        ),
+        (
+            'import subprocess\ncapture = True\n'
+            'subprocess.run(["x"], capture_output=capture, text=True)',
+            "a variable capture flag still captures",
+        ),
+        (
+            'import subprocess\nsubprocess.run(["x"], capture_output=True, text=1)',
+            "a truthy non-True literal still selects text mode",
+        ),
+        (
+            'import subprocess\nsubprocess.run(["x"], capture_output=True, text=True, **kw)',
+            "splatted keywords cannot prove the codec is pinned",
+        ),
+    ],
+)
+def test_detector_closes_the_evasions(source: str, why: str) -> None:
+    """Holes found by adversarial review. Each one decodes under the locale codec."""
+    assert unpinned_lines(source) != [], f"missed {why}"

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -1,0 +1,185 @@
+"""Every subprocess call that captures text under ``scripts/`` pins its codec.
+
+``subprocess`` with ``text=True`` and no explicit ``encoding`` decodes captured
+bytes with ``locale.getpreferredencoding(False)``. That is UTF-8 on the Linux
+runners and something else on the Windows runner in this repo's CI matrix.
+
+The tools we shell out to emit raw UTF-8, not escaped ASCII. ``gh`` writes
+non-ASCII straight into JSON string values, and ``git`` hands back filesystem
+paths, branch names, and commit messages as raw bytes. Decoding those under a
+legacy codec does not raise: cp1252 maps almost every byte, so the call
+succeeds and returns different characters than the tool wrote. ``json.loads``
+accepts the result, so the corruption reaches the caller silently.
+
+This module is the standing guard. It walks the AST rather than the text so a
+reformatted call site cannot slip past, and it checks only ``encoding``.
+``errors`` is deliberately left to each call site: the default is ``strict``,
+which fails loudly, and a lenient handler would reintroduce the silent
+corruption this guard exists to prevent.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+
+_CAPTURING_ATTRS = frozenset({"run", "check_output", "Popen"})
+
+
+def _keyword(call: ast.Call, name: str) -> ast.expr | None:
+    """Return the value node for keyword *name*, or ``None`` when absent."""
+    for keyword in call.keywords:
+        if keyword.arg == name:
+            return keyword.value
+    return None
+
+
+def _is_literal_true(node: ast.expr | None) -> bool:
+    """Report whether *node* is the literal ``True``."""
+    return isinstance(node, ast.Constant) and node.value is True
+
+
+def _is_subprocess_call(call: ast.Call) -> bool:
+    """Report whether *call* targets a capturing ``subprocess`` entry point."""
+    func = call.func
+    if not isinstance(func, ast.Attribute) or func.attr not in _CAPTURING_ATTRS:
+        return False
+    owner = func.value
+    if isinstance(owner, ast.Name):
+        return owner.id == "subprocess"
+    return isinstance(owner, ast.Attribute) and owner.attr == "subprocess"
+
+
+def _captures_text(call: ast.Call) -> bool:
+    """Report whether *call* decodes captured output into ``str``.
+
+    Both halves matter. Without ``text``/``universal_newlines`` the call yields
+    bytes and no decoding happens, and without a captured stream there is
+    nothing to decode in the first place.
+    """
+    if not (
+        _is_literal_true(_keyword(call, "text"))
+        or _is_literal_true(_keyword(call, "universal_newlines"))
+    ):
+        return False
+    if _is_literal_true(_keyword(call, "capture_output")):
+        return True
+    return _keyword(call, "stdout") is not None or _keyword(call, "stderr") is not None
+
+
+def unpinned_lines(source: str) -> list[int]:
+    """Return the line numbers of text-capturing calls that omit ``encoding``."""
+    offenders: list[int] = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_subprocess_call(node) or not _captures_text(node):
+            continue
+        if _keyword(node, "encoding") is None:
+            offenders.append(node.lineno)
+    return offenders
+
+
+def _python_sources() -> list[Path]:
+    """Return every Python file under ``scripts/``, skipping caches."""
+    return [
+        path
+        for path in sorted(_SCRIPTS_DIR.rglob("*.py"))
+        if "__pycache__" not in path.parts
+    ]
+
+
+def test_every_capturing_call_under_scripts_pins_utf8() -> None:
+    """No text-capturing subprocess call may inherit the locale's codec."""
+    offenders: list[str] = []
+    for path in _python_sources():
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        offenders.extend(f"{rel}:{line}" for line in unpinned_lines(path.read_text("utf-8")))
+    assert offenders == [], (
+        "text-capturing subprocess calls must pass encoding=\"utf-8\": "
+        + ", ".join(offenders)
+    )
+
+
+def test_the_scan_actually_reaches_files() -> None:
+    """Guard the guard: an empty file list would make the policy test vacuous."""
+    sources = _python_sources()
+    assert len(sources) > 50, f"only found {len(sources)} sources under scripts/"
+
+
+@pytest.mark.parametrize(
+    ("source", "why"),
+    [
+        (
+            "import subprocess\nsubprocess.run(['x'], capture_output=True, text=True)",
+            "capture_output plus text",
+        ),
+        (
+            "import subprocess\nsubprocess.run(['x'], stdout=subprocess.PIPE, text=True)",
+            "an explicit stdout pipe",
+        ),
+        (
+            "import subprocess\nsubprocess.check_output(['x'], text=True, stderr=None)",
+            "check_output",
+        ),
+        (
+            "import subprocess\n"
+            "subprocess.run(['x'], capture_output=True, universal_newlines=True)",
+            "the legacy universal_newlines spelling",
+        ),
+    ],
+)
+def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
+    """A detector that never fires would let the policy test pass on anything."""
+    assert unpinned_lines(source) == [2], f"missed {why}"
+
+
+@pytest.mark.parametrize(
+    ("source", "why"),
+    [
+        (
+            'import subprocess\n'
+            'subprocess.run(["x"], capture_output=True, text=True, encoding="utf-8")',
+            "a pinned call is compliant",
+        ),
+        (
+            'import subprocess\nsubprocess.run(["x"], capture_output=True)',
+            "no text means bytes, so nothing is decoded",
+        ),
+        (
+            'import subprocess\nsubprocess.run(["x"], text=True)',
+            "nothing captured means nothing to decode",
+        ),
+        (
+            'import subprocess\nsubprocess.run(["x"], capture_output=True, text=False)',
+            "text=False is an explicit bytes request",
+        ),
+        (
+            'import shutil\nshutil.run(["x"], capture_output=True, text=True)',
+            "a same-named method on another module is not ours",
+        ),
+        (
+            'import subprocess\nsubprocess.run(["x"], capture_output=True, text=flag)',
+            "a non-literal text argument is not provably a decode",
+        ),
+    ],
+)
+def test_detector_stays_quiet(source: str, why: str) -> None:
+    """The guard must not fire on calls that decode nothing."""
+    assert unpinned_lines(source) == [], f"false positive on {why}"
+
+
+def test_detector_reports_every_offender_in_one_file() -> None:
+    """A file with several bad calls must surface all of them, not just the first."""
+    source = (
+        "import subprocess\n"
+        "subprocess.run(['a'], capture_output=True, text=True)\n"
+        'subprocess.run(["b"], capture_output=True, text=True, encoding="utf-8")\n'
+        "subprocess.run(['c'], capture_output=True, text=True)\n"
+    )
+    assert unpinned_lines(source) == [2, 4]


### PR DESCRIPTION
## Summary

`subprocess` with `text=True` and no explicit `encoding` decodes captured bytes with `locale.getpreferredencoding(False)`. That is UTF-8 on our Linux runners and something else on the Windows runner in the CI matrix. This pins UTF-8 on every text-capturing subprocess call under `scripts/`, and adds a standing guard so the next one cannot regress.

Refs #3762, which fixed this in one place. This finishes the sweep I offered there.

## The bug is real, and it is silent

`gh` writes raw UTF-8. It does not `\u`-escape non-ASCII inside JSON string values. Measured against a live endpoint, `repos/rjmurillo/ai-agents/pulls/3762/comments`:

```
bytes above 127:  22
\u escapes:        0
first occurrence:  "Semgrep identified a blocking \xf0\x9f\x94\xb4 issue"
```

Feeding those exact bytes through the old call shape:

| decoded as | result |
| --- | --- |
| utf-8 | `Semgrep identified a blocking 🔴 issue` |
| cp1252 | `Semgrep identified a blocking ðŸ”´ issue` |
| cp932 | `Semgrep identified a blocking \ue05e閥 issue` |

`json.loads` accepts all three. Nothing raises. A caller that round-trips a comment body writes the corrupted text back to GitHub.

## What changed

Every text-capturing `subprocess.run` under `scripts/` now passes `encoding="utf-8"`. Twelve call sites across five modules.

`scripts/github_core/gh_client.py` had five calls repeating an identical keyword list, so they now route through one `_run` helper. That consolidation has a cost worth naming: a single dropped keyword would regress all five at once, so the tests assert `encoding`, `errors`, and `timeout` separately across every method.

Two sites matter beyond defence in depth:

- `scripts/github_core/repo.py` decodes `git rev-parse --show-toplevel`. Every caller anchors derived paths on the result, so a corrupted read poisons path resolution everywhere downstream.
- `scripts/ai_review_common/workflow.py` returns changed filenames that callers regex-match and then open. A mis-decoded name silently matches nothing.

## `errors` is left strict, deliberately

The first draft of this branch passed `errors="replace"`. An adversarial review with a different model caught that as a defect in my own fix, and it was right.

`errors="replace"` turns malformed input into U+FFFD, and `json.loads` accepts a replacement character without complaint:

```
b'{"b":"\x80"}'  ->  '{"b":"\ufffd"}'  ->  json.loads succeeds  ->  {'b': '\ufffd'}
```

That is the same silent corruption this branch exists to remove, so the lenient handler was working against its own fix. The GitHub API emits valid UTF-8, so a decode failure means the stream is broken and the caller needs to hear about it. Strict is the default, so the keyword is simply absent.

Two functions needed one extra step, because both already report failure through a return value rather than an exception, and bare strict decoding would have made them raise instead:

- `scripts/github_core/repo.py` documents "Returns: Resolved Path to the repo root, or None on failure". `UnicodeDecodeError` joins its except clause.
- `scripts/validation/validate_review_marker.py` returns `(-1, "", message)`. It runs arbitrary git commands and hands back stdout, which carries commit messages and paths, so this is the one call site where undecodable bytes are genuinely plausible. A review gate that crashes on an odd commit message blocks a ship for no good reason.

## The guard

`tests/test_subprocess_text_encoding.py` walks the AST of every file under `scripts/` and fails on any text-capturing subprocess call missing `encoding="utf-8"`. Walking the tree rather than the text means a reformatted or re-indented call site cannot slip past, and it catches new call sites nobody thought to check.

It checks `encoding` only. Requiring `errors` would force back the lenient handler the section above argues against.

### Five evasions, found by review and closed

A guard meant to hold forever is worth more than any one call site it protects, so a hole in it is the worse defect. A second adversarial review, same model family, wrote five calls that genuinely decode under the locale codec and that the first version waved through. Each now has a case in `test_detector_closes_the_evasions`.

| Evasion | Why it decoded anyway |
| --- | --- |
| `encoding=None` | An explicit request for the locale codec. The keyword is present, so an is-it-there check passes it. |
| `import subprocess as sp`, `from subprocess import run` | The owner check matched the literal word `subprocess` and nothing else. |
| `text=1`, `capture_output=some_flag` | Both decode at runtime. Only literal `True` was recognised. |
| `getoutput`, `getstatusoutput` | No text or capture flag to inspect. Always return decoded text, and `getoutput` defaults `encoding` to `None`. |
| `encoding="utf-8-sig"` | Passes an is-there-an-encoding check, then quietly strips a byte order mark. |

`os.popen` joins them. It has no `encoding` parameter at all, so the only compliant move is not to use it.

The rules are now conservative in the safe direction: the detector tracks module aliases and direct imports per file, treats anything but a literal `False` as text mode or capture, and accepts only the literal string `"utf-8"` as pinned. A `**kwargs` splat without explicit encoding is flagged too, because a forwarding wrapper defeats call-site explicitness by construction.

Strictness was measured before it was adopted. The tightened detector finds **zero** additional offenders under `scripts/`, so it costs no churn now and only binds new code.

### The detector carries its own tests

A policy test whose detector never fires passes just as happily on an empty list:

- fires on four unpinned spellings, including the legacy `universal_newlines` one
- stays quiet on five compliant or irrelevant shapes, including bytes captures and a same-named method on another module
- reports every offender in a file, not just the first
- asserts the scan reaches more than fifty real files
- twelve evasion cases covering the table above

One case that previously asserted the detector stays quiet on `text=some_flag` moved to the evasion list. It contradicted the stricter policy, which is the point of the stricter policy.

## Mutation testing

Seven mutants against the fix, seven distinct kill sets.

| Mutation | Killed by |
| --- | --- |
| drop `encoding` from the client helper | `test_pins_utf8`, all five methods |
| re-add `errors="replace"` to the client helper | `test_leaves_decode_errors_strict`, all five methods |
| drop `input=stdin` from the client helper | `TestGhCliClientRestPost::test_success_returns_parsed_json` |
| drop `timeout` from the client helper | `test_keeps_the_timeout` |
| drop `encoding` from the rate limit reader | `test_rate_limit_pins_utf8` |
| drop `encoding` from the repo root reader | `test_repo_root_pins_utf8` |
| drop `UnicodeDecodeError` from the repo root except clause | `test_repo_root_returns_none_when_git_output_will_not_decode` |

Dropping `encoding` from any of the six remaining sites is caught by the standing guard, which names the offending file and line. Verified by deleting one and watching the repo-wide test fail.

Five more mutants against the detector itself, because a guard that cannot be shown to fail is not evidence of anything. Five distinct kill counts: accepting any encoding keyword (3 failures), dropping alias tracking (3), requiring literal `True` again (1), forgetting `getoutput` and `getstatusoutput` (2), and ignoring `os.popen` (1).

## Verification

```
502 passed   github_core, client, guard, review gate, activation gate, workflows
 24 passed   the guard alone, on a tree it reports as clean
```

`ruff check` clean on every changed file. `mypy` clean on the three modules that gained logic. Mirrors regenerated by the two sync scripts, never hand edited.

One unrelated line came along: the pre-push lint ratchet holds this branch responsible for a pre-existing over-length regex in the review gate, since the branch touches that file. The rewrap splits it across two adjacent string literals, verified by string equality rather than by eye, so the compiled pattern is unchanged.

## Out of scope

While pinning `scripts/eval/software_engineering_library_activation_ci.py` I noticed it writes two artifacts to the repository root with bare relative paths, and neither is gitignored. That is the defect class #3764 closed, with two names missed. Filed as #3774 rather than folded in here: different defect, different justification.

## Files changed

Hand edited:

- `scripts/github_core/gh_client.py`, `scripts/github_core/rate_limit.py`, `scripts/github_core/repo.py`
- `scripts/ai_review_common/workflow.py`, `scripts/eval/software_engineering_library_activation_ci.py`
- `scripts/validation/validate_review_marker.py`
- `tests/test_github_client.py`, `tests/test_github_core.py`, `tests/test_subprocess_text_encoding.py`

Regenerated by the two sync scripts (see `scripts/sync_plugin_lib.py` and see `build/scripts/build_all.py`), never hand edited:

- `.claude/lib/github_core/gh_client.py`, `.claude/lib/github_core/rate_limit.py`, `.claude/lib/github_core/repo.py`
- `.claude/lib/ai_review_common/workflow.py`, `.claude/skills/review/scripts/validate_review_marker.py`
- `src/copilot-cli/lib/github_core/gh_client.py`, `src/copilot-cli/lib/github_core/rate_limit.py`, `src/copilot-cli/lib/github_core/repo.py`
- `src/copilot-cli/lib/ai_review_common/workflow.py`, `src/copilot-cli/skills/review/scripts/validate_review_marker.py`
- `.claude/.claude-plugin/plugin.json` and `src/copilot-cli/.claude-plugin/plugin.json`, bumped to 0.6.240
