### PR TITLE
fix(ci): enforce the ADR-080 model pin gate in CI

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-29-session-2840-model-pin-ci-gate.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-2840-model-pin-ci-gate.json
@@ -1,0 +1,75 @@
+{
+  "id": "episode-2026-07-29-session-2840-model-pin-ci-gate",
+  "session": "2026-07-29-session-2840-model-pin-ci-gate",
+  "timestamp": "2026-07-29T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Wire the ADR-080 model-pin gate into CI. check_model_pins.py has shipped a working --mode enforce since ADR-080 was accepted, but nothing under .github/ ever invoked it, so a new unjustified model: pin was detected in warn mode and merged anyway.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Re-measured every premise in #2840 before acting. The issue claims 71 skills carry model: pins across 5 distinct values with format drift (4-6 vs 4.6) and one bare alias. Measured today: 7 skills, all a single bare haiku value, no version drift. Four of the issue's five acceptance criteria are already met by work that landed after it was filed: ADR-080 accepted 2026-07-11 via PR #3028, scripts/eval/eval-model-panel.py sweep() for the model sweep, the 71-to-7 migration, and scripts/validation/model_pin_baseline.json as the single registry.",
+      "caused_by": [],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Isolated the one criterion still missing: the CI check. grep -rn check_model_pins .github/ returns nothing. The sole caller is checks_spec.validate_model_pins, which runs --mode warn; its docstring states enforcement stays in CI, and that was not true. Proved the gap by planting a pinned skill: warn mode printed VIOLATION: [new pin] bare alias 'opus' lacks a model-rationale field and exited 0. Enforce mode exited 1 on the identical tree.",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Proved wiring is safe before wiring it. Enforce mode exits 0 against clean main today because model_pin_baseline.json grandfathers the 46-pin backlog and fails only on new or changed pins, so the new gate does not red main on arrival.",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Hosted the step in the validate-pr job, following the precedent the #3330 comment block records for the workflow-YAML check: a model: pin can land in any skill, agent, or command file, so the gate must fire on every PR regardless of touched paths, and validate-pr is the only required check carrying no job-level if.",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Added four wiring tests and mutation-tested each one. Deleting the step, switching it to warn mode, adding a job-level if to the host job, and planting a new unjustified pin each fail a distinct test; the warn-mode mutation fails two, which is correct because both the enforce assertion and the warn assertion are load-bearing. The first draft of the warn-mode test read the raw file text and was tripped by the explanatory comment naming warn mode; it was tightened to read parsed run blocks.",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 4
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-29-session-2840-model-pin-ci-gate.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-2840-model-pin-ci-gate.json
@@ -61,6 +61,14 @@
         "e004"
       ],
       "leads_to": []
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 28f31d60b",
+      "caused_by": [],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -68,7 +76,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/sessions/2026-07-29-session-2840-model-pin-ci-gate.json
+++ b/.agents/sessions/2026-07-29-session-2840-model-pin-ci-gate.json
@@ -1,0 +1,108 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 2840,
+    "date": "2026-07-29",
+    "branch": "fix/2840-model-pin-ci-gate",
+    "startingCommit": "1eb5bea17a",
+    "objective": "Wire the ADR-080 model-pin gate into CI. check_model_pins.py has shipped a working --mode enforce since ADR-080 was accepted, but nothing under .github/ ever invoked it, so a new unjustified model: pin was detected in warn mode and merged anyway."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "branchVerified": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "git branch --show-current returned fix/2840-model-pin-ci-gate after checkout -b from origin/main at 1eb5bea17a"
+      },
+      "notOnMain": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Branch is fix/2840-model-pin-ci-gate, not main"
+      },
+      "handoffRead": {
+        "complete": true,
+        "level": "SHOULD",
+        "evidence": "Read .agents/HANDOFF.md and the open issue backlog at campaign start; issue #2840 discourse read before measuring"
+      },
+      "sessionLogCreated": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "This file, created before the first commit so branch-context-policy resolves the branch"
+      },
+      "serenaActivated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Serena MCP was not reachable in this harness. Fell back to reading .serena/memories/ directly per AGENTS.md."
+      },
+      "serenaInstructions": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Not available; see serenaActivated"
+      },
+      "constraintsRead": {
+        "complete": true,
+        "level": "SHOULD",
+        "evidence": "Read ADR-080 (model pins require cited eval evidence), .agents/architecture ADR-006 (no logic in workflow run blocks; this step calls a script and adds no logic), and the #3330 comment block in pr-validation.yml establishing the host-job precedent"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Enforce mode wired into the validate-pr job; four wiring tests added, each proven load-bearing by mutation"
+      },
+      "handoffPreserved": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": ".agents/HANDOFF.md was not modified; git status shows no entry for it"
+      },
+      "serenaMemoryUpdated": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Serena MCP unavailable this session"
+      },
+      "markdownLintRun": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "No Markdown files changed in this commit; scoped lint is a no-op"
+      },
+      "changesCommitted": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "Single commit on fix/2840-model-pin-ci-gate covering the workflow step and its wiring tests"
+      },
+      "validationPassed": {
+        "complete": true,
+        "level": "MUST",
+        "evidence": "scripts/validate_workflows.py exits 0; uv run ruff check passes; yamllint warning count unchanged at 6 before and after; 42/42 tests pass in tests/ci/test_pr_validation_workflow.py"
+      },
+      "retrospectiveInvoked": {
+        "complete": false,
+        "level": "SHOULD",
+        "evidence": "Campaign is still in flight; the retrospective belongs at the end of it"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "step": "Re-measured every premise in #2840 before acting. The issue claims 71 skills carry model: pins across 5 distinct values with format drift (4-6 vs 4.6) and one bare alias. Measured today: 7 skills, all a single bare haiku value, no version drift. Four of the issue's five acceptance criteria are already met by work that landed after it was filed: ADR-080 accepted 2026-07-11 via PR #3028, scripts/eval/eval-model-panel.py sweep() for the model sweep, the 71-to-7 migration, and scripts/validation/model_pin_baseline.json as the single registry."
+    },
+    {
+      "step": "Isolated the one criterion still missing: the CI check. grep -rn check_model_pins .github/ returns nothing. The sole caller is checks_spec.validate_model_pins, which runs --mode warn; its docstring states enforcement stays in CI, and that was not true. Proved the gap by planting a pinned skill: warn mode printed VIOLATION: [new pin] bare alias 'opus' lacks a model-rationale field and exited 0. Enforce mode exited 1 on the identical tree."
+    },
+    {
+      "step": "Proved wiring is safe before wiring it. Enforce mode exits 0 against clean main today because model_pin_baseline.json grandfathers the 46-pin backlog and fails only on new or changed pins, so the new gate does not red main on arrival."
+    },
+    {
+      "step": "Hosted the step in the validate-pr job, following the precedent the #3330 comment block records for the workflow-YAML check: a model: pin can land in any skill, agent, or command file, so the gate must fire on every PR regardless of touched paths, and validate-pr is the only required check carrying no job-level if."
+    },
+    {
+      "step": "Added four wiring tests and mutation-tested each one. Deleting the step, switching it to warn mode, adding a job-level if to the host job, and planting a new unjustified pin each fail a distinct test; the warn-mode mutation fails two, which is correct because both the enforce assertion and the warn assertion are load-bearing. The first draft of the warn-mode test read the raw file text and was tripped by the explanatory comment naming warn mode; it was tightened to read parsed run blocks."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Open the PR for #2840",
+    "Continue the open-issue campaign"
+  ]
+}

--- a/.agents/sessions/2026-07-29-session-2840-model-pin-ci-gate.json
+++ b/.agents/sessions/2026-07-29-session-2840-model-pin-ci-gate.json
@@ -100,7 +100,7 @@
       "step": "Added four wiring tests and mutation-tested each one. Deleting the step, switching it to warn mode, adding a job-level if to the host job, and planting a new unjustified pin each fail a distinct test; the warn-mode mutation fails two, which is correct because both the enforce assertion and the warn assertion are load-bearing. The first draft of the warn-mode test read the raw file text and was tripped by the explanatory comment naming warn mode; it was tightened to read parsed run blocks."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "28f31d60b",
   "nextSteps": [
     "Open the PR for #2840",
     "Continue the open-issue campaign"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -231,3 +231,22 @@ jobs:
 
       - name: Validate workflow YAML
         run: uv run --frozen python3 scripts/validate_workflows.py
+
+      # Issue #2840: ADR-080 requires an unjustified `model:` pin to fail CI.
+      # `check_model_pins.py --mode enforce` exits 1 on a new or changed pin
+      # that lacks a model-rationale field, and `checks_spec.validate_model_pins`
+      # documents that "enforcement stays in CI" -- but nothing under .github/
+      # ever invoked it. The pre-PR runner wraps only `--mode warn`, which
+      # prints `VIOLATION` and exits 0 by design, so until now a new unjustified
+      # pin was detected, reported, and merged anyway.
+      #
+      # Hosted in this job for the same reason as the workflow-YAML step above:
+      # a `model:` pin can land in any skill, agent, or command file, so the
+      # gate has to fire on every PR regardless of touched paths, and this is
+      # the only required check that always reports status.
+      #
+      # Enforce mode grandfathers the existing backlog through
+      # scripts/validation/model_pin_baseline.json and fails only on new or
+      # changed pins, so it passes clean on today's tree.
+      - name: Enforce model pin policy
+        run: uv run --frozen python3 scripts/validation/check_model_pins.py --mode enforce

--- a/tests/ci/test_pr_validation_workflow.py
+++ b/tests/ci/test_pr_validation_workflow.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / "scripts" / "ci"
@@ -671,3 +672,82 @@ class TestBlockedMessageNamesTheLimitThatWasApplied:
     def test_the_workflow_still_supplies_the_variable(self) -> None:
         """Edge: the fix is inert unless the workflow binds COMMIT_LIMIT."""
         assert "COMMIT_LIMIT:" in WORKFLOW.read_text(encoding="utf-8")
+
+
+class TestModelPinEnforcementIsWiredIntoCI:
+    """The ADR-080 model-pin gate has to be able to fail a PR (Issue #2840).
+
+    ``check_model_pins.py`` shipped a correct ``--mode enforce`` that exits 1 on
+    a new or changed ``model:`` pin lacking a model-rationale field, and
+    ``checks_spec.validate_model_pins`` documents that "enforcement stays in
+    CI". Nothing under ``.github/`` invoked it. The only caller was the pre-PR
+    runner in ``--mode warn``, which prints ``VIOLATION`` and exits 0 by
+    design. A new unjustified pin was therefore detected, printed, and merged.
+    These tests pin the wiring, not the script; the script's own exit codes are
+    covered in ``tests/validation/test_check_model_pins.py``.
+    """
+
+    HOST_JOB = "validate-pr"
+
+    @staticmethod
+    def _jobs() -> dict:
+        return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+
+    @classmethod
+    def _host_steps(cls) -> list:
+        return cls._jobs()[cls.HOST_JOB]["steps"]
+
+    @classmethod
+    def _pin_steps(cls) -> list:
+        return [
+            step
+            for step in cls._host_steps()
+            if "check_model_pins.py" in str(step.get("run", ""))
+        ]
+
+    def test_ci_invokes_the_gate_in_enforce_mode(self) -> None:
+        """Positive: the gate that can fail is the one CI actually runs."""
+        steps = self._pin_steps()
+        assert len(steps) == 1, "expected exactly one model-pin step"
+        assert "--mode enforce" in steps[0]["run"]
+
+    def test_ci_never_invokes_the_gate_in_warn_mode(self) -> None:
+        """Negative: warn mode exits 0 on violations, so it cannot gate.
+
+        Wiring warn mode here would look like enforcement in the checks list
+        while blocking nothing, which is the exact defect this test guards.
+        Parsed ``run`` blocks only: a comment may name warn mode to explain why
+        it is the wrong choice, and that prose must not fail this test.
+        """
+        runs = [str(step.get("run", "")) for step in self._host_steps()]
+        assert not [run for run in runs if "--mode warn" in run]
+
+    def test_the_hosting_job_cannot_be_skipped(self) -> None:
+        """Edge: a ``model:`` pin can land in any file, so no path filter.
+
+        The gate is inert if its host job is conditional, because a PR that
+        touches no filtered path would skip it. This job carries no job-level
+        ``if`` on purpose; it is the required check that always reports status.
+        """
+        assert "if" not in self._jobs()[self.HOST_JOB]
+
+    def test_enforce_mode_passes_against_the_current_tree(self) -> None:
+        """Edge: wiring the gate must not red main on arrival.
+
+        Enforce mode grandfathers the existing backlog through
+        ``model_pin_baseline.json`` and fails only on new or changed pins. If
+        this ever fails, the baseline and the tree have diverged and the gate
+        would block every PR, including the one that tries to fix it.
+        """
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "validation" / "check_model_pins.py"),
+                "--mode",
+                "enforce",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary

Wires the ADR-080 model pin gate into CI. It was written, tested, and never run.

`Fixes #2840`

## The gap

ADR-080 requires a `model:` pin to cite eval evidence. The validator for it
has shipped a correct `enforce` mode since the ADR was accepted: it exits 1 on
a new or changed pin with no model-rationale field, and grandfathers the
existing backlog through a baseline file.

Nothing invoked it. `grep -rn check_model_pins .github/` returns nothing. The
sole caller is the pre-PR runner, in warn mode, and the docstring of that
wrapper states that "enforcement stays in CI". That was not true.

Warn mode prints `VIOLATION` and exits 0 by design. So a new unjustified pin
was detected, printed into the pre-PR log, and merged anyway.

## Evidence

Planted a skill carrying `model: opus` and no rationale, then ran both modes
against the identical tree:

| Mode | Output | Exit |
|------|--------|------|
| warn | `VIOLATION: [new pin] bare alias 'opus' lacks a model-rationale field` | 0 |
| enforce | same violation | 1 |

Enforce mode exits 0 against clean main today, so wiring it does not red main
on arrival. The baseline grandfathers the 46 pin backlog and fails only on new
or changed pins.

## Why this job

Issue #3330 already established the precedent in this workflow for the
workflow-YAML check, and its comment block gives the reason: this is the only
required check that reports status on every PR regardless of touched paths. A
`model:` pin can land in any skill, agent, or command file, so a path-filtered
host would let a pin through on any PR that touched nothing filtered. The job
carries no job-level `if` for exactly this reason.

## Scope correction

The issue text is stale. It claims 71 skills carry pins across 5 distinct
values with format drift and one bare alias. Measured today: 7 skills, all a
single bare `haiku` value, no version drift. Four of the five acceptance
criteria were already met by work that landed after the issue was filed. This
PR closes the fifth and last one.

## Tests

Four wiring tests, each proven load-bearing by mutation:

| Mutation | Tests that fail |
|----------|-----------------|
| Delete the step | 1 |
| Switch it to warn mode | 2 |
| Add a job-level `if` to the host job | 1 |
| Plant a new unjustified pin | 1 |

The warn-mode mutation failing two tests is correct: both the enforce
assertion and the warn-mode assertion are load-bearing.

The first draft of the warn-mode test read raw file text and was tripped by
the explanatory comment that names warn mode. It now reads parsed `run`
blocks, so prose explaining why warn mode is wrong cannot fail the test.

42/42 pass in the touched test file. Workflow schema validation passes. Ruff
passes. The yamllint warning count is unchanged at 6 before and after.

## References

- `scripts/validation/check_model_pins.py` (the validator, unchanged here)
- `scripts/validation/model_pin_baseline.json` (the draining ratchet baseline)
- `scripts/validation/checks_spec.py` (the warn-mode pre-PR wrapper)
