### PR TITLE
fix(scripts): read every ADR status spelling, not just the heading

### DIFF
--- a/scripts/sync_adr_protocol.py
+++ b/scripts/sync_adr_protocol.py
@@ -21,6 +21,8 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
+
 # Exit codes per ADR-035
 EXIT_SUCCESS = 0
 EXIT_GAPS_DETECTED = 1
@@ -34,6 +36,7 @@ RFC2119_PATTERN = re.compile(
 
 # ADR number extraction from filename
 ADR_NUMBER_PATTERN = re.compile(r"ADR-(\d+)")
+INLINE_STATUS_PATTERN = re.compile(r"^\*\*Status\*\*\s*:\s*(.+?)\s*$", re.MULTILINE)
 
 
 @dataclass
@@ -100,17 +103,84 @@ def parse_adr_title(content: str) -> str:
     return "Unknown"
 
 
-def parse_adr_status(content: str) -> str:
-    """Extract status from ADR markdown content."""
+def _status_from_heading(content: str) -> str | None:
+    """Read the prose under a ``## Status`` section, joining wrapped lines.
+
+    ADR-004 wraps its status across two lines, so reading only the first
+    would report the truncated "Superseded by".
+    """
     in_status = False
+    collected: list[str] = []
     for line in content.splitlines():
-        if line.strip() == "## Status":
+        stripped = line.strip()
+        if stripped == "## Status":
             in_status = True
             continue
-        if in_status and line.strip():
-            return line.strip()
-        if in_status and line.startswith("## ") and line.strip() != "## Status":
-            break
+        if in_status:
+            if stripped.startswith("## "):
+                break
+            if not stripped:
+                if collected:
+                    break
+                continue
+            collected.append(stripped)
+    return " ".join(collected) or None
+
+
+def _status_from_inline(content: str) -> str | None:
+    """Read a bold ``**Status**:`` line from the preamble.
+
+    Bounded to the text before the first ``##`` heading so a body mention
+    cannot be mistaken for lifecycle state.
+    """
+    preamble = re.split(r"^## ", content, maxsplit=1, flags=re.MULTILINE)[0]
+    match = INLINE_STATUS_PATTERN.search(preamble)
+    return match.group(1).strip() if match else None
+
+
+def _status_from_frontmatter(content: str) -> str | None:
+    """Read ``status:`` from the YAML frontmatter block (ADR-073).
+
+    Parsed as YAML so quoting and comments resolve to the scalar value
+    rather than to raw text.
+    """
+    if not content.startswith("---\n"):
+        return None
+    match = re.search(r"^---[ \t]*$", content[4:], re.MULTILINE)
+    if match is None:
+        return None
+    try:
+        data = yaml.safe_load(content[4 : 4 + match.start()])
+    except yaml.YAMLError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    status = data.get("status")
+    if isinstance(status, str) and status.strip():
+        return status.strip()
+    return None
+
+
+def parse_adr_status(content: str) -> str:
+    """Extract status from ADR markdown content.
+
+    The corpus spells status three ways: a ``## Status`` section, a bold
+    ``**Status**:`` preamble line, and YAML frontmatter (ADR-073).
+
+    Frontmatter wins because it is the controlled enum. The prose sections
+    are unbounded: ADR-071 runs a full debate summary under ``## Status``,
+    which is not a lifecycle value. Prose remains the fallback for the 60
+    ADRs that carry no frontmatter yet, pending the ADR-073 Phase 2
+    backfill.
+    """
+    for extract in (
+        _status_from_frontmatter,
+        _status_from_heading,
+        _status_from_inline,
+    ):
+        status = extract(content)
+        if status:
+            return status
     return "Unknown"
 
 

--- a/tests/test_sync_adr_protocol.py
+++ b/tests/test_sync_adr_protocol.py
@@ -51,6 +51,100 @@ class TestParseAdrStatus:
         content = "# ADR-001\n\n## Date\n\n2026-01-01\n"
         assert parse_adr_status(content) == "Unknown"
 
+    def test_extracts_bold_inline_status(self) -> None:
+        """ADR-005 and ADR-055 spell status as a bold header line."""
+        content = (
+            "# ADR-005: PowerShell-Only\n\n"
+            "**Status**: Superseded by [ADR-042](./ADR-042-python-migration-strategy.md)\n"
+            "**Date**: 2025-12-18\n"
+        )
+        assert parse_adr_status(content) == (
+            "Superseded by [ADR-042](./ADR-042-python-migration-strategy.md)"
+        )
+
+    def test_extracts_frontmatter_status(self) -> None:
+        """ADR-073 introduced machine-readable lifecycle frontmatter."""
+        content = "---\nid: ADR-073\nstatus: accepted\n---\n\n# ADR-073\n\n## Context\n"
+        assert parse_adr_status(content) == "accepted"
+
+    def test_frontmatter_wins_over_prose(self) -> None:
+        """The enum is the lifecycle value; prose sections are unbounded."""
+        content = (
+            "---\nstatus: superseded\n---\n\n"
+            "# ADR-004\n\n## Status\n\nAccepted (2026-01-01). Long debate summary.\n"
+        )
+        assert parse_adr_status(content) == "superseded"
+
+    def test_frontmatter_status_is_unquoted(self) -> None:
+        """A quoted YAML scalar must not carry its quotes into the report."""
+        content = '---\nstatus: "accepted"\n---\n\n# ADR-066\n'
+        assert parse_adr_status(content) == "accepted"
+
+    def test_frontmatter_without_closing_delimiter_is_ignored(self) -> None:
+        content = "---\nstatus: accepted\n\n# ADR-001\n\n## Status\n\nProposed\n"
+        assert parse_adr_status(content) == "Proposed"
+
+    def test_ignores_status_mention_in_body(self) -> None:
+        """A bold Status line below the first heading is prose, not state."""
+        content = "# ADR-001\n\n## Context\n\n**Status**: COMPLETE\n"
+        assert parse_adr_status(content) == "Unknown"
+
+    def test_ignores_status_key_outside_frontmatter(self) -> None:
+        """A body line reading 'status: ...' is prose, not lifecycle state."""
+        content = "# ADR-001\n\n## Context\n\nThe report prints status: Unknown for these.\n"
+        assert parse_adr_status(content) == "Unknown"
+
+    def test_joins_a_status_wrapped_across_lines(self) -> None:
+        """ADR-004 wraps its status; reading one line truncates it."""
+        content = "# ADR-004\n\n## Status\n\nSuperseded by\n[ADR-086](ADR-086.md) on 2026-07-20.\n"
+        assert parse_adr_status(content) == (
+            "Superseded by [ADR-086](ADR-086.md) on 2026-07-20."
+        )
+
+    def test_empty_status_section_falls_through(self) -> None:
+        """An empty '## Status' must not report the next heading as the status."""
+        content = "# ADR-001\n\n## Status\n\n## Date\n\n2026-01-01\n"
+        assert parse_adr_status(content) == "Unknown"
+
+
+class TestStatusParsingCoversTheRealCorpus:
+    """Guards the spelling drift that made 17 of 90 ADRs unreadable.
+
+    ADR-073 flagged this exact risk against ``sync_adr_protocol.py``
+    ("Confirm no prose-status assumption breaks") and the confirmation was
+    never run. These tests are that confirmation, pinned to the corpus.
+    """
+
+    def test_no_committed_adr_reports_unknown_status(self) -> None:
+        adr_dir = Path(__file__).resolve().parents[1] / ".agents" / "architecture"
+        unreadable = [
+            path.name
+            for path in sorted(adr_dir.glob("ADR-*.md"))
+            if path.name != "ADR-TEMPLATE.md"
+            and parse_adr_status(path.read_text(encoding="utf-8")) == "Unknown"
+        ]
+        assert not unreadable, f"ADRs with unreadable status: {unreadable}"
+
+    def test_superseded_status_is_preserved_verbatim(self) -> None:
+        """A superseded ADR must not read as active state to a consumer."""
+        adr_dir = Path(__file__).resolve().parents[1] / ".agents" / "architecture"
+        adr_005 = adr_dir / "ADR-005-powershell-only-scripting.md"
+        status = parse_adr_status(adr_005.read_text(encoding="utf-8"))
+        assert status.lower().startswith("superseded"), status
+
+    def test_no_status_is_truncated_mid_sentence(self) -> None:
+        """ADR-004 wraps its status; a line-at-a-time read ends on 'Superseded by'."""
+        adr_dir = Path(__file__).resolve().parents[1] / ".agents" / "architecture"
+        dangling = ("by", "and", "on", "the", "a", "to", "of", "in", "for", "with")
+        truncated = [
+            f"{path.name}: {status}"
+            for path in sorted(adr_dir.glob("ADR-*.md"))
+            if path.name != "ADR-TEMPLATE.md"
+            and (status := parse_adr_status(path.read_text(encoding="utf-8")))
+            and status.rstrip().split()[-1].lower() in dangling
+        ]
+        assert not truncated, f"statuses ending on a dangling word: {truncated}"
+
 
 class TestCountRequirements:
     """Tests for count_requirements function."""


### PR DESCRIPTION
## Problem

`parse_adr_status()` matched one of the three status spellings the ADR corpus actually uses. Seventeen of ninety ADRs parsed as `Unknown`; nine of those reached the actionable GAPS report.

The worst line the tool printed:

```
ADR-005 (8 MUST) [Unknown]
```

ADR-005 is PowerShell-only scripting. Its real status is `Superseded by ADR-042`, and ADR-042 mandates Python-first. An agent acting on that report would work to satisfy 8 MUST requirements from a superseded ADR that contradicts current policy.

## The corpus is fine; the reader was not

I measured all three spellings before writing any code. `## Status` heading: 73. Frontmatter `status:`: 30. Bold inline `**Status**:`: 10. Every ADR carries at least one, and no ADR disagrees with itself across spellings. My first hypothesis, that ten ADRs were silently un-statused, was wrong and I discarded it.

## This was predicted and never confirmed

ADR-073 introduced the frontmatter spelling. Its own impact table carries the row:

```
| scripts/sync_adr_protocol.py | Indirect | Confirm no prose-status assumption breaks | Low |
```

Its Phase 2 text names the case that would break it, inline-formatted status (ADR-055). The confirmation was never run and the assumption broke.

## Precedence, and why I reversed my first answer

Precedence is frontmatter, then heading, then bold inline.

I initially argued for prose-first, on the grounds that prose carries qualifiers the enum drops and that ADR-073 defers authoritative frontmatter reads to a consumer-gated later phase. Measurement defeated that. Fixing the wrapped-line truncation exposed that the prose is unbounded: ADR-071's `## Status` section is a ~900 character debate summary. That is not a status for a one-line audit report. Frontmatter answers for the 30 ADRs that have it; prose still answers for the 60 that do not.

## Result across the corpus

| Measure | Before | After |
| --- | --- | --- |
| ADRs reporting `Unknown` | 9 | 0 |
| Statuses truncated mid-sentence | 12 | 0 |
| Longest single status | ~900 chars | 430 chars |

I diffed the full script output before and after. Twenty-one lines changed and every one is an improvement. No previously-correct line moved.

## Review

Reviewed by gpt-5.6-sol (different model family). Three Required findings, all fixed:

1. ADR-004 wraps its `## Status` across two source lines, so a line-at-a-time read returned the dangling fragment `Superseded by`. Headings now join wrapped lines.
2. A bold `**Status**:` in the body could pose as lifecycle state. Inline reads are bounded to the preamble before the first `##`.
3. Frontmatter was parsed by regex, so `status: "accepted"` kept its quotes. Now parsed with `yaml.safe_load`.

The reviewer also caught a false count in my own analysis: 30 ADRs have frontmatter, not 33. My loose regex over the file head was matching body lines.

## Tests

Nine of the forty-one tests in the module fail against the pre-fix parser, verified by reverting `parse_adr_status` to its old body behind an `assert` guard that the new code is present.

Two of those are corpus-pinned rather than fixture-based, because a fixture cannot catch this class. One asserts no committed ADR reports `Unknown`. The other asserts no status ends on a dangling connective, and against the old parser it fails naming `ADR-004: Superseded by` exactly.

## Out of scope

Superseded ADRs still appear in the GAPS list as actionable gaps. Filtering them changes the tool's verdict, which `.github/instructions/ci-scripts.instructions.md` MUST NOT 2 says needs its own decision. Noted in the issue.

Fixes #3783
