### PR TITLE
test(scripts): resolve subprocess bindings, closing nine guard evasions

### DIFF
--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -52,6 +52,7 @@ fail towards a redundant keyword, never towards a missed decode.
 from __future__ import annotations
 
 import ast
+import time
 from pathlib import Path
 
 import pytest
@@ -158,9 +159,8 @@ def _resolve_elements(
     """Return the entry point a container of *values* yields when subscripted.
 
     The index is deliberately not modelled, so any element reaching subprocess
-    taints the whole container. Elements that disagree collapse to the dynamic
-    sentinel, which is the conservative reading: the subscript may select the
-    one that decodes.
+    taints the whole container. Elements that disagree resolve to the member
+    that is hardest to make compliant, because the subscript may select it.
     """
     found = {
         resolved
@@ -171,13 +171,28 @@ def _resolve_elements(
     }
     if not found:
         return None
-    return found.pop() if len(found) == 1 else _DYNAMIC
+    if len(found) == 1:
+        return found.pop()
+    if _OS_POPEN in found:
+        return _OS_POPEN
+    if found & _DECODES_UNCONDITIONALLY:
+        return _DYNAMIC
+    # Every remaining member decodes only when the same keywords say so, so the
+    # call site answers for all of them and any one of them stands in.
+    return sorted(found)[0]
 
 
 def _resolve_callable(
     node: ast.expr, modules: set[str], functions: dict[str, str]
 ) -> str | None:
     """Return the subprocess entry point *node* evaluates to, or ``None``."""
+    while isinstance(node, ast.Subscript):
+        # ``RUNNERS[0](...)`` reaches whatever the container holds. Resolving
+        # the base rather than the index means a computed index cannot slip a
+        # subprocess reference past this scan. A subscript chain is left
+        # recursive, so the parser caps no depth and unwinding it must not
+        # recurse.
+        node = node.value
     if isinstance(node, ast.Name):
         resolved = functions.get(node.id)
         return None if resolved == _PARTIAL else resolved
@@ -198,12 +213,29 @@ def _resolve_callable(
         return _resolve_elements(
             [value for value in node.values if value is not None], modules, functions
         )
-    if isinstance(node, ast.Subscript):
-        # ``RUNNERS[0](...)`` reaches whatever the container holds. Resolving
-        # the base rather than the index means a computed index cannot slip a
-        # subprocess reference past this scan.
-        return _resolve_callable(node.value, modules, functions)
     return None
+
+
+def _unpack(target: ast.expr, value: ast.expr) -> list[tuple[str, ast.expr]]:
+    """Pair every name in an assignment *target* with the value it may receive.
+
+    Shapes that line up are matched element by element. When they do not line
+    up the right side is unknown, so every name on the left is paired with the
+    whole of it rather than dropped.
+    """
+    if isinstance(target, ast.Name):
+        return [(target.id, value)]
+    if isinstance(target, ast.Starred):
+        return _unpack(target.value, value)
+    if not isinstance(target, (ast.Tuple, ast.List)):
+        return []
+    if isinstance(value, (ast.Tuple, ast.List)) and len(value.elts) == len(target.elts):
+        return [
+            pair
+            for sub, item in zip(target.elts, value.elts, strict=True)
+            for pair in _unpack(sub, item)
+        ]
+    return [pair for sub in target.elts for pair in _unpack(sub, value)]
 
 
 def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
@@ -211,15 +243,14 @@ def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
 
     Covers plain assignment, annotated assignment, and the walrus, which binds
     a name in the middle of an expression and needs no statement of its own.
+    Assignment targets are unpacked, so a name bound by destructuring is as
+    visible as one bound on its own.
     """
     found: list[tuple[str, ast.expr]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign):
-            found.extend(
-                (target.id, node.value)
-                for target in node.targets
-                if isinstance(target, ast.Name)
-            )
+            for target in node.targets:
+                found.extend(_unpack(target, node.value))
         elif isinstance(node, ast.AnnAssign):
             if isinstance(node.target, ast.Name) and node.value is not None:
                 found.append((node.target.id, node.value))
@@ -252,25 +283,38 @@ def _subprocess_names(tree: ast.Module) -> tuple[set[str], dict[str, str]]:
                 if alias.name == "partial":
                     functions[alias.asname or alias.name] = _PARTIAL
 
-    # Assignments resolve against names discovered so far, so a chain needs
-    # more than one sweep: ``ast.walk`` is breadth first, so ``b = a`` at the
-    # top level is visited before an ``a = subprocess.run`` nested in an
-    # ``if`` body, even though the source reads the other way round. The
-    # first binding of a name wins, which keeps ``functions`` monotonically
-    # growing and therefore guarantees this loop terminates even when a name
-    # is rebound to a different entry point later in the file.
+    # Assignments resolve against names discovered so far, so one pass is not
+    # enough: ``ast.walk`` is breadth first, so ``b = a`` at the top level is
+    # visited before an ``a = subprocess.run`` nested in an ``if`` body, even
+    # though the source reads the other way round.
+    #
+    # Rather than sweep every binding repeatedly, each one is queued again only
+    # when a name it reads becomes known. A name resolves at most once, so the
+    # queue takes at most one push per binding plus one per dependency edge,
+    # which makes the work linear in the size of the file. A repeated sweep is
+    # quadratic instead, and measurably so: a reverse-ordered chain of 2000
+    # bindings took 0.41 seconds that way.
     bindings = _bindings(tree)
-    for _ in range(len(bindings)):
-        grew = False
-        for name, value in bindings:
-            if name in functions:
-                continue
-            resolved = _resolve_callable(value, modules, functions)
-            if resolved is not None:
-                functions[name] = resolved
-                grew = True
-        if not grew:
-            break
+    dependents: dict[str, list[int]] = {}
+    for index, (_, value) in enumerate(bindings):
+        for free in {
+            node.id for node in ast.walk(value) if isinstance(node, ast.Name)
+        }:
+            dependents.setdefault(free, []).append(index)
+
+    queue = list(range(len(bindings)))
+    while queue:
+        name, value = bindings[queue.pop()]
+        # The first binding of a name wins. That is what bounds the queue, and
+        # it is why a name rebound to an unrelated callable keeps reading as a
+        # subprocess entry point.
+        if name in functions:
+            continue
+        resolved = _resolve_callable(value, modules, functions)
+        if resolved is None:
+            continue
+        functions[name] = resolved
+        queue.extend(dependents.get(name, ()))
     return modules, functions
 
 
@@ -460,6 +504,22 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
         (
             'import json\n_loads = json.loads\n_loads("{}")',
             "binding an unrelated callable is ordinary Python",
+        ),
+        (
+            'import subprocess\nrunners = [subprocess.run, subprocess.Popen]\n'
+            'runners[0](["echo", "hi"])',
+            "two entry points that both need keywords decode nothing without one",
+        ),
+        (
+            'import subprocess\nfrom mylib import render\n'
+            'runner, drawer = subprocess.run, render\n'
+            'drawer("x", capture_output=True, text=True)',
+            "unpacking pairs by position, so the neighbour keeps its own identity",
+        ),
+        (
+            'import subprocess\nrunners = [subprocess.run, subprocess.Popen]\n'
+            'runners[0](["x"], capture_output=True, text=True, encoding="utf-8")',
+            "a container call that pins the codec is as safe as a direct one",
         ),
         (
             'from functools import partial as p\n'
@@ -672,7 +732,7 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             "a tuple element that always decodes needs no text keyword",
         ),
         (
-            'import subprocess\nR = [subprocess.run, subprocess.getoutput]\n'
+            'import subprocess\nR = [subprocess.Popen, subprocess.getoutput]\n'
             'R[1]("ls")',
             "a mixed container may yield the member that decodes regardless",
         ),
@@ -680,6 +740,36 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             'import subprocess\nfrom functools import partial as p\n'
             'f = p(subprocess.run, text=True)\nf(["x"], capture_output=True)',
             "an aliased partial import is not spelled partial at the call",
+        ),
+        (
+            'import subprocess\na, b = subprocess.run, None\n'
+            'a(["x"], capture_output=True, text=True)',
+            "tuple unpacking binds a name without an ast.Name target",
+        ),
+        (
+            'import subprocess\n(a, (b, c)) = (None, (subprocess.run, None))\n'
+            'b(["x"], capture_output=True, text=True)',
+            "a nested unpacking target is still a binding",
+        ),
+        (
+            'import subprocess\n*runners, tail = subprocess.run, None\n'
+            'runners[0](["x"], capture_output=True, text=True)',
+            "a starred target collects the reference into a container",
+        ),
+        (
+            'import subprocess\nrunners = [subprocess.run, subprocess.run]\n'
+            'a, b = runners\na(["x"], capture_output=True, text=True)',
+            "unpacking a name of unknown shape may hand it to either side",
+        ),
+        (
+            'import subprocess\nrunners = [subprocess.run, subprocess.Popen]\n'
+            'runners[0](["x"], capture_output=True, text=True)',
+            "members that share a keyword contract still honour that contract",
+        ),
+        (
+            'import subprocess, os\nrunners = [subprocess.check_output, os.popen]\n'
+            'runners[1]("ls")',
+            "a container holding os.popen may yield the one that cannot pin",
         ),
     ],
 )
@@ -728,3 +818,57 @@ def test_detector_over_approximates_deliberately(source: str, why: str) -> None:
     trade cheap: the repo-wide scan above is green.
     """
     assert unpinned_lines(source) != [], f"expected over-approximation: {why}"
+
+
+def test_name_resolution_stays_linear_on_a_deep_reverse_chain() -> None:
+    """A long chain resolved in the worst order must not cost quadratic work.
+
+    Every binding here reads the name defined on the following line, so a
+    repeated sweep learns exactly one name per pass and does N passes over N
+    bindings. The queue learns the whole chain in one pass over the dependency
+    edges instead.
+
+    The bound is deliberately loose. Measured on this machine the queue takes
+    0.36 seconds and a repeated sweep takes about 40, so anything under the
+    ceiling is the linear implementation and anything over it is a regression
+    to the sweep, not a slow CI runner.
+    """
+    depth = 20000
+    source = "\n".join(
+        ["import subprocess"]
+        + [f"v{index} = v{index + 1}" for index in range(depth)]
+        + [f"v{depth} = subprocess.run", 'v0(["x"], capture_output=True, text=True)']
+    )
+    started = time.perf_counter()
+    flagged = unpinned_lines(source)
+    elapsed = time.perf_counter() - started
+
+    assert flagged, "a chain of any depth still reaches a subprocess entry point"
+    assert elapsed < 10.0, f"name resolution took {elapsed:.1f}s for {depth} bindings"
+
+
+@pytest.mark.parametrize(
+    ("source", "why"),
+    [
+        (
+            'import subprocess\nv1 = v2\nv2 = subprocess.run\n'
+            'v1(["x"], capture_output=True, text=True)',
+            "a binding that reads a name defined below it still resolves",
+        ),
+    ],
+)
+def test_detector_resolves_out_of_order_chains(source: str, why: str) -> None:
+    """Source order does not decide resolution order, so neither can evade."""
+    assert unpinned_lines(source) != [], f"missed {why}"
+
+
+def test_name_resolution_survives_a_deep_subscript_chain() -> None:
+    """A long subscript chain must not exhaust the interpreter stack.
+
+    ``a[0][0][0]...`` is left recursive rather than nested, so the parser
+    imposes no bracket-depth limit and hands back an arbitrarily deep tree.
+    Unwinding it with recursion crashes; unwinding it in a loop does not.
+    """
+    source = "import subprocess\na = subprocess.run" + "[0]" * 2000 + "\na()"
+
+    assert unpinned_lines(source) == [], "a bare call with no keywords decodes nothing"

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -40,9 +40,13 @@ single pass, and why a ``partial`` that selects text mode counts even with no
 capture keyword beside it.
 
 What this cannot see, stated plainly: a subprocess reference that crosses a
-module boundary, one stored in a container or an attribute, and one produced
-by a call this module does not model. The scan is a ratchet against the shapes
-people actually write, not a proof.
+module boundary, one stored in an attribute, and one produced by a call this
+module does not model. The scan is a ratchet against the shapes people
+actually write, not a proof.
+
+Where it deliberately says too much rather than too little, see
+``test_detector_over_approximates_deliberately``. Every rule here is tuned to
+fail towards a redundant keyword, never towards a missed decode.
 """
 
 from __future__ import annotations
@@ -69,6 +73,11 @@ _OS_POPEN = "os.popen"
 # scan can name. Because it may be getoutput, which decodes with no flag to
 # read, invoking one counts as decoding text whatever keywords are present.
 _DYNAMIC = "subprocess.<dynamic>"
+
+# Marks a name that reaches functools.partial. Held in the same map as the
+# subprocess names for want of a second one to thread, and filtered out of
+# every path that answers "is this a subprocess entry point".
+_PARTIAL = "functools.partial"
 
 # Entry points that hand back str no matter what keywords a call passes.
 _DECODES_UNCONDITIONALLY = _ALWAYS_TEXT_ATTRS | frozenset({_DYNAMIC})
@@ -105,6 +114,18 @@ def _call_label(call: ast.Call) -> str:
     return func.id if isinstance(func, ast.Name) else ""
 
 
+def _is_partial(label: str, functions: dict[str, str]) -> bool:
+    """Report whether *label* names functools.partial under any spelling.
+
+    The bare name is accepted on sight rather than anchored to a functools
+    import, because ``partial`` from any library applies arguments the same
+    way, and anchoring would drop every re-export. An aliased import needs the
+    name map, since ``from functools import partial as p`` leaves no ``partial``
+    anywhere at the call site.
+    """
+    return label == "partial" or functions.get(label) == _PARTIAL
+
+
 def _resolve_indirect(
     call: ast.Call, modules: set[str], functions: dict[str, str]
 ) -> str | None:
@@ -115,7 +136,7 @@ def _resolve_indirect(
     disguise: the name is right there in the source.
     """
     label = _call_label(call)
-    if label == "partial" and call.args:
+    if _is_partial(label, functions) and call.args:
         return _resolve_callable(call.args[0], modules, functions)
     if label == "getattr" and len(call.args) >= 2:
         owner, attr = call.args[0], call.args[1]
@@ -158,7 +179,8 @@ def _resolve_callable(
 ) -> str | None:
     """Return the subprocess entry point *node* evaluates to, or ``None``."""
     if isinstance(node, ast.Name):
-        return functions.get(node.id)
+        resolved = functions.get(node.id)
+        return None if resolved == _PARTIAL else resolved
     if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
         owner, attr = node.value.id, node.attr
         if owner in modules and attr in _SUBPROCESS_ATTRS:
@@ -225,6 +247,10 @@ def _subprocess_names(tree: ast.Module) -> tuple[set[str], dict[str, str]]:
             for alias in node.names:
                 if alias.name in _SUBPROCESS_ATTRS:
                     functions[alias.asname or alias.name] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module == "functools":
+            for alias in node.names:
+                if alias.name == "partial":
+                    functions[alias.asname or alias.name] = _PARTIAL
 
     # Assignments resolve against names discovered so far, so a chain needs
     # more than one sweep: ``ast.walk`` is breadth first, so ``b = a`` at the
@@ -265,7 +291,7 @@ def _target(call: ast.Call, modules: set[str], functions: dict[str, str]) -> str
     return fallback
 
 
-def _captures_text(call: ast.Call) -> bool:
+def _captures_text(call: ast.Call, functions: dict[str, str]) -> bool:
     """Report whether *call* may decode captured output into ``str``.
 
     Deliberately conservative. Anything other than a literal ``False`` counts,
@@ -288,7 +314,7 @@ def _captures_text(call: ast.Call) -> bool:
         legacy is None or _is_literal_false(legacy)
     ):
         return False
-    if _call_label(call) == "partial":
+    if _is_partial(_call_label(call), functions):
         # A partial can select text mode here and be handed capture_output at
         # the eventual call site, which this scan has no way to reach.
         return True
@@ -327,7 +353,7 @@ def unpinned_lines(source: str) -> list[int]:
             # move is to not use it.
             offenders.append(node.lineno)
             continue
-        if target not in _DECODES_UNCONDITIONALLY and not _captures_text(node):
+        if target not in _DECODES_UNCONDITIONALLY and not _captures_text(node, functions):
             continue
         if not _pins_utf8(node):
             offenders.append(node.lineno)
@@ -434,6 +460,22 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
         (
             'import json\n_loads = json.loads\n_loads("{}")',
             "binding an unrelated callable is ordinary Python",
+        ),
+        (
+            'from functools import partial as p\n'
+            'x = p(open, "f")\nx()',
+            "a partial over an unrelated callable is not a subprocess call",
+        ),
+        (
+            'from functools import partial as p\n'
+            'q = p\nq(open, "f")()',
+            "the alias itself is functools.partial, not a subprocess entry point",
+        ),
+        (
+            'from functools import partial as p\n'
+            'def fetch(cmd, text=False):\n    return cmd\n'
+            'go = p(fetch, text=True)\ngo(["x"])',
+            "a partial over a local function that takes text is not subprocess",
         ),
         (
             'import shutil\n_run = shutil.run\n'
@@ -634,8 +676,55 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             'R[1]("ls")',
             "a mixed container may yield the member that decodes regardless",
         ),
+        (
+            'import subprocess\nfrom functools import partial as p\n'
+            'f = p(subprocess.run, text=True)\nf(["x"], capture_output=True)',
+            "an aliased partial import is not spelled partial at the call",
+        ),
     ],
 )
 def test_detector_closes_the_evasions(source: str, why: str) -> None:
     """Holes found by adversarial review. Each one decodes under the locale codec."""
     assert unpinned_lines(source) != [], f"missed {why}"
+
+
+@pytest.mark.parametrize(
+    ("source", "why"),
+    [
+        (
+            'import subprocess, sys\n'
+            'subprocess.run(["x"], stdout=sys.stdout, text=True)',
+            "a redirect that is not a pipe leaves the parent nothing to decode",
+        ),
+        (
+            'import subprocess\na = subprocess.run\n'
+            'a = lambda *args, **kwargs: None\n'
+            'a(["x"], capture_output=True, text=True)',
+            "the later binding wins at runtime, but not in a flow-blind scan",
+        ),
+        (
+            'import subprocess\nkwargs = {}\n'
+            'subprocess.run(["x"], **kwargs)',
+            "an empty splat carries no text keyword and returns bytes",
+        ),
+    ],
+)
+def test_detector_over_approximates_deliberately(source: str, why: str) -> None:
+    """Known false positives, kept on purpose and recorded here as decisions.
+
+    Each costs a redundant ``encoding="utf-8"`` on a call that decodes nothing.
+    Each precise alternative costs a missed decode, which is the failure this
+    file exists to prevent:
+
+    Reading the redirect would mean resolving the keyword's value, and an alias
+    or a computed mode defeats that, so ``stdout=PIPE`` would slip through.
+    Letting the last binding win would mean ordering the bindings, which
+    ``ast.walk`` does not give, so a rebinding nested in a branch would decide
+    the answer for code that never runs it. Reading an absent keyword inside a
+    splat as proof of bytes mode is the exact hole an adversarial review walked
+    through.
+
+    No file in this repository trips any of these, which is what makes the
+    trade cheap: the repo-wide scan above is green.
+    """
+    assert unpinned_lines(source) != [], f"expected over-approximation: {why}"

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -66,8 +66,12 @@ _SUBPROCESS_ATTRS = _CAPTURING_ATTRS | _ALWAYS_TEXT_ATTRS
 _PINNED_CODEC = "utf-8"
 _OS_POPEN = "os.popen"
 # Stands for a subprocess entry point selected at runtime, which no static
-# scan can name. Treated as a real target so the codec check still runs.
+# scan can name. Because it may be getoutput, which decodes with no flag to
+# read, invoking one counts as decoding text whatever keywords are present.
 _DYNAMIC = "subprocess.<dynamic>"
+
+# Entry points that hand back str no matter what keywords a call passes.
+_DECODES_UNCONDITIONALLY = _ALWAYS_TEXT_ATTRS | frozenset({_DYNAMIC})
 
 
 def _keyword(call: ast.Call, name: str) -> ast.expr | None:
@@ -210,7 +214,13 @@ def _target(call: ast.Call, modules: set[str], functions: dict[str, str]) -> str
     # ``functools.partial(subprocess.run, text=True)`` decides the codec where
     # the partial is built, not where the result is finally called, so the
     # partial itself has to be treated as the subprocess call.
-    return _resolve_indirect(call, modules, functions)
+    fallback = _resolve_indirect(call, modules, functions)
+    if fallback == _DYNAMIC:
+        # A bare ``getattr(subprocess, name)`` only fetches. It decodes
+        # nothing until something calls the result, and that call is the node
+        # this scan flags instead.
+        return None
+    return fallback
 
 
 def _captures_text(call: ast.Call) -> bool:
@@ -275,7 +285,7 @@ def unpinned_lines(source: str) -> list[int]:
             # move is to not use it.
             offenders.append(node.lineno)
             continue
-        if target not in _ALWAYS_TEXT_ATTRS and not _captures_text(node):
+        if target not in _DECODES_UNCONDITIONALLY and not _captures_text(node):
             continue
         if not _pins_utf8(node):
             offenders.append(node.lineno)
@@ -398,6 +408,10 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'import subprocess\nname = "run"\n'
             'getattr(subprocess, name)(["x"], capture_output=True, encoding="utf-8")',
             "a dynamic lookup that still pins the codec decodes correctly",
+        ),
+        (
+            'import subprocess\nname = "run"\nf = getattr(subprocess, name)',
+            "fetching an attribute decodes nothing until something calls it",
         ),
     ],
 )
@@ -532,6 +546,16 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             'import subprocess\nname = "run"\n'
             'getattr(subprocess, name)(["x"], capture_output=True, text=True)',
             "a computed attribute name still reaches a subprocess entry point",
+        ),
+        (
+            'import subprocess\nname = "getoutput"\n'
+            'getattr(subprocess, name)("ls")',
+            "a computed name can land on getoutput, which decodes with no flag",
+        ),
+        (
+            'import subprocess\nname = "getoutput"\n'
+            'f = getattr(subprocess, name)\nf("ls")',
+            "binding a computed lookup defers the decode, it does not avoid it",
         ),
         (
             'import subprocess\nif True:\n    a = subprocess.run\n'

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -19,12 +19,30 @@ the default is ``strict``, which fails loudly, and a lenient handler would
 reintroduce the silent corruption this guard exists to prevent.
 
 The checks below are deliberately conservative, because a guard meant to hold
-forever is worth more than any single call site it protects. An adversarial
-review found five ways to write a genuinely locale-decoding call that an
-earlier, looser version waved through: ``encoding=None``, an aliased or
-directly imported ``run``, a non-literal ``text`` or ``capture_output`` flag,
-``getoutput`` and its siblings, and ``utf-8-sig``. Each has a case in
-``test_detector_closes_the_evasions``.
+forever is worth more than any single call site it protects. Four rounds of
+adversarial review found genuinely locale-decoding calls that earlier, looser
+versions waved through. Each one has a case in
+``test_detector_closes_the_evasions``:
+
+* ``encoding=None``, and ``utf-8-sig``, which strips a BOM and so is not the
+  pinned codec.
+* An aliased or directly imported ``run``.
+* A non-literal ``text`` or ``capture_output`` flag, such as ``text=1``.
+* ``getoutput`` and ``getstatusoutput``, which always decode and take no flag.
+* A ``**kwargs`` splat, which can carry ``text=True`` with no literal keyword
+  left in the source to read.
+* Any binding that reaches an entry point without an import: ``_run =
+  subprocess.run``, a chain of those, an annotated assignment, a binding made
+  inside a function body, ``functools.partial``, and ``getattr``.
+
+The last group is why name resolution runs to a fixed point rather than in a
+single pass, and why a ``partial`` that selects text mode counts even with no
+capture keyword beside it.
+
+What this cannot see, stated plainly: a subprocess reference that crosses a
+module boundary, one stored in a container or an attribute, and one produced
+by a call this module does not model. The scan is a ratchet against the shapes
+people actually write, not a proof.
 """
 
 from __future__ import annotations
@@ -46,6 +64,10 @@ _ALWAYS_TEXT_ATTRS = frozenset({"getoutput", "getstatusoutput"})
 _SUBPROCESS_ATTRS = _CAPTURING_ATTRS | _ALWAYS_TEXT_ATTRS
 
 _PINNED_CODEC = "utf-8"
+_OS_POPEN = "os.popen"
+# Stands for a subprocess entry point selected at runtime, which no static
+# scan can name. Treated as a real target so the codec check still runs.
+_DYNAMIC = "subprocess.<dynamic>"
 
 
 def _keyword(call: ast.Call, name: str) -> ast.expr | None:
@@ -56,17 +78,95 @@ def _keyword(call: ast.Call, name: str) -> ast.expr | None:
     return None
 
 
+def _has_splat(call: ast.Call) -> bool:
+    """Report whether *call* forwards ``**kwargs``.
+
+    Live, and load bearing. This helper was dead once, and the reason it was
+    dead was a hole in :func:`_captures_text`, not an excess of caution. See
+    the splat cases in ``test_detector_closes_the_evasions``.
+    """
+    return any(keyword.arg is None for keyword in call.keywords)
+
+
 def _is_literal_false(node: ast.expr | None) -> bool:
     """Report whether *node* is the literal ``False``."""
     return isinstance(node, ast.Constant) and node.value is False
 
 
+def _call_label(call: ast.Call) -> str:
+    """Return the bare name being called, dropping any dotted owner."""
+    func = call.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return func.id if isinstance(func, ast.Name) else ""
+
+
+def _resolve_indirect(
+    call: ast.Call, modules: set[str], functions: dict[str, str]
+) -> str | None:
+    """Resolve a wrapper call that yields a subprocess entry point.
+
+    Covers ``functools.partial(subprocess.run, ...)`` and
+    ``getattr(subprocess, "run")``. Both are static references wearing a
+    disguise: the name is right there in the source.
+    """
+    label = _call_label(call)
+    if label == "partial" and call.args:
+        return _resolve_callable(call.args[0], modules, functions)
+    if label == "getattr" and len(call.args) >= 2:
+        owner, attr = call.args[0], call.args[1]
+        if not (isinstance(owner, ast.Name) and owner.id in modules):
+            return None
+        if not isinstance(attr, ast.Constant):
+            # ``getattr(subprocess, name)`` hides which entry point it reaches.
+            # Nothing in this repository needs that, so the safe reading is
+            # that it reaches one of them.
+            return _DYNAMIC
+        if attr.value in _SUBPROCESS_ATTRS:
+            return str(attr.value)
+    return None
+
+
+def _resolve_callable(
+    node: ast.expr, modules: set[str], functions: dict[str, str]
+) -> str | None:
+    """Return the subprocess entry point *node* evaluates to, or ``None``."""
+    if isinstance(node, ast.Name):
+        return functions.get(node.id)
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+        owner, attr = node.value.id, node.attr
+        if owner in modules and attr in _SUBPROCESS_ATTRS:
+            return attr
+        if owner == "os" and attr == "popen":
+            return _OS_POPEN
+    if isinstance(node, ast.Call):
+        return _resolve_indirect(node, modules, functions)
+    return None
+
+
+def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
+    """Collect every ``name = value`` binding, annotated or not, at any depth."""
+    found: list[tuple[str, ast.expr]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            found.extend(
+                (target.id, node.value)
+                for target in node.targets
+                if isinstance(target, ast.Name)
+            )
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name) and node.value is not None:
+                found.append((node.target.id, node.value))
+    return found
+
+
 def _subprocess_names(tree: ast.Module) -> tuple[set[str], dict[str, str]]:
-    """Collect the module aliases and directly imported names for subprocess.
+    """Collect every name in *tree* that reaches a subprocess entry point.
 
     ``import subprocess as sp`` and ``from subprocess import run`` are both
     ordinary Python, and an owner-name check that only knows the literal word
-    ``subprocess`` misses each of them.
+    ``subprocess`` misses each of them. So is ``_run = subprocess.run``, which
+    needs no import statement at all.
     """
     modules = {"subprocess"}
     functions: dict[str, str] = {}
@@ -79,21 +179,38 @@ def _subprocess_names(tree: ast.Module) -> tuple[set[str], dict[str, str]]:
             for alias in node.names:
                 if alias.name in _SUBPROCESS_ATTRS:
                     functions[alias.asname or alias.name] = alias.name
+
+    # Assignments resolve against names discovered so far, so a chain needs
+    # more than one sweep: ``ast.walk`` is breadth first, so ``b = a`` at the
+    # top level is visited before an ``a = subprocess.run`` nested in an
+    # ``if`` body, even though the source reads the other way round. The
+    # first binding of a name wins, which keeps ``functions`` monotonically
+    # growing and therefore guarantees this loop terminates even when a name
+    # is rebound to a different entry point later in the file.
+    bindings = _bindings(tree)
+    for _ in range(len(bindings)):
+        grew = False
+        for name, value in bindings:
+            if name in functions:
+                continue
+            resolved = _resolve_callable(value, modules, functions)
+            if resolved is not None:
+                functions[name] = resolved
+                grew = True
+        if not grew:
+            break
     return modules, functions
 
 
 def _target(call: ast.Call, modules: set[str], functions: dict[str, str]) -> str | None:
     """Return the subprocess entry point *call* reaches, or ``None``."""
-    func = call.func
-    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
-        owner, attr = func.value.id, func.attr
-        if owner in modules and attr in _SUBPROCESS_ATTRS:
-            return attr
-        if owner == "os" and attr == "popen":
-            return "os.popen"
-    if isinstance(func, ast.Name) and func.id in functions:
-        return functions[func.id]
-    return None
+    direct = _resolve_callable(call.func, modules, functions)
+    if direct is not None:
+        return direct
+    # ``functools.partial(subprocess.run, text=True)`` decides the codec where
+    # the partial is built, not where the result is finally called, so the
+    # partial itself has to be treated as the subprocess call.
+    return _resolve_indirect(call, modules, functions)
 
 
 def _captures_text(call: ast.Call) -> bool:
@@ -102,13 +219,27 @@ def _captures_text(call: ast.Call) -> bool:
     Deliberately conservative. Anything other than a literal ``False`` counts,
     because ``text=1`` and ``capture_output=flag`` both decode at runtime while
     reading as compliant to a check that only recognises ``True``.
+
+    A ``functools.partial`` that selects text mode counts even with no capture
+    keyword, because the capture can be supplied where the partial is called.
+
+    A ``**kwargs`` splat is treated as text mode outright. The keywords it
+    carries are not visible here, so ``text`` may be among them, and reading
+    the absence of a literal keyword as proof of bytes mode is the hole an
+    adversarial review walked through.
     """
+    if _has_splat(call):
+        return True
     text = _keyword(call, "text")
     legacy = _keyword(call, "universal_newlines")
     if (text is None or _is_literal_false(text)) and (
         legacy is None or _is_literal_false(legacy)
     ):
         return False
+    if _call_label(call) == "partial":
+        # A partial can select text mode here and be handed capture_output at
+        # the eventual call site, which this scan has no way to reach.
+        return True
     capture = _keyword(call, "capture_output")
     if capture is not None and not _is_literal_false(capture):
         return True
@@ -229,6 +360,45 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'import shutil\nshutil.run(["x"], capture_output=True, text=True)',
             "a same-named method on another module is not ours",
         ),
+        (
+            'import subprocess\nsubprocess.run(["x"], encoding="utf-8", **kw)',
+            "a splat is harmless once the codec is pinned at the call site",
+        ),
+        (
+            'import subprocess\n_run = subprocess.run\n'
+            '_run(["x"], capture_output=True, text=True, encoding="utf-8")',
+            "an alias that pins the codec is exactly as safe as the original",
+        ),
+        (
+            'import functools, subprocess\n'
+            '_run = functools.partial(subprocess.run, text=True, encoding="utf-8")',
+            "a partial that pins the codec has nothing left to decide",
+        ),
+        (
+            'import functools, subprocess\n'
+            '_popen = functools.partial(subprocess.Popen, stdout=subprocess.PIPE)',
+            "a partial that never selects text mode returns bytes",
+        ),
+        (
+            'import json\n_loads = json.loads\n_loads("{}")',
+            "binding an unrelated callable is ordinary Python",
+        ),
+        (
+            'import shutil\n_run = shutil.run\n'
+            '_run(["x"], capture_output=True, text=True)',
+            "an alias of a same-named function on another module is not ours",
+        ),
+        (
+            'import subprocess\n'
+            'getattr(subprocess, "PIPE")\n'
+            'getattr(shutil, "run")(["x"], capture_output=True, text=True)',
+            "getattr only counts when it names our module and our function",
+        ),
+        (
+            'import subprocess\nname = "run"\n'
+            'getattr(subprocess, name)(["x"], capture_output=True, encoding="utf-8")',
+            "a dynamic lookup that still pins the codec decodes correctly",
+        ),
     ],
 )
 def test_detector_stays_quiet(source: str, why: str) -> None:
@@ -301,6 +471,72 @@ def test_detector_reports_every_offender_in_one_file() -> None:
         (
             'import subprocess\nsubprocess.run(["x"], capture_output=True, text=True, **kw)',
             "splatted keywords cannot prove the codec is pinned",
+        ),
+        (
+            'import subprocess\nkw = {"text": True}\n'
+            'subprocess.run(["x"], capture_output=True, **kw)',
+            "a splat can supply text= with no literal keyword to read",
+        ),
+        (
+            'import subprocess\nkw = {"text": True, "capture_output": True}\n'
+            'subprocess.run(["x"], **kw)',
+            "a splat can supply every decoding keyword at once",
+        ),
+        (
+            'import subprocess\nkw = {"text": True}\n'
+            'subprocess.check_output(["x"], **kw)',
+            "the splat hole is not specific to run",
+        ),
+        (
+            'import subprocess\n_run = subprocess.run\n'
+            '_run(["x"], capture_output=True, text=True)',
+            "a plain assignment rebinds run without any import to read",
+        ),
+        (
+            'import subprocess\na = subprocess.run\nb = a\n'
+            'b(["x"], capture_output=True, text=True)',
+            "an alias of an alias still reaches run",
+        ),
+        (
+            'from subprocess import run\n_r = run\n'
+            '_r(["x"], capture_output=True, text=True)',
+            "a directly imported name can be rebound too",
+        ),
+        (
+            'import subprocess\nfrom typing import Any\n'
+            '_run: Any = subprocess.run\n'
+            '_run(["x"], capture_output=True, text=True)',
+            "an annotated assignment binds exactly like a plain one",
+        ),
+        (
+            'import subprocess\ndef f():\n    r = subprocess.run\n'
+            '    return r(["x"], capture_output=True, text=True)',
+            "a binding inside a function body is just as reachable",
+        ),
+        (
+            'import functools, subprocess\n'
+            '_run = functools.partial(subprocess.run, text=True)\n'
+            '_run(["x"], capture_output=True)',
+            "partial pins text mode at the partial, not at the call",
+        ),
+        (
+            'import subprocess\n'
+            'getattr(subprocess, "run")(["x"], capture_output=True, text=True)',
+            "getattr with a literal name is still a static reference",
+        ),
+        (
+            'import os\np = os.popen\np("x").read()',
+            "os.popen can be rebound as readily as run",
+        ),
+        (
+            'import subprocess\nname = "run"\n'
+            'getattr(subprocess, name)(["x"], capture_output=True, text=True)',
+            "a computed attribute name still reaches a subprocess entry point",
+        ),
+        (
+            'import subprocess\nif True:\n    a = subprocess.run\n'
+            'b = a\nb(["x"], capture_output=True, text=True)',
+            "a nested binding is walked after the top-level one that uses it",
         ),
     ],
 )

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -131,6 +131,28 @@ def _resolve_indirect(
     return None
 
 
+def _resolve_elements(
+    values: list[ast.expr], modules: set[str], functions: dict[str, str]
+) -> str | None:
+    """Return the entry point a container of *values* yields when subscripted.
+
+    The index is deliberately not modelled, so any element reaching subprocess
+    taints the whole container. Elements that disagree collapse to the dynamic
+    sentinel, which is the conservative reading: the subscript may select the
+    one that decodes.
+    """
+    found = {
+        resolved
+        for resolved in (
+            _resolve_callable(value, modules, functions) for value in values
+        )
+        if resolved is not None
+    }
+    if not found:
+        return None
+    return found.pop() if len(found) == 1 else _DYNAMIC
+
+
 def _resolve_callable(
     node: ast.expr, modules: set[str], functions: dict[str, str]
 ) -> str | None:
@@ -145,11 +167,29 @@ def _resolve_callable(
             return _OS_POPEN
     if isinstance(node, ast.Call):
         return _resolve_indirect(node, modules, functions)
+    if isinstance(node, ast.NamedExpr):
+        # ``(r := subprocess.run)(...)`` binds and calls in one expression.
+        return _resolve_callable(node.value, modules, functions)
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return _resolve_elements(list(node.elts), modules, functions)
+    if isinstance(node, ast.Dict):
+        return _resolve_elements(
+            [value for value in node.values if value is not None], modules, functions
+        )
+    if isinstance(node, ast.Subscript):
+        # ``RUNNERS[0](...)`` reaches whatever the container holds. Resolving
+        # the base rather than the index means a computed index cannot slip a
+        # subprocess reference past this scan.
+        return _resolve_callable(node.value, modules, functions)
     return None
 
 
 def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
-    """Collect every ``name = value`` binding, annotated or not, at any depth."""
+    """Collect every ``name = value`` binding at any depth.
+
+    Covers plain assignment, annotated assignment, and the walrus, which binds
+    a name in the middle of an expression and needs no statement of its own.
+    """
     found: list[tuple[str, ast.expr]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign):
@@ -161,6 +201,8 @@ def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
         elif isinstance(node, ast.AnnAssign):
             if isinstance(node.target, ast.Name) and node.value is not None:
                 found.append((node.target.id, node.value))
+        elif isinstance(node, ast.NamedExpr):
+            found.append((node.target.id, node.value))
     return found
 
 
@@ -561,6 +603,36 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             'import subprocess\nif True:\n    a = subprocess.run\n'
             'b = a\nb(["x"], capture_output=True, text=True)',
             "a nested binding is walked after the top-level one that uses it",
+        ),
+        (
+            'import subprocess\n'
+            '(r := subprocess.run)(["x"], capture_output=True, text=True)',
+            "a walrus binds and calls in one expression",
+        ),
+        (
+            'import subprocess\nif (r := subprocess.run):\n    pass\n'
+            'r(["x"], capture_output=True, text=True)',
+            "a name bound by a walrus is still bound at the later call",
+        ),
+        (
+            'import subprocess\nRUNNERS = [subprocess.run]\n'
+            'RUNNERS[0](["x"], capture_output=True, text=True)',
+            "a list can hold the entry point as readily as a bare name",
+        ),
+        (
+            'import subprocess\nR = {"go": subprocess.run}\n'
+            'R["go"](["x"], capture_output=True, text=True)',
+            "a dict value is reached by subscript, not by attribute",
+        ),
+        (
+            'import subprocess\nR = (subprocess.getoutput,)\n'
+            'R[0]("ls")',
+            "a tuple element that always decodes needs no text keyword",
+        ),
+        (
+            'import subprocess\nR = [subprocess.run, subprocess.getoutput]\n'
+            'R[1]("ls")',
+            "a mixed container may yield the member that decodes regardless",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

The subprocess UTF-8 guard on `main` misses nine call shapes. Each one
genuinely decodes with the ambient locale codec, which is the failure the
guard exists to prevent, and each reports green today. This teaches name
resolution to follow bindings, not just imports, and closes all nine.

Fixes #3788

## Why this matters

The guard is the standing enforcement behind the encoding work merged in
#3776. A guard that can be walked around is worse than no guard, because it
converts "nobody checked" into "something checked and said it was fine."

Nothing under `scripts/` uses any of these shapes today, so this changes no
production behaviour. It changes what the guard will catch tomorrow.

## The evasions

Reproduce any of them by writing the snippet under `scripts/` and running the
repo-wide scan.

| shape | why it evaded |
| --- | --- |
| `kw = {"text": True}` then `run(..., **kw)` | no literal `text=` keyword left to read |
| `_run = subprocess.run` | name resolution read import statements only |
| `b = a` where `a = subprocess.run` | alias of an alias |
| `_r = run` after `from subprocess import run` | rebinding an imported name |
| `_run: Any = subprocess.run` | annotated assignment |
| `r = subprocess.run` inside a `def` | binding in a function body |
| `functools.partial(subprocess.run, text=True)` | text mode selected away from the call |
| `getattr(subprocess, "run")(...)` | literal dynamic lookup |
| `getattr(subprocess, name)(...)` | computed lookup |
| `p = os.popen` | same trick on a different entry point |
| `getattr(subprocess, name)("ls")` | may land on `getoutput`, which decodes with no keyword to read |
| `(r := subprocess.run)(...)` | the walrus binds mid-expression, with no assignment statement to find |
| `RUNNERS = [subprocess.run]` then `RUNNERS[0](...)` | a container subscript is neither a name nor an attribute |
| `R = {"go": subprocess.run}` then `R["go"](...)` | same, reached through a dict value |
| `from functools import partial as p` | no token spelled `partial` survives to the call site |
| `a, b = subprocess.run, None` | an unpacking target is not an `ast.Name`, so nothing was bound |
| `(a, (b, c)) = (None, (subprocess.run, None))` | same, one level deeper |
| `*runners, tail = subprocess.run, None` | a starred target collects the reference into a container |
| `a, b = runners` where `runners` holds one | the two sides do not line up, so no pairing was possible |

Before, against `main`:

```console
$ printf 'import subprocess\n_run = subprocess.run\n_run(["echo","hi"], capture_output=True, text=True)\n' > scripts/probe_x.py
$ uv run --frozen python -m pytest -q tests/test_subprocess_text_encoding.py -k pins_utf8
1 passed, 27 deselected
```

After, on this branch, the same probe:

```console
E   AssertionError: text-capturing subprocess calls must pass encoding="utf-8": scripts/probe_x.py:3
1 failed, 44 deselected
```

## What changed

Two gaps, one class underneath: indirection through a binding.

1. `_captures_text` returned early when `text=` and `universal_newlines=` were
   absent as literal keywords, so a `**kwargs` splat was never inspected. A
   splat now counts as text mode outright.
2. `_subprocess_names` built its table from `ast.Import` and `ast.ImportFrom`
   only. It now also follows assignments, annotated assignments, `partial`,
   and `getattr`.

Three judgement calls worth review:

- **A dependency queue, not a repeated sweep.** `ast.walk` is breadth first,
  so `b = a` at the top level is visited *before* an `a = subprocess.run`
  nested inside an `if` body. That is valid, runnable Python, so one pass is
  not enough. Sweeping every binding until nothing changes is quadratic: a
  reverse-ordered chain learns one name per pass. Each binding is now
  re-queued only when a name it reads becomes known, and the first binding of
  a name wins, so a name resolves at most once and the queue costs one push
  per binding plus one per dependency edge. On a 10000-link reverse chain that
  is 9.67 seconds down to 0.169.
- **Container disagreement resolves to the member hardest to make compliant,
  not to "decodes no matter what".** `os.popen` first, because it has no
  encoding parameter to pin, then anything that decodes with no keyword, and
  otherwise any member, because the rest all answer to the same keywords at
  the call site. Collapsing every disagreement to the unconditional sentinel
  flagged `[subprocess.run, subprocess.Popen][0](["echo", "hi"])`, which
  captures nothing and returns bytes.
- **Unpacking pairs by position when the shapes line up, and offers the whole
  right side to every name on the left when they do not.** Dropping the
  mismatched case would miss `a, b = runners`; pairing everything
  unconditionally turns an ordinary neighbour into a false positive.
- **A `partial` that selects text mode counts as capturing** even with no
  capture keyword beside it, because `capture_output` can arrive where the
  partial is called, which this scan cannot see.
- **`getattr(subprocess, name)` with a computed name resolves to an unnamed
  entry point** rather than to nothing. No call site in any tree needs that
  shape, so the safe reading is that it reaches one of them.

## On the deleted helper

A `_has_splat` helper for gap 1 existed and was never called, so
`_captures_text` never reached it. It read as dead code and was removed in
`29257c34d`, merged with #3776. It was dead *because of* the defect. This
restores it wired in, with a docstring recording why it looks unused.

## Testing

28 tests to 73. Nineteen new evasion cases, twelve new quiet cases, three
recorded over-approximations, and two cases that bound cost rather than
behaviour.

The quiet cases are the ones that bound the cost: an alias that pins the
codec, a partial that pins it, a partial that never selects text mode, an
alias of an unrelated callable, an alias of a same-named function on another
module, a splat that pins the codec at the call site, and a dynamic lookup
that pins it.

Seven mutants run against the new resolution logic, seven killed:

| mutant | tests killed |
| --- | --- |
| drop binding resolution | 6 |
| single sweep instead of fixed point | 1 |
| drop `partial` resolution | 1 |
| drop the `partial` capture rule | 1 |
| drop dynamic `getattr` | 1 |
| drop partial-as-call in `_target` | 1 |
| ignore annotated assignments | 1 |
| dynamic lookups not unconditional | 2 |
| bare `getattr` fetch not suppressed | 2 |
| drop the always-decodes set | 4 |
| no walrus in the resolver | 1 |
| no walrus in the binding scan | 1 |
| no subscript resolution | 3 |
| no list, tuple, or set literals | 2 |
| no dict literals | 1 |
| container disagreement yields nothing | 1 |
| ignore container elements entirely | 3 |
| alias lookup dropped from `partial` | 1 |
| functools imports not scanned | 1 |
| `partial` sentinel leaks as a target | 1 |
| ignore unpacking targets | 4 |
| drop the starred target | 1 |
| pair unpacking by whole value, not position | 1 |
| drop the shape-mismatch pairing | 1 |
| drop the `os.popen` precedence | 1 |
| drop the unconditional-member check | 1 |
| no subscript unwinding | 7 |
| unwind subscripts by recursion | 1 |
| sweep instead of the dependency queue | 1 |
| never re-queue a dependent binding | 2 |

Four mutants survived a first attempt: the single sweep, the container
disagreement branch, the `partial` sentinel filter, and positional pairing in
the unpacker. Each one stayed only
after a case was found that could kill its absence. The single sweep produced
the breadth-first regression case, because `ast.walk` visits a top-level
`b = a` before an `a = subprocess.run` nested in an `if` body. Positional
pairing needed a neighbour that is called with `capture_output=True,
text=True` and is not subprocess at all, which is the only shape where
mispairing turns into a false positive.

Two of the older cases were retargeted at members whose names sort earlier, so
that a mutant which drops the container precedence rule and returns an
arbitrary member can no longer pass on alphabetical luck.

## Cost

Zero false positives measured. A search of `scripts/`, `.claude/lib/`, and
`src/copilot-cli/lib/` found no `**kwargs` forwarding near subprocess and no
call site that binds a subprocess entry point to a name.

Three over-approximations are recorded as cases with their reasoning, so the
next reader sees decisions rather than oversights: a redirect that is not a
pipe, a name rebound to an unrelated callable, and an empty keyword splat.
Each costs a redundant `encoding="utf-8"` on a call that decodes nothing, and
each precise alternative costs a missed decode. No file in the repository
trips any of them.

The module docstring states plainly what the scan cannot see: a reference
crossing a module boundary, one stored on an attribute, and one produced by a
call the module does not model. It is a ratchet against the shapes people
write, not a proof.

## Provenance

Adversarial review, rounds 3 through 6, each with an executed surviving mutant
rather than speculation. Round 5 produced two: the walrus and the container.
Round 6 produced the unpacking mutant, a real false positive on a mixed
container, and a `RecursionError` from a 2000-link subscript chain, which is
left recursive and therefore capped by no parser limit. Round 6 also measured
the quadratic name resolution that round 5 had cleared as "milliseconds" on
the reasoning that AST depth bounds it; the pathological input is flat, so it
does not.
A review bot found the `getoutput` hole while flagging what looked like a
comment nit.

The reviews ran on a different model family from rounds 1 and 2 deliberately;
the earlier rounds declined to produce a mutant when asked for one.


