### PR TITLE
fix(scripts): drop PyYAML from the ADR status parser

### DIFF
--- a/scripts/sync_adr_protocol.py
+++ b/scripts/sync_adr_protocol.py
@@ -21,8 +21,6 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import yaml
-
 # Exit codes per ADR-035
 EXIT_SUCCESS = 0
 EXIT_GAPS_DETECTED = 1
@@ -37,6 +35,15 @@ RFC2119_PATTERN = re.compile(
 # ADR number extraction from filename
 ADR_NUMBER_PATTERN = re.compile(r"ADR-(\d+)")
 INLINE_STATUS_PATTERN = re.compile(r"^\*\*Status\*\*\s*:\s*(.+?)\s*$", re.MULTILINE)
+
+# Matches `_split_frontmatter` in
+# .claude/skills/adr-review/scripts/detect_adr_changes.py, which compares
+# `lines[0].strip()` against this same literal.
+FRONTMATTER_DELIM = "---"
+
+# A status ending on one of these is a wrapped line, not a finished value.
+# Used by the corpus regression test to detect truncation.
+DANGLING_WORDS = frozenset({"by", "and", "on", "the", "a", "to", "of", "in", "for", "with"})
 
 
 @dataclass
@@ -106,8 +113,17 @@ def parse_adr_title(content: str) -> str:
 def _status_from_heading(content: str) -> str | None:
     """Read the prose under a ``## Status`` section, joining wrapped lines.
 
-    ADR-004 wraps its status across two lines, so reading only the first
-    would report the truncated "Superseded by".
+    ADR-004 wraps its status as "Superseded by" / "[ADR-086](...) on
+    2026-07-20.", so reading one line reports the truncated "Superseded by".
+    The block ends at a blank line or the next heading.
+
+    Rejected alternative: join only while the text ends on a word from
+    :data:`DANGLING_WORDS`. That reads ADR-004 more precisely, but measured
+    against the corpus it truncated ADR-072 mid-sentence at "this" and left
+    ADR-039 unreadable, because ADR-039 opens with ``**PROVISIONAL**`` and a
+    bullet-style stop cannot tell bold emphasis from a list marker. Stopping
+    only at a heading loses nothing: no ADR's status block contains a
+    subheading, list, fence, quote, or table row.
     """
     in_status = False
     collected: list[str] = []
@@ -116,14 +132,15 @@ def _status_from_heading(content: str) -> str | None:
         if stripped == "## Status":
             in_status = True
             continue
-        if in_status:
-            if stripped.startswith("## "):
+        if not in_status:
+            continue
+        if not stripped:
+            if collected:
                 break
-            if not stripped:
-                if collected:
-                    break
-                continue
-            collected.append(stripped)
+            continue
+        if stripped.startswith("#"):
+            break
+        collected.append(stripped)
     return " ".join(collected) or None
 
 
@@ -141,24 +158,59 @@ def _status_from_inline(content: str) -> str | None:
 def _status_from_frontmatter(content: str) -> str | None:
     """Read ``status:`` from the YAML frontmatter block (ADR-073).
 
-    Parsed as YAML so quoting and comments resolve to the scalar value
-    rather than to raw text.
+    Delimiter handling matches the sibling ADR frontmatter reader,
+    ``.claude/skills/adr-review/scripts/detect_adr_changes.py``, whose
+    ``_split_frontmatter`` compares stripped lines:
+
+        lines = content.splitlines(keepends=True)
+        if not lines or lines[0].strip() != FRONTMATTER_DELIM:
+            return "", content
+
+    Comparing stripped lines tolerates CRLF and a trailing space on the
+    fence. A ``content.startswith("---\\n")`` test does not, and would drop
+    frontmatter this repo's other reader accepts.
+
+    Stricter than canonical: that reader hands the block to ``yaml`` and
+    needs every key. This one needs a single scalar, so it stays on the
+    standard library. ``CONTRIBUTING.md`` and ``.agents/SESSION-PROTOCOL.md``
+    both document invoking this script as bare ``python3``, which resolves
+    outside the project venv and has no PyYAML guarantee. A third-party
+    import here would turn a missing optional dependency into a tool that
+    never starts.
     """
-    if not content.startswith("---\n"):
+    block = _frontmatter_lines(content)
+    if block is None:
         return None
-    match = re.search(r"^---[ \t]*$", content[4:], re.MULTILINE)
-    if match is None:
-        return None
-    try:
-        data = yaml.safe_load(content[4 : 4 + match.start()])
-    except yaml.YAMLError:
-        return None
-    if not isinstance(data, dict):
-        return None
-    status = data.get("status")
-    if isinstance(status, str) and status.strip():
-        return status.strip()
+    for line in block:
+        if not line.startswith("status:"):
+            continue
+        return _scalar_value(line[len("status:") :])
     return None
+
+
+def _frontmatter_lines(content: str) -> list[str] | None:
+    """Return the lines inside a complete frontmatter block, else None."""
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != FRONTMATTER_DELIM:
+        return None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == FRONTMATTER_DELIM:
+            return lines[1:idx]
+    return None
+
+
+def _scalar_value(raw: str) -> str | None:
+    """Resolve a YAML scalar to its text, or None when it is not a scalar."""
+    value = raw.strip()
+    if not value:
+        return None
+    if value[0] in "\"'":
+        end = value.find(value[0], 1)
+        return value[1:end].strip() or None if end > 0 else None
+    if value[0] in "[{|>&*!":
+        return None
+    value = re.split(r"\s+#", value, maxsplit=1)[0].strip()
+    return value or None
 
 
 def parse_adr_status(content: str) -> str:

--- a/tests/test_sync_adr_protocol.py
+++ b/tests/test_sync_adr_protocol.py
@@ -5,9 +5,13 @@ Verifies ADR parsing, requirement counting, and protocol reference checking.
 
 from __future__ import annotations
 
+import ast
+import subprocess
+import sys
 from pathlib import Path
 
 from scripts.sync_adr_protocol import (
+    DANGLING_WORDS,
     AdrRequirements,
     SyncReport,
     check_protocol_reference,
@@ -80,6 +84,30 @@ class TestParseAdrStatus:
         content = '---\nstatus: "accepted"\n---\n\n# ADR-066\n'
         assert parse_adr_status(content) == "accepted"
 
+    def test_frontmatter_tolerates_crlf_and_a_trailing_space(self) -> None:
+        """The sibling reader compares stripped fence lines; so must this one."""
+        assert parse_adr_status("---\r\nstatus: accepted\r\n---\r\n\r\n# A\r\n") == "accepted"
+        assert parse_adr_status("---  \nstatus: accepted\n---\n\n# A\n") == "accepted"
+
+    def test_frontmatter_strips_an_inline_comment(self) -> None:
+        content = "---\nstatus: accepted  # backfilled 2026-07-20\n---\n\n# A\n"
+        assert parse_adr_status(content) == "accepted"
+
+    def test_non_scalar_frontmatter_status_falls_through(self) -> None:
+        """A list, a mapping, or an empty value is not a lifecycle state."""
+        for value in ("[a, b]", "{k: v}", "", "|", ">"):
+            content = f"---\nstatus: {value}\n---\n\n# A\n\n## Status\n\nProposed\n"
+            assert parse_adr_status(content) == "Proposed", value
+
+    def test_ignores_an_indented_status_key(self) -> None:
+        """Only a top-level frontmatter key is lifecycle state."""
+        content = "---\nmeta:\n  status: sneaky\n---\n\n# A\n\n## Status\n\nProposed\n"
+        assert parse_adr_status(content) == "Proposed"
+
+    def test_horizontal_rule_is_not_frontmatter(self) -> None:
+        content = "Some prose.\n\n---\n\nMore prose.\n"
+        assert parse_adr_status(content) == "Unknown"
+
     def test_frontmatter_without_closing_delimiter_is_ignored(self) -> None:
         content = "---\nstatus: accepted\n\n# ADR-001\n\n## Status\n\nProposed\n"
         assert parse_adr_status(content) == "Proposed"
@@ -97,9 +125,17 @@ class TestParseAdrStatus:
     def test_joins_a_status_wrapped_across_lines(self) -> None:
         """ADR-004 wraps its status; reading one line truncates it."""
         content = "# ADR-004\n\n## Status\n\nSuperseded by\n[ADR-086](ADR-086.md) on 2026-07-20.\n"
-        assert parse_adr_status(content) == (
-            "Superseded by [ADR-086](ADR-086.md) on 2026-07-20."
-        )
+        assert parse_adr_status(content) == "Superseded by [ADR-086](ADR-086.md) on 2026-07-20."
+
+    def test_join_stops_at_a_subheading(self) -> None:
+        """A '###' inside the section is structure, not status."""
+        content = "# A\n\n## Status\n\nAccepted\n### Sub-note\nNot the status\n"
+        assert parse_adr_status(content) == "Accepted"
+
+    def test_bold_emphasis_is_not_a_list_marker(self) -> None:
+        """ADR-039 opens its status with '**PROVISIONAL**'."""
+        content = "# A\n\n## Status\n\n**PROVISIONAL** (2026-01-03 to 2026-01-17)\n"
+        assert parse_adr_status(content) == "**PROVISIONAL** (2026-01-03 to 2026-01-17)"
 
     def test_empty_status_section_falls_through(self) -> None:
         """An empty '## Status' must not report the next heading as the status."""
@@ -135,7 +171,7 @@ class TestStatusParsingCoversTheRealCorpus:
     def test_no_status_is_truncated_mid_sentence(self) -> None:
         """ADR-004 wraps its status; a line-at-a-time read ends on 'Superseded by'."""
         adr_dir = Path(__file__).resolve().parents[1] / ".agents" / "architecture"
-        dangling = ("by", "and", "on", "the", "a", "to", "of", "in", "for", "with")
+        dangling = DANGLING_WORDS
         truncated = [
             f"{path.name}: {status}"
             for path in sorted(adr_dir.glob("ADR-*.md"))
@@ -335,3 +371,37 @@ class TestScanAdrs:
         (adr_dir / "ADR-099-secret.md").symlink_to(secret)
         results = scan_adrs(adr_dir)
         assert len(results) == 0
+
+
+class TestRunsOnAStdlibOnlyInterpreter:
+    """CONTRIBUTING.md and SESSION-PROTOCOL.md document invoking this script
+    as bare ``python3``, which resolves outside the project venv. A
+    third-party import would turn a missing optional dependency into a tool
+    that never starts."""
+
+    def test_imports_nothing_outside_the_standard_library(self) -> None:
+        script = Path(__file__).resolve().parents[1] / "scripts" / "sync_adr_protocol.py"
+        tree = ast.parse(script.read_text(encoding="utf-8"))
+        imported = {
+            (node.module or "").split(".")[0]
+            if isinstance(node, ast.ImportFrom)
+            else alias.name.split(".")[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import | ast.ImportFrom)
+            for alias in getattr(node, "names", [None]) or [None]
+        }
+        outside = sorted(imported - set(sys.stdlib_module_names) - {"", "__future__"})
+        assert not outside, f"third-party imports break the documented entrypoint: {outside}"
+
+    def test_runs_with_site_packages_disabled(self) -> None:
+        """python3 -S is the closest reproduction of an interpreter with no
+        PyYAML on sys.path."""
+        root = Path(__file__).resolve().parents[1]
+        result = subprocess.run(
+            [sys.executable, "-S", str(root / "scripts" / "sync_adr_protocol.py")],
+            capture_output=True,
+            text=True,
+            cwd=root,
+        )
+        assert "ModuleNotFoundError" not in result.stderr, result.stderr
+        assert "[Unknown]" not in result.stdout


### PR DESCRIPTION
## Summary

Fixes #3791.

PR #3785 (mine) added a PyYAML import to `scripts/sync_adr_protocol.py`, which
had been standard library only. A round-2 adversarial review on a different
model family flagged it. The review returned before that PR merged, but the
merge landed while the fixes were still being verified, so the correction ships
here.

The parser reads one scalar out of the frontmatter block. It never needed a YAML
document model. It now reads that block with the standard library.

## Scope, stated precisely

My first draft of this change overstated the problem, so here is the measured
version.

PyYAML is a declared project dependency, so every `uv run` invocation resolves
it and CI was never affected. On the machine where this was found, bare
`python3` also resolves yaml from a linuxbrew site-packages directory, so it
does not reproduce there either.

The reproducible failure is `python3 -S scripts/sync_adr_protocol.py`, which
raises `ModuleNotFoundError`. The `-S` flag disables site-packages and stands in
for any interpreter that lacks PyYAML. This is a portability regression on a
documented entrypoint, not an outage. It is worth fixing because removing one
import costs less than changing two documents, and because the resulting script
runs anywhere.

## Second finding, same function

The opening fence test was `content.startswith("---\n")`. That form drops CRLF
files and fences carrying trailing whitespace. It now matches the canonical
delimiter check used elsewhere in this repository, which compares the stripped
first line. The canonical source is cited and quoted in the docstring.

## The optional finding I implemented, measured, and rejected

The reviewer suggested structural stop characters when joining a status that
wraps across lines. I implemented it. It regressed two real ADRs.

ADR-039's status opens with bold `**PROVISIONAL**`, so the `*` stop read bold
emphasis as a bullet and the status became Unknown. ADR-072 carries a 430
character prose status that truncated mid sentence.

I then measured whether the guard protected anything. A scan of all 90 Status
sections found zero occurrences of `###`, a list dash, a list star, a code
fence, a block quote, or a pipe anywhere in a joined block. The guard defended
against shapes that do not exist in the corpus while breaking two that do. Only
the heading stop survives, because a leading hash cannot collide with emphasis.
The rejected alternative is documented in the parser docstring so it is not
reintroduced.

## Verification

- 50 tests pass. Ruff check and mypy are clean.
- `python3 -S scripts/sync_adr_protocol.py` reports 0 Unknown across all 90 ADRs.
- Corpus output is byte identical to the previously measured good run, so this
  change is behavior preserving on real inputs while removing the dependency.
- Negative control: reverting the parser to the pre-#3785 heading only
  implementation fails 12 of the 50 tests, and restoring is byte identical.
- Restoring `import yaml` fails both new guards.

## New guards

An AST check asserts the module imports nothing outside
`sys.stdlib_module_names`. A subprocess test runs the script under `python3 -S`.
Together they pin the entrypoint contract so a future third party import cannot
land silently.

The corpus truncation test now imports the dangling word list from the module
instead of re-declaring it, so the parser and its test cannot drift apart.

## Evidence

Paths consulted while verifying the above, none of them modified by this change:

- `CONTRIBUTING.md` line 829 invokes the script as bare `python3`.
- `.agents/SESSION-PROTOCOL.md` line 1163 does the same.
- `.github/copilot-instructions.md` names yaml as the example module that fails
  under bare `python3` and says to prefer `uv run python`.
- `pyproject.toml` line 14 declares `PyYAML==6.0.3`.
- `.claude/skills/adr-review/scripts/detect_adr_changes.py` line 182 holds the
  canonical frontmatter delimiter check.
- `.claude/rules/canonical-source-mirror.md` requires citing and quoting a
  canonical source when claiming to match it.
