### PR TITLE
docs(rules): bind claims about what other code does to its source

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.234",
+  "version": "0.6.235",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/rules/canonical-source-mirror.md
+++ b/.claude/rules/canonical-source-mirror.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - ".claude/hooks/**"
+  - ".claude/rules/**"
   - "scripts/validation/**"
   - "build/scripts/**"
   - ".claude/skills/**"
@@ -16,7 +17,7 @@ This rule binds those claims to evidence. It exists because PR #1887 (the M4 evi
 
 ## What this rule binds
 
-This rule binds any new component under `.claude/hooks/`, `scripts/validation/`, `build/scripts/`, `.claude/skills/`, or `.github/prompts/` whose contract is derived from another source in the repository. The two Copilot-side mirrors scope differently by consumer. `.github/instructions/canonical-source-mirror.instructions.md`, read by Copilot in full-repo context, keeps the full path set (`.claude/hooks/**`, `scripts/validation/**`, `build/scripts/**`, `.claude/skills/**`, `.github/prompts/**`). Its `src/copilot-cli/` twin ships inside the plugin, so it narrows to the paths that travel with the plugin (`scripts/validation/**`, `build/scripts/**`, `.github/prompts/**`). The rule still binds the `.claude/` paths on the Claude side. Examples:
+This rule binds any new component under `.claude/hooks/`, `.claude/rules/`, `scripts/validation/`, `build/scripts/`, `.claude/skills/`, or `.github/prompts/` whose contract is derived from another source in the repository. The two Copilot-side mirrors scope differently by consumer. `.github/instructions/canonical-source-mirror.instructions.md`, read by Copilot in full-repo context, keeps the full path set (`.claude/hooks/**`, `.claude/rules/**`, `scripts/validation/**`, `build/scripts/**`, `.claude/skills/**`, `.github/prompts/**`). Its `src/copilot-cli/` twin ships inside the plugin, so it narrows to the paths that travel with the plugin (`scripts/validation/**`, `build/scripts/**`, `.github/prompts/**`). The rule still binds the `.claude/` paths on the Claude side. Examples:
 
 - A pre-push hook that "mirrors" a CI validator's regex.
 - A skill helper that "matches" the exit codes of a validator script.
@@ -58,6 +59,24 @@ A guard that is silently stricter than canonical is a bug in waiting. A guard th
 - **"Aligned with X" with no divergence section, when the implementation diverges.** The reader assumes parity; the code does not deliver parity; the bug compounds with the false claim. Reject.
 - **First-commit citation deferred to "I will add it later".** The cost of citing the canonical source is roughly zero at write time and roughly one round of review later. Pay the zero. Reject.
 - **Self-referential test that mirrors the producer's own output.** A test that asserts a generator emits a specific string, then checks the generator emitted that string, pins the output to itself. It proves the producer is internally consistent; it proves nothing about the canonical contract the output is supposed to honor, and it cannot catch a wrong variable, a wrong path, or a wrong exit code. This is this rule applied at the test layer. The test that satisfies the rule exercises the contract INDEPENDENTLY: it runs the artifact under the real runtime conditions (the cwd and environment the host sets) and asserts the intended effect, with a negative control proving the test fails when the artifact is wrong. PR #2205 shipped a string-match test of this shape against `generate_hooks._build_copilot_entry`; it passed while the generated hooks wedged customer environments. See `.claude/rules/generated-artifacts.md` and `.agents/retrospective/2026-06-02-pr-2205-customer-wedge-incident.md`.
+
+## Behavioral claims: read the body, not the name
+
+A claim about what another component **does** is load-bearing in the same way a "mirrors" claim is. "Validator X skips directory Y." "Hook Z runs on push." "Helper W returns None on failure." The reader acts on these without re-deriving them, and a rule file that carries one is read by every agent on every session it applies to.
+
+A function's name is not evidence of its behavior. Neither is its call site, a prior PR description, or your memory of it. Open the file and read the body. Then quote the line you are relying on, with its path and line number:
+
+```python
+# build/scripts/validate_plugin_manifests.py:318-327 prunes it by name:
+#     excluded_dirs = {".agent-tmp", ".worktrees", "worktrees", "node_modules",
+#                      ".git", "cache", ".pytest_cache", ".pytest_tmp"}
+```
+
+PR #3775 shipped rule text in `.claude/rules/testing.md` claiming `.pytest_tmp` was "the only name both `validate_plugin_manifests.py` and `check_placeholder_identity.py` skip". The second half was false. `scripts/validation/check_placeholder_identity.py:36 _is_pytest_tmp` never inspects a directory of that name. It returns true only when the whole repository root sits under `tempfile.gettempdir()` and its resolved path contains `pytest-of-`, which is a different question entirely. The author reasoned from the function's name and never opened the file. The false claim reached always-on instruction text and survived two review rounds before a third-model review caught it.
+
+The function's own docstring stated the real behavior accurately. Reading it would have cost seconds. That is the asymmetry this section exists for: verification is cheap at write time, and a false behavioral claim in a rule file is expensive for as long as it stands, because every reader who trusts it inherits the error and some of them build on it.
+
+This section binds any assertion about another component's behavior, whatever words carry it. The trigger is not a phrase like "mirrors"; the trigger is that you told the reader what some other code does.
 
 ## Reference: the M4 episode
 

--- a/.github/instructions/canonical-source-mirror.instructions.md
+++ b/.github/instructions/canonical-source-mirror.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: .claude/hooks/**,scripts/validation/**,build/scripts/**,.claude/skills/**,.github/prompts/**
+applyTo: .claude/hooks/**,.claude/rules/**,scripts/validation/**,build/scripts/**,.claude/skills/**,.github/prompts/**
 ---
 
 # Canonical Source Mirror Rule
@@ -10,7 +10,7 @@ This rule binds those claims to evidence. It exists because PR #1887 (the M4 evi
 
 ## What this rule binds
 
-This rule binds any new component under `.claude/hooks/`, `scripts/validation/`, `build/scripts/`, `.claude/skills/`, or `.github/prompts/` whose contract is derived from another source in the repository. The two Copilot-side mirrors scope differently by consumer. `.github/instructions/canonical-source-mirror.instructions.md`, read by Copilot in full-repo context, keeps the full path set (`.claude/hooks/**`, `scripts/validation/**`, `build/scripts/**`, `.claude/skills/**`, `.github/prompts/**`). Its `src/copilot-cli/` twin ships inside the plugin, so it narrows to the paths that travel with the plugin (`scripts/validation/**`, `build/scripts/**`, `.github/prompts/**`). The rule still binds the `.claude/` paths on the Claude side. Examples:
+This rule binds any new component under `.claude/hooks/`, `.claude/rules/`, `scripts/validation/`, `build/scripts/`, `.claude/skills/`, or `.github/prompts/` whose contract is derived from another source in the repository. The two Copilot-side mirrors scope differently by consumer. `.github/instructions/canonical-source-mirror.instructions.md`, read by Copilot in full-repo context, keeps the full path set (`.claude/hooks/**`, `.claude/rules/**`, `scripts/validation/**`, `build/scripts/**`, `.claude/skills/**`, `.github/prompts/**`). Its `src/copilot-cli/` twin ships inside the plugin, so it narrows to the paths that travel with the plugin (`scripts/validation/**`, `build/scripts/**`, `.github/prompts/**`). The rule still binds the `.claude/` paths on the Claude side. Examples:
 
 - A pre-push hook that "mirrors" a CI validator's regex.
 - A skill helper that "matches" the exit codes of a validator script.
@@ -52,6 +52,24 @@ A guard that is silently stricter than canonical is a bug in waiting. A guard th
 - **"Aligned with X" with no divergence section, when the implementation diverges.** The reader assumes parity; the code does not deliver parity; the bug compounds with the false claim. Reject.
 - **First-commit citation deferred to "I will add it later".** The cost of citing the canonical source is roughly zero at write time and roughly one round of review later. Pay the zero. Reject.
 - **Self-referential test that mirrors the producer's own output.** A test that asserts a generator emits a specific string, then checks the generator emitted that string, pins the output to itself. It proves the producer is internally consistent; it proves nothing about the canonical contract the output is supposed to honor, and it cannot catch a wrong variable, a wrong path, or a wrong exit code. This is this rule applied at the test layer. The test that satisfies the rule exercises the contract INDEPENDENTLY: it runs the artifact under the real runtime conditions (the cwd and environment the host sets) and asserts the intended effect, with a negative control proving the test fails when the artifact is wrong. PR #2205 shipped a string-match test of this shape against `generate_hooks._build_copilot_entry`; it passed while the generated hooks wedged customer environments. See `.claude/rules/generated-artifacts.md` and `.agents/retrospective/2026-06-02-pr-2205-customer-wedge-incident.md`.
+
+## Behavioral claims: read the body, not the name
+
+A claim about what another component **does** is load-bearing in the same way a "mirrors" claim is. "Validator X skips directory Y." "Hook Z runs on push." "Helper W returns None on failure." The reader acts on these without re-deriving them, and a rule file that carries one is read by every agent on every session it applies to.
+
+A function's name is not evidence of its behavior. Neither is its call site, a prior PR description, or your memory of it. Open the file and read the body. Then quote the line you are relying on, with its path and line number:
+
+```python
+# build/scripts/validate_plugin_manifests.py:318-327 prunes it by name:
+#     excluded_dirs = {".agent-tmp", ".worktrees", "worktrees", "node_modules",
+#                      ".git", "cache", ".pytest_cache", ".pytest_tmp"}
+```
+
+PR #3775 shipped rule text in `.claude/rules/testing.md` claiming `.pytest_tmp` was "the only name both `validate_plugin_manifests.py` and `check_placeholder_identity.py` skip". The second half was false. `scripts/validation/check_placeholder_identity.py:36 _is_pytest_tmp` never inspects a directory of that name. It returns true only when the whole repository root sits under `tempfile.gettempdir()` and its resolved path contains `pytest-of-`, which is a different question entirely. The author reasoned from the function's name and never opened the file. The false claim reached always-on instruction text and survived two review rounds before a third-model review caught it.
+
+The function's own docstring stated the real behavior accurately. Reading it would have cost seconds. That is the asymmetry this section exists for: verification is cheap at write time, and a false behavioral claim in a rule file is expensive for as long as it stands, because every reader who trusts it inherits the error and some of them build on it.
+
+This section binds any assertion about another component's behavior, whatever words carry it. The trigger is not a phrase like "mirrors"; the trigger is that you told the reader what some other code does.
 
 ## Reference: the M4 episode
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.234",
+  "version": "0.6.235",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
+++ b/src/copilot-cli/instructions/canonical-source-mirror.instructions.md
@@ -10,7 +10,7 @@ This rule binds those claims to evidence. It exists because PR #1887 (the M4 evi
 
 ## What this rule binds
 
-This rule binds any new component under `.claude/hooks/`, `scripts/validation/`, `build/scripts/`, `.claude/skills/`, or `.github/prompts/` whose contract is derived from another source in the repository. The two Copilot-side mirrors scope differently by consumer. `.github/instructions/canonical-source-mirror.instructions.md`, read by Copilot in full-repo context, keeps the full path set (`.claude/hooks/**`, `scripts/validation/**`, `build/scripts/**`, `.claude/skills/**`, `.github/prompts/**`). Its `src/copilot-cli/` twin ships inside the plugin, so it narrows to the paths that travel with the plugin (`scripts/validation/**`, `build/scripts/**`, `.github/prompts/**`). The rule still binds the `.claude/` paths on the Claude side. Examples:
+This rule binds any new component under `.claude/hooks/`, `.claude/rules/`, `scripts/validation/`, `build/scripts/`, `.claude/skills/`, or `.github/prompts/` whose contract is derived from another source in the repository. The two Copilot-side mirrors scope differently by consumer. `.github/instructions/canonical-source-mirror.instructions.md`, read by Copilot in full-repo context, keeps the full path set (`.claude/hooks/**`, `.claude/rules/**`, `scripts/validation/**`, `build/scripts/**`, `.claude/skills/**`, `.github/prompts/**`). Its `src/copilot-cli/` twin ships inside the plugin, so it narrows to the paths that travel with the plugin (`scripts/validation/**`, `build/scripts/**`, `.github/prompts/**`). The rule still binds the `.claude/` paths on the Claude side. Examples:
 
 - A pre-push hook that "mirrors" a CI validator's regex.
 - A skill helper that "matches" the exit codes of a validator script.
@@ -52,6 +52,24 @@ A guard that is silently stricter than canonical is a bug in waiting. A guard th
 - **"Aligned with X" with no divergence section, when the implementation diverges.** The reader assumes parity; the code does not deliver parity; the bug compounds with the false claim. Reject.
 - **First-commit citation deferred to "I will add it later".** The cost of citing the canonical source is roughly zero at write time and roughly one round of review later. Pay the zero. Reject.
 - **Self-referential test that mirrors the producer's own output.** A test that asserts a generator emits a specific string, then checks the generator emitted that string, pins the output to itself. It proves the producer is internally consistent; it proves nothing about the canonical contract the output is supposed to honor, and it cannot catch a wrong variable, a wrong path, or a wrong exit code. This is this rule applied at the test layer. The test that satisfies the rule exercises the contract INDEPENDENTLY: it runs the artifact under the real runtime conditions (the cwd and environment the host sets) and asserts the intended effect, with a negative control proving the test fails when the artifact is wrong. PR #2205 shipped a string-match test of this shape against `generate_hooks._build_copilot_entry`; it passed while the generated hooks wedged customer environments. See `.claude/rules/generated-artifacts.md` and `.agents/retrospective/2026-06-02-pr-2205-customer-wedge-incident.md`.
+
+## Behavioral claims: read the body, not the name
+
+A claim about what another component **does** is load-bearing in the same way a "mirrors" claim is. "Validator X skips directory Y." "Hook Z runs on push." "Helper W returns None on failure." The reader acts on these without re-deriving them, and a rule file that carries one is read by every agent on every session it applies to.
+
+A function's name is not evidence of its behavior. Neither is its call site, a prior PR description, or your memory of it. Open the file and read the body. Then quote the line you are relying on, with its path and line number:
+
+```python
+# build/scripts/validate_plugin_manifests.py:318-327 prunes it by name:
+#     excluded_dirs = {".agent-tmp", ".worktrees", "worktrees", "node_modules",
+#                      ".git", "cache", ".pytest_cache", ".pytest_tmp"}
+```
+
+PR #3775 shipped rule text in `.claude/rules/testing.md` claiming `.pytest_tmp` was "the only name both `validate_plugin_manifests.py` and `check_placeholder_identity.py` skip". The second half was false. `scripts/validation/check_placeholder_identity.py:36 _is_pytest_tmp` never inspects a directory of that name. It returns true only when the whole repository root sits under `tempfile.gettempdir()` and its resolved path contains `pytest-of-`, which is a different question entirely. The author reasoned from the function's name and never opened the file. The false claim reached always-on instruction text and survived two review rounds before a third-model review caught it.
+
+The function's own docstring stated the real behavior accurately. Reading it would have cost seconds. That is the asymmetry this section exists for: verification is cheap at write time, and a false behavioral claim in a rule file is expensive for as long as it stands, because every reader who trusts it inherits the error and some of them build on it.
+
+This section binds any assertion about another component's behavior, whatever words carry it. The trigger is not a phrase like "mirrors"; the trigger is that you told the reader what some other code does.
 
 ## Reference: the M4 episode
 


### PR DESCRIPTION
## Summary

Fixes #3786.

I shipped a false behavioral claim into always-on instruction text. This change
makes the rule that should have caught it actually cover the case.

## The incident

PR #3775 added rule text asserting that `.pytest_tmp` was "the only name both
`validate_plugin_manifests.py` and `check_placeholder_identity.py` skip". The
second half was false. I reasoned from a function's name and never opened its
body. The claim reached always-on instruction text and survived two review
rounds before a third-model adversarial review caught it.

## Why the existing rule missed it

The canonical-source-mirror rule is the natural home for "do not claim what
another file does without reading it". It missed on two independent axes.

First, scope. Its `paths:` list did not include `.claude/rules/**`, so it never
loaded while I was editing a rule file. The rule that governs claims about
canonical sources did not bind the artifact class most likely to make them.

Second, trigger. Its existing guidance keys on phrases like "matches" and
"mirrors". My false sentence used neither. It said one file "skips" something,
which is a behavioral claim about a function body, not a mirroring claim.

## The change

Adds `.claude/rules/**` to the rule's path set, and adds a section covering
behavioral claims: an assertion about what another file does must be verified
against that file's body, not inferred from its name, its docstring, or a
caller's expectations.

## Why extend rather than add a new rule

The always-on instruction budget for `.md` sits at 98.3 percent of ceiling,
roughly 1378 bytes free, with 11 book-derived rule files loaded. A new
always-on rule is not affordable. A path-scoped rule costs zero against that
budget, because it loads only when a matching file is edited. I verified the
budget was unchanged after this edit.

## Verification

Every claim in the new rule text was verified against source before it was
written, which is the discipline being codified.

The excluded directory set is a literal set of eight names including
`.pytest_tmp`, at the exact lines cited. The other function never inspects a
directory of that name at all; it returns true only when the repository root
resolves under the system temp directory and the resolved path contains
`pytest-of-`. Its own docstring stated that accurately the whole time, which is
what makes the failure a reading failure rather than a documentation failure.

I also caught this change creating a fresh stale claim. The rule's prose
enumerates its own path set in two places, and adding a path invalidated both.
I fixed them and then verified mechanically, by parsing the generated `applyTo`
lines and comparing sets, that both prose enumerations equal the generated
output. Both match. Reading them and judging them equal is the same mistake
this rule exists to prevent.

The mirrors regenerate with no drift. The generator narrows the plugin-side
mirror automatically, dropping the `.claude/**` globs that do not ship, so no
generator change was needed.

## A third instance, found while writing this

While preparing the sibling PR #3793 I wrote "yaml is not a project dependency"
into a commit message and nearly shipped it. It is declared. I had also misread
my own test output, reporting a collection failure when the log plainly showed
collection succeeding. I caught both before pushing, by checking rather than
recalling. That is three instances of the same failure mode in one session,
which is the argument for encoding it rather than resolving to be careful.

## Evidence

Paths consulted while verifying the above, none of them modified by this change:

- `build/scripts/validate_plugin_manifests.py` lines 318 to 327 hold the
  excluded directory set.
- `scripts/validation/check_placeholder_identity.py` line 36 defines the
  function whose name I trusted.
- `.claude/rules/testing.md` carries the corrected text from PR #3775.
- `build/scripts/generate_rules.py` performs the plugin-side narrowing.
