### PR TITLE
docs(memories): retire three references to a deleted validator

### DIFF
--- a/.serena/memories/project/organization-001-script-placement-convention.md
+++ b/.serena/memories/project/organization-001-script-placement-convention.md
@@ -6,7 +6,8 @@
 
 **Context**: When creating new validation or utility scripts for the project
 
-**Evidence**: Validate-Consistency.ps1 (since migrated to `scripts/validation/consistency.py`)
+**Evidence**: Validate-Consistency.ps1 (migrated to Python per ADR-042, then retired
+in #3557 once `.agents/planning` stopped carrying feature PRD and task pairs)
 placed in scripts/ following the PowerShell conventions of the time; duplicate in
 .agents/utilities/ removed to maintain single source of truth. Corrected 2026-07-28: the
 statement previously said `scripts/` only, which was false. Six validators live under
@@ -19,7 +20,7 @@ generator output and run in the build pipeline, not at runtime.
 
 **Tags**: organization, conventions, file-structure, DRY
 
-**Note**: All agent references should use `scripts/validation/consistency.py` directly
+**Note**: All agent references should use the script's single home directly, never a duplicate
 
 **Directory Structure**:
 

--- a/.serena/memories/validation/validation-tooling-patterns.md
+++ b/.serena/memories/validation/validation-tooling-patterns.md
@@ -62,7 +62,7 @@ Patterns identified from Phase 3 consistency validation implementation.
 
 - Runtime: `scripts/` and `scripts/validation/` (Python, per ADR-042; originally PowerShell)
 - Build pipeline: `build/scripts/validate_*.py` (validates generator output, runs in the build)
-- Agents: Reference `scripts/validation/consistency.py` directly
+- Agents: Reference the script at its single home (for example `scripts/validation/pre_pr.py`), never a copy
 - NO duplication to `.agents/utilities/`
 
 **Benefits**:


### PR DESCRIPTION
## Summary

`scripts/validation/consistency.py` was deleted from `main` on 2026-07-28 in commit `03569ca578` (PR #3557). That PR updated `.agents/governance/consistency-protocol.md` to document the successor, `build/scripts/validate_planning_artifacts.py`, but left four references to the deleted path behind. Three are in the Serena memory corpus. This fixes those three.

## Why only three, and not the other findings in the corpus

`.serena/memories/decision-orphan-ref-scope-serena-memories.md` is the decision of record here. It triaged this corpus under issue #3629, took `script_path` findings from 21 to 14, and deliberately **kept** the remaining 14 after reading them in context: a memory that records what a retired tool used to do is correct as written.

That gives the discriminator this change uses, which is **live directive versus historical record**, not mere existence:

- A memory that tells an agent to reference a deleted script is a live directive pointing at nothing. Fixed.
- A memory that records a migration for provenance is a historical record. Left alone.

All three lines changed here are the first kind. Two of them literally instruct agents where to point.

## The changes

The Evidence line keeps the historical migration but names the retirement and its cause, so the provenance survives without pointing at a dead path.

The two Note lines drop the specific script and state the rule they were illustrating, which is the single-home convention. Neither line was ever about `consistency.py` specifically; it was the example.

## Verification

Measured by stashing and restoring this diff **in one tree at one commit**, using the repo's own validator rather than an ad-hoc scan:

```
.claude/skills/orphan-ref-validator/scripts/scan.py --targets .serena/memories --output json
```

| metric | before | after |
|--------|--------|-------|
| `script_path` findings | 30 | 27 |
| `consistency.py` references | 3 | 0 |

The memory size check is unchanged, with the same two pre-existing failures in files this change does not touch.

> [!NOTE]
> The 30 here is not comparable to the 14 recorded in the #3629 decision memo. `refs_checked` moved from 390 to 255 when PR #3735 rescoped the detector, so the two counts measure different denominators. No regression is being claimed.

## Scope

`.serena/memories` is not mirrored into any plugin tree, so there is no mirror to regenerate and no manifest to bump.

The fourth reference lives in `.agents/SESSION-PROTOCOL.md` and is left for a separate change, because edits on that path trip the adr-review gate and need their own session-log evidence.

Refs #3629
