### PR TITLE
fix(scripts): reject leading whitespace on ADR frontmatter fences

### DIFF
--- a/scripts/sync_adr_protocol.py
+++ b/scripts/sync_adr_protocol.py
@@ -144,15 +144,18 @@ def _status_from_frontmatter(content: str) -> str | None:
     Parsed as YAML so quoting and comments resolve to the scalar value
     rather than to raw text.
 
-    Both fences are matched after stripping surrounding whitespace, so a
-    CRLF checkout or a trailing space survives. A rejected fence is not a
-    parse error here: it falls through to the unbounded prose readers
-    below, which return a debate summary in place of a lifecycle value.
+    Both fences allow trailing horizontal whitespace and a single carriage
+    return, so a file an editor rewrote with CRLF or a stray space still
+    parses. Leading whitespace is rejected: a space makes the line a
+    CommonMark horizontal rule and a tab makes it a code block, neither of
+    which is frontmatter. A rejected fence is not a parse error here, it
+    falls through to the unbounded prose readers below, which return a
+    debate summary in place of a lifecycle value.
     """
     first_line, newline, body = content.partition("\n")
-    if not newline or first_line.strip() != "---":
+    if not newline or not re.fullmatch(r"---[ \t]*\r?", first_line):
         return None
-    match = re.search(r"^---[ \t\r]*$", body, re.MULTILINE)
+    match = re.search(r"^---[ \t]*\r?$", body, re.MULTILINE)
     if match is None:
         return None
     try:

--- a/tests/test_sync_adr_protocol.py
+++ b/tests/test_sync_adr_protocol.py
@@ -119,6 +119,26 @@ class TestParseAdrStatus:
         content = "--- x\nstatus: accepted\n---\n\n# ADR-001\n\n## Status\n\nProposed\n"
         assert parse_adr_status(content) == "Proposed"
 
+    def test_leading_whitespace_is_not_a_fence(self) -> None:
+        """A leading space is a horizontal rule and a tab is a code block.
+
+        Neither is frontmatter, so widening the fence must not admit them.
+        Non-Markdown whitespace is rejected for the same reason: ``str.strip``
+        would consume a non-breaking space or a form feed, which no Markdown
+        parser treats as indentation.
+        """
+        for fence in (" ---", "\t---", "\u00a0---", "\x0c---", "\x0b---"):
+            content = (
+                f"{fence}\nstatus: accepted\n---\n\n"
+                "# ADR-001\n\n## Status\n\nProposed\n"
+            )
+            assert parse_adr_status(content) == "Proposed", repr(fence)
+
+    def test_repeated_carriage_returns_are_not_a_fence(self) -> None:
+        """One CR is a line ending. Three is a malformed line, not a fence."""
+        content = "---\nstatus: accepted\n---\r\r\r\n\n# ADR-001\n\n## Status\n\nProposed\n"
+        assert parse_adr_status(content) == "Proposed"
+
     def test_ignores_status_mention_in_body(self) -> None:
         """A bold Status line below the first heading is prose, not state."""
         content = "# ADR-001\n\n## Context\n\n**Status**: COMPLETE\n"


### PR DESCRIPTION
## Summary

PR #3804 widened the opening frontmatter fence check from an exact `startswith("---\n")` to `first_line.strip() == "---"`. That is too loose in both directions it was not aiming at, and it merged before the adversarial review came back. This tightens it.

## The regression on main

`str.strip()` with no arguments removes **leading** whitespace as well as trailing, and it removes characters no markdown parser treats as indentation. Measured against the parser currently on `main`:

| opening line | main resolves | correct answer | why |
|--------------|---------------|----------------|-----|
| `' ---'` | `accepted` | `Proposed` | CommonMark horizontal rule |
| `'\t---'` | `accepted` | `Proposed` | CommonMark indented code block |
| `'\xa0---'` | `accepted` | `Proposed` | non-breaking space |
| `'\x0c---'` | `accepted` | `Proposed` | form feed |
| `'\x0b---'` | `accepted` | `Proposed` | vertical tab |

A document that opens with a horizontal rule now has its first `---`-delimited block read as lifecycle metadata.

The closing regex had the matching problem in the other direction: `[ \t\r]*` accepted any run of carriage returns, so `---\r\r\r` matched as a fence.

## The change

Both fences now use an explicit grammar instead of `strip()`:

```python
re.fullmatch(r"---[ \t]*\r?", first_line)
re.search(r"^---[ \t]*\r?$", body, re.MULTILINE)
```

Trailing horizontal whitespace and a single carriage return are allowed, which is exactly what #3804 set out to fix. Everything else is rejected.

## Verification

- 48 tests pass.
- 2 new tests cover the five leading-whitespace forms and the repeated-CR closing fence.
- **Negative control**, with the source change stashed and the new tests present, in one tree at one commit: both new tests fail on current `main`, both pass with this change.
- The 4 real cases #3804 targeted (CRLF, one space, two spaces, tab) still resolve correctly. That was re-measured, not assumed.
- `ruff check` clean.

## Why this is a follow-up and not an amendment

The adversarial review on GPT-5.6 Sol returned DO-NOT-SHIP with this as its first Required finding. It completed after #3804 had already merged, so the amended branch could not be pushed. Two of its three findings were corrected in the #3804 description before merge; this one needed code.

> [!NOTE]
> This is the third time this session a PR merged while its review was still running. The standing requirement is that every change gets an adversarial review on a different model family before it lands. Merging on green CI defeats that, and in this case it put a real over-permissiveness bug on `main` for the duration. Worth considering a required status check or a merge queue.

Refs #3791
