### PR TITLE
test(scripts): read a literal index, group shared values, restore the complexity bar

### DIFF
--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import ast
 import time
+from collections import Counter
 from pathlib import Path
 
 import pytest
@@ -79,7 +80,12 @@ _DYNAMIC = "subprocess.<dynamic>"
 # subprocess names for want of a second one to thread, and filtered out of
 # every path that answers "is this a subprocess entry point".
 _ATTRIBUTE = "."
+_UNKNOWN = object()
 _PARTIAL = "functools.partial"
+
+# The literal container shapes an index can be read out of. Named so the
+# non-mapping branch of _element is known to carry elts.
+_Container = ast.Dict | ast.List | ast.Tuple
 
 # Entry points that hand back str no matter what keywords a call passes.
 _DECODES_UNCONDITIONALLY = _ALWAYS_TEXT_ATTRS | frozenset({_DYNAMIC})
@@ -183,17 +189,73 @@ def _resolve_elements(
     return sorted(found)[0]
 
 
+def _literal(node: ast.expr) -> object:
+    """Return the constant *node* spells, or ``_UNKNOWN`` when it spells none.
+
+    ``ast.literal_eval`` reads a negative index, which the parser stores as a
+    unary operation rather than a constant, and refuses anything computed. It
+    evaluates no code, so a hostile subscript cannot reach this scan.
+    """
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
+        return _UNKNOWN
+
+
+def _element(node: ast.Subscript, containers: dict[str, _Container]) -> ast.expr | None:
+    """Return the one element *node* selects, when the scan can name it.
+
+    Only a literal index into a name bound exactly once to a literal container
+    qualifies. Everything else returns ``None``, which leaves the caller
+    holding the whole container. That is the safe direction: a dispatch table
+    is flagged wholesale rather than read wrongly.
+    """
+    if not isinstance(node.value, ast.Name):
+        return None
+    literal = containers.get(node.value.id)
+    if literal is None:
+        return None
+    key = _literal(node.slice)
+    if key is _UNKNOWN:
+        return None
+    if isinstance(literal, ast.Dict):
+        # A ``**splat`` key reads as ``None`` and can carry any name, so the
+        # keys on show are not the whole mapping.
+        stored = [_literal(k) if k is not None else _UNKNOWN for k in literal.keys]
+        if _UNKNOWN in stored:
+            return None
+        for held, value in zip(stored, literal.values, strict=True):
+            # ``True`` equals ``1`` and ``1`` equals ``1.0`` in Python, but a
+            # dict written with one of them was not written with the other.
+            if type(held) is type(key) and held == key:
+                return value
+        return None
+    if not isinstance(key, int) or isinstance(key, bool):
+        return None
+    if any(isinstance(element, ast.Starred) for element in literal.elts):
+        # A starred element expands to an unknown count, so every index after
+        # it names something the scan cannot see.
+        return None
+    return literal.elts[key] if -len(literal.elts) <= key < len(literal.elts) else None
+
+
 def _resolve_callable(
-    node: ast.expr, modules: set[str], functions: dict[str, str]
+    node: ast.expr,
+    modules: set[str],
+    functions: dict[str, str],
+    containers: dict[str, _Container] | None = None,
 ) -> str | None:
     """Return the subprocess entry point *node* evaluates to, or ``None``."""
     while isinstance(node, ast.Subscript):
-        # ``RUNNERS[0](...)`` reaches whatever the container holds. Resolving
-        # the base rather than the index means a computed index cannot slip a
-        # subprocess reference past this scan. A subscript chain is left
+        # ``RUNNERS[0](...)`` reaches whatever the container holds. A literal
+        # index into a literal container names one element, so a dispatch
+        # table does not taint every handler in it. Anything less certain
+        # resolves the base instead, which means a computed index cannot slip
+        # a subprocess reference past this scan. A subscript chain is left
         # recursive, so the parser caps no depth and unwinding it must not
         # recurse.
-        node = node.value
+        selected = _element(node, containers) if containers else None
+        node = node.value if selected is None else selected
     if isinstance(node, ast.Name):
         resolved = functions.get(node.id)
         return None if resolved == _PARTIAL else resolved
@@ -212,7 +274,7 @@ def _resolve_callable(
         return _resolve_indirect(node, modules, functions)
     if isinstance(node, ast.NamedExpr):
         # ``(r := subprocess.run)(...)`` binds and calls in one expression.
-        return _resolve_callable(node.value, modules, functions)
+        return _resolve_callable(node.value, modules, functions, containers)
     if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
         return _resolve_elements(list(node.elts), modules, functions)
     if isinstance(node, ast.Dict):
@@ -304,7 +366,37 @@ def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
     return found
 
 
-def _subprocess_names(tree: ast.Module) -> tuple[set[str], dict[str, str]]:
+def _containers(
+    tree: ast.AST, bindings: list[tuple[str, ast.expr]]
+) -> dict[str, _Container]:
+    """Map each name bound exactly once to a literal container, to that literal.
+
+    Bound exactly once is the whole guarantee. A second binding anywhere,
+    including a loop target or a parameter default, means the name may hold
+    something the literal does not show, and indexing the literal would then
+    answer for the wrong object. Such names are left out, so the caller falls
+    back to tainting the container whole.
+    """
+    counts = Counter(name for name, _ in bindings)
+    found: dict[str, _Container] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, (ast.AnnAssign, ast.NamedExpr)) and node.value is not None:
+            targets, value = [node.target], node.value
+        else:
+            continue
+        if not isinstance(value, (ast.Dict, ast.List, ast.Tuple)):
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name) and counts.get(target.id) == 1:
+                found[target.id] = value
+    return found
+
+
+def _subprocess_names(
+    tree: ast.Module,
+) -> tuple[set[str], dict[str, str], dict[str, _Container]]:
     """Collect every name in *tree* that reaches a subprocess entry point.
 
     ``import subprocess as sp`` and ``from subprocess import run`` are both
@@ -340,6 +432,7 @@ def _subprocess_names(tree: ast.Module) -> tuple[set[str], dict[str, str]]:
     # quadratic instead, and measurably so: a reverse-ordered chain of 2000
     # bindings took 0.41 seconds that way.
     bindings = _bindings(tree)
+    containers = _containers(tree, bindings)
     dependents: dict[str, list[int]] = {}
     for index, (_, value) in enumerate(bindings):
         for free in {
@@ -355,17 +448,22 @@ def _subprocess_names(tree: ast.Module) -> tuple[set[str], dict[str, str]]:
         # subprocess entry point.
         if name in functions:
             continue
-        resolved = _resolve_callable(value, modules, functions)
+        resolved = _resolve_callable(value, modules, functions, containers)
         if resolved is None:
             continue
         functions[name] = resolved
         queue.extend(dependents.get(name, ()))
-    return modules, functions
+    return modules, functions, containers
 
 
-def _target(call: ast.Call, modules: set[str], functions: dict[str, str]) -> str | None:
+def _target(
+    call: ast.Call,
+    modules: set[str],
+    functions: dict[str, str],
+    containers: dict[str, _Container] | None = None,
+) -> str | None:
     """Return the subprocess entry point *call* reaches, or ``None``."""
-    direct = _resolve_callable(call.func, modules, functions)
+    direct = _resolve_callable(call.func, modules, functions, containers)
     if direct is not None:
         return direct
     # ``functools.partial(subprocess.run, text=True)`` decides the codec where
@@ -429,12 +527,12 @@ def _pins_utf8(call: ast.Call) -> bool:
 def unpinned_lines(source: str) -> list[int]:
     """Return the line numbers of text-capturing calls that do not pin UTF-8."""
     tree = ast.parse(source)
-    modules, functions = _subprocess_names(tree)
+    modules, functions, containers = _subprocess_names(tree)
     offenders: list[int] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
-        target = _target(node, modules, functions)
+        target = _target(node, modules, functions, containers)
         if target is None:
             continue
         if target == "os.popen":
@@ -619,6 +717,26 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'import subprocess\nname = "run"\nf = getattr(subprocess, name)',
             "fetching an attribute decodes nothing until something calls it",
         ),
+        (
+            'import subprocess\nH = {"run": subprocess.run, "build": local}\n'
+            'H["build"](["x"], capture_output=True, text=True)',
+            "a literal key selects one handler, and this one is not an entry point",
+        ),
+        (
+            'import subprocess\nR = [local, subprocess.run]\n'
+            'R[0](["x"], capture_output=True, text=True)',
+            "a literal index selects one element, and this one is not an entry point",
+        ),
+        (
+            'import subprocess\nR = [subprocess.run, local]\n'
+            'R[-1](["x"], capture_output=True, text=True)',
+            "a negative index counts from the end of the literal",
+        ),
+        (
+            'import subprocess\nH = {"a": local, "b": subprocess.run}\n'
+            '(f := H["a"])(["x"], capture_output=True, text=True)',
+            "a walrus over an indexed table still selects the one element",
+        ),
     ],
 )
 def test_detector_stays_quiet(source: str, why: str) -> None:
@@ -787,6 +905,48 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             'import subprocess\nR = {"go": subprocess.run}\n'
             'R["go"](["x"], capture_output=True, text=True)',
             "a dict value is reached by subscript, not by attribute",
+        ),
+        (
+            'import subprocess\nH = {"go": subprocess.run}\nk = "go"\n'
+            'H[k](["x"], capture_output=True, text=True)',
+            "a computed key names no element the scan can read, so all of them count",
+        ),
+        (
+            'import subprocess\nH = {"go": subprocess.run}\n'
+            'H["absent"](["x"], capture_output=True, text=True)',
+            "a key that is not in the literal says nothing about what is",
+        ),
+        (
+            'import subprocess\nH = {1: local, "go": subprocess.run}\n'
+            'H[True](["x"], capture_output=True, text=True)',
+            "True equals 1 in Python but names no key a dict was written with",
+        ),
+        (
+            'import subprocess\nbase = {"safe": subprocess.run}\n'
+            'H = {**base, "safe": local}\n'
+            'H["safe"](["x"], capture_output=True, text=True)',
+            "a mapping splat can carry an entry point under any key",
+        ),
+        (
+            'import subprocess\nR = [*others, subprocess.run]\n'
+            'R[0](["x"], capture_output=True, text=True)',
+            "a starred element shifts every index after it",
+        ),
+        (
+            'import subprocess\nR = [local, subprocess.run]\n'
+            'R[7](["x"], capture_output=True, text=True)',
+            "an index past the end of the literal reads nothing from it",
+        ),
+        (
+            'import subprocess\nR = [local, subprocess.run]\n'
+            'R[0:1][0](["x"], capture_output=True, text=True)',
+            "a slice yields a container the scan did not build",
+        ),
+        (
+            'import subprocess\nH = {"safe": subprocess.run}\n'
+            'H = {"safe": local}\n'
+            'H["safe"](["x"], capture_output=True, text=True)',
+            "a name bound twice names no one literal the scan can index",
         ),
         (
             'import subprocess\nR = (subprocess.getoutput,)\n'

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -431,28 +431,38 @@ def _subprocess_names(
     # which makes the work linear in the size of the file. A repeated sweep is
     # quadratic instead, and measurably so: a reverse-ordered chain of 2000
     # bindings took 0.41 seconds that way.
+    # Bindings that share a value node are read together. A left side that
+    # does not line up with the right side pairs every name with the whole of
+    # it, so one node can be shared by thousands of names, and reading it once
+    # per name is quadratic: 4000 names took 17.76 seconds that way. Every
+    # name in a group reads the same node, so one read answers for all of them.
     bindings = _bindings(tree)
     containers = _containers(tree, bindings)
+    groups: dict[int, tuple[ast.expr, list[str]]] = {}
+    for name, value in bindings:
+        groups.setdefault(id(value), (value, []))[1].append(name)
+
     dependents: dict[str, list[int]] = {}
-    for index, (_, value) in enumerate(bindings):
+    for key, (value, _) in groups.items():
         for free in {
             node.id for node in ast.walk(value) if isinstance(node, ast.Name)
         }:
-            dependents.setdefault(free, []).append(index)
+            dependents.setdefault(free, []).append(key)
 
-    queue = list(range(len(bindings)))
+    queue = list(groups)
     while queue:
-        name, value = bindings[queue.pop()]
-        # The first binding of a name wins. That is what bounds the queue, and
-        # it is why a name rebound to an unrelated callable keeps reading as a
-        # subprocess entry point.
-        if name in functions:
-            continue
+        value, names = groups[queue.pop()]
         resolved = _resolve_callable(value, modules, functions, containers)
         if resolved is None:
             continue
-        functions[name] = resolved
-        queue.extend(dependents.get(name, ()))
+        for name in names:
+            # The first binding of a name wins. That is what bounds the queue,
+            # and it is why a name rebound to an unrelated callable keeps
+            # reading as a subprocess entry point.
+            if name in functions:
+                continue
+            functions[name] = resolved
+            queue.extend(dependents.get(name, ()))
     return modules, functions, containers
 
 
@@ -984,6 +994,11 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             "unpacking a name of unknown shape may hand it to either side",
         ),
         (
+            'import subprocess\nrunners = [subprocess.run, subprocess.run]\n'
+            'a, b = runners\nb(["x"], capture_output=True, text=True)',
+            "every name on the left of an unknown shape carries the same answer",
+        ),
+        (
             'import subprocess\nclass C:\n    def __init__(self):\n'
             '        self.run = subprocess.run\n'
             'C().run(["x"], capture_output=True, text=True)',
@@ -1114,6 +1129,31 @@ def test_name_resolution_stays_linear_on_a_deep_reverse_chain() -> None:
 
     assert flagged, "a chain of any depth still reaches a subprocess entry point"
     assert elapsed < 10.0, f"name resolution took {elapsed:.1f}s for {depth} bindings"
+
+
+def test_unpacking_a_wide_container_stays_linear() -> None:
+    """One value shared by many names must be read once, not once per name.
+
+    A left side that does not line up with the right side pairs every name
+    with the whole of it, so ``width`` bindings share a single value node.
+    Reading that node once per binding walks the same subtree ``width`` times,
+    which is quadratic and measurably so: 4000 names took 17.76 seconds.
+
+    Grouping the bindings that share a value node bounds the work at one read
+    per node. Nothing here resolves, which is the point: the cost has to stay
+    bounded even when no answer is ever found.
+    """
+    width = 4000
+    names = ", ".join(f"a{index}" for index in range(width))
+    values = ", ".join(f"b{index}" for index in range(width))
+    source = f"import subprocess\n{names} = {{{values}}}\n"
+
+    started = time.perf_counter()
+    flagged = unpinned_lines(source)
+    elapsed = time.perf_counter() - started
+
+    assert flagged == [], "no call is made, so nothing can decode"
+    assert elapsed < 3.0, f"unpacking took {elapsed:.1f}s for {width} names"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -90,6 +90,14 @@ _Container = ast.Dict | ast.List | ast.Tuple
 # Entry points that hand back str no matter what keywords a call passes.
 _DECODES_UNCONDITIONALLY = _ALWAYS_TEXT_ATTRS | frozenset({_DYNAMIC})
 
+# Per module, the names worth binding from a ``from ... import`` and what each
+# one resolves to. A table rather than a branch per module, so a new source of
+# subprocess entry points is one row.
+_IMPORTED_NAMES: dict[str, dict[str, str]] = {
+    "subprocess": {attr: attr for attr in _SUBPROCESS_ATTRS},
+    "functools": {"partial": _PARTIAL},
+}
+
 
 def _keyword(call: ast.Call, name: str) -> ast.expr | None:
     """Return the value node for keyword *name*, or ``None`` when absent."""
@@ -239,6 +247,22 @@ def _element(node: ast.Subscript, containers: dict[str, _Container]) -> ast.expr
     return literal.elts[key] if -len(literal.elts) <= key < len(literal.elts) else None
 
 
+def _attribute(
+    node: ast.Attribute, modules: set[str], functions: dict[str, str]
+) -> str | None:
+    """Return the subprocess entry point ``owner.attr`` names, or ``None``."""
+    if isinstance(node.value, ast.Name):
+        owner, attr = node.value.id, node.attr
+        if owner in modules and attr in _SUBPROCESS_ATTRS:
+            return attr
+        if owner == "os" and attr == "popen":
+            return _OS_POPEN
+    # No partial filter here, unlike the bare-name branch in the caller. The
+    # sentinel is only ever written for an imported name, and every attribute
+    # binding is resolved through that branch, which drops it.
+    return functions.get(_ATTRIBUTE + node.attr)
+
+
 def _resolve_callable(
     node: ast.expr,
     modules: set[str],
@@ -260,16 +284,7 @@ def _resolve_callable(
         resolved = functions.get(node.id)
         return None if resolved == _PARTIAL else resolved
     if isinstance(node, ast.Attribute):
-        if isinstance(node.value, ast.Name):
-            owner, attr = node.value.id, node.attr
-            if owner in modules and attr in _SUBPROCESS_ATTRS:
-                return attr
-            if owner == "os" and attr == "popen":
-                return _OS_POPEN
-        # No partial filter here, unlike the bare-name branch above. The
-        # sentinel is only ever written for an imported name, and every
-        # attribute binding is resolved through that branch, which drops it.
-        return functions.get(_ATTRIBUTE + node.attr)
+        return _attribute(node, modules, functions)
     if isinstance(node, ast.Call):
         return _resolve_indirect(node, modules, functions)
     if isinstance(node, ast.NamedExpr):
@@ -329,6 +344,24 @@ def _defaults(spec: ast.arguments) -> list[tuple[str, ast.expr]]:
     return found
 
 
+def _class_bindings(node: ast.ClassDef) -> list[tuple[str, ast.expr]]:
+    """Pair every attribute a class body binds with the value it receives.
+
+    A class body binds attributes without ever naming ``self``, so the names
+    are recorded under the attribute prefix and read back the same way.
+    """
+    found: list[tuple[str, ast.expr]] = []
+    for statement in node.body:
+        if not isinstance(statement, ast.Assign):
+            continue
+        for target in statement.targets:
+            found.extend(
+                (_ATTRIBUTE + name, bound)
+                for name, bound in _unpack(target, statement.value)
+            )
+    return found
+
+
 def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
     """Collect every ``name = value`` binding at any depth.
 
@@ -353,14 +386,7 @@ def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
             # assignment statement anywhere in sight.
             found.extend(_unpack(node.target, node.iter))
         elif isinstance(node, ast.ClassDef):
-            # A class body binds attributes without ever naming ``self``.
-            for statement in node.body:
-                if isinstance(statement, ast.Assign):
-                    for target in statement.targets:
-                        found.extend(
-                            (_ATTRIBUTE + name, bound)
-                            for name, bound in _unpack(target, statement.value)
-                        )
+            found.extend(_class_bindings(node))
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             found.extend(_defaults(node.args))
     return found
@@ -394,15 +420,12 @@ def _containers(
     return found
 
 
-def _subprocess_names(
-    tree: ast.Module,
-) -> tuple[set[str], dict[str, str], dict[str, _Container]]:
-    """Collect every name in *tree* that reaches a subprocess entry point.
+def _imports(tree: ast.AST) -> tuple[set[str], dict[str, str]]:
+    """Collect the module aliases and imported names that reach subprocess.
 
     ``import subprocess as sp`` and ``from subprocess import run`` are both
     ordinary Python, and an owner-name check that only knows the literal word
-    ``subprocess`` misses each of them. So is ``_run = subprocess.run``, which
-    needs no import statement at all.
+    ``subprocess`` misses each of them.
     """
     modules = {"subprocess"}
     functions: dict[str, str] = {}
@@ -411,14 +434,35 @@ def _subprocess_names(
             for alias in node.names:
                 if alias.name == "subprocess":
                     modules.add(alias.asname or alias.name)
-        elif isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+        elif isinstance(node, ast.ImportFrom):
+            wanted = _IMPORTED_NAMES.get(node.module or "", {})
             for alias in node.names:
-                if alias.name in _SUBPROCESS_ATTRS:
-                    functions[alias.asname or alias.name] = alias.name
-        elif isinstance(node, ast.ImportFrom) and node.module == "functools":
-            for alias in node.names:
-                if alias.name == "partial":
-                    functions[alias.asname or alias.name] = _PARTIAL
+                if alias.name in wanted:
+                    functions[alias.asname or alias.name] = wanted[alias.name]
+    return modules, functions
+
+
+def _dependents(groups: dict[int, tuple[ast.expr, list[str]]]) -> dict[str, list[int]]:
+    """Map each name a binding group reads to the groups that read it."""
+    found: dict[str, list[int]] = {}
+    for key, (value, _) in groups.items():
+        for free in {
+            node.id for node in ast.walk(value) if isinstance(node, ast.Name)
+        }:
+            found.setdefault(free, []).append(key)
+    return found
+
+
+def _subprocess_names(
+    tree: ast.Module,
+) -> tuple[set[str], dict[str, str], dict[str, _Container]]:
+    """Collect every name in *tree* that reaches a subprocess entry point.
+
+    Imports seed the search, and every binding is then resolved against what
+    is known so far. ``_run = subprocess.run`` needs no import statement at
+    all, so the binding pass is what closes that shape.
+    """
+    modules, functions = _imports(tree)
 
     # Assignments resolve against names discovered so far, so one pass is not
     # enough: ``ast.walk`` is breadth first, so ``b = a`` at the top level is
@@ -442,14 +486,22 @@ def _subprocess_names(
     for name, value in bindings:
         groups.setdefault(id(value), (value, []))[1].append(name)
 
-    dependents: dict[str, list[int]] = {}
-    for key, (value, _) in groups.items():
-        for free in {
-            node.id for node in ast.walk(value) if isinstance(node, ast.Name)
-        }:
-            dependents.setdefault(free, []).append(key)
-
+    dependents = _dependents(groups)
     queue = list(groups)
+    while queue:
+        value, names = groups[queue.pop()]
+        resolved = _resolve_callable(value, modules, functions, containers)
+        if resolved is None:
+            continue
+        for name in names:
+            # The first binding of a name wins. That is what bounds the queue,
+            # and it is why a name rebound to an unrelated callable keeps
+            # reading as a subprocess entry point.
+            if name in functions:
+                continue
+            functions[name] = resolved
+            queue.extend(dependents.get(name, ()))
+    return modules, functions, containers
     while queue:
         value, names = groups[queue.pop()]
         resolved = _resolve_callable(value, modules, functions, containers)
@@ -711,6 +763,11 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'import shutil\n_run = shutil.run\n'
             '_run(["x"], capture_output=True, text=True)',
             "an alias of a same-named function on another module is not ours",
+        ),
+        (
+            'from mypackage import run, getoutput\n'
+            'run(["x"], capture_output=True, text=True)\ngetoutput("x")',
+            "a from-import of a same-named function elsewhere is not ours",
         ),
         (
             'import subprocess\n'


### PR DESCRIPTION
## Summary

Three defects in the subprocess text-encoding guard, found by adversarial
review rounds 7 and 8. Two are precision fixes and one is a performance fix.
Stacked on #3803.

Fixes #3801
Fixes #3802
Refs #3800

## 1. A dispatch table tainted every handler in it

The guard resolved `RUNNERS[0]` by throwing the index away and reading the
whole container. One `subprocess.run` in a table therefore made every entry
in that table read as a subprocess entry point.

Reproduction, before:

```
RUNNERS = [my_builder, subprocess.run]
RUNNERS[0](["x"], capture_output=True, text=True)
```

`RUNNERS[0]` is `my_builder`, which captures nothing. The guard flagged it.

A literal index into a literal container now names one element. Precision
features can only lose flags, so this one falls back to whole-container taint
in seven places, each with a test behind it:

| Shape | Why the index is not trusted |
| --- | --- |
| `H[compute()]` | the key is not a literal |
| `H["absent"]` | no such key is on show |
| `H = {**base, "k": v}` | a splat can carry any name |
| `R = [*others, run]` | a starred element hides the count |
| `R[9]` past the end | the index names nothing |
| `R[1:2]` | a slice is not one element |
| a name bound twice | the literal may not be what the name holds |

Bound exactly once is the whole guarantee, so `_containers` does its own walk
rather than reuse the binding pairs, which deliberately over-approximate.

Two shapes that read as one thing in Python but not in a written dict are
handled: `-1` parses as a `UnaryOp` rather than a `Constant`, so keys go
through `ast.literal_eval`, which also refuses anything computed and executes
nothing. And `True == 1` holds in Python, but a dict written with one was not
written with the other, so key matching compares type as well as value.

## 2. Unpacking a wide container was quadratic

A left side that does not line up with the right side pairs every name with
the whole of it, so one value node could be read once per name.

| Names | Before | After |
| --- | --- | --- |
| 1000 | 1.12s | 0.014s |
| 2000 | 4.49s | 0.027s |
| 4000 | 17.76s | 0.053s |
| 8000 | not measured | 0.11s |

Clean 4x per doubling before, linear after. Bindings are now grouped by the
identity of their value node, so a shared node is walked once and resolved
once. A bound test at width 4000 holds the shape.

## 3. The guard broke its own complexity bar

The two fixes above pushed ruff C901 from one offender on main to three:
`_subprocess_names` at 18, `_bindings` at 13, `_resolve_callable` at 11,
against a ceiling of 10. Four extract-method moves with no behaviour change
bring the file to zero offenders, one fewer than main. The two per-module
import branches became rows in a table, so a new source of subprocess entry
points is one row rather than one branch.

## Mutation testing

Every new branch was mutated. 31 of 31 killed across four batteries.

| Battery | Mutants | Survivors |
| --- | --- | --- |
| bindings (round 7) | 8 | 0 |
| container indexing | 9 | 0 |
| grouped worklist | 6 | 0 |
| helper extraction | 8 | 0 |

Three of those mutants were only killed after diagnosing why they survived,
and the diagnosis differed each time:

- A dict-key test with a single parameter cannot tell head alignment from
  tail alignment. A second parameter was added.
- Merging the import table rows so any module answers for every name left
  `from mypackage import run` reading as `subprocess.run`. That guard is
  older than this branch; the table only made it visible. A quiet case now
  covers it.
- One filter turned out unreachable. Six candidate shapes were probed before
  deleting it, and the invariant that makes it dead is now a comment.

## What was deleted

- A per-group resolved flag: each name is set at most once, so the number of
  re-queues is already bounded by the dependency edges.
- A separate insertion-order list: redundant with the insertion-ordered dict.
- A lint suppression that was never needed, since the code already compares
  types rather than using the operator the rule is about.

## Not in scope

Round 8 found five more defects in this same guard, all filed and none fixed
here: #3810, #3811, #3812, #3813, #3814. They land in different functions and
merit their own commits.

## Provenance

Adversarial review rounds 7 and 8 were run with `gemini-3.1-pro-preview`
against an isolated copy of the file, so the reviewer could not see the
tests it was trying to evade.
