### PR TITLE
fix(validation): report what markdown lint actually checked

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-29-session-3710.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-3710.json
@@ -79,7 +79,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 1,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-29-session-3710.json
+++ b/.agents/memory/episodes/episode-2026-07-29-session-3710.json
@@ -1,0 +1,86 @@
+{
+  "id": "episode-2026-07-29-session-3710",
+  "session": "2026-07-29-session-3710",
+  "timestamp": "2026-07-29T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Fix #3710: markdown lint gate reports PASS when it selected zero files",
+  "decisions": [
+    {
+      "id": "d001",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "routing",
+      "context": "",
+      "chosen": "Reproduce #3710: markdown lint gate returns PASS on zero selected files",
+      "rationale": "Verified live with markdownlint-cli2 0.23.2: a file carrying MD041 and MD032 placed under .agents/ prints 'Linting: 0 files' and exits 0. .markdownlint-cli2.yaml excludes 3,529 of 3,935 tracked markdown files (89.7%) through 44 ignores patterns.",
+      "outcome": "success",
+      "effects": []
+    }
+  ],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Reproduce #3710: markdown lint gate returns PASS on zero selected files",
+      "caused_by": [],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Find and fix a second defect in the same function",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Establish that Summary cannot substitute for the Linting banner",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Ship the fix with tests and mutation coverage",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-29T00:00:00+00:00",
+      "type": "milestone",
+      "content": "File the second call site rather than expand the diff",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 4
+  },
+  "lessons": []
+}

--- a/.agents/sessions/2026-07-29-session-3710.json
+++ b/.agents/sessions/2026-07-29-session-3710.json
@@ -1,0 +1,149 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3710,
+    "date": "2026-07-29",
+    "branch": "fix/3710-markdownlint-zero-file-green",
+    "startingCommit": "9cf7ff896",
+    "objective": "Fix #3710: markdown lint gate reports PASS when it selected zero files"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP unavailable; fell back to .serena/memories/ on disk per AGENTS.md."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP unavailable this session; no serena/ or mcp__serena__ tools exposed by the harness."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .agents/HANDOFF.md; unmodified per ADR-014."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Listed scripts/validation/; validate_markdown_lint lives in checks_tooling.py and is re-exported by pre_pr.py."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read AGENTS.md Skill-First table; no skill covers pre_pr validator repair, so worked inline."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .claude/rules/universal.md, code-quality.md, ci-scripts.instructions.md and AGENTS.md before editing scripts/validation/."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Read .serena/memories/ on disk; no entry covers markdownlint selection behavior."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/3710-markdownlint-zero-file-green"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/3710-markdownlint-zero-file-green"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "9cf7ff896"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All items recorded with evidence below."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md not modified."
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP unavailable; findings recorded in this log and in issue #3808 instead."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "npx markdownlint-cli2 run on the changed markdown; this session's only markdown is this log, which is under the .agents/ exclusion."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Committed on fix/3710-markdownlint-zero-file-green."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "scripts/validation/pre_pr.py reports all validations passed; 102 tests pass in tests/test_validation_pre_pr.py; 12/12 mutants caught."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "task": "Reproduce #3710: markdown lint gate returns PASS on zero selected files",
+      "status": "completed",
+      "evidence": "Verified live with markdownlint-cli2 0.23.2: a file carrying MD041 and MD032 placed under .agents/ prints 'Linting: 0 files' and exits 0. .markdownlint-cli2.yaml excludes 3,529 of 3,935 tracked markdown files (89.7%) through 44 ignores patterns."
+    },
+    {
+      "task": "Find and fix a second defect in the same function",
+      "status": "completed",
+      "evidence": "validate_markdown_lint discarded both stdout and stderr, so a failing run printed canned advice about MD040 and MD033 while the real MD041 and MD032 were thrown away. cli2 writes violations to stderr and its progress banner to stdout; _run_subprocess already captured both."
+    },
+    {
+      "task": "Establish that Summary cannot substitute for the Linting banner",
+      "status": "completed",
+      "evidence": "The Summary trailing count is files *with issues*, so a clean file and a never-selected file both print '0 issues in 0 files'. Only the 'Linting: N files' banner separates them."
+    },
+    {
+      "task": "Ship the fix with tests and mutation coverage",
+      "status": "completed",
+      "evidence": "9 new tests plus 2 corrected fixtures; 102 pass in tests/test_validation_pre_pr.py. 12-mutant harness: 12 caught, 0 survived, re-run after ruff format rewrote the source. ruff check, ruff format and mypy clean."
+    },
+    {
+      "task": "File the second call site rather than expand the diff",
+      "status": "completed",
+      "evidence": "Verified --no-globs does not disable ignores, so the lefthook markdown-check and markdown-autofix jobs share the defect. Filed as issue #3808 with the measurement and the open question about whether lefthook surfaces the banner on a green job."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Confirm PR closes #3710; Fixes-N auto-close has been unreliable this session.",
+    "Decide #3808: whether lefthook shows the Linting banner on a green job.",
+    "Record endingCommit once the branch tip is final."
+  ]
+}

--- a/.agents/sessions/2026-07-29-session-3710.json
+++ b/.agents/sessions/2026-07-29-session-3710.json
@@ -140,7 +140,7 @@
       "evidence": "Verified --no-globs does not disable ignores, so the lefthook markdown-check and markdown-autofix jobs share the defect. Filed as issue #3808 with the measurement and the open question about whether lefthook surfaces the banner on a green job."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "c9eb7675",
   "nextSteps": [
     "Confirm PR closes #3710; Fixes-N auto-close has been unreliable this session.",
     "Decide #3808: whether lefthook shows the Linting banner on a green job.",

--- a/scripts/validation/checks_tooling.py
+++ b/scripts/validation/checks_tooling.py
@@ -114,16 +114,82 @@ def validate_markdown_lint(repo_root: Path) -> bool:
         command.append("--fix")
     command.extend(target_args)
 
-    exit_code, _, _ = _run_subprocess(command, cwd=repo_root)
+    exit_code, stdout, stderr = _run_subprocess(command, cwd=repo_root)
     if exit_code == 0:
+        _report_selection(target_args, stdout)
         return True
 
     print("[FAIL] Markdown linting failed")
+    print()
+    # markdownlint-cli2 writes violations to stderr and a progress banner to
+    # stdout, and both were discarded here. A failing run printed the canned
+    # list below and nothing else, so an MD041 and an MD032 arrived as advice
+    # about MD040 and MD033. Print what the tool actually said.
+    #
+    # stderr only, when it has anything: stdout's "Finding:" line restates all
+    # 44 exclusion globs on one ~1,000-character line and would bury the two
+    # lines that name the file, the line and the rule. stdout is the fallback
+    # for the failure modes that never reach the violation reporter, such as an
+    # unparsable config.
+    detail = stderr if stderr.strip() else stdout
+    for line in detail.splitlines():
+        if line.strip():
+            print(f"  {line}")
     print()
     print("Common issues:")
     print("  - MD040: Add language identifier to code blocks")
     print("  - MD033: Wrap generic types like ArrayPool<T> in backticks")
     return False
+
+
+# markdownlint-cli2 prints "Linting: 3 files" (or "Linting: 1 file") before it
+# reads anything. The trailing count in its "Summary" line is files *with
+# issues*, so a clean file and a file that was never selected both summarise as
+# "0 issues in 0 files". This line is the only one that distinguishes them.
+_LINTED_COUNT_PATTERN = re.compile(r"^Linting: (\d+) files?$", re.MULTILINE)
+
+
+def _linted_file_count(stdout: str) -> int | None:
+    """Return how many files markdownlint-cli2 actually selected, or None.
+
+    None means the banner was absent, which happens if the tool changes its
+    output. Callers must not read that as zero or as "all of them"; it is
+    "unknown", and saying so beats guessing.
+    """
+    match = _LINTED_COUNT_PATTERN.search(stdout)
+    return int(match.group(1)) if match else None
+
+
+def _report_selection(target_args: list[str], stdout: str) -> None:
+    """Say whether a green run checked anything (issue #3710).
+
+    ``.markdownlint-cli2.yaml`` excludes 89.7% of tracked markdown, including
+    ``.claude/skills/**``, ``.agents/**`` and ``**/CLAUDE.md``, which is most of
+    what anyone edits here. Naming an excluded file on the command line selects
+    nothing and exits 0, so this check reported PASS on a branch where every
+    changed file went unread, and the session log recorded "markdownlint passed"
+    as evidence. The exclusions are deliberate, so this is not a failure. It is
+    a PASS that has to say which kind of PASS it is.
+    """
+    selected = _linted_file_count(stdout)
+    if selected is None:
+        print(
+            "[WARNING] Markdown linting: could not read the 'Linting: N files' "
+            "banner, so how many files were checked is unknown"
+        )
+        return
+    if selected == 0 and target_args:
+        print(
+            f"[WARNING] Markdown linting selected 0 of {len(target_args)} target(s): "
+            "every one is excluded by .markdownlint-cli2.yaml, so nothing was "
+            "checked. This PASS means 'not linted', not 'clean'."
+        )
+        return
+    if selected < len(target_args):
+        print(
+            f"[WARNING] Markdown linting checked {selected} of {len(target_args)} "
+            "target(s); the rest are excluded by .markdownlint-cli2.yaml"
+        )
 
 
 def _markdown_lint_targets(repo_root: Path) -> list[str] | None:

--- a/scripts/validation/checks_tooling.py
+++ b/scripts/validation/checks_tooling.py
@@ -181,14 +181,16 @@ def _report_selection(target_args: list[str], stdout: str) -> None:
     if selected == 0 and target_args:
         print(
             f"[WARNING] Markdown linting selected 0 of {len(target_args)} target(s): "
-            "every one is excluded by .markdownlint-cli2.yaml, so nothing was "
-            "checked. This PASS means 'not linted', not 'clean'."
+            "each is excluded by .markdownlint-cli2.yaml, matched no file, or no "
+            "longer exists, so nothing was checked. This PASS means 'not "
+            "linted', not 'clean'."
         )
         return
     if selected < len(target_args):
         print(
             f"[WARNING] Markdown linting checked {selected} of {len(target_args)} "
-            "target(s); the rest are excluded by .markdownlint-cli2.yaml"
+            "target(s); the rest were excluded by .markdownlint-cli2.yaml, "
+            "matched no file, or no longer exist"
         )
 
 

--- a/tests/test_validation_pre_pr.py
+++ b/tests/test_validation_pre_pr.py
@@ -451,6 +451,22 @@ class TestMain:
 # ---------------------------------------------------------------------------
 
 
+# Captured verbatim from markdownlint-cli2 v0.23.2 (markdownlint v0.41.1) on
+# 2026-07-29. The tool splits output across both streams: this progress banner
+# and the trailing summary go to stdout, while rule violations go to stderr.
+# The banner is the only signal separating "checked and clean" from "never
+# selected", because the summary counts files *with issues* and prints
+# "0 issues in 0 files" for both.
+def _clean_stdout(count: int) -> str:
+    """Return real cli2 stdout for a run that selected `count` clean files."""
+    unit = "file" if count == 1 else "files"
+    return (
+        "markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)\n"
+        f"Linting: {count} {unit}\n"
+        "Summary: 0 issues in 0 files\n"
+    )
+
+
 class TestValidateMarkdownLint:
     """Markdown linting checks branch changes without masking unknown scope."""
 
@@ -476,7 +492,7 @@ class TestValidateMarkdownLint:
                 return_value=["README.md", "docs/guide.md"],
             ):
                 with patch("checks_tooling._run_subprocess") as mock_run:
-                    mock_run.return_value = (0, "", "")
+                    mock_run.return_value = (0, _clean_stdout(2), "")
                     assert validate_markdown_lint(tmp_path) is True
 
         mock_run.assert_called_once_with(
@@ -499,7 +515,7 @@ class TestValidateMarkdownLint:
                 return_value=["README.md"],
             ):
                 with patch("checks_tooling._run_subprocess") as mock_run:
-                    mock_run.return_value = (0, "", "")
+                    mock_run.return_value = (0, _clean_stdout(1), "")
                     assert validate_markdown_lint(tmp_path) is True
 
         mock_run.assert_called_once_with(
@@ -1228,3 +1244,176 @@ class TestValidateCiDependencyPinsSkipsBeforeImporting:
             '[project]\nname="x"\ndependencies=["pytest>=9.0.3"]\n', encoding="utf-8"
         )
         assert validate_ci_dependency_pins(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #3710: a markdown gate that selects nothing must not report success
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownLintReportsWhatItActuallyChecked:
+    """A PASS on zero selected files is 'not linted', not 'clean'.
+
+    `.markdownlint-cli2.yaml` excludes 89.7% of tracked markdown (3,529 of
+    3,935 files as of 2026-07-29) through 44 `ignores` patterns. Naming an
+    excluded path on the command line selects zero files and exits 0, so the
+    gate printed nothing and returned True on markdown it never read. The
+    exclusions are deliberate, so the fix is an honest message, not a hard
+    failure.
+    """
+
+    def _run(
+        self,
+        tmp_path: Path,
+        targets: list[str] | None,
+        result: tuple[int, str, str],
+        capsys: pytest.CaptureFixture[str],
+    ) -> tuple[bool, str]:
+        from scripts.validation.pre_pr import validate_markdown_lint
+
+        with patch("checks_tooling.shutil.which", return_value="npx"):
+            with patch(
+                "checks_tooling._markdown_lint_targets", return_value=targets
+            ):
+                with patch("checks_tooling._run_subprocess") as mock_run:
+                    mock_run.return_value = result
+                    outcome = validate_markdown_lint(tmp_path)
+        return outcome, capsys.readouterr().out
+
+    def test_zero_selected_files_warns_instead_of_passing_silently(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        outcome, out = self._run(
+            tmp_path,
+            [".agents/analysis/notes.md"],
+            (0, _clean_stdout(0), ""),
+            capsys,
+        )
+
+        assert outcome is True, "excluded paths are deliberate, so do not fail"
+        assert "0 of 1 target" in out
+        assert "This PASS means 'not linted', not 'clean'." in out
+
+    def test_a_fully_selected_clean_run_stays_quiet(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        outcome, out = self._run(
+            tmp_path, ["README.md"], (0, _clean_stdout(1), ""), capsys
+        )
+
+        assert outcome is True
+        assert "WARNING" not in out, "a fully checked run has nothing to report"
+
+    def test_a_partially_excluded_run_names_the_shortfall(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        outcome, out = self._run(
+            tmp_path,
+            ["README.md", ".agents/analysis/notes.md"],
+            (0, _clean_stdout(1), ""),
+            capsys,
+        )
+
+        assert outcome is True
+        assert "checked 1 of 2 target" in out
+
+    def test_an_unreadable_banner_admits_the_count_is_unknown(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Guards against a future cli2 release renaming the banner: the parser
+        # must say it could not tell rather than claim full coverage.
+        outcome, out = self._run(
+            tmp_path,
+            ["README.md"],
+            (0, "Checked: 1 document\nSummary: 0 issues in 0 files\n", ""),
+            capsys,
+        )
+
+        assert outcome is True
+        assert "could not read the 'Linting: N files' banner" in out
+
+    def test_the_full_repo_fallback_does_not_warn_about_its_own_glob(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # `_markdown_lint_targets` returns None when scope is unknown and the
+        # command becomes a single `**/*.md` glob. Comparing 406 linted files
+        # against one glob argument would warn on every clean full-repo run.
+        outcome, out = self._run(
+            tmp_path, None, (0, _clean_stdout(406), ""), capsys
+        )
+
+        assert outcome is True
+        assert "WARNING" not in out
+
+    def test_a_full_repo_run_that_matches_nothing_still_warns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        outcome, out = self._run(
+            tmp_path, None, (0, _clean_stdout(0), ""), capsys
+        )
+
+        assert outcome is True
+        assert "0 of 1 target" in out
+
+    def test_failures_print_the_violations_the_tool_reported(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The defect behind the canned advice: violations arrive on stderr and
+        # the caller discarded it, so an MD041 reached the operator as advice
+        # about MD040 and MD033.
+        violations = (
+            "docs/guide.md:1 error MD041/first-line-heading/first-line-h1 "
+            'First line in a file should be a top-level heading [Context: "Text"]\n'
+            "docs/guide.md:2 error MD032/blanks-around-lists Lists should be "
+            'surrounded by blank lines [Context: "- a"]\n'
+        )
+        outcome, out = self._run(
+            tmp_path,
+            ["docs/guide.md"],
+            (1, "Linting: 1 file\nSummary: 2 issues in 1 file\n", violations),
+            capsys,
+        )
+
+        assert outcome is False
+        assert "MD041/first-line-heading" in out
+        assert "MD032/blanks-around-lists" in out
+        assert "docs/guide.md:2" in out
+
+    def test_a_failure_omits_the_thousand_character_exclusion_banner(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # cli2 restates all 44 exclusion globs on one `Finding:` line. Printing
+        # stdout alongside stderr buried the lines that named the rule.
+        finding = "Finding: docs/guide.md " + " ".join(
+            f"!excluded/{n}/**" for n in range(44)
+        )
+        outcome, out = self._run(
+            tmp_path,
+            ["docs/guide.md"],
+            (
+                1,
+                f"{finding}\nLinting: 1 file\nSummary: 1 issues in 1 file\n",
+                "docs/guide.md:1 error MD041/first-line-heading\n",
+            ),
+            capsys,
+        )
+
+        assert outcome is False
+        assert "MD041" in out
+        assert "!excluded/0/**" not in out
+
+    def test_a_failure_with_no_stderr_falls_back_to_stdout(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Failure modes that never reach the violation reporter, such as an
+        # unparsable config, report on stdout only. Dropping stdout entirely
+        # would restore the silence this issue is about.
+        outcome, out = self._run(
+            tmp_path,
+            ["docs/guide.md"],
+            (2, "Unable to parse JSONC in .markdownlint-cli2.jsonc\n", ""),
+            capsys,
+        )
+
+        assert outcome is False
+        assert "Unable to parse JSONC" in out


### PR DESCRIPTION
## Summary

The markdown gate returned PASS on files it never read. `Fixes #3710`.

## What was wrong

`.markdownlint-cli2.yaml` excludes 89.7% of tracked markdown, 3,529 of 3,935 files, through 44 `ignores` patterns. Those exclusions cover `.claude/skills/**`, `.agents/**`, `src/copilot-cli/skills/**` and `**/CLAUDE.md`, which is most of what anyone edits here.

Naming an excluded path on the command line selects zero files and exits 0. Verified live with cli2 0.23.2 on bytes carrying MD041 and MD032:

```
$ npx markdownlint-cli2 .agents/analysis/probe.md
Linting: 0 files
Summary: 0 issues in 0 files
$ echo $?
0
```

So the check printed nothing, returned True, and the session log recorded "markdownlint passed" as evidence for markdown that was never parsed.

The exclusions are deliberate: skills are treated as third-party plugins. This is not a failure. It is a PASS that has to say which kind of PASS it is. A green run now reports whether it checked everything, some of the targets, or nothing.

## A second, larger defect in the same function

The call was `exit_code, _, _ = _run_subprocess(...)`. Both streams were discarded, so a failing run printed only a canned list suggesting MD040 and MD033. A real run producing MD041 and MD032 reached the operator as advice about two unrelated rules.

`_run_subprocess` already captured both streams, so the data was always there.

Violations arrive on stderr and are now printed. stdout is the fallback for failures that never reach the violation reporter, such as an unparsable config, but it is not printed alongside stderr: its `Finding:` line restates all 44 exclusion globs on one 1,000-character line and buried the two lines that named the rule.

## Why the Summary line cannot substitute

The `Summary` trailing count is *files with issues*. A clean file and a never-selected file both print `0 issues in 0 files`. Only the `Linting: N files` banner separates them, so that banner is what the parser reads, and a test asserts the parser reports "unknown" rather than claiming full coverage if a future release renames it.

## Evidence

- 9 new tests; 102 pass in the file
- 12-mutant harness, 12 caught, 0 survived, re-run after the diff was rebuilt
- `ruff check` and `mypy` clean
- `pre_pr.py`: all validations passed
- End-to-end run against the real tool for all four output shapes

## Notes

Two existing fixtures mocked empty stdout, which the real tool never emits. Corrected to output captured from cli2 0.23.2.

The diff carries zero new lint suppressions. An earlier revision ran `ruff format` over the two touched files; that reflowed 63 pre-existing lines and was reverted, because `ruff format` is enforced nowhere in this repository and the churn re-attributed old suppressions to this commit.

## Scope

The `markdown-check` and `markdown-autofix` lefthook jobs call the tool directly and share the same blind spot. Confirmed that `--no-globs` does not disable `ignores`. Filed separately as issue #3808 rather than widening this change.
