### PR TITLE
fix(tests): close five defects in the subprocess text-encoding guard

### DIFF
--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -93,6 +93,7 @@ _PARTIAL = "functools.partial"
 # The literal container shapes an index can be read out of. Named so the
 # non-mapping branch of _element is known to carry elts.
 _Container = ast.Dict | ast.List | ast.Tuple
+_Assign = ast.Assign | ast.AnnAssign | ast.NamedExpr | ast.AugAssign
 
 # Entry points that hand back str no matter what keywords a call passes.
 _DECODES_UNCONDITIONALLY = _ALWAYS_TEXT_ATTRS | frozenset({_DYNAMIC})
@@ -323,6 +324,12 @@ def _unpack(target: ast.expr, value: ast.expr) -> list[tuple[str, ast.expr]]:
         # name alone carries the binding. The leading dot cannot appear in an
         # identifier, so these keys never collide with a plain name.
         return [(_ATTRIBUTE + target.attr, value)]
+    if isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name):
+        # ``H[0] = subprocess.run`` puts the value into H without rebinding
+        # the name, so the base takes the binding. Which slot it lands in
+        # does not matter: the write is what stops H being read from its
+        # literal, so the whole container has to answer for it.
+        return [(target.value.id, value)]
     if not isinstance(target, (ast.Tuple, ast.List)):
         return []
     if isinstance(value, (ast.Tuple, ast.List)) and len(value.elts) == len(target.elts):
@@ -351,6 +358,52 @@ def _defaults(spec: ast.arguments) -> list[tuple[str, ast.expr]]:
     return found
 
 
+def _receives(call: ast.Call) -> list[tuple[str, ast.expr]]:
+    """Pair the receiver of a method call with everything handed to it.
+
+    ``H.append(subprocess.run)`` puts a reference into H, and so does
+    ``H.update(k=subprocess.run)``. Telling a method that stores its argument
+    from one that only reads it needs the type of the receiver, which this
+    scan does not have, so every argument is treated as flowing in. The
+    direction is safe: a name that takes on a value it never really holds is
+    read too loudly, never too quietly.
+    """
+    if not isinstance(call.func, ast.Attribute):
+        return []
+    if not isinstance(call.func.value, ast.Name):
+        return []
+    name = call.func.value.id
+    handed = [*call.args, *(keyword.value for keyword in call.keywords)]
+    return [(name, value) for value in handed]
+
+
+def _written(tree: ast.AST) -> set[str]:
+    """Return every name whose object may change without receiving a value.
+
+    A literal answers for a name only while the object it built is untouched,
+    and most ways of touching one hand it something, so ``_bindings`` records
+    them and the count rule retires the name. Two shapes hand over nothing.
+    ``H.reverse()`` reorders in place, and no static scan can tell a method
+    that mutates from one that reads without knowing the type, so every
+    method call on a name counts. ``del H[0]`` drops an element and shifts
+    the rest. Both leave the literal stale with no value to record, which is
+    why they need a rule of their own.
+    """
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if isinstance(node.func.value, ast.Name):
+                found.add(node.func.value.id)
+        elif isinstance(node, ast.Delete):
+            found.update(
+                target.value.id
+                for target in node.targets
+                if isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Name)
+            )
+    return found
+
+
 def _class_bindings(node: ast.ClassDef) -> list[tuple[str, ast.expr]]:
     """Pair every attribute a class body binds with the value it receives.
 
@@ -369,6 +422,26 @@ def _class_bindings(node: ast.ClassDef) -> list[tuple[str, ast.expr]]:
     return found
 
 
+def _assigned(node: _Assign) -> list[tuple[str, ast.expr]]:
+    """Pair the names an assignment statement writes with the value it writes.
+
+    The four shapes differ only in where the target sits. An annotated
+    assignment with no value declares a type and binds nothing, so it is the
+    one shape that can come back empty.
+    """
+    if isinstance(node, ast.Assign):
+        return [pair for target in node.targets for pair in _unpack(target, node.value)]
+    if isinstance(node, ast.AnnAssign):
+        if node.value is None:
+            return []
+        return _unpack(node.target, node.value)
+    if isinstance(node, ast.NamedExpr):
+        return [(node.target.id, node.value)]
+    # ``H += [subprocess.run]`` rebinds H to something the first literal
+    # never showed, with no assignment statement to find.
+    return _unpack(node.target, node.value)
+
+
 def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
     """Collect every ``name = value`` binding at any depth.
 
@@ -380,14 +453,10 @@ def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
     """
     found: list[tuple[str, ast.expr]] = []
     for node in ast.walk(tree):
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                found.extend(_unpack(target, node.value))
-        elif isinstance(node, ast.AnnAssign):
-            if isinstance(node.target, ast.Name) and node.value is not None:
-                found.append((node.target.id, node.value))
-        elif isinstance(node, ast.NamedExpr):
-            found.append((node.target.id, node.value))
+        if isinstance(node, _Assign):
+            found.extend(_assigned(node))
+        elif isinstance(node, ast.Call):
+            found.extend(_receives(node))
         elif isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)):
             # ``for runner in (subprocess.run,)`` binds a name with no
             # assignment statement anywhere in sight.
@@ -402,15 +471,19 @@ def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
 def _containers(
     tree: ast.AST, bindings: list[tuple[str, ast.expr]]
 ) -> dict[str, _Container]:
-    """Map each name bound exactly once to a literal container, to that literal.
+    """Map each name bound once to an untouched literal container, to that literal.
 
-    Bound exactly once is the whole guarantee. A second binding anywhere,
-    including a loop target or a parameter default, means the name may hold
-    something the literal does not show, and indexing the literal would then
-    answer for the wrong object. Such names are left out, so the caller falls
-    back to tainting the container whole.
+    Two guarantees, and the literal is only worth reading when both hold.
+    Bound exactly once: a second binding anywhere, including a loop target or
+    a parameter default, means the name may hold something the literal does
+    not show. Never written to: a subscript write, a delete, or any method
+    call can change the object the literal built while the name stays put.
+    Indexing a stale literal answers for the wrong object either way, so such
+    names are left out and the caller falls back to tainting the container
+    whole.
     """
     counts = Counter(name for name, _ in bindings)
+    written = _written(tree)
     found: dict[str, _Container] = {}
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign):
@@ -422,7 +495,9 @@ def _containers(
         if not isinstance(value, (ast.Dict, ast.List, ast.Tuple)):
             continue
         for target in targets:
-            if isinstance(target, ast.Name) and counts.get(target.id) == 1:
+            if not isinstance(target, ast.Name) or target.id in written:
+                continue
+            if counts.get(target.id) == 1:
                 found[target.id] = value
     return found
 
@@ -698,6 +773,17 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             "check_output without text mode hands back bytes",
         ),
         (
+            'import subprocess\nH = [subprocess.check_call, subprocess.run]\n'
+            'H[0](["x"], capture_output=True, text=True)',
+            "a table nobody writes to still reads one element",
+        ),
+        (
+            'import subprocess\nH = [subprocess.check_call, subprocess.run]\n'
+            'G = [subprocess.run]\nG[0] = subprocess.run\n'
+            'H[0](["x"], capture_output=True, text=True)',
+            "writing to one table does not cost another its precision",
+        ),
+        (
             'import subprocess\nsubprocess.check_output(["x"], text=True, encoding="utf-8")',
             "check_output that pins its codec is compliant",
         ),
@@ -829,6 +915,17 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'import subprocess\nH = {"a": local, "b": subprocess.run}\n'
             '(f := H["a"])(["x"], capture_output=True, text=True)',
             "a walrus over an indexed table still selects the one element",
+        ),
+        (
+            'import subprocess\nH: object = [subprocess.check_call, subprocess.run]\n'
+            'H: object\n'
+            'H[0](["x"], capture_output=True, text=True)',
+            "a bare annotation declares a type and binds nothing",
+        ),
+        (
+            "import subprocess\nH = [[subprocess.check_call]]\ndel H[0][1]\n"
+            'H[0](["x"], capture_output=True, text=True)',
+            "a delete may reach through a subscript the scan cannot name",
         ),
     ],
 )
@@ -1127,6 +1224,46 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             'import subprocess, os\nrunners = [subprocess.check_output, os.popen]\n'
             'runners[1]("ls")',
             "a container holding os.popen may yield the one that cannot pin",
+        ),
+        (
+            "import subprocess\nH = [subprocess.check_call]\n"
+            "H[0] = subprocess.run\nH[0](['x'], capture_output=True, text=True)",
+            "a list written through a subscript no longer matches its literal",
+        ),
+        (
+            "import subprocess\nH = [subprocess.check_call]\n"
+            "H.append(subprocess.run)\nH[0](['x'], capture_output=True, text=True)",
+            "a list appended to no longer matches its literal",
+        ),
+        (
+            "import subprocess\nH = [subprocess.check_call]\n"
+            "H += [subprocess.run]\nH[0](['x'], capture_output=True, text=True)",
+            "augmented assignment rebinds a name with no assignment in sight",
+        ),
+        (
+            "import subprocess\nH = {'a': subprocess.check_call}\n"
+            "H['b'] = subprocess.run\nH['a'](['x'], capture_output=True, text=True)",
+            "a mapping written through a key no longer matches its literal",
+        ),
+        (
+            "import subprocess\nH = {'a': subprocess.check_call}\n"
+            "H.update(b=subprocess.run)\nH['a'](['x'], capture_output=True, text=True)",
+            "a mapping updated by keyword no longer matches its literal",
+        ),
+        (
+            "import subprocess\nH = [subprocess.check_call, subprocess.run]\n"
+            "del H[0]\nH[0](['x'], capture_output=True, text=True)",
+            "deleting an element shifts every index after it",
+        ),
+        (
+            "import subprocess\nH = [subprocess.check_call, subprocess.run]\n"
+            "H.reverse()\nH[0](['x'], capture_output=True, text=True)",
+            "a method that takes no arguments can still reorder the container",
+        ),
+        (
+            "import subprocess\nH = [subprocess.check_call]\n"
+            "H[0], y = subprocess.run, 1\nH[0](['x'], capture_output=True, text=True)",
+            "a subscript inside a tuple target writes just the same",
         ),
     ],
 )

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -236,7 +236,10 @@ def _element(node: ast.Subscript, containers: dict[str, _Container]) -> ast.expr
         return None
     if isinstance(literal, ast.Dict):
         # A ``**splat`` key reads as ``None`` and can carry any name, so the
-        # keys on show are not the whole mapping.
+        # keys on show are not the whole mapping. No test can pin the
+        # conditional, because ``_literal`` answers ``_UNKNOWN`` for ``None``
+        # anyway. It is the type checker that requires it: ``keys`` holds
+        # ``expr | None`` and ``_literal`` takes an ``expr``.
         stored = [_literal(k) if k is not None else _UNKNOWN for k in literal.keys]
         if _UNKNOWN in stored:
             return None
@@ -1424,6 +1427,12 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             '    runner(["x"], capture_output=True, text=True)',
             "every item of the iterable is a value the name can take",
         ),
+        (
+            'import subprocess\n'
+            'def go(runner=subprocess.run, /):\n'
+            '    runner(["x"], capture_output=True, text=True)',
+            "a positional-only parameter takes a default like any other",
+        ),
     ],
 )
 def test_detector_closes_the_evasions(source: str, why: str) -> None:
@@ -1456,6 +1465,12 @@ def test_detector_closes_the_evasions(source: str, why: str) -> None:
             'def go(parser):\n'
             '    parser.run(["x"], capture_output=True, text=True)',
             "an unrelated object with a same-named method reads as the one bound",
+        ),
+        (
+            'import subprocess\n'
+            'held = [subprocess.run, subprocess.check_call]\n'
+            'held[True](["x"], capture_output=True, text=True)',
+            "a bool index is a valid int index, and reading it as one is a guess",
         ),
     ],
 )

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -572,6 +572,13 @@ def _subprocess_names(
     queue = list(groups)
     while queue:
         value, names = groups[queue.pop()]
+        # A group whose names are all known has nothing left to learn, and
+        # reading it again would walk the whole value for nothing. That walk
+        # is what turns one value reading many names quadratic, because each
+        # of those names resolving queues the group afresh: 4000 names took
+        # 3.28 seconds that way.
+        if all(name in functions for name in names):
+            continue
         resolved = _resolve_callable(value, modules, functions, containers)
         if resolved is None:
             continue
@@ -1265,6 +1272,12 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             "H[0], y = subprocess.run, 1\nH[0](['x'], capture_output=True, text=True)",
             "a subscript inside a tuple target writes just the same",
         ),
+        (
+            "import subprocess\nb = c = a\na = subprocess.run\n"
+            "b = subprocess.check_output\n"
+            'c(["x"], capture_output=True, text=True)',
+            "one name of a shared binding resolving does not answer for the rest",
+        ),
     ],
 )
 def test_detector_closes_the_evasions(source: str, why: str) -> None:
@@ -1374,6 +1387,32 @@ def test_unpacking_a_wide_container_stays_linear() -> None:
 
     assert flagged == [], "no call is made, so nothing can decode"
     assert elapsed < 3.0, f"unpacking took {elapsed:.1f}s for {width} names"
+
+
+def test_a_value_reading_many_names_stays_linear() -> None:
+    """A binding that reads many names must be read once, not once per name.
+
+    The mirror of the case above. There one value was shared by many names;
+    here one value reads many names, and each of them resolving queues the
+    group that reads it. Reading that group again walks the whole node, so a
+    container of ``width`` names is walked ``width`` times: 4000 names took
+    3.28 seconds, growing fourfold for every doubling.
+
+    A group whose names are all resolved has nothing left to learn, so it can
+    be dropped without reading it. Every later queue entry for it is then
+    free, and the node is walked at most twice.
+    """
+    width = 4000
+    bindings = "\n".join(f"held{index} = subprocess.run" for index in range(width))
+    elements = ", ".join(f"held{index}" for index in range(width))
+    source = f"import subprocess\n{bindings}\nkept = [{elements}]\n"
+
+    started = time.perf_counter()
+    flagged = unpinned_lines(source)
+    elapsed = time.perf_counter() - started
+
+    assert flagged == [], "no call is made, so nothing can decode"
+    assert elapsed < 1.5, f"resolution took {elapsed:.1f}s for {width} names"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -69,6 +69,13 @@ _ALWAYS_TEXT_ATTRS = frozenset({"getoutput", "getstatusoutput"})
 
 _SUBPROCESS_ATTRS = _CAPTURING_ATTRS | _ALWAYS_TEXT_ATTRS
 
+# check_output passes stdout=PIPE itself, so it captures whatever the call
+# site says. Nothing in the source has to ask for capture, which means text
+# mode on its own is enough to decode. run and Popen are not like this: with
+# no capture keyword their output goes to the inherited handles and never
+# becomes a str.
+_ALWAYS_CAPTURING_ATTRS = frozenset({"check_output"})
+
 _PINNED_CODEC = "utf-8"
 _OS_POPEN = "os.popen"
 # Stands for a subprocess entry point selected at runtime, which no static
@@ -526,7 +533,7 @@ def _target(
     return fallback
 
 
-def _captures_text(call: ast.Call, functions: dict[str, str]) -> bool:
+def _captures_text(call: ast.Call, functions: dict[str, str], target: str) -> bool:
     """Report whether *call* may decode captured output into ``str``.
 
     Deliberately conservative. Anything other than a literal ``False`` counts,
@@ -535,6 +542,9 @@ def _captures_text(call: ast.Call, functions: dict[str, str]) -> bool:
 
     A ``functools.partial`` that selects text mode counts even with no capture
     keyword, because the capture can be supplied where the partial is called.
+    So does an entry point in :data:`_ALWAYS_CAPTURING_ATTRS`, which captures
+    without being asked, so *target* has to be known here rather than inferred
+    from the spelling at the call site.
 
     A ``**kwargs`` splat is treated as text mode outright. The keywords it
     carries are not visible here, so ``text`` may be among them, and reading
@@ -552,6 +562,10 @@ def _captures_text(call: ast.Call, functions: dict[str, str]) -> bool:
     if _is_partial(_call_label(call), functions):
         # A partial can select text mode here and be handed capture_output at
         # the eventual call site, which this scan has no way to reach.
+        return True
+    if target in _ALWAYS_CAPTURING_ATTRS:
+        # The callee captures on its own behalf, so there is no capture
+        # keyword for this scan to find and none is needed.
         return True
     capture = _keyword(call, "capture_output")
     if capture is not None and not _is_literal_false(capture):
@@ -588,7 +602,9 @@ def unpinned_lines(source: str) -> list[int]:
             # move is to not use it.
             offenders.append(node.lineno)
             continue
-        if target not in _DECODES_UNCONDITIONALLY and not _captures_text(node, functions):
+        if target not in _DECODES_UNCONDITIONALLY and not _captures_text(
+            node, functions, target
+        ):
             continue
         if not _pins_utf8(node):
             offenders.append(node.lineno)
@@ -638,6 +654,18 @@ def test_the_scan_actually_reaches_files() -> None:
             "check_output",
         ),
         (
+            "import subprocess\nsubprocess.check_output(['x'], text=True)",
+            "check_output captures stdout with no capture keyword to read",
+        ),
+        (
+            "import subprocess\nsubprocess.check_output(['x'], universal_newlines=True)",
+            "check_output under the legacy text spelling",
+        ),
+        (
+            "from subprocess import check_output as co\nco(['x'], text=True)",
+            "an alias of check_output captures just the same",
+        ),
+        (
             "import subprocess\n"
             "subprocess.run(['x'], capture_output=True, universal_newlines=True)",
             "the legacy universal_newlines spelling",
@@ -664,6 +692,18 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
         (
             'import subprocess\nsubprocess.run(["x"], text=True)',
             "nothing captured means nothing to decode",
+        ),
+        (
+            'import subprocess\nsubprocess.check_output(["x"])',
+            "check_output without text mode hands back bytes",
+        ),
+        (
+            'import subprocess\nsubprocess.check_output(["x"], text=True, encoding="utf-8")',
+            "check_output that pins its codec is compliant",
+        ),
+        (
+            'import subprocess\nsubprocess.Popen(["x"], text=True)',
+            "Popen captures nothing unless the call site asks it to",
         ),
         (
             'import subprocess\nsubprocess.run(["x"], capture_output=True, text=False)',

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -442,12 +442,41 @@ def _assigned(node: _Assign) -> list[tuple[str, ast.expr]]:
     return _unpack(node.target, node.value)
 
 
+def _captured(node: ast.Match) -> list[tuple[str, ast.expr]]:
+    """Pair every name a match statement captures with the subject it reads.
+
+    Structural patterns name a capture in exactly three places: ``case r``
+    and ``case P as r`` set ``MatchAs.name``, ``case [*rest]`` sets
+    ``MatchStar.name``, and ``case {**rest}`` sets ``MatchMapping.rest``.
+    Every other pattern is a shape holding those, so walking each case finds
+    all of them. ``case _`` leaves the name unset and captures nothing.
+
+    Which part of the subject a capture receives depends on the shape that
+    matched, which is a runtime question, so each one is paired with the
+    whole subject. That reads a sequence element as the whole sequence, and
+    the direction is safe: too loud, never too quiet.
+    """
+    found: list[tuple[str, ast.expr]] = []
+    for case in node.cases:
+        for pattern in ast.walk(case.pattern):
+            if isinstance(pattern, (ast.MatchAs, ast.MatchStar)):
+                name = pattern.name
+            elif isinstance(pattern, ast.MatchMapping):
+                name = pattern.rest
+            else:
+                continue
+            if name is not None:
+                found.append((name, node.subject))
+    return found
+
+
 def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
     """Collect every ``name = value`` binding at any depth.
 
     Covers plain assignment, annotated assignment, the walrus, loop and
-    comprehension targets, class bodies, and default arguments, every one of
-    which binds a name without an assignment statement to find.
+    comprehension targets, class bodies, match captures, values handed to a
+    method, and default arguments, every one of which binds a name without an
+    assignment statement to find.
     Assignment targets are unpacked, so a name bound by destructuring is as
     visible as one bound on its own.
     """
@@ -457,6 +486,8 @@ def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
             found.extend(_assigned(node))
         elif isinstance(node, ast.Call):
             found.extend(_receives(node))
+        elif isinstance(node, ast.Match):
+            found.extend(_captured(node))
         elif isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)):
             # ``for runner in (subprocess.run,)`` binds a name with no
             # assignment statement anywhere in sight.
@@ -934,6 +965,16 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'H[0](["x"], capture_output=True, text=True)',
             "a delete may reach through a subscript the scan cannot name",
         ),
+        (
+            'import subprocess\nmatch subprocess.run:\n    case _:\n'
+            '        _(["x"], capture_output=True, text=True)',
+            "a wildcard pattern matches everything and captures nothing",
+        ),
+        (
+            'import subprocess\nmatch subprocess.check_call:\n    case runner:\n'
+            '        runner(["x"], capture_output=True, text=True)',
+            "a capture is only as loud as the subject it reads",
+        ),
     ],
 )
 def test_detector_stays_quiet(source: str, why: str) -> None:
@@ -1277,6 +1318,56 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             "b = subprocess.check_output\n"
             'c(["x"], capture_output=True, text=True)',
             "one name of a shared binding resolving does not answer for the rest",
+        ),
+        (
+            'import subprocess\nmatch subprocess.run:\n    case runner:\n'
+            '        runner(["x"], capture_output=True, text=True)',
+            "a bare match case captures the subject under a new name",
+        ),
+        (
+            'import subprocess\nmatch subprocess.run:\n'
+            '    case object() as runner:\n'
+            '        runner(["x"], capture_output=True, text=True)',
+            "an as-pattern captures under a name too",
+        ),
+        (
+            'import subprocess\nmatch [subprocess.run]:\n    case [*rest]:\n'
+            '        rest[0](["x"], capture_output=True, text=True)',
+            "a star pattern collects the subject into a new container",
+        ),
+        (
+            'import subprocess\nmatch {"k": subprocess.run}:\n'
+            '    case {**rest}:\n'
+            '        rest["k"](["x"], capture_output=True, text=True)',
+            "a mapping rest pattern captures what the other keys left",
+        ),
+        (
+            'import subprocess\nmatch [subprocess.run]:\n    case [runner]:\n'
+            '        runner(["x"], capture_output=True, text=True)',
+            "a sequence pattern captures an element by position",
+        ),
+        (
+            'import subprocess\nmatch subprocess.run:\n'
+            '    case runner if runner:\n'
+            '        runner(["x"], capture_output=True, text=True)',
+            "a guarded case still captures before the guard runs",
+        ),
+        (
+            'import subprocess\nmatch subprocess.run:\n'
+            '    case object(__doc__=held):\n'
+            '        held(["x"], capture_output=True, text=True)',
+            "a class pattern captures through a keyword",
+        ),
+        (
+            'import subprocess\nmatch subprocess.run:\n    case [] | runner:\n'
+            '        runner(["x"], capture_output=True, text=True)',
+            "an or-pattern captures in whichever alternative matches",
+        ),
+        (
+            'import subprocess\nmatch subprocess.run:\n    case []:\n'
+            '        pass\n    case runner:\n'
+            '        runner(["x"], capture_output=True, text=True)',
+            "a later case captures just as much as the first",
         ),
     ],
 )

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -341,6 +341,24 @@ def _unpack(target: ast.expr, value: ast.expr) -> list[tuple[str, ast.expr]]:
     return [pair for sub in target.elts for pair in _unpack(sub, value)]
 
 
+def _iterated(target: ast.expr, iterable: ast.expr) -> list[tuple[str, ast.expr]]:
+    """Pair the names a loop target binds with the values it may take.
+
+    A loop target does not line up with the iterable, it lines up with one
+    item of it at a time, so unpacking it against the iterable reads the
+    wrong column: ``for label, runner in [(check_call, run)]`` would give
+    ``label`` the whole first item and ``runner`` the whole second, when the
+    source has only one item and two columns.
+
+    A literal iterable makes its items visible, so each name is paired with
+    every item it can take, one binding per item. Anything else is opaque and
+    keeps the old reading, where every name may hold any part of it.
+    """
+    if not isinstance(iterable, (ast.List, ast.Tuple, ast.Set)):
+        return _unpack(target, iterable)
+    return [pair for item in iterable.elts for pair in _unpack(target, item)]
+
+
 def _defaults(spec: ast.arguments) -> list[tuple[str, ast.expr]]:
     """Pair each parameter of *spec* with its default, where it has one.
 
@@ -491,7 +509,7 @@ def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
         elif isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)):
             # ``for runner in (subprocess.run,)`` binds a name with no
             # assignment statement anywhere in sight.
-            found.extend(_unpack(node.target, node.iter))
+            found.extend(_iterated(node.target, node.iter))
         elif isinstance(node, ast.ClassDef):
             found.extend(_class_bindings(node))
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -975,6 +993,31 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             '        runner(["x"], capture_output=True, text=True)',
             "a capture is only as loud as the subject it reads",
         ),
+        (
+            'import subprocess\n'
+            'for label, runner in [(subprocess.check_call, subprocess.run)]:\n'
+            '    label(["x"], capture_output=True, text=True)',
+            "a loop target takes one column of the pairs, not both",
+        ),
+        (
+            'import subprocess\n'
+            'for label, runner in ((subprocess.check_call, 1), (subprocess.run, 2)):\n'
+            '    runner(["x"], capture_output=True, text=True)',
+            "the second column of every pair is what the second name reads",
+        ),
+        (
+            'import subprocess\n'
+            'for label, runner in {(subprocess.check_call, subprocess.run)}:\n'
+            '    label(["x"], capture_output=True, text=True)',
+            "a set literal of pairs still has columns",
+        ),
+        (
+            'import subprocess\n'
+            'runner = other = subprocess.check_output\n'
+            'runner = subprocess.run\n'
+            'runner(["x"], text=True)',
+            "the first binding of a name wins over a later group it shares",
+        ),
     ],
 )
 def test_detector_stays_quiet(source: str, why: str) -> None:
@@ -1368,6 +1411,18 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             '        pass\n    case runner:\n'
             '        runner(["x"], capture_output=True, text=True)',
             "a later case captures just as much as the first",
+        ),
+        (
+            'import subprocess\nheld = [subprocess.run]\n'
+            'for runner in held:\n'
+            '    runner(["x"], capture_output=True, text=True)',
+            "an opaque iterable still resolves through its own binding",
+        ),
+        (
+            'import subprocess\n'
+            'for runner in [subprocess.check_call, subprocess.run]:\n'
+            '    runner(["x"], capture_output=True, text=True)',
+            "every item of the iterable is a value the name can take",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

Round eight of adversarial review against the subprocess text-encoding
guard. Five defects, five fixes, one of them a performance cliff and one a
false positive. Every fix was mutation tested, and three mutation runs
found gaps the fix itself had not closed.

Refs #3823

Fixes #3810
Fixes #3811
Fixes #3812
Fixes #3813
Fixes #3814

## The five defects

### 1. check_output captured without being asked (#3810)

check_output passes stdout=PIPE for you. It is the only entry point that
captures with no keyword at the call site, so a call with text=True and no
capture keyword decodes bytes the scan believed were never read.

```python
import subprocess
subprocess.check_output(["x"], text=True)
```

Quiet before. Loud now. run and Popen keep the old reading, because
without a capture keyword their output goes to inherited handles and never
becomes a str.

### 2. A container mutated after its literal (#3811)

A name bound to a literal container was read from that literal forever,
so anything put into the container afterwards was invisible.

```python
import subprocess
held = [print]
held.append(subprocess.run)
held[0](["x"], capture_output=True, text=True)
```

The review demonstrated one shape. Probing the class found seven: append,
insert, extend, setdefault, a subscript write, an augmented assignment, and
a del. All seven are closed by two rules working together. What flows into
a container is recorded as a binding of the container's own name, which
retires the name from precise indexing. The two shapes that hand over
nothing, reverse and del, are disqualified directly.

### 3. Match captures bound nothing (#3812)

A structural pattern binds names, and none of them were read.

```python
import subprocess
match subprocess.run:
    case runner:
        runner(["x"], capture_output=True, text=True)
```

Eight shapes evade: a bare capture, an as-pattern, a star pattern, a
mapping rest, a sequence element, a guarded case, a class-pattern keyword,
and an or-pattern. All eight reduce to one rule. A structural pattern names
a capture in exactly three places, and every other pattern is a shape
holding those, so one walk per case finds them all.

### 4. A loop target read the wrong column (#3813)

A loop target does not line up with the iterable. It lines up with one item
at a time, and unpacking it against the iterable read across the rows
instead of down the columns.

```python
import subprocess
for label, runner in [(subprocess.check_call, subprocess.run)]:
    label(["x"], capture_output=True, text=True)
```

label holds check_call, which decodes nothing, but the scan paired label
with the whole literal and flagged the call. A loop target is now paired
with each item of a literal iterable in turn, one binding per item, so a
name that takes several values across iterations gets one binding for each
and stays loud whenever any item is an entry point.

### 5. One value read by many names was quadratic (#3814)

A left side that does not line up with its right side pairs every name with
the whole of it, so one node can be read by thousands of names. Each name
resolving queued the group afresh, and each pop walked the whole value
again.

| names | before | after |
|-------|--------|-------|
| 500   | 0.067s | 0.012s |
| 1000  | 0.229s | 0.026s |
| 2000  | 0.868s | 0.061s |
| 4000  | 3.279s | 0.172s |

Clean four times per doubling before, roughly two times per doubling after,
and linear out to 8000. A group whose names are all known has nothing left
to learn, so it is skipped before the walk.

## Mutation testing

Every fix was mutated and every mutant killed.

| battery | mutants | first-run survivors | outcome |
|---------|---------|---------------------|---------|
| container mutation | 12 | 3 | 3 dead-code paths deleted, 1 test added |
| quadratic | 4 | 1 | 1 test added |
| match captures | 6 | 2 | 1 test added, 1 equivalent mutant proved |
| loop columns | 6 | 3 | 3 tests added |
| bindings and indexing | 5 | 3 | 2 tests added, 1 equivalent mutant proved |

Two survivors were proved equivalent by experiment rather than argued. In
both cases the type checker is what rejects the mutant, so no test can
reach it, and both are now documented in place so the next run does not
chase them again.

Three survivors in the container battery were not test gaps at all. They
were unreachable branches, which is how three dead arms and a whole helper
came to be deleted. Mutation testing is a dead-code detector as well as a
test-quality one.

## What was deleted

Three arms of the container-write rule and the helper behind them. Every
single-level subscript write already binds through the other half of the
rule, and a nested one cannot be read back either way, so the arms could
never fire.

## Not in scope

Seven shapes where a call returns a view of a literal still read quiet,
along with a value returned from a function. They share one cause and are
filed as #3823 with two candidate rules. No file in this repository uses
any of them, which the repo-wide scan confirms on every run.

## Verification

138 tests pass. The repo-wide scan over every Python file in the
repository stays green, which is the standing check on whether an
over-approximation costs a real false positive. Lint, cyclomatic
complexity, and type checking all pass.

## Provenance

Adversarial review by gemini-3.1-pro-preview against an isolated copy of
the guard. Round eight of eight; every round so far has found something.
