### PR TITLE
fix(skills): drop the phantom select_depth.py command from buy-vs-build

### DIFF
--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.5421",
+  "version": "0.6.5424",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.5420",
+  "version": "0.6.5421",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/buy-vs-build-framework/SKILL.md
+++ b/.claude/skills/buy-vs-build-framework/SKILL.md
@@ -68,10 +68,7 @@ Select appropriate analysis depth to prevent over-engineering.
 
 **Why:** Time-box effort proportional to decision magnitude. Prevents analysis paralysis on small decisions while ensuring rigor for strategic decisions.
 
-```bash
-python3 scripts/select_depth.py --budget 100000 --impact medium --reversibility moderate
-# Output: STANDARD tier (1-2 days, full 4 phases)
-```
+**Example:** A $100K budget with medium impact and moderate reversibility matches the Standard row on all three axes, so the depth is Standard: 1-2 days, full 4 phases.
 
 ### Phase 1: Classify (Core vs Context)
 

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.5421",
+  "version": "0.6.5424",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.5420",
+  "version": "0.6.5421",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/buy-vs-build-framework/SKILL.md
+++ b/src/copilot-cli/skills/buy-vs-build-framework/SKILL.md
@@ -68,10 +68,7 @@ Select appropriate analysis depth to prevent over-engineering.
 
 **Why:** Time-box effort proportional to decision magnitude. Prevents analysis paralysis on small decisions while ensuring rigor for strategic decisions.
 
-```bash
-python3 scripts/select_depth.py --budget 100000 --impact medium --reversibility moderate
-# Output: STANDARD tier (1-2 days, full 4 phases)
-```
+**Example:** A $100K budget with medium impact and moderate reversibility matches the Standard row on all three axes, so the depth is Standard: 1-2 days, full 4 phases.
 
 ### Phase 1: Classify (Core vs Context)
 


### PR DESCRIPTION
## Summary

Phase 0 of the buy-vs-build-framework skill told the agent to run a script that does not exist, and printed fabricated output underneath it. An agent following the skill ran a command that failed.

Refs #3916

## The defect

The skill's Phase 0 section carried this fence:

```bash
python3 scripts/select_depth.py --budget 100000 --impact medium --reversibility moderate
# Output: STANDARD tier (1-2 days, full 4 phases)
```

No such script exists anywhere in the repository:

```console
$ git ls-files | grep -i select_depth
$ echo "rc=$?"
rc=1
```

The skill ships four scripts, and its own contract enumerates exactly those four. None of them is the one Phase 0 invoked:

```console
$ ls .claude/skills/buy-vs-build-framework/scripts/
calculate_tco.py
check_reassessment_triggers.py
score_decision.py
score_vendor.py

$ grep -c 'script name=' .claude/skills/buy-vs-build-framework/references/SKILL_SPEC.xml
4
```

So this was never a missing file. It was a hallucinated command, and the output comment under it was invented too.

## The fix

The tier table sitting directly above the fence already specifies depth selection in full: budget, impact, reversibility, duration, and output for each of the three tiers. Selecting a depth is a table lookup, not a computation, so there is nothing for a script to do.

The fence is replaced by the worked example it was pretending to compute, with the same inputs and the same answer:

> **Example:** A $100K budget with medium impact and moderate reversibility matches the Standard row on all three axes, so the depth is Standard: 1-2 days, full 4 phases.

Comprehension is preserved. The reader still sees a concrete case mapped to a concrete tier. What goes away is the claim that a command exists.

## Verification

Every claim below was measured on the branch, not assumed.

Ghost reference is gone from both trees:

```console
$ git grep -c select_depth
$ echo "rc=$?"
rc=1
```

All four gates pass:

```console
$ python3 build/scripts/build_all.py --check
build --check rc=0

$ python3 build/scripts/validate_plugin_version_bump.py
plugin-version-bump: OK
bump rc=0

$ python3 build/scripts/check_plugin_manifest_parity.py
Plugin manifest versions match: 0.6.5424
parity rc=0

$ python3 scripts/validation/check_skill_md_exec_portability.py
portability rc=0
```

`build_all.py --check` returning 0 is what proves the Copilot mirror is genuine generator output rather than a hand edit. The two skill files are byte-identical.

## Defect class now at zero

This was the last invocation of its kind in the skills tree. A fence-aware scan of every markdown file under the canonical skills directory, counting only `python3` invocations inside bash fences whose target resolves neither against the containing skill directory nor against the repository root, reports:

```console
before (three weeks of accumulation):  20
after PR #3921 merged:                  9
after PR #3771 merged:                  1
after this change:                      0
```

The scanner was negative-controlled before its output was trusted. Against a synthetic tree containing one resolving path, one non-resolving path in a bash fence, one non-resolving path in prose, and one inside a PowerShell fence, it flagged exactly the bash-fence non-resolving case and nothing else.

Worth naming: the repository's own portability validator returns 0 on this defect. It only inspects paths prefixed with the tree root, so a bare `scripts/...` target that resolves nowhere is invisible to it. That blind spot is the subject of #3916, and it is why twenty of these accumulated unnoticed.

## Scope

Four files. Three lines removed, one added, plus the two manifest bumps. No script was created, no behavior changed, and no other section of the skill was touched.

## Notes

The two skillforge warnings on this skill (phase count, missing extension points) and the size warning at 428 of 500 lines are pre-existing and unrelated. This change reduces the file by three lines.
