### PR TITLE
fix(milestone): accept v-prefixed milestone titles in semver detection

### DIFF
--- a/.agents/sessions/2026-07-30-session-3876-fix-milestone-semver-regex-accept.json
+++ b/.agents/sessions/2026-07-30-session-3876-fix-milestone-semver-regex-accept.json
@@ -1,0 +1,119 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3876,
+    "date": "2026-07-30",
+    "branch": "fix/milestone-semver-v-prefix",
+    "startingCommit": "2d05bc86",
+    "objective": "Fix milestone semver regex to accept v-prefixed titles (issue #3945)"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "fix/milestone-semver-v-prefix"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On fix/milestone-semver-v-prefix"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "2d05bc86"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [],
+  "endingCommit": "",
+  "nextSteps": []
+}

--- a/.agents/sessions/2026-07-30-session-3876-fix-milestone-semver-regex-accept.json
+++ b/.agents/sessions/2026-07-30-session-3876-fix-milestone-semver-regex-accept.json
@@ -11,18 +11,18 @@
     "sessionStart": {
       "serenaActivated": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "mcp__serena__activate_project: ai-agents activated"
       },
       "serenaInstructions": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Serena initial instructions loaded via MCP server instructions"
       },
       "handoffRead": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "HANDOFF.md auto-injected by SessionStart context loader"
       },
       "sessionLogCreated": {
         "level": "MUST",
@@ -31,23 +31,23 @@
       },
       "skillScriptsListed": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Skill catalog auto-injected in session context"
       },
       "usageMandatoryRead": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "usage-mandatory memory listed in activation output"
       },
       "constraintsRead": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": ".claude/rules/* auto-loaded (universal, ci-scripts, python, testing)"
       },
       "memoriesLoaded": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Serena memory catalog loaded at activation; ci/ci-infrastructure-milestone-tracking relevant"
       },
       "branchVerified": {
         "level": "MUST",
@@ -61,8 +61,8 @@
       },
       "gitStatusVerified": {
         "level": "SHOULD",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "git status clean before branch, 3 untracked scratch files flagged"
       },
       "startingCommitNoted": {
         "level": "SHOULD",
@@ -73,47 +73,52 @@
     "sessionEnd": {
       "checklistComplete": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "All MUST items complete with evidence"
       },
       "handoffPreserved": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "HANDOFF.md not modified (read-only respected)"
       },
       "serenaMemoryUpdated": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Wrote ci/milestone-tracking-v-prefix-fix"
       },
       "markdownLintRun": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "npx markdownlint-cli2: 0 issues (no md changed)"
       },
       "changesCommitted": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Commits 4fff196d, 20a264fa, ca3a1314 + session log commit"
       },
       "validationPassed": {
         "level": "MUST",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "validate_session_json.py exit 0; pre_pr checks pass under uv (2 pre-existing ModuleNotFoundError = #3938)"
       },
       "tasksUpdated": {
         "level": "SHOULD",
-        "Complete": false,
-        "Evidence": ""
+        "Complete": true,
+        "Evidence": "Task list updated through session"
       },
       "retrospectiveInvoked": {
         "level": "SHOULD",
         "Complete": false,
         "Evidence": ""
+      },
+      "reworkWarning": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "rework-warning: none"
       }
     }
   },
   "workLog": [],
-  "endingCommit": "",
+  "endingCommit": "ca3a1314",
   "nextSteps": []
 }

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Complete project development toolkit: agents, slash commands, lifecycle hooks, and reusable skills for Claude Code workflows",
-  "version": "0.6.5424",
+  "version": "0.6.5425",
   "author": {
     "name": "rjmurillo"
   }

--- a/.claude/skills/github/scripts/milestone/get_latest_semantic_milestone.py
+++ b/.claude/skills/github/scripts/milestone/get_latest_semantic_milestone.py
@@ -47,12 +47,14 @@ from github_core.output import (  # noqa: E402
     write_skill_output,
 )
 
-_SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+# Optional v prefix matches the repository tag and milestone convention
+# (every milestone since 0.3.0 is v-prefixed; see issue #3945).
+_SEMVER_PATTERN = re.compile(r"^v?\d+\.\d+\.\d+$")
 
 
 def _parse_semver_tuple(version: str) -> tuple[int, ...]:
     """Parse 'X.Y.Z' into (X, Y, Z) for proper numeric sorting."""
-    return tuple(int(part) for part in version.split("."))
+    return tuple(int(part) for part in version.removeprefix("v").split("."))
 
 
 def _write_github_output(outputs: dict[str, str]) -> None:

--- a/.claude/skills/github/scripts/milestone/set_item_milestone.py
+++ b/.claude/skills/github/scripts/milestone/set_item_milestone.py
@@ -51,7 +51,9 @@ from github_core.output import (  # noqa: E402
     write_skill_output,
 )
 
-_SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+# Optional v prefix matches the repository tag and milestone convention
+# (every milestone since 0.3.0 is v-prefixed; see issue #3945).
+_SEMVER_PATTERN = re.compile(r"^v?\d+\.\d+\.\d+$")
 
 
 # Upper bound (seconds) for each gh network call.
@@ -59,7 +61,7 @@ GH_TIMEOUT_SECONDS = 30
 
 
 def _parse_semver_tuple(version: str) -> tuple[int, ...]:
-    return tuple(int(part) for part in version.split("."))
+    return tuple(int(part) for part in version.removeprefix("v").split("."))
 
 
 def _write_github_output(outputs: dict[str, str]) -> None:

--- a/.github/scripts/set_item_milestone.py
+++ b/.github/scripts/set_item_milestone.py
@@ -31,8 +31,10 @@ from scripts.github_core.api import (  # noqa: E402
     resolve_repo_params,
 )
 
-# Matches semantic version strings like "0.2.0", "1.10.3"
-_SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+# Matches semantic version strings like "0.2.0", "v0.4.0", "1.10.3".
+# The optional v prefix matches the repository's tag and milestone convention
+# (every milestone since 0.3.0 is v-prefixed; see issue #3945).
+_SEMVER_PATTERN = re.compile(r"^v?\d+\.\d+\.\d+$")
 
 
 # -------------------------------------------------------------------
@@ -41,8 +43,8 @@ _SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
 
 
 def _parse_semver_tuple(version: str) -> tuple[int, ...]:
-    """Parse "X.Y.Z" into (X, Y, Z) for proper numeric sorting."""
-    return tuple(int(part) for part in version.split("."))
+    """Parse "X.Y.Z" or "vX.Y.Z" into (X, Y, Z) for proper numeric sorting."""
+    return tuple(int(part) for part in version.removeprefix("v").split("."))
 
 
 def get_latest_semantic_milestone(

--- a/src/copilot-cli/.claude-plugin/plugin.json
+++ b/src/copilot-cli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "project-toolkit",
   "description": "Specialized agent definitions, reusable skills, and lifecycle hooks for GitHub Copilot CLI, generated from Claude canonical sources",
-  "version": "0.6.5424",
+  "version": "0.6.5425",
   "author": {
     "name": "rjmurillo"
   }

--- a/src/copilot-cli/skills/github/scripts/milestone/get_latest_semantic_milestone.py
+++ b/src/copilot-cli/skills/github/scripts/milestone/get_latest_semantic_milestone.py
@@ -47,12 +47,14 @@ from github_core.output import (  # noqa: E402
     write_skill_output,
 )
 
-_SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+# Optional v prefix matches the repository tag and milestone convention
+# (every milestone since 0.3.0 is v-prefixed; see issue #3945).
+_SEMVER_PATTERN = re.compile(r"^v?\d+\.\d+\.\d+$")
 
 
 def _parse_semver_tuple(version: str) -> tuple[int, ...]:
     """Parse 'X.Y.Z' into (X, Y, Z) for proper numeric sorting."""
-    return tuple(int(part) for part in version.split("."))
+    return tuple(int(part) for part in version.removeprefix("v").split("."))
 
 
 def _write_github_output(outputs: dict[str, str]) -> None:

--- a/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
+++ b/src/copilot-cli/skills/github/scripts/milestone/set_item_milestone.py
@@ -51,7 +51,9 @@ from github_core.output import (  # noqa: E402
     write_skill_output,
 )
 
-_SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+# Optional v prefix matches the repository tag and milestone convention
+# (every milestone since 0.3.0 is v-prefixed; see issue #3945).
+_SEMVER_PATTERN = re.compile(r"^v?\d+\.\d+\.\d+$")
 
 
 # Upper bound (seconds) for each gh network call.
@@ -59,7 +61,7 @@ GH_TIMEOUT_SECONDS = 30
 
 
 def _parse_semver_tuple(version: str) -> tuple[int, ...]:
-    return tuple(int(part) for part in version.split("."))
+    return tuple(int(part) for part in version.removeprefix("v").split("."))
 
 
 def _write_github_output(outputs: dict[str, str]) -> None:

--- a/tests/skills/github/test_milestone_scripts.py
+++ b/tests/skills/github/test_milestone_scripts.py
@@ -66,6 +66,25 @@ class TestGetLatestSemanticMilestone:
         assert result["Data"]["title"] == "0.2.1"
         assert result["Data"]["number"] == 3
 
+    def test_v_prefixed_titles(self, capsys):
+        mod = self._import()
+        milestones = [
+            {"title": "v0.4.0", "number": 1},
+            {"title": "v0.6.x close-out", "number": 2},
+            {"title": "v0.5.0", "number": 3},
+        ]
+        with (
+            patch("get_latest_semantic_milestone.assert_gh_authenticated"),
+            patch("get_latest_semantic_milestone.resolve_repo_params", return_value=_mock_repo()),
+            patch("get_latest_semantic_milestone.gh_api_paginated", return_value=milestones),
+        ):
+            rc = mod.main([])
+        assert rc == 0
+        result = json.loads(capsys.readouterr().out)
+        assert result["Data"]["found"] is True
+        assert result["Data"]["title"] == "v0.5.0"
+        assert result["Data"]["number"] == 3
+
     def test_no_milestones(self, capsys):
         mod = self._import()
         with (

--- a/tests/test_set_item_milestone.py
+++ b/tests/test_set_item_milestone.py
@@ -89,6 +89,12 @@ class TestParseSemverTuple:
     def test_large_numbers(self):
         assert _parse_semver_tuple("10.20.30") == (10, 20, 30)
 
+    def test_v_prefix(self):
+        assert _parse_semver_tuple("v1.2.3") == (1, 2, 3)
+
+    def test_v_prefix_sorts_equal_to_bare(self):
+        assert _parse_semver_tuple("v0.4.0") == _parse_semver_tuple("0.4.0")
+
 
 # ---------------------------------------------------------------------------
 # Tests: get_latest_semantic_milestone
@@ -135,6 +141,33 @@ class TestGetLatestSemanticMilestone:
             result = get_latest_semantic_milestone("o", "r")
         assert result["found"] is True
         assert result["title"] == "1.0.0"
+
+    def test_v_prefixed_milestones(self):
+        milestones = [
+            {"title": "v0.4.0", "number": 1},
+            {"title": "v0.5.0", "number": 2},
+        ]
+        with patch("subprocess.run", return_value=_completed(
+            stdout=json.dumps(milestones),
+        )):
+            result = get_latest_semantic_milestone("o", "r")
+        assert result["found"] is True
+        assert result["title"] == "v0.5.0"
+        assert result["number"] == 2
+
+    def test_mixed_bare_and_v_prefixed_sorts_numerically(self):
+        milestones = [
+            {"title": "0.3.0", "number": 1},
+            {"title": "v0.7.0", "number": 2},
+            {"title": "v0.6.x close-out", "number": 3},
+        ]
+        with patch("subprocess.run", return_value=_completed(
+            stdout=json.dumps(milestones),
+        )):
+            result = get_latest_semantic_milestone("o", "r")
+        assert result["found"] is True
+        assert result["title"] == "v0.7.0"
+        assert result["number"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_skill_set_item_milestone.py
+++ b/tests/test_skill_set_item_milestone.py
@@ -54,6 +54,31 @@ def test_assign_auto_detected(mock_run, capsys):
 
 
 @patch("subprocess.run")
+def test_assign_auto_detected_v_prefixed(mock_run, capsys):
+    item_data = json.dumps({"milestone": None})
+    milestones = json.dumps(
+        [
+            {"title": "v0.6.x close-out", "number": 10},
+            {"title": "v0.7.0", "number": 11},
+            {"title": "v0.6.0", "number": 12},
+        ]
+    )
+
+    mock_run.side_effect = [
+        _completed(rc=0),  # auth
+        _completed(stdout="https://github.com/o/r\n"),  # remote
+        _completed(stdout=item_data),  # get item
+        _completed(stdout=milestones),  # list milestones
+        _completed(rc=0),  # assign milestone
+    ]
+
+    rc = main(["--item-type", "pr", "--item-number", "42"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "v0.7.0" in out
+
+
+@patch("subprocess.run")
 def test_skip_existing_milestone(mock_run, capsys):
     item_data = json.dumps({"milestone": {"title": "0.2.0"}})
 


### PR DESCRIPTION
## Summary

The milestone-tracking workflow has been a silent no-op since milestone 0.3.0 closed (2026-02). `set_item_milestone.py` matched milestone titles with `^\d+\.\d+\.\d+$`, but every milestone created since is v-prefixed (v0.3.1, v0.4.0, v0.5.0). No open milestone ever matched, and `--missing-milestone-ok` turned every run into a green no-op. Result: the v0.4.0 milestone held 14 issues while its release window closed 412.

## Changes

- Accept an optional `v` prefix: `^v?\d+\.\d+\.\d+$`
- Strip the prefix in `_parse_semver_tuple` before numeric sorting, so bare and v-prefixed titles sort together
- Applied to all five copies: workflow script, both skill scripts under `.claude/skills/github/scripts/milestone/`, and their `src/copilot-cli` mirrors (byte-identical; DRY consolidation tracked in #3947)
- Tests: v-prefix parse, mixed bare/prefixed sorting, non-semver titles (`v0.6.x close-out`) excluded; 58 pass across the four milestone test suites
- Plugin manifests bumped to 0.6.5425 (parity pair)

## Verification

- `uv run pytest tests/test_set_item_milestone.py tests/test_skill_set_item_milestone.py tests/skills/github/test_milestone_scripts.py tests/skills/github/test_set_item_milestone.py`: 58 passed
- Adversarial review (independent reviewer agent): regex edge cases (bare `v`, uppercase `V`, `-rc1` suffix, four-part versions) rejected correctly; `_parse_semver_tuple` only reachable through pattern-matched titles; no downstream consumer assumes bare titles; mirrors byte-identical; files are source, not generated
- `pre_pr.py`: passes except two pre-existing ModuleNotFoundError failures under ambient python3 (#3938) which pass under `uv run`

Fixes #3945

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013evy3Yp5FY12WVhSKL9A5w