### PR TITLE
test(guard): port the superseded branch's unique subprocess detections onto main

### DIFF
--- a/.agents/memory/episodes/episode-2026-07-30-session-3422-guard-detection-port.json
+++ b/.agents/memory/episodes/episode-2026-07-30-session-3422-guard-detection-port.json
@@ -1,0 +1,131 @@
+{
+  "id": "episode-2026-07-30-session-3422-guard-detection-port",
+  "session": "2026-07-30-session-3422-guard-detection-port",
+  "timestamp": "2026-07-30T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Port the unique subprocess-guard detections from the superseded branch (closed PR #3835) forward onto current main, one family per commit, tests first, and verify with a differential harness that no detection is lost.",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Measure the abandoned branch against main before choosing a base",
+      "caused_by": [],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Port family F2, itertools filters and heapq selectors",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fix a lambda owner-name crash surfaced by F2",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": [
+        "e004"
+      ]
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Port family F1, operator selectors",
+      "caused_by": [
+        "e003"
+      ],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Port family F3, module alias through container and class body",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": [
+        "e006"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Port family F5, partial fixed capture through a container",
+      "caused_by": [
+        "e005"
+      ],
+      "leads_to": [
+        "e007"
+      ]
+    },
+    {
+      "id": "e007",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Port family F4, partial keyword mutation undoing a codec pin",
+      "caused_by": [
+        "e006"
+      ],
+      "leads_to": [
+        "e008"
+      ]
+    },
+    {
+      "id": "e008",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Fix main's construction-site codec-pin false positive",
+      "caused_by": [
+        "e007"
+      ],
+      "leads_to": [
+        "e009"
+      ]
+    },
+    {
+      "id": "e009",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Port operator.methodcaller, previously deferred as expensive",
+      "caused_by": [
+        "e008"
+      ],
+      "leads_to": []
+    },
+    {
+      "id": "e010",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 707f016fc222a8691266181171b24d4adfa90beb",
+      "caused_by": [],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 1,
+    "files_changed": 3
+  },
+  "lessons": []
+}

--- a/.agents/memory/episodes/episode-2026-07-30-session-3422-guard-detection-port.json
+++ b/.agents/memory/episodes/episode-2026-07-30-session-3422-guard-detection-port.json
@@ -114,6 +114,62 @@
       "id": "e010",
       "timestamp": "2026-07-30T00:00:00+00:00",
       "type": "commit",
+      "content": "Commit: 4fabd3819",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e011",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 691c21ac5",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e012",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 067d4c986",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e013",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: bd1fadd7f",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e014",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: a6c911400",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e015",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: d928b6346",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e016",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 8ce470bfd",
+      "caused_by": [],
+      "leads_to": []
+    },
+    {
+      "id": "e017",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "commit",
       "content": "Commit: 707f016fc222a8691266181171b24d4adfa90beb",
       "caused_by": [],
       "leads_to": []
@@ -124,7 +180,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 1,
+    "commits": 8,
     "files_changed": 3
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-30-session-3878-address-3961-review-feedback.json
+++ b/.agents/memory/episodes/episode-2026-07-30-session-3878-address-3961-review-feedback.json
@@ -37,6 +37,26 @@
         "e002"
       ],
       "leads_to": []
+    },
+    {
+      "id": "e004",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: a104d29c82de9924b87a694e74506071ef152282",
+      "caused_by": [],
+      "leads_to": [
+        "e005"
+      ]
+    },
+    {
+      "id": "e005",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: 89358b55b",
+      "caused_by": [
+        "e004"
+      ],
+      "leads_to": []
     }
   ],
   "metrics": {
@@ -44,7 +64,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 0,
+    "commits": 2,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-30-session-3878-address-3961-review-feedback.json
+++ b/.agents/memory/episodes/episode-2026-07-30-session-3878-address-3961-review-feedback.json
@@ -56,6 +56,18 @@
       "caused_by": [
         "e004"
       ],
+      "leads_to": [
+        "e006"
+      ]
+    },
+    {
+      "id": "e006",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "commit",
+      "content": "Commit: a104d29c8b11b186a94614668615da4cfc68ce97",
+      "caused_by": [
+        "e005"
+      ],
       "leads_to": []
     }
   ],
@@ -64,7 +76,7 @@
     "tool_calls": 0,
     "errors": 0,
     "recoveries": 0,
-    "commits": 2,
+    "commits": 3,
     "files_changed": 4
   },
   "lessons": []

--- a/.agents/memory/episodes/episode-2026-07-30-session-3878-address-3961-review-feedback.json
+++ b/.agents/memory/episodes/episode-2026-07-30-session-3878-address-3961-review-feedback.json
@@ -1,0 +1,51 @@
+{
+  "id": "episode-2026-07-30-session-3878-address-3961-review-feedback",
+  "session": "2026-07-30-session-3878-address-3961-review-feedback",
+  "timestamp": "2026-07-30T00:00:00+00:00",
+  "outcome": "success",
+  "task": "Address PR 3961 review feedback",
+  "decisions": [],
+  "events": [
+    {
+      "id": "e001",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Address three PR review findings",
+      "caused_by": [],
+      "leads_to": [
+        "e002"
+      ]
+    },
+    {
+      "id": "e002",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Add regression and performance coverage",
+      "caused_by": [
+        "e001"
+      ],
+      "leads_to": [
+        "e003"
+      ]
+    },
+    {
+      "id": "e003",
+      "timestamp": "2026-07-30T00:00:00+00:00",
+      "type": "milestone",
+      "content": "Run independent review and repository gates",
+      "caused_by": [
+        "e002"
+      ],
+      "leads_to": []
+    }
+  ],
+  "metrics": {
+    "duration_minutes": 0,
+    "tool_calls": 0,
+    "errors": 0,
+    "recoveries": 0,
+    "commits": 0,
+    "files_changed": 4
+  },
+  "lessons": []
+}

--- a/.agents/retrospective/2026-07-30-differential-harness-over-test-suite.md
+++ b/.agents/retrospective/2026-07-30-differential-harness-over-test-suite.md
@@ -1,0 +1,135 @@
+# A Passing Test Suite Missed Six Defects a Differential Harness Caught
+
+Date: 2026-07-30
+Failure mode: Class 9, confident-incorrectness recurrence
+(`.agents/governance/FAILURE-MODES.md`). Secondary: Class 4, verification
+theater, where a green suite is read as proof of no regression.
+
+## Summary
+
+A long-lived branch hardened the subprocess text-encoding guard in
+`tests/test_subprocess_text_encoding.py` over roughly twenty rounds. The owner
+closed that branch as superseded once two competing guard PRs merged to `main`.
+The correct recovery was to port the branch's unique detections forward onto
+current `main`, not to rebase or merge the divergent branch.
+
+During that port, a differential harness (run the old guard and the new guard
+over the same corpus of payloads and diff the flagged line sets) caught six
+defects across three classes. Every one of them was invisible to a suite that
+was passing at the time, including the tests written for the very change that
+introduced the defect.
+
+The suite went from 228 tests on `main` to 283 on the port. It was green at
+every point where the harness found a problem.
+
+## Impact
+
+| Area | Severity | Effect |
+|------|----------|--------|
+| Detection correctness | High | Three real regressions were introduced by one 40-line change and caught only by the diff. All three would have silenced genuine detections on `main`. |
+| False-positive rate | High | Two false positives were caught, one of them pre-existing on `main` and inherited by every consumer of that guard since it merged. |
+| Base-branch selection | High | Measuring the abandoned branch against `main` showed it carried 8 false positives `main` does not have. Merging it would have shipped all 8. |
+| Sequencing cost | Medium | One deferral (`operator.methodcaller`) was correct when made and trivial three commits later. Re-checking deferrals after adjacent work lands is nearly free. |
+| Complexity | Positive | `_resolve_indirect` fell from 15 to 10 while gaining five capability families, because each family reused the extraction the previous one forced. |
+
+## Timeline
+
+1. The branch `feat/guard-multi-hop-detection` was closed by the owner as
+   superseded (PR #3835). Two guard PRs, #3826 and #3894, had already merged to
+   `main`.
+2. Rather than assume the closed branch was the better base, both guards were
+   snapshotted and run over the same 489-payload corpus. The closed branch
+   flagged 27 shapes `main` did not. Tracing those 27 by hand found 8 were
+   **false positives** the branch had introduced, not detections `main` was
+   missing. That measurement, not the owner's authority, is what settled the
+   base-branch question.
+3. A fresh branch off current `main` ported five detection families forward,
+   one commit each, tests first in every case.
+4. Family F4 (mutating a `functools.partial`'s keyword mapping to undo a codec
+   pin) passed its own 5 tests. The differential harness immediately flagged
+   `runner.keywords.get('encoding')` as newly detected. The rule "any mention of
+   `.keywords` voids the pin" had swept in **read-only** access. Fixed by adding
+   a parent map and a `_reads_only` predicate. 3 new quiet tests.
+5. The same diff surfaced a payload where `main` flagged a `partial` whose
+   construction site pinned `encoding='utf-8'`. A two-module probe confirmed the
+   codec is pinned at runtime. **That was `main`'s bug, inherited, not the
+   port's.** Fixed with `_prepinned`, the exact mirror of the existing
+   `_presupplied`.
+6. `_prepinned` passed its own 4 tests. The differential harness caught **three
+   real regressions it had introduced**: a call site naming `encoding="latin-1"`
+   (which wins at runtime), a call site splatting `**overrides` (which may carry
+   `encoding`), and `alias = runner; alias.keywords['encoding'] = None` (an alias
+   shares the mapping, so a node-id-keyed void set misses it). All three were
+   written as failing tests, then fixed.
+7. `operator.methodcaller` had been deferred earlier as expensive: it needs
+   keywords from a node other than the call site. After the operator-getter
+   machinery landed for family F1, the same deferral cost one word in a table
+   plus a nine-line helper. The deferral was correct when made and wrong three
+   commits later.
+
+## What Went Wrong
+
+- Reading a green suite as proof that a behavioral change introduced no
+  regression. It is proof that the change satisfies the assertions someone
+  thought to write, which is a strictly smaller claim.
+- Writing the void rule for `.keywords` as "any mention" without asking what a
+  read looks like. The tests written for that change all used writes.
+- Assuming a closed branch was the better base because it had more rounds of
+  work in it. Round count is not detection quality. It had 8 false positives.
+- Treating a deferral as permanent. The cost estimate that justified it was
+  accurate against the code as it stood, and stale two commits later.
+
+## What Went Right
+
+- Snapshotting both guards to separate files and diffing their flagged line sets
+  over a shared corpus. Cheap to build, and it earned its keep six times.
+- Running the diff **against `main`** and not only against the abandoned branch.
+  The vs-`main` direction is the important one: entries there are behaviors the
+  port **removed**, each of which must be justified as a false positive or it is
+  a lost detection.
+- Writing every fix as a failing test first, and confirming the red matched
+  exactly the intended cases before implementing.
+- Extracting shared helpers as each family arrived rather than after. That is
+  why complexity fell while capability grew.
+
+## Remediation
+
+| Action | Owner | Tracking |
+|--------|-------|----------|
+| Port five detection families plus `methodcaller` onto current `main` | shipped | this branch, Refs #3422 |
+| Fix `main`'s construction-site codec-pin false positive | shipped | commit `8ce470bfd` |
+| Record that the abandoned branch carried 8 false positives | this document | see Timeline item 2 |
+| Decide the `capture_output=False` conservatism policy | open | see Follow-Ups |
+| 162 test-tree calls need a codec pinned | open | issue #3925 |
+| Widen the guard's scan root beyond `scripts/` | open | issue #3927 |
+
+## Follow-Ups Not Yet Filed
+
+1. The differential-harness pattern is not encoded anywhere. It is three small
+   scripts in `/tmp` that any future guard author will rebuild from scratch.
+   Worth a skill or a checked-in tool: snapshot two versions of a scanner, run
+   both over a corpus, diff the flagged sets, and require every removed
+   detection to be justified.
+2. `capture_output=False` at a call site that overrides a `partial`'s
+   `capture_output=True`. `main` flags it. Runtime proof shows `stdout` is
+   `None`, so nothing is decoded and the flag is a false positive. This is a
+   conservatism **policy** call, not a bug, and belongs to the owner.
+3. No CI gate runs a differential diff on guard changes. A guard PR can silently
+   remove detections and stay green. The corpus exists; the comparison does not.
+
+## Learning
+
+A test suite answers "did the behaviors I thought of still work." A differential
+harness answers "what behaviors changed," including the ones nobody thought of.
+Those are different questions, and only the second one catches a regression in a
+scanner, because a scanner's output is a set and a suite only ever samples it.
+
+The cost of the harness was under an hour. It caught three regressions in one
+40-line change, two false positives (one inherited from `main`), and settled a
+base-branch decision that would otherwise have been made on authority or on
+round count. Both of those would have been wrong.
+
+The transferable rule: when a change alters what a scanner flags, diff the
+flagged sets before and after over a real corpus, and read the **removals** as
+carefully as the additions. A removal is either a false positive you fixed or a
+detection you lost, and the test suite cannot tell you which.

--- a/.agents/sessions/2026-07-30-session-3422-guard-detection-port.json
+++ b/.agents/sessions/2026-07-30-session-3422-guard-detection-port.json
@@ -1,0 +1,161 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3422,
+    "date": "2026-07-30",
+    "branch": "feat/guard-operator-iterator-resolution",
+    "startingCommit": "561035125",
+    "objective": "Port the unique subprocess-guard detections from the superseded branch (closed PR #3835) forward onto current main, one family per commit, tests first, and verify with a differential harness that no detection is lost."
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena unavailable in this worktree; fell back to .serena/memories per AGENTS.md."
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena unavailable in this worktree; fell back to .serena/memories per AGENTS.md."
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read at session start; not modified (ADR-014)."
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Guard work is a single test-tree file; no skill script applies."
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "gh operations routed through the GitHub skill; raw gh used only for read-only state checks."
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md and TESTING-RIGOR.md applied: pos+neg+edge per new function."
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Prior-session guard context loaded from checkpoints before resuming the port."
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "feat/guard-operator-iterator-resolution"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On feat/guard-operator-iterator-resolution, branched from origin/main 561035125"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Clean tree confirmed before each of the 8 commits; explicit paths staged, never git add -A."
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "561035125"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "283 tests pass in 8.51s (228 on main's baseline); ruff clean; C901 at main's baseline; mypy clean; 0 em/en dashes byte-verified."
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md untouched this session (ADR-014)."
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Durable findings recorded in .agents/retrospective/2026-07-30-differential-harness-over-test-suite.md; Serena MCP unavailable in this worktree."
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Scoped markdownlint run on the retrospective added this session (ADR-043)."
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "8 commits, one detection family each, single file per code commit."
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Differential vs main over a 276-payload corpus: 26 detections added, exactly 1 false positive removed, 0 real detections lost, 0 errors."
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Issues #3925 and #3927 repointed from the closed #3835 to this branch's PR."
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": ".agents/retrospective/2026-07-30-differential-harness-over-test-suite.md"
+      }
+    }
+  },
+  "workLog": [
+    {
+      "task": "Measure the abandoned branch against main before choosing a base",
+      "outcome": "27 old-branch-only shapes traced by hand. 8 were false positives the branch introduced. Main is the better base; the branch was abandoned rather than merged."
+    },
+    {
+      "task": "Port family F2, itertools filters and heapq selectors",
+      "outcome": "Commit 4fabd3819"
+    },
+    {
+      "task": "Fix a lambda owner-name crash surfaced by F2",
+      "outcome": "Commit 691c21ac5"
+    },
+    {
+      "task": "Port family F1, operator selectors",
+      "outcome": "Commit 067d4c986"
+    },
+    {
+      "task": "Port family F3, module alias through container and class body",
+      "outcome": "Commit bd1fadd7f"
+    },
+    {
+      "task": "Port family F5, partial fixed capture through a container",
+      "outcome": "Commit a6c911400"
+    },
+    {
+      "task": "Port family F4, partial keyword mutation undoing a codec pin",
+      "outcome": "Commit d928b6346. Differential harness then caught a read-only .keywords false positive; fixed with a parent map and _reads_only."
+    },
+    {
+      "task": "Fix main's construction-site codec-pin false positive",
+      "outcome": "Commit 8ce470bfd. Added _prepinned as the mirror of _presupplied. Differential harness caught 3 real regressions the change introduced; all three written as failing tests first, then fixed."
+    },
+    {
+      "task": "Port operator.methodcaller, previously deferred as expensive",
+      "outcome": "Commit 707f016fc. One word in _OPERATOR_GETTERS plus a nine-line _keyword_site helper, because the F1 operator machinery had already landed."
+    }
+  ],
+  "endingCommit": "707f016fc222a8691266181171b24d4adfa90beb",
+  "nextSteps": [
+    "Open the PR with Refs #3422 and the differential numbers in the body.",
+    "Repoint issues #3925 and #3927 from the closed #3835 to the new PR.",
+    "File the capture_output=False conservatism policy question with its runtime table for owner decision.",
+    "Consider a checked-in differential-diff tool so guard PRs cannot silently remove detections."
+  ]
+}

--- a/.agents/sessions/2026-07-30-session-3878-address-3961-review-feedback.json
+++ b/.agents/sessions/2026-07-30-session-3878-address-3961-review-feedback.json
@@ -127,7 +127,7 @@
       "outcome": "Independent reviewer found no blockers. Ruff and full pre-PR validation passed."
     }
   ],
-  "endingCommit": "a104d29c82de9924b87a694e74506071ef152282",
+  "endingCommit": "a104d29c8b11b186a94614668615da4cfc68ce97",
   "nextSteps": [
     "Push the autofix commit to feat/guard-operator-iterator-resolution.",
     "Reply to and resolve the three review threads.",

--- a/.agents/sessions/2026-07-30-session-3878-address-3961-review-feedback.json
+++ b/.agents/sessions/2026-07-30-session-3878-address-3961-review-feedback.json
@@ -1,0 +1,136 @@
+{
+  "schemaVersion": "1.0",
+  "session": {
+    "number": 3878,
+    "date": "2026-07-30",
+    "branch": "autofix/pr-3961",
+    "startingCommit": "68f11db07",
+    "objective": "Address PR 3961 review feedback"
+  },
+  "protocolCompliance": {
+    "sessionStart": {
+      "serenaActivated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena MCP project tools available for /tmp/ai-agents-pr3961; activation resource was not exposed by this harness"
+      },
+      "serenaInstructions": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "serena-initial_instructions completed"
+      },
+      "handoffRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md read and preserved as read-only"
+      },
+      "sessionLogCreated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "This file"
+      },
+      "skillScriptsListed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".claude/skills/github/scripts/pr directory listed; PR lifecycle scripts identified"
+      },
+      "usageMandatoryRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".serena/memories/usage-mandatory.md read"
+      },
+      "constraintsRead": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/governance/PROJECT-CONSTRAINTS.md read"
+      },
+      "memoriesLoaded": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Serena usage-mandatory memory loaded; no issue-specific handoff exists for PR 3961"
+      },
+      "branchVerified": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "autofix/pr-3961"
+      },
+      "notOnMain": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "On autofix/pr-3961"
+      },
+      "gitStatusVerified": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "Two intended modified files and this new session log; HEAD 68f11db07, 12 commits ahead of origin/main"
+      },
+      "startingCommitNoted": {
+        "level": "SHOULD",
+        "Complete": true,
+        "Evidence": "68f11db07"
+      }
+    },
+    "sessionEnd": {
+      "checklistComplete": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "518 targeted tests passed; Ruff passed; full pre-PR validation passed with 37 passes, 0 failures, and 4 documented skips"
+      },
+      "handoffPreserved": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": ".agents/HANDOFF.md remained unchanged"
+      },
+      "serenaMemoryUpdated": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Existing episode memory updated with all eight source commits and corrected commit metrics"
+      },
+      "markdownLintRun": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Full pre-PR Markdown Linting gate passed; no Markdown files changed"
+      },
+      "changesCommitted": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "All three intended files staged for one atomic PR autofix commit"
+      },
+      "validationPassed": {
+        "level": "MUST",
+        "Complete": true,
+        "Evidence": "Guard, episode extraction, episode staging, Ruff, session JSON, and full pre-PR gates passed"
+      },
+      "tasksUpdated": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      },
+      "retrospectiveInvoked": {
+        "level": "SHOULD",
+        "Complete": false,
+        "Evidence": ""
+      }
+    }
+  },
+  "workLog": [
+    {
+      "task": "Address three PR review findings",
+      "outcome": "Replaced quadratic FIFO removal, corrected episode commit metrics, and blocked codec-pin propagation through direct, transitive, and container-held unpinned alternatives."
+    },
+    {
+      "task": "Add regression and performance coverage",
+      "outcome": "Added positive, negative, edge, transitive, empty-container, and mixed-container cases. Targeted suites pass 518 tests."
+    },
+    {
+      "task": "Run independent review and repository gates",
+      "outcome": "Independent reviewer found no blockers. Ruff and full pre-PR validation passed."
+    }
+  ],
+  "endingCommit": "",
+  "nextSteps": [
+    "Push the autofix commit to feat/guard-operator-iterator-resolution.",
+    "Reply to and resolve the three review threads.",
+    "Run the completion gate and merge when all required checks pass."
+  ]
+}

--- a/.agents/sessions/2026-07-30-session-3878-address-3961-review-feedback.json
+++ b/.agents/sessions/2026-07-30-session-3878-address-3961-review-feedback.json
@@ -94,7 +94,7 @@
       "changesCommitted": {
         "level": "MUST",
         "Complete": true,
-        "Evidence": "All three intended files staged for one atomic PR autofix commit"
+        "Evidence": "Fix commit 89358b55b and concurrent-work merge commit a104d29c8"
       },
       "validationPassed": {
         "level": "MUST",
@@ -127,7 +127,7 @@
       "outcome": "Independent reviewer found no blockers. Ruff and full pre-PR validation passed."
     }
   ],
-  "endingCommit": "",
+  "endingCommit": "a104d29c82de9924b87a694e74506071ef152282",
   "nextSteps": [
     "Push the autofix commit to feat/guard-operator-iterator-resolution.",
     "Reply to and resolve the three review threads.",

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -101,7 +101,26 @@ _DEVNULL = "subprocess.DEVNULL"
 # either reads as what it is rather than as an opaque attribute.
 _PIPE = "subprocess.PIPE"
 _STDOUT = "subprocess.STDOUT"
-_NOT_ENTRY_POINTS = frozenset({_PARTIAL, _DEVNULL, _PIPE, _STDOUT})
+
+# The ``operator`` factories that reach a runner without ever spelling its
+# name at the call site. Each builds a callable, and it is the object handed
+# to that callable that decides what comes back: ``attrgetter("run")`` reads
+# the attribute off whatever module it is given, ``itemgetter(0)`` selects an
+# element out of whatever container it is given. The factory call and the
+# call that uses it are two separate nodes, so a scan that only reads the
+# outer ``func`` sees a call on a call and stops.
+_OPERATOR_GETTERS = frozenset({"attrgetter"})
+_OPERATOR_SELECTOR = "itemgetter"
+_OPERATOR_FACTORIES = _OPERATOR_GETTERS | frozenset({_OPERATOR_SELECTOR})
+_OPERATOR_MODULE = "operator"
+# Namespace prefix for every ``operator`` name recorded in the imported-name
+# table. The table's other values are entry points, so an unprefixed factory
+# name would read as one; the prefix keeps the two apart in one dict.
+_OPERATOR_ALIAS = "*op*"
+
+_NOT_ENTRY_POINTS = frozenset({_PARTIAL, _DEVNULL, _PIPE, _STDOUT}) | frozenset(
+    _OPERATOR_ALIAS + name for name in _OPERATOR_FACTORIES
+)
 
 # Calls the scan treats as pass-through: the reference handed in is the one
 # tracked coming out. ``nullcontext`` literally returns its argument;
@@ -178,7 +197,7 @@ _TRAILING_CONTAINERS = frozenset(
 # argument that is a container. One table rather than a branch per family, so
 # a new element-yielding callable is one row and the resolution reads once.
 _CONTAINER_ARGS: dict[str, int] = {
-    label: 0 for label in _ELEMENT_BUILTINS | _PASS_THROUGH
+    label: 0 for label in _ELEMENT_BUILTINS | _PASS_THROUGH | {"getitem"}
 } | {label: 1 for label in _TRAILING_CONTAINERS}
 
 # Dict methods that yield a view, mapped to the halves of the literal the view
@@ -218,6 +237,9 @@ _IMPORTED_NAMES: dict[str, dict[str, str]] = {
     | {"DEVNULL": _DEVNULL, "PIPE": _PIPE, "STDOUT": _STDOUT},
     "functools": {"partial": _PARTIAL},
     "os": {"popen": _OS_POPEN},
+    _OPERATOR_MODULE: {
+        name: _OPERATOR_ALIAS + name for name in _OPERATOR_FACTORIES
+    },
 }
 
 
@@ -382,6 +404,11 @@ def _resolve_indirect(
     subscript does: the element is not known, so the whole receiver answers.
     """
     label = _call_label(call)
+    if isinstance(call.func, ast.Call):
+        # ``attrgetter("run")(subprocess)`` is a call on a call, so the label
+        # above is empty and every branch below keys off it. Nothing else here
+        # can match, which is what makes returning straight out safe.
+        return _resolve_operator_getter(call, call.func, modules, functions)
     if _is_partial(label, functions) and call.args:
         return _resolve_callable(call.args[0], modules, functions)
     if label in _PASSTHROUGH and call.args:
@@ -411,24 +438,85 @@ def _resolve_indirect(
     if returned is not None:
         return returned
     if label == "getattr" and len(call.args) >= 2:
-        owner, attr = call.args[0], call.args[1]
-        if isinstance(attr, ast.Constant) and attr.value in _FORWARDING_ATTRS:
-            # ``getattr(subprocess.run, "__call__")`` composes the two shapes
-            # below, so resolving the owner answers for the pair.
-            return _resolve_callable(owner, modules, functions)
-        held = modules.get(owner.id) if isinstance(owner, ast.Name) else None
-        if held is None:
-            return None
-        if not isinstance(attr, ast.Constant):
-            # ``getattr(subprocess, name)`` hides which entry point it reaches.
-            # Nothing in this repository needs that, so the safe reading is
-            # that it reaches one of them.
-            return _DYNAMIC
-        if held == "subprocess" and attr.value in _SUBPROCESS_ATTRS:
-            return str(attr.value)
-        if held == "os" and attr.value == "popen":
-            return _OS_POPEN
+        return _module_attribute(call.args[0], call.args[1], modules, functions)
     return None
+
+
+def _module_attribute(
+    owner: ast.expr,
+    attr: ast.expr,
+    modules: dict[str, str],
+    functions: dict[str, str],
+) -> str | None:
+    """Resolve the attribute *attr* names, read off the module *owner* names.
+
+    ``getattr(subprocess, "run")`` and ``operator.attrgetter("run")(subprocess)``
+    both spell the owner and the attribute as two separate expressions, so one
+    resolution answers for both rather than two that can drift apart.
+    """
+    if isinstance(attr, ast.Constant) and attr.value in _FORWARDING_ATTRS:
+        # ``getattr(subprocess.run, "__call__")`` composes the two shapes
+        # below, so resolving the owner answers for the pair.
+        return _resolve_callable(owner, modules, functions)
+    held = modules.get(owner.id) if isinstance(owner, ast.Name) else None
+    if held is None:
+        return None
+    if not isinstance(attr, ast.Constant):
+        # ``getattr(subprocess, name)`` hides which entry point it reaches.
+        # Nothing in this repository needs that, so the safe reading is
+        # that it reaches one of them.
+        return _DYNAMIC
+    if held == "subprocess" and attr.value in _SUBPROCESS_ATTRS:
+        return str(attr.value)
+    if held == "os" and attr.value == "popen":
+        return _OS_POPEN
+    return None
+
+
+def _operator_label(factory: ast.Call, functions: dict[str, str]) -> str:
+    """Return the canonical ``operator`` factory *factory* builds, or ``""``.
+
+    Reads both spellings: an attribute on an imported ``operator`` module, and
+    a name bound by ``from operator import ... as ...``. A name reaching
+    neither is some other callable that happens to share a word, which is why
+    a local ``def itemgetter`` does not answer here.
+    """
+    func = factory.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        owner = functions.get(_OPERATOR_ALIAS + func.value.id)
+        if owner == _OPERATOR_MODULE and func.attr in _OPERATOR_FACTORIES:
+            return func.attr
+        return ""
+    if isinstance(func, ast.Name):
+        canonical = functions.get(func.id, "")
+        if canonical.startswith(_OPERATOR_ALIAS):
+            return canonical[len(_OPERATOR_ALIAS) :]
+    return ""
+
+
+def _resolve_operator_getter(
+    call: ast.Call,
+    factory: ast.Call,
+    modules: dict[str, str],
+    functions: dict[str, str],
+) -> str | None:
+    """Resolve ``attrgetter("run")(subprocess)`` and ``itemgetter(0)(RUNNERS)``.
+
+    The factory call names what to read; the call using it names what to read
+    it from. Neither node alone spells a runner, which is what makes the pair
+    an evasion: a scan reading only the outer ``func`` sees a call on a call
+    and stops one step short of the entry point.
+    """
+    label = _operator_label(factory, functions)
+    if not label or not call.args:
+        return None
+    if label == _OPERATOR_SELECTOR:
+        # The index is not modelled, exactly as for a subscript, so every
+        # element of the container handed in answers.
+        return _resolve_elements(list(call.args), modules, functions)
+    if not factory.args:
+        return None
+    return _module_attribute(call.args[0], factory.args[0], modules, functions)
 
 
 def _resolve_elements(
@@ -1007,6 +1095,13 @@ def _imports(tree: ast.AST) -> tuple[dict[str, str], dict[str, str]]:
             for alias in node.names:
                 if alias.name in _TRACKED_MODULES:
                     modules[alias.asname or alias.name] = alias.name
+                elif alias.name == _OPERATOR_MODULE:
+                    # Recorded beside the imported names rather than in
+                    # ``modules`` because ``operator`` holds no entry point.
+                    # It only names the factories that reach one.
+                    functions[_OPERATOR_ALIAS + (alias.asname or alias.name)] = (
+                        _OPERATOR_MODULE
+                    )
         elif isinstance(node, ast.ImportFrom):
             wanted = _IMPORTED_NAMES.get(node.module or "", {})
             for alias in node.names:
@@ -1780,6 +1875,37 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             '    ["x"], capture_output=True, text=True, encoding="utf-8"\n'
             ')',
             "a runner reached through a filter is still pinned by its call site",
+        ),
+        (
+            'import operator, shutil\n'
+            'operator.attrgetter("which")(shutil)(["x"], capture_output=True, text=True)',
+            "an attribute read off a module we do not track starts nothing",
+        ),
+        (
+            'import subprocess\n'
+            'from operator import itemgetter\n'
+            'itemgetter(0)([print])(["x"], capture_output=True, text=True)',
+            "a selector over a container of something else selects something else",
+        ),
+        (
+            'import subprocess\n'
+            'from operator import attrgetter\n'
+            'attrgetter("run")(subprocess)(\n'
+            '    ["x"], capture_output=True, text=True, encoding="utf-8"\n'
+            ')',
+            "a runner reached through a getter is still pinned by its call site",
+        ),
+        (
+            'import subprocess\n'
+            'def itemgetter(index):\n'
+            '    return lambda rows: print\n'
+            'itemgetter(0)([subprocess.run])(["x"], capture_output=True, text=True)',
+            "a local factory sharing the name is not the one from operator",
+        ),
+        (
+            'import operator, subprocess\n'
+            'operator.attrgetter("Popen")(subprocess)(["x"])',
+            "a spawn with neither capture nor text decodes nothing",
         ),
     ],
 )
@@ -2647,6 +2773,48 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             'from heapq import nsmallest\n'
             'nsmallest(1, [subprocess.run])[0](["x"], capture_output=True, text=True)',
             "nsmallest selects from the same container from the other end",
+        ),
+        (
+            'import operator, subprocess\n'
+            'operator.attrgetter("run")(subprocess)(["x"], capture_output=True, text=True)',
+            "attrgetter reads the named attribute off the module handed to it",
+        ),
+        (
+            'import operator as op, subprocess\n'
+            'op.attrgetter("run")(subprocess)(["x"], capture_output=True, text=True)',
+            "an aliased operator module builds the same factory",
+        ),
+        (
+            'import subprocess\n'
+            'from operator import attrgetter\n'
+            'name = "run"\n'
+            'attrgetter(name)(subprocess)(["x"], capture_output=True, text=True)',
+            "a computed attribute on a subprocess module still reaches one of ours",
+        ),
+        (
+            'import subprocess\n'
+            'from operator import itemgetter\n'
+            'itemgetter(0)([subprocess.run])(["x"], capture_output=True, text=True)',
+            "itemgetter selects an element, so the container it reads answers",
+        ),
+        (
+            'import subprocess\n'
+            'from operator import itemgetter as pick\n'
+            'pick(0)([subprocess.run])(["x"], capture_output=True, text=True)',
+            "an import alias renames the selector and nothing else",
+        ),
+        (
+            'import subprocess\n'
+            'from operator import itemgetter\n'
+            'HOLDER = [subprocess.run]\n'
+            'itemgetter(0)(HOLDER)(["x"], capture_output=True, text=True)',
+            "a selector reading a named container reads what the name holds",
+        ),
+        (
+            'import subprocess\n'
+            'from operator import getitem\n'
+            'getitem([subprocess.run], 0)(["x"], capture_output=True, text=True)',
+            "getitem is the subscript spelled as a call",
         ),
     ],
 )

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -1411,6 +1411,36 @@ def _presupplied(
     return set(_settle(bindings, seed))
 
 
+def _pins_codec(value: ast.expr, functions: dict[str, str]) -> bool:
+    """Report whether *value* is a partial fixing the codec where it is built."""
+    return (
+        isinstance(value, ast.Call)
+        and _is_partial(_call_label(value), functions)
+        and _pins_utf8(value)
+    )
+
+
+def _rebound_bare(
+    bindings: list[tuple[str, ast.expr]], functions: dict[str, str]
+) -> set[str]:
+    """Name every binding holding something no pin can reach it through.
+
+    A value that pins the codec answers for itself. A value naming other
+    names defers to the fixpoint, which answers only if those names are
+    pinned. Anything else is a plain callable with no codec of its own.
+
+    Keeping these out of the seed is not enough, because the fixpoint grows
+    by name: ``alias = runner`` puts an alias back however it was later
+    rebound. A name that ever holds a bare callable is dropped after the
+    fixpoint has run, so the rebinding wins over what it inherited.
+    """
+    return {
+        name
+        for name, value in bindings
+        if not _pins_codec(value, functions) and not _module_sources(value)
+    }
+
+
 def _prepinned(
     bindings: list[tuple[str, ast.expr]],
     functions: dict[str, str],
@@ -1432,22 +1462,19 @@ def _prepinned(
 
     A name is only trusted when every binding it carries pins the codec. One
     name can be bound in two scopes, and a pinned partial built inside some
-    unrelated function says nothing about the runner called out here.
+    unrelated function says nothing about the runner called out here. The
+    same holds after the fixpoint has grown the set, because a name can
+    inherit a pin from an alias and then be rebound to something bare.
     """
     pinning: dict[str, bool] = {}
     for name, value in bindings:
-        pins = (
-            isinstance(value, ast.Call)
-            and _is_partial(_call_label(value), functions)
-            and _pins_utf8(value)
-        )
-        pinning[name] = pinning.get(name, True) and pins
+        pinning[name] = pinning.get(name, True) and _pins_codec(value, functions)
     seed = {
         name: name
         for name, pins in pinning.items()
         if pins and name not in undone
     }
-    return set(_settle(bindings, seed))
+    return set(_settle(bindings, seed)) - _rebound_bare(bindings, functions)
 
 
 def _parameter_bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
@@ -2361,6 +2388,15 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'runner.keywords["timeout"] = 1\n'
             'runner(["x"], text=True)',
             "storing under some other key leaves the bound codec where it was",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'alias = runner\n'
+            'alias(["x"], text=True)',
+            "an alias that only ever holds the pinned runner still answers for it",
         ),
         (
             'import functools, subprocess\n'
@@ -3511,6 +3547,16 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             '    return runner\n'
             'runner(["x"], capture_output=True, text=True)',
             "a pin bound to the same name somewhere else answers for nothing here",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'alias = runner\n'
+            'alias = subprocess.run\n'
+            'alias(["x"], capture_output=True, text=True)',
+            "an alias that inherits a pin and is then rebound holds it no longer",
         ),
     ],
 )

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -1171,10 +1171,10 @@ def _module_sources(value: ast.expr) -> list[str]:
     the walk inside one expression is what bounds it: chasing bindings from
     here re-walks a chain of length N once per link and costs N squared.
     """
-    queue = [value]
+    queue = deque([value])
     found: list[str] = []
     while queue:
-        node = queue.pop(0)
+        node = queue.popleft()
         if isinstance(node, ast.Name):
             found.append(node.id)
         elif isinstance(node, ast.Subscript):
@@ -1184,7 +1184,12 @@ def _module_sources(value: ast.expr) -> list[str]:
     return found
 
 
-def _settle(bindings: list[tuple[str, ast.expr]], seed: dict[str, str]) -> dict[str, str]:
+def _settle(
+    bindings: list[tuple[str, ast.expr]],
+    seed: dict[str, str],
+    *,
+    blocked: set[str] | None = None,
+) -> dict[str, str]:
     """Grow *seed* with every name that inherits from a name already in it.
 
     ``sp = subprocess`` and ``runner = base`` are one problem twice: a name
@@ -1209,7 +1214,8 @@ def _settle(bindings: list[tuple[str, ast.expr]], seed: dict[str, str]) -> dict[
     name can answer for, and a group that has settled is skipped outright, so
     each group is read once and each edge is followed once.
     """
-    grown = dict(seed)
+    blocked = blocked or set()
+    grown = {name: value for name, value in seed.items() if name not in blocked}
     groups: dict[int, tuple[list[str], list[str]]] = {}
     for name, value in bindings:
         key = id(value)
@@ -1227,7 +1233,7 @@ def _settle(bindings: list[tuple[str, ast.expr]], seed: dict[str, str]) -> dict[
         if key in settled:
             continue
         candidates, names = groups[key]
-        pending = [one for one in names if one not in grown]
+        pending = [one for one in names if one not in grown and one not in blocked]
         if not pending:
             settled.add(key)
             continue
@@ -1428,6 +1434,7 @@ def _prepinned(
     unrelated function says nothing about the runner called out here.
     """
     pinning: dict[str, bool] = {}
+    source_groups: dict[int, tuple[bool, bool, list[str], set[str]]] = {}
     for name, value in bindings:
         pins = (
             isinstance(value, ast.Call)
@@ -1435,12 +1442,48 @@ def _prepinned(
             and _pins_utf8(value)
         )
         pinning[name] = pinning.get(name, True) and pins
+        key = id(value)
+        if key not in source_groups:
+            empty_container = (
+                isinstance(value, (ast.List, ast.Tuple, ast.Set)) and not value.elts
+            ) or (isinstance(value, ast.Dict) and not value.keys)
+            source_groups[key] = (
+                pins,
+                empty_container,
+                _module_sources(value),
+                set(),
+            )
+        source_groups[key][3].add(name)
     seed = {
         name: name
         for name, pins in pinning.items()
         if pins and name not in undone
     }
-    return set(_settle(bindings, seed))
+    bound = set(pinning)
+    blocked: set[str] = set()
+    waiting: dict[str, list[int]] = {}
+    for key, (pins, empty_container, sources, names) in source_groups.items():
+        if pins:
+            continue
+        if (not sources and not empty_container) or any(
+            source not in bound for source in sources
+        ):
+            blocked.update(names)
+        for source in sources:
+            waiting.setdefault(source, []).append(key)
+    queue = deque(blocked)
+    blocked_groups: set[int] = set()
+    while queue:
+        source = queue.popleft()
+        for key in waiting.get(source, ()):
+            if key in blocked_groups:
+                continue
+            blocked_groups.add(key)
+            for name in source_groups[key][3]:
+                if name not in blocked:
+                    blocked.add(name)
+                    queue.append(name)
+    return set(_settle(bindings, seed, blocked=blocked))
 
 
 def _parameter_bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
@@ -2402,6 +2445,38 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             "import operator, subprocess\n"
             'operator.methodcaller("run", ["x"])(subprocess)',
             "a methodcaller that captures nothing decodes nothing",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'alias = runner\n'
+            'next_alias = alias\n'
+            'next_alias(["x"], text=True)',
+            "a wholly pinned alias chain keeps the construction-site codec",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'holders = []\n'
+            'holders.append(runner)\n'
+            'alias = holders[0]\n'
+            'alias(["x"], text=True)',
+            "an empty container can later receive a wholly pinned runner",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'holders = {}\n'
+            'holders["runner"] = runner\n'
+            'alias = holders["runner"]\n'
+            'alias(["x"], text=True)',
+            "an empty mapping can later receive a wholly pinned runner",
         ),
     ],
 )
@@ -3449,6 +3524,39 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             'alias.keywords["encoding"] = None\n'
             'runner(["x"], text=True)',
             "an alias shares the keyword mapping rather than copying it",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'alias = runner\n'
+            'alias = subprocess.run\n'
+            'alias(["x"], capture_output=True, text=True)',
+            "a later unpinned binding keeps a mixed alias out of the pinned set",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'raw = subprocess.run\n'
+            'alias = runner\n'
+            'alias = raw\n'
+            'next_alias = alias\n'
+            'next_alias(["x"], capture_output=True, text=True)',
+            "a transitive unpinned binding taints every downstream alias",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'raw = subprocess.run\n'
+            'holders = [runner, raw]\n'
+            'alias = holders[1]\n'
+            'alias(["x"], capture_output=True, text=True)',
+            "a container with an unpinned alternative cannot confer a codec pin",
         ),
         (
             "import operator, subprocess\n"

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -1151,21 +1151,24 @@ def _module_sources(value: ast.expr) -> list[str]:
     return found
 
 
-def _rebound_modules(
-    bindings: list[tuple[str, ast.expr]], modules: dict[str, str]
-) -> dict[str, str]:
-    """Grow *modules* with every name bound to a module already in it.
+def _settle(bindings: list[tuple[str, ast.expr]], seed: dict[str, str]) -> dict[str, str]:
+    """Grow *seed* with every name that inherits from a name already in it.
 
-    ``sp = subprocess`` needs no import statement and leaves an owner name an
-    import scan never sees, and so does ``sp = [subprocess][0]``. A chain of
-    them settles because each pass can only add names, and there are finitely
-    many. The sources each binding may name do not depend on what has settled
-    so far, so they are read once per value node rather than once per name.
-    An unpacking that does not line up pairs every name with the whole right
-    side, so one node can back thousands of bindings; reading it per name is
-    quadratic and measurably so.
+    ``sp = subprocess`` and ``runner = base`` are one problem twice: a name
+    takes on what another name holds, with no import or construction site of
+    its own to read. A container in between changes nothing, so sources are
+    read through one. Each pass can only add names and there are finitely
+    many, so the repetition settles.
+
+    Sources do not depend on what has settled, so they are read once per
+    value node rather than once per pass or once per name. Reading them per
+    pass re-walks a chain of length N once per link: 20000 links took 83.2
+    seconds against a 10 second budget. Reading them per name re-walks a
+    shared node once per name, and an unpacking that does not line up pairs
+    every name with the whole right side, so 4000 names took 4.5 seconds
+    against a 3 second budget.
     """
-    grown = dict(modules)
+    grown = dict(seed)
     groups: dict[int, tuple[list[str], list[str]]] = {}
     for name, value in bindings:
         key = id(value)
@@ -1225,25 +1228,17 @@ def _presupplied(
     construction site, and the call site that adds ``text=True`` carries no
     capture keyword for :func:`_captures_text` to find. Without this the two
     halves of one decoding call read as compliant apart. An alias inherits the
-    mark, because rebinding the name changes nothing about what it holds.
+    mark, through a container or not, because rebinding the name changes
+    nothing about what it holds.
     """
-    marked: set[str] = set()
-    changed = True
-    while changed:
-        changed = False
-        for name, value in bindings:
-            if name in marked:
-                continue
-            if isinstance(value, ast.Call) and _is_partial(
-                _call_label(value), functions
-            ):
-                found = _supplies_capture(value, modules, functions)
-            else:
-                found = isinstance(value, ast.Name) and value.id in marked
-            if found:
-                marked.add(name)
-                changed = True
-    return marked
+    seed = {
+        name: name
+        for name, value in bindings
+        if isinstance(value, ast.Call)
+        and _is_partial(_call_label(value), functions)
+        and _supplies_capture(value, modules, functions)
+    }
+    return set(_settle(bindings, seed))
 
 
 def _parameter_bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
@@ -1334,7 +1329,7 @@ def _subprocess_names(
     # per name is quadratic: 4000 names took 17.76 seconds that way. Every
     # name in a group reads the same node, so one read answers for all of them.
     bindings = _bindings(tree) + _parameter_bindings(tree)
-    modules = _rebound_modules(bindings, modules)
+    modules = _settle(bindings, modules)
     containers = _containers(tree, bindings)
     groups: dict[int, tuple[ast.expr, list[str]]] = {}
     for name, value in bindings:
@@ -1982,6 +1977,22 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'module = [subprocess][0]\n'
             'module.run(["x"])',
             "a module reached through a container still decodes nothing untold",
+        ),
+        (
+            'import functools, subprocess\n'
+            'base = functools.partial(subprocess.run, capture_output=True)\n'
+            'holders = [base]\n'
+            'runner = holders[0]\n'
+            'runner(["x"], text=True, encoding="utf-8")',
+            "a partial reached through a container is still pinned at its call site",
+        ),
+        (
+            'import functools, subprocess\n'
+            'base = functools.partial(subprocess.run)\n'
+            'holders = [base]\n'
+            'runner = holders[0]\n'
+            'runner(["x"], text=True)',
+            "a partial that fixed no capture leaves nothing to decode",
         ),
     ],
 )
@@ -2911,6 +2922,14 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             '    sp = subprocess\n'
             'Holder.sp.run(["x"], capture_output=True, text=True)',
             "a class body binds a module alias that no import statement shows",
+        ),
+        (
+            'import functools, subprocess\n'
+            'base = functools.partial(subprocess.run, capture_output=True)\n'
+            'holders = [base]\n'
+            'runner = holders[0]\n'
+            'runner(["x"], text=True)',
+            "a partial keeps its fixed capture through a container",
         ),
     ],
 )

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -458,7 +458,7 @@ def _module_attribute(
         # ``getattr(subprocess.run, "__call__")`` composes the two shapes
         # below, so resolving the owner answers for the pair.
         return _resolve_callable(owner, modules, functions)
-    held = modules.get(owner.id) if isinstance(owner, ast.Name) else None
+    held = _owner_module(owner, modules)
     if held is None:
         return None
     if not isinstance(attr, ast.Constant):
@@ -602,12 +602,11 @@ def _attribute(
     node: ast.Attribute, modules: dict[str, str], functions: dict[str, str]
 ) -> str | None:
     """Return the subprocess entry point ``owner.attr`` names, or ``None``."""
-    if isinstance(node.value, ast.Name):
-        owner, attr = modules.get(node.value.id), node.attr
-        if owner == "subprocess" and attr in _SUBPROCESS_ATTRS:
-            return attr
-        if owner == "os" and attr == "popen":
-            return _OS_POPEN
+    owner, attr = _owner_module(node.value, modules), node.attr
+    if owner == "subprocess" and attr in _SUBPROCESS_ATTRS:
+        return attr
+    if owner == "os" and attr == "popen":
+        return _OS_POPEN
     if node.attr in _FORWARDING_ATTRS:
         # ``subprocess.run.__call__`` is the same callable read through an
         # attribute that hands it back, so the owner answers for it.
@@ -1125,24 +1124,82 @@ def _dependents(groups: dict[int, tuple[ast.expr, list[str]]]) -> dict[str, list
     return found
 
 
+def _module_sources(value: ast.expr) -> list[str]:
+    """Return every name *value* may evaluate to, unwinding containers.
+
+    A module reference reaches a name through a container as easily as
+    through a plain assignment: ``[subprocess][0]`` and ``HOLDER[0]`` both
+    hand the module back with no name on the right to match against. The
+    index is not modelled, exactly as for a subscript elsewhere, so every
+    element answers, breadth-first so the answer follows source order.
+
+    Only the node handed in is unwound. A name bound to another binding is
+    left to the caller's fixpoint, which already settles those, and keeping
+    the walk inside one expression is what bounds it: chasing bindings from
+    here re-walks a chain of length N once per link and costs N squared.
+    """
+    queue = [value]
+    found: list[str] = []
+    while queue:
+        node = queue.pop(0)
+        if isinstance(node, ast.Name):
+            found.append(node.id)
+        elif isinstance(node, ast.Subscript):
+            queue.append(node.value)
+        elif isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+            queue.extend(node.elts)
+    return found
+
+
 def _rebound_modules(
     bindings: list[tuple[str, ast.expr]], modules: dict[str, str]
 ) -> dict[str, str]:
     """Grow *modules* with every name bound to a module already in it.
 
     ``sp = subprocess`` needs no import statement and leaves an owner name an
-    import scan never sees. A chain of them settles because each pass can only
-    add names, and there are finitely many.
+    import scan never sees, and so does ``sp = [subprocess][0]``. A chain of
+    them settles because each pass can only add names, and there are finitely
+    many. The sources each binding may name do not depend on what has settled
+    so far, so they are read once per value node rather than once per name.
+    An unpacking that does not line up pairs every name with the whole right
+    side, so one node can back thousands of bindings; reading it per name is
+    quadratic and measurably so.
     """
     grown = dict(modules)
+    groups: dict[int, tuple[list[str], list[str]]] = {}
+    for name, value in bindings:
+        key = id(value)
+        if key not in groups:
+            groups[key] = (_module_sources(value), [])
+        groups[key][1].append(name)
     changed = True
     while changed:
         changed = False
-        for name, value in bindings:
-            if isinstance(value, ast.Name) and value.id in grown and name not in grown:
-                grown[name] = grown[value.id]
-                changed = True
+        for candidates, names in groups.values():
+            pending = [one for one in names if one not in grown]
+            if not pending:
+                continue
+            source = next((one for one in candidates if one in grown), None)
+            if source is None:
+                continue
+            for one in pending:
+                grown[one] = grown[source]
+            changed = True
     return grown
+
+
+def _owner_module(node: ast.expr, modules: dict[str, str]) -> str | None:
+    """Return the module the owner expression *node* names, or ``None``.
+
+    A class body binds its attributes under the attribute prefix, the same
+    way the function table records them, so ``Holder.sp`` reads back exactly
+    as a plain ``sp`` does.
+    """
+    if isinstance(node, ast.Name):
+        return modules.get(node.id)
+    if isinstance(node, ast.Attribute):
+        return modules.get(_ATTRIBUTE + node.attr)
+    return None
 
 
 def _supplies_capture(
@@ -1906,6 +1963,25 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'import operator, subprocess\n'
             'operator.attrgetter("Popen")(subprocess)(["x"])',
             "a spawn with neither capture nor text decodes nothing",
+        ),
+        (
+            'import shutil\n'
+            'module = [shutil][0]\n'
+            'module.which("x", capture_output=True, text=True)',
+            "a container holding a module we do not track holds no entry point",
+        ),
+        (
+            'import subprocess\n'
+            'class Holder:\n'
+            '    sp = subprocess\n'
+            'Holder.sp.run(["x"], capture_output=True, text=True, encoding="utf-8")',
+            "a module reached through a class body is still pinned at its call site",
+        ),
+        (
+            'import subprocess\n'
+            'module = [subprocess][0]\n'
+            'module.run(["x"])',
+            "a module reached through a container still decodes nothing untold",
         ),
     ],
 )
@@ -2816,6 +2892,26 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             'getitem([subprocess.run], 0)(["x"], capture_output=True, text=True)',
             "getitem is the subscript spelled as a call",
         ),
+        (
+            'import subprocess\n'
+            'module = [subprocess][0]\n'
+            'module.run(["x"], capture_output=True, text=True)',
+            "a module reaches a name through a container with no name to match",
+        ),
+        (
+            'import subprocess\n'
+            'HOLDER = (subprocess,)\n'
+            'module = HOLDER[0]\n'
+            'module.run(["x"], capture_output=True, text=True)',
+            "the container holding the module can itself be behind a name",
+        ),
+        (
+            'import subprocess\n'
+            'class Holder:\n'
+            '    sp = subprocess\n'
+            'Holder.sp.run(["x"], capture_output=True, text=True)',
+            "a class body binds a module alias that no import statement shows",
+        ),
     ],
 )
 def test_detector_closes_the_evasions(source: str, why: str) -> None:
@@ -2928,6 +3024,34 @@ def test_unpacking_a_wide_container_stays_linear() -> None:
 
 
 def test_one_value_reading_many_names_stays_linear() -> None:
+    """A module chained through containers is found, and the chain stays cheap.
+
+    Each link wraps the next in a container, so settling the chain needs both
+    the fixpoint that resolves names and the unwinding that reads through a
+    subscript. Reading the sources of a link once per pass rather than once
+    per node turns that into a walk per pass per link: 20000 plain links took
+    83.2 seconds that way against a 10 second budget.
+
+    The spawn at the end is what makes this a correctness test and not only a
+    timing one. A chain that settles fast but loses the module answers
+    nothing.
+    """
+    depth = 2000
+    lines = ["import subprocess"]
+    lines += [f"m{index} = [m{index + 1}][0]" for index in range(depth)]
+    lines.append(f"m{depth} = subprocess")
+    lines.append('m0.run(["x"], capture_output=True, text=True)')
+    source = "\n".join(lines)
+
+    started = time.perf_counter()
+    flagged = unpinned_lines(source)
+    elapsed = time.perf_counter() - started
+
+    assert flagged == [depth + 3], "the module survives every container on the way"
+    assert elapsed < 3.0, f"chain resolution took {elapsed:.1f}s for {depth} links"
+
+
+def test_a_value_reading_many_names_stays_linear() -> None:
     """A value node that reads N names must be walked once, not once per name.
 
     The mirror of the wide-unpack shape. One list literal reading ``width``

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -918,7 +918,11 @@ def _bindings(tree: ast.Module) -> list[tuple[str, ast.expr]]:
             found.extend(_class_bindings(node))
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
             found.extend(_defaults(node.args))
-            found.extend(_return_bindings(node))
+            if not isinstance(node, ast.Lambda):
+                # A lambda body is an expression, so it holds no return for
+                # _return_bindings to attribute, and no name to attribute it
+                # to. Asking anyway read an attribute lambdas do not have.
+                found.extend(_return_bindings(node))
     return found
 
 
@@ -1782,6 +1786,26 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
 def test_detector_stays_quiet(source: str, why: str) -> None:
     """The guard must not fire on calls that decode nothing."""
     assert unpinned_lines(source) == [], f"false positive on {why}"
+
+
+def test_a_lambda_carries_no_return_for_the_scan_to_attribute() -> None:
+    """A lambda has no name, and no return to bind to one.
+
+    ``_return_bindings`` reads ``node.name`` while building its result, and
+    ``ast.Lambda`` has no such attribute. The read sat behind a comprehension
+    that a lambda always leaves empty, because a lambda body is an expression
+    and an expression cannot hold a ``return``. That made the call latent
+    rather than live, but it was one edit away from an ``AttributeError`` and
+    the type checker flagged it on every run. The scan now asks only the two
+    node types that carry a name. The lambda default case in
+    ``test_detector_flags_an_unpinned_call`` is the control proving the other
+    half of the branch, ``_defaults``, still runs for lambdas.
+    """
+    lam = ast.parse("f = lambda a=subprocess.run: a").body[0]
+    assert isinstance(lam, ast.Assign)
+    assert isinstance(lam.value, ast.Lambda)
+    assert not hasattr(lam.value, "name")
+    assert [node for node in ast.walk(lam.value) if isinstance(node, ast.Return)] == []
 
 
 def test_detector_reports_every_offender_in_one_file() -> None:

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -54,7 +54,7 @@ from __future__ import annotations
 import ast
 import codecs
 import time
-from collections import Counter
+from collections import Counter, deque
 from pathlib import Path
 from typing import NamedTuple
 
@@ -1200,6 +1200,14 @@ def _settle(bindings: list[tuple[str, ast.expr]], seed: dict[str, str]) -> dict[
     shared node once per name, and an unpacking that does not line up pairs
     every name with the whole right side, so 4000 names took 4.5 seconds
     against a 3 second budget.
+
+    Which group to revisit is decided by the dependency edges rather than by
+    repeating the sweep. A sweep that repeats until nothing changes learns
+    one link per pass on a chain of aliases and scans every group on every
+    pass, which is quadratic: 8000 links took 14.0 seconds. Indexing each
+    group under the names it waits on wakes only the groups a newly settled
+    name can answer for, and a group that has settled is skipped outright, so
+    each group is read once and each edge is followed once.
     """
     grown = dict(seed)
     groups: dict[int, tuple[list[str], list[str]]] = {}
@@ -1208,19 +1216,28 @@ def _settle(bindings: list[tuple[str, ast.expr]], seed: dict[str, str]) -> dict[
         if key not in groups:
             groups[key] = (_module_sources(value), [])
         groups[key][1].append(name)
-    changed = True
-    while changed:
-        changed = False
-        for candidates, names in groups.values():
-            pending = [one for one in names if one not in grown]
-            if not pending:
-                continue
-            source = next((one for one in candidates if one in grown), None)
-            if source is None:
-                continue
-            for one in pending:
-                grown[one] = grown[source]
-            changed = True
+    waiting: dict[str, list[int]] = {}
+    for key, (candidates, _) in groups.items():
+        for candidate in candidates:
+            waiting.setdefault(candidate, []).append(key)
+    settled: set[int] = set()
+    queue = deque(groups)
+    while queue:
+        key = queue.popleft()
+        if key in settled:
+            continue
+        candidates, names = groups[key]
+        pending = [one for one in names if one not in grown]
+        if not pending:
+            settled.add(key)
+            continue
+        source = next((one for one in candidates if one in grown), None)
+        if source is None:
+            continue
+        for one in pending:
+            grown[one] = grown[source]
+            queue.extend(waiting.get(one, ()))
+        settled.add(key)
     return grown
 
 
@@ -3572,6 +3589,40 @@ def test_name_resolution_stays_linear_on_a_deep_reverse_chain() -> None:
 
     assert flagged, "a chain of any depth still reaches a subprocess entry point"
     assert elapsed < 10.0, f"name resolution took {elapsed:.1f}s for {depth} bindings"
+
+
+def test_a_deep_module_alias_chain_stays_linear() -> None:
+    """A chain of module aliases must cost one pass, not one pass per link.
+
+    The sibling test above ends its chain at ``subprocess.run``. That is an
+    attribute rather than a module name, so no link ever resolves as a module
+    alias, the fixpoint makes a single pass and the shape is linear whatever
+    the implementation does. Ending the chain at the module instead is what
+    makes every link resolvable, and a sweep that repeats until nothing
+    changes then learns exactly one link per pass.
+
+    That difference is worth 14.0 seconds at this depth: repeated sweeps
+    measured 0.235s at 1000 links, 0.887 at 2000, 3.425 at 4000 and 14.047 at
+    8000, near enough 4x per doubling. Propagating along the dependency edges
+    instead settles the whole chain in one pass over the edges.
+
+    The budget is loose on purpose. Linear finishes this in well under a
+    second, so anything near the ceiling is the sweep coming back rather than
+    a slow machine.
+    """
+    depth = 8000
+    source = "\n".join(
+        ["import subprocess"]
+        + [f"m{index} = m{index + 1}" for index in range(depth)]
+        + [f"m{depth} = subprocess", 'm0.run(["x"], capture_output=True, text=True)']
+    )
+
+    started = time.perf_counter()
+    flagged = unpinned_lines(source)
+    elapsed = time.perf_counter() - started
+
+    assert flagged == [depth + 3], "the module survives every alias on the way"
+    assert elapsed < 3.0, f"alias resolution took {elapsed:.1f}s for {depth} links"
 
 
 def test_unpacking_a_wide_container_stays_linear() -> None:

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -104,6 +104,21 @@ _WALKING_PARENTS = (ast.For, ast.AsyncFor, ast.comprehension)
 # The nodes that only look at what they are given. A comparison answers a
 # question about the mapping; an interpolation renders it.
 _INSPECTING_PARENTS = (ast.Compare, ast.FormattedValue)
+# The keyword the pin is bound under. A store or a delete that spells out some
+# other key cannot reach it.
+_ENCODING = "encoding"
+# The builtin that fetches an attribute by name. It reaches a partial's
+# keyword mapping exactly as the attribute does.
+_GETATTR = "getattr"
+# The builtins that consume a mapping without the means to change it. Every
+# other callee can hand it on, so the mapping is treated as at risk.
+_MAPPING_READERS = frozenset(
+    {
+        "all", "any", "bool", "dict", "frozenset", "id", "iter", "len",
+        "list", "max", "min", "print", "repr", "reversed", "set", "sorted",
+        "str", "sum", "tuple",
+    }
+)
 _UNKNOWN = object()
 _PARTIAL = "functools.partial"
 # Marks the null sink. Held beside the entry points so an imported ``DEVNULL``
@@ -1229,24 +1244,38 @@ def _owner_module(node: ast.expr, modules: dict[str, str]) -> str | None:
     return None if key is None else modules.get(key)
 
 
-def _reads_only(node: ast.AST, parent: ast.AST | None) -> bool:
-    """Report whether the keywords mapping at *node* is only being read.
+def _names_other_key(parent: ast.Subscript) -> bool:
+    """Report whether a subscript spells out a key that is not the codec.
 
-    Five shapes are provably harmless: one of the dict methods that cannot
-    change the mapping, a subscript being loaded rather than stored or
-    deleted, a walk that yields the keys, a double-star splat that fills a
-    fresh mapping for someone else, and a comparison or an interpolation.
-    Everything else counts as a write, including handing the mapping to
-    another function, which can change it out of sight.
+    ``runner.keywords["timeout"] = 1`` reaches the mapping but cannot reach
+    the pin. A key the source does not spell out could be any key, so only a
+    literal answers here.
+    """
+    key = parent.slice
+    return isinstance(key, ast.Constant) and key.value != _ENCODING
+
+
+def _spares_pin(node: ast.AST, parent: ast.AST | None) -> bool:
+    """Report whether the keywords mapping at *node* leaves its codec standing.
+
+    Six shapes are provably harmless: one of the dict methods that cannot
+    change the mapping, a subscript that either loads or names some other
+    key, a walk that yields the keys, a double-star splat that fills a fresh
+    mapping for someone else, a builtin that only consumes the mapping, and a
+    comparison or an interpolation. Everything else counts against the pin,
+    including handing the mapping to a function that could pass it on, which
+    can change it out of sight.
     """
     if isinstance(parent, ast.Attribute):
         return parent.attr in _KEYWORD_READERS
     if isinstance(parent, ast.Subscript):
-        return isinstance(parent.ctx, ast.Load)
+        return isinstance(parent.ctx, ast.Load) or _names_other_key(parent)
     if isinstance(parent, _WALKING_PARENTS):
         return parent.iter is node
     if isinstance(parent, ast.keyword):
         return parent.arg is None
+    if isinstance(parent, ast.Call):
+        return isinstance(parent.func, ast.Name) and parent.func.id in _MAPPING_READERS
     return isinstance(parent, _INSPECTING_PARENTS)
 
 
@@ -1266,6 +1295,30 @@ def _partial_roots(
         if isinstance(value, ast.Call) and _is_partial(_call_label(value), functions)
     }
     return _settle(bindings, seed)
+
+
+def _fetched_keywords(node: ast.AST) -> ast.expr | None:
+    """Return the owner in ``getattr(x, "keywords")``, or None."""
+    if not isinstance(node, ast.Call) or len(node.args) != 2:
+        return None
+    if not isinstance(node.func, ast.Name) or node.func.id != _GETATTR:
+        return None
+    name = node.args[1]
+    if not isinstance(name, ast.Constant) or name.value != _KEYWORDS:
+        return None
+    return node.args[0]
+
+
+def _keyword_mapping(node: ast.AST) -> ast.expr | None:
+    """Return the expression whose keywords mapping *node* reaches, if any.
+
+    Two spellings arrive at the same dict. ``runner.keywords`` reads the
+    attribute directly; ``getattr(runner, "keywords")`` asks for it by name.
+    A scan that knows only the first lets the second undo a pin in silence.
+    """
+    if isinstance(node, ast.Attribute) and node.attr == _KEYWORDS:
+        return node.value
+    return _fetched_keywords(node)
 
 
 def _undone_pins(tree: ast.AST, roots: dict[str, str]) -> set[str]:
@@ -1289,11 +1342,10 @@ def _undone_pins(tree: ast.AST, roots: dict[str, str]) -> set[str]:
     }
     undone: set[str] = set()
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Attribute) or node.attr != _KEYWORDS:
+        owner = _keyword_mapping(node)
+        if owner is None or _spares_pin(node, parents.get(id(node))):
             continue
-        if _reads_only(node, parents.get(id(node))):
-            continue
-        name = _owner_name(node.value)
+        name = _owner_name(owner)
         if name is not None and name in roots:
             undone.add(roots[name])
     return undone
@@ -1353,14 +1405,23 @@ def _prepinned(
 
     A construction site the source can undo supplies no pin at all, which is
     what keeps ``del runner.keywords["encoding"]`` reported at both ends.
+
+    A name is only trusted when every binding it carries pins the codec. One
+    name can be bound in two scopes, and a pinned partial built inside some
+    unrelated function says nothing about the runner called out here.
     """
+    pinning: dict[str, bool] = {}
+    for name, value in bindings:
+        pins = (
+            isinstance(value, ast.Call)
+            and _is_partial(_call_label(value), functions)
+            and _pins_utf8(value)
+        )
+        pinning[name] = pinning.get(name, True) and pins
     seed = {
         name: name
-        for name, value in bindings
-        if isinstance(value, ast.Call)
-        and _is_partial(_call_label(value), functions)
-        and _pins_utf8(value)
-        and name not in undone
+        for name, pins in pinning.items()
+        if pins and name not in undone
     }
     return set(_settle(bindings, seed))
 
@@ -2267,6 +2328,33 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             '    print(key)\n'
             'runner(["x"], text=True)',
             "a walked mapping still answers for a call site that adds the text",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'runner.keywords["timeout"] = 1\n'
+            'runner(["x"], text=True)',
+            "storing under some other key leaves the bound codec where it was",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'del runner.keywords["timeout"]\n'
+            'runner(["x"], text=True)',
+            "deleting some other key leaves the bound codec where it was",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'seen = len(runner.keywords)\n'
+            'runner(["x"], text=True)',
+            "a builtin that only measures the mapping cannot change it",
         ),
         (
             'import functools, subprocess\n'
@@ -3362,6 +3450,43 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             "import subprocess\n"
             'methodcaller("run", ["x"], capture_output=True, text=True)(subprocess)',
             "a directly imported methodcaller needs no module name at all",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'getattr(runner, "keywords")["encoding"] = None\n'
+            'runner(["x"], text=True)',
+            "getattr reaches the same mapping the attribute does",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'getattr(runner, "keywords").pop("encoding")\n'
+            'runner(["x"], text=True)',
+            "a mapping fetched by getattr can be emptied by any of its methods",
+        ),
+        (
+            'import functools, subprocess\n'
+            'key = "encoding"\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'runner.keywords[key] = None\n'
+            'runner(["x"], text=True)',
+            "a key that is not spelled out could be any key, including the codec",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = subprocess.run\n'
+            'def unrelated():\n'
+            '    runner = functools.partial(print, encoding="utf-8")\n'
+            '    return runner\n'
+            'runner(["x"], capture_output=True, text=True)',
+            "a pin bound to the same name somewhere else answers for nothing here",
         ),
     ],
 )

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -1170,11 +1170,18 @@ def _module_sources(value: ast.expr) -> list[str]:
     left to the caller's fixpoint, which already settles those, and keeping
     the walk inside one expression is what bounds it: chasing bindings from
     here re-walks a chain of length N once per link and costs N squared.
+
+    The queue is a deque because a list pops its front by shifting every
+    remaining element. A wide container puts all of its elements in at once,
+    so that shift costs the width on every pop. It hides at the sizes real
+    sources reach, where the shift is a cache-friendly move, and shows up
+    plainly past it: 50000 elements took 0.160s, 100000 took 0.664 and 200000
+    took 2.779, near enough 4x per doubling.
     """
-    queue = [value]
+    queue = deque([value])
     found: list[str] = []
     while queue:
-        node = queue.pop(0)
+        node = queue.popleft()
         if isinstance(node, ast.Name):
             found.append(node.id)
         elif isinstance(node, ast.Subscript):
@@ -3623,6 +3630,34 @@ def test_a_deep_module_alias_chain_stays_linear() -> None:
 
     assert flagged == [depth + 3], "the module survives every alias on the way"
     assert elapsed < 3.0, f"alias resolution took {elapsed:.1f}s for {depth} links"
+
+
+def test_unwinding_a_wide_container_stays_linear() -> None:
+    """Reading the names out of one wide container must not cost the width.
+
+    Every element goes into the queue at once, so a queue that pops its front
+    by shifting the rest pays the width on every pop. At the sizes a real
+    source reaches that shift is a cache-friendly move and the shape looks
+    linear, which is why the wide-unpack test above passes either way. Past
+    that it is plainly quadratic: 50000 elements took 0.160s, 100000 took
+    0.664 and 200000 took 2.779.
+
+    Only the unwinding is timed. Parsing a literal this wide costs about
+    0.45 seconds on its own and would swamp the measurement. The budget
+    leaves a wide margin: popping from both ends does this in 0.015 seconds
+    and shifting does it in about 0.95.
+    """
+    width = 120000
+    source = "WIDE = [" + ", ".join(f"n{index}" for index in range(width)) + "]"
+    container = ast.parse(source).body[0]
+    assert isinstance(container, ast.Assign)
+
+    started = time.perf_counter()
+    found = _module_sources(container.value)
+    elapsed = time.perf_counter() - started
+
+    assert len(found) == width, "every element of the container answers"
+    assert elapsed < 0.3, f"unwinding took {elapsed:.2f}s for {width} elements"
 
 
 def test_unpacking_a_wide_container_stays_linear() -> None:

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -91,6 +91,8 @@ _DYNAMIC = "subprocess.<dynamic>"
 # subprocess names for want of a second one to thread, and filtered out of
 # every path that answers "is this a subprocess entry point".
 _ATTRIBUTE = "."
+# The attribute a functools.partial keeps its bound keywords under.
+_KEYWORDS = "keywords"
 _UNKNOWN = object()
 _PARTIAL = "functools.partial"
 # Marks the null sink. Held beside the entry points so an imported ``DEVNULL``
@@ -1191,18 +1193,53 @@ def _settle(bindings: list[tuple[str, ast.expr]], seed: dict[str, str]) -> dict[
     return grown
 
 
-def _owner_module(node: ast.expr, modules: dict[str, str]) -> str | None:
-    """Return the module the owner expression *node* names, or ``None``.
+def _owner_name(node: ast.expr) -> str | None:
+    """Return the table key the owner expression *node* reads under.
 
     A class body binds its attributes under the attribute prefix, the same
     way the function table records them, so ``Holder.sp`` reads back exactly
     as a plain ``sp`` does.
     """
     if isinstance(node, ast.Name):
-        return modules.get(node.id)
+        return node.id
     if isinstance(node, ast.Attribute):
-        return modules.get(_ATTRIBUTE + node.attr)
+        return _ATTRIBUTE + node.attr
     return None
+
+
+def _owner_module(node: ast.expr, modules: dict[str, str]) -> str | None:
+    """Return the module the owner expression *node* names, or ``None``."""
+    key = _owner_name(node)
+    return None if key is None else modules.get(key)
+
+
+def _voided_pins(tree: ast.AST, bindings: list[tuple[str, ast.expr]]) -> set[int]:
+    """Return the construction sites whose bound codec the source can undo.
+
+    ``functools.partial`` keeps its bound keywords in a plain dict that stays
+    reachable through the result, so ``del runner.keywords["encoding"]`` and
+    ``runner.keywords["encoding"] = None`` both drop a pin the construction
+    site still spells out. Reading that site alone reports a codec the call
+    will never use.
+
+    Any mention of the mapping counts, not writes alone. Telling a write from
+    a read needs the enclosing statement, and a partial whose keywords are
+    read but never changed is both rare and harmless to report: the answer
+    errs toward flagging, which is the direction this scan takes throughout.
+
+    Node identity is the key because a construction site is a value node, not
+    a name, and the same expression can be bound to several names. Every node
+    stays alive for as long as the tree that owns it, which outlives this
+    answer, so an address cannot be recycled underneath it.
+    """
+    touched: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute) or node.attr != _KEYWORDS:
+            continue
+        name = _owner_name(node.value)
+        if name is not None:
+            touched.add(name)
+    return {id(value) for name, value in bindings if name in touched}
 
 
 def _supplies_capture(
@@ -1303,7 +1340,7 @@ def _matched(
 
 def _subprocess_names(
     tree: ast.Module,
-) -> tuple[dict[str, str], dict[str, str], dict[str, _Container], set[str]]:
+) -> tuple[dict[str, str], dict[str, str], dict[str, _Container], set[str], set[int]]:
     """Collect every name in *tree* that reaches a subprocess entry point.
 
     Imports seed the search, and every binding is then resolved against what
@@ -1361,7 +1398,13 @@ def _subprocess_names(
                 # A group reading ``get()`` registers a dependency on the bare
                 # name ``get``, because that is the only Name node in it.
                 queue.extend(dependents.get(name[: -len(_CALL_SUFFIX)], ()))
-    return modules, functions, containers, _presupplied(bindings, modules, functions)
+    return (
+        modules,
+        functions,
+        containers,
+        _presupplied(bindings, modules, functions),
+        _voided_pins(tree, bindings),
+    )
 
 
 def _target(
@@ -1490,7 +1533,7 @@ def _pins_utf8(call: ast.Call) -> bool:
 def unpinned_lines(source: str) -> list[int]:
     """Return the line numbers of text-capturing calls that do not pin UTF-8."""
     tree = ast.parse(source)
-    modules, functions, containers, presupplied = _subprocess_names(tree)
+    modules, functions, containers, presupplied, voided = _subprocess_names(tree)
     offenders: list[int] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -1507,7 +1550,7 @@ def unpinned_lines(source: str) -> list[int]:
             node, functions, target, modules, presupplied
         ):
             continue
-        if not _pins_utf8(node):
+        if not _pins_utf8(node) or id(node) in voided:
             offenders.append(node.lineno)
     return sorted(offenders)
 
@@ -1993,6 +2036,15 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'runner = holders[0]\n'
             'runner(["x"], text=True)',
             "a partial that fixed no capture leaves nothing to decode",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'other.keywords["encoding"] = None\n'
+            'runner(["x"])',
+            "a mapping belonging to some other name leaves this pin standing",
         ),
     ],
 )
@@ -2930,6 +2982,35 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             'runner = holders[0]\n'
             'runner(["x"], text=True)',
             "a partial keeps its fixed capture through a container",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'del runner.keywords["encoding"]\n'
+            'runner(["x"])',
+            "deleting the bound encoding leaves the locale codec behind",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'runner.keywords["encoding"] = None\n'
+            'runner(["x"])',
+            "overwriting the bound encoding asks for the locale codec by name",
+        ),
+        (
+            'import functools, subprocess\n'
+            'class A:\n'
+            '    b = functools.partial(\n'
+            '        subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            '    )\n'
+            'a = A()\n'
+            'a.b.keywords["encoding"] = None\n'
+            'a.b(["x"])',
+            "a partial bound in a class body is mutated the same way",
         ),
     ],
 )

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -97,6 +97,13 @@ _KEYWORDS = "keywords"
 # The dict methods that answer a question about the mapping without changing
 # it. Every other way of reaching the mapping is treated as a write.
 _KEYWORD_READERS = frozenset({"copy", "get", "items", "keys", "values"})
+# The nodes that hold the thing they walk under ``iter``. Walking a mapping
+# yields its keys and leaves the mapping itself alone. All three also accept
+# an assignment target, so the node has to be the ``iter`` to count as a read.
+_WALKING_PARENTS = (ast.For, ast.AsyncFor, ast.comprehension)
+# The nodes that only look at what they are given. A comparison answers a
+# question about the mapping; an interpolation renders it.
+_INSPECTING_PARENTS = (ast.Compare, ast.FormattedValue)
 _UNKNOWN = object()
 _PARTIAL = "functools.partial"
 # Marks the null sink. Held beside the entry points so an imported ``DEVNULL``
@@ -1222,20 +1229,25 @@ def _owner_module(node: ast.expr, modules: dict[str, str]) -> str | None:
     return None if key is None else modules.get(key)
 
 
-def _reads_only(parent: ast.AST | None) -> bool:
-    """Report whether a keywords mapping under *parent* is only being read.
+def _reads_only(node: ast.AST, parent: ast.AST | None) -> bool:
+    """Report whether the keywords mapping at *node* is only being read.
 
-    Three shapes are provably harmless: one of the dict methods that cannot
+    Five shapes are provably harmless: one of the dict methods that cannot
     change the mapping, a subscript being loaded rather than stored or
-    deleted, and a comparison. Everything else counts as a write, including
-    handing the mapping to another function, which can change it out of
-    sight.
+    deleted, a walk that yields the keys, a double-star splat that fills a
+    fresh mapping for someone else, and a comparison or an interpolation.
+    Everything else counts as a write, including handing the mapping to
+    another function, which can change it out of sight.
     """
     if isinstance(parent, ast.Attribute):
         return parent.attr in _KEYWORD_READERS
     if isinstance(parent, ast.Subscript):
         return isinstance(parent.ctx, ast.Load)
-    return isinstance(parent, ast.Compare)
+    if isinstance(parent, _WALKING_PARENTS):
+        return parent.iter is node
+    if isinstance(parent, ast.keyword):
+        return parent.arg is None
+    return isinstance(parent, _INSPECTING_PARENTS)
 
 
 def _partial_roots(
@@ -1279,7 +1291,7 @@ def _undone_pins(tree: ast.AST, roots: dict[str, str]) -> set[str]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.Attribute) or node.attr != _KEYWORDS:
             continue
-        if _reads_only(parents.get(id(node))):
+        if _reads_only(node, parents.get(id(node))):
             continue
         name = _owner_name(node.value)
         if name is not None and name in roots:
@@ -2208,6 +2220,53 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'codec = runner.keywords["encoding"]\n'
             'runner(["x"])',
             "loading one key out of the mapping leaves the mapping alone",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'for key in runner.keywords:\n'
+            '    print(key)\n'
+            'runner(["x"])',
+            "walking the mapping yields its keys and leaves the mapping alone",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'names = [key for key in runner.keywords]\n'
+            'runner(["x"])',
+            "a comprehension walks the mapping the same way a for loop does",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'print(f"{runner.keywords}")\n'
+            'runner(["x"])',
+            "interpolating the mapping into a string only formats it",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'copied = dict(**runner.keywords)\n'
+            'runner(["x"])',
+            "splatting the mapping fills a new dict and leaves the source alone",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'for key in runner.keywords:\n'
+            '    print(key)\n'
+            'runner(["x"], text=True)',
+            "a walked mapping still answers for a call site that adds the text",
         ),
         (
             'import functools, subprocess\n'
@@ -3213,6 +3272,24 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             'runner.keywords.update({"encoding": None})\n'
             'runner(["x"])',
             "updating the mapping replaces the bound encoding wholesale",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'dropped = [runner.keywords.pop(k) for k in list(runner.keywords)]\n'
+            'runner(["x"])',
+            "a comprehension that walks the mapping can still empty it",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'print(f"{runner.keywords.pop(\'encoding\')}")\n'
+            'runner(["x"])',
+            "interpolation formats whatever it is given, including a mutation",
         ),
         (
             'import functools, subprocess\n'

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -56,6 +56,7 @@ import codecs
 import time
 from collections import Counter
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
@@ -93,6 +94,9 @@ _DYNAMIC = "subprocess.<dynamic>"
 _ATTRIBUTE = "."
 # The attribute a functools.partial keeps its bound keywords under.
 _KEYWORDS = "keywords"
+# The dict methods that answer a question about the mapping without changing
+# it. Every other way of reaching the mapping is treated as a write.
+_KEYWORD_READERS = frozenset({"copy", "get", "items", "keys", "values"})
 _UNKNOWN = object()
 _PARTIAL = "functools.partial"
 # Marks the null sink. Held beside the entry points so an imported ``DEVNULL``
@@ -1213,8 +1217,42 @@ def _owner_module(node: ast.expr, modules: dict[str, str]) -> str | None:
     return None if key is None else modules.get(key)
 
 
-def _voided_pins(tree: ast.AST, bindings: list[tuple[str, ast.expr]]) -> set[int]:
-    """Return the construction sites whose bound codec the source can undo.
+def _reads_only(parent: ast.AST | None) -> bool:
+    """Report whether a keywords mapping under *parent* is only being read.
+
+    Three shapes are provably harmless: one of the dict methods that cannot
+    change the mapping, a subscript being loaded rather than stored or
+    deleted, and a comparison. Everything else counts as a write, including
+    handing the mapping to another function, which can change it out of
+    sight.
+    """
+    if isinstance(parent, ast.Attribute):
+        return parent.attr in _KEYWORD_READERS
+    if isinstance(parent, ast.Subscript):
+        return isinstance(parent.ctx, ast.Load)
+    return isinstance(parent, ast.Compare)
+
+
+def _partial_roots(
+    bindings: list[tuple[str, ast.expr]], functions: dict[str, str]
+) -> dict[str, str]:
+    """Map every name holding a partial back to the name it was built under.
+
+    An alias shares the partial's keyword mapping rather than copying it, so
+    ``alias.keywords["encoding"] = None`` unpins the call made through the
+    original name too. Resolving both to one root is what lets a mutation
+    found under either name answer for both.
+    """
+    seed = {
+        name: name
+        for name, value in bindings
+        if isinstance(value, ast.Call) and _is_partial(_call_label(value), functions)
+    }
+    return _settle(bindings, seed)
+
+
+def _undone_pins(tree: ast.AST, roots: dict[str, str]) -> set[str]:
+    """Return the partials whose bound codec the source can undo.
 
     ``functools.partial`` keeps its bound keywords in a plain dict that stays
     reachable through the result, so ``del runner.keywords["encoding"]`` and
@@ -1222,24 +1260,26 @@ def _voided_pins(tree: ast.AST, bindings: list[tuple[str, ast.expr]]) -> set[int
     site still spells out. Reading that site alone reports a codec the call
     will never use.
 
-    Any mention of the mapping counts, not writes alone. Telling a write from
-    a read needs the enclosing statement, and a partial whose keywords are
-    read but never changed is both rare and harmless to report: the answer
-    errs toward flagging, which is the direction this scan takes throughout.
-
-    Node identity is the key because a construction site is a value node, not
-    a name, and the same expression can be bound to several names. Every node
-    stays alive for as long as the tree that owns it, which outlives this
-    answer, so an address cannot be recycled underneath it.
+    Everything that is not a provable read counts, because a mapping handed
+    to another function comes back changed with nothing at this site to say
+    so. The answer errs toward flagging, which is the direction this scan
+    takes throughout.
     """
-    touched: set[str] = set()
+    parents = {
+        id(child): parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
+    }
+    undone: set[str] = set()
     for node in ast.walk(tree):
         if not isinstance(node, ast.Attribute) or node.attr != _KEYWORDS:
             continue
+        if _reads_only(parents.get(id(node))):
+            continue
         name = _owner_name(node.value)
-        if name is not None:
-            touched.add(name)
-    return {id(value) for name, value in bindings if name in touched}
+        if name is not None and name in roots:
+            undone.add(roots[name])
+    return undone
 
 
 def _supplies_capture(
@@ -1274,6 +1314,36 @@ def _presupplied(
         if isinstance(value, ast.Call)
         and _is_partial(_call_label(value), functions)
         and _supplies_capture(value, modules, functions)
+    }
+    return set(_settle(bindings, seed))
+
+
+def _prepinned(
+    bindings: list[tuple[str, ast.expr]],
+    functions: dict[str, str],
+    undone: set[str],
+) -> set[str]:
+    """Name every callable whose codec was pinned where it was built.
+
+    The mirror of :func:`_presupplied`. ``partial(subprocess.run,
+    capture_output=True, encoding="utf-8")`` decides the codec at the
+    construction site, and the call site that adds ``text=True`` carries no
+    ``encoding`` keyword for :func:`_pins_utf8` to find. Without this, a call
+    that pins its codec correctly reads as a violation, which is worse than a
+    missed one: it nags the author who did the right thing. An alias inherits
+    the pin, through a container or not, because rebinding the name changes
+    nothing about what it holds.
+
+    A construction site the source can undo supplies no pin at all, which is
+    what keeps ``del runner.keywords["encoding"]`` reported at both ends.
+    """
+    seed = {
+        name: name
+        for name, value in bindings
+        if isinstance(value, ast.Call)
+        and _is_partial(_call_label(value), functions)
+        and _pins_utf8(value)
+        and name not in undone
     }
     return set(_settle(bindings, seed))
 
@@ -1338,9 +1408,31 @@ def _matched(
     return found
 
 
-def _subprocess_names(
-    tree: ast.Module,
-) -> tuple[dict[str, str], dict[str, str], dict[str, _Container], set[str], set[int]]:
+class _Names(NamedTuple):
+    """Everything one pass over a tree learns about the names in it.
+
+    Held as a named bundle rather than a bare tuple because the members are
+    six tables that all read alike at a call site, and a positional mix-up
+    between two of them would type-check silently.
+    """
+
+    modules: dict[str, str]
+    functions: dict[str, str]
+    containers: dict[str, _Container]
+    presupplied: set[str]
+    voided: set[int]
+    """Construction sites whose bound codec the source undoes.
+
+    Node identity is the key because a construction site is a value node, not
+    a name. Every node stays alive for as long as the tree that owns it,
+    which outlives this answer, so an address cannot be recycled underneath
+    it.
+    """
+
+    prepinned: set[str]
+
+
+def _subprocess_names(tree: ast.Module) -> _Names:
     """Collect every name in *tree* that reaches a subprocess entry point.
 
     Imports seed the search, and every binding is then resolved against what
@@ -1398,12 +1490,18 @@ def _subprocess_names(
                 # A group reading ``get()`` registers a dependency on the bare
                 # name ``get``, because that is the only Name node in it.
                 queue.extend(dependents.get(name[: -len(_CALL_SUFFIX)], ()))
-    return (
+    undone = _undone_pins(tree, _partial_roots(bindings, functions))
+    return _Names(
         modules,
         functions,
         containers,
         _presupplied(bindings, modules, functions),
-        _voided_pins(tree, bindings),
+        {
+            id(value)
+            for name, value in bindings
+            if name in undone and isinstance(value, ast.Call)
+        },
+        _prepinned(bindings, functions, undone),
     )
 
 
@@ -1533,12 +1631,12 @@ def _pins_utf8(call: ast.Call) -> bool:
 def unpinned_lines(source: str) -> list[int]:
     """Return the line numbers of text-capturing calls that do not pin UTF-8."""
     tree = ast.parse(source)
-    modules, functions, containers, presupplied, voided = _subprocess_names(tree)
+    names = _subprocess_names(tree)
     offenders: list[int] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
-        target = _target(node, modules, functions, containers)
+        target = _target(node, names.modules, names.functions, names.containers)
         if target is None:
             continue
         if target == "os.popen":
@@ -1547,11 +1645,22 @@ def unpinned_lines(source: str) -> list[int]:
             offenders.append(node.lineno)
             continue
         if target not in _DECODES_UNCONDITIONALLY and not _captures_text(
-            node, functions, target, modules, presupplied
+            node, names.functions, target, names.modules, names.presupplied
         ):
             continue
-        if not _pins_utf8(node) or id(node) in voided:
-            offenders.append(node.lineno)
+        if _pins_utf8(node) and id(node) not in names.voided:
+            continue
+        if (
+            _keyword(node, "encoding") is None
+            and not _has_splat(node)
+            and _call_label(node) in names.prepinned
+        ):
+            # The codec was pinned where this callable was built, and nothing
+            # since has undone it, so the call site needs no keyword of its
+            # own. A call site that names an encoding, or splats keywords this
+            # scan cannot read, overrides that pin and answers for itself.
+            continue
+        offenders.append(node.lineno)
     return sorted(offenders)
 
 
@@ -2045,6 +2154,51 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'other.keywords["encoding"] = None\n'
             'runner(["x"])',
             "a mapping belonging to some other name leaves this pin standing",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'assert runner.keywords.get("encoding") == "utf-8"\n'
+            'runner(["x"])',
+            "asking the mapping what it holds cannot change what it holds",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'assert "encoding" in runner.keywords\n'
+            'runner(["x"])',
+            "testing the mapping for a key cannot change what it holds",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'codec = runner.keywords["encoding"]\n'
+            'runner(["x"])',
+            "loading one key out of the mapping leaves the mapping alone",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'runner(["x"], text=True)',
+            "a codec pinned where the partial was built covers the call site",
+        ),
+        (
+            'import functools, subprocess\n'
+            'base = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'holders = [base]\n'
+            'runner = holders[0]\n'
+            'runner(["x"], text=True)',
+            "the pin follows the partial through a container",
         ),
     ],
 )
@@ -3011,6 +3165,69 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             'a.b.keywords["encoding"] = None\n'
             'a.b(["x"])',
             "a partial bound in a class body is mutated the same way",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'runner.keywords.update({"encoding": None})\n'
+            'runner(["x"])',
+            "updating the mapping replaces the bound encoding wholesale",
+        ),
+        (
+            'import functools, subprocess\n'
+            'def mutate(mapping):\n'
+            '    mapping.pop("encoding")\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, text=True, encoding="utf-8"\n'
+            ')\n'
+            'mutate(runner.keywords)\n'
+            'runner(["x"])',
+            "handing the mapping to something else changes it out of sight",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="latin-1"\n'
+            ')\n'
+            'runner(["x"], text=True)',
+            "a construction site pinning the wrong codec pins nothing",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'del runner.keywords["encoding"]\n'
+            'runner(["x"], text=True)',
+            "a construction pin the source undoes covers no later call site",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'runner(["x"], text=True, encoding="latin-1")',
+            "a call site naming its own codec overrides the one it was built with",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'runner(["x"], text=True, **overrides)',
+            "a splat at the call site can carry an encoding nothing here can read",
+        ),
+        (
+            'import functools, subprocess\n'
+            'runner = functools.partial(\n'
+            '    subprocess.run, capture_output=True, encoding="utf-8"\n'
+            ')\n'
+            'alias = runner\n'
+            'alias.keywords["encoding"] = None\n'
+            'runner(["x"], text=True)',
+            "an alias shares the keyword mapping rather than copying it",
         ),
     ],
 )

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -162,8 +162,24 @@ _TEXT_MODE_KEYWORDS = ("text", "universal_newlines", "encoding", "errors")
 # the round trip and the chain has to follow.
 _PASS_THROUGH = frozenset(
     {"list", "tuple", "set", "frozenset", "sorted", "reversed", "iter", "zip",
-     "enumerate"}
+     "enumerate", "chain"}
 )
+
+# Callables that yield elements of the containers handed to them, but only
+# after a leading argument that is not one: a predicate for the itertools
+# filters, a count for the heapq selectors. Reading that leading argument as a
+# container would flag ``filter(subprocess.run, rows)``, where the runner
+# merely decides which row comes out and never starts a process itself.
+_TRAILING_CONTAINERS = frozenset(
+    {"filter", "filterfalse", "takewhile", "dropwhile", "nlargest", "nsmallest"}
+)
+
+# Every callable that yields elements of its arguments, mapped to the first
+# argument that is a container. One table rather than a branch per family, so
+# a new element-yielding callable is one row and the resolution reads once.
+_CONTAINER_ARGS: dict[str, int] = {
+    label: 0 for label in _ELEMENT_BUILTINS | _PASS_THROUGH
+} | {label: 1 for label in _TRAILING_CONTAINERS}
 
 # Dict methods that yield a view, mapped to the halves of the literal the view
 # reads. ``items`` yields both, so both taint what the loop target binds.
@@ -380,10 +396,14 @@ def _resolve_indirect(
         if label in _DEFAULTING_METHODS:
             reached.extend(call.args[1:])
         return _resolve_elements(reached, modules, functions)
-    if label in _ELEMENT_BUILTINS and call.args:
-        return _resolve_elements(list(call.args), modules, functions)
-    if label in _PASS_THROUGH:
-        return _resolve_elements(list(call.args), modules, functions)
+    first = _CONTAINER_ARGS.get(label)
+    if first is not None and len(call.args) > first:
+        # ``list(RUNNERS)`` reads every argument; ``filter(None, RUNNERS)`` and
+        # ``nlargest(1, RUNNERS)`` read every argument after the first, because
+        # theirs is a predicate or a count. Reading that leading argument as a
+        # container would flag a runner that only decides which element comes
+        # out and never starts a process itself.
+        return _resolve_elements(list(call.args[first:]), modules, functions)
     view = _dict_view(call)
     if view is not None:
         return _resolve_elements(view, modules, functions)
@@ -1733,6 +1753,30 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'go(subprocess.run)',
             "a runner handed in is still pinned by the call site that uses it",
         ),
+        (
+            'import subprocess\n'
+            'next(filter(subprocess.run, [print]))(["x"], capture_output=True, text=True)',
+            "a filter predicate decides which element comes out and is not one",
+        ),
+        (
+            'import subprocess\n'
+            'from heapq import nlargest\n'
+            'nlargest(1, [print])[0](["x"], capture_output=True, text=True)',
+            "a selector over a container of something else selects something else",
+        ),
+        (
+            'import subprocess\n'
+            'from itertools import chain\n'
+            'next(chain())(["x"], capture_output=True, text=True)',
+            "chain with nothing to chain yields nothing that starts a process",
+        ),
+        (
+            'import subprocess\n'
+            'next(filter(None, [subprocess.run]))(\n'
+            '    ["x"], capture_output=True, text=True, encoding="utf-8"\n'
+            ')',
+            "a runner reached through a filter is still pinned by its call site",
+        ),
     ],
 )
 def test_detector_stays_quiet(source: str, why: str) -> None:
@@ -2538,6 +2582,47 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             '    inner(runner)\n'
             'outer(subprocess.run)',
             "a runner forwarded through a second definition still arrives",
+        ),
+        (
+            'import subprocess\n'
+            'next(filter(None, [subprocess.run]))(["x"], capture_output=True, text=True)',
+            "filter yields the elements it was handed, so the runner comes out",
+        ),
+        (
+            'import subprocess\n'
+            'from itertools import filterfalse\n'
+            'next(filterfalse(None, [subprocess.run]))(["x"], capture_output=True, text=True)',
+            "filterfalse keeps what filter drops and yields the same elements",
+        ),
+        (
+            'import subprocess\n'
+            'from itertools import takewhile\n'
+            'next(takewhile(None, [subprocess.run]))(["x"], capture_output=True, text=True)',
+            "takewhile yields a prefix of its input, and a prefix holds elements",
+        ),
+        (
+            'import subprocess\n'
+            'from itertools import dropwhile\n'
+            'next(dropwhile(None, [subprocess.run]))(["x"], capture_output=True, text=True)',
+            "dropwhile yields a suffix of its input, and a suffix holds elements",
+        ),
+        (
+            'import subprocess\n'
+            'from itertools import chain\n'
+            'next(chain([], [subprocess.run]))(["x"], capture_output=True, text=True)',
+            "chain yields the elements of every container handed to it",
+        ),
+        (
+            'import subprocess\n'
+            'from heapq import nlargest\n'
+            'nlargest(1, [subprocess.run])[0](["x"], capture_output=True, text=True)',
+            "nlargest returns a list of the elements it selected from",
+        ),
+        (
+            'import subprocess\n'
+            'from heapq import nsmallest\n'
+            'nsmallest(1, [subprocess.run])[0](["x"], capture_output=True, text=True)',
+            "nsmallest selects from the same container from the other end",
         ),
     ],
 )

--- a/tests/test_subprocess_text_encoding.py
+++ b/tests/test_subprocess_text_encoding.py
@@ -115,7 +115,12 @@ _STDOUT = "subprocess.STDOUT"
 # element out of whatever container it is given. The factory call and the
 # call that uses it are two separate nodes, so a scan that only reads the
 # outer ``func`` sees a call on a call and stops.
-_OPERATOR_GETTERS = frozenset({"attrgetter"})
+_OPERATOR_METHODCALLER = "methodcaller"
+# methodcaller reads an attribute off its argument exactly as attrgetter does.
+# What sets it apart is that it also calls the result, so the keywords that
+# decide the codec sit on the factory rather than on the call this scan
+# resolves. See _keyword_site.
+_OPERATOR_GETTERS = frozenset({"attrgetter", _OPERATOR_METHODCALLER})
 _OPERATOR_SELECTOR = "itemgetter"
 _OPERATOR_FACTORIES = _OPERATOR_GETTERS | frozenset({_OPERATOR_SELECTOR})
 _OPERATOR_MODULE = "operator"
@@ -1628,6 +1633,27 @@ def _pins_utf8(call: ast.Call) -> bool:
         return False
 
 
+def _keyword_site(call: ast.Call, functions: dict[str, str]) -> ast.Call:
+    """Return the call whose keywords decide what *call* does.
+
+    ``methodcaller("run", ["x"], text=True)(subprocess)`` runs
+    ``subprocess.run(["x"], text=True)``, but the keywords are given to the
+    factory, not to the call this scan resolves. Reading the resolved node
+    alone finds no keywords at all and reports nothing, which is what let the
+    shape through.
+
+    Every other shape answers for itself, so the call handed in comes back
+    unchanged.
+    """
+    factory = call.func
+    if (
+        isinstance(factory, ast.Call)
+        and _operator_label(factory, functions) == _OPERATOR_METHODCALLER
+    ):
+        return factory
+    return call
+
+
 def unpinned_lines(source: str) -> list[int]:
     """Return the line numbers of text-capturing calls that do not pin UTF-8."""
     tree = ast.parse(source)
@@ -1644,15 +1670,16 @@ def unpinned_lines(source: str) -> list[int]:
             # move is to not use it.
             offenders.append(node.lineno)
             continue
+        site = _keyword_site(node, names.functions)
         if target not in _DECODES_UNCONDITIONALLY and not _captures_text(
-            node, names.functions, target, names.modules, names.presupplied
+            site, names.functions, target, names.modules, names.presupplied
         ):
             continue
-        if _pins_utf8(node) and id(node) not in names.voided:
+        if _pins_utf8(site) and id(node) not in names.voided:
             continue
         if (
-            _keyword(node, "encoding") is None
-            and not _has_splat(node)
+            _keyword(site, "encoding") is None
+            and not _has_splat(site)
             and _call_label(node) in names.prepinned
         ):
             # The codec was pinned where this callable was built, and nothing
@@ -2199,6 +2226,18 @@ def test_detector_flags_an_unpinned_call(source: str, why: str) -> None:
             'runner = holders[0]\n'
             'runner(["x"], text=True)',
             "the pin follows the partial through a container",
+        ),
+        (
+            "import operator, subprocess\n"
+            'operator.methodcaller(\n'
+            '    "run", ["x"], capture_output=True, text=True, encoding="utf-8"\n'
+            ")(subprocess)",
+            "a methodcaller carrying the codec pins it where the keywords sit",
+        ),
+        (
+            "import operator, subprocess\n"
+            'operator.methodcaller("run", ["x"])(subprocess)',
+            "a methodcaller that captures nothing decodes nothing",
         ),
     ],
 )
@@ -3228,6 +3267,24 @@ def test_detector_reports_every_offender_in_one_file() -> None:
             'alias.keywords["encoding"] = None\n'
             'runner(["x"], text=True)',
             "an alias shares the keyword mapping rather than copying it",
+        ),
+        (
+            "import operator, subprocess\n"
+            'operator.methodcaller("run", ["x"], capture_output=True, text=True)(\n'
+            "    subprocess\n"
+            ")",
+            "methodcaller runs the entry point with keywords held one call out",
+        ),
+        (
+            "import operator as op, subprocess\n"
+            'op.methodcaller("run", ["x"], capture_output=True, text=True)(subprocess)',
+            "an operator alias hides the methodcaller the same way",
+        ),
+        (
+            "from operator import methodcaller\n"
+            "import subprocess\n"
+            'methodcaller("run", ["x"], capture_output=True, text=True)(subprocess)',
+            "a directly imported methodcaller needs no module name at all",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

Ports the unique subprocess-guard detections from the superseded branch (closed PR #3835) forward onto current `main`, one detection family per commit, tests first in every case. Also fixes one false positive that `main` shipped.

Net effect over a 276-payload corpus, measured by running both guards side by side and diffing the flagged line sets:

| Metric | Count |
|---|---|
| Detections added over `main` | 26 |
| False positives removed from `main` | 1 |
| Real detections lost | 0 |
| Test count | 228 to 283 |
| `_resolve_indirect` complexity | 15 to 10 |

Complexity fell while five capability families were added, because each family reused the extraction the previous one forced.

## Why a port and not a merge

PR #3835 was closed as superseded after #3826 and #3894 merged. Rather than assume the closed branch was the better base, both guards were snapshotted and run over the same 489-payload corpus. The closed branch flagged 27 shapes `main` did not. Tracing all 27 by hand found that **8 were false positives the branch had introduced**, not detections `main` was missing:

positional `universal_newlines=False`, starred-arg slot shift, imported `DEVNULL`, `{}.get` lookup, `mymod.PIPE`, filter-pinned-with-encoding, a local `def itemgetter`, and `subprocess.run(["x"], -1)`.

Merging that branch would have shipped all 8. The measurement, not the round count, is what settled the base-branch question. This is the empirical justification for the consolidation call.

Of the 27, the remaining 19 are ported here or are this branch's own intentional quiet cases. Nothing is left to take from the abandoned branch.

## Detection families ported

| Commit | Family |
|---|---|
| `4fabd3819` | F2: a runner through the `itertools` filters and `heapq` selectors |
| `691c21ac5` | Fix: stop asking a lambda for a name it does not have |
| `067d4c986` | F1: a runner through the `operator` selectors |
| `bd1fadd7f` | F3: a module alias through a container and a class body |
| `a6c911400` | F5: a `partial`'s fixed capture through a container |
| `d928b6346` | F4: dropping a `partial`'s codec pin once the source can undo it |
| `8ce470bfd` | Letting a `partial`'s codec pin answer for the call site |
| `707f016fc` | `operator.methodcaller` |

## Behavior change, not only additions

Commit `8ce470bfd` **removes** a detection. `partial(subprocess.run, capture_output=True, encoding="utf-8")` followed by `runner(["x"], text=True)` was flagged on `main`. At runtime the codec is pinned; a two-module probe confirmed it. This is a false positive, and it is the one worth reviewing closely because it changes behavior rather than adding to it.

The fix adds `_prepinned` as the exact mirror of the existing `_presupplied`: seed the names whose construction site pins UTF-8, then settle through aliases and containers. The two must stay in sync.

A construction pin correctly does **not** survive three things, all three added as detections here: a call site naming its own `encoding` (it wins at runtime), a call site splatting `**kwargs` (may carry `encoding`), and any mutation of the shared keyword mapping.

## How the regressions were caught

Seven of them exist because a differential diff caught them, not because a test failed. `_prepinned`'s own four tests passed while it silently removed three real detections. The same harness caught a read-only `.keywords` false positive after family F4's five tests passed, caught `main`'s inherited false positive above, and caught the wholly pinned alias changing when the rebinding fix landed.

Seven defects, every one found while the suite was green. Written up in the retrospective added by `a9f9c0d4d`. The harness itself is still an ad-hoc script rather than a gate, filed as #3973.

## Verification

```
$ uv run --frozen pytest tests/test_subprocess_text_encoding.py -q
301 passed in 8.40s

$ uv run --frozen ruff check
All checks passed!

$ uv run --frozen ruff check --select C901
_resolve_callable is too complex (14)     # identical to main's baseline

$ uv run --frozen mypy tests/test_subprocess_text_encoding.py
Success: no issues found
```

Differential scan against `main` over the repository: 28 detections added, 6 removed. Every removal is a payload where a codec is pinned and reaches the call, listed in the review threads with the runtime evidence.

Push gates: all green, including `python-tests` at 406s.

Every new function carries positive, negative, and edge cases, see `.agents/governance/TESTING-RIGOR.md`. Every fix in this branch was written as a failing test first, with the red confirmed to match exactly the intended cases before implementing.

## Two performance cliffs, found during review

Both were real, both are fixed, and both were invisible to the perf tests that already existed.

`_settle` was quadratic on chains of module aliases. The shipped perf test walked a chain ending at `subprocess.run`, which is an attribute rather than a module, so no link ever resolved and the quadratic path never ran. A chain of 8000 module aliases took 14.047s and now takes 0.386s, a 36x speedup, fixed in `68f11db07` by propagating along edges instead of sweeping repeatedly.

`_module_sources` used `list.pop(0)`. It measures linear out to 32000 elements because the shift is a cache-friendly memmove, and only shows its class past 100k. 200000 elements took 2.779s and now take 0.025s, a 111x speedup, fixed in `540b10dbb`.

Both fixes carry a test proven red against the commit before them, since a threshold test written after a fix proves nothing.

## Known policy question, deliberately not folded in

`main` flags `partial(subprocess.run, capture_output=True)` followed by `runner(["x"], capture_output=False, text=True)`. Runtime proof shows `capture_output=False` yields `stdout=None`, so nothing is decoded. The abandoned branch made this quiet. That is a conservatism **policy** difference, not a bug, and it belongs to the repository owner rather than to this PR.

Refs #3422

