### PR TITLE
fix(ci): repair the memory health CLI contract and close its fail-open paths

### DIFF
--- a/.github/workflows/memory-health.yml
+++ b/.github/workflows/memory-health.yml
@@ -2,9 +2,9 @@
 #
 # Runs batch health checks on Serena memories for PRs.
 # Detects stale citations, generates a health report, and posts a PR comment.
-# Supports exemption mechanism (memories with exempt: true in frontmatter).
 #
-# Exit codes: 0 = all healthy/exempt, 1 = stale citations (warning), 2 = error
+# Exit codes from `memory_enhancement health`: 0 = no stale memories,
+# 1 = stale memories found (warning, absorbed by continue-on-error).
 #
 # IMPORTANT: This workflow runs on ALL PRs to satisfy required status checks,
 # but skips actual health checks when no relevant files are changed.
@@ -48,8 +48,9 @@ jobs:
             memories:
               - '.serena/memories/**'
             code:
-              - '.claude/skills/memory-enhancement/src/memory_enhancement/**'
               - 'scripts/**/*.py'
+              - 'scripts/memory_enhancement/**'
+              - 'memory_enhancement'
               - 'pyproject.toml'
 
       - name: Determine if memory health should run
@@ -80,16 +81,14 @@ jobs:
           enable-git-hooks: false
 
       - name: Run health check (JSON)
-        id: health-json
         continue-on-error: true
         run: |
-          PYTHONPATH=.claude/skills/memory-enhancement/src python3 -m memory_enhancement health --json --repo-root . > health-report.json
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          python3 -m memory_enhancement --repo-root . health --json > health-report.json
 
       - name: Run health check (Markdown)
         continue-on-error: true
         run: |
-          PYTHONPATH=.claude/skills/memory-enhancement/src python3 -m memory_enhancement health --markdown --repo-root . > health-report.md
+          python3 -m memory_enhancement --repo-root . health --markdown > health-report.md
 
       - name: Upload health reports
         if: always()
@@ -113,10 +112,10 @@ jobs:
         env:
           HEALTH_STALE: ${{ steps.parse.outputs.has_stale }}
           HEALTH_TOTAL: ${{ steps.parse.outputs.total }}
-          HEALTH_HEALTHY: ${{ steps.parse.outputs.healthy }}
+          HEALTH_SCORE: ${{ steps.parse.outputs.health_score }}
           HEALTH_STALE_COUNT: ${{ steps.parse.outputs.stale }}
-          HEALTH_EXEMPT: ${{ steps.parse.outputs.exempt }}
-          HEALTH_ERRORS: ${{ steps.parse.outputs.errors }}
+          HEALTH_BROKEN: ${{ steps.parse.outputs.broken_citations }}
+          HEALTH_UNVERIFIED: ${{ steps.parse.outputs.unverified_citations }}
         with:
           script: |
             const fs = require('fs');
@@ -141,10 +140,10 @@ jobs:
               '<summary>Health Check Details</summary>',
               '',
               `- **Total memories**: ${process.env.HEALTH_TOTAL}`,
-              `- **Healthy**: ${process.env.HEALTH_HEALTHY}`,
-              `- **Stale**: ${process.env.HEALTH_STALE_COUNT}`,
-              `- **Exempt**: ${process.env.HEALTH_EXEMPT}`,
-              `- **Errors**: ${process.env.HEALTH_ERRORS}`,
+              `- **Health score**: ${process.env.HEALTH_SCORE}`,
+              `- **Stale memories**: ${process.env.HEALTH_STALE_COUNT}`,
+              `- **Broken citations**: ${process.env.HEALTH_BROKEN}`,
+              `- **Unverified citations**: ${process.env.HEALTH_UNVERIFIED}`,
               '',
               '</details>',
             ].join('\n');
@@ -181,7 +180,7 @@ jobs:
         env:
           STALE_COUNT: ${{ steps.parse.outputs.stale }}
         run: |
-          echo "::warning::Found $STALE_COUNT memories with stale citations"
+          echo "::warning::Found $STALE_COUNT stale memories"
 
   skip-health-check:
     name: Skip health check (no changes)

--- a/.github/workflows/memory-validation.yml
+++ b/.github/workflows/memory-validation.yml
@@ -36,8 +36,9 @@ jobs:
             memories:
               - '.serena/memories/**'
             code:
-              - '.claude/skills/memory-enhancement/src/memory_enhancement/**'
               - 'scripts/**/*.py'
+              - 'scripts/memory_enhancement/**'
+              - 'memory_enhancement'
               - 'pyproject.toml'
               - 'uv.lock'
 

--- a/scripts/ci/parse_memory_health_results.py
+++ b/scripts/ci/parse_memory_health_results.py
@@ -4,16 +4,22 @@
 Extracted from ``.github/workflows/memory-health.yml`` under ADR-006 (no logic
 in workflow YAML). Issue #3541.
 
-The shell this replaces read five ``.summary.*`` fields with five separate
-``jq`` calls and derived a ``has_stale`` flag from the stale count. Two
-behaviours are load-bearing and preserved exactly:
+The report is produced by ``memory_enhancement health --json``, which emits a
+flat object. Every key this module reads is listed in ``_FIELD_SOURCES`` and
+``_STALE_LIST_KEY`` so a contract test can compare them against a payload from
+the real producer rather than against a hand-written fixture. Issue #3971.
 
-* A missing report is not a failure. It emits ``has_stale=false`` and
-  ``total=0`` and nothing else, so the downstream comment step still runs.
-* A stale count that is not an integer (a missing key makes ``jq`` emit
-  ``null``) reads as "not stale". In shell, ``[ "null" -gt 0 ]`` errors and
-  the ``if`` takes its else branch; the same outcome is produced here rather
-  than crashing.
+Anything the producer could not have emitted is fatal: a missing or empty
+file, unparseable JSON, a non-object payload, an absent key, or a
+``stale_memories`` that is not a list. The ``jq`` shell this replaces was
+tolerant of all of them, and that tolerance is the bug. The producer step runs
+under ``continue-on-error``, so a crash or a regression arrives here as
+malformed input; reading it as "no stale memories" turns a broken gate into a
+green "Pass", which is exactly how #3971 stayed hidden.
+
+Values are still rendered rather than type-checked. The count fields only
+reach a PR comment, so a wrong-typed one is cosmetic. ``stale_memories`` is
+checked because it alone decides whether the gate passes.
 """
 
 from __future__ import annotations
@@ -24,7 +30,27 @@ import os
 import sys
 from pathlib import Path
 
-_SUMMARY_FIELDS = ("total", "healthy", "stale", "exempt", "errors")
+# Output name -> key emitted by ``_cmd_health`` in memory_enhancement/__main__.
+_FIELD_SOURCES: dict[str, str] = {
+    "total": "total_memories",
+    "health_score": "health_score",
+    "broken_citations": "broken_citations",
+    "stale_citations": "stale_citations",
+    "unverified_citations": "unverified_citations",
+}
+
+# The producer emits the stale memories as a list, not a count.
+_STALE_LIST_KEY = "stale_memories"
+
+
+def producer_keys_read() -> frozenset[str]:
+    """Return every producer key this script reads.
+
+    The contract test compares this against the keys a real health report
+    carries. Deriving the set from the same tables the parser uses is what
+    makes that test a contract rather than a restatement.
+    """
+    return frozenset(_FIELD_SOURCES.values()) | {_STALE_LIST_KEY}
 
 
 def _write_outputs(pairs: list[tuple[str, str]], output_path: str | None) -> None:
@@ -38,41 +64,50 @@ def _write_outputs(pairs: list[tuple[str, str]], output_path: str | None) -> Non
             handle.write(f"{key}={value}\n")
 
 
-def _is_stale(value: object) -> bool:
-    """Report whether a stale count is a positive integer.
-
-    ``jq`` emits ``null`` for a missing key and the shell comparison that
-    consumed it failed rather than raising, so anything non-integral is
-    treated as "not stale".
-    """
-    if isinstance(value, bool) or not isinstance(value, int):
-        return False
-    return value > 0
-
-
-def parse_results(results: Path) -> list[tuple[str, str]]:
-    """Return the step outputs for a health report, present or not."""
-    if not results.is_file():
-        return [("has_stale", "false"), ("total", "0")]
-
-    payload = json.loads(results.read_text(encoding="utf-8"))
-    summary = payload.get("summary") if isinstance(payload, dict) else None
-    if not isinstance(summary, dict):
-        # jq emitted null for non-object shapes instead of crashing; a report
-        # whose summary is an array or scalar reads as absent, not fatal.
-        summary = {}
-    pairs = [(field, _render(summary.get(field))) for field in _SUMMARY_FIELDS]
-    pairs.append(("has_stale", "true" if _is_stale(summary.get("stale")) else "false"))
-    return pairs
-
-
 def _render(value: object) -> str:
-    """Render a summary value the way ``jq`` rendered it for the shell."""
+    """Render a report value the way ``jq`` rendered it for the shell."""
     if value is None:
         return "null"
     if isinstance(value, bool):
         return "true" if value else "false"
     return str(value)
+
+
+def parse_results(results: Path) -> list[tuple[str, str]]:
+    """Return the step outputs for a health report.
+
+    Raises:
+        ValueError: The file is empty, is not a JSON object, omits a key the
+            parser reads, or carries a non-list ``stale_memories``.
+        json.JSONDecodeError: The file is not valid JSON.
+        OSError: The file is missing or unreadable.
+    """
+    raw = results.read_text(encoding="utf-8")
+    if not raw.strip():
+        raise ValueError(
+            "report is empty, which means the health command exited without "
+            "writing output"
+        )
+
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError(f"report is a {type(payload).__name__}, not an object")
+
+    missing = sorted(producer_keys_read() - payload.keys())
+    if missing:
+        raise ValueError(f"report is missing keys the producer emits: {missing}")
+
+    stale = payload[_STALE_LIST_KEY]
+    if not isinstance(stale, list):
+        raise ValueError(
+            f"{_STALE_LIST_KEY} is a {type(stale).__name__}, not a list, so the "
+            "stale gate cannot be trusted"
+        )
+
+    pairs = [(name, _render(payload[key])) for name, key in _FIELD_SOURCES.items()]
+    pairs.append(("stale", str(len(stale))))
+    pairs.append(("has_stale", "true" if stale else "false"))
+    return pairs
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -87,7 +122,7 @@ def main(argv: list[str] | None = None) -> int:
     results = Path(args.results)
     try:
         pairs = parse_results(results)
-    except (json.JSONDecodeError, OSError) as exc:
+    except (json.JSONDecodeError, OSError, ValueError) as exc:
         print(f"::error::Could not read {results.name}: {exc}")
         return 1
 

--- a/tests/ci/test_parse_memory_health_results.py
+++ b/tests/ci/test_parse_memory_health_results.py
@@ -1,25 +1,64 @@
-"""Tests for the memory health result parser (#3541).
+"""Tests for the memory health result parser (#3541, #3971).
 
-The shell this replaces derived a ``has_stale`` flag from a ``jq`` read and
-tolerated both a missing report and a missing key. Those two tolerances are
-the reason the downstream comment step never breaks, so they are pinned here.
+Every payload here comes from the real producer rather than a hand-written
+object. The suite this replaces built each fixture as ``{"summary": {...}}``,
+a shape ``memory_enhancement health --json`` has never emitted, so fifteen
+green tests certified a parser that read nothing. Deriving the fixtures from
+the producer is what keeps that from happening again.
 """
 
 from __future__ import annotations
 
 import json
+import re
+import shlex
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
+from memory_enhancement.__main__ import _build_parser
 from scripts.ci import parse_memory_health_results as parser
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 
 
-def _report(tmp_path: Path, summary: object) -> Path:
+@pytest.fixture(scope="module")
+def real_payload(tmp_path_factory: pytest.TempPathFactory) -> dict[str, object]:
+    """Return a health report produced by the real command.
+
+    Runs against a throwaway memories directory so the payload is cheap and
+    deterministic, but the keys are the producer's own.
+    """
+    root = tmp_path_factory.mktemp("memories-root")
+    memories = root / ".serena" / "memories"
+    memories.mkdir(parents=True)
+    (memories / "sample.md").write_text("# Sample\n\nNo citations.\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "memory_enhancement",
+            "--repo-root",
+            str(root),
+            "health",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _write(tmp_path: Path, payload: object) -> Path:
     path = tmp_path / "health-report.json"
-    path.write_text(json.dumps({"summary": summary}), encoding="utf-8")
+    path.write_text(json.dumps(payload), encoding="utf-8")
     return path
 
 
@@ -36,164 +75,289 @@ def _parsed(out: Path) -> dict[str, str]:
     )
 
 
-class TestMissingReport:
-    """A missing report is not a failure."""
+_REDIRECT = re.compile(r"\d?>>?\s*\S+")
+_SEPARATOR = re.compile(r"&&|\|\||[|;]")
 
-    def test_missing_report_succeeds(self, tmp_path: Path, monkeypatch) -> None:
-        """Positive: the step exits zero so the comment step still runs."""
-        out = _outputs(tmp_path, monkeypatch)
-        rc = parser.main(["--results", str(tmp_path / "absent.json")])
-        assert rc == 0
-        assert _parsed(out) == {"has_stale": "false", "total": "0"}
+# Output names that intentionally differ from the producer key they read.
+_APPROVED_RENAMES = {"total": "total_memories"}
 
-    def test_missing_report_emits_no_other_fields(self, tmp_path: Path, monkeypatch) -> None:
-        """Negative: the summary fields must stay absent, not empty."""
+
+def _argv_after_module(line: str) -> list[str]:
+    """Return the argv a workflow passes to the module, redirects removed.
+
+    Redirections are stripped wherever they sit, because arguments may legally
+    follow one. Truncating at the first ``>`` hid that: it made
+    ``... health --json > /dev/null --repo-root .`` look valid when the shell
+    rejects it with the exact exit 2 this gate exists to catch.
+    """
+    body = line.split("-m memory_enhancement", 1)[1]
+    return shlex.split(_SEPARATOR.split(_REDIRECT.sub(" ", body), 1)[0])
+
+
+def _unapproved_renames(sources: dict[str, str]) -> list[str]:
+    """Return output names reading a producer key they were not mapped to."""
+    return sorted(
+        name
+        for name, key in sources.items()
+        if name != key and _APPROVED_RENAMES.get(name) != key
+    )
+
+
+class TestProducerContract:
+    """The parser may only read keys the producer actually emits."""
+
+    def test_every_key_read_exists_in_a_real_report(self, real_payload) -> None:
+        """Positive: the read set is a subset of the emitted set."""
+        missing = parser.producer_keys_read() - set(real_payload)
+        assert not missing, f"parser reads keys the producer never emits: {sorted(missing)}"
+
+    def test_the_contract_check_can_fail(self, real_payload) -> None:
+        """Negative control: a bogus key is reported as missing.
+
+        Without this, a producer that emitted every conceivable key would make
+        the test above unfalsifiable.
+        """
+        assert {"summary"} - set(real_payload) == {"summary"}
+
+    def test_a_real_report_parses_into_non_null_outputs(
+        self, real_payload, tmp_path, monkeypatch
+    ) -> None:
+        """Positive: the end-to-end read produces real values, not nulls."""
+        results = _write(tmp_path, real_payload)
         out = _outputs(tmp_path, monkeypatch)
-        parser.main(["--results", str(tmp_path / "absent.json")])
-        assert "healthy=" not in out.read_text(encoding="utf-8")
+        assert parser.main(["--results", str(results)]) == 0
+        parsed = _parsed(out)
+        assert parsed["total"] == "1"
+        assert parsed["stale"] == "0"
+        assert parsed["has_stale"] == "false"
+        assert "null" not in parsed.values()
+
+    def test_no_output_reads_an_unapproved_key(self) -> None:
+        """Positive: every mapping is identity or a declared rename."""
+        assert not _unapproved_renames(parser._FIELD_SOURCES)
+
+    def test_a_swapped_mapping_is_caught(self) -> None:
+        """Negative control: pointing an output at a sibling key fails.
+
+        Key membership alone cannot see this. Every candidate key is present
+        in a real report, and a healthy fixture's counts are all zero, so a
+        swap stays invisible to both the subset check and the value check.
+        """
+        swapped = dict(parser._FIELD_SOURCES) | {"broken_citations": "valid_citations"}
+        assert _unapproved_renames(swapped) == ["broken_citations"]
+
+
+class TestWorkflowInvocations:
+    """Every workflow call of the module must parse under the real parser."""
+
+    @staticmethod
+    def _invocations() -> list[tuple[str, list[str]]]:
+        found: list[tuple[str, list[str]]] = []
+        for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+            for line in path.read_text(encoding="utf-8").splitlines():
+                if "-m memory_enhancement" not in line:
+                    continue
+                found.append((f"{path.name}: {line.strip()}", _argv_after_module(line)))
+        return found
+
+    def test_at_least_one_invocation_is_discovered(self) -> None:
+        """Negative control: an empty scan would make the next test vacuous."""
+        assert self._invocations(), "no workflow invokes the module; the scan is broken"
+
+    def test_all_invocations_parse(self) -> None:
+        """Positive: each workflow argv is accepted by the module's parser."""
+        for label, argv in self._invocations():
+            try:
+                _build_parser().parse_args(argv)
+            except SystemExit as exc:  # argparse exits 2 on a bad argv
+                pytest.fail(f"{label} -> argparse rejected {argv} (code {exc.code})")
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "python3 -m memory_enhancement health --json --repo-root . > r.json",
+            "python3 -m memory_enhancement --repo-root . health --json > /dev/null --repo-root .",
+        ],
+    )
+    def test_a_bad_invocation_is_rejected(self, line: str) -> None:
+        """Negative: bad argv fails *through the scanner*, not around it.
+
+        ``--repo-root`` is declared on the top-level parser, so placing it
+        after the subcommand exits 2. That is the defect from #3971. The
+        second line is the one an earlier scanner passed by truncating at the
+        first ``>``: arguments may legally follow a redirection, and the shell
+        rejects that command with the same exit 2.
+        """
+        with pytest.raises(SystemExit):
+            _build_parser().parse_args(_argv_after_module(line))
+
+    def test_the_scanner_keeps_arguments_that_follow_a_redirect(self) -> None:
+        """Edge: a redirect is removed, but nothing after it is dropped."""
+        line = "python3 -m memory_enhancement --repo-root . health --json > /dev/null --x 1"
+        assert _argv_after_module(line) == [
+            "--repo-root",
+            ".",
+            "health",
+            "--json",
+            "--x",
+            "1",
+        ]
+
+
+class TestFatalReports:
+    """Every shape the producer could not have emitted is fatal.
+
+    Before #3971 each of these read as ``has_stale=false`` and exited 0, so a
+    broken producer posted a green "Pass". That is the failure this module
+    exists to surface, so tolerance here is the bug, not a feature.
+    """
+
+    def test_a_missing_report_fails_loudly(self, tmp_path, monkeypatch, capsys) -> None:
+        """Positive: an absent file cannot read as a healthy run.
+
+        The producer step redirects into the report, so the file exists even
+        when the command dies. Its absence means the step never ran at all.
+        """
+        _outputs(tmp_path, monkeypatch)
+        assert parser.main(["--results", str(tmp_path / "absent.json")]) == 1
+        assert "::error::Could not read absent.json" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("body", ["", "   ", "\n\n"])
+    def test_an_empty_report_fails_loudly(self, tmp_path, monkeypatch, capsys, body) -> None:
+        """Positive: the shape a crashed producer leaves behind is fatal.
+
+        ``continue-on-error`` on the producer step means a crash shows up here
+        as a zero-byte file.
+        """
+        results = tmp_path / "health-report.json"
+        results.write_text(body, encoding="utf-8")
+        _outputs(tmp_path, monkeypatch)
+        assert parser.main(["--results", str(results)]) == 1
+        assert "empty" in capsys.readouterr().out
+
+    def test_invalid_json_fails_loudly(self, tmp_path, monkeypatch, capsys) -> None:
+        """Positive: a truncated report exits 1 with an annotation."""
+        results = tmp_path / "health-report.json"
+        results.write_text("{not json", encoding="utf-8")
+        _outputs(tmp_path, monkeypatch)
+        assert parser.main(["--results", str(results)]) == 1
+        assert "::error::Could not read health-report.json" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("payload", [[], "x", 1, None, True])
+    def test_a_non_object_report_fails_loudly(self, tmp_path, monkeypatch, payload) -> None:
+        """Edge: valid JSON that is not an object is still not a report."""
+        _outputs(tmp_path, monkeypatch)
+        assert parser.main(["--results", str(_write(tmp_path, payload))]) == 1
+
+    def test_the_pre_fix_summary_shape_fails_loudly(self, tmp_path, monkeypatch, capsys) -> None:
+        """Edge: the fabricated shape the old suite tested is now rejected.
+
+        ``{"summary": {...}}`` is what fifteen green tests asserted against a
+        parser that read nothing. It carries no key the producer emits.
+        """
+        payload = {"summary": {"total": 9, "healthy": 6, "stale": 3}}
+        _outputs(tmp_path, monkeypatch)
+        assert parser.main(["--results", str(_write(tmp_path, payload))]) == 1
+        assert "missing keys the producer emits" in capsys.readouterr().out
+
+    def test_dropping_any_read_key_fails_loudly(
+        self, real_payload, tmp_path, monkeypatch
+    ) -> None:
+        """Positive: a producer regression that drops one key is caught.
+
+        Rendering the survivors and calling it a Pass is what defect B did.
+        The key list is read inside the test so that removing the accessor
+        fails one test rather than breaking collection for the whole suite.
+        """
+        for dropped in sorted(parser.producer_keys_read()):
+            payload = {k: v for k, v in real_payload.items() if k != dropped}
+            _outputs(tmp_path, monkeypatch)
+            assert parser.main(["--results", str(_write(tmp_path, payload))]) == 1, (
+                f"dropping {dropped} was tolerated"
+            )
+
+    @pytest.mark.parametrize("value", [None, "3", 3, {}])
+    def test_a_non_list_stale_value_fails_loudly(
+        self, real_payload, tmp_path, monkeypatch, value
+    ) -> None:
+        """Edge: the one field that decides the gate must be the right type."""
+        payload = {**real_payload, "stale_memories": value}
+        _outputs(tmp_path, monkeypatch)
+        assert parser.main(["--results", str(_write(tmp_path, payload))]) == 1
+
+    def test_a_real_report_is_not_fatal(
+        self, real_payload, tmp_path, monkeypatch, capsys
+    ) -> None:
+        """Negative control: none of the above fires on a real report.
+
+        Without this, making every branch fatal would pass this class while
+        breaking the workflow outright.
+        """
+        _outputs(tmp_path, monkeypatch)
+        assert parser.main(["--results", str(_write(tmp_path, real_payload))]) == 0
+        assert "::error::" not in capsys.readouterr().out
 
 
 class TestStaleFlag:
-    """``has_stale`` drives whether a PR comment is posted."""
+    """``has_stale`` is derived from the length of the stale list."""
 
-    def test_positive_stale_count_sets_the_flag(self, tmp_path: Path, monkeypatch) -> None:
-        """Positive: any stale memory raises the flag."""
+    def test_stale_memories_set_the_flag(self, real_payload, tmp_path, monkeypatch) -> None:
+        """Positive: a non-empty stale list reads as stale."""
+        payload = {**real_payload, "stale_memories": ["a", "b", "c"]}
         out = _outputs(tmp_path, monkeypatch)
-        summary = {"total": 9, "healthy": 6, "stale": 3, "exempt": 0, "errors": 0}
-        results = _report(tmp_path, summary)
-        assert parser.main(["--results", str(results)]) == 0
-        assert _parsed(out)["has_stale"] == "true"
-
-    def test_zero_stale_count_clears_the_flag(self, tmp_path: Path, monkeypatch) -> None:
-        """Negative: a healthy repository must not post a comment."""
-        out = _outputs(tmp_path, monkeypatch)
-        summary = {"total": 9, "healthy": 9, "stale": 0, "exempt": 0, "errors": 0}
-        results = _report(tmp_path, summary)
-        parser.main(["--results", str(results)])
-        assert _parsed(out)["has_stale"] == "false"
-
-    def test_all_summary_fields_are_emitted(self, tmp_path: Path, monkeypatch) -> None:
-        """Positive: every value the comment step reads is present."""
-        out = _outputs(tmp_path, monkeypatch)
-        summary = {"total": 9, "healthy": 6, "stale": 3, "exempt": 1, "errors": 2}
-        results = _report(tmp_path, summary)
-        parser.main(["--results", str(results)])
+        parser.main(["--results", str(_write(tmp_path, payload))])
         parsed = _parsed(out)
-        assert parsed["total"] == "9"
-        assert parsed["healthy"] == "6"
         assert parsed["stale"] == "3"
-        assert parsed["exempt"] == "1"
-        assert parsed["errors"] == "2"
+        assert parsed["has_stale"] == "true"
 
-    def test_a_missing_stale_key_is_not_stale(self, tmp_path: Path, monkeypatch) -> None:
-        """Edge: ``jq`` emitted ``null`` and the shell test errored to false."""
-        out = _outputs(tmp_path, monkeypatch)
-        results = _report(tmp_path, {"total": 9})
-        assert parser.main(["--results", str(results)]) == 0
-        parsed = _parsed(out)
-        assert parsed["has_stale"] == "false"
-        assert parsed["stale"] == "null"
-
-    def test_a_non_numeric_stale_value_is_not_stale(self, tmp_path: Path, monkeypatch) -> None:
-        """Edge: a string count must not crash the step."""
-        out = _outputs(tmp_path, monkeypatch)
-        results = _report(tmp_path, {"stale": "many"})
-        assert parser.main(["--results", str(results)]) == 0
-        assert _parsed(out)["has_stale"] == "false"
-
-    def test_a_boolean_stale_value_is_not_stale(self, tmp_path: Path, monkeypatch) -> None:
-        """Edge: ``True`` is an int in Python but was never a count."""
-        out = _outputs(tmp_path, monkeypatch)
-        results = _report(tmp_path, {"stale": True})
-        parser.main(["--results", str(results)])
-        assert _parsed(out)["has_stale"] == "false"
-
-    def test_a_negative_stale_count_is_not_stale(self, tmp_path: Path, monkeypatch) -> None:
-        """Edge: the shell used ``-gt 0``, not "non-zero"."""
-        out = _outputs(tmp_path, monkeypatch)
-        results = _report(tmp_path, {"stale": -1})
-        parser.main(["--results", str(results)])
-        assert _parsed(out)["has_stale"] == "false"
-
-    def test_an_absent_summary_object_is_tolerated(self, tmp_path: Path, monkeypatch) -> None:
-        """Edge: a report with no summary reads as all null, not a crash."""
-        out = _outputs(tmp_path, monkeypatch)
-        path = tmp_path / "health-report.json"
-        path.write_text(json.dumps({"other": 1}), encoding="utf-8")
-        assert parser.main(["--results", str(path)]) == 0
-        assert _parsed(out)["total"] == "null"
-
-    @pytest.mark.parametrize("payload", [[], "x", 1, {"summary": []}, {"summary": "x"}])
-    def test_a_non_object_shape_reads_as_absent(
-        self, tmp_path: Path, monkeypatch, payload
+    def test_an_empty_stale_list_clears_the_flag(
+        self, real_payload, tmp_path, monkeypatch
     ) -> None:
-        """Edge: jq emitted null for non-object shapes instead of crashing."""
+        """Negative: zero stale memories must not raise the flag."""
+        payload = {**real_payload, "stale_memories": []}
         out = _outputs(tmp_path, monkeypatch)
-        path = tmp_path / "health-report.json"
-        path.write_text(json.dumps(payload), encoding="utf-8")
-        assert parser.main(["--results", str(path)]) == 0
-        assert _parsed(out)["total"] == "null"
-        assert _parsed(out)["has_stale"] == "false"
-
-
-class TestFailureModes:
-    """Only an unreadable report is an error."""
-
-    def test_malformed_json_fails_loudly(self, tmp_path: Path, monkeypatch, capsys) -> None:
-        """Negative: a truncated report must not read as zero stale."""
-        _outputs(tmp_path, monkeypatch)
-        path = tmp_path / "health-report.json"
-        path.write_text("{not json", encoding="utf-8")
-        assert parser.main(["--results", str(path)]) == 1
-        assert "::error::" in capsys.readouterr().out
-
-    def test_the_error_names_the_report(self, tmp_path: Path, monkeypatch, capsys) -> None:
-        """Edge: the annotation must identify which file failed."""
-        _outputs(tmp_path, monkeypatch)
-        path = tmp_path / "health-report.json"
-        path.write_text("{not json", encoding="utf-8")
-        parser.main(["--results", str(path)])
-        assert "health-report.json" in capsys.readouterr().out
+        parser.main(["--results", str(_write(tmp_path, payload))])
+        parsed = _parsed(out)
+        assert parsed["stale"] == "0"
+        assert parsed["has_stale"] == "false"
 
 
 class TestOutputHandling:
-    """Step outputs append; they never truncate."""
+    """Outputs go to ``GITHUB_OUTPUT`` when set and to stdout otherwise."""
 
-    def test_existing_output_content_is_preserved(self, tmp_path: Path, monkeypatch) -> None:
-        """Edge: a prior step's outputs must survive."""
-        out = _outputs(tmp_path, monkeypatch)
-        out.write_text("earlier=kept\n", encoding="utf-8")
-        results = _report(tmp_path, {"stale": 0})
-        parser.main(["--results", str(results)])
-        assert _parsed(out)["earlier"] == "kept"
-
-    def test_without_the_env_var_values_go_to_stdout(
-        self, tmp_path: Path, monkeypatch, capsys
+    def test_outputs_append_rather_than_truncate(
+        self, real_payload, tmp_path, monkeypatch
     ) -> None:
-        """Edge: running outside Actions must still be inspectable."""
+        """Edge: an existing output file keeps its earlier lines."""
+        out = _outputs(tmp_path, monkeypatch)
+        out.write_text("earlier=1\n", encoding="utf-8")
+        parser.main(["--results", str(_write(tmp_path, real_payload))])
+        assert _parsed(out)["earlier"] == "1"
+
+    def test_outputs_fall_back_to_stdout(
+        self, real_payload, tmp_path, monkeypatch, capsys
+    ) -> None:
+        """Negative: no GITHUB_OUTPUT means print, not crash."""
         monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
-        results = _report(tmp_path, {"stale": 2})
-        assert parser.main(["--results", str(results)]) == 0
-        assert "has_stale=true" in capsys.readouterr().out
+        assert parser.main(["--results", str(_write(tmp_path, real_payload))]) == 0
+        assert "total=1" in capsys.readouterr().out
 
 
 class TestWorkflowWiring:
-    """The workflow must call the script this module tests."""
+    """The workflow must consume the outputs this script actually emits."""
 
-    def test_memory_health_calls_the_parser(self) -> None:
-        """Positive: extraction is only real once the YAML points here."""
-        text = (REPO_ROOT / ".github" / "workflows" / "memory-health.yml").read_text(
-            encoding="utf-8"
-        )
-        assert "scripts/ci/parse_memory_health_results.py" in text
+    def test_every_consumed_output_is_emitted(self, real_payload, tmp_path, monkeypatch) -> None:
+        """Positive: no ``steps.parse.outputs.X`` reads a field we dropped."""
+        out = _outputs(tmp_path, monkeypatch)
+        parser.main(["--results", str(_write(tmp_path, real_payload))])
+        emitted = set(_parsed(out))
 
-    def test_memory_health_no_longer_shells_out_to_jq(self) -> None:
-        """Negative: the replaced shell must be gone, not merely bypassed."""
-        text = (REPO_ROOT / ".github" / "workflows" / "memory-health.yml").read_text(
-            encoding="utf-8"
-        )
-        assert "jq '.summary.total'" not in text
+        text = (WORKFLOW_DIR / "memory-health.yml").read_text(encoding="utf-8")
+        consumed = set(re.findall(r"steps\.parse\.outputs\.([A-Za-z0-9_-]+)", text))
+        assert consumed, "no workflow step consumes the parser; the scan is broken"
+        assert consumed <= emitted, f"workflow reads unemitted outputs: {consumed - emitted}"
 
-
-if __name__ == "__main__":
-    raise SystemExit(pytest.main([__file__, "-q"]))
+    def test_the_inline_jq_is_gone(self) -> None:
+        """Negative: ADR-006 forbids the shell this script replaced."""
+        text = (WORKFLOW_DIR / "memory-health.yml").read_text(encoding="utf-8")
+        assert "jq '.summary" not in text


### PR DESCRIPTION
## Summary

### What

Repairs the Memory Health workflow, which has been reporting a green "Pass"
while measuring nothing. Fixes the CLI argument order, replaces a consumer that
read five keys the producer never emits, and makes every malformed report shape
fatal instead of fail-open.

### Why

`.github/workflows/memory-health.yml` invoked the health command with
`--repo-root` after the subcommand. That flag is declared on the top-level
parser, so argparse exited 2 and wrote nothing:

```text
python3 -m memory_enhancement health --json --repo-root .   rc=2, 0 bytes
python3 -m memory_enhancement --repo-root . health --json   rc=1, 679 bytes
```

Correcting the order alone would not have helped. The consumer read
`payload["summary"]` and the keys `total`, `healthy`, `stale`, `exempt`,
`errors`. The producer emits nine flat keys and none of those five. Two of them
(`healthy`, `exempt`) appear nowhere in the producer package at all. Every
output would still have rendered `null`, and `has_stale` would have been false
forever.

Both defects survived because the parser treated every malformed shape as "no
stale memories" and exited 0.

## Changes

- **Argument order** fixed on both invocations in
  `.github/workflows/memory-health.yml`. The JSON and Markdown steps were both
  affected.
- **Data contract** rewritten in `scripts/ci/parse_memory_health_results.py`.
  Producer keys now live in one table with a public accessor so a contract test
  can compare the read set against a real payload.
- **Fail-open paths closed.** A missing file, an empty file, unparseable JSON, a
  non-object payload, a dropped key, or a non-list `stale_memories` are now all
  fatal. Count fields are still rendered without type checks because they only
  reach a PR comment. `stale_memories` is checked because it alone decides the
  gate.
- **Dead path filter** replaced in `.github/workflows/memory-health.yml` and
  `.github/workflows/memory-validation.yml`. The old glob pointed at a
  directory that does not exist. The replacement covers the real package plus
  the tracked root symlink that makes `python -m memory_enhancement` resolve.
  This is the only change to `.github/workflows/memory-validation.yml`.
- **Dead wiring removed**: an inert `PYTHONPATH`, a step `id` with no consumers,
  and an `exit_code` output nothing reads.
- **False header claims corrected.** The workflow advertised an exemption
  mechanism and an exit code 2. The producer has zero occurrences of `exempt`
  and never returns 2.

## Verification

```text
33 tests pass
same suite against pre-fix source: 23 fail, including both new gates
ruff: All checks passed
end to end on this repo: total=878, stale=7, has_stale=true
  (previously: every output null, has_stale=false)
```

The old suite's fifteen cases were built on `{"summary": {...}}`, a shape the
producer has never emitted, so they certified a parser that read nothing.
Fixtures in `tests/ci/test_parse_memory_health_results.py` now come from a
subprocess call to the real producer.

Two class-level gates keep the contract from rotting again:

1. Every key the parser reads must exist in a real report, and each mapping must
   be identity or a declared rename. A swap between sibling keys is caught.
2. Every `-m memory_enhancement` line in the workflows must parse under the real
   parser. The scanner strips redirections wherever they appear, because
   arguments may legally follow one.

## Blast radius

`Memory health check` is not a required status check, so the new hard failures
cannot block PRs. `Validate memory citations` is required, and the only change
there adds trigger paths, so it can run more often but never less.

## Out of Scope

Both workflows exceed the ADR-006 ceiling of 100 lines, as do 37 of 61
workflows in the repository. This change reduces them (201 to 198, and 200 to
199). Extracting the comment rendering and upsert logic is a separate refactor.

The active memory-enhancement skill documentation advertises several
subcommands that the CLI does not implement. That is a different defect class,
it touches both plugin roots, and it needs its own manifest bump. Filed
separately.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [x] Infrastructure/CI change

## Reviewer Expectations

**Review kind / scrutiny / urgency**: targeted, standard scrutiny, no rush.

**Focus areas**: the decision to make malformed reports fatal rather than
tolerant, and whether the two new gates are falsifiable. Both were rewritten
after an adversarial review demonstrated the first versions could be fooled.

## Testing

- [x] Tests added/updated
- [x] Manual testing completed

## Agent Review

### Security Review

- [x] No security-critical changes in this PR

### Other Agent Reviews

- [x] QA verified test coverage

An adversarial review on a different model family reproduced every measurement
and returned REQUEST CHANGES. Four findings were reproduced independently and
fixed in this branch: the fail-open paths, a workflow scanner that could pass a
command the shell rejects, a contract gate blind to a mapping swap, and the
dropped symlink coverage. Two further findings are recorded under Out of Scope
above.

## Author Pre-flight

- [x] Pre-PR validation passed
- [x] Lint and formatting clean (scoped to changed files)
- [x] Self-review completed
- [x] No new warnings introduced

## References

Producer and prior art consulted while diagnosing, not modified here:

- `scripts/memory_enhancement/__main__.py` declares `--repo-root` on the
  top-level parser.
- `scripts/memory_enhancement/health.py` builds the stale list, which is why
  `has_stale` derived from its length is equivalent to the producer's own
  failure condition.
- `.github/workflows/citation-verify.yml` is the in-repo precedent for the
  correct argument order.

## Related Issues

Fixes #3971
